### PR TITLE
fix(whatsapp): strip the multi-device suffix when normalizing bot ids

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -183,7 +183,16 @@ class WhatsAppBehaviorMixin:
             return ""
         normalized = str(value).strip()
         if ":" in normalized and "@" in normalized:
-            normalized = normalized.replace(":", "@", 1)
+            # Baileys multi-device JIDs embed a device index between the user
+            # part and the server ("<user>:<device>@<server>" — e.g. the
+            # bridge's sock.user.id arrives as "15551234567:17@s.whatsapp.net"),
+            # while mentionedIds / quotedParticipant arrive without it. The
+            # device part is not identity — strip it, the same way the authz
+            # path's normalize_whatsapp_identifier does. (Folding the colon
+            # into an "@" here, as this used to do, produced a malformed
+            # two-@ id that could never match the clean inbound form, which
+            # silently broke bot-mention and reply-to-bot set matching.)
+            normalized = re.sub(r":[^@]*@", "@", normalized, count=1)
         return normalized
 
     @staticmethod

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -20,9 +20,29 @@ import {
   extractBridgeEvent,
   inboundReadReceiptKeys,
   mediaPayloadForFile,
+  normalizeWhatsAppId,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
+
+// -- bot id normalization (multi-device suffix) ---------------------------
+{
+  // sock.user.id / sock.user.lid arrive with a device index; mentionedJid
+  // and contextInfo.participant arrive without one. Both must normalize to
+  // the same clean JID or botIds set-membership checks can never match.
+  assert.equal(
+    normalizeWhatsAppId('15551234567:17@s.whatsapp.net'),
+    '15551234567@s.whatsapp.net',
+  );
+  assert.equal(normalizeWhatsAppId('98765432101112:5@lid'), '98765432101112@lid');
+  assert.equal(
+    normalizeWhatsAppId('15551234567@s.whatsapp.net'),
+    '15551234567@s.whatsapp.net',
+  );
+  assert.equal(normalizeWhatsAppId('120363001234567890@g.us'), '120363001234567890@g.us');
+  assert.equal(normalizeWhatsAppId(''), '');
+  console.log('  ✓ normalizeWhatsAppId strips the multi-device suffix so bot ids match mention/quote ids');
+}
 
 // -- inbound read receipts ------------------------------------------------
 {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -15,7 +15,15 @@ export const MIME_MAP = {
 
 export function normalizeWhatsAppId(value) {
   if (!value) return '';
-  return String(value).replace(':', '@');
+  // Baileys multi-device JIDs embed a device index between the user part and
+  // the server ("<user>:<device>@<server>" — e.g. sock.user.id arrives as
+  // "15551234567:17@s.whatsapp.net"), while mentionedJid / contextInfo
+  // participants arrive without it. The device part is not identity — strip
+  // it so the same account compares equal across both shapes. (The owner
+  // message gate already does this inline via .replace(/:.*@/, '@'); the
+  // old ':'→'@' fold here instead produced a malformed two-@ id, which
+  // broke botIds set-membership checks against mention/quote ids.)
+  return String(value).replace(/:[^@]*@/, '@');
 }
 
 export function getMessageContent(msg) {

--- a/tests/gateway/test_whatsapp_botids_device_suffix.py
+++ b/tests/gateway/test_whatsapp_botids_device_suffix.py
@@ -1,0 +1,125 @@
+"""Bot-identity matching with realistic Baileys multi-device JIDs.
+
+The bridge's ``sock.user.id`` / ``sock.user.lid`` carry a device index
+(``"15551230000:17@s.whatsapp.net"``) while inbound ``mentionedIds`` and
+``quotedParticipant`` arrive without it.  ``botIds`` must normalize to the
+clean form or every set-membership check against them silently fails —
+which is exactly what happened when normalization folded the colon into an
+``"@"`` instead of stripping the suffix (the existing gating tests never
+caught it because they hand-write clean botIds).
+"""
+
+from unittest.mock import AsyncMock
+
+from gateway.config import Platform, PlatformConfig
+
+# What Baileys actually hands the bridge for the bot's own identity:
+BOT_ID_RAW = "15551230000:17@s.whatsapp.net"
+BOT_LID_RAW = "98765432101112:5@lid"
+# What WhatsApp puts in mentionedJid / contextInfo.participant:
+BOT_ID_CLEAN = "15551230000@s.whatsapp.net"
+BOT_LID_CLEAN = "98765432101112@lid"
+
+
+def _make_adapter(**extra):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    extra.setdefault("require_mention", True)
+    extra.setdefault("group_policy", "open")
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True, extra=extra)
+    adapter._message_handler = AsyncMock()
+    adapter._dm_policy = "pairing"
+    adapter._allow_from = set()
+    adapter._group_policy = "open"
+    adapter._group_allow_from = set()
+    adapter._mention_patterns = adapter._compile_mention_patterns()
+    return adapter
+
+
+def _group_message(body="hello", **overrides):
+    data = {
+        "isGroup": True,
+        "body": body,
+        "chatId": "120363001234567890@g.us",
+        "senderId": "6281234567890@s.whatsapp.net",
+        "senderName": "Alice",
+        "mentionedIds": [],
+        # Realistic device-suffixed identities, as the bridge computes them
+        # from sock.user.id / sock.user.lid.
+        "botIds": [BOT_ID_RAW, BOT_LID_RAW],
+        "quotedParticipant": "",
+    }
+    data.update(overrides)
+    return data
+
+
+def test_normalize_strips_device_suffix_only_inside_jids():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    norm = WhatsAppAdapter._normalize_whatsapp_id
+    assert norm(BOT_ID_RAW) == BOT_ID_CLEAN
+    assert norm(BOT_LID_RAW) == BOT_LID_CLEAN
+    # Already-clean forms pass through untouched.
+    assert norm(BOT_ID_CLEAN) == BOT_ID_CLEAN
+    assert norm("120363001234567890@g.us") == "120363001234567890@g.us"
+    assert norm("15551230000") == "15551230000"
+    assert norm("") == ""
+    assert norm(None) == ""
+
+
+def test_native_mention_matches_device_suffixed_bot_ids():
+    adapter = _make_adapter()
+
+    # Body deliberately contains no digits: the only trigger signal is the
+    # native mentionedIds entry, so this fails unless botIds normalize to
+    # the clean form (the bare-number substring fallback can't save it).
+    message = _group_message("what do you think?", mentionedIds=[BOT_ID_CLEAN])
+    assert adapter._message_mentions_bot(message) is True
+    assert adapter._should_process_message(message) is True
+
+
+def test_quote_reply_to_bot_retriggers_under_require_mention():
+    adapter = _make_adapter()
+
+    # A resident replies (quotes) the bot's answer — WhatsApp reports the
+    # quoted author without a device suffix.
+    message = _group_message("thanks, and on friday?", quotedParticipant=BOT_ID_CLEAN)
+    assert adapter._message_is_reply_to_bot(message) is True
+    assert adapter._should_process_message(message) is True
+
+    # Quoting anyone else still does not trigger.
+    other = _group_message("what did he say?", quotedParticipant="6289999999999@s.whatsapp.net")
+    assert adapter._message_is_reply_to_bot(other) is False
+    assert adapter._should_process_message(other) is False
+
+
+def test_lid_quote_reply_matches_too():
+    adapter = _make_adapter()
+
+    message = _group_message("replying", quotedParticipant=BOT_LID_CLEAN)
+    assert adapter._message_is_reply_to_bot(message) is True
+
+
+def test_suffixed_quoted_participant_matches_clean_bot_ids():
+    # Defense in depth for the mirror case: if a producer ever emits the
+    # quoted author WITH a device suffix, normalization on both sides still
+    # converges on the same clean form.
+    adapter = _make_adapter()
+
+    message = _group_message(
+        "replying",
+        botIds=[BOT_ID_CLEAN, BOT_LID_CLEAN],
+        quotedParticipant=BOT_ID_RAW,
+    )
+    assert adapter._message_is_reply_to_bot(message) is True
+
+
+def test_mention_stripping_still_removes_bare_number():
+    adapter = _make_adapter()
+
+    data = _group_message("@15551230000 what is the weather?")
+    cleaned = adapter._clean_bot_mention_text(data["body"], data)
+    assert "15551230000" not in cleaned
+    assert "weather" in cleaned


### PR DESCRIPTION
## Bug

Baileys hands the bridge its own identity **with a device index** — `sock.user.id` is `"15551234567:17@s.whatsapp.net"` — while inbound `mentionedJid` entries and `contextInfo.participant` arrive **without** one.

Both normalizers (`normalizeWhatsAppId` in `bridge_helpers.js`, `_normalize_whatsapp_id` in `whatsapp_common.py`) folded the first `:` into an `@` instead of stripping the suffix, producing a malformed two-`@` id:

```
"15551234567:17@s.whatsapp.net"  →  "15551234567@17@s.whatsapp.net"   ← never equals the clean form
```

So every set-membership comparison of `botIds` against clean inbound ids silently failed.

## User-visible impact

| Path | Effect |
|---|---|
| `_message_mentions_bot` — `mentionedIds ∩ botIds` | Never matched. @-mentions only kept working through the bare-number **substring fallback** on the body text. |
| `_message_is_reply_to_bot` — `quotedParticipant ∈ botIds` | Never matched. Under `require_mention`, **quote-replying the bot's own answer does not re-trigger it** — the natural "reply to the bot in a group" flow is dead, with no fallback. |
| `reply_to_is_own_message` | Always `False` — the gateway renders `[Replying to: ...]` instead of `[Replying to your previous message: ...]`, and downstream logic keyed on it never fires. |

## Why this is clearly a bug, from the tree itself

- The **owner message gate** in `bridge.js` strips the suffix inline (`.replace(/:.*@/, '@')`) when resolving "my" number, with a comment documenting the `sock.user.id` shape.
- `gateway/whatsapp_identity.normalize_whatsapp_identifier` both splits on `:` and lists `"60123456789:47@s.whatsapp.net"` in its docstring as a shape "the WhatsApp bridge may emit".

Only the `botIds` path missed it — and the existing tests never caught the mismatch because they hand-write clean botIds (`tests/gateway/test_whatsapp_group_gating.py`, `bridge.native.test.mjs`).

## Fix

Strip `":<device>"` before the `"@"` in **both** normalizers, so any producer/consumer combination converges on the clean JID. No behavior change for already-clean ids, group JIDs, or bare numbers.

## Tests

- `tests/gateway/test_whatsapp_botids_device_suffix.py` — drives the mention/quote gates with the **realistic suffixed identities**. **5 of the 6 tests fail against the previous normalization** (the passing one is the substring fallback, matching the analysis above). Includes the mirror case (suffixed `quotedParticipant` vs clean botIds) as defense in depth.
- `bridge.native.test.mjs` — new `normalizeWhatsAppId` block with the suffixed → clean cases.

```
tests/gateway -k whatsapp: 186 passed, 4 skipped
bridge JS test files: all pass
ruff check (changed files): clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
