### PR TITLE
fix(discord): harden send errors and connect deadline

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -80,6 +80,8 @@ from hermes_cli.fallback_config import get_fallback_chain
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
+_ADAPTER_CONNECT_CLEANUP_TIMEOUT_SECS = 2.0
+_ADAPTER_CONNECT_SHUTDOWN_CLEANUP_TIMEOUT_SECS = 0.25
 # Telegram cold polling now proves one real getUpdates round trip before connect
 # returns. Leave enough outer budget for initialize/deleteWebhook/start_polling
 # wall deadlines plus readiness; other platforms retain the 30s isolation bound.
@@ -6403,6 +6405,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+        # Cleanup hooks that exceeded their hard connect-time bound remain
+        # owned and observable until they finish. The residual metadata does
+        # not retain adapters; only the exceptional task itself can do so.
+        self._connect_cleanup_tasks: set[asyncio.Task] = set()
+        self._connect_cleanup_residuals: dict[asyncio.Task, dict[str, Any]] = {}
 
         # Event-loop liveness heartbeat (#66892): rewritten every 30s while
         # the loop is dispatching. External supervisors use the file mtime /
@@ -6775,6 +6782,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT
         return _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
 
+    async def _wait_for_pending_connect_cleanups(self) -> None:
+        """Make one bounded shutdown pass over residual connect cleanups."""
+        tasks = set(getattr(self, "_connect_cleanup_tasks", set()))
+        if not tasks:
+            return
+        done, pending = await asyncio.wait(
+            tasks,
+            timeout=_ADAPTER_CONNECT_SHUTDOWN_CLEANUP_TIMEOUT_SECS,
+        )
+        if pending:
+            residuals = getattr(self, "_connect_cleanup_residuals", {})
+            logger.warning(
+                "Shutdown leaving %d tracked connect cleanup(s) pending: %r",
+                len(pending),
+                [residuals.get(task) for task in pending],
+            )
+
     async def _connect_adapter_with_timeout(
         self, adapter, platform, *, is_reconnect: bool = False
     ) -> bool:
@@ -6798,17 +6822,101 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         task = asyncio.ensure_future(
             adapter.connect(is_reconnect=is_reconnect)
         )
+
+        def _track_pending_cleanup(cleanup_task: asyncio.Task) -> None:
+            tasks = getattr(self, "_connect_cleanup_tasks", None)
+            if tasks is None:
+                tasks = set()
+                self._connect_cleanup_tasks = tasks
+            residuals = getattr(self, "_connect_cleanup_residuals", None)
+            if residuals is None:
+                residuals = {}
+                self._connect_cleanup_residuals = residuals
+            process = getattr(adapter, "_slash_discovery_process", None)
+            residuals[cleanup_task] = {
+                "platform": platform.value,
+                "pid": getattr(process, "pid", None),
+                "state": "cleanup_pending_after_hard_timeout",
+            }
+            tasks.add(cleanup_task)
+
+            def _cleanup_done(done_task: asyncio.Task) -> None:
+                tasks.discard(done_task)
+                residual = residuals.pop(done_task, None)
+                try:
+                    done_task.result()
+                except asyncio.CancelledError:
+                    logger.warning(
+                        "%s connect residual cleanup was cancelled (%r)",
+                        platform.value,
+                        residual,
+                    )
+                except Exception:
+                    logger.warning(
+                        "%s connect residual cleanup failed (%r)",
+                        platform.value,
+                        residual,
+                        exc_info=True,
+                    )
+
+            cleanup_task.add_done_callback(_cleanup_done)
+
+        async def _cancel_connect() -> None:
+            task.cancel()
+            cleanup = getattr(adapter, "cancel_slash_discovery", None)
+            if callable(cleanup):
+                # Discord's synchronous plugin imports run in a child process.
+                # Reap it before releasing the runner at the deadline; a done
+                # callback alone owns the task but cannot own an OS process.
+                cleanup_task = asyncio.create_task(cleanup())
+                try:
+                    done, _pending = await asyncio.wait(
+                        {cleanup_task},
+                        timeout=_ADAPTER_CONNECT_CLEANUP_TIMEOUT_SECS,
+                    )
+                except asyncio.CancelledError:
+                    _track_pending_cleanup(cleanup_task)
+                    logger.warning(
+                        "%s connect cleanup wait was cancelled; cleanup remains tracked",
+                        platform.value,
+                    )
+                else:
+                    if cleanup_task not in done:
+                        _track_pending_cleanup(cleanup_task)
+                        residual = self._connect_cleanup_residuals[cleanup_task]
+                        logger.warning(
+                            "%s connect cleanup exceeded %.1fs; preserving original "
+                            "connect outcome with residual=%r",
+                            platform.value,
+                            _ADAPTER_CONNECT_CLEANUP_TIMEOUT_SECS,
+                            residual,
+                        )
+                    else:
+                        try:
+                            await cleanup_task
+                        except asyncio.CancelledError:
+                            logger.warning(
+                                "%s connect cleanup was cancelled; preserving the "
+                                "original connect outcome",
+                                platform.value,
+                            )
+                        except Exception:
+                            logger.warning(
+                                "%s connect cleanup failed after cancellation",
+                                platform.value,
+                                exc_info=True,
+                            )
+            task.add_done_callback(consume_detached_task_result)
+
         try:
             done, _pending = await asyncio.wait({task}, timeout=timeout)
         except asyncio.CancelledError:
-            task.cancel()
-            task.add_done_callback(consume_detached_task_result)
+            await _cancel_connect()
             raise
         if task in done:
             result = await task
             return bool(result)
-        task.cancel()
-        task.add_done_callback(consume_detached_task_result)
+        await _cancel_connect()
         raise TimeoutError(
             f"{platform.value} connect timed out after {timeout:g}s"
         )
@@ -13558,6 +13666,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _amap.clear()
             if hasattr(self, "_profile_adapters"):
                 self._profile_adapters.clear()
