### PR TITLE
feat(enterprise): control-plane core — resource model, store, audit, driver contracts

### DIFF
--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -1,0 +1,27 @@
+"""Hermes Enterprise: multi-tenant control plane for deploying and operating
+Hermes agents.
+
+This package is the control-plane counterpart to the hermes-agent runtime
+(the "Harness" in platform terms). It is deliberately standalone: nothing in
+the core agent imports it, it adds no model tools, and it never runs inside
+an agent conversation. It is operated via the ``hermes enterprise`` CLI and
+(in later work) the controller service.
+
+Layout:
+    resources.py  - platform resource model (Namespace, Agent, AgentRevision, ...)
+    iam.py        - IAM entities (Principal, Role, AccessBinding, ...)
+    store.py      - SQLite-backed resource store with optimistic concurrency
+    audit.py      - append-only audit log
+    contracts.py  - Driver / Adapter ABCs (compute, sandbox, secrets, IAM)
+    errors.py     - typed error hierarchy (all failures are fail-closed)
+"""
+
+__all__ = [
+    "resources",
+    "store",
+    "audit",
+    "contracts",
+    "errors",
+]
+
+ENTERPRISE_SCHEMA_VERSION = 1

--- a/enterprise/audit.py
+++ b/enterprise/audit.py
@@ -1,0 +1,131 @@
+"""Append-only audit log for the enterprise control plane.
+
+Every control-plane mutation and authorization decision produces one
+attributable record. Records never contain credentials, secret values,
+provider message contents, or runtime message contents — the writer
+actively refuses payloads that look like they do.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from .resources import _find_secretlike_keys  # shared secret-shape detector
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS audit_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts          REAL NOT NULL,
+    actor       TEXT NOT NULL,
+    actor_kind  TEXT NOT NULL,
+    action      TEXT NOT NULL,
+    kind        TEXT,
+    namespace   TEXT,
+    resource    TEXT,
+    outcome     TEXT NOT NULL,
+    reason      TEXT,
+    detail      TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_audit_ts ON audit_log(ts);
+CREATE INDEX IF NOT EXISTS idx_audit_resource ON audit_log(kind, namespace, resource);
+"""
+
+ALLOWED_OUTCOMES = ("allow", "deny", "error", "applied", "rolled-back")
+
+
+class AuditLog:
+    def __init__(self, db_path: str | Path):
+        self._path = Path(db_path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(str(self._path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        try:
+            self._conn.execute("PRAGMA journal_mode=WAL")
+        except sqlite3.DatabaseError:
+            pass
+        with self._lock, self._conn:
+            self._conn.executescript(_SCHEMA)
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def record(
+        self,
+        *,
+        actor: str,
+        actor_kind: str,
+        action: str,
+        outcome: str,
+        kind: str | None = None,
+        namespace: str | None = None,
+        resource: str | None = None,
+        reason: str | None = None,
+        detail: dict[str, Any] | None = None,
+    ) -> int:
+        if outcome not in ALLOWED_OUTCOMES:
+            raise ValueError(f"outcome must be one of {ALLOWED_OUTCOMES}")
+        if detail:
+            leaked = _find_secretlike_keys(detail)
+            if leaked:
+                raise ValueError(
+                    f"audit detail contains secret-like values at {sorted(leaked)}; "
+                    "audit records must never carry secrets"
+                )
+        with self._lock, self._conn:
+            cur = self._conn.execute(
+                "INSERT INTO audit_log (ts, actor, actor_kind, action, kind,"
+                " namespace, resource, outcome, reason, detail)"
+                " VALUES (?,?,?,?,?,?,?,?,?,?)",
+                (
+                    time.time(),
+                    actor,
+                    actor_kind,
+                    action,
+                    kind,
+                    namespace,
+                    resource,
+                    outcome,
+                    reason,
+                    json.dumps(detail) if detail else None,
+                ),
+            )
+            return int(cur.lastrowid or 0)
+
+    def query(
+        self,
+        *,
+        kind: str | None = None,
+        namespace: str | None = None,
+        resource: str | None = None,
+        since: float | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        clauses, params = [], []  # type: ignore[var-annotated]
+        for col, val in (("kind", kind), ("namespace", namespace),
+                         ("resource", resource)):
+            if val is not None:
+                clauses.append(f"{col}=?")
+                params.append(val)
+        if since is not None:
+            clauses.append("ts>=?")
+            params.append(since)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        params.append(max(1, min(int(limit), 1000)))
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT * FROM audit_log {where} ORDER BY id DESC LIMIT ?", params
+            ).fetchall()
+        out = []
+        for r in rows:
+            rec = dict(r)
+            if rec.get("detail"):
+                rec["detail"] = json.loads(rec["detail"])
+            out.append(rec)
+        return out

--- a/enterprise/contracts.py
+++ b/enterprise/contracts.py
@@ -1,0 +1,206 @@
+"""Driver / Adapter contracts for Hermes Enterprise.
+
+These ABCs are the extension seams of the platform:
+
+    ComputeDriver  - provisions/observes the workload for an admitted revision
+    SandboxDriver  - establishes + verifies containment before harness start
+    SecretDriver   - performs brokered operations against a secret backend
+    IAMAdapter     - authorizes exact actions on exact resources
+    IdentityVerifier - verifies external identity evidence (OAG boundary)
+
+Ownership rules (enforced by the controller, documented here for
+implementers): drivers and adapters consume admitted intent at their
+boundary. They never own platform resources, select themselves, grant
+permissions, or rewrite revisions. Any failure or inability to verify is a
+denial — implementations raise, they do not degrade.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+from .resources import Resource
+
+# ---------------------------------------------------------------------------
+# Identity / authorization
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VerifiedIdentity:
+    """Output of the OAG boundary: verified identity + admitted scope.
+
+    Carries evidence, not permission. OCC authorization is always a separate,
+    independent decision.
+    """
+
+    issuer: str
+    subject: str            # immutable subject from the identity provider
+    installation: str       # server-selected, never caller-selected
+    namespace: str | None   # admitted namespace, when the request required one
+    claims: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AuthzRequest:
+    """One exact authorization question."""
+
+    principal: str          # resolved platform identity (never raw claims)
+    principal_kind: str     # principal | service-principal | workload-identity
+    action: str             # e.g. "openclaw.agents.deploy" -> ours: "hermes.agents.deploy"
+    kind: str               # resource kind
+    namespace: str | None
+    resource: str | None    # exact resource name; None only for create/list scope checks
+
+
+class IdentityVerifier(ABC):
+    """Verifies external identity evidence and admits exact scope (OAG)."""
+
+    @abstractmethod
+    def verify(self, token: str, *, require_namespace: str | None = None) -> VerifiedIdentity:
+        """Return a VerifiedIdentity or raise AdmissionError. Fail closed."""
+
+
+class IAMAdapter(ABC):
+    """Authoritative authorization for the resource kinds assigned to it."""
+
+    name: str = "abstract"
+
+    @abstractmethod
+    def authorize(self, request: AuthzRequest) -> None:
+        """Return None on allow; raise AuthorizationError (or
+        RestrictionError) on deny. An unavailable authority must raise —
+        never default-allow."""
+
+
+# ---------------------------------------------------------------------------
+# Compute / sandbox
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WorkloadRef:
+    """Handle to one provisioned candidate workload."""
+
+    revision_uid: str
+    namespace: str
+    workload_identity: str
+    driver: str
+    handle: dict[str, Any] = field(default_factory=dict)  # driver-specific ids
+
+
+class ComputeDriver(ABC):
+    """Provisions and observes infrastructure for an admitted AgentRevision."""
+
+    name: str = "abstract"
+
+    @abstractmethod
+    def provision_candidate(self, revision: Resource) -> WorkloadRef:
+        """Create a separate, non-serving candidate workload whose harness
+        cannot start yet. Must not mutate the previously active workload."""
+
+    @abstractmethod
+    def workload_ready(self, ref: WorkloadRef) -> bool:
+        """Infrastructure readiness for the candidate (not harness health)."""
+
+    @abstractmethod
+    def start_harness(self, ref: WorkloadRef) -> None:
+        """Permit the harness to execute. Called only after containment is
+        verified and the previous revision is retired."""
+
+    @abstractmethod
+    def stop_harness(self, ref: WorkloadRef) -> None:
+        """Stop the harness and verify it has stopped."""
+
+    @abstractmethod
+    def teardown(self, ref: WorkloadRef) -> None:
+        """Remove the workload's infrastructure."""
+
+
+class SandboxDriver(ABC):
+    """Enforces the exact admitted SandboxPolicy for one revision."""
+
+    name: str = "abstract"
+
+    @abstractmethod
+    def supports(self, policy: dict[str, Any]) -> bool:
+        """True only if the ENTIRE policy can be enforced. Partial support
+        is unsupported; the controller rejects deployment."""
+
+    @abstractmethod
+    def enforce(self, ref: WorkloadRef, policy: dict[str, Any]) -> None:
+        """Establish containment for the candidate workload. Raise
+        DriverError if enforcement cannot be established."""
+
+    @abstractmethod
+    def verify(self, ref: WorkloadRef, policy: dict[str, Any]) -> None:
+        """Independently verify enforcement is in place. Raise DriverError
+        when verification is unavailable or ambiguous — unverifiable
+        containment blocks activation."""
+
+
+# ---------------------------------------------------------------------------
+# Secrets
+# ---------------------------------------------------------------------------
+
+
+class SecretDriver(ABC):
+    """Performs permitted operations against an external secret backend.
+
+    The driver mediates; it never returns raw secret values to workloads.
+    ``use`` executes an operation that needs the secret (e.g. signing a
+    request, minting a scoped short-lived token) backend-side and returns
+    only the operation result.
+    """
+
+    name: str = "abstract"
+
+    @abstractmethod
+    def exists(self, backend: dict[str, Any], key: str) -> bool:
+        """Whether the backend can serve this key (no value retrieval)."""
+
+    @abstractmethod
+    def use(self, backend: dict[str, Any], key: str, operation: str,
+            params: dict[str, Any]) -> dict[str, Any]:
+        """Execute one permitted, secret-backed operation. The result must
+        not contain the secret value or reusable backend credentials."""
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class DriverRegistry:
+    """Installation-owned selection of exactly one implementation per
+    capability. Nothing can register over an existing selection, and lookup
+    of an unselected capability fails closed."""
+
+    def __init__(self) -> None:
+        self._impls: dict[tuple[str, str], Any] = {}
+
+    def select(self, capability: str, impl: Any) -> None:
+        name = getattr(impl, "name", None)
+        if not name or name == "abstract":
+            raise ValueError("implementation must carry a concrete .name")
+        key = (capability, name)
+        if any(cap == capability for cap, _ in self._impls):
+            raise ValueError(
+                f"capability {capability!r} already has a selected "
+                "implementation; changing selection requires explicit "
+                "reconfiguration, not re-registration"
+            )
+        self._impls[key] = impl
+
+    def get(self, capability: str) -> Any:
+        matches = [impl for (cap, _), impl in self._impls.items() if cap == capability]
+        if not matches:
+            from .errors import DriverError
+
+            raise DriverError(f"no implementation selected for {capability!r}")
+        return matches[0]
+
+    def selected_name(self, capability: str) -> str:
+        return str(getattr(self.get(capability), "name"))

--- a/enterprise/errors.py
+++ b/enterprise/errors.py
@@ -1,0 +1,62 @@
+"""Typed error hierarchy for the enterprise control plane.
+
+Every error here is fail-closed: callers must treat any EnterpriseError as a
+denial of the requested operation. There is no "retry against another
+implementation" path anywhere in the control plane.
+"""
+
+from __future__ import annotations
+
+
+class EnterpriseError(Exception):
+    """Base class for all control-plane errors."""
+
+
+class ValidationError(EnterpriseError):
+    """A resource or request failed structural validation."""
+
+
+class ScopeError(EnterpriseError):
+    """A reference crossed an Installation or Namespace boundary."""
+
+
+class NotFoundError(EnterpriseError):
+    """The exact requested resource does not exist in the requested scope."""
+
+
+class ConflictError(EnterpriseError):
+    """Optimistic-concurrency conflict or duplicate resource name."""
+
+
+class AuthorizationError(EnterpriseError):
+    """The authoritative IAMAdapter denied (or could not verify) the action.
+
+    An unavailable adapter raises this too: unverifiable == denied.
+    """
+
+
+class AdmissionError(EnterpriseError):
+    """Identity evidence could not be verified or admitted (OAG boundary)."""
+
+
+class RestrictionError(AuthorizationError):
+    """A platform Restriction narrowed an otherwise-allowed operation."""
+
+
+class DriverError(EnterpriseError):
+    """A selected Driver failed, is unavailable, or cannot verify enforcement."""
+
+
+class DeploymentError(EnterpriseError):
+    """Deployment choreography failed; the previous revision remains active."""
+
+
+class RollbackError(DeploymentError):
+    """Post-activation failure whose rollback could not be verified.
+
+    The Agent must remain inactive and serve no traffic.
+    """
+
+
+class SecretAccessError(EnterpriseError):
+    """A brokered secret operation was denied or could not be mediated."""

--- a/enterprise/resources.py
+++ b/enterprise/resources.py
@@ -1,0 +1,323 @@
+"""Platform resource model for Hermes Enterprise.
+
+v1 resources (mirroring the platform spec):
+
+    Installation-scoped:  Harness, Restriction (optionally), IAM config
+    Namespace-scoped:     Configuration, Agent, AgentRevision, Channel,
+                          Secret, SecretBroker, SandboxPolicy, Restriction
+
+Design rules encoded here:
+  * Every resource belongs to the Installation or to exactly one Namespace.
+  * Namespace-scoped references never cross the Namespace boundary
+    (validated in the store, not just documented).
+  * AgentRevision is an immutable snapshot: it embeds resolved copies of the
+    configuration and policy that were admitted, not live references.
+  * Secret resources carry no secret value, ever.
+  * Resources are plain dataclasses serialized to/from JSON dicts so the
+    store, CLI, and controller share one wire shape.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+from .errors import ValidationError
+
+# ---------------------------------------------------------------------------
+# Common
+# ---------------------------------------------------------------------------
+
+_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")  # DNS-1123 label
+
+
+def validate_name(name: str, kind: str = "resource") -> str:
+    """Names are DNS-1123 labels so they can back Kubernetes objects 1:1."""
+    if not isinstance(name, str) or not _NAME_RE.match(name):
+        raise ValidationError(
+            f"invalid {kind} name {name!r}: must be a lowercase DNS-1123 label "
+            "(a-z, 0-9, '-', max 63 chars, no leading/trailing '-')"
+        )
+    return name
+
+
+def new_uid() -> str:
+    return uuid.uuid4().hex
+
+
+def now_ts() -> float:
+    return time.time()
+
+
+class Scope(str, Enum):
+    INSTALLATION = "installation"
+    NAMESPACE = "namespace"
+
+
+class Kind(str, Enum):
+    NAMESPACE = "Namespace"
+    CONFIGURATION = "Configuration"
+    AGENT = "Agent"
+    AGENT_REVISION = "AgentRevision"
+    HARNESS = "Harness"
+    CHANNEL = "Channel"
+    SECRET = "Secret"
+    SECRET_BROKER = "SecretBroker"
+    SANDBOX_POLICY = "SandboxPolicy"
+    RESTRICTION = "Restriction"
+
+
+#: Which scope each kind lives in. Restriction may live in either.
+KIND_SCOPES: dict[Kind, tuple[Scope, ...]] = {
+    Kind.NAMESPACE: (Scope.INSTALLATION,),
+    Kind.CONFIGURATION: (Scope.NAMESPACE,),
+    Kind.AGENT: (Scope.NAMESPACE,),
+    Kind.AGENT_REVISION: (Scope.NAMESPACE,),
+    Kind.HARNESS: (Scope.INSTALLATION,),
+    Kind.CHANNEL: (Scope.NAMESPACE,),
+    Kind.SECRET: (Scope.NAMESPACE,),
+    Kind.SECRET_BROKER: (Scope.NAMESPACE,),
+    Kind.SANDBOX_POLICY: (Scope.NAMESPACE,),
+    Kind.RESTRICTION: (Scope.INSTALLATION, Scope.NAMESPACE),
+}
+
+
+@dataclass
+class ResourceMeta:
+    """Identity + lifecycle metadata shared by every platform resource."""
+
+    kind: str
+    name: str
+    uid: str = field(default_factory=new_uid)
+    namespace: str | None = None  # None => installation-scoped
+    generation: int = 1  # bumped on every spec change (optimistic concurrency)
+    created_at: float = field(default_factory=now_ts)
+    updated_at: float = field(default_factory=now_ts)
+    labels: dict[str, str] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        kind = Kind(self.kind)
+        validate_name(self.name, kind.value)
+        scopes = KIND_SCOPES[kind]
+        if self.namespace is None and Scope.INSTALLATION not in scopes:
+            raise ValidationError(f"{kind.value} {self.name!r} requires a namespace")
+        if self.namespace is not None:
+            if Scope.NAMESPACE not in scopes:
+                raise ValidationError(
+                    f"{kind.value} {self.name!r} is installation-scoped and "
+                    "cannot carry a namespace"
+                )
+            validate_name(self.namespace, "Namespace")
+
+
+@dataclass
+class Resource:
+    """Envelope: metadata + kind-specific spec + controller-owned status."""
+
+    meta: ResourceMeta
+    spec: dict[str, Any] = field(default_factory=dict)
+    status: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"meta": asdict(self.meta), "spec": self.spec, "status": self.status}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Resource":
+        return cls(
+            meta=ResourceMeta(**data["meta"]),
+            spec=dict(data.get("spec") or {}),
+            status=dict(data.get("status") or {}),
+        )
+
+    def validate(self) -> None:
+        self.meta.validate()
+        validator = _SPEC_VALIDATORS.get(Kind(self.meta.kind))
+        if validator is not None:
+            validator(self)
+
+
+# ---------------------------------------------------------------------------
+# Per-kind spec validation
+# ---------------------------------------------------------------------------
+
+def _require(spec: dict[str, Any], key: str, typ: type, kind: str) -> Any:
+    val = spec.get(key)
+    if not isinstance(val, typ) or (typ is str and not val):
+        raise ValidationError(f"{kind}.spec.{key} must be a non-empty {typ.__name__}")
+    return val
+
+
+def _validate_namespace(res: Resource) -> None:
+    # Namespace spec is minimal in v1; phase/readiness live in status.
+    phase = res.status.get("phase", NamespacePhase.PENDING.value)
+    NamespacePhase(phase)
+
+
+def _validate_configuration(res: Resource) -> None:
+    _require(res.spec, "config", dict, "Configuration")
+    forbidden = _find_secretlike_keys(res.spec["config"])
+    if forbidden:
+        raise ValidationError(
+            "Configuration must not embed secret values; found secret-like "
+            f"keys: {sorted(forbidden)}. Reference a Secret resource instead."
+        )
+
+
+_SECRETLIKE = re.compile(r"(api[_-]?key|token|password|secret|credential)", re.I)
+_REFERENCE_KEYS = re.compile(r"^(secretRef|secret_ref|secretName|secret_name)$")
+
+
+def _find_secretlike_keys(cfg: Any, path: str = "") -> set[str]:
+    hits: set[str] = set()
+    if isinstance(cfg, dict):
+        for k, v in cfg.items():
+            p = f"{path}.{k}" if path else str(k)
+            # {"secretRef": "<resource name>"} is the sanctioned reference
+            # shape — the value is a resource NAME, not a secret.
+            if isinstance(v, str) and _REFERENCE_KEYS.match(str(k)):
+                continue
+            # A *string value* under a secret-like key is an embedded secret.
+            # A dict/reference shape ({"secretRef": name}) is fine.
+            if isinstance(v, str) and v and _SECRETLIKE.search(str(k)):
+                hits.add(p)
+            hits |= _find_secretlike_keys(v, p)
+    elif isinstance(cfg, list):
+        for i, v in enumerate(cfg):
+            hits |= _find_secretlike_keys(v, f"{path}[{i}]")
+    return hits
+
+
+def _validate_agent(res: Resource) -> None:
+    spec = res.spec
+    _require(spec, "harness", str, "Agent")            # Harness name (installation)
+    _require(spec, "configuration", str, "Agent")      # Configuration name (ns)
+    for key in ("channels", "secrets"):
+        vals = spec.get(key, [])
+        if not isinstance(vals, list) or not all(isinstance(v, str) and v for v in vals):
+            raise ValidationError(f"Agent.spec.{key} must be a list of resource names")
+    sandbox = spec.get("sandboxPolicy")
+    if sandbox is not None and (not isinstance(sandbox, str) or not sandbox):
+        raise ValidationError("Agent.spec.sandboxPolicy must be a resource name")
+
+
+def _validate_agent_revision(res: Resource) -> None:
+    spec = res.spec
+    _require(spec, "agent", str, "AgentRevision")
+    _require(spec, "agentUid", str, "AgentRevision")
+    _require(spec, "workloadIdentity", str, "AgentRevision")
+    _require(spec, "harness", dict, "AgentRevision")          # snapshot {name, version}
+    _require(spec, "configuration", dict, "AgentRevision")    # snapshot of config contents
+    _require(spec, "computeDriver", str, "AgentRevision")     # pinned implementation
+    _require(spec, "sandboxDriver", str, "AgentRevision")     # pinned implementation
+    if "sandboxPolicy" in spec and not isinstance(spec["sandboxPolicy"], dict):
+        raise ValidationError("AgentRevision.spec.sandboxPolicy must be a snapshot dict")
+    phase = res.status.get("phase", RevisionPhase.CANDIDATE.value)
+    RevisionPhase(phase)
+
+
+def _validate_harness(res: Resource) -> None:
+    _require(res.spec, "version", str, "Harness")
+    _require(res.spec, "image", str, "Harness")  # OCI image ref for the runtime
+
+
+def _validate_channel(res: Resource) -> None:
+    _require(res.spec, "platform", str, "Channel")  # telegram/discord/slack/...
+
+
+def _validate_secret(res: Resource) -> None:
+    _require(res.spec, "broker", str, "Secret")     # SecretBroker name (same ns)
+    _require(res.spec, "key", str, "Secret")        # backend key/path identifier
+    if "value" in res.spec or "data" in res.spec:
+        raise ValidationError("Secret resources must not contain secret values")
+
+
+def _validate_secret_broker(res: Resource) -> None:
+    _require(res.spec, "driver", str, "SecretBroker")   # selected SecretDriver
+    backend = res.spec.get("backend", {})
+    if not isinstance(backend, dict):
+        raise ValidationError("SecretBroker.spec.backend must be a dict")
+    if _find_secretlike_keys(backend):
+        raise ValidationError(
+            "SecretBroker.spec.backend must reference backend credentials "
+            "out-of-band; it cannot embed them"
+        )
+
+
+def _validate_sandbox_policy(res: Resource) -> None:
+    spec = res.spec
+    network = spec.get("network", "isolated")
+    if network not in ("isolated", "egress-allowlist", "open"):
+        raise ValidationError(
+            "SandboxPolicy.spec.network must be one of "
+            "'isolated', 'egress-allowlist', 'open'"
+        )
+    if network == "egress-allowlist":
+        allow = spec.get("egressAllow", [])
+        if not isinstance(allow, list) or not allow:
+            raise ValidationError(
+                "SandboxPolicy with network=egress-allowlist requires a "
+                "non-empty spec.egressAllow list"
+            )
+    for key in ("readOnlyRootFilesystem", "allowPrivilegeEscalation"):
+        if key in spec and not isinstance(spec[key], bool):
+            raise ValidationError(f"SandboxPolicy.spec.{key} must be a bool")
+
+
+def _validate_restriction(res: Resource) -> None:
+    _require(res.spec, "rule", dict, "Restriction")
+    rule = res.spec["rule"]
+    if not isinstance(rule.get("deny"), list) or not rule["deny"]:
+        raise ValidationError(
+            "Restriction.spec.rule.deny must be a non-empty list of "
+            "'<action>:<kind>[:<name>]' patterns; Restrictions can only "
+            "narrow, never grant"
+        )
+
+
+_SPEC_VALIDATORS = {
+    Kind.NAMESPACE: _validate_namespace,
+    Kind.CONFIGURATION: _validate_configuration,
+    Kind.AGENT: _validate_agent,
+    Kind.AGENT_REVISION: _validate_agent_revision,
+    Kind.HARNESS: _validate_harness,
+    Kind.CHANNEL: _validate_channel,
+    Kind.SECRET: _validate_secret,
+    Kind.SECRET_BROKER: _validate_secret_broker,
+    Kind.SANDBOX_POLICY: _validate_sandbox_policy,
+    Kind.RESTRICTION: _validate_restriction,
+}
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle phases
+# ---------------------------------------------------------------------------
+
+class NamespacePhase(str, Enum):
+    PENDING = "Pending"        # created, backing infra not ready
+    READY = "Ready"            # backing k8s namespace + gateway ready
+    FAILED = "Failed"          # reconcile failed; cannot admit deployments
+    TERMINATING = "Terminating"
+
+
+class RevisionPhase(str, Enum):
+    CANDIDATE = "Candidate"    # created; workload may be provisioning
+    CONTAINED = "Contained"    # sandbox enforcement verified
+    ACTIVE = "Active"          # sole active revision; serving
+    RETIRED = "Retired"        # superseded; harness stopped
+    FAILED = "Failed"          # never activated (previous revision unchanged)
+
+
+#: Namespace-scoped reference fields per kind: (spec key, target kind, is_list)
+REFERENCE_FIELDS: dict[Kind, tuple[tuple[str, Kind, bool], ...]] = {
+    Kind.AGENT: (
+        ("configuration", Kind.CONFIGURATION, False),
+        ("channels", Kind.CHANNEL, True),
+        ("secrets", Kind.SECRET, True),
+        ("sandboxPolicy", Kind.SANDBOX_POLICY, False),
+    ),
+    Kind.SECRET: (("broker", Kind.SECRET_BROKER, False),),
+}

--- a/enterprise/store.py
+++ b/enterprise/store.py
@@ -1,0 +1,263 @@
+"""SQLite-backed resource store for the enterprise control plane.
+
+One store per Installation. The store enforces the invariants the resource
+model declares:
+
+  * unique (kind, namespace, name)
+  * namespace-scoped resources require an existing, non-terminating Namespace
+  * namespace-scoped references resolve within the same namespace only
+    (REFERENCE_FIELDS), fail-closed
+  * optimistic concurrency via meta.generation
+  * AgentRevision rows are immutable after creation except for their status
+  * deletion is refused while dependents reference the resource
+
+WAL journaling is used when available (mirrors hermes_state.py behavior).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Any
+
+from .errors import ConflictError, NotFoundError, ScopeError, ValidationError
+from .resources import (
+    Kind,
+    NamespacePhase,
+    REFERENCE_FIELDS,
+    Resource,
+    now_ts,
+)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS resources (
+    uid        TEXT PRIMARY KEY,
+    kind       TEXT NOT NULL,
+    namespace  TEXT,
+    name       TEXT NOT NULL,
+    generation INTEGER NOT NULL DEFAULT 1,
+    doc        TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_resources_identity
+    ON resources(kind, COALESCE(namespace, ''), name);
+CREATE INDEX IF NOT EXISTS idx_resources_kind_ns ON resources(kind, namespace);
+"""
+
+
+class ResourceStore:
+    def __init__(self, db_path: str | Path):
+        self._path = Path(db_path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(str(self._path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        try:
+            self._conn.execute("PRAGMA journal_mode=WAL")
+        except sqlite3.DatabaseError:
+            pass
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        with self._lock, self._conn:
+            self._conn.executescript(_SCHEMA)
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    def create(self, res: Resource) -> Resource:
+        res.validate()
+        with self._lock, self._conn:
+            self._check_scope(res)
+            self._check_references(res)
+            try:
+                self._conn.execute(
+                    "INSERT INTO resources (uid, kind, namespace, name, generation,"
+                    " doc, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?)",
+                    (
+                        res.meta.uid,
+                        res.meta.kind,
+                        res.meta.namespace,
+                        res.meta.name,
+                        res.meta.generation,
+                        json.dumps(res.to_dict()),
+                        res.meta.created_at,
+                        res.meta.updated_at,
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise ConflictError(
+                    f"{res.meta.kind} {self._fqn(res)} already exists"
+                ) from exc
+        return res
+
+    def get(self, kind: Kind | str, name: str, namespace: str | None = None) -> Resource:
+        kind = Kind(kind).value
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT doc FROM resources WHERE kind=? AND"
+                " COALESCE(namespace,'')=COALESCE(?,'') AND name=?",
+                (kind, namespace, name),
+            ).fetchone()
+        if row is None:
+            where = f"namespace {namespace!r}" if namespace else "installation scope"
+            raise NotFoundError(f"{kind} {name!r} not found in {where}")
+        return Resource.from_dict(json.loads(row["doc"]))
+
+    def list(self, kind: Kind | str, namespace: str | None = None) -> list[Resource]:
+        kind = Kind(kind).value
+        with self._lock:
+            if namespace is None:
+                rows = self._conn.execute(
+                    "SELECT doc FROM resources WHERE kind=? ORDER BY name", (kind,)
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    "SELECT doc FROM resources WHERE kind=? AND namespace=?"
+                    " ORDER BY name",
+                    (kind, namespace),
+                ).fetchall()
+        return [Resource.from_dict(json.loads(r["doc"])) for r in rows]
+
+    def update_spec(self, res: Resource) -> Resource:
+        """Update spec with optimistic concurrency; bumps generation.
+
+        AgentRevision specs are immutable: only status may change after
+        creation (use update_status).
+        """
+        res.validate()
+        if Kind(res.meta.kind) is Kind.AGENT_REVISION:
+            raise ValidationError(
+                "AgentRevision is immutable; only its status may be updated"
+            )
+        with self._lock, self._conn:
+            current = self.get(res.meta.kind, res.meta.name, res.meta.namespace)
+            if current.meta.generation != res.meta.generation:
+                raise ConflictError(
+                    f"{res.meta.kind} {self._fqn(res)} generation conflict: "
+                    f"store has {current.meta.generation}, caller has "
+                    f"{res.meta.generation}"
+                )
+            self._check_references(res)
+            res.meta.generation += 1
+            res.meta.updated_at = now_ts()
+            res.meta.uid = current.meta.uid
+            res.meta.created_at = current.meta.created_at
+            self._conn.execute(
+                "UPDATE resources SET generation=?, doc=?, updated_at=? WHERE uid=?",
+                (res.meta.generation, json.dumps(res.to_dict()), res.meta.updated_at,
+                 res.meta.uid),
+            )
+        return res
+
+    def update_status(self, kind: Kind | str, name: str, namespace: str | None,
+                      status: dict[str, Any]) -> Resource:
+        """Controller-owned status update; does not bump generation."""
+        with self._lock, self._conn:
+            res = self.get(kind, name, namespace)
+            res.status = dict(status)
+            res.validate()
+            res.meta.updated_at = now_ts()
+            self._conn.execute(
+                "UPDATE resources SET doc=?, updated_at=? WHERE uid=?",
+                (json.dumps(res.to_dict()), res.meta.updated_at, res.meta.uid),
+            )
+        return res
+
+    def delete(self, kind: Kind | str, name: str, namespace: str | None = None) -> None:
+        kind_e = Kind(kind)
+        with self._lock, self._conn:
+            res = self.get(kind_e, name, namespace)
+            dependents = self._find_dependents(res)
+            if dependents:
+                raise ConflictError(
+                    f"cannot delete {kind_e.value} {name!r}: referenced by "
+                    + ", ".join(sorted(dependents))
+                )
+            if kind_e is Kind.NAMESPACE:
+                with_ns = self._conn.execute(
+                    "SELECT COUNT(*) AS n FROM resources WHERE namespace=?", (name,)
+                ).fetchone()["n"]
+                if with_ns:
+                    raise ConflictError(
+                        f"cannot delete Namespace {name!r}: {with_ns} resources "
+                        "remain; drain the namespace first"
+                    )
+            self._conn.execute("DELETE FROM resources WHERE uid=?", (res.meta.uid,))
+
+    # ------------------------------------------------------------------
+    # Invariant enforcement
+    # ------------------------------------------------------------------
+
+    def _check_scope(self, res: Resource) -> None:
+        if res.meta.namespace is None:
+            return
+        try:
+            ns = self.get(Kind.NAMESPACE, res.meta.namespace)
+        except NotFoundError as exc:
+            raise ScopeError(
+                f"{res.meta.kind} {res.meta.name!r} references missing "
+                f"Namespace {res.meta.namespace!r}"
+            ) from exc
+        phase = ns.status.get("phase", NamespacePhase.PENDING.value)
+        if phase == NamespacePhase.TERMINATING.value:
+            raise ScopeError(
+                f"Namespace {res.meta.namespace!r} is terminating and cannot "
+                "admit new resources"
+            )
+
+    def _check_references(self, res: Resource) -> None:
+        fields = REFERENCE_FIELDS.get(Kind(res.meta.kind), ())
+        for key, target_kind, is_list in fields:
+            raw = res.spec.get(key)
+            if raw in (None, "", []):
+                continue
+            names = raw if is_list else [raw]
+            for target in names:
+                try:
+                    self.get(target_kind, target, res.meta.namespace)
+                except NotFoundError as exc:
+                    raise ScopeError(
+                        f"{res.meta.kind} {res.meta.name!r} references "
+                        f"{target_kind.value} {target!r} which does not exist "
+                        f"in namespace {res.meta.namespace!r} (cross-namespace "
+                        "references are not permitted)"
+                    ) from exc
+        # Agent.harness is installation-scoped:
+        if Kind(res.meta.kind) is Kind.AGENT:
+            harness = res.spec.get("harness")
+            if harness:
+                self.get(Kind.HARNESS, harness, None)  # raises NotFoundError
+
+    def _find_dependents(self, res: Resource) -> set[str]:
+        """Names of same-namespace resources whose reference fields point here."""
+        deps: set[str] = set()
+        target_kind = Kind(res.meta.kind)
+        for src_kind, fields in REFERENCE_FIELDS.items():
+            relevant = [(k, lst) for k, tk, lst in fields if tk is target_kind]
+            if not relevant:
+                continue
+            for candidate in self.list(src_kind, res.meta.namespace):
+                for key, is_list in relevant:
+                    raw = candidate.spec.get(key)
+                    names = raw if is_list else [raw]
+                    if names and res.meta.name in [n for n in names if n]:
+                        deps.add(f"{src_kind.value}/{candidate.meta.name}")
+        if target_kind is Kind.HARNESS:
+            for ns in self.list(Kind.NAMESPACE):
+                for agent in self.list(Kind.AGENT, ns.meta.name):
+                    if agent.spec.get("harness") == res.meta.name:
+                        deps.add(f"Agent/{ns.meta.name}/{agent.meta.name}")
+        return deps
+
+    @staticmethod
+    def _fqn(res: Resource) -> str:
+        if res.meta.namespace:
+            return f"{res.meta.namespace}/{res.meta.name}"
+        return res.meta.name

--- a/tests/enterprise/test_core.py
+++ b/tests/enterprise/test_core.py
@@ -1,0 +1,265 @@
+"""Tests for the enterprise core: resource model, store invariants, audit."""
+
+from __future__ import annotations
+
+import pytest
+
+from enterprise.audit import AuditLog
+from enterprise.contracts import DriverRegistry
+from enterprise.errors import (
+    ConflictError,
+    DriverError,
+    NotFoundError,
+    ScopeError,
+    ValidationError,
+)
+from enterprise.resources import (
+    Kind,
+    NamespacePhase,
+    Resource,
+    ResourceMeta,
+    validate_name,
+)
+from enterprise.store import ResourceStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = ResourceStore(tmp_path / "occ.db")
+    yield s
+    s.close()
+
+
+def mk(kind: Kind, name: str, namespace=None, spec=None, status=None) -> Resource:
+    return Resource(
+        meta=ResourceMeta(kind=kind.value, name=name, namespace=namespace),
+        spec=spec or {},
+        status=status or {},
+    )
+
+
+def ready_ns(store: ResourceStore, name: str = "acme") -> None:
+    store.create(mk(Kind.NAMESPACE, name))
+    store.update_status(Kind.NAMESPACE, name, None,
+                        {"phase": NamespacePhase.READY.value})
+
+
+# ---------------------------------------------------------------------------
+# Names + scope
+# ---------------------------------------------------------------------------
+
+class TestNamesAndScope:
+    def test_valid_dns_label(self):
+        assert validate_name("acme-prod-1") == "acme-prod-1"
+
+    @pytest.mark.parametrize("bad", ["", "UPPER", "-lead", "trail-", "a" * 64,
+                                     "under_score", "dot.name"])
+    def test_invalid_names(self, bad):
+        with pytest.raises(ValidationError):
+            validate_name(bad)
+
+    def test_namespace_scoped_kind_requires_namespace(self):
+        with pytest.raises(ValidationError):
+            mk(Kind.AGENT, "bot", spec={"harness": "h", "configuration": "c"}).validate()
+
+    def test_installation_kind_rejects_namespace(self):
+        with pytest.raises(ValidationError):
+            mk(Kind.HARNESS, "hermes", namespace="acme",
+               spec={"version": "1.0", "image": "img"}).validate()
+
+    def test_restriction_valid_in_both_scopes(self):
+        rule = {"rule": {"deny": ["deploy:Agent"]}}
+        mk(Kind.RESTRICTION, "no-deploys", spec=rule).validate()
+        mk(Kind.RESTRICTION, "no-deploys", namespace="acme", spec=rule).validate()
+
+
+# ---------------------------------------------------------------------------
+# Spec validation
+# ---------------------------------------------------------------------------
+
+class TestSpecValidation:
+    def test_configuration_rejects_embedded_secret(self):
+        res = mk(Kind.CONFIGURATION, "cfg", namespace="acme",
+                 spec={"config": {"model": {"api_key": "sk-123"}}})
+        with pytest.raises(ValidationError, match="secret-like"):
+            res.validate()
+
+    def test_configuration_allows_secret_reference_shape(self):
+        res = mk(Kind.CONFIGURATION, "cfg", namespace="acme",
+                 spec={"config": {"model": {"api_key": {"secretRef": "llm-key"}}}})
+        res.validate()
+
+    def test_secret_must_not_carry_value(self):
+        res = mk(Kind.SECRET, "llm-key", namespace="acme",
+                 spec={"broker": "vault", "key": "prod/llm", "value": "sk-x"})
+        with pytest.raises(ValidationError, match="must not contain secret values"):
+            res.validate()
+
+    def test_sandbox_allowlist_requires_entries(self):
+        res = mk(Kind.SANDBOX_POLICY, "locked", namespace="acme",
+                 spec={"network": "egress-allowlist"})
+        with pytest.raises(ValidationError, match="egressAllow"):
+            res.validate()
+
+    def test_restriction_cannot_be_empty(self):
+        res = mk(Kind.RESTRICTION, "noop", spec={"rule": {"deny": []}})
+        with pytest.raises(ValidationError, match="narrow, never grant"):
+            res.validate()
+
+
+# ---------------------------------------------------------------------------
+# Store invariants
+# ---------------------------------------------------------------------------
+
+class TestStore:
+    def test_create_get_roundtrip(self, store):
+        ready_ns(store)
+        store.create(mk(Kind.CONFIGURATION, "cfg", namespace="acme",
+                        spec={"config": {"model": "hermes-4"}}))
+        got = store.get(Kind.CONFIGURATION, "cfg", "acme")
+        assert got.spec["config"]["model"] == "hermes-4"
+
+    def test_duplicate_identity_conflicts(self, store):
+        ready_ns(store)
+        res = mk(Kind.CHANNEL, "tg", namespace="acme", spec={"platform": "telegram"})
+        store.create(res)
+        with pytest.raises(ConflictError):
+            store.create(mk(Kind.CHANNEL, "tg", namespace="acme",
+                            spec={"platform": "telegram"}))
+
+    def test_namespaced_resource_requires_existing_namespace(self, store):
+        with pytest.raises(ScopeError, match="missing Namespace"):
+            store.create(mk(Kind.CHANNEL, "tg", namespace="ghost",
+                            spec={"platform": "telegram"}))
+
+    def test_terminating_namespace_admits_nothing(self, store):
+        ready_ns(store)
+        store.update_status(Kind.NAMESPACE, "acme", None,
+                            {"phase": NamespacePhase.TERMINATING.value})
+        with pytest.raises(ScopeError, match="terminating"):
+            store.create(mk(Kind.CHANNEL, "tg", namespace="acme",
+                            spec={"platform": "telegram"}))
+
+    def test_cross_namespace_reference_denied(self, store):
+        ready_ns(store, "acme")
+        ready_ns(store, "globex")
+        store.create(mk(Kind.HARNESS, "hermes",
+                        spec={"version": "1.0", "image": "ghcr.io/x"}))
+        # configuration lives in globex, agent in acme -> must fail
+        store.create(mk(Kind.CONFIGURATION, "cfg", namespace="globex",
+                        spec={"config": {}}))
+        with pytest.raises(ScopeError, match="cross-namespace"):
+            store.create(mk(Kind.AGENT, "bot", namespace="acme",
+                            spec={"harness": "hermes", "configuration": "cfg"}))
+
+    def test_agent_requires_existing_harness(self, store):
+        ready_ns(store)
+        store.create(mk(Kind.CONFIGURATION, "cfg", namespace="acme",
+                        spec={"config": {}}))
+        with pytest.raises(NotFoundError):
+            store.create(mk(Kind.AGENT, "bot", namespace="acme",
+                            spec={"harness": "ghost", "configuration": "cfg"}))
+
+    def test_generation_conflict(self, store):
+        ready_ns(store)
+        store.create(mk(Kind.CONFIGURATION, "cfg", namespace="acme",
+                        spec={"config": {"a": 1}}))
+        first = store.get(Kind.CONFIGURATION, "cfg", "acme")
+        second = store.get(Kind.CONFIGURATION, "cfg", "acme")
+        first.spec["config"]["a"] = 2
+        store.update_spec(first)
+        second.spec["config"]["a"] = 3
+        with pytest.raises(ConflictError, match="generation conflict"):
+            store.update_spec(second)
+
+    def test_revision_spec_immutable(self, store):
+        ready_ns(store)
+        rev = mk(Kind.AGENT_REVISION, "bot-rev-1", namespace="acme", spec={
+            "agent": "bot", "agentUid": "u1", "workloadIdentity": "wi-bot",
+            "harness": {"name": "hermes", "version": "1.0"},
+            "configuration": {"model": "hermes-4"},
+            "computeDriver": "kubernetes", "sandboxDriver": "k8s-baseline",
+        })
+        store.create(rev)
+        rev2 = store.get(Kind.AGENT_REVISION, "bot-rev-1", "acme")
+        rev2.spec["configuration"] = {"model": "other"}
+        with pytest.raises(ValidationError, match="immutable"):
+            store.update_spec(rev2)
+        # status updates remain allowed
+        store.update_status(Kind.AGENT_REVISION, "bot-rev-1", "acme",
+                            {"phase": "Active"})
+
+    def test_delete_blocked_by_dependents(self, store):
+        ready_ns(store)
+        store.create(mk(Kind.HARNESS, "hermes",
+                        spec={"version": "1.0", "image": "img"}))
+        store.create(mk(Kind.CONFIGURATION, "cfg", namespace="acme",
+                        spec={"config": {}}))
+        store.create(mk(Kind.AGENT, "bot", namespace="acme",
+                        spec={"harness": "hermes", "configuration": "cfg"}))
+        with pytest.raises(ConflictError, match="referenced by"):
+            store.delete(Kind.CONFIGURATION, "cfg", "acme")
+        with pytest.raises(ConflictError, match="referenced by"):
+            store.delete(Kind.HARNESS, "hermes")
+
+    def test_namespace_delete_requires_drain(self, store):
+        ready_ns(store)
+        store.create(mk(Kind.CHANNEL, "tg", namespace="acme",
+                        spec={"platform": "telegram"}))
+        with pytest.raises(ConflictError, match="drain"):
+            store.delete(Kind.NAMESPACE, "acme")
+        store.delete(Kind.CHANNEL, "tg", "acme")
+        store.delete(Kind.NAMESPACE, "acme")
+
+
+# ---------------------------------------------------------------------------
+# Audit
+# ---------------------------------------------------------------------------
+
+class TestAudit:
+    def test_record_and_query(self, tmp_path):
+        log = AuditLog(tmp_path / "audit.db")
+        log.record(actor="kevin@acme.com", actor_kind="principal",
+                   action="hermes.agents.deploy", outcome="allow",
+                   kind="Agent", namespace="acme", resource="bot")
+        rows = log.query(kind="Agent", namespace="acme")
+        assert len(rows) == 1
+        assert rows[0]["outcome"] == "allow"
+        log.close()
+
+    def test_refuses_secretlike_detail(self, tmp_path):
+        log = AuditLog(tmp_path / "audit.db")
+        with pytest.raises(ValueError, match="never carry secrets"):
+            log.record(actor="x", actor_kind="principal", action="a",
+                       outcome="allow", detail={"api_key": "sk-live-123"})
+        log.close()
+
+    def test_rejects_unknown_outcome(self, tmp_path):
+        log = AuditLog(tmp_path / "audit.db")
+        with pytest.raises(ValueError):
+            log.record(actor="x", actor_kind="principal", action="a",
+                       outcome="maybe")
+        log.close()
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+class TestRegistry:
+    def test_single_selection_per_capability(self):
+        reg = DriverRegistry()
+
+        class FakeDriver:
+            name = "kubernetes"
+
+        reg.select("compute", FakeDriver())
+        with pytest.raises(ValueError, match="already has a selected"):
+            class Other:
+                name = "nomad"
+            reg.select("compute", Other())
+
+    def test_unselected_capability_fails_closed(self):
+        reg = DriverRegistry()
+        with pytest.raises(DriverError):
+            reg.get("compute")


### PR DESCRIPTION
## Summary
Adds the foundation of **Hermes Enterprise**: a standalone control-plane core (resource model, fail-closed resource store, audit log, and driver contracts) for deploying and operating fleets of Hermes agents multi-tenant on Kubernetes — with the hermes-agent runtime as the Harness.

Part of the one-wave Enterprise draft series; this PR defines the contracts every sibling PR builds against (`ent/iam`, `ent/oag`, `ent/controller`, `ent/compute-k8s`, `ent/sandbox`, `ent/secrets`, `ent/deploy`, `ent/docs`).

## Changes
- `enterprise/resources.py`: v1 resource model — `Namespace`, `Configuration`, `Agent`, `AgentRevision` (immutable snapshot), `Harness`, `Channel`, `Secret`/`SecretBroker` (never carry values), `SandboxPolicy`, `Restriction` (narrows, never grants). DNS-1123 names so resources back K8s objects 1:1; per-kind spec validation; secret-shape detector rejects embedded credentials in configs.
- `enterprise/store.py`: SQLite store enforcing unique identity, namespace containment, same-namespace reference resolution (cross-namespace refs denied), optimistic concurrency via generations, AgentRevision spec immutability, dependent-blocking deletes + namespace drain.
- `enterprise/audit.py`: append-only attributable audit log; refuses secret-like payloads at write time.
- `enterprise/contracts.py`: `ComputeDriver` / `SandboxDriver` / `SecretDriver` / `IAMAdapter` / `IdentityVerifier` ABCs + single-selection `DriverRegistry` (unselected capability fails closed; no self-selection).

Standalone package: nothing in the core agent imports it, zero model tools, no runtime coupling, stdlib only.

## Validation
| | Result |
|---|---|
| `tests/enterprise/test_core.py` | 31/31 pass |
| ruff | clean |
| Core-agent footprint | zero (no imports from agent code) |

## Infographic

![Hermes Enterprise control plane core](https://files.catbox.moe/hk10pj.png)
