### PR TITLE
feat(enterprise): controller — deploy choreography, rollback, namespace lifecycle, CLI

### DIFF
--- a/enterprise/__main__.py
+++ b/enterprise/__main__.py
@@ -1,0 +1,6 @@
+"""``python -m enterprise`` entrypoint."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/enterprise/cli.py
+++ b/enterprise/cli.py
@@ -1,0 +1,386 @@
+"""hermes-enterprise CLI.
+
+Invoked as ``python -m enterprise.cli`` (console-script wiring lands later).
+Subcommands operate a local control plane rooted at ``--home``
+(default ``~/.hermes/enterprise``): a SQLite resource store, an append-only
+audit log, and — with the default ``--driver memory`` — in-process dev
+drivers so the whole deploy path is demoable without Kubernetes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .audit import AuditLog
+from .contracts import (
+    AuthzRequest,
+    ComputeDriver,
+    DriverRegistry,
+    IAMAdapter,
+    SandboxDriver,
+    WorkloadRef,
+)
+from .controller import Controller, InMemoryGatewayManager
+from .errors import EnterpriseError
+from .resources import Kind, Resource, ResourceMeta
+from .store import ResourceStore
+
+DEFAULT_HOME = Path.home() / ".hermes" / "enterprise"
+
+# ---------------------------------------------------------------------------
+# Dev-mode drivers (used ONLY with --driver memory)
+# ---------------------------------------------------------------------------
+
+
+class MemoryComputeDriver(ComputeDriver):
+    """In-process compute driver: tracks workloads in a dict. Dev/demo only."""
+
+    name = "memory"
+
+    def __init__(self) -> None:
+        self.workloads: dict[str, dict[str, Any]] = {}
+
+    def provision_candidate(self, revision: Resource) -> WorkloadRef:
+        ref = WorkloadRef(
+            revision_uid=revision.meta.uid,
+            namespace=revision.meta.namespace or "",
+            workload_identity=str(revision.spec.get("workloadIdentity", "")),
+            driver=self.name,
+        )
+        self.workloads[ref.revision_uid] = {"ready": True, "harness": "stopped"}
+        return ref
+
+    def workload_ready(self, ref: WorkloadRef) -> bool:
+        return bool(self.workloads.get(ref.revision_uid, {}).get("ready"))
+
+    def start_harness(self, ref: WorkloadRef) -> None:
+        self.workloads.setdefault(ref.revision_uid, {})["harness"] = "running"
+
+    def stop_harness(self, ref: WorkloadRef) -> None:
+        self.workloads.setdefault(ref.revision_uid, {})["harness"] = "stopped"
+
+    def teardown(self, ref: WorkloadRef) -> None:
+        self.workloads.pop(ref.revision_uid, None)
+
+
+class MemorySandboxDriver(SandboxDriver):
+    """Dev sandbox driver: 'enforces' any policy in memory. Dev/demo only."""
+
+    name = "memory"
+
+    def __init__(self) -> None:
+        self.enforced: dict[str, dict[str, Any]] = {}
+
+    def supports(self, policy: dict[str, Any]) -> bool:
+        return True
+
+    def enforce(self, ref: WorkloadRef, policy: dict[str, Any]) -> None:
+        self.enforced[ref.revision_uid] = dict(policy)
+
+    def verify(self, ref: WorkloadRef, policy: dict[str, Any]) -> None:
+        if self.enforced.get(ref.revision_uid) != policy:
+            from .errors import DriverError
+
+            raise DriverError("containment not enforced for this workload")
+
+
+class PermissiveIAMAdapter(IAMAdapter):
+    """DEV-MODE ONLY: allows every action and warns loudly.
+
+    Never wire this into a real installation; an IAM adapter that
+    default-allows defeats the entire authorization model.
+    """
+
+    name = "permissive-dev"
+
+    def __init__(self) -> None:
+        self._warned = False
+
+    def authorize(self, request: AuthzRequest) -> None:
+        if not self._warned:
+            print(
+                "warning: PermissiveIAMAdapter is DEV-MODE ONLY — every "
+                "action is allowed without authorization checks",
+                file=sys.stderr,
+            )
+            self._warned = True
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def _paths(home: Path) -> tuple[Path, Path]:
+    return home / "resources.db", home / "audit.db"
+
+
+def _build(args: argparse.Namespace) -> Controller:
+    home = Path(args.home).expanduser()
+    store_db, audit_db = _paths(home)
+    store = ResourceStore(store_db)
+    audit = AuditLog(audit_db)
+    registry = DriverRegistry()
+    if args.driver == "memory":
+        registry.select("compute", MemoryComputeDriver())
+        registry.select("sandbox", MemorySandboxDriver())
+        iam: IAMAdapter = PermissiveIAMAdapter()
+        gateway = InMemoryGatewayManager()
+    else:
+        raise SystemExit(
+            f"driver {args.driver!r} is not wired yet; only 'memory' is "
+            "available in this build"
+        )
+    return Controller(store, audit, registry, gateway, iam)
+
+
+def _load_doc(path: str) -> dict[str, Any]:
+    text = Path(path).read_text(encoding="utf-8")
+    if path.endswith((".yaml", ".yml")):
+        try:
+            import yaml  # type: ignore[import-untyped]
+        except ImportError as exc:  # pragma: no cover
+            raise SystemExit(
+                "PyYAML is not installed; provide a JSON file instead"
+            ) from exc
+        return dict(yaml.safe_load(text) or {})
+    return dict(json.loads(text))
+
+
+def _print(obj: Any) -> None:
+    print(json.dumps(obj, indent=2, sort_keys=True, default=str))
+
+
+# ---------------------------------------------------------------------------
+# Subcommand handlers
+# ---------------------------------------------------------------------------
+
+
+def _cmd_init(args: argparse.Namespace) -> int:
+    home = Path(args.home).expanduser()
+    home.mkdir(parents=True, exist_ok=True)
+    store_db, audit_db = _paths(home)
+    ResourceStore(store_db).close()
+    AuditLog(audit_db).close()
+    print(f"initialized enterprise home at {home}")
+    return 0
+
+
+def _cmd_ns_create(args: argparse.Namespace) -> int:
+    ctl = _build(args)
+    ns = ctl.ensure_namespace(args.name, actor=args.actor)
+    _print({"name": ns.meta.name, "phase": ns.status.get("phase")})
+    return 0
+
+
+def _cmd_ns_list(args: argparse.Namespace) -> int:
+    ctl = _build(args)
+    _print([
+        {"name": r.meta.name, "phase": r.status.get("phase")}
+        for r in ctl.store.list(Kind.NAMESPACE)
+    ])
+    return 0
+
+
+def _cmd_harness_register(args: argparse.Namespace) -> int:
+    ctl = _build(args)
+    res = Resource(
+        meta=ResourceMeta(kind=Kind.HARNESS.value, name=args.name),
+        spec={"version": args.version, "image": args.image},
+    )
+    ctl.store.create(res)
+    print(f"Harness/{args.name} registered ({args.version})")
+    return 0
+
+
+def _cmd_config_put(args: argparse.Namespace) -> int:
+    ctl = _build(args)
+    config = _load_doc(args.file)
+    res = Resource(
+        meta=ResourceMeta(
+            kind=Kind.CONFIGURATION.value, name=args.name,
+            namespace=args.namespace,
+        ),
+        spec={"config": config},
+    )
+    try:
+        existing = ctl.store.get(Kind.CONFIGURATION, args.name, args.namespace)
+        res.meta = existing.meta
+        res.meta.generation = existing.meta.generation
+        ctl.store.update_spec(res)
+        print(f"Configuration/{args.namespace}/{args.name} updated")
+    except EnterpriseError:
+        ctl.store.create(res)
+        print(f"Configuration/{args.namespace}/{args.name} created")
+    return 0
+
+
+def _cmd_agent_create(args: argparse.Namespace) -> int:
+    ctl = _build(args)
+    spec: dict[str, Any] = {
+        "harness": args.harness,
+        "configuration": args.configuration,
+        "channels": args.channel or [],
+        "secrets": args.secret or [],
+    }
+    if args.sandbox_policy:
+        spec["sandboxPolicy"] = args.sandbox_policy
+    res = Resource(
+        meta=ResourceMeta(
+            kind=Kind.AGENT.value, name=args.name, namespace=args.namespace
+        ),
+        spec=spec,
+    )
+    ctl.store.create(res)
+    print(f"Agent/{args.namespace}/{args.name} created")
+    return 0
+
+
+def _cmd_agent_deploy(args: argparse.Namespace) -> int:
+    ctl = _build(args)
+    rev = ctl.deploy(args.name, args.namespace, actor=args.actor)
+    _print({
+        "revision": rev.meta.name,
+        "phase": rev.status.get("phase"),
+        "workloadIdentity": rev.spec.get("workloadIdentity"),
+    })
+    return 0
+
+
+def _cmd_agent_rollback(args: argparse.Namespace) -> int:
+    ctl = _build(args)
+    rev = ctl.rollback(args.name, args.namespace, actor=args.actor)
+    _print({"revision": rev.meta.name, "phase": rev.status.get("phase")})
+    return 0
+
+
+def _cmd_get(args: argparse.Namespace) -> int:
+    ctl = _build(args)
+    res = ctl.store.get(Kind(args.kind), args.name, args.namespace)
+    _print(res.to_dict())
+    return 0
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    ctl = _build(args)
+    _print([
+        {
+            "name": r.meta.name,
+            "namespace": r.meta.namespace,
+            "phase": r.status.get("phase"),
+        }
+        for r in ctl.store.list(Kind(args.kind), args.namespace)
+    ])
+    return 0
+
+
+def _cmd_audit_tail(args: argparse.Namespace) -> int:
+    home = Path(args.home).expanduser()
+    _, audit_db = _paths(home)
+    audit = AuditLog(audit_db)
+    _print(audit.query(limit=args.limit))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="hermes-enterprise",
+        description="Hermes Enterprise control-plane CLI",
+    )
+    p.add_argument("--home", default=str(DEFAULT_HOME),
+                   help="enterprise home directory (default: %(default)s)")
+    p.add_argument("--driver", default="memory", choices=["memory"],
+                   help="driver set (default: %(default)s; dev-mode)")
+    p.add_argument("--actor", default="cli-user",
+                   help="principal recorded in the audit log")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    sp = sub.add_parser("init", help="create store/audit databases")
+    sp.set_defaults(func=_cmd_init)
+
+    ns = sub.add_parser("ns", help="namespace operations")
+    nssub = ns.add_subparsers(dest="ns_command", required=True)
+    sp = nssub.add_parser("create", help="create + reconcile a namespace")
+    sp.add_argument("name")
+    sp.set_defaults(func=_cmd_ns_create)
+    sp = nssub.add_parser("list", help="list namespaces")
+    sp.set_defaults(func=_cmd_ns_list)
+
+    hr = sub.add_parser("harness", help="harness operations")
+    hrsub = hr.add_subparsers(dest="harness_command", required=True)
+    sp = hrsub.add_parser("register", help="register a Harness")
+    sp.add_argument("name")
+    sp.add_argument("--version", required=True)
+    sp.add_argument("--image", required=True)
+    sp.set_defaults(func=_cmd_harness_register)
+
+    cf = sub.add_parser("config", help="configuration operations")
+    cfsub = cf.add_subparsers(dest="config_command", required=True)
+    sp = cfsub.add_parser("put", help="create/update a Configuration from file")
+    sp.add_argument("name")
+    sp.add_argument("--namespace", "-n", required=True)
+    sp.add_argument("--file", "-f", required=True,
+                    help="YAML or JSON file with the config contents")
+    sp.set_defaults(func=_cmd_config_put)
+
+    ag = sub.add_parser("agent", help="agent operations")
+    agsub = ag.add_subparsers(dest="agent_command", required=True)
+    sp = agsub.add_parser("create", help="create an Agent")
+    sp.add_argument("name")
+    sp.add_argument("--namespace", "-n", required=True)
+    sp.add_argument("--harness", required=True)
+    sp.add_argument("--configuration", required=True)
+    sp.add_argument("--channel", action="append")
+    sp.add_argument("--secret", action="append")
+    sp.add_argument("--sandbox-policy")
+    sp.set_defaults(func=_cmd_agent_create)
+    sp = agsub.add_parser("deploy", help="deploy the agent's current spec")
+    sp.add_argument("name")
+    sp.add_argument("--namespace", "-n", required=True)
+    sp.set_defaults(func=_cmd_agent_deploy)
+    sp = agsub.add_parser("rollback", help="roll back to the last Retired revision")
+    sp.add_argument("name")
+    sp.add_argument("--namespace", "-n", required=True)
+    sp.set_defaults(func=_cmd_agent_rollback)
+
+    sp = sub.add_parser("get", help="get one resource")
+    sp.add_argument("kind", choices=[k.value for k in Kind])
+    sp.add_argument("name")
+    sp.add_argument("--namespace", "-n")
+    sp.set_defaults(func=_cmd_get)
+
+    sp = sub.add_parser("list", help="list resources of a kind")
+    sp.add_argument("kind", choices=[k.value for k in Kind])
+    sp.add_argument("--namespace", "-n")
+    sp.set_defaults(func=_cmd_list)
+
+    au = sub.add_parser("audit", help="audit log operations")
+    ausub = au.add_subparsers(dest="audit_command", required=True)
+    sp = ausub.add_parser("tail", help="show recent audit records")
+    sp.add_argument("--limit", type=int, default=20)
+    sp.set_defaults(func=_cmd_audit_tail)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except EnterpriseError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/enterprise/controller.py
+++ b/enterprise/controller.py
@@ -1,0 +1,657 @@
+"""Deployment choreography + namespace lifecycle for Hermes Enterprise.
+
+The Controller owns every state transition in the control plane. Drivers and
+adapters consume admitted intent at their boundary; they never own resources
+or select themselves. The single deploy path implemented here is:
+
+    authorize -> resolve references -> per-reference authorize
+    -> namespace gateway ready -> sandbox supports(ENTIRE policy)
+    -> immutable AgentRevision snapshot -> provision candidate
+    -> enforce + verify containment (BEFORE start)
+    -> prepare non-serving route -> retire previous revision
+    -> activate candidate (sole active) -> start harness -> enable route
+
+Every failure before activation leaves the previous revision serving,
+marks the candidate Failed, and tears its workload down. A failure after
+activation triggers rollback to the previous revision; an unverifiable
+rollback raises RollbackError and leaves the agent inactive with all
+routes disabled.
+"""
+
+from __future__ import annotations
+
+import threading
+from abc import ABC, abstractmethod
+from typing import Any
+
+from .audit import AuditLog
+from .contracts import (
+    AuthzRequest,
+    ComputeDriver,
+    DriverRegistry,
+    IAMAdapter,
+    SandboxDriver,
+    WorkloadRef,
+)
+from .errors import (
+    AuthorizationError,
+    DeploymentError,
+    NotFoundError,
+    RollbackError,
+)
+from .resources import (
+    Kind,
+    NamespacePhase,
+    Resource,
+    ResourceMeta,
+    RevisionPhase,
+)
+from .store import ResourceStore
+
+# ---------------------------------------------------------------------------
+# Gateway management
+# ---------------------------------------------------------------------------
+
+
+class GatewayManager(ABC):
+    """Manages the per-namespace ingress gateway and per-revision routes.
+
+    Routes are prepared non-serving so activation is a flip, not a build.
+    """
+
+    @abstractmethod
+    def ensure_gateway(self, namespace: str) -> bool:
+        """Ensure the namespace gateway exists; return True when ready."""
+
+    @abstractmethod
+    def prepare_route(self, namespace: str, revision_uid: str) -> None:
+        """Create a non-serving route for the revision. Must not serve."""
+
+    @abstractmethod
+    def enable_route(self, namespace: str, revision_uid: str) -> None:
+        """Begin serving traffic to the revision's route."""
+
+    @abstractmethod
+    def disable_route(self, namespace: str, revision_uid: str) -> None:
+        """Stop serving traffic to the revision's route."""
+
+    @abstractmethod
+    def teardown_gateway(self, namespace: str) -> None:
+        """Remove the namespace gateway and all its routes."""
+
+
+class InMemoryGatewayManager(GatewayManager):
+    """In-process gateway manager for tests and local development."""
+
+    def __init__(self) -> None:
+        self.gateways: set[str] = set()
+        # (namespace, revision_uid) -> serving?
+        self.routes: dict[tuple[str, str], bool] = {}
+        self.calls: list[tuple[str, ...]] = []
+
+    def ensure_gateway(self, namespace: str) -> bool:
+        self.calls.append(("ensure_gateway", namespace))
+        self.gateways.add(namespace)
+        return True
+
+    def prepare_route(self, namespace: str, revision_uid: str) -> None:
+        self.calls.append(("prepare_route", namespace, revision_uid))
+        self.routes[(namespace, revision_uid)] = False
+
+    def enable_route(self, namespace: str, revision_uid: str) -> None:
+        self.calls.append(("enable_route", namespace, revision_uid))
+        self.routes[(namespace, revision_uid)] = True
+
+    def disable_route(self, namespace: str, revision_uid: str) -> None:
+        self.calls.append(("disable_route", namespace, revision_uid))
+        self.routes[(namespace, revision_uid)] = False
+
+    def teardown_gateway(self, namespace: str) -> None:
+        self.calls.append(("teardown_gateway", namespace))
+        self.gateways.discard(namespace)
+        for key in [k for k in self.routes if k[0] == namespace]:
+            del self.routes[key]
+
+
+# ---------------------------------------------------------------------------
+# Controller
+# ---------------------------------------------------------------------------
+
+_READ_ACTIONS: dict[Kind, str] = {
+    Kind.CONFIGURATION: "hermes.configurations.read",
+    Kind.HARNESS: "hermes.harnesses.read",
+    Kind.CHANNEL: "hermes.channels.read",
+    Kind.SECRET: "hermes.secrets.read",
+    Kind.SANDBOX_POLICY: "hermes.sandboxpolicies.read",
+}
+
+
+class Controller:
+    """Owns namespace lifecycle and the single deploy/rollback path."""
+
+    def __init__(
+        self,
+        store: ResourceStore,
+        audit: AuditLog,
+        registry: DriverRegistry,
+        gateway_manager: GatewayManager,
+        iam_adapter: IAMAdapter,
+    ) -> None:
+        self.store = store
+        self.audit = audit
+        self.registry = registry
+        self.gateway = gateway_manager
+        self.iam = iam_adapter
+        self._agent_locks: dict[tuple[str, str], threading.Lock] = {}
+        self._locks_guard = threading.Lock()
+
+    # -- internals ---------------------------------------------------------
+
+    def _agent_lock(self, namespace: str, agent_name: str) -> threading.Lock:
+        key = (namespace, agent_name)
+        with self._locks_guard:
+            lock = self._agent_locks.get(key)
+            if lock is None:
+                lock = threading.Lock()
+                self._agent_locks[key] = lock
+            return lock
+
+    def _compute(self) -> ComputeDriver:
+        return self.registry.get("compute")
+
+    def _sandbox(self) -> SandboxDriver:
+        return self.registry.get("sandbox")
+
+    def _audit(self, **kw: Any) -> None:
+        self.audit.record(**kw)
+
+    # -- namespace lifecycle -------------------------------------------------
+
+    def ensure_namespace(self, name: str, actor: str = "controller") -> Resource:
+        """Create the Namespace if missing and reconcile it toward Ready.
+
+        Ready requires the gateway to report ready; any gateway failure
+        moves the namespace to Failed. Each transition is audited.
+        """
+        try:
+            ns = self.store.get(Kind.NAMESPACE, name)
+        except NotFoundError:
+            ns = Resource(
+                meta=ResourceMeta(kind=Kind.NAMESPACE.value, name=name),
+                status={"phase": NamespacePhase.PENDING.value},
+            )
+            self.store.create(ns)
+            self._audit(
+                actor=actor, actor_kind="principal",
+                action="hermes.namespaces.create", outcome="applied",
+                kind=Kind.NAMESPACE.value, resource=name,
+            )
+
+        prev_phase = ns.status.get("phase", NamespacePhase.PENDING.value)
+        try:
+            ready = bool(self.gateway.ensure_gateway(name))
+            phase = NamespacePhase.READY if ready else NamespacePhase.PENDING
+            reason = None if ready else "gateway not ready"
+        except Exception as exc:  # gateway failure -> Failed, fail-closed
+            phase = NamespacePhase.FAILED
+            reason = f"gateway error: {exc}"
+
+        if phase.value != prev_phase:
+            ns = self.store.update_status(
+                Kind.NAMESPACE, name, None, {"phase": phase.value}
+            )
+            self._audit(
+                actor=actor, actor_kind="principal",
+                action="hermes.namespaces.reconcile",
+                outcome="applied" if phase is not NamespacePhase.FAILED else "error",
+                kind=Kind.NAMESPACE.value, resource=name,
+                reason=reason,
+                detail={"from": prev_phase, "to": phase.value},
+            )
+        return self.store.get(Kind.NAMESPACE, name)
+
+    # -- helpers -------------------------------------------------------------
+
+    def active_revision(self, agent_name: str, namespace: str) -> Resource | None:
+        """The sole Active revision for the agent, or None."""
+        for rev in self.store.list(Kind.AGENT_REVISION, namespace):
+            if (
+                rev.spec.get("agent") == agent_name
+                and rev.status.get("phase") == RevisionPhase.ACTIVE.value
+            ):
+                return rev
+        return None
+
+    def _revisions_for(self, agent_name: str, namespace: str) -> list[Resource]:
+        revs = [
+            r
+            for r in self.store.list(Kind.AGENT_REVISION, namespace)
+            if r.spec.get("agent") == agent_name
+        ]
+        revs.sort(key=lambda r: int(r.spec.get("serial", 0)))
+        return revs
+
+    def _next_serial(self, agent_name: str, namespace: str) -> int:
+        revs = self._revisions_for(agent_name, namespace)
+        return (int(revs[-1].spec.get("serial", 0)) + 1) if revs else 1
+
+    def _authorize(self, actor: str, action: str, kind: Kind,
+                   namespace: str | None, resource: str | None) -> None:
+        req = AuthzRequest(
+            principal=actor,
+            principal_kind="principal",
+            action=action,
+            kind=kind.value,
+            namespace=namespace,
+            resource=resource,
+        )
+        try:
+            self.iam.authorize(req)
+        except AuthorizationError:
+            self._audit(
+                actor=actor, actor_kind="principal", action=action,
+                outcome="deny", kind=kind.value, namespace=namespace,
+                resource=resource, reason="denied by IAM adapter",
+            )
+            raise
+        self._audit(
+            actor=actor, actor_kind="principal", action=action,
+            outcome="allow", kind=kind.value, namespace=namespace,
+            resource=resource,
+        )
+
+    @staticmethod
+    def _workload_ref(revision: Resource, driver_name: str) -> WorkloadRef:
+        return WorkloadRef(
+            revision_uid=revision.meta.uid,
+            namespace=revision.meta.namespace or "",
+            workload_identity=str(revision.spec.get("workloadIdentity", "")),
+            driver=driver_name,
+        )
+
+    # -- deploy ----------------------------------------------------------------
+
+    def deploy(self, agent_name: str, namespace: str, actor: str) -> Resource:
+        """Deploy the agent's current spec as a new immutable revision."""
+        with self._agent_lock(namespace, agent_name):
+            return self._deploy_locked(agent_name, namespace, actor)
+
+    def _deploy_locked(self, agent_name: str, namespace: str, actor: str) -> Resource:
+        # 1. Authorize deploy on the exact Agent.
+        self._authorize(
+            actor, "hermes.agents.deploy", Kind.AGENT, namespace, agent_name
+        )
+
+        agent = self.store.get(Kind.AGENT, agent_name, namespace)
+
+        # 2. Resolve + per-reference authorize protected references.
+        config = self.store.get(
+            Kind.CONFIGURATION, agent.spec["configuration"], namespace
+        )
+        self._authorize(
+            actor, _READ_ACTIONS[Kind.CONFIGURATION], Kind.CONFIGURATION,
+            namespace, config.meta.name,
+        )
+
+        harness = self.store.get(Kind.HARNESS, agent.spec["harness"], None)
+        self._authorize(
+            actor, _READ_ACTIONS[Kind.HARNESS], Kind.HARNESS, None,
+            harness.meta.name,
+        )
+
+        for ch_name in agent.spec.get("channels", []) or []:
+            self.store.get(Kind.CHANNEL, ch_name, namespace)
+            self._authorize(
+                actor, _READ_ACTIONS[Kind.CHANNEL], Kind.CHANNEL,
+                namespace, ch_name,
+            )
+        for sec_name in agent.spec.get("secrets", []) or []:
+            self.store.get(Kind.SECRET, sec_name, namespace)
+            self._authorize(
+                actor, _READ_ACTIONS[Kind.SECRET], Kind.SECRET,
+                namespace, sec_name,
+            )
+
+        policy: dict[str, Any] = {}
+        policy_name = agent.spec.get("sandboxPolicy")
+        if policy_name:
+            policy_res = self.store.get(Kind.SANDBOX_POLICY, policy_name, namespace)
+            self._authorize(
+                actor, _READ_ACTIONS[Kind.SANDBOX_POLICY], Kind.SANDBOX_POLICY,
+                namespace, policy_name,
+            )
+            policy = dict(policy_res.spec)
+
+        # 3. Namespace gateway must be ready.
+        ns = self.ensure_namespace(namespace, actor=actor)
+        if ns.status.get("phase") != NamespacePhase.READY.value:
+            self._audit(
+                actor=actor, actor_kind="principal",
+                action="hermes.agents.deploy", outcome="error",
+                kind=Kind.AGENT.value, namespace=namespace,
+                resource=agent_name,
+                reason=f"namespace not Ready (phase={ns.status.get('phase')})",
+            )
+            raise DeploymentError(
+                f"namespace {namespace!r} is not Ready; cannot deploy"
+            )
+
+        compute = self._compute()
+        sandbox = self._sandbox()
+
+        # 4. Sandbox driver must support the ENTIRE policy.
+        if not sandbox.supports(policy):
+            self._audit(
+                actor=actor, actor_kind="principal",
+                action="hermes.agents.deploy", outcome="deny",
+                kind=Kind.AGENT.value, namespace=namespace,
+                resource=agent_name,
+                reason=(
+                    f"sandbox driver {sandbox.name!r} cannot enforce the "
+                    "entire SandboxPolicy; partial support is unsupported"
+                ),
+            )
+            raise DeploymentError(
+                f"sandbox driver {sandbox.name!r} does not support the "
+                "entire SandboxPolicy"
+            )
+
+        # 5. Immutable AgentRevision snapshot.
+        previous = self.active_revision(agent_name, namespace)
+        serial = self._next_serial(agent_name, namespace)
+        revision = Resource(
+            meta=ResourceMeta(
+                kind=Kind.AGENT_REVISION.value,
+                name=f"{agent_name}-rev-{serial}",
+                namespace=namespace,
+            ),
+            spec={
+                "agent": agent_name,
+                "agentUid": agent.meta.uid,
+                "serial": serial,
+                "workloadIdentity": f"wi-{agent_name}",
+                "harness": {
+                    "name": harness.meta.name,
+                    "version": harness.spec["version"],
+                    "image": harness.spec["image"],
+                },
+                "configuration": dict(config.spec.get("config", {})),
+                "sandboxPolicy": policy,
+                "computeDriver": self.registry.selected_name("compute"),
+                "sandboxDriver": self.registry.selected_name("sandbox"),
+            },
+            status={"phase": RevisionPhase.CANDIDATE.value},
+        )
+        self.store.create(revision)
+        self._audit(
+            actor=actor, actor_kind="principal",
+            action="hermes.agentrevisions.create", outcome="applied",
+            kind=Kind.AGENT_REVISION.value, namespace=namespace,
+            resource=revision.meta.name,
+            detail={"serial": serial, "agent": agent_name},
+        )
+
+        ref: WorkloadRef | None = None
+
+        def _fail_candidate(stage: str, exc: Exception) -> None:
+            """Pre-activation failure: candidate Failed, workload torn down,
+            previous revision and its route untouched."""
+            self.store.update_status(
+                Kind.AGENT_REVISION, revision.meta.name, namespace,
+                {"phase": RevisionPhase.FAILED.value, "reason": f"{stage}: {exc}"},
+            )
+            if ref is not None:
+                try:
+                    compute.teardown(ref)
+                except Exception:
+                    pass  # best-effort teardown; candidate is already Failed
+            self._audit(
+                actor=actor, actor_kind="principal",
+                action="hermes.agents.deploy", outcome="error",
+                kind=Kind.AGENT.value, namespace=namespace,
+                resource=agent_name,
+                reason=f"deploy failed at {stage}: {exc}",
+                detail={"revision": revision.meta.name, "stage": stage},
+            )
+
+        # 6. Provision candidate; enforce + verify containment BEFORE start.
+        try:
+            ref = compute.provision_candidate(revision)
+        except Exception as exc:
+            _fail_candidate("provision_candidate", exc)
+            raise DeploymentError(f"provisioning failed: {exc}") from exc
+
+        try:
+            sandbox.enforce(ref, policy)
+            sandbox.verify(ref, policy)
+        except Exception as exc:
+            _fail_candidate("sandbox containment", exc)
+            raise DeploymentError(f"containment failed: {exc}") from exc
+
+        self.store.update_status(
+            Kind.AGENT_REVISION, revision.meta.name, namespace,
+            {"phase": RevisionPhase.CONTAINED.value},
+        )
+
+        # 7. Prepare non-serving route.
+        try:
+            self.gateway.prepare_route(namespace, revision.meta.uid)
+        except Exception as exc:
+            _fail_candidate("prepare_route", exc)
+            raise DeploymentError(f"route preparation failed: {exc}") from exc
+
+        # 8. Retire previous active revision (stop harness, verify stopped).
+        prev_ref: WorkloadRef | None = None
+        if previous is not None:
+            prev_ref = self._workload_ref(
+                previous, str(previous.spec.get("computeDriver", compute.name))
+            )
+            try:
+                compute.stop_harness(prev_ref)
+                self.gateway.disable_route(namespace, previous.meta.uid)
+            except Exception as exc:
+                _fail_candidate("retire previous revision", exc)
+                raise DeploymentError(
+                    f"could not retire previous revision: {exc}"
+                ) from exc
+            self.store.update_status(
+                Kind.AGENT_REVISION, previous.meta.name, namespace,
+                {"phase": RevisionPhase.RETIRED.value},
+            )
+            self._audit(
+                actor=actor, actor_kind="principal",
+                action="hermes.agentrevisions.retire", outcome="applied",
+                kind=Kind.AGENT_REVISION.value, namespace=namespace,
+                resource=previous.meta.name,
+            )
+
+        # 9. Activate candidate (sole active), start harness, enable route.
+        self.store.update_status(
+            Kind.AGENT_REVISION, revision.meta.name, namespace,
+            {"phase": RevisionPhase.ACTIVE.value},
+        )
+        try:
+            compute.start_harness(ref)
+            self.gateway.enable_route(namespace, revision.meta.uid)
+        except Exception as exc:
+            self._rollback_after_activation(
+                agent_name, namespace, actor, revision, ref,
+                previous, prev_ref, cause=exc,
+            )
+            raise DeploymentError(
+                f"post-activation failure, rolled back: {exc}"
+            ) from exc
+
+        self._audit(
+            actor=actor, actor_kind="principal",
+            action="hermes.agents.deploy", outcome="applied",
+            kind=Kind.AGENT.value, namespace=namespace, resource=agent_name,
+            detail={"revision": revision.meta.name, "serial": serial},
+        )
+        return self.store.get(Kind.AGENT_REVISION, revision.meta.name, namespace)
+
+    # -- rollback ----------------------------------------------------------
+
+    def _rollback_after_activation(
+        self,
+        agent_name: str,
+        namespace: str,
+        actor: str,
+        candidate: Resource,
+        candidate_ref: WorkloadRef,
+        previous: Resource | None,
+        prev_ref: WorkloadRef | None,
+        cause: Exception,
+    ) -> None:
+        """Roll back to `previous` after a post-activation failure.
+
+        On unverifiable rollback the agent is left inactive with all routes
+        disabled and RollbackError is raised (chained to the cause).
+        """
+        compute = self._compute()
+
+        # Retire the failed candidate first: no traffic, no harness.
+        try:
+            self.gateway.disable_route(namespace, candidate.meta.uid)
+        except Exception:
+            pass
+        try:
+            compute.stop_harness(candidate_ref)
+        except Exception:
+            pass
+        self.store.update_status(
+            Kind.AGENT_REVISION, candidate.meta.name, namespace,
+            {"phase": RevisionPhase.RETIRED.value,
+             "reason": f"rolled back: {cause}"},
+        )
+
+        if previous is None or prev_ref is None:
+            self._audit(
+                actor=actor, actor_kind="principal",
+                action="hermes.agents.rollback", outcome="error",
+                kind=Kind.AGENT.value, namespace=namespace,
+                resource=agent_name,
+                reason=f"no previous revision to roll back to ({cause})",
+            )
+            raise RollbackError(
+                f"post-activation failure and no previous revision; agent "
+                f"{agent_name!r} is inactive: {cause}"
+            ) from cause
+
+        try:
+            compute.start_harness(prev_ref)
+            self.gateway.enable_route(namespace, previous.meta.uid)
+        except Exception as exc:
+            # Unverifiable rollback: everything stays down.
+            try:
+                self.gateway.disable_route(namespace, previous.meta.uid)
+            except Exception:
+                pass
+            self._audit(
+                actor=actor, actor_kind="principal",
+                action="hermes.agents.rollback", outcome="error",
+                kind=Kind.AGENT.value, namespace=namespace,
+                resource=agent_name,
+                reason=f"rollback unverifiable: {exc}",
+                detail={"candidate": candidate.meta.name,
+                        "previous": previous.meta.name},
+            )
+            raise RollbackError(
+                f"rollback to {previous.meta.name!r} could not be verified; "
+                f"agent {agent_name!r} left inactive with routes disabled"
+            ) from exc
+
+        self.store.update_status(
+            Kind.AGENT_REVISION, previous.meta.name, namespace,
+            {"phase": RevisionPhase.ACTIVE.value},
+        )
+        self._audit(
+            actor=actor, actor_kind="principal",
+            action="hermes.agents.rollback", outcome="rolled-back",
+            kind=Kind.AGENT.value, namespace=namespace, resource=agent_name,
+            reason=f"post-activation failure: {cause}",
+            detail={"candidate": candidate.meta.name,
+                    "restored": previous.meta.name},
+        )
+
+    def rollback(self, agent_name: str, namespace: str, actor: str) -> Resource:
+        """Explicit rollback to the most recently Retired revision."""
+        with self._agent_lock(namespace, agent_name):
+            return self._rollback_locked(agent_name, namespace, actor)
+
+    def _rollback_locked(self, agent_name: str, namespace: str,
+                         actor: str) -> Resource:
+        self._authorize(
+            actor, "hermes.agents.rollback", Kind.AGENT, namespace, agent_name
+        )
+        revs = self._revisions_for(agent_name, namespace)
+        retired = [
+            r for r in revs
+            if r.status.get("phase") == RevisionPhase.RETIRED.value
+        ]
+        if not retired:
+            raise DeploymentError(
+                f"agent {agent_name!r} has no Retired revision to roll back to"
+            )
+        target = retired[-1]
+        current = self.active_revision(agent_name, namespace)
+        compute = self._compute()
+
+        # Stop the current active revision first (fail-closed).
+        if current is not None:
+            cur_ref = self._workload_ref(
+                current, str(current.spec.get("computeDriver", compute.name))
+            )
+            try:
+                compute.stop_harness(cur_ref)
+                self.gateway.disable_route(namespace, current.meta.uid)
+            except Exception as exc:
+                self._audit(
+                    actor=actor, actor_kind="principal",
+                    action="hermes.agents.rollback", outcome="error",
+                    kind=Kind.AGENT.value, namespace=namespace,
+                    resource=agent_name,
+                    reason=f"could not stop current revision: {exc}",
+                )
+                raise RollbackError(
+                    f"could not stop current revision {current.meta.name!r}: {exc}"
+                ) from exc
+            self.store.update_status(
+                Kind.AGENT_REVISION, current.meta.name, namespace,
+                {"phase": RevisionPhase.RETIRED.value},
+            )
+
+        target_ref = self._workload_ref(
+            target, str(target.spec.get("computeDriver", compute.name))
+        )
+        try:
+            compute.start_harness(target_ref)
+            self.gateway.enable_route(namespace, target.meta.uid)
+        except Exception as exc:
+            try:
+                self.gateway.disable_route(namespace, target.meta.uid)
+            except Exception:
+                pass
+            self._audit(
+                actor=actor, actor_kind="principal",
+                action="hermes.agents.rollback", outcome="error",
+                kind=Kind.AGENT.value, namespace=namespace,
+                resource=agent_name,
+                reason=f"rollback unverifiable: {exc}",
+            )
+            raise RollbackError(
+                f"rollback to {target.meta.name!r} could not be verified; "
+                f"agent {agent_name!r} left inactive with routes disabled"
+            ) from exc
+
+        self.store.update_status(
+            Kind.AGENT_REVISION, target.meta.name, namespace,
+            {"phase": RevisionPhase.ACTIVE.value},
+        )
+        self._audit(
+            actor=actor, actor_kind="principal",
+            action="hermes.agents.rollback", outcome="rolled-back",
+            kind=Kind.AGENT.value, namespace=namespace, resource=agent_name,
+            detail={"restored": target.meta.name},
+        )
+        return self.store.get(Kind.AGENT_REVISION, target.meta.name, namespace)

