### PR TITLE
fix(providers): deepseek reasoning passback condicional + effort off/high/max

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3417,6 +3417,37 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             dropped_empty_tool_calls,
         )
 
+    # --- Assistant content: "" never null on the wire ---
+    # Reasoning-only turns (the model answers entirely in the reasoning
+    # channel, e.g. a DeepSeek v4-flash greeting) and host-fed histories can
+    # persist assistant messages with explicit content=None.  OpenAI-compatible
+    # endpoints reject a null-content assistant turn that also lacks
+    # tool_calls ("content or tool_calls must be set" — DeepSeek 400), and
+    # strict gateways reject null outright.  The official DeepSeek samples
+    # replay text-less turns as content:"" — normalize an EXPLICIT None to ""
+    # here, on the per-call copy, so stored history (and prompt caching) stays
+    # byte-stable.  An ABSENT content key is left untouched: it serializes as
+    # an absent field (not null) and clean histories pass through by identity.
+    content_fixed = 0
+    normalized = []
+    for msg in messages:
+        if (
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and "content" in msg
+            and msg["content"] is None
+        ):
+            msg = {**msg, "content": ""}
+            content_fixed += 1
+        normalized.append(msg)
+    if content_fixed:
+        messages = normalized
+        _ra().logger.debug(
+            "Pre-call sanitizer: normalized content=None to '' on %d "
+            "assistant message(s)",
+            content_fixed,
+        )
+
     # --- Repair tool_calls whose function.name is empty/missing ---
     # Some providers (and partially-streamed responses) emit a tool_call with
     # id="call_xxx" but function.name="". Downstream Responses-API adapters
@@ -3710,12 +3741,18 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
 
     Forwarder — the strip-vs-repad POLICY is owned by
     ``agent.message_sanitization.apply_reasoning_content_policy`` (audit F4);
-    this only supplies the agent's cached provider-direction flag.
+    this only supplies the agent's cached provider-direction flag.  The
+    ``native_deepseek`` flag narrows the policy to the conditional passback
+    (reasoning_content dropped on plain, non-tool-call turns) for the native
+    DeepSeek API only.
     """
     from agent.message_sanitization import apply_reasoning_content_policy
 
     apply_reasoning_content_policy(
-        source_msg, api_msg, agent._needs_thinking_reasoning_pad()
+        source_msg,
+        api_msg,
+        agent._needs_thinking_reasoning_pad(),
+        native_deepseek=agent._is_native_deepseek_endpoint(),
     )
 
 
@@ -3741,6 +3778,12 @@ def reapply_reasoning_echo_for_provider(agent, api_messages: list) -> int:
       fallback bug from #45655 — a DeepSeek primary pads history with ``" "``,
       the request falls back to Mistral, and Mistral 422s on the stale pad.
 
+    On the NATIVE DeepSeek endpoint the reconciliation additionally applies
+    the conditional passback: plain (non-tool-call) assistant turns never
+    carry ``reasoning_content`` on the wire (the API ignores it there), so
+    pads baked in under a prior provider are stripped even though the
+    endpoint is a require-side one.
+
     Calling this immediately before building the request kwargs reconciles the
     fields against the *current* provider.  It is idempotent and safe to call
     every iteration; it covers every fallback path.
@@ -3751,7 +3794,9 @@ def reapply_reasoning_echo_for_provider(agent, api_messages: list) -> int:
     from agent.message_sanitization import reapply_reasoning_echo
 
     return reapply_reasoning_echo(
-        api_messages, agent._needs_thinking_reasoning_pad()
+        api_messages,
+        agent._needs_thinking_reasoning_pad(),
+        native_deepseek=agent._is_native_deepseek_endpoint(),
     )
 
 

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -643,12 +643,22 @@ def uniquify_tool_call_ids(tool_calls: list) -> list:
 #                aggregators re-exporting kimi models reject the echo.
 #     deepseek — provider "deepseek", model contains "deepseek", or host
 #                api.deepseek.com (#15250; V4 rejects empty-string pads,
-#                hence the " " single-space pad, #17341).
+#                hence the " " single-space pad, #17341).  The NATIVE
+#                endpoint (provider "deepseek" / api.deepseek.com host)
+#                additionally applies the conditional passback: plain
+#                non-tool-call turns drop reasoning_content (the API
+#                ignores it there — token savings); aggregator-hosted
+#                deepseek models (OpenRouter etc.) keep the legacy
+#                all-assistant echo.
 #     mimo     — provider "xiaomi", model contains "mimo", or host
 #                *.xiaomimimo.com.
 #   strict side (field rejected with 400/422 "Extra inputs are not
 #     permitted"): everyone else — Mistral, Cerebras, Groq, SambaNova, …
 #     (#45655). Strip the key entirely, even a single-space pad.
+
+# Hosts that serve the native DeepSeek API (also referenced by
+# ``is_native_deepseek_endpoint``).
+_DEEPSEEK_NATIVE_HOSTS = ("api.deepseek.com",)
 
 _REASONING_ECHO_RULES: tuple = (
     # (family, exact providers (raw), exact providers (lowered),
@@ -656,10 +666,26 @@ _REASONING_ECHO_RULES: tuple = (
     ("kimi", frozenset({"kimi-coding", "kimi-coding-cn"}), frozenset(), (),
      ("api.kimi.com", "moonshot.ai", "moonshot.cn")),
     ("deepseek", frozenset(), frozenset({"deepseek"}), ("deepseek",),
-     ("api.deepseek.com",)),
+     _DEEPSEEK_NATIVE_HOSTS),
     ("mimo", frozenset(), frozenset({"xiaomi"}), ("mimo",),
      ("api.xiaomimimo.com", "xiaomimimo.com")),
 )
+
+
+def is_native_deepseek_endpoint(provider: Any, base_url: Any) -> bool:
+    """True when the wire target is the native DeepSeek API.
+
+    Provider ``deepseek`` or the ``api.deepseek.com`` host.  Aggregators
+    re-exporting deepseek models (OpenRouter, custom proxies) return False —
+    they speak their own protocol and keep the legacy all-assistant echo
+    behavior.
+    """
+    from utils import base_url_host_matches
+
+    provider_lower = (provider or "").lower()
+    if provider_lower == "deepseek":
+        return True
+    return any(base_url_host_matches(base_url, host) for host in _DEEPSEEK_NATIVE_HOSTS)
 
 
 def _family_rule(family: str) -> tuple:
@@ -710,15 +736,37 @@ def needs_reasoning_echo(provider: Any, model: Any, base_url: Any) -> bool:
 
 
 def apply_reasoning_content_policy(
-    source_msg: dict, api_msg: dict, needs_thinking_pad: bool
+    source_msg: dict,
+    api_msg: dict,
+    needs_thinking_pad: bool,
+    *,
+    native_deepseek: bool = False,
 ) -> None:
     """Copy provider-facing reasoning fields onto an API replay message.
 
     ``needs_thinking_pad`` is the require-side flag (see
     ``needs_reasoning_echo`` / the agent's cached
     ``_needs_thinking_reasoning_pad``). Mutates ``api_msg`` in place.
