### PR TITLE
fix: keep transient foreground turns recovering

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1257,6 +1257,7 @@ def recover_with_credential_pool(
 
 def try_recover_primary_transport(
     agent, api_error: Exception, *, retry_count: int, max_retries: int,
+    wait: bool = True,
 ) -> bool:
     """Attempt one extra primary-provider recovery cycle for transient transport failures.
 
@@ -1346,13 +1347,14 @@ def try_recover_primary_transport(
                 shared=True,
             )
 
-        wait_time = min(3 + retry_count, 8)
-        agent._vprint(
-            f"{agent.log_prefix}🔁 Transient {error_type} on {agent.provider} — "
-            f"rebuilt client, waiting {wait_time}s before one last primary attempt.",
-            force=True,
-        )
-        time.sleep(wait_time)
+        if wait:
+            wait_time = min(3 + retry_count, 8)
+            agent._vprint(
+                f"{agent.log_prefix}🔁 Transient {error_type} on {agent.provider} — "
+                f"rebuilt client, waiting {wait_time}s before one last primary attempt.",
+                force=True,
+            )
+            time.sleep(wait_time)
         return True
     except Exception as e:
         logger.warning("Primary transport recovery failed: %s", e)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5748,6 +5748,81 @@ def run_conversation(
                         _retry.primary_recovery_attempted = False
                         _retry.restart_with_rebuilt_messages = True
                         break
+                    # A direct provider can remain temporarily unavailable for
+                    # longer than the normal retry + one rebuilt-client cycle.
+                    # Errors reaching this except path were raised before any
+                    # stream delta was delivered (partial streams return a
+                    # continuation stub instead), so reissuing this model call
+                    # cannot replay a delivered tool call or side effect.
+                    #
+                    # Stale-stream watchdog failures stay bounded: each attempt
+                    # can already cost minutes and their circuit breaker owns
+                    # recovery. The transport helper is the single classifier
+                    # for eligible direct-provider connection errors.
+                    if (
+                        getattr(agent, "platform", None) in {"cli", "tui"}
+                        and not getattr(agent, "_consecutive_stale_streams", 0)
+                        and agent._try_recover_primary_transport(
+                            api_error,
+                            retry_count=retry_count,
+                            max_retries=max_retries,
+                            wait=False,
+                        )
+                    ):
+                        _retry.transient_recovery_cycles += 1
+                        retry_count = 0
+                        _retry.has_retried_429 = False
+                        agent._fallback_index = 0
+                        agent._fallback_activated = False
+                        wait_time = jittered_backoff(
+                            _retry.transient_recovery_cycles,
+                            base_delay=5.0,
+                            max_delay=60.0,
+                        )
+                        agent._flush_status_buffer()
+                        agent._emit_status(
+                            "⏳ Provider temporarily unavailable. "
+                            f"Hermes will retry automatically in {wait_time:.1f}s "
+                            f"(recovery cycle {_retry.transient_recovery_cycles}). "
+                            "Interrupt to stop."
+                        )
+                        logger.warning(
+                            "Transient turn recovery cycle=%s delay=%ss reason=%s %s",
+                            _retry.transient_recovery_cycles,
+                            wait_time,
+                            classified.reason.value,
+                            agent._client_log_context(),
+                        )
+                        sleep_end = time.time() + wait_time
+                        _recovery_touch_counter = 0
+                        while time.time() < sleep_end:
+                            if agent._interrupt_requested:
+                                if agent.clear_interrupt(preserve_redirect=True):
+                                    _retry.restart_with_redirected_messages = True
+                                    break
+                                _interrupt_text = (
+                                    "Operation interrupted: waiting for provider recovery."
+                                )
+                                close_interrupted_tool_sequence(messages, _interrupt_text)
+                                agent._persist_session(messages, conversation_history)
+                                agent.clear_interrupt()
+                                return {
+                                    "final_response": _interrupt_text,
+                                    "messages": messages,
+                                    "api_calls": api_call_count,
+                                    "completed": False,
+                                    "interrupted": True,
+                                }
+                            time.sleep(0.2)
+                            _recovery_touch_counter += 1
+                            if _recovery_touch_counter % 150 == 0:
+                                agent._touch_activity(
+                                    "transient provider recovery, "
+                                    f"{int(sleep_end - time.time())}s remaining"
+                                )
+                        if _retry.restart_with_redirected_messages:
+                            break
+                        continue
                     # Terminal — flush buffered retry/fallback trace.
                     agent._flush_status_buffer()
                     _final_summary = agent._summarize_api_error(api_error)

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -66,6 +66,10 @@ class TurnRetryState:
 
     # ── Transport / rate-limit recovery ──────────────────────────────────
     primary_recovery_attempted: bool = False
+    # Number of post-exhaustion foreground recovery cycles for a transient
+    # pre-delivery transport outage. Unlike the one-shot guard above, this may
+    # grow until the provider recovers or the user interrupts the turn.
+    transient_recovery_cycles: int = 0
     has_retried_429: bool = False
 
     # ── Auth-failure provider failover ───────────────────────────────────

--- a/run_agent.py
+++ b/run_agent.py
@@ -6689,10 +6689,17 @@ class AIAgent:
 
     def _try_recover_primary_transport(
         self, api_error: Exception, *, retry_count: int, max_retries: int,
+        wait: bool = True,
     ) -> bool:
         """Forwarder — see ``agent.agent_runtime_helpers.try_recover_primary_transport``."""
         from agent.agent_runtime_helpers import try_recover_primary_transport
-        return try_recover_primary_transport(self, api_error, retry_count=retry_count, max_retries=max_retries)
+        return try_recover_primary_transport(
+            self,
+            api_error,
+            retry_count=retry_count,
+            max_retries=max_retries,
+            wait=wait,
+        )
 
     @staticmethod
     def _content_has_image_parts(content: Any) -> bool:

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -29,6 +29,7 @@ EXPECTED_FIELDS = {
     "oauth_1m_beta_retry_attempted",
     "llama_cpp_grammar_retry_attempted",
     "primary_recovery_attempted",
+    "transient_recovery_cycles",
     "has_retried_429",
     "auth_failover_attempted",
     "restart_with_compressed_messages",

--- a/tests/run_agent/test_transient_turn_recovery.py
+++ b/tests/run_agent/test_transient_turn_recovery.py
@@ -1,0 +1,120 @@
+"""Regression coverage for #85426: transient outages recover the open turn."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+class ReadTimeout(Exception):
+    pass
+
+
+def _response(text: str):
+    message = SimpleNamespace(content=text, tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="test-model", usage=None)
+
+
+def _agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            api_key="test-key-12345678",
+            base_url="https://direct.example.com/v1",
+            provider="custom",
+            model="test-model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            platform="tui",
+        )
+    agent.client = MagicMock()
+    setattr(agent, "_api_max_retries", 2)
+    return agent
+
+
+def test_pre_delivery_outage_survives_multiple_recovery_cycles():
+    agent = _agent()
+    calls = []
+
+    def api_call(_kwargs):
+        calls.append(len(calls) + 1)
+        if len(calls) <= 6:
+            raise ReadTimeout("temporary outage")
+        return _response("recovered")
+
+    with (
+        patch.object(agent, "_interruptible_api_call", side_effect=api_call),
+        patch.object(agent, "_persist_session") as persist,
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+        patch("agent.agent_runtime_helpers.time.sleep"),
+        patch("agent.conversation_loop.jittered_backoff", return_value=0),
+    ):
+        result = agent.run_conversation("continue the task")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "recovered"
+    assert calls == [1, 2, 3, 4, 5, 6, 7]
+    assert [m["role"] for m in result["messages"]] == ["user", "assistant"]
+    persist.assert_called()
+
+
+def test_interrupt_stops_transient_recovery_wait():
+    agent = _agent()
+
+    def api_call(_kwargs):
+        raise ReadTimeout("temporary outage")
+
+    def interrupt_sleep(_seconds):
+        if _seconds == 0.2:
+            agent._interrupt_requested = True
+
+    def backoff(_attempt, *, base_delay=1.0, **_kwargs):
+        return 60 if base_delay == 5.0 else 0
+
+    with (
+        patch.object(agent, "_interruptible_api_call", side_effect=api_call),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch.object(agent, "_try_recover_primary_transport", return_value=True),
+        patch("agent.conversation_loop.time.sleep", side_effect=interrupt_sleep),
+        patch("agent.conversation_loop.jittered_backoff", side_effect=backoff),
+    ):
+        result = agent.run_conversation("continue the task")
+
+    assert result["completed"] is False
+    assert result["interrupted"] is True
+    assert result["final_response"] == (
+        "Operation interrupted: waiting for provider recovery."
+    )
+
+
+def test_background_surface_keeps_bounded_retry_policy():
+    agent = _agent()
+    setattr(agent, "platform", "telegram")
+
+    with (
+        patch.object(
+            agent,
+            "_interruptible_api_call",
+            side_effect=ReadTimeout("temporary outage"),
+        ),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch.object(agent, "_try_recover_primary_transport", return_value=True) as recover,
+        patch("agent.conversation_loop.time.sleep"),
+        patch("agent.conversation_loop.jittered_backoff", return_value=0),
+    ):
+        result = agent.run_conversation("continue the task")
+
+    assert result["completed"] is False
+    assert result.get("interrupted") is not True
+    assert recover.call_count == 1


