### PR TITLE
fix(xai): drop stale 256K grok-4.6 context cache + generalize pre-catalog guard

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2021,6 +2021,19 @@ def _model_name_suggests_grok_4_3(model: str) -> bool:
     return "grok-4.3" in model.lower()
 
 
+def _model_name_suggests_grok_4_6(model: str) -> bool:
+    """Return True if the model name looks like a Grok 4.6 variant.
+
+    Catches ``grok-4.6`` and aggregator-prefixed slugs. Used as a guard
+    against stale cache entries seeded by pre-catalog builds that resolved
+    grok-4.6 via the generic ``grok-4`` catch-all (256,000) before the
+    500K entry existed. Official card: docs.x.ai/developers/models/grok-4.6.
+    Live GET /v1/models lists ``grok-4.6`` at context_length 500000 and does
+    not publish a ``grok-4.6-latest`` alias.
+    """
+    return "grok-4.6" in model.lower()
+
+
 def _query_local_context_length(model: str, base_url: str, api_key: str = "") -> Optional[int]:
     """Query a local server for the model's context length (short-TTL cached).
 
@@ -2641,6 +2654,15 @@ def get_model_context_length(
             elif cached <= 256_000 and _model_name_suggests_grok_4_3(model):
                 logger.info(
                     "Dropping stale Grok-4.3 cache entry %s@%s -> %s (pre-catalog value); "
+                    "re-resolving via hardcoded defaults",
+                    model, base_url, f"{cached:,}",
+                )
+                _invalidate_cached_context_length(model, base_url)
+            # Same class of leftover as grok-4.3: grok-4.6 is 500K, but
+            # pre-catalog builds persisted the grok-4 catch-all (256,000).
+            elif cached <= 256_000 and _model_name_suggests_grok_4_6(model):
+                logger.info(
+                    "Dropping stale Grok-4.6 cache entry %s@%s -> %s (pre-catalog value); "
                     "re-resolving via hardcoded defaults",
                     model, base_url, f"{cached:,}",
                 )

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2001,37 +2001,64 @@ def _model_name_suggests_minimax_m3(model: str) -> bool:
     """Return True if the model name looks like MiniMax M3.
 
     Catches ``MiniMax-M3``, ``minimax/minimax-m3``, and similar variants
-    across surfaces (native MiniMax-M3, OpenRouter/Nous minimax/minimax-m3).
-    Used as a guard against stale cache entries seeded by pre-catalog builds
-    that resolved M3 via the generic ``minimax`` catch-all (204,800) before
-    the ``minimax-m3`` (1M) entry existed in DEFAULT_CONTEXT_LENGTHS.
+    across surfaces. Used by the models.dev underreport guard below and the
+    cache-control gating in agent_runtime_helpers (stale persisted cache
+    entries are handled generically by _stale_pre_catalog_cache_entry).
     """
     return "minimax-m3" in model.lower()
 
 
-def _model_name_suggests_grok_4_3(model: str) -> bool:
-    """Return True if the model name looks like a Grok 4.3 variant.
+# Catalog keys whose DEFAULT_CONTEXT_LENGTHS entry was added AFTER the model
+# first became reachable through a shorter catch-all (or the 256K probe
+# fallback).  Builds from that window persisted the catch-all's value, and
+# the step-1 persistent-cache hit would otherwise pin it forever.  Each key
+# listed here gets a stale-entry guard in get_model_context_length(): a
+# cached value at or below what the old resolution path could have produced
+# is treated as a pre-catalog leftover and dropped so the entry re-resolves
+# against the current catalog.
+#
+# Only add keys whose catalog value is STRICTLY ABOVE every shorter matching
+# key (and above the 256K fallback) — the guard infers the stale threshold
+# from those shorter keys, so a model whose true window is below its
+# catch-all can never be listed here.
+_PRE_CATALOG_STALE_KEYS = frozenset({
+    "minimax-m3",    # 1M; older builds persisted the "minimax" catch-all (204,800)
+    "grok-4.3",      # 1M; pre-2026-05-15 builds persisted the "grok-4" catch-all (256,000)
+    "grok-4.6",      # 500K; pre-catalog builds persisted the "grok-4" catch-all (256,000)
+    "grok-4-fast",   # 2M; pre-2026-04-10 builds fell through to the 256K probe fallback
+    "grok-4.20",     # 2M; pre-2026-04-10 builds fell through to the 256K probe fallback
+    "qwen3.6-plus",  # 1M; pre-2026-05-17 builds persisted the "qwen" catch-all (131,072)
+})
 