+
+    ``native_deepseek`` narrows the require-side policy for the NATIVE
+    DeepSeek API: plain (non-tool-call) assistant turns drop
+    ``reasoning_content`` entirely — the API ignores the field there
+    (thinking-mode guide), so replaying it only burns input tokens.
+    Tool-call turns keep the full echo-back logic below (verbatim
+    reasoning, or the single-space pad).  Kimi / MiMo and aggregator-hosted
+    deepseek models keep the legacy all-assistant behavior.
     """
     if source_msg.get("role") != "assistant":
+        return
+
+    # Native DeepSeek thinking mode: reasoning_content is only meaningful on
+    # tool-call turns.  Plain turns never carry it on the wire — the API
+    # ignores it (guides/thinking_mode.mdx) and every replayed token is
+    # billed input.  The persisted message keeps the field (kimi/mimo replay
+    # and reasoning-only payload accounting still read it); only the wire
+    # copy drops it.
+    if native_deepseek and not source_msg.get("tool_calls"):
+        api_msg.pop("reasoning_content", None)
         return
 
     # 1. Explicit reasoning_content already set.
@@ -800,7 +848,9 @@ def apply_reasoning_content_policy(
     api_msg.pop("reasoning_content", None)
 
 
-def reapply_reasoning_echo(api_messages: list, needs_thinking_pad: bool) -> int:
+def reapply_reasoning_echo(
+    api_messages: list, needs_thinking_pad: bool, *, native_deepseek: bool = False
+) -> int:
     """Re-pad (or strip) assistant turns' reasoning_content for the active provider.
 
     ``api_messages`` is built once, before the retry loop, while the *primary*
@@ -822,6 +872,12 @@ def reapply_reasoning_echo(api_messages: list, needs_thinking_pad: bool) -> int:
       fallback bug from #45655 — a DeepSeek primary pads history with ``" "``,
       the request falls back to Mistral, and Mistral 422s on the stale pad.
 
+    ``native_deepseek`` applies the conditional passback for the native
+    DeepSeek API: plain (non-tool-call) assistant turns never carry
+    ``reasoning_content`` on the wire (the API ignores it there — token
+    savings), so any pad/text a prior provider's build baked into them is
+    stripped; tool-call turns keep the full echo-back logic.
+
     Calling this immediately before building the request kwargs reconciles the
     fields against the *current* provider.  It is idempotent and safe to call
     every iteration; it covers every fallback path.
@@ -832,6 +888,14 @@ def reapply_reasoning_echo(api_messages: list, needs_thinking_pad: bool) -> int:
     changed = 0
     for api_msg in api_messages:
         if api_msg.get("role") != "assistant":
