### PR TITLE
fix(discord): bound stop_typing reap so a stuck typing loop can't block delivery

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -39,6 +39,13 @@ logger = logging.getLogger(__name__)
 _DISCORD_MARKDOWN_LINK_LABEL_RE = re.compile(r"([\\\[\]])")
 _DISCORD_URL_LABEL_SCHEME_RE = re.compile(r"^https?://", re.IGNORECASE)
 
+# Upper bound on how long stop_typing() waits for a cancelled typing loop to
+# finish before detaching. A loop stuck in a hung /channels/{id}/typing POST
+# only receives CancelledError at its next await, so without this bound
+# stop_typing would block message delivery for the full transport timeout.
+# Mirrors base._stop_typing_refresh's 0.5s reap timeout.
+_TYPING_STOP_REAP_TIMEOUT = 0.5
+
 
 def _format_discord_markdown_link(label: str, url: str) -> str:
     """Return a Discord Markdown link whose label is not itself a URL.
@@ -5596,13 +5603,25 @@ class DiscordAdapter(BasePlatformAdapter):
         self._typing_tasks[chat_id] = asyncio.create_task(_typing_loop())
 
     async def stop_typing(self, chat_id: str) -> None:
-        """Stop the persistent typing indicator for a channel."""
+        """Stop the persistent typing indicator for a channel.
+
+        The cancelled loop is reaped with a bounded timeout so a loop stuck
+        in a slow or hung ``/channels/{id}/typing`` POST can never block
+        message delivery. Cancellation is only delivered at the loop's next
+        await point; if that await is the HTTP request (which historically
+        had no timeout), the request must finish or hit the transport
+        timeout first. Rather than hold up the response, detach after
+        ``_TYPING_STOP_REAP_TIMEOUT`` and let the already-cancelled loop
+        finish in the background (mirrors ``base._stop_typing_refresh``).
+        """
         task = self._typing_tasks.pop(chat_id, None)
         if task:
             task.cancel()
             try:
-                await task
-            except (asyncio.CancelledError, Exception):
+                await asyncio.wait_for(
+                    asyncio.shield(task), timeout=_TYPING_STOP_REAP_TIMEOUT
+                )
+            except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
                 pass
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:

--- a/tests/gateway/test_discord_typing_stop_nonblocking.py
+++ b/tests/gateway/test_discord_typing_stop_nonblocking.py
@@ -1,0 +1,105 @@
+"""Regression test for the Discord ``stop_typing`` blocking-delivery bug.
+
+``stop_typing`` previously did an unbounded ``await task`` after cancelling the
+typing loop. Cancellation is only delivered at the loop's next await point; if
+that await is an HTTP POST that ignores cancellation until the request
+completes (the failure mode described in #64874 — a stuck ``/typing`` request
+that only clears at the transport timeout), ``stop_typing`` blocks for the full
+transport timeout and holds up message delivery.
+
+The fix reaps the cancelled task with a bounded timeout
+(``_TYPING_STOP_REAP_TIMEOUT``) and detaches if it does not finish promptly,
+mirroring ``base._stop_typing_refresh``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _make_adapter() -> DiscordAdapter:
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = SimpleNamespace(http=SimpleNamespace(request=None))
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_stop_typing_does_not_block_on_cancellation_immune_request() -> None:
+    """``stop_typing`` returns promptly even when the loop ignores cancellation.
+
+    Emulates a transport that swallows ``CancelledError`` mid-flight (the
+    #64874 failure mode). ``asyncio.wait`` (not ``wait_for``) is used so the
+    *test* still fails fast on the buggy code — wrapping ``stop_typing`` in
+    ``wait_for`` would itself deadlock, because ``stop_typing``'s unbounded
+    ``await task`` is stuck on the cancellation-immune loop and cannot be
+    cancelled cleanly either.
+    """
+    adapter = _make_adapter()
+    chat_id = "123456789012345678"
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _cancellation_immune_request(_route) -> None:
+        entered.set()
+        # Swallow cancellation until the request "completes" (release set),
+        # emulating an HTTP transport that ignores task cancellation.
+        while not release.is_set():
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                continue
+
+    adapter._client.http.request = _cancellation_immune_request
+
+    await adapter.send_typing(chat_id)
+    loop = adapter._typing_tasks[chat_id]
+    assert loop is not None
+
+    # Let the loop reach the cancellation-immune request.
+    await asyncio.wait_for(entered.wait(), timeout=1.0)
+
+    stop_task = asyncio.create_task(adapter.stop_typing(chat_id))
+    done, _pending = await asyncio.wait({stop_task}, timeout=1.0)
+
+    try:
+        # stop_typing must detach within the reap bound (0.5s); the 1.0s
+        # window here leaves margin while still failing fast on a regression.
+        assert stop_task in done, (
+            "stop_typing blocked on the cancellation-immune loop instead of "
+            "detaching after the reap timeout"
+        )
+    finally:
+        # Free the request so every in-flight task can unwind, then reap them.
+        release.set()
+        with suppress(asyncio.CancelledError, asyncio.TimeoutError, Exception):
+            await asyncio.wait_for(stop_task, timeout=1.0)
+        with suppress(asyncio.CancelledError, asyncio.TimeoutError, Exception):
+            await asyncio.wait_for(loop, timeout=1.0)
+
+    assert chat_id not in adapter._typing_tasks
+
+
+@pytest.mark.asyncio
+async def test_stop_typing_clears_registry_in_normal_path() -> None:
+    """The non-hung path still clears the registry entry immediately."""
+    adapter = _make_adapter()
+    chat_id = "123456789012345678"
+
+    async def _request(_route) -> None:
+        return None
+
+    adapter._client.http.request = _request
+
+    await adapter.send_typing(chat_id)
+    assert chat_id in adapter._typing_tasks
+
+    await adapter.stop_typing(chat_id)
+    assert chat_id not in adapter._typing_tasks


