### PR TITLE
feat(agent): repeat-tool-reminder advisory (loop hygiene)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -280,6 +280,15 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
     agent._current_streamed_assistant_text = ""
     agent._stream_needs_break = True
 
+    # A real user correction (steer/interrupt) resets the consecutive-repeat
+    # tool-call chain: repetition across user input is not a loop. Advisory.
+    try:
+        from agent.repeat_tool_reminder import reset as _reset_repeat_reminder
+
+        _reset_repeat_reminder(agent)
+    except Exception:
+        pass
+
 
 def _is_copilot_provider(agent: Any) -> bool:
     """Delegate to ``AIAgent._is_copilot_provider`` (single owner of the check).
@@ -1492,6 +1501,18 @@ def run_conversation(
     agent._last_compaction_in_place = False
     agent._last_compression_attempt_recorded = False
     agent._last_compression_attempt_in_place = None
+
+    # A real user turn starts here (CLI/gateway invoke run_conversation once
+    # per user message; synthetic continuations like auto_continue and the
+    # background-review fork run on separate agent instances or inside the
+    # loop below). Reset the consecutive-repeat tool-call chain so repetition
+    # across turns is never counted as a loop. Advisory; never raises.
+    try:
+        from agent.repeat_tool_reminder import reset as _reset_repeat_reminder
+
+        _reset_repeat_reminder(agent)
+    except Exception:
+        pass
 
     # If a background memory/skill review spawned at the end of a PRIOR turn
     # (agent/background_review.py) is still running its own run_conversation()

--- a/agent/repeat_tool_reminder.py
+++ b/agent/repeat_tool_reminder.py
@@ -1,0 +1,270 @@
+"""Advisory consecutive-repeat tool-call reminder (loop hygiene).
+
+Detects consecutive identical tool calls — same tool name plus canonically
+identical arguments — and appends a soft, advisory reminder to the CURRENT
+tool result when the run length hits a configured threshold. It never
+blocks, never vetoes, and never touches tool schemas.
+
+How it works
+------------
+- Identity: ``(tool_name, canonical_tool_args(args))``. Argument
+  canonicalization reuses ``agent.tool_guardrails.canonical_tool_args``
+  (compact JSON with recursively sorted keys), so two calls that differ
+  only in property order are identical for the detector.
+- Chain: one consecutive-run chain per agent instance (the long-lived
+  ``AIAgent`` the gateway caches across turns — i.e. per session). A call
+  with a different name or canonical arguments resets the chain to 1; an
+  identical call increments it. ``reset()`` clears the chain and is called
+  when a REAL user message arrives (a new user turn at the top of
+  ``run_conversation``, or a mid-turn user correction via
+  ``_apply_active_turn_redirect``) — repetition across user input is not
+  a loop.
+- Thresholds: when the run length hits a configured threshold, a reminder
+  is appended to the tail of the current tool result. The first threshold
+  gets the gentle tier; later thresholds get the detailed tier naming the
+  tool, the run length, and a capped preview of the canonical arguments.
+- Injection: the reminder is appended at the very END of the current tool
+  result (after untrusted-content wrapping inside
+  ``make_tool_result_message``), so the cached conversation prefix stays
+  byte-identical and the reminder is never wrapped as untrusted data.
+
+Advisory contract
+-----------------
+- Never raises: every failure path degrades to "no reminder".
+- Never blocks or vetoes tool execution; there is no hard-stop option.
+- The chain is an in-memory attribute on the agent instance
+  (``_repeat_tool_reminder_state``), never persisted.
+
+Config (config.yaml, ``repeat_tool_reminder`` section)
+------------------------------------------------------
+    repeat_tool_reminder:
+      enabled: true                # master switch (advisory: safe by default)
+      thresholds: [3, 5, 8]        # run lengths that trigger a reminder
+      include: []                  # wildcard patterns; empty = track every tool
+      exclude: []                  # wildcard patterns; matched tools are transparent
+      arguments_preview_chars: 500 # cap for the args preview in detailed reminders
+
+``include``/``exclude`` entries are ``*``-wildcard predicates over tool
+names (``*`` matches any run of characters; every other character matches
+literally). ``exclude`` wins over ``include``. Untracked calls are
+transparent: they neither count nor reset the chain.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from typing import Any, Mapping, Optional
+
+from agent.tool_guardrails import canonical_tool_args
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_THRESHOLDS = [3, 5, 8]
+DEFAULT_PREVIEW_CHARS = 500
+
+# Stable, documented prefix for every reminder this guard emits — the same
+# bracket-tag family as the tool-loop-guardrail warnings.
+_REMINDER_TAG = "[reminder]"
+
+# Serializes chain mutation across concurrent tool-execution worker threads.
+_LOCK = threading.Lock()
+
+# Per-agent chain state attribute (lazily created; see ``_state``).
+_STATE_ATTR = "_repeat_tool_reminder_state"
+
+
+def canonicalize_arguments(value: Any) -> str:
+    """Return the canonical string identity for parsed tool arguments.
+
+    Delegates to ``agent.tool_guardrails.canonical_tool_args`` (compact
+    JSON with recursively sorted keys — deep key sort), so argument objects
+    that differ only in property order canonicalize identically. Non-mapping
+    input canonicalizes as ``{}`` (the identity used for calls whose
+    arguments could not be parsed).
+    """
+    return canonical_tool_args(value if isinstance(value, Mapping) else {})
+
+
+def wildcard_to_regex(pattern: str) -> "re.Pattern[str]":
+    """Compile one ``*``-wildcard pattern to an anchored regex.
+
+    ``*`` matches any run of characters; every other regex metacharacter
+    is escaped and matched literally.
+    """
+    escaped = re.escape(pattern).replace("\\*", ".*")
+    return re.compile(f"^{escaped}$")
+
+
+def _tool_is_tracked(tool_name: str, include, exclude) -> bool:
+    """Whether a tool participates in the chain.
+
+    Untracked calls are transparent: they neither count nor reset.
+    ``exclude`` wins over ``include``; an empty ``include`` means every
+    tool is tracked.
+    """
+    if include and not any(p.match(tool_name) for p in include):
+        return False
+    if any(p.match(tool_name) for p in exclude):
+        return False
+    return True
+
+
+def _preview_arguments(canonical: str, cap: int) -> str:
+    """Head-truncate canonical arguments for quoting in detailed reminders.
+
+    Bounds only the model-visible preview — the chain identity always
+    compares the FULL canonical string.
+    """
+    if len(canonical) <= cap:
+        return canonical
+    return f"{canonical[:cap]}… (+{len(canonical) - cap} more chars)"
+
+
+def gentle_reminder(tool_name: str, count: int) -> str:
+    """The gentle first-threshold reminder.
+
+    Keyed to the first configured threshold (not a literal count) by the
+    caller, so a custom first threshold keeps the gentle→detailed
+    escalation.
+    """
+    return (
+        f'{_REMINDER_TAG} You have called "{tool_name}" with identical '
+        f"arguments {count} times in a row. Carefully analyze the previous "
+        "result before calling again: if the task is not complete, try a "
+        "different approach or different arguments instead of repeating "
+        "the call."
+    )
+
+
+def detailed_reminder(
+    tool_name: str,
+    count: int,
+    canonical_arguments: str,
+    preview_chars: int = DEFAULT_PREVIEW_CHARS,
+) -> str:
+    """The detailed later-threshold reminder naming the tool, the run
+    length, and a capped preview of the canonical arguments."""
+    return (
+        f'{_REMINDER_TAG} You have called "{tool_name}" with identical '
+        f"arguments {count} times in a row.\n"
+        f"- consecutive_calls: {count}\n"
+        f"- arguments: {_preview_arguments(canonical_arguments, preview_chars)}\n"
+        "The repeated calls are not making progress. Do not call this tool "
+        "with these exact arguments again. Inspect the latest result and "
+        "choose a different action, different arguments, or finish the task "
+        "if enough evidence has been gathered."
+    )
+
+
+def _resolve_config(config: Any) -> dict:
+    """Normalize the ``repeat_tool_reminder`` config section, fail-safe.
+
+    Invalid values fall back to defaults; the result never raises. An
+    explicitly empty ``thresholds`` list means "never remind".
+    """
+    if not isinstance(config, Mapping):
+        return {
+            "enabled": True,
+            "thresholds": list(DEFAULT_THRESHOLDS),
+            "include": [],
+            "exclude": [],
+            "preview_chars": DEFAULT_PREVIEW_CHARS,
+        }
+    thresholds = []
+    for value in config.get("thresholds", DEFAULT_THRESHOLDS):
+        if isinstance(value, bool) or not isinstance(value, int) or value < 2:
+            continue
+        thresholds.append(value)
+    thresholds = sorted(set(thresholds))
+    if "thresholds" not in config:
+        thresholds = thresholds or list(DEFAULT_THRESHOLDS)
+    enabled = config.get("enabled", True)
+    preview = config.get("arguments_preview_chars", DEFAULT_PREVIEW_CHARS)
+    return {
+        "enabled": enabled if isinstance(enabled, bool) else True,
+        "thresholds": thresholds,
+        "include": [s for s in config.get("include", []) if isinstance(s, str)],
+        "exclude": [s for s in config.get("exclude", []) if isinstance(s, str)],
+        "preview_chars": (
+            preview
+            if isinstance(preview, int) and not isinstance(preview, bool) and preview >= 1
+            else DEFAULT_PREVIEW_CHARS
+        ),
+    }
+
+
+def _read_config() -> Mapping[str, Any]:
+    """Read the live ``repeat_tool_reminder`` config section.
+
+    Uses the cached read-only config loader; any failure (no config file,
+    malformed YAML, missing section) degrades to an empty mapping so the
+    module falls back to defaults.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        section = load_config_readonly().get("repeat_tool_reminder")
+        return section if isinstance(section, Mapping) else {}
+    except Exception:
+        return {}
+
+
+def _state(agent: Any) -> dict:
+    """Lazily create the agent's chain state: the last tracked call's
+    identity key and its run length."""
+    state = getattr(agent, _STATE_ATTR, None)
+    if state is None:
+        state = {"key": None, "count": 0}
+        setattr(agent, _STATE_ATTR, state)
+    return state
+
+
+def maybe_remind(agent: Any, tool_name: str, args: Any, config: Any = None) -> Optional[str]:
+    """Advance the agent's consecutive-repeat chain for one tool call.
+
+    Returns the reminder text to append to the CURRENT tool result when
+    the run length hits a configured threshold, else ``None``. Purely
+    advisory: never raises and never blocks — any failure degrades to
+    ``None``. ``config`` may be injected for tests; production reads the
+    live ``repeat_tool_reminder`` section.
+    """
+    try:
+        cfg = _resolve_config(config if config is not None else _read_config())
+        if not cfg["enabled"] or not cfg["thresholds"]:
+            return None
+        include = [wildcard_to_regex(p) for p in cfg["include"]]
+        exclude = [wildcard_to_regex(p) for p in cfg["exclude"]]
+        if not _tool_is_tracked(tool_name, include, exclude):
+            return None
+        canonical = canonicalize_arguments(args)
+        key = (tool_name, canonical)
+        with _LOCK:
+            state = _state(agent)
+            count = state["count"] + 1 if state["key"] == key else 1
+            state["key"] = key
+            state["count"] = count
+        thresholds = cfg["thresholds"]
+        if count not in thresholds:
+            return None
+        if count == thresholds[0]:
+            return gentle_reminder(tool_name, count)
+        return detailed_reminder(tool_name, count, canonical, cfg["preview_chars"])
+    except Exception:
+        logger.debug("repeat_tool_reminder suppressed (advisory)", exc_info=True)
+        return None
+
+
+def reset(agent: Any) -> None:
+    """Clear the agent's consecutive-repeat chain.
+
+    Called when a REAL user message arrives (a new user turn, or a mid-turn
+    user correction) — repetition across user input is not a loop. Never
+    raises.
+    """
+    try:
+        with _LOCK:
+            setattr(agent, _STATE_ATTR, {"key": None, "count": 0})
+    except Exception:
+        pass

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -536,6 +536,7 @@ def make_tool_result_message(
     tool_call_id: str,
     *,
     effect_disposition: str | None = None,
+    append_tail: str | None = None,
 ) -> dict:
     """Build a tool-result message dict with both the OpenAI-format ``name``
     field (required by the wire format and provider adapters) and the internal
