### PR TITLE
fix(gateway): pin active-session lease to its acquire-time registry (#85431)

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -261,6 +261,14 @@ class ActiveSessionLease:
     surface: str
     enabled: bool = True
     released: bool = False
+    # Registry + lock paths resolved at acquire time. A lease is created against
+    # the root HERMES_HOME, but release/transfer may run inside a named-profile
+    # scope (``_profile_runtime_scope``) where ``get_hermes_home()`` points at
+    # the profile — re-resolving there would look in the wrong registry and leak
+    # the slot (#85431). Pinning the paths keeps release/transfer on the same
+    # registry the lease was written to. ``None`` for a disabled/no-op lease.
+    state_path: Optional[Path] = None
+    lock_path: Optional[Path] = None
 
     def release(self) -> None:
         if self.released or not self.enabled:
@@ -306,7 +314,8 @@ def try_acquire_active_session(
         }
 
     state_path = _state_path()
-    with _FileLock(_lock_path()):
+    lock_path = _lock_path()
+    with _FileLock(lock_path):
         raw_entries = _read_entries(state_path)
         entries = _prune_dead(raw_entries)
         pruned = len(raw_entries) - len(entries)
@@ -331,13 +340,18 @@ def try_acquire_active_session(
         lease_id=lease_id,
         session_id=str(session_id),
         surface=str(surface),
+        state_path=state_path,
+        lock_path=lock_path,
     ), None
 
 
 def release_active_session(lease: ActiveSessionLease) -> None:
-    state_path = _state_path()
+    # Use the registry the lease was acquired against, not whatever HERMES_HOME
+    # is current now — release can run inside a named-profile scope (#85431).
+    state_path = lease.state_path or _state_path()
+    lock_path = lease.lock_path or _lock_path()
     try:
-        with _FileLock(_lock_path()):
+        with _FileLock(lock_path):
             entries = _prune_dead(_read_entries(state_path))
             kept = [
                 entry
@@ -366,8 +380,10 @@ def transfer_active_session(
         lease.session_id = new_session_id
         return True
 
-    state_path = _state_path()
-    with _FileLock(_lock_path()):
+    # Pinned to the acquire-time registry for the same reason as release (#85431).
+    state_path = lease.state_path or _state_path()
+    lock_path = lease.lock_path or _lock_path()
+    with _FileLock(lock_path):
         entries = _prune_dead(_read_entries(state_path))
         updated = False
         for entry in entries:

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -46,6 +46,86 @@ def test_resolve_max_concurrent_sessions_values(caplog):
 
 
 
+def test_release_under_named_profile_scope_frees_the_root_slot(tmp_path, monkeypatch):
+    """#85431: a lease acquired against the root HERMES_HOME must release from
+    that same registry even when release runs inside a named-profile scope.
+
+    In a native multiplex gateway the cleanup path calls release() inside
+    ``_profile_runtime_scope(profile_home)``; before the fix, release re-resolved
+    the registry from the (profile) HERMES_HOME, left the root entry alive, and
+    the slot leaked until the gateway restarted."""
+    import json
+
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    lease, error = active_sessions.try_acquire_active_session(
+        session_id="agent:worker:telegram:dm:synthetic",
+        surface="gateway:telegram",
+        config={"max_concurrent_sessions": 2},
+    )
+    assert lease is not None and error is None
+    root_registry = root / "runtime" / "active_sessions.json"
+    assert len(json.loads(root_registry.read_text(encoding="utf-8"))["entries"]) == 1
+
+    # Release while a named-profile scope is active — get_hermes_home() now
+    # points at the profile, not the root the lease was written to.
+    token = set_hermes_home_override(str(profile))
+    try:
+        lease.release()
+    finally:
+        reset_hermes_home_override(token)
+
+    assert lease.released is True
+    # The root entry is gone (slot freed) and no stray profile registry leaked.
+    assert json.loads(root_registry.read_text(encoding="utf-8"))["entries"] == []
+    assert not (profile / "runtime" / "active_sessions.json").exists()
+
+
+def test_transfer_under_named_profile_scope_updates_the_root_registry(tmp_path, monkeypatch):
+    """transfer_active_session shares release's acquire-time registry pinning."""
+    import json
+
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    root = tmp_path / "hermes"
+    profile = root / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    lease, error = active_sessions.try_acquire_active_session(
+        session_id="agent:worker:telegram:dm:old",
+        surface="gateway:telegram",
+        config={"max_concurrent_sessions": 2},
+    )
+    assert lease is not None and error is None
+    root_registry = root / "runtime" / "active_sessions.json"
+
+    token = set_hermes_home_override(str(profile))
+    try:
+        ok = active_sessions.transfer_active_session(
+            lease, session_id="agent:worker:telegram:dm:new"
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    assert ok is True
+    entries = json.loads(root_registry.read_text(encoding="utf-8"))["entries"]
+    assert len(entries) == 1
+    assert entries[0]["session_id"] == "agent:worker:telegram:dm:new"
+    assert not (profile / "runtime" / "active_sessions.json").exists()
+
+
 def test_cross_process_acquire_claims_only_one_last_slot(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     monkeypatch.setenv("HERMES_HOME", str(home))


### PR DESCRIPTION
## What does this PR do?

Fixes #85431: in a native multiplex gateway, an active-session lease routed to a named profile leaks its slot on release, so after `max_concurrent_sessions` routed turns every new session is rejected — *"Hermes is at the active session limit (N/N)"* — even though no agent turn is running.

## Root cause

`try_acquire_active_session()` writes the lease entry to the registry resolved from the **root** `HERMES_HOME`. But `release_active_session()` and `transfer_active_session()` re-resolved `_state_path()` / `_lock_path()` from the *current* `HERMES_HOME`. A turn routed to a named profile runs under `_profile_runtime_scope(profile_home)`, and the agent cleanup path calls `release()` inside that scope — so the release looked under `…/profiles/<name>/runtime/active_sessions.json` instead of the root registry where the lease was created. The root entry survived (its `pid` is the still-running gateway, so pruning keeps it), the in-memory lease was marked `released=True`, and the slot was never reclaimed.

The issue's deterministic repro (temp dir, no credentials) reproduces it with Hermes' own profile-override and active-session primitives.

## The fix

Pin the registry to acquire time. `ActiveSessionLease` gains `state_path` / `lock_path`, set when the lease is created; `release_active_session()` and `transfer_active_session()` use those pinned paths (falling back to the live resolver only for a disabled/no-op lease). Release/transfer therefore always act on the registry the lease was written to, regardless of the `HERMES_HOME` scope active at cleanup.

## Tests

`tests/hermes_cli/test_active_sessions.py`:
- `test_release_under_named_profile_scope_frees_the_root_slot` — the issue's exact scenario: acquire against root, release inside a `set_hermes_home_override(profile)` scope, assert the root slot is freed and no stray profile registry was written. Verified failing before the fix, passing after.
- `test_transfer_under_named_profile_scope_updates_the_root_registry` — the same pinning for `transfer_active_session()`.

Affected-test, ruff, and windows-footgun gates pass locally.

Fixes #85431
