### PR TITLE
feat: server-side ui_meta on profiles.list/configure

### DIFF
--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -36,6 +36,15 @@ def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
+        # Unit tests must not probe live endpoints. The compressor resolves
+        # context length lazily via a real network call against base_url; for
+        # reachable hosts (the nous portal case) the endpoint's answer for the
+        # empty test model (32K) trips agent_init's 64K floor and fails the
+        # test on network behavior, not code under test.
+        patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=200_000,
+        ),
     ):
         agent = AIAgent(
             api_key="test-key-12345678",

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -89,6 +89,23 @@ def _(rid, params: dict) -> dict:
             }
             if include_sessions:
                 row["last_session"] = _latest_profile_session_row(p.path)
+
+            # Client-agnostic UI metadata (avatars, accent colors, pinned
+            # order, …) — stored server-side in profile.yaml so every
+            # machine connecting to this gateway paints the same roster.
+            try:
+                import yaml as _yaml
+                from pathlib import Path as _Path
+
+                meta_path = _Path(str(p.path)) / "profile.yaml"
+                if meta_path.is_file():
+                    with open(meta_path, "r", encoding="utf-8") as f:
+                        raw_meta = _yaml.safe_load(f) or {}
+                    ui_meta = raw_meta.get("ui_meta")
+                    if isinstance(ui_meta, dict) and ui_meta:
+                        row["ui_meta"] = ui_meta
+            except Exception:
+                pass
             out.append(row)
         return _ok(rid, {"profiles": out})
     except Exception as e:
@@ -381,6 +398,50 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 4064, f"profile '{name}' not found")
 
         applied = {}
+
+        if isinstance(params.get("ui_meta"), dict):
+            # Client-agnostic UI metadata (avatar/pet/etc.), merged key-wise
+            # into profile.yaml's ui_meta block. A key set to None deletes it.
+            # Size-capped: this rides profiles.list on every roster paint, so
+            # large blobs (e.g. raw base64 images) are rejected — persist big
+            # assets elsewhere and store a reference.
+            try:
+                import json as _json
+
+                incoming = params["ui_meta"]
+                if len(_json.dumps(incoming)) > 65536:
+                    applied["ui_meta"] = False
+                else:
+                    import yaml as _yaml
+
+                    meta_path = profile_dir / "profile.yaml"
+                    existing = {}
+                    if meta_path.is_file():
+                        try:
+                            with open(meta_path, "r", encoding="utf-8") as f:
+                                loaded = _yaml.safe_load(f) or {}
+                            if isinstance(loaded, dict):
+                                existing = loaded
+                        except Exception:
+                            existing = {}
+                    current = existing.get("ui_meta")
+                    if not isinstance(current, dict):
+                        current = {}
+                    for key, value in incoming.items():
+                        if value is None:
+                            current.pop(key, None)
+                        else:
+                            current[key] = value
+                    if current:
+                        existing["ui_meta"] = current
+                    else:
+                        existing.pop("ui_meta", None)
+                    from utils import atomic_yaml_write
+
+                    atomic_yaml_write(meta_path, existing, sort_keys=False)
+                    applied["ui_meta"] = True
+            except Exception:
+                applied["ui_meta"] = False
 
         if isinstance(params.get("soul"), str):
             try:


### PR DESCRIPTION
## What

Adds server-side, client-agnostic UI metadata to the profiles ws surface (follow-up to #85216).

Problem: roster/team UIs built on `profiles.*` (e.g. the Hermes-Bot-Mode plugin) have per-profile presentation state — avatar geometry, accent color, display title, attached pet — with nowhere server-side to keep it. Client-side plugin storage means a second machine connecting to the same gateway paints a different roster.

- `profiles.configure` accepts `ui_meta: dict` — merged key-wise into a `ui_meta` block in the profile's existing `profile.yaml` (same file as `description`, same `atomic_yaml_write`). A top-level key set to `null` deletes it. Consumers are expected to namespace under their own key (`ui_meta["hermes-bots"] = {...}`).
- `profiles.list` returns the block as `ui_meta` per row (omitted when empty), so a roster paints in one call.
- Size cap 64KB on the incoming dict: this rides every roster paint, so raw base64 image blobs are rejected — store big assets elsewhere and reference them.

No new files, no new config keys, no schema migration: profiles without the block behave exactly as before, and `read_profile_meta`'s description contract is untouched.

## Verification

Against the real registry on a live named profile: configure wrote `ui_meta` (`applied: {ui_meta: true}`); `profiles.list` returned it verbatim; a second configure merged (namespace replaced, other keys preserved); a 70KB payload was rejected (`applied: {ui_meta: false}`) leaving the file untouched; `description`/`description_auto` survived all writes (`profile.yaml` keys: description, description_auto, ui_meta).

Consumer: Hermes-Bot-Mode stores avatar/pet selections server-side so every client machine sees the same bots.
