### PR TITLE
docs(enterprise): overview, concepts, deployment, installation, security

### DIFF
--- a/website/docs/enterprise/concepts.md
+++ b/website/docs/enterprise/concepts.md
@@ -1,0 +1,63 @@
+---
+sidebar_position: 2
+title: "Concepts & Resource Model"
+description: "Hermes Enterprise resource kinds, IAM entities, and the fail-closed philosophy"
+---
+
+# Concepts & Resource Model
+
+:::warning Status: draft / under development
+
+This section documents Hermes Enterprise while its components are still landing as in-flight pull requests. Interfaces, commands, and resource shapes described here may change before release.
+
+:::
+
+Hermes Enterprise is driven by a declarative resource model. You declare resources; the controller reconciles them into running workloads. Every resource is an envelope of **metadata + kind-specific spec + controller-owned status**, and names must be lowercase DNS-1123 labels.
+
+Resources live in one of two scopes:
+
+- **Installation scope** — global to the control plane (Namespace, Harness).
+- **Namespace scope** — owned by a single tenant (everything else).
+
+Cross-namespace references are rejected. A resource in `tenant-a` can never point at a resource in `tenant-b`.
+
+## Resource kinds
+
+| Kind | Scope | What it is |
+|---|---|---|
+| **Namespace** | Installation | A tenant boundary. Maps 1:1 to a Kubernetes namespace holding that tenant's gateway and agent workloads. All namespace-scoped resources live inside exactly one. |
+| **Configuration** | Namespace | A named bundle of agent configuration (models, tools, behavior settings) that agents reference. Versioned by the store; deploys snapshot it. |
+| **Agent** | Namespace | The declared intent for a running agent: which Configuration, Harness, Channels, and policies it uses. Mutable — editing an Agent does not change anything running until a deploy creates a new revision. |
+| **AgentRevision** | Namespace | An **immutable snapshot** of an Agent and everything it referenced at deploy time. What actually runs. Revisions are never edited; rolling forward or back means activating a different revision. |
+| **Harness** | Installation | A registered hermes-agent runtime image/version that revisions pin to. Registering a harness makes a runtime version available; it grants nothing by itself. |
+| **Channel** | Namespace | An ingress/egress binding for an agent (e.g. a messaging platform connection) attached to the namespace's gateway. |
+| **Secret** | Namespace | A named reference to a value held in an external backend. The control plane stores the *reference*, never the value. |
+| **SecretBroker** | Namespace | The broker configuration that performs operations against secret backends on a workload's behalf. **Secret values never enter agent workloads** — workloads ask the broker to *use* a secret (sign, inject at the proxy, exchange), and only the broker touches the backend. |
+| **SandboxPolicy** | Namespace | Containment requirements for agent workloads (isolation level, filesystem/network constraints). A policy is **verified against the live workload before it is allowed to start serving** — an unverifiable policy means the workload does not start. |
+| **Restriction** | Installation or Namespace | A constraint layered on top of existing grants, expressed as `<action>:<kind>[:<name>]` patterns. A Restriction **narrows what is already allowed — it never grants anything**. Installation-scoped restrictions bound every namespace; namespace-scoped ones bound only their tenant. |
+
+## IAM entities
+
+Identity and access are modeled separately from the resource kinds above:
+
+| Entity | What it is |
+|---|---|
+| **Principal** | A human identity, established by OIDC verification at the access gateway. |
+| **ServicePrincipal** | A non-human caller (CI systems, external automation) with its own credentials and bindings. |
+| **WorkloadIdentity** | The identity a running agent workload holds. This is how a workload authenticates to the broker and controller — it is never a user's identity. |
+| **Group** | A set of principals, typically mapped from the identity provider's claims. |
+| **Role** | A named bundle of allowed actions on resource kinds. |
+| **AccessBinding** | Attaches a Role to a Principal, ServicePrincipal, or Group within a scope. Nothing is permitted without a binding. |
+
+## Fail-closed philosophy
+
+Every decision point in the control plane defaults to **no**:
+
+- A request with no verifiable identity is rejected at the access gateway — it never reaches the controller.
+- An action with no matching AccessBinding is denied. There are no implicit or default grants.
+- Restrictions can only subtract from that result, never add to it.
+- A SandboxPolicy that cannot be verified against the running workload prevents the workload from serving.
+- A dangling or cross-namespace reference fails validation at write time rather than being resolved leniently later.
+- A driver (compute, sandbox, secret) that is not explicitly selected for a capability is an error, not a fallback.
+
+The practical consequence: misconfiguration in Hermes Enterprise manifests as *things refusing to start or serve*, not as workloads quietly running with broader access than intended.

