### PR TITLE
feat(delegation): workflow batch orchestration with semaphore and caps

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7897,6 +7897,7 @@ class AIAgent:
         """
         from tools.delegate_tool import (
             _strip_model_hidden_task_fields,
+            _strip_workflow_model_hidden_fields,
             delegate_task as _delegate_task,
         )
         # Delegations from the top-level MODEL always run in the background —
@@ -7918,6 +7919,7 @@ class AIAgent:
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            workflow=_strip_workflow_model_hidden_fields(function_args.get("workflow")),
             parent_agent=self,
         )
 

--- a/tests/tools/test_delegate_workflow.py
+++ b/tests/tools/test_delegate_workflow.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""
+Tests for the delegate_task workflow mode (parallel/pipeline batch
+orchestration with semaphore + caps).
+
+Uses a stubbed runner — no real LLM or AIAgent is ever constructed:
+  - `_run_single_child` is patched with a side_effect returning
+    structured per-item entries (or raising, to simulate item failure),
+  - `_build_child_preserving_parent_tools` is patched to return a
+    MagicMock child and to capture the context each child was built with
+    (how pipeline context chaining is asserted).
+
+Run with:  python -m pytest tests/tools/test_delegate_workflow.py -v
+"""
+
+import json
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import (
+    DELEGATE_TASK_SCHEMA,
+    _build_dynamic_schema_overrides,
+    _build_top_level_description,
+    delegate_task,
+)
+from tools.delegation_workflow import (
+    WORKFLOW_MAX_ITEMS,
+    _pipeline_context,
+    _strip_workflow_model_hidden_fields,
+    _validate_workflow,
+    workflow_max_concurrent,
+)
+
+GOOD = (
+    "Investigate the session expiry watcher and report concrete findings "
+    "with file paths and line numbers"
+)
+
+
+def _make_mock_parent(depth=0):
+    """Mock parent agent with the fields delegate_task expects."""
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "test-key"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    return parent
+
+
+def _completed(idx, summary="ok", **overrides):
+    entry = {
+        "task_index": idx,
+        "status": "completed",
+        "summary": summary,
+        "api_calls": 1,
+        "duration_seconds": 1.0,
+        "exit_reason": "completed",
+        "_child_role": None,
+        "_child_cost_usd": 0.0,
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _call(workflow, parent=None):
+    return json.loads(
+        delegate_task(workflow=workflow, parent_agent=parent or _make_mock_parent())
+    )
+
+
+class TestWorkflowValidation(unittest.TestCase):
+    def test_valid_workflow_normalizes_steps(self):
+        wf = {
+            "steps": [
+                {"parallel": [{"goal": GOOD}, {"goal": GOOD}]},
+                {"pipeline": [{"goal": GOOD}, {"goal": GOOD}]},
+            ]
+        }
+        normalized, err = _validate_workflow(wf)
+        self.assertIsNone(err)
+        self.assertEqual(
+            [(s["kind"], len(s["items"])) for s in normalized["steps"]],
+            [("parallel", 2), ("pipeline", 2)],
+        )
+
+    def test_step_must_have_exactly_one_kind(self):
+        both = {"steps": [{"parallel": [{"goal": GOOD}], "pipeline": [{"goal": GOOD}]}]}
+        _, err = _validate_workflow(both)
+        self.assertIn("exactly one of 'parallel' or 'pipeline'", err)
+
+        none = {"steps": [{"foo": [{"goal": GOOD}]}]}
+        _, err = _validate_workflow(none)
+        self.assertIn("exactly one of 'parallel' or 'pipeline'", err)
+
+    def test_item_requires_goal(self):
+        wf = {"steps": [{"parallel": [{"context": "no goal here"}]}]}
+        _, err = _validate_workflow(wf)
+        self.assertIn("missing a 'goal'", err)
+
+    def test_workflow_must_be_object_with_steps(self):
+        _, err = _validate_workflow([{"goal": GOOD}])
+        self.assertIn("object with a 'steps' array", err)
+        _, err = _validate_workflow({"steps": []})
+        self.assertIn("non-empty array", err)
+
+    def test_total_item_cap_rejected_before_spawn(self):
+        """Over-cap workflows fail the whole call — no child is ever built."""
+        wf = {
+            "steps": [
+                {"parallel": [{"goal": GOOD}] * (WORKFLOW_MAX_ITEMS + 1)}
+            ]
+        }
+        with patch("tools.delegate_tool._build_child_preserving_parent_tools") as build:
+            result = _call(wf)
+        build.assert_not_called()
+        self.assertIn(f"{WORKFLOW_MAX_ITEMS}-item cap", result["error"])
+
+    def test_short_and_placeholder_goals_rejected(self):
+        for goal in ("TODO", "task 3", "short"):
+            _, err = _validate_workflow({"steps": [{"parallel": [{"goal": goal}]}]})
+            self.assertIsNotNone(err, f"goal {goal!r} should be rejected")
+
+    def test_pipeline_context_threading(self):
+        prev_ok = {"status": "completed", "summary": "STAGE-OUTPUT"}
+        ctx = _pipeline_context({"context": "base ctx"}, prev_ok)
+        self.assertIn("base ctx", ctx)
+        self.assertIn("STAGE-OUTPUT", ctx)
+
+        prev_bad = {"status": "error", "error": "BOOM"}
+        ctx = _pipeline_context({"context": "base ctx"}, prev_bad)
+        self.assertIn("BOOM", ctx)
+        self.assertIn("FAILED", ctx)
+
+        # First stage: no previous output -> context untouched.
+        self.assertEqual(_pipeline_context({"context": "base"}, None), "base")
+
+
+class TestWorkflowParallel(unittest.TestCase):
+    def test_parallel_runs_all_items_under_concurrency_cap(self):
+        """6 items, max_concurrent=2: all complete, never more than 2 at once."""
+        parent = _make_mock_parent()
+        lock = threading.Lock()
+        state = {"active": 0, "max_active": 0}
+
+        def fake_run(task_index, goal, child, parent_agent, **_kwargs):
+            with lock:
+                state["active"] += 1
+                state["max_active"] = max(state["max_active"], state["active"])
+            time.sleep(0.05)
+            try:
+                return _completed(task_index, summary=f"result-{task_index}")
+            finally:
+                with lock:
+                    state["active"] -= 1
+
+        wf = {"steps": [{"parallel": [{"goal": GOOD}] * 6}]}
+        with (
+            patch("tools.delegate_tool._get_max_concurrent_children", return_value=2),
+            patch("tools.delegate_tool._build_child_preserving_parent_tools",
+                  return_value=MagicMock()),
+            patch("tools.delegate_tool._run_single_child", side_effect=fake_run),
+        ):
+            result = _call(wf, parent=parent)
+
+        self.assertNotIn("error", result)
+        self.assertEqual(result["mode"], "workflow")
+        self.assertEqual(result["max_concurrent"], 2)
+        self.assertEqual(len(result["results"]), 6)
+        self.assertTrue(all(r["status"] == "completed" for r in result["results"]))
+        # Parallelism actually happened, but never beyond the semaphore cap.
+        self.assertGreater(state["max_active"], 1)
+        self.assertLessEqual(state["max_active"], 2)
+        # Results preserve input order (task_index is the global item index).
+        self.assertEqual([r["task_index"] for r in result["results"]], list(range(6)))
+        for r in result["results"]:
+            self.assertEqual(r["step_kind"], "parallel")
+            self.assertEqual(r["step_index"], 0)
+
+    def test_item_error_does_not_kill_batch(self):
+        """A raising item becomes a structured error entry; the rest continue."""
+        parent = _make_mock_parent()
+        calls = []
+
+        def fake_run(task_index, goal, child, parent_agent, **_kwargs):
+            calls.append(task_index)
+            if task_index == 1:
+                raise RuntimeError("child exploded")
+            return _completed(task_index, summary=f"ok-{task_index}")
+
+        wf = {"steps": [{"parallel": [{"goal": GOOD}, {"goal": GOOD}, {"goal": GOOD}]}]}
+        with (
+            patch("tools.delegate_tool._build_child_preserving_parent_tools",
+                  return_value=MagicMock()),
+            patch("tools.delegate_tool._run_single_child", side_effect=fake_run),
+        ):
+            result = _call(wf, parent=parent)
+
+        # Every item was attempted; the batch survived the failure.
+        self.assertEqual(sorted(calls), [0, 1, 2])
+        self.assertEqual(len(result["results"]), 3)
+        by_index = {r["task_index"]: r for r in result["results"]}
+        self.assertEqual(by_index[1]["status"], "error")
+        self.assertIn("child exploded", by_index[1]["error"])
+        self.assertEqual(by_index[0]["status"], "completed")
+        self.assertEqual(by_index[2]["status"], "completed")
+
+    def test_non_completed_status_normalized_to_error(self):
+        """failed/interrupted entries from the runner collapse to status=error."""
+        parent = _make_mock_parent()
+
+        def fake_run(task_index, goal, child, parent_agent, **_kwargs):
+            if task_index == 0:
+                return {
+                    "task_index": 0,
+                    "status": "failed",
+                    "summary": "",
+                    "exit_reason": "max_iterations",
+                    "api_calls": 3,
+                    "duration_seconds": 2.0,
+                    "_child_role": None,
+                    "_child_cost_usd": 0.0,
+                }
+            return _completed(task_index)
+
+        wf = {"steps": [{"parallel": [{"goal": GOOD}, {"goal": GOOD}]}]}
+        with (
+            patch("tools.delegate_tool._build_child_preserving_parent_tools",
+                  return_value=MagicMock()),
+            patch("tools.delegate_tool._run_single_child", side_effect=fake_run),
+        ):
+            result = _call(wf, parent=parent)
+
+        by_index = {r["task_index"]: r for r in result["results"]}
+        self.assertEqual(by_index[0]["status"], "error")
+        self.assertEqual(by_index[0]["exit_reason"], "max_iterations")
+        self.assertEqual(by_index[1]["status"], "completed")
+
+
+class TestWorkflowPipeline(unittest.TestCase):
+    def _run_pipeline(self, side_effect, stages):
+        parent = _make_mock_parent()
+        built_contexts = []
+
+        def fake_build(**kwargs):
+            built_contexts.append(kwargs.get("context"))
+            return MagicMock()
+
+        with (
+            patch("tools.delegate_tool._build_child_preserving_parent_tools",
+                  side_effect=fake_build),
+            patch("tools.delegate_tool._run_single_child", side_effect=side_effect),
+        ):
+            result = _call(
+                {"steps": [{"pipeline": [{"goal": GOOD} for _ in stages]}]},
+                parent=parent,
+            )
+        return result, built_contexts
+
+    def test_pipeline_chains_stage_output_into_next_context(self):
+        """Output of stage N must appear in the context of stage N+1's prompts."""
+        stage_outputs = ["STAGE-0-OUT", "STAGE-1-OUT", "STAGE-2-OUT"]
+        side_effect = [
+            _completed(i, summary=stage_outputs[i]) for i in range(3)
+        ]
+        result, built_contexts = self._run_pipeline(side_effect, stages=[1, 2, 3])
+
+        self.assertNotIn("error", result)
+        self.assertEqual([r["task_index"] for r in result["results"]], [0, 1, 2])
+        for r in result["results"]:
+            self.assertEqual(r["step_kind"], "pipeline")
+            self.assertEqual(r["step_index"], 0)
+        # First stage: no previous output. Later stages: previous output present.
+        self.assertNotIn("STAGE-0-OUT", built_contexts[0])
+        self.assertIn("STAGE-0-OUT", built_contexts[1])
+        self.assertIn("STAGE-1-OUT", built_contexts[2])
+
+    def test_pipeline_failed_stage_feeds_error_forward_and_continues(self):
+        """A failed stage must not abort the pipeline: its error text is
+        passed to the next stage's context and later stages still run."""
+        def side_effect(task_index, goal, child, parent_agent, **_kwargs):
+            if task_index == 0:
+                raise RuntimeError("stage-0 exploded")
+            return _completed(task_index, summary=f"stage-{task_index}-ok")
+
+        result, built_contexts = self._run_pipeline(side_effect, stages=[1, 2, 3])
+
+        by_index = {r["task_index"]: r for r in result["results"]}
+        self.assertEqual(by_index[0]["status"], "error")
+        self.assertIn("stage-0 exploded", by_index[0]["error"])
+        # Later stages ran and received the failure context.
+        self.assertEqual(by_index[1]["status"], "completed")
+        self.assertEqual(by_index[2]["status"], "completed")
+        self.assertIn("stage-0 exploded", built_contexts[1])
+
+    def test_pipeline_stages_are_strictly_sequential(self):
+        """Pipeline stages never overlap: stage N+1 starts after stage N ends."""
+        parent = _make_mock_parent()
+        lock = threading.Lock()
+        state = {"active": 0, "max_active": 0}
+        entered_order = []
+
+        def fake_run(task_index, goal, child, parent_agent, **_kwargs):
+            with lock:
+                state["active"] += 1
+                state["max_active"] = max(state["max_active"], state["active"])
+                entered_order.append(task_index)
+            time.sleep(0.03)
+            try:
+                return _completed(task_index, summary=f"stage-{task_index}")
+            finally:
+                with lock:
+                    state["active"] -= 1
+
+        with (
+            patch("tools.delegate_tool._build_child_preserving_parent_tools",
+                  return_value=MagicMock()),
+            patch("tools.delegate_tool._run_single_child", side_effect=fake_run),
+        ):
+            result = _call(
+                {"steps": [{"pipeline": [{"goal": GOOD} for _ in range(4)]}]},
+                parent=parent,
+            )
+
+        self.assertEqual(state["max_active"], 1)
+        self.assertEqual(entered_order, [0, 1, 2, 3])
+        self.assertEqual(len(result["results"]), 4)
+
+
+class TestWorkflowComposition(unittest.TestCase):
+    def test_mixed_steps_run_in_order_with_correct_metadata(self):
+        """parallel step then pipeline step: flat ordered results, per-step
+        metadata intact, item cap enforced across the WHOLE workflow."""
+        parent = _make_mock_parent()
+
+        def fake_run(task_index, goal, child, parent_agent, **_kwargs):
+            return _completed(task_index, summary=f"item-{task_index}")
+
+        wf = {
+            "steps": [
+                {"parallel": [{"goal": GOOD}, {"goal": GOOD}]},
+                {"pipeline": [{"goal": GOOD}, {"goal": GOOD}]},
+            ]
+        }
+        with (
+            patch("tools.delegate_tool._build_child_preserving_parent_tools",
+                  return_value=MagicMock()),
+            patch("tools.delegate_tool._run_single_child", side_effect=fake_run),
+        ):
+            result = _call(wf, parent=parent)
+
+        self.assertNotIn("error", result)
+        self.assertEqual(len(result["results"]), 4)
+        self.assertEqual([r["task_index"] for r in result["results"]], [0, 1, 2, 3])
+        kinds = [(r["step_index"], r["step_kind"]) for r in result["results"]]
+        self.assertEqual(kinds, [(0, "parallel"), (0, "parallel"),
+                                 (1, "pipeline"), (1, "pipeline")])
+
+    def test_workflow_wins_over_goal_and_tasks(self):
+        """When workflow is provided, top-level goal/tasks are ignored."""
+        parent = _make_mock_parent()
+
+        def fake_run(task_index, goal, child, parent_agent, **_kwargs):
+            return _completed(task_index)
+
+        with (
+            patch("tools.delegate_tool._build_child_preserving_parent_tools",
+                  return_value=MagicMock()),
+            patch("tools.delegate_tool._run_single_child", side_effect=fake_run),
+        ):
+            result = json.loads(
+                delegate_task(
+                    goal="ignore me",
+                    tasks=[{"goal": "ignore me too"}],
+                    workflow={"steps": [{"parallel": [{"goal": GOOD}]}]},
+                    parent_agent=parent,
+                )
+            )
+        self.assertNotIn("error", result)
+        self.assertEqual(len(result["results"]), 1)
+
+
+class TestWorkflowSchema(unittest.TestCase):
+    def test_schema_exposes_workflow_param(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("workflow", props)
+        wf_props = props["workflow"]["properties"]["steps"]["items"]["properties"]
+        self.assertIn("parallel", wf_props)
+        self.assertIn("pipeline", wf_props)
+        item_props = wf_props["parallel"]["items"]["properties"]
+        self.assertIn("goal", item_props)
+        self.assertIn("context", item_props)
+        self.assertIn("role", item_props)
+        # v1 limitation: workflow items are goal/context/role only.
+        self.assertNotIn("output_schema", item_props)
+
+    def test_dynamic_overrides_inject_current_limits(self):
+        with patch("tools.delegate_tool._get_max_concurrent_children", return_value=10):
+            overrides = _build_dynamic_schema_overrides()
+        wf_desc = overrides["parameters"]["properties"]["workflow"]["description"]
+        self.assertIn("parallel", wf_desc)
+        self.assertIn("pipeline", wf_desc)
+        self.assertIn("up to 8 at a time", wf_desc)  # min(8, 10)
+        self.assertIn(str(WORKFLOW_MAX_ITEMS), wf_desc)
+
+    def test_registry_definition_includes_workflow(self):
+        """The registry get_definitions() pass must ship the workflow param
+        with the user's actual limits (same path the model sees)."""
+        from tools.registry import registry
+
+        with (
+            patch("tools.delegate_tool._get_max_concurrent_children", return_value=7),
+            patch("tools.delegate_tool._get_max_spawn_depth", return_value=4),
+            patch("tools.delegate_tool._get_orchestrator_enabled", return_value=True),
+        ):
+            definition = registry.get_definitions({"delegate_task"})[0]["function"]
+        props = definition["parameters"]["properties"]
+        self.assertIn("workflow", props)
+        self.assertIn("up to 7", props["tasks"]["description"])
+        self.assertIn("up to 7 at a time", props["workflow"]["description"])
+
+    def test_top_level_description_stays_within_budget(self):
+        desc = _build_top_level_description()
+        self.assertLessEqual(len(desc), 2200)
+        self.assertIn("workflow", desc)
+
+    def test_workflow_max_concurrent_clamped(self):
+        with patch("tools.delegate_tool._get_max_concurrent_children", return_value=10):
+            self.assertEqual(workflow_max_concurrent(), 8)
+        with patch("tools.delegate_tool._get_max_concurrent_children", return_value=2):
+            self.assertEqual(workflow_max_concurrent(), 2)
+        with patch("tools.delegate_tool._get_max_concurrent_children", return_value=0):
+            self.assertEqual(workflow_max_concurrent(), 1)
+
+
+class TestWorkflowModelHiddenFields(unittest.TestCase):
+    def test_hidden_fields_stripped_from_items(self):
+        wf = {
+            "steps": [
+                {"parallel": [{"goal": GOOD, "acp_command": "x", "acp_args": ["y"]}]},
+                {"pipeline": [{"goal": GOOD}]},
+            ]
+        }
+        stripped = _strip_workflow_model_hidden_fields(wf)
+        self.assertNotIn("acp_command", stripped["steps"][0]["parallel"][0])
+        self.assertNotIn("acp_args", stripped["steps"][0]["parallel"][0])
+        self.assertEqual(stripped["steps"][0]["parallel"][0]["goal"], GOOD)
+        # Unchanged steps returned as-is (identity preserved when nothing stripped).
+        unchanged = {"steps": [{"pipeline": [{"goal": GOOD}]}]}
+        self.assertIs(_strip_workflow_model_hidden_fields(unchanged), unchanged)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3215,14 +3215,22 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
+    workflow: Optional[Dict[str, Any]] = None,
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
-    Supports two modes:
-      - Single: provide goal (+ optional context and role)
-      - Batch:  provide tasks array [{goal, context, role}, ...]
+    Supports three modes:
+      - Single:   provide goal (+ optional context and role)
+      - Batch:    provide tasks array [{goal, context, role}, ...]
+      - Workflow: provide workflow object with ordered 'steps', each
+                  step a 'parallel' fan-out or a 'pipeline' of sequential
+                  stages (output of stage N feeds the context of stage
+                  N+1). Runs under a semaphore (max_concurrent) with a
+                  total item cap (max_items); a failed item becomes a
+                  structured error entry and the rest of the batch
+                  continues. See tools.delegation_workflow for the caps.
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
@@ -3293,6 +3301,58 @@ def delegate_task(
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
         return tool_error(str(exc))
+
+    # ----- Workflow mode (batch orchestration: parallel/pipeline steps) -----
+    # Design decision (PR feat(delegation) workflow-batch): EXTEND the existing
+    # delegate_task with a workflow mode instead of adding a new core tool —
+    # the batch (tasks=[]) already accepts parallel item lists and runs them
+    # through a thread pool, so a workflow is a superset reusing the exact
+    # child build/run/finalize machinery. v1 runs SYNCHRONOUSLY: pipeline
+    # stages depend on each other's output, so the whole workflow joins on
+    # itself and returns ONE consolidated result (same contract as a sync
+    # batch). The deprecated `background` flag is ignored here.
+    if workflow is not None:
+        from tools.delegation_workflow import run_workflow
+
+        if isinstance(workflow, str):
+            try:
+                parsed_workflow = json.loads(workflow)
+            except json.JSONDecodeError as exc:
+                return tool_error(
+                    "workflow must be a JSON object; received a string that "
+                    f"could not be parsed ({exc.msg})."
+                )
+            if not isinstance(parsed_workflow, dict):
+                return tool_error(
+                    "workflow must be a JSON object with a 'steps' array."
+                )
+            workflow = parsed_workflow
+
+        # Capture the originating session BEFORE any child construction
+        # (AIAgent clobbers HERMES_SESSION_ID; see the batch path).
+        _wf_ui_session_id = ""
+        try:
+            from gateway.session_context import get_session_env
+
+            _wf_ui_session_id = get_session_env("HERMES_UI_SESSION_ID", "")
+        except Exception:
+            _wf_ui_session_id = ""
+        _wf_transport, _wf_record = _capture_gateway_steer_authority(
+            _wf_ui_session_id
+        )
+        wf_result = run_workflow(
+            workflow,
+            parent_agent=parent_agent,
+            creds=creds,
+            effective_max_iter=effective_max_iter,
+            top_role=top_role,
+            origin_ui_session_id=_wf_ui_session_id or None,
+            origin_owner_transport=_wf_transport,
+            origin_owner_session_record=_wf_record,
+        )
+        if isinstance(wf_result, dict) and wf_result.get("error"):
+            return tool_error(wf_result["error"])
+        return json.dumps(wf_result, ensure_ascii=False)
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -4162,12 +4222,14 @@ def _build_top_level_description() -> str:
     return (
         "Spawn subagents in isolated contexts; each gets its own conversation, "
         "terminal session, and toolset, and only its final summary returns to "
-        "you. Provide 'goal' for a single task or 'tasks' for a parallel batch "
-        "(limits and nesting rules are in the parameter descriptions).\n\n"
+        "you. Provide 'goal' for a single task, 'tasks' for a parallel batch, "
+        "or 'workflow' for ordered parallel/pipeline orchestration (caps and "
+        "semantics are in the parameter descriptions).\n\n"
         "Runs in the background: dispatch returns immediately with live "
         "transcript paths, and the completed result (one consolidated message "
-        "for a batch) re-enters the conversation on its own. Do NOT wait or "
-        "poll; continue other work.\n\n"
+        "for a batch) re-enters the conversation on its own. The exception is "
+        "'workflow', which returns its consolidated result synchronously in "
+        "this turn. Do NOT wait or poll; continue other work.\n\n"
         "USE FOR: reasoning-heavy subtasks, work that would flood your context "
         "with intermediate data, or independent parallel workstreams.\n"
         "DO NOT USE FOR (use these instead):\n"
@@ -4207,6 +4269,30 @@ def _build_tasks_param_description() -> str:
         f"user, set via delegation.max_concurrent_children). Each gets "
         "its own subagent with isolated context and terminal session. "
         "When provided, top-level goal/context/role are ignored."
+    )
+
+
+def _build_workflow_param_description() -> str:
+    """Compose the 'workflow' parameter description with current limits."""
+    from tools.delegation_workflow import WORKFLOW_MAX_ITEMS
+
+    try:
+        max_concurrent = min(8, _get_max_concurrent_children())
+    except Exception:
+        max_concurrent = min(8, _DEFAULT_MAX_CONCURRENT_CHILDREN)
+    return (
+        "Workflow mode: ordered batch orchestration instead of one flat "
+        "fan-out. 'steps' is an array; each step defines EXACTLY ONE of:\n"
+        "- parallel: N independent tasks run concurrently under a semaphore "
+        f"(up to {max_concurrent} at a time for this user). A failing task "
+        "becomes an error entry; the other tasks continue.\n"
+        "- pipeline: strictly sequential stages; the output of each stage "
+        "is appended to the context of the next stage's prompts.\n"
+        f"Total items across all steps are capped at {WORKFLOW_MAX_ITEMS}. "
+        "Results come back as one flat array, one entry per item, status "
+        "completed or error, in input order. Runs synchronously (v1) — the "
+        "consolidated result returns in this turn. When provided, "
+        "top-level goal/context/tasks/role are ignored."
     )
 
 
@@ -4263,11 +4349,39 @@ def _build_dynamic_schema_overrides() -> dict:
     }
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
     overrides_params["properties"]["role"]["description"] = _build_role_param_description()
+    if "workflow" in overrides_params["properties"]:
+        overrides_params["properties"]["workflow"]["description"] = (
+            _build_workflow_param_description()
+        )
 
     return {
         "description": _build_top_level_description(),
         "parameters": overrides_params,
     }
+
+
+# Item schema shared by workflow 'parallel' and 'pipeline' step arrays.
+# Same shape as tasks[] items (minus output_schema — workflow items are
+# goal/context/role only in v1; see PR limitations).
+_WORKFLOW_STEP_ITEM_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "goal": {"type": "string", "description": "Task goal"},
+        "context": {
+            "type": "string",
+            "description": (
+                "Task-specific context. For pipeline stages, the previous "
+                "stage's output is appended here automatically."
+            ),
+        },
+        "role": {
+            "type": "string",
+            "enum": ["leaf", "orchestrator"],
+            "description": "Per-task role override. See top-level 'role' for semantics.",
+        },
+    },
+    "required": ["goal"],
+}
 
 
 DELEGATE_TASK_SCHEMA = {
@@ -4365,6 +4479,40 @@ DELEGATE_TASK_SCHEMA = {
                     "backward compatibility."
                 ),
             },
