### PR TITLE
fix(honcho): isolate clients per profile, resolve baseUrl/apiKey, enforce saveMessages containment

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -559,8 +559,13 @@ class MemoryManager:
             except Exception as exc:  # pragma: no cover - re-raised by caller
                 error_box["value"] = exc
 
+        # Propagate the caller's contextvars (profile HERMES_HOME override)
+        # to the prefetch thread — see _submit_background.
+        import contextvars
+
+        _ctx = contextvars.copy_context()
         thread = threading.Thread(
-            target=_run,
+            target=lambda: _ctx.run(_run),
             daemon=True,
             name=f"memory-prefetch-{provider.name}",
         )
@@ -696,7 +701,19 @@ class MemoryManager:
     # -- Background dispatch -------------------------------------------------
 
     def _submit_background(self, fn, *, kind: str = "write") -> None:
-        """Queue ``fn`` on the serialized worker and track its durability class."""
+        """Queue ``fn`` on the serialized worker and track its durability class.
+
+        The submitted callable is wrapped with the CALLER's contextvars:
+        profile isolation in multi-profile processes (gateway multiplexer,
+        dashboard, cron) is a ContextVar-scoped HERMES_HOME override, and
+        executor worker threads start with empty contexts — without the
+        wrap, a provider resolving ambient state (config paths, secrets)
+        from the worker would silently land on the default profile.
+        """
+        import contextvars
+
+        ctx = contextvars.copy_context()
+        fn = (lambda inner: (lambda: ctx.run(inner)))(fn)
         executor = self._get_sync_executor()
         if executor is None:
             if self._shutting_down:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -562,10 +562,10 @@ class MemoryManager:
         # Propagate the caller's contextvars (profile HERMES_HOME override)
         # to the prefetch thread — see _submit_background.
         import contextvars
+        from functools import partial
 
-        _ctx = contextvars.copy_context()
         thread = threading.Thread(
-            target=lambda: _ctx.run(_run),
+            target=partial(contextvars.copy_context().run, _run),
             daemon=True,
             name=f"memory-prefetch-{provider.name}",
         )
@@ -711,9 +711,10 @@ class MemoryManager:
         from the worker would silently land on the default profile.
         """
         import contextvars
+        from functools import partial
 
         ctx = contextvars.copy_context()
-        fn = (lambda inner: (lambda: ctx.run(inner)))(fn)
+        fn = partial(ctx.run, fn)
         executor = self._get_sync_executor()
         if executor is None:
             if self._shutting_down:

--- a/contributors/emails/carnie-bot@openclaw.local
+++ b/contributors/emails/carnie-bot@openclaw.local
@@ -1,0 +1,2 @@
+menhguin
+# agent bot from PR #82038

--- a/contributors/emails/daniel21436@hotmail.com
+++ b/contributors/emails/daniel21436@hotmail.com
@@ -1,0 +1,2 @@
+strzhao
+# PR #81214 adoption

--- a/contributors/emails/danielrpike9@gmail.com
+++ b/contributors/emails/danielrpike9@gmail.com
@@ -1,0 +1,2 @@
+Bartok9
+# PR #62757 adoption

--- a/contributors/emails/dillontownsel@gmail.com
+++ b/contributors/emails/dillontownsel@gmail.com
@@ -1,0 +1,2 @@
+dtownsel
+# PR #82130 adoption

--- a/contributors/emails/eri@plasticlabs.ai
+++ b/contributors/emails/eri@plasticlabs.ai
@@ -1,0 +1,2 @@
+erosika
+# PR author

--- a/contributors/emails/mohamed.origami@gmail.com
+++ b/contributors/emails/mohamed.origami@gmail.com
@@ -1,0 +1,2 @@
+Morad37
+# PR #37671 adoption

--- a/contributors/emails/rsherman@velocityinteractive.com
+++ b/contributors/emails/rsherman@velocityinteractive.com
@@ -1,0 +1,2 @@
+cfdude
+# PR #43803 adoption

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -215,7 +215,7 @@ Pick **[e]** at the prompt to set the three keys directly instead of going throu
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `writeFrequency` | string/int | `"async"` | `"async"` (background), `"turn"` (sync per turn), `"session"` (batch on end), or integer N (every N turns) |
-| `saveMessages` | bool | `true` | Persist messages to Honcho API |
+| `saveMessages` | bool | `true` | Persist messages to Honcho API. When `false`, all automatic writes are skipped — raw turns (`sync_turn`), conclusion mirroring (`on_memory_write`), and session-end/shutdown flushes — while read and tools paths stay fully functional. |
 
 ### Session Resolution
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1665,7 +1665,12 @@ class HonchoMemoryProvider(MemoryProvider):
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
-        # Flush any remaining messages
+        # Flush any remaining messages. Honors saveMessages: false — skip
+        # persistence, but the worker-thread joins above still run (cleanup
+        # is independent of persistence; placing the guard here rather than
+        # at the top avoids leaking _prefetch_thread/_sync_thread).
+        if not getattr(self._config, "save_messages", True):
+            return
         if self._manager and not (self._init_thread and self._init_thread.is_alive() and not self._session_initialized):
             try:
                 self._manager.flush_all()

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1449,7 +1449,10 @@ class HonchoMemoryProvider(MemoryProvider):
                 if clean_assistant_content:
                     for chunk in self._chunk_message(clean_assistant_content, msg_limit):
                         session.add_message("assistant", chunk)
-                self._manager._flush_session(session)
+                # Route through save() so writeFrequency is honored —
+                # _flush_session() directly bypassed "session"/N batching
+                # and flushed every turn regardless of config.
+                self._manager.save(session)
             except Exception as e:
                 logger.debug("Honcho sync_turn failed: %s", e)
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1672,15 +1672,26 @@ class HonchoMemoryProvider(MemoryProvider):
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
-        # Flush any remaining messages. Honors saveMessages: false — skip
-        # persistence, but the worker-thread joins above still run (cleanup
-        # is independent of persistence; placing the guard here rather than
-        # at the top avoids leaking _prefetch_thread/_sync_thread).
+        manager = self._manager
+        if manager and self._init_thread and self._init_thread.is_alive() and not self._session_initialized:
+            manager = None
+        # Honors saveMessages: false — skip persistence, but thread cleanup
+        # still runs: the session manager's async-writer thread must be
+        # joined either way so daemon threads aren't left blocked in httpx
+        # I/O during interpreter finalization.
         if not getattr(self._config, "save_messages", True):
+            if manager:
+                try:
+                    manager.stop_async_writer()
+                except Exception:
+                    pass
             return
-        if self._manager and not (self._init_thread and self._init_thread.is_alive() and not self._session_initialized):
+        if manager:
             try:
-                self._manager.flush_all()
+                # manager.shutdown() = flush_all() + join the async-writer
+                # thread. Previously only flush_all() ran here, leaving the
+                # writer thread alive at exit.
+                manager.shutdown()
             except Exception:
                 pass
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1496,8 +1496,8 @@ class HonchoMemoryProvider(MemoryProvider):
             except Exception as e:
                 logger.debug("Honcho memory mirror failed: %s", e)
 
-        t = spawn_context_thread(_write, name="honcho-memwrite")
-        t.start()
+        self._memwrite_thread = spawn_context_thread(_write, name="honcho-memwrite")
+        self._memwrite_thread.start()
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Flush all pending messages to Honcho on session end."""
@@ -1672,7 +1672,7 @@ class HonchoMemoryProvider(MemoryProvider):
             return tool_error(f"Honcho {tool_name} failed: {e}")
 
     def shutdown(self) -> None:
-        for t in (self._prefetch_thread, self._sync_thread):
+        for t in (self._prefetch_thread, self._sync_thread, getattr(self, "_memwrite_thread", None)):
             if t and t.is_alive():
                 t.join(timeout=5.0)
         manager = self._manager

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -24,6 +24,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from agent.memory_manager import sanitize_context
 from agent.memory_provider import TRIVIAL_PROMPT_RE, MemoryProvider, is_trivial_prompt
+from plugins.memory.honcho.client import spawn_context_thread
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -467,9 +468,8 @@ class HonchoMemoryProvider(MemoryProvider):
                     self._manager = None
                     logger.warning("Honcho background session init failed: %s", e)
 
