### PR TITLE
fix(desktop): map subagent timeout/error completion to terminal failed state

### DIFF
--- a/apps/desktop/src/store/subagents.test.ts
+++ b/apps/desktop/src/store/subagents.test.ts
@@ -251,6 +251,13 @@ describe('subagent store', () => {
     expect(listFor('s1')).toHaveLength(0)
   })
 
+  it('falls back to a placeholder when timeout duration is missing', () => {
+    upsertSubagent('s1', { goal: 'scan files', status: 'running', subagent_id: 't2', task_index: 0 })
+    upsertSubagent('s1', { status: 'timeout', subagent_id: 't2', task_index: 0 }, false, 'subagent.complete')
+
+    expect(listFor('s1')[0]?.summary).toBe('Timed out after ?s')
+  })
+
   // Fail-closed guard: subagent.complete is terminal by definition, so an
   // unrecognized status on it must not resurrect a row as 'running'. Live
   // events keep the lenient fallback (a status we don't know is still active).

--- a/apps/desktop/src/store/subagents.test.ts
+++ b/apps/desktop/src/store/subagents.test.ts
@@ -227,4 +227,52 @@ describe('subagent store', () => {
     pruneFinishedSessionSubagents('s1')
     expect(listFor('s1')).toHaveLength(0)
   })
+
+  // The backend completes subagents with status "timeout" (hard child timeout,
+  // delegation.child_timeout_seconds) and no summary — synthesize the reason
+  // so the failed row explains itself instead of rendering as a bare failure.
+  it('maps backend timeout status to a terminal failure with a synthesized reason', () => {
+    upsertSubagent('s1', { goal: 'scan files', status: 'running', subagent_id: 't1', task_index: 0 })
+    upsertSubagent(
+      's1',
+      { status: 'timeout', subagent_id: 't1', task_index: 0, duration_seconds: 612.3 },
+      false,
+      'subagent.complete'
+    )
+
+    const item = listFor('s1')[0]
+    expect(item?.status).toBe('failed')
+    expect(item?.durationSeconds).toBe(612.3)
+    expect(item?.summary).toBe('Timed out after 612.3s')
+
+    // A timed-out row must be pruned at the next message.start boundary like
+    // any other finished row — it must not linger as a live spinner.
+    pruneFinishedSessionSubagents('s1')
+    expect(listFor('s1')).toHaveLength(0)
+  })
+
+  // Fail-closed guard: subagent.complete is terminal by definition, so an
+  // unrecognized status on it must not resurrect a row as 'running'. Live
+  // events keep the lenient fallback (a status we don't know is still active).
+  it('fails closed on unrecognized completion statuses but stays lenient for live events', () => {
+    upsertSubagent('s1', { goal: 'scan files', status: 'running', subagent_id: 'u1', task_index: 0 })
+    upsertSubagent(
+      's1',
+      { status: 'some_future_terminal_status', subagent_id: 'u1', task_index: 0 },
+      false,
+      'subagent.complete'
+    )
+    expect(listFor('s1')[0]?.status).toBe('failed')
+    expect(activeSubagentCount(listFor('s1'))).toBe(0)
+
+    upsertSubagent('s1', { goal: 'scan files', status: 'running', subagent_id: 'u2', task_index: 1 })
+    upsertSubagent(
+      's1',
+      { status: 'some_future_live_status', subagent_id: 'u2', task_index: 1, text: 'still working' },
+      false,
+      'subagent.progress'
+    )
+    expect(listFor('s1')[1]?.status).toBe('running')
+    expect(activeSubagentCount(listFor('s1'))).toBe(1)
+  })
 })

--- a/apps/desktop/src/store/subagents.test.ts
+++ b/apps/desktop/src/store/subagents.test.ts
@@ -190,4 +190,41 @@ describe('subagent store', () => {
         .sort()
     ).toEqual(['c', 'd'])
   })
