### PR TITLE
fix(kanban): terminalize iteration exhaustion

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -147,38 +147,49 @@ def finalize_turn(
         # worker could not complete (rather than treating it as a
         # protocol violation). This applies whether the user-facing fallback
         # came from the summary call or an explicitly pending continuation;
-        # both exhausted the task budget and must advance the failure circuit.
+        # both exhausted the task budget and must terminalize this exact run.
         #
-        # We route through ``_record_task_failure(outcome="timed_out")``
-        # rather than ``kanban_block`` so this counts toward the dispatcher's
-        # consecutive-failure circuit breaker (#29747 gap 2).
+        # Iteration exhaustion is not a wall-clock timeout: retrying the same
+        # revision just repeats an emergency stop while risking its preserved
+        # workspace. Park it for owner replan instead. The run-id guard keeps
+        # a late finalizer from blocking a successor that already owns the card.
         _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
         if _kanban_task:
             try:
                 from hermes_cli import kanban_db as _kb
+                _kanban_run_raw = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+                try:
+                    _kanban_run_id = int(_kanban_run_raw)
+                except (TypeError, ValueError):
+                    _kanban_run_id = None
+                if _kanban_run_id is None:
+                    raise RuntimeError(
+                        "iteration exhaustion requires HERMES_KANBAN_RUN_ID "
+                        "to terminalize the exact task revision"
+                    )
                 _conn = _kb.connect()
                 try:
-                    _kb._record_task_failure(
+                    _closed_run_id = _kb._record_iteration_exhaustion(
                         _conn,
                         _kanban_task,
-                        error=(
-                            f"Iteration budget exhausted "
-                            f"({api_call_count}/{agent.max_iterations}) — "
-                            "task could not complete within the allowed "
-                            "iterations"
-                        ),
-                        outcome="timed_out",
-                        release_claim=True,
-                        end_run=True,
-                        event_payload_extra={
-                            "budget_used": api_call_count,
-                            "budget_max": agent.max_iterations,
-                        },
+                        expected_run_id=_kanban_run_id,
+                        budget_used=api_call_count,
+                        budget_max=agent.max_iterations,
                     )
-                    logger.info(
-                        "recorded budget-exhausted failure for task %s (%d/%d)",
-                        _kanban_task, api_call_count, agent.max_iterations,
-                    )
+                    if _closed_run_id is None:
+                        logger.warning(
+                            "ignored stale iteration exhaustion for task %s "
+                            "run %d (%d/%d)",
+                            _kanban_task, _kanban_run_id,
+                            api_call_count, agent.max_iterations,
+                        )
+                    else:
+                        logger.info(
+                            "recorded terminal iteration exhaustion for task %s "
+                            "run %d (%d/%d)",
+                            _kanban_task, _closed_run_id,
+                            api_call_count, agent.max_iterations,
+                        )
                 finally:
                     try:
                         _conn.close()

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -178,7 +178,7 @@ class GatewayKanbanWatchersMixin:
         # but is not a block (see kanban_db.request_review); the task is not
         # done/archived, so the subscription stays alive and later review
         # cycles keep notifying.
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected", "review_requested")
+        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "iteration_exhausted", "status", "archived", "unblocked", "block_loop_detected", "review_requested")
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -484,6 +484,22 @@ class GatewayKanbanWatchersMixin:
                                 f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
                                 f"(max_runtime={limit}s); will retry"
                             )
+                        elif kind == "iteration_exhausted":
+                            payload = ev.payload or {}
+                            used = payload.get("budget_used")
+                            maximum = payload.get("budget_max")
+                            budget = (
+                                f" ({used}/{maximum})"
+                                if used is not None and maximum is not None
+                                else ""
+                            )
+                            run_id = ev.run_id or payload.get("terminal_run_id")
+                            run = f" · run {run_id}" if run_id is not None else ""
+                            msg = (
+                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} "
+                                f"iteration budget exhausted{budget}{run}; "
+                                "terminal for this revision, no automatic retry"
+                            )
                         elif kind == "status":
                             new_status = ""
                             if ev.payload and ev.payload.get("status"):
