### PR TITLE
feat(compression): cache-aware summarization + thinking-off aux titles

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3617,6 +3617,213 @@ class ContextCompressor(ContextEngine):
 
         return "\n\n".join(parts)
 
+    def _summarizer_wire_message(self, msg: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert one transcript message into a wire-safe summarizer message.
+
+        Cache-aware summarization (PR feat(compression): cache-aware compaction)
+        replays the head + compacted region as REAL chat messages — instead of
+        flattening them into labeled text — so the auxiliary call is a genuine
+        prefix of the last routed request and the provider's KV cache is reused.
+        This transform applies exactly the same safety bounds the flattened
+        ``_serialize_for_summary`` path applies, but preserves the message
+        shape (role / content / tool_calls / tool_call_id) so the replayed
+        prefix stays byte-identical to the real request wherever content is
+        unchanged:
+
+        - Secrets redacted (``_redact_compaction_text``)
+        - Media directives replaced with ``[media attachment]``
+        - Multimodal image parts collapsed to ``[image]`` / ``[image: url]``
+          labels (a text summarizer must stay text-only; divergence is bounded
+          to image-bearing messages)
+        - Inline reasoning blocks stripped from assistant content
+        - Long content / tool-call arguments truncated (``_CONTENT_MAX`` /
+          ``_TOOL_ARGS_MAX``)
+        - ``tool_calls`` / ``tool_call_id`` preserved so the tool-call/result
+          pairs survive replay in order
+
+        Returns a new dict; the input message is never mutated.
+        """
+        from agent.agent_runtime_helpers import strip_think_blocks
+
+        role = msg.get("role", "unknown")
+        content = msg.get("content")
+        if isinstance(content, list):
+            text_parts: list[str] = []
+            for part in content:
+                if isinstance(part, dict):
+                    ptype = part.get("type")
+                    if ptype == "text":
+                        text_parts.append(part.get("text", ""))
+                    elif ptype in {"image", "image_url", "input_image"}:
+                        text_parts.append(_image_part_label(part))
+                    else:
+                        # Unknown part type — keep a marker so the
+                        # summarizer knows content existed here.
+                        text_parts.append(f"[{ptype or 'attachment'}]")
+                elif isinstance(part, str):
+                    text_parts.append(part)
+            content = "\n".join(text_parts)
+        content = _redact_compaction_text(content or "")
+        content = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", content)
+        if role == "assistant" and content:
+            content = strip_think_blocks(None, content)
+
+        out: Dict[str, Any] = {"role": role, "content": content}
+
+        # Tool-call assistant messages: keep the calls as real tool_calls so
+        # the replayed prefix matches the request wire shape (and the paired
+        # tool messages keep their tool_call_id references valid).
+        if role == "assistant" and msg.get("tool_calls"):
+            tc_list = msg["tool_calls"]
+            if isinstance(tc_list, list) and tc_list:
+                cleaned = []
+                for tc in tc_list:
+                    if isinstance(tc, dict):
+                        fn = tc.get("function")
+                        if isinstance(fn, dict):
+                            name = fn.get("name", "?")
+                            args = _redact_compaction_text(fn.get("arguments", ""))
+                            if len(args) > self._TOOL_ARGS_MAX:
+                                args = args[:self._TOOL_ARGS_HEAD] + "..."
+                            cleaned.append(
+                                {
+                                    "id": tc.get("id", ""),
+                                    "type": "function",
+                                    "function": {"name": name, "arguments": args},
+                                }
+                            )
+                            continue
+                        # Non-dict function field (defensive): keep the call id
+                        # so tool pairing still works, drop the body.
+                        cleaned.append(
+                            {
+                                "id": tc.get("id", ""),
+                                "type": "function",
+                                "function": {"name": "?", "arguments": ""},
+                            }
+                        )
+                        continue
+                    fn = getattr(tc, "function", None)
+                    name = getattr(fn, "name", "?") if fn else "?"
+                    cleaned.append(
+                        {
+                            "id": getattr(tc, "id", ""),
+                            "type": "function",
+                            "function": {"name": name, "arguments": ""},
+                        }
+                    )
+                out["tool_calls"] = cleaned
+
+        if role == "tool" and msg.get("tool_call_id"):
+            out["tool_call_id"] = msg["tool_call_id"]
+
+        if len(content) > self._CONTENT_MAX:
+            out["content"] = (
+                content[:self._CONTENT_HEAD]
+                + "\n...[truncated]...\n"
+                + content[-self._CONTENT_TAIL:]
+            )
+        return out
+
+    @classmethod
+    def _bound_summarizer_messages(cls, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Cap total structured summarizer input while preserving the edges.
+
+        Structured sibling of ``_bound_summary_input``: when the aggregate
+        character count of the replay messages exceeds
+        ``_SUMMARY_INPUT_MAX_CHARS``, keep the earliest and latest messages
+        (the beginning often holds task setup and the tail the most recent
+        state) and mark the omitted middle by appending the same explicit
+        marker to the last retained pre-gap message. Messages that survive are
+        left byte-identical, so prefix-cache reuse is only lost from the first
+        truncated message onward — exactly the bounded divergence the flat
+        truncation already accepted.
+        """
+        total = 0
+        for msg in messages:
+            content = msg.get("content")
+            total += len(content) if isinstance(content, str) else 0
+        if total <= cls._SUMMARY_INPUT_MAX_CHARS:
+            return messages
+
+        marker_template = (
+            "\n\n...[summary input truncated: omitted "
+            "{omitted:,} chars from the middle to keep compression prompt bounded]...\n\n"
+        )
+        marker = marker_template.format(omitted=total)
+        remaining = max(cls._SUMMARY_INPUT_MAX_CHARS - len(marker), 0)
+        head_chars = int(remaining * 0.45)
+        tail_chars = remaining - head_chars
+
+        def _size(msg: Dict[str, Any]) -> int:
+            content = msg.get("content")
+            return len(content) if isinstance(content, str) else 0
+
+        # Greedy head pass: keep whole messages while they fit the head share.
+        head_msgs: List[Dict[str, Any]] = []
+        head_used = 0
+        split_idx = 0
+        for msg in messages:
+            size = _size(msg)
+            if head_used + size <= head_chars:
+                head_msgs.append(msg)
+                head_used += size
+                split_idx += 1
+            else:
+                break
+        # Greedy tail pass (from the end): keep whole messages while they fit.
+        tail_msgs: List[Dict[str, Any]] = []
+        tail_used = 0
+        for msg in reversed(messages[split_idx:]):
+            size = _size(msg)
+            if tail_used + size <= tail_chars:
+                tail_msgs.append(msg)
+                tail_used += size
+            else:
+                break
+        tail_msgs.reverse()
+
+        if not head_msgs and not tail_msgs:
+            # Degenerate: no whole message fits its share (very tight cap or a
+            # single oversized message). Keep the first and last messages with
+            # their contents individually capped, so the summarizer still gets
+            # bounded input with both edges.
+            kept: List[Dict[str, Any]] = []
+            for msg in (messages[0], messages[-1]):
+                clone = dict(msg)
+                content = clone.get("content")
+                if isinstance(content, str):
+                    clone["content"] = cls._bound_summary_input(content)
+                kept.append(clone)
+            if messages[0] is messages[-1]:
+                kept = kept[:1]
+            # The omission marker rides the first kept message.
+            first = dict(kept[0])
+            first["content"] = (first.get("content") or "") + marker
+            kept[0] = first
+            return kept
+
+        omitted = total - head_used - tail_used
+        if omitted <= 0:
+            # Everything actually fit the greedy passes — return untouched.
+            return messages
+        marker = marker_template.format(omitted=omitted)
+        if head_msgs:
+            last = head_msgs[-1]
+            prev_content = last.get("content") or ""
+            if not isinstance(prev_content, str):
+                prev_content = str(prev_content)
+            last = dict(last)
+            last["content"] = prev_content + marker
+            head_msgs[-1] = last
+        else:
+            # No pre-gap head message survived: the marker rides the first
+            # retained tail message instead.
+            first_tail = dict(tail_msgs[0])
+            first_tail["content"] = marker + (first_tail.get("content") or "")
+            tail_msgs[0] = first_tail
+        return head_msgs + tail_msgs
+
     def _build_static_fallback_summary(
         self,
         turns_to_summarize: List[Dict[str, Any]],
@@ -3888,6 +4095,8 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         turns_to_summarize: List[Dict[str, Any]],
         focus_topic: Optional[str] = None,
         memory_context: str = "",
+        prefix_messages: Optional[List[Dict[str, Any]]] = None,
+        tools: Optional[list] = None,
     ) -> Optional[str]:
         """Generate a structured summary of conversation turns.
 
@@ -3895,6 +4104,17 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         Questions, Files, Remaining Work) with explicit preamble telling the
         summarizer not to answer questions.  When a previous summary exists,
         generates an iterative update instead of summarizing from scratch.
+
+        The auxiliary call is CACHE-AWARE: the summarizer input is a genuine
+        prefix of the last routed request — the conversation's own system
+        prompt, the tool schemas, then the protected head + compacted region as
+        real chat messages in order — with the summarization instruction as the
+        FINAL user message. The provider's KV cache is therefore reused for the
+        replayed prefix; only the instruction and the generated summary are new
+        tokens. ``prefix_messages`` is the protected head (``messages[:start]``,
+        including the system message when present) and ``tools`` the request's
+        tool schemas; both are optional so legacy/direct callers keep working
+        with a region-only input.
 
         Args:
             focus_topic: Optional focus string for guided compression.  When
@@ -3924,7 +4144,31 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             self._previous_summary = _redact_compaction_text(self._previous_summary)
 
         summary_budget = self._compute_summary_budget(turns_to_summarize)
-        content_to_summarize = self._serialize_for_summary(turns_to_summarize)
+        # CACHE-AWARE summarizer input: replay the conversation's own prefix
+        # (system prompt + protected head) and the compacted region as REAL chat
+        # messages so the auxiliary call is a genuine prefix of the last routed
+        # request — the provider's KV cache is reused for everything before the
+        # instruction message. The instruction (preamble + template + dynamic
+        # sections) is appended as the final user message below.
+        _system_prompt = ""
+        _prefix_wire: List[Dict[str, Any]] = []
+        if prefix_messages:
+            _head = list(prefix_messages)
+            if _head and _head[0].get("role") == "system":
+                _sys_content = _head[0].get("content")
+                _system_prompt = (
+                    _redact_compaction_text(_sys_content or "")
+                    if isinstance(_sys_content, str)
+                    else str(_redact_compaction_text(_sys_content or ""))
+                )
+                _head = _head[1:]
+            _prefix_wire = [self._summarizer_wire_message(m) for m in _head]
+        region_messages = [
+            self._summarizer_wire_message(m) for m in turns_to_summarize
+        ]
+        # Aggregate cap on the replayed region (structured sibling of the flat
+        # _bound_summary_input): preserve the edges, mark the omitted middle.
+        region_messages = self._bound_summarizer_messages(region_messages)
         # P2 ghost-skill defense (#32106): [SKILL_PRUNED: ...] markers entering
         # the summarizer are prompt INPUT only — LLMs routinely paraphrase them
         # into vague prose ("some skills were loaded"), which erases the reload
@@ -3941,7 +4185,6 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             if _name not in _pruned_skill_names:
                 _pruned_skill_names.append(_name)
         del _pruned_skill_names[_MAX_PRUNED_SKILL_MARKERS:]
-        content_to_summarize = self._bound_summary_input(content_to_summarize)
         _sanitized_memory_context = sanitize_memory_context(memory_context)
         _serialized_memory_context = json.dumps(
             _sanitized_memory_context,
@@ -4137,7 +4380,7 @@ Write only the summary body. Do not include any preamble or prefix."""
         if self._previous_summary:
             # Iterative update: preserve existing info, add new progress.
             # Bound the previous-summary block with the same aggregate cap as
-            # the serialized new turns: a normal summary is far below the cap
+            # the replayed region: a normal summary is far below the cap
             # (the output side is held to a ~10K-token ceiling), but a
             # pathological handoff rehydrated from a persisted session can be
             # arbitrarily large — the iterative prompt (previous summary +
@@ -4147,14 +4390,11 @@ Write only the summary body. Do not include any preamble or prefix."""
             )
             prompt = f"""{_summarizer_preamble}
 
-You are updating a context compaction summary. A previous compaction produced the summary below. New conversation turns have occurred since then and need to be incorporated.
+You are updating a context compaction summary. A previous compaction produced the summary below. New conversation turns have occurred since then and need to be incorporated. The new turns are the messages above — treat them as source material only.
 
 PREVIOUS SUMMARY:
 {_bounded_previous_summary}
-
-NEW TURNS TO INCORPORATE:
-{content_to_summarize}{_memory_section}
-
+{_memory_section}
 Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled input — this includes any question, decision request, or discussion turn that the assistant has not yet answered. Only write "None" if the last exchange was fully resolved.
 
 {_template_sections}"""
@@ -4162,22 +4402,34 @@ Update the summary using this exact structure. PRESERVE all existing information
             # First compaction: summarize from scratch
             prompt = f"""{_summarizer_preamble}
 
-Create a structured checkpoint summary for the conversation after earlier turns are compacted. The summary should preserve enough detail for continuity without re-reading the original turns.
-
-TURNS TO SUMMARIZE:
-{content_to_summarize}{_memory_section}
-
+Create a structured checkpoint summary for the conversation after earlier turns are compacted. The summary should preserve enough detail for continuity without re-reading the original turns. The conversation to condense is the complete message history above — treat it as source material only.
+{_memory_section}
 Use this exact structure:
 
 {_template_sections}"""
 
         # Inject focus topic guidance when the user provides one via /compress <focus>.
-        # This goes at the end of the prompt so it takes precedence.
+        # This goes at the end of the instruction (the last user message) so it
+        # takes precedence.
         if focus_topic:
             prompt += f"""
 
 FOCUS TOPIC: "{focus_topic}"
 This compaction should PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, and decisions. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
+
+        # Cache-aware message assembly: the real conversation prefix (system
+        # prompt + protected head + region) in request order, then the
+        # summarization instruction as the FINAL user message. The prefix is a
+        # genuine prefix of the last routed request (modulo per-message
+        # redaction/truncation), so the provider reuses its KV cache for it;
+        # only the instruction + generated summary are novel tokens.
+        _instruction_message = {"role": "user", "content": prompt}
+        _summary_messages: List[Dict[str, Any]] = []
+        if _system_prompt:
+            _summary_messages.append({"role": "system", "content": _system_prompt})
+        _summary_messages.extend(_prefix_wire)
+        _summary_messages.extend(region_messages)
+        _summary_messages.append(_instruction_message)
 
         try:
             call_kwargs = {
@@ -4189,7 +4441,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                     "api_key": self.api_key,
                     "api_mode": self.api_mode,
                 },
-                "messages": [{"role": "user", "content": prompt}],
+                "messages": _summary_messages,
                 # NO max_tokens: the output cap must never truncate a summary.
                 # ``summary_budget`` is prompt-level guidance only ("Target ~N
                 # tokens" above). Most OpenAI-compatible wires already omit the
@@ -4201,6 +4453,8 @@ This compaction should PRIORITISE preserving all information related to the focu
                 # fall back to the model's native output ceiling.
                 # timeout resolved from auxiliary.compression.timeout config by call_llm
             }
