### PR TITLE
feat(enterprise): KubernetesComputeDriver — candidate provisioning via kubectl, gated harness start

### DIFF
--- a/enterprise/drivers/__init__.py
+++ b/enterprise/drivers/__init__.py
@@ -1,0 +1,1 @@
+"""Concrete driver implementations for Hermes Enterprise."""

--- a/enterprise/drivers/kubernetes.py
+++ b/enterprise/drivers/kubernetes.py
@@ -1,0 +1,248 @@
+"""Kubernetes ComputeDriver — provisions candidate workloads via kubectl.
+
+Design notes:
+
+  * Shells out to ``kubectl`` (binary path configurable); no python
+    kubernetes client dependency, stdlib only.
+  * A *candidate* workload is a Deployment with ``replicas=0`` — the harness
+    literally cannot start until the controller calls :meth:`start_harness`,
+    which scales to 1 only after containment is verified.
+  * Every kubectl invocation goes through :meth:`_kubectl` so tests can
+    monkeypatch the seam and no other subprocess path exists.
+  * Manifests never embed secret values. The pod only receives non-secret
+    platform coordinates (revision UID, namespace); secret access is always
+    brokered out-of-band by a SecretDriver.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from typing import Any
+
+from ..contracts import ComputeDriver, WorkloadRef
+from ..errors import DriverError
+from ..resources import Resource
+
+#: Prefix that maps a platform Namespace onto its backing k8s namespace.
+K8S_NAMESPACE_PREFIX = "hermes-"
+
+_LABEL_AGENT = "app.hermes/agent"
+_LABEL_REVISION_UID = "app.hermes/revision-uid"
+
+
+class KubernetesComputeDriver(ComputeDriver):
+    """Provisions AgentRevision workloads as Kubernetes Deployments."""
+
+    name = "kubernetes"
+
+    def __init__(
+        self,
+        *,
+        kubectl_path: str = "kubectl",
+        kubeconfig: str | None = None,
+        context: str | None = None,
+        start_timeout: float = 120.0,
+        poll_interval: float = 2.0,
+    ) -> None:
+        self.kubectl_path = kubectl_path
+        self.kubeconfig = kubeconfig
+        self.context = context
+        self.start_timeout = start_timeout
+        self.poll_interval = poll_interval
+
+    # -- kubectl seam -----------------------------------------------------
+
+    def _kubectl(self, args: list[str], stdin: str | None = None) -> str:
+        """Run one kubectl command; return stdout or raise DriverError."""
+        cmd = [self.kubectl_path]
+        if self.kubeconfig:
+            cmd += ["--kubeconfig", self.kubeconfig]
+        if self.context:
+            cmd += ["--context", self.context]
+        cmd += args
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=stdin,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError as exc:  # kubectl binary missing/unrunnable
+            raise DriverError(f"kubectl unavailable: {exc}") from exc
+        if proc.returncode != 0:
+            raise DriverError(
+                f"kubectl {' '.join(args)} failed "
+                f"(exit {proc.returncode}): {proc.stderr.strip()}"
+            )
+        return proc.stdout
+
+    # -- naming / rendering ------------------------------------------------
+
+    @staticmethod
+    def _k8s_namespace(platform_namespace: str) -> str:
+        return f"{K8S_NAMESPACE_PREFIX}{platform_namespace}"
+
+    @staticmethod
+    def _deployment_name(revision: Resource) -> str:
+        return f"{revision.spec['agent']}-{revision.meta.uid[:12]}"
+
+    def _render_service_account(self, revision: Resource) -> dict[str, Any]:
+        return {
+            "apiVersion": "v1",
+            "kind": "ServiceAccount",
+            "metadata": {
+                "name": revision.spec["workloadIdentity"],
+                "namespace": self._k8s_namespace(revision.meta.namespace or ""),
+                "labels": {_LABEL_AGENT: revision.spec["agent"]},
+            },
+        }
+
+    def _render_deployment(self, revision: Resource) -> dict[str, Any]:
+        spec = revision.spec
+        k8s_ns = self._k8s_namespace(revision.meta.namespace or "")
+        name = self._deployment_name(revision)
+        labels = {
+            _LABEL_AGENT: spec["agent"],
+            _LABEL_REVISION_UID: revision.meta.uid,
+        }
+        container: dict[str, Any] = {
+            "name": "harness",
+            "image": spec["harness"]["image"],
+            "env": [
+                {"name": "HERMES_REVISION_UID", "value": revision.meta.uid},
+                {"name": "HERMES_NAMESPACE", "value": revision.meta.namespace},
+            ],
+        }
+        resources = self._render_resources(spec.get("sandboxPolicy") or {})
+        if resources:
+            container["resources"] = resources
+        return {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": name, "namespace": k8s_ns, "labels": dict(labels)},
+            "spec": {
+                # Candidate workloads must not run the harness: zero replicas.
+                "replicas": 0,
+                "selector": {"matchLabels": dict(labels)},
+                "template": {
+                    "metadata": {"labels": dict(labels)},
+                    "spec": {
+                        "serviceAccountName": spec["workloadIdentity"],
+                        "containers": [container],
+                    },
+                },
+            },
+        }
+
+    @staticmethod
+    def _render_resources(policy: dict[str, Any]) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        for section in ("requests", "limits"):
+            values = policy.get("resources", {}).get(section)
+            if isinstance(values, dict) and values:
+                out[section] = dict(values)
+        return out
+
+    # -- ComputeDriver interface --------------------------------------------
+
+    def provision_candidate(self, revision: Resource) -> WorkloadRef:
+        k8s_ns = self._k8s_namespace(revision.meta.namespace or "")
+        # ServiceAccount first: the Deployment's pod spec references it.
+        self._kubectl(
+            ["apply", "-f", "-"],
+            stdin=json.dumps(self._render_service_account(revision)),
+        )
+        self._kubectl(
+            ["apply", "-f", "-"],
+            stdin=json.dumps(self._render_deployment(revision)),
+        )
+        return WorkloadRef(
+            revision_uid=revision.meta.uid,
+            namespace=revision.meta.namespace or "",
+            workload_identity=revision.spec["workloadIdentity"],
+            driver=self.name,
+            handle={
+                "deployment": self._deployment_name(revision),
+                "k8s_namespace": k8s_ns,
+            },
+        )
+
+    def _get_deployment(self, ref: WorkloadRef) -> dict[str, Any]:
+        out = self._kubectl(
+            [
+                "get",
+                "deployment",
+                ref.handle["deployment"],
+                "-n",
+                ref.handle["k8s_namespace"],
+                "-o",
+                "json",
+            ]
+        )
+        try:
+            return json.loads(out)
+        except json.JSONDecodeError as exc:
+            raise DriverError(f"unparseable deployment state: {exc}") from exc
+
+    def workload_ready(self, ref: WorkloadRef) -> bool:
+        obj = self._get_deployment(ref)
+        generation = obj.get("metadata", {}).get("generation", 0)
+        observed = obj.get("status", {}).get("observedGeneration", -1)
+        return observed >= generation
+
+    def start_harness(self, ref: WorkloadRef) -> None:
+        self._scale(ref, 1)
+        deadline = time.monotonic() + self.start_timeout
+        while True:
+            status = self._get_deployment(ref).get("status", {})
+            if status.get("availableReplicas") == 1:
+                return
+            if time.monotonic() >= deadline:
+                raise DriverError(
+                    f"harness for revision {ref.revision_uid} did not become "
+                    f"available within {self.start_timeout}s"
+                )
+            time.sleep(self.poll_interval)
+
+    def stop_harness(self, ref: WorkloadRef) -> None:
+        self._scale(ref, 0)
+        deadline = time.monotonic() + self.start_timeout
+        while True:
+            status = self._get_deployment(ref).get("status", {})
+            if not status.get("replicas"):  # 0 or absent => stopped
+                return
+            if time.monotonic() >= deadline:
+                raise DriverError(
+                    f"harness for revision {ref.revision_uid} did not stop "
+                    f"within {self.start_timeout}s"
+                )
+            time.sleep(self.poll_interval)
+
+    def teardown(self, ref: WorkloadRef) -> None:
+        self._kubectl(
+            [
+                "delete",
+                "deployment",
+                ref.handle["deployment"],
+                "-n",
+                ref.handle["k8s_namespace"],
+                "--ignore-not-found",
+            ]
+        )
+
+    # -- internals ----------------------------------------------------------
+
+    def _scale(self, ref: WorkloadRef, replicas: int) -> None:
+        self._kubectl(
+            [
+                "scale",
+                "deployment",
+                ref.handle["deployment"],
+                "-n",
+                ref.handle["k8s_namespace"],
+                f"--replicas={replicas}",
+            ]
+        )

--- a/tests/enterprise/test_compute_k8s.py
+++ b/tests/enterprise/test_compute_k8s.py
@@ -1,0 +1,323 @@
+"""Tests for the KubernetesComputeDriver (kubectl-backed)."""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from enterprise.contracts import WorkloadRef
+from enterprise.drivers.kubernetes import KubernetesComputeDriver
+from enterprise.errors import DriverError
+from enterprise.resources import Kind, Resource, ResourceMeta
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def make_revision(**spec_overrides) -> Resource:
+    spec = {
+        "agent": "support-bot",
+        "agentUid": "a" * 32,
+        "workloadIdentity": "wi-support-bot",
+        "harness": {"name": "hermes", "version": "1.9.0", "image": "ghcr.io/nous/hermes-harness:1.9.0"},
+        "configuration": {"config": {"model": "hermes-4"}},
+        "computeDriver": "kubernetes",
+        "sandboxDriver": "gvisor",
+        "sandboxPolicy": {
+            "network": "isolated",
+            "resources": {
+                "requests": {"cpu": "500m", "memory": "512Mi"},
+                "limits": {"cpu": "2", "memory": "2Gi"},
+            },
+        },
+    }
+    spec.update(spec_overrides)
+    res = Resource(
+        meta=ResourceMeta(
+            kind=Kind.AGENT_REVISION.value,
+            name="support-bot-rev-1",
+            namespace="acme",
+        ),
+        spec=spec,
+    )
+    res.validate()
+    return res
+
+
+class KubectlRecorder:
+    """Monkeypatch target for KubernetesComputeDriver._kubectl."""
+
+    def __init__(self, responses=None):
+        self.calls: list[tuple[list[str], str | None]] = []
+        self.responses = list(responses or [])
+
+    def __call__(self, args: list[str], stdin: str | None = None) -> str:
+        self.calls.append((list(args), stdin))
+        if self.responses:
+            resp = self.responses.pop(0)
+            if isinstance(resp, Exception):
+                raise resp
+            return resp
+        return ""
+
+
+def make_driver(recorder: KubectlRecorder, **kwargs) -> KubernetesComputeDriver:
+    driver = KubernetesComputeDriver(poll_interval=0.0, **kwargs)
+    driver._kubectl = recorder  # type: ignore[method-assign]
+    return driver
+
+
+def make_ref(driver: KubernetesComputeDriver, revision: Resource) -> WorkloadRef:
+    return WorkloadRef(
+        revision_uid=revision.meta.uid,
+        namespace="acme",
+        workload_identity=revision.spec["workloadIdentity"],
+        driver=driver.name,
+        handle={"deployment": "support-bot-" + revision.meta.uid[:12], "k8s_namespace": "hermes-acme"},
+    )
+
+
+def deployment_json(*, generation=3, observed=3, replicas=None, available=None) -> str:
+    status = {"observedGeneration": observed}
+    if replicas is not None:
+        status["replicas"] = replicas
+    if available is not None:
+        status["availableReplicas"] = available
+    return json.dumps(
+        {"metadata": {"generation": generation}, "status": status}
+    )
+
+
+# ---------------------------------------------------------------------------
+# provision_candidate
+# ---------------------------------------------------------------------------
+
+
+def test_provision_renders_zero_replica_deployment_from_revision():
+    revision = make_revision()
+    recorder = KubectlRecorder()
+    driver = make_driver(recorder)
+
+    ref = driver.provision_candidate(revision)
+
+    # Two applies: ServiceAccount first, then Deployment.
+    assert len(recorder.calls) == 2
+    for args, _ in recorder.calls:
+        assert args == ["apply", "-f", "-"]
+    sa = json.loads(recorder.calls[0][1])
+    dep = json.loads(recorder.calls[1][1])
+    assert sa["kind"] == "ServiceAccount"
+    assert dep["kind"] == "Deployment"
+    assert sa["metadata"]["name"] == "wi-support-bot"
+    assert sa["metadata"]["namespace"] == "hermes-acme"
+
+    # Candidate = harness cannot start = zero replicas.
+    assert dep["spec"]["replicas"] == 0
+    assert dep["metadata"]["namespace"] == "hermes-acme"
+
+    labels = dep["metadata"]["labels"]
+    assert labels["app.hermes/agent"] == "support-bot"
+    assert labels["app.hermes/revision-uid"] == revision.meta.uid
+
+    pod = dep["spec"]["template"]["spec"]
+    assert pod["serviceAccountName"] == "wi-support-bot"
+    container = pod["containers"][0]
+    assert container["image"] == "ghcr.io/nous/hermes-harness:1.9.0"
+    env = {e["name"]: e["value"] for e in container["env"]}
+    assert env == {
+        "HERMES_REVISION_UID": revision.meta.uid,
+        "HERMES_NAMESPACE": "acme",
+    }
+    assert container["resources"] == {
+        "requests": {"cpu": "500m", "memory": "512Mi"},
+        "limits": {"cpu": "2", "memory": "2Gi"},
+    }
+
+    # Returned handle points at what was applied.
+    assert ref.driver == "kubernetes"
+    assert ref.revision_uid == revision.meta.uid
+    assert ref.handle["k8s_namespace"] == "hermes-acme"
+    assert ref.handle["deployment"] == dep["metadata"]["name"]
+
+
+def test_provision_without_sandbox_policy_omits_resources():
+    revision = make_revision()
+    del revision.spec["sandboxPolicy"]
+    recorder = KubectlRecorder()
+    make_driver(recorder).provision_candidate(revision)
+    dep = json.loads(recorder.calls[1][1])
+    assert "resources" not in dep["spec"]["template"]["spec"]["containers"][0]
+
+
+def test_manifests_contain_no_secretlike_env_values():
+    revision = make_revision()
+    recorder = KubectlRecorder()
+    make_driver(recorder).provision_candidate(revision)
+    secretlike = re.compile(r"(api[_-]?key|token|password|secret|credential)", re.I)
+    for _, stdin in recorder.calls:
+        manifest = json.loads(stdin)
+        containers = (
+            manifest.get("spec", {})
+            .get("template", {})
+            .get("spec", {})
+            .get("containers", [])
+        )
+        for container in containers:
+            for env in container.get("env", []):
+                assert not secretlike.search(env["name"]), env
+        # Nothing secret-like anywhere in the serialized manifest keys/values.
+        assert not secretlike.search(stdin)
+
+
+# ---------------------------------------------------------------------------
+# workload_ready
+# ---------------------------------------------------------------------------
+
+
+def test_workload_ready_true_when_observed_generation_caught_up():
+    revision = make_revision()
+    recorder = KubectlRecorder([deployment_json(generation=2, observed=2)])
+    driver = make_driver(recorder)
+    assert driver.workload_ready(make_ref(driver, revision)) is True
+    args, _ = recorder.calls[0]
+    assert args[:2] == ["get", "deployment"]
+    assert "-o" in args and "json" in args
+    assert "hermes-acme" in args
+
+
+def test_workload_ready_false_when_observed_generation_stale():
+    revision = make_revision()
+    recorder = KubectlRecorder([deployment_json(generation=5, observed=4)])
+    driver = make_driver(recorder)
+    assert driver.workload_ready(make_ref(driver, revision)) is False
+
+
+# ---------------------------------------------------------------------------
+# start / stop harness
+# ---------------------------------------------------------------------------
+
+
+def test_start_harness_scales_to_one_and_polls_until_available():
+    revision = make_revision()
+    recorder = KubectlRecorder(
+        [
+            "",  # scale
+            deployment_json(replicas=1, available=None),
+            deployment_json(replicas=1, available=0),
+            deployment_json(replicas=1, available=1),
+        ]
+    )
+    driver = make_driver(recorder)
+    driver.start_harness(make_ref(driver, revision))
+
+    scale_args = recorder.calls[0][0]
+    assert scale_args[:2] == ["scale", "deployment"]
+    assert "--replicas=1" in scale_args
+    # Polled three times before availability.
+    gets = [args for args, _ in recorder.calls[1:]]
+    assert all(args[:2] == ["get", "deployment"] for args in gets)
+    assert len(gets) == 3
+
+
+def test_start_harness_times_out_with_driver_error():
+    revision = make_revision()
+    recorder = KubectlRecorder(["", *[deployment_json(replicas=1, available=0)] * 50])
+    driver = make_driver(recorder, start_timeout=0.0)
+    with pytest.raises(DriverError, match="did not become available"):
+        driver.start_harness(make_ref(driver, revision))
+
+
+def test_stop_harness_scales_to_zero_and_verifies_stopped():
+    revision = make_revision()
+    recorder = KubectlRecorder(
+        [
+            "",  # scale
+            deployment_json(replicas=1),
+            deployment_json(replicas=0),
+        ]
+    )
+    driver = make_driver(recorder)
+    driver.stop_harness(make_ref(driver, revision))
+    assert "--replicas=0" in recorder.calls[0][0]
+    assert len(recorder.calls) == 3  # verified via polling, not assumed
+
+
+def test_stop_harness_timeout_raises_driver_error():
+    revision = make_revision()
+    recorder = KubectlRecorder(["", *[deployment_json(replicas=1)] * 50])
+    driver = make_driver(recorder, start_timeout=0.0)
+    with pytest.raises(DriverError, match="did not stop"):
+        driver.stop_harness(make_ref(driver, revision))
+
+
+# ---------------------------------------------------------------------------
+# teardown / error handling
+# ---------------------------------------------------------------------------
+
+
+def test_teardown_deletes_with_ignore_not_found():
+    revision = make_revision()
+    recorder = KubectlRecorder()
+    driver = make_driver(recorder)
+    driver.teardown(make_ref(driver, revision))
+    args = recorder.calls[0][0]
+    assert args[:2] == ["delete", "deployment"]
+    assert "--ignore-not-found" in args
+
+
+def test_kubectl_failure_surfaces_as_driver_error():
+    revision = make_revision()
+    recorder = KubectlRecorder([DriverError("kubectl apply failed (exit 1): forbidden")])
+    driver = make_driver(recorder)
+    with pytest.raises(DriverError, match="forbidden"):
+        driver.provision_candidate(revision)
+
+
+def test_real_kubectl_wrapper_nonzero_exit_raises(monkeypatch):
+    """Exercise the actual _kubectl subprocess seam (no monkeypatched seam)."""
+    import subprocess
+
+    driver = KubernetesComputeDriver(kubectl_path="kubectl")
+
+    class Proc:
+        returncode = 1
+        stdout = ""
+        stderr = "error: the server doesn't have a resource type"
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: Proc())
+    with pytest.raises(DriverError, match="exit 1"):
+        driver._kubectl(["get", "deployment", "x"])
+
+
+def test_kubectl_command_includes_kubeconfig_and_context(monkeypatch):
+    import subprocess
+
+    seen = {}
+
+    class Proc:
+        returncode = 0
+        stdout = "{}"
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
+        return Proc()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    driver = KubernetesComputeDriver(
+        kubectl_path="/usr/local/bin/kubectl",
+        kubeconfig="/tmp/kc",
+        context="prod",
+    )
+    driver._kubectl(["get", "ns"])
+    assert seen["cmd"][:5] == [
+        "/usr/local/bin/kubectl",
+        "--kubeconfig",
+        "/tmp/kc",
+        "--context",
+        "prod",
+    ]


### PR DESCRIPTION
## Summary
The v1 `ComputeDriver`: provisions candidate workloads on Kubernetes via `kubectl` (no python k8s dependency). Candidates are created at `replicas: 0` — the harness literally cannot start until the controller activates the revision and the driver scales to 1.

Stacked on #85461 (`ent/core`). Part of the one-wave Enterprise draft series.

## Changes
- `enterprise/drivers/kubernetes.py`: ServiceAccount + Deployment (JSON on stdin) with `app.hermes/*` labels, workload-identity SA, sandbox resource limits; readiness via observedGeneration; `start_harness` scales 0→1 with bounded polling; `stop_harness` verifies zero; teardown `--ignore-not-found`; any nonzero kubectl exit ⇒ `DriverError` with stderr.
- Single `_kubectl()` seam for testability; secrets never appear in manifests.

## Validation
| | Result |
|---|---|
| `tests/enterprise/test_compute_k8s.py` | 13/13 pass (manifest render from a real AgentRevision, ordering, timeouts, error paths) |
| ruff | clean |

## Infographic

![Kubernetes compute driver](https://files.catbox.moe/fzsuir.png)