+            await self._wait_for_pending_connect_cleanups()
             logger.info(
                 "Shutdown phase: all adapters disconnected at +%.2fs",
                 _phase_elapsed(),

--- a/hermes_cli/discord_slash_discovery.py
+++ b/hermes_cli/discord_slash_discovery.py
@@ -1,0 +1,62 @@
+"""Isolated discovery for Discord slash-command metadata.
+
+This module is both the single discovery implementation and the child-process
+entrypoint used by the Discord adapter. Keep its output JSON-only: callback
+objects stay in the gateway process and are built from this metadata there.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def discover_discord_slash_metadata() -> dict[str, Any]:
+    """Return JSON-safe gateway, plugin, and skill command metadata."""
+    from hermes_cli.commands import (
+        COMMAND_REGISTRY,
+        _is_gateway_available,
+        _iter_plugin_command_entries,
+        _resolve_config_gates,
+        discord_skill_commands_by_category,
+    )
+
+    config_overrides = _resolve_config_gates()
+    commands = [
+        [command.name, command.description, command.args_hint]
+        for command in COMMAND_REGISTRY
+        if _is_gateway_available(command, config_overrides)
+    ]
+    plugins = [list(entry) for entry in _iter_plugin_command_entries()]
+    categories, uncategorized, hidden = discord_skill_commands_by_category(
+        reserved_names=set()
+    )
+    skills = list(uncategorized)
+    for category_skills in categories.values():
+        skills.extend(category_skills)
+
+    return {
+        "schema_version": 1,
+        "commands": commands,
+        "plugins": plugins,
+        "skills": [list(entry) for entry in skills],
+        "skill_hidden": hidden,
+    }
+
+
+def serialize_discord_slash_metadata() -> str:
+    """Serialize discovery output for the adapter child-process protocol."""
+    return json.dumps(
+        discover_discord_slash_metadata(),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def main() -> None:
+    print(serialize_discord_slash_metadata())
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -40,6 +40,22 @@ _DISCORD_MARKDOWN_LINK_LABEL_RE = re.compile(r"([\\\[\]])")
 _DISCORD_URL_LABEL_SCHEME_RE = re.compile(r"^https?://", re.IGNORECASE)
 
 
+def _discord_exception_detail(exc: BaseException) -> str:
+    """Return actionable Discord error detail without serializing internals."""
+    exception_type = type(exc).__name__
+    message = str(exc).strip()
+    if not message:
+        return exception_type
+    from agent.redact import redact_sensitive_text
+
+    safe_message = redact_sensitive_text(
+        message,
+        force=True,
+        redact_url_credentials=True,
+    ).strip()
+    return f"{exception_type}: {safe_message}" if safe_message else exception_type
+
+
 def _format_discord_markdown_link(label: str, url: str) -> str:
     """Return a Discord Markdown link whose label is not itself a URL.
 
@@ -77,6 +93,8 @@ _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.
 
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+_DISCORD_SLASH_DISCOVERY_TERMINATE_GRACE_SECONDS = 1.0
+_DISCORD_SLASH_DISCOVERY_KILL_GRACE_SECONDS = 0.25
 # Discord enforces a hard cap of 100 global application (slash) commands per
 # app. Registering more makes the ENTIRE sync fail with error 30032
 # ("Maximum number of application commands reached"), which silently breaks
@@ -1108,6 +1126,10 @@ class DiscordAdapter(BasePlatformAdapter):
         # show the standard typing gateway event for bots)
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._bot_task: Optional[asyncio.Task] = None
+        self._slash_discovery_process: Optional[Any] = None
+        self._slash_discovery_cleanup_residual: Optional[dict[str, Any]] = None
+        self._slash_discovery_wait_residual_tasks: set[asyncio.Task] = set()
+        self._slash_discovery_cleanup_lock = asyncio.Lock()
         self._post_connect_task: Optional[asyncio.Task] = None
         # WebSocket-level liveness probe. Discord REST and Gateway are distinct
         # transports: a REST 200 cannot prove that this client is still receiving
@@ -1443,9 +1465,15 @@ class DiscordAdapter(BasePlatformAdapter):
                         guild_id,
                     )
 
-            # Register slash commands
+            # Discover potentially blocking plugin/skill metadata in a
+            # killable child. Only the parent mutates the command tree.
             if self._slash_commands:
-                self._register_slash_commands()
+                slash_metadata = await self._discover_slash_command_metadata()
+                # Give cancellation one final checkpoint after discovery. Once
+                # execution reaches the synchronous apply, the event loop cannot
+                # return a timeout midway through tree mutation.
+                await asyncio.sleep(0)
+                self._register_slash_commands(slash_metadata)
 
             # Start the bot in background
             self._disconnecting = False
@@ -1465,6 +1493,12 @@ class DiscordAdapter(BasePlatformAdapter):
             self._start_liveness_probe()
             return True
 
+        except asyncio.CancelledError:
+            # The runner cancels connect() when its wall-clock deadline wins.
+            # Teardown before propagating cancellation so no client or
+            # Bot.start task can outlive the timed-out adapter.
+            await self.disconnect()
+            raise
         except asyncio.TimeoutError:
             logger.error("[%s] Timeout waiting for connection to Discord", self.name, exc_info=True)
             # Cancel the background bot task so it cannot fire on_message after
@@ -3542,7 +3576,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
-            result = SendResult(success=False, error=str(e))
+            result = SendResult(success=False, error=_discord_exception_detail(e))
             await asyncio.to_thread(
                 self._record_discord_response,
                 reply_to=reply_to,
@@ -3578,7 +3612,10 @@ class DiscordAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             logger.error("[%s] Failed to create forum thread in %s: %s", self.name, forum_channel.id, e)
-            return SendResult(success=False, error=f"Forum thread creation failed: {e}")
+            return SendResult(
+                success=False,
+                error=f"Forum thread creation failed: {_discord_exception_detail(e)}",
+            )
 
         thread_channel = thread if hasattr(thread, "send") else getattr(thread, "thread", None)
         thread_id = str(getattr(thread_channel, "id", getattr(thread, "id", "")))
@@ -3594,7 +3631,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 msg = await thread_channel.send(content=chunk)
                 message_ids.append(str(msg.id))
             except Exception as e:
-                warning = f"Failed to send follow-up chunk to forum thread {thread_id}: {e}"
+                warning = (
+                    f"Failed to send follow-up chunk to forum thread {thread_id}: "
+                    f"{_discord_exception_detail(e)}"
+                )
                 logger.warning("[%s] %s", self.name, warning)
                 warnings.append(warning)
 
@@ -3655,7 +3695,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 getattr(forum_channel, "id", "?"),
                 e,
             )