+            if tools:
+                call_kwargs["tools"] = list(tools)
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
             _aux_provider = ""
@@ -4398,6 +4652,8 @@ This compaction should PRIORITISE preserving all information related to the focu
                     turns_to_summarize,
                     focus_topic=focus_topic,
                     memory_context=memory_context,
+                    prefix_messages=prefix_messages,
+                    tools=tools,
                 )  # retry immediately
 
             # Unknown-error best-effort retry on main model.  Losing N turns of
@@ -4419,6 +4675,8 @@ This compaction should PRIORITISE preserving all information related to the focu
                     turns_to_summarize,
                     focus_topic=focus_topic,
                     memory_context=memory_context,
+                    prefix_messages=prefix_messages,
+                    tools=tools,
                 )
 
             # Transient errors (timeout, rate limit, network, JSON decode,
@@ -6427,6 +6685,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         focus_topic: Optional[str] = None,
         force: bool = False,
         memory_context: str = "",
+        tools: Optional[list] = None,
     ) -> List[Dict[str, Any]]:
         """Compress conversation messages by summarizing middle turns.
 
@@ -6463,6 +6722,12 @@ This compaction should PRIORITISE preserving all information related to the focu
                 summary path.  Auto-compress callers pass False.
             memory_context: Optional provider-supplied context to preserve in
                 the summary prompt. Whitespace-only values are ignored.
+            tools: Optional list of OpenAI-shaped tool schemas (the same
+                schemas sent on the last routed request). When provided, they
+                are replayed ahead of the conversation prefix so the auxiliary
+                summarization call is a genuine prefix of the real request and
+                the provider's KV cache is reused. Must be the request's actual
+                tool list — a different list would break prefix alignment.
         """
         # Reset per-call summary failure state — callers inspect these fields
         # after compress() returns to decide whether to surface a warning.