--- a/tests/enterprise/test_controller.py
+++ b/tests/enterprise/test_controller.py
@@ -1,0 +1,480 @@
+"""Controller tests: deploy choreography, rollback, namespace lifecycle, CLI.
+
+All drivers are in-memory fakes that record their call order into one shared
+event list, so the tests can assert the EXACT choreography the platform spec
+requires.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from enterprise import cli as ent_cli
+from enterprise.audit import AuditLog
+from enterprise.contracts import (
+    AuthzRequest,
+    ComputeDriver,
+    DriverRegistry,
+    IAMAdapter,
+    SandboxDriver,
+    WorkloadRef,
+)
+from enterprise.controller import Controller, InMemoryGatewayManager
+from enterprise.errors import (
+    AuthorizationError,
+    DeploymentError,
+    DriverError,
+    RollbackError,
+)
+from enterprise.resources import Kind, NamespacePhase, Resource, ResourceMeta, RevisionPhase
+from enterprise.store import ResourceStore
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeComputeDriver(ComputeDriver):
+    name = "fake-compute"
+
+    def __init__(self, events: list[tuple[str, ...]]):
+        self.events = events
+        self.fail_provision = False
+        self.fail_start = False
+        self.fail_start_uids: set[str] = set()
+        self.torn_down: list[str] = []
+
+    def provision_candidate(self, revision: Resource) -> WorkloadRef:
+        self.events.append(("provision", revision.meta.name))
+        if self.fail_provision:
+            raise DriverError("provision blew up")
+        return WorkloadRef(
+            revision_uid=revision.meta.uid,
+            namespace=revision.meta.namespace or "",
+            workload_identity=str(revision.spec.get("workloadIdentity", "")),
+            driver=self.name,
+        )
+
+    def workload_ready(self, ref: WorkloadRef) -> bool:
+        return True
+
+    def start_harness(self, ref: WorkloadRef) -> None:
+        self.events.append(("start", ref.revision_uid))
+        if self.fail_start or ref.revision_uid in self.fail_start_uids:
+            raise DriverError("start blew up")
+
+    def stop_harness(self, ref: WorkloadRef) -> None:
+        self.events.append(("stop", ref.revision_uid))
+
+    def teardown(self, ref: WorkloadRef) -> None:
+        self.events.append(("teardown", ref.revision_uid))
+        self.torn_down.append(ref.revision_uid)
+
+
+class FakeSandboxDriver(SandboxDriver):
+    name = "fake-sandbox"
+
+    def __init__(self, events: list[tuple[str, ...]]):
+        self.events = events
+        self.supports_policy = True
+        self.fail_enforce = False
+        self.fail_verify = False
+
+    def supports(self, policy):
+        return self.supports_policy
+
+    def enforce(self, ref: WorkloadRef, policy) -> None:
+        self.events.append(("enforce", ref.revision_uid))
+        if self.fail_enforce:
+            raise DriverError("enforce blew up")
+
+    def verify(self, ref: WorkloadRef, policy) -> None:
+        self.events.append(("verify", ref.revision_uid))
+        if self.fail_verify:
+            raise DriverError("verify blew up")
+
+
+class RecordingGateway(InMemoryGatewayManager):
+    def __init__(self, events: list[tuple[str, ...]]):
+        super().__init__()
+        self.events = events
+        self.fail_enable = False
+        self.fail_enable_uids: set[str] = set()
+
+    def prepare_route(self, namespace, revision_uid):
+        self.events.append(("prepare_route", revision_uid))
+        super().prepare_route(namespace, revision_uid)
+
+    def enable_route(self, namespace, revision_uid):
+        self.events.append(("enable_route", revision_uid))
+        if self.fail_enable or revision_uid in self.fail_enable_uids:
+            raise DriverError("enable_route blew up")
+        super().enable_route(namespace, revision_uid)
+
+    def disable_route(self, namespace, revision_uid):
+        self.events.append(("disable_route", revision_uid))
+        super().disable_route(namespace, revision_uid)
+
+
+class AllowAllIAM(IAMAdapter):
+    name = "allow-all"
+
+    def __init__(self):
+        self.requests: list[AuthzRequest] = []
+
+    def authorize(self, request: AuthzRequest) -> None:
+        self.requests.append(request)
+
+
+class DenyIAM(IAMAdapter):
+    name = "deny"
+
+    def __init__(self, deny_actions: set[str]):
+        self.deny_actions = deny_actions
+
+    def authorize(self, request: AuthzRequest) -> None:
+        if request.action in self.deny_actions:
+            raise AuthorizationError(f"denied: {request.action}")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+NS = "team-a"
+AGENT = "helper"
+ACTOR = "alice"
+
+
+@pytest.fixture
+def world(tmp_path):
+    events: list[tuple[str, ...]] = []
+    store = ResourceStore(tmp_path / "resources.db")
+    audit = AuditLog(tmp_path / "audit.db")
+    compute = FakeComputeDriver(events)
+    sandbox = FakeSandboxDriver(events)
+    gateway = RecordingGateway(events)
+    iam = AllowAllIAM()
+    registry = DriverRegistry()
+    registry.select("compute", compute)
+    registry.select("sandbox", sandbox)
+    ctl = Controller(store, audit, registry, gateway, iam)
+    yield {
+        "events": events, "store": store, "audit": audit,
+        "compute": compute, "sandbox": sandbox, "gateway": gateway,
+        "iam": iam, "registry": registry, "ctl": ctl,
+    }
+    store.close()
+    audit.close()
+
+
+def seed(w, with_policy=True):
+    ctl, store = w["ctl"], w["store"]
+    ns = ctl.ensure_namespace(NS, actor=ACTOR)
+    assert ns.status["phase"] == NamespacePhase.READY.value
+    store.create(Resource(
+        meta=ResourceMeta(kind=Kind.HARNESS.value, name="hermes"),
+        spec={"version": "1.2.3", "image": "ghcr.io/nous/hermes:1.2.3"},
+    ))
+    store.create(Resource(
+        meta=ResourceMeta(kind=Kind.CONFIGURATION.value, name="cfg", namespace=NS),
+        spec={"config": {"model": "hermes-4", "temperature": 0.7}},
+    ))
+    store.create(Resource(
+        meta=ResourceMeta(kind=Kind.CHANNEL.value, name="tg", namespace=NS),
+        spec={"platform": "telegram"},
+    ))
+    agent_spec = {
+        "harness": "hermes", "configuration": "cfg",
+        "channels": ["tg"], "secrets": [],
+    }
+    if with_policy:
+        store.create(Resource(
+            meta=ResourceMeta(kind=Kind.SANDBOX_POLICY.value, name="strict",
+                              namespace=NS),
+            spec={"network": "isolated", "readOnlyRootFilesystem": True},
+        ))
+        agent_spec["sandboxPolicy"] = "strict"
+    store.create(Resource(
+        meta=ResourceMeta(kind=Kind.AGENT.value, name=AGENT, namespace=NS),
+        spec=agent_spec,
+    ))
+
+
+def rev(w, name):
+    return w["store"].get(Kind.AGENT_REVISION, name, NS)
+
+
+# ---------------------------------------------------------------------------
+# Deploy choreography
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_happy_path_exact_call_order(world):
+    seed(world)
+    ctl, events = world["ctl"], world["events"]
+
+    rev1 = ctl.deploy(AGENT, NS, ACTOR)
+    assert rev1.status["phase"] == RevisionPhase.ACTIVE.value
+    assert rev1.meta.name == f"{AGENT}-rev-1"
+
+    events.clear()
+    rev2 = ctl.deploy(AGENT, NS, ACTOR)
+    assert rev2.status["phase"] == RevisionPhase.ACTIVE.value
+
+    kinds = [e[0] for e in events]
+    assert kinds == [
+        "provision",        # candidate provisioned
+        "enforce",          # containment established
+        "verify",           # containment verified BEFORE start
+        "prepare_route",    # non-serving route
+        "stop",             # previous harness stopped
+        "disable_route",    # previous route disabled
+        "start",            # candidate harness started
+        "enable_route",     # candidate route enabled
+    ]
+    # stop targets the previous revision; start targets the candidate
+    assert events[4] == ("stop", rev1.meta.uid)
+    assert events[6] == ("start", rev2.meta.uid)
+    assert events[7] == ("enable_route", rev2.meta.uid)
+
+    assert rev(world, rev1.meta.name).status["phase"] == RevisionPhase.RETIRED.value
+    assert ctl.active_revision(AGENT, NS).meta.name == rev2.meta.name
+    # candidate route serving, previous route not
+    assert world["gateway"].routes[(NS, rev2.meta.uid)] is True
+    assert world["gateway"].routes[(NS, rev1.meta.uid)] is False
+
+
+def test_deploy_blocked_when_sandbox_unsupported(world):
+    seed(world)
+    world["sandbox"].supports_policy = False
+    with pytest.raises(DeploymentError, match="does not support"):
+        world["ctl"].deploy(AGENT, NS, ACTOR)
+    assert world["store"].list(Kind.AGENT_REVISION, NS) == []
+    assert ("provision",) not in [e[:1] for e in world["events"]] or all(
+        e[0] != "provision" for e in world["events"]
+    )
+
+
+def test_provision_failure_leaves_previous_active(world):
+    seed(world)
+    ctl = world["ctl"]
+    rev1 = ctl.deploy(AGENT, NS, ACTOR)
+
+    world["compute"].fail_provision = True
+    with pytest.raises(DeploymentError, match="provisioning failed"):
+        ctl.deploy(AGENT, NS, ACTOR)
+
+    assert ctl.active_revision(AGENT, NS).meta.name == rev1.meta.name
+    failed = rev(world, f"{AGENT}-rev-2")
+    assert failed.status["phase"] == RevisionPhase.FAILED.value
+    # previous route untouched
+    assert world["gateway"].routes[(NS, rev1.meta.uid)] is True
+
+
+@pytest.mark.parametrize("stage", ["enforce", "verify"])
+def test_containment_failure_leaves_previous_active(world, stage):
+    seed(world)
+    ctl = world["ctl"]
+    rev1 = ctl.deploy(AGENT, NS, ACTOR)
+
+    setattr(world["sandbox"], f"fail_{stage}", True)
+    with pytest.raises(DeploymentError, match="containment failed"):
+        ctl.deploy(AGENT, NS, ACTOR)
+
+    assert ctl.active_revision(AGENT, NS).meta.name == rev1.meta.name
+    failed = rev(world, f"{AGENT}-rev-2")
+    assert failed.status["phase"] == RevisionPhase.FAILED.value
+    # candidate workload torn down
+    assert failed.meta.uid in world["compute"].torn_down
+    assert world["gateway"].routes[(NS, rev1.meta.uid)] is True
+
+
+def test_start_failure_triggers_rollback_to_previous(world):
+    seed(world)
+    ctl = world["ctl"]
+    rev1 = ctl.deploy(AGENT, NS, ACTOR)
+
+    # Fail start only for the NEW candidate; the rollback re-start of the
+    # previous revision must succeed.
+    def selective_start(self, ref):
+        self.events.append(("start", ref.revision_uid))
+        if ref.revision_uid != rev1.meta.uid:
+            raise DriverError("start blew up")
+
+    world["compute"].start_harness = selective_start.__get__(world["compute"])
+
+    with pytest.raises(DeploymentError, match="rolled back"):
+        ctl.deploy(AGENT, NS, ACTOR)
+
+    active = ctl.active_revision(AGENT, NS)
+    assert active is not None and active.meta.name == rev1.meta.name
+    assert rev(world, f"{AGENT}-rev-2").status["phase"] == RevisionPhase.RETIRED.value
+    assert world["gateway"].routes[(NS, rev1.meta.uid)] is True
+
+
+def test_unverifiable_rollback_leaves_no_active_revision(world):
+    seed(world)
+    ctl = world["ctl"]
+    rev1 = ctl.deploy(AGENT, NS, ACTOR)
+
+    # Every start fails: candidate start fails, and the rollback re-start of
+    # the previous revision also fails -> RollbackError.
+    world["compute"].fail_start = True
+    world["compute"].fail_start_uids = set()
+
+    def all_fail(self, ref):
+        self.events.append(("start", ref.revision_uid))
+        raise DriverError("start blew up")
+
+    world["compute"].start_harness = all_fail.__get__(world["compute"])
+
+    with pytest.raises(RollbackError):
+        ctl.deploy(AGENT, NS, ACTOR)
+
+    assert ctl.active_revision(AGENT, NS) is None
+    # all routes disabled
+    assert not any(world["gateway"].routes.values())
+
+
+def test_unauthorized_deploy_creates_no_revision(world):
+    seed(world)
+    world["ctl"].iam = DenyIAM({"hermes.agents.deploy"})
+    with pytest.raises(AuthorizationError):
+        world["ctl"].deploy(AGENT, NS, ACTOR)
+    assert world["store"].list(Kind.AGENT_REVISION, NS) == []
+    assert all(e[0] != "provision" for e in world["events"])
+
+
+def test_per_reference_authz_denial_blocks_deploy(world):
+    seed(world)
+    world["ctl"].iam = DenyIAM({"hermes.secrets.read", "hermes.channels.read"})
+    with pytest.raises(AuthorizationError):
+        world["ctl"].deploy(AGENT, NS, ACTOR)
+    assert world["store"].list(Kind.AGENT_REVISION, NS) == []
+
+
+def test_revisions_numbered_monotonically_and_stable_identity(world):
+    seed(world)
+    ctl = world["ctl"]
+    names, identities = [], []
+    for _ in range(3):
+        r = ctl.deploy(AGENT, NS, ACTOR)
+        names.append(r.meta.name)
+        identities.append(r.spec["workloadIdentity"])
+    assert names == [f"{AGENT}-rev-{i}" for i in (1, 2, 3)]
+    assert identities == [f"wi-{AGENT}"] * 3
+
+    # snapshots are immutable + embed pinned drivers and contents
+    r = rev(world, names[-1])
+    assert r.spec["computeDriver"] == "fake-compute"
+    assert r.spec["sandboxDriver"] == "fake-sandbox"
+    assert r.spec["configuration"] == {"model": "hermes-4", "temperature": 0.7}
+    assert r.spec["harness"] == {
+        "name": "hermes", "version": "1.2.3", "image": "ghcr.io/nous/hermes:1.2.3"
+    }
+    assert r.spec["sandboxPolicy"]["network"] == "isolated"
+
+
+def test_explicit_rollback_to_retired_revision(world):
+    seed(world)
+    ctl = world["ctl"]
+    rev1 = ctl.deploy(AGENT, NS, ACTOR)
+    rev2 = ctl.deploy(AGENT, NS, ACTOR)
+
+    restored = ctl.rollback(AGENT, NS, ACTOR)
+    assert restored.meta.name == rev1.meta.name
+    assert restored.status["phase"] == RevisionPhase.ACTIVE.value
+    assert rev(world, rev2.meta.name).status["phase"] == RevisionPhase.RETIRED.value
+    assert world["gateway"].routes[(NS, rev1.meta.uid)] is True
+    assert world["gateway"].routes[(NS, rev2.meta.uid)] is False
+
+
+def test_explicit_rollback_unverifiable_fails_closed(world):
+    seed(world)
+    ctl = world["ctl"]
+    ctl.deploy(AGENT, NS, ACTOR)
+    rev1 = ctl.active_revision(AGENT, NS)
+    ctl.deploy(AGENT, NS, ACTOR)
+
+    def all_fail(self, ref):
+        self.events.append(("start", ref.revision_uid))
+        raise DriverError("start blew up")
+
+    world["compute"].start_harness = all_fail.__get__(world["compute"])
+    with pytest.raises(RollbackError):
+        ctl.rollback(AGENT, NS, ACTOR)
+    assert ctl.active_revision(AGENT, NS) is None
+    assert not any(world["gateway"].routes.values())
+
+
+def test_audit_rows_written_for_deploy_and_rollback(world):
+    seed(world)
+    ctl = world["ctl"]
+    ctl.deploy(AGENT, NS, ACTOR)
+    ctl.deploy(AGENT, NS, ACTOR)
+    ctl.rollback(AGENT, NS, ACTOR)
+
+    rows = world["audit"].query(limit=200)
+    actions = {r["action"] for r in rows}
+    assert "hermes.agents.deploy" in actions
+    assert "hermes.agents.rollback" in actions
+    assert "hermes.agentrevisions.create" in actions
+    assert "hermes.namespaces.create" in actions
+    deploy_applied = [
+        r for r in rows
+        if r["action"] == "hermes.agents.deploy" and r["outcome"] == "applied"
+    ]
+    assert len(deploy_applied) == 2
+    rolled = [r for r in rows if r["outcome"] == "rolled-back"]
+    assert rolled and rolled[0]["actor"] == ACTOR
+
+
+def test_namespace_gateway_failure_marks_failed(world):
+    ctl = world["ctl"]
+
+    def boom(namespace):
+        raise RuntimeError("gateway down")
+
+    world["gateway"].ensure_gateway = boom
+    ns = ctl.ensure_namespace("broken-ns", actor=ACTOR)
+    assert ns.status["phase"] == NamespacePhase.FAILED.value
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke test (memory driver)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_smoke_deploy_through_memory_driver(tmp_path, capsys):
+    home = str(tmp_path / "ent-home")
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"model": "hermes-4"}))
+
+    def run(*argv):
+        rc = ent_cli.main(["--home", home, *argv])
+        assert rc == 0, capsys.readouterr()
+        return capsys.readouterr().out
+
+    run("init")
+    out = run("ns", "create", "team-a")
+    assert json.loads(out)["phase"] == "Ready"
+    run("harness", "register", "hermes", "--version", "1.0.0",
+        "--image", "ghcr.io/nous/hermes:1.0.0")
+    run("config", "put", "cfg", "-n", "team-a", "-f", str(cfg))
+    run("agent", "create", "helper", "-n", "team-a",
+        "--harness", "hermes", "--configuration", "cfg")
+    out = run("agent", "deploy", "helper", "-n", "team-a")
+    deployed = json.loads(out)
+    assert deployed["revision"] == "helper-rev-1"
+    assert deployed["phase"] == "Active"
+    assert deployed["workloadIdentity"] == "wi-helper"
+
+    out = run("list", "AgentRevision", "-n", "team-a")
+    assert [r["name"] for r in json.loads(out)] == ["helper-rev-1"]
+
+    out = run("audit", "tail", "--limit", "50")
+    actions = {r["action"] for r in json.loads(out)}
+    assert "hermes.agents.deploy" in actions


### PR DESCRIPTION
## Summary
The controller: owns namespace lifecycle and the single deployment path — authorize → resolve + per-reference authorize → gateway ready → sandbox supports entire policy → immutable `AgentRevision` snapshot → provision candidate → enforce + verify containment → prepare nonserving route → retire previous → activate → start harness → enable route. Failures before activation leave the previous revision untouched; failures after trigger verified rollback, and an unverifiable rollback leaves the agent inactive (`RollbackError`).

Stacked on #85461 (`ent/core`). Part of the one-wave Enterprise draft series.

## Changes
- `enterprise/controller.py`: `Controller` + `GatewayManager` ABC (+ in-memory impl); per-agent deploy serialization; monotonic revision numbering; stable `wi-<agent>` workload identity; every decision audited.
- `enterprise/cli.py` + `__main__.py`: `python -m enterprise.cli` — init, ns create/list, harness register, config put, agent create/deploy/rollback, get/list, audit tail. Dev-mode memory drivers gated behind `--driver memory`; no wiring into `hermes_cli` yet (kept zero-footprint until the stack lands).

## Validation
| | Result |
|---|---|
| `tests/enterprise/test_controller.py` | 15/15 pass (exact call-order, all failure stages, rollback, CLI smoke deploy) |
| ruff | clean |

## Infographic

![The controller](https://files.catbox.moe/oatdc9.png)