@@ -555,8 +556,16 @@ def make_tool_result_message(
     neutralized and framed). Non-text parts (e.g. image_url) are preserved.
     The outer list itself is rebuilt rather than returned by identity, so
     callers should compare by value, not by ``is``.
+
+    ``append_tail`` (optional): advisory text appended at the very END of the
+    result content, AFTER untrusted-content wrapping — so a reminder is never
+    wrapped as untrusted data and never interrupts the wrapped payload. String
+    content gets ``"\\n\\n" + tail``; multimodal content lists get a trailing
+    text part. Any other content shape is returned unchanged.
     """
     wrapped = _maybe_wrap_untrusted(name, content)
+    if append_tail:
+        wrapped = _append_tail_to_content(wrapped, append_tail)
     message = {
         "role": "tool",
         "name": name,
@@ -574,6 +583,21 @@ def make_tool_result_message(
     if effect_disposition is not None:
         message["effect_disposition"] = effect_disposition
     return message
+
+
+def _append_tail_to_content(content: Any, tail: str) -> Any:
+    """Append advisory text to the END of tool-result content.
+
+    Handles plain string content (separated by a blank line) and OpenAI-style
+    multimodal content lists (adds a trailing text part so image blocks stay
+    intact). Any other content shape is returned unchanged — the tail must
+    never break a valid tool-result message.
+    """
+    if isinstance(content, str):
+        return f"{content}\n\n{tail}" if content else tail
+    if isinstance(content, list):
+        return [*content, {"type": "text", "text": tail}]
+    return content
 
 
 # Tools whose results carry attacker-controllable content.  Wrapping their

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -40,6 +40,7 @@ from agent.tool_dispatch_helpers import (
     _plan_tool_batch_segments,
     make_tool_result_message,
 )
+from agent.repeat_tool_reminder import maybe_remind as _maybe_repeat_remind
 from tools.terminal_tool import (
     get_active_env,
 )
@@ -1494,11 +1495,18 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # image tool result never poisons canonical session history.
         # String results pass through unchanged.
         _tool_content = agent._tool_result_content_for_active_model(name, function_result)
+        # Advisory loop-hygiene: append a repeat-call reminder to the tail of
+        # this result when the same tool has been called with canonically
+        # identical arguments N consecutive times (never blocks, never vetoes).
+        # ``name``/``args`` (not the worker-unpacked locals) are used so the
+        # identity is correct on every outcome path (success, timeout, cancel).
+        _reminder_tail = _maybe_repeat_remind(agent, name, args)
         tool_message = make_tool_result_message(
             name,
             _tool_content,
             tc.id,
             effect_disposition=effect_disposition,
+            append_tail=_reminder_tail,
         )
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
@@ -2286,7 +2294,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
-        tool_message = make_tool_result_message(function_name, _tool_content, tool_call.id)
+        # Advisory loop-hygiene: append a repeat-call reminder to the tail of
+        # this result when the same tool has been called with canonically
+        # identical arguments N consecutive times (never blocks, never vetoes).
+        _reminder_tail = _maybe_repeat_remind(agent, function_name, function_args)
+        tool_message = make_tool_result_message(
+            function_name, _tool_content, tool_call.id, append_tail=_reminder_tail,
+        )
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
         if not _flush_session_db_after_tool_progress(

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -428,6 +428,26 @@ tool_loop_guardrails:
     idempotent_no_progress: 5
 
 # =============================================================================
+# Repeat Tool Reminder (advisory loop hygiene)
+# =============================================================================
+# Detects CONSECUTIVE identical tool calls (same tool name + canonically
+# identical arguments — property order does not matter) and appends a soft
+# reminder to the tail of the current tool result when the run length hits a
+# threshold. Purely advisory: never blocks execution, never vetoes, never
+# touches tool schemas, and the cached conversation prefix stays unchanged.
+# The counter is per session and resets whenever a real user message arrives.
+repeat_tool_reminder:
+  enabled: true                 # master switch (advisory: safe by default)
+  thresholds: [3, 5, 8]         # run lengths that trigger a reminder; first
+                                # threshold = gentle tier, later = detailed
+                                # tier (tool, count, args preview)
+  include: []                   # tool-name wildcard patterns to track;
+                                # empty = track every tool ("*" = any run)
+  exclude: []                   # wildcard patterns transparent to the chain
+                                # (neither count nor reset); wins over include
+  arguments_preview_chars: 500  # cap for args quoted in the detailed reminder
+
+# =============================================================================
 # Context Compression (Auto-shrinks long conversations)
 # =============================================================================
 # When conversation approaches model's context limit, middle turns are

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3279,6 +3279,37 @@ DEFAULT_CONFIG = {
         "region": "global",
     },
 
+    # Advisory loop-hygiene guard (agent/repeat_tool_reminder.py): detects
+    # consecutive identical tool calls (same tool name + canonically identical
+    # arguments, deep key-sorted JSON) and appends a soft reminder to the tail
+    # of the CURRENT tool result when the run length hits a threshold.
+    # Advisory only — never blocks execution, never vetoes, never touches tool
+    # schemas, and the cached conversation prefix stays byte-identical.
+    # The chain is per agent instance (per session in the gateway) and resets
+    # when a real user message arrives (new turn or mid-turn steer).
+    "repeat_tool_reminder": {
+        # Master switch. On by default: the reminder is low-risk (tail-only,
+        # advisory text that only appears after N identical consecutive calls)
+        # and is the cheapest loop-hygiene signal available. Set false to
+        # disable entirely.
+        "enabled": True,
+        # Run lengths that trigger a reminder. The first threshold gets the
+        # gentle tier; later thresholds get the detailed tier (tool name, run
+        # length, capped canonical-arguments preview). An explicitly empty
+        # list disables reminders. Every value must be an integer >= 2.
+        "thresholds": [3, 5, 8],
+        # Tool-name wildcard patterns to track; empty = every tool is tracked.
+        # "*" matches any run of characters, everything else matches literally.
+        "include": [],
+        # Tool-name wildcard patterns that are transparent to the chain
+        # (neither count nor reset). "exclude" wins over "include".
+        "exclude": [],
+        # Maximum characters of canonical arguments quoted in the DETAILED
+        # reminder. Bounds only the model-visible preview — detection always
+        # compares the full canonical arguments.
+        "arguments_preview_chars": 500,
+    },
+
     # Config schema version - bump this when adding new required fields
     "_config_version": 34,
 }

--- a/tests/agent/test_repeat_tool_reminder.py
+++ b/tests/agent/test_repeat_tool_reminder.py
@@ -1,0 +1,359 @@
+"""Unit tests for the advisory repeat-tool-reminder guard
+(``agent/repeat_tool_reminder.py``).
+
+Covers: argument canonicalization (deep key sort), thresholds and tone
+escalation, reset on real user messages, include/exclude wildcards, chain
+semantics (a different call resets the run), and the advisory contract
+(never raises, never blocks).
+"""
+
+import threading
+
+import pytest
+
+from agent.repeat_tool_reminder import (
+    DEFAULT_PREVIEW_CHARS,
+    DEFAULT_THRESHOLDS,
+    canonicalize_arguments,
+    detailed_reminder,
+    gentle_reminder,
+    maybe_remind,
+    reset,
+    wildcard_to_regex,
+)
+
+DEFAULT_CFG = {
+    "enabled": True,
+    "thresholds": list(DEFAULT_THRESHOLDS),
+    "include": [],
+    "exclude": [],
+    "arguments_preview_chars": DEFAULT_PREVIEW_CHARS,
+}
+
+
+def _agent():
+    """A minimal stand-in for the AIAgent: chain state is an attribute."""
+    return type("FakeAgent", (), {})()
+
+
+# =========================================================================
+# Canonicalization (deep key sort)
+# =========================================================================
+
+
+class TestCanonicalization:
+    def test_property_order_is_irrelevant(self):
+        a = {"z": 1, "a": {"d": 2, "c": {"q": 1, "p": 2}}, "m": [{"y": 1, "x": 2}]}
+        b = {"a": {"c": {"p": 2, "q": 1}, "d": 2}, "m": [{"x": 2, "y": 1}], "z": 1}
+        assert canonicalize_arguments(a) == canonicalize_arguments(b)
+
+    def test_nested_lists_of_dicts_are_sorted(self):
+        a = {"items": [{"b": 1, "a": 2}, {"d": 1, "c": 2}]}
+        b = {"items": [{"a": 2, "b": 1}, {"c": 2, "d": 1}]}
+        assert canonicalize_arguments(a) == canonicalize_arguments(b)
+
+    def test_different_values_differ(self):
+        assert canonicalize_arguments({"a": 1}) != canonicalize_arguments({"a": 2})
+
+    def test_non_mapping_input_canonicalizes_to_empty_object(self):
+        # Calls whose arguments could not be parsed as an object share the
+        # "{}" identity — repeats of the same malformed call still accumulate.
+        assert canonicalize_arguments(None) == canonicalize_arguments({})
+        assert canonicalize_arguments("not a dict") == canonicalize_arguments({})
+
+    def test_identity_through_the_chain(self):
+        # Two calls that differ only in argument property order advance the
+        # SAME chain run (the second call increments, it does not reset).
+        agent = _agent()
+        assert maybe_remind(agent, "terminal", {"cmd": "ls", "cwd": "/tmp"}, DEFAULT_CFG) is None
+        assert maybe_remind(agent, "terminal", {"cwd": "/tmp", "cmd": "ls"}, DEFAULT_CFG) is None
+        assert maybe_remind(agent, "terminal", {"cmd": "ls", "cwd": "/tmp"}, DEFAULT_CFG) is not None
+
+
+# =========================================================================
+# Thresholds and tone escalation
+# =========================================================================
+
+
+class TestThresholdsAndEscalation:
+    def test_default_thresholds_escalate(self):
+        agent = _agent()
+        args = {"cmd": "ls"}
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is None  # 1
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is None  # 2
+        third = maybe_remind(agent, "terminal", args, DEFAULT_CFG)         # 3 -> gentle
+        assert third == gentle_reminder("terminal", 3)
+        assert third.startswith("[reminder]")
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is None  # 4
+        fifth = maybe_remind(agent, "terminal", args, DEFAULT_CFG)         # 5 -> detailed
+        assert fifth == detailed_reminder("terminal", 5, canonicalize_arguments(args))
+        assert "consecutive_calls: 5" in fifth
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is None  # 6
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is None  # 7
+        eighth = maybe_remind(agent, "terminal", args, DEFAULT_CFG)        # 8 -> detailed
+        assert "consecutive_calls: 8" in eighth
+
+    def test_custom_thresholds_first_is_gentle(self):
+        cfg = {**DEFAULT_CFG, "thresholds": [2, 4]}
+        agent = _agent()
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is None  # 1
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) == gentle_reminder("terminal", 2)
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is None  # 3
+        detailed = maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg)      # 4
+        assert "consecutive_calls: 4" in detailed
+        assert detailed != gentle_reminder("terminal", 4)
+
+    def test_detailed_reminder_names_tool_and_arguments(self):
+        text = detailed_reminder("read_file", 5, '{"path":"a.txt"}')
+        assert '"read_file"' in text
+        assert "- arguments: {\"path\":\"a.txt\"}" in text
+        assert text.startswith("[reminder] You have called")
+
+    def test_detailed_preview_is_capped(self):
+        args = {"payload": "x" * 200}
+        canonical = canonicalize_arguments(args)
+        text = detailed_reminder("write_file", 5, canonical, preview_chars=32)
+        assert "(+%d more chars)" % (len(canonical) - 32) in text
+        assert "payload" in text
+
+    def test_preview_within_cap_is_verbatim(self):
+        assert detailed_reminder("t", 5, '{"a":1}', preview_chars=50) == detailed_reminder(
+            "t", 5, '{"a":1}', preview_chars=DEFAULT_PREVIEW_CHARS
+        )
+
+    def test_chain_resets_on_different_arguments(self):
+        agent = _agent()
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, DEFAULT_CFG) is None  # 1
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, DEFAULT_CFG) is None  # 2
+        assert maybe_remind(agent, "terminal", {"cmd": "pwd"}, DEFAULT_CFG) is None  # different -> 1
+        assert maybe_remind(agent, "terminal", {"cmd": "pwd"}, DEFAULT_CFG) is None  # 2
+        assert maybe_remind(agent, "terminal", {"cmd": "pwd"}, DEFAULT_CFG) is not None  # 3
+
+    def test_chain_resets_on_different_tool(self):
+        agent = _agent()
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, DEFAULT_CFG) is None  # 1
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, DEFAULT_CFG) is None  # 2
+        assert maybe_remind(agent, "read_file", {"path": "a"}, DEFAULT_CFG) is None  # different -> 1
+        assert maybe_remind(agent, "read_file", {"path": "a"}, DEFAULT_CFG) is None  # 2
+        assert maybe_remind(agent, "read_file", {"path": "a"}, DEFAULT_CFG) is not None  # 3
+
+    def test_chain_is_per_agent(self):
+        a, b = _agent(), _agent()
+        assert maybe_remind(a, "terminal", {"cmd": "ls"}, DEFAULT_CFG) is None
+        assert maybe_remind(a, "terminal", {"cmd": "ls"}, DEFAULT_CFG) is None
+        assert maybe_remind(b, "terminal", {"cmd": "ls"}, DEFAULT_CFG) is None  # b starts at 1
+        assert maybe_remind(a, "terminal", {"cmd": "ls"}, DEFAULT_CFG) is not None  # a hits 3
+        assert maybe_remind(b, "terminal", {"cmd": "ls"}, DEFAULT_CFG) is None  # b at 2
+
+
+# =========================================================================
+# Reset on real user messages
+# =========================================================================
+
+
+class TestReset:
+    def test_reset_clears_the_chain(self):
+        agent = _agent()
+        args = {"cmd": "ls"}
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is None
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is None
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is not None  # 3 -> gentle
+        reset(agent)
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is None  # back to 1
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is None  # 2
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is not None  # 3 again
+
+    def test_reset_is_idempotent_and_safe_on_plain_objects(self):
+        agent = _agent()
+        reset(agent)
+        reset(agent)
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, DEFAULT_CFG) is None
+
+    def test_mid_turn_user_correction_resets_the_chain(self):
+        # Wiring check for conversation_loop._apply_active_turn_redirect: a
+        # real user correction (steer/interrupt) must clear the chain so
+        # repetition across user input is never counted as a loop.
+        from types import SimpleNamespace
+
+        from agent.conversation_loop import _apply_active_turn_redirect
+
+        agent = SimpleNamespace(
+            _strip_think_blocks=lambda text: text,
+            _current_streamed_assistant_text="",
+            _stream_needs_break=False,
+        )
+        # Advance the chain to the gentle threshold.
+        args = {"cmd": "ls"}
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is None
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is None
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is not None
+
+        _apply_active_turn_redirect(agent, [], "please stop and reconsider")
+
+        # After the correction the chain restarts: two more identical calls
+        # produce no reminder, the third hits the gentle threshold again.
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is None
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is None
+        assert maybe_remind(agent, "terminal", args, DEFAULT_CFG) is not None
+
+
+# =========================================================================
+# include / exclude wildcards
+# =========================================================================
+
+
+class TestIncludeExclude:
+    def test_include_limits_tracking(self):
+        cfg = {**DEFAULT_CFG, "include": ["terminal*"]}
+        agent = _agent()
+        # read_file is transparent: it neither counts nor resets.
+        assert maybe_remind(agent, "read_file", {"path": "a"}, cfg) is None
+        assert maybe_remind(agent, "read_file", {"path": "a"}, cfg) is None
+        assert maybe_remind(agent, "read_file", {"path": "a"}, cfg) is None
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is None  # 1 (untracked calls ignored)
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is None  # 2
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is not None  # 3
+
+    def test_exclude_makes_tools_transparent(self):
+        cfg = {**DEFAULT_CFG, "exclude": ["mcp_*"]}
+        agent = _agent()
+        assert maybe_remind(agent, "mcp_x", {"a": 1}, cfg) is None
+        assert maybe_remind(agent, "mcp_x", {"a": 1}, cfg) is None
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is None  # 1
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is None  # 2
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is not None  # 3
+
+    def test_exclude_wins_over_include(self):
+        cfg = {**DEFAULT_CFG, "include": ["*"], "exclude": ["todo"]}
+        agent = _agent()
+        assert maybe_remind(agent, "todo", {"todos": []}, cfg) is None
+        assert maybe_remind(agent, "todo", {"todos": []}, cfg) is None
+        assert maybe_remind(agent, "todo", {"todos": []}, cfg) is None  # never counts
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is None  # 1
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is None  # 2
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is not None  # 3
+
+    def test_wildcard_matches_any_run(self):
+        assert wildcard_to_regex("terminal*").match("terminal")
+        assert wildcard_to_regex("terminal*").match("terminal_tool")
+        assert not wildcard_to_regex("terminal*").match("my_terminal")
+        assert wildcard_to_regex("*_tool").match("read_tool")
+        assert not wildcard_to_regex("*_tool").match("tool_read")
+        assert wildcard_to_regex("*").match("anything")
+
+    def test_literal_metacharacters_do_not_leak(self):
+        # "a.b" must match literally, not as regex "any-char b".
+        assert wildcard_to_regex("a.b").match("a.b")
+        assert not wildcard_to_regex("a.b").match("axb")
+
+
+# =========================================================================
+# Config handling
+# =========================================================================
+
+
+class TestConfig:
+    def test_disabled_returns_none(self):
+        cfg = {**DEFAULT_CFG, "enabled": False}
+        agent = _agent()
+        for _ in range(5):
+            assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is None
+
+    def test_empty_thresholds_disables_reminders(self):
+        cfg = {**DEFAULT_CFG, "thresholds": []}
+        agent = _agent()
+        for _ in range(5):
+            assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is None
+
+    def test_invalid_thresholds_are_filtered(self):
+        # [3, 2, 2, 1, "x", True, 5] -> deduped/sorted valid integers [2, 3, 5].
+        cfg = {**DEFAULT_CFG, "thresholds": [3, 2, 2, 1, "x", True, 5]}
+        agent = _agent()
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is None  # 1
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) == gentle_reminder("terminal", 2)
+        third = maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg)         # 3 -> detailed
+        assert "consecutive_calls: 3" in third
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg) is None  # 4
+        fifth = maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg)         # 5 -> detailed
+        assert "consecutive_calls: 5" in fifth
+
+    def test_missing_section_falls_back_to_defaults(self):
+        # An empty/absent section behaves exactly like the defaults.
+        agent = _agent()
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, {}) is None
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, {}) is None
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, {}) is not None
+
+
+# =========================================================================
+# Advisory contract: never raises, never blocks
+# =========================================================================
+
+
+class TestAdvisoryContract:
+    def test_broken_config_read_degrades_to_none(self, monkeypatch):
+        import agent.repeat_tool_reminder as rtr
+
+        def _boom():
+            raise RuntimeError("config unavailable")
+
+        monkeypatch.setattr(rtr, "_read_config", _boom)
+        agent = _agent()
+        # No exception, no reminder — the guard must never break the loop.
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}) is None
+
+    def test_unserializable_args_never_raise(self):
+        agent = _agent()
+        cyclic = {}
+        cyclic["self"] = cyclic  # json.dumps raises ValueError
+        # Must not raise; degrades to no reminder.
+        assert maybe_remind(agent, "terminal", cyclic, DEFAULT_CFG) is None
+        # And the chain still works afterwards.
+        assert maybe_remind(agent, "terminal", {"cmd": "ls"}, DEFAULT_CFG) is None
+
+    def test_bad_config_shapes_never_raise(self):
+        for bad in (None, "nope", 42, ["list"]):
+            # Fresh agent per shape: bad configs fall back to defaults, and
+            # the chain must still advance without raising.
+            agent = _agent()
+            assert maybe_remind(agent, "terminal", {"cmd": "ls"}, bad) is None
+
+    def test_reminder_is_append_only_text(self):
+        # The returned value is plain text meant for the result tail; it must
+        # never look like a tool schema change or a blocking directive.
+        text = detailed_reminder("terminal", 5, '{"cmd":"ls"}')
+        assert text.startswith("[reminder]")
+        assert "Do not call this tool with these exact arguments again" in text
+
+
+# =========================================================================
+# Thread safety (concurrent tool-execution workers)
+# =========================================================================
+
+
+class TestThreadSafety:
+    def test_concurrent_identical_calls_advance_one_chain(self):
+        agent = _agent()
+        cfg = {**DEFAULT_CFG, "thresholds": [8, 10]}
+        results = []
+        errors = []
+
+        def worker():
+            try:
+                results.append(maybe_remind(agent, "terminal", {"cmd": "ls"}, cfg))
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        reminders = [r for r in results if r is not None]
+        # Exactly two of the ten calls hit a threshold: count 8 (gentle) and
+        # count 10 (detailed).
+        assert len(reminders) == 2
+        assert any("identical arguments 8 times" in r for r in reminders)
+        assert any("consecutive_calls: 10" in r for r in reminders)

--- a/tests/agent/test_tool_dispatch_helpers.py
+++ b/tests/agent/test_tool_dispatch_helpers.py
@@ -195,6 +195,57 @@ class TestMakeToolResultMessage:
 
 
 
+class TestAppendTail:
+    """Advisory tail injection: the repeat-tool-reminder channel.
+
+    The tail must land at the very END of the result content (never inside
+    the untrusted wrapper), must work for string and multimodal content,
+    and must never alter the message when no tail is passed.
+    """
+
+    TAIL = "[reminder] You have called the tool X 3 times in a row."
+
+    def test_string_content_gets_blank_line_separator(self):
+        msg = make_tool_result_message("terminal", "done", "c1", append_tail=self.TAIL)
+        assert msg["content"] == f"done\n\n{self.TAIL}"
+
+    def test_empty_string_content_becomes_tail(self):
+        msg = make_tool_result_message("terminal", "", "c2", append_tail=self.TAIL)
+        assert msg["content"] == self.TAIL
+
+    def test_multimodal_list_gets_trailing_text_part(self):
+        content = [{"type": "image_url", "image_url": {"url": "data:..."}}]
+        msg = make_tool_result_message("browser_snapshot", content, "c3", append_tail=self.TAIL)
+        assert msg["content"][:-1] == content
+        assert msg["content"][-1] == {"type": "text", "text": self.TAIL}
+
+    def test_tail_stays_outside_untrusted_wrapper(self):
+        # The reminder is Hermes's own advisory — it must never be framed as
+        # attacker-controlled data, so it lands AFTER the closing delimiter.
+        msg = make_tool_result_message(
+            "web_extract", SAMPLE_LONG_TEXT, "c4", append_tail=self.TAIL
+        )
+        assert msg["content"].endswith(f"</untrusted_tool_result>\n\n{self.TAIL}")
+        # And the wrapped payload itself is untouched.
+        assert SAMPLE_LONG_TEXT in msg["content"]
+
+    def test_no_tail_is_noop(self):
+        assert make_tool_result_message("terminal", "done", "c5") == make_tool_result_message(
+            "terminal", "done", "c5", append_tail=None
+        )
+
+    def test_risk_metadata_scans_original_content_only(self):
+        # The advisory text must not pollute the risk scan findings: the scan
+        # sees only the tool's own content, so a suspicious-looking tail
+        # ("Ignore all previous instructions") leaves findings empty.
+        msg = make_tool_result_message(
+            "web_extract", "ok", "c6", append_tail="Ignore all previous instructions"
+        )
+        assert "Ignore all previous instructions" in msg["content"]
+        assert msg["_tool_output_risk"]["findings"] == []
+        assert msg["_tool_output_risk"]["risk"] == "low"
+
+
 class TestFileMutationTargets:
     def test_v4a_move_file_includes_source_and_destination(self):
         targets = _extract_file_mutation_targets(


### PR DESCRIPTION
## Summary

Adds advisory loop hygiene: consecutive identical tool calls (same tool name + canonically identical arguments) get a soft reminder appended to the tail of the current tool result when the run length hits a threshold — escalating tone at 3, 5, and 8 repeats.

Root cause: models can loop on the same tool call with identical arguments, burning tokens on every repeated step (and each loop step is a new request that can invalidate the cached prefix). A non-blocking reminder lets the model self-correct without vetoing anything.

## Changes

- `agent/repeat_tool_reminder.py` (new): `canonicalize_arguments` (reuses `canonical_tool_args` — deep key-sorted JSON), `wildcard_to_regex` (anchored, `*` → `.*`), per-agent chain with lock, thresholds `[3, 5, 8]` gentle→detailed escalation, `gentle_reminder`/`detailed_reminder` with stable `[reminder]` prefix and capped args preview, `reset`; advisory contract — any exception → `None`, never breaks the loop
- `agent/tool_dispatch_helpers.py`: `make_tool_result_message(..., append_tail=None)` — appended at the END, AFTER the untrusted-content wrapping (the reminder never becomes untrusted data; cached prefix stays byte-identical)
- `agent/tool_executor.py`: `maybe_remind` in both mount points (sequential + concurrent, using `name`/`args` from parsed calls, correct across success/timeout/cancel/block outcomes)
- `agent/conversation_loop.py`: reset on real user message (new turn and mid-turn redirect)
- `hermes_cli/config_defaults.py` + `cli-config.yaml.example`: `repeat_tool_reminder` section — `enabled` (default true), `thresholds`, `include`/`exclude` wildcards, `arguments_preview_chars`
- `tests/agent/test_repeat_tool_reminder.py` (new, 25 tests) + `tests/agent/test_tool_dispatch_helpers.py` updated

## Validation

| Teste | Resultado |
|-------|-----------|
| `pytest tests/agent/test_repeat_tool_reminder.py tests/agent/test_tool_dispatch_helpers.py` | 54 passed |
| Non-blocking contract | reminder appends only; execution never vetoed (tested) |