+
+  // Regression test for #73728: backend terminal statuses like `timeout` and
+  // `error` were normalised to `running`, making timed-out subagents immortal
+  // in the active status stack. `cancelled`/`canceled` must also map to
+  // `interrupted`.
+  it('normalises backend terminal statuses to recognised SubagentStatus values', () => {
+    upsertSubagent('s1', { goal: 'a', status: 'running', subagent_id: 'a', task_index: 0 })
+    upsertSubagent('s1', { goal: 'b', status: 'running', subagent_id: 'b', task_index: 1 })
+    upsertSubagent('s1', { goal: 'c', status: 'running', subagent_id: 'c', task_index: 2 })
+    upsertSubagent('s1', { goal: 'd', status: 'running', subagent_id: 'd', task_index: 3 })
+
+    // Emit terminal events with backend-native status strings
+    upsertSubagent('s1', { status: 'timeout', subagent_id: 'a', task_index: 0, summary: 'timed out' }, false, 'subagent.complete')
+    upsertSubagent('s1', { status: 'error', subagent_id: 'b', task_index: 1, summary: 'errored' }, false, 'subagent.complete')
+    upsertSubagent('s1', { status: 'cancelled', subagent_id: 'c', task_index: 2 }, false, 'subagent.complete')
+    upsertSubagent('s1', { status: 'canceled', subagent_id: 'd', task_index: 3 }, false, 'subagent.complete')
+
+    const items = listFor('s1')
+    const byId = Object.fromEntries(items.map(i => [i.id, i]))
+
+    // timeout → failed
+    expect(byId['a']?.status).toBe('failed')
+    expect(byId['a']?.currentTool).toBeUndefined()
+
+    // error → failed
+    expect(byId['b']?.status).toBe('failed')
+
+    // cancelled → interrupted
+    expect(byId['c']?.status).toBe('interrupted')
+
+    // canceled → interrupted
+    expect(byId['d']?.status).toBe('interrupted')
+
+    // All four are terminal — prune should remove them all
+    pruneFinishedSessionSubagents('s1')
+    expect(listFor('s1')).toHaveLength(0)
+  })
 })

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -55,8 +55,12 @@ const str = (v: unknown) => (isStr(v) ? v : '')
 const num = (v: unknown) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined)
 const strList = (v: unknown) => (Array.isArray(v) ? v.filter(isStr) : [])
 
-const asStatus = (v: unknown): SubagentStatus =>
-  v === 'completed' || v === 'failed' || v === 'interrupted' || v === 'queued' ? v : 'running'
+const asStatus = (v: unknown): SubagentStatus => {
+  if (v === 'completed' || v === 'failed' || v === 'interrupted' || v === 'queued') return v
+  if (v === 'timeout' || v === 'error') return 'failed'
+  if (v === 'cancelled' || v === 'canceled') return 'interrupted'
+  return 'running'
+}
 
 const compact = (text: string, max = PREVIEW_MAX) => {
   const line = text.replace(/\s+/g, ' ').trim()

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -55,10 +55,27 @@ const str = (v: unknown) => (isStr(v) ? v : '')
 const num = (v: unknown) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined)
 const strList = (v: unknown) => (Array.isArray(v) ? v.filter(isStr) : [])
 
-const asStatus = (v: unknown): SubagentStatus => {
-  if (v === 'completed' || v === 'failed' || v === 'interrupted' || v === 'queued') return v
-  if (v === 'timeout' || v === 'error') return 'failed'
-  if (v === 'cancelled' || v === 'canceled') return 'interrupted'
+const asStatus = (v: unknown, terminalEvent = false): SubagentStatus => {
+  if (v === 'completed' || v === 'failed' || v === 'interrupted' || v === 'queued') {
+    return v
+  }
+
+  if (v === 'timeout' || v === 'error') {
+    return 'failed'
+  }
+
+  if (v === 'cancelled' || v === 'canceled') {
+    return 'interrupted'
+  }
+
+  // Fail closed on completion: a subagent.complete event is terminal by
+  // definition, so an unrecognized status must render as a failure rather
+  // than leave a dead row spinning as 'running' forever. Live events keep
+  // the lenient 'running' fallback.
+  if (terminalEvent) {
+    return 'failed'
+  }
+
   return 'running'
 }
 
@@ -110,6 +127,15 @@ const appendStream = (stream: SubagentStreamEntry[], entry: SubagentStreamEntry)
   return [...stream, entry].slice(-MAX_STREAM)
 }
 