@@ -6811,6 +7076,12 @@ This compaction should PRIORITISE preserving all information related to the focu
                     turns_to_summarize,
                     focus_topic=summary_focus_topic,
                     memory_context=memory_context,
+                    # Cache-aware replay prefix: the protected head (system
+                    # prompt + first exchange) must precede the region for the
+                    # auxiliary call to be a genuine prefix of the last routed
+                    # request. tools (when provided) are replayed ahead of it.
+                    prefix_messages=messages[:compress_start],
+                    tools=tools,
                 )
             except AuxiliaryExplicitCancellation:
                 # Explicit cancellation is a true no-op. Restore state mutated by

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1371,6 +1371,7 @@ def _supported_compression_kwargs(
     focus_topic: Optional[str],
     force: bool,
     memory_context: str,
+    tools: Optional[list] = None,
 ) -> dict:
     """Return only compression kwargs accepted by an engine callable.
 
@@ -1386,6 +1387,11 @@ def _supported_compression_kwargs(
     }
     if memory_context:
         candidates["memory_context"] = memory_context
+    if tools:
+        # The request's tool schemas, replayed ahead of the summarizer prefix
+        # so the auxiliary compression call is a genuine prefix of the last
+        # routed request (cache-aware compaction).
+        candidates["tools"] = tools
     try:
         parameters = inspect.signature(compress_fn).parameters
     except (TypeError, ValueError):
@@ -2836,12 +2842,25 @@ def compress_context(
                 pass
 
         compress_fn = agent.context_compressor.compress
+        # The live tool schemas ride along so the summarizer call replays the
+        # request's own prefix (cache-aware compaction). agent.tools is the
+        # exact list sent on the last routed request; a copy is taken inside
+        # the compressor so a later toolset swap cannot mutate the replayed
+        # schemas mid-call.
+        _compress_tools = None
+        try:
+            _agent_tools = getattr(agent, "tools", None)
+            if _agent_tools:
+                _compress_tools = list(_agent_tools)
+        except Exception:
+            _compress_tools = None
         compress_kwargs = _supported_compression_kwargs(
             compress_fn,
             current_tokens=approx_tokens,
             focus_topic=focus_topic,
             force=force,
             memory_context=memory_context,
+            tools=_compress_tools,
         )
         if memory_context.strip() and "memory_context" not in compress_kwargs:
             engine_name = getattr(

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -402,6 +402,15 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
             extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+            # Thinking OFF, enforced for every thinking-capable model (DeepSeek
+            # V4 family, Kimi, Qwen, OpenRouter reasoning tiers, Anthropic
+            # Messages, ...). A titler must not spend its 64-token budget on
+            # reasoning_content: the JSON-schema response would come back
+            # truncated or empty and the session stays named by the instant
+            # derived title. Maps through the same per-provider reasoning
+            # hooks as the main request (e.g. the DeepSeek profile emits
+            # extra_body.thinking={"type": "disabled"} for deepseek-v4-*).
+            reasoning_config={"enabled": False},
         )
         content = response.choices[0].message.content or ""
         return _clean_title(_extract_title_text(content))

--- a/tests/agent/test_compaction_redaction_boundaries.py
+++ b/tests/agent/test_compaction_redaction_boundaries.py
@@ -143,8 +143,14 @@ def test_manual_focus_topic_redacted_before_summary_prompt():
         )
 
     assert result is not None
-    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    # Cache-aware assembly: the instruction (with the focus topic) is the
+    # FINAL message; the replayed region precedes it as real messages.
+    messages = mock_call.call_args.kwargs["messages"]
+    assert messages[-1]["role"] == "user"
+    prompt = messages[-1]["content"]
     _assert_clean(prompt)
+    # The region is replayed structurally, not flattened into the prompt.
+    assert messages[0]["content"] == "Summarize safely"
 
 
 def test_auto_focus_topic_redacted():
@@ -178,7 +184,7 @@ def test_previous_summary_redacted_before_iterative_prompt_reentry():
         )
 
     assert result is not None
-    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    prompt = mock_call.call_args.kwargs["messages"][-1]["content"]
     assert "PREVIOUS SUMMARY:" in prompt
     _assert_clean(prompt)
     # After generation, _previous_summary holds the new (clean) LLM output —
@@ -218,6 +224,6 @@ def test_resumed_handoff_summary_redacted_before_iterative_prompt():
     ) as mock_call:
         c.compress(messages)
 
-    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    prompt = mock_call.call_args.kwargs["messages"][-1]["content"]
     assert "PREVIOUS SUMMARY:" in prompt
     _assert_clean(prompt)

--- a/tests/agent/test_compress_focus.py
+++ b/tests/agent/test_compress_focus.py
@@ -57,7 +57,7 @@ def test_focus_topic_injected_into_summary_prompt():
         result = compressor._generate_summary(turns, focus_topic="database schema")
 
     assert result is not None
-    prompt_text = captured_prompt["messages"][0]["content"]
+    prompt_text = captured_prompt["messages"][-1]["content"]
     assert 'FOCUS TOPIC: "database schema"' in prompt_text
     assert "PRIORITISE" in prompt_text
     assert "60-70%" in prompt_text
@@ -83,7 +83,7 @@ def test_no_focus_topic_no_injection():
     with patch("agent.context_compressor.call_llm", mock_call_llm):
         result = compressor._generate_summary(turns)
 
-    prompt_text = captured_prompt["messages"][0]["content"]
+    prompt_text = captured_prompt["messages"][-1]["content"]
     assert "FOCUS TOPIC" not in prompt_text
 
 

--- a/tests/agent/test_compression_cache_aware_input.py
+++ b/tests/agent/test_compression_cache_aware_input.py
@@ -1,0 +1,382 @@
+"""Cache-aware summarization input assembly (feat(compression): cache-aware compaction).
+
+The auxiliary summarization call must be a GENUINE PREFIX of the last routed
+request — the conversation's own system prompt, the tool schemas, then the
+protected head + compacted region as real chat messages in order, with the
+summarization instruction as the FINAL user message. That lets the provider
+reuse its KV cache for the replayed prefix; only the instruction + generated
+summary are novel tokens.
+
+Contracts under test:
+- message order: system → head → region → instruction (last)
+- tools are replayed ahead of the prefix when provided
+- region messages stay STRUCTURED (role/content/tool_calls/tool_call_id),
+  never flattened into the instruction text
+- per-message safety bounds still apply (redaction, think-strip, truncation)
+- the aggregate input cap preserves edges and marks the omitted middle
+- legacy callers without prefix/tools still work (region + instruction)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.context_compressor import (
+    ContextCompressor,
+    SUMMARY_PREFIX,
+    HISTORICAL_TASK_HEADING,
+)
+
+SECRET = "sk-proj-" + ("a" * 40)
+
+
+def _compressor() -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100000,
+    ):
+        return ContextCompressor(model="test/model", quiet_mode=True)
+
+
+def _response(content: str):
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = content
+    return mock_response
+
+
+def _call_kwargs(c, turns, **kwargs):
+    """Run _generate_summary with a mocked call_llm and return its kwargs."""
+    with patch(
+        "agent.context_compressor.call_llm",
+        return_value=_response("## Goal\nsafe summary"),
+    ) as mock_call:
+        result = c._generate_summary(turns, **kwargs)
+    assert result is not None
+    assert result.startswith(SUMMARY_PREFIX)
+    return mock_call.call_args.kwargs
+
+
+class TestSummarizerWireMessage:
+    def test_plain_string_content_preserved(self):
+        c = _compressor()
+        out = c._summarizer_wire_message({"role": "user", "content": "hello"})
+        assert out == {"role": "user", "content": "hello"}
+
+    def test_secrets_redacted(self):
+        c = _compressor()
+        out = c._summarizer_wire_message(
+            {"role": "user", "content": f"deploy with {SECRET}"}
+        )
+        # _redact_compaction_text masks the secret (keeps a short fragment);
+        # the full value must never reach the summarizer.
+        assert SECRET not in out["content"]
+        assert "sk-proj-" not in out["content"]
+
+    def test_content_list_flattened_with_image_label(self):
+        c = _compressor()
+        out = c._summarizer_wire_message(
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look at this"},
+                    {"type": "image_url", "image_url": {"url": "https://x.io/i.png"}},
+                    {"type": "input_audio", "data": "..."},
+                ],
+            }
+        )
+        assert out["content"] == "look at this\n[image: https://x.io/i.png]\n[input_audio]"
+
+    def test_media_directive_replaced(self):
+        c = _compressor()
+        out = c._summarizer_wire_message(
+            {"role": "user", "content": "see MEDIA:C:/tmp/x.png here"}
+        )
+        assert "[media attachment]" in out["content"]
+        assert "MEDIA:" not in out["content"]
+
+    def test_assistant_think_blocks_stripped(self):
+        c = _compressor()
+        out = c._summarizer_wire_message(
+            {
+                "role": "assistant",
+                "content": "<think>scratch work</think>real answer",
+            }
+        )
+        assert "<think>" not in out["content"]
+        assert "real answer" in out["content"]
+
+    def test_tool_calls_preserved_with_redacted_args(self):
+        c = _compressor()
+        out = c._summarizer_wire_message(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": f'{{"command": "echo {SECRET}"}}',
+                        },
+                    }
+                ],
+            }
+        )
+        assert out["role"] == "assistant"
+        assert out["tool_calls"][0]["id"] == "call-1"
+        assert out["tool_calls"][0]["function"]["name"] == "terminal"
+        assert SECRET not in out["tool_calls"][0]["function"]["arguments"]
+
+    def test_tool_message_keeps_tool_call_id(self):
+        c = _compressor()
+        out = c._summarizer_wire_message(
+            {"role": "tool", "tool_call_id": "call-1", "content": "result"}
+        )
+        assert out["tool_call_id"] == "call-1"
+        assert out["content"] == "result"
+
+    def test_long_content_truncated(self):
+        c = _compressor()
+        big = "x" * (c._CONTENT_MAX * 2)
+        out = c._summarizer_wire_message({"role": "user", "content": big})
+        assert "..." in out["content"]
+        assert len(out["content"]) < c._CONTENT_MAX + 100
+
+    def test_input_not_mutated(self):
+        c = _compressor()
+        msg = {"role": "user", "content": f"secret {SECRET}"}
+        c._summarizer_wire_message(msg)
+        assert msg["content"] == f"secret {SECRET}"
+
+
+class TestBoundSummarizerMessages:
+    def test_under_cap_unchanged(self):
+        msgs = [{"role": "user", "content": "a"}, {"role": "assistant", "content": "b"}]
+        out = ContextCompressor._bound_summarizer_messages(msgs)
+        assert out is msgs
+
+    def test_over_cap_keeps_edges_and_marks_middle(self, monkeypatch):
+        monkeypatch.setattr(
+            ContextCompressor, "_SUMMARY_INPUT_MAX_CHARS", 200
+        )
+        msgs = [
+            {"role": "user", "content": "head " * 30},
+            {"role": "assistant", "content": "mid1 " * 30},
+            {"role": "assistant", "content": "mid2 " * 30},
+            {"role": "user", "content": "tail " * 30},
+        ]
+        out = ContextCompressor._bound_summarizer_messages(msgs)
+        # Edges kept, middle dropped, marker appended to the last pre-gap msg.
+        assert out[0]["content"].startswith("head")
+        assert out[-1]["content"].startswith("tail")
+        assert any("summary input truncated" in m["content"] for m in out)
+        total = sum(len(m.get("content") or "") for m in out)
+        assert total < 200 + 500  # marker inflates the last kept message
+
+    def test_roles_preserved_through_cap(self, monkeypatch):
+        monkeypatch.setattr(
+            ContextCompressor, "_SUMMARY_INPUT_MAX_CHARS", 100
+        )
+        msgs = [
+            {"role": "user", "content": "u" * 60},
+            {"role": "tool", "tool_call_id": "c1", "content": "t" * 60},
+            {"role": "assistant", "content": "a" * 60},
+        ]
+        out = ContextCompressor._bound_summarizer_messages(msgs)
+        assert out[0]["role"] == "user"
+        assert out[-1]["role"] == "assistant"
+        assert len(out) == 2
+
+
+class TestGenerateSummaryCacheAwareInput:
+    def _head_and_region(self):
+        head = [
+            {"role": "system", "content": "You are Hermes. Be helpful."},
+            {"role": "user", "content": "protected first ask"},
+            {"role": "assistant", "content": "protected first answer"},
+        ]
+        region = [
+            {"role": "user", "content": "middle ask"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call-9",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": '{"cmd": "ls"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-9", "content": "file list"},
+            {"role": "assistant", "content": "middle answer"},
+        ]
+        return head, region
+
+    def test_message_order_system_head_region_instruction_last(self):
+        c = _compressor()
+        head, region = self._head_and_region()
+        kwargs = _call_kwargs(c, region, prefix_messages=head)
+        messages = kwargs["messages"]
+
+        assert messages[0] == {"role": "system", "content": "You are Hermes. Be helpful."}
+        # Head replayed next, in order.
+        assert messages[1] == {"role": "user", "content": "protected first ask"}
+        assert messages[2] == {"role": "assistant", "content": "protected first answer"}
+        # Region follows, structured (tool_calls / tool_call_id preserved).
+        assert messages[3] == {"role": "user", "content": "middle ask"}
+        assert messages[4]["role"] == "assistant"
+        assert messages[4]["tool_calls"][0]["id"] == "call-9"
+        assert messages[5] == {
+            "role": "tool",
+            "tool_call_id": "call-9",
+            "content": "file list",
+        }
+        assert messages[6] == {"role": "assistant", "content": "middle answer"}
+        # Instruction is the FINAL message.
+        assert messages[-1]["role"] == "user"
+        assert messages[-1] is not messages[3]  # separate message, not merged
+        instruction = messages[-1]["content"]
+        assert "You are a summarization agent" in instruction
+        assert HISTORICAL_TASK_HEADING in instruction
+        assert "## Goal" in instruction
+        # Region content is NOT flattened into the instruction.
+        assert "middle ask" not in instruction
+        assert "file list" not in instruction
+        assert "[ASSISTANT]:" not in instruction
+        assert "TURNS TO SUMMARIZE" not in instruction
+
+    def test_tools_replayed_before_prefix(self):
+        c = _compressor()
+        head, region = self._head_and_region()
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "terminal", "description": "run a command"},
+            }
+        ]
+        kwargs = _call_kwargs(c, region, prefix_messages=head, tools=tools)
+        assert kwargs["tools"] == tools
+        # Tools don't appear as messages; messages still start with system.
+        messages = kwargs["messages"]
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "You are Hermes. Be helpful."
+
+    def test_no_prefix_legacy_shape(self):
+        c = _compressor()
+        region = [
+            {"role": "user", "content": "ask"},
+            {"role": "assistant", "content": "answer"},
+        ]
+        kwargs = _call_kwargs(c, region)
+        messages = kwargs["messages"]
+        # No system, no head: region first, instruction last.
+        assert messages[0] == {"role": "user", "content": "ask"}
+        assert messages[1] == {"role": "assistant", "content": "answer"}
+        assert messages[2]["role"] == "user"
+        assert messages[2]["content"].startswith("You are a summarization agent")
+        assert "tools" not in kwargs
+
+    def test_region_without_system_prompt_in_prefix(self):
+        c = _compressor()
+        head = [{"role": "user", "content": "head only, no system"}]
+        region = [{"role": "user", "content": "region ask"}]
+        kwargs = _call_kwargs(c, region, prefix_messages=head)
+        messages = kwargs["messages"]
+        assert messages[0] == {"role": "user", "content": "head only, no system"}
+        assert messages[1] == {"role": "user", "content": "region ask"}
+        assert messages[-1]["role"] == "user"
+        assert messages[-1]["content"].startswith("You are a summarization agent")
+
+    def test_iterative_update_keeps_previous_summary_in_instruction(self):
+        c = _compressor()
+        c._previous_summary = "PREVIOUS-SUMMARY-BODY unique"
+        region = [{"role": "user", "content": "REGION-UNIQUE-TOKEN"}]
+        kwargs = _call_kwargs(c, region)
+        instruction = kwargs["messages"][-1]["content"]
+        assert "PREVIOUS-SUMMARY-BODY unique" in instruction
+        assert "You are updating a context compaction summary" in instruction
+        assert "PREVIOUS SUMMARY:" in instruction
+        # The region is not duplicated into the instruction.
+        assert "REGION-UNIQUE-TOKEN" not in instruction
+
+    def test_memory_context_lands_in_instruction(self):
+        c = _compressor()
+        region = [{"role": "user", "content": "turn"}]
+        kwargs = _call_kwargs(c, region, memory_context="memory provider payload")
+        instruction = kwargs["messages"][-1]["content"]
+        assert "MEMORY PROVIDER CONTEXT:" in instruction
+        assert "memory provider payload" in instruction
+        # Not injected into the replayed region.
+        assert kwargs["messages"][0]["content"] == "turn"
+
+    def test_no_wire_max_tokens_cap(self):
+        c = _compressor()
+        kwargs = _call_kwargs(c, [{"role": "user", "content": "turn"}])
+        assert "max_tokens" not in kwargs
+
+
+class TestCompressCacheAwarePlumbing:
+    def test_compress_forwards_prefix_and_tools(self):
+        c = _compressor()
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "ask 1"},
+            {"role": "assistant", "content": "ans 1"},
+            {"role": "user", "content": "ask 2"},
+            {"role": "assistant", "content": "ans 2"},
+            {"role": "user", "content": "ask 3"},
+            {"role": "assistant", "content": "ans 3"},
+            {"role": "user", "content": "tail ask"},
+            {"role": "assistant", "content": "tail ans"},
+        ]
+        tools = [{"type": "function", "function": {"name": "x"}}]
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            return_value=_response("## Goal\ncompressed"),
+        ) as mock_call:
+            with patch(
+                "agent.context_compressor.ContextCompressor._derive_auto_focus_topic",
+                return_value=None,
+            ):
+                result = c.compress(messages, tools=tools)
+
+        assert len(result) < len(messages)
+        assert mock_call.called
+        kwargs = mock_call.call_args.kwargs
+        assert kwargs["tools"] == tools
+        sent = kwargs["messages"]
+        # System first, then the protected head before the region.
+        assert sent[0] == {"role": "system", "content": "sys"}
+        assert sent[1] == {"role": "user", "content": "ask 1"}
+        # Instruction always last.
+        assert sent[-1]["role"] == "user"
+        assert sent[-1]["content"].startswith("You are a summarization agent")
+
+    def test_compress_without_tools_omits_key(self):
+        c = _compressor()
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "ask 1"},
+            {"role": "assistant", "content": "ans 1"},
+            {"role": "user", "content": "ask 2"},
+            {"role": "assistant", "content": "ans 2"},
+            {"role": "user", "content": "ask 3"},
+            {"role": "assistant", "content": "ans 3"},
+            {"role": "user", "content": "tail ask"},
+            {"role": "assistant", "content": "tail ans"},
+        ]
+        with patch(
+            "agent.context_compressor.call_llm",
+            return_value=_response("## Goal\ncompressed"),
+        ) as mock_call:
+            with patch(
+                "agent.context_compressor.ContextCompressor._derive_auto_focus_topic",
+                return_value=None,
+            ):
+                c.compress(messages)
+
+        assert "tools" not in mock_call.call_args.kwargs

