### PR TITLE
feat(tools): spill oversized tool outputs to session files with preview + locator

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -48,6 +48,10 @@ from tools.tool_result_storage import (
     maybe_persist_tool_result,
     enforce_turn_budget,
 )
+from tools.tool_spill import (
+    load_config as _load_spill_config,
+    maybe_spill_tool_result,
+)
 from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context_window
 
 logger = logging.getLogger(__name__)
@@ -772,6 +776,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     # Resolve the context-scaled tool-output budget once per turn (cheap, but
     # avoids rebuilding it per result inside the loop below).
     _tool_budget = _budget_for_agent(agent)
+    # Config-gated spill settings (opt-in, default off) — resolved once per
+    # turn so the hot path does not re-read the config file per tool result.
+    _spill_cfg = _load_spill_config()
 
     # ── Pre-flight: interrupt check ──────────────────────────────────
     if agent._interrupt_requested:
@@ -1476,6 +1483,20 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
 
+        # Config-gated spill (opt-in, default off): a result over
+        # tools.spill.max_inline_bytes is written ONCE to a session-scoped
+        # file and replaced inline by a head/tail preview + locator notice.
+        # Applied here, at write time — the stored message is the final form,
+        # so the transcript between steps stays byte-identical.
+        if not _is_multimodal_tool_result(function_result):
+            function_result = maybe_spill_tool_result(
+                content=function_result,
+                tool_name=name,
+                tool_use_id=tc.id,
+                session_id=getattr(agent, "session_id", "") or "",
+                config=_spill_cfg,
+            )
+
         subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