+            continue
+        if native_deepseek and not api_msg.get("tool_calls"):
+            # Plain turn on the native DeepSeek wire: reasoning_content is
+            # ignored by the API there, so drop whatever the prior provider
+            # baked in (space pad, verbatim text, promoted reasoning).
+            if "reasoning_content" in api_msg:
+                api_msg.pop("reasoning_content", None)
+                changed += 1
             continue
         if needs_thinking_pad:
             if api_msg.get("reasoning_content"):

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -249,6 +249,13 @@ class ChatCompletionsTransport(ProviderTransport):
           gateways (e.g. opencode-go, codex.nekos.me) reject with
           ``Extra inputs are not permitted, field: 'messages[N]._empty_recovery_synthetic'``,
           which then poisons every subsequent request in the session.
+        - Assistant ``content: null`` → normalized to ``""``. Reasoning-only
+          turns (model answered entirely in the reasoning channel) and
+          host-fed histories can persist an explicit ``content=None``;
+          OpenAI-compatible endpoints reject a null-content assistant turn
+          that also lacks ``tool_calls`` ("content or tool_calls must be set"
+          — DeepSeek 400) and strict gateways reject null outright.  An
+          absent content key is left untouched.
         """
         strip_extra_content = not _model_consumes_thought_signature(
             kwargs.get("model")
@@ -268,6 +275,21 @@ class ChatCompletionsTransport(ProviderTransport):
                 needs_sanitize = True
                 break
             if any(isinstance(k, str) and k.startswith("_") for k in msg):
+                needs_sanitize = True
+                break
+            # Assistant turns must never carry content:null on the wire.
+            # Reasoning-only turns and host-fed histories can persist an
+            # explicit content=None; OpenAI-compat endpoints reject a
+            # null-content assistant turn that also lacks tool_calls
+            # ("content or tool_calls must be set" — DeepSeek 400), and
+            # strict gateways reject null outright.  An ABSENT content key is
+            # left untouched (serializes as absent, not null — clean histories
+            # pass through by identity).
+            if (
+                msg.get("role") == "assistant"
+                and "content" in msg
+                and msg["content"] is None
+            ):
                 needs_sanitize = True
                 break
             tool_calls = msg.get("tool_calls")
@@ -325,6 +347,17 @@ class ChatCompletionsTransport(ProviderTransport):
                 out_msg = mutable_msg()
                 for key in internal_keys:
                     out_msg.pop(key, None)
+
+            # Assistant turns must never carry content:null on the wire.
+            # Normalize an explicit None → "" (the official DeepSeek samples
+            # replay text-less turns as ""); the stored history stays
+            # untouched.  Absent content keys are left alone.
+            if (
+                msg.get("role") == "assistant"
+                and "content" in msg
+                and msg["content"] is None
+            ):
+                mutable_msg()["content"] = ""
 
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -7,11 +7,19 @@ replays history this lands on the notorious HTTP 400
 ``reasoning_content must be passed back`` error after the first tool call
 (#15700, #17212, #17825).
 
-This profile overrides :meth:`build_api_kwargs_extras` to mirror the Kimi /
-Moonshot wire shape that DeepSeek's OpenAI-compat endpoint expects:
+This profile overrides :meth:`build_api_kwargs_extras` to produce the exact
+wire shape DeepSeek's OpenAI-compat endpoint expects:
 
-    {"reasoning_effort": "<low|medium|high|max>",
+    {"reasoning_effort": "<high|max>",
      "extra_body": {"thinking": {"type": "enabled" | "disabled"}}}
+
+Effort vocabulary is the official DeepSeek one — ``off|high|max`` on the
+wire.  ``off`` (and the user-facing alias ``none``) disable thinking mode
+entirely, so no ``reasoning_effort`` is sent.  ``low`` / ``medium`` /
+``minimal`` normalize to ``high`` (DeepSeek maps them server-side to high
+anyway) and ``xhigh`` / ``ultra`` normalize to ``max``.  Any other value
+raises ``ValueError`` *before* any I/O so a bad config fails loudly instead
+of silently degrading to the server default.
 
 Non-thinking models (``deepseek-v3-*`` variants) are left as no-ops so we
 don't perturb the V3 wire format.
@@ -46,6 +54,26 @@ def _model_supports_thinking(model: str | None) -> bool:
     return False
 
 
+# Effort values that disable thinking mode entirely (official "off" plus the
+# user-facing "none" alias).  No reasoning_effort goes on the wire.
+_DEEPSEEK_DISABLE_EFFORTS = frozenset({"none", "off"})
+
+# User-facing effort → official DeepSeek wire vocabulary (off|high|max).
+# DeepSeek's server maps medium/xhigh to high (api-docs.deepseek.com, thinking
+# mode guide); low is normalized to high here too so the wire only ever
+# carries the official off|high|max set.  xhigh/ultra have historically
+# resolved to max in Hermes and keep doing so.
+_DEEPSEEK_EFFORT_ALIASES = {
+    "minimal": "high",
+    "low": "high",
+    "medium": "high",
+    "high": "high",
+    "xhigh": "max",
+    "max": "max",
+    "ultra": "max",
+}
+
+
 class DeepSeekProfile(ProviderProfile):
     """DeepSeek — extra_body.thinking + top-level reasoning_effort."""
 
@@ -66,21 +94,45 @@ class DeepSeekProfile(ProviderProfile):
         if isinstance(reasoning_config, dict) and reasoning_config.get("enabled") is False:
             enabled = False
 
-        extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
-
         if not enabled:
+            # Thinking off → explicit disabled marker (DeepSeek defaults to ON
+            # when the field is absent) and NO reasoning_effort on the wire —
+            # DeepSeek rejects effort alongside disabled thinking.
+            extra_body["thinking"] = {"type": "disabled"}
             return extra_body, top_level
 
-        # Effort mapping. Pass low/medium/high through; stronger levels → max.
-        # When no effort is set we omit reasoning_effort so DeepSeek applies
-        # its server default (currently high).
-        if isinstance(reasoning_config, dict):
-            effort = (reasoning_config.get("effort") or "").strip().lower()
-            if effort in {"xhigh", "max", "ultra"}:
-                top_level["reasoning_effort"] = "max"
-            elif effort in {"low", "medium", "high"}:
-                top_level["reasoning_effort"] = effort
+        effort = reasoning_config.get("effort") if isinstance(reasoning_config, dict) else None
+        if effort is None:
+            effort = ""
+        if not isinstance(effort, str):
+            effort = str(effort)
+        effort = effort.strip().lower()
 
+        if not effort:
+            # Unset → omit reasoning_effort so DeepSeek applies its server
+            # default (currently high).
+            extra_body["thinking"] = {"type": "enabled"}
+            return extra_body, top_level
+
+        if effort in _DEEPSEEK_DISABLE_EFFORTS:
+            # "off" / "none" → thinking disabled, no effort on the wire.
+            # Matches the official vocabulary: off is not a wire effort, it
+            # is the disabled switch.
+            extra_body["thinking"] = {"type": "disabled"}
+            return extra_body, top_level
+
+        mapped = _DEEPSEEK_EFFORT_ALIASES.get(effort)
+        if mapped is None:
+            # Invalid effort must fail BEFORE any I/O with a clear error —
+            # never silently degrade to the server default.
+            raise ValueError(
+                f"DeepSeek does not support reasoning effort {effort!r}; expected one of "
+                "off, none, minimal, low, medium, high, xhigh, max, ultra "
+                "(wire vocabulary: off|high|max)"
+            )
+
+        extra_body["thinking"] = {"type": "enabled"}
+        top_level["reasoning_effort"] = mapped
         return extra_body, top_level
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -7490,6 +7490,30 @@ class AIAgent:
             "mimo", (self.provider or "").lower(), self.model, self.base_url
         )
 
+    def _is_native_deepseek_endpoint(self) -> bool:
+        """Return True when the wire target is the native DeepSeek API.
+
+        Provider ``deepseek`` or the ``api.deepseek.com`` host.  Only the
+        native endpoint gets the conditional reasoning passback (plain,
+        non-tool-call assistant turns drop ``reasoning_content`` — the API
+        ignores it there); aggregators re-exporting deepseek models
+        (OpenRouter, custom proxies) keep the legacy all-assistant echo.
+
+        Cached on the AIAgent instance keyed by (provider, base_url), the
+        same pattern as ``_needs_thinking_reasoning_pad`` — this runs per
+        assistant message per send.
+
+        Rule table owner: ``agent.message_sanitization.is_native_deepseek_endpoint``.
+        """
+        key = (self.provider, getattr(self, "_base_url_lower", self.base_url))
+        cached = getattr(self, "_native_deepseek_cache", None)
+        if cached is not None and cached[0] == key:
+            return cached[1]
+        from agent.message_sanitization import is_native_deepseek_endpoint
+        result = is_native_deepseek_endpoint(self.provider, self.base_url)
+        self._native_deepseek_cache = (key, result)
+        return result
+
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.copy_reasoning_content_for_api``."""
         from agent.agent_runtime_helpers import copy_reasoning_content_for_api