--- a/tests/agent/test_compression_small_ctx_threshold_floor.py
+++ b/tests/agent/test_compression_small_ctx_threshold_floor.py
@@ -121,7 +121,7 @@ class TestSummaryBudgetEnvelope:
         assert out is not None
         assert "max_tokens" not in captured
         # The budget still lands as prompt guidance, within the envelope.
-        prompt = captured["messages"][0]["content"]
+        prompt = captured["messages"][-1]["content"]
         import re
         m = re.search(r"Target ~(\d+) tokens", prompt)
         assert m, "prompt-level token target guidance missing"

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2911,7 +2911,7 @@ class TestSummaryPromptBounding:
         with patch("agent.context_compressor.call_llm", return_value=mock_response) as mock_call:
             summary = c._generate_summary(messages)
 
-        prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+        prompt = mock_call.call_args.kwargs["messages"][-1]["content"]
         assert summary.startswith(SUMMARY_PREFIX)
         # previous summary block + new-turns block each capped, plus the
         # fixed template: well under 3x the cap (unbounded would be ~800K).

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -177,13 +177,23 @@ def test_resume_handoff_after_default_protected_head_decays_initial_turns():
     with patch("agent.context_compressor.call_llm", return_value=_response("fresh summary")) as mock_call:
         result = compressor.compress(_messages_with_default_handoff(old_summary))
 