@@ -661,7 +677,10 @@ class GatewayKanbanWatchersMixin:
                         #   claim exactly like a failed send() above, so the
                         #   next tick retries.
                         task_terminal = task and task.status in {"done", "archived"}
-                        _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
+                        _WAKE_KINDS = (
+                            "completed", "gave_up", "crashed", "timed_out",
+                            "iteration_exhausted", "blocked",
+                        )
                         _wake_kinds = (
                             {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
                             if wake_agent
@@ -682,6 +701,7 @@ class GatewayKanbanWatchersMixin:
                             if "gave_up" in _wake_kinds: _parts.append(t("gateway.kanban.wake.gave_up"))
                             if "crashed" in _wake_kinds: _parts.append(t("gateway.kanban.wake.crashed"))
                             if "timed_out" in _wake_kinds: _parts.append(t("gateway.kanban.wake.timed_out"))
+                            if "iteration_exhausted" in _wake_kinds: _parts.append("iteration exhausted; owner replan required")
                             if "blocked" in _wake_kinds: _parts.append(t("gateway.kanban.wake.blocked"))
                             _status = t("gateway.kanban.wake.status_joiner").join(_parts) or t("gateway.kanban.wake.status_default")
                             _synth = t(
@@ -692,6 +712,31 @@ class GatewayKanbanWatchersMixin:
                                 assignee=_assignee,
                                 board=board_slug,
                             )
+                            if "iteration_exhausted" in _wake_kinds:
+                                _terminal_event = next(
+                                    (
+                                        ev for ev in reversed(d["events"])
+                                        if ev.kind == "iteration_exhausted"
+                                    ),
+                                    None,
+                                )
+                                _terminal_payload = (
+                                    _terminal_event.payload
+                                    if _terminal_event and _terminal_event.payload
+                                    else {}
+                                )
+                                _terminal_run = (
+                                    _terminal_event.run_id
+                                    if _terminal_event
+                                    else None
+                                ) or _terminal_payload.get("terminal_run_id")
+                                _workspace = _terminal_payload.get("workspace_path") or ""
+                                _synth += (
+                                    f"\nTerminal task revision/run: {_terminal_run}."
+                                    f"\nPreserved workspace: {_workspace or '(not recorded)'}."
+                                    "\nResume policy: never; create an owner-planned "
+                                    "replacement revision to continue."
+                                )
 
                         if not _is_push_adapter and _wake_kinds and _session_key:
                             # Wake self-post IS the delivery on this path —

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -122,7 +122,10 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # ``BLOCK_RECURRENCE_LIMIT``) escalates them to ``triage`` if a cron keeps
 # unblocking them only to have the worker re-block for the same reason.
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
-VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
+VALID_BLOCK_KINDS = {
+    "dependency", "needs_input", "capability", "transient",
+    "iteration_exhausted",
+}
 
 # After a task has been blocked, unblocked, and re-blocked this many times for
 # the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
@@ -4884,6 +4887,7 @@ def goal_run_status(
                 "changes_requested": "changes_requested",
                 "blocked": "blocked",
                 "dependency_wait": "blocked",
+                "iteration_exhausted": "blocked",
             }.get(outcome)
             if outcome is not None
             else None
@@ -6799,6 +6803,10 @@ def _landing_status_after_parents(conn: sqlite3.Connection, task_id: str) -> str
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """Transition ``blocked``/``scheduled`` to its safe resumable phase.
 
+    Iteration-exhausted revisions are deliberately not resumable. Their
+    workspace remains available for an owner-created replacement, but the
+    exhausted card itself stays parked with ``resume_policy=never``.
+
     Defensively closes any stale ``current_run_id`` pointer before flipping
     status. In the common path (``block_task`` closed the run already) this
     is a no-op. If a future or external write left the pointer dangling,
@@ -6809,9 +6817,11 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     now = int(time.time())
     with write_txn(conn):
         current = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?",
+            "SELECT status, block_kind FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
+        if current and current["block_kind"] == "iteration_exhausted":
+            return False
         resume_status = (
             _resume_status_from_events(conn, task_id)
             if current and current["status"] == "blocked"
@@ -9222,6 +9232,102 @@ def _record_task_failure(
                 )
             # Timeout/crash path's caller already emitted its own event.
     return blocked
+
+
+def _record_iteration_exhaustion(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_run_id: int,
+    budget_used: int,
+    budget_max: int,
+    error: Optional[str] = None,
+) -> Optional[int]:
+    """Terminalize one exhausted worker run without entering retry routing.
+
+    The iteration ceiling is an emergency stop, not a retry trigger. The
+    expected run id binds the transition to the exact task revision so a late
+    finalizer cannot park a successor run. Repeating the call for an already
+    terminalized run is an idempotent success.
+    """
+    run_id = int(expected_run_id)
+    used = max(0, int(budget_used))
+    maximum = max(0, int(budget_max))
+    message = str(
+        redact_review_value(
+            error
+            or f"Iteration budget exhausted ({used}/{maximum}) — task could not complete within the allowed iterations"
+        )
+    )[:500]
+
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, current_run_id, consecutive_failures, workspace_path "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            return None
+
+        current_run_id = (
+            int(row["current_run_id"])
+            if row["current_run_id"] is not None
+            else None
+        )
+        if current_run_id != run_id:
+            ended = conn.execute(
+                "SELECT outcome FROM task_runs WHERE id = ? AND task_id = ?",
+                (run_id, task_id),
+            ).fetchone()
+            if ended and ended["outcome"] == "iteration_exhausted":
+                return run_id
+            return None
+
+        failures = int(row["consecutive_failures"] or 0) + 1
+        workspace_path = str(row["workspace_path"] or "")
+        updated = conn.execute(
+            "UPDATE tasks SET status = 'blocked', "
+            "block_kind = 'iteration_exhausted', max_retries = 0, "
+            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
+            "last_heartbeat_at = NULL, consecutive_failures = ?, "
+            "last_failure_error = ? "
+            "WHERE id = ? AND status = 'running' AND current_run_id = ?",
+            (failures, message, task_id, run_id),
+        )
+        if updated.rowcount != 1:
+            return None
+
+        metadata = {
+            "budget_used": used,
+            "budget_max": maximum,
+            "checkpoint_required": True,
+            "workspace_preserved": True,
+            "workspace_path": workspace_path,
+            "retryable": False,
+            "resume_policy": "never",
+        }
+        closed_run_id = _end_run(
+            conn,
+            task_id,
+            outcome="iteration_exhausted",
+            status="iteration_exhausted",
+            error=message,
+            metadata=metadata,
+        )
+        payload = {
+            "error": message,
+            **metadata,
+            "blocker_type": "iteration_exhausted",
+            "terminal_run_id": closed_run_id,
+        }
+        _append_event(
+            conn,
+            task_id,
+            "iteration_exhausted",
+            payload,
+            run_id=closed_run_id,
+        )
+    return closed_run_id
 
 
 # Backward-compat alias. Old name is referenced from tests and possibly

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -165,13 +165,17 @@ def test_pending_response_does_not_mask_later_terminal_exit(
     assert agent._handle_max_iterations_called is False
 
 
-def test_pending_response_records_kanban_timeout(monkeypatch):
+def test_pending_response_records_terminal_kanban_iteration_exhaustion(monkeypatch):
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
-    record = MagicMock(name="record_task_failure")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+    record = MagicMock(name="record_iteration_exhaustion")
     conn = SimpleNamespace(close=lambda: None)
     monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
-    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db._record_iteration_exhaustion", record,
+        raising=False,
+    )
     agent = _LimitAgent()
 
     result = _finalize(
@@ -185,14 +189,9 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
     record.assert_called_once_with(
         conn,
         "task-123",
-        error=(
-            "Iteration budget exhausted (60/60) — task could not complete "
-            "within the allowed iterations"
-        ),
-        outcome="timed_out",
-        release_claim=True,
-        end_run=True,
-        event_payload_extra={"budget_used": 60, "budget_max": 60},
+        expected_run_id=42,
+        budget_used=60,
+        budget_max=60,
     )
 
 
@@ -233,5 +232,4 @@ def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch)
     assert agent.persisted_messages is not None
     persisted_roles = [m["role"] for m in agent.persisted_messages]
     assert persisted_roles == ["user", "assistant"]
-
 

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -354,6 +354,66 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
     assert "crashed" in adapter.sent[1]["text"].lower()
 
 
+def test_iteration_exhaustion_notifies_and_wakes_owner_without_retry(tmp_path, monkeypatch):
+    db_path = tmp_path / "iteration-exhausted-wakeup.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        workspace = tmp_path / "preserved-workspace"
+        workspace.mkdir()
+        tid = kb.create_task(
+            conn,
+            title="bounded execution",
+            assignee="worker",
+            session_id="origin-session",
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-1",
+            chat_type="group",
+            delivery_mode="notify+wake",
+        )
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None and claimed.current_run_id is not None
+        kb._record_iteration_exhaustion(
+            conn,
+            tid,
+            expected_run_id=claimed.current_run_id,
+            budget_used=60,
+            budget_max=60,
+        )
+    finally:
+        conn.close()
+
+    async def _direct_to_thread(func, /, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    # Keep this focused watcher test deterministic in restricted test
+    # environments where asyncio's default executor cannot complete work.
+    monkeypatch.setattr(asyncio, "to_thread", _direct_to_thread)
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"].lower()
+    assert "iteration budget exhausted (60/60)" in text
+    assert "terminal for this revision" in text
+    assert "no automatic retry" in text
+    assert len(adapter.handled) == 1
+    wake_text = adapter.handled[0].text.lower()
+    assert "iteration exhausted" in wake_text
+    assert "owner replan required" in wake_text
+    assert f"terminal task revision/run: {claimed.current_run_id}" in wake_text
+    assert f"preserved workspace: {workspace}" in wake_text
+    assert "resume policy: never" in wake_text
+
+
 def test_notifier_wakeup_uses_subscription_chat_type(tmp_path, monkeypatch):
     db_path = tmp_path / "chat-type-wakeup.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))

--- a/tests/hermes_cli/test_kanban_iteration_exhaustion.py
+++ b/tests/hermes_cli/test_kanban_iteration_exhaustion.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    return db_path
+
+
+def test_iteration_exhaustion_terminalizes_exact_run_and_preserves_workspace(
+    kanban_db: Path, tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    evidence = workspace / "evidence.txt"
+    evidence.write_text("preserve me", encoding="utf-8")
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="bounded implementation",
+            assignee="worker",
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+        claimed = kb.claim_task(conn, task_id, claimer="worker:one")
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert run_id is not None
+
+        closed_run_id = kb._record_iteration_exhaustion(
+            conn,
+            task_id,
+            expected_run_id=run_id,
+            budget_used=60,
+            budget_max=60,
+        )
+        assert closed_run_id == run_id
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.block_kind == "iteration_exhausted"
+        assert task.current_run_id is None
+        assert task.worker_pid is None
+        assert task.claim_lock is None
+        assert task.workspace_path == str(workspace)
+        assert evidence.read_text(encoding="utf-8") == "preserve me"
+        assert task.max_retries == 0
+
+        run = conn.execute(
+            "SELECT status, outcome, metadata FROM task_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+        assert run["status"] == "iteration_exhausted"
+        assert run["outcome"] == "iteration_exhausted"
+        metadata = json.loads(run["metadata"])
+        assert metadata == {
+            "budget_used": 60,
+            "budget_max": 60,
+            "checkpoint_required": True,
+            "workspace_preserved": True,
+            "workspace_path": str(workspace),
+            "retryable": False,
+            "resume_policy": "never",
+        }
+
+        events = conn.execute(
+            "SELECT run_id, payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'iteration_exhausted'",
+            (task_id,),
+        ).fetchall()
+        assert len(events) == 1
+        assert events[0]["run_id"] == run_id
+        payload = json.loads(events[0]["payload"])
+        assert payload["terminal_run_id"] == run_id
+        assert payload["budget_used"] == 60
+        assert payload["budget_max"] == 60
+        assert payload["checkpoint_required"] is True
+        assert payload["workspace_preserved"] is True
+        assert payload["workspace_path"] == str(workspace)
+        assert payload["retryable"] is False
+        assert payload["resume_policy"] == "never"
+
+        assert kb.claim_task(conn, task_id, claimer="worker:retry") is None
+        assert kb.recompute_ready(conn) == 0
+        assert kb.unblock_task(conn, task_id) is False
+        assert kb.get_task(conn, task_id).status == "blocked"
+        assert kb.goal_run_status(conn, task_id, expected_run_id=run_id) == "blocked"
+
+        # Same run finalization is idempotent: no duplicate event or mutation.
+        assert kb._record_iteration_exhaustion(
+            conn,
+            task_id,
+            expected_run_id=run_id,
+            budget_used=60,
+            budget_max=60,
+        ) == run_id
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events "
+            "WHERE task_id = ? AND kind = 'iteration_exhausted'",
+            (task_id,),
+        ).fetchone()[0] == 1
+
+
+def test_iteration_exhaustion_cannot_terminalize_a_successor_run(
+    kanban_db: Path,
+) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="revision guard", assignee="worker")
+        first = kb.claim_task(conn, task_id, claimer="worker:first")
+        assert first is not None and first.current_run_id is not None
+        stale_run_id = first.current_run_id
+
+        with kb.write_txn(conn):
+            kb._end_run(conn, task_id, outcome="released", status="released")
+            conn.execute(
+                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "claim_expires = NULL, worker_pid = NULL WHERE id = ?",
+                (task_id,),
+            )
+        successor = kb.claim_task(conn, task_id, claimer="worker:successor")
+        assert successor is not None
+        successor_run_id = successor.current_run_id
+        assert successor_run_id is not None and successor_run_id != stale_run_id
+
+        assert kb._record_iteration_exhaustion(
+            conn,
+            task_id,
+            expected_run_id=stale_run_id,
+            budget_used=60,
+            budget_max=60,
+        ) is None
+        current = kb.get_task(conn, task_id)
+        assert current is not None
+        assert current.status == "running"
+        assert current.current_run_id == successor_run_id
+        assert current.claim_lock == "worker:successor"
+
+
+def test_wall_clock_timeout_remains_retryable(kanban_db: Path, monkeypatch) -> None:
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="wall clock timeout",
+            assignee="worker",
+            max_runtime_seconds=1,
+        )
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        kb._set_worker_pid(conn, task_id, os.getpid())
+        old_started = int(time.time()) - 30
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_runs SET started_at = ? WHERE id = ?",
+                (old_started, claimed.current_run_id),
+            )
+
+        assert kb.enforce_max_runtime(conn, signal_fn=lambda *_args: None) == [task_id]
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+        assert task.block_kind is None
+        assert task.max_retries is None
+        assert kb.claim_task(conn, task_id, claimer="worker:retry") is not None
+        timeout = next(e for e in kb.list_events(conn, task_id) if e.kind == "timed_out")
+        assert timeout.payload["retry_status"] == "ready"


### PR DESCRIPTION
## Summary

- make Kanban iteration-budget exhaustion terminal for the exact run/revision instead of routing it through retryable wall-clock timeout handling
- preserve workspace/evidence, record `retryable=false` and `resume_policy=never`, and prevent automatic claim/unblock of the exhausted card
- notify and wake the owner for replan while retaining the existing delivery-mode boundary
- keep normal wall-clock timeout retry behavior unchanged

## Why

The iteration ceiling is an emergency stop. Retrying the same task revision after it has exhausted its model/tool budget can repeat the same broad run and risks obscuring the preserved partial artifact. Continuing work should use an owner-planned replacement revision that references the preserved workspace.

## Tests

```text
17 passed, 5 third-party deprecation warnings
ruff: pass
py_compile: pass
git diff --check: pass
```

Focused coverage includes:

- exact-run terminal task/run state
- stale-finalizer guard against a successor run
- idempotent repeated finalization
- preserved workspace/evidence and terminal metadata
- no automatic claim or unblock
- notifier text and owner wake context
- unchanged retryable wall-clock timeout semantics