--- a/website/docs/enterprise/deployment.md
+++ b/website/docs/enterprise/deployment.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 3
+title: "Deployment Choreography"
+description: "How an AgentRevision goes live: staged deploy choreography, rollback semantics, and failure behavior at each stage"
+---
+
+# Deployment Choreography
+
+:::warning Status: draft / under development
+
+This section documents Hermes Enterprise while its components are still landing as in-flight pull requests. Interfaces, commands, and resource shapes described here may change before release.
+
+:::
+
+Deploying an agent in Hermes Enterprise never mutates a running workload. A deploy creates an immutable [AgentRevision](./concepts.md) and walks it through a fixed sequence of stages. Each stage must fully succeed before the next begins, and each stage has a defined answer to "what is left behind if this fails?"
+
+## The stages
+
+```mermaid
+flowchart LR
+    A[Candidate<br/>provisioned] --> B[Containment<br/>verified]
+    B --> C[Route prepared<br/>nonserving]
+    C --> D[Previous<br/>retired]
+    D --> E[Activate]
+    E --> F[Route<br/>enabled]
+```
+
+1. **Candidate provisioned.** The controller snapshots the Agent and its references into a new AgentRevision and asks the compute driver to provision the candidate workload in the tenant's namespace. The candidate exists but serves nothing.
+2. **Containment verified.** The sandbox driver enforces the revision's SandboxPolicy and then independently **verifies** it against the live candidate. Verification is a separate step from enforcement — the controller does not trust that enforcement worked; it checks.
+3. **Route prepared (nonserving).** The namespace gateway learns the route to the candidate but keeps it disabled. No traffic flows yet; this proves the routing configuration is valid before anything depends on it.
+4. **Previous retired.** The currently active revision (if any) is taken out of service. This is the start of the cutover window.
+5. **Activate.** The candidate revision is marked active — it becomes the revision of record for the agent.
+6. **Route enabled.** The gateway enables the prepared route and traffic flows to the new revision. The deploy is complete.
+
+The ordering is deliberate: everything that can be checked without touching live traffic (provisioning, containment, routing config) happens **before** the previous revision is disturbed. The window in which the agent is not serving is confined to stages 4–6.
+
+## Failure at each stage
+
+| Stage that failed | What is left behind | Serving impact |
+|---|---|---|
+| Candidate provisioned | A failed revision record; any partial workload is torn down by the compute driver. | None — previous revision still serving. |
+| Containment verified | The candidate workload, stopped and torn down; the revision marked failed with the verification error. **An unverified workload never starts serving.** | None — previous revision still serving. |
+| Route prepared | Candidate torn down; the prepared (disabled) route removed from the gateway. | None — previous revision still serving. |
+| Previous retired | Candidate is up and verified but the old revision may already be out of service. The controller proceeds to activate the candidate rather than resurrect the old one — forward is the recovery path at this point. | Brief gap possible. |
+| Activate | Candidate verified and routed-nonserving; activation is retried. The store's revision phase records exactly where things stopped. | Gap until activation completes or an operator intervenes. |
+| Route enabled | New revision is active but unreachable until the route flip is retried. | Gap until the route is enabled. |
+
+Two invariants hold throughout:
+
+- **Failure before retirement is invisible to users.** Stages 1–3 can fail all day; the previous revision keeps serving untouched.
+- **Nothing unverified ever serves.** The route to a candidate is not enabled unless containment verification passed for that exact workload.
+
+## Rollback semantics
+
+Because revisions are immutable, rollback is not an "undo" — it is **a new deploy of a previous revision**:
+
+- `agent deploy` targeting an earlier revision walks that revision's snapshot through the same six stages, including fresh containment verification. A revision that passed verification last month is re-verified today.
+- There is no partial rollback: configuration, harness version, channels, and policies travel together in the snapshot. You get back exactly what that revision was.
+- Failed candidate revisions are kept as records (spec + failure reason) for audit, but they hold no compute — teardown is part of failure handling, not a separate cleanup task.
+
+The result is that the fleet's state is always describable as "revision X is active for agent Y," never as an in-between blend of two versions.