-    prompt = mock_call.call_args.kwargs["messages"][0]["content"]
+    prompt = mock_call.call_args.kwargs["messages"][-1]["content"]
     assert "PREVIOUS SUMMARY:" in prompt
     assert prompt.count(old_summary) == 1
-    assert "original task before first compaction" in prompt
-    assert "original answer before first compaction" in prompt
-    assert "original follow-up before first compaction" in prompt
-    assert f"[ASSISTANT]: {SUMMARY_PREFIX}" not in prompt
+    # Cache-aware assembly: the decayed head + region are replayed as REAL
+    # messages ahead of the instruction, not flattened into the prompt.
+    replayed = "\n".join(
+        str(m.get("content") or "")
+        for m in mock_call.call_args.kwargs["messages"][:-1]
+        if m.get("role") != "system"
+    )
+    assert "original task before first compaction" in replayed
+    assert "original answer before first compaction" in replayed
+    assert "original follow-up before first compaction" in replayed
+    # The handoff rides only the instruction's PREVIOUS SUMMARY block, and no
+    # flattened [ROLE]: labels survive in the replay.
+    assert f"[ASSISTANT]: {SUMMARY_PREFIX}" not in replayed
+    assert "[ASSISTANT]:" not in replayed
     # Grounding (761a0b124e) may prepend a deterministic task-snapshot
     # section — pin the contract, not the exact stored string.
     stored_summary = compressor._previous_summary or ""