-            self._init_thread = threading.Thread(
-                target=_run,
-                daemon=True,
+            self._init_thread = spawn_context_thread(
+                _run,
                 name="honcho-session-init",
             )
             self._init_thread.start()
@@ -546,9 +546,8 @@ class HonchoMemoryProvider(MemoryProvider):
                         self._dialectic_empty_streak += 1
 
                 self._prefetch_thread_started_at = time.monotonic()
-                prewarm_thread = threading.Thread(
-                    target=_prewarm_dialectic,
-                    daemon=True,
+                prewarm_thread = spawn_context_thread(
+                    _prewarm_dialectic,
                     name="honcho-prewarm-dialectic",
                 )
                 prewarm_thread.start()
@@ -776,9 +775,7 @@ class HonchoMemoryProvider(MemoryProvider):
                     except Exception as e:
                         logger.debug("Honcho first-turn base context failed: %s", e)
 
-                _bt = threading.Thread(
-                    target=_fetch_base, daemon=True, name="honcho-base-first"
-                )
+                _bt = spawn_context_thread(_fetch_base, name="honcho-base-first")
                 _bt.start()
                 _base_wait = (
                     max(0.0, first_turn_base_deadline - time.monotonic())
@@ -853,8 +850,8 @@ class HonchoMemoryProvider(MemoryProvider):
                         self._dialectic_empty_streak += 1
 
                 self._prefetch_thread_started_at = time.monotonic()
-                first_turn_thread = threading.Thread(
-                    target=_run_first_turn, daemon=True, name="honcho-prefetch-first"
+                first_turn_thread = spawn_context_thread(
+                    _run_first_turn, name="honcho-prefetch-first"
                 )
                 first_turn_thread.start()
                 self._prefetch_thread = first_turn_thread
@@ -1009,9 +1006,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 self._dialectic_empty_streak += 1
 
         self._prefetch_thread_started_at = time.monotonic()
-        prefetch_thread = threading.Thread(
-            target=_run, daemon=True, name="honcho-prefetch"
-        )
+        prefetch_thread = spawn_context_thread(_run, name="honcho-prefetch")
         prefetch_thread.start()
         self._prefetch_thread = prefetch_thread
 
@@ -1416,9 +1411,7 @@ class HonchoMemoryProvider(MemoryProvider):
 
         if self._sync_thread and self._sync_thread.is_alive():
             self._sync_thread.join(timeout=5.0)
-        self._sync_thread = threading.Thread(
-            target=_sync, daemon=True, name="honcho-sync"
-        )
+        self._sync_thread = spawn_context_thread(_sync, name="honcho-sync")
         self._sync_thread.start()
 
     def on_memory_write(
@@ -1451,7 +1444,7 @@ class HonchoMemoryProvider(MemoryProvider):
             except Exception as e:
                 logger.debug("Honcho memory mirror failed: %s", e)
 
-        t = threading.Thread(target=_write, daemon=True, name="honcho-memwrite")
+        t = spawn_context_thread(_write, name="honcho-memwrite")
         t.start()
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1527,13 +1527,31 @@ class HonchoMemoryProvider(MemoryProvider):
                     return tool_error("Missing required parameter: query")
                 peer = args.get("peer", "user")
                 reasoning_level = args.get("reasoning_level")
-                result = self._manager.dialectic_query(
-                    self._session_key, query,
-                    reasoning_level=reasoning_level,
-                    peer=peer,
-                    # Explicit reasoning bypasses the automatic-injection cap.
-                    apply_injection_cap=False,
-                )
+                try:
+                    result = self._manager.dialectic_query(
+                        self._session_key, query,
+                        reasoning_level=reasoning_level,
+                        peer=peer,
+                        # Explicit reasoning bypasses the automatic-injection cap.
+                        apply_injection_cap=False,
+                        # Explicit tool call: surface timeouts/server errors as
+                        # errors instead of collapsing them into "no result",
+                        # which is indistinguishable from an empty answer.
+                        raise_errors=True,
+                    )
+                except HonchoAuthError:
+                    # Let the outer dispatch's auth-specific handler render this.
+                    raise
+                except Exception as e:
+                    logger.warning("honcho_reasoning failed: %s", e)
+                    return tool_error(
+                        f"Honcho reasoning query failed ({e}). This is a backend "
+                        "error, not an empty result — the peer may still have "
+                        "relevant context. Slow dialectic calls at higher "
+                        "reasoning levels can exceed the configured timeout; "
+                        "consider a lower reasoning_level or raising the "
+                        "'timeout' value in honcho.json."
+                    )
                 # Update cadence tracker so auto-injection respects the gap after an explicit call
                 self._last_dialectic_turn = self._turn_count
                 return json.dumps({"result": result or "No result from Honcho."})

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -30,6 +30,30 @@ from tools.registry import tool_error
 logger = logging.getLogger(__name__)
 
 
+# Gateway-internal notifications can arrive through the same user-role channel
+# as genuine user messages. They are execution metadata, not conversation, and
+# must never become durable personal memory. Keep this deliberately anchored:
+# a human discussing one of these strings mid-message is still valid input.
+_INTERNAL_GATEWAY_TURN_RE = re.compile(
+    r"^\s*(?:"
+    r"\[ASYNC (?:DELEGATION )?(?:BATCH )?COMPLETE[^\]]*\]|"
+    r"\[CONTEXT COMPACTION[^\]]*\]|"
+    r"\[CONTEXT SUMMARY\]:?|"
+    r"\[PRIOR CONTEXT[^\]]*\]|"
+    r"\[Your active task list was preserved across context compression\]|"
+    r"\[IMPORTANT: Background process \d+ matched watch pattern[^\n]*|"
+    r"A background fan-out of \d+ subagent\(s\) you dispatched earlier has finished\.|"
+    r"A background subagent you dispatched earlier has finished\."
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _is_internal_gateway_turn(text: str) -> bool:
+    """Return True for machine-generated gateway/delegation notifications."""
+    return bool(_INTERNAL_GATEWAY_TURN_RE.match(text or ""))
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas (moved from tools/honcho_tools.py)
 # ---------------------------------------------------------------------------
@@ -1388,6 +1412,14 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if self._cron_skipped:
             return
+        # ``saveMessages`` is the operator's hard write gate. Previously it
+        # was parsed into HonchoClientConfig but never enforced here, so a
+        # cached hybrid provider kept writing even after containment was set.
+        if self._config and not getattr(self._config, "save_messages", True):
+            return
+        if _is_internal_gateway_turn(user_content):
+            logger.debug("Honcho sync skipped machine-generated gateway turn")
+            return
         if self._recall_mode == "tools" and not self._session_ready():
             return
         if not self._session_ready():
@@ -1397,6 +1429,8 @@ class HonchoMemoryProvider(MemoryProvider):
         msg_limit = self._config.message_max_chars if self._config else 25000
         clean_user_content = sanitize_context(user_content or "").strip()
         clean_assistant_content = sanitize_context(assistant_content or "").strip()
+        if not clean_user_content or not clean_assistant_content:
+            return
 
         def _sync():
             try:
@@ -1431,6 +1465,11 @@ class HonchoMemoryProvider(MemoryProvider):
         if action != "add" or target != "user" or not content:
             return
         if self._cron_skipped:
+            return
+        # ``saveMessages`` is the operator's hard write gate; the memory-tool
+        # mirror is an automatic Honcho mutation path and must respect it too,
+        # otherwise containment would only cover conversation turns.
+        if self._config and not getattr(self._config, "save_messages", True):
             return
         if self._recall_mode == "tools" and not self._session_ready():
             return

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1409,6 +1409,9 @@ class HonchoMemoryProvider(MemoryProvider):
 
         Messages exceeding the Honcho API limit (default 25k chars) are
         split into multiple messages with continuation markers.
+
+        Honors saveMessages: false — the provider then never persists raw
+        turns to Honcho (read/tools paths stay fully functional).
         """
         if self._cron_skipped:
             return
@@ -1489,6 +1492,8 @@ class HonchoMemoryProvider(MemoryProvider):
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Flush all pending messages to Honcho on session end."""
         if self._cron_skipped:
+            return
+        if not getattr(self._config, "save_messages", True):
             return
         if not self._manager:
             return

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1432,16 +1432,23 @@ class HonchoMemoryProvider(MemoryProvider):
         msg_limit = self._config.message_max_chars if self._config else 25000
         clean_user_content = sanitize_context(user_content or "").strip()
         clean_assistant_content = sanitize_context(assistant_content or "").strip()
-        if not clean_user_content or not clean_assistant_content:
+        # Skip only when the whole turn is empty. An interrupted or tool-only
+        # turn can legitimately have an empty assistant side; the user's
+        # message must still be persisted (the manager already drops
+        # empty-user turns upstream). Empty sides are skipped per-loop below
+        # so we never write empty-string messages either.
+        if not clean_user_content and not clean_assistant_content:
             return
 
         def _sync():
             try:
                 session = self._manager.get_or_create(self._session_key)
-                for chunk in self._chunk_message(clean_user_content, msg_limit):
-                    session.add_message("user", chunk)
-                for chunk in self._chunk_message(clean_assistant_content, msg_limit):
-                    session.add_message("assistant", chunk)
+                if clean_user_content:
+                    for chunk in self._chunk_message(clean_user_content, msg_limit):
+                        session.add_message("user", chunk)
+                if clean_assistant_content:
+                    for chunk in self._chunk_message(clean_assistant_content, msg_limit):
+                        session.add_message("assistant", chunk)
                 self._manager._flush_session(session)
             except Exception as e:
                 logger.debug("Honcho sync_turn failed: %s", e)

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -1110,8 +1110,11 @@ def _all_profile_host_configs() -> list[tuple[str, str, dict]]:
     for p in profiles:
         if p.name == "default":
             continue
-        h = f"{HOST}.{p.name}"
-        results.append((p.name, h, hosts.get(h, {})))
+        h = profile_host_key(p.name)
+        # _host_block (not hosts.get) so legacy dot-form keys
+        # ("hermes.work") stay readable per the README's back-compat
+        # promise — the canonical key resolves first, legacy falls back.
+        results.append((p.name, h, _host_block(cfg, h)))
 
     return results
 

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -578,6 +578,23 @@ class HonchoClientConfig:
             or raw.get("apiKey")
             or get_secret("HONCHO_API_KEY")
         )
+        # Named-profile host blocks do NOT inherit the default host's apiKey —
+        # profiles are isolated islands by design (see resolve_active_host).
+        # But the failure mode is silent: the profile runs unauthenticated and
+        # every write 401s while tools report "no context". Warn loudly so the
+        # operator learns the key must be set on THIS host block (#36098, #66125).
+        if (
+            not api_key
+            and host_block
+            and resolved_host != HOST
+            and _host_block(raw, HOST).get("apiKey")
+        ):
+            logger.warning(
+                "Honcho host block '%s' has no apiKey; the default '%s' host's key "
+                "is NOT inherited (profiles are credential-isolated). Set apiKey on "
+                "hosts.%s in %s or this profile runs unauthenticated.",
+                resolved_host, HOST, resolved_host, path,
+            )
 
         environment = (
             host_block.get("environment")
@@ -1299,19 +1316,19 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
 
         # Local Honcho instances don't require an API key, but the SDK
         # expects a non-empty string.  Use a placeholder for local URLs.
-        # For local: only use config.api_key if the host block explicitly
-        # sets apiKey (meaning the user wants local auth). Otherwise skip
-        # the stored key -- it's likely a cloud key that would break local.
+        # For local: honor config.api_key when the user set it EXPLICITLY in
+        # honcho.json — host block or top-level (#36098 issue 2: the top-level
+        # key was dropped for the placeholder, 401ing AUTH_USE_AUTH=true
+        # self-hosts). Only an env-sourced key (HONCHO_API_KEY) is still
+        # treated as likely-cloud and skipped for local URLs.
         _is_local = _is_local_base_url(resolved_base_url)
         if _is_local:
-            # Check if the host block has its own apiKey (explicit local auth).
-            # For local/LAN/VPN self-hosts, a stored root key is likely a cloud
-            # key that would break a no-auth local server, so we substitute the
-            # SDK's required-non-empty placeholder unless the host block opts in.
             _raw = config.raw or {}
             _host_block_local = _host_block(_raw, config.host)  # uses dot-form legacy fallback (#37436)
-            _host_has_key = bool(_host_block_local.get("apiKey"))
-            effective_api_key = config.api_key if _host_has_key else "local"
+            _explicit_key = bool(
+                _host_block_local.get("apiKey") or _raw.get("apiKey")
+            )
+            effective_api_key = config.api_key if _explicit_key else "local"
         else:
             effective_api_key = config.api_key
 

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -33,6 +33,26 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _sanitize_url(url: str | None) -> str | None:
+    """Return url unchanged, or None if it contains non-printable ASCII characters.
+
+    A stray terminal escape sequence (e.g. \x1b from copy-paste) in a URL can
+    cause upstream SDKs to raise ``Invalid non-printable ASCII character`` at
+    client construction time. Dropping the bad value keeps Honcho disabled with
+    a clear warning rather than poisoning startup.
+    """
+    if url is None:
+        return None
+    if all(0x20 <= ord(c) < 0x7F for c in url):
+        return url
+    logger.warning(
+        "Honcho base_url contains non-printable characters and will be ignored: %r",
+        url,
+    )
+    return None
+
+
 HOST = "hermes"
 
 
@@ -494,7 +514,7 @@ class HonchoClientConfig:
         # behaves the same as from_global_config() when no config file exists.
         # Read straight from os.environ, matching HONCHO_BASE_URL: a base URL
         # is a deployment setting, not a profile-scoped credential.
-        base_url = (
+        base_url = _sanitize_url(
             os.environ.get("HONCHO_BASE_URL", "").strip()
             or os.environ.get("HONCHO_URL", "").strip()
             or None
@@ -574,7 +594,7 @@ class HonchoClientConfig:
             if isinstance(endpoint_block, dict)
             else None
         )
-        base_url = (
+        base_url = _sanitize_url(
             host_block.get("baseUrl")
             or host_block.get("base_url")
             or native_base_url
@@ -1249,7 +1269,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
                 honcho_cfg = hermes_cfg.get("honcho", {})
                 if isinstance(honcho_cfg, dict):
                     if not resolved_base_url:
-                        resolved_base_url = honcho_cfg.get("base_url", "").strip() or None
+                        resolved_base_url = _sanitize_url(honcho_cfg.get("base_url", "").strip() or None)
                     if resolved_timeout is None:
                         resolved_timeout = _resolve_optional_float(
                             honcho_cfg.get("timeout"),

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -877,7 +877,123 @@ class HonchoClientConfig:
 
 
 _honcho_client_slot: SingletonSlot = SingletonSlot()
-_cached_timeout: float | None = None
+# --- per-identity client cache -------------------------------------------
+# One slot per client identity, replacing the single process-wide slot that
+# pinned the first profile's workspace and bearer for every later profile in
+# multi-profile processes (#69123 multiplexed gateway, #74065 dashboard).
+# The legacy names above are retained only for reset bookkeeping.
+import threading as _threading
+
+_client_slots: dict[tuple, SingletonSlot] = {}
+_client_slot_timeouts: dict[tuple, float] = {}
+_client_slots_lock = _threading.Lock()
+
+
+def _credential_fingerprint(config: HonchoClientConfig | None) -> str:
+    """Stable identity for the credential a client will be built with.
+
+    OAuth grants rotate their access token in place (apply_token_to_client),
+    so the fingerprint must NOT change on rotation — it hashes the REFRESH
+    token, which is stable across access-token rotation but changes on
+    re-auth or account switch. Static keys hash the key itself. This is what
+    makes 'hermes honcho setup' account switches produce a NEW cache identity
+    instead of silently reusing the old account's client (a first-config-wins
+    hole that per-path keys alone cannot close).
+    """
+    try:
+        if config is not None:
+            block = _host_block(config.raw or {}, config.host)
+            oauth_block = block.get("oauth")
+            if isinstance(oauth_block, dict) and oauth_block.get("refreshToken"):
+                basis = f"oauth:{oauth_block['refreshToken']}"
+            elif config.api_key:
+                basis = f"key:{config.api_key}"
+            else:
+                return ""
+            return hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]
+        # Ambient: read the active file so legacy no-config callers still get
+        # a credential-aware key (correct on main threads; bound configs are
+        # the supported path for background threads).
+        path = resolve_config_path()
+        if path.exists():
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            block = _host_block(raw, resolve_active_host())
+            oauth_block = block.get("oauth")
+            if isinstance(oauth_block, dict) and oauth_block.get("refreshToken"):
+                basis = f"oauth:{oauth_block['refreshToken']}"
+            else:
+                key = block.get("apiKey") or raw.get("apiKey") or get_secret("HONCHO_API_KEY") or ""
+                if not key:
+                    return ""
+                basis = f"key:{key}"
+            return hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]
+    except Exception:
+        pass
+    return ""
+
+
+def _client_cache_key(config: HonchoClientConfig | None) -> tuple:
+    """Cache identity for a Honcho client build.
+
+    Explicit configs key on the connection identity ``_build`` embeds in the
+    client (host, workspace, base_url, environment), the provenance paths the
+    config was resolved from, the effective timeout, and a credential
+    fingerprint that is stable across OAuth access-token rotation but changes
+    on re-auth/account switch. The access token itself is deliberately NOT in
+    the key — in-place rotation must stay within one slot.
+
+    Ambient callers (config=None: CLI one-shots, tests) key on what
+    from_global_config() would resolve. Ambient resolution reads the profile
+    ContextVar and is therefore only correct on threads that can see it;
+    bound configs are the supported path everywhere else.
+    """
+    if config is not None:
+        return (
+            "explicit",
+            config.host,
+            config.workspace_id,
+            config.base_url or "",
+            config.environment,
+            str(config.config_path) if config.config_path is not None else "",
+            str(config.hermes_home) if config.hermes_home is not None else "",
+            _resolve_timeout_from_sources(config),
+            _credential_fingerprint(config),
+        )
+    return (
+        "ambient",
+        str(resolve_config_path()),
+        resolve_active_host(),
+        _resolve_timeout_from_sources(None),
+        _credential_fingerprint(None),
+    )
+
+
+def _slot_for(key: tuple) -> SingletonSlot:
+    """Return the slot for ``key``, evicting stale same-identity slots.
+
+    When a (kind, host, config_path/hermes_home) identity reappears with a
+    DIFFERENT credential fingerprint or timeout, the old slot is dropped so
+    the replaced client stops being served and its pools can close once the
+    last holder releases it. Without eviction, credential churn leaks one
+    pinned client per change — the gap that made #81401's retirement
+    machinery inert.
+    """
+    identity = key[:3] if key[0] == "ambient" else (key[0], key[1], key[5], key[6])
+    with _client_slots_lock:
+        slot = _client_slots.get(key)
+        if slot is None:
+            stale = [
+                k for k in _client_slots
+                if k != key and (
+                    (k[:3] if k[0] == "ambient" else (k[0], k[1], k[5], k[6])) == identity
+                )
+            ]
+            for k in stale:
+                _client_slots.pop(k, None)
+                _client_slot_timeouts.pop(k, None)
+            slot = SingletonSlot()
+            _client_slots[key] = slot
+        return slot
 # Memo for the honcho.json-derived timeout, keyed PER CONFIG PATH on the
 # file's mtime_ns so the staleness check on every get_honcho_client() call
 # costs one stat() instead of a JSON parse. Path-keyed because multi-profile
@@ -977,11 +1093,16 @@ def _apply_fresh_oauth_token(config: HonchoClientConfig) -> None:
         logger.warning("Honcho OAuth pre-build refresh failed", exc_info=True)
 
 
-def _refresh_cached_oauth(client: "Honcho", config: HonchoClientConfig | None) -> None:
+def _refresh_cached_oauth(
+    client: "Honcho",
+    config: HonchoClientConfig | None,
+    slot: SingletonSlot | None = None,
+) -> None:
     """Rotate the cached client's Bearer in place when its OAuth token is stale.
 
-    If the SDK shape changed and the in-place rotation can't apply, the slot is
-    reset so the next acquisition rebuilds with the fresh token.
+    If the SDK shape changed and the in-place rotation can't apply, the
+    client's own slot is reset so the next acquisition rebuilds with the
+    fresh token.
     """
     try:
         from plugins.memory.honcho import oauth
@@ -994,35 +1115,39 @@ def _refresh_cached_oauth(client: "Honcho", config: HonchoClientConfig | None) -
             path = resolve_config_path()
         token, refreshed = oauth.ensure_fresh_token(path, host)
         if refreshed and token and not oauth.apply_token_to_client(client, token):
-            _honcho_client_slot.reset()
+            if slot is not None:
+                slot.reset()
     except Exception:
         logger.warning("Honcho OAuth cached refresh failed", exc_info=True)
 
 
 def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
-    """Get or create the Honcho client singleton.
+    """Get or create the Honcho client for this config's identity.
 
-    When no config is provided, attempts to load ~/.honcho/config.json
-    first, falling back to environment variables.
+    Clients are cached PER IDENTITY (host, workspace, provenance paths,
+    credential fingerprint, timeout), not per process: multi-profile
+    processes (gateway multiplexer, dashboard, cron) previously shared one
+    first-config-wins client, so every profile's memory landed in whichever
+    workspace initialized first (#69123, #74065).
 
-    Thread-safe: the client is built exactly once even under concurrent
-    first calls (double-checked locking via ``SingletonSlot``), so racing
-    threads can't each construct a client and leak the loser's connection.
+    When no config is provided, resolves the active honcho.json — correct
+    only on threads that can see the profile ContextVar; pass a bound config
+    everywhere else (HonchoSessionManager does).
+
+    Thread-safe: each identity's client is built exactly once even under
+    concurrent first calls (double-checked locking via SingletonSlot), so
+    racing threads can't each construct a client and leak the loser's
+    connection.
     """
-    global _cached_timeout
-    cached = _honcho_client_slot.peek()
+    key = _client_cache_key(config)
+    slot = _slot_for(key)
+    cached = slot.peek()
     if cached is not None:
-        # Detect timeout config changes in long-lived processes (gateway,
-        # dashboard).  If the user changed the timeout after the client was
-        # built, rebuild with the new value.
-        new_timeout = _resolve_timeout_from_sources(config)
-        if new_timeout != _cached_timeout:
-            _honcho_client_slot.reset()
-            _cached_timeout = None
-            cached = None
-        else:
-            _refresh_cached_oauth(cached, config)
-            return cached
+        _refresh_cached_oauth(cached, config, slot)
+        refreshed = slot.peek()
+        if refreshed is not None:
+            return refreshed
+        # Slot was reset by a failed in-place rotation — rebuild below.
 
     if config is None:
         config = HonchoClientConfig.from_global_config()
@@ -1133,16 +1258,17 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         if resolved_timeout is not None:
             kwargs["timeout"] = resolved_timeout
 
-        global _cached_timeout
-        _cached_timeout = resolved_timeout
+        with _client_slots_lock:
+            _client_slot_timeouts[key] = resolved_timeout
         return Honcho(**kwargs)
 
-    return _honcho_client_slot.get(_build)
+    return slot.get(_build)
 
 
 def reset_honcho_client() -> None:
-    """Reset the Honcho client singleton (useful for testing)."""
-    global _cached_timeout
+    """Reset all cached Honcho clients (tests, OAuth re-login)."""
+    with _client_slots_lock:
+        _client_slots.clear()
+        _client_slot_timeouts.clear()
     _honcho_client_slot.reset()
-    _cached_timeout = None
     _honcho_json_timeout_memo.clear()

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -885,7 +885,6 @@ _honcho_client_slot: SingletonSlot = SingletonSlot()
 import threading as _threading
 
 _client_slots: dict[tuple, SingletonSlot] = {}
-_client_slot_timeouts: dict[tuple, float] = {}
 _client_slots_lock = _threading.Lock()
 
 
@@ -1017,7 +1016,6 @@ def _slot_for(key: tuple) -> SingletonSlot:
             ]
             for k in stale:
                 _client_slots.pop(k, None)
-                _client_slot_timeouts.pop(k, None)
             slot = SingletonSlot()
             _client_slots[key] = slot
         return slot
@@ -1285,8 +1283,6 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         if resolved_timeout is not None:
             kwargs["timeout"] = resolved_timeout
 
-        with _client_slots_lock:
-            _client_slot_timeouts[key] = resolved_timeout
         return Honcho(**kwargs)
 
     return slot.get(_build)
@@ -1296,6 +1292,5 @@ def reset_honcho_client() -> None:
     """Reset all cached Honcho clients (tests, OAuth re-login)."""
     with _client_slots_lock:
         _client_slots.clear()
-        _client_slot_timeouts.clear()
     _honcho_client_slot.reset()
     _honcho_json_timeout_memo.clear()

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -575,7 +575,9 @@ class HonchoClientConfig:
             else None
         )
         base_url = (
-            native_base_url
+            host_block.get("baseUrl")
+            or host_block.get("base_url")
+            or native_base_url
             or raw.get("baseUrl")
             or raw.get("base_url")
             or os.environ.get("HONCHO_BASE_URL", "").strip()

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -461,6 +461,24 @@ class HonchoClientConfig:
     # block exists or enabled was set explicitly), vs auto-enabled from a
     # stray HONCHO_API_KEY env var.
     explicitly_configured: bool = False
+    # Provenance: WHERE this config was resolved from, captured at resolution
+    # time (inside the caller's profile scope). Bound consumers (session
+    # manager, OAuth refresh paths) use these instead of re-resolving
+    # resolve_config_path()/get_hermes_home() later — those resolvers read a
+    # ContextVar that background threads cannot see, so re-resolution from a
+    # daemon thread silently lands on the DEFAULT profile (#69123, #74065).
+    config_path: Path | None = None
+    hermes_home: Path | None = None
+
+    def bound_config_path(self) -> Path:
+        """Return the config path this config was resolved from.
+
+        Falls back to ambient resolution only for hand-constructed configs
+        (tests, env-only setups) that carry no provenance.
+        """
+        if self.config_path is not None:
+            return self.config_path
+        return resolve_config_path()
 
     @classmethod
     def from_env(
@@ -482,6 +500,7 @@ class HonchoClientConfig:
             timeout=timeout,
             ai_peer=resolved_host,
             enabled=bool(api_key or base_url),
+            hermes_home=get_hermes_home(),
         )
 
     @classmethod
@@ -733,6 +752,8 @@ class HonchoClientConfig:
             sessions=raw.get("sessions", {}),
             raw=raw,
             explicitly_configured=_explicitly_configured,
+            config_path=path,
+            hermes_home=get_hermes_home(),
         )
 
     @staticmethod
@@ -857,13 +878,16 @@ class HonchoClientConfig:
 
 _honcho_client_slot: SingletonSlot = SingletonSlot()
 _cached_timeout: float | None = None
-# Memo for the honcho.json-derived timeout, keyed on the file's mtime_ns so
-# the staleness check on every get_honcho_client() call costs one stat()
-# instead of a JSON parse. mtime -1 = file absent; (None, None) = not yet
-# populated. config.yaml needs no such memo: load_config_readonly() is
-# internally cached on both the user and managed files' signatures, and a
-# bespoke key here would have to duplicate that invalidation logic.
-_honcho_json_timeout_memo: tuple[int | None, float | None] = (None, None)
+# Memo for the honcho.json-derived timeout, keyed PER CONFIG PATH on the
+# file's mtime_ns so the staleness check on every get_honcho_client() call
+# costs one stat() instead of a JSON parse. Path-keyed because multi-profile
+# processes resolve different honcho.json files — a single-slot memo would
+# thrash between profiles and return profile A's timeout for profile B.
+# mtime -1 = file absent. config.yaml needs no such memo:
+# load_config_readonly() is internally cached on both the user and managed
+# files' signatures, and a bespoke key here would have to duplicate that
+# invalidation logic.
+_honcho_json_timeout_memo: dict[str, tuple[int, float | None]] = {}
 
 
 def _config_yaml_timeout() -> float | None:
@@ -884,15 +908,16 @@ def _config_yaml_timeout() -> float | None:
 
 def _honcho_json_timeout() -> float | None:
     """Read timeout/requestTimeout from honcho.json (host block wins), memoized on mtime."""
-    global _honcho_json_timeout_memo
     try:
         path = resolve_config_path()
+        path_key = str(path)
         try:
             mtime_ns: int = path.stat().st_mtime_ns
         except OSError:
             mtime_ns = -1
-        if _honcho_json_timeout_memo[0] == mtime_ns:
-            return _honcho_json_timeout_memo[1]
+        memo = _honcho_json_timeout_memo.get(path_key)
+        if memo is not None and memo[0] == mtime_ns:
+            return memo[1]
 
         timeout = None
         if mtime_ns != -1:
@@ -904,7 +929,7 @@ def _honcho_json_timeout() -> float | None:
                 raw.get("timeout"),
                 raw.get("requestTimeout"),
             )
-        _honcho_json_timeout_memo = (mtime_ns, timeout)
+        _honcho_json_timeout_memo[path_key] = (mtime_ns, timeout)
         return timeout
     except Exception:
         return None
@@ -941,7 +966,11 @@ def _apply_fresh_oauth_token(config: HonchoClientConfig) -> None:
     try:
         from plugins.memory.honcho import oauth
 
-        token, _ = oauth.ensure_fresh_token(resolve_config_path(), config.host)
+        # Bound path: refresh against the honcho.json this config came from,
+        # not whatever the current context resolves to. On daemon threads the
+        # ambient resolver lands on the default profile and a refresh here
+        # would persist the rotated token into the WRONG profile's file.
+        token, _ = oauth.ensure_fresh_token(config.bound_config_path(), config.host)
         if token:
             config.api_key = token
     except Exception:
@@ -957,8 +986,13 @@ def _refresh_cached_oauth(client: "Honcho", config: HonchoClientConfig | None) -
     try:
         from plugins.memory.honcho import oauth
 
-        host = config.host if config is not None else resolve_active_host()
-        token, refreshed = oauth.ensure_fresh_token(resolve_config_path(), host)
+        if config is not None:
+            host = config.host
+            path = config.bound_config_path()
+        else:
+            host = resolve_active_host()
+            path = resolve_config_path()
+        token, refreshed = oauth.ensure_fresh_token(path, host)
         if refreshed and token and not oauth.apply_token_to_client(client, token):
             _honcho_client_slot.reset()
     except Exception:
@@ -1108,7 +1142,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
 
 def reset_honcho_client() -> None:
     """Reset the Honcho client singleton (useful for testing)."""
-    global _cached_timeout, _honcho_json_timeout_memo
+    global _cached_timeout
     _honcho_client_slot.reset()
     _cached_timeout = None
-    _honcho_json_timeout_memo = (None, None)
+    _honcho_json_timeout_memo.clear()

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -491,6 +491,7 @@ class HonchoClientConfig:
         api_key = get_secret("HONCHO_API_KEY")
         base_url = os.environ.get("HONCHO_BASE_URL", "").strip() or None
         timeout = _resolve_optional_float(os.environ.get("HONCHO_TIMEOUT"))
+        _resolved_path = resolve_config_path()
         return cls(
             host=resolved_host,
             workspace_id=workspace_id,
@@ -500,6 +501,7 @@ class HonchoClientConfig:
             timeout=timeout,
             ai_peer=resolved_host,
             enabled=bool(api_key or base_url),
+            config_path=_resolved_path,
             hermes_home=get_hermes_home(),
         )
 

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -489,7 +489,16 @@ class HonchoClientConfig:
         """Create config from environment variables (fallback)."""
         resolved_host = host or resolve_active_host()
         api_key = get_secret("HONCHO_API_KEY")
-        base_url = os.environ.get("HONCHO_BASE_URL", "").strip() or None
+        # HONCHO_URL is the SDK's own env var (honcho.client resolves it when
+        # no environment is passed); accept it here so the fallback path
+        # behaves the same as from_global_config() when no config file exists.
+        # Read straight from os.environ, matching HONCHO_BASE_URL: a base URL
+        # is a deployment setting, not a profile-scoped credential.
+        base_url = (
+            os.environ.get("HONCHO_BASE_URL", "").strip()
+            or os.environ.get("HONCHO_URL", "").strip()
+            or None
+        )
         timeout = _resolve_optional_float(os.environ.get("HONCHO_TIMEOUT"))
         _resolved_path = resolve_config_path()
         return cls(
@@ -555,10 +564,22 @@ class HonchoClientConfig:
             or raw.get("environment", "production")
         )
 
+        # The Honcho SDK's native config format — and what Claude Desktop
+        # writes — nests the URL at endpoint.baseUrl. Read it first: a user
+        # who has that block set almost certainly means it, and the flat
+        # baseUrl / base_url keys below are the Hermes-specific spelling.
+        endpoint_block = raw.get("endpoint")
+        native_base_url = (
+            endpoint_block.get("baseUrl")
+            if isinstance(endpoint_block, dict)
+            else None
+        )
         base_url = (
-            raw.get("baseUrl")
+            native_base_url
+            or raw.get("baseUrl")
             or raw.get("base_url")
             or os.environ.get("HONCHO_BASE_URL", "").strip()
+            or os.environ.get("HONCHO_URL", "").strip()
             or None
         )
         # Host config wins over flat/global config and environment.
@@ -1243,7 +1264,16 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         if resolved_base_url:
             logger.info("Initializing Honcho client (base_url: %s, workspace: %s)", resolved_base_url, config.workspace_id)
         else:
-            logger.info("Initializing Honcho client (host: %s, workspace: %s)", config.host, config.workspace_id)
+            # No base_url resolved, so the SDK falls back to its own
+            # ENVIRONMENTS map (honcho.client: local -> http://localhost:8000,
+            # production -> https://api.honcho.dev). Name the target at INFO:
+            # a self-hosted user whose config wasn't picked up otherwise sees
+            # a healthy-looking startup and silently talks to the public cloud.
+            logger.info(
+                "Initializing Honcho client (host: %s, workspace: %s, "
+                "base_url unset — SDK will resolve from environment=%s)",
+                config.host, config.workspace_id, config.environment,
+            )
 
         # Local Honcho instances don't require an API key, but the SDK
         # expects a non-empty string.  Use a placeholder for local URLs.

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -1289,8 +1289,8 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
             # key that would break a no-auth local server, so we substitute the
             # SDK's required-non-empty placeholder unless the host block opts in.
             _raw = config.raw or {}
-            _host_block = (_raw.get("hosts") or {}).get(config.host, {})
-            _host_has_key = bool(_host_block.get("apiKey"))
+            _host_block_local = _host_block(_raw, config.host)  # uses dot-form legacy fallback (#37436)
+            _host_has_key = bool(_host_block_local.get("apiKey"))
             effective_api_key = config.api_key if _host_has_key else "local"
         else:
             effective_api_key = config.api_key

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -889,6 +889,33 @@ _client_slot_timeouts: dict[tuple, float] = {}
 _client_slots_lock = _threading.Lock()
 
 
+def spawn_context_thread(
+    target,
+    *,
+    name: str,
+    daemon: bool = True,
+    args: tuple = (),
+) -> "_threading.Thread":
+    """Spawn a thread that inherits the caller's contextvars.
+
+    Profile isolation in multi-profile processes is a ContextVar
+    (set_hermes_home_override); plain threading.Thread targets start with an
+    EMPTY context, so any ambient resolution on the thread
+    (resolve_config_path, resolve_active_host, get_hermes_home) silently
+    lands on the default profile. Copying the caller's context at spawn time
+    makes the thread see the profile scope it was created under.
+    """
+    import contextvars
+
+    ctx = contextvars.copy_context()
+    t = _threading.Thread(
+        target=lambda: ctx.run(target, *args),
+        name=name,
+        daemon=daemon,
+    )
+    return t
+
+
 def _credential_fingerprint(config: HonchoClientConfig | None) -> str:
     """Stable identity for the credential a client will be built with.
 

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -9,6 +9,7 @@ import logging
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Callable, TYPE_CHECKING
 
 from plugins.memory.honcho.client import get_honcho_client
@@ -209,10 +210,15 @@ class HonchoSessionManager:
     def honcho(self) -> Honcho:
         """Get the Honcho client, refreshing a near-expiry OAuth token in place.
 
-        Routes every access through ``get_honcho_client`` (which returns the same
-        cached singleton) so a long session can't outlive its 1h access token.
+        Routes every access through ``get_honcho_client`` WITH this manager's
+        bound config so a long session can't outlive its 1h access token AND
+        so background threads (async writer, prefetch, sync) acquire the
+        client for the profile this manager was built under — a bare
+        ``get_honcho_client()`` re-resolves ambient ContextVar-backed state
+        that daemon threads cannot see, migrating every access onto the
+        first-built profile's client (#69123, #74065).
         """
-        self._honcho = get_honcho_client()
+        self._honcho = get_honcho_client(self._config)
         return self._honcho
 
     def _record_auth_failure(self, exc: BaseException) -> None:
@@ -238,6 +244,20 @@ class HonchoSessionManager:
         self._auth_notice_emitted = True
         return self._auth_failure
 
+    def _bound_config_path(self) -> Path:
+        """Config path for OAuth checks, bound to this manager's profile.
+
+        Falls back to ambient resolution only when the manager was built
+        without a config (tests) — on the hot path the bound path keeps
+        background threads reading THIS profile's honcho.json, not the
+        default profile the ContextVar-blind resolver would land on.
+        """
+        from plugins.memory.honcho.client import HonchoClientConfig, resolve_config_path
+
+        if isinstance(self._config, HonchoClientConfig):
+            return self._config.bound_config_path()
+        return resolve_config_path()
+
     def _reauth_required(self) -> bool:
         """True when the grant is dead and only a new login can fix it.
 
@@ -251,12 +271,10 @@ class HonchoSessionManager:
             if not oauth.any_dead_grants():
                 return False
 
-            from plugins.memory.honcho.client import resolve_config_path
-
             host = getattr(self._config, "host", "") or ""
             if not host:
                 return False
-            return oauth.reauth_required(resolve_config_path(), host)
+            return oauth.reauth_required(self._bound_config_path(), host)
         except Exception:
             return False
 
@@ -267,15 +285,12 @@ class HonchoSessionManager:
         """
         try:
             from plugins.memory.honcho import oauth
-            from plugins.memory.honcho.client import (
-                reset_honcho_client,
-                resolve_config_path,
-            )
+            from plugins.memory.honcho.client import reset_honcho_client
 
             host = getattr(self._config, "host", "") or ""
             if not host:
                 return False
-            token = oauth.force_refresh_token(resolve_config_path(), host)
+            token = oauth.force_refresh_token(self._bound_config_path(), host)
             if not token:
                 return False
             if not oauth.apply_token_to_client(self.honcho, token):

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1138,13 +1138,17 @@ class HonchoSessionManager:
             return False
 
         # Only migrate the owner-describing memory files (MEMORY.md / USER.md)
-        # when the session's user peer IS the configured owner peer. Otherwise a
+        # when the session's user peer IS the owner peer. Otherwise a
         # non-owner triggering a new session (e.g. any other human in a shared
         # Slack/Discord channel) gets the owner's full profile files uploaded
         # under the NON-OWNER's peer, and Honcho's deriver attributes the
         # owner's facts to that person. SOUL.md describes the agent, not a
         # human, but skipping it here too keeps the migration owner-scoped.
-        if session.user_peer_id != self._sanitize_id(self._config.peer_name):
+        # The owner is resolved through _resolve_user_peer_id (pin/runtime/
+        # alias aware) — config.peer_name alone is optional and None for
+        # most single-user setups.
+        owner_peer_id = self._resolve_user_peer_id(session_key)
+        if session.user_peer_id != owner_peer_id:
             logger.info(
                 "Skipping memory-file migration for non-owner session (user=%s)",
                 session.user_peer_id,

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -553,6 +553,19 @@ class HonchoSessionManager:
             return f"{sanitized_peer_id}-{digest}"
         return sanitized_peer_id
 
+    def _declared_owner_peer_id(self) -> str | None:
+        """Peer ID of the install owner, or None when no owner is declared.
+
+        The owner is the identity setup writes as ``peerName``. A runtime
+        gateway identity is the owner only when an alias maps it onto that
+        peer — which _resolve_user_peer_id already does, so callers can
+        compare a session's resolved user peer against this value.
+        """
+        peer_name = getattr(self._config, "peer_name", None) if self._config else None
+        if peer_name and str(peer_name).strip():
+            return self._sanitize_id(str(peer_name).strip())
+        return None
+
     def _resolve_user_peer_id(self, key: str) -> str:
         """Resolve the Honcho user peer ID for this manager/session."""
         pin_peer_name = (
@@ -1138,20 +1151,34 @@ class HonchoSessionManager:
             return False
 
         # Only migrate the owner-describing memory files (MEMORY.md / USER.md)
-        # when the session's user peer IS the owner peer. Otherwise a
+        # when the session's user peer IS the install owner. Otherwise a
         # non-owner triggering a new session (e.g. any other human in a shared
         # Slack/Discord channel) gets the owner's full profile files uploaded
         # under the NON-OWNER's peer, and Honcho's deriver attributes the
         # owner's facts to that person. SOUL.md describes the agent, not a
         # human, but skipping it here too keeps the migration owner-scoped.
-        # The owner is resolved through _resolve_user_peer_id (pin/runtime/
-        # alias aware) — config.peer_name alone is optional and None for
-        # most single-user setups.
-        owner_peer_id = self._resolve_user_peer_id(session_key)
-        if session.user_peer_id != owner_peer_id:
+        #
+        # The owner is a CONFIG fact — the declared peerName — never a
+        # re-resolution of the session's own peer: _resolve_user_peer_id
+        # answers "who is this session's user", so comparing its output to
+        # session.user_peer_id compares the triggering user to themselves
+        # and passes for the non-owner too.
+        owner_peer_id = self._declared_owner_peer_id()
+        if owner_peer_id is not None:
+            session_is_owner = session.user_peer_id == owner_peer_id
+        else:
+            # No declared owner. Without a runtime identity this is the
+            # single-operator path (peer id from config defaults or the
+            # session key) and the files describe that operator. With a
+            # runtime identity the session belongs to whoever messaged
+            # through the gateway — nobody can be proven to be the owner.
+            session_is_owner = not self._runtime_user_ids()
+        if not session_is_owner:
             logger.info(
-                "Skipping memory-file migration for non-owner session (user=%s)",
+                "Skipping memory-file migration: session user peer '%s' is not the "
+                "declared owner (peerName=%s)",
                 session.user_peer_id,
+                owner_peer_id or "unset",
             )
             return False
 

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -844,6 +844,7 @@ class HonchoSessionManager:
         reasoning_level: str | None = None,
         peer: str = "user",
         apply_injection_cap: bool = True,
+        raise_errors: bool = False,
     ) -> str:
         """
         Query Honcho's dialectic endpoint about a peer.
@@ -862,6 +863,11 @@ class HonchoSessionManager:
             apply_injection_cap: Clip automatic injections to
                 ``dialecticMaxChars``. Explicit ``honcho_reasoning`` calls pass
                 False because Honcho already bounds their output.
+            raise_errors: Re-raise backend failures instead of returning "".
+                Explicit tool calls pass True so a timeout or server error
+                surfaces as an error, not as "no result" (#36098 issue 4:
+                collapsing failures to "" made auth errors, timeouts, and
+                genuinely-empty answers indistinguishable).
 
         Returns:
             Honcho's synthesized answer, or empty string on failure.
@@ -917,6 +923,8 @@ class HonchoSessionManager:
             raise
         except Exception as e:
             logger.warning("Honcho dialectic query failed: %s", e)
+            if raise_errors:
+                raise
             return ""
 
     def prefetch_context(self, session_key: str, user_message: str | None = None) -> None:

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -785,6 +785,18 @@ class HonchoSessionManager:
                 )
                 self._async_thread.start()
 
+    def stop_async_writer(self) -> None:
+        """Stop the async writer thread WITHOUT flushing pending messages.
+
+        Used on shutdown when persistence is disabled (saveMessages: false):
+        the thread must still be joined so process exit is clean, but nothing
+        may be written.
+        """
+        if self._async_queue is not None:
+            if self._async_thread is not None and self._async_thread.is_alive():
+                self._async_queue.put(_ASYNC_SHUTDOWN)
+                self._async_thread.join(timeout=10)
+
     def shutdown(self) -> None:
         """Gracefully shut down the async writer thread."""
         if self._async_queue is not None:

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, TYPE_CHECKING
 
-from plugins.memory.honcho.client import get_honcho_client
+from plugins.memory.honcho.client import get_honcho_client, spawn_context_thread
 from plugins.memory.honcho.oauth import redact_tokens as _redact_tokens
 
 if TYPE_CHECKING:
@@ -779,10 +779,9 @@ class HonchoSessionManager:
             return
         with self._async_thread_lock:
             if self._async_thread is None or not self._async_thread.is_alive():
-                self._async_thread = threading.Thread(
-                    target=self._async_writer_loop,
+                self._async_thread = spawn_context_thread(
+                    self._async_writer_loop,
                     name="honcho-async-writer",
-                    daemon=True,
                 )
                 self._async_thread.start()
 
@@ -932,7 +931,7 @@ class HonchoSessionManager:
             if result:
                 self.set_context_result(session_key, result)
 
-        t = threading.Thread(target=_run, name="honcho-context-prefetch", daemon=True)
+        t = spawn_context_thread(_run, name="honcho-context-prefetch")
         t.start()
 
     def set_context_result(self, session_key: str, result: dict[str, str]) -> None:

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1137,6 +1137,20 @@ class HonchoSessionManager:
             logger.warning("No Honcho session cached for '%s', skipping memory migration", session_key)
             return False
 
+        # Only migrate the owner-describing memory files (MEMORY.md / USER.md)
+        # when the session's user peer IS the configured owner peer. Otherwise a
+        # non-owner triggering a new session (e.g. any other human in a shared
+        # Slack/Discord channel) gets the owner's full profile files uploaded
+        # under the NON-OWNER's peer, and Honcho's deriver attributes the
+        # owner's facts to that person. SOUL.md describes the agent, not a
+        # human, but skipping it here too keeps the migration owner-scoped.
+        if session.user_peer_id != self._sanitize_id(self._config.peer_name):
+            logger.info(
+                "Skipping memory-file migration for non-owner session (user=%s)",
+                session.user_peer_id,
+            )
+            return False
+
         uploaded = False
         files = [
             (

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -54,13 +54,23 @@ def make_manager(monkeypatch):
     monkeypatch.setattr(session_module, "get_honcho_client", lambda *a, **k: client)
     created = []
 
-    def _make(write_frequency="turn") -> HonchoSessionManager:
+    def _make(
+        write_frequency="turn",
+        *,
+        runtime_user_peer_name=None,
+        **cfg_kwargs,
+    ) -> HonchoSessionManager:
         cfg = HonchoClientConfig(
             write_frequency=write_frequency,
             api_key="test-key",
             enabled=True,
+            **cfg_kwargs,
         )
-        mgr = HonchoSessionManager(honcho=client, config=cfg)
+        mgr = HonchoSessionManager(
+            honcho=client,
+            config=cfg,
+            runtime_user_peer_name=runtime_user_peer_name,
+        )
         created.append(mgr)
         return mgr
 
@@ -420,28 +430,34 @@ class TestAsyncWriterRetry:
         assert call_count[0] == 2
 
 
+def _prime_migration_session(mgr, key, honcho_session_id, ai_peer_id="custom-ai"):
+    """Cache a session whose user peer is what the REAL resolver returns for
+    this manager — exactly what get_or_create stores — so the owner gate is
+    tested against reachable states, not hand-picked peer ids."""
+    session = _make_session(
+        key=key,
+        user_peer_id=mgr._resolve_user_peer_id(key),
+        assistant_peer_id=ai_peer_id,
+        honcho_session_id=honcho_session_id,
+    )
+    mgr._cache[session.key] = session
+    honcho_session = MagicMock()
+    mgr._sessions_cache[session.honcho_session_id] = honcho_session
+    return session, honcho_session
+
+
 class TestMemoryFileMigrationTargets:
     def test_soul_upload_targets_ai_peer(self, tmp_path, make_manager):
-        mgr = make_manager(write_frequency="turn")
-        # Migration is owner-gated: the session's user peer must match what
-        # _resolve_user_peer_id returns. Make the runtime identity match the
-        # crafted session so this reads as the owner's own session.
-        mgr._runtime_user_peer_name = "custom-user"
-        session = _make_session(
-            key="cli:test",
-            user_peer_id="custom-user",
-            assistant_peer_id="custom-ai",
-            honcho_session_id="cli-test",
-        )
-        mgr._cache[session.key] = session
+        # peerName declares the owner; no runtime identity, so the session
+        # resolves to the owner peer and migration proceeds.
+        mgr = make_manager(write_frequency="turn", peer_name="custom-user")
+        session, honcho_session = _prime_migration_session(mgr, "cli:test", "cli-test")
+        assert session.user_peer_id == "custom-user"
 
         user_peer = MagicMock(name="user-peer")
         ai_peer = MagicMock(name="ai-peer")
         mgr._peers_cache[session.user_peer_id] = user_peer
         mgr._peers_cache[session.assistant_peer_id] = ai_peer
-
-        honcho_session = MagicMock()
-        mgr._sessions_cache[session.honcho_session_id] = honcho_session
 
         (tmp_path / "MEMORY.md").write_text("memory facts", encoding="utf-8")
         (tmp_path / "USER.md").write_text("user profile", encoding="utf-8")
@@ -461,26 +477,108 @@ class TestMemoryFileMigrationTargets:
         assert peer_by_upload_name["user_profile.md"] is user_peer
         assert peer_by_upload_name["agent_soul.md"] is ai_peer
 
-    def test_migration_skipped_for_non_owner_session(self, tmp_path, make_manager):
-        """A non-owner user peer in the session must not receive the owner's
-        memory files — see #43752-adjacent shared-channel misattribution."""
-        mgr = make_manager(write_frequency="turn")
-        mgr._runtime_user_peer_name = "owner-user"
-        session = _make_session(
-            key="discord:shared",
-            user_peer_id="some-other-human",
-            assistant_peer_id="custom-ai",
-            honcho_session_id="shared-chan",
+
+class TestMemoryFileMigrationOwnerGate:
+    def test_non_owner_gateway_user_is_skipped(self, tmp_path, make_manager):
+        """The shared-channel scenario: a declared owner exists, but the
+        session was triggered by someone else's platform identity. The old
+        gate (re-resolving the session's own peer) passed here."""
+        mgr = make_manager(
+            write_frequency="turn",
+            peer_name="owner-user",
+            runtime_user_peer_name="some-other-human",
         )
-        mgr._cache[session.key] = session
-        mgr._sessions_cache[session.honcho_session_id] = MagicMock()
+        session, honcho_session = _prime_migration_session(
+            mgr, "discord:shared", "shared-chan"
+        )
+        assert session.user_peer_id == "some-other-human"
 
         (tmp_path / "MEMORY.md").write_text("owner facts", encoding="utf-8")
 
         uploaded = mgr.migrate_memory_files(session.key, str(tmp_path))
 
         assert uploaded is False
-        assert mgr._sessions_cache[session.honcho_session_id].upload_file.call_count == 0
+        assert honcho_session.upload_file.call_count == 0
+
+    def test_no_declared_owner_with_gateway_identity_is_skipped(
+            self, tmp_path, make_manager):
+        """Without peerName nobody messaging through a gateway can be proven
+        to be the owner — migration must not run."""
+        mgr = make_manager(
+            write_frequency="turn",
+            runtime_user_peer_name="discord-123",
+        )
+        session, honcho_session = _prime_migration_session(
+            mgr, "discord:shared", "shared-chan"
+        )
+
+        (tmp_path / "MEMORY.md").write_text("owner facts", encoding="utf-8")
+
+        uploaded = mgr.migrate_memory_files(session.key, str(tmp_path))
+
+        assert uploaded is False
+        assert honcho_session.upload_file.call_count == 0
+
+    def test_no_declared_owner_single_operator_migrates(self, tmp_path, make_manager):
+        """No peerName and no runtime identity is the plain CLI install —
+        the only person who exists is the operator the files describe."""
+        mgr = make_manager(write_frequency="turn")
+        session, honcho_session = _prime_migration_session(mgr, "cli:test", "cli-test")
+        mgr._peers_cache[session.user_peer_id] = MagicMock()
+        mgr._peers_cache[session.assistant_peer_id] = MagicMock()
+
+        (tmp_path / "MEMORY.md").write_text("memory facts", encoding="utf-8")
+
+        uploaded = mgr.migrate_memory_files(session.key, str(tmp_path))
+
+        assert uploaded is True
+        assert honcho_session.upload_file.call_count == 1
+
+    def test_aliased_owner_identity_migrates(self, tmp_path, make_manager):
+        """An alias mapping the owner's platform ID onto peerName makes that
+        gateway identity the owner."""
+        mgr = make_manager(
+            write_frequency="turn",
+            peer_name="owner-user",
+            user_peer_aliases={"discord-999": "owner-user"},
+            runtime_user_peer_name="discord-999",
+        )
+        session, honcho_session = _prime_migration_session(
+            mgr, "discord:dm", "discord-dm"
+        )
+        assert session.user_peer_id == "owner-user"
+        mgr._peers_cache[session.user_peer_id] = MagicMock()
+        mgr._peers_cache[session.assistant_peer_id] = MagicMock()
+
+        (tmp_path / "USER.md").write_text("user profile", encoding="utf-8")
+
+        uploaded = mgr.migrate_memory_files(session.key, str(tmp_path))
+
+        assert uploaded is True
+        assert honcho_session.upload_file.call_count == 1
+
+    def test_pinned_peer_name_migrates(self, tmp_path, make_manager):
+        """pinPeerName collapses every identity onto the owner peer by
+        explicit config, so the files land on the peer they describe."""
+        mgr = make_manager(
+            write_frequency="turn",
+            peer_name="owner-user",
+            pin_peer_name=True,
+            runtime_user_peer_name="anyone-at-all",
+        )
+        session, honcho_session = _prime_migration_session(
+            mgr, "discord:shared", "shared-chan"
+        )
+        assert session.user_peer_id == "owner-user"
+        mgr._peers_cache[session.user_peer_id] = MagicMock()
+        mgr._peers_cache[session.assistant_peer_id] = MagicMock()
+
+        (tmp_path / "MEMORY.md").write_text("memory facts", encoding="utf-8")
+
+        uploaded = mgr.migrate_memory_files(session.key, str(tmp_path))
+
+        assert uploaded is True
+        assert honcho_session.upload_file.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -423,6 +423,10 @@ class TestAsyncWriterRetry:
 class TestMemoryFileMigrationTargets:
     def test_soul_upload_targets_ai_peer(self, tmp_path, make_manager):
         mgr = make_manager(write_frequency="turn")
+        # Migration is owner-gated: the session's user peer must match what
+        # _resolve_user_peer_id returns. Make the runtime identity match the
+        # crafted session so this reads as the owner's own session.
+        mgr._runtime_user_peer_name = "custom-user"
         session = _make_session(
             key="cli:test",
             user_peer_id="custom-user",
@@ -456,6 +460,27 @@ class TestMemoryFileMigrationTargets:
         assert peer_by_upload_name["consolidated_memory.md"] is user_peer
         assert peer_by_upload_name["user_profile.md"] is user_peer
         assert peer_by_upload_name["agent_soul.md"] is ai_peer
+
+    def test_migration_skipped_for_non_owner_session(self, tmp_path, make_manager):
+        """A non-owner user peer in the session must not receive the owner's
+        memory files — see #43752-adjacent shared-channel misattribution."""
+        mgr = make_manager(write_frequency="turn")
+        mgr._runtime_user_peer_name = "owner-user"
+        session = _make_session(
+            key="discord:shared",
+            user_peer_id="some-other-human",
+            assistant_peer_id="custom-ai",
+            honcho_session_id="shared-chan",
+        )
+        mgr._cache[session.key] = session
+        mgr._sessions_cache[session.honcho_session_id] = MagicMock()
+
+        (tmp_path / "MEMORY.md").write_text("owner facts", encoding="utf-8")
+
+        uploaded = mgr.migrate_memory_files(session.key, str(tmp_path))
+
+        assert uploaded is False
+        assert mgr._sessions_cache[session.honcho_session_id].upload_file.call_count == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -316,6 +316,28 @@ class TestAsyncWriterThread:
         mgr.shutdown()
         assert mgr._async_thread is None
 
+    def test_stop_async_writer_joins_thread_without_flushing(self, make_manager):
+        mgr = make_manager(write_frequency="async")
+        mgr._ensure_async_writer()
+        sess = _make_session()
+        sess.add_message("user", "must not be written")
+        with mgr._cache_lock:
+            mgr._cache[sess.key] = sess
+
+        flushed = []
+        mgr._flush_session = lambda session: flushed.append(session) or True
+
+        thread = mgr._async_thread
+        mgr.stop_async_writer()
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+        assert flushed == []
+
+    def test_stop_async_writer_without_started_thread_is_noop(self, make_manager):
+        mgr = make_manager(write_frequency="async")
+        mgr.stop_async_writer()
+        assert mgr._async_thread is None
+
 
 # ---------------------------------------------------------------------------
 # async retry on failure

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -416,8 +416,9 @@ class TestGetHonchoClient:
         reason="honcho SDK not installed"
     )
     def test_local_base_url_without_host_key_uses_placeholder(self):
-        """Without an explicit host-block apiKey, a local base_url still gets
-        the SDK's non-empty placeholder instead of the (likely cloud) root key."""
+        """Without an explicit apiKey anywhere in honcho.json, a local
+        base_url gets the SDK's non-empty placeholder instead of the (likely
+        cloud, env-sourced) resolved key."""
         fake_honcho = MagicMock(name="Honcho")
         cfg = HonchoClientConfig(
             api_key="cloud-root-key",
@@ -431,6 +432,29 @@ class TestGetHonchoClient:
             get_honcho_client(cfg)
 
         assert mock_honcho.call_args.kwargs["api_key"] == "local"
+
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("honcho"),
+        reason="honcho SDK not installed"
+    )
+    def test_local_base_url_honors_top_level_api_key(self):
+        """Regression for #36098 issue 2: a top-level apiKey in honcho.json is
+        explicit user intent and must be honored for local base_urls (AUTH_USE_AUTH
+        self-hosts). Previously only a host-block apiKey escaped the 'local'
+        placeholder, so the top-level key was dropped and every request 401'd."""
+        fake_honcho = MagicMock(name="Honcho")
+        cfg = HonchoClientConfig(
+            api_key="explicit-top-level-key",
+            base_url="http://localhost:8000",
+            host="hermes",
+            workspace_id="hermes",
+            raw={"apiKey": "explicit-top-level-key"},
+        )
+
+        with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho:
+            get_honcho_client(cfg)
+
+        assert mock_honcho.call_args.kwargs["api_key"] == "explicit-top-level-key"
 
     @pytest.mark.skipif(
         not importlib.util.find_spec("honcho"),

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -202,6 +202,18 @@ class TestFromGlobalConfig:
         # Should fall back to from_env without crashing
         assert isinstance(config, HonchoClientConfig)
 
+    def test_base_url_host_block_overrides_root_and_env(self, tmp_path):
+        """Host-specific baseUrl should win for self-hosted Honcho deployments."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "baseUrl": "http://root:9000",
+            "hosts": {"hermes": {"baseUrl": "http://host-block:9001"}},
+        }))
+
+        with patch.dict(os.environ, {"HONCHO_BASE_URL": "http://env:8000"}, clear=False):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://host-block:9001"
+
 
 class TestResolveSessionName:
     def test_manual_override(self):

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -214,6 +214,41 @@ class TestFromGlobalConfig:
             config = HonchoClientConfig.from_global_config(config_path=config_file)
         assert config.base_url == "http://host-block:9001"
 
+    def test_base_url_full_precedence_chain(self, tmp_path):
+        """Invariant: host block > endpoint.baseUrl (SDK-native) > flat root
+        > HONCHO_BASE_URL > HONCHO_URL. Pins the composed order of #14489
+        (host block) and #43803 (endpoint block + HONCHO_URL)."""
+        config_file = tmp_path / "config.json"
+        layers = {
+            "hosts": {"hermes": {"baseUrl": "http://host:1"}},
+            "endpoint": {"baseUrl": "http://endpoint:2"},
+            "baseUrl": "http://flat:3",
+        }
+        env = {"HONCHO_BASE_URL": "http://envbase:4", "HONCHO_URL": "http://envurl:5"}
+        expected = [
+            "http://host:1",     # full stack -> host block wins
+            "http://endpoint:2", # drop host block -> SDK-native endpoint
+            "http://flat:3",     # drop endpoint -> flat root key
+            "http://envbase:4",  # empty file -> HONCHO_BASE_URL
+            "http://envurl:5",   # drop HONCHO_BASE_URL -> HONCHO_URL
+        ]
+
+        for i, want in enumerate(expected):
+            cfg_dict = dict(layers)
+            if i >= 1:
+                cfg_dict.pop("hosts")
+            if i >= 2:
+                cfg_dict.pop("endpoint")
+            if i >= 3:
+                cfg_dict.pop("baseUrl")
+            env_dict = dict(env)
+            if i >= 4:
+                env_dict.pop("HONCHO_BASE_URL")
+            config_file.write_text(json.dumps(cfg_dict))
+            with patch.dict(os.environ, env_dict, clear=True):
+                config = HonchoClientConfig.from_global_config(config_path=config_file)
+            assert config.base_url == want, f"layer {i}: got {config.base_url!r}, want {want!r}"
+
 
 class TestResolveSessionName:
     def test_manual_override(self):
@@ -352,6 +387,50 @@ class TestObservationModeMigration:
 class TestGetHonchoClient:
     def teardown_method(self):
         reset_honcho_client()
+
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("honcho"),
+        reason="honcho SDK not installed"
+    )
+    def test_dot_form_legacy_host_key_keeps_local_api_key(self):
+        """Regression for #37436: a legacy dot-form host block (hermes.work)
+        must be found by the local-auth check. Before the _host_block fallback,
+        the direct dict lookup missed it, the stored apiKey was dropped for the
+        'local' placeholder, and every write 401'd silently."""
+        fake_honcho = MagicMock(name="Honcho")
+        cfg = HonchoClientConfig(
+            api_key="explicit-local-key",
+            base_url="http://localhost:8000",
+            host="hermes_work",
+            workspace_id="hermes",
+            raw={"hosts": {"hermes.work": {"apiKey": "explicit-local-key"}}},
+        )
+
+        with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho:
+            get_honcho_client(cfg)
+
+        assert mock_honcho.call_args.kwargs["api_key"] == "explicit-local-key"
+
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("honcho"),
+        reason="honcho SDK not installed"
+    )
+    def test_local_base_url_without_host_key_uses_placeholder(self):
+        """Without an explicit host-block apiKey, a local base_url still gets
+        the SDK's non-empty placeholder instead of the (likely cloud) root key."""
+        fake_honcho = MagicMock(name="Honcho")
+        cfg = HonchoClientConfig(
+            api_key="cloud-root-key",
+            base_url="http://localhost:8000",
+            host="hermes",
+            workspace_id="hermes",
+            raw={},
+        )
+
+        with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho:
+            get_honcho_client(cfg)
+
+        assert mock_honcho.call_args.kwargs["api_key"] == "local"
 
     @pytest.mark.skipif(
         not importlib.util.find_spec("honcho"),

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -67,6 +67,29 @@ class TestFromEnv:
         assert config.enabled is True
 
 
+    def test_honcho_url_env_var_is_honored(self):
+        """HONCHO_URL is the SDK's own env var; from_env() accepts it too."""
+        with patch.dict(os.environ, {"HONCHO_URL": "http://localhost:8000"}, clear=False):
+            os.environ.pop("HONCHO_API_KEY", None)
+            os.environ.pop("HONCHO_BASE_URL", None)
+            config = HonchoClientConfig.from_env()
+        assert config.base_url == "http://localhost:8000"
+        assert config.enabled is True
+
+
+    def test_honcho_base_url_wins_over_honcho_url(self):
+        with patch.dict(
+            os.environ,
+            {
+                "HONCHO_BASE_URL": "http://localhost:8000",
+                "HONCHO_URL": "http://localhost:9999",
+            },
+            clear=False,
+        ):
+            config = HonchoClientConfig.from_env()
+        assert config.base_url == "http://localhost:8000"
+
+
 class TestFromGlobalConfig:
     def test_missing_config_falls_back_to_env(self, tmp_path):
         with patch.dict(os.environ, {}, clear=True):
@@ -76,6 +99,60 @@ class TestFromGlobalConfig:
         # Should fall back to from_env
         assert config.enabled is False
         assert config.api_key is None
+
+
+    def test_missing_config_still_reads_honcho_url(self, tmp_path):
+        """The env fallback path must honor HONCHO_URL, not just HONCHO_BASE_URL.
+
+        from_global_config() returns from_env() when the config file is
+        absent, so a fallback that only from_global_config() understood
+        would silently do nothing for users with no ~/.honcho/config.json.
+        """
+        with patch.dict(os.environ, {"HONCHO_URL": "http://localhost:8000"}, clear=True):
+            config = HonchoClientConfig.from_global_config(
+                config_path=tmp_path / "nonexistent.json"
+            )
+        assert config.base_url == "http://localhost:8000"
+        assert config.enabled is True
+
+
+    def test_base_url_from_sdk_native_endpoint_block(self, tmp_path):
+        """endpoint.baseUrl is the SDK-native spelling Claude Desktop writes."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "apiKey": "key",
+            "endpoint": {"baseUrl": "http://localhost:8000"},
+        }))
+
+        with patch.dict(os.environ, {}, clear=True):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://localhost:8000"
+
+
+    def test_endpoint_base_url_wins_over_top_level_and_env(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "endpoint": {"baseUrl": "http://localhost:8000"},
+            "baseUrl": "http://localhost:9001",
+            "base_url": "http://localhost:9002",
+        }))
+
+        with patch.dict(os.environ, {"HONCHO_BASE_URL": "http://localhost:9003"}, clear=True):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://localhost:8000"
+
+
+    def test_endpoint_block_non_dict_is_ignored(self, tmp_path):
+        """A malformed endpoint value falls through instead of crashing."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "endpoint": "http://localhost:8000",
+            "baseUrl": "http://localhost:9001",
+        }))
+
+        with patch.dict(os.environ, {}, clear=True):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://localhost:9001"
 
 
     def test_host_block_overrides_root(self, tmp_path):

--- a/tests/honcho_plugin/test_client_identity_isolation.py
+++ b/tests/honcho_plugin/test_client_identity_isolation.py
@@ -1,0 +1,314 @@
+"""Multi-profile client isolation tests.
+
+Pin the cross-tenant bleed class (#69123 multiplexed gateway, #74065
+dashboard): a process-wide first-config-wins client singleton baked the
+first profile's workspace_id and bearer into one shared client, so every
+later profile's memory landed in the first profile's workspace.
+
+The tests drive the REAL resolution chain — HonchoClientConfig.from_global_config
+against real honcho.json files under temp HERMES_HOMEs, with the same
+ContextVar override the gateway multiplexer / dashboard use — and assert
+client identity, not internals.
+
+The two-profile repro mirrors issue #69123's minimal in-process repro;
+per-config-identity caching was first proposed in #69142 (NaMinhyeok) and
+extended in #81401 (angel12).
+"""
+
+import json
+import threading
+
+import pytest
+
+import plugins.memory.honcho.client as client_mod
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from plugins.memory.honcho.client import (
+    HonchoClientConfig,
+    get_honcho_client,
+    reset_honcho_client,
+)
+
+pytestmark = pytest.mark.skipif(
+    not pytest.importorskip("honcho", reason="honcho SDK not installed"),
+    reason="honcho SDK not installed",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_client_cache():
+    reset_honcho_client()
+    yield
+    reset_honcho_client()
+
+
+def _make_profile(tmp_path, name: str, workspace: str, api_key: str,
+                  host: str | None = None, oauth: dict | None = None):
+    home = tmp_path / name
+    home.mkdir(parents=True, exist_ok=True)
+    host = host or "hermes"
+    block: dict = {"apiKey": api_key, "workspace": workspace}
+    if oauth:
+        block["oauth"] = oauth
+    (home / "honcho.json").write_text(json.dumps({"hosts": {host: block}}))
+    return home
+
+
+class _FakeHoncho:
+    """Stands in for honcho.Honcho; records constructor kwargs."""
+
+    instances: list = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        _FakeHoncho.instances.append(self)
+
+
+@pytest.fixture
+def fake_honcho(monkeypatch):
+    _FakeHoncho.instances = []
+    import honcho
+
+    monkeypatch.setattr(honcho, "Honcho", _FakeHoncho)
+    return _FakeHoncho
+
+
+class TestTwoProfileIsolation:
+    def test_profiles_get_distinct_clients_and_workspaces(self, tmp_path, fake_honcho):
+        """#69123's minimal repro: override -> client -> reset -> override -> client."""
+        home_a = _make_profile(tmp_path, "profiles/a", "tenant-a", "key-a")
+        home_b = _make_profile(tmp_path, "profiles/b", "tenant-b", "key-b")
+
+        token = set_hermes_home_override(home_a)
+        try:
+            cfg_a = HonchoClientConfig.from_global_config()
+            client_a = get_honcho_client(cfg_a)
+        finally:
+            reset_hermes_home_override(token)
+
+        token = set_hermes_home_override(home_b)
+        try:
+            cfg_b = HonchoClientConfig.from_global_config()
+            client_b = get_honcho_client(cfg_b)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert client_a is not client_b
+        assert client_a.kwargs["workspace_id"] == "tenant-a"
+        assert client_b.kwargs["workspace_id"] == "tenant-b"
+        assert client_a.kwargs["api_key"] == "key-a"
+        assert client_b.kwargs["api_key"] == "key-b"
+
+    def test_same_profile_reuses_client(self, tmp_path, fake_honcho):
+        home_a = _make_profile(tmp_path, "profiles/a", "tenant-a", "key-a")
+
+        token = set_hermes_home_override(home_a)
+        try:
+            cfg1 = HonchoClientConfig.from_global_config()
+            c1 = get_honcho_client(cfg1)
+            cfg2 = HonchoClientConfig.from_global_config()
+            c2 = get_honcho_client(cfg2)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert c1 is c2
+        assert len(fake_honcho.instances) == 1
+
+
+class TestBackgroundThreadIsolation:
+    def test_bound_config_wins_on_bare_thread(self, tmp_path, fake_honcho):
+        """A manager's bound config must acquire ITS profile's client even
+        from a thread that cannot see the profile ContextVar — the pattern
+        of every plugin daemon thread (async writer, prefetch, sync)."""
+        home_a = _make_profile(tmp_path, "profiles/a", "tenant-a", "key-a")
+        home_b = _make_profile(tmp_path, "profiles/b", "tenant-b", "key-b")
+
+        # Default-profile client exists first (the "pinning" client).
+        token = set_hermes_home_override(home_a)
+        try:
+            cfg_a = HonchoClientConfig.from_global_config()
+            get_honcho_client(cfg_a)
+        finally:
+            reset_hermes_home_override(token)
+
+        # Profile B's config resolved inside its scope (as initialize() does).
+        token = set_hermes_home_override(home_b)
+        try:
+            cfg_b = HonchoClientConfig.from_global_config()
+        finally:
+            reset_hermes_home_override(token)
+
+        # A bare thread (empty context — no profile override visible)
+        # acquires via the bound config, as manager.honcho now does.
+        box: dict = {}
+
+        def _worker():
+            box["client"] = get_honcho_client(cfg_b)
+
+        t = threading.Thread(target=_worker)
+        t.start()
+        t.join(timeout=10)
+
+        assert box["client"].kwargs["workspace_id"] == "tenant-b"
+        assert box["client"].kwargs["api_key"] == "key-b"
+
+    def test_spawn_context_thread_sees_profile_override(self, tmp_path):
+        """spawn_context_thread must carry the caller's HERMES_HOME override."""
+        from hermes_constants import get_hermes_home
+        from plugins.memory.honcho.client import spawn_context_thread
+
+        home_b = tmp_path / "profiles" / "b"
+        home_b.mkdir(parents=True)
+        seen: dict = {}
+
+        def _probe():
+            seen["home"] = get_hermes_home()
+
+        token = set_hermes_home_override(home_b)
+        try:
+            t = spawn_context_thread(_probe, name="probe")
+            t.start()
+            t.join(timeout=10)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert seen["home"] == home_b
+
+    def test_plain_thread_does_not_see_override(self, tmp_path):
+        """Control: documents WHY propagation is needed — a plain thread
+        resolves the process home, not the caller's profile override."""
+        from hermes_constants import get_hermes_home
+
+        home_b = tmp_path / "profiles" / "b"
+        home_b.mkdir(parents=True)
+        seen: dict = {}
+
+        def _probe():
+            seen["home"] = get_hermes_home()
+
+        token = set_hermes_home_override(home_b)
+        try:
+            t = threading.Thread(target=_probe)
+            t.start()
+            t.join(timeout=10)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert seen["home"] != home_b
+
+
+class TestCredentialIdentity:
+    def test_account_swap_creates_new_client_and_evicts_old(self, tmp_path, fake_honcho):
+        """Switching accounts via setup (same path/host, new apiKey) must not
+        keep serving the old account's client — the collision a
+        provenance-only cache key cannot close."""
+        home = _make_profile(tmp_path, "profiles/a", "tenant-a", "key-account-1")
+
+        token = set_hermes_home_override(home)
+        try:
+            cfg1 = HonchoClientConfig.from_global_config()
+            c1 = get_honcho_client(cfg1)
+
+            # Operator re-runs setup: same file, new account credentials.
+            (home / "honcho.json").write_text(json.dumps({
+                "hosts": {"hermes": {"apiKey": "key-account-2", "workspace": "tenant-a"}},
+            }))
+            cfg2 = HonchoClientConfig.from_global_config()
+            c2 = get_honcho_client(cfg2)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert c1 is not c2
+        assert c2.kwargs["api_key"] == "key-account-2"
+        # Old slot evicted: the stale client is no longer reachable via the map.
+        with client_mod._client_slots_lock:
+            cached_clients = [
+                s.peek() for s in client_mod._client_slots.values()
+            ]
+        assert c1 not in cached_clients
+
+    def test_oauth_refresh_token_is_fingerprint_basis(self, tmp_path):
+        """Fingerprint must survive access-token rotation (in-place bearer
+        swap) but change when the refresh token (re-auth) changes."""
+        home = tmp_path / "p"
+        home.mkdir()
+        oauth_block = {
+            "refreshToken": "refresh-1",
+            "tokenEndpoint": "https://auth.example/token",
+            "clientId": "cid",
+            "expiresAt": 9999999999,
+        }
+        (home / "honcho.json").write_text(json.dumps({
+            "hosts": {"hermes": {"apiKey": "access-token-1", "workspace": "w",
+                                  "oauth": oauth_block}},
+        }))
+
+        token = set_hermes_home_override(home)
+        try:
+            cfg1 = HonchoClientConfig.from_global_config()
+            fp1 = client_mod._credential_fingerprint(cfg1)
+
+            # Access token rotates in place; refresh token unchanged.
+            cfg_rotated = HonchoClientConfig.from_global_config()
+            cfg_rotated.api_key = "access-token-2"
+            fp_rotated = client_mod._credential_fingerprint(cfg_rotated)
+
+            # Re-auth: new refresh token.
+            oauth_block2 = dict(oauth_block, refreshToken="refresh-2")
+            (home / "honcho.json").write_text(json.dumps({
+                "hosts": {"hermes": {"apiKey": "access-token-3", "workspace": "w",
+                                      "oauth": oauth_block2}},
+            }))
+            cfg2 = HonchoClientConfig.from_global_config()
+            fp2 = client_mod._credential_fingerprint(cfg2)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert fp1 == fp_rotated, "access-token rotation must not change identity"
+        assert fp1 != fp2, "re-auth must change identity"
+
+    def test_timeout_change_rebuilds_via_key(self, tmp_path, fake_honcho):
+        """The old singleton had an explicit timeout-staleness check; with
+        timeout in the key, a change produces a new identity + eviction."""
+        home = _make_profile(tmp_path, "profiles/a", "w", "k")
+        token = set_hermes_home_override(home)
+        try:
+            cfg1 = HonchoClientConfig.from_global_config()
+            c1 = get_honcho_client(cfg1)
+
+            raw = json.loads((home / "honcho.json").read_text())
+            raw["hosts"]["hermes"]["timeout"] = 77
+            (home / "honcho.json").write_text(json.dumps(raw))
+            cfg2 = HonchoClientConfig.from_global_config()
+            c2 = get_honcho_client(cfg2)
+        finally:
+            reset_hermes_home_override(token)
+
+        assert c1 is not c2
+        assert c2.kwargs["timeout"] == 77.0
+
+
+class TestProvenance:
+    def test_from_global_config_captures_provenance(self, tmp_path):
+        home = _make_profile(tmp_path, "profiles/a", "w", "k")
+        token = set_hermes_home_override(home)
+        try:
+            cfg = HonchoClientConfig.from_global_config()
+        finally:
+            reset_hermes_home_override(token)
+
+        assert cfg.config_path == home / "honcho.json"
+        assert cfg.hermes_home == home
+        assert cfg.bound_config_path() == home / "honcho.json"
+
+    def test_bound_path_stable_outside_scope(self, tmp_path):
+        """The captured path must not drift when read outside the profile
+        scope (the daemon-thread situation)."""
+        home = _make_profile(tmp_path, "profiles/a", "w", "k")
+        token = set_hermes_home_override(home)
+        try:
+            cfg = HonchoClientConfig.from_global_config()
+        finally:
+            reset_hermes_home_override(token)
+
+        # Now OUTSIDE the scope — bound path still points at profile a.
+        assert cfg.bound_config_path() == home / "honcho.json"

--- a/tests/honcho_plugin/test_save_messages.py
+++ b/tests/honcho_plugin/test_save_messages.py
@@ -1,0 +1,65 @@
+"""Tests for the saveMessages knob: when false, the provider never writes to Honcho.
+
+The knob has always been parsed by HonchoClientConfig but was not consumed by
+the write paths (sync_turn / on_memory_write / on_session_end). These tests pin
+the contract: saveMessages=false disables all automatic persistence while read
+and tools paths remain untouched.
+"""
+
+from unittest.mock import MagicMock
+
+from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho.client import HonchoClientConfig
+
+
+def _provider(save_messages: bool) -> HonchoMemoryProvider:
+    p = HonchoMemoryProvider()
+    p._config = HonchoClientConfig(save_messages=save_messages)
+    p._manager = MagicMock()
+    p._session_key = 'test-session'
+    p._session_initialized = True
+    return p
+
+
+class TestSyncTurn:
+    def test_disabled_writes_nothing(self):
+        p = _provider(save_messages=False)
+        p.sync_turn('user says', 'assistant says')
+        p._manager.get_or_create.assert_not_called()
+        p._manager._flush_session.assert_not_called()
+
+    def test_enabled_writes(self):
+        p = _provider(save_messages=True)
+        p.sync_turn('user says', 'assistant says')
+        if p._sync_thread is not None:
+            p._sync_thread.join(timeout=5)
+        p._manager.get_or_create.assert_called_once()
+
+
+class TestOnMemoryWrite:
+    def test_disabled_skips_conclusion_mirror(self):
+        p = _provider(save_messages=False)
+        p.on_memory_write('add', 'user', 'user likes coffee')
+        p._manager.create_conclusion.assert_not_called()
+
+    def test_enabled_mirrors(self):
+        import time
+
+        p = _provider(save_messages=True)
+        p.on_memory_write('add', 'user', 'user likes coffee')
+        deadline = time.time() + 5
+        while time.time() < deadline and not p._manager.create_conclusion.called:
+            time.sleep(0.05)
+        p._manager.create_conclusion.assert_called_once()
+
+
+class TestOnSessionEnd:
+    def test_disabled_skips_flush(self):
+        p = _provider(save_messages=False)
+        p.on_session_end([])
+        p._manager.flush_all.assert_not_called()
+
+    def test_enabled_flushes(self):
+        p = _provider(save_messages=True)
+        p.on_session_end([])
+        p._manager.flush_all.assert_called_once()

--- a/tests/honcho_plugin/test_save_messages.py
+++ b/tests/honcho_plugin/test_save_messages.py
@@ -26,7 +26,16 @@ class TestSyncTurn:
         p = _provider(save_messages=False)
         p.sync_turn('user says', 'assistant says')
         p._manager.get_or_create.assert_not_called()
-        p._manager._flush_session.assert_not_called()
+        p._manager.save.assert_not_called()
+
+    def test_enabled_routes_through_save(self):
+        p = _provider(save_messages=True)
+        p.sync_turn('user says', 'assistant says')
+        if p._sync_thread is not None:
+            p._sync_thread.join(timeout=5)
+        p._manager.get_or_create.assert_called_once()
+        # save() (not _flush_session) so writeFrequency batching is honored
+        p._manager.save.assert_called_once()
 
     def test_enabled_writes(self):
         p = _provider(save_messages=True)

--- a/tests/honcho_plugin/test_save_messages.py
+++ b/tests/honcho_plugin/test_save_messages.py
@@ -66,8 +66,10 @@ class TestOnSessionEnd:
 
 
 class TestShutdown:
-    """shutdown() joins worker threads then flushes; saveMessages=false must
-    skip the flush (persistence) while still running the joins (cleanup)."""
+    """shutdown() joins worker threads then delegates to the session manager:
+    manager.shutdown() (flush + join async writer) when persistence is on,
+    manager.stop_async_writer() (join only, no flush) when saveMessages=false.
+    Cleanup runs in both cases; only persistence is gated."""
 
     def _provider_for_shutdown(self, save_messages: bool) -> HonchoMemoryProvider:
         p = _provider(save_messages=save_messages)
@@ -78,12 +80,16 @@ class TestShutdown:
         p._sync_thread = None
         return p
 
-    def test_disabled_skips_flush(self):
+    def test_disabled_skips_flush_but_stops_writer(self):
         p = self._provider_for_shutdown(save_messages=False)
         p.shutdown()
         p._manager.flush_all.assert_not_called()
+        p._manager.shutdown.assert_not_called()
+        p._manager.stop_async_writer.assert_called_once()
 
-    def test_enabled_flushes(self):
+    def test_enabled_shuts_down_manager(self):
         p = self._provider_for_shutdown(save_messages=True)
         p.shutdown()
-        p._manager.flush_all.assert_called_once()
+        # manager.shutdown() flushes AND joins the async-writer thread;
+        # calling flush_all() alone left the writer thread alive at exit.
+        p._manager.shutdown.assert_called_once()

--- a/tests/honcho_plugin/test_save_messages.py
+++ b/tests/honcho_plugin/test_save_messages.py
@@ -63,3 +63,27 @@ class TestOnSessionEnd:
         p = _provider(save_messages=True)
         p.on_session_end([])
         p._manager.flush_all.assert_called_once()
+
+
+class TestShutdown:
+    """shutdown() joins worker threads then flushes; saveMessages=false must
+    skip the flush (persistence) while still running the joins (cleanup)."""
+
+    def _provider_for_shutdown(self, save_messages: bool) -> HonchoMemoryProvider:
+        p = _provider(save_messages=save_messages)
+        # shutdown() iterates these thread handles; if no turn/session-end ran
+        # they may be unset, so default to None (= "no thread started").
+        p._init_thread = None
+        p._prefetch_thread = None
+        p._sync_thread = None
+        return p
+
+    def test_disabled_skips_flush(self):
+        p = self._provider_for_shutdown(save_messages=False)
+        p.shutdown()
+        p._manager.flush_all.assert_not_called()
+
+    def test_enabled_flushes(self):
+        p = self._provider_for_shutdown(save_messages=True)
+        p.shutdown()
+        p._manager.flush_all.assert_called_once()

--- a/tests/plugins/memory/test_honcho_cli_peers.py
+++ b/tests/plugins/memory/test_honcho_cli_peers.py
@@ -1,0 +1,125 @@
+"""Regression tests for #76414: `hermes honcho peers` showed "(not set)"
+for every non-default profile.
+
+_all_profile_host_configs() built the per-profile host key inline as
+f"{HOST}.{profile}" ("hermes.work") while every other reader/writer —
+profile_host_key(), resolve_active_host(), honcho status/enable/sync and
+the runtime plugin — uses the underscore form ("hermes_work"). The lookup
+always missed, so cmd_peers fell back to "(not set)" and leaked the raw
+malformed key into the AI-peer column.
+
+These tests drive the real cmd_peers / _all_profile_host_configs against
+a real honcho.json (temp HERMES_HOME, no network).
+"""
+import io
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import plugins.memory.honcho.cli as honcho_cli
+
+
+@pytest.fixture
+def honcho_home(tmp_path, monkeypatch):
+    cfg = {
+        "peerName": "alice",
+        "hosts": {
+            "hermes": {"peerName": "alice", "aiPeer": "hermes"},
+            "hermes_work": {"peerName": "alice", "aiPeer": "hermes"},
+            "hermes_my_profile": {"peerName": "bob", "aiPeer": "hermes"},
+        },
+    }
+    path = tmp_path / "honcho.json"
+    path.write_text(json.dumps(cfg))
+    monkeypatch.setattr(honcho_cli, "_config_path", lambda: path)
+    return tmp_path
+
+
+def _peers_output(profiles):
+    buf = io.StringIO()
+    old = sys.stdout
+    sys.stdout = buf
+    try:
+        honcho_cli.cmd_peers(SimpleNamespace())
+    finally:
+        sys.stdout = old
+    return buf.getvalue()
+
+
+class TestAllProfileHostConfigs:
+    def test_profile_host_keys_match_writer_form(self, honcho_home, monkeypatch):
+        """The lookup key must be profile_host_key()'s underscore form —
+        the same one honcho sync/enable/status and the runtime write to."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.list_profiles",
+            lambda: [SimpleNamespace(name="default"), SimpleNamespace(name="work")],
+        )
+        rows = honcho_cli._all_profile_host_configs()
+        by_name = {name: (host, block) for name, host, block in rows}
+        host, block = by_name["work"]
+        assert host == "hermes_work"  # not "hermes.work"
+        assert block.get("peerName") == "alice"  # the populated block was found
+
+    def test_sanitized_profile_names_resolve(self, honcho_home, monkeypatch):
+        """Profiles needing sanitization (dots/spaces in the name) also
+        resolve — profile_host_key maps 'my.profile' -> 'hermes_my_profile';
+        the inline dot form never could."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.list_profiles",
+            lambda: [SimpleNamespace(name="default"),
+                     SimpleNamespace(name="my.profile")],
+        )
+        rows = honcho_cli._all_profile_host_configs()
+        by_name = {name: block for name, _, block in rows}
+        assert by_name["my.profile"].get("peerName") == "bob"
+
+    def test_legacy_dot_form_host_key_still_readable(self, honcho_home, monkeypatch):
+        """Back-compat: honcho.json files with LEGACY dot-form host keys
+        ("hermes.work") must keep working — the README promises those keys
+        stay readable, and _host_block() exists precisely for that fallback.
+        A bare hosts.get(profile_host_key(...)) would regress them."""
+        path = honcho_home / "honcho.json"
+        cfg = json.loads(path.read_text())
+        del cfg["hosts"]["hermes_work"]
+        cfg["hosts"]["hermes.work"] = {"peerName": "carol", "aiPeer": "hermes"}
+        path.write_text(json.dumps(cfg))
+        monkeypatch.setattr(
+            "hermes_cli.profiles.list_profiles",
+            lambda: [SimpleNamespace(name="default"), SimpleNamespace(name="work")],
+        )
+        rows = honcho_cli._all_profile_host_configs()
+        by_name = {name: block for name, _, block in rows}
+        assert by_name["work"].get("peerName") == "carol"
+
+
+class TestCmdPeers:
+    def test_peers_shows_populated_identity_not_host_key_leak(
+            self, honcho_home, monkeypatch):
+        """Issue #76414's visible symptom: the AI-peer column showed the
+        raw malformed key 'hermes.work' (or '(not set)')."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.list_profiles",
+            lambda: [SimpleNamespace(name="default"), SimpleNamespace(name="work")],
+        )
+        out = _peers_output(SimpleNamespace())
+        assert "hermes.work" not in out
+        assert "(not set)" not in out
+        # work row shows the populated block's values
+        work_line = [l for l in out.splitlines() if l.strip().startswith("work")][0]
+        assert "alice" in work_line and "hermes" in work_line
+
+    def test_peers_falls_back_cleanly_when_block_missing(
+            self, honcho_home, monkeypatch):
+        """A profile with no host block still falls back to the top-level
+        peerName and the (well-formed) host key — not a crash or a leak."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.list_profiles",
+            lambda: [SimpleNamespace(name="default"), SimpleNamespace(name="new")],
+        )
+        out = _peers_output(SimpleNamespace())
+        assert "hermes.new" not in out  # well-formed key, no dot-form leak
+        new_line = [l for l in out.splitlines() if l.strip().startswith("new")][0]
+        assert "alice" in new_line  # top-level peerName fallback

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -36,6 +36,15 @@ def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
+        # Unit tests must not probe live endpoints. The compressor resolves
+        # context length lazily via a real network call against base_url; for
+        # reachable hosts (the nous portal case) the endpoint's answer for the
+        # empty test model (32K) trips agent_init's 64K floor and fails the
+        # test on network behavior, not code under test.
+        patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=200_000,
+        ),
     ):
         agent = AIAgent(
             api_key="test-key-12345678",

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -151,3 +151,56 @@ class TestHonchoBaseUrlSanitize:
         monkeypatch.delenv('HONCHO_API_KEY', raising=False)
         cfg = HonchoClientConfig.from_env()
         assert cfg.base_url is None
+
+
+class TestProfileKeyIsolationWarning:
+    """#36098 / #66125: a named-profile host block without apiKey does NOT
+    inherit the default host's key (isolation by design), but the failure
+    must be loud, not silent."""
+
+    def test_keyless_profile_block_warns_when_default_has_key(self, tmp_path, monkeypatch, caplog):
+        import logging
+        monkeypatch.delenv('HONCHO_API_KEY', raising=False)
+        config_path = tmp_path / 'config.json'
+        config_path.write_text(json.dumps({
+            'hosts': {
+                'hermes': {'apiKey': 'shared-key'},
+                'hermes_coder': {'baseUrl': 'http://192.168.1.50:8000'},
+            },
+        }))
+        with caplog.at_level(logging.WARNING, logger='plugins.memory.honcho.client'):
+            cfg = HonchoClientConfig.from_global_config(
+                host='hermes_coder', config_path=config_path,
+            )
+        assert cfg.api_key is None  # isolation preserved — no silent inheritance
+        assert any('NOT inherited' in r.message for r in caplog.records)
+
+    def test_no_warning_when_profile_block_has_key(self, tmp_path, monkeypatch, caplog):
+        import logging
+        monkeypatch.delenv('HONCHO_API_KEY', raising=False)
+        config_path = tmp_path / 'config.json'
+        config_path.write_text(json.dumps({
+            'hosts': {
+                'hermes': {'apiKey': 'shared-key'},
+                'hermes_coder': {'apiKey': 'coder-key'},
+            },
+        }))
+        with caplog.at_level(logging.WARNING, logger='plugins.memory.honcho.client'):
+            cfg = HonchoClientConfig.from_global_config(
+                host='hermes_coder', config_path=config_path,
+            )
+        assert cfg.api_key == 'coder-key'
+        assert not any('NOT inherited' in r.message for r in caplog.records)
+
+    def test_no_warning_for_default_host(self, tmp_path, monkeypatch, caplog):
+        import logging
+        monkeypatch.delenv('HONCHO_API_KEY', raising=False)
+        config_path = tmp_path / 'config.json'
+        config_path.write_text(json.dumps({
+            'hosts': {'hermes': {'baseUrl': 'http://localhost:8000'}},
+        }))
+        with caplog.at_level(logging.WARNING, logger='plugins.memory.honcho.client'):
+            HonchoClientConfig.from_global_config(
+                host='hermes', config_path=config_path,
+            )
+        assert not any('NOT inherited' in r.message for r in caplog.records)

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -123,3 +123,31 @@ class TestLatencyFlagResolution:
         cfg = HonchoClientConfig.from_global_config(config_path=config_path)
         assert cfg.timeout == 5.0
 
+
+class TestHonchoBaseUrlSanitize:
+    def test_clean_base_url_accepted(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('HONCHO_BASE_URL', raising=False)
+        config_path = tmp_path / 'config.json'
+        config_path.write_text(json.dumps({
+            'apiKey': 'k',
+            'baseUrl': 'https://honcho.example.com',
+        }))
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+        assert cfg.base_url == 'https://honcho.example.com'
+
+    def test_nonprintable_base_url_dropped(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('HONCHO_BASE_URL', raising=False)
+        config_path = tmp_path / 'config.json'
+        bad = 'https://honcho.example.com\x1b'
+        config_path.write_text(json.dumps({
+            'apiKey': 'k',
+            'baseUrl': bad,
+        }))
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+        assert cfg.base_url is None
+
+    def test_env_nonprintable_dropped(self, monkeypatch):
+        monkeypatch.setenv('HONCHO_BASE_URL', 'https://x.example\x1b')
+        monkeypatch.delenv('HONCHO_API_KEY', raising=False)
+        cfg = HonchoClientConfig.from_env()
+        assert cfg.base_url is None

--- a/tests/test_honcho_startup_fail_open.py
+++ b/tests/test_honcho_startup_fail_open.py
@@ -324,3 +324,227 @@ def test_honcho_tools_lazy_hooks_do_not_prestart_background_init(monkeypatch):
     assert result == {"result": ["ready"]}
     assert init_calls == ["session-1"]
     assert not background_started.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Write-containment regression tests
+# ---------------------------------------------------------------------------
+
+
+def test_honcho_sync_turn_skips_write_when_save_messages_is_disabled():
+    """The resolved write-disable switch must gate an initialized provider."""
+    provider = HonchoMemoryProvider()
+    cfg = _configured_tools_config(init_on_session_start=True)
+    cfg.save_messages = False
+    manager_calls = []
+
+    class Manager:
+        def get_or_create(self, session_key):
+            manager_calls.append(session_key)
+            return SimpleNamespace()
+
+    provider._config = cfg
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    provider.sync_turn("a genuine user turn", "a genuine assistant reply")
+
+    assert provider._sync_thread is None
+    assert manager_calls == []
+
+
+def test_honcho_sync_turn_skips_anchored_gateway_notifications():
+    """Known bracketed gateway wrappers must not become durable messages."""
+    wrappers = (
+        "[ASYNC DELEGATION BATCH COMPLETE — deleg_1]\nworker results follow",
+        "[ASYNC DELEGATION COMPLETE — deleg_2]",
+        "[CONTEXT COMPACTION — REFERENCE ONLY]\nsummary follows",
+        "[CONTEXT COMPACTION - REFERENCE ONLY]",
+        "[CONTEXT COMPACTION]",
+        "[PRIOR CONTEXT — for reference only; not a new message]",
+        "[Your active task list was preserved across context compression]",
+        "[CONTEXT SUMMARY]: previous context",
+        "[IMPORTANT: Background process 12 matched watch pattern \"foo\"\nCommand: x",
+    )
+
+    for wrapper in wrappers:
+        provider = HonchoMemoryProvider()
+        manager_calls = []
+
+        class Manager:
+            def get_or_create(self, session_key):
+                manager_calls.append(session_key)
+                return SimpleNamespace()
+
+        provider._config = _configured_tools_config(init_on_session_start=True)
+        provider._manager = Manager()
+        provider._session_key = "test-session"
+        provider._session_initialized = True
+
+        provider.sync_turn(wrapper, "assistant reply")
+
+        assert provider._sync_thread is None, f"wrapper not suppressed: {wrapper[:60]!r}"
+        assert manager_calls == [], f"wrapper not suppressed: {wrapper[:60]!r}"
+
+
+def test_honcho_sync_turn_skips_prose_gateway_notifications():
+    """Prose-form gateway notifications must not become durable messages."""
+    prose_wrappers = (
+        "A background fan-out of 3 subagent(s) you dispatched earlier has finished.",
+        "A background subagent you dispatched earlier has finished. You may have moved on.",
+    )
+
+    for wrapper in prose_wrappers:
+        provider = HonchoMemoryProvider()
+        manager_calls = []
+
+        class Manager:
+            def get_or_create(self, session_key):
+                manager_calls.append(session_key)
+                return SimpleNamespace()
+
+        provider._config = _configured_tools_config(init_on_session_start=True)
+        provider._manager = Manager()
+        provider._session_key = "test-session"
+        provider._session_initialized = True
+
+        provider.sync_turn(wrapper, "assistant reply")
+
+        assert provider._sync_thread is None, f"prose wrapper not suppressed: {wrapper[:60]!r}"
+        assert manager_calls == [], f"prose wrapper not suppressed: {wrapper[:60]!r}"
+
+
+def test_honcho_sync_turn_does_not_suppress_genuine_user_messages():
+    """Genuine user messages that mention gateway terms must still be stored."""
+    genuine = (
+        "A background process I ran has finished — can you check the output?",
+        "A background subagent you dispatched earlier has finished? no wait, I was asking about the report",
+        "the async delegation batch complete marker disappeared from my log",
+        "CONTEXT COMPACTION happened mid-message and I want to see it",
+        "When you see PRIOR CONTEXT, treat it carefully",
+        "I want to know about your task list",
+        "IMPORTANT: Background process — can you explain what that means?",
+        "[IMPORTANT: Background process — what does that mean?]",
+    )
+
+    for msg in genuine:
+        provider = HonchoMemoryProvider()
+        manager_calls = []
+
+        class Manager:
+            def get_or_create(self, session_key):
+                manager_calls.append(session_key)
+                return SimpleNamespace()
+
+        provider._config = _configured_tools_config(init_on_session_start=True)
+        provider._manager = Manager()
+        provider._session_key = "test-session"
+        provider._session_initialized = True
+
+        provider.sync_turn(msg, "assistant reply")
+
+        assert provider._sync_thread is not None, f"genuine message suppressed: {msg[:60]!r}"
+        assert manager_calls != [], f"genuine message suppressed: {msg[:60]!r}"
+
+
+def test_honcho_sync_turn_skips_empty_content():
+    """Empty or whitespace-only turns must not be stored."""
+    provider = HonchoMemoryProvider()
+    manager_calls = []
+
+    class Manager:
+        def get_or_create(self, session_key):
+            manager_calls.append(session_key)
+            return SimpleNamespace()
+
+    provider._config = _configured_tools_config(init_on_session_start=True)
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    provider.sync_turn("   ", "  ")
+
+    assert provider._sync_thread is None
+    assert manager_calls == []
+
+
+def test_honcho_sync_turn_same_instance_config_flip_gates_writes():
+    """The cached-provider regression: flipping save_messages on the SAME
+    configured instance must stop writes without re-initialization."""
+    provider = HonchoMemoryProvider()
+    cfg = _configured_tools_config(init_on_session_start=True)
+    cfg.save_messages = True
+    manager_calls = []
+    write_done = threading.Event()
+
+    class Manager:
+        def get_or_create(self, session_key):
+            manager_calls.append(session_key)
+            return SimpleNamespace(add_message=lambda role, content: None)
+
+        def _flush_session(self, session):
+            write_done.set()
+
+    provider._config = cfg
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    # enabled -> write happens
+    provider.sync_turn("user turn", "assistant reply")
+    assert write_done.wait(timeout=5), "first write never completed"
+
+    # operator flips containment on the same cached config object
+    cfg.save_messages = False
+    manager_calls.clear()
+    provider.sync_turn("user turn two", "assistant reply two")
+
+    # no new write may occur; the stale _sync_thread from the enabled write is fine
+    assert manager_calls == []
+
+
+def test_honcho_on_memory_write_honors_save_messages_false():
+    """The memory-tool mirror is an automatic write path and must respect the
+    write-disable switch; otherwise containment only covers conversation turns."""
+    provider = HonchoMemoryProvider()
+    cfg = _configured_tools_config(init_on_session_start=True)
+    cfg.save_messages = False
+    conclusion_calls = []
+
+    class Manager:
+        def create_conclusion(self, session_key, content):
+            conclusion_calls.append((session_key, content))
+
+    provider._config = cfg
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    provider.on_memory_write("add", "user", "prefers fail-open memory")
+
+    assert conclusion_calls == []
+
+
+def test_honcho_on_memory_write_still_writes_when_enabled():
+    """With save_messages enabled, the memory-tool mirror still writes."""
+    provider = HonchoMemoryProvider()
+    cfg = _configured_tools_config(init_on_session_start=True)
+    cfg.save_messages = True
+    conclusion_calls = []
+    write_done = threading.Event()
+
+    class Manager:
+        def create_conclusion(self, session_key, content):
+            conclusion_calls.append((session_key, content))
+            write_done.set()
+
+    provider._config = cfg
+    provider._manager = Manager()
+    provider._session_key = "test-session"
+    provider._session_initialized = True
+
+    provider.on_memory_write("add", "user", "prefers fail-open memory")
+
+    assert write_done.wait(timeout=5), "memory mirror write never completed"
+    assert conclusion_calls != []

--- a/tests/test_honcho_startup_fail_open.py
+++ b/tests/test_honcho_startup_fail_open.py
@@ -483,7 +483,7 @@ def test_honcho_sync_turn_same_instance_config_flip_gates_writes():
             manager_calls.append(session_key)
             return SimpleNamespace(add_message=lambda role, content: None)
 
-        def _flush_session(self, session):
+        def save(self, session):
             write_done.set()
 
     provider._config = cfg

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -89,6 +89,23 @@ def _(rid, params: dict) -> dict:
             }
             if include_sessions:
                 row["last_session"] = _latest_profile_session_row(p.path)
+
+            # Client-agnostic UI metadata (avatars, accent colors, pinned
+            # order, …) — stored server-side in profile.yaml so every
+            # machine connecting to this gateway paints the same roster.
+            try:
+                import yaml as _yaml
+                from pathlib import Path as _Path
+
+                meta_path = _Path(str(p.path)) / "profile.yaml"
+                if meta_path.is_file():
+                    with open(meta_path, "r", encoding="utf-8") as f:
+                        raw_meta = _yaml.safe_load(f) or {}
+                    ui_meta = raw_meta.get("ui_meta")
+                    if isinstance(ui_meta, dict) and ui_meta:
+                        row["ui_meta"] = ui_meta
+            except Exception:
+                pass
             out.append(row)
         return _ok(rid, {"profiles": out})
     except Exception as e:
@@ -381,6 +398,50 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 4064, f"profile '{name}' not found")
 
         applied = {}
+
+        if isinstance(params.get("ui_meta"), dict):
+            # Client-agnostic UI metadata (avatar/pet/etc.), merged key-wise
+            # into profile.yaml's ui_meta block. A key set to None deletes it.
+            # Size-capped: this rides profiles.list on every roster paint, so
+            # large blobs (e.g. raw base64 images) are rejected — persist big
+            # assets elsewhere and store a reference.
+            try:
+                import json as _json
+
+                incoming = params["ui_meta"]
+                if len(_json.dumps(incoming)) > 65536:
+                    applied["ui_meta"] = False
+                else:
+                    import yaml as _yaml
+
+                    meta_path = profile_dir / "profile.yaml"
+                    existing = {}
+                    if meta_path.is_file():
+                        try:
+                            with open(meta_path, "r", encoding="utf-8") as f:
+                                loaded = _yaml.safe_load(f) or {}
+                            if isinstance(loaded, dict):
+                                existing = loaded
+                        except Exception:
+                            existing = {}
+                    current = existing.get("ui_meta")
+                    if not isinstance(current, dict):
+                        current = {}
+                    for key, value in incoming.items():
+                        if value is None:
+                            current.pop(key, None)
+                        else:
+                            current[key] = value
+                    if current:
+                        existing["ui_meta"] = current
+                    else:
+                        existing.pop("ui_meta", None)
+                    from utils import atomic_yaml_write
+
+                    atomic_yaml_write(meta_path, existing, sort_keys=False)
+                    applied["ui_meta"] = True
+            except Exception:
+                applied["ui_meta"] = False
 
         if isinstance(params.get("soul"), str):
             try:

--- a/uv.lock
+++ b/uv.lock
@@ -12,13 +12,12 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
-h2 = false
 vercel = false
 aiohttp = false
 cryptography = false
 nemo-relay = false
 huggingface-hub = false
-honcho-ai = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+h2 = false
 
 [manifest]
 overrides = [

--- a/uv.lock
+++ b/uv.lock
@@ -12,12 +12,13 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
+h2 = false
 vercel = false
 aiohttp = false
 cryptography = false
 nemo-relay = false
 huggingface-hub = false
-h2 = false
+honcho-ai = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 
 [manifest]
 overrides = [


### PR DESCRIPTION
## Summary

Consolidates and salvages three Honcho plugin PRs by @erosika (#83500, #83508, #83525) onto latest main, with review follow-up fixes applied on top. All three address distinct bug classes in the Honcho memory plugin that cause silent data corruption in multi-profile/self-hosted setups.

## What this PR makes true

The Honcho plugin correctly isolates per-profile clients, resolves self-hosted baseUrl/apiKey configs, and respects saveMessages=false — fixing cross-tenant memory bleed, silent cloud routing, and ignored write containment.

## Changes

### From PR #83525 — client identity isolation (closes #69123, #74065)
- Replaces process-wide client singleton with per-identity caching (host, workspace, base_url, environment, provenance, timeout, credential fingerprint)
- Configs capture provenance (config_path, hermes_home) at resolution time
- `spawn_context_thread()` carries contextvars into all 9 plugin daemon threads
- Credential fingerprint hashes OAuth refresh token (stable across access-token rotation, changes on re-auth)
- Stale same-identity slots evicted on replacement
- Path-keyed timeout memo (was single-slot, thrashed between profiles)
- MemoryManager background dispatch wraps with caller's contextvars (general fix for ALL memory providers)
- **Follow-up fix:** replaced unreadable double-lambda with `functools.partial(ctx.run, fn)`
- **Follow-up fix:** `from_env()` now sets `config_path` so `bound_config_path()` doesn't re-resolve from ContextVar on daemon threads

### From PR #83508 — baseUrl/apiKey resolution (closes #43800, #37436, #76414; addresses #36098, #66125)
- Reads `endpoint.baseUrl` (SDK-native, what Claude Desktop writes)
- Accepts `HONCHO_URL` env var as fallback
- Host-block baseUrl takes precedence over flat root
- Uses `_host_block()` for dot-form legacy host key fallback in local-auth check
- Honors top-level `apiKey` for local URLs
- Warns loudly when keyless profile doesn't inherit default host's key
- `raise_errors=True` in `dialectic_query` for explicit tool calls
- `_sanitize_url()` drops non-printable chars before client init
- Peers command uses `profile_host_key()` (underscore form)

### From PR #83500 — saveMessages containment (closes #35209)
- Gates all four automatic write paths on `saveMessages` (sync_turn, on_memory_write, on_session_end, shutdown)
- Rejects machine-generated gateway notifications from being persisted as user turns
- Routes `sync_turn` through `manager.save()` so `writeFrequency` batching applies
- Provider shutdown calls `manager.shutdown()` (flush + join writer thread) or `manager.stop_async_writer()` (join only, no flush)
- Owner-gates memory-file migration so non-owner users in shared channels don't get the owner's MEMORY.md/USER.md
- **Follow-up fix:** tracks and joins the `honcho-memwrite` thread in `shutdown()` (was fire-and-forget, the exact problem the PR fixes for the async writer)

## Attribution

Adopted with original authorship preserved. Contributors credited:
- @dtownsel — saveMessages gates on sync_turn/on_memory_write + gateway-internal-turn rejection (#82130)
- @strzhao, salvaging @Matroskin86 — saveMessages gates on session-end + shutdown flush (#81214, #67559)
- @menhguin — non-owner migration skip (#82038)
- @cfdude — endpoint.baseUrl + HONCHO_URL + fallback logging (#43803)
- @LeonSGP43 — host-block baseUrl precedence (#14489)
- @Morad37 — _host_block dot-form fallback (#37671)
- @Bartok9, salvaging @teyrebaz33 — non-printable base_url sanitization (#62757, #2757)
- @spfcraze — peers command underscore host keys (#76455)
- @NaMinhyeok, @angel12 — per-identity cache approach (#69142, #81401)

## Validation

| | Before | After |
|---|---|---|
| Tests | 0 honcho isolation tests | 363 passed across honcho_plugin/, test_honcho_*, test_honcho_client_config, test_honcho_cli_peers |
| E2E smoke | N/A | 9 combined smoke tests passed (saveMessages gate, gateway regex, memwrite tracking, _sanitize_url, endpoint.baseUrl, provenance, bound path, from_env config_path) |
| ruff | — | clean |
| Cross-tenant bleed | #69123 live | per-identity cache + contextvar propagation |

Closes #83500, #83508, #83525, #69123, #74065, #43800, #37436, #76414, #35209
