### PR TITLE
docs(telegram): document media routing tables and batch-timing env vars

### DIFF
--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -320,7 +320,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `TELEGRAM_PROXY` | Proxy URL for Telegram connections — overrides `HTTPS_PROXY`. Supports `http://`, `https://`, `socks5://` |
 | `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` | Debounce window for Telegram photo/album bursts (default: `0.8`). |
 | `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` | Debounce window for rapid consecutive Telegram text messages (default: `0.3`, clamped `0.08`–`2.0`). |
-| `HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS` | Extra window to detect client-side splits of one long Telegram message (default: `1.0`, clamped to the text batch delay…`4.0`). |
+| `HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS` | Extra window to detect client-side splits of one long Telegram message (default: `1.0`, clamped between the text batch delay and `4.0`). |
 | `DISCORD_BOT_TOKEN` | Discord bot token |
 | `DISCORD_ALLOWED_USERS` | Comma-separated Discord user IDs allowed to use the bot |
 | `DISCORD_ALLOW_ALL_USERS` | Allow any Discord user to trigger the bot (dev only). |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -318,6 +318,9 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `TELEGRAM_REPLY_TO_MODE` | Reply-reference behavior: `off`, `first` (default), or `all`. Matches the Discord pattern. |
 | `TELEGRAM_IGNORED_THREADS` | Comma-separated Telegram forum topic/thread IDs where the bot never responds |
 | `TELEGRAM_PROXY` | Proxy URL for Telegram connections — overrides `HTTPS_PROXY`. Supports `http://`, `https://`, `socks5://` |
+| `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` | Debounce window for Telegram photo/album bursts (default: `0.8`). |
+| `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` | Debounce window for rapid consecutive Telegram text messages (default: `0.3`, clamped `0.08`–`2.0`). |
+| `HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS` | Extra window to detect client-side splits of one long Telegram message (default: `1.0`, clamped to the text batch delay…`4.0`). |
 | `DISCORD_BOT_TOKEN` | Discord bot token |
 | `DISCORD_ALLOWED_USERS` | Comma-separated Discord user IDs allowed to use the bot |
 | `DISCORD_ALLOW_ALL_USERS` | Allow any Discord user to trigger the bot (dev only). |

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -242,6 +242,18 @@ The gateway extracts `MEDIA:/path/to/file` tags from agent replies and ships the
 
 Anything on this list is delivered as a native attachment on platforms that support it (Telegram, Discord, Signal, Slack, WhatsApp, Feishu, Matrix, etc.); on platforms without native support it falls back to a link or plain-text indicator. The **bold** categories were added in the last few releases — if you were relying on the model saying `here is the file: /path/to/report.docx` instead, swap to `MEDIA:/path/to/report.docx` for native delivery.
 
+### Media routing and batching
+
+Inbound media routing on Telegram is table-driven. The adapter maps image extensions and MIME types via `_TELEGRAM_IMAGE_EXTENSIONS`, `_TELEGRAM_IMAGE_MIME_TO_EXT`, and `_TELEGRAM_IMAGE_EXT_TO_MIME` (currently `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`); voice/audio use `_TELEGRAM_VOICE_EXTS` / `_TELEGRAM_AUDIO_ATTACHMENT_EXTS` from the base platform class. These tables are module constants and not user-configurable today.
+
+Rapid bursts (albums, client-side message splits) are debounced into a single agent turn. Operators can tune the timing via environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` | `0.8` | Debounce window for photo/album bursts. Photos arriving within this window are merged into one MessageEvent instead of triggering multiple turns. |
+| `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` | `0.3` | Debounce window for rapid consecutive text messages (clamped to `0.08`–`2.0`). Short replies settle in ~180ms via the adaptive fast-path. |
+| `HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS` | `1.0` | Extra window to detect a client-side split of one long message into several updates (clamped between the text batch delay and `4.0`). |
+
 ## Webhook Mode
 
 By default, Hermes connects to Telegram using **long polling** — the gateway makes outbound requests to Telegram's servers to fetch new updates. This works well for local and always-on deployments.

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -244,7 +244,7 @@ Anything on this list is delivered as a native attachment on platforms that supp
 
 ### Media routing and batching
 
-Inbound media routing on Telegram is table-driven. The adapter maps image extensions and MIME types via `_TELEGRAM_IMAGE_EXTENSIONS`, `_TELEGRAM_IMAGE_MIME_TO_EXT`, and `_TELEGRAM_IMAGE_EXT_TO_MIME` (currently `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`); voice/audio use `_TELEGRAM_VOICE_EXTS` / `_TELEGRAM_AUDIO_ATTACHMENT_EXTS` from the base platform class. These tables are module constants and not user-configurable today.
+Inbound media routing on Telegram is table-driven. The adapter maps image extensions and MIME types (currently `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`); voice/audio are handled via the base platform class. These tables are module constants and not user-configurable today.
 
 Rapid bursts (albums, client-side message splits) are debounced into a single agent turn. Operators can tune the timing via environment variables:
 


### PR DESCRIPTION
Fixes #78710.

Telegram inbound media routing is table-driven (`_TELEGRAM_IMAGE_EXTENSIONS`, `_TELEGRAM_IMAGE_MIME_TO_EXT`, `_TELEGRAM_IMAGE_EXT_TO_MIME`, `_TELEGRAM_VOICE_EXTS`, `_TELEGRAM_AUDIO_ATTACHMENT_EXTS`) and the three batch-debounce knobs (`HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS`, `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS`, `HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS`) are read by the adapter, but none of this was documented.

This PR:
- Adds a "Media routing and batching" subsection to `telegram.md` (right after the MEDIA extensions table) describing the routing tables and the three debounce env vars with their defaults and clamps
- Mirrors the three vars in `environment-variables.md`

Defaults (`0.8`, `0.3`, `1.0`) and clamps (`0.08`–`2.0`, ≤`4.0`) verified against `plugins/platforms/telegram/adapter.py` on main. Docs-only.