--- a/tests/agent/test_pre_compress_memory_context.py
+++ b/tests/agent/test_pre_compress_memory_context.py
@@ -54,7 +54,7 @@ def test_memory_context_injected_into_initial_summary_prompt_with_focus():
     prompts = []
 
     def mock_call_llm(**kwargs):
-        prompts.append(kwargs["messages"][0]["content"])
+        prompts.append(kwargs["messages"][-1]["content"])
         return _summary_response()
 
     with patch("agent.context_compressor.call_llm", mock_call_llm):
@@ -80,7 +80,7 @@ def test_memory_context_injected_into_iterative_summary_prompt():
     prompts = []
 
     def mock_call_llm(**kwargs):
-        prompts.append(kwargs["messages"][0]["content"])
+        prompts.append(kwargs["messages"][-1]["content"])
         return _summary_response("## Goal\nMigration updated.")
 
     with patch("agent.context_compressor.call_llm", mock_call_llm):
@@ -107,7 +107,7 @@ def test_memory_context_is_strictly_redacted_before_summary_llm(monkeypatch):
     prompts = []
 
     def mock_call_llm(**kwargs):
-        prompts.append(kwargs["messages"][0]["content"])
+        prompts.append(kwargs["messages"][-1]["content"])
         return _summary_response()
 
     monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