--- a/website/docs/enterprise/installation.md
+++ b/website/docs/enterprise/installation.md
@@ -1,0 +1,99 @@
+---
+sidebar_position: 4
+title: "Installation"
+description: "Install Hermes Enterprise on Kubernetes with Helm, configure OIDC trust, and deploy your first agent"
+---
+
+# Installation
+
+:::warning Status: draft / under development
+
+This section documents Hermes Enterprise while its components are still landing as in-flight pull requests. Interfaces, commands, and resource shapes described here may change before release.
+
+:::
+
+Hermes Enterprise installs onto an existing Kubernetes cluster with Helm. The chart lives at `deploy/enterprise/helm` and ships with the enterprise packaging.
+
+## Prerequisites
+
+- A Kubernetes cluster (1.28+) you have admin access to, with a working ingress controller
+- Helm 3
+- An OIDC identity provider (issuer URL + a client/audience for Hermes Enterprise)
+- `kubectl` context pointing at the target cluster
+
+## Helm quickstart
+
+```bash
+helm install hermes-enterprise ./deploy/enterprise/helm \
+  --namespace hermes-system \
+  --create-namespace \
+  --values values.yaml
+```
+
+This installs the controller and the access gateway into `hermes-system`. Tenant namespaces are **not** created by the chart — they are created later through the control plane, which provisions the per-tenant Kubernetes namespace, gateway, and workloads itself.
+
+## OIDC trust configuration
+
+The access gateway admits a request only when it can verify the caller's token against a configured trust and map the identity to a tenant. Configure trust in your `values.yaml`:
+
+```yaml
+accessGateway:
+  oidc:
+    issuer: "https://login.example.com/realms/acme"
+    audience: "hermes-enterprise"
+    # Map verified identities to tenant namespaces.
+    tenantMap:
+      # by claim: members of these IdP groups land in these namespaces
+      claim: "groups"
+      rules:
+        - match: "acme-research"
+          namespace: "research"
+        - match: "acme-support"
+          namespace: "support"
+```
+
+Fail-closed rules apply: a token from any other issuer, with the wrong audience, or whose claims match no tenant rule is rejected at the gateway. There is no default tenant.
+
+## First namespace and first agent
+
+The enterprise CLI drives the control plane. Run it from the repo (or the packaged wheel) with a kube context that can reach the controller:
+
+```bash
+# 1. Initialize the control plane store and register your identity as the
+#    initial administrator.
+python -m enterprise.cli init
+
+# 2. Create a tenant namespace. This provisions the Kubernetes namespace
+#    and the per-tenant gateway.
+python -m enterprise.cli ns create research
+
+# 3. Register a Harness — the hermes-agent runtime version agents will run.
+python -m enterprise.cli harness register hermes-agent:1.9.0
+
+# 4. Put a Configuration into the namespace (models, tools, behavior).
+python -m enterprise.cli config put research/default --file ./agent-config.yaml
+
+# 5. Declare an Agent that ties the configuration and harness together.
+python -m enterprise.cli agent create research/assistant \
+  --config default \
+  --harness hermes-agent:1.9.0
+
+# 6. Deploy. This creates an immutable AgentRevision and walks it through
+#    the deploy choreography.
+python -m enterprise.cli agent deploy research/assistant
+```
+
+The deploy command reports each stage as it completes (candidate → containment verified → route prepared → previous retired → activate → route enabled). See [Deployment Choreography](./deployment.md) for what each stage means and how failures behave.
+
+Once the route is enabled, users whose OIDC identity maps to the `research` tenant can reach the agent through the ingress.
+
+## Verifying the install
+
+- `kubectl get pods -n hermes-system` — controller and access gateway should be `Running`.
+- `python -m enterprise.cli ns create <name>` failing with an authorization error means your identity has no AccessBinding — re-run `init` checks or ask an admin for a binding; this is the fail-closed model working as intended.
+- Deploy stalls at *containment verified* mean the SandboxPolicy could not be verified against the candidate workload; the candidate is torn down and the previous revision (if any) keeps serving.
+
+## Next steps
+
+- [Concepts & Resource Model](./concepts.md) — what each resource kind does
+- [Security Model](./security.md) — trust boundaries, secret brokering, audit