### PR DESCRIPTION
## Summary

- keep transient pre-delivery transport failures recovering in open CLI/TUI turns after the normal retry and one-shot client rebuild are exhausted
- rebuild the direct-provider client for each recovery cycle, with capped jittered backoff and visible status
- stop immediately on user interrupt
- keep gateway/background surfaces on the existing bounded retry policy
- preserve partial-stream handling, so delivered text/tool calls are never replayed by this path

## Safety boundaries

- only existing `_TRANSIENT_TRANSPORT_ERRORS` accepted by `try_recover_primary_transport`
- no HTTP/auth/context/policy/programming errors enter the loop
- no aggregator providers or active fallback runtime
- no stale-stream watchdog loops
- no recovery for closed processes
- only `platform in {"cli", "tui"}`

## Validation

```text
scripts/run_tests.sh \
  tests/run_agent/test_transient_turn_recovery.py \
  tests/agent/test_turn_retry_state.py \
  tests/run_agent/test_32646_fallback_429_after_timeout.py \
  tests/run_agent/test_partial_stream_finish_reason.py -q

28 passed
```

Fault injection covers six consecutive transient failures followed by success on call seven, one user message, one assistant message, interrupt during recovery wait, and bounded behavior on Telegram.

The branch was rebased onto current upstream `main` immediately before this validation.

Coordinates with #69186 / #69190 by reusing its one-shot primary transport rebuild instead of adding a parallel classifier or client lifecycle.

Closes #85426
