### PR TITLE
feat(desktop): expose session archive action to plugins

### DIFF
--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -527,7 +527,7 @@ export function SessionTabMenu({
   return (
     <span className="contents" onContextMenu={event => event.stopPropagation()}>
       <SessionContextMenu
-        onArchive={() => void sessionTileDelegate()?.archiveSession(storedSessionId)}
+        onArchive={() => void sessionTileDelegate()?.archiveSession(storedSessionId).catch(() => undefined)}
         onBranch={() => void sessionTileDelegate()?.branchSession(storedSessionId)}
         onClose={onClose}
         onDelete={() => void sessionTileDelegate()?.deleteSession(storedSessionId)}

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -14,7 +14,7 @@ import type { GatewayRequester } from '../types'
 type SessionStateCache = ReturnType<typeof useSessionStateCache>
 
 interface SessionTileDelegateParams {
-  archiveSession: (storedSessionId: string) => Promise<unknown>
+  archiveSession: (storedSessionId: string, options?: { profile?: null | string }) => Promise<unknown>
   branchStoredSession: (storedSessionId: string) => Promise<unknown>
   executeSlashCommand: ReturnType<typeof usePromptActions>['executeSlashCommand']
   removeSession: (storedSessionId: string) => Promise<unknown>
@@ -72,8 +72,8 @@ export function useSessionTileDelegate({
     }
 
     setSessionTileDelegate({
-      archiveSession: async storedSessionId => {
-        await archiveSession(storedSessionId)
+      archiveSession: async (storedSessionId, options) => {
+        await archiveSession(storedSessionId, options)
       },
       branchSession: async storedSessionId => {
         await branchStoredSession(storedSessionId)

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -843,7 +843,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       return
     }
 
-    void archiveSession(sessionId)
+    void archiveSession(sessionId).catch(() => undefined)
   }, [archiveSession])
 
   // Single global listener for every rebindable hotkey plus the on-screen
@@ -883,7 +883,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const nextActions: WiringActions = {
     onAddContextRef: composer.addContextRefAttachment,
     onAddUrl: url => composer.addContextRefAttachment(`@url:${formatRefValue(url)}`, url),
-    onArchiveSession: sessionId => void archiveSession(sessionId),
+    onArchiveSession: sessionId => void archiveSession(sessionId).catch(() => undefined),
     onAttachDroppedItems: composer.attachDroppedItems,
     onAttachImageBlob: composer.attachImageBlob,
     onAttachPrCommentUrl: composer.attachPrCommentUrl,

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -11,7 +11,8 @@ import {
   getLatestSessionMessages,
   getSession,
   type SessionInfo,
-  type SessionResumeResponse
+  type SessionResumeResponse,
+  setSessionArchived
 } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
@@ -29,6 +30,7 @@ import {
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
   $selectedStoredSessionId,
+  $sessions,
   $turnStartedAt,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
@@ -46,7 +48,7 @@ import {
   setSessions,
   setTurnStartedAt
 } from '@/store/session'
-import { $sessionTiles } from '@/store/session-states'
+import { $sessionTiles, openSessionTile } from '@/store/session-states'
 
 import sessionResumeActiveTurn from '../../../../../../tests/fixtures/session-resume-active-turn.json'
 import { sessionRoute } from '../../routes'
@@ -91,7 +93,7 @@ function deferred<T>() {
 
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
-  'createBackendSessionForSend' | 'selectSidebarItem' | 'startFreshSessionDraft'
+  'archiveSession' | 'createBackendSessionForSend' | 'selectSidebarItem' | 'startFreshSessionDraft'
 >
 
 function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
@@ -116,11 +118,13 @@ function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
 function Harness({
   navigate = vi.fn(),
   onReady,
-  requestGateway
+  requestGateway,
+  selectedStoredSessionId = null
 }: {
   navigate?: ReturnType<typeof vi.fn>
   onReady: (handle: HarnessHandle) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  selectedStoredSessionId?: string | null
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
 
@@ -136,8 +140,8 @@ function Harness({
     requestGateway,
     resetViewSync: vi.fn(),
     runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
-    selectedStoredSessionId: null,
-    selectedStoredSessionIdRef: ref<string | null>(null),
+    selectedStoredSessionId,
+    selectedStoredSessionIdRef: ref<string | null>(selectedStoredSessionId),
     sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
     syncSessionStateToView: vi.fn(),
     updateSessionState: () => ({}) as ClientSessionState
@@ -149,6 +153,76 @@ function Harness({
 
   return null
 }
+
+describe('archiveSession', () => {
+  afterEach(() => {
+    cleanup()
+    setActiveSessionId(null)
+    setSelectedStoredSessionId(null)
+    setSessions([])
+    $activeGatewayProfile.set('default')
+    $sessionTiles.set([])
+    vi.mocked(setSessionArchived).mockReset()
+  })
+
+  it('keeps the selected session in place when archive fails', async () => {
+    let handle: HarnessHandle | null = null
+    const session = storedSession({ id: 'tip-1', _lineage_root_id: 'root-1' })
+
+    setSessions([session])
+    setSelectedStoredSessionId('root-1')
+    setActiveSessionId('runtime-1')
+    vi.mocked(setSessionArchived).mockRejectedValueOnce(new Error('archive failed'))
+
+    render(
+      <Harness
+        onReady={value => (handle = value)}
+        requestGateway={async () => ({}) as never}
+        selectedStoredSessionId="root-1"
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await expect(handle!.archiveSession('root-1')).rejects.toThrow('archive failed')
+    expect($selectedStoredSessionId.get()).toBe('root-1')
+    expect($activeSessionId.get()).toBe('runtime-1')
+    expect($sessions.get()).toContainEqual(session)
+  })
+
+  it.each([
+    ['omitted', undefined, 'cached-profile'],
+    ['explicit null', { profile: null }, null],
+    ['empty', { profile: '' }, ''],
+    ['named', { profile: 'work' }, 'work']
+  ] as const)('preserves %s profile routing', async (_label, options, expectedProfile) => {
+    let handle: HarnessHandle | null = null
+
+    setSessions([storedSession({ profile: 'cached-profile' })])
+    vi.mocked(setSessionArchived).mockResolvedValueOnce({ ok: true })
+    render(<Harness onReady={value => (handle = value)} requestGateway={async () => ({}) as never} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await handle!.archiveSession('stored-1', options)
+    expect(setSessionArchived).toHaveBeenCalledWith('stored-1', true, expectedProfile)
+  })
+
+  it('cleans a cached named-profile tile when explicit null routes the mutation to default', async () => {
+    let handle: HarnessHandle | null = null
+
+    $activeGatewayProfile.set('work')
+    openSessionTile('stored-1')
+    $activeGatewayProfile.set('default')
+    setSessions([storedSession({ profile: 'work' })])
+    vi.mocked(setSessionArchived).mockResolvedValueOnce({ ok: true })
+    render(<Harness onReady={value => (handle = value)} requestGateway={async () => ({}) as never} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await handle!.archiveSession('stored-1', { profile: null })
+    $activeGatewayProfile.set('work')
+
+    expect($sessionTiles.get().some(tile => tile.storedSessionId === 'stored-1')).toBe(false)
+  })
+})
 
 function StoredIdRotationHarness({
   activeSessionIdRef,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -63,6 +63,7 @@ import {
 import {
   $sessionTiles,
   closeSessionTile,
+  discardSessionTile,
   dropSessionState,
   openSessionTile,
   patchSessionTile,
@@ -1702,16 +1703,25 @@ export function useSessionActions({
   )
 
   const archiveSession = useCallback(
-    async (storedSessionId: string) => {
+    async (storedSessionId: string, options?: { profile?: null | string }) => {
       clearNotifications()
 
       const archived = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
-      const wasSelected = selectedStoredSessionId === storedSessionId
+      // Callers may hold the stable lineage root while the backend row has
+      // rotated to a newer tip. Normalize every mutation/cleanup operation to
+      // that current row id when the row is cached.
+      const archivedStoredSessionId = archived?.id ?? storedSessionId
+
+      const wasSelected = archived
+        ? Boolean(selectedStoredSessionId && sessionMatchesStoredId(archived, selectedStoredSessionId))
+        : selectedStoredSessionId === storedSessionId
+
       const previousPinned = $pinnedSessionIds.get()
+
       // Pins are keyed on the durable lineage-root id; the stored id may be the
       // live tip after compression. Drop both so the pin can't linger.
       const archivedPinId = archived ? sessionPinId(archived) : storedSessionId
-      const archivedIds = [storedSessionId, archived?.id, archived?._lineage_root_id]
+      const archivedIds = [storedSessionId, archivedStoredSessionId, archived?._lineage_root_id]
 
       // Soft-hide: drop from the sidebar immediately, keep the data.
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
@@ -1719,23 +1729,38 @@ export function useSessionActions({
       beginSessionMutation(archivedIds)
       $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== archivedPinId))
 
-      if (wasSelected) {
-        startFreshSessionDraft(true)
-      }
-
       try {
-        await setSessionArchived(storedSessionId, true, archived?.profile)
+        const profile = options && 'profile' in options ? options.profile : archived?.profile
+        const cleanupProfiles = [...new Set([profile, archived?.profile])]
+
+        await setSessionArchived(archivedStoredSessionId, true, profile)
+
         // Archived rows never reach the sidebar, so their persisted unread can
         // only rot. Dropped after the RPC so a failed archive keeps it.
-        forgetSessionUnread(archivedIds, archived?.profile)
-        // An archived session is hidden from the sidebar; its tile must go too.
-        const tiledRuntimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
-        closeSessionTile(storedSessionId)
+        cleanupProfiles.forEach(cleanupProfile => forgetSessionUnread(archivedIds, cleanupProfile))
 
-        if (tiledRuntimeId) {
-          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
-          sessionStateByRuntimeIdRef.current.delete(tiledRuntimeId)
-          dropSessionState(tiledRuntimeId)
+        if (wasSelected) {
+          // Keep the foreground intact until the authoritative write succeeds;
+          // a rejected archive therefore needs no unsafe whole-view rollback.
+          startFreshSessionDraft(true)
+        }
+
+        // An archived session is hidden from the sidebar; its tile must go too.
+        const tileIds = [...new Set(archivedIds.filter((id): id is string => Boolean(id)))]
+
+        const tiledRuntimeIds = new Set(
+          tileIds.map(id => runtimeIdByStoredSessionIdRef.current.get(id)).filter((id): id is string => Boolean(id))
+        )
+
+        for (const cleanupProfile of cleanupProfiles) {
+          tileIds.forEach(id => discardSessionTile(id, cleanupProfile))
+        }
+
+        tileIds.forEach(id => runtimeIdByStoredSessionIdRef.current.delete(id))
+
+        for (const runtimeId of tiledRuntimeIds) {
+          sessionStateByRuntimeIdRef.current.delete(runtimeId)
+          dropSessionState(runtimeId)
         }
 
         notify({ durationMs: 2_000, kind: 'success', message: copy.archived })
@@ -1747,6 +1772,7 @@ export function useSessionActions({
         untombstoneSessions(archivedIds)
         $pinnedSessionIds.set(previousPinned)
         notifyError(err, copy.archiveFailed)
+        throw err
       } finally {
         endSessionMutation(archivedIds)
       }

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -24,6 +24,7 @@ import {
   listSidebarSessions,
   resetSidebarBatchCapability,
   setApiRequestProfile,
+  setSessionArchived,
   speakText,
   transcribeAudio,
   triggerCronJob
@@ -65,6 +66,23 @@ describe('Hermes REST helpers', () => {
         timeoutMs: 60_000
       })
     )
+  })
+
+  it.each([
+    ['omitted', undefined, false],
+    ['explicit null', null, true],
+    ['empty', '', true],
+    ['named', 'work', true]
+  ] as const)('preserves %s archive profile routing at the IPC boundary', async (_label, profile, hasProfile) => {
+    await setSessionArchived('stored-1', true, profile)
+
+    const request = api.mock.calls.at(-1)?.[0]
+
+    expect(Object.hasOwn(request, 'profile')).toBe(hasProfile)
+
+    if (hasProfile) {
+      expect(request.profile).toBe(profile)
+    }
   })
 
   it('uses a longer timeout for the all-profile session list', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -639,7 +639,7 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
 // that hit the local primary would no-op or 404. Omit for the current/default.
 export function setSessionArchived(id: string, archived: boolean, profile?: string | null): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    ...(profile ? { profile } : {}),
+    ...(profile !== undefined ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
     body: { archived }

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { host } from '@/sdk'
@@ -8,6 +8,19 @@ import {
   setBusy
 } from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+
+const archiveSession = vi.fn<(storedSessionId: string, options?: { profile?: null | string }) => Promise<void>>()
+let delegateAvailable = true
+
+vi.mock('@/store/session-states', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  sessionTileDelegate: () => (delegateAvailable ? { archiveSession } : null)
+}))
+
+afterEach(() => {
+  archiveSession.mockReset()
+  delegateAvailable = true
+})
 
 describe('host.state turn flags', () => {
   afterEach(() => {
@@ -109,5 +122,33 @@ describe('host.state turn flags', () => {
     expect(host.state.awaitingResponse.get()).toBe(false)
 
     $sessionTiles.set([])
+  })
+})
+
+describe('plugin host session actions', () => {
+  it('archives through the native session delegate', async () => {
+    const { host } = await import('./index')
+
+    archiveSession.mockResolvedValueOnce()
+    await host.archiveSession('stored-session', { profile: 'work' })
+
+    expect(archiveSession).toHaveBeenCalledWith('stored-session', { profile: 'work' })
+  })
+
+  it('rejects when native session actions are unavailable', async () => {
+    const { host } = await import('./index')
+
+    delegateAvailable = false
+
+    await expect(host.archiveSession('stored-session')).rejects.toThrow('Hermes session actions unavailable')
+  })
+
+  it('propagates native archive failures to the plugin', async () => {
+    const { host } = await import('./index')
+    const failure = new Error('archive failed')
+
+    archiveSession.mockRejectedValueOnce(failure)
+
+    await expect(host.archiveSession('stored-session')).rejects.toBe(failure)
   })
 })

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -49,7 +49,8 @@ import {
   $focusedRuntimeId,
   $focusedSessionState,
   $focusedStoredSessionId,
-  $sessionStates
+  $sessionStates,
+  sessionTileDelegate
 } from '@/store/session-states'
 import { runGatewayRestart } from '@/store/system-actions'
 import type { UsageStats } from '@/types/hermes'
@@ -312,6 +313,19 @@ export const host = {
   newChat: (profile?: null | string): void => {
     newSessionInProfile((profile ?? '').trim() || $activeGatewayProfile.get())
     window.location.hash = '#/'
+  },
+
+  /** Archive a durable stored session through Desktop's canonical action path.
+   *  This preserves optimistic list updates, pin/tile cleanup, selected-session
+   *  replacement, profile routing, rollback, and native user feedback. */
+  archiveSession: async (storedSessionId: string, options?: { profile?: null | string }): Promise<void> => {
+    const delegate = sessionTileDelegate()
+
+    if (!delegate) {
+      throw new Error('Hermes session actions unavailable')
+    }
+
+    await delegate.archiveSession(storedSessionId, options)
   },
 
   /** HEAR the gateway stream (message deltas, session lifecycle, tool

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -249,4 +249,20 @@ describe('reopenLastClosedTile focuses the restored tab', () => {
     expect(findGroupOfPane(tree.$layoutTree.get()!, tilePane('closed'))?.active).toBe(tilePane('closed'))
     expect(tree.$activeTreeGroup.get()).toBe('grp-main')
   })
+
+  it('discards a background profile tile and its closed-tab entry', async () => {
+    const profile = await import('@/store/profile')
+    const states = await import('@/store/session-states')
+
+    profile.$activeGatewayProfile.set('work')
+    states.openSessionTile('background-session', 'center', 'workspace')
+    states.closeSessionTile('background-session')
+
+    profile.$activeGatewayProfile.set('default')
+    states.discardSessionTile('background-session', 'work')
+    profile.$activeGatewayProfile.set('work')
+    states.reopenLastClosedTile()
+
+    expect(states.$sessionTiles.get().some(tile => tile.storedSessionId === 'background-session')).toBe(false)
+  })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -586,7 +586,7 @@ export function resetTileRuntimeBindings() {
 
 export interface SessionTileDelegate {
   /** Archive a stored session (the sidebar's archive, incl. tile cleanup). */
-  archiveSession(storedSessionId: string): Promise<void>
+  archiveSession(storedSessionId: string, options?: { profile?: null | string }): Promise<void>
   /** Branch a stored session into a new chat (the sidebar's branch). */
   branchSession(storedSessionId: string): Promise<void>
   /** Delete a stored session (the sidebar's delete, incl. tile cleanup). */
@@ -832,7 +832,7 @@ export function reuseBlankDraftTile(storedSessionId: string): boolean {
 // tiles themselves, so ⌘⇧T after a profile switch never resurrects the other
 // profile's session. The tile's placement is remembered so it returns in place.
 const closedTilesByProfile: Record<string, SessionTile[]> = {}
-const closedStack = (): SessionTile[] => (closedTilesByProfile[profileKey()] ??= [])
+const closedStack = (key = profileKey()): SessionTile[] => (closedTilesByProfile[key] ??= [])
 
 export function closeSessionTile(storedSessionId: string) {
   const tile = $sessionTiles.get().find(t => t.storedSessionId === storedSessionId)
@@ -860,14 +860,39 @@ export function closeSessionTile(storedSessionId: string) {
  *  backend (resume 404s). Unlike close, it leaves no ⌘⇧T undo (resurrecting it
  *  would just 404 again) and evicts any cached state. This is what clears the
  *  "Session not found" resume spam from stale/cross-profile persisted tiles. */
-export function discardSessionTile(storedSessionId: string) {
-  const runtimeId = $sessionTiles.get().find(t => t.storedSessionId === storedSessionId)?.runtimeId
+export function discardSessionTile(storedSessionId: string, profile?: null | string) {
+  const key = profile === undefined ? profileKey() : normalizeProfileKey(profile)
+  const active = key === profileKey()
+  const tiles = active ? $sessionTiles.get() : [...(tilesByProfile[key] ?? [])]
+  const runtimeId = active ? $sessionTiles.get().find(t => t.storedSessionId === storedSessionId)?.runtimeId : undefined
+
+  // Destructive removals (archive/delete/404) must not remain eligible for
+  // ⌘⇧T resurrection, including a tile the user closed before the mutation.
+  const stack = closedStack(key)
+
+  for (let index = stack.length - 1; index >= 0; index -= 1) {
+    if (stack[index]?.storedSessionId === storedSessionId) {
+      stack.splice(index, 1)
+    }
+  }
 
   if (runtimeId) {
     dropSessionState(runtimeId)
   }
 
-  saveTiles($sessionTiles.get().filter(t => t.storedSessionId !== storedSessionId))
+  const remaining = tiles.filter(t => t.storedSessionId !== storedSessionId)
+
+  if (active) {
+    saveTiles(remaining)
+  } else {
+    if (remaining.length > 0) {
+      tilesByProfile[key] = remaining.map(toStored)
+    } else {
+      delete tilesByProfile[key]
+    }
+
+    persistTiles()
+  }
 }
 
 /** ⌘⇧T — reopen the most recently closed tab where it was, then focus it.

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -42,7 +42,8 @@ plugin, and fail to resolve in a disk plugin). Capability comes in tiers:
   atoms): active session, per-session turn-busy, cwd, gateway socket status,
   model, profile, viewport. `gateway` is the WebSocket, not turn-busy.
 - **`host.*` actions** — curated safe verbs: toast, navigate, tail logs,
-  restart the gateway, subscribe to the gateway event stream.
+  restart the gateway, archive stored sessions, subscribe to the gateway event
+  stream.
 - **`host.request`** — the gateway JSON-RPC door: sessions, config, skills,
   cron — everything the app itself calls.
 - **`ctx.rest` / `ctx.socket`** — your plugin's own backend namespace
@@ -406,7 +407,9 @@ host.navigate('/route')                    // hash-route navigation
 host.openSession(id, { profile?, intent? }) // open a stored session core-style;
                                            //   profile: soft-swap to that profile's backend first
                                            //   intent: 'in-place' (default) | 'stack' | 'tab' | 'window'
-host.newChat(profile?)                     // fresh chat draft, optionally in another profile
+await host.archiveSession(storedSessionId, { profile? }) // native archive workflow + cleanup;
+                                                     // rejects when the mutation rolls back
+host.newChat(profile?)                     // fresh draft; optional background-profile target
 host.onEvent(type, fn)                     // gateway event stream ('*' = all); returns disposer
 host.logs(...)                             // tail an app log file
 host.status()                              // one-shot system status snapshot


### PR DESCRIPTION
## Summary

- expose `host.archiveSession(storedSessionId, { profile? })` to runtime-loaded Desktop plugins
- route the action through Desktop's canonical archive workflow so optimistic visibility, pins, selected-session behavior, and native notifications stay consistent
- normalize lineage-root IDs, preserve exact profile routing, propagate rollback failures to plugin callers, and destructively clean associated tiles across profiles
- document the SDK action and its rejection contract

## Why

Desktop plugins can render native session context menus and read session lists, but they cannot currently invoke Desktop's archive lifecycle. Plugin authors must either omit the action or bypass Desktop's state cleanup through a lower-level mutation.

This adds a narrow, reusable host action rather than exposing internal stores or adding plugin-specific behavior to core.

A concrete consumer is an external work-queue plugin that presents sessions in a docked queue and offers Archive from its native right-click menu.

## Test plan

- [x] `npm run test:ui -- src/hermes.test.ts src/sdk/index.test.ts src/app/session/hooks/use-session-actions.test.tsx src/store/session-states.test.ts`
- [x] `npm run typecheck`
- [x] focused ESLint on all changed Desktop TypeScript files
- [x] `git diff origin/main...HEAD --check`
- [x] packaged and code-signed the macOS arm64 Desktop candidate locally

Tested on macOS arm64.

## Review evidence

An independent review inspected the exact pre-rebase staged diff through four iterations. Final verdict: **PASS**, with no concrete blockers. It specifically verified IPC profile-property semantics, selected-session success/failure behavior, lineage identity normalization, active/inactive profile tile cleanup, closed-tab purge, promise rejection handling, and SDK documentation alignment.

Residual risk: no live multi-backend Electron smoke test was run for background-profile cleanup; that path is covered through persisted profile-switching tests.