--- a/tests/agent/test_message_sanitization_policy.py
+++ b/tests/agent/test_message_sanitization_policy.py
@@ -15,6 +15,7 @@ from agent.message_sanitization import (
     apply_reasoning_content_policy,
     coalesce_tool_call_id,
     deterministic_call_id,
+    is_native_deepseek_endpoint,
     matches_reasoning_echo_family,
     needs_reasoning_echo,
     reapply_reasoning_echo,
@@ -203,6 +204,31 @@ class TestReasoningEchoFamily:
             matches_reasoning_echo_family("nope", "p", "m", "https://x")
 
 
+class TestIsNativeDeepseekEndpoint:
+    """Only the native DeepSeek API gets the conditional reasoning passback."""
+
+    @pytest.mark.parametrize("provider,base_url", [
+        ("deepseek", ""),
+        ("DeepSeek", "https://custom-proxy.example/v1"),
+        ("custom", "https://api.deepseek.com/v1"),
+        ("custom", "https://api.deepseek.com/beta"),
+    ])
+    def test_native_endpoint(self, provider, base_url):
+        assert is_native_deepseek_endpoint(provider, base_url) is True
+
+    @pytest.mark.parametrize("provider,base_url", [
+        ("openrouter", "https://openrouter.ai/api/v1"),
+        ("custom", "https://api.kimi.com/v1"),
+        ("custom", "https://api.moonshot.ai/v1"),
+        ("kimi-coding", ""),
+        ("xiaomi", ""),
+        ("", ""),
+        (None, None),
+    ])
+    def test_aggregator_or_other_endpoints(self, provider, base_url):
+        assert is_native_deepseek_endpoint(provider, base_url) is False
+
+
 # ---------------------------------------------------------------------------
 # apply_reasoning_content_policy
 # ---------------------------------------------------------------------------
@@ -254,6 +280,43 @@ class TestApplyReasoningContentPolicy:
         apply_reasoning_content_policy({"role": "assistant", "content": "x"}, api, True)
         assert api["reasoning_content"] == " "
 
+    def test_native_deepseek_plain_turn_drops_reasoning_content(self):
+        """Native DeepSeek: a plain (no tool-call) assistant turn never
+        carries reasoning_content on the wire — the API ignores it there and
+        every replayed token is billed input."""
+        for src in (
+            {"role": "assistant", "content": "x", "reasoning_content": "thoughts"},
+            {"role": "assistant", "content": "x", "reasoning_content": " "},
+            {"role": "assistant", "content": "x", "reasoning": "healthy"},
+            {"role": "assistant", "content": "x"},
+        ):
+            api = {"role": "assistant", "content": src["content"]}
+            apply_reasoning_content_policy(src, api, True, native_deepseek=True)
+            assert "reasoning_content" not in api, src
+
+    def test_native_deepseek_tool_call_turn_keeps_passback(self):
+        """Native DeepSeek: tool-call turns keep the full echo-back — verbatim
+        reasoning_content, the space pad, and the poisoned-history pad."""
+        src = {"role": "assistant", "content": "",
+               "reasoning_content": "thoughts",
+               "tool_calls": [{"id": "c", "function": {"name": "t", "arguments": "{}"}}]}
+        api = {"role": "assistant", "content": ""}
+        apply_reasoning_content_policy(src, api, True, native_deepseek=True)
+        assert api["reasoning_content"] == "thoughts"
+
+        src2 = {"role": "assistant", "content": "",
+                "tool_calls": [{"id": "c", "function": {"name": "t", "arguments": "{}"}}]}
+        api2 = {"role": "assistant", "content": ""}
+        apply_reasoning_content_policy(src2, api2, True, native_deepseek=True)
+        assert api2["reasoning_content"] == " "
+
+    def test_native_deepseek_plain_turn_still_pads_without_flag(self):
+        """Without the native_deepseek flag (kimi/mimo, aggregator-hosted
+        deepseek models) plain turns keep the legacy pad."""
+        api = {"role": "assistant", "content": "x"}
+        apply_reasoning_content_policy({"role": "assistant", "content": "x"}, api, True)
+        assert api["reasoning_content"] == " "
+
     def test_non_string_reasoning_content_removed(self):
         api = {"role": "assistant", "content": "x", "reasoning_content": None}
         apply_reasoning_content_policy(
@@ -294,3 +357,32 @@ class TestReapplyReasoningEcho:
         assert reapply_reasoning_echo(msgs, True) == 0
         reapply_reasoning_echo(msgs, False)
         assert reapply_reasoning_echo(msgs, False) == 0
+
+    def test_native_deepseek_plain_turns_stripped(self):
+        """Native DeepSeek reconciliation: plain turns lose reasoning_content
+        (pads baked in under a prior provider), tool-call turns keep it."""
+        import copy
+        msgs = copy.deepcopy(self.MSGS)
+        assert reapply_reasoning_echo(msgs, True, native_deepseek=True) == 1
+        assert "reasoning_content" not in msgs[0]  # plain turn stripped (was " ")
+        assert "reasoning_content" not in msgs[1]  # plain turn stays bare
+        assert "reasoning_content" not in msgs[2]
+
+    def test_native_deepseek_idempotent(self):
+        import copy
+        msgs = copy.deepcopy(self.MSGS)
+        reapply_reasoning_echo(msgs, True, native_deepseek=True)
+        assert reapply_reasoning_echo(msgs, True, native_deepseek=True) == 0
+
+    def test_native_deepseek_tool_call_turns_repadded_from_bare(self):
+        """Switch to native DeepSeek from a bare builder: tool-call turns get
+        padded, plain turns stay bare (conditional passback)."""
+        msgs = [
+            {"role": "assistant", "content": "plain answer"},
+            {"role": "assistant", "content": "",
+             "tool_calls": [{"id": "c", "function": {"name": "t", "arguments": "{}"}}]},
+        ]
+        changed = reapply_reasoning_echo(msgs, True, native_deepseek=True)
+        assert changed == 1
+        assert "reasoning_content" not in msgs[0]
+        assert msgs[1]["reasoning_content"] == " "

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -149,6 +149,40 @@ class TestChatCompletionsBasic:
         assert "call_id" in msgs[1]["tool_calls"][1]
         assert "extra_content" in msgs[1]["tool_calls"][1]
 
+    def test_convert_messages_normalizes_assistant_content_none_to_empty(self, transport):
+        """Assistant turns must never carry content:null on the wire —
+        reasoning-only turns and host-fed histories can persist content=None.
+        Normalized to "" (the official DeepSeek samples replay text-less
+        turns as ""); the input list stays untouched."""
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": None},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "c1", "type": "function",
+                             "function": {"name": "t", "arguments": "{}"}}]},
+        ]
+        result = transport.convert_messages(msgs)
+        assert result is not msgs
+        assert result[1]["content"] == ""
+        assert result[2]["content"] == ""
+        assert result[2]["tool_calls"] == msgs[2]["tool_calls"]
+        # Original list untouched (copy-on-demand)
+        assert msgs[1]["content"] is None
+        assert msgs[2]["content"] is None
+
+    def test_convert_messages_clean_list_still_identity(self, transport):
+        """A clean list (no None assistant content) is returned by identity —
+        the copy-on-demand contract is preserved.  An ABSENT content key (a
+        tool-call turn built without one) is clean, not null."""
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "assistant",
+             "tool_calls": [{"id": "c1", "type": "function",
+                             "function": {"name": "t", "arguments": "{}"}}]},
+        ]
+        assert transport.convert_messages(msgs) is msgs
+
 
 
 class TestChatCompletionsBuildKwargs:

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -45,21 +45,41 @@ class TestDeepSeekThinkingWireShape:
         assert top_level == {}
 
 
