### PR TITLE
fix(container): honor config multiplexing at boot

### DIFF
--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -136,11 +136,23 @@ def reconcile_profile_gateways(
     # for every profile. Named slots must still be registered (so explicit
     # lifecycle management remains available), but booting them from their
     # persisted run intent would create additional multiplex owners.
+    # Keep the boot reconciler aligned with the gateway that will own these
+    # slots. The runtime resolver gives a recognized environment override
+    # precedence over config.yaml and otherwise preserves the configured value.
+    from gateway.config import load_gateway_config
     from utils import is_truthy_value
 
-    multiplex_profiles = is_truthy_value(
-        os.environ.get("GATEWAY_MULTIPLEX_PROFILES"),
-    )
+    try:
+        multiplex_profiles = load_gateway_config().multiplex_profiles
+    except Exception:
+        log.warning(
+            "Unable to load gateway configuration during container boot; "
+            "using the GATEWAY_MULTIPLEX_PROFILES override if set.",
+            exc_info=True,
+        )
+        multiplex_profiles = is_truthy_value(
+            os.environ.get("GATEWAY_MULTIPLEX_PROFILES"),
+        )
 
     # Default profile — always register, even if nothing has ever
     # populated the root profile dir. The slot exists so

--- a/tests/hermes_cli/test_container_boot.py
+++ b/tests/hermes_cli/test_container_boot.py
@@ -128,6 +128,120 @@ def test_running_profile_is_registered_and_autostarted(tmp_path: Path) -> None:
     assert not (svc / "down").exists()
 
 
+def test_config_multiplexing_registers_running_named_profile_down(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Container boot must honor the config-only multiplexing opt-in."""
+    scandir = tmp_path / "run-service"
+    scandir.mkdir()
+    _make_profile(tmp_path, "coder", state="running")
+    (tmp_path / "config.yaml").write_text(
+        "multiplex_profiles: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
+
+    actions = reconcile_profile_gateways(
+        hermes_home=tmp_path,
+        scandir=scandir,
+        dry_run=False,
+    )
+
+    assert _named_actions(actions) == [ReconcileAction(
+        profile="coder",
+        prior_state="running",
+        action="registered",
+    )]
+    assert (scandir / "gateway-coder" / "down").exists()
+
+
+def test_multiplex_environment_override_wins_over_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recognized operator override keeps precedence over config.yaml."""
+    scandir = tmp_path / "run-service"
+    scandir.mkdir()
+    _make_profile(tmp_path, "coder", state="running")
+    (tmp_path / "config.yaml").write_text(
+        "multiplex_profiles: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", "false")
+
+    actions = reconcile_profile_gateways(
+        hermes_home=tmp_path,
+        scandir=scandir,
+        dry_run=False,
+    )
+
+    assert _named_actions(actions) == [ReconcileAction(
+        profile="coder",
+        prior_state="running",
+        action="started",
+    )]
+    assert not (scandir / "gateway-coder" / "down").exists()
+
+
+def test_multiplex_true_environment_override_wins_over_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scandir = tmp_path / "run-service"
+    scandir.mkdir()
+    _make_profile(tmp_path, "coder", state="running")
+    (tmp_path / "config.yaml").write_text(
+        "multiplex_profiles: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", "true")
+
+    actions = reconcile_profile_gateways(
+        hermes_home=tmp_path,
+        scandir=scandir,
+        dry_run=False,
+    )
+
+    assert _named_actions(actions) == [ReconcileAction(
+        profile="coder",
+        prior_state="running",
+        action="registered",
+    )]
+    assert (scandir / "gateway-coder" / "down").exists()
+
+
+def test_config_load_failure_uses_multiplex_environment_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scandir = tmp_path / "run-service"
+    scandir.mkdir()
+    _make_profile(tmp_path, "coder", state="running")
+    monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", "true")
+
+    def raise_config_error() -> object:
+        raise ValueError("invalid config")
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", raise_config_error)
+
+    actions = reconcile_profile_gateways(
+        hermes_home=tmp_path,
+        scandir=scandir,
+        dry_run=False,
+    )
+
+    assert _named_actions(actions) == [ReconcileAction(
+        profile="coder",
+        prior_state="running",
+        action="registered",
+    )]
+    assert (scandir / "gateway-coder" / "down").exists()
+
+
 def test_registered_profile_has_finish_script(tmp_path: Path) -> None:
     """The finish script must be written so s6 stops restarting on
     fatal config errors (exit 78 → exit 125).  See #51228."""
@@ -297,7 +411,5 @@ def _write_lifecycle_sentinel(profile_dir: Path, payload: dict) -> None:
     state_dir = profile_dir / "state"
     state_dir.mkdir(parents=True, exist_ok=True)
     (state_dir / "gateway.lifecycle.json").write_text(json.dumps(payload))
-
-
 
 


### PR DESCRIPTION
## Summary

- Resolve profile multiplexing through the same environment > `config.yaml` > default path used by the gateway.
- Prevent config-only multiplex deployments from autostarting named s6 slots into duplicate-bind restart loops.
- Preserve explicit recognized environment overrides and keep slot registration available if config loading fails.

Fixes #85413.

## Problem

`reconcile_profile_gateways` previously read only `GATEWAY_MULTIPLEX_PROFILES`. When `config.yaml` enabled `multiplex_profiles: true`, the runtime was multiplexed but boot treated named profiles as dedicated gateways. A persisted named profile in `running` state therefore generated an s6 service without `down`, which s6 would autostart.

## Evidence

- Exact proof base: `5dd15872a6878a19b9b5478b6968b38f48dd311f`
- Exact current head: `0b01471a7ade3efed0c129be51d87747befee61a`

On the base, config-only multiplexing emitted `action=started`; `gateway-work/down` was absent. On this head, the same production boot reconciliation emits `action=registered` and creates `gateway-work/down`.

The current head also covers both precedence directions: env `false` over config `true`, and env `true` over config `false`. If config loading raises, container boot retains a recognized `GATEWAY_MULTIPLEX_PROFILES` override rather than preventing service registration.

This exercises the production boot reconciler with a temporary `HERMES_HOME` and generated s6 service directory; it does not launch an s6 daemon.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_container_boot.py -q` (9 passed)
- Ruff check on the changed production and test files: passed
- `git diff --check`: passed
- Hosted `CI`, Docker, and Nix workflows are currently `action_required` and await upstream approval for this fork head

`ruff format --check` reports pre-existing whole-file drift, so this focused PR does not include unrelated formatting changes.

## Scope and selection gate

One boot-time resolver change plus focused regressions; no config schema, protocol, dependency, or service-layout change. Related PR #86114 implements the same user-visible fix with a separate resolver; both are open and the remaining choice between approaches belongs to maintainers.
