### PR TITLE
fix(xai): preserve xhigh effort and priority service_tier for Grok 4.6

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -604,6 +604,14 @@ def grok_supports_reasoning_effort(model: str) -> bool:
     return any(name.startswith(prefix) for prefix in _GROK_EFFORT_CAPABLE_PREFIXES)
 
 
+def is_grok_46_family(model: str) -> bool:
+    """Return whether *model* is a Grok 4.6 family identifier."""
+    name = (model or "").strip().lower().replace("_", "-")
+    if "/" in name:
+        name = name.rsplit("/", 1)[-1]
+    return name == "grok-4.6" or name.startswith("grok-4.6-")
+
+
 _CONTEXT_LENGTH_KEYS = (
     "context_length",
     "context_window",

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -300,8 +300,13 @@ class ResponsesApiTransport(ProviderTransport):
             # Ultra is the Codex product tier; the Responses API wire value is max.
             _effort_clamp["ultra"] = "max"
         if params.get("is_xai_responses", False):
-            # xAI Responses tops out at high; keep generic stronger values usable.
-            _effort_clamp.update({"xhigh": "high", "max": "high", "ultra": "high"})
+            from agent.model_metadata import is_grok_46_family
+
+            # Grok 4.6 accepts xhigh as a wire value. Older Grok models top out
+            # at high, while max/ultra remain Hermes aliases for every xAI model.
+            if not is_grok_46_family(model):
+                _effort_clamp["xhigh"] = "high"
+            _effort_clamp.update({"max": "high", "ultra": "high"})
         if (params.get("provider") or "").strip().lower() == "actual":
             # Actual Computer relays to SGLang/vLLM backends that accept only
             # none/low/medium/high/max for reasoning effort — a forwarded
@@ -441,16 +446,18 @@ class ResponsesApiTransport(ProviderTransport):
             else:
                 kwargs.pop("prompt_cache_key", None)
 
-        # xAI Responses API rejects ``service_tier`` (HTTP 400 "Argument not
-        # supported: service_tier") — hit when ``/fast`` priority-processing
-        # mode lingers from a prior model in the same session, or when a
-        # user explicitly sets ``agent.service_tier`` in config.yaml.  The
-        # main-loop guard (``resolve_fast_mode_overrides`` only returns
-        # ``service_tier`` for OpenAI fast-eligible models) doesn't cover
-        # those leak paths, so strip defensively when targeting xAI.  See
-        # #28490 for the original report.
+        # Older xAI Responses models reject ``service_tier`` (HTTP 400
+        # "Argument not supported: service_tier"). Grok 4.6 accepts Priority
+        # Processing, but continue stripping stale or unsupported tier values
+        # on every other xAI path. See #28490 and #84799.
         if is_xai_responses:
-            kwargs.pop("service_tier", None)
+            from agent.model_metadata import is_grok_46_family
+
+            if not (
+                is_grok_46_family(model)
+                and kwargs.get("service_tier") == "priority"
+            ):
+                kwargs.pop("service_tier", None)
 
         # Forward per-request timeout to the SDK so OpenAI/Anthropic clients
         # honor it.  Without this, ``providers.<id>.request_timeout_seconds``

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2870,7 +2870,13 @@ def _strip_vendor_prefix(model_id: str) -> str:
 
 def model_supports_fast_mode(model_id: Optional[str]) -> bool:
     """Return whether Hermes should expose the /fast toggle for this model."""
-    return _is_anthropic_fast_model(model_id) or _is_openai_fast_model(model_id)
+    from agent.model_metadata import is_grok_46_family
+
+    return (
+        _is_anthropic_fast_model(model_id)
+        or _is_openai_fast_model(model_id)
+        or is_grok_46_family(str(model_id or ""))
+    )
 
 
 def _is_anthropic_fast_model(model_id: Optional[str]) -> bool:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2904,6 +2904,7 @@ def resolve_fast_mode_overrides(model_id: Optional[str]) -> dict[str, Any] | Non
     Returns provider-appropriate overrides:
     - OpenAI models: ``{"service_tier": "priority"}`` (Priority Processing)
     - Anthropic models: ``{"speed": "fast"}`` (Anthropic Fast Mode beta)
+    - Grok 4.6: ``{"service_tier": "priority"}`` (xAI Priority Processing)
 
     The overrides are injected into the API request kwargs by
     ``_build_api_kwargs`` in run_agent.py — each API path handles its own

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -689,6 +689,47 @@ class TestCodexTransportTimeout:
 
 
 
+class TestCodexTransportXaiReasoningEffort:
+    @pytest.fixture
+    def transport(self):
+        from agent.transports.codex import ResponsesApiTransport
+        return ResponsesApiTransport()
+
+    def test_grok_46_preserves_xhigh(self, transport):
+        kw = transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": "xhigh"},
+        )
+
+        assert kw["reasoning"]["effort"] == "xhigh"
+
+    @pytest.mark.parametrize("effort", ["max", "ultra"])
+    def test_grok_46_clamps_hermes_aliases_to_high(self, transport, effort):
+        kw = transport.build_kwargs(
+            model="x-ai/grok-4.6-latest",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": effort},
+        )
+
+        assert kw["reasoning"]["effort"] == "high"
+
+    def test_older_grok_clamps_xhigh_to_high(self, transport):
+        kw = transport.build_kwargs(
+            model="grok-4.5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": "xhigh"},
+        )
+
+        assert kw["reasoning"]["effort"] == "high"
+
+
 class TestCodexTransportXaiServiceTierStrip:
     """xAI Responses API rejects ``service_tier`` (#28490).
 
@@ -720,6 +761,28 @@ class TestCodexTransportXaiServiceTierStrip:
             f"service_tier must be stripped on xAI requests, "
             f"got {kw.get('service_tier')!r}"
         )
+
+    def test_grok_46_preserves_priority_service_tier(self, transport):
+        kw = transport.build_kwargs(
+            model="x-ai/grok-4.6-latest",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_xai_responses=True,
+            request_overrides={"service_tier": "priority"},
+        )
+
+        assert kw.get("service_tier") == "priority"
+
+    def test_grok_46_strips_non_priority_service_tier(self, transport):
+        kw = transport.build_kwargs(
+            model="grok-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_xai_responses=True,
+            request_overrides={"service_tier": "unsupported"},
+        )
+
+        assert "service_tier" not in kw
 
     def test_non_xai_codex_preserves_service_tier(self, transport):
         """The strip is xAI-only — native Codex DOES accept

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -123,6 +123,17 @@ class TestPriorityProcessingModels(unittest.TestCase):
 
 
 