+            "workflow": {
+                "type": "object",
+                "description": "(rebuilt at get_definitions() time)",
+                "properties": {
+                    "steps": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "parallel": {
+                                    "type": "array",
+                                    "items": _WORKFLOW_STEP_ITEM_SCHEMA,
+                                    "description": (
+                                        "Independent tasks for this step; run "
+                                        "concurrently under the workflow "
+                                        "semaphore. A failing task becomes an "
+                                        "error entry; the others continue."
+                                    ),
+                                },
+                                "pipeline": {
+                                    "type": "array",
+                                    "items": _WORKFLOW_STEP_ITEM_SCHEMA,
+                                    "description": (
+                                        "Sequential stages for this step; the "
+                                        "output of each stage is appended to "
+                                        "the context of the next stage's "
+                                        "prompts."
+                                    ),
+                                },
+                            },
+                        },
+                    },
+                },
+            },
         },
         "required": [],
     },
@@ -4414,6 +4562,17 @@ def _strip_model_hidden_task_fields(tasks: Any) -> Any:
     return stripped_tasks if changed else tasks
 
 
+def _strip_workflow_model_hidden_fields(workflow: Any) -> Any:
+    """Lazy wrapper around tools.delegation_workflow's nested strip.
+
+    Kept here (not imported at module level) to avoid a circular import:
+    tools.delegation_workflow imports this module at top level.
+    """
+    from tools.delegation_workflow import _strip_workflow_model_hidden_fields as _impl
+
+    return _impl(workflow)
+
+
 registry.register(
     name="delegate_task",
     toolset="delegation",
@@ -4426,6 +4585,7 @@ registry.register(
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
         output_schema=args.get("output_schema"),
+        workflow=_strip_workflow_model_hidden_fields(args.get("workflow")),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegation_workflow.py
+++ b/tools/delegation_workflow.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""
+Workflow orchestration layer for delegate_task.
+
+The parent describes a batch workflow as an ordered list of steps. Each
+step defines EXACTLY ONE of:
+
+  - {"parallel": [task, ...]}  -- independent items run concurrently under a
+                                  semaphore bounded by max_concurrent. A
+                                  failing item becomes a structured error
+                                  entry; the rest of the batch continues.
+  - {"pipeline": [task, ...]}  -- strictly sequential stages; the output of
+                                  stage N is appended to the context of the
+                                  prompts of stage N+1 (a failed stage feeds
+                                  its error text forward so the next stage
+                                  can decide to recover or proceed).
+
+Caps (see workflow_max_concurrent / WORKFLOW_MAX_ITEMS):
+  - max_concurrent = min(8, delegation.max_concurrent_children)
+  - max_items      = 32 total items across ALL steps
+
+Failure semantics: item failure NEVER kills the workflow. Only a
+validation failure (malformed schema, missing goal, over-cap) aborts the
+whole call before any child is spawned. The result is a flat per-item
+array with status in {completed, error}; pipeline/parallel order is
+preserved via task_index.
+
+Pattern reference: deepseek-harness packages/workflow/workflow-worker-thread
+(runtime.ts agent()/parallel()/pipeline(); FIFO semaphore maxConcurrentAgents,
+maxTotalAgents backstop, fatal-vs-item error semantics). Ported as a pattern,
+not code.
+
+Design decision (see PR): (a) extend the existing delegate_task batch with a
+workflow mode, instead of a new core tool -- the batch already accepts
+tasks=[] with thread-pool parallelism, so a workflow is a superset that
+reuses the exact child build/run/finalize machinery. v1 runs synchronously:
+pipeline stages depend on each other's output, so the whole workflow joins
+on itself and returns ONE consolidated result (same contract as a sync
+batch).
+"""
+
+import json
+import logging
+import threading
+import time
+from concurrent.futures import as_completed
+from typing import Any, Dict, List, Optional, Tuple
+
+# Reference the delegate machinery through the module (NOT via
+# `from tools.delegate_tool import X`): the existing delegation tests patch
+# `tools.delegate_tool._run_single_child` / `_build_child_preserving_parent_tools`
+# on the module attribute, so call-time lookup keeps those patches effective.
+from tools import delegate_tool as _delegate_tool
+
+logger = logging.getLogger(__name__)
+
+# Total item cap across all steps of one workflow call (max_items).
+WORKFLOW_MAX_ITEMS = 32
+# Hard ceiling on the workflow semaphore width, independent of the user's
+# delegation.max_concurrent_children knob. Mirrors the reference harness's
+# "bounded fan-out" posture: max_concurrent = min(8, configured cap).
+WORKFLOW_MAX_CONCURRENT_CAP = 8
+
+_STEP_KIND_PARALLEL = "parallel"
+_STEP_KIND_PIPELINE = "pipeline"
+_STEP_KINDS = (_STEP_KIND_PARALLEL, _STEP_KIND_PIPELINE)
+
+
+def workflow_max_concurrent() -> int:
+    """Semaphore width for workflow runs: min(8, delegation.max_concurrent_children).
+
+    Always >= 1. Reads the same config knob as the flat batch path so the
+    user's delegation.max_concurrent_children governs workflow fan-out too,
+    but never lets a single workflow exceed 8 concurrent children (the
+    reference harness caps at min(16, cores-2); 8 is the Hermes-side bound
+    on top of the user's explicit knob).
+    """
+    from tools.delegate_tool import _get_max_concurrent_children
+
+    try:
+        configured = _get_max_concurrent_children()
+    except Exception:
+        configured = 3
+    return max(1, min(WORKFLOW_MAX_CONCURRENT_CAP, configured))
+
+
+def _validate_workflow(
+    workflow: Any,
+) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Validate + normalize a workflow description.
+
+    Returns (normalized, error). normalized is
+    {"steps": [{"kind": "parallel"|"pipeline", "items": [task, ...]}, ...]}
+    with every item guaranteed to have a non-empty 'goal' and the total
+    item count under WORKFLOW_MAX_ITEMS. On any structural problem the
+    error string is actionable and the call is aborted BEFORE any child is
+    spawned (fatal-vs-item: schema errors are fatal, item failures are not).
+    """
+    if not isinstance(workflow, dict):
+        return None, (
+            "workflow must be an object with a 'steps' array "
+            f"(got {type(workflow).__name__})."
+        )
+    steps = workflow.get("steps")
+    if not isinstance(steps, list) or not steps:
+        return None, "workflow.steps must be a non-empty array of step objects."
+
+    normalized_steps: List[Dict[str, Any]] = []
+    total_items = 0
+    for si, step in enumerate(steps):
+        if not isinstance(step, dict):
+            return None, f"workflow.steps[{si}] must be an object."
+
+        kind_keys = [k for k in _STEP_KINDS if step.get(k) is not None]
+        if len(kind_keys) != 1:
+            return None, (
+                f"workflow.steps[{si}] must define exactly one of "
+                f"'parallel' or 'pipeline' (got {sorted(kind_keys) or 'none'})."
+            )
+        kind = kind_keys[0]
+        items = step[kind]
+        if not isinstance(items, list) or not items:
+            return None, (
+                f"workflow.steps[{si}].{kind} must be a non-empty array of "
+                "task objects."
+            )
+
+        normalized_items: List[Dict[str, Any]] = []
+        for ii, item in enumerate(items):
+            if not isinstance(item, dict):
+                return None, (
+                    f"workflow.steps[{si}].{kind}[{ii}] must be an object "
+                    f"(got {type(item).__name__})."
+                )
+            goal = str(item.get("goal") or "").strip()
+            if not goal:
+                return None, (
+                    f"workflow.steps[{si}].{kind}[{ii}] is missing a 'goal'."
+                )
+            # Same placeholder/short-goal quality gate as the flat batch
+            # (batch-only rules that the single-goal form is exempt from).
+            normalized = " ".join(goal.lower().split())
+            if _delegate_tool._PLACEHOLDER_GOAL_RE.match(normalized):
+                return None, (
+                    f"workflow.steps[{si}].{kind}[{ii}] has a placeholder "
+                    f"goal ({goal!r}). Replace it with a specific, "
+                    "self-contained description."
+                )
+            marker = _delegate_tool._TEMPLATE_MARKER_RE.search(goal)
+            if marker:
+                return None, (
+                    f"workflow.steps[{si}].{kind}[{ii}] goal contains an "
+                    f"unexpanded template marker ({marker.group(0)!r}). "
+                    "Substitute the real value before calling delegate_task."
+                )
+            if len(goal) < _delegate_tool._MIN_BATCH_GOAL_LEN:
+                return None, (
+                    f"workflow.steps[{si}].{kind}[{ii}] goal is too short "
+                    f"({goal!r}). Write a specific, self-contained goal of "
+                    f"at least {_delegate_tool._MIN_BATCH_GOAL_LEN} characters."
+                )
+            normalized_items.append(item)
+
+        total_items += len(normalized_items)
+        if total_items > WORKFLOW_MAX_ITEMS:
+            return None, (
+                f"workflow exceeds the {WORKFLOW_MAX_ITEMS}-item cap: "
+                f"{total_items} items across {len(steps)} step(s). Split "
+                "into multiple delegate_task calls."
+            )
+        normalized_steps.append({"kind": kind, "items": normalized_items})
+
+    return {"steps": normalized_steps}, None
+
+
+def _workflow_item_error_entry(
+    task_index: int,
+    item: Dict[str, Any],
+    error: str,
+    top_role: str,
+    *,
+    step_index: int,
+    step_kind: str,
+) -> Dict[str, Any]:
+    """Structured error entry for a failed workflow item (batch continues)."""
+    return {
+        "task_index": task_index,
+        "step_index": step_index,
+        "step_kind": step_kind,
+        "status": "error",
+        "summary": None,
+        "error": error,
+        "api_calls": 0,
+        "duration_seconds": 0.0,
+        "_child_role": _delegate_tool._normalize_role(item.get("role") or top_role),
+    }
+
+
+def _pipeline_context(item: Dict[str, Any], prev_entry: Optional[Dict[str, Any]]) -> str:
+    """Context for a pipeline stage, threading the previous stage's output.
+
+    v1 contract: the output (summary) of stage N is included in the context
+    of the prompts of stage N+1. When stage N failed there is no output —
+    its structured error text is passed forward instead, labeled, so the
+    next stage can decide whether to recover or proceed. The workflow
+    itself is never aborted by a failed stage.
+    """
+    ctx = item.get("context") or ""
+    if prev_entry is None:
+        return ctx
+    if prev_entry.get("status") == "completed":
+        header = (
+            "OUTPUT FROM THE PREVIOUS PIPELINE STAGE — build on it "
+            "to continue the work:"
+        )
+        body = prev_entry.get("summary") or ""
+    else:
+        header = (
+            "THE PREVIOUS PIPELINE STAGE FAILED — its error is below. "
+            "Recover from it or proceed with what you have:"
+        )
+        body = prev_entry.get("error") or ""
+    sep = "\n\n" if ctx else ""
+    return f"{ctx}{sep}{header}\n{body}"
+
+
+def run_workflow(
+    workflow: Dict[str, Any],
+    *,
+    parent_agent,
+    creds: Dict[str, Any],
+    effective_max_iter: int,
+    top_role: str,
+    origin_ui_session_id: Optional[str] = None,
+    origin_owner_transport: Any = None,
+    origin_owner_session_record: Any = None,
+) -> Dict[str, Any]:
+    """Execute a workflow description and return the consolidated result.
+
+    Returns either {"error": str} (fatal, pre-spawn validation failure —
+    the caller turns that into a tool_error) or the combined result dict:
+
+        {
+          "mode": "workflow",
+          "results": [per-item entries, ordered by task_index],
+          "max_items": 32,
+          "max_concurrent": N,
+          "total_duration_seconds": X,
+        }
+
+    Each per-item entry: {task_index, step_index, step_kind, status,
+    summary, error?, api_calls, duration_seconds, ...} with status in
+    {completed, error}. Internal fields (_child_role, _child_cost_usd) are
+    stripped by _finalize_child_results, same as the flat batch path.
+    """
+    validated, err = _validate_workflow(workflow)
+    if err:
+        return {"error": err}
+    steps = validated["steps"]
+
+    max_concurrent = workflow_max_concurrent()
+    sem = threading.BoundedSemaphore(max_concurrent)
+
+    total_items = sum(len(step["items"]) for step in steps)
+    results: List[Dict[str, Any]] = []
+    # (global_index, item, child) + flat item list feed the shared
+    # _finalize_child_results (summary budget, memory manager, hooks, cost
+    # rollup) exactly like the flat batch path.
+    all_children: List[Tuple[int, Dict[str, Any], Any]] = []
+    flat_items: List[Dict[str, Any]] = []
+
+    overall_start = time.monotonic()
+
+    def _build_child(task_index: int, item: Dict[str, Any], context: str):
+        effective_role = _delegate_tool._normalize_role(item.get("role") or top_role)
+        return _delegate_tool._build_child_preserving_parent_tools(
+            task_index=task_index,
+            goal=item["goal"],
+            context=context,
+            toolsets=None,  # children always inherit the parent's toolsets
+            model=creds.get("model"),
+            max_iterations=effective_max_iter,
+            task_count=total_items,
+            parent_agent=parent_agent,
+            override_provider=creds.get("provider"),
+            override_base_url=creds.get("base_url"),
+            override_api_key=creds.get("api_key"),
+            override_api_mode=creds.get("api_mode"),
+            override_request_overrides=creds.get("request_overrides"),
+            override_max_tokens=creds.get("max_output_tokens"),
+            override_acp_command=creds.get("command"),
+            override_acp_args=creds.get("args"),
+            role=effective_role,
+        )
+
+    def _run_item(
+        task_index: int,
+        item: Dict[str, Any],
+        child,
+        step_index: int,
+        step_kind: str,
+    ) -> Dict[str, Any]:
+        """Run one item under the semaphore; item errors never propagate."""
+        with sem:
+            try:
+                entry = _delegate_tool._run_single_child(
+                    task_index,
+                    item["goal"],
+                    child,
+                    parent_agent,
+                    owner_session_id=origin_ui_session_id,
+                    owner_transport=origin_owner_transport,
+                    owner_session_record=origin_owner_session_record,
+                )
+            except Exception as exc:  # noqa: BLE001 — item isolation contract
+                logger.debug(
+                    "workflow item %d (%s step %d) raised: %s",
+                    task_index, step_kind, step_index, exc,
+                )
+                entry = _workflow_item_error_entry(
+                    task_index, item, str(exc), top_role,
+                    step_index=step_index, step_kind=step_kind,
+                )
+        entry = dict(entry)
+        entry["task_index"] = task_index
+        entry["step_index"] = step_index
+        entry["step_kind"] = step_kind
+        # Workflow contract: status ∈ {completed, error}. The child runner
+        # may report failed/interrupted — normalize those to error while
+        # keeping the exit reason visible.
+        if entry.get("status") != "completed":
+            entry["status"] = "error"
+            entry.setdefault(
+                "error",
+                entry.get("exit_reason")
+                or entry.get("summary")
+                or "child agent failed",
+            )
+        return entry
+
+    global_index = 0
+    for step_index, step in enumerate(steps):
+        kind = step["kind"]
+        items = step["items"]
+
+        if kind == _STEP_KIND_PARALLEL:
+            # Build every child on the calling thread (thread-safe
+            # construction, same as the flat batch), then fan out. The pool
+            # width AND the semaphore both cap at max_concurrent; the
+            # semaphore is the authoritative cap that also covers pipeline
+            # stages and any future interleaved execution.
+            built: List[Tuple[int, Dict[str, Any], Any]] = []
+            for item in items:
+                child = _build_child(global_index, item, item.get("context") or "")
+                built.append((global_index, item, child))
+                all_children.append((global_index, item, child))
+                flat_items.append(item)
+                global_index += 1
+
+            from tools.daemon_pool import DaemonThreadPoolExecutor
+
+            with DaemonThreadPoolExecutor(max_workers=max_concurrent) as pool:
+                futures = {
+                    pool.submit(_run_item, gi, item, child, step_index, kind): gi
+                    for gi, item, child in built
+                }
+                for future in as_completed(futures):
+                    results.append(future.result())
+
+        else:  # pipeline: strictly sequential stages, context threading
+            prev_entry: Optional[Dict[str, Any]] = None
+            for item in items:
+                context = _pipeline_context(item, prev_entry)
+                child = _build_child(global_index, item, context)
+                all_children.append((global_index, item, child))
+                flat_items.append(item)
+                prev_entry = _run_item(global_index, item, child, step_index, kind)
+                results.append(prev_entry)
+                global_index += 1
+
+    # Match input order (task_index is the global item index).
+    results.sort(key=lambda r: r.get("task_index", -1))
+
+    # Shared finalization: summary budget against parent context headroom,
+    # memory manager on_delegation, subagent_stop hooks, cost rollup.
+    _delegate_tool._finalize_child_results(results, flat_items, all_children, parent_agent)
+
+    return {
+        "mode": "workflow",
+        "results": results,
+        "max_items": WORKFLOW_MAX_ITEMS,
+        "max_concurrent": max_concurrent,
+        "total_duration_seconds": round(time.monotonic() - overall_start, 2),
+    }
+
+
+def _strip_workflow_model_hidden_fields(workflow: Any) -> Any:
+    """Strip model-hidden task fields (acp_command/acp_args) from workflow items.
+
+    Mirrors delegate_tool._strip_model_hidden_task_fields for the nested
+    step/item shape. Returns the input unchanged when nothing was stripped.
+    """
+    if not isinstance(workflow, dict):
+        return workflow
+    steps = workflow.get("steps")
+    if not isinstance(steps, list):
+        return workflow
+
+
+    changed = False
+    new_steps = []
+    for step in steps:
+        if not isinstance(step, dict):
+            new_steps.append(step)
+            continue
+        new_step = dict(step)
+        for key in _STEP_KINDS:
+            items = step.get(key)
+            if isinstance(items, list):
+                stripped = _delegate_tool._strip_model_hidden_task_fields(items)
+                if stripped is not items:
+                    new_step[key] = stripped
+                    changed = True
+        new_steps.append(new_step)
+    if not changed:
+        return workflow
+    new_workflow = dict(workflow)
+    new_workflow["steps"] = new_steps
+    return new_workflow


### PR DESCRIPTION
## Summary

Extends `delegate_task` with a `workflow` mode: the parent describes an ordered list of steps, each either a `parallel` fan-out (independent items under a semaphore) or a `pipeline` of sequential stages (output of stage N is appended to the context of stage N+1's prompts). Item failure never kills the batch — a failed item becomes a structured error entry and the rest continues.

Root cause: batch fan-out is capped at `max_concurrent_children` with no composition layer — the parent must orchestrate multi-stage work turn-by-turn, multiplying turns and context. The dsh workflow worker-thread runtime (agent/parallel/pipeline, FIFO semaphore, maxTotalAgents backstop, fatal-vs-item semantics) is the pattern reference.

## Changes

- `tools/delegation_workflow.py` (new): step engine — `parallel`/`pipeline` step types, semaphore (max_concurrent = `min(8, delegation.max_concurrent_children)`), `max_items = 32` total across all steps, pipeline context chaining (stage N output appended to stage N+1 prompts), flat per-item result array with `status: completed|error`, ordered by `task_index`
- `tools/delegate_tool.py`: `workflow` schema on the existing batch tool (no new core tool — narrow waist)
- `run_agent.py`: workflow plumbing
- `tests/tools/test_delegate_workflow.py` (new, 21 tests, stubbed runner — no real LLM): concurrency cap, per-item error isolation, pipeline context chaining, failed-stage continuation, caps, schema

## Validation

| Teste | Resultado |
|-------|-----------|
| `pytest tests/tools/test_delegate_workflow.py` | 21 passed |
| Reuses | exact child build/run/finalize machinery of the flat batch — summary budgets, memory manager, subagent_stop hooks, cost rollup apply unchanged |

## Limitation

v1 runs synchronously (pipeline depends on prior stage output); no live transcripts; semaphore is the authoritative cap but steps never interleave in v1.