-            return SendResult(success=False, error=f"Forum thread creation failed: {e}")
+            return SendResult(
+                success=False,
+                error=f"Forum thread creation failed: {_discord_exception_detail(e)}",
+            )
 
         thread_channel = thread if hasattr(thread, "send") else getattr(thread, "thread", None)
         thread_id = str(getattr(thread_channel, "id", getattr(thread, "id", "")))
@@ -3791,7 +3834,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return result
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=_discord_exception_detail(e))
 
     @staticmethod
     def _is_length_overflow_error(err: Exception) -> bool:
@@ -3847,7 +3890,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 "[%s] Overflow split: first-chunk edit failed: %s",
                 self.name, e, exc_info=True,
             )
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=_discord_exception_detail(e))
 
         # Step 2 — send each remaining chunk threaded as a reply to the prior.
         continuation_ids: list[str] = []
@@ -5797,10 +5840,123 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.debug("Discord interaction cleanup failed: %s", e)
 
-    def _register_slash_commands(self) -> None:
+    async def cancel_slash_discovery(self) -> None:
+        """Idempotently terminate and reap the active discovery child."""
+        async with self._slash_discovery_cleanup_lock:
+            process = self._slash_discovery_process
+            if process is None:
+                return
+            try:
+                if process.returncode is None:
+                    try:
+                        process.terminate()
+                    except ProcessLookupError:
+                        pass
+                    wait_task = asyncio.create_task(process.wait())
+                    done, _pending = await asyncio.wait(
+                        {wait_task},
+                        timeout=_DISCORD_SLASH_DISCOVERY_TERMINATE_GRACE_SECONDS,
+                    )
+                    if wait_task not in done:
+                        try:
+                            process.kill()
+                        except ProcessLookupError:
+                            pass
+                        done, _pending = await asyncio.wait(
+                            {wait_task},
+                            timeout=_DISCORD_SLASH_DISCOVERY_KILL_GRACE_SECONDS,
+                        )
+                    if wait_task not in done:
+                        residual = {
+                            "pid": getattr(process, "pid", None),
+                            "state": "killed_but_wait_unconfirmed",
+                        }
+                        self._slash_discovery_cleanup_residual = residual
+                        logger.warning(
+                            "[%s] Slash discovery child pid=%s did not confirm "
+                            "exit after kill; recording residual cleanup state",
+                            self.name,
+                            getattr(process, "pid", "unknown"),
+                        )
+                        wait_task.cancel()
+                        self._slash_discovery_wait_residual_tasks.add(wait_task)
+
+                        def _wait_residual_done(done_task: asyncio.Task) -> None:
+                            self._slash_discovery_wait_residual_tasks.discard(done_task)
+                            try:
+                                done_task.result()
+                            except asyncio.CancelledError:
+                                pass
+                            except Exception:
+                                logger.warning(
+                                    "[%s] Slash discovery residual wait failed",
+                                    self.name,
+                                    exc_info=True,
+                                )
+                            else:
+                                if self._slash_discovery_cleanup_residual is residual:
+                                    self._slash_discovery_cleanup_residual = None
+
+                        wait_task.add_done_callback(_wait_residual_done)
+                    else:
+                        await wait_task
+                        self._slash_discovery_cleanup_residual = None
+                else:
+                    await process.wait()
+                    self._slash_discovery_cleanup_residual = None
+            finally:
+                if self._slash_discovery_process is process:
+                    self._slash_discovery_process = None
+
+    async def _discover_slash_command_metadata(self) -> dict[str, Any]:
+        """Run the single slash-discovery implementation in a child process."""
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            "hermes_cli.discord_slash_discovery",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        self._slash_discovery_cleanup_residual = None
+        self._slash_discovery_process = process
+        try:
+            stdout, stderr = await process.communicate()
+        except BaseException:
+            await self.cancel_slash_discovery()
+            raise
+        finally:
+            if process.returncode is not None and self._slash_discovery_process is process:
+                self._slash_discovery_process = None
+
+        if process.returncode != 0:
+            detail = stderr.decode("utf-8", errors="replace").strip()
+            raise RuntimeError(
+                "Discord slash-command discovery failed"
+                + (f": {detail}" if detail else "")
+            )
+        try:
+            payload = json.loads(stdout.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("Discord slash-command discovery returned invalid JSON") from exc
+        if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+            raise RuntimeError("Discord slash-command discovery returned an unsupported schema")
+        return payload
+
+    def _register_slash_commands(
+        self,
+        discovered: Optional[dict[str, Any]] = None,
+    ) -> None:
         """Register Discord slash commands on the command tree."""
         if not self._client:
             return
+
+        if discovered is None:
+            from hermes_cli.discord_slash_discovery import (
+                discover_discord_slash_metadata,
+            )
+
+            discovered = discover_discord_slash_metadata()
 
         tree = self._client.tree
 
@@ -6011,29 +6167,25 @@ class DiscordAdapter(BasePlatformAdapter):
         slot_cap = _DISCORD_MAX_APP_COMMANDS - 1
         dropped_over_cap = 0
         try:
-            from hermes_cli.commands import COMMAND_REGISTRY, _is_gateway_available, _resolve_config_gates
-
             try:
                 already_registered = {cmd.name for cmd in tree.get_commands()}
             except Exception:
                 pass
 
-            config_overrides = _resolve_config_gates()
-
-            for cmd_def in COMMAND_REGISTRY:
-                if not _is_gateway_available(cmd_def, config_overrides):
-                    continue
+            for command_name, command_description, command_args_hint in discovered.get(
+                "commands", []
+            ):
                 # Discord command names: lowercase, hyphens OK, max 32 chars.
-                discord_name = cmd_def.name.lower()[:32]
+                discord_name = command_name.lower()[:32]
                 if discord_name in already_registered:
                     continue
                 if len(already_registered) >= slot_cap:
                     dropped_over_cap += 1
                     continue
                 auto_cmd = _build_auto_slash_command(
-                    cmd_def.name,
-                    cmd_def.description,
-                    cmd_def.args_hint,
+                    command_name,
+                    command_description,
+                    command_args_hint,
                 )
                 try:
                     tree.add_command(auto_cmd)
@@ -6056,9 +6208,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # autocomplete UX as for built-in commands. No per-platform plugin
         # API needed — plugin commands are platform-agnostic.
         try:
-            from hermes_cli.commands import _iter_plugin_command_entries
-
-            for plugin_name, plugin_desc, plugin_args_hint in _iter_plugin_command_entries():
+            for plugin_name, plugin_desc, plugin_args_hint in discovered.get(
+                "plugins", []
+            ):
                 discord_name = plugin_name.lower()[:32]
                 if discord_name in already_registered:
                     continue
@@ -6085,7 +6237,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # Register skills under a single /skill command group with category
         # subcommand groups.  This uses 1 top-level slot instead of N,
         # supporting up to 25 categories × 25 skills = 625 skills.
-        self._register_skill_group(tree)
+        self._register_skill_group(
+            tree,
+            discovered_entries=discovered.get("skills", []),
+            discovered_hidden=int(discovered.get("skill_hidden", 0)),
+        )
 
         if dropped_over_cap:
             # Staying under the cap keeps the whole sync succeeding; without
@@ -6149,7 +6305,13 @@ class DiscordAdapter(BasePlatformAdapter):
             applied,
         )
 