-    Catches ``grok-4.3``, ``grok-4.3-latest``, and similar slugs.
-    Used as a guard against stale cache entries seeded by pre-catalog builds
-    that resolved grok-4.3 via the generic ``grok-4`` catch-all (256,000)
-    before the ``grok-4.3`` (1M) entry was added to DEFAULT_CONTEXT_LENGTHS
-    on 2026-05-15.
+
+def _stale_pre_catalog_cache_entry(model: str, cached: int) -> bool:
+    """Return True when a persisted context length is a pre-catalog leftover.
+
+    Generic replacement for the per-model ``_model_name_suggests_*`` guards
+    (MiniMax-M3, Grok-4.3, Grok-4.6, ...).  The model must resolve — by the
+    same longest-key-first substring match step 8 uses — to a catalog key
+    listed in ``_PRE_CATALOG_STALE_KEYS``, and the cached value must be at or
+    below the best value the OLD resolution path could have produced: the
+    largest shorter matching catch-all entry, or ``DEFAULT_FALLBACK_CONTEXT``
+    when no shorter key matches.  Cached values above that threshold (e.g. a
+    genuine probe result) are never dropped.
     """
-    return "grok-4.3" in model.lower()
-
-
-def _model_name_suggests_grok_4_6(model: str) -> bool:
-    """Return True if the model name looks like a Grok 4.6 variant.
-
-    Catches ``grok-4.6`` and aggregator-prefixed slugs. Used as a guard
-    against stale cache entries seeded by pre-catalog builds that resolved
-    grok-4.6 via the generic ``grok-4`` catch-all (256,000) before the
-    500K entry existed. Official card: docs.x.ai/developers/models/grok-4.6.
-    Live GET /v1/models lists ``grok-4.6`` at context_length 500000 and does
-    not publish a ``grok-4.6-latest`` alias.
-    """
-    return "grok-4.6" in model.lower()
+    model_lower = model.lower()
+    matches = [
+        (key, value)
+        for key, value in DEFAULT_CONTEXT_LENGTHS.items()
+        if key in model_lower
+    ]
+    if not matches:
+        return False
+    specific_key, specific_value = max(matches, key=lambda kv: len(kv[0]))
+    if specific_key not in _PRE_CATALOG_STALE_KEYS:
+        return False
+    if cached >= specific_value:
+        return False
+    shorter_values = [v for k, v in matches if len(k) < len(specific_key)]
+    threshold = max(shorter_values, default=DEFAULT_FALLBACK_CONTEXT)
+    return cached <= threshold
 
 
 def _query_local_context_length(model: str, base_url: str, api_key: str = "") -> Optional[int]:
@@ -2632,37 +2659,14 @@ def get_model_context_length(
                     model, base_url, f"{cached:,}",
                 )
                 _invalidate_cached_context_length(model, base_url)