@@ -155,7 +155,7 @@ def test_whitespace_memory_context_is_not_injected():
     prompts = []
 
     def mock_call_llm(**kwargs):
-        prompts.append(kwargs["messages"][0]["content"])
+        prompts.append(kwargs["messages"][-1]["content"])
         return _summary_response()
 
     with patch("agent.context_compressor.call_llm", mock_call_llm):

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -46,6 +46,35 @@ class TestGenerateTitle:
         assert captured_kwargs["task"] == "title_generation"
         assert captured_kwargs["timeout"] is None
 
+    def test_forces_thinking_off(self):
+        """Title calls must disable thinking for every thinking-capable model.
+
+        A titler must not spend its 64-token budget on reasoning_content: the
+        JSON-schema title would come back truncated or empty. reasoning_config
+        maps through the same per-provider hooks as the main request (DeepSeek
+        profile → extra_body.thinking={"type": "disabled"} for deepseek-v4-*;
+        Anthropic adapters → native thinking off; generic wires →
+        extra_body.reasoning={"enabled": false}).
+        """
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Thinking-Off Title"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("help me fix this import") == "Thinking-Off Title"
+
+        assert captured_kwargs["reasoning_config"] == {"enabled": False}
+        # Minimal input: the user message alone (already the contract), plus a
+        # strict output cap and the caller-owned timeout.
+        assert len(captured_kwargs["messages"]) == 2
+        assert captured_kwargs["messages"][1]["role"] == "user"
+        assert captured_kwargs["max_tokens"] == 64
+
 
 
     def test_strips_think_blocks(self):