+// The backend sends no summary on a hard child timeout (only a preview like
+// "Timed out after 612.3s" + duration_seconds). Synthesize it so the terminal
+// row explains why it failed instead of rendering as a bare failure.
+const timeoutSummary = (payload: SubagentPayload): string => {
+  const seconds = num(payload.duration_seconds)
+
+  return str(payload.status) === 'timeout' ? `Timed out after ${seconds ?? '?'}s` : ''
+}
+
 function streamFromPayload(
   payload: SubagentPayload,
   status: SubagentStatus,
@@ -141,7 +167,7 @@ function streamFromPayload(
     out.push({ at, kind: 'thinking', text })
   }
 
-  const summary = compact(str(payload.summary) || str(payload.text))
+  const summary = compact(str(payload.summary) || str(payload.text) || timeoutSummary(payload))
 
   if (TERMINAL.has(status) && summary) {
     out.push({ at, isError: status === 'failed', kind: 'summary', text: summary })
@@ -152,7 +178,7 @@ function streamFromPayload(
 
 function toProgress(payload: SubagentPayload, prev: SubagentProgress | undefined, eventType = ''): SubagentProgress {
   const at = Date.now()
-  const status = asStatus(payload.status)
+  const status = asStatus(payload.status, eventType === 'subagent.complete')
   const tool = str(payload.tool_name)
   const stream = streamFromPayload(payload, status, eventType, at).reduce(appendStream, prev?.stream ?? [])
   const filesRead = strList(payload.files_read)
@@ -177,7 +203,7 @@ function toProgress(payload: SubagentPayload, prev: SubagentProgress | undefined
     filesRead: filesRead.length ? filesRead : (prev?.filesRead ?? []),
     filesWritten: filesWritten.length ? filesWritten : (prev?.filesWritten ?? []),
     stream,
-    summary: str(payload.summary) || prev?.summary,
+    summary: str(payload.summary) || prev?.summary || timeoutSummary(payload) || undefined,
     currentTool: TERMINAL.has(status) ? undefined : tool || prev?.currentTool
   }
 }

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -203,7 +203,7 @@ function toProgress(payload: SubagentPayload, prev: SubagentProgress | undefined
     filesRead: filesRead.length ? filesRead : (prev?.filesRead ?? []),
     filesWritten: filesWritten.length ? filesWritten : (prev?.filesWritten ?? []),
     stream,
-    summary: str(payload.summary) || prev?.summary || timeoutSummary(payload) || undefined,
+    summary: str(payload.summary) || timeoutSummary(payload) || prev?.summary || undefined,
     currentTool: TERMINAL.has(status) ? undefined : tool || prev?.currentTool
   }
 }


### PR DESCRIPTION
## Summary

Timed-out (or exception-failed) subagents stay stuck as **"running"** in the desktop Agents panel and status-bar count forever — spinner glyph, counted in "Agents N running", never pruned — even though the parent conversation already received the failure. Fixes the immortal false-active rows reported in #73728 (also addresses #85492, filed as a duplicate; same root cause as #80018 and #81602, which this fix resolves too).

## Root cause

Status-vocabulary drift between the Python backend and the desktop store. The backend completes subagents with statuses the UI never learned:

- `tools/delegate_tool.py:2479-2488` — hard child timeout (`delegation.child_timeout_seconds`) emits `subagent.complete` with `status="timeout"` (status introduced in #13770)
- `tools/delegate_tool.py:2485` — non-timeout exception exit emits the same event with `status="error"`

The desktop store's `asStatus()` (apps/desktop/src/store/subagents.ts) was an allowlist of `completed | failed | interrupted | queued`; anything else fell through to `'running'`. A stuck `running` row is never cleaned up because `pruneFinishedSessionSubagents` only prunes terminal-status rows at the `message.start` boundary, and `activeSubagentCount` keeps counting it in the status bar.

## Changes

- **`apps/desktop/src/store/subagents.ts`**
  - Map backend `"timeout"` / `"error"` completion statuses to the existing terminal `failed` status; `"cancelled"` / `"canceled"` map to `interrupted` (compatibility aliases).
  - **Fail closed on completion:** `subagent.complete` is terminal by definition — an unrecognized status on it now renders `failed` instead of falling through to `running`, so a future backend status can't recreate the immortal false-active row. Live events keep the lenient `running` fallback. (This is the event-aware handling requested in review on #73859.)
  - Synthesize a `Timed out after Xs` summary (from the backend's `duration_seconds`) when the raw status is `timeout` and no summary arrived, so the row explains why it failed instead of rendering as a bare failure.
- **`apps/desktop/src/store/subagents.test.ts`** — normalization regression test (timeout/error → failed, cancelled/canceled → interrupted, all prunable), timeout reason synthesis, missing-duration placeholder, event-aware fail-closed vs. lenient live fallback. 14 tests.

## Relationship to #73859

This PR cherry-picks the commit from #73859 (by @RelaxJonh — same normalization mapping, authorship preserved in history) and adds the event-aware fail-closed handling that maintainer review requested on #73859 (@teknium1 `keep_open`, @GottZ triage 08-02/08-03). That PR has had no author response since 07-30; this PR supersedes it so the requested change doesn't stall the fix.

## Testing

- `npx vitest run src/store/subagents.test.ts` — **14 passed** (10 pre-existing + 4 new)
- `npx eslint src/store/subagents.ts src/store/subagents.test.ts` — clean

## Notes

**Open question:** a distinct `timeout` status with its own glyph/label (instead of mapping to `failed`) would be richer UI, but is a much larger surface change — type union, glyph mapping, i18n strings, status-bar counts — for the same user-visible outcome. This PR keeps the narrow mapping; the synthesized summary line preserves the reason.

Closes #73728