-            # Invalidate stale ≤204,800 cache entries for MiniMax-M3.  Pre-catalog
-            # builds resolved M3 via the generic ``minimax`` catch-all (204,800)
-            # and persisted it before the ``minimax-m3`` (1M) entry existed; that
-            # stale value would otherwise stick forever here at step 1.  M3 is 1M,
-            # so any sub-256K cached value for an M3 slug is a leftover — drop it
-            # and fall through to the hardcoded default.
-            elif cached <= 204_800 and _model_name_suggests_minimax_m3(model):
+            # Invalidate pre-catalog leftovers: models whose catalog entry was
+            # added after a shorter catch-all (or the 256K fallback) had
+            # already persisted a smaller value — MiniMax-M3, Grok-4.3/-4.6/
+            # -4-fast/-4.20, qwen3.6-plus, ... (see _PRE_CATALOG_STALE_KEYS).
+            # Drop the stale entry and fall through to the hardcoded default.
+            elif _stale_pre_catalog_cache_entry(model, cached):
                 logger.info(
-                    "Dropping stale MiniMax-M3 cache entry %s@%s -> %s (pre-catalog value); "
-                    "re-resolving via hardcoded defaults",
-                    model, base_url, f"{cached:,}",
-                )
-                _invalidate_cached_context_length(model, base_url)
-            # Invalidate stale ≤256,000 cache entries for Grok-4.3.  The
-            # ``grok-4.3`` (1M) entry was added to DEFAULT_CONTEXT_LENGTHS on
-            # 2026-05-15; prior to that, grok-4.3 slugs resolved via the
-            # ``grok-4`` catch-all (256,000) and that value was persisted.
-            # grok-4.3 is 1M, so any sub-262K cached value is a pre-catalog
-            # leftover — drop it and fall through to the hardcoded default.
-            elif cached <= 256_000 and _model_name_suggests_grok_4_3(model):
-                logger.info(
-                    "Dropping stale Grok-4.3 cache entry %s@%s -> %s (pre-catalog value); "
-                    "re-resolving via hardcoded defaults",
-                    model, base_url, f"{cached:,}",
-                )
-                _invalidate_cached_context_length(model, base_url)
-            # Same class of leftover as grok-4.3: grok-4.6 is 500K, but
-            # pre-catalog builds persisted the grok-4 catch-all (256,000).
-            elif cached <= 256_000 and _model_name_suggests_grok_4_6(model):
-                logger.info(
-                    "Dropping stale Grok-4.6 cache entry %s@%s -> %s (pre-catalog value); "
+                    "Dropping stale pre-catalog cache entry %s@%s -> %s; "
                     "re-resolving via hardcoded defaults",
                     model, base_url, f"{cached:,}",
                 )

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1221,6 +1221,36 @@ class TestGrok43StaleCacheGuard:
             assert ctx == 256_000, f"{slug} should stay 256000, got {ctx}"
 
 
