### PR TITLE
feat(image-gen): add Azure Foundry backend provider plugin

### DIFF
--- a/plugins/image_gen/azure-foundry/__init__.py
+++ b/plugins/image_gen/azure-foundry/__init__.py
@@ -1,0 +1,552 @@
+"""Azure Foundry image generation backend.
+
+Exposes GPT Image deployments hosted on Azure AI Foundry at three quality
+tiers as an :class:`ImageGenProvider` implementation, mirroring the bundled
+OpenAI backend. Azure Foundry exposes OpenAI-compatible image APIs
+(``images.generate`` / ``images.edit``); the user supplies their own
+resource endpoint and deployment name since those are per-resource.
+
+The tiers are implemented as three virtual model IDs so the ``hermes tools``
+model picker and the ``image_gen.model`` config key behave like any other
+multi-model backend:
+
+    azure-gpt-image-low     ~15s   fastest, good for iteration
+    azure-gpt-image-medium  ~40s   default — balanced
+    azure-gpt-image-high    ~2min  slowest, highest fidelity
+
+All three hit the same underlying Azure deployment (``image_gen.azure_foundry.
+deployment``, default ``gpt-image-2``) with a different ``quality`` parameter.
+Output is base64 JSON → saved under ``$HERMES_HOME/cache/images/``.
+
+Authentication supports both contracts Azure Foundry offers:
+
+* **API key** — ``AZURE_FOUNDRY_IMAGE_API_KEY`` (dedicated secret; the LLM
+  provider's ``AZURE_FOUNDRY_API_KEY`` is intentionally NOT reused so the
+  two surfaces stay independently scoped).
+* **Microsoft Entra ID** — ``auth_mode: entra_id`` under
+  ``image_gen.azure_foundry``. Uses :func:`agent.azure_identity_adapter.
+  build_token_provider` (``DefaultAzureCredential`` chain) exactly like the
+  LLM provider; the OpenAI SDK calls the returned callable before every
+  request, so token refresh is transparent.
+
+Selection precedence (first hit wins):
+
+1. ``AZURE_FOUNDRY_IMAGE_MODEL`` env var (escape hatch for scripts / tests)
+2. ``image_gen.azure_foundry.model`` in ``config.yaml``
+3. ``image_gen.model`` in ``config.yaml`` (when it's one of our tier IDs)
+4. :data:`DEFAULT_MODEL` — ``azure-gpt-image-medium``
+
+Example configuration:
+
+.. code-block:: yaml
+
+    image_gen:
+      provider: azure-foundry
+      model: azure-gpt-image-medium
+      azure_foundry:
+        endpoint: https://YOUR-RESOURCE.openai.azure.com
+        deployment: gpt-image-2
+        auth_mode: api_key        # or: entra_id
+        entra:
+          scope: https://ai.azure.com/.default
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.azure_identity_adapter import (
+    SCOPE_AI_AZURE_DEFAULT,
+    EntraIdentityConfig,
+    build_token_provider,
+    has_azure_identity_installed,
+)
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    normalize_reference_images,
+    resolve_aspect_ratio,
+    save_b64_image,
+    save_url_image,
+    success_response,
+)
+from agent.secret_scope import get_secret
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+# All three IDs resolve to the same underlying Azure deployment with a
+# different ``quality`` setting. ``api_model`` (the deployment name) comes
+# from config; ``quality`` is the knob that changes generation time and
+# output fidelity.
+
+DEFAULT_DEPLOYMENT = "gpt-image-2"
+
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "azure-gpt-image-low": {
+        "display": "GPT Image (Low)",
+        "speed": "~15s",
+        "strengths": "Fast iteration, lowest cost",
+        "quality": "low",
+    },
+    "azure-gpt-image-medium": {
+        "display": "GPT Image (Medium)",
+        "speed": "~40s",
+        "strengths": "Balanced — default",
+        "quality": "medium",
+    },
+    "azure-gpt-image-high": {
+        "display": "GPT Image (High)",
+        "speed": "~2min",
+        "strengths": "Highest fidelity, strongest prompt adherence",
+        "quality": "high",
+    },
+}
+
+DEFAULT_MODEL = "azure-gpt-image-medium"
+
+_SIZES = {
+    "landscape": "1536x1024",
+    "square": "1024x1024",
+    "portrait": "1024x1536",
+}
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def _load_azure_config() -> Dict[str, Any]:
+    """Read ``image_gen.azure_foundry`` from config.yaml ({} on failure)."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        if not isinstance(section, dict):
+            return {}
+        azure_cfg = section.get("azure_foundry")
+        return azure_cfg if isinstance(azure_cfg, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen.azure_foundry config: %s", exc)
+        return {}
+
+
+def _build_base_url(endpoint: str) -> str:
+    """Normalize a user-supplied Azure resource endpoint into the OpenAI SDK
+    base URL for the image APIs.
+
+    Accepts either the resource root (``https://RESOURCE.openai.azure.com``)
+    or an already-suffixed form (``.../openai`` or ``.../openai/v1``).
+    """
+    url = str(endpoint or "").strip().rstrip("/")
+    if not url:
+        return ""
+    if url.endswith("/openai/v1"):
+        return url
+    if url.endswith("/openai"):
+        return f"{url}/v1"
+    return f"{url}/openai/v1"
+
+
+def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+    """Decide which tier to use and return ``(model_id, meta)``."""
+    env_override = os.environ.get("AZURE_FOUNDRY_IMAGE_MODEL")
+    if env_override and env_override in _MODELS:
+        return env_override, _MODELS[env_override]
+
+    cfg = _load_azure_config()
+    candidate: Optional[str] = None
+    value = cfg.get("model")
+    if isinstance(value, str) and value in _MODELS:
+        candidate = value
+    if candidate is None:
+        try:
+            from hermes_cli.config import load_config
+
+            top = load_config().get("image_gen")
+            if isinstance(top, dict):
+                value = top.get("model")
+                if isinstance(value, str) and value in _MODELS:
+                    candidate = value
+        except Exception:
+            pass
+
+    if candidate is not None:
+        return candidate, _MODELS[candidate]
+
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_deployment() -> str:
+    """Return the Azure deployment name to send as the API ``model``."""
+    cfg = _load_azure_config()
+    deployment = str(cfg.get("deployment") or "").strip()
+    return deployment or DEFAULT_DEPLOYMENT
+
+
+def _resolve_auth_mode() -> str:
+    """Return ``entra_id`` or ``api_key`` (default)."""
+    cfg = _load_azure_config()
+    return str(cfg.get("auth_mode") or "api_key").strip().lower() or "api_key"
+
+
+def _load_azure_api_key() -> str:
+    """Return the dedicated Azure Foundry image API key, if set."""
+    try:
+        return str(get_secret("AZURE_FOUNDRY_IMAGE_API_KEY", "") or "").strip()
+    except Exception:
+        return str(os.getenv("AZURE_FOUNDRY_IMAGE_API_KEY", "") or "").strip()
+
+
+# ---------------------------------------------------------------------------
+# Source-image loading (for image-to-image / edit)
+# ---------------------------------------------------------------------------
+
+
+def _load_image_bytes(ref: str) -> Tuple[bytes, str]:
+    """Load image bytes from a URL or local file path.
+
+    Returns ``(data, filename)``. Raises on any network / IO error so the
+    caller can surface a clean error_response.
+    """
+    ref = ref.strip()
+    lower = ref.lower()
+    if lower.startswith(("http://", "https://")):
+        import requests
+
+        resp = requests.get(ref, timeout=60)
+        resp.raise_for_status()
+        name = ref.split("?", 1)[0].rsplit("/", 1)[-1] or "image.png"
+        return resp.content, name
+    if lower.startswith("data:"):
+        import base64
+
+        header, _, b64 = ref.partition(",")
+        ext = "png"
+        if "image/" in header:
+            ext = header.split("image/", 1)[1].split(";", 1)[0] or "png"
+        return base64.b64decode(b64), f"image.{ext}"
+    # Local file path — enforce the shared credential-read guard before reading.
+    from agent.file_safety import raise_if_read_blocked
+
+    raise_if_read_blocked(ref)
+    with open(ref, "rb") as fh:
+        data = fh.read()
+    name = os.path.basename(ref) or "image.png"
+    return data, name
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class AzureFoundryImageGenProvider(ImageGenProvider):
+    """Azure Foundry ``images.generate`` / ``images.edit`` backend (GPT Image
+    deployments via Azure's OpenAI-compatible image APIs)."""
+
+    @property
+    def name(self) -> str:
+        return "azure-foundry"
+
+    @property
+    def display_name(self) -> str:
+        return "Azure Foundry"
+
+    def is_available(self) -> bool:
+        if _load_azure_api_key():
+            return True
+        # Entra ID mode: available when configured and azure-identity present.
+        # No token is minted here — keeps CLI/picker startup latency flat.
+        if _resolve_auth_mode() == "entra_id":
+            return has_azure_identity_installed()
+        return False
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": model_id,
+                "display": meta["display"],
+                "speed": meta["speed"],
+                "strengths": meta["strengths"],
+                "price": "varies",
+            }
+            for model_id, meta in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Azure Foundry",
+            "badge": "paid",
+            "tag": "GPT Image deployments at low/medium/high quality tiers — text-to-image & image editing (API key or Entra ID)",
+            "env_vars": [
+                {
+                    "key": "AZURE_FOUNDRY_IMAGE_API_KEY",
+                    "prompt": "Azure Foundry image API key (skip when using Entra ID auth)",
+                    "url": "https://ai.azure.com/",
+                },
+            ],
+        }
+
+    def capabilities(self) -> Dict[str, Any]:
+        # GPT Image deployments support editing via images.edit() with up to
+        # 16 source images — same surface as the OpenAI backend.
+        return {"modalities": ["text", "image"], "max_reference_images": 16}
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        *,
+        image_url: Optional[str] = None,
+        reference_image_urls: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="azure-foundry",
+                aspect_ratio=aspect,
+            )
+
+        cfg = _load_azure_config()
+        endpoint = str(cfg.get("endpoint") or "").strip()
+        if not endpoint:
+            return error_response(
+                error=(
+                    "image_gen.azure_foundry.endpoint is not set. Configure "
+                    "your Azure resource endpoint in config.yaml (e.g. "
+                    "https://YOUR-RESOURCE.openai.azure.com)."
+                ),
+                error_type="auth_required",
+                provider="azure-foundry",
+                aspect_ratio=aspect,
+            )
+        base_url = _build_base_url(endpoint)
+        deployment = _resolve_deployment()
+
+        auth_mode = _resolve_auth_mode()
+        api_key: Any = _load_azure_api_key()
+        if auth_mode == "entra_id" and not api_key:
+            try:
+                entra_cfg = cfg.get("entra")
+                scope = ""
+                if isinstance(entra_cfg, dict):
+                    scope = str(entra_cfg.get("scope") or "").strip()
+                identity_config = EntraIdentityConfig(
+                    scope=scope or SCOPE_AI_AZURE_DEFAULT,
+                )
+                api_key = build_token_provider(config=identity_config)
+            except ImportError as exc:
+                return error_response(
+                    error=(
+                        "Azure Foundry Entra ID auth requires the "
+                        "'azure-identity' package. Install it with: "
+                        f"pip install azure-identity (import failed: {exc})"
+                    ),
+                    error_type="missing_dependency",
+                    provider="azure-foundry",
+                    aspect_ratio=aspect,
+                )
+
+        if not api_key:
+            return error_response(
+                error=(
+                    "AZURE_FOUNDRY_IMAGE_API_KEY not set and Entra ID auth is "
+                    "not configured. Run `hermes tools` → Image Generation → "
+                    "Azure Foundry to configure, or set "
+                    "image_gen.azure_foundry.auth_mode: entra_id in config.yaml."
+                ),
+                error_type="auth_required",
+                provider="azure-foundry",
+                aspect_ratio=aspect,
+            )
+
+        try:
+            import openai
+        except ImportError:
+            return error_response(
+                error="openai Python package not installed (pip install openai)",
+                error_type="missing_dependency",
+                provider="azure-foundry",
+                aspect_ratio=aspect,
+            )
+
+        tier_id, meta = _resolve_model()
+        size = _SIZES.get(aspect, _SIZES["square"])
+
+        # Collect source images (primary + references) for image-to-image.
+        sources: List[str] = []
+        if isinstance(image_url, str) and image_url.strip():
+            sources.append(image_url.strip())
+        for ref in (normalize_reference_images(reference_image_urls) or []):
+            sources.append(ref)
+        sources = sources[:16]  # GPT Image edit caps at 16 images
+        is_edit = bool(sources)
+        modality = "image" if is_edit else "text"
+
+        client = openai.OpenAI(api_key=api_key, base_url=base_url)
+
+        if is_edit:
+            # images.edit() expects file-like objects. Download/read each
+            # source into a named BytesIO so the SDK sends correct multipart.
+            import io
+
+            try:
+                files = []
+                for ref in sources:
+                    data, fname = _load_image_bytes(ref)
+                    bio = io.BytesIO(data)
+                    bio.name = fname
+                    files.append(bio)
+            except Exception as exc:
+                return error_response(
+                    error=f"Could not load source image for editing: {exc}",
+                    error_type="io_error",
+                    provider="azure-foundry",
+                    model=tier_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+
+            try:
+                response = client.images.edit(
+                    model=deployment,
+                    image=files if len(files) > 1 else files[0],
+                    prompt=prompt,
+                    size=size,  # type: ignore[arg-type]  # _SIZES values are valid GPT Image sizes
+                    quality=meta["quality"],
+                    n=1,
+                )
+            except Exception as exc:
+                logger.debug("Azure Foundry image edit failed", exc_info=True)
+                return error_response(
+                    error=f"Azure Foundry image editing failed: {exc}",
+                    error_type="api_error",
+                    provider="azure-foundry",
+                    model=tier_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+        else:
+            # GPT Image returns b64_json unconditionally and REJECTS
+            # ``response_format`` as an unknown parameter. Don't send it.
+            payload: Dict[str, Any] = {
+                "model": deployment,
+                "prompt": prompt,
+                "size": size,
+                "n": 1,
+                "quality": meta["quality"],
+            }
+
+            try:
+                response = client.images.generate(**payload)
+            except Exception as exc:
+                logger.debug("Azure Foundry image generation failed", exc_info=True)
+                return error_response(
+                    error=f"Azure Foundry image generation failed: {exc}",
+                    error_type="api_error",
+                    provider="azure-foundry",
+                    model=tier_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+
+        data = getattr(response, "data", None) or []
+        if not data:
+            return error_response(
+                error="Azure Foundry returned no image data",
+                error_type="empty_response",
+                provider="azure-foundry",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        first = data[0]
+        b64 = getattr(first, "b64_json", None)
+        url = getattr(first, "url", None)
+        revised_prompt = getattr(first, "revised_prompt", None)
+
+        if b64:
+            try:
+                saved_path = save_b64_image(b64, prefix=f"azure_foundry_{tier_id}")
+            except Exception as exc:
+                return error_response(
+                    error=f"Could not save image to cache: {exc}",
+                    error_type="io_error",
+                    provider="azure-foundry",
+                    model=tier_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+            image_ref = str(saved_path)
+        elif url:
+            # Defensive — GPT Image returns b64 today, but Azure's
+            # OpenAI-compatible API may return URLs. Cache the bytes locally
+            # so the gateway never tries to fetch an ephemeral / signed URL
+            # after it expires — same rationale as the xAI provider (#26942).
+            try:
+                saved_path = save_url_image(url, prefix=f"azure_foundry_{tier_id}")
+            except Exception as exc:
+                logger.warning(
+                    "Azure Foundry image URL %s could not be cached (%s); falling back to bare URL.",
+                    url,
+                    exc,
+                )
+                image_ref = url
+            else:
+                image_ref = str(saved_path)
+        else:
+            return error_response(
+                error="Azure Foundry response contained neither b64_json nor URL",
+                error_type="empty_response",
+                provider="azure-foundry",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        extra: Dict[str, Any] = {
+            "size": size,
+            "quality": meta["quality"],
+            "deployment": deployment,
+        }
+        if revised_prompt:
+            extra["revised_prompt"] = revised_prompt
+
+        return success_response(
+            image=image_ref,
+            model=tier_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="azure-foundry",
+            modality=modality,
+            extra=extra,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+
+def register(ctx) -> None:
+    """Plugin entry point — wire ``AzureFoundryImageGenProvider`` into the
+    registry."""
+    ctx.register_image_gen_provider(AzureFoundryImageGenProvider())

--- a/plugins/image_gen/azure-foundry/plugin.yaml
+++ b/plugins/image_gen/azure-foundry/plugin.yaml
@@ -1,0 +1,7 @@
+name: azure-foundry
+version: 1.0.0
+description: "Azure Foundry image generation backend (GPT Image deployments via Azure's OpenAI-compatible image APIs). API-key or Microsoft Entra ID auth. Saves generated images to $HERMES_HOME/cache/images/."
+author: NousResearch
+kind: backend
+requires_env:
+  - AZURE_FOUNDRY_IMAGE_API_KEY

--- a/tests/plugins/image_gen/test_azure_foundry_provider.py
+++ b/tests/plugins/image_gen/test_azure_foundry_provider.py
@@ -1,0 +1,364 @@
+"""Tests for the bundled Azure Foundry image_gen plugin (GPT Image
+deployments, three quality tiers, API-key + Entra ID auth)."""
+
+from __future__ import annotations
+
+import base64
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The plugin directory uses a hyphen, which is not a valid Python identifier
+# for the dotted-import form. Load it via importlib so tests don't need to
+# touch sys.path or rename the directory (mirrors test_openai_codex_provider).
+azure_plugin = importlib.import_module("plugins.image_gen.azure-foundry")
+
+
+# 1×1 transparent PNG — valid bytes for save_b64_image()
+_PNG_HEX = (
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000d49444154789c6300010000000500010d0a2db40000000049454e44"
+    "ae426082"
+)
+
+
+def _b64_png() -> str:
+    return base64.b64encode(bytes.fromhex(_PNG_HEX)).decode()
+
+
+def _fake_response(*, b64=None, url=None, revised_prompt=None):
+    item = SimpleNamespace(b64_json=b64, url=url, revised_prompt=revised_prompt)
+    return SimpleNamespace(data=[item])
+
+
+@pytest.fixture(autouse=True)
+def _tmp_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_API_KEY", "test-key")
+    return azure_plugin.AzureFoundryImageGenProvider()
+
+
+def _write_config(tmp_path, **azure_overrides):
+    """Write config.yaml with an image_gen.azure_foundry block and reset the
+    load_config cache so the next read sees it."""
+    import yaml
+
+    azure_cfg = {
+        "endpoint": "https://my-resource.openai.azure.com",
+        "deployment": "gpt-image-2",
+        "auth_mode": "api_key",
+    }
+    azure_cfg.update(azure_overrides)
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"image_gen": {"azure_foundry": azure_cfg}})
+    )
+    try:
+        import hermes_cli.config as cfg_mod
+
+        if hasattr(cfg_mod, "_invalidate_load_config_cache"):
+            cfg_mod._invalidate_load_config_cache()
+    except Exception:
+        pass
+
+
+def _patched_openai(fake_client: MagicMock):
+    fake_openai = MagicMock()
+    fake_openai.OpenAI.return_value = fake_client
+    return patch.dict("sys.modules", {"openai": fake_openai})
+
+
+# ── Metadata ────────────────────────────────────────────────────────────────
+
+
+class TestMetadata:
+    def test_name(self, provider):
+        assert provider.name == "azure-foundry"
+
+    def test_display_name(self, provider):
+        assert provider.display_name == "Azure Foundry"
+
+    def test_default_model(self, provider):
+        assert provider.default_model() == "azure-gpt-image-medium"
+
+    def test_list_models_three_tiers(self, provider):
+        ids = [m["id"] for m in provider.list_models()]
+        assert ids == [
+            "azure-gpt-image-low",
+            "azure-gpt-image-medium",
+            "azure-gpt-image-high",
+        ]
+
+    def test_catalog_entries_have_display_speed_strengths(self, provider):
+        for entry in provider.list_models():
+            assert entry["display"].startswith("GPT Image")
+            assert entry["speed"]
+            assert entry["strengths"]
+
+    def test_get_setup_schema(self, provider):
+        schema = provider.get_setup_schema()
+        assert schema["name"] == "Azure Foundry"
+        assert schema["badge"] == "paid"
+        assert schema["env_vars"][0]["key"] == "AZURE_FOUNDRY_IMAGE_API_KEY"
+
+    def test_capabilities_include_editing(self, provider):
+        caps = provider.capabilities()
+        assert caps["modalities"] == ["text", "image"]
+        assert caps["max_reference_images"] == 16
+
+
+# ── Availability ────────────────────────────────────────────────────────────
+
+
+class TestAvailability:
+    def test_no_key_no_config_unavailable(self, monkeypatch):
+        monkeypatch.delenv("AZURE_FOUNDRY_IMAGE_API_KEY", raising=False)
+        assert azure_plugin.AzureFoundryImageGenProvider().is_available() is False
+
+    def test_api_key_set_available(self, monkeypatch):
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_API_KEY", "test")
+        assert azure_plugin.AzureFoundryImageGenProvider().is_available() is True
+
+    def test_entra_mode_requires_azure_identity(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AZURE_FOUNDRY_IMAGE_API_KEY", raising=False)
+        _write_config(tmp_path, auth_mode="entra_id")
+        with patch.object(azure_plugin, "has_azure_identity_installed", return_value=True):
+            assert azure_plugin.AzureFoundryImageGenProvider().is_available() is True
+        with patch.object(azure_plugin, "has_azure_identity_installed", return_value=False):
+            assert azure_plugin.AzureFoundryImageGenProvider().is_available() is False
+
+
+# ── Config / model resolution ───────────────────────────────────────────────
+
+
+class TestConfig:
+    def test_env_var_override(self, monkeypatch):
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_MODEL", "azure-gpt-image-high")
+        model_id, meta = azure_plugin._resolve_model()
+        assert model_id == "azure-gpt-image-high"
+        assert meta["quality"] == "high"
+
+    def test_config_model_tier(self, tmp_path):
+        _write_config(tmp_path, model="azure-gpt-image-low")
+        model_id, meta = azure_plugin._resolve_model()
+        assert model_id == "azure-gpt-image-low"
+        assert meta["quality"] == "low"
+
+    def test_default_model_fallback(self):
+        model_id, meta = azure_plugin._resolve_model()
+        assert model_id == "azure-gpt-image-medium"
+        assert meta["quality"] == "medium"
+
+    def test_deployment_default(self, tmp_path):
+        _write_config(tmp_path)
+        assert azure_plugin._resolve_deployment() == "gpt-image-2"
+
+    def test_deployment_custom(self, tmp_path):
+        _write_config(tmp_path, deployment="gpt-image-2-pro")
+        assert azure_plugin._resolve_deployment() == "gpt-image-2-pro"
+
+    def test_auth_mode_default_api_key(self):
+        assert azure_plugin._resolve_auth_mode() == "api_key"
+
+    def test_auth_mode_entra(self, tmp_path):
+        _write_config(tmp_path, auth_mode="entra_id")
+        assert azure_plugin._resolve_auth_mode() == "entra_id"
+
+    @pytest.mark.parametrize(
+        "endpoint,expected",
+        [
+            ("https://res.openai.azure.com", "https://res.openai.azure.com/openai/v1"),
+            ("https://res.openai.azure.com/", "https://res.openai.azure.com/openai/v1"),
+            ("https://res.openai.azure.com/openai", "https://res.openai.azure.com/openai/v1"),
+            ("https://res.openai.azure.com/openai/v1", "https://res.openai.azure.com/openai/v1"),
+            ("", ""),
+        ],
+    )
+    def test_build_base_url(self, endpoint, expected):
+        assert azure_plugin._build_base_url(endpoint) == expected
+
+
+# ── Generate ────────────────────────────────────────────────────────────────
+
+
+class TestGenerate:
+    def test_empty_prompt_rejected(self, provider):
+        result = provider.generate("", aspect_ratio="square")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
+    def test_missing_endpoint(self, provider):
+        result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+        assert "endpoint" in result["error"]
+
+    def test_missing_api_key(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AZURE_FOUNDRY_IMAGE_API_KEY", raising=False)
+        _write_config(tmp_path)
+        result = azure_plugin.AzureFoundryImageGenProvider().generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+
+    def test_b64_saves_to_cache(self, provider, tmp_path):
+        _write_config(tmp_path)
+        png_bytes = bytes.fromhex(_PNG_HEX)
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat", aspect_ratio="landscape")
+
+        assert result["success"] is True
+        assert result["model"] == "azure-gpt-image-medium"
+        assert result["aspect_ratio"] == "landscape"
+        assert result["provider"] == "azure-foundry"
+        assert result["quality"] == "medium"
+
+        saved = Path(result["image"])
+        assert saved.exists()
+        assert saved.parent == tmp_path / "cache" / "images"
+        assert saved.read_bytes() == png_bytes
+
+        call_kwargs = fake_client.images.generate.call_args.kwargs
+        # All tiers hit the single configured Azure deployment.
+        assert call_kwargs["model"] == "gpt-image-2"
+        assert call_kwargs["quality"] == "medium"
+        assert call_kwargs["size"] == "1536x1024"
+        # GPT Image rejects response_format — we must NOT send it.
+        assert "response_format" not in call_kwargs
+
+    def test_client_uses_azure_base_url(self, provider, tmp_path):
+        _write_config(tmp_path)
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        fake_client_holder = {}
+
+        def _capture_client(*args, **kwargs):
+            fake_client_holder["kwargs"] = kwargs
+            return fake_client
+
+        fake_openai.OpenAI.side_effect = _capture_client
+        with patch.dict("sys.modules", {"openai": fake_openai}):
+            provider.generate("a cat")
+
+        assert fake_client_holder["kwargs"]["base_url"] == (
+            "https://my-resource.openai.azure.com/openai/v1"
+        )
+        assert fake_client_holder["kwargs"]["api_key"] == "test-key"
+
+    @pytest.mark.parametrize(
+        "tier,expected_quality",
+        [
+            ("azure-gpt-image-low", "low"),
+            ("azure-gpt-image-medium", "medium"),
+            ("azure-gpt-image-high", "high"),
+        ],
+    )
+    def test_tier_maps_to_quality(self, provider, tmp_path, monkeypatch, tier, expected_quality):
+        _write_config(tmp_path)
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_MODEL", tier)
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["model"] == tier
+        assert result["quality"] == expected_quality
+        assert fake_client.images.generate.call_args.kwargs["quality"] == expected_quality
+        # Always the same underlying Azure deployment regardless of tier.
+        assert fake_client.images.generate.call_args.kwargs["model"] == "gpt-image-2"
+
+    @pytest.mark.parametrize(
+        "aspect,expected_size",
+        [
+            ("landscape", "1536x1024"),
+            ("square", "1024x1024"),
+            ("portrait", "1024x1536"),
+        ],
+    )
+    def test_aspect_ratio_mapping(self, provider, tmp_path, aspect, expected_size):
+        _write_config(tmp_path)
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            provider.generate("a cat", aspect_ratio=aspect)
+
+        assert fake_client.images.generate.call_args.kwargs["size"] == expected_size
+
+    def test_revised_prompt_passed_through(self, provider, tmp_path):
+        _write_config(tmp_path)
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(
+            b64=_b64_png(), revised_prompt="A photo of a cat",
+        )
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["revised_prompt"] == "A photo of a cat"
+        assert result["deployment"] == "gpt-image-2"
+
+    def test_entra_id_uses_token_provider(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AZURE_FOUNDRY_IMAGE_API_KEY", raising=False)
+        _write_config(tmp_path, auth_mode="entra_id")
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        fake_openai = MagicMock()
+        captured = {}
+
+        def _capture_client(*args, **kwargs):
+            captured.update(kwargs)
+            return fake_client
+
+        fake_openai.OpenAI.side_effect = _capture_client
+        fake_token_provider = MagicMock(return_value="fake-entra-token")
+
+        with patch.dict("sys.modules", {"openai": fake_openai}), patch.object(
+            azure_plugin, "build_token_provider", return_value=fake_token_provider
+        ):
+            result = azure_plugin.AzureFoundryImageGenProvider().generate("a cat")
+
+        assert result["success"] is True
+        # The SDK receives the callable (it mints a fresh JWT per request).
+        assert captured["api_key"] is fake_token_provider
+        assert captured["base_url"] == "https://my-resource.openai.azure.com/openai/v1"
+
+    def test_edit_routes_to_images_edit(self, provider, tmp_path):
+        _write_config(tmp_path)
+        png_bytes = bytes.fromhex(_PNG_HEX)
+        src = tmp_path / "src.png"
+        src.write_bytes(png_bytes)
+        fake_client = MagicMock()
+        fake_client.images.edit.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("make it blue", image_url=str(src))
+
+        assert result["success"] is True
+        assert result["modality"] == "image"
+        call_kwargs = fake_client.images.edit.call_args.kwargs
+        assert call_kwargs["model"] == "gpt-image-2"
+        assert call_kwargs["quality"] == "medium"
+
+    def test_api_error_surfaces(self, provider, tmp_path):
+        _write_config(tmp_path)
+        fake_client = MagicMock()
+        fake_client.images.generate.side_effect = RuntimeError("boom")
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "boom" in result["error"]


### PR DESCRIPTION
## Summary
Adds Azure Foundry as a backend provider for the `image_generate` tool. Organizations using Azure-hosted GPT Image deployments can now keep image generation in-platform instead of switching out.

## Change (plugin, per Contributing guide)
- `plugins/image_gen/azure-foundry/` (new): `plugin.yaml` (backend manifest, `requires_env: AZURE_FOUNDRY_IMAGE_API_KEY`) + `__init__.py` (`ImageGenProvider` + `register(ctx)`, 552 lines) — follows the existing `plugins/image_gen/<name>/` pattern. Auth via the existing `agent/azure_identity_adapter.build_token_provider()` (callable accepted by the OpenAI SDK as `api_key`).
- `tests/plugins/image_gen/test_azure_foundry_provider.py` (new, +37): provider registration, env-gating, Entra ID auth wiring, payload shape.

## Verification
- `tests/plugins/image_gen/test_azure_foundry_provider.py`: **37 passed**. Zero modifications to existing files (3 new files only).

Closes #85448