-    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
-    def test_standard_efforts_pass_through(self, deepseek_profile, effort):
+    @pytest.mark.parametrize(
+        "effort,expected",
+        [
+            ("low", "high"),      # low/medium are not official wire values — normalize to high
+            ("medium", "high"),
+            ("high", "high"),
+            ("minimal", "high"),  # user-facing alias; nearest official level is low → high
+        ],
+    )
+    def test_efforts_normalize_to_high(self, deepseek_profile, effort, expected):
         _, top_level = deepseek_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort},
             model="deepseek-v4-pro",
         )
-        assert top_level == {"reasoning_effort": effort}
+        assert top_level == {"reasoning_effort": expected}
 
-    @pytest.mark.parametrize("effort", ["xhigh", "max", "MAX", "  Max  "])
+    @pytest.mark.parametrize("effort", ["xhigh", "max", "ultra", "MAX", "  Max  "])
     def test_xhigh_and_max_normalize_to_max(self, deepseek_profile, effort):
         _, top_level = deepseek_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort},
             model="deepseek-v4-pro",
         )
         assert top_level == {"reasoning_effort": "max"}
+
+    @pytest.mark.parametrize("effort", ["off", "none", "OFF", "  off  "])
+    def test_off_and_none_disable_thinking(self, deepseek_profile, effort):
+        """The official vocabulary's ``off`` (and the ``none`` alias) is the
+        disabled switch — thinking.type=disabled and NO reasoning_effort on
+        the wire (DeepSeek rejects effort alongside disabled thinking)."""
+        extra_body, top_level = deepseek_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="deepseek-v4-pro",
+        )
+        assert extra_body == {"thinking": {"type": "disabled"}}
+        assert top_level == {}
 
     def test_explicitly_disabled_sends_disabled_marker(self, deepseek_profile):
         """``reasoning_config.enabled=False`` → ``thinking.type=disabled``.
@@ -75,20 +95,36 @@ class TestDeepSeekThinkingWireShape:
         assert top_level == {}
 
     def test_disabled_ignores_effort_field(self, deepseek_profile):
-        """Effort silently dropped when thinking is off."""
+        """Effort silently dropped when thinking is off (user choice wins)."""
         _, top_level = deepseek_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": False, "effort": "high"},
             model="deepseek-v4-pro",
         )
         assert top_level == {}
 
-    def test_unknown_effort_omits_top_level(self, deepseek_profile):
-        """Garbage effort → omit reasoning_effort so DeepSeek applies its default."""
-        _, top_level = deepseek_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "garbage"},
-            model="deepseek-v4-pro",
-        )
-        assert top_level == {}
+    @pytest.mark.parametrize("effort", ["garbage", "turbo", "5", "ultra-fast"])
+    def test_unknown_effort_raises_before_io(self, deepseek_profile, effort):
+        """Invalid effort must fail with a clear error BEFORE any I/O — never
+        silently degrade to the server default."""
+        with pytest.raises(ValueError) as exc:
+            deepseek_profile.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": effort},
+                model="deepseek-v4-pro",
+            )
+        message = str(exc.value)
+        assert "DeepSeek" in message
+        assert "off|high|max" in message
+        assert effort in message
+
+    def test_non_string_effort_raises_clear_error(self, deepseek_profile):
+        """Numeric/bool effort values must not crash with AttributeError —
+        they are invalid and raise the same pre-I/O ValueError."""
+        with pytest.raises(ValueError) as exc:
+            deepseek_profile.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": 5},
+                model="deepseek-v4-pro",
+            )
+        assert "does not support reasoning effort" in str(exc.value)
 
     def test_empty_effort_omits_top_level(self, deepseek_profile):
         _, top_level = deepseek_profile.build_api_kwargs_extras(

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -84,6 +84,33 @@ class TestNeedsDeepSeekToolReasoning:
 
 
 
+class TestIsNativeDeepSeekEndpoint:
+    """Only the native DeepSeek API gets the conditional reasoning passback —
+    aggregators re-exporting deepseek models (OpenRouter) keep legacy echo."""
+
+    @pytest.mark.parametrize("provider,model,base_url", [
+        ("deepseek", "deepseek-v4-flash", ""),
+        ("custom", "deepseek-v4-flash", "https://api.deepseek.com/v1"),
+    ])
+    def test_native(self, provider, model, base_url) -> None:
+        agent = _make_agent(provider=provider, model=model, base_url=base_url)
+        assert agent._is_native_deepseek_endpoint() is True
+
+    @pytest.mark.parametrize("provider,model,base_url", [
+        ("openrouter", "deepseek/deepseek-v4-flash", "https://openrouter.ai/api/v1"),
+        ("kimi-coding", "kimi-k2.6", ""),
+        ("custom", "deepseek-v4-flash", "https://api.kimi.com/v1"),
+    ])
+    def test_aggregator(self, provider, model, base_url) -> None:
+        agent = _make_agent(provider=provider, model=model, base_url=base_url)
+        assert agent._is_native_deepseek_endpoint() is False
+
+    def test_cached_per_provider_base_url(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        assert agent._is_native_deepseek_endpoint() is True
+        assert agent._is_native_deepseek_endpoint() is True  # cache hit
+
+
 class TestCopyReasoningContentForApi:
     """_copy_reasoning_content_for_api pads reasoning_content for DeepSeek tool-calls."""
 
@@ -98,6 +125,50 @@ class TestCopyReasoningContentForApi:
         api_msg: dict = {}
         agent._copy_reasoning_content_for_api(source, api_msg)
         assert api_msg.get("reasoning_content") == " "
+
+    def test_native_deepseek_plain_turn_drops_reasoning_content(self) -> None:
+        """Conditional passback: a plain (no tool-call) assistant turn on the
+        native DeepSeek endpoint drops reasoning_content from the wire copy."""
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        for source in (
+            {"role": "assistant", "content": "hi", "reasoning_content": "thoughts"},
+            {"role": "assistant", "content": "hi", "reasoning": "healthy"},
+            {"role": "assistant", "content": "hi"},
+        ):
+            api_msg: dict = {"role": "assistant", "content": "hi"}
+            agent._copy_reasoning_content_for_api(source, api_msg)
+            assert "reasoning_content" not in api_msg, source
+
+    def test_native_deepseek_tool_call_turn_keeps_reasoning_content(self) -> None:
+        """Conditional passback: tool-call turns keep the echo-back — verbatim
+        reasoning wins, otherwise the space pad."""
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        src = {"role": "assistant", "content": "", "reasoning_content": "thoughts",
+               "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}]}
+        api_msg: dict = {"role": "assistant", "content": ""}
+        agent._copy_reasoning_content_for_api(src, api_msg)
+        assert api_msg["reasoning_content"] == "thoughts"
+
+        src2 = {"role": "assistant", "content": "",
+                "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}]}
+        api_msg2: dict = {"role": "assistant", "content": ""}
+        agent._copy_reasoning_content_for_api(src2, api_msg2)
+        assert api_msg2["reasoning_content"] == " "
+
+    def test_openrouter_deepseek_model_keeps_legacy_echo(self) -> None:
+        """Scope guard: an OpenRouter-hosted deepseek model is NOT the native
+        endpoint — plain turns keep the legacy all-assistant pad."""
+        agent = _make_agent(
+            provider="openrouter",
+            model="deepseek/deepseek-v4-flash",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        api_msg: dict = {"role": "assistant", "content": "hi"}
+        agent._copy_reasoning_content_for_api(
+            {"role": "assistant", "content": "hi"}, api_msg
+        )
+        assert api_msg.get("reasoning_content") == " "
+
 
 
 
@@ -305,6 +376,28 @@ class TestReapplyReasoningEchoForProviderSwitch:
         # existing summary preserved verbatim, not clobbered with the pad
         assert msgs[2]["reasoning_content"] == "summary from codex"
         assert msgs[4]["reasoning_content"] == " "
+    def test_switch_to_native_deepseek_strips_plain_turns_pads_tool_turns(self) -> None:
+        """Conditional passback reconciliation: on the native DeepSeek
+        endpoint a fallback re-pads tool-call turns but leaves plain
+        (non-tool-call) turns bare — their reasoning_content is ignored by
+        the API and only burns input tokens."""
+        from agent.agent_runtime_helpers import reapply_reasoning_echo_for_provider
+
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "do the thing"},
+            {"role": "assistant", "content": "plain answer", "reasoning_content": "stale pad"},
+            {"role": "user", "content": "and now"},
+            {"role": "assistant", "content": "",
+             "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        ]
+        changed = reapply_reasoning_echo_for_provider(agent, msgs)
+        assert changed == 2
+        assert "reasoning_content" not in msgs[2]          # plain turn stripped
+        assert msgs[4]["reasoning_content"] == " "         # tool-call turn padded
+
 
     def test_strips_stale_pad_under_strict_provider(self) -> None:
         """Switching TO a strict provider (Codex/Mistral/Cerebras) must STRIP

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -370,13 +370,44 @@ def test_sanitize_drops_empty_tool_calls_array():
 # such turns on the per-call copy so the session recovers itself in memory.
 
 
