### PR TITLE
docs(telegram): document TELEGRAM_WEBHOOK_HOST and other undocumented adapter env vars

### DIFF
--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -319,7 +319,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT` | HTTP write timeout in seconds (default: `20.0`). File uploads use a separate 60s media-write budget. |
 | `HERMES_TELEGRAM_INIT_TIMEOUT` | Seconds to wait for `getMe`/webhook bootstrap before declaring startup failure (default: `30.0`). Lower it to fail fast on misconfigured networks. |
 | `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS` | When `true`, do not fall back to hardcoded Telegram API IP ranges if DNS resolution fails (default: `false`). |
-| `TELEGRAM_ALLOW_BOTS` | Allow messages from other bots to be processed (default: `false`). Equivalent to `telegram.allow_bots`. |
+| `TELEGRAM_ALLOW_BOTS` | Allow messages from other bots to be processed (`none` = reject all bot messages, `mentions` = allow only when the bot is @mentioned, `all` = allow all bot messages; default: `none`). Equivalent to `telegram.allow_bots`. |
 | `TELEGRAM_GUEST_MODE` | Guest mode: read group messages without being a member, where Telegram permits (default: `false`). Equivalent to `telegram.guest_mode`. |
 | `TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES` | Passively observe unmentioned group messages into shared session context (default: `false`). Equivalent to `telegram.observe_unmentioned_group_messages`. |
 | `TELEGRAM_REACTIONS` | Enable emoji reactions on messages during processing (default: `false`) |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -310,7 +310,18 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `TELEGRAM_CRON_THREAD_ID` | Forum topic ID to receive cron deliveries; overrides `TELEGRAM_HOME_CHANNEL_THREAD_ID` for cron only. Use in topic mode so replies to cron messages open a new session instead of hitting the system lobby (#24409). |
 | `TELEGRAM_WEBHOOK_URL` | Public HTTPS URL for webhook mode (enables webhook instead of polling) |
 | `TELEGRAM_WEBHOOK_PORT` | Local listen port for webhook server (default: `8443`) |
+| `TELEGRAM_WEBHOOK_HOST` | Local bind host for the webhook server. Default: unset → dual-stack bind on all interfaces (IPv4+IPv6). Set explicitly on IPv6-only deployments (e.g. Fly.io 6PN). Equivalent to `platforms.telegram.extra.webhook_host`. |
 | `TELEGRAM_WEBHOOK_SECRET` | Secret token Telegram echoes back in each update for verification. **Required whenever `TELEGRAM_WEBHOOK_URL` is set** — the gateway refuses to start without it (GHSA-3vpc-7q5r-276h). Generate with `openssl rand -hex 32`. |
+| `HERMES_TELEGRAM_HTTP_POOL_SIZE` | Max HTTP connections in the Telegram client pool (default: `512`). |
+| `HERMES_TELEGRAM_HTTP_POOL_TIMEOUT` | Seconds to wait for a free connection from the pool before failing (default: `8.0`). Raise on flaky networks if you see `Pool timeout` errors. |
+| `HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT` | HTTP connect timeout in seconds (default: `10.0`). |
+| `HERMES_TELEGRAM_HTTP_READ_TIMEOUT` | HTTP read timeout in seconds (default: `20.0`). |
+| `HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT` | HTTP write timeout in seconds (default: `20.0`). File uploads use a separate 60s media-write budget. |
+| `HERMES_TELEGRAM_INIT_TIMEOUT` | Seconds to wait for `getMe`/webhook bootstrap before declaring startup failure (default: `30.0`). Lower it to fail fast on misconfigured networks. |
+| `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS` | When `true`, do not fall back to hardcoded Telegram API IP ranges if DNS resolution fails (default: `false`). |
+| `TELEGRAM_ALLOW_BOTS` | Allow messages from other bots to be processed (default: `false`). Equivalent to `telegram.allow_bots`. |
+| `TELEGRAM_GUEST_MODE` | Guest mode: read group messages without being a member, where Telegram permits (default: `false`). Equivalent to `telegram.guest_mode`. |
+| `TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES` | Passively observe unmentioned group messages into shared session context (default: `false`). Equivalent to `telegram.observe_unmentioned_group_messages`. |
 | `TELEGRAM_REACTIONS` | Enable emoji reactions on messages during processing (default: `false`) |
 | `TELEGRAM_REQUIRE_MENTION` | Require an explicit trigger before responding in Telegram groups. Equivalent to `telegram.require_mention` in `config.yaml`. |
 | `TELEGRAM_MENTION_PATTERNS` | JSON array, newline-separated list, or comma-separated list of regex wake-word patterns accepted when Telegram group mention gating is enabled. Equivalent to `telegram.mention_patterns`. |

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -263,6 +263,7 @@ Add the following to `~/.hermes/.env`:
 TELEGRAM_WEBHOOK_URL=https://my-app.fly.dev/telegram
 TELEGRAM_WEBHOOK_SECRET="$(openssl rand -hex 32)"  # required
 # TELEGRAM_WEBHOOK_PORT=8443        # optional, default 8443
+# TELEGRAM_WEBHOOK_HOST=::          # optional, bind host (e.g. IPv6-only)
 ```
 
 | Variable | Required | Description |