+    def test_grok_46_supports_priority_processing(self):
+        from hermes_cli.models import (
+            model_supports_fast_mode,
+            resolve_fast_mode_overrides,
+        )
+
+        assert model_supports_fast_mode("grok-4.6") is True
+        assert model_supports_fast_mode("x-ai/grok-4.6-latest") is True
+        assert model_supports_fast_mode("grok-4.5") is False
+        assert resolve_fast_mode_overrides("grok-4.6") == {"service_tier": "priority"}
+
     def test_resolve_overrides_returns_service_tier(self):
         from hermes_cli.models import resolve_fast_mode_overrides
 


### PR DESCRIPTION
## Summary
Grok 4.6 is the first xAI Responses model to accept `reasoning.effort=xhigh` and xAI Priority Processing (`service_tier`), but Hermes' provider-wide xAI guards silently clamped xhigh→high and stripped `service_tier` for every Grok model — so 4.6 users were silently downgraded. This model-gates both guards on the 4.6 family and exposes the `/fast` toggle for it. Fixes #84799.

Salvages #84820 by @fangliquanflq (cherry-picked, authorship preserved), the tighter of two competing fixes (exact-slug family matcher + priority-value check on the service_tier preserve). #84848 by @Chukwuebuka-2003 was submitted 1h21m later with the same coverage — both credited; we carried over its docstring line for `resolve_fast_mode_overrides` as a follow-up commit.

## Changes
- `agent/model_metadata.py` (@fangliquanflq): `is_grok_46_family()` matcher.
- `agent/transports/codex.py` (@fangliquanflq): xhigh clamp and `service_tier` strip both model-gated on the 4.6 family.
- `hermes_cli/models.py` (@fangliquanflq): `/fast` toggle exposed for Grok 4.6 (`model_supports_fast_mode`), falls through to `{"service_tier": "priority"}`.
- Tests (@fangliquanflq): transport preserve/strip/clamp matrix + fast-command coverage.
- Docstring follow-up (ours), mirroring #84848.

## Validation
| | Result |
|---|---|
| `test_codex_transport.py` + `test_fast_command.py` + `test_model_metadata.py` | 169/169 pass |
| Stale-base gate | 0 behind, 5-file diff |

## Infographic

![Grok 4.6 wire capabilities — xhigh + priority preserved](https://files.catbox.moe/3xg4ww.png)