### PR DESCRIPTION
## Summary

Bounds `DiscordAdapter.stop_typing()` so a stuck typing loop can never block message delivery. This closes member #3 of the Discord typing race family tracked in **#85427** (design issue).

## Root cause

`stop_typing()` cancelled the typing loop and then awaited it with no bound:

```python
task = self._typing_tasks.pop(chat_id, None)
if task:
    task.cancel()
    try:
        await task          # ← unbounded
    except (asyncio.CancelledError, Exception):
        pass
```

Cancellation is only delivered at the loop's next await point. If that await is a `/channels/{id}/typing` POST that ignores cancellation until the request completes (the failure mode described in **#64874** — a stuck request that only clears at the ~30s transport timeout), `stop_typing` blocks for the whole timeout, holding up response delivery after the turn has already finished.

## Fix

Reap the cancelled task with a bounded timeout and detach if it does not finish promptly, mirroring the existing `base._stop_typing_refresh` pattern (`wait_for(shield(task), timeout=0.5)`):

```python
task = self._typing_tasks.pop(chat_id, None)
if task:
    task.cancel()
    try:
        await asyncio.wait_for(
            asyncio.shield(task), timeout=_TYPING_STOP_REAP_TIMEOUT
        )
    except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
        pass
```

`_TYPING_STOP_REAP_TIMEOUT = 0.5` (module constant, matching `base._stop_typing_refresh`).

## Test

`tests/gateway/test_discord_typing_stop_nonblocking.py` emulates a cancellation-immune transport (a request coroutine that swallows `CancelledError` until released) and asserts `stop_typing` detaches within the reap bound.

The test uses `asyncio.wait` (not `wait_for`) deliberately: wrapping `stop_typing` in `wait_for` would itself deadlock on the buggy code, because `stop_typing`'s unbounded `await task` is stuck on the cancellation-immune loop and cannot be cancelled cleanly either.

- **buggy code**: fails fast (~2.8s) with `AssertionError: stop_typing blocked on the cancellation-immune loop…`
- **fixed code**: passes (2/2).

## Relationship to the rest of the race family (#85427)

| Member | Mechanism | Covered by |
|--------|-----------|-----------|
| Orphaned re-registered loop | loop `finally` popped the registry entry unconditionally | **#85425** |
| HTTP hang stalls cancellation | `await request(route)` has no timeout | **#64910** |
| **`stop_typing` blocks delivery** | **unbounded `await task`** | **this PR** |
| Redundant double refresh | `_keep_typing` no-op calls for Discord | design issue #85427 (long-term) |

This PR is independent and non-conflicting with **#85425** (different lines: `stop_typing` vs the loop's `finally`) and complements **#64910** (which bounds the *request*; this bounds the *reap*). Together they close the whole class short of the single-ownership refactor proposed in #85427.