--- a/website/docs/enterprise/overview.md
+++ b/website/docs/enterprise/overview.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 1
+title: "Enterprise Overview"
+description: "Hermes Enterprise — a multi-tenant control plane that deploys the hermes-agent runtime per tenant namespace on Kubernetes"
+---
+
+# Hermes Enterprise Overview
+
+:::warning Status: draft / under development
+
+This section documents Hermes Enterprise while its components are still landing as in-flight pull requests. Interfaces, commands, and resource shapes described here may change before release.
+
+:::
+
+Hermes Enterprise is a **multi-tenant control plane** for running fleets of Hermes agents inside an organization. It takes the same hermes-agent runtime you run on a laptop — referred to in enterprise contexts as the **Harness** — and deploys it per tenant **Namespace** on Kubernetes, with centralized identity, configuration, secret brokering, sandbox verification, and audit.
+
+The single-user product does not change: your local CLI, TUI, desktop app, and personal gateway remain single-tenant by design. Enterprise is a separate control plane *around* the runtime, not a rewrite of it.
+
+## What it adds
+
+| Capability | Single-user Hermes | Hermes Enterprise |
+|---|---|---|
+| Tenancy | One user, one machine | Many tenants, each isolated in a Namespace |
+| Identity | Local OS user / platform allowlists | OIDC-verified principals, groups, roles, access bindings |
+| Deployment | `hermes update` in place | Immutable AgentRevisions with staged deploy choreography |
+| Secrets | Local `.env` / secret sources | Brokered secrets — values never enter agent workloads |
+| Sandbox | Local Docker/Modal settings | SandboxPolicy verified before a workload may start |
+| Audit | Session logs | Structured audit trail (no secrets, no message contents) |
+
+## Architecture
+
+The control plane is a **controller** that reconciles declarative resources into per-namespace workloads. All traffic enters through an **access gateway** that verifies OIDC tokens and performs tenant admission before anything reaches the controller.
+
+```mermaid
+flowchart TB
+    U[Users / Clients] --> I[Ingress]
+    I --> AG["Access Gateway<br/>OIDC verification + tenant admission"]
+    AG --> C[Controller]
+    C --> NS1
+    C --> NS2
+    subgraph NS1["Namespace: tenant-a"]
+        G1[Gateway] --> A1[Agent workloads<br/>Harness]
+    end
+    subgraph NS2["Namespace: tenant-b"]
+        G2[Gateway] --> A2[Agent workloads<br/>Harness]
+    end
+```
+
+- **Ingress** terminates external traffic and routes it to the access gateway.
+- The **access gateway** verifies the caller's OIDC token against the configured issuer and audience, maps the identity to a tenant, and rejects anything it cannot positively admit. Requests without a verified tenant identity never reach the controller.
+- The **controller** owns the resource store, runs the deploy choreography, and drives compute, sandbox, and secret drivers.
+- Each tenant Namespace gets its own **gateway** and **agent workloads** (the Harness) on Kubernetes — tenants never share a runtime process.
+
+:::note Single-user gateway stays single-tenant
+
+The existing hermes-agent messaging gateway is, and remains, **single-tenant by design**. Enterprise does not retrofit multi-tenancy into it; instead the controller deploys a dedicated gateway per Namespace. If you run personal Hermes today, nothing about your setup changes.
+
+:::
+
+## Design principles
+
+- **Fail closed.** Unknown identities, unverified sandboxes, and unresolvable references are rejected, never defaulted. See [Concepts & Resource Model](./concepts.md).
+- **Immutable deploys.** Agents roll forward through immutable [AgentRevisions](./concepts.md) using a staged [deploy choreography](./deployment.md) with well-defined rollback semantics.
+- **Secrets stay out of workloads.** Secret values are brokered — workloads request *operations*, never raw values. See [Security Model](./security.md).
+- **Narrow v1 scope.** No cross-namespace references, no external IAM adapters beyond OIDC, no non-Kubernetes compute. The [security page](./security.md) lists these exclusions explicitly.
+
+## Where to go next
+
+- [Concepts & Resource Model](./concepts.md) — the resource kinds and IAM entities
+- [Deployment Choreography](./deployment.md) — how an agent revision goes live
+- [Installation](./installation.md) — Helm quickstart and first agent walkthrough
+- [Security Model](./security.md) — trust boundaries and audit guarantees