-    def _register_skill_group(self, tree) -> None:
+    def _register_skill_group(
+        self,
+        tree,
+        *,
+        discovered_entries: Optional[list] = None,
+        discovered_hidden: int = 0,
+    ) -> None:
         """Register a single ``/skill`` command with autocomplete on the name.
 
         Discord enforces an ~8000-byte per-command payload limit. The older
@@ -6188,7 +6350,25 @@ class DiscordAdapter(BasePlatformAdapter):
             self._skill_entries: list[tuple[str, str, str]] = []
             self._skill_lookup: dict[str, tuple[str, str]] = {}
             self._skill_group_reserved_names: set[str] = set(existing_names)
-            self._refresh_skill_catalog_state()
+            if discovered_entries is None:
+                self._refresh_skill_catalog_state()
+            else:
+                entries: list[tuple[str, str, str]] = []
+                names_used = set(existing_names)
+                hidden = discovered_hidden
+                for name, description, command_key in discovered_entries:
+                    if name in names_used:
+                        hidden += 1
+                        continue
+                    names_used.add(name)
+                    entries.append((name, description, command_key))
+                entries.sort(key=lambda entry: entry[0])
+                self._skill_entries = entries
+                self._skill_lookup = {
+                    name: (description, command_key)
+                    for name, description, command_key in entries
+                }
+                self._skill_group_hidden_count = hidden
 
             if not self._skill_entries:
                 return
@@ -7151,7 +7331,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 return {
                     "error": (
                         "Discord rejected direct thread creation and the fallback also failed. "
-                        f"Direct error: {direct_error}. Fallback error: {fallback_error}"
+                        f"Direct error: {_discord_exception_detail(direct_error)}. "
+                        f"Fallback error: {_discord_exception_detail(fallback_error)}"
                     )
                 }
 
@@ -7512,7 +7693,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=str(msg.id))
 
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=_discord_exception_detail(e))
 
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
@@ -7556,7 +7737,7 @@ class DiscordAdapter(BasePlatformAdapter):
             view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=_discord_exception_detail(e))
 
     async def send_clarify(
         self,
@@ -7683,7 +7864,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
             logger.warning("[%s] send_clarify failed: %s", self.name, e)
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=_discord_exception_detail(e))
 
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
@@ -7725,7 +7906,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._nonconversational_messages.mark_many([str(msg.id)])
             return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=_discord_exception_detail(e))
 
     async def send_model_picker(
         self,
@@ -7787,7 +7968,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         except Exception as e:
             logger.warning("[%s] send_model_picker failed: %s", self.name, e)
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=_discord_exception_detail(e))
 
     async def send_choice_picker(
         self,
@@ -7835,7 +8016,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         except Exception as e:
             logger.warning("[%s] send_choice_picker failed: %s", self.name, e)
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=_discord_exception_detail(e))
 
     def _get_parent_channel_id(self, channel: Any) -> Optional[str]:
         """Return the parent channel ID for a Discord thread-like channel, if present."""
@@ -10045,7 +10226,12 @@ async def _standalone_send(
                                     _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
                                 )
                         except Exception as e:
-                            return {"error": _standalone_sanitize_error(f"Discord forum thread upload failed: {e}")}
+                            return {
+                                "error": _standalone_sanitize_error(
+                                    "Discord forum thread upload failed: "
+                                    f"{_discord_exception_detail(e)}"
+                                )
+                            }
                     else:
                         # No media — simple JSON POST creates the thread with
                         # just the text starter.
@@ -10152,7 +10338,9 @@ async def _standalone_send(
                                 _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
                             )
                 except Exception as e:
-                    warning = _standalone_sanitize_error(f"Failed to send media {media_path}: {e}")
+                    warning = _standalone_sanitize_error(
+                        f"Failed to send media {media_path}: {_discord_exception_detail(e)}"
+                    )
                     logger.error(warning)
                     warnings.append(warning)
 
@@ -10167,10 +10355,12 @@ async def _standalone_send(
             result["warnings"] = warnings
         return result
     except Exception as e:
-        # Include the exception type: TimeoutError().str() is empty, so
-        # "Discord send failed: " alone gave no diagnostic signal.
         logger.error("Discord standalone send failed", exc_info=True)
-        return {"error": _standalone_sanitize_error(f"Discord send failed: {type(e).__name__}: {e}")}
+        return {
+            "error": _standalone_sanitize_error(
+                f"Discord send failed: {_discord_exception_detail(e)}"
+            )
+        }
 
 
 # ── Plugin entry point ────────────────────────────────────────────────────────

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -2,12 +2,14 @@ import asyncio
 import json
 import os
 import sys
+import time
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
+from gateway.run import GatewayRunner
 
 
 class _FakeAllowedMentions:
@@ -50,6 +52,7 @@ def _ensure_discord_mock():
         discord_mod.app_commands = SimpleNamespace(
             describe=lambda **kwargs: (lambda fn: fn),
             choices=lambda **kwargs: (lambda fn: fn),
+            autocomplete=lambda **kwargs: (lambda fn: fn),
             Choice=lambda **kwargs: SimpleNamespace(**kwargs),
         )
         discord_mod.opus = SimpleNamespace(is_loaded=lambda: True)
@@ -63,12 +66,16 @@ def _ensure_discord_mock():
         sys.modules.setdefault("discord.ext", ext_mod)
         sys.modules.setdefault("discord.ext.commands", commands_mod)
 
+    app_commands = getattr(sys.modules["discord"], "app_commands", None)
+    if app_commands is not None and not hasattr(app_commands, "autocomplete"):
+        app_commands.autocomplete = lambda **kwargs: (lambda fn: fn)
     sys.modules["discord"].AllowedMentions = _FakeAllowedMentions
 
 
 _ensure_discord_mock()
 
 import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+import gateway.run as gateway_run  # noqa: E402
 from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
 
 
@@ -296,6 +303,430 @@ async def test_connect_timeout_cancels_bot_task(monkeypatch):
         "leaving it alive creates a zombie Discord client that produces duplicate threads"
     )
 
+
+@pytest.mark.asyncio
+async def test_outer_connect_deadline_covers_sync_slash_discovery(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    runner = object.__new__(GatewayRunner)
+    runner._platform_connect_timeout_secs = lambda _platform: 0.01
+    process_started = asyncio.Event()
+    process_reaped = asyncio.Event()
+    process_killed = asyncio.Event()
+
+    class HangingDiscoveryProcess:
+        returncode = None
+        stdout = None
+        stderr = None
+
+        async def communicate(self):
+            process_started.set()
+            await asyncio.Future()
+
+        def terminate(self):
+            pass
+
+        def kill(self):
+            self.returncode = -9
+            process_killed.set()
+            process_reaped.set()
+
+        async def wait(self):
+            await process_reaped.wait()
+            return self.returncode
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock", lambda scope, identity: None
+    )
+    intents = SimpleNamespace(
+        message_content=False,
+        dm_messages=False,
+        guild_messages=False,
+        members=False,
+        voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    monkeypatch.setattr(discord_platform.commands, "Bot", FakeBot)
+    monkeypatch.setattr(
+        discord_platform,
+        "_DISCORD_SLASH_DISCOVERY_TERMINATE_GRACE_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr(
+        discord_platform,
+        "_DISCORD_SLASH_DISCOVERY_KILL_GRACE_SECONDS",
+        0.01,
+    )
+    register = MagicMock()
+    monkeypatch.setattr(adapter, "_register_slash_commands", register)
+    create_process = AsyncMock(return_value=HangingDiscoveryProcess())
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_process)
+
+    started = time.monotonic()
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(
+            runner._connect_adapter_with_timeout(adapter, Platform.DISCORD),
+            timeout=0.5,
+        )
+    elapsed = time.monotonic() - started
+    await asyncio.sleep(0)
+
+    assert elapsed < 0.5
+    assert process_started.is_set()
+    assert process_killed.is_set()
+    assert process_reaped.is_set()
+    create_process.assert_awaited_once_with(
+        sys.executable,
+        "-m",
+        "hermes_cli.discord_slash_discovery",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    register.assert_not_called()
+    assert adapter._slash_discovery_process is None
+    assert adapter._slash_discovery_wait_residual_tasks == set()
+    assert adapter._bot_task is None
+    assert adapter._client is None
+    assert getattr(runner, "_connect_cleanup_tasks", set()) == set()
+    assert getattr(runner, "_connect_cleanup_residuals", {}) == {}
+
+
+@pytest.mark.asyncio
+async def test_connect_deadline_does_not_wait_forever_after_discovery_kill(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    runner = object.__new__(GatewayRunner)
+    runner._platform_connect_timeout_secs = lambda _platform: 0.01
+    process_started = asyncio.Event()
+    kill_attempted = asyncio.Event()
+    wait_suppressed_cancellation = asyncio.Event()
+    release_wait = asyncio.Event()
+
+    class UnreapableDiscoveryProcess:
+        pid = 424242
+        returncode = None
+        stdout = None
+        stderr = None
+
+        async def communicate(self):
+            process_started.set()
+            await asyncio.Future()
+
+        def terminate(self):
+            pass
+
+        def kill(self):
+            kill_attempted.set()
+
+        async def wait(self):
+            while not release_wait.is_set():
+                try:
+                    await release_wait.wait()
+                except asyncio.CancelledError:
+                    wait_suppressed_cancellation.set()
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock", lambda scope, identity: None
+    )
+    intents = SimpleNamespace(
+        message_content=False,
+        dm_messages=False,
+        guild_messages=False,
+        members=False,
+        voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    monkeypatch.setattr(discord_platform.commands, "Bot", FakeBot)
+    monkeypatch.setattr(
+        discord_platform,
+        "_DISCORD_SLASH_DISCOVERY_TERMINATE_GRACE_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr(
+        discord_platform,
+        "_DISCORD_SLASH_DISCOVERY_KILL_GRACE_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        AsyncMock(return_value=UnreapableDiscoveryProcess()),
+    )
+
+    try:
+        with pytest.raises(TimeoutError, match="discord connect timed out"):
+            await asyncio.wait_for(
+                runner._connect_adapter_with_timeout(adapter, Platform.DISCORD),
+                timeout=0.2,
+            )
+
+        assert process_started.is_set()
+        assert kill_attempted.is_set()
+        assert wait_suppressed_cancellation.is_set()
+        assert adapter._slash_discovery_process is None
+        assert adapter._slash_discovery_cleanup_residual == {
+            "pid": 424242,
+            "state": "killed_but_wait_unconfirmed",
+        }
+        assert len(adapter._slash_discovery_wait_residual_tasks) == 1
+    finally:
+        release_wait.set()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    assert adapter._slash_discovery_wait_residual_tasks == set()
+    assert adapter._slash_discovery_cleanup_residual is None
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_preserved_when_cleanup_never_returns(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    runner._platform_connect_timeout_secs = lambda _platform: 0.01
+    cleanup_started = asyncio.Event()
+    cleanup_suppressed_cancellation = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    class AdapterWithHungCleanup:
+        async def connect(self, *, is_reconnect=False):
+            await asyncio.Future()
+
+        async def cancel_slash_discovery(self):
+            cleanup_started.set()
+            while not release_cleanup.is_set():
+                try:
+                    await release_cleanup.wait()
+                except asyncio.CancelledError:
+                    cleanup_suppressed_cancellation.set()
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_ADAPTER_CONNECT_CLEANUP_TIMEOUT_SECS",
+        0.01,
+    )
+
+    connect_task = asyncio.create_task(
+        runner._connect_adapter_with_timeout(
+            AdapterWithHungCleanup(),
+            Platform.DISCORD,
+        )
+    )
+    done, _pending = await asyncio.wait({connect_task}, timeout=0.08)
+    returned_within_hard_bound = connect_task in done
+
+    with pytest.raises(TimeoutError, match="discord connect timed out"):
+        await connect_task
+
+    assert cleanup_started.is_set()
+    assert returned_within_hard_bound is True
+    residual_task = next(iter(runner._connect_cleanup_tasks))
+    monkeypatch.setattr(
+        gateway_run,
+        "_ADAPTER_CONNECT_SHUTDOWN_CLEANUP_TIMEOUT_SECS",
+        0.01,
+    )
+    await asyncio.wait_for(runner._wait_for_pending_connect_cleanups(), timeout=0.08)
+    assert residual_task in runner._connect_cleanup_tasks
+
+    residual_task.cancel()
+    await cleanup_suppressed_cancellation.wait()
+    release_cleanup.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert runner._connect_cleanup_tasks == set()
+    assert runner._connect_cleanup_residuals == {}
+
+
+@pytest.mark.asyncio
+async def test_connect_cancellation_preserved_when_cleanup_never_returns(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    runner._platform_connect_timeout_secs = lambda _platform: 30.0
+    connect_started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    class AdapterWithHungCleanup:
+        async def connect(self, *, is_reconnect=False):
+            connect_started.set()
+            await asyncio.Future()
+
+        async def cancel_slash_discovery(self):
+            cleanup_started.set()
+            await release_cleanup.wait()
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_ADAPTER_CONNECT_CLEANUP_TIMEOUT_SECS",
+        0.01,
+    )
+    connect_task = asyncio.create_task(
+        runner._connect_adapter_with_timeout(
+            AdapterWithHungCleanup(),
+            Platform.DISCORD,
+        )
+    )
+    await connect_started.wait()
+    connect_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(connect_task, timeout=0.2)
+
+    assert cleanup_started.is_set()
+    assert len(runner._connect_cleanup_tasks) == 1
+    release_cleanup.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert runner._connect_cleanup_tasks == set()
+    assert runner._connect_cleanup_residuals == {}
+
+
+@pytest.mark.asyncio
+async def test_connect_cancellation_before_parent_apply_does_not_mutate_tree(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    async def discovery_then_cancel():
+        current_task = asyncio.current_task()
+        assert current_task is not None
+        asyncio.get_running_loop().call_soon(current_task.cancel)
+        return {"schema_version": 1, "commands": [], "plugins": [], "skills": []}
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock", lambda scope, identity: None
+    )
+    intents = SimpleNamespace(
+        message_content=False,
+        dm_messages=False,
+        guild_messages=False,
+        members=False,
+        voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    monkeypatch.setattr(discord_platform.commands, "Bot", FakeBot)
+    monkeypatch.setattr(adapter, "_discover_slash_command_metadata", discovery_then_cancel)
+    register = MagicMock()
+    monkeypatch.setattr(adapter, "_register_slash_commands", register)
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter.connect()
+
+    register.assert_not_called()
+    assert adapter._bot_task is None
+    assert adapter._client is None
+
+
+@pytest.mark.asyncio
+async def test_successful_discovery_metadata_is_applied_before_bot_start(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    metadata = {
+        "schema_version": 1,
+        "commands": [["status", "Show status", ""]],
+        "plugins": [["wave", "Wave hello", "[name]"]],
+        "skills": [["proof", "Run proof", "/proof"]],
+        "skill_hidden": 0,
+    }
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock", lambda scope, identity: None
+    )
+    intents = SimpleNamespace(
+        message_content=False,
+        dm_messages=False,
+        guild_messages=False,
+        members=False,
+        voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    monkeypatch.setattr(discord_platform.commands, "Bot", FakeBot)
+    monkeypatch.setattr(
+        adapter,
+        "_discover_slash_command_metadata",
+        AsyncMock(return_value=metadata),
+    )
+    register = MagicMock()
+    monkeypatch.setattr(adapter, "_register_slash_commands", register)
+
+    assert await adapter.connect() is True
+
+    register.assert_called_once_with(metadata)
+    assert adapter._running is True
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_discovered_plugin_and_skill_callbacks_preserve_parent_semantics(
+    monkeypatch,
+):
+    class RecordingTree:
+        def __init__(self):
+            self.commands = {}
+
+        def command(self, *, name, description):
+            def decorator(callback):
+                self.commands[name] = SimpleNamespace(
+                    name=name,
+                    description=description,
+                    callback=callback,
+                )
+                return callback
+
+            return decorator
+
+        def add_command(self, command):
+            self.commands[command.name] = command
+
+        def get_commands(self):
+            return list(self.commands.values())
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    tree = RecordingTree()
+    monkeypatch.setattr(adapter, "_client", SimpleNamespace(tree=tree))
+    run_simple_slash = AsyncMock()
+    check_slash_authorization = AsyncMock(return_value=True)
+    monkeypatch.setattr(adapter, "_run_simple_slash", run_simple_slash)
+    monkeypatch.setattr(
+        adapter,
+        "_check_slash_authorization",
+        check_slash_authorization,
+    )
+    metadata = {
+        "schema_version": 1,
+        "commands": [],
+        "plugins": [["wave", "Wave hello", "[name]"]],
+        "skills": [["proof", "Run proof", "/proof"]],
+        "skill_hidden": 0,
+    }
+
+    adapter._register_slash_commands(metadata)
+
+    await tree.commands["wave"].callback(SimpleNamespace(), args="Ray")
+    run_simple_slash.assert_awaited_once_with(
+        ANY,
+        "/wave Ray",
+    )
+    assert adapter._skill_lookup == {"proof": ("Run proof", "/proof")}
+    assert "skill" in tree.commands
+    run_simple_slash.reset_mock()
+    await tree.commands["skill"].callback(
+        SimpleNamespace(),
+        name="proof",
+        args="fast",
+    )
+    run_simple_slash.assert_awaited_once_with(ANY, "/proof fast")
+
 @pytest.mark.asyncio
 async def test_disconnect_cancels_running_bot_task(monkeypatch):
     """Regression: disconnect() must cancel _bot_task even when connect() timed out.