@@ -270,6 +271,7 @@ TELEGRAM_WEBHOOK_SECRET="$(openssl rand -hex 32)"  # required
 | `TELEGRAM_WEBHOOK_URL` | Yes | Public HTTPS URL where Telegram will send updates. The URL path is auto-extracted (e.g., `/telegram` from the example above). |
 | `TELEGRAM_WEBHOOK_SECRET` | **Yes** (when `TELEGRAM_WEBHOOK_URL` is set) | Secret token that Telegram echoes in every webhook request for verification. The gateway refuses to start without it — see [GHSA-3vpc-7q5r-276h](https://github.com/NousResearch/hermes-agent/security/advisories/GHSA-3vpc-7q5r-276h). Generate with `openssl rand -hex 32`. |
 | `TELEGRAM_WEBHOOK_PORT` | No | Local port the webhook server listens on (default: `8443`). |
+| `TELEGRAM_WEBHOOK_HOST` | No | Local bind host for the webhook server. Default: unset → dual-stack bind on all interfaces (IPv4+IPv6). Set this on IPv6-only deployments (e.g. Fly.io 6PN) or to pin the listener to a specific interface. Can also be set via `platforms.telegram.extra.webhook_host` in `config.yaml`. |
 
 When `TELEGRAM_WEBHOOK_URL` is set, the gateway starts an HTTP webhook server instead of polling. When unset, polling mode is used — no behavior change from previous versions.
 


### PR DESCRIPTION
Fixes #78697.

`TELEGRAM_WEBHOOK_HOST` is read in `plugins/platforms/telegram/adapter.py` and controls the webhook bind host — critical for IPv6-only deployments (Fly.io 6PN) — but appeared nowhere in `website/docs/`. A scan of the adapter shows it reads ~22 `TELEGRAM_*` and `HERMES_TELEGRAM_*` env vars, of which several were undocumented.

This PR adds:
- `TELEGRAM_WEBHOOK_HOST` to the env-var reference table **and** the Webhook Mode section of `telegram.md` (with the IPv6 rationale)
- `HERMES_TELEGRAM_HTTP_POOL_SIZE` / `POOL_TIMEOUT` / `CONNECT_TIMEOUT` / `READ_TIMEOUT` / `WRITE_TIMEOUT` (PTB request tuning)
- `HERMES_TELEGRAM_INIT_TIMEOUT` (bootstrap timeout)
- `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS`
- `TELEGRAM_ALLOW_BOTS`, `TELEGRAM_GUEST_MODE`, `TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES` (with their `config.yaml` equivalents)

All defaults verified against the code on `main`. Docs-only, no behavior change.