--- a/website/docs/enterprise/security.md
+++ b/website/docs/enterprise/security.md
@@ -1,0 +1,65 @@
+---
+sidebar_position: 5
+title: "Security Model"
+description: "Hermes Enterprise trust boundaries, secret brokering, sandbox verification, audit guarantees, and explicit v1 exclusions"
+---
+
+# Security Model
+
+:::warning Status: draft / under development
+
+This section documents Hermes Enterprise while its components are still landing as in-flight pull requests. Interfaces, commands, and resource shapes described here may change before release.
+
+:::
+
+Hermes Enterprise is built fail-closed: every boundary defaults to deny, and anything that cannot be positively verified does not run. This page maps the trust boundaries and states plainly what the system guarantees — and what it deliberately does not attempt in v1.
+
+## Trust boundaries
+
+| Boundary | Trusts | Is trusted for | Never trusted for |
+|---|---|---|---|
+| **Identity provider (OIDC)** | — (external root of trust) | Authenticating who a caller is (issuer, audience, claims) | Authorization decisions — the IdP says *who*, never *what they may do* |
+| **Access gateway** | The configured OIDC issuer only | Token verification and tenant admission; rejecting everything unmappable | Resource-level authorization; it admits to a tenant, it does not grant actions |
+| **Controller** | Identities admitted by the access gateway | Authorization (roles, bindings, restrictions), the resource store, deploy choreography, audit emission | Holding secret values; executing tenant workloads itself |
+| **Drivers (compute / sandbox / secret)** | Controller instructions only | Their single capability: provisioning workloads, enforcing+verifying containment, performing secret operations | Making policy decisions; a driver executes, the controller decides |
+| **Kubernetes** | Cluster admin configuration | Namespace isolation primitives, workload scheduling, network policy enforcement | Tenant admission or identity — a workload's K8s service account is not a Hermes identity |
+
+Each layer only narrows what the layer above allowed. A compromised lower layer cannot mint identity or grants that the layers above never issued.
+
+## Secret brokering
+
+Secret values **never enter agent workloads**. The model:
+
+1. A `Secret` resource is a *reference* — backend + key — not a value. The control plane store never contains secret material.
+2. A `SecretBroker` in the tenant namespace is the only component that talks to the secret backend.
+3. A workload, authenticated by its `WorkloadIdentity`, asks the broker to **use** a secret for a named operation (inject a credential at the egress proxy, sign a request, perform an exchange). The broker performs the operation and returns the *result*, never the value.
+4. Whether a secret exists can be checked; what it contains cannot be read through the control plane at all.
+
+Consequences: a fully compromised agent workload can abuse the operations its bindings allow (visible in audit), but it cannot exfiltrate the underlying credentials, and rotation happens in the backend without touching workloads.
+
+## Sandbox verification
+
+Enforcement and verification are separate steps, performed by the sandbox driver during deploy:
+
+- **Enforce** applies the `SandboxPolicy` to the candidate workload.
+- **Verify** independently checks the live workload against the policy afterward.
+
+A candidate that fails verification is torn down and never serves — the route to it is not enabled. Verification runs on every deploy, including rollbacks to previously verified revisions. See [Deployment Choreography](./deployment.md).
+
+## Audit guarantees
+
+The controller emits a structured audit event for every control-plane action and every brokered secret operation. Guarantees:
+
+- **No secret values in audit.** Events record *that* a secret was used, by which workload identity, for which operation — never the material.
+- **No message contents in audit.** Conversations between users and agents are not part of the audit stream. Audit covers control-plane and broker activity, not chat transcripts.
+- Events record the acting identity, the action, the target resource, and the outcome — including denials, so fail-closed rejections are observable.
+
+## What Hermes Enterprise does NOT do in v1
+
+Stated explicitly so nobody designs around a capability that is not there:
+
+- **No cross-namespace references.** A resource in one namespace can never reference a resource in another. There is no sharing mechanism, no "global" configuration a tenant can import.
+- **No external IAM adapters.** Identity comes from OIDC verification at the access gateway; authorization is the built-in Role/AccessBinding/Restriction model. There are no plug-in adapters for external policy engines or enterprise IAM suites in v1.
+- **No non-Kubernetes compute.** The compute driver targets Kubernetes namespaces only. No VM fleets, no serverless backends, no bare-metal scheduling.
+
+These are scope boundaries, not oversights — the contracts (driver registry, IAM interfaces) are designed so later versions can widen them without changing the trust model above.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -740,6 +740,18 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: 'Enterprise',
+      collapsed: true,
+      items: [
+        'enterprise/overview',
+        'enterprise/concepts',
+        'enterprise/deployment',
+        'enterprise/installation',
+        'enterprise/security',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Developer Guide',
       collapsed: true,
       items: [


### PR DESCRIPTION
## Summary
Docs-site section for Hermes Enterprise: five pages (overview, concepts, deployment, installation, security) registered as a new **Enterprise** sidebar category. All pages carry a draft-status admonition since they document the in-flight `ent/*` series.

Stacked on #85461 (`ent/core`). Part of the one-wave Enterprise draft series.

## Changes
- `website/docs/enterprise/`: architecture + choreography mermaid diagrams, resource-model and IAM reference tables grounded in the `ent/core` contracts, trust-boundary table, explicit v1 non-goals.
- `website/sidebars.ts`: Enterprise category registered (pages reachable).

## Validation
| | Result |
|---|---|
| `npx docusaurus build` | SUCCESS (only pre-existing zh-Hans anchor warnings) |

## Infographic

![Enterprise docs](https://files.catbox.moe/8tprcw.png)
