### PR TITLE
feat(delegation): subagent result never-rejects with stop_reason + partial text

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1748,5 +1748,185 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIsNone(kwargs["fallback_model"])
 
 
+class TestSubagentStopReasonContract(unittest.TestCase):
+    """Never-reject structured child results: {output, stop_reason}.
+
+    Mirrors the deepseek-harness SubagentResult contract
+    (packages/subagent/subagent/src/types.ts): a failed child settles into a
+    structured entry carrying stop_reason plus its preserved partial text,
+    instead of breaking the parent turn or silently dropping the child's
+    output.  The readable text stays in `summary`; `stop_reason` and
+    `partial_output` are additive fields.
+    """
+
+    def _run_child(self, run_conversation_return, child=None, parent=None):
+        from tools.delegate_tool import _run_single_child
+
+        child = child or MagicMock()
+        child.run_conversation.return_value = run_conversation_return
+        return _run_single_child(
+            task_index=0,
+            goal="stop-reason test",
+            child=child,
+            parent_agent=parent or _make_mock_parent(depth=0),
+        )
+
+    def test_success_maps_to_completed_and_keeps_existing_fields(self):
+        """Success keeps the previous contract (status/summary/exit_reason)
+        and gains stop_reason='completed'; no partial_output is emitted."""
+        entry = self._run_child(
+            {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["exit_reason"], "completed")
+        self.assertEqual(entry["stop_reason"], "completed")
+        self.assertEqual(entry["summary"], "done")
+        self.assertNotIn("partial_output", entry)
+
+    def test_child_error_preserves_partial_text(self):
+        """A failing child (failed=True, empty final_response) maps to
+        stop_reason='error' and keeps its last real assistant text."""
+        entry = self._run_child(
+            {
+                "final_response": "",
+                "completed": False,
+                "interrupted": False,
+                "failed": True,
+                "error": "model exploded",
+                "api_calls": 2,
+                "messages": [
+                    {"role": "user", "content": "task"},
+                    {"role": "assistant", "content": "I started working on it and"},
+                ],
+            }
+        )
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(entry["stop_reason"], "error")
+        self.assertEqual(entry["error"], "model exploded")
+        self.assertEqual(entry["partial_output"], "I started working on it and")
+
+    def test_interrupted_maps_to_aborted(self):
+        """User/parent cancellation maps to stop_reason='aborted'."""
+        entry = self._run_child(
+            {
+                "final_response": "partial answer before stop",
+                "completed": False,
+                "interrupted": True,
+                "api_calls": 1,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "interrupted")
+        self.assertEqual(entry["exit_reason"], "interrupted")
+        self.assertEqual(entry["stop_reason"], "aborted")
+        # summary already carries the text — no duplicate partial_output.
+        self.assertNotIn("partial_output", entry)
+
+    def test_interrupted_with_dropped_text_sets_partial_output(self):
+        """Interrupted with an empty summary still surfaces the partial text."""
+        entry = self._run_child(
+            {
+                "final_response": "",
+                "completed": False,
+                "interrupted": True,
+                "api_calls": 1,
+                "messages": [{"role": "assistant", "content": "work in progress..."}],
+            }
+        )
+        self.assertEqual(entry["stop_reason"], "aborted")
+        self.assertEqual(entry["partial_output"], "work in progress...")
+
+    def test_max_tokens_sentinel_maps_to_max_tokens_with_partial_text(self):
+        """Output-length truncation maps to stop_reason='max-tokens'; the
+        sentinel summary is not real content, so the real partial text is
+        preserved in partial_output."""
+        entry = self._run_child(
+            {
+                "final_response": "Response truncated due to output length limit",
+                "completed": False,
+                "interrupted": False,
+                "partial": True,
+                "error": "Response truncated due to output length limit",
+                "api_calls": 1,
+                "messages": [{"role": "assistant", "content": "half of the answer"}],
+            }
+        )
+        self.assertEqual(entry["stop_reason"], "max-tokens")
+        self.assertEqual(
+            entry["summary"], "Response truncated due to output length limit"
+        )
+        self.assertEqual(entry["partial_output"], "half of the answer")
+
+    def test_max_iterations_with_real_text_maps_to_max_tokens(self):
+        """completed=False with real text means the run ended on its
+        iteration/token budget: stop_reason='max-tokens'."""
+        entry = self._run_child(
+            {
+                "final_response": "mostly done but ran out of iterations",
+                "completed": False,
+                "interrupted": False,
+                "api_calls": 10,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["exit_reason"], "max_iterations")
+        self.assertEqual(entry["stop_reason"], "max-tokens")
+        # summary carries the text — no duplicate partial_output.
+        self.assertNotIn("partial_output", entry)
+
+    def test_empty_sentinel_maps_to_error(self):
+        """The run_agent.py '(empty)' sentinel (empty-LLM retries) is a
+        transport failure, not a token ceiling: stop_reason='error'."""
+        entry = self._run_child(
+            {
+                "final_response": "(empty)",
+                "completed": False,
+                "interrupted": False,
+                "error": "empty LLM responses",
+                "api_calls": 3,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(entry["stop_reason"], "error")
+
+    def test_timeout_maps_to_error_and_preserves_partial_text(self):
+        """A timed-out child never breaks the turn: the entry carries
+        stop_reason='error' (closest available value; status='timeout'
+        retains the finer distinction) and the partial text captured from the
+        abandoned child's session."""
+        from tools import delegate_tool
+
+        child = MagicMock()
+        child._session_messages = [
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "partial before timeout"},
+        ]
+        child.run_conversation.side_effect = lambda **kw: time.sleep(10)
+        child.get_activity_summary.return_value = {
+            "api_call_count": 1,
+            "max_iterations": 30,
+            "current_tool": None,
+            "last_activity_ts": time.time(),
+        }
+        with patch("tools.delegate_tool._get_child_timeout", return_value=0.1):
+            entry = delegate_tool._run_single_child(
+                task_index=0,
+                goal="timeout test",
+                child=child,
+                parent_agent=_make_mock_parent(depth=0),
+            )
+        self.assertEqual(entry["status"], "timeout")
+        self.assertEqual(entry["stop_reason"], "error")
+        self.assertIsNone(entry["summary"])
+        self.assertEqual(entry["partial_output"], "partial before timeout")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2284,3 +2284,72 @@ class TestSystemdCgroupIsolation:
         )
 
         assert pr._stop_systemd_unit("hermes-worker-gone.scope") is True
+
+
+def test_format_async_delegation_renders_stop_reason_and_partial_output():
+    """Never-reject contract on the async surface: a failed background child
+    whose summary is empty still reports its stop_reason and preserved
+    partial text in the re-injected parent message."""
+    from tools.process_registry import _format_async_delegation
+
+    text = _format_async_delegation(
+        {
+            "type": "async_delegation",
+            "delegation_id": "deleg_timeout_1",
+            "session_key": "cli",
+            "goal": "research X",
+            "status": "timeout",
+            "summary": None,
+            "error": "Subagent timed out after 60s",
+            "api_calls": 1,
+            "duration_seconds": 60.0,
+            "exit_reason": "timeout",
+            "stop_reason": "error",
+            "partial_output": "partial research before timeout",
+        }
+    )
+    assert "Stop reason: error" in text
+    assert "did not complete successfully (status=timeout)" in text
+    assert "Partial output (before the run ended):" in text
+    assert "partial research before timeout" in text
+
+    # Batch formatter: a child entry with no summary falls back to
+    # partial_output instead of rendering "(no summary)".
+    batch_text = _format_async_delegation(
+        {
+            "type": "async_delegation",
+            "delegation_id": "deleg_batch_1",
+            "is_batch": True,
+            "goals": ["task 1"],
+            "status": "completed",
+            "results": [
+                {
+                    "task_index": 0,
+                    "status": "error",
+                    "summary": None,
+                    "error": "model failed",
+                    "stop_reason": "error",
+                    "partial_output": "half-finished task text",
+                }
+            ],
+        }
+    )
+    assert "Partial output (before the run ended):" in batch_text
+    assert "half-finished task text" in batch_text
+
+    # Completed runs are untouched: summary renders, no partial block.
+    ok_text = _format_async_delegation(
+        {
+            "type": "async_delegation",
+            "delegation_id": "deleg_ok_1",
+            "goal": "task",
+            "status": "completed",
+            "summary": "finished fine",
+            "api_calls": 1,
+            "duration_seconds": 1.0,
+            "exit_reason": "completed",
+            "stop_reason": "completed",
+        }
+    )
+    assert "finished fine" in ok_text
+    assert "Partial output" not in ok_text

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -984,6 +984,11 @@ def _push_completion_event(
         "dispatched_at": dispatched_at,
         "completed_at": completed_at,
         "exit_reason": result.get("exit_reason"),
+        # Never-reject contract (additive): structured stop reason + preserved
+        # partial text so a failed background child still reports why it
+        # stopped and what it produced before that.
+        "stop_reason": result.get("stop_reason"),
+        "partial_output": result.get("partial_output"),
     }
     # Routing origin captured at dispatch (see _capture_routing_origin):
     # additive, lets the gateway reconstruct a full SessionSource (incl.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -58,6 +58,154 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
 
 
 # ---------------------------------------------------------------------------
+# Subagent stop-reason contract (never-reject structured child result)
+#
+# Mirrors the deepseek-harness SubagentResult vocabulary
+# (packages/subagent/subagent/src/types.ts): every child run — success or
+# failure — settles into a structured entry {output, stop_reason} delivered
+# to the parent, instead of surfacing as an exception that can break the
+# parent turn or as a lost failure.  The readable text stays in `summary`
+# (semantics unchanged); `stop_reason` and `partial_output` are ADDITIVE
+# fields, so existing readers of status/summary/error/exit_reason keep
+# working untouched.
+#
+# stop_reason values and the Hermes signals they map from today:
+#   completed  — the child finished its turn normally
+#                (completed=True, non-empty real summary).
+#   aborted    — cancelled: user interrupt, parent interrupt, or the
+#                close-steering race (interrupted=True / fabricated batch
+#                "interrupted" entries).
+#   error      — model/transport failure, child exception, or timeout.
+#                Timeout has no dedicated vocabulary value; the closest is
+#                error and the finer distinction stays in the existing
+#                status="timeout" / timeout_phase fields.
+#   max-tokens — the child hit its iteration/token budget before finishing
+#                (exit_reason="max_iterations", result.partial=True, or a
+#                run_agent.py output-length sentinel in final_response).
+#   refusal    — NOT distinguishable today: a model that declines the task
+#                produces a normal completed turn, so no signal exists.  The
+#                value is reserved for forward compatibility and never
+#                emitted; a refusal currently settles as "completed".
+# ---------------------------------------------------------------------------
+
+STOP_REASON_COMPLETED = "completed"
+STOP_REASON_ABORTED = "aborted"
+STOP_REASON_ERROR = "error"
+STOP_REASON_MAX_TOKENS = "max-tokens"
+STOP_REASON_REFUSAL = "refusal"
+
+# Fixed ceiling for the preserved partial text (auxiliary channel; the full
+# conversation stays available in the child's messages / live transcripts).
+MAX_PARTIAL_OUTPUT_CHARS = 12000
+
+# run_agent.py emits these sentinel strings as final_response when the real
+# content was dropped due to output-length limits (truncated responses,
+# broken mid tool-call streams).  They are error markers, not child text.
+# NOTE: the "(empty)" sentinel (empty-LLM retries — a transport bug) is NOT
+# listed here on purpose: it maps to stop_reason='error', not 'max-tokens'.
+_TRUNCATION_SENTINELS = frozenset(
+    {
+        "Response truncated due to output length limit",
+        "First response truncated due to output length limit",
+        "Stream repeatedly dropped mid tool-call (network); the tool was not executed",
+    }
+)
+
+
+def _looks_like_truncation(text: str) -> bool:
+    """True when a final_response is an output-length/iteration marker."""
+    return bool(text) and text.strip() in _TRUNCATION_SENTINELS
+
+
+def _extract_partial_assistant_text(
+    result: Dict[str, Any],
+    child=None,
+    *,
+    max_chars: int = MAX_PARTIAL_OUTPUT_CHARS,
+) -> str:
+    """Best-effort capture of the child's last real assistant text.
+
+    Failure paths must not lose what the child produced before failing.
+    Selection order:
+      1. result['final_response'] when it is real content (not an error
+         sentinel emitted by run_agent.py);
+      2. the last non-empty assistant message in result['messages'];
+      3. a racy read of the still-running child's ``_session_messages``
+         (timeout/exception path: the worker thread is abandoned, never
+         joined, and no result dict ever arrives).
+
+    Never raises; returns '' when nothing usable exists.  The timeout read is
+    explicitly best-effort — the child thread keeps mutating the list, so a
+    torn snapshot is acceptable: anything captured beats the current behavior
+    of discarding all partial text.
+    """
+    text = ""
+    if isinstance(result, dict):
+        candidate = result.get("final_response")
+        if (
+            isinstance(candidate, str)
+            and candidate.strip()
+            and not _looks_like_truncation(candidate)
+        ):
+            text = candidate.strip()
+        if not text:
+            messages = result.get("messages")
+            if isinstance(messages, list):
+                for msg in reversed(messages):
+                    if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                        continue
+                    if msg.get("tool_calls"):
+                        continue
+                    content = _stringify_tool_content(msg.get("content") or "")
+                    if content.strip():
+                        text = content.strip()
+                        break
+    if not text and child is not None:
+        try:
+            session_messages = getattr(child, "_session_messages", None)
+            for msg in reversed(list(session_messages or [])):
+                if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                    continue
+                if msg.get("tool_calls"):
+                    continue
+                content = _stringify_tool_content(msg.get("content") or "")
+                if content.strip():
+                    text = content.strip()
+                    break
+        except Exception:
+            logger.debug("Partial assistant text capture failed", exc_info=True)
+    if len(text) > max_chars:
+        text = text[:max_chars]
+    return text
+
+
+def _compute_stop_reason(
+    *,
+    interrupted: bool,
+    completed: bool,
+    summary: str,
+    empty_sentinel: bool,
+    partial: bool,
+) -> str:
+    """Map the child run's terminal state onto the stop-reason vocabulary.
+
+    Called only on the normal (non-raising) child path; the timeout/exception
+    and outer-catch paths hard-code STOP_REASON_ERROR (their existing
+    status="timeout" / error fields retain the finer distinction).
+    """
+    if interrupted:
+        return STOP_REASON_ABORTED
+    if completed and summary and not empty_sentinel:
+        return STOP_REASON_COMPLETED
+    if partial or _looks_like_truncation(summary) or (summary and not empty_sentinel):
+        # partial=True, an output-length sentinel, or real text with
+        # completed=False all mean the run ended on its iteration/token
+        # budget before finishing.
+        return STOP_REASON_MAX_TOKENS
+    return STOP_REASON_ERROR
+
+
+# ---------------------------------------------------------------------------
 # Subagent approval callbacks
 # ---------------------------------------------------------------------------
 # Subagents run inside a ThreadPoolExecutor worker. The CLI's interactive
@@ -2529,6 +2677,15 @@ def _run_single_child(
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
             }
+            # Never-reject contract: a timeout/exception is a structured
+            # `error` result (the finer timeout distinction stays in
+            # status/timeout_phase), and any text the child produced before
+            # the failure is preserved instead of being discarded with the
+            # abandoned worker thread.
+            _error_entry["stop_reason"] = STOP_REASON_ERROR
+            _partial_text = _extract_partial_assistant_text({}, child=child)
+            if _partial_text:
+                _error_entry["partial_output"] = _partial_text
             if _late_pending_steer:
                 _error_entry["missed_steer"] = _late_pending_steer
                 _error_entry["error"] += (
@@ -2695,6 +2852,17 @@ def _run_single_child(
         else:
             exit_reason = "max_iterations"
 
+        # Never-reject contract: map the terminal state onto the structured
+        # stop-reason vocabulary (additive field; the readable text stays in
+        # `summary`).  See the module docstring for the signal mapping.
+        stop_reason = _compute_stop_reason(
+            interrupted=interrupted,
+            completed=completed,
+            summary=summary,
+            empty_sentinel=_empty_sentinel,
+            partial=bool(result.get("partial")),
+        )
+
         # Extract token counts (safe for mock objects)
         _input_tokens = getattr(child, "session_prompt_tokens", 0)
         _output_tokens = getattr(child, "session_completion_tokens", 0)
@@ -2708,6 +2876,7 @@ def _run_single_child(
             "duration_seconds": duration,
             "model": _model if isinstance(_model, str) else None,
             "exit_reason": exit_reason,
+            "stop_reason": stop_reason,
             "tokens": {
                 "input": (
                     _input_tokens if isinstance(_input_tokens, (int, float)) else 0
@@ -2746,6 +2915,15 @@ def _run_single_child(
             _cost_status if isinstance(_cost_status, str) and _cost_status
             else "unknown"
         )
+        # Never-reject contract: on any non-completed run, preserve the
+        # child's last real assistant text when it is not already what the
+        # parent sees in `summary` (e.g. summary is empty, a run_agent.py
+        # sentinel, or was superseded).  Completed runs keep their exact
+        # previous payload shape plus the additive stop_reason field.
+        if stop_reason != STOP_REASON_COMPLETED:
+            _partial_text = _extract_partial_assistant_text(result, child=child)
+            if _partial_text and _partial_text != (summary or "").strip():
+                entry["partial_output"] = _partial_text
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
@@ -2894,8 +3072,12 @@ def _run_single_child(
             "error": str(exc),
             "api_calls": 0,
             "duration_seconds": duration,
+            "stop_reason": STOP_REASON_ERROR,
             "_child_role": getattr(child, "_delegate_role", None),
         }
+        _partial_text = _extract_partial_assistant_text({}, child=child)
+        if _partial_text:
+            _error_entry["partial_output"] = _partial_text
         if _late_pending_steer:
             _error_entry["missed_steer"] = _late_pending_steer
             _error_entry["error"] += (
@@ -3541,6 +3723,7 @@ def delegate_task(
                                         "error": str(exc),
                                         "api_calls": 0,
                                         "duration_seconds": 0,
+                                        "stop_reason": STOP_REASON_ERROR,
                                         "_child_role": getattr(
                                             _child_by_index.get(idx), "_delegate_role", None
                                         ),
@@ -3553,6 +3736,7 @@ def delegate_task(
                                     "error": "Parent agent interrupted — child did not finish in time",
                                     "api_calls": 0,
                                     "duration_seconds": 0,
+                                    "stop_reason": STOP_REASON_ABORTED,
                                     "_child_role": getattr(
                                         _child_by_index.get(idx), "_delegate_role", None
                                     ),
@@ -3578,6 +3762,7 @@ def delegate_task(
                                 "error": str(exc),
                                 "api_calls": 0,
                                 "duration_seconds": 0,
+                                "stop_reason": STOP_REASON_ERROR,
                                 "_child_role": getattr(
                                     _child_by_index.get(idx), "_delegate_role", None
                                 ),

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2743,11 +2743,21 @@ def _format_async_delegation(evt: dict) -> str:
                 lines.append("Partial output:")
                 lines.append(r_summary)
             else:
-                lines.append(
-                    f"(no summary — status={r_status}"
-                    + (f": {r_error}" if r_error else "")
-                    + ")"
-                )
+                r_partial = r.get("partial_output")
+                if r_partial:
+                    lines.append(
+                        f"(status={r_status}"
+                        + (f": {r_error}" if r_error else "")
+                        + ")"
+                    )
+                    lines.append("Partial output (before the run ended):")
+                    lines.append(r_partial)
+                else:
+                    lines.append(
+                        f"(no summary — status={r_status}"
+                        + (f": {r_error}" if r_error else "")
+                        + ")"
+                    )
             r_live = r.get("live_transcript")
             if r_live:
                 lines.append(
@@ -2775,7 +2785,10 @@ def _format_async_delegation(evt: dict) -> str:
     if toolsets:
         lines.append(f"Toolsets: {', '.join(toolsets)}")
     lines.append(f"Role: {role}   Model: {model}")
-    lines.append(f"Status: {status}   API calls: {api_calls}   Duration: {duration}s")
+    status_line = f"Status: {status}   API calls: {api_calls}   Duration: {duration}s"
+    if evt.get("stop_reason"):
+        status_line += f"   Stop reason: {evt['stop_reason']}"
+    lines.append(status_line)
     lines.append("--- RESULT ---")
     if status in ("completed", "success") and summary:
         lines.append(summary)
@@ -2787,6 +2800,9 @@ def _format_async_delegation(evt: dict) -> str:
         if summary:
             lines.append("Partial output:")
             lines.append(summary)
+        elif evt.get("partial_output"):
+            lines.append("Partial output (before the run ended):")
+            lines.append(evt["partial_output"])
     else:
         # error / timeout / failed
         lines.append(
@@ -2796,6 +2812,9 @@ def _format_async_delegation(evt: dict) -> str:
         if summary:
             lines.append("Partial output:")
             lines.append(summary)
+        elif evt.get("partial_output"):
+            lines.append("Partial output (before the run ended):")
+            lines.append(evt["partial_output"])
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary

A failing delegation child (model error, timeout, user cancel, token budget) now settles into a structured result entry instead of surfacing as a lost failure: each `delegate_task` result gains an additive `stop_reason` (`completed|aborted|error|max-tokens`; `refusal` is reserved — Hermes has no refusal signal today) and, when the failure would otherwise discard the child's output, a `partial_output` field preserving its last real assistant text.

Root cause: child failures previously settled with `summary=None` and no trace of what the child produced before failing; the parent could not distinguish "declined" from "ran out of tokens" from "cancelled". This mirrors the dsh `SubagentResult` contract (`result` never rejects; the tool maps non-completed stop reasons to `isError` while preserving partial text).

## Changes

- `tools/delegate_tool.py`: `stop_reason` + `partial_output` fields per entry; timeout/exception paths capture partial text best-effort from the abandoned worker's session messages; completed payloads only gain the additive `stop_reason` field
- `tools/process_registry.py`: `_format_async_delegation` renders partial output and `stop_reason` in re-injected completion blocks
- `tools/async_delegation.py`: async completions propagate the new fields
- `tests/tools/test_delegate.py`, `tests/tools/test_process_registry.py`: error → structured entry with partial text; cancel → aborted; success → completed (existing behavior preserved)

## Validation

| Teste | Resultado |
|-------|-----------|
| `pytest tests/tools/test_delegate.py tests/tools/test_process_registry.py` | 117 passed, 28 skipped |
| Pre-existing Windows env failures | 6 failed on this PR AND on clean base `1fd21cbd0` (PTY/POSIX/thread tests) — not introduced by this PR |
| Backward compatibility | `summary`/`status`/`error`/`exit_reason` semantics unchanged; `stop_reason` additive |