@@ -506,7 +937,7 @@ async def test_post_connect_initialization_retries_fingerprint_after_timeout(tmp
 
 
 @pytest.mark.asyncio
-async def test_safe_sync_reads_permission_attrs_from_existing_command():
+async def test_safe_sync_reads_permission_attrs_from_existing_command(monkeypatch):
     """Regression: AppCommand.to_dict() in discord.py does NOT include
     nsfw, dm_permission, or default_member_permissions — they live only
     on the attributes. Without reading those attrs, any command with
@@ -578,11 +1009,15 @@ async def test_safe_sync_reads_permission_attrs_from_existing_command():
         edit_global_command=AsyncMock(),
         delete_global_command=AsyncMock(),
     )
-    adapter._client = SimpleNamespace(
-        tree=fake_tree,
-        http=fake_http,
-        application_id=999,
-        user=SimpleNamespace(id=999),
+    monkeypatch.setattr(
+        adapter,
+        "_client",
+        SimpleNamespace(
+            tree=fake_tree,
+            http=fake_http,
+            application_id=999,
+            user=SimpleNamespace(id=999),
+        ),
     )
 
     summary = await adapter._safe_sync_slash_commands()
@@ -706,4 +1141,3 @@ class TestPrivilegedIntentsRequiredFatal:
         assert "Message Content Intent" in (adapter.fatal_error_message or "")
         assert "discord.com/developers/applications" in (adapter.fatal_error_message or "")
         assert adapter._bot_task is None
-

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -3,9 +3,12 @@ import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aiohttp import ClientResponseError, RequestInfo
+from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
 
 from gateway.config import PlatformConfig
 
@@ -44,7 +47,23 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+import discord as _discord_mod  # noqa: E402 — imported after _ensure_discord_mock
+from plugins.platforms.discord.adapter import (  # noqa: E402
+    DiscordAdapter,
+    _remember_channel_is_forum,
+    _standalone_send,
+)
+
+
+def _response_error_with_authorization(canary: str) -> ClientResponseError:
+    headers = CIMultiDictProxy(CIMultiDict({"Authorization": f"Bot {canary}"}))
+    url = URL("https://discord.com/api/v10/channels/555/messages")
+    return ClientResponseError(
+        RequestInfo(url=url, method="POST", headers=headers, real_url=url),
+        (),
+        status=401,
+        message="request failed",
+    )
 
 
 @pytest.mark.asyncio
@@ -151,11 +170,112 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
     assert send_calls[2]["reference"] is None
 
 
+@pytest.mark.asyncio
+async def test_send_failure_preserves_empty_string_exception_type(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(send=AsyncMock(side_effect=TimeoutError()))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "hello")
+
+    assert result.success is False
+    assert result.error == "TimeoutError"
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_preserves_empty_string_exception_type():
+    chat_id = "999000333"
+    _remember_channel_is_forum(chat_id, False)
+    config = SimpleNamespace(token="bot-token", extra={})
+
+    with patch("aiohttp.ClientSession", side_effect=TimeoutError()):
+        result = await _standalone_send(config, chat_id, "hello")
+
+    assert result == {"error": "Discord send failed: TimeoutError"}
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_does_not_expose_exception_request_headers():
+    canary = "discord-auth-canary-value"
+    error = _response_error_with_authorization(canary)
+    chat_id = "999000334"
+    _remember_channel_is_forum(chat_id, False)
+    config = SimpleNamespace(token="bot-token", extra={})
+
+    with patch("aiohttp.ClientSession", side_effect=error):
+        result = await _standalone_send(config, chat_id, "hello")
+
+    rendered = result["error"]
+    assert canary not in rendered
+    assert "Authorization" not in rendered
+    assert "RequestInfo" not in rendered
+    assert rendered == (
+        "Discord send failed: ClientResponseError: 401, message='request failed', "
+        "url='https://discord.com/api/v10/channels/555/messages'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_live_send_does_not_expose_exception_request_headers(tmp_path, monkeypatch):
+    canary = "discord-live-auth-canary"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    error = _response_error_with_authorization(canary)
+    channel = SimpleNamespace(send=AsyncMock(side_effect=error))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "hello")
+
+    assert result.error is not None
+    assert canary not in result.error
+    assert "Authorization" not in result.error
+    assert "RequestInfo" not in result.error
+    assert result.error == (
+        "ClientResponseError: 401, message='request failed', "
+        "url='https://discord.com/api/v10/channels/555/messages'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_thread_failure_preserves_both_empty_exception_types():
+    class FakeInteraction(_discord_mod.Interaction):
+        pass
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    parent_channel = SimpleNamespace(
+        create_thread=AsyncMock(side_effect=TimeoutError()),
+        send=AsyncMock(side_effect=TimeoutError()),
+    )
+    interaction = object.__new__(FakeInteraction)
+    object.__setattr__(interaction, "channel", parent_channel)
+    object.__setattr__(
+        interaction,
+        "user",
+        SimpleNamespace(display_name="Tester"),
+    )
+
+    result = await adapter._create_thread(interaction, name="incident")
+
+    assert result == {
+        "error": (
+            "Discord rejected direct thread creation and the fallback also failed. "
+            "Direct error: TimeoutError. Fallback error: TimeoutError"
+        )
+    }
+
+
 # ---------------------------------------------------------------------------
 # Forum channel tests
 # ---------------------------------------------------------------------------
-
-import discord as _discord_mod  # noqa: E402 — imported after _ensure_discord_mock
 
 
 class TestIsForumParent:
@@ -356,7 +476,7 @@ async def test_send_video_fails_loud_when_message_has_no_attachments(tmp_path, m
 
 
 @pytest.mark.asyncio
-async def test_send_video_missing_file_fails_fast_without_touching_channel():
+async def test_send_video_missing_file_fails_fast_without_touching_channel(monkeypatch):
     """A missing MEDIA path must fail loud before any Discord I/O (#66797).
 
     The pre-flight ``os.path.isfile`` guard turns a would-be crash inside
@@ -367,7 +487,14 @@ async def test_send_video_missing_file_fails_fast_without_touching_channel():
         raise AssertionError("channel must not be resolved for a missing file")
 
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
-    adapter._client = SimpleNamespace(get_channel=_boom, fetch_channel=AsyncMock(side_effect=_boom))
+    monkeypatch.setattr(
+        adapter,
+        "_client",
+        SimpleNamespace(
+            get_channel=_boom,
+            fetch_channel=AsyncMock(side_effect=_boom),
+        ),
+    )
 
     result = await adapter.send_video("555", "/no/such/clip.mp4")
 
@@ -403,9 +530,13 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
         id=7,
         create_thread=AsyncMock(return_value=created_thread),
     )
-    adapter._client = SimpleNamespace(
-        get_channel=lambda _chat_id: forum_channel,
-        fetch_channel=AsyncMock(),
+    monkeypatch.setattr(
+        adapter,
+        "_client",
+        SimpleNamespace(
+            get_channel=lambda _chat_id: forum_channel,
+            fetch_channel=AsyncMock(),
+        ),
     )
     monkeypatch.setattr(adapter, "_is_forum_parent", lambda _ch: True)
 
@@ -416,5 +547,3 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     thread_kwargs = forum_channel.create_thread.await_args.kwargs
     assert thread_kwargs.get("file") is None
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
-
-

--- a/tests/hermes_cli/test_discord_slash_discovery.py
+++ b/tests/hermes_cli/test_discord_slash_discovery.py
@@ -1,0 +1,64 @@
+import json
+from types import SimpleNamespace
+
+import hermes_cli.commands as command_module
+from hermes_cli.discord_slash_discovery import (
+    discover_discord_slash_metadata,
+    serialize_discord_slash_metadata,
+)
+
+
+def test_serialized_discovery_matches_direct_metadata_without_mutating_handlers(
+    monkeypatch,
+):
+    registry = [
+        SimpleNamespace(
+            name="status",
+            description="Show status",
+            args_hint="",
+        ),
+        SimpleNamespace(
+            name="hidden",
+            description="Hidden command",
+            args_hint="",
+        ),
+    ]
+    handler = object()
+    parent_plugin_handlers = {"wave": handler}
+    monkeypatch.setattr(command_module, "COMMAND_REGISTRY", registry)
+    monkeypatch.setattr(command_module, "_resolve_config_gates", lambda: {"status"})
+    monkeypatch.setattr(
+        command_module,
+        "_is_gateway_available",
+        lambda command, overrides: command.name in overrides,
+    )
+    monkeypatch.setattr(
+        command_module,
+        "_iter_plugin_command_entries",
+        lambda: [("wave", "Wave hello", "[name]")],
+    )
+    monkeypatch.setattr(
+        command_module,
+        "discord_skill_commands_by_category",
+        lambda reserved_names: (
+            {"testing": [("proof", "Run proof", "/proof")]},
+            [("plain", "Plain skill", "/plain")],
+            2,
+        ),
+    )
+
+    direct = discover_discord_slash_metadata()
+    serialized = json.loads(serialize_discord_slash_metadata())
+
+    assert serialized == direct
+    assert direct == {
+        "schema_version": 1,
+        "commands": [["status", "Show status", ""]],
+        "plugins": [["wave", "Wave hello", "[name]"]],
+        "skills": [
+            ["plain", "Plain skill", "/plain"],
+            ["proof", "Run proof", "/proof"],
+        ],
+        "skill_hidden": 2,
+    }
+    assert parent_plugin_handlers == {"wave": handler}


### PR DESCRIPTION
## Summary

- move Discord slash-command metadata discovery into a killable child process while keeping command-tree mutation parent-owned
- bound connect cancellation cleanup and preserve explicit residual observability without masking the original timeout or cancellation
- make Discord send errors nonblank and redact credential-bearing exception details

## Root cause

Synchronous slash-command discovery could block the adapter connect path before its effective cancellation boundary. Separately, empty-string exceptions produced opaque delivery errors, while using exception representations risked exposing request headers.

## Verification

- focused connect/send/discovery suite: 37 passed, 0 failed
- explicit 51-file Discord inventory: 339 passed, 1 skipped, 0 failed
- exact-base ty differential: 0 net-new diagnostics, 1 fixed in analyzed coverage
- Ruff, compileall, and diff-check passed across the exact six-file change
- independent specification review: compliant
- independent quality review: approved, 0 Critical / 0 Important

## Known repository-wide blockers

- both base and candidate `ty` scans hit the same `tools/checkpoint_manager.py` cycle panic, so complete-project type coverage is not claimed
- the completed repository suite exited 1 with 101 failures across 36 files plus 11 collection/import/no-test files, all outside this six-file candidate scope and concentrated in unavailable optional SDKs, platform assumptions, and unrelated runtime tests

## Release boundary

This is a draft PR. Merge, packaging, deployment, gateway restart, and live Discord proof remain separately gated. Any release must build and verify the exact integrated SHA from an isolated worktree.
