### PR TITLE
fix(agent): default context lookup for empty model IDs (salvage #65515) — un-reds main CI

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2579,6 +2579,19 @@ def get_model_context_length(
         except ValueError:
             base_url = ""
 
+    # An empty/blank model id can't be meaningfully resolved: every probe
+    # below would either miss or — worse — fuzzy-match an arbitrary catalog
+    # entry (the endpoint matcher's `model in key` check is vacuously true
+    # for ""), returning whatever context length that random entry has and
+    # persisting it under a junk "@<base_url>" cache key. Fall back to the
+    # default immediately instead.
+    if not str(model or "").strip():
+        logger.info(
+            "No model id provided for context length resolution — defaulting to %s tokens.",
+            f"{DEFAULT_FALLBACK_CONTEXT:,}",
+        )
+        return DEFAULT_FALLBACK_CONTEXT
+
     # Normalise provider-prefixed model names (e.g. "local:model-name" →
     # "model-name") so cache lookups and server queries use the bare ID that
     # local servers actually know about.  Ollama "model:tag" colons are preserved.

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -285,6 +285,10 @@ class TestDefaultContextLengths:
                         model, provider="kimi-coding", base_url=base_url
                     ) == 1_048_576
 
+    def test_empty_model_uses_fallback_context(self):
+        assert get_model_context_length("") == DEFAULT_FALLBACK_CONTEXT
+        assert get_model_context_length(None) == DEFAULT_FALLBACK_CONTEXT  # type: ignore[arg-type]
+
 
     def test_xai_oauth_grok_build_uses_xai_models_dev_context(self):
         """xAI OAuth should share the xAI provider metadata path.


### PR DESCRIPTION
## Summary

Every open PR's CI is currently red on one shard with:

```
FAILED tests/run_agent/test_primary_runtime_restore.py::TestTryRecoverPrimaryTransport::test_allowed_for_nous_anthropic_messages
ValueError: Model  has a context window of 32,000 tokens, which is below the minimum 64,000 required by Hermes Agent.
```

(Seen on #85444 slice 7/12, #85452 slice 2/12; reproduces locally on plain `upstream/main` files.)

Root cause: the test constructs an agent with `model=""` against the live Nous portal URL. `get_model_context_length("")` reaches `_resolve_endpoint_context_length`, whose fuzzy matcher

```python
if model in key or key in model:
```

is **vacuously true for an empty model** — `"" in key` matches every entry — so it picks an arbitrary model from the live `/v1/models` response and returns that entry's context length. The portal catalog changed recently; the arbitrary match now lands on a 32K entry, `init_agent` raises the 64K-floor `ValueError`, and the junk value is persisted under a `@https://inference-api.nousresearch.com/v1` cache key (visible in the failing log: `Cached context length @https://... -> 32,000 tokens`).

This is a salvage of #65515 by @whirmill (open since July 16), rebased onto current main — the same guard, now positioned after the malformed-base_url normalization that landed since, plus an explanatory comment documenting the fuzzy-match footgun. Contributor authorship preserved on the commit.

## Changes

- `agent/model_metadata.py`: a blank/empty model id falls back to `DEFAULT_FALLBACK_CONTEXT` immediately — before any cache write or network probe.
- `tests/agent/test_model_metadata.py`: `test_empty_model_uses_fallback_context` (covers `""` and `None`).

## Validation

- The two previously failing/new tests pass: `test_allowed_for_nous_anthropic_messages` + `test_empty_model_uses_fallback_context`.
- Full `tests/agent/test_model_metadata.py` + `tests/run_agent/test_primary_runtime_restore.py`: 92 passed.
- Mutation check: removing the guard makes `test_empty_model_uses_fallback_context` fail (arbitrary live-catalog match returns non-default), restoring goes green.
- `ruff check` clean.

Closes #65515.
