### PR TITLE
feat(slack): add channel approval gate

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1632,6 +1632,15 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["allowed_topics"] = platform_cfg["allowed_topics"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if plat == Platform.SLACK:
+                    for key in (
+                        "channel_approval_required",
+                        "channel_approval_owners",
+                        "channel_approval_aliases",
+                        "channel_approval_file",
+                    ):
+                        if key in platform_cfg:
+                            bridged[key] = platform_cfg[key]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1973,6 +1973,10 @@ DEFAULT_CONFIG = {
         "require_mention": True,       # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
+        "channel_approval_required": False,  # If true, unknown Slack channels get an approval prompt before the bot can work there
+        "channel_approval_owners": "",      # Comma-separated Slack user IDs allowed to approve/revoke channels; defaults to allow_from / SLACK_ALLOWED_USERS
+        "channel_approval_aliases": "",     # Comma-separated agent names accepted in "approve <agent> here" / "revoke <agent> here"
+        "channel_approval_file": "",        # Optional JSON state file path; defaults to $HERMES_HOME/slack_channel_approvals.json
         # Channel IDs where @mention is ALWAYS required, even when
         # require_mention is false globally (per-channel force-mention override).
         "require_mention_channels": "",

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5662,8 +5662,21 @@ class SlackAdapter(BasePlatformAdapter):
                     return
 
         if not is_one_to_one_dm and bot_uid:
-            # Check allowed channels — if set, only respond in these channels (whitelist)
-            allowed_channels = self._slack_allowed_channels()
+            if self._slack_channel_approval_required():
+                if await self._handle_slack_channel_approval_gate(
+                    channel_id=channel_id,
+                    user_id=user_id,
+                    text=routing_text,
+                    is_mentioned=is_mentioned,
+                    thread_ts=thread_ts,
+                    team_id=team_id,
+                    force_process=force_process,
+                ):
+                    return
+                allowed_channels = self._slack_approved_channels(team_id=team_id)
+            else:
+                # Check allowed channels — if set, only respond in these channels (whitelist)
+                allowed_channels = self._slack_allowed_channels()
             if allowed_channels and channel_id not in allowed_channels:
                 logger.debug(
                     "[Slack] Ignoring message in non-allowed channel: %s", channel_id
@@ -7742,6 +7755,17 @@ class SlackAdapter(BasePlatformAdapter):
                 user_id,
             )
             return
+        if not is_dm and channel_id and self._slack_channel_approval_required():
+            if await self._handle_slack_channel_approval_gate(
+                channel_id=channel_id,
+                user_id=user_id,
+                text=text,
+                is_mentioned=True,
+                thread_ts=thread_id,
+                team_id=team_id,
+                force_process=True,
+            ):
+                return
         source = self.build_source(
             chat_id=channel_id,
             chat_type="dm" if is_dm else "group",
@@ -8411,6 +8435,299 @@ class SlackAdapter(BasePlatformAdapter):
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
 
+    def _slack_channel_approval_required(self) -> bool:
+        """Return whether unapproved shared Slack channels should ask Patrick.
+
+        This is intentionally a tiny overlay on top of ``allowed_channels``:
+        when enabled, the existing allowed-channel list becomes the initial set
+        of approved channels, and unknown channels get a local approval prompt
+        instead of a silent drop.
+        """
+        raw = self.config.extra.get("channel_approval_required")
+        if raw is None:
+            raw = os.getenv("SLACK_CHANNEL_APPROVAL_REQUIRED", "false")
+        if isinstance(raw, str):
+            return raw.strip().lower() in {"true", "1", "yes", "on"}
+        return bool(raw)
+
+    def _slack_channel_approval_owners(self) -> set:
+        """Return Slack user IDs allowed to approve this agent in a channel."""
+        raw = self.config.extra.get("channel_approval_owners")
+        if raw is None:
+            raw = os.getenv("SLACK_CHANNEL_APPROVAL_OWNERS", "")
+        if raw is None or raw == "":
+            # Keep setup dead simple for existing local agents: their Slack
+            # ``allow_from`` is already Patrick-only, so use it as the default
+            # owner list unless an explicit owner list is configured.
+            raw = self.config.extra.get("allow_from") or os.getenv("SLACK_ALLOWED_USERS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip() and str(part).strip() != "*"}
+        if isinstance(raw, str) and raw.strip():
+            return {part.strip() for part in raw.split(",") if part.strip() and part.strip() != "*"}
+        return set()
+
+    def _slack_channel_approval_file(self) -> _Path:
+        raw = self.config.extra.get("channel_approval_file") or os.getenv(
+            "SLACK_CHANNEL_APPROVAL_FILE",
+            "",
+        )
+        if raw:
+            path = _Path(str(raw)).expanduser()
+            if not path.is_absolute():
+                path = _Path(os.getcwd()) / path
+            return path
+        try:
+            from hermes_constants import get_hermes_home
+
+            return get_hermes_home() / "slack_channel_approvals.json"
+        except Exception:  # pragma: no cover - defensive fallback
+            return _Path(os.path.expanduser("~/.hermes/slack_channel_approvals.json"))
+
+    def _read_slack_channel_approval_state(self) -> dict:
+        path = self._slack_channel_approval_file()
+        if not path.exists():
+            return {"approved_channels": {}, "pending_channels": {}, "revoked_channels": {}}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            logger.warning("[Slack] Could not read channel approval file: %s", path)
+            return {"approved_channels": {}, "pending_channels": {}, "revoked_channels": {}}
+        if not isinstance(data, dict):
+            data = {}
+        for key in ("approved_channels", "pending_channels", "revoked_channels"):
+            if not isinstance(data.get(key), dict):
+                data[key] = {}
+        return data
+
+    def _write_slack_channel_approval_state(self, data: dict) -> None:
+        path = self._slack_channel_approval_file()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(f".{path.name}.tmp")
+        tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+
+    def _slack_channel_approval_state_key(self, channel_id: str, team_id: str = "") -> str:
+        channel = str(channel_id or "").strip()
+        team = str(team_id or "").strip()
+        return f"{team}:{channel}" if team else channel
+
+    def _slack_channel_approval_state_entry_matches(
+        self,
+        key: str,
+        meta: Any,
+        channel_id: str,
+        team_id: str = "",
+    ) -> bool:
+        channel = str(channel_id or "").strip()
+        team = str(team_id or "").strip()
+        if not channel:
+            return False
+        if team and str(key) == f"{team}:{channel}":
+            return True
+        stored_team = str(meta.get("team_id", "")) if isinstance(meta, dict) else ""
+        if stored_team:
+            # Team-scoped state is never global; missing team_id must not match.
+            return bool(team and stored_team == team and str(key) == channel)
+        if str(key) != channel:
+            return False
+        # Legacy no-team state remains valid for single-workspace adapters only.
+        return not self._slack_multi_workspace_active()
+
+    def _slack_multi_workspace_active(self) -> bool:
+        return len(getattr(self, "_team_clients", {}) or {}) > 1
+
+    def _slack_allowed_channels_for_team(self, team_id: str = "") -> set:
+        allowed = set()
+        team = str(team_id or "").strip()
+        multi = self._slack_multi_workspace_active()
+        for raw in self._slack_allowed_channels():
+            entry = str(raw).strip()
+            if not entry:
+                continue
+            if ":" in entry:
+                entry_team, entry_channel = entry.split(":", 1)
+                if team and entry_team.strip() == team and entry_channel.strip():
+                    allowed.add(entry_channel.strip())
+            elif not multi:
+                allowed.add(entry)
+        return allowed
+
+    def _slack_approved_channels(self, team_id: str = "") -> set:
+        approved = set(self._slack_allowed_channels_for_team(team_id=team_id))
+        state = self._read_slack_channel_approval_state()
+        for ch, meta in state.get("approved_channels", {}).items():
+            channel = str(ch).split(":", 1)[-1].strip()
+            if channel and self._slack_channel_approval_state_entry_matches(ch, meta, channel, team_id):
+                approved.add(channel)
+        for ch, meta in state.get("revoked_channels", {}).items():
+            channel = str(ch).split(":", 1)[-1].strip()
+            if channel and self._slack_channel_approval_state_entry_matches(ch, meta, channel, team_id):
+                approved.discard(channel)
+        return approved
+
+    def _slack_agent_approval_aliases(self) -> set:
+        raw = self.config.extra.get("channel_approval_aliases") or os.getenv(
+            "SLACK_CHANNEL_APPROVAL_ALIASES",
+            "",
+        )
+        aliases = set()
+        has_explicit_aliases = False
+        if isinstance(raw, list):
+            aliases.update(str(item).strip().lower() for item in raw if str(item).strip())
+            has_explicit_aliases = bool(aliases)
+        elif isinstance(raw, str) and raw.strip():
+            aliases.update(part.strip().lower() for part in raw.split(",") if part.strip())
+            has_explicit_aliases = bool(aliases)
+        if not has_explicit_aliases:
+            bot_name = (self._bot_display_name or "").strip().lower()
+            if bot_name:
+                aliases.add(bot_name)
+                aliases.add(bot_name.replace("_local", ""))
+                aliases.add(bot_name.replace("-local", ""))
+            try:
+                profile_name = _Path(os.environ.get("HERMES_HOME", "")).name.lower()
+                if profile_name:
+                    aliases.add(profile_name)
+            except Exception:
+                pass
+        return {alias for alias in aliases if alias}
+
+    def _slack_channel_approval_action(self, text: str) -> Optional[str]:
+        """Return 'approve'/'revoke' for owner channel commands, else None."""
+        norm = re.sub(r"<@([^>|\s]+)(?:\|[^>]*)?>", " ", text or "")
+        norm = re.sub(r"[^a-z0-9_ -]+", " ", norm.lower())
+        norm = re.sub(r"\s+", " ", norm).strip()
+        if not norm:
+            return None
+        for alias in self._slack_agent_approval_aliases():
+            alias_norm = re.sub(r"[^a-z0-9_ -]+", " ", alias.lower()).strip()
+            if not alias_norm:
+                continue
+            if norm == f"approve {alias_norm} here":
+                return "approve"
+            if norm == f"revoke {alias_norm} here":
+                return "revoke"
+        return None
+
+    async def _send_slack_channel_approval_message(
+        self,
+        channel_id: str,
+        text: str,
+        *,
+        thread_ts: Optional[str] = None,
+        team_id: str = "",
+    ) -> None:
+        kwargs = {"channel": channel_id, "text": text}
+        if thread_ts:
+            kwargs["thread_ts"] = thread_ts
+        try:
+            await self._get_client(channel_id, team_id=team_id).chat_postMessage(**kwargs)
+        except Exception as exc:  # pragma: no cover - best-effort notice
+            logger.warning("[Slack] Failed to send channel approval notice in %s: %s", channel_id, exc)
+
+    async def _handle_slack_channel_approval_gate(
+        self,
+        *,
+        channel_id: str,
+        user_id: str,
+        text: str,
+        is_mentioned: bool,
+        thread_ts: Optional[str],
+        team_id: str,
+        force_process: bool = False,
+    ) -> bool:
+        """Return True when the message was handled and must not reach the agent."""
+        if not self._slack_channel_approval_required():
+            return False
+        owners = self._slack_channel_approval_owners()
+        action = self._slack_channel_approval_action(text)
+        is_owner = bool(user_id and user_id in owners)
+        state = self._read_slack_channel_approval_state()
+        state_key = self._slack_channel_approval_state_key(channel_id, team_id)
+
+        # Approval/revoke commands must be honored even in currently approved
+        # channels; otherwise Patrick could not revoke without editing files.
+        if action == "approve":
+            if not is_owner:
+                await self._send_slack_channel_approval_message(
+                    channel_id,
+                    "Only an approval owner can approve me to work in this channel.",
+                    thread_ts=thread_ts,
+                    team_id=team_id,
+                )
+                return True
+            state.setdefault("approved_channels", {})[state_key] = {
+                "approved_by": user_id,
+                "approved_at": time.time(),
+                "team_id": team_id,
+                "channel_id": channel_id,
+            }
+            state.setdefault("pending_channels", {}).pop(state_key, None)
+            state.setdefault("pending_channels", {}).pop(channel_id, None)
+            state.setdefault("revoked_channels", {}).pop(state_key, None)
+            state.setdefault("revoked_channels", {}).pop(channel_id, None)
+            self._write_slack_channel_approval_state(state)
+            await self._send_slack_channel_approval_message(
+                channel_id,
+                "Approved — I can now work in this channel when mentioned.",
+                thread_ts=thread_ts,
+                team_id=team_id,
+            )
+            return True
+
+        if action == "revoke":
+            if not is_owner:
+                await self._send_slack_channel_approval_message(
+                    channel_id,
+                    "Only an approval owner can revoke my access to this channel.",
+                    thread_ts=thread_ts,
+                    team_id=team_id,
+                )
+                return True
+            state.setdefault("approved_channels", {}).pop(state_key, None)
+            state.setdefault("approved_channels", {}).pop(channel_id, None)
+            state.setdefault("pending_channels", {}).pop(state_key, None)
+            state.setdefault("pending_channels", {}).pop(channel_id, None)
+            state.setdefault("revoked_channels", {})[state_key] = {
+                "revoked_by": user_id,
+                "revoked_at": time.time(),
+                "team_id": team_id,
+                "channel_id": channel_id,
+            }
+            self._write_slack_channel_approval_state(state)
+            await self._send_slack_channel_approval_message(
+                channel_id,
+                "Revoked — I will not work in this channel unless an approval owner approves me again.",
+                thread_ts=thread_ts,
+                team_id=team_id,
+            )
+            return True
+
+        if channel_id in self._slack_approved_channels(team_id=team_id):
+            return False
+
+        if is_mentioned or force_process:
+            pending = state.setdefault("pending_channels", {}).setdefault(state_key, {})
+            pending.setdefault("first_seen_at", time.time())
+            pending["channel_id"] = channel_id
+            if user_id:
+                pending["last_requested_by"] = user_id
+            if team_id:
+                pending["team_id"] = team_id
+            self._write_slack_channel_approval_state(state)
+            owner_hint = "an approval owner"
+            if owners:
+                owner_hint = "an approval owner " + " ".join(f"<@{owner}>" for owner in sorted(owners))
+            aliases = sorted(a for a in self._slack_agent_approval_aliases() if a != "this agent")
+            alias = aliases[0] if aliases else "this agent"
+            await self._send_slack_channel_approval_message(
+                channel_id,
+                f"I’m not approved to work in this channel yet. {owner_hint} needs to reply `approve {alias} here` before I can help here.",
+                thread_ts=thread_ts,
+                team_id=team_id,
+            )
+        return True
+
     def _slack_require_mention_channels(self) -> set:
         """Return channel IDs where a bot @mention is ALWAYS required.
 
@@ -9043,6 +9360,22 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["SLACK_ALLOWED_CHANNELS"] = str(ac)
+    if "channel_approval_required" in slack_cfg and not os.getenv("SLACK_CHANNEL_APPROVAL_REQUIRED"):
+        os.environ["SLACK_CHANNEL_APPROVAL_REQUIRED"] = str(
+            slack_cfg["channel_approval_required"]
+        ).lower()
+    owners = slack_cfg.get("channel_approval_owners")
+    if owners is not None and not os.getenv("SLACK_CHANNEL_APPROVAL_OWNERS"):
+        if isinstance(owners, list):
+            owners = ",".join(str(v) for v in owners)
+        os.environ["SLACK_CHANNEL_APPROVAL_OWNERS"] = str(owners)
+    aliases = slack_cfg.get("channel_approval_aliases")
+    if aliases is not None and not os.getenv("SLACK_CHANNEL_APPROVAL_ALIASES"):
+        if isinstance(aliases, list):
+            aliases = ",".join(str(v) for v in aliases)
+        os.environ["SLACK_CHANNEL_APPROVAL_ALIASES"] = str(aliases)
+    if "channel_approval_file" in slack_cfg and not os.getenv("SLACK_CHANNEL_APPROVAL_FILE"):
+        os.environ["SLACK_CHANNEL_APPROVAL_FILE"] = str(slack_cfg["channel_approval_file"])
     # ignored_channels: blacklist channels where Slack must never respond.
     ic = slack_cfg.get("ignored_channels")
     if ic is not None and not os.getenv("SLACK_IGNORED_CHANNELS"):
@@ -9087,7 +9420,8 @@ def register(ctx) -> None:
         # YAML→env config bridge — owns the translation of config.yaml slack:
         # keys (require_mention, strict_mention, ignore_other_user_mentions,
         # thread_require_mention, allow_bots, free_response_channels,
-        # reactions, disable_dms, allowed_channels, ignored_channels) into
+        # reactions, disable_dms, allowed_channels, channel approval settings,
+        # ignored_channels) into
         # SLACK_* env vars that
         # the adapter reads via os.getenv(). Replaces the
         # hardcoded block in gateway/config.py. Hook contract: #24849.

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -351,6 +351,31 @@ class TestLoadGatewayConfig:
         assert os.getenv("SLACK_IGNORED_CHANNELS") == "C0123456789,C0987654321"
 
 
+    def test_slack_channel_approval_config_bridges_to_extra(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n"
+            "  enabled: true\n"
+            "  channel_approval_required: true\n"
+            "  channel_approval_owners:\n"
+            "    - U_OWNER\n"
+            "  channel_approval_aliases:\n"
+            "    - cleo\n"
+            "  channel_approval_file: /tmp/approvals.json\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        extra = config.platforms[Platform.SLACK].extra
+        assert extra["channel_approval_required"] is True
+        assert extra["channel_approval_owners"] == ["U_OWNER"]
+        assert extra["channel_approval_aliases"] == ["cleo"]
+        assert extra["channel_approval_file"] == "/tmp/approvals.json"
+
+
     def test_typing_status_text_from_nested_platforms_block(self, tmp_path, monkeypatch):
         """``platforms.slack.typing_status_text`` reaches PlatformConfig via
         _merge_platform_map + the from_dict top-level read."""

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -7,6 +7,7 @@ Follows the same pattern as test_whatsapp_group_gating.py.
 import sys
 import inspect
 import logging
+import os
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -60,7 +61,7 @@ OTHER_CHANNEL_ID = "C9999999999"
 
 
 def _make_adapter(require_mention=None, strict_mention=None, free_response_channels=None,
-                  allowed_channels=None, mention_patterns=None):
+                  allowed_channels=None, mention_patterns=None, **extra_overrides):
     extra = {}
     if require_mention is not None:
         extra["require_mention"] = require_mention
@@ -72,12 +73,14 @@ def _make_adapter(require_mention=None, strict_mention=None, free_response_chann
         extra["allowed_channels"] = allowed_channels
     if mention_patterns is not None:
         extra["mention_patterns"] = mention_patterns
+    extra.update(extra_overrides)
 
     adapter = object.__new__(SlackAdapter)
     adapter.platform = Platform.SLACK
     adapter.config = PlatformConfig(enabled=True, extra=extra)
     adapter._bot_user_id = BOT_USER_ID
     adapter._team_bot_user_ids = {}
+    adapter._bot_display_name = "cleo_local"
     return adapter
 
 
@@ -496,6 +499,346 @@ def test_allowed_channels_env_var_blocks_channel(monkeypatch):
     adapter = _make_adapter()  # no config value → falls back to env
     assert _would_process(adapter, channel_id=OTHER_CHANNEL_ID, text="hello") is False
     assert _would_process(adapter, channel_id=CHANNEL_ID, mentioned=True) is True
+
+
+def test_explicit_channel_approval_aliases_do_not_include_profile_or_bot_name(monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", "/Users/agents/.hermes/profiles/cleo")
+    adapter = _make_adapter(
+        channel_approval_aliases=["cleo"],
+    )
+    adapter._bot_display_name = "cleo_local"
+
+    aliases = adapter._slack_agent_approval_aliases()
+
+    assert "cleo" in aliases
+    assert "cleo_local" not in aliases
+
+
+def test_channel_approval_commands_require_exact_here_phrase():
+    adapter = _make_adapter(
+        channel_approval_aliases=["cleo"],
+    )
+
+    assert adapter._slack_channel_approval_action("approve cleo here") == "approve"
+    assert adapter._slack_channel_approval_action("revoke cleo here") == "revoke"
+    assert adapter._slack_channel_approval_action("approve cleo") is None
+    assert adapter._slack_channel_approval_action("cleo approved") is None
+    assert adapter._slack_channel_approval_action("remove cleo here") is None
+
+
+@pytest.mark.asyncio
+async def test_unapproved_slash_command_is_intercepted_before_agent(tmp_path):
+    adapter = _make_adapter(
+        channel_approval_required=True,
+        channel_approval_owners=["U_OWNER"],
+        channel_approval_aliases=["cleo"],
+        channel_approval_file=str(tmp_path / "approvals.json"),
+    )
+    adapter._channel_team = {}
+    adapter._channel_teams = {}
+    adapter._CHANNEL_TEAM_MAX = 10000
+    adapter.handle_message = AsyncMock()
+    client = MagicMock()
+    client.chat_postMessage = AsyncMock()
+    adapter._get_client = MagicMock(return_value=client)
+
+    await adapter._handle_slash_command({
+        "command": "/hermes",
+        "text": "please do work",
+        "user_id": "U_OWNER",
+        "channel_id": CHANNEL_ID,
+        "team_id": "T1",
+    })
+
+    adapter.handle_message.assert_not_awaited()
+    client.chat_postMessage.assert_awaited_once()
+    assert "not approved" in client.chat_postMessage.await_args.kwargs["text"]
+
+
+
+
+def test_apply_slack_yaml_config_bridges_channel_approval_env(monkeypatch):
+    from plugins.platforms.slack.adapter import _apply_yaml_config
+
+    _apply_yaml_config({}, {
+        "channel_approval_required": True,
+        "channel_approval_owners": ["U_OWNER"],
+        "channel_approval_aliases": ["cleo"],
+        "channel_approval_file": "/tmp/approvals.json",
+    })
+
+    assert os.environ["SLACK_CHANNEL_APPROVAL_REQUIRED"] == "true"
+    assert os.environ["SLACK_CHANNEL_APPROVAL_OWNERS"] == "U_OWNER"
+    assert os.environ["SLACK_CHANNEL_APPROVAL_ALIASES"] == "cleo"
+    assert os.environ["SLACK_CHANNEL_APPROVAL_FILE"] == "/tmp/approvals.json"
+
+
+def test_approved_channels_are_scoped_by_team_id(tmp_path):
+    approval_file = tmp_path / "approvals.json"
+    adapter = _make_adapter(
+        channel_approval_file=str(approval_file),
+    )
+    adapter._write_slack_channel_approval_state({
+        "approved_channels": {OTHER_CHANNEL_ID: {"approved_by": "U_OWNER", "team_id": "T_APPROVED"}},
+        "pending_channels": {},
+        "revoked_channels": {},
+    })
+
+    assert OTHER_CHANNEL_ID in adapter._slack_approved_channels(team_id="T_APPROVED")
+    assert OTHER_CHANNEL_ID not in adapter._slack_approved_channels(team_id="T_OTHER")
+    assert OTHER_CHANNEL_ID not in adapter._slack_approved_channels()
+
+
+def test_approved_channel_state_keys_are_team_scoped(tmp_path):
+    approval_file = tmp_path / "approvals.json"
+    adapter = _make_adapter(
+        channel_approval_file=str(approval_file),
+    )
+    adapter._team_clients = {"T1": object(), "T2": object()}
+    adapter._write_slack_channel_approval_state({
+        "approved_channels": {
+            f"T1:{OTHER_CHANNEL_ID}": {"approved_by": "U_OWNER", "team_id": "T1", "channel_id": OTHER_CHANNEL_ID}
+        },
+        "pending_channels": {},
+        "revoked_channels": {},
+    })
+
+    assert OTHER_CHANNEL_ID in adapter._slack_approved_channels(team_id="T1")
+    assert OTHER_CHANNEL_ID not in adapter._slack_approved_channels(team_id="T2")
+    assert OTHER_CHANNEL_ID not in adapter._slack_approved_channels()
+
+
+def test_allowed_channels_require_team_qualification_in_multi_workspace():
+    adapter = _make_adapter(
+        allowed_channels=[OTHER_CHANNEL_ID, f"T1:{CHANNEL_ID}"],
+    )
+    adapter._team_clients = {"T1": object(), "T2": object()}
+
+    assert CHANNEL_ID in adapter._slack_approved_channels(team_id="T1")
+    assert CHANNEL_ID not in adapter._slack_approved_channels(team_id="T2")
+    assert OTHER_CHANNEL_ID not in adapter._slack_approved_channels(team_id="T1")
+
+
+@pytest.mark.asyncio
+async def test_unapproved_channel_mention_posts_approval_prompt(tmp_path):
+    approval_file = tmp_path / "approvals.json"
+    adapter = _make_adapter(
+        channel_approval_required=True,
+        channel_approval_owners=["U_OWNER"],
+        channel_approval_aliases=["cleo"],
+        channel_approval_file=str(approval_file),
+    )
+    client = MagicMock()
+    client.chat_postMessage = AsyncMock()
+    adapter._get_client = MagicMock(return_value=client)
+
+    handled = await adapter._handle_slack_channel_approval_gate(
+        channel_id=OTHER_CHANNEL_ID,
+        user_id="U_REQUESTER",
+        text=f"<@{BOT_USER_ID}> help",
+        is_mentioned=True,
+        thread_ts="1710000000.000100",
+        team_id="T1",
+    )
+
+    assert handled is True
+    client.chat_postMessage.assert_awaited_once()
+    kwargs = client.chat_postMessage.await_args.kwargs
+    assert kwargs["channel"] == OTHER_CHANNEL_ID
+    assert "not approved" in kwargs["text"]
+    assert "approve cleo here" in kwargs["text"]
+    assert f"T1:{OTHER_CHANNEL_ID}" in adapter._read_slack_channel_approval_state()["pending_channels"]
+
+
+@pytest.mark.asyncio
+async def test_owner_can_approve_unapproved_channel(tmp_path):
+    approval_file = tmp_path / "approvals.json"
+    adapter = _make_adapter(
+        channel_approval_required=True,
+        channel_approval_owners=["U_OWNER"],
+        channel_approval_aliases=["cleo"],
+        channel_approval_file=str(approval_file),
+    )
+    client = MagicMock()
+    client.chat_postMessage = AsyncMock()
+    adapter._get_client = MagicMock(return_value=client)
+
+    handled = await adapter._handle_slack_channel_approval_gate(
+        channel_id=OTHER_CHANNEL_ID,
+        user_id="U_OWNER",
+        text="approve cleo here",
+        is_mentioned=False,
+        thread_ts=None,
+        team_id="T1",
+    )
+
+    assert handled is True
+    assert OTHER_CHANNEL_ID in adapter._slack_approved_channels(team_id="T1")
+    kwargs = client.chat_postMessage.await_args.kwargs
+    assert "Approved" in kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_approve_unapproved_channel(tmp_path):
+    approval_file = tmp_path / "approvals.json"
+    adapter = _make_adapter(
+        channel_approval_required=True,
+        channel_approval_owners=["U_OWNER"],
+        channel_approval_aliases=["cleo"],
+        channel_approval_file=str(approval_file),
+    )
+    client = MagicMock()
+    client.chat_postMessage = AsyncMock()
+    adapter._get_client = MagicMock(return_value=client)
+
+    handled = await adapter._handle_slack_channel_approval_gate(
+        channel_id=OTHER_CHANNEL_ID,
+        user_id="U_OTHER",
+        text="approve cleo here",
+        is_mentioned=False,
+        thread_ts=None,
+        team_id="T1",
+    )
+
+    assert handled is True
+    assert OTHER_CHANNEL_ID not in adapter._slack_approved_channels()
+    kwargs = client.chat_postMessage.await_args.kwargs
+    assert "approval owner" in kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_approved_channel_passes_gate_without_handling(tmp_path):
+    approval_file = tmp_path / "approvals.json"
+    adapter = _make_adapter(
+        channel_approval_required=True,
+        channel_approval_owners=["U_OWNER"],
+        channel_approval_aliases=["cleo"],
+        channel_approval_file=str(approval_file),
+    )
+    adapter._write_slack_channel_approval_state({
+        "approved_channels": {OTHER_CHANNEL_ID: {"approved_by": "U_OWNER"}},
+        "pending_channels": {},
+        "revoked_channels": {},
+    })
+
+    handled = await adapter._handle_slack_channel_approval_gate(
+        channel_id=OTHER_CHANNEL_ID,
+        user_id="U_REQUESTER",
+        text=f"<@{BOT_USER_ID}> help",
+        is_mentioned=True,
+        thread_ts=None,
+        team_id="T1",
+    )
+
+    assert handled is False
+
+
+@pytest.mark.asyncio
+async def test_owner_can_revoke_channel_approval(tmp_path):
+    approval_file = tmp_path / "approvals.json"
+    adapter = _make_adapter(
+        channel_approval_required=True,
+        channel_approval_owners=["U_OWNER"],
+        channel_approval_aliases=["cleo"],
+        channel_approval_file=str(approval_file),
+    )
+    adapter._write_slack_channel_approval_state({
+        "approved_channels": {OTHER_CHANNEL_ID: {"approved_by": "U_OWNER"}},
+        "pending_channels": {},
+        "revoked_channels": {},
+    })
+    client = MagicMock()
+    client.chat_postMessage = AsyncMock()
+    adapter._get_client = MagicMock(return_value=client)
+
+    handled = await adapter._handle_slack_channel_approval_gate(
+        channel_id=OTHER_CHANNEL_ID,
+        user_id="U_OWNER",
+        text="revoke cleo here",
+        is_mentioned=False,
+        thread_ts=None,
+        team_id="T1",
+    )
+
+    assert handled is True
+    state = adapter._read_slack_channel_approval_state()
+    assert OTHER_CHANNEL_ID not in state["approved_channels"]
+    assert f"T1:{OTHER_CHANNEL_ID}" in state["revoked_channels"]
+
+
+@pytest.mark.asyncio
+async def test_channel_approval_gate_intercepts_unapproved_mention_before_agent(tmp_path):
+    approval_file = tmp_path / "approvals.json"
+    adapter = _make_adapter(
+        allowed_channels=[CHANNEL_ID],
+        channel_approval_required=True,
+        channel_approval_owners=["U_OWNER"],
+        channel_approval_aliases=["cleo"],
+        channel_approval_file=str(approval_file),
+    )
+    adapter._dedup = MagicMock(is_duplicate=MagicMock(return_value=False))
+    adapter._lookup_assistant_thread_metadata = MagicMock(return_value={})
+    adapter._channel_team = {}
+    adapter._CHANNEL_TEAM_MAX = 10000
+    adapter._resolve_user_is_bot = AsyncMock(return_value=False)
+    adapter.handle_message = AsyncMock()
+    client = MagicMock()
+    client.chat_postMessage = AsyncMock()
+    adapter._get_client = MagicMock(return_value=client)
+
+    event = {
+        "channel": OTHER_CHANNEL_ID,
+        "channel_type": "channel",
+        "ts": "1710000000.000100",
+        "team": "T1",
+        "user": "U_REQUESTER",
+        "client_msg_id": "cmid-approval-needed",
+        "text": f"<@{BOT_USER_ID}> help here",
+    }
+
+    await adapter._handle_slack_message(event)
+
+    adapter.handle_message.assert_not_awaited()
+    client.chat_postMessage.assert_awaited_once()
+    assert f"T1:{OTHER_CHANNEL_ID}" in adapter._read_slack_channel_approval_state()["pending_channels"]
+
+
+@pytest.mark.asyncio
+async def test_channel_approval_command_intercepts_without_mention(tmp_path):
+    approval_file = tmp_path / "approvals.json"
+    adapter = _make_adapter(
+        allowed_channels=[CHANNEL_ID],
+        channel_approval_required=True,
+        channel_approval_owners=["U_OWNER"],
+        channel_approval_aliases=["cleo"],
+        channel_approval_file=str(approval_file),
+    )
+    adapter._dedup = MagicMock(is_duplicate=MagicMock(return_value=False))
+    adapter._lookup_assistant_thread_metadata = MagicMock(return_value={})
+    adapter._channel_team = {}
+    adapter._CHANNEL_TEAM_MAX = 10000
+    adapter._resolve_user_is_bot = AsyncMock(return_value=False)
+    adapter.handle_message = AsyncMock()
+    client = MagicMock()
+    client.chat_postMessage = AsyncMock()
+    adapter._get_client = MagicMock(return_value=client)
+
+    event = {
+        "channel": OTHER_CHANNEL_ID,
+        "channel_type": "channel",
+        "ts": "1710000000.000101",
+        "team": "T1",
+        "user": "U_OWNER",
+        "client_msg_id": "cmid-approve-command",
+        "text": "approve cleo here",
+    }
+
+    await adapter._handle_slack_message(event)
+
+    adapter.handle_message.assert_not_awaited()
+    assert OTHER_CHANNEL_ID in adapter._slack_approved_channels(team_id="T1")
+    kwargs = client.chat_postMessage.await_args.kwargs
+    assert "Approved" in kwargs["text"]
 
 
 @pytest.mark.asyncio

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -346,6 +346,10 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `SLACK_ALLOW_ALL_USERS` | Allow any Slack user to trigger the bot (dev only). |
 | `SLACK_ALLOW_BOTS` | Accept messages from other Slack bots: `none` (default), `mentions`, or `all`. The bot always ignores its own messages. |
 | `SLACK_THREAD_REQUIRE_MENTION` | Require an explicit @mention for Slack thread replies while preserving top-level free-response channels |
+| `SLACK_CHANNEL_APPROVAL_REQUIRED` | Enable the one-time Slack shared-channel approval gate (`true`/`false`). |
+| `SLACK_CHANNEL_APPROVAL_OWNERS` | Comma-separated Slack user IDs allowed to approve/revoke an agent in a channel. Defaults to `SLACK_ALLOWED_USERS` when unset. |
+| `SLACK_CHANNEL_APPROVAL_ALIASES` | Comma-separated agent names accepted in exact `approve <agent> here` / `revoke <agent> here` phrases. |
+| `SLACK_CHANNEL_APPROVAL_FILE` | Optional JSON state file path for channel approvals; defaults to `$HERMES_HOME/slack_channel_approvals.json`. |
 | `SLACK_HOME_CHANNEL` | Default Slack channel for cron delivery |
 | `SLACK_HOME_CHANNEL_NAME` | Display name for the Slack home channel |
 | `GOOGLE_CHAT_PROJECT_ID` | GCP project hosting the Pub/Sub topic (falls back to `GOOGLE_CLOUD_PROJECT`) |

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -562,6 +562,18 @@ slack:
   # Opt-in; default off. Env: SLACK_THREAD_REQUIRE_MENTION.
   thread_require_mention: false
 
+  # Optional one-time channel approval gate. When enabled, channels not in
+  # allowed_channels or the local approval state get a short approval-needed
+  # reply and do not reach the agent until an owner says exactly
+  # "approve <agent> here" in that channel. In multi-workspace Socket Mode,
+  # qualify initial allowed channels as "T123:C123" to avoid cross-workspace
+  # channel-ID collisions; unqualified allowed_channels are single-workspace
+  # convenience entries.
+  channel_approval_required: false
+  channel_approval_owners: ""       # Slack user IDs; defaults to allow_from / SLACK_ALLOWED_USERS
+  channel_approval_aliases: ""      # Agent names accepted in approve/revoke phrases
+  channel_approval_file: ""         # Defaults to $HERMES_HOME/slack_channel_approvals.json
+
   # Per-channel force-mention override — the opposite direction of
   # free_response_channels. Channels listed here ALWAYS require an
   # explicit @mention, even when require_mention is false globally.
@@ -606,6 +618,7 @@ The gating options compose — each answers a different question:
 | `free_response_channels` | Which channels are exempt from `require_mention`? | none | Listed channels |
 | `require_mention_channels` | Which channels ALWAYS need an @mention, even when `require_mention` is `false` or the channel is free-response? Wins over both. | none | Listed channels |
 | `thread_require_mention` | Do **thread replies** need an @mention, even when top-level messages don't? Mentioned threads are not remembered. | `false` | Threads only |
+| `channel_approval_required` | Should newly seen shared Slack channels start pending until an owner approves the agent in-channel? | `false` | Channels + group DMs |
 | `strict_mention` | Does **every** channel message (top-level and thread) need a fresh @mention? Disables all auto-follow: mentioned-thread memory, bot-reply follow-ups, active-session resume. | `false` | All channels + threads |
 | `ignore_other_user_mentions` | Should a message that **opens by @mentioning someone else** (`@rasha can you take this?`) be skipped? Overrides free-response and thread auto-follow; mid-sentence references still reach the bot. | `false` | Channels + group DMs |
 


### PR DESCRIPTION
## Summary
- add an opt-in Slack shared-channel approval gate before normal message dispatch, including Slack slash-command dispatch
- store local approval/pending/revoked channel state per Hermes profile with team-scoped keys where Slack team IDs are available
- honor configured approval owners/agent aliases with exact `approve <agent> here` / `revoke <agent> here` phrases
- document the new Slack config/env settings and cover approval, revoke, exact command, slash-command interception, team scoping, and config bridge behavior in tests

## Test Plan
- `scripts/run_tests.sh tests/gateway/test_slack_mention.py tests/gateway/test_slack.py tests/gateway/test_config.py -q`
- `git diff --check`
- `python3 -m py_compile plugins/platforms/slack/adapter.py tests/gateway/test_slack_mention.py tests/gateway/test_config.py gateway/config.py hermes_cli/config_defaults.py`
