### PR TITLE
fix(clients): hide compaction scaffolding across surfaces

### DIFF
--- a/agent/compaction_display.py
+++ b/agent/compaction_display.py
@@ -1,0 +1,47 @@
+"""Client-facing projection helpers for model-only compaction carriers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from agent.context_compressor import (
+    ContextCompressor,
+    is_compaction_summary_message,
+)
+
+
+_COMPACTION_INTERNAL_FIELDS = (
+    "tool_calls",
+    "finish_reason",
+    "reasoning",
+    "reasoning_content",
+    "reasoning_details",
+    "codex_reasoning_items",
+    "codex_message_items",
+)
+
+
+def project_compaction_message_for_display(
+    message: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Return authentic transcript content, or ``None`` for a pure handoff.
+
+    Model-facing recovery history retains the complete carrier. Display
+    projections instead remove the handoff, inherited tool state, and internal
+    reasoning while preserving any real prior-tail content or live user ask
+    embedded in the carrier.
+    """
+    if not isinstance(message, dict):
+        return None
+    if not is_compaction_summary_message(message):
+        return message.copy()
+
+    projected = ContextCompressor._strip_context_summary_handoff_message(message)
+    if projected is None:
+        return None
+
+    projected = projected.copy()
+    for key in _COMPACTION_INTERNAL_FIELDS:
+        projected.pop(key, None)
+    projected.pop("display_kind", None)
+    return projected

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -418,31 +418,53 @@ def _request_agent_overrides(
     return overrides
 
 
-def _message_text_prefix(content: Any) -> str:
-    if isinstance(content, str):
-        return content[:128]
-    if not isinstance(content, list):
-        return ""
-    parts: List[str] = []
-    for item in content[:4]:
-        if isinstance(item, str):
-            parts.append(item)
-        elif isinstance(item, dict):
-            text = item.get("text")
-            if isinstance(text, str):
-                parts.append(text)
-        if sum(len(part) for part in parts) >= 128:
-            break
-    return "\n".join(parts)[:128]
-
-
 def _is_compressed_summary_message(message: Any) -> bool:
+    """Recognize every model-side compaction carrier shape.
+
+    SessionDB does not persist the in-process metadata marker, so client
+    projections must share the compressor's content classifier rather than a
+    prefix-only approximation that misses merge-into-tail carriers.
+    """
     if not isinstance(message, dict):
         return False
-    if message.get(_COMPRESSED_SUMMARY_METADATA_KEY):
-        return True
-    prefix = _message_text_prefix(message.get("content"))
-    return prefix.startswith("[CONTEXT COMPACTION") or prefix.startswith("[CONTEXT SUMMARY]:")
+    from agent.context_compressor import is_compaction_summary_message
+
+    return is_compaction_summary_message(message)
+
+
+def _project_client_message(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove model-only compaction scaffolding from a client message.
+
+    Standalone handoffs have no transcript content and remain as hidden empty
+    rows so clients can reconcile stable message identities. Merged handoffs
+    preserve only the real prior-tail content that precedes the internal
+    summary delimiter. Tool calls are dropped from both shapes because a
+    carrier's inherited calls are historical context, not live client output.
+    """
+    projected = message.copy()
+    if not _is_compressed_summary_message(projected):
+        return projected
+
+    from agent.context_compressor import ContextCompressor
+
+    unwrapped = ContextCompressor._strip_context_summary_handoff_message(
+        projected
+    )
+    for internal_key in (
+        "tool_calls",
+        "finish_reason",
+        "reasoning",
+        "reasoning_content",
+    ):
+        projected.pop(internal_key, None)
+    if unwrapped is None:
+        projected["content"] = ""
+        projected["display_kind"] = "hidden"
+        return projected
+
+    projected["content"] = unwrapped.get("content")
+    projected.pop("display_kind", None)
+    return projected
 
 
 def _auto_truncate_response_history(
@@ -3358,10 +3380,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _message_response(message: Dict[str, Any]) -> Dict[str, Any]:
+        message = _project_client_message(message)
         safe_keys = (
             "id", "session_id", "role", "content", "tool_call_id", "tool_calls",
             "tool_name", "timestamp", "token_count", "finish_reason", "reasoning",
-            "reasoning_content",
+            "reasoning_content", "display_kind",
         )
         return {key: message.get(key) for key in safe_keys if key in message}
 
@@ -6185,6 +6208,12 @@ class APIServerAdapter(BasePlatformAdapter):
             if not isinstance(msg, dict):
                 continue
             if msg.get("role") not in {"assistant", "tool"}:
+                continue
+            if _is_compressed_summary_message(msg):
+                projected = cls._message_response(msg)
+                if projected.get("display_kind") == "hidden":
+                    continue
+                out.append(projected)
                 continue
             out.append(cls._message_response(msg))
         return out

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -441,29 +441,23 @@ def _project_client_message(message: Dict[str, Any]) -> Dict[str, Any]:
     summary delimiter. Tool calls are dropped from both shapes because a
     carrier's inherited calls are historical context, not live client output.
     """
-    projected = message.copy()
-    if not _is_compressed_summary_message(projected):
-        return projected
+    from agent.compaction_display import project_compaction_message_for_display
 
-    from agent.context_compressor import ContextCompressor
-
-    unwrapped = ContextCompressor._strip_context_summary_handoff_message(
-        projected
-    )
-    for internal_key in (
-        "tool_calls",
-        "finish_reason",
-        "reasoning",
-        "reasoning_content",
-    ):
-        projected.pop(internal_key, None)
-    if unwrapped is None:
+    projected = project_compaction_message_for_display(message)
+    if projected is None:
+        projected = message.copy()
+        for internal_key in (
+            "tool_calls",
+            "finish_reason",
+            "reasoning",
+            "reasoning_content",
+            "reasoning_details",
+            "codex_reasoning_items",
+            "codex_message_items",
+        ):
+            projected.pop(internal_key, None)
         projected["content"] = ""
         projected["display_kind"] = "hidden"
-        return projected
-
-    projected["content"] = unwrapped.get("content")
-    projected.pop("display_kind", None)
     return projected
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -59,6 +59,7 @@ from agent.conversation_compression import (
     PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
 )
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+from agent.compaction_display import project_compaction_message_for_display
 from agent.i18n import t
 from agent.interrupt_compat import request_hard_interrupt
 from agent.turn_context import (
@@ -23157,8 +23158,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         last_assistant = None
         try:
             for message in reversed(await self._session_db.get_messages(session_id)):
-                if message.get("role") == "assistant" and message.get("content"):
-                    last_assistant = str(message.get("content"))
+                if message.get("role") != "assistant":
+                    continue
+                projected = project_compaction_message_for_display(message)
+                if projected is not None and projected.get("content"):
+                    last_assistant = str(projected.get("content"))
                     break
         except Exception:
             last_assistant = None

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -54,6 +54,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _FTS_CJK_TRIGGERS,
     _FTS_TRIGGERS,
     _LISTABLE_CHILD_SQL,
+    _PREVIEW_ELIGIBLE_SQL,
     _PREVIEW_RAW_SELECT,
     _RESET_END_REASONS,
     _RESET_END_REASONS_SQL,
@@ -8878,6 +8879,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         (SELECT {_PREVIEW_RAW_SELECT}
                          FROM messages m
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                           AND {_PREVIEW_ELIGIBLE_SQL}
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
@@ -8901,6 +8903,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         (SELECT {_PREVIEW_RAW_SELECT}
                          FROM messages m
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                           AND {_PREVIEW_ELIGIBLE_SQL}
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
@@ -8940,6 +8943,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         (SELECT {_PREVIEW_RAW_SELECT}
                          FROM messages m
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                           AND {_PREVIEW_ELIGIBLE_SQL}
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
@@ -12681,6 +12685,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             (SELECT {_PREVIEW_RAW_SELECT}
                              FROM messages m
                              WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                               AND {_PREVIEW_ELIGIBLE_SQL}
                              ORDER BY m.timestamp, m.id LIMIT 1),
                             ''
                         ) AS _preview_raw,
@@ -12711,6 +12716,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             (SELECT {_PREVIEW_RAW_SELECT}
                              FROM messages m
                              WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                               AND {_PREVIEW_ELIGIBLE_SQL}
                              ORDER BY m.timestamp, m.id LIMIT 1),
                             ''
                         ) AS _preview_raw,

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -13,6 +13,13 @@ from agent.skill_commands import (
     SKILL_SCAFFOLD_SQL_LIKE,
     describe_skill_invocation,
 )
+from agent.context_compressor import (
+    LEGACY_SUMMARY_PREFIX,
+    SUMMARY_PREFIX,
+    _MERGED_PRIOR_CONTEXT_HEADER,
+    _MERGED_SUMMARY_DELIMITER,
+    _SUMMARY_END_MARKER,
+)
 
 
 # Session preview = the head of the first user message, shown wherever a
@@ -52,12 +59,90 @@ _PREVIEW_CONTENT_SQL = "REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' ')"
 _PREVIEW_SCAFFOLDED_SQL = f"m.content LIKE '{SKILL_SCAFFOLD_SQL_LIKE}'"
 
 
+def _sql_literal(text: str) -> str:
+    return "'" + text.replace("'", "''") + "'"
+
+
+_SQL_WHITESPACE = "CHAR(9) || CHAR(10) || CHAR(13) || CHAR(32)"
+
+
+def _sql_ltrim_whitespace(expression: str) -> str:
+    return f"LTRIM({expression}, {_SQL_WHITESPACE})"
+
+
+def _sql_trim_whitespace(expression: str) -> str:
+    return f"TRIM({expression}, {_SQL_WHITESPACE})"
+
+
+def _sql_starts_with(expression: str, prefixes: tuple[str, ...]) -> str:
+    trimmed = _sql_ltrim_whitespace(expression)
+    checks = [
+        f"SUBSTR({trimmed}, 1, {len(prefix)}) = {_sql_literal(prefix)}"
+        for prefix in prefixes
+    ]
+    return "(" + " OR ".join(checks) + ")"
+
+
+# Current and historical long-form prefixes share this complete introduction;
+# their stale-item guidance diverges only after it. Matching the whole intro
+# avoids treating an ordinary user message that merely starts with the short
+# bracketed label as a compaction carrier.
+_PREVIEW_LONG_FORM_PREFIX = SUMMARY_PREFIX.split("Do NOT answer", 1)[0]
+_PREVIEW_SUMMARY_PREFIXES = (
+    _PREVIEW_LONG_FORM_PREFIX,
+    LEGACY_SUMMARY_PREFIX,
+)
+_PREVIEW_STANDALONE_SUMMARY_SQL = _sql_starts_with(
+    "m.content", _PREVIEW_SUMMARY_PREFIXES
+)
+_PREVIEW_MERGED_AFTER_SQL = (
+    f"SUBSTR(m.content, INSTR(m.content, {_sql_literal(_MERGED_SUMMARY_DELIMITER)})"
+    f" + {len(_MERGED_SUMMARY_DELIMITER)})"
+)
+_PREVIEW_MERGED_SUMMARY_SQL = (
+    f"(INSTR(m.content, {_sql_literal(_MERGED_SUMMARY_DELIMITER)}) > 0"
+    f" AND {_sql_starts_with(_PREVIEW_MERGED_AFTER_SQL, _PREVIEW_SUMMARY_PREFIXES)})"
+)
+_PREVIEW_MERGED_PRIOR_SQL = _sql_trim_whitespace(
+    f"SUBSTR(m.content, 1, INSTR(m.content, {_sql_literal(_MERGED_SUMMARY_DELIMITER)}) - 1)"
+)
+_PREVIEW_MERGED_PRIOR_LTRIMMED_SQL = _sql_ltrim_whitespace(
+    _PREVIEW_MERGED_PRIOR_SQL
+)
+_PREVIEW_MERGED_PRIOR_UNWRAPPED_SQL = (
+    f"CASE WHEN SUBSTR({_PREVIEW_MERGED_PRIOR_LTRIMMED_SQL}, 1,"
+    f" {len(_MERGED_PRIOR_CONTEXT_HEADER)}) = {_sql_literal(_MERGED_PRIOR_CONTEXT_HEADER)}"
+    f" THEN {_sql_ltrim_whitespace(f'SUBSTR({_PREVIEW_MERGED_PRIOR_LTRIMMED_SQL}, {len(_MERGED_PRIOR_CONTEXT_HEADER) + 1})')}"
+    f" ELSE {_PREVIEW_MERGED_PRIOR_SQL} END"
+)
+_PREVIEW_FORCE_USER_REMAINDER_SQL = (
+    f"SUBSTR(m.content, INSTR(m.content, {_sql_literal(_SUMMARY_END_MARKER)})"
+    f" + {len(_SUMMARY_END_MARKER)})"
+)
+
+# Session preview subqueries select their first eligible user-authored content.
+# Pure compaction rows are ineligible; force-user-leading and merged carriers
+# remain eligible only when authentic content survives the wire boundary.
+_PREVIEW_ELIGIBLE_SQL = (
+    f"((NOT {_PREVIEW_STANDALONE_SUMMARY_SQL} AND NOT {_PREVIEW_MERGED_SUMMARY_SQL})"
+    f" OR ({_PREVIEW_STANDALONE_SUMMARY_SQL}"
+    f" AND INSTR(m.content, {_sql_literal(_SUMMARY_END_MARKER)}) > 0"
+    f" AND LENGTH({_sql_trim_whitespace(_PREVIEW_FORCE_USER_REMAINDER_SQL)}) > 0)"
+    f" OR ({_PREVIEW_MERGED_SUMMARY_SQL}"
+    f" AND LENGTH({_sql_trim_whitespace(_PREVIEW_MERGED_PRIOR_UNWRAPPED_SQL)}) > 0))"
+)
+
+
 # The shared ``_preview_raw`` SELECT expression, interpolated by every listing
 # query. A scaffolded row gets a wider excerpt: the whole message while it fits
 # the budget, else head + tail (where the typed instruction lands) spliced
 # around SKILL_EXCERPT_JOINT.
 _PREVIEW_RAW_SELECT = (
-    f"CASE WHEN {_PREVIEW_SCAFFOLDED_SQL}"
+    f"CASE WHEN {_PREVIEW_STANDALONE_SUMMARY_SQL}"
+    f" THEN {_PREVIEW_FORCE_USER_REMAINDER_SQL}"
+    f" WHEN {_PREVIEW_MERGED_SUMMARY_SQL}"
+    f" THEN {_PREVIEW_MERGED_PRIOR_UNWRAPPED_SQL}"
+    f" WHEN {_PREVIEW_SCAFFOLDED_SQL}"
     f" AND LENGTH(m.content) > {_PREVIEW_SCAFFOLD_WINDOW * 2}"
     f" THEN SUBSTR({_PREVIEW_CONTENT_SQL}, 1, {_PREVIEW_SCAFFOLD_WINDOW})"
     f" || '{SKILL_EXCERPT_JOINT}'"
@@ -73,6 +158,7 @@ def _shape_preview(raw: Any) -> str:
     text = str(raw or "").strip()
     if not text:
         return ""
+    text = text.replace("\n", " ").replace("\r", " ")
     described = describe_skill_invocation(text)
     text = described if described is not None else text.split(SKILL_EXCERPT_JOINT)[0]
     if len(text) > _PREVIEW_MAX_CHARS:

--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional
 from agent.skill_commands import SKILL_SCAFFOLD_SQL_LIKE
 from hermes_state_common import (
     SCHEMA_SQL,
+    _PREVIEW_ELIGIBLE_SQL,
     _PREVIEW_RAW_SELECT,
     _shape_preview,
     _sql_session_last_active,
@@ -107,6 +108,7 @@ class SessionPortabilityMixin:
                     (SELECT {_PREVIEW_RAW_SELECT}
                      FROM messages m
                      WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                       AND {_PREVIEW_ELIGIBLE_SQL}
                      ORDER BY m.timestamp, m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,
@@ -191,6 +193,7 @@ class SessionPortabilityMixin:
                     (SELECT {_PREVIEW_RAW_SELECT}
                      FROM messages m
                      WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                       AND {_PREVIEW_ELIGIBLE_SQL}
                      ORDER BY m.timestamp, m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,

--- a/tests/gateway/test_api_server_compaction_projection.py
+++ b/tests/gateway/test_api_server_compaction_projection.py
@@ -1,0 +1,212 @@
+"""Client projections must not expose model-only compaction scaffolding."""
+
+from __future__ import annotations
+
+from aiohttp.test_utils import TestClient, TestServer
+import pytest
+
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    HISTORICAL_TASK_HEADING,
+    SUMMARY_PREFIX,
+    _MERGED_PRIOR_CONTEXT_HEADER,
+    _MERGED_SUMMARY_DELIMITER,
+    _SUMMARY_END_MARKER,
+)
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _is_compressed_summary_message,
+)
+from hermes_state import SessionDB
+
+
+STANDALONE_SUMMARY = (
+    f"{SUMMARY_PREFIX}\n\n"
+    f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+    f"{_SUMMARY_END_MARKER}"
+)
+MERGED_CARRIER = (
+    f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"
+    "Refactor complete.\n\n"
+    f"{_MERGED_SUMMARY_DELIMITER}\n\n"
+    f"{STANDALONE_SUMMARY}"
+)
+REAL_USER = "test the browser controller again"
+
+
+def _row(role: str, content, **extra) -> dict:
+    row = {"id": 1, "session_id": "s1", "role": role, "content": content}
+    row.update(extra)
+    return row
+
+
+@pytest.fixture
+def session_db(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        yield db
+    finally:
+        close = getattr(db, "close", None)
+        if callable(close):
+            close()
+
+
+@pytest.fixture
+def adapter(session_db):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = session_db
+    return adapter
+
+
+def _messages_app(adapter: APIServerAdapter):
+    from aiohttp import web
+
+    app = web.Application()
+    app.router.add_get(
+        "/api/sessions/{session_id}/messages",
+        adapter._handle_session_messages,
+    )
+    return app
+
+
+class TestMessageProjection:
+    def test_standalone_summary_is_hidden_without_scaffolding(self):
+        projected = APIServerAdapter._message_response(
+            _row(
+                "user",
+                STANDALONE_SUMMARY,
+                tool_calls=[{"id": "stale"}],
+                reasoning="internal compression reasoning",
+                reasoning_content="internal compression reasoning",
+            )
+        )
+
+        assert projected["content"] == ""
+        assert projected["display_kind"] == "hidden"
+        assert "tool_calls" not in projected
+        assert "finish_reason" not in projected
+        assert "reasoning" not in projected
+        assert "reasoning_content" not in projected
+
+    def test_merged_carrier_preserves_only_real_prior_content(self):
+        projected = APIServerAdapter._message_response(
+            _row(
+                "assistant",
+                MERGED_CARRIER,
+                tool_calls=[{"id": "prior-call"}],
+                finish_reason="tool_calls",
+            )
+        )
+
+        assert projected["content"] == "Refactor complete."
+        assert "tool_calls" not in projected
+        assert "finish_reason" not in projected
+        assert "PRIOR CONTEXT" not in projected["content"]
+        assert "CONTEXT COMPACTION" not in projected["content"]
+
+    def test_merged_content_array_preserves_blocks_before_summary(self):
+        projected = APIServerAdapter._message_response(
+            _row(
+                "user",
+                [
+                    {
+                        "type": "text",
+                        "text": f"{_MERGED_PRIOR_CONTEXT_HEADER}\n{REAL_USER}",
+                    },
+                    {
+                        "type": "text",
+                        "text": f"{_MERGED_SUMMARY_DELIMITER}\n{STANDALONE_SUMMARY}",
+                    },
+                ],
+            )
+        )
+
+        assert projected["content"] == [{"type": "text", "text": REAL_USER}]
+
+    def test_real_message_that_mentions_marker_text_is_untouched(self):
+        content = "please explain the string [CONTEXT COMPACTION] in this bug report"
+        projected = APIServerAdapter._message_response(_row("user", content))
+
+        assert projected["content"] == content
+        assert "display_kind" not in projected
+
+    def test_unrelated_hidden_message_is_not_reclassified_as_compaction(self):
+        message = _row("assistant", "ordinary hidden control row", display_kind="hidden")
+
+        assert _is_compressed_summary_message(message) is False
+
+
+class TestSummaryRecognizer:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            _row("user", STANDALONE_SUMMARY),
+            _row("assistant", MERGED_CARRIER),
+            _row("assistant", "metadata-only", **{COMPRESSED_SUMMARY_METADATA_KEY: True}),
+        ],
+    )
+    def test_recognizes_all_compaction_carrier_shapes(self, message):
+        assert _is_compressed_summary_message(message) is True
+
+    def test_ignores_real_message(self):
+        assert _is_compressed_summary_message(_row("user", REAL_USER)) is False
+
+
+class TestTurnTranscriptProjection:
+    def test_run_completed_strips_scaffolding_but_keeps_real_carrier_content(self):
+        result = {
+            "messages": [
+                {"role": "user", "content": REAL_USER},
+                {"role": "assistant", "content": "checking the controller"},
+                _row("user", STANDALONE_SUMMARY),
+                _row("assistant", MERGED_CARRIER),
+                {"role": "assistant", "content": "the controller is ready"},
+            ],
+            "final_response": "the controller is ready",
+        }
+
+        turn = APIServerAdapter._turn_transcript_messages(
+            [{"role": "user", "content": REAL_USER}],
+            REAL_USER,
+            result,
+        )
+
+        assert [message.get("content") for message in turn] == [
+            "checking the controller",
+            "Refactor complete.",
+            "the controller is ready",
+        ]
+
+
+class TestMessagesEndpointProjection:
+    @pytest.mark.asyncio
+    async def test_messages_endpoint_never_serves_compaction_scaffolding(
+        self,
+        adapter,
+        session_db,
+    ):
+        session_id = session_db.create_session("projection-session", "api_server")
+        session_db.replace_messages(
+            session_id,
+            [
+                _row("user", STANDALONE_SUMMARY),
+                _row("assistant", MERGED_CARRIER),
+                _row("user", REAL_USER),
+            ],
+        )
+
+        async with TestClient(TestServer(_messages_app(adapter))) as client:
+            response = await client.get(f"/api/sessions/{session_id}/messages")
+            assert response.status == 200
+            payload = await response.json()
+
+        messages = payload["data"]
+        assert len(messages) == 3
+        assert messages[0]["content"] == ""
+        assert messages[0]["display_kind"] == "hidden"
+        assert messages[1]["content"] == "Refactor complete."
+        assert messages[2]["content"] == REAL_USER
+        rendered = " ".join(str(message.get("content") or "") for message in messages)
+        assert "PRIOR CONTEXT" not in rendered
+        assert "CONTEXT COMPACTION" not in rendered

--- a/tests/gateway/test_api_server_compaction_projection.py
+++ b/tests/gateway/test_api_server_compaction_projection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from aiohttp.test_utils import TestClient, TestServer
 import pytest
 
+from agent.compaction_display import project_compaction_message_for_display
 from agent.context_compressor import (
     COMPRESSED_SUMMARY_METADATA_KEY,
     HISTORICAL_TASK_HEADING,
@@ -79,6 +80,9 @@ class TestMessageProjection:
                 tool_calls=[{"id": "stale"}],
                 reasoning="internal compression reasoning",
                 reasoning_content="internal compression reasoning",
+                reasoning_details=[{"type": "reasoning.summary", "summary": "internal"}],
+                codex_reasoning_items=[{"type": "reasoning", "id": "internal"}],
+                codex_message_items=[{"type": "message", "id": "internal"}],
             )
         )
 
@@ -88,6 +92,9 @@ class TestMessageProjection:
         assert "finish_reason" not in projected
         assert "reasoning" not in projected
         assert "reasoning_content" not in projected
+        assert "reasoning_details" not in projected
+        assert "codex_reasoning_items" not in projected
+        assert "codex_message_items" not in projected
 
     def test_merged_carrier_preserves_only_real_prior_content(self):
         projected = APIServerAdapter._message_response(
@@ -125,11 +132,16 @@ class TestMessageProjection:
         assert projected["content"] == [{"type": "text", "text": REAL_USER}]
 
     def test_real_message_that_mentions_marker_text_is_untouched(self):
-        content = "please explain the string [CONTEXT COMPACTION] in this bug report"
-        projected = APIServerAdapter._message_response(_row("user", content))
+        message = _row(
+            "user",
+            "please explain the string [CONTEXT COMPACTION] in this bug report",
+            tool_calls=[{"id": "real"}],
+            reasoning="real provider payload",
+        )
+        projected = project_compaction_message_for_display(message)
 
-        assert projected["content"] == content
-        assert "display_kind" not in projected
+        assert projected == message
+        assert projected is not message
 
     def test_unrelated_hidden_message_is_not_reclassified_as_compaction(self):
         message = _row("assistant", "ordinary hidden control row", display_kind="hidden")

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -10,6 +10,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agent.context_compressor import (
+    HISTORICAL_TASK_HEADING,
+    SUMMARY_PREFIX,
+    _MERGED_PRIOR_CONTEXT_HEADER,
+    _MERGED_SUMMARY_DELIMITER,
+    _SUMMARY_END_MARKER,
+)
 from hermes_state import SessionDB
 from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
@@ -159,6 +166,67 @@ def _make_runner(session_db=None):
     runner._set_session_reasoning_override = MagicMock()
     runner._format_session_info = MagicMock(return_value="")
     return runner
+
+
+@pytest.mark.asyncio
+async def test_topic_restore_quote_never_exposes_compaction_scaffolding(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session(
+        session_id="restorable",
+        source="telegram",
+        user_id="208214988",
+    )
+    db.set_session_title("restorable", "Browser control")
+    db.append_message("restorable", "assistant", "real completed answer")
+    summary = (
+        f"{SUMMARY_PREFIX}\n\n"
+        f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+        f"{_SUMMARY_END_MARKER}"
+    )
+    db.append_message("restorable", "assistant", summary)
+    runner = _make_runner(session_db=db)
+
+    result = await runner._restore_telegram_topic_session(
+        _make_event("/topic restorable", thread_id="17585"),
+        "restorable",
+    )
+
+    assert "Last Hermes message:\nreal completed answer" in result
+    assert "CONTEXT COMPACTION" not in result
+    assert "Historical Task Snapshot" not in result
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_topic_restore_quote_unwraps_merged_assistant_carrier(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session(
+        session_id="restorable",
+        source="telegram",
+        user_id="208214988",
+    )
+    carrier = (
+        f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"
+        "real completed answer\n\n"
+        f"{_MERGED_SUMMARY_DELIMITER}\n\n"
+        f"{SUMMARY_PREFIX}\n\n"
+        f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+        f"{_SUMMARY_END_MARKER}"
+    )
+    db.append_message("restorable", "assistant", carrier)
+    runner = _make_runner(session_db=db)
+
+    result = await runner._restore_telegram_topic_session(
+        _make_event("/topic restorable", thread_id="17585"),
+        "restorable",
+    )
+
+    assert "Last Hermes message:\nreal completed answer" in result
+    assert "PRIOR CONTEXT" not in result
+    assert "CONTEXT COMPACTION" not in result
+    db.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_skill_previews.py
+++ b/tests/test_session_skill_previews.py
@@ -12,6 +12,14 @@ shaper directly, so the CASE expression and the Python side are covered together
 
 import pytest
 
+from agent.context_compressor import (
+    HISTORICAL_TASK_HEADING,
+    SUMMARY_PREFIX,
+    _HISTORICAL_SUMMARY_PREFIXES,
+    _MERGED_PRIOR_CONTEXT_HEADER,
+    _MERGED_SUMMARY_DELIMITER,
+    _SUMMARY_END_MARKER,
+)
 import agent.skill_commands as skill_commands
 import tools.skills_tool as skills_tool
 from hermes_state import SessionDB
@@ -80,8 +88,6 @@ class TestSkillPreview:
         (row,) = db.list_sessions_rich(limit=10)
         assert row["preview"] == "/work"
 
-
-
     def test_rewind_picker_shows_the_typed_instruction(
         self, db, tmp_path, monkeypatch
     ):
@@ -92,6 +98,92 @@ class TestSkillPreview:
         _seed(db, "s1", message)
         (entry,) = db.list_recent_user_messages("s1")
         assert entry["preview"] == "/work — fix the title leak"
+
+
+class TestCompactionPreview:
+    def test_literal_marker_text_is_still_a_real_user_preview(self, db):
+        message = "[CONTEXT COMPACTION — REFERENCE ONLY] what does this label mean?"
+        db.create_session(session_id="s1", source="cli", model="m")
+        db.append_message("s1", role="user", content=message)
+
+        (row,) = db.list_sessions_rich(limit=10)
+
+        assert row["preview"].startswith("[CONTEXT COMPACTION — REFERENCE ONLY]")
+        assert row["preview"] != ""
+
+    def test_pure_compaction_row_cannot_become_session_preview(self, db):
+        summary = (
+            f"{SUMMARY_PREFIX}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+            f"{_SUMMARY_END_MARKER}"
+        )
+        db.create_session(session_id="s1", source="cli", model="m")
+        db.append_message("s1", role="user", content=summary)
+        db.append_message("s1", role="user", content="test the browser controller")
+
+        (row,) = db.list_sessions_rich(limit=10)
+
+        assert row["preview"] == "test the browser controller"
+
+    def test_historical_compaction_row_cannot_become_session_preview(self, db):
+        summary = (
+            f"{_HISTORICAL_SUMMARY_PREFIXES[-1]}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+            f"{_SUMMARY_END_MARKER}\n\n"
+        )
+        db.create_session(session_id="s1", source="cli", model="m")
+        db.append_message("s1", role="user", content=summary)
+        db.append_message("s1", role="user", content="test the browser controller")
+
+        (row,) = db.list_sessions_rich(limit=10)
+
+        assert row["preview"] == "test the browser controller"
+
+    def test_force_user_leading_compaction_preview_preserves_live_ask(self, db):
+        carrier = (
+            f"{SUMMARY_PREFIX}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+            f"{_SUMMARY_END_MARKER}\n\n"
+            "test the browser controller"
+        )
+        db.create_session(session_id="s1", source="cli", model="m")
+        db.append_message("s1", role="user", content=carrier)
+
+        (row,) = db.list_sessions_rich(limit=10)
+
+        assert row["preview"] == "test the browser controller"
+
+    def test_merged_compaction_preview_preserves_prior_user_content(self, db):
+        carrier = (
+            f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"
+            "test the browser controller\n\n"
+            f"{_MERGED_SUMMARY_DELIMITER}\n\n"
+            f"{SUMMARY_PREFIX}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+            f"{_SUMMARY_END_MARKER}"
+        )
+        db.create_session(session_id="s1", source="cli", model="m")
+        db.append_message("s1", role="user", content=carrier)
+
+        (row,) = db.list_sessions_rich(limit=10)
+
+        assert row["preview"] == "test the browser controller"
+
+    def test_empty_merged_carrier_does_not_block_later_user_preview(self, db):
+        carrier = (
+            f"{_MERGED_PRIOR_CONTEXT_HEADER}\n\n"
+            f"{_MERGED_SUMMARY_DELIMITER}\n\n"
+            f"{SUMMARY_PREFIX}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+            f"{_SUMMARY_END_MARKER}"
+        )
+        db.create_session(session_id="s1", source="cli", model="m")
+        db.append_message("s1", role="user", content=carrier)
+        db.append_message("s1", role="user", content="test the browser controller")
+
+        (row,) = db.list_sessions_rich(limit=10)
+
+        assert row["preview"] == "test the browser controller"
 
 
 class TestSkillScaffoldedSessionLookup:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2582,6 +2582,83 @@ def test_history_to_messages_preserves_tool_calls_for_resume_display():
     ]
 
 
+def test_history_to_messages_drops_pure_compaction_scaffolding():
+    from agent.context_compressor import (
+        HISTORICAL_TASK_HEADING,
+        SUMMARY_PREFIX,
+        _SUMMARY_END_MARKER,
+    )
+
+    summary = (
+        f"{SUMMARY_PREFIX}\n\n"
+        f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+        f"{_SUMMARY_END_MARKER}"
+    )
+
+    assert server._history_to_messages(
+        [
+            {"role": "user", "content": summary},
+            {"role": "assistant", "content": "real answer"},
+        ]
+    ) == [{"role": "assistant", "text": "real answer"}]
+
+
+def test_history_to_messages_preserves_live_ask_without_compaction_scaffolding():
+    from agent.context_compressor import (
+        HISTORICAL_TASK_HEADING,
+        SUMMARY_PREFIX,
+        _SUMMARY_END_MARKER,
+    )
+
+    carrier = (
+        f"{SUMMARY_PREFIX}\n\n"
+        f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+        f"{_SUMMARY_END_MARKER}\n\n"
+        "test the browser controller"
+    )
+
+    assert server._history_to_messages(
+        [
+            {
+                "role": "user",
+                "content": carrier,
+                "tool_calls": [{"id": "stale"}],
+                "reasoning": "internal compaction reasoning",
+            }
+        ]
+    ) == [{"role": "user", "text": "test the browser controller"}]
+
+
+def test_history_to_messages_unwraps_merged_assistant_carrier():
+    from agent.context_compressor import (
+        HISTORICAL_TASK_HEADING,
+        SUMMARY_PREFIX,
+        _MERGED_PRIOR_CONTEXT_HEADER,
+        _MERGED_SUMMARY_DELIMITER,
+        _SUMMARY_END_MARKER,
+    )
+
+    carrier = (
+        f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"
+        "real completed answer\n\n"
+        f"{_MERGED_SUMMARY_DELIMITER}\n\n"
+        f"{SUMMARY_PREFIX}\n\n"
+        f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+        f"{_SUMMARY_END_MARKER}"
+    )
+
+    assert server._history_to_messages(
+        [
+            {
+                "role": "assistant",
+                "content": carrier,
+                "tool_calls": [{"id": "stale"}],
+                "reasoning_details": [{"summary": "internal"}],
+            }
+        ]
+    ) == [{"role": "assistant", "text": "real completed answer"}]
+
+
 def test_history_to_messages_ships_full_tool_args():
     # This is the display projection. `context` is an 80-char preview for
     # collapsed row titles. A renderer that shows the full call (the expanded

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -35,6 +35,7 @@ from hermes_cli.env_loader import load_hermes_dotenv
 from utils import is_truthy_value
 from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
+from agent.compaction_display import project_compaction_message_for_display
 from agent.skill_commands import describe_skill_invocation
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from tui_gateway import git_probe
@@ -7647,6 +7648,9 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
 
     for m in history:
         if not isinstance(m, dict):
+            continue
+        m = project_compaction_message_for_display(m)
+        if m is None:
             continue
         role = m.get("role")
         if role not in {"user", "assistant", "tool", "system"}:


### PR DESCRIPTION
## What does this PR do?

Prevents model-only compaction scaffolding from leaking through client-visible Hermes surfaces while preserving authentic transcript content embedded in a carrier.

The model must retain compaction summaries for recovery. Client projections must not render those internal handoffs as ordinary chat, previews, or restore quotes.

This patch keeps model-facing recovery unchanged and applies one canonical display projection across the affected surfaces:

- `GET /api/sessions/{session_id}/messages`
- `run.completed.messages`
- TUI/Desktop history projection
- session-list and rich-row previews
- Telegram topic restore quotes

The projection:

- delegates recognition and unwrapping to the canonical compressor classifier
- renders standalone handoffs as empty `display_kind="hidden"` API rows so message identity and ordering remain reconcilable
- drops pure summaries from surfaces that do not require stable hidden rows
- unwraps merged carriers to their authentic pre-summary transcript content
- preserves a live user ask after the compaction end boundary
- removes inherited tool calls, finish state, reasoning fields, and Codex replay sidecars from projected carriers
- skips pure compaction rows when selecting session previews but preserves real content embedded in force-user-leading and merged carriers
- leaves ordinary messages and literal mentions of compaction marker text untouched

## Issue linkage

- Complements #85394, which prevents a completed reference carrier from driving another model turn
- Addresses the separate user-visible transcript boundary in #42768

## Tests

The initial projection regressions were RED on current upstream `main` with `6 failed, 5 passed` across session history and `run.completed.messages`.

The hardened branch now has:

- `856 passed, 3 deselected` across the affected gateway, session, Telegram, TUI/Desktop, preview, and state suites
- `ruff` clean
- `compileall` clean
- `git diff --check` clean
- added-diff secret scan clean
- fresh import smoke for all touched modules clean
- GitNexus change analysis completed

The three deselected tests reproduce unchanged on a clean current-main worktree:

- two stale TUI toolset assertions omit the separately shipped `desktop_ui` default
- one FTS trace-count assertion observes no traced context query even though context is returned

## Checklist

- [x] I have read the contributing guidelines
- [x] This PR targets current `main`
- [x] Relevant affected suites pass locally
- [x] No dependencies added
- [x] Model-facing compaction recovery remains unchanged
- [x] Client-visible compaction scaffolding is covered across API, TUI/Desktop, previews, and Telegram restore
