### PR TITLE
fix(discord): prevent typing indicator sticking when _typing_loop cleanup races a concurrent send_typing

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5591,7 +5591,17 @@ class DiscordAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
             finally:
-                self._typing_tasks.pop(chat_id, None)
+                # Only clear the registry entry if it still points at THIS
+                # loop. A concurrent send_typing() can re-register a fresh
+                # loop after stop_typing() popped this one (the tool-progress
+                # path in gateway/run.py and the base _keep_typing refresh both
+                # call send_typing during a turn). Popping unconditionally
+                # would orphan that newer loop — it would run forever, hitting
+                # the typing endpoint every 12s, and stop_typing() could never
+                # cancel it because it is no longer in the dict. Result: the
+                # Discord "is typing…" indicator stays on permanently.
+                if self._typing_tasks.get(chat_id) is asyncio.current_task():
+                    self._typing_tasks.pop(chat_id, None)
 
         self._typing_tasks[chat_id] = asyncio.create_task(_typing_loop())
 

--- a/tests/gateway/test_discord_typing_stuck.py
+++ b/tests/gateway/test_discord_typing_stuck.py
@@ -1,0 +1,108 @@
+"""Regression test for the Discord typing-indicator stuck-on race.
+
+The Discord adapter's ``send_typing`` starts a persistent background loop per
+chat that POSTs ``/channels/{id}/typing`` every 12s; ``stop_typing`` cancels
+it. The loop's ``finally`` previously popped the registry entry
+unconditionally::
+
+    finally:
+        self._typing_tasks.pop(chat_id, None)
+
+Race: ``stop_typing()`` pops the entry and cancels the old loop, but before
+the old loop's ``finally`` runs, a fresh ``send_typing()`` (from the tool
+progress path in ``gateway/run.py`` or the base ``_keep_typing`` refresh)
+re-registers a new loop for the same chat. The old loop's ``finally`` then
+pops the *new* loop out of the registry, orphaning it — it keeps POSTing
+``/typing`` every 12s forever and ``stop_typing()`` can never cancel it again,
+so Discord shows "is typing…" permanently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _make_adapter() -> DiscordAdapter:
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = SimpleNamespace(http=SimpleNamespace(request=None))
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_cancelled_typing_loop_does_not_orphan_newer_loop() -> None:
+    """A cancelled loop's ``finally`` must not pop a re-registered sibling.
+
+    Reproduces the interleaving directly: stop_typing's pop happens first,
+    a new send_typing re-registers loop B, then loop A's cancellation unwinds
+    through its ``finally``. With the bug, A's ``finally`` pops B and B is
+    orphaned (still tracked nowhere, still POSTing /typing, unstoppable).
+    """
+    adapter = _make_adapter()
+    chat_id = "123456789012345678"
+
+    # Signal once loop A has actually started POSTing, so the later cancel()
+    # lands while A is inside its 12s sleep — not before the coroutine body
+    # (and therefore its finally) has even begun.
+    a_started = asyncio.Event()
+
+    async def _request(_route) -> None:
+        a_started.set()
+
+    adapter._client.http.request = _request
+
+    # Turn 1: send_typing registers loop A.
+    await adapter.send_typing(chat_id)
+    loop_a = adapter._typing_tasks[chat_id]
+    assert loop_a is not None
+
+    # Let loop A start and reach its first POST, then settle into sleep(12).
+    await asyncio.wait_for(a_started.wait(), timeout=1.0)
+    await asyncio.sleep(0)
+
+    # stop_typing pops the entry, then cancels. We emulate the pop explicitly
+    # so we can interleave a re-registration the way the real code does.
+    popped = adapter._typing_tasks.pop(chat_id)
+    assert popped is loop_a
+
+    # A fresh send_typing re-registers loop B before A's finally runs.
+    await adapter.send_typing(chat_id)
+    loop_b = adapter._typing_tasks[chat_id]
+    assert loop_b is not None and loop_b is not loop_a
+
+    # Now A's cancellation unwinds through its finally.
+    loop_a.cancel()
+    try:
+        await loop_a
+    except asyncio.CancelledError:
+        pass
+
+    # B must still be tracked — otherwise it is orphaned and unstoppable.
+    assert adapter._typing_tasks.get(chat_id) is loop_b
+
+    # And stop_typing can still cancel B cleanly.
+    await adapter.stop_typing(chat_id)
+    assert adapter._typing_tasks.get(chat_id) is None
+
+
+@pytest.mark.asyncio
+async def test_stop_typing_clears_registry_in_normal_path() -> None:
+    """The non-raced path still clears the registry entry."""
+    adapter = _make_adapter()
+    chat_id = "123456789012345678"
+
+    async def _request(_route) -> None:
+        return None
+
+    adapter._client.http.request = _request
+
+    await adapter.send_typing(chat_id)
+    assert chat_id in adapter._typing_tasks
+
+    await adapter.stop_typing(chat_id)
+    assert chat_id not in adapter._typing_tasks


### PR DESCRIPTION
## Summary

Fixes a race in the Discord adapter's typing loop that leaves the **"is typing…" indicator stuck permanently**, even after the agent has finished and the message has been delivered.

## Root cause

`send_typing()` registers a persistent per-chat loop that POSTs `/channels/{id}/typing` every 12s; `stop_typing()` cancels it. The loop's `finally` popped the registry entry **unconditionally**:

```python
finally:
    self._typing_tasks.pop(chat_id, None)
```

The race:

1. `stop_typing()` pops the entry for loop **A** and cancels it.
2. Before A's `finally` unwinds, a concurrent `send_typing()` re-registers a fresh loop **B** for the same chat. This happens routinely: the tool-progress path in `gateway/run.py` and the base `_keep_typing` refresh both call `send_typing()` during a turn.
3. A's `finally` runs `pop(chat_id)`, which removes **B** — not A — from the registry.
4. B is now orphaned: it keeps POSTing `/typing` every 12s forever, and `stop_typing()` can never cancel it again because it is no longer in the dict.

Result: Discord keeps showing "is typing…" indefinitely until the gateway is restarted.

This line was introduced by the adapter refactor `cc8e5ec2a` (Discord → bundled plugin) and is still present on `main` (line 5594).

## Fix

Only clear the entry when it still points at *this* loop:

```python
finally:
    if self._typing_tasks.get(chat_id) is asyncio.current_task():
        self._typing_tasks.pop(chat_id, None)
```

If the entry has been replaced by a newer loop, the old loop leaves it alone.

## Test

`tests/gateway/test_discord_typing_stuck.py` reproduces the exact interleaving deterministically:

- register loop A → `stop_typing` pops A → re-register loop B → cancel A → assert B is still tracked (was `None` before the fix) → assert `stop_typing` can still cancel B cleanly.

Verified: the test fails on the buggy code and passes with the fix (2/2).

## Relationship to existing issues

This is a **complementary** fix, not a duplicate of the open work:

- **#64874** (open, P2) — `_typing_loop` HTTP request hangs with no timeout. Different mechanism (needs a timeout on the HTTP call; PR **#64910** addresses that).
- **#49290** (open, P3) — indicator lingers ~10s after the message (Discord has no early-clear API; unrelated to orphaning).
- **#26854** / **#26728** (closed) — earlier `_keep_typing`/base.py races, fixed separately.

This PR closes the orphaned-re-registered-loop variant, which is not yet covered by any open PR.
