### PR TITLE
fix(search): guide empty timed-out searches

### DIFF
--- a/tests/tools/test_search_budget_truncation.py
+++ b/tests/tools/test_search_budget_truncation.py
@@ -63,6 +63,36 @@ def test_rg_timeout_returns_partial_results_without_marker(ops, monkeypatch, tar
         assert all("timed out" not in path for path in result.files)
 
 
+@pytest.mark.parametrize(
+    ("target", "output_mode"),
+    [
+        ("files", "content"),
+        ("content", "files_only"),
+        ("content", "count"),
+        ("content", "content"),
+    ],
+)
+def test_rg_timeout_without_partial_results_returns_scoping_guidance(
+    ops, monkeypatch, target, output_mode
+):
+    ops.env.execute.side_effect = path_exists_or(TIMEOUT)
+    monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == "rg")
+
+    result = ops.search(
+        "campaign-id",
+        path="/Users/example",
+        target=target,
+        output_mode=output_mode,
+        file_glob="*.md" if target == "content" else None,
+    )
+
+    assert_timed_out(result)
+    assert result.warning is not None
+    assert "Narrow path" in result.warning
+    if target == "content":
+        assert "file_glob" in result.warning
+
+
 def test_real_rg_error_still_hard_fails(ops, monkeypatch):
     ops.env.execute.side_effect = path_exists_or("rg: regex parse error:", returncode=2)
     monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == "rg")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -363,6 +363,27 @@ def _search_stdout_and_limit(result: ExecuteResult) -> tuple[str, Optional[str]]
     return result.stdout, None
 
 
+def _add_empty_timeout_guidance(
+    result: SearchResult, path: str, file_glob: Optional[str]
+) -> SearchResult:
+    """Give a recovery action when a timed search emitted no usable results."""
+    if result.limit_reason != "search_timeout" or any(
+        (result.matches, result.files, result.counts)
+    ):
+        return result
+
+    guidance = (
+        f"Search timed out before any results were emitted from {path}. "
+        "Narrow path to a likely project or subdirectory"
+    )
+    if file_glob:
+        guidance += f" or use a more specific file_glob than {file_glob!r}"
+    else:
+        guidance += " or add file_glob (for example, '*.py')"
+    result.warning = guidance + "."
+    return result
+
+
 def _split_tool_diagnostics(output: str) -> tuple[str, str]:
     """Separate rg/grep diagnostic lines from real match output.
 
@@ -2661,10 +2682,11 @@ class ShellFileOperations(FileOperations):
             )
         
         if target == "files":
-            return self._search_files(pattern, path, limit, offset)
+            result = self._search_files(pattern, path, limit, offset)
         else:
-            return self._search_content(pattern, path, file_glob, limit, offset, 
-                                        output_mode, context)
+            result = self._search_content(pattern, path, file_glob, limit, offset,
+                                          output_mode, context)
+        return _add_empty_timeout_guidance(result, path, file_glob)
     
     def _try_multi_path_search(self, pattern: str, path: str, target: str,
                                file_glob: Optional[str], limit: int, offset: int,


### PR DESCRIPTION
## Summary
- keep existing partial-result behavior for timed-out file searches
- add explicit path/file_glob scoping guidance when a timeout emitted no usable results
- cover file-name and all content output modes

## Verification
- `scripts/run_tests.sh tests/tools/test_search_budget_truncation.py tests/tools/test_search_error_guard.py tests/tools/test_search_zero_match_and_multipath.py` (34 passed)
- `.venv/bin/ruff check tools/file_operations.py tests/tools/test_search_budget_truncation.py`
- real home-wide ShellFileOperations search returned `limit_reason: search_timeout` plus scoping warning