### PR TITLE
fix(file): fail closed on silent read transport

### DIFF
--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -247,6 +247,64 @@ class TestPaginationBounds:
         assert "| head -n 1" in rg_commands[0]
 
 
+class TestReadFileTransportFailures:
+    """Transport silence must not be reported as an empty regular file."""
+
+    @pytest.fixture()
+    def ops(self):
+        env = MagicMock()
+        env.cwd = "/tmp"
+        return ShellFileOperations(env)
+
+    def test_empty_size_probe_fails_instead_of_claiming_file_is_empty(self, ops):
+        with patch.object(
+            ops,
+            "_exec",
+            return_value=MagicMock(exit_code=0, stdout=""),
+        ):
+            result = ops.read_file("linked-worktree.ts")
+
+        assert "Failed to determine file size" in result.error
+        assert "terminal backend returned ''" in result.error
+
+    def test_empty_line_count_probe_fails_instead_of_returning_zero_lines(self, ops):
+        def fake_exec(command, *args, **kwargs):
+            if command.startswith("if [ -f "):
+                return MagicMock(exit_code=0, stdout="17\n")
+            if command.startswith("head -c"):
+                return MagicMock(exit_code=0, stdout="aGVsbG8gd29ybGQ=\n")
+            if command.startswith("sed -n"):
+                return MagicMock(exit_code=0, stdout="hello world\n")
+            if command.startswith("wc -l"):
+                return MagicMock(exit_code=0, stdout="")
+            return MagicMock(exit_code=0, stdout="")
+
+        with patch.object(ops, "_exec", side_effect=fake_exec):
+            result = ops.read_file("linked-worktree.ts")
+
+        assert "Failed to determine line count" in result.error
+        assert "terminal backend returned ''" in result.error
+
+    def test_empty_content_for_positive_size_in_range_fails_closed(self, ops):
+        def fake_exec(command, *args, **kwargs):
+            if command.startswith("if [ -f "):
+                return MagicMock(exit_code=0, stdout="17\n")
+            if command.startswith("head -c"):
+                return MagicMock(exit_code=0, stdout="aGVsbG8gd29ybGQ=\n")
+            if command.startswith("sed -n"):
+                return MagicMock(exit_code=0, stdout="")
+            if command.startswith("wc -l"):
+                return MagicMock(exit_code=0, stdout="1\n")
+            return MagicMock(exit_code=0, stdout="")
+
+        with patch.object(ops, "_exec", side_effect=fake_exec):
+            result = ops.read_file("delegation-summary.txt")
+
+        assert "terminal backend returned empty content" in result.error
+        assert "nonempty 17-byte file" in result.error
+        assert result.content == ""
+
+
 # =========================================================================
 # Search context parsing
 # =========================================================================

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1390,13 +1390,22 @@ class ShellFileOperations(FileOperations):
             # No equivalent spelling — suggest similar files
             return self._suggest_similar_files(path)
 
+        # A successful size probe must still carry its numeric payload. Some
+        # backend failures have returned exit 0 with empty stdout; coercing that
+        # transport silence to zero falsely labels a committed file as empty.
         stat_output = _strip_terminal_fence_leaks(stat_result.stdout)
         if stat_output.strip() == NOT_REGULAR_SENTINEL:
             return self._not_regular_error(path)
         try:
             file_size = int(stat_output.strip())
         except ValueError:
-            file_size = 0
+            return ReadResult(
+                error=(
+                    f"Failed to determine file size for '{path}': terminal backend "
+                    f"returned {stat_output!r}. Retry the read; if this persists, "
+                    "check the terminal backend diagnostics."
+                )
+            )
         
         # Check if file is too large
         if file_size > MAX_FILE_SIZE:
@@ -1483,7 +1492,22 @@ class ShellFileOperations(FileOperations):
         try:
             total_lines = int(wc_output.strip())
         except ValueError:
-            total_lines = 0
+            return ReadResult(
+                error=(
+                    f"Failed to determine line count for '{path}': terminal backend "
+                    f"returned {wc_output!r}. Retry the read; if this persists, "
+                    "check the terminal backend diagnostics."
+                )
+            )
+
+        if not read_output and file_size > 0 and (offset == 1 or offset <= total_lines):
+            return ReadResult(
+                error=(
+                    f"Failed to read '{path}': terminal backend returned empty content "
+                    f"for a nonempty {file_size}-byte file at in-range offset {offset}. "
+                    "Retry the read; if this persists, check the terminal backend diagnostics."
+                )
+            )
         
         # Check if truncated
         truncated = total_lines > end_line


### PR DESCRIPTION
## Summary
- reject empty or malformed successful size/line-count probes instead of coercing them to zero
- reject empty in-range content for a known nonempty regular file
- add transport-shaped regressions for linked-worktree and delegation-summary false empties

## Verification
- `scripts/run_tests.sh tests/tools/test_file_operations_edge_cases.py tests/tools/test_file_operations.py tests/tools/test_read_shell_line_clamp.py` (97 passed, 2 platform skips)
- `.venv/bin/ruff check tools/file_operations.py tests/tools/test_file_operations_edge_cases.py`
- real `ShellFileOperations.read_file` smoke on this linked worktree and a delegation-cache summary