### PR DESCRIPTION
## Summary

Summarization calls now replay a genuine prefix of the last routed request: the conversation's own system prompt, the real tool schemas, the protected head + compacted region as actual chat messages in order, with the summarization instruction as the final user message. Auxiliary session-title calls force thinking OFF so the titler never burns its budget on reasoning.

Root cause: the summarizer built its own standalone prompt, so the auxiliary call started from a cold cache — the provider's KV cache for the conversation prefix was invalidated instead of reused. The dsh harness avoids this by making the auxiliary call a genuine prefix of the last routed request ("the provider's KV cache is reused instead of invalidated").

## Changes

- `agent/context_compressor.py`: `_summarizer_wire_message` (role/content/tool_calls/tool_call_id preserved; redaction, think-strip, media/image labels and per-message truncation unchanged), `_bound_summarizer_messages` (structured sibling of `_bound_summary_input`, 160K char cap), `_generate_summary(prefix_messages, tools)`, `compress(tools)` plumbing
- `agent/conversation_compression.py`: forward `agent.tools` (the exact request schemas) through `_supported_compression_kwargs`
- `agent/title_generator.py`: force thinking OFF via `reasoning_config={"enabled": False}` (DeepSeek profile maps it to `extra_body.thinking={"type": "disabled"}`); minimal input + `max_tokens=64` + caller-owned timeout were already the contract
- Tests: `test_compression_cache_aware_input.py` (new) + updated `test_title_generator.py`, `test_compress_focus.py`, `test_compression_small_ctx_threshold_floor.py`, `test_compaction_redaction_boundaries.py`, `test_context_compressor_summary_continuity.py`, `test_pre_compress_memory_context.py`

## Validation

| Teste | Resultado |
|-------|-----------|
| `pytest` (7 compression/title suites) | 84 passed |
| Input assembly | system → head → region (chat messages) → instruction LAST — verified by test |