+def test_sanitize_normalizes_assistant_content_none_to_empty():
+    """sanitize_api_messages guarantees assistant content is "" — never null —
+    on the wire. Reasoning-only turns and host-fed histories can persist
+    content=None; OpenAI-compat endpoints reject a null-content assistant
+    turn that also lacks tool_calls ("content or tool_calls must be set" —
+    DeepSeek 400). The stored history stays untouched (copy-on-change)."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": None},
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"id": "call_X", "type": "function",
+                         "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_X", "content": "A"},
+        {"role": "assistant", "content": "done"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    # The bare non-final assistant turn (index 1) is healed by the existing
+    # empty-turn repair pass; the tool-call turn (index 2, has payload) is
+    # normalized by the content pass — "" never null on the wire.
+    assert out[1]["content"] == "[response interrupted]"
+    assert out[2]["content"] == ""
+    # Original list untouched — stored history / prompt caching byte-stable.
+    assert messages[1]["content"] is None
+    assert messages[2]["content"] is None
 
 
+def test_sanitize_normalizes_only_assistant_content():
+    """User turns with content=None are NOT rewritten by the assistant
+    content pass (the empty-turn repair pass owns non-final user healing;
+    a FINAL empty user turn is legal and left untouched)."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
 
-
-
-
-
-
-
-
+    messages = [
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": None},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert out[0]["content"] == "ok"
+    assert out[1]["content"] is None


### PR DESCRIPTION
## Summary

Makes DeepSeek wire replay token- and cache-efficient: `reasoning_content` is only serialized on assistant turns that carried tool calls (the official thinking-mode passback rule), assistant `content` is normalized to `""` (never null), and `reasoning_effort` uses the official DeepSeek vocabulary `off|high|max`.

Root cause: Hermes replayed `reasoning_content` on every assistant turn even though the DeepSeek API ignores it on plain turns — every replayed token is billed input. It also passed `low`/`medium` effort values outside the official vocabulary and could serialize an explicit `content: null`, which some gateways reject outright and bricks later turns.

## Changes

- `plugins/model-providers/deepseek/__init__.py`: effort mapping — `off`/`none` disable thinking without a wire effort, `minimal`/`low`/`medium` normalize to `high`, `xhigh`/`ultra` to `max`; any other value raises `ValueError` before I/O with a clear message
- `agent/message_sanitization.py`: conditional reasoning passback policy + `is_native_deepseek_endpoint` predicate (drop applies only to the native DeepSeek endpoint)
- `run_agent.py`: cached `_is_native_deepseek_endpoint()` on `AIAgent`
- `agent/agent_runtime_helpers.py`: `copy_reasoning_content_for_api` / `reapply_reasoning_echo_for_provider` plumbing; `sanitize_api_messages` normalizes explicit `None` content to `""`
- `agent/transports/chat_completions.py`: `convert_messages` normalizes `None` → `""` on the per-call copy (stored history stays byte-stable)
- `tests/plugins/model_providers/test_deepseek_profile.py`, `tests/agent/test_message_sanitization_policy.py`, `tests/agent/transports/test_chat_completions.py`, `tests/run_agent/test_deepseek_reasoning_content_echo.py`, `tests/run_agent/test_message_sequence_repair.py`: coverage for the drop rule (deepseek-only), passback retention on tool-call turns, effort mapping, and null-content normalization

## Validation

| Teste | Resultado |
|-------|-----------|
| `pytest` deepseek profile + message sanitization + transports + run_agent reasoning/sequence suites | 195 passed |
| Live API validation (`test_deepseek_v4_thinking_live.py`) | skipped — requires `DEEPSEEK_API_KEY` + `HERMES_LIVE_TESTS=1` |

Kimi/Moonshot/MiMo and aggregator-hosted deepseek models (OpenRouter) keep the legacy all-assistant echo — the change is scoped to the native endpoint.
