### PR TITLE
feat(delegation): continuable children v1 — durable id + settlement notice + report

### DIFF
--- a/docs/delegation-continuable-children.md
+++ b/docs/delegation-continuable-children.md
@@ -1,0 +1,131 @@
+# Continuable Children v1 — Durable ID + Settlement Notice + Report
+
+Status: implemented (safe subset) · Area: delegation (`delegate_task`)
+
+## Problem
+
+`delegate_task` children have no durable identity today: a result entry tells
+the parent *what* happened (`summary`, `status`) but not *which* child it was.
+The ephemeral `subagent_id` (`sa-<task>-<hex>`) lives only for the process
+lifetime, the child's persisted session id is never surfaced, and nothing
+names the child when its background completion re-enters the conversation.
+The parent cannot re-open a finished child's transcript by id, and a child
+that dies with the parent cannot be revisited at all.
+
+## Goal (v1)
+
+Give a delegated child a **durable id** the parent can name, receive a
+**settlement notice** keyed by that id, and **re-read the child's final
+report** by id — without changing the default delegation model in any way.
+
+## Design
+
+### Opt-in flag: `delegate_task(continuable=True)`
+
+Everything is additive and opt-in. The `continuable` parameter (boolean,
+default `False`, exposed in the tool schema) is the only surface change to
+`delegate_task`. When `False` (the default), result payloads, dispatch
+payloads, and completion events are byte-identical to previous behavior. The
+flag rides on each built child as `child._continuable` so every entry-
+construction site (`_run_single_child`) and event relay sees it without extra
+plumbing.
+
+### 1. Durable ID — `child_session_id`
+
+Each child is already an `AIAgent` with its own **persisted session id**:
+`_build_child_agent` constructs it with the parent's `session_db` and
+`parent_session_id`, and `AIAgent._ensure_db_session` creates a
+`source='subagent'` session row in the same SQLite state DB, linked to the
+parent. That session id is durable (survives process death) — it *is* the
+child's stable identity. The ephemeral `subagent_id` is exposed alongside it
+as a convenience for TUI/tooling correlation.
+
+When `continuable=True`:
+- every result entry (success, timeout, error, crash) gains
+  `child_session_id` + `subagent_id` (`_attach_continuable_ids`);
+- the background dispatch payload (`status: dispatched`) gains a `children`
+  list naming each child up-front (`task_index`, `goal`, `child_session_id`,
+  `subagent_id`).
+
+### 2. Settlement notice — "Child <id> finished"
+
+Hermes already has an async context-injection channel: background delegation
+completions are pushed onto `process_registry.completion_queue` and
+re-injected into the parent's conversation as a `[ASYNC DELEGATION COMPLETE
+...]` block on the next turn. v1 uses that channel, keyed by the durable id:
+
+- `_push_completion_event` copies `child_session_id`/`subagent_id` from the
+  child result onto the completion event (batch events already carry the full
+  per-task `results` list).
+- `_format_async_delegation` renders a settlement line per child:
+  - `Child <id> finished (status=completed).`
+  - `Child <id> was stopped before it finished (status=interrupted).`
+  - `Child <id> failed before it finished (status=<status>).`
+
+This mirrors the continuation-manager pattern from the TS subagent package
+(durable childId + one-line settlement summary), without copying its
+registry/disposal machinery.
+
+For synchronous delegations the notice is the tool result itself — the entry
+now carries the ids, so the parent sees "which child" in the same turn.
+
+### 3. Report v1 — re-read by id via `session_search`
+
+No new tool. The child's transcript is persisted in the same session DB, so
+the existing `session_search` **READ** shape (`session_id=<id>` only) returns
+the child's full transcript, including its final answer. Subagent sessions
+are excluded from *browse* (`_HIDDEN_SESSION_SOURCES`) but remain readable by
+id — exactly the property REPORT v1 needs. The `continuable` schema
+description tells the model to use `session_search` with
+`session_id=<child_session_id>`.
+
+## Files changed
+
+- `tools/delegate_tool.py` — `continuable` param + schema property;
+  `child._continuable`; `_continuable_child_ids` /
+  `_attach_continuable_ids`; dispatch payload `children`.
+- `tools/async_delegation.py` — `_push_completion_event` carries child ids.
+- `tools/process_registry.py` — `_settlement_line` + rendering in
+  `_format_async_delegation` (single and batch shapes).
+- `run_agent.py` — `_dispatch_delegate_task` forwards `continuable`.
+- `tests/tools/test_delegate_continuable.py` — new mock-based tests.
+
+## Testing
+
+`tests/tools/test_delegate_continuable.py` (25 tests, no LLM calls):
+
+- default path emits no id fields (byte-identical guarantee);
+- continuable success/crash/timeout entries carry both ids;
+- background dispatch payload names children only when continuable;
+- completion event carries child ids; re-injection block renders
+  `Child <id> finished/failed/stopped` lines (single + batch);
+- report path: a `source='subagent'` session with `parent_session_id` is
+  re-readable via `session_search` READ by id.
+
+## Deferred (explicitly NOT in v1)
+
+- **send_message to a child** — messaging a settled child requires a durable
+  per-child inbox and delivery into a live turn; out of scope.
+- **interrupt of a detached child** — `interrupt_subagent`/`steer_subagent`
+  work only while the child is live in-process (`_active_subagents`); a
+  durable interrupt path for resumed children is out of scope.
+- **cold resume of a child by the parent** — resuming a finished child's
+  session (re-attach to its persisted conversation) is the natural next step
+  once ids are durable; the resume machinery in `run_agent.py` already
+  supports `parent_session_id` lineage, but wiring it to a resumed
+  delegation is not done here.
+- **durable settlement registry** — the TS reference keeps a per-child
+  settlement/disposal registry; v1 relies on the session DB (authoritative
+  transcript) + delegation records (event replay) instead of a new table.
+
+## Known limitations
+
+- `child_session_id` is only as durable as the session DB row: sessions
+  pruned by retention, or a child whose first turn never created its row
+  (e.g. crash before any API call), lose the transcript. The id itself is
+  still returned.
+- The settlement line is rendered for *background* completions; a
+  synchronous result's notice is the tool output itself (no separate line).
+- Nested orchestrator children are continuable too (the flag is inherited
+  through `_build_child_agent`), but their ids appear on the *parent's*
+  result, not on the top-level aggregation.

--- a/run_agent.py
+++ b/run_agent.py
@@ -7918,6 +7918,7 @@ class AIAgent:
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            continuable=function_args.get("continuable"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_delegate_continuable.py
+++ b/tests/tools/test_delegate_continuable.py
@@ -1,0 +1,517 @@
+"""Tests for continuable-children v1 (delegation durable identity).
+
+Covers the SAFE SUBSET of the continuable-children feature:
+  1. Durable ID — children spawned with the ``continuable`` opt-in expose
+     ``child_session_id`` (the child's persisted session id) and
+     ``subagent_id`` on every result entry and on the background dispatch
+     payload. Default (non-continuable) delegations stay byte-identical.
+  2. Settlement notice — the async completion event carries the child ids
+     and the re-injection block renders a 'Child <id> finished ...' line
+     keyed by the durable id (single and batch shapes).
+  3. Report v1 — a subagent session (source='subagent', parent_session_id
+     set) is re-readable by id via session_search's READ shape.
+
+All tests run with mocks — no LLM calls. Deferred (send_message to child,
+interrupt, cold resume) are intentionally NOT covered here.
+"""
+
+import json
+import queue
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.delegate_tool import (
+    DELEGATE_TASK_SCHEMA,
+    _attach_continuable_ids,
+    _continuable_child_ids,
+    _run_single_child,
+    delegate_task,
+)
+from tools.process_registry import format_process_notification
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_parent():
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "***"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = 0
+    parent._active_children = []
+    parent._active_children_lock = MagicMock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    return parent
+
+
+def _mock_child(*, continuable=True, session_id="child-sess-1", subagent_id="sa-0-ab12cd34"):
+    child = MagicMock()
+    child.model = "claude-sonnet-4-6"
+    child.session_prompt_tokens = 100
+    child.session_completion_tokens = 50
+    child._credential_pool = None
+    child._continuable = continuable
+    child.session_id = session_id
+    child._subagent_id = subagent_id
+    child._delegate_role = "leaf"
+    child.run_conversation.return_value = {
+        "final_response": "done",
+        "completed": True,
+        "interrupted": False,
+        "api_calls": 1,
+        "messages": [],
+    }
+    return child
+
+
+def _ok_entry(task_index=0, **extra):
+    entry = {
+        "task_index": task_index,
+        "status": "completed",
+        "summary": "done",
+        "api_calls": 1,
+        "duration_seconds": 0.1,
+        "model": "m",
+        "exit_reason": "completed",
+        "tokens": {"input": 0, "output": 0},
+        "tool_trace": [],
+    }
+    entry.update(extra)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Schema / opt-in surface
+# ---------------------------------------------------------------------------
+
+class TestSchema:
+    def test_continuable_param_exposed_but_optional(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        assert "continuable" in props
+        assert props["continuable"]["type"] == "boolean"
+        # Not required — the default path must not change.
+        assert "continuable" not in DELEGATE_TASK_SCHEMA["parameters"]["required"]
+
+    def test_existing_params_untouched(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        for name in ("goal", "context", "tasks", "role", "output_schema", "background"):
+            assert name in props
+
+
+# ---------------------------------------------------------------------------
+# _continuable_child_ids / _attach_continuable_ids
+# ---------------------------------------------------------------------------
+
+class TestContinuableIds:
+    def test_default_child_returns_none(self):
+        child = MagicMock()  # MagicMock auto-creates attrs — must stay None
+        assert _continuable_child_ids(child) is None
+
+    def test_explicit_false_returns_none(self):
+        child = _mock_child(continuable=False)
+        assert _continuable_child_ids(child) is None
+
+    def test_continuable_returns_durable_session_id(self):
+        child = _mock_child(continuable=True, session_id="sess-xyz", subagent_id="sa-9-deadbeef")
+        ids = _continuable_child_ids(child)
+        assert ids == {"child_session_id": "sess-xyz", "subagent_id": "sa-9-deadbeef"}
+
+    def test_continuable_without_subagent_id_still_has_session_id(self):
+        child = _mock_child(continuable=True, session_id="sess-abc")
+        child._subagent_id = None
+        assert _continuable_child_ids(child) == {"child_session_id": "sess-abc"}
+
+    def test_attach_is_noop_on_default_child(self):
+        entry = _ok_entry()
+        _attach_continuable_ids(entry, MagicMock())
+        assert "child_session_id" not in entry
+        assert "subagent_id" not in entry
+
+    def test_attach_folds_ids_into_entry(self):
+        entry = _ok_entry()
+        _attach_continuable_ids(entry, _mock_child(continuable=True))
+        assert entry["child_session_id"] == "child-sess-1"
+        assert entry["subagent_id"] == "sa-0-ab12cd34"
+
+
+# ---------------------------------------------------------------------------
+# _run_single_child entry shape (success / crash / timeout)
+# ---------------------------------------------------------------------------
+
+class TestRunSingleChildIds:
+    def test_default_path_has_no_id_fields(self):
+        child = _mock_child(continuable=False)
+        result = _run_single_child(0, "goal", child, _mock_parent())
+        assert result["status"] == "completed"
+        assert "child_session_id" not in result
+        assert "subagent_id" not in result
+
+    def test_continuable_success_entry_carries_ids(self):
+        child = _mock_child(continuable=True)
+        result = _run_single_child(0, "goal", child, _mock_parent())
+        assert result["status"] == "completed"
+        assert result["child_session_id"] == "child-sess-1"
+        assert result["subagent_id"] == "sa-0-ab12cd34"
+        # The summary itself is untouched — ids are additive.
+        assert result["summary"] == "done"
+
+    def test_continuable_crash_entry_carries_ids(self):
+        child = _mock_child(continuable=True)
+        child.run_conversation.side_effect = RuntimeError("boom")
+        result = _run_single_child(1, "goal", child, _mock_parent())
+        assert result["status"] == "error"
+        assert result["child_session_id"] == "child-sess-1"
+        assert result["subagent_id"] == "sa-0-ab12cd34"
+
+    def test_continuable_timeout_entry_carries_ids(self):
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+        class _FakeFuture:
+            def result(self, timeout=None):
+                raise FuturesTimeoutError("timed out")
+
+        class _FakeExecutor:
+            def __init__(self, *a, **kw):
+                pass
+
+            def submit(self, fn, *a, **kw):
+                return _FakeFuture()
+
+            def shutdown(self, wait=True):
+                pass
+
+        child = _mock_child(continuable=True)
+        with (
+            patch("tools.daemon_pool.DaemonThreadPoolExecutor", _FakeExecutor),
+            patch(
+                "tools.delegate_tool._dump_subagent_timeout_diagnostic",
+                return_value=None,
+            ),
+        ):
+            result = _run_single_child(0, "goal", child, _mock_parent())
+        assert result["status"] == "timeout"
+        assert result["child_session_id"] == "child-sess-1"
+        assert result["subagent_id"] == "sa-0-ab12cd34"
+
+
+# ---------------------------------------------------------------------------
+# delegate_task end-to-end (mock AIAgent) — sync + background dispatch
+# ---------------------------------------------------------------------------
+
+class TestDelegateTaskContinuable:
+    def test_sync_single_continuable_result_exposes_ids(self):
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = _mock_child(
+                continuable=True, session_id="sess-e2e", subagent_id="sa-0-e2e"
+            )
+            result = json.loads(
+                delegate_task(goal="Do it", parent_agent=_mock_parent(), continuable=True)
+            )
+        entry = result["results"][0]
+        assert entry["child_session_id"] == "sess-e2e"
+        # subagent_id is generated by _build_child_agent (sa-<task>-<hex>);
+        # the durable id is what the parent keys on.
+        assert entry["subagent_id"].startswith("sa-0-")
+
+    def test_sync_single_default_result_has_no_ids(self):
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = _mock_child(continuable=False)
+            result = json.loads(
+                delegate_task(goal="Do it", parent_agent=_mock_parent())
+            )
+        entry = result["results"][0]
+        assert "child_session_id" not in entry
+        assert "subagent_id" not in entry
+
+    def test_background_dispatch_payload_names_children_when_continuable(self):
+        child = _mock_child(continuable=True, session_id="sess-bg", subagent_id="sa-0-bg")
+        with (
+            patch("run_agent.AIAgent", return_value=child),
+            patch(
+                "tools.async_delegation.dispatch_async_delegation_batch",
+                return_value={"status": "dispatched", "delegation_id": "deleg_test_1"},
+            ) as mock_dispatch,
+            patch("gateway.session_context.async_delivery_supported", return_value=True),
+            patch("tools.approval.get_current_session_key", return_value="test-session"),
+        ):
+            result = json.loads(
+                delegate_task(
+                    goal="Background task",
+                    parent_agent=_mock_parent(),
+                    continuable=True,
+                    background=True,
+                )
+            )
+        assert result["status"] == "dispatched"
+        children = result["children"]
+        assert len(children) == 1
+        assert children[0]["task_index"] == 0
+        assert children[0]["goal"] == "Background task"
+        assert children[0]["child_session_id"] == "sess-bg"
+        assert children[0]["subagent_id"].startswith("sa-0-")
+        mock_dispatch.assert_called_once()
+
+    def test_background_dispatch_payload_omits_children_by_default(self):
+        child = _mock_child(continuable=False, session_id="sess-bg")
+        with (
+            patch("run_agent.AIAgent", return_value=child),
+            patch(
+                "tools.async_delegation.dispatch_async_delegation_batch",
+                return_value={"status": "dispatched", "delegation_id": "deleg_test_1"},
+            ),
+            patch("gateway.session_context.async_delivery_supported", return_value=True),
+            patch("tools.approval.get_current_session_key", return_value="test-session"),
+        ):
+            result = json.loads(
+                delegate_task(
+                    goal="Background task",
+                    parent_agent=_mock_parent(),
+                    background=True,
+                )
+            )
+        assert result["status"] == "dispatched"
+        assert "children" not in result
+
+
+# ---------------------------------------------------------------------------
+# Settlement notice — async completion event + re-injection block
+# ---------------------------------------------------------------------------
+
+def _drain_one(timeout=5.0):
+    from tools.process_registry import process_registry
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not process_registry.completion_queue.empty():
+            return process_registry.completion_queue.get_nowait()
+        time.sleep(0.02)
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _clean_delegation_state():
+    from tools import async_delegation as ad
+    from tools.process_registry import process_registry
+
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    yield
+    deadline = time.monotonic() + 2.0
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+class TestSettlementNotice:
+    def test_completion_event_carries_child_ids(self):
+        from tools import async_delegation as ad
+
+        def runner():
+            return {
+                "status": "completed",
+                "summary": "the result",
+                "api_calls": 1,
+                "duration_seconds": 0.1,
+                "model": "m",
+                "child_session_id": "sess-child-9",
+                "subagent_id": "sa-0-99999999",
+            }
+
+        res = ad.dispatch_async_delegation(
+            goal="g", context=None, toolsets=None, role="leaf", model="m",
+            session_key="", runner=runner, max_async_children=3,
+        )
+        assert res["status"] == "dispatched"
+        evt = _drain_one()
+        assert evt is not None
+        assert evt["child_session_id"] == "sess-child-9"
+        assert evt["subagent_id"] == "sa-0-99999999"
+
+    def test_completion_event_without_ids_stays_clean(self):
+        from tools import async_delegation as ad
+
+        def runner():
+            return {
+                "status": "completed",
+                "summary": "plain",
+                "api_calls": 1,
+                "duration_seconds": 0.1,
+                "model": "m",
+            }
+
+        ad.dispatch_async_delegation(
+            goal="g", context=None, toolsets=None, role="leaf", model="m",
+            session_key="", runner=runner, max_async_children=3,
+        )
+        evt = _drain_one()
+        assert evt is not None
+        assert "child_session_id" not in evt
+        assert "subagent_id" not in evt
+
+    def test_single_block_renders_settlement_line_by_id(self):
+        text = format_process_notification(
+            {
+                "type": "async_delegation",
+                "delegation_id": "deleg_1",
+                "goal": "original goal",
+                "status": "completed",
+                "summary": "answer",
+                "api_calls": 2,
+                "duration_seconds": 1.0,
+                "dispatched_at": time.time(),
+                "completed_at": time.time(),
+                "child_session_id": "sess-child-1",
+                "subagent_id": "sa-0-aaaa1111",
+            }
+        )
+        assert text is not None
+        assert "Child sess-child-1 finished (status=completed)." in text
+        assert "(subagent_id=sa-0-aaaa1111)" in text
+
+    def test_single_block_error_status_renders_failure_line(self):
+        text = format_process_notification(
+            {
+                "type": "async_delegation",
+                "delegation_id": "deleg_2",
+                "goal": "g",
+                "status": "error",
+                "error": "boom",
+                "api_calls": 0,
+                "duration_seconds": 1.0,
+                "dispatched_at": time.time(),
+                "completed_at": time.time(),
+                "child_session_id": "sess-child-2",
+            }
+        )
+        assert text is not None
+        assert "Child sess-child-2 failed before it finished (status=error)." in text
+
+    def test_single_block_without_ids_has_no_settlement_line(self):
+        text = format_process_notification(
+            {
+                "type": "async_delegation",
+                "delegation_id": "deleg_3",
+                "goal": "g",
+                "status": "completed",
+                "summary": "answer",
+                "api_calls": 1,
+                "duration_seconds": 1.0,
+                "dispatched_at": time.time(),
+                "completed_at": time.time(),
+            }
+        )
+        assert text is not None
+        assert "Child " not in text
+
+    def test_batch_block_renders_per_task_settlement_lines(self):
+        now = time.time()
+        text = format_process_notification(
+            {
+                "type": "async_delegation",
+                "delegation_id": "deleg_batch",
+                "is_batch": True,
+                "goals": ["task A", "task B"],
+                "status": "completed",
+                "results": [
+                    _ok_entry(
+                        task_index=0,
+                        status="completed",
+                        summary="A done",
+                        child_session_id="sess-child-a",
+                        subagent_id="sa-0-aaaa",
+                    ),
+                    _ok_entry(
+                        task_index=1,
+                        status="failed",
+                        summary=None,
+                        error="went wrong",
+                        child_session_id="sess-child-b",
+                        subagent_id="sa-1-bbbb",
+                    ),
+                ],
+                "total_duration_seconds": 2.0,
+                "dispatched_at": now,
+                "completed_at": now,
+            }
+        )
+        assert text is not None
+        assert "Child sess-child-a finished (status=completed)." in text
+        assert "Child sess-child-b failed before it finished (status=failed)." in text
+
+    def test_batch_block_without_ids_has_no_settlement_lines(self):
+        now = time.time()
+        text = format_process_notification(
+            {
+                "type": "async_delegation",
+                "delegation_id": "deleg_batch_plain",
+                "is_batch": True,
+                "goals": ["task A"],
+                "status": "completed",
+                "results": [_ok_entry(task_index=0, status="completed", summary="A done")],
+                "total_duration_seconds": 1.0,
+                "dispatched_at": now,
+                "completed_at": now,
+            }
+        )
+        assert text is not None
+        assert "Child " not in text
+
+
+# ---------------------------------------------------------------------------
+# Report v1 — child session re-readable by id via session_search READ
+# ---------------------------------------------------------------------------
+
+class TestReportBySessionId:
+    def test_subagent_session_readable_by_id(self, tmp_path):
+        """A subagent session (source='subagent', parent_session_id set) is
+        re-readable via session_search's READ shape — this is the REPORT v1
+        path: the durable child_session_id names a persisted transcript."""
+        from hermes_state import SessionDB
+        from tools.session_search_tool import _read_session
+
+        db = SessionDB(tmp_path / "state.db")
+        db.create_session("parent-sess-1", source="cli")
+        db.create_session(
+            "child-sess-report",
+            source="subagent",
+            parent_session_id="parent-sess-1",
+        )
+        db.append_message("child-sess-report", role="user", content="delegated goal")
+        db.append_message(
+            "child-sess-report", role="assistant", content="final answer of the child"
+        )
+        db._conn.commit()
+
+        payload = json.loads(_read_session(db, "child-sess-report"))
+        assert payload["success"] is True
+        assert payload["session_id"] == "child-sess-report"
+        assert payload["session_meta"]["source"] == "subagent"
+        contents = [m["content"] for m in payload["messages"]]
+        assert "final answer of the child" in contents
+        db.close()
+
+    def test_unknown_session_id_errors(self, tmp_path):
+        from hermes_state import SessionDB
+        from tools.session_search_tool import _read_session
+
+        db = SessionDB(tmp_path / "state.db")
+        payload = json.loads(_read_session(db, "no-such-session"))
+        assert payload.get("success") is False
+        db.close()

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -985,6 +985,14 @@ def _push_completion_event(
         "completed_at": completed_at,
         "exit_reason": result.get("exit_reason"),
     }
+    # Continuable-children v1: the durable child session id (+ ephemeral
+    # subagent id) ride on the completion event so the settlement notice can
+    # name the child. Absent on non-continuable children (default path
+    # unchanged).
+    if isinstance(result.get("child_session_id"), str):
+        evt["child_session_id"] = result["child_session_id"]
+    if isinstance(result.get("subagent_id"), str):
+        evt["subagent_id"] = result["subagent_id"]
     # Routing origin captured at dispatch (see _capture_routing_origin):
     # additive, lets the gateway reconstruct a full SessionSource (incl.
     # scope_id for relay tenant egress) when its own caches are cold.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1339,6 +1339,13 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Continuable-children v1 opt-in (default OFF). When True the child's
+    # durable session id (+ ephemeral subagent id) are exposed on every
+    # result entry and on the background dispatch payload, so the parent
+    # can name the child, receive a settlement notice keyed by id, and
+    # re-read its full transcript later. Default mode stays byte-identical:
+    # no id fields are emitted unless this flag is set.
+    continuable: bool = False,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1684,6 +1691,11 @@ def _build_child_agent(
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
     child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
+    # Continuable-children v1: the durable-id opt-in rides on the child so
+    # every entry-construction site in _run_single_child (and every event
+    # that relays the child's identity) sees the same flag without extra
+    # plumbing. Absent/False → the default wire shape is untouched.
+    child._continuable = bool(continuable)
     # Stable sidebar marker: delegate subagent sessions must stay out of
     # session pickers even when a parent delete orphans them (parent_session_id
     # → NULL). Mirrors /branch's ``_branched_from`` pattern — see
@@ -2085,6 +2097,37 @@ def _apply_summary_budget(results: List[Dict[str, Any]], parent_agent) -> None:
             cap,
             spill_path or "none",
         )
+
+
+def _continuable_child_ids(child) -> Optional[Dict[str, str]]:
+    """Return ``{child_session_id, subagent_id}`` for a continuable child, else None.
+
+    The durable id is the child's own AIAgent session id — the same row
+    persisted in the shared session DB (``parent_session_id`` links it to
+    the parent), so it survives process death and can be re-read later via
+    ``session_search`` READ (``session_id=<id>``). Emitted ONLY when the
+    child was spawned with the continuable opt-in; the default path stays
+    byte-identical. Strict ``is True`` / ``isinstance`` guards keep
+    MagicMock test doubles (which auto-create truthy attributes) on the
+    default path.
+    """
+    if getattr(child, "_continuable", False) is not True:
+        return None
+    session_id = getattr(child, "session_id", "")
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    ids: Dict[str, str] = {"child_session_id": session_id}
+    subagent_id = getattr(child, "_subagent_id", None)
+    if isinstance(subagent_id, str) and subagent_id:
+        ids["subagent_id"] = subagent_id
+    return ids
+
+
+def _attach_continuable_ids(entry: Dict[str, Any], child) -> None:
+    """Fold continuable child ids into *entry* in place (no-op by default)."""
+    ids = _continuable_child_ids(child)
+    if ids:
+        entry.update(ids)
 
 
 def _run_single_child(
@@ -2536,6 +2579,7 @@ def _run_single_child(
                     f"{_late_pending_steer}]"
                 )
             _attach_worktree(_error_entry)
+            _attach_continuable_ids(_error_entry, child)
             return _error_entry
         finally:
             # Shut down executor without waiting — if the child thread
@@ -2868,6 +2912,7 @@ def _run_single_child(
                 logger.debug("Progress callback completion failed: %s", e)
 
         _attach_worktree(entry)
+        _attach_continuable_ids(entry, child)
         return entry
 
     except Exception as exc:
@@ -2904,6 +2949,7 @@ def _run_single_child(
             )
         # _attach_worktree defaults to a no-op when isolation never engaged.
         _attach_worktree(_error_entry)
+        _attach_continuable_ids(_error_entry, child)
         return _error_entry
 
     finally:
@@ -3215,6 +3261,12 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
+    # Continuable-children v1 opt-in (default OFF): when True every child
+    # result entry carries the child's durable session id (child_session_id)
+    # plus its ephemeral subagent_id, the background dispatch payload names
+    # the children up-front, and the settlement notice is keyed by id. The
+    # default mode is byte-identical to today — no id fields are emitted.
+    continuable: Optional[bool] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -3228,6 +3280,11 @@ def delegate_task(
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    The 'continuable' parameter (default false) opts children into a
+    durable identity: result entries carry child_session_id/subagent_id,
+    background dispatches name their children up-front, and the
+    settlement notice is keyed by id.
 
     Returns JSON with results array, one entry per task.
     """
@@ -3254,6 +3311,14 @@ def delegate_task(
     # as one message once ALL children finish — the chat is not blocked while
     # they run.
     background = is_truthy_value(background, default=False) if background is not None else False
+
+    # Continuable-children v1: explicit opt-in, off by default. The model may
+    # request it via the schema param; direct Python callers pass it through.
+    continuable = (
+        is_truthy_value(continuable, default=False)
+        if continuable is not None
+        else False
+    )
 
     # Depth limit — configurable via delegation.max_spawn_depth,
     # default 2 for parity with the original MAX_DEPTH constant.
@@ -3440,6 +3505,7 @@ def delegate_task(
             override_acp_command=creds.get("command"),
             override_acp_args=creds.get("args"),
             role=effective_role,
+            continuable=continuable,
         )
         # Attach the validated schema for the completion-side validation
         # hook in _run_single_child. Absent (None) on schema-less tasks.
@@ -3858,6 +3924,25 @@ def delegate_task(
                 "goals": _goals,
                 "note": note,
             }
+            # Continuable-children v1: name every child up-front (durable
+            # session id + ephemeral subagent id) so the parent knows which
+            # ids to expect on the settlement notice and can re-read a
+            # child's full transcript later via session_search READ
+            # (session_id=<child_session_id>).
+            if continuable:
+                payload["children"] = [
+                    {
+                        "task_index": i,
+                        "goal": t["goal"],
+                        "child_session_id": str(
+                            getattr(c, "session_id", "") or ""
+                        ),
+                        "subagent_id": str(
+                            getattr(c, "_subagent_id", "") or ""
+                        ),
+                    }
+                    for (i, t, c) in children
+                ]
             if live_paths:
                 payload["live_transcripts"] = list(live_paths)
                 payload["live_transcripts_hint"] = (
@@ -4365,6 +4450,21 @@ DELEGATE_TASK_SCHEMA = {
                     "backward compatibility."
                 ),
             },
+            "continuable": {
+                "type": "boolean",
+                "description": (
+                    "Optional (default false): give each child a durable "
+                    "identity. When true, every result entry carries "
+                    "child_session_id (the child's persisted session id) and "
+                    "subagent_id, and a background dispatch names its children "
+                    "up-front. The settlement notice is then keyed by id — you "
+                    "will see 'Child <id> finished (status=...)' — and you can "
+                    "re-read a child's full transcript any time later via "
+                    "session_search with session_id=<child_session_id>. "
+                    "When false (default), results are identical to previous "
+                    "behavior."
+                ),
+            },
         },
         "required": [],
     },
@@ -4426,6 +4526,7 @@ registry.register(
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
         output_schema=args.get("output_schema"),
+        continuable=args.get("continuable"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2660,6 +2660,22 @@ def _format_age(seconds: float) -> str:
     return f"{h}h" if m == 0 else f"{h}h{m}m"
 
 
+def _settlement_line(child_session_id: str, status: str) -> str:
+    """One line telling the parent which durable child settled and how.
+
+    Mirrors the continuation-manager pattern from the TS subagent package
+    (durable childId + settlement summary): the parent knows the child by
+    ``child_session_id`` (a persisted session id it can re-read via
+    session_search), so the notice names that id, not an ephemeral handle.
+    """
+    subject = f"Child {child_session_id}"
+    if status in ("completed", "success"):
+        return f"{subject} finished (status={status})."
+    if status == "interrupted":
+        return f"{subject} was stopped before it finished (status=interrupted)."
+    return f"{subject} failed before it finished (status={status})."
+
+
 def _format_async_delegation(evt: dict) -> str:
     """Format an async-delegation completion into a self-contained re-injection.
 
@@ -2735,6 +2751,14 @@ def _format_async_delegation(evt: dict) -> str:
                 header += f", {r['duration_seconds']}s"
             header += ") ---"
             lines.append(header)
+            # Continuable-children v1: settlement notice keyed by the durable
+            # child session id (re-readable via session_search READ).
+            _r_csid = r.get("child_session_id")
+            if isinstance(_r_csid, str) and _r_csid:
+                _settle = _settlement_line(_r_csid, r_status)
+                if isinstance(r.get("subagent_id"), str):
+                    _settle += f" (subagent_id={r['subagent_id']})"
+                lines.append(_settle)
             if r_status in ("completed", "success") and r_summary:
                 lines.append(r_summary)
             elif r_summary:
@@ -2776,6 +2800,14 @@ def _format_async_delegation(evt: dict) -> str:
         lines.append(f"Toolsets: {', '.join(toolsets)}")
     lines.append(f"Role: {role}   Model: {model}")
     lines.append(f"Status: {status}   API calls: {api_calls}   Duration: {duration}s")
+    # Continuable-children v1: settlement notice keyed by the durable child
+    # session id (re-readable via session_search READ).
+    _csid = evt.get("child_session_id")
+    if isinstance(_csid, str) and _csid:
+        _settle = _settlement_line(_csid, status)
+        if isinstance(evt.get("subagent_id"), str):
+            _settle += f" (subagent_id={evt['subagent_id']})"
+        lines.append(_settle)
     lines.append("--- RESULT ---")
     if status in ("completed", "success") and summary:
         lines.append(summary)


### PR DESCRIPTION
## Summary

Adds an opt-in `continuable` flag to `delegate_task` that gives every child a durable identity without changing the default delegation model: result entries carry `child_session_id` (the child's persisted session id, linked to the parent via `parent_session_id`) plus the ephemeral `subagent_id`, the async completion event renders a settlement notice per child, and the child's transcript is re-readable by id via the existing `session_search` READ shape.

Root cause: `delegate_task` is ephemeral — children die with the parent session and there is no durable identity, no settlement channel, and no way to re-read a finished child's work. This is the v1 (safe, additive) slice of the dsh continuable-subagent pattern (stable child id + settlement notice + report), with the heavy features explicitly deferred.

## Changes

- `tools/delegate_tool.py`: `continuable` flag (default `False` → output byte-identical); entries (success/timeout/error/crash) gain `child_session_id` + `subagent_id`
- `tools/async_delegation.py`: background dispatch payloads name all children up-front (`children` list)
- `tools/process_registry.py`: completion block renders `Child <id> finished (status=...)` / `was stopped before it finished` / `failed before it finished` (single + batch shapes)
- `run_agent.py`: plumbing
- `docs/delegation-continuable-children.md` (new): design + explicitly deferred items
- `tests/tools/test_delegate_continuable.py` (new, 25 tests, mock-based — no LLM calls)

## Validation

| Teste | Resultado |
|-------|-----------|
| `pytest tests/tools/test_delegate_continuable.py` | 25 passed |
| Default mode | byte-identical — no id fields emitted unless `continuable=true` (tested) |
| Deferred (documented) | `send_message` to child, `interrupt`, cold resume by parent |

## Limitation

`child_session_id` is only as durable as the session row (retention pruning or a crash before the first turn loses the transcript; the id is still returned).
