### PR TITLE
fix(gateway): expire same-epoch orphaned drain markers past a max-age (#85433)

### DIFF
--- a/gateway/drain_control.py
+++ b/gateway/drain_control.py
@@ -63,6 +63,21 @@ _log = logging.getLogger(__name__)
 
 _DRAIN_REQUEST_FILENAME = ".drain_request.json"
 
+# Max-age fallback for a *same-epoch* orphan (#85433). The epoch check only
+# catches a marker that outlived a machine restart; it cannot catch a marker
+# orphaned WITHOUT a restart (a maintenance action that finishes and whose
+# writer never clears the marker, e.g. a crash between "action done" and
+# "cancel drain"). Then the epoch still matches and the watcher honours the
+# orphan forever. Drain-gated lifecycle actions (auto-update / image migrate /
+# env edit / profile change) complete in minutes, so a marker whose
+# ``requested_at`` is older than this generous bound is treated as stale —
+# mirroring the neighbouring ``.restart_notify.json`` marker, which
+# ``gateway/run.py`` already guards with a ``requested_at`` staleness check so a
+# legitimately old marker cannot swallow a fresh action. A deliberately long
+# drain keeps itself alive by re-writing the marker (see
+# :func:`write_drain_request`, documented idempotent), which refreshes the stamp.
+_DRAIN_MARKER_MAX_AGE_SECONDS = 60 * 60  # 60 minutes
+
 
 @functools.lru_cache(maxsize=1)
 def current_instantiation_epoch() -> str:
@@ -207,6 +222,56 @@ def _marker_epoch_is_stale(body: dict[str, Any]) -> bool:
     return marker_epoch != current
 
 
+@functools.lru_cache(maxsize=32)
+def _warn_marker_age_stale(requested_at_iso: str) -> None:
+    """Log the orphaned-marker warning at most once per ``requested_at`` value.
+
+    The 1s drain watcher calls the reader every tick; memoising on the marker's
+    timestamp keeps a single WARNING per distinct orphan instead of one per
+    second while the file still sits on disk.
+    """
+    _log.warning(
+        "drain-control: ignoring drain marker stamped %s — its requested_at is "
+        "older than the %ds max-age, so it is almost certainly an orphan whose "
+        "writer never cleared it (#85433). Re-write the marker to keep a "
+        "deliberately long drain alive.",
+        requested_at_iso,
+        _DRAIN_MARKER_MAX_AGE_SECONDS,
+    )
+
+
+def _marker_age_is_stale(body: dict[str, Any]) -> bool:
+    """True iff the marker's ``requested_at`` is older than the max-age bound.
+
+    Lenient in the same spirit as :func:`_marker_epoch_is_stale`: a marker with
+    no ``requested_at``, a non-string one, or an unparseable timestamp returns
+    False (honour it), preserving the fail-safe-toward-quiescing contract for
+    legacy/corrupt markers. Only a present, parseable timestamp that is
+    definitively older than :data:`_DRAIN_MARKER_MAX_AGE_SECONDS` reads as stale
+    (#85433). A naive (tz-less) timestamp is assumed UTC, matching the writer.
+    """
+    raw = body.get("requested_at")
+    if not isinstance(raw, str) or not raw:
+        return False
+    try:
+        requested = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if requested.tzinfo is None:
+        requested = requested.replace(tzinfo=timezone.utc)
+    age = (datetime.now(timezone.utc) - requested).total_seconds()
+    if age > _DRAIN_MARKER_MAX_AGE_SECONDS:
+        _warn_marker_age_stale(raw)
+        return True
+    return False
+
+
+def _marker_is_inactive(body: dict[str, Any]) -> bool:
+    """True iff the marker should be ignored — a prior-instantiation epoch
+    (NS-570) or a same-epoch orphan past its max-age (#85433)."""
+    return _marker_epoch_is_stale(body) or _marker_age_is_stale(body)
+
+
 def drain_requested(*, home: Optional[Path] = None) -> bool:
     """True iff a begin-drain marker for THIS instantiation is present.
 
@@ -214,14 +279,17 @@ def drain_requested(*, home: Optional[Path] = None) -> bool:
     treated as absent: it survived a container/VM restart (HERMES_HOME is a
     durable Fly volume on Hermes Cloud) and the lifecycle action that triggered
     the drain has already completed — honouring it would wedge the
-    freshly-restarted gateway in ``draining`` (NS-570). The staleness check is
-    lenient (see :func:`_marker_epoch_is_stale`): a legacy/corrupt marker with
-    no epoch, or an environment without ``/proc``, still reads as drain-active.
+    freshly-restarted gateway in ``draining`` (NS-570). A same-epoch marker
+    whose ``requested_at`` is older than :data:`_DRAIN_MARKER_MAX_AGE_SECONDS`
+    is likewise treated as an orphan and read as absent (#85433). Both checks
+    are lenient (see :func:`_marker_epoch_is_stale` / :func:`_marker_age_is_stale`):
+    a legacy/corrupt marker with no epoch, an environment without ``/proc``, or a
+    marker with no/unparseable ``requested_at`` still reads as drain-active.
     """
     body = read_drain_request(home=home)
     if body is None:
         return False
-    if _marker_epoch_is_stale(body):
+    if _marker_is_inactive(body):
         return False
     return True
 
@@ -229,12 +297,12 @@ def drain_requested(*, home: Optional[Path] = None) -> bool:
 def drain_notification_suppressed(*, home: Optional[Path] = None) -> bool:
     """True iff an ACTIVE drain marker asks to suppress the shutdown broadcast.
 
-    "Active" means exactly what :func:`drain_requested` means — a marker present
-    AND stamped with the current instantiation epoch. A stale (other-epoch)
-    marker that survived a machine restart on the durable HERMES_HOME volume is
-    ignored here just as it is for drain state (NS-570): we must never let an
-    orphaned marker's flag silence a *fresh* gateway's legitimate shutdown
-    broadcast.
+    "Active" means exactly what :func:`drain_requested` means — a marker present,
+    stamped with the current instantiation epoch, AND within the max-age bound.
+    A stale marker (other-epoch survivor of a machine restart, NS-570, or a
+    same-epoch orphan past its max-age, #85433) is ignored here just as it is for
+    drain state: we must never let an orphaned marker's flag silence a *fresh*
+    gateway's legitimate shutdown broadcast.
 
     Only honours the flag when it is explicitly truthy in the marker body. A
     legacy marker without the field, a corrupt/contentless ``{}`` body, or an
@@ -246,7 +314,7 @@ def drain_notification_suppressed(*, home: Optional[Path] = None) -> bool:
     body = read_drain_request(home=home)
     if body is None:
         return False
-    if _marker_epoch_is_stale(body):
+    if _marker_is_inactive(body):
         return False
     return bool(body.get("suppress_notification"))
 

--- a/tests/gateway/test_external_drain_control.py
+++ b/tests/gateway/test_external_drain_control.py
@@ -12,6 +12,7 @@ Q-B, exercises a real `hermes gateway run`); these lock the unit contract.
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -119,6 +120,92 @@ class TestInstantiationEpoch:
             assert dc.current_instantiation_epoch() == ""
         finally:
             dc.current_instantiation_epoch.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# requested_at max-age fallback (#85433: same-epoch orphan with no restart)
+# ---------------------------------------------------------------------------
+
+
+def _restamp_requested_at(iso: str, *, home) -> None:
+    """Rewrite the on-disk marker's requested_at, preserving the live epoch."""
+    body = dc.read_drain_request(home=home)
+    assert body is not None
+    body["requested_at"] = iso
+    from utils import atomic_json_write
+
+    atomic_json_write(dc.drain_request_path(home), body)
+
+
+class TestRequestedAtMaxAge:
+    def setup_method(self):
+        dc._warn_marker_age_stale.cache_clear()
+
+    def test_fresh_marker_stays_active(self, home):
+        # A just-written marker (requested_at ≈ now, same epoch) is honoured.
+        dc.write_drain_request(principal="nas")
+        assert dc.drain_requested() is True
+
+    def test_same_epoch_orphan_past_max_age_reads_as_absent(self, home):
+        # THE #85433 REGRESSION. The marker keeps the CURRENT epoch (no restart
+        # happened, so NS-570 cannot catch it), but its requested_at is old:
+        # the maintenance action finished and its writer never cleared it.
+        dc.write_drain_request(principal="nas")
+        assert dc.drain_requested() is True  # epoch matches, fresh → active
+
+        stale = datetime.now(timezone.utc) - timedelta(
+            seconds=dc._DRAIN_MARKER_MAX_AGE_SECONDS + 60
+        )
+        _restamp_requested_at(stale.isoformat(), home=home)
+
+        # Same-epoch marker still physically present…
+        assert dc.drain_request_path(home).exists() is True
+        # …but ignored because it aged out (orphan defence).
+        assert dc.drain_requested() is False
+
+    def test_marker_just_within_max_age_stays_active(self, home):
+        dc.write_drain_request(principal="nas")
+        recent = datetime.now(timezone.utc) - timedelta(
+            seconds=dc._DRAIN_MARKER_MAX_AGE_SECONDS - 120
+        )
+        _restamp_requested_at(recent.isoformat(), home=home)
+        assert dc.drain_requested() is True
+
+    def test_missing_requested_at_stays_active(self, home):
+        # Fail-safe leniency: a marker with no requested_at is still honoured.
+        dc.write_drain_request(principal="nas")
+        body = dc.read_drain_request(home=home)
+        body.pop("requested_at", None)
+        from utils import atomic_json_write
+
+        atomic_json_write(dc.drain_request_path(home), body)
+        assert dc.drain_requested() is True
+
+    def test_unparseable_requested_at_stays_active(self, home):
+        dc.write_drain_request(principal="nas")
+        _restamp_requested_at("not-a-timestamp", home=home)
+        assert dc.drain_requested() is True
+
+    def test_naive_timestamp_is_treated_as_utc(self, home):
+        # Writer emits tz-aware UTC; a naive stamp (no offset) must still be
+        # comparable rather than raising — assume UTC.
+        dc.write_drain_request(principal="nas")
+        stale_naive = (
+            datetime.now(timezone.utc)
+            - timedelta(seconds=dc._DRAIN_MARKER_MAX_AGE_SECONDS + 60)
+        ).replace(tzinfo=None)
+        _restamp_requested_at(stale_naive.isoformat(), home=home)
+        assert dc.drain_requested() is False
+
+    def test_suppress_notification_ignored_on_aged_orphan(self, home):
+        # An aged-out orphan must not silence a fresh gateway's shutdown ping.
+        dc.write_drain_request(principal="nas", suppress_notification=True)
+        assert dc.drain_notification_suppressed() is True
+        stale = datetime.now(timezone.utc) - timedelta(
+            seconds=dc._DRAIN_MARKER_MAX_AGE_SECONDS + 60
+        )
+        _restamp_requested_at(stale.isoformat(), home=home)
+        assert dc.drain_notification_suppressed() is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes #85433: a `.drain_request.json` marker orphaned **without a machine restart** wedges the gateway in `draining` forever — every inbound message on every platform is bounced with *"⏳ This agent is draining for a maintenance action…"* until someone removes the marker by hand.

## Root cause

The NS-570 fix (PR #53050) stamps the marker with an instantiation epoch, so a marker that survives a **machine restart** on the durable `HERMES_HOME` volume is recognised as stale. But that defence rests on the assumption that every drain-gated lifecycle action restarts the machine. When a maintenance action finishes **without** recreating the container and its writer never clears the marker (e.g. a crash between "action done" and "cancel drain"), the epoch still matches, `_marker_epoch_is_stale()` correctly returns `False`, and the 1s watcher honours the orphan indefinitely. In the reported incident a Hermes Cloud instance bounced every Telegram message for ~3 days.

The marker already carries `requested_at`, but no reader ever consulted it — there was no TTL/max-age fallback, so a same-epoch orphan had unbounded lifetime.

## The fix

Add a lenient max-age fallback (`_DRAIN_MARKER_MAX_AGE_SECONDS = 60 min`) alongside the epoch check, consumed by both `drain_requested()` and `drain_notification_suppressed()` via a shared `_marker_is_inactive()`:

- a marker whose `requested_at` is present, parseable, and older than the bound reads as **stale**, with a once-per-marker warning log (memoised so the 1s watcher doesn't spam);
- a marker with **no** `requested_at`, a non-string one, or an unparseable one **stays honoured** — the same fail-safe-toward-quiescing leniency the epoch check already uses for legacy/corrupt markers;
- a naive (tz-less) timestamp is assumed UTC, matching the writer;
- a deliberately long drain keeps a sanctioned keep-alive: `write_drain_request()` is documented idempotent, and re-writing refreshes `requested_at`.

60 min is deliberately generous — drain-gated actions (auto-update / image migrate / env edit / profile change) complete in minutes. This mirrors the `requested_at` staleness guard the neighbouring `.restart_notify.json` marker already applies in `gateway/run.py`, precisely so "a legitimately old marker should not swallow a fresh action."

The writer-side clean-up (the cloud control plane clearing the marker in a `finally`) is out of scope for this repo, as the issue notes — the gateway should defend itself regardless, since any writer crash reproduces this.

## Tests

`tests/gateway/test_external_drain_control.py::TestRequestedAtMaxAge` — the same-epoch aged-out orphan reading as absent (the regression), a just-within-bound marker staying active, missing/unparseable `requested_at` staying active (leniency), naive-timestamp handling, and an aged orphan no longer suppressing the shutdown broadcast. Full `test_external_drain_control.py` and the neighbouring drain suites pass locally; ruff + windows-footgun gates clean.

Fixes #85433