@@ -1610,6 +1631,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     """
     # Resolve the context-scaled tool-output budget once per turn.
     _tool_budget = _budget_for_agent(agent)
+    # Config-gated spill settings (opt-in, default off) — resolved once per
+    # turn so the hot path does not re-read the config file per tool result.
+    _spill_cfg = _load_spill_config()
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         if getattr(agent, "_incremental_persistence_failed", False):
             return
@@ -2274,6 +2298,20 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             env=get_active_env(effective_task_id),
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
+
+        # Config-gated spill (opt-in, default off): a result over
+        # tools.spill.max_inline_bytes is written ONCE to a session-scoped
+        # file and replaced inline by a head/tail preview + locator notice.
+        # Applied here, at write time — the stored message is the final form,
+        # so the transcript between steps stays byte-identical.
+        if not _is_multimodal_tool_result(function_result):
+            function_result = maybe_spill_tool_result(
+                content=function_result,
+                tool_name=function_name,
+                tool_use_id=tool_call.id,
+                session_id=getattr(agent, "session_id", "") or "",
+                config=_spill_cfg,
+            )
 
         # Discover subdirectory context files from tool arguments
         subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2487,6 +2487,18 @@ DEFAULT_CONFIG = {
             # estimate), regardless of context size. Range 200..60000.
             "listing_max_tokens": 4000,
         },
+        # Spill of oversized tool results to session-scoped files
+        # (tools/tool_spill.py). When enabled and a tool result's UTF-8 size
+        # exceeds max_inline_bytes, the FULL text is written once to
+        # HERMES_HOME/sessions/spill/<session>/ and the inline message becomes
+        # a bounded head/tail preview plus a locator notice the model can
+        # follow with read_file. Default OFF (conservative): the legacy
+        # char-based persistence (tools.tool_result_storage) remains the
+        # always-on safety net.
+        "spill": {
+            "enabled": False,
+            "max_inline_bytes": 100_000,
+        },
     },
 
     # Logging — controls file logging to ~/.hermes/logs/.

--- a/tests/tools/test_tool_spill.py
+++ b/tests/tools/test_tool_spill.py
@@ -1,0 +1,376 @@
+"""Tests for tools/tool_spill.py — config-gated spill of oversized tool outputs.
+
+Coverage: cap applied, locator notice format + byte budget reservation,
+best-effort storage failures, read-tool skip, unicode safety, path
+traversal safety, deterministic session-scoped paths, and the disabled
+(default) no-op.
+"""
+
+import re
+
+import pytest
+
+from tools.tool_spill import (
+    READ_TOOLS,
+    SpillConfig,
+    _preview_head_tail,
+    _spill_notice,
+    _truncate_utf8,
+    _utf8_len,
+    load_config,
+    maybe_spill_tool_result,
+    spill_dir,
+    spill_path,
+)
+
+BIG = "x" * 10_000  # 10_000 UTF-8 bytes
+
+
+def _enabled(cap: int) -> SpillConfig:
+    return SpillConfig(enabled=True, max_inline_bytes=cap)
+
+
+def _result_path(replaced: str) -> str:
+    """Extract the locator path from a spill replacement string."""
+    match = re.search(r"Full result stored at: ([^\n)]+)\)$", replaced)
+    assert match, f"no locator notice in: {replaced!r}"
+    return match.group(1)
+
+
+# ── config parsing ────────────────────────────────────────────────────
+
+class TestSpillConfig:
+    def test_default_disabled(self):
+        cfg = SpillConfig()
+        assert cfg.enabled is False
+        assert cfg.max_inline_bytes == 100_000
+
+    def test_from_raw_none_and_false_are_disabled(self):
+        assert SpillConfig.from_raw(None).enabled is False
+        assert SpillConfig.from_raw(False).enabled is False
+
+    def test_from_raw_true_enables_with_default_cap(self):
+        cfg = SpillConfig.from_raw(True)
+        assert cfg.enabled is True
+        assert cfg.max_inline_bytes == 100_000
+
+    def test_from_raw_dict(self):
+        cfg = SpillConfig.from_raw({"enabled": True, "max_inline_bytes": 500})
+        assert cfg.enabled is True
+        assert cfg.max_inline_bytes == 500
+
+    def test_from_raw_garbage_falls_back(self):
+        cfg = SpillConfig.from_raw({"enabled": "yes", "max_inline_bytes": "lots"})
+        assert cfg.enabled is True  # truthy string
+        assert cfg.max_inline_bytes == 100_000
+        cfg2 = SpillConfig.from_raw([1, 2, 3])
+        assert cfg2.enabled is False
+
+
+# ── byte helpers ──────────────────────────────────────────────────────
+
+class TestByteHelpers:
+    def test_truncate_ascii(self):
+        assert _truncate_utf8("abcdef", 3) == "abc"
+        assert _truncate_utf8("abcdef", 0) == ""
+        assert _truncate_utf8("abc", 10) == "abc"
+
+    def test_truncate_never_splits_multibyte(self):
+        text = "αβγδε"  # 2 bytes per char
+        out = _truncate_utf8(text, 3)
+        assert "\ufffd" not in out
+        assert _utf8_len(out) <= 3
+        assert out == "α"  # byte 2 boundary keeps exactly one char
+
+    def test_truncate_budget_lands_inside_char(self):
+        text = "αβγδε"
+        out = _truncate_utf8(text, 4)
+        assert out == "αβ"
+        assert _utf8_len(out) == 4
+
+    def test_truncate_emoji(self):
+        text = "🎉🎉🎉"  # 4 bytes each
+        out = _truncate_utf8(text, 6)
+        assert out == "🎉"
+        assert _utf8_len(out) == 4
+
+    def test_preview_head_tail_ascii(self):
+        text = "abcdef"
+        preview, omitted = _preview_head_tail(text, 4)
+        assert preview == "abef"
+        assert omitted == 2
+
+    def test_preview_head_tail_fits_whole(self):
+        text = "abcdef"
+        preview, omitted = _preview_head_tail(text, 6)
+        assert preview == text
+        assert omitted == 0
+
+    def test_preview_head_tail_unicode_boundaries(self):
+        text = "αβγδεζηθ"  # 8 chars x 2 bytes = 16 bytes
+        preview, omitted = _preview_head_tail(text, 8)
+        assert "\ufffd" not in preview
+        assert _utf8_len(preview) <= 8
+        assert omitted == 16 - _utf8_len(preview)
+        # head and tail are disjoint: head + tail covers the two ends
+        assert preview.startswith("αβ")
+        assert preview.endswith("ηθ")
+
+    def test_preview_zero_budget(self):
+        preview, omitted = _preview_head_tail("abc", 0)
+        assert preview == ""
+        assert omitted == 3
+
+
+# ── notice format ─────────────────────────────────────────────────────
+
+class TestNotice:
+    def test_exact_format(self):
+        notice = _spill_notice(1_234, "/tmp/spill/s/file.txt")
+        assert notice == "(1234 bytes omitted. Full result stored at: /tmp/spill/s/file.txt)"
+
+    def test_spill_notice_present_with_path(self, tmp_path):
+        replaced = maybe_spill_tool_result(
+            content=BIG,
+            tool_name="terminal",
+            tool_use_id="call_1",
+            session_id="sess_1",
+            config=_enabled(2_000),
+            hermes_home=tmp_path,
+        )
+        assert replaced != BIG
+        path = _result_path(replaced)
+        assert path.endswith("terminal_call_1.txt")
+        assert "bytes omitted. Full result stored at: " in replaced
+        # The file exists and holds the FULL original text.
+        assert open(path, encoding="utf-8").read() == BIG
+
+
+# ── maybe_spill_tool_result ───────────────────────────────────────────
+
+class TestMaybeSpillToolResult:
+    def test_disabled_by_default_keeps_inline(self, tmp_path):
+        replaced = maybe_spill_tool_result(
+            content=BIG,
+            tool_name="terminal",
+            tool_use_id="call_1",
+            session_id="sess_1",
+            config=SpillConfig(),  # default: enabled=False
+            hermes_home=tmp_path,
+        )
+        assert replaced == BIG
+
+    def test_under_cap_unchanged(self, tmp_path):
+        replaced = maybe_spill_tool_result(
+            content="small result",
+            tool_name="terminal",
+            tool_use_id="call_1",
+            session_id="sess_1",
+            config=_enabled(100_000),
+            hermes_home=tmp_path,
+        )
+        assert replaced == "small result"
+        assert not (tmp_path / "sessions" / "spill").exists()
+
+    def test_oversized_spilled_with_preview(self, tmp_path):
+        replaced = maybe_spill_tool_result(
+            content=BIG,
+            tool_name="terminal",
+            tool_use_id="call_1",
+            session_id="sess_1",
+            config=_enabled(2_000),
+            hermes_home=tmp_path,
+        )
+        assert replaced != BIG
+        # Head/tail preview is present (both ends of the original); the
+        # preview is the part before the "\n\n" notice separator.
+        preview_part = replaced.split("\n\n", 1)[0]
+        assert preview_part.startswith("x" * 900)
+        assert preview_part.endswith("x" * 900)
+        assert _utf8_len(replaced) <= 2_000
+        # Notice states bytes omitted and the path.
+        assert re.search(r"\(\d+ bytes omitted\. Full result stored at: ", replaced)
+
+    def test_replacement_never_exceeds_cap(self, tmp_path):
+        """The reservation (notice cost + 2-byte join) guarantees the
+        replacement fits inside max_inline_bytes for any oversized input."""
+        for cap in (500, 2_000, 10_000):
+            content = "y" * (cap * 3)
+            replaced = maybe_spill_tool_result(
+                content=content,
+                tool_name="terminal",
+                tool_use_id=f"call_{cap}",
+                session_id="sess_1",
+                config=_enabled(cap),
+                hermes_home=tmp_path,
+            )
+            assert _utf8_len(replaced) <= cap, f"cap {cap}: replacement {_utf8_len(replaced)} bytes"
+
+    def test_best_effort_write_failure_keeps_inline(self, tmp_path, monkeypatch):
+        from tools import tool_spill as mod
+
+        def _fail(content, path):
+            return False
+
+        monkeypatch.setattr(mod, "_write_spill_file", _fail)
+        replaced = maybe_spill_tool_result(
+            content=BIG,
+            tool_name="terminal",
+            tool_use_id="call_1",
+            session_id="sess_1",
+            config=_enabled(2_000),
+            hermes_home=tmp_path,
+        )
+        assert replaced == BIG  # original kept, never an error
+
+    def test_best_effort_real_oserror_keeps_inline(self, tmp_path):
+        # Make the sessions dir un-creatable: a FILE in the way.
+        (tmp_path / "sessions").write_text("blocking file", encoding="utf-8")
+        replaced = maybe_spill_tool_result(
+            content=BIG,
+            tool_name="terminal",
+            tool_use_id="call_1",
+            session_id="sess_1",
+            config=_enabled(2_000),
+            hermes_home=tmp_path,
+        )
+        assert replaced == BIG
+
+    def test_read_file_is_skipped(self, tmp_path):
+        assert "read_file" in READ_TOOLS
+        replaced = maybe_spill_tool_result(
+            content=BIG,
+            tool_name="read_file",
+            tool_use_id="call_1",
+            session_id="sess_1",
+            config=_enabled(2_000),
+            hermes_home=tmp_path,
+        )
+        assert replaced == BIG
+        assert not (tmp_path / "sessions" / "spill").exists()
+
+    def test_no_session_id_keeps_inline(self, tmp_path):
+        replaced = maybe_spill_tool_result(
+            content=BIG,
+            tool_name="terminal",
+            tool_use_id="call_1",
+            session_id="",
+            config=_enabled(2_000),
+            hermes_home=tmp_path,
+        )
+        assert replaced == BIG
+        assert not (tmp_path / "sessions" / "spill").exists()
+
+    def test_tiny_cap_notice_exceeds_keeps_inline(self, tmp_path):
+        """When even the notice alone exceeds the cap, there is no within-cap
+        replacement: the original stays inline (the written file is a
+        documented harmless orphan)."""
+        cap = 50
+        replaced = maybe_spill_tool_result(
+            content=BIG,
+            tool_name="terminal",
+            tool_use_id="call_1",
+            session_id="sess_1",
+            config=_enabled(cap),
+            hermes_home=tmp_path,
+        )
+        assert replaced == BIG
+        # The orphan file was still written (best-effort write happens first).
+        files = list((tmp_path / "sessions" / "spill").rglob("*.txt"))
+        assert len(files) == 1
+
+    def test_unicode_content_roundtrip(self, tmp_path):
+        content = "αβγδεζηθκλμνξοπρστυφχψω\n" * 400  # multibyte, oversized
+        cap = 1_500
+        replaced = maybe_spill_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="call_uni",
+            session_id="sess_1",
+            config=_enabled(cap),
+            hermes_home=tmp_path,
+        )
+        assert "\ufffd" not in replaced
+        assert _utf8_len(replaced) <= cap
+        path = _result_path(replaced)
+        assert open(path, encoding="utf-8").read() == content
+
+    def test_omitted_count_is_accurate(self, tmp_path):
+        replaced = maybe_spill_tool_result(
+            content=BIG,
+            tool_name="terminal",
+            tool_use_id="call_1",
+            session_id="sess_1",
+            config=_enabled(2_000),
+            hermes_home=tmp_path,
+        )
+        m = re.search(r"\((\d+) bytes omitted\.", replaced)
+        assert m
+        omitted = int(m.group(1))
+        kept = _utf8_len(replaced) - _utf8_len(_spill_notice(omitted, _result_path(replaced))) - 2
+        assert omitted == 10_000 - kept
+
+    def test_deterministic_path_and_idempotent_write(self, tmp_path):
+        p1 = spill_path("sess_1", "terminal", "call_1", hermes_home=tmp_path)
+        p2 = spill_path("sess_1", "terminal", "call_1", hermes_home=tmp_path)
+        assert p1 == p2
+        # Re-processing the same call overwrites the same file: still one file.
+        for _ in range(2):
+            maybe_spill_tool_result(
+                content=BIG,
+                tool_name="terminal",
+                tool_use_id="call_1",
+                session_id="sess_1",
+                config=_enabled(2_000),
+                hermes_home=tmp_path,
+            )
+        files = list((tmp_path / "sessions" / "spill").rglob("*.txt"))
+        assert len(files) == 1
+        assert files[0] == p1
+
+
+# ── path safety ───────────────────────────────────────────────────────
+
+class TestPathSafety:
+    def test_session_scoped_dirs(self, tmp_path):
+        d1 = spill_dir("sess_1", hermes_home=tmp_path)
+        d2 = spill_dir("sess_2", hermes_home=tmp_path)
+        assert d1.parent == d2.parent  # both under sessions/spill/
+        assert d1 != d2
+
+    def test_tool_use_id_cannot_traverse(self, tmp_path):
+        path = spill_path("sess_1", "terminal", "../outside/$(whoami);x", hermes_home=tmp_path)
+        rel = path.relative_to(tmp_path / "sessions" / "spill")
+        assert ".." not in rel.parts
+        assert "$" not in str(path)
+        assert ";" not in str(path)
+        assert path.name.startswith("terminal_")
+
+    def test_session_id_cannot_traverse(self, tmp_path):
+        path = spill_dir("../../etc/passwd", hermes_home=tmp_path)
+        rel = path.relative_to(tmp_path / "sessions" / "spill")
+        assert ".." not in rel.parts
+        assert len(rel.parts) == 1
+
+    def test_weird_session_id_sanitized(self, tmp_path):
+        replaced = maybe_spill_tool_result(
+            content=BIG,
+            tool_name="terminal",
+            tool_use_id="call_1",
+            session_id="chat-1/../x",
+            config=_enabled(2_000),
+            hermes_home=tmp_path,
+        )
+        path = _result_path(replaced)
+        assert "/../" not in path
+        assert (tmp_path / "sessions" / "spill") in __import__("pathlib").Path(path).parents
+
+
+# ── load_config ───────────────────────────────────────────────────────
+
+class TestLoadConfig:
+    def test_load_config_returns_disabled_default(self):
+        cfg = load_config()
+        assert isinstance(cfg, SpillConfig)
+        # Defaults in config_defaults.py keep spill off.
+        assert cfg.enabled is False

--- a/tools/tool_spill.py
+++ b/tools/tool_spill.py
@@ -1,0 +1,326 @@
+"""Config-gated spill of oversized tool results to session-scoped files.
+
+When ``tools.spill.enabled`` is true and a tool result's UTF-8 size exceeds
+``tools.spill.max_inline_bytes``, the FULL text is written once to a
+session-scoped file under ``HERMES_HOME/sessions/spill/<session>/`` and the
+inline message becomes a bounded head/tail preview plus a locator notice::
+
+    (N bytes omitted. Full result stored at: /path/to/file)
+
+The model recovers the full content by calling ``read_file`` on the path.
+
+Design rules (mirroring the dsh spill-policy reference implementation):
+
+1. **The notice's byte cost is reserved INSIDE the cap.** The replacement is
+   ``preview + "\\n\\n" + notice``; the preview budget is
+   ``cap - len(notice at worst-case omitted count) - 2`` (the 2 is the join),
+   and the final replacement is re-checked against the cap before it is
+   returned. A replacement that would exceed the cap is abandoned and the
+   original stays inline — the policy NEVER emits something larger than the
+   advertised cap.
+2. **Best-effort storage.** A write failure (permissions, ENOSPC, missing
+   HERMES_HOME) logs a warning and keeps the result inline. A spill failure
+   must never hide a tool result.
+3. **Read tools are skipped.** ``read_file`` (and siblings) never spill —
+   otherwise the model's recovery path would itself spill and loop
+   (read → spill → read again).
+4. **The transform happens exactly once, at write time.** This module is
+   invoked where the tool result string becomes a conversation message; the
+   stored message is already the preview+notice form, so the transcript
+   between steps stays byte-identical (no re-spill on later requests — a
+   prompt-cache-safe property, per AGENTS.md).
+5. **Default off.** ``enabled: false`` is the conservative default; the
+   legacy char-based persistence (``tools.tool_result_storage``) remains the
+   always-on safety net.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: Tools whose purpose is reading files. Spilling their results would create a
+#: read → spill → read-again loop, because the model recovers spilled content
+#: via ``read_file``. Keep the set deliberately small and conservative.
+READ_TOOLS: frozenset[str] = frozenset({"read_file"})
+
+#: Cap (UTF-8 bytes) used when ``max_inline_bytes`` is not configured. Matches
+#: the legacy char-based default (100_000) so the two layers align.
+DEFAULT_MAX_INLINE_BYTES: int = 100_000
+
+#: Subdirectory under ``HERMES_HOME`` for session artifacts (existing
+#: convention: ``agent.logs_dir = hermes_home / "sessions"``).
+_SESSIONS_DIR_NAME = "sessions"
+#: Spill artifact root under the sessions dir.
+_SPILL_DIR_NAME = "spill"
+
+#: Path-segment sanitization, mirroring ``tools.tool_result_storage``.
+_UNSAFE_SEGMENT_CHARS = re.compile(r"[^A-Za-z0-9_.-]+")
+_MAX_SEGMENT_LEN = 80
+_MAX_FILENAME_STEM = 120
+
+
+@dataclass(frozen=True)
+class SpillConfig:
+    """Resolved, validated spill configuration for tool result bounding."""
+
+    enabled: bool = False
+    max_inline_bytes: int = DEFAULT_MAX_INLINE_BYTES
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "SpillConfig":
+        """Build a config from a raw dict / bool / None.
+
+        ``False``/``None``/missing → disabled (the conservative default).
+        Numeric fields are clamped to sane ranges instead of raising, so a
+        typo in user config cannot break tool execution.
+        """
+        if raw is True:
+            return cls(enabled=True)
+        if raw is False or raw is None:
+            return cls()
+        if not isinstance(raw, dict):
+            return cls()
+
+        enabled = bool(raw.get("enabled", False))
+        cap = _safe_int(raw.get("max_inline_bytes"), DEFAULT_MAX_INLINE_BYTES)
+        cap = max(1, min(cap, 50_000_000))
+        return cls(enabled=enabled, max_inline_bytes=cap)
+
+    def resolve(self) -> "SpillConfig":
+        """Return self; kept for API symmetry with budget resolution helpers."""
+        return self
+
+
+def _safe_int(value: Any, fallback: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def load_config() -> SpillConfig:
+    """Load ``tools.spill`` from the user config file (best-effort)."""
+    try:
+        from hermes_cli.config import load_config as _load
+
+        cfg = _load() or {}
+        tools_cfg = cfg.get("tools") if isinstance(cfg.get("tools"), dict) else {}
+        if not isinstance(tools_cfg, dict):
+            tools_cfg = {}
+        return SpillConfig.from_raw(tools_cfg.get("spill"))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Failed to load spill config: %s", exc)
+        return SpillConfig()
+
+
+# ---------------------------------------------------------------------------
+# Byte-safe text helpers
+# ---------------------------------------------------------------------------
+
+
+def _utf8_len(text: str) -> int:
+    """UTF-8 byte length of ``text``."""
+    return len(text.encode("utf-8"))
+
+
+def _truncate_utf8(text: str, max_bytes: int) -> str:
+    """Truncate ``text`` to at most ``max_bytes`` UTF-8 bytes, never splitting
+    a multibyte character. ``max_bytes`` <= 0 yields ``""``."""
+    if max_bytes <= 0:
+        return ""
+    raw = text.encode("utf-8")
+    if len(raw) <= max_bytes:
+        return text
+    cut = raw[:max_bytes]
+    # ``cut`` is a prefix of valid UTF-8, so the ONLY invalid part is a
+    # possibly-truncated final character; back off byte-by-byte until it
+    # decodes (at most one multibyte char's width of iterations).
+    while cut:
+        try:
+            return cut.decode("utf-8")
+        except UnicodeDecodeError:
+            cut = cut[:-1]
+    return ""
+
+
+def _preview_head_tail(text: str, budget_bytes: int) -> Tuple[str, int]:
+    """Split ``text`` into a head/tail preview within ``budget_bytes``.
+
+    head gets ``ceil(budget/2)`` bytes, tail gets ``floor(budget/2)`` bytes
+    (mirrors the TextRetainer headTail split). Returns ``(preview, omitted)``
+    where ``omitted`` is the number of UTF-8 bytes NOT kept inline.
+    """
+    if budget_bytes <= 0:
+        return "", _utf8_len(text)
+    total = _utf8_len(text)
+    head_bytes = math.ceil(budget_bytes / 2)
+    tail_bytes = math.floor(budget_bytes / 2)
+    head = _truncate_utf8(text, head_bytes)
+    kept_head = _utf8_len(head)
+    tail = _truncate_utf8(text[::-1], tail_bytes)[::-1]
+    kept = kept_head + _utf8_len(tail)
+    if kept >= total:
+        return text, 0
+    preview = head + tail
+    # Defensive: the byte-safe truncations guarantee kept <= budget; kept can
+    # never exceed total (head/tail are disjoint ends of the same string).
+    return preview, total - kept
+
+
+# ---------------------------------------------------------------------------
+# Notice + storage
+# ---------------------------------------------------------------------------
+
+
+def _spill_notice(omitted_bytes: int, path: str) -> str:
+    """The locator notice appended to a spilled preview.
+
+    Format is fixed and model-facing: ``(N bytes omitted. Full result stored
+    at: <path>)``. ``path`` is the absolute spill file path the model can pass
+    to ``read_file``.
+    """
+    return f"({omitted_bytes} bytes omitted. Full result stored at: {path})"
+
+
+def _safe_segment(raw: str, fallback: str = "segment") -> str:
+    """Sanitize an untrusted string (session id, tool name, tool use id) into
+    one traversal-safe path segment. Mirrors ``_safe_result_filename`` from
+    ``tools.tool_result_storage``: unsafe chars become ``_``, whole-segment
+    dots are neutralized, and overlong stems get a sha256 digest suffix."""
+    raw_str = str(raw or "")
+    safe = _UNSAFE_SEGMENT_CHARS.sub("_", raw_str).strip("._-")
+    if not safe:
+        return fallback
+    if len(safe) > _MAX_SEGMENT_LEN:
+        digest = hashlib.sha256(raw_str.encode("utf-8")).hexdigest()[:12]
+        safe = f"{safe[:_MAX_SEGMENT_LEN].rstrip('._-') or fallback}_{digest}"
+    return safe
+
+
+def spill_dir(session_id: str, hermes_home: Optional[Path] = None) -> Path:
+    """The session-scoped spill directory.
+
+    ``<HERMES_HOME>/sessions/spill/<safe-session-id>/`` — follows the existing
+    ``hermes_home / "sessions"`` artifact convention (``agent.logs_dir``).
+    The directory is created lazily by the writer.
+    """
+    from hermes_constants import get_hermes_home
+
+    home = Path(hermes_home) if hermes_home is not None else get_hermes_home()
+    return home / _SESSIONS_DIR_NAME / _SPILL_DIR_NAME / _safe_segment(session_id, "session")
+
+
+def spill_path(
+    session_id: str,
+    tool_name: str,
+    tool_use_id: str,
+    hermes_home: Optional[Path] = None,
+) -> Path:
+    """The deterministic spill file path for one tool call.
+
+    Deterministic (derived from the call id, not random) so re-processing the
+    same call overwrites the same file — the transform is idempotent and no
+    orphans accumulate. Tool name and call id are both sanitized to single
+    safe segments, so a model-controlled id can never traverse the tree.
+    """
+    name = _safe_segment(tool_name, "tool")
+    call = _safe_segment(tool_use_id, "result")
+    stem = f"{name}_{call}"
+    if len(stem) > _MAX_FILENAME_STEM:
+        digest = hashlib.sha256(f"{tool_name}|{tool_use_id}".encode("utf-8")).hexdigest()[:12]
+        stem = f"{stem[:_MAX_FILENAME_STEM].rstrip('._-') or 'result'}_{digest}"
+    return spill_dir(session_id, hermes_home) / f"{stem}.txt"
+
+
+def _write_spill_file(content: str, path: Path) -> bool:
+    """Best-effort local write of the FULL result. Returns True on success;
+    on any failure logs a warning and returns False (caller keeps inline)."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return True
+    except OSError as exc:
+        logger.warning("tool-spill: could not write spill file %s: %s", path, exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def maybe_spill_tool_result(
+    content: str,
+    tool_name: str,
+    tool_use_id: str,
+    session_id: Optional[str] = None,
+    config: Optional[SpillConfig] = None,
+    hermes_home: Optional[Path] = None,
+) -> str:
+    """Spill an oversized tool result to a session-scoped file.
+
+    Returns the (possibly replaced) string to store as the tool message
+    content. The transform is applied once, here, at write time — the stored
+    message is already the final form, so the transcript between steps is
+    byte-identical and no later request re-spills it.
+
+    Best-effort: disabled config, a read tool, a missing session id, a write
+    failure, or an over-cap replacement all keep ``content`` unchanged (with
+    a warning log), never an error.
+    """
+    cfg = config if config is not None else load_config()
+    if not cfg.enabled:
+        return content
+    if tool_name in READ_TOOLS:
+        return content
+
+    total_bytes = _utf8_len(content)
+    cap = cfg.max_inline_bytes
+    if total_bytes <= cap:
+        return content
+
+    if not session_id:
+        logger.warning("tool-spill: no session id for %s; keeping inline content", tool_name)
+        return content
+
+    path = spill_path(session_id, tool_name, tool_use_id, hermes_home=hermes_home)
+    if not _write_spill_file(content, path):
+        return content
+
+    # Reserve the notice's byte cost INSIDE the cap so the replacement
+    # (preview + "\n\n" + notice) never exceeds it. The reservation prices
+    # the notice at the worst-case omitted count (the full byte total): its
+    # digit count bounds the real count's, so the reserved size is a safe
+    # upper bound and the final notice is never longer than reserved.
+    reserve = _utf8_len(_spill_notice(total_bytes, str(path))) + 2
+    preview_budget = max(0, cap - reserve)
+    preview_text, omitted = _preview_head_tail(content, preview_budget)
+    notice = _spill_notice(omitted, str(path))
+    replaced = f"{preview_text}\n\n{notice}" if preview_text else notice
+
+    # Invariant: never emit a replacement larger than the cap. When the notice
+    # alone exceeds the cap (tiny cap or a long spill root), there is no
+    # within-cap replacement — keep the inline content. A within-cap
+    # replacement is always smaller than the original (which is > cap by the
+    # entry condition), so this one check subsumes "not smaller than the
+    # original". The already-written spill file is a harmless orphan.
+    if _utf8_len(replaced) > cap:
+        logger.warning(
+            "tool-spill: replacement for %s exceeds max_inline_bytes; keeping inline content",
+            tool_name,
+        )
+        return content
+
+    logger.info(
+        "tool-spill: spilled %s result (%d bytes -> %s)",
+        tool_name, total_bytes, path,
+    )
+    return replaced


### PR DESCRIPTION
## Summary

When `tools.spill.enabled` is true and a tool result's UTF-8 size exceeds `tools.spill.max_inline_bytes`, the full text is written ONCE to a session-scoped file and the inline message becomes a bounded head/tail preview plus a locator notice the model follows with `read_file`.

Root cause: large unique tool outputs (web extractions, dumps) grow the conversation prefix on every request, pushing the transcript toward compaction and invalidating the provider cache. Spilling at write time keeps every node under a byte cap, so the transcript stays byte-identical between steps and compaction fires far less often.

## Changes

- `tools/tool_spill.py` (new): `SpillConfig` (`enabled` default false, `max_inline_bytes` default 100_000), `maybe_spill_tool_result`, byte-safe UTF-8 truncation (no multibyte splits), `_preview_head_tail` (head=ceil/2, tail=floor/2), notice `(N bytes omitted. Full result stored at: <path>)` with its byte cost reserved INSIDE the cap (`budget = cap − notice − 2`, replacement re-checked), traversal-safe session-scoped paths, best-effort storage (write failure keeps the result inline), `read_file` skipped (anti read→spill→read loop)
- `agent/tool_executor.py`: integration at both write points (`execute_tool_calls_concurrent` and `execute_tool_calls_sequential`), config resolved once per turn, applied before `make_tool_result_message`; multimodal results untouched
- `hermes_cli/config_defaults.py`: `tools.spill` defaults
- `tests/tools/test_tool_spill.py` (new): 32 tests — cap applied, notice with path, reserved-budget invariant, best-effort with failing storage, read_file skip, unicode

## Validation

| Teste | Resultado |
|-------|-----------|
| `pytest tests/tools/test_tool_spill.py` | 32 passed |
| Default behavior | disabled (`enabled: false`) — conservative, opt-in |