+class TestGrok46StaleCacheGuard:
+    """Pre-catalog builds resolved grok-4.6 via the generic 'grok-4' catch-all
+    (256,000) and persisted it before the 500K catalog entry existed.
+    The step-1 cache guard must drop that stale value and re-resolve to 500K.
+    Official card: 500,000 context (docs.x.ai/developers/models/grok-4.6).
+    """
+
+    def test_suggests_grok_4_6(self):
+        from agent.model_metadata import _model_name_suggests_grok_4_6
+        assert _model_name_suggests_grok_4_6("grok-4.6")
+        assert _model_name_suggests_grok_4_6("xai/grok-4.6")
+        assert _model_name_suggests_grok_4_6("x-ai/grok-4.6")
+        assert not _model_name_suggests_grok_4_6("grok-4")
+        assert not _model_name_suggests_grok_4_6("grok-4-fast")
+        assert not _model_name_suggests_grok_4_6("grok-4.5")
+        assert not _model_name_suggests_grok_4_6("grok-4.3")
+
+    def test_stale_grok_4_6_dropped_and_reresolves_to_500k(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import importlib
+        import agent.model_metadata as mm
+        importlib.reload(mm)
+        base = "https://api.x.ai/v1"
+        mm.save_context_length("grok-4.6", base, 256_000)
+        ctx = mm.get_model_context_length(
+            "grok-4.6", base_url=base, api_key="", provider="xai"
+        )
+        assert ctx == 500_000
+
+
 class TestMoAContextLength:
     """MoA virtual provider resolves context from the aggregator slot, not 256K default."""
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1184,14 +1184,16 @@ class TestGrok43StaleCacheGuard:
     untouched.
     """
 
-    def test_suggests_grok_4_3(self):
-        from agent.model_metadata import _model_name_suggests_grok_4_3
-        assert _model_name_suggests_grok_4_3("grok-4.3")
-        assert _model_name_suggests_grok_4_3("grok-4.3-latest")
-        assert _model_name_suggests_grok_4_3("xai/grok-4.3")
-        assert not _model_name_suggests_grok_4_3("grok-4")
-        assert not _model_name_suggests_grok_4_3("grok-4-fast")
-        assert not _model_name_suggests_grok_4_3("grok-4.20")
+    def test_stale_grok_4_3_detected_by_generic_guard(self):
+        from agent.model_metadata import _stale_pre_catalog_cache_entry
+        # 256,000 is the old grok-4 catch-all value — stale for grok-4.3 (1M).
+        assert _stale_pre_catalog_cache_entry("grok-4.3", 256_000)
+        assert _stale_pre_catalog_cache_entry("grok-4.3-latest", 256_000)
+        assert _stale_pre_catalog_cache_entry("xai/grok-4.3", 256_000)
+        # Correct/probed values are never dropped.
+        assert not _stale_pre_catalog_cache_entry("grok-4.3", 1_000_000)
+        # Non-listed slugs are untouched even at low cached values.
+        assert not _stale_pre_catalog_cache_entry("grok-4", 256_000)
 
     def test_stale_grok_4_3_dropped_and_reresolves_to_1m(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -1228,15 +1230,17 @@ class TestGrok46StaleCacheGuard:
     Official card: 500,000 context (docs.x.ai/developers/models/grok-4.6).
     """
 
-    def test_suggests_grok_4_6(self):
-        from agent.model_metadata import _model_name_suggests_grok_4_6
-        assert _model_name_suggests_grok_4_6("grok-4.6")
-        assert _model_name_suggests_grok_4_6("xai/grok-4.6")
-        assert _model_name_suggests_grok_4_6("x-ai/grok-4.6")
-        assert not _model_name_suggests_grok_4_6("grok-4")
-        assert not _model_name_suggests_grok_4_6("grok-4-fast")
-        assert not _model_name_suggests_grok_4_6("grok-4.5")
-        assert not _model_name_suggests_grok_4_6("grok-4.3")
+    def test_stale_grok_4_6_detected_by_generic_guard(self):
+        from agent.model_metadata import _stale_pre_catalog_cache_entry
+        # 256,000 is the old grok-4 catch-all value — stale for grok-4.6 (500K).
+        assert _stale_pre_catalog_cache_entry("grok-4.6", 256_000)
+        assert _stale_pre_catalog_cache_entry("xai/grok-4.6", 256_000)
+        assert _stale_pre_catalog_cache_entry("x-ai/grok-4.6", 256_000)
+        # Correct/probed values are never dropped.
+        assert not _stale_pre_catalog_cache_entry("grok-4.6", 500_000)
+        # Sibling slugs with correct catalog values are untouched.
+        assert not _stale_pre_catalog_cache_entry("grok-4", 256_000)
+        assert not _stale_pre_catalog_cache_entry("grok-4.5", 500_000)
 
     def test_stale_grok_4_6_dropped_and_reresolves_to_500k(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -1249,6 +1253,53 @@ class TestGrok46StaleCacheGuard:
             "grok-4.6", base_url=base, api_key="", provider="xai"
         )
         assert ctx == 500_000
+
+
+class TestGenericPreCatalogStaleGuard:
+    """Generic _stale_pre_catalog_cache_entry guard: models whose catalog
+    entry postdates a shorter catch-all (qwen3.6-plus, grok-4-fast,
+    grok-4.20, ...) get their pre-catalog cached values dropped, while
+    correct or probe-derived values survive. Absorbs the per-model
+    predicates and PR #37684's requested guards.
+    """
+
+    def test_absorbed_pr_37684_models(self):
+        from agent.model_metadata import _stale_pre_catalog_cache_entry
+        # qwen3.6-plus (1M): old "qwen" catch-all persisted 131,072.
+        assert _stale_pre_catalog_cache_entry("qwen3.6-plus", 131_072)
+        assert _stale_pre_catalog_cache_entry("alibaba/qwen3.6-plus", 131_072)
+        assert not _stale_pre_catalog_cache_entry("qwen3.6-plus", 1_048_576)
+        # A 256K value for qwen3.6-plus is above the "qwen" catch-all —
+        # could be a genuine probe result, so it is NOT dropped.
+        assert not _stale_pre_catalog_cache_entry("qwen3.6-plus", 262_144)
+        # grok-4-fast / grok-4.20 (2M each): pre-catalog builds fell to 256K.
+        assert _stale_pre_catalog_cache_entry("grok-4-fast", 256_000)
+        assert _stale_pre_catalog_cache_entry("grok-4-fast-reasoning", 256_000)
+        assert _stale_pre_catalog_cache_entry("grok-4.20", 256_000)
+        assert not _stale_pre_catalog_cache_entry("grok-4-fast", 2_000_000)
+        assert not _stale_pre_catalog_cache_entry("grok-4.20", 2_000_000)
+        # Sibling qwen slugs with legitimately small windows are untouched.
+        assert not _stale_pre_catalog_cache_entry("qwen3-coder", 131_072)
+
+    def test_unknown_models_never_dropped(self):
+        from agent.model_metadata import _stale_pre_catalog_cache_entry
+        assert not _stale_pre_catalog_cache_entry("totally-unknown-model", 4096)
+        assert not _stale_pre_catalog_cache_entry("minimax", 204_800)
+
+    def test_stale_qwen36_plus_dropped_and_reresolves(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import importlib
+        import agent.model_metadata as mm
+        importlib.reload(mm)
+        base = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        mm.save_context_length("qwen3.6-plus", base, 131_072)
+        ctx = mm.get_model_context_length(
+            "qwen3.6-plus", base_url=base, api_key="", provider="alibaba"
+        )
+        # Stale 131,072 must be dropped; re-resolution lands on a 1M-class
+        # value (models.dev reports 1,000,000; hardcoded catalog 1,048,576 —
+        # either proves the pre-catalog leftover was invalidated).
+        assert ctx >= 1_000_000
 
 
 class TestMoAContextLength:


### PR DESCRIPTION
## Summary
Users who ran `grok-4.6` before its 500K catalog entry landed keep a stale persisted 256K context length forever — this drops that leftover so it re-resolves, and generalizes the guard so the whole class (MiniMax-M3, Grok-4.3/-4.6/-4-fast/-4.20, qwen3.6-plus) is covered by one rule instead of per-model patches.

Salvages #84341 by @Julientalbot (cherry-picked, authorship preserved), then widens per the never-patch-predicates rule; also absorbs the guards requested in #37684 by @AhmetArif0.

## Changes
- `agent/model_metadata.py`: cherry-picked grok-4.6 guard (@Julientalbot), then replaced the three per-model `_model_name_suggests_*` stale-cache predicates with one generic `_stale_pre_catalog_cache_entry()` driven by `_PRE_CATALOG_STALE_KEYS`. A cached value is dropped only when the model resolves (longest-key-first, same as step 8) to a listed catalog key AND the cached value is at or below what the old resolution path could have produced (largest shorter matching catch-all, or the 256K fallback). Probe-derived values above that threshold are never dropped. `_model_name_suggests_minimax_m3` kept for its two non-cache callers.
- `tests/agent/test_model_metadata.py`: contributor's `TestGrok46StaleCacheGuard` E2E test preserved; predicate unit tests migrated to the generic guard; new `TestGenericPreCatalogStaleGuard` covering qwen3.6-plus / grok-4-fast / grok-4.20 incl. an E2E stale-drop-and-re-resolve.

## Validation
| | Result |
|---|---|
| `tests/agent/test_model_metadata.py` + `test_minimax_provider.py` | 93/93 pass |
| Sabotage run (guard disabled) | 3 E2E tests fail as expected, restore → green |
| Stale-base gate | 0 behind origin/main, 2-file diff |

## Infographic

![Stale context cache guard — one generic rule replaces per-model patches](https://files.catbox.moe/wmwc6u.png)
