### PR TITLE
fix(model_metadata): never fuzzy-match an empty model name against endpoint catalogs

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1399,7 +1399,12 @@ def _resolve_endpoint_context_length(
     if not matched:
         if len(endpoint_metadata) == 1:
             matched = next(iter(endpoint_metadata.values()))
-        else:
+        elif model:
+            # Substring fuzzy match — only meaningful with a non-empty model
+            # name.  An empty string is a substring of EVERY key, which would
+            # "match" whatever model the endpoint happens to list first (e.g.
+            # a 32K embedding model on the Nous portal) and poison the
+            # resolved context length for the whole agent.
             for key, entry in endpoint_metadata.items():
                 if model in key or key in model:
                     matched = entry

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -592,6 +592,30 @@ class TestNousPortalContextResolution:
 
 
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_empty_model_never_fuzzy_matches_endpoint_catalog(self, mock_fetch):
+        """An empty model name must not substring-match arbitrary catalog
+        entries — '' is a substring of every key, so pre-fix it "matched"
+        whatever the endpoint listed first (e.g. a 32K embedding model on
+        the Nous portal) and poisoned the resolved context length."""
+        import agent.model_metadata as mm
+        mock_fetch.return_value = {
+            "voyageai/voyage-code-4": {"context_length": 32_000},
+            "x-ai/grok-4.6": {"context_length": 500_000},
+        }
+        assert mm._resolve_endpoint_context_length(
+            "", "https://inference-api.nousresearch.com/v1"
+        ) is None
+        # Non-empty names still fuzzy-match.
+        assert mm._resolve_endpoint_context_length(
+            "grok-4.6", "https://inference-api.nousresearch.com/v1"
+        ) == 500_000
+        # Single-model endpoints still resolve even with an empty name.
+        mock_fetch.return_value = {"only-model": {"context_length": 131_072}}
+        assert mm._resolve_endpoint_context_length(
+            "", "http://localhost:8080/v1"
+        ) == 131_072
+
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
     @patch("agent.model_metadata.fetch_model_metadata")
     def test_openrouter_fallback_is_not_persisted(
         self, mock_or, mock_portal, tmp_path, monkeypatch


### PR DESCRIPTION
## Summary
CI slice 7/12 is red on every PR right now: `test_allowed_for_nous_anthropic_messages` fails because an empty model name fuzzy-matches the FIRST entry of the Nous portal's live /v1/models catalog — currently a 32K embedding model — and AIAgent init then rejects the 32K window as below the 64K minimum. `""` is a substring of every key, so the substring match in `_resolve_endpoint_context_length()` matched everything; the fix gates fuzzy matching on a non-empty model name.

Not a code regression: reproduces identically on origin/main 25 commits back — the portal catalog reordering is what flipped it.

## Changes
- `agent/model_metadata.py`: `_resolve_endpoint_context_length()` skips substring fuzzy-match when `model` is empty. Single-model endpoints still resolve with an empty name (unambiguous); non-empty names unchanged.
- `tests/agent/test_model_metadata.py`: regression test — empty name resolves to None against multi-model catalogs, non-empty still matches, single-model endpoints still resolve.

## Validation
| | Before | After |
|---|---|---|
| `test_primary_runtime_restore.py` | 1 failed (live portal hit) | 24/24 pass |
| `test_model_metadata.py` | n/a | 68/68 pass (incl. new regression test) |

## Infographic

![Empty model name matches everything — endpoint catalog fuzzy-match fix](https://files.catbox.moe/a0q1hj.png)
