### PR TITLE
feat(tools): tool-aware relevance filtering for tool results before context injection

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1469,6 +1469,18 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         agent._touch_activity(f"tool completed: {name} ({tool_duration:.1f}s){_status_suffix}")
 
         display_function_result = function_result
+
+        # Tool-aware relevance filter: replace the raw blob with the parts
+        # this tool type's profile says the agent needs (see
+        # ``tools/tool_result_profiles.py``). Runs BEFORE the size caps and
+        # persistence thresholds so every result — including ones big
+        # enough to trigger persistence — gets shrunk to its informative
+        # parts first; only results that are still oversized are
+        # spilled/truncated below. The filter is shrink-only and fail-open,
+        # so it can never raise context above what ``tool_output`` allows.
+        if not _is_multimodal_tool_result(function_result):
+            function_result = apply_tool_result_filter(name, function_result)
+
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=name,
@@ -1476,14 +1488,6 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             env=get_active_env(effective_task_id),
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
-
-        # Tool-aware relevance filter: replace the raw blob with the parts
-        # this tool type's profile says the agent needs (see
-        # ``tools/tool_result_profiles.py``). Runs after persistence so the
-        # full output is still spilled/tracked, and before subdir-hint
-        # injection so appended hint payloads are never trimmed mid-result.
-        if not _is_multimodal_tool_result(function_result):
-            function_result = apply_tool_result_filter(name, function_result)
 
         subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
         if subdir_hints:
@@ -2279,6 +2283,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             logging.debug("Tool result (%d chars): %s", len(_log_result), _log_result)
 
         display_function_result = function_result
+
+        # Tool-aware relevance filter — see the concurrent path for
+        # rationale. Runs before the size caps/persistence thresholds.
+        if not _is_multimodal_tool_result(function_result):
+            function_result = apply_tool_result_filter(function_name, function_result)
+
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=function_name,
@@ -2286,10 +2296,6 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             env=get_active_env(effective_task_id),
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
-
-        # Tool-aware relevance filter — see the concurrent path for rationale.
-        if not _is_multimodal_tool_result(function_result):
-            function_result = apply_tool_result_filter(function_name, function_result)
 
         # Discover subdirectory context files from tool arguments
         subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -48,6 +48,7 @@ from tools.tool_result_storage import (
     maybe_persist_tool_result,
     enforce_turn_budget,
 )
+from tools.tool_result_profiles import apply_tool_result_filter
 from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context_window
 
 logger = logging.getLogger(__name__)
@@ -1476,6 +1477,14 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
 
+        # Tool-aware relevance filter: replace the raw blob with the parts
+        # this tool type's profile says the agent needs (see
+        # ``tools/tool_result_profiles.py``). Runs after persistence so the
+        # full output is still spilled/tracked, and before subdir-hint
+        # injection so appended hint payloads are never trimmed mid-result.
+        if not _is_multimodal_tool_result(function_result):
+            function_result = apply_tool_result_filter(name, function_result)
+
         subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
@@ -2277,6 +2286,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             env=get_active_env(effective_task_id),
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
+
+        # Tool-aware relevance filter — see the concurrent path for rationale.
+        if not _is_multimodal_tool_result(function_result):
+            function_result = apply_tool_result_filter(function_name, function_result)
 
         # Discover subdirectory context files from tool arguments
         subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -752,6 +752,7 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tool_output.max_bytes',
       'tool_output.max_lines',
       'tool_output.max_line_length',
+      'tool_result_profiles.enabled',
       'checkpoints.max_snapshots',
       'agent.max_turns',
       'agent.api_max_retries',

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -595,12 +595,18 @@ DEFAULT_CONFIG = {
     # - search_files ``bounded_matches``: keep the first N + last N matches
     #   (or densified text lines), summarize the middle. Most searches'
     #   signal lives in the first few matches + the boundary ones.
+    #   ``middle_summary`` renders the note for the verbose ``matches``
+    #   array (counts matches); ``middle_summary_lines`` renders the note
+    #   for the densified ``matches_text`` block (counts lines, since that
+    #   form has no per-match boundaries).
     # - read_file ``tail_or_head``: when a page is large, keep the head and
     #   tail (function defs at the top, the answer near the bottom) instead
     #   of the whole page. Small reads pass through untouched.
     # - patch / write_file ``summary``: the agent already knows what it asked
     #   for; keep the compact JSON envelope (success/files/targets), drop
-    #   verbose diff bodies.
+    #   verbose diff bodies. ``keep_keys``/``deny_keys`` extend or prune the
+    #   built-in keep-list per tool, so new result fields can surface (or be
+    #   hidden) without a code change.
     # - terminal ``smart_tail``: keep the head + tail of the output field
     #   (banner/version at the top, errors at the bottom), keep all other
     #   result metadata intact.
@@ -609,7 +615,9 @@ DEFAULT_CONFIG = {
     # passthrough). The filter runs BEFORE the size caps and persistence
     # thresholds, so nothing here raises context above what
     # ``tool_output`` already allows — it only fills the allowed size with
-    # the relevant parts. Disable the whole system with ``enabled: false``.
+    # the relevant parts. Profiles are cached for the process lifetime
+    # (same as ``tool_output``), so changes require a restart. Disable the
+    # whole system with ``enabled: false``.
     "tool_result_profiles": {
         "enabled": True,
         "tools": {
@@ -618,6 +626,7 @@ DEFAULT_CONFIG = {
                 "first_matches": 5,
                 "last_matches": 5,
                 "middle_summary": "{omitted} additional matches omitted — use a narrower pattern or offset to page through them",
+                "middle_summary_lines": "{omitted} additional lines omitted — use a narrower pattern or offset to page through them",
             },
             "read_file": {
                 "mode": "tail_or_head",
@@ -627,9 +636,13 @@ DEFAULT_CONFIG = {
             },
             "patch": {
                 "mode": "summary",
+                "keep_keys": [],
+                "deny_keys": [],
             },
             "write_file": {
                 "mode": "summary",
+                "keep_keys": [],
+                "deny_keys": [],
             },
             "terminal": {
                 "mode": "smart_tail",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -587,6 +587,58 @@ DEFAULT_CONFIG = {
         "max_line_length": 2000,
     },
 
+    # Tool-result relevance profiles. Where `tool_output` caps *size*,
+    # this section filters *relevance*: per tool type, which subset of the
+    # result the agent is likely to need before it is injected into the
+    # context. Each tool declares a result-handling profile:
+    #
+    # - search_files ``bounded_matches``: keep the first N + last N matches
+    #   (or densified text lines), summarize the middle. Most searches'
+    #   signal lives in the first few matches + the boundary ones.
+    # - read_file ``tail_or_head``: when a page is large, keep the head and
+    #   tail (function defs at the top, the answer near the bottom) instead
+    #   of the whole page. Small reads pass through untouched.
+    # - patch / write_file ``summary``: the agent already knows what it asked
+    #   for; keep the compact JSON envelope (success/files/targets), drop
+    #   verbose diff bodies.
+    # - terminal ``smart_tail``: keep the head + tail of the output field
+    #   (banner/version at the top, errors at the bottom), keep all other
+    #   result metadata intact.
+    #
+    # Tools without a profile keep the current behavior (``full``
+    # passthrough). The filter runs BEFORE the size caps and persistence
+    # thresholds, so nothing here raises context above what
+    # ``tool_output`` already allows — it only fills the allowed size with
+    # the relevant parts. Disable the whole system with ``enabled: false``.
+    "tool_result_profiles": {
+        "enabled": True,
+        "tools": {
+            "search_files": {
+                "mode": "bounded_matches",
+                "first_matches": 5,
+                "last_matches": 5,
+                "middle_summary": "{omitted} additional matches omitted — use a narrower pattern or offset to page through them",
+            },
+            "read_file": {
+                "mode": "tail_or_head",
+                "head_lines": 50,
+                "tail_lines": 100,
+                "full_if_under_chars": 4000,
+            },
+            "patch": {
+                "mode": "summary",
+            },
+            "write_file": {
+                "mode": "summary",
+            },
+            "terminal": {
+                "mode": "smart_tail",
+                "head_lines": 50,
+                "tail_lines": 100,
+            },
+        },
+    },
+
     # Tool loop guardrails nudge models when they repeat failed or
     # non-progressing tool calls. Soft warnings are always-on by default;
     # hard stops are opt-in so interactive CLI/TUI sessions keep flowing.

--- a/tests/tools/test_tool_result_profiles.py
+++ b/tests/tools/test_tool_result_profiles.py
@@ -17,6 +17,11 @@ Covers:
      small output no-op, non-JSON passthrough.
 4. Fail-open contract: unknown tools, disabled config, non-string content,
    and malformed input never raise and never mutate the original.
+5. Config escapes: per-tool ``middle_summary_lines`` for the densified text
+   form (trimmed by lines, counted as lines) and ``keep_keys``/``deny_keys``
+   for the summary envelope.
+6. Executor ordering: the filter runs before the size caps/persistence, so
+   persistence always receives the already-filtered result.
 """
 
 from __future__ import annotations
@@ -157,9 +162,40 @@ class TestBoundedMatches:
         data = json.loads(out)
         text = data["matches_text"]
         assert text.startswith("src/a.py")
-        assert "9 additional matches omitted" in text
+        assert "9 additional lines omitted" in text
         assert "  11: line 11" in text  # last match kept
         assert data["truncated"] is True
+        assert data["_relevance"]["omitted_lines"] == 9
+
+    def test_densified_note_uses_middle_summary_lines_template(self):
+        cfg = _cfg_with({"enabled": True, "tools": {
+            "search_files": {
+                "mode": "bounded_matches",
+                "first_matches": 2,
+                "last_matches": 2,
+                "middle_summary_lines": "{omitted} lines hidden — page with offset",
+            },
+        }})
+        content = self._search_content(12, densify=True)
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = trp.apply_tool_result_filter("search_files", content)
+        data = json.loads(out)
+        assert "9 lines hidden — page with offset" in data["matches_text"]
+
+    def test_custom_tool_without_defaults_uses_provided_lines_template(self):
+        cfg = _cfg_with({"enabled": True, "tools": {
+            "my_search": {
+                "mode": "bounded_matches",
+                "first_matches": 2,
+                "last_matches": 2,
+                "middle_summary_lines": "{omitted} lines hidden — page with offset",
+            },
+        }})
+        content = json.dumps({"matches_text": "\n".join(f"l{i}" for i in range(12))})
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = trp.apply_tool_result_filter("my_search", content)
+        data = json.loads(out)
+        assert "8 lines hidden — page with offset" in data["matches_text"]
 
     def test_small_result_unchanged(self):
         content = self._search_content(3)
@@ -264,6 +300,65 @@ class TestSummary:
         content = "Some plain text confirmation"
         with patch("hermes_cli.config.load_config", return_value=self._cfg()):
             assert trp.apply_tool_result_filter("write_file", content) == content
+
+    def test_keep_keys_preserve_new_fields(self):
+        cfg = _cfg_with({"enabled": True, "tools": {
+            "patch": {
+                "mode": "summary",
+                "keep_keys": ["conflicts"],
+                "deny_keys": [],
+            },
+        }})
+        content = json.dumps({
+            "success": True,
+            "files_modified": ["src/a.py"],
+            "conflicts": ["src/b.py"],
+            "diff": "--- a\n+++ b\n",
+        })
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = trp.apply_tool_result_filter("patch", content)
+        data = json.loads(out)
+        assert data["success"] is True
+        assert data["conflicts"] == ["src/b.py"]  # new field surfaced via config
+        assert "diff" not in data
+        assert data["_relevance"]["dropped_keys"] == ["diff"]
+
+    def test_deny_keys_drop_default_kept_keys(self):
+        cfg = _cfg_with({"enabled": True, "tools": {
+            "patch": {
+                "mode": "summary",
+                "keep_keys": [],
+                "deny_keys": ["status", "files_modified"],
+            },
+        }})
+        content = json.dumps({
+            "success": True,
+            "status": "applied",
+            "files_modified": ["src/a.py"],
+            "diff": "--- a\n+++ b\n",
+        })
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = trp.apply_tool_result_filter("patch", content)
+        data = json.loads(out)
+        assert data["success"] is True
+        assert "status" not in data
+        assert "files_modified" not in data
+        assert data["_relevance"]["dropped_keys"] == ["diff", "files_modified", "status"]
+
+    def test_garbage_keep_deny_entries_are_ignored(self):
+        cfg = _cfg_with({"enabled": True, "tools": {
+            "write_file": {
+                "mode": "summary",
+                "keep_keys": "not-a-list",
+                "deny_keys": [123, None],
+            },
+        }})
+        content = json.dumps({"success": True, "diff": "--- a\n+++ b\n"})
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = trp.apply_tool_result_filter("write_file", content)
+        data = json.loads(out)
+        assert data["success"] is True
+        assert "diff" not in data  # built-in defaults still apply
 
 
 class TestSmartTail:
@@ -390,7 +485,7 @@ class TestExecutorWiring:
             ],
         }, ensure_ascii=False)
 
-    def _run_sequential(self, agent, function_name, result, profiles_cfg):
+    def _run_sequential(self, agent, function_name, result, profiles_cfg, persist_hook=None):
         from types import SimpleNamespace
 
         tool_call = SimpleNamespace(
@@ -401,11 +496,16 @@ class TestExecutorWiring:
         messages: list = []
         assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
 
+        def _fake_persist(**kwargs):
+            if persist_hook is not None:
+                persist_hook(kwargs["content"])
+            return kwargs["content"]
+
         with (
             patch("run_agent.handle_function_call", return_value=result),
             patch(
                 "agent.tool_executor.maybe_persist_tool_result",
-                side_effect=lambda **kwargs: kwargs["content"],
+                side_effect=_fake_persist,
             ),
             patch("hermes_cli.config.load_config", return_value=profiles_cfg),
         ):
@@ -428,6 +528,27 @@ class TestExecutorWiring:
         assert data["matches"][0]["line"] == 0
         assert data["matches"][-1]["line"] == 19
         assert data["truncated"] is True
+
+    def test_filter_runs_before_size_caps_and_persistence(self):
+        """The relevance filter must shrink the result BEFORE persistence
+        sees it — otherwise an oversized result is replaced by a preview
+        blob (no longer JSON) and the filter fails open, i.e. it is a no-op
+        exactly for the results it exists for."""
+        agent = _make_executor_agent()
+        cfg = {"tool_result_profiles": {"enabled": True, "tools": {
+            "search_files": {"mode": "bounded_matches", "first_matches": 2, "last_matches": 2},
+        }}}
+        seen_by_persist: list = []
+
+        def _capture(content: str) -> None:
+            seen_by_persist.append(content)
+
+        self._run_sequential(
+            agent, "search_files", self._big_search_result(), cfg, persist_hook=_capture
+        )
+        assert len(seen_by_persist) == 1
+        data = json.loads(seen_by_persist[0])
+        assert len(data["matches"]) == 4  # persistence received the filtered form
 
     def test_filter_skipped_when_disabled(self):
         agent = _make_executor_agent()

--- a/tests/tools/test_tool_result_profiles.py
+++ b/tests/tools/test_tool_result_profiles.py
@@ -1,0 +1,441 @@
+"""Tests for tools.tool_result_profiles (tool-aware relevance filtering).
+
+Covers:
+1. Defaults: DEFAULT_PROFILES mirrors DEFAULT_CONFIG; fallback when config
+   read fails.
+2. Config resolution: user overrides, disabled, unknown mode -> full,
+   malformed section fallback.
+3. Mode behavior:
+   - bounded_matches (search_files): verbose ``matches`` array trimming,
+     densified ``matches_text`` trimming, hint-suffix preservation,
+     small-result passthrough, error-JSON passthrough.
+   - tail_or_head (read_file): large pages keep head + tail, small pages
+     pass through, JSON error results pass through.
+   - summary (patch/write_file): compact envelope kept, verbose keys
+     dropped, no-op when nothing would be dropped, non-JSON passthrough.
+   - smart_tail (terminal): output field trimmed, metadata intact,
+     small output no-op, non-JSON passthrough.
+4. Fail-open contract: unknown tools, disabled config, non-string content,
+   and malformed input never raise and never mutate the original.
+"""
+
+from __future__ import annotations
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools import tool_result_profiles as trp
+
+
+@pytest.fixture(autouse=True)
+def _reset_profiles_cache():
+    """get_tool_result_profiles() memoizes for the process lifetime, so each
+    test must start from a clean cache to observe the config it patches in."""
+    trp._reset_tool_result_profiles_cache()
+    yield
+    trp._reset_tool_result_profiles_cache()
+
+
+def _cfg_with(tool_profiles: dict) -> dict:
+    return {"tool_result_profiles": tool_profiles}
+
+
+def _default_cfg() -> dict:
+    """Full config dict (root key included) with a bounded search profile."""
+    return {
+        "tool_result_profiles": {
+            "enabled": True,
+            "tools": {
+                "search_files": {
+                    "mode": "bounded_matches",
+                    "first_matches": 2,
+                    "last_matches": 2,
+                },
+            },
+        },
+    }
+
+
+class TestDefaults:
+    def test_default_profiles_mirror_default_config(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        assert "tool_result_profiles" in DEFAULT_CONFIG
+        assert DEFAULT_CONFIG["tool_result_profiles"] == trp.DEFAULT_PROFILES
+
+    def test_get_profiles_returns_defaults_when_load_config_raises(self):
+        def _boom():
+            raise RuntimeError("boom")
+
+        with patch("hermes_cli.config.load_config", side_effect=_boom):
+            profiles = trp.get_tool_result_profiles()
+        assert profiles["enabled"] is True
+        assert profiles["tools"]["search_files"]["mode"] == "bounded_matches"
+
+
+class TestConfigResolution:
+    def test_user_config_overrides_mode(self):
+        cfg = _cfg_with({"enabled": True, "tools": {
+            "search_files": {"mode": "bounded_matches", "first_matches": 1, "last_matches": 1},
+        }})
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            profiles = trp.get_tool_result_profiles()
+        assert profiles["tools"]["search_files"]["first_matches"] == 1
+        assert profiles["tools"]["search_files"]["last_matches"] == 1
+
+    def test_disabled_passes_everything_through(self):
+        cfg = _cfg_with({"enabled": False, "tools": {"search_files": {"mode": "bounded_matches"}}})
+        content = json.dumps({
+            "total_count": 20,
+            "matches": [{"path": f"f{i}.py", "line": i, "content": "x"} for i in range(20)],
+        })
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = trp.apply_tool_result_filter("search_files", content)
+        assert out == content
+
+    def test_unknown_mode_coerces_to_full(self):
+        cfg = _cfg_with({"enabled": True, "tools": {"search_files": {"mode": "teleport"}}})
+        content = "plain text that must pass through unchanged"
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert trp.apply_tool_result_filter("search_files", content) == content
+
+    def test_section_not_a_dict_falls_back_to_defaults(self):
+        cfg = {"tool_result_profiles": "nonsense"}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            profiles = trp.get_tool_result_profiles()
+        assert profiles["enabled"] is True
+        assert profiles["tools"]["search_files"]["mode"] == "bounded_matches"
+
+    def test_unknown_tool_passes_through(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert trp.apply_tool_result_filter("some_other_tool", "anything") == "anything"
+
+    def test_non_string_content_passes_through(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert trp.apply_tool_result_filter("search_files", None) is None
+            assert trp.apply_tool_result_filter("search_files", {"a": 1}) == {"a": 1}
+
+
+class TestBoundedMatches:
+    def _search_content(self, n: int, densify: bool = False) -> str:
+        if densify:
+            data = {
+                "total_count": n,
+                "matches_format": "path-grouped",
+                "matches_text": "\n".join(
+                    ["src/a.py", *[f"  {i}: line {i}" for i in range(n)]]
+                ),
+            }
+        else:
+            data = {
+                "total_count": n,
+                "matches": [
+                    {"path": "src/a.py", "line": i, "content": f"line {i}"}
+                    for i in range(n)
+                ],
+            }
+        return json.dumps(data, ensure_ascii=False)
+
+    def test_verbose_matches_array_is_bounded(self):
+        content = self._search_content(20)
+        with patch("hermes_cli.config.load_config", return_value=_default_cfg()):
+            out = trp.apply_tool_result_filter("search_files", content)
+        data = json.loads(out)
+        assert len(data["matches"]) == 4  # first 2 + last 2
+        assert data["matches"][0]["line"] == 0
+        assert data["matches"][-1]["line"] == 19
+        assert data["truncated"] is True
+        assert data["_relevance"]["omitted"] == 16
+        assert data["total_count"] == 20
+
+    def test_densified_matches_text_is_bounded_with_note(self):
+        content = self._search_content(12, densify=True)
+        with patch("hermes_cli.config.load_config", return_value=_default_cfg()):
+            out = trp.apply_tool_result_filter("search_files", content)
+        data = json.loads(out)
+        text = data["matches_text"]
+        assert text.startswith("src/a.py")
+        assert "9 additional matches omitted" in text
+        assert "  11: line 11" in text  # last match kept
+        assert data["truncated"] is True
+
+    def test_small_result_unchanged(self):
+        content = self._search_content(3)
+        with patch("hermes_cli.config.load_config", return_value=_default_cfg()):
+            assert trp.apply_tool_result_filter("search_files", content) == content
+
+    def test_hint_suffix_is_preserved(self):
+        content = self._search_content(20) + "\n\n[Hint: Results truncated. Use offset=10 to see more.]"
+        with patch("hermes_cli.config.load_config", return_value=_default_cfg()):
+            out = trp.apply_tool_result_filter("search_files", content)
+        assert out.endswith("[Hint: Results truncated. Use offset=10 to see more.]")
+        json.loads(out.split("\n\n[Hint:")[0])  # JSON part still parseable
+
+    def test_error_json_passes_through(self):
+        content = json.dumps({"error": "Path not found: /nope"})
+        with patch("hermes_cli.config.load_config", return_value=_default_cfg()):
+            assert trp.apply_tool_result_filter("search_files", content) == content
+
+    def test_non_json_passes_through(self):
+        content = "plain text that is not JSON"
+        with patch("hermes_cli.config.load_config", return_value=_default_cfg()):
+            assert trp.apply_tool_result_filter("search_files", content) == content
+
+    def test_zero_keep_config_is_noop(self):
+        cfg = _cfg_with({"enabled": True, "tools": {
+            "search_files": {"mode": "bounded_matches", "first_matches": 0, "last_matches": 0},
+        }})
+        content = self._search_content(20)
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert trp.apply_tool_result_filter("search_files", content) == content
+
+
+class TestTailOrHead:
+    def _big_page(self, n: int = 500) -> str:
+        return "\n".join(f"{i}|line of content {i}" for i in range(1, n + 1))
+
+    def _cfg(self, **overrides) -> dict:
+        base = {
+            "enabled": True,
+            "tools": {
+                "read_file": {
+                    "mode": "tail_or_head",
+                    "head_lines": 5,
+                    "tail_lines": 5,
+                    "full_if_under_chars": 4000,
+                    **overrides,
+                },
+            },
+        }
+        return _cfg_with(base)
+
+    def test_large_page_keeps_head_and_tail(self):
+        content = self._big_page(500)
+        with patch("hermes_cli.config.load_config", return_value=self._cfg()):
+            out = trp.apply_tool_result_filter("read_file", content)
+        lines = out.split("\n")
+        assert lines[0] == "1|line of content 1"
+        assert lines[-1] == "500|line of content 500"
+        assert "490 lines omitted" in out
+        assert len(lines) == 11  # 5 head + note + 5 tail
+
+    def test_small_read_passes_through(self):
+        content = self._big_page(20)
+        assert len(content) < 4000
+        with patch("hermes_cli.config.load_config", return_value=self._cfg()):
+            assert trp.apply_tool_result_filter("read_file", content) == content
+
+    def test_json_error_result_passes_through(self):
+        content = json.dumps({"success": False, "note": "not a regular file"})
+        with patch("hermes_cli.config.load_config", return_value=self._cfg(full_if_under_chars=0)):
+            assert trp.apply_tool_result_filter("read_file", content) == content
+
+
+class TestSummary:
+    def _cfg(self) -> dict:
+        return _cfg_with({"enabled": True, "tools": {
+            "patch": {"mode": "summary"},
+            "write_file": {"mode": "summary"},
+        }})
+
+    def test_dropped_keys_are_removed(self):
+        content = json.dumps({
+            "success": True,
+            "files_modified": ["src/a.py"],
+            "resolved_path": "/work/src/a.py",
+            "diff": "--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new\n",
+        })
+        with patch("hermes_cli.config.load_config", return_value=self._cfg()):
+            out = trp.apply_tool_result_filter("patch", content)
+        data = json.loads(out)
+        assert data["success"] is True
+        assert data["files_modified"] == ["src/a.py"]
+        assert "diff" not in data
+        assert data["_relevance"]["dropped_keys"] == ["diff"]
+
+    def test_already_compact_json_unchanged(self):
+        content = json.dumps({"success": True, "files_modified": ["src/a.py"]})
+        with patch("hermes_cli.config.load_config", return_value=self._cfg()):
+            assert trp.apply_tool_result_filter("write_file", content) == content
+
+    def test_non_json_passes_through(self):
+        content = "Some plain text confirmation"
+        with patch("hermes_cli.config.load_config", return_value=self._cfg()):
+            assert trp.apply_tool_result_filter("write_file", content) == content
+
+
+class TestSmartTail:
+    def _cfg(self) -> dict:
+        return _cfg_with({"enabled": True, "tools": {
+            "terminal": {"mode": "smart_tail", "head_lines": 2, "tail_lines": 2},
+        }})
+
+    def _terminal_content(self, n: int = 100, exit_code: int = 0) -> str:
+        return json.dumps({
+            "output": "\n".join(f"out line {i}" for i in range(n)),
+            "exit_code": exit_code,
+            "output_total_chars": 10_000,
+        }, ensure_ascii=False)
+
+    def test_output_field_is_trimmed_metadata_kept(self):
+        content = self._terminal_content(100)
+        with patch("hermes_cli.config.load_config", return_value=self._cfg()):
+            out = trp.apply_tool_result_filter("terminal", content)
+        data = json.loads(out)
+        lines = data["output"].split("\n")
+        assert lines[0] == "out line 0"
+        assert lines[-1] == "out line 99"
+        assert "96 lines of output omitted" in data["output"]
+        assert data["exit_code"] == 0
+        assert data["output_total_chars"] == 10_000
+        assert data["relevance_note"] == "96 lines trimmed from output"
+
+    def test_small_output_unchanged(self):
+        content = self._terminal_content(3)
+        with patch("hermes_cli.config.load_config", return_value=self._cfg()):
+            assert trp.apply_tool_result_filter("terminal", content) == content
+
+    def test_non_json_output_passes_through(self):
+        content = "just raw output text"
+        with patch("hermes_cli.config.load_config", return_value=self._cfg()):
+            assert trp.apply_tool_result_filter("terminal", content) == content
+
+    def test_error_exit_code_still_trimmed(self):
+        content = self._terminal_content(50, exit_code=1)
+        with patch("hermes_cli.config.load_config", return_value=self._cfg()):
+            out = trp.apply_tool_result_filter("terminal", content)
+        data = json.loads(out)
+        assert data["exit_code"] == 1
+        assert "46 lines of output omitted" in data["output"]
+
+
+class TestFailOpen:
+    @pytest.mark.parametrize("mode", ["bounded_matches", "tail_or_head", "summary", "smart_tail"])
+    def test_never_raises_on_garbage_input(self, mode):
+        cfg = _cfg_with({"enabled": True, "tools": {"t": {"mode": mode}}})
+        garbage = ["", "{", "not json at all", "[", "\x00\x01\x02"]
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            for g in garbage:
+                assert trp.apply_tool_result_filter("t", g) == g
+
+    def test_config_read_failure_still_filters_with_defaults(self):
+        def _boom():
+            raise RuntimeError("boom")
+
+        content = json.dumps({
+            "total_count": 20,
+            "matches": [{"path": "a.py", "line": i, "content": "x"} for i in range(20)],
+        })
+        with patch("hermes_cli.config.load_config", side_effect=_boom):
+            out = trp.apply_tool_result_filter("search_files", content)
+        data = json.loads(out)
+        assert len(data["matches"]) == 10  # defaults: first 5 + last 5
+
+
+# ---------------------------------------------------------------------------
+# Executor wiring: the filter must actually run between tool dispatch and
+# context injection, on the real sequential executor surface.
+# ---------------------------------------------------------------------------
+def _make_executor_agent():
+    from pathlib import Path
+    import tempfile
+    from run_agent import AIAgent
+
+    hermes_home = Path(tempfile.mkdtemp(prefix="hermes-test-home-"))
+    (hermes_home / "logs").mkdir(parents=True, exist_ok=True)
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=[{
+                "type": "function",
+                "function": {
+                    "name": "search_files",
+                    "description": "search",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }],
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent._hermes_home", hermes_home),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+class TestExecutorWiring:
+    """The sequential executor is the real injection surface — verify the
+    filter is applied to results before they become tool messages."""
+
+    def _big_search_result(self) -> str:
+        return json.dumps({
+            "total_count": 20,
+            "matches": [
+                {"path": "src/a.py", "line": i, "content": f"line {i}"}
+                for i in range(20)
+            ],
+        }, ensure_ascii=False)
+
+    def _run_sequential(self, agent, function_name, result, profiles_cfg):
+        from types import SimpleNamespace
+
+        tool_call = SimpleNamespace(
+            id="call_1",
+            type="function",
+            function=SimpleNamespace(name=function_name, arguments="{}"),
+        )
+        messages: list = []
+        assistant_message = SimpleNamespace(content="", tool_calls=[tool_call])
+
+        with (
+            patch("run_agent.handle_function_call", return_value=result),
+            patch(
+                "agent.tool_executor.maybe_persist_tool_result",
+                side_effect=lambda **kwargs: kwargs["content"],
+            ),
+            patch("hermes_cli.config.load_config", return_value=profiles_cfg),
+        ):
+            agent._execute_tool_calls_sequential(
+                assistant_message, messages, "task-1"
+            )
+        return messages
+
+    def test_search_result_is_bounded_before_context_injection(self):
+        agent = _make_executor_agent()
+        cfg = {"tool_result_profiles": {"enabled": True, "tools": {
+            "search_files": {"mode": "bounded_matches", "first_matches": 2, "last_matches": 2},
+        }}}
+        messages = self._run_sequential(
+            agent, "search_files", self._big_search_result(), cfg
+        )
+        assert messages and messages[-1]["role"] == "tool"
+        data = json.loads(messages[-1]["content"])
+        assert len(data["matches"]) == 4
+        assert data["matches"][0]["line"] == 0
+        assert data["matches"][-1]["line"] == 19
+        assert data["truncated"] is True
+
+    def test_filter_skipped_when_disabled(self):
+        agent = _make_executor_agent()
+        cfg = {"tool_result_profiles": {"enabled": False, "tools": {
+            "search_files": {"mode": "bounded_matches", "first_matches": 2, "last_matches": 2},
+        }}}
+        messages = self._run_sequential(
+            agent, "search_files", self._big_search_result(), cfg
+        )
+        data = json.loads(messages[-1]["content"])
+        assert len(data["matches"]) == 20  # untouched

--- a/tools/tool_result_profiles.py
+++ b/tools/tool_result_profiles.py
@@ -1,0 +1,380 @@
+"""Tool-aware relevance filtering for tool results before context injection.
+
+``tool_output.*`` caps tool results by *size*; this module caps them by
+*relevance*. Each tool type declares a result-handling profile (the
+``tool_result_profiles`` section in ``config.yaml``) describing which subset
+of its output the agent is likely to need. The filter runs on the result
+string right before it is appended to the conversation context, so the
+context window is filled with the informative part of a tool result instead
+of a raw blob.
+
+Supported modes (``mode`` per tool in ``tool_result_profiles.tools``):
+
+- ``full`` — passthrough (the current behavior; also the behavior for any
+  tool without a profile). Compatible with existing installs.
+- ``bounded_matches`` — search-like results. Keeps the first N matches and
+  the last N matches (works on both the verbose ``matches`` array and the
+  densified path-grouped ``matches_text`` block), summarizes the middle,
+  re-serializes the JSON envelope.
+- ``tail_or_head`` — large read_file pages. Keeps the head and tail lines
+  (function defs at the top, the answer near the bottom), drops the middle.
+  Small reads pass through untouched (``full_if_under_chars``).
+- ``summary`` — patch/write_file style results. The agent already knows what
+  it asked for; keep the compact JSON envelope (success/files/targets)
+  and drop verbose diff bodies.
+- ``smart_tail`` — terminal output. Keeps the head + tail of the ``output``
+  field inside the JSON wrapper (banner/version at the top, errors at the
+  bottom) while leaving all other result metadata (exit_code, spill paths,
+  truncation notes) intact.
+
+Design invariants:
+
+- **Fail-open.** Every filter is defensive: malformed input, unknown tools,
+  disabled config, or an unexpected result shape all pass the content
+  through unchanged. A relevance filter must never break a tool result.
+- **Complement, not replacement.** The mode filter runs before the size
+  caps and persistence thresholds, so it can only *shrink* what enters
+  context — never raise it above what ``tool_output`` already allows.
+- **Full output stays available where it already is.** Persist spill files
+  and ``full_output_path`` references are written before the filter runs
+  and are untouched by it.
+- **Process-lifetime cache.** Profiles are read from config once and cached
+  (same pattern as ``tools/tool_output_limits.py``); tests reset the cache
+  via ``_reset_tool_result_profiles_cache()``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict
+
+# Fail-safe defaults matching hermes_cli/config_defaults.py. Used only if
+# config can't be read at all; load_config() normally supplies this exact
+# section (deep-merged over user overrides).
+DEFAULT_PROFILES: Dict[str, Any] = {
+    "enabled": True,
+    "tools": {
+        "search_files": {
+            "mode": "bounded_matches",
+            "first_matches": 5,
+            "last_matches": 5,
+            "middle_summary": "{omitted} additional matches omitted — use a narrower pattern or offset to page through them",
+        },
+        "read_file": {
+            "mode": "tail_or_head",
+            "head_lines": 50,
+            "tail_lines": 100,
+            "full_if_under_chars": 4000,
+        },
+        "patch": {
+            "mode": "summary",
+        },
+        "write_file": {
+            "mode": "summary",
+        },
+        "terminal": {
+            "mode": "smart_tail",
+            "head_lines": 50,
+            "tail_lines": 100,
+        },
+    },
+}
+
+_MODES = frozenset({"full", "bounded_matches", "tail_or_head", "summary", "smart_tail"})
+
+# Keys a patch/write_file ``summary`` profile keeps from the result JSON.
+# Everything else (diff bodies, echoed content, verbose metadata) is dropped
+# because the agent already knows what it asked the tool to do.
+_SUMMARY_KEEP_KEYS = frozenset({
+    "success", "error", "status", "message", "note",
+    "files_modified", "resolved_path", "warning", "_warning", "_omitted",
+})
+
+# search_files emits a trailing "\n\n[Hint: Results truncated. Use
+# offset=... to see more, ...]" suffix after the JSON payload. Parse the
+# JSON part and re-append the hint, because after filtering the hint is
+# *more* important (the model should page for the omitted middle).
+_SEARCH_HINT_RE = re.compile(r"\n\n\[Hint:.*$", re.DOTALL)
+
+# Module-level cache — populated on first call.
+_cached_profiles: dict | None = None
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    """Return ``value`` as a non-negative int, or ``default`` on any issue."""
+    try:
+        iv = int(value)
+    except (TypeError, ValueError):
+        return default
+    if iv < 0:
+        return default
+    return iv
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    """Return ``value`` as a bool, tolerating common YAML truthiness."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    try:
+        return bool(value)
+    except Exception:
+        return default
+
+
+def _middle_note(template: str, omitted: int, suffix: str = "") -> str:
+    """Render the omitted-middle summary line from a config template."""
+    try:
+        text = template.replace("{omitted}", str(omitted)).strip()
+    except Exception:
+        text = f"{omitted} lines omitted by the relevance filter"
+    return f"... [{text}{suffix}] ..."
+
+
+def get_tool_result_profiles() -> Dict[str, Any]:
+    """Return resolved tool-result profiles, reading ``tool_result_profiles``
+    from config.
+
+    Structure: ``{"enabled": bool, "tools": {tool_name: {"mode": str,
+    ...params}}``. Unknown modes are coerced to ``full`` so a typo in
+    config degrades to current behavior instead of failing. This function
+    NEVER raises, and caches for the process lifetime — call
+    ``_reset_tool_result_profiles_cache()`` in tests that need a fresh read.
+    """
+    global _cached_profiles
+    if _cached_profiles is not None:
+        return _cached_profiles
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        section = cfg.get("tool_result_profiles") if isinstance(cfg, dict) else None
+        if not isinstance(section, dict):
+            section = {}
+    except Exception:
+        section = {}
+
+    resolved: Dict[str, Any] = {
+        "enabled": _coerce_bool(section.get("enabled"), DEFAULT_PROFILES["enabled"]),
+        "tools": {},
+    }
+    raw_tools = section.get("tools")
+    if not isinstance(raw_tools, dict):
+        raw_tools = DEFAULT_PROFILES["tools"]
+    for tool_name, raw_profile in raw_tools.items():
+        if not isinstance(raw_profile, dict):
+            continue
+        mode = raw_profile.get("mode", "full")
+        if mode not in _MODES:
+            mode = "full"
+        profile: Dict[str, Any] = {"mode": mode}
+        if mode == "bounded_matches":
+            defaults = DEFAULT_PROFILES["tools"].get(tool_name, {})
+            profile["first_matches"] = _coerce_int(
+                raw_profile.get("first_matches"), defaults.get("first_matches", 5)
+            )
+            profile["last_matches"] = _coerce_int(
+                raw_profile.get("last_matches"), defaults.get("last_matches", 5)
+            )
+            profile["middle_summary"] = str(
+                raw_profile.get("middle_summary")
+                or defaults.get(
+                    "middle_summary",
+                    "{omitted} additional matches omitted — use a narrower pattern or offset to page through them",
+                )
+            )
+        elif mode in ("tail_or_head", "smart_tail"):
+            defaults = DEFAULT_PROFILES["tools"].get(tool_name, {})
+            profile["head_lines"] = _coerce_int(
+                raw_profile.get("head_lines"), defaults.get("head_lines", 50)
+            )
+            profile["tail_lines"] = _coerce_int(
+                raw_profile.get("tail_lines"), defaults.get("tail_lines", 100)
+            )
+            if mode == "tail_or_head":
+                profile["full_if_under_chars"] = _coerce_int(
+                    raw_profile.get("full_if_under_chars"),
+                    defaults.get("full_if_under_chars", 4000),
+                )
+        resolved["tools"][tool_name] = profile
+    _cached_profiles = resolved
+    return _cached_profiles
+
+
+def _reset_tool_result_profiles_cache() -> None:
+    """Reset the cached profiles — for tests or after a config hot-reload."""
+    global _cached_profiles
+    _cached_profiles = None
+
+
+def _looks_like_json(content: str) -> bool:
+    """True when a result string begins with a JSON object/array token."""
+    stripped = content.lstrip()
+    return stripped.startswith("{") or stripped.startswith("[")
+
+
+def _filter_bounded_matches(content: str, profile: Dict[str, Any]) -> str:
+    """search_files: keep first N + last N matches, summarize the middle."""
+    first_n = _coerce_int(profile.get("first_matches"), 5)
+    last_n = _coerce_int(profile.get("last_matches"), 5)
+    if first_n <= 0 and last_n <= 0:
+        return content
+    middle_summary = profile.get("middle_summary", "")
+
+    payload = content
+    hint = ""
+    hint_match = _SEARCH_HINT_RE.search(content)
+    if hint_match:
+        hint = hint_match.group(0)
+        payload = content[: hint_match.start()]
+
+    try:
+        data = json.loads(payload)
+    except Exception:
+        return content
+    if not isinstance(data, dict):
+        return content
+
+    omitted = 0
+    changed = False
+    matches = data.get("matches")
+    if isinstance(matches, list) and len(matches) > first_n + last_n:
+        total = len(matches)
+        data["matches"] = matches[:first_n] + matches[-last_n:]
+        omitted = total - len(data["matches"])
+        data["truncated"] = True
+        data["_relevance"] = {
+            "mode": "bounded_matches",
+            "omitted": omitted,
+            "total": total,
+        }
+        changed = True
+
+    matches_text = data.get("matches_text")
+    if isinstance(matches_text, str):
+        lines = matches_text.split("\n")
+        if len(lines) > first_n + last_n:
+            omitted = len(lines) - first_n - last_n
+            note = _middle_note(middle_summary, omitted)
+            data["matches_text"] = "\n".join(
+                lines[:first_n] + [note] + lines[-last_n:]
+            )
+            data["truncated"] = True
+            data["_relevance"] = {"mode": "bounded_matches", "omitted": omitted}
+            changed = True
+
+    if not changed:
+        return content
+    return json.dumps(data, ensure_ascii=False) + hint
+
+
+def _filter_tail_or_head(content: str, profile: Dict[str, Any]) -> str:
+    """read_file: keep head + tail of large pages, pass small ones through."""
+    if len(content) <= _coerce_int(profile.get("full_if_under_chars"), 4000):
+        return content
+    if _looks_like_json(content):
+        # Error/note results (e.g. unsupported file) are not line-numbered
+        # pages — leave them intact.
+        try:
+            json.loads(content)
+            return content
+        except Exception:
+            pass
+    head = _coerce_int(profile.get("head_lines"), 50)
+    tail = _coerce_int(profile.get("tail_lines"), 100)
+    if head <= 0 and tail <= 0:
+        return content
+    lines = content.split("\n")
+    if len(lines) <= head + tail:
+        return content
+    omitted = len(lines) - head - tail
+    note = _middle_note(
+        "{omitted} lines omitted by the relevance filter — use offset/limit to page",
+        omitted,
+        suffix="",
+    )
+    return "\n".join(lines[:head] + [note] + lines[-tail:])
+
+
+def _filter_summary(content: str, profile: Dict[str, Any]) -> str:
+    """patch/write_file: keep the compact JSON envelope, drop diffs."""
+    if not _looks_like_json(content):
+        return content
+    try:
+        data = json.loads(content)
+    except Exception:
+        return content
+    if not isinstance(data, dict):
+        return content
+    keep = {k: v for k, v in data.items() if k in _SUMMARY_KEEP_KEYS}
+    dropped = sorted(set(data.keys()) - _SUMMARY_KEEP_KEYS)
+    if not dropped:
+        return content
+    keep["_relevance"] = {"mode": "summary", "dropped_keys": dropped}
+    return json.dumps(keep, ensure_ascii=False)
+
+
+def _filter_smart_tail(content: str, profile: Dict[str, Any]) -> str:
+    """terminal: keep head + tail of the ``output`` field, all metadata."""
+    if not _looks_like_json(content):
+        return content
+    try:
+        data = json.loads(content)
+    except Exception:
+        return content
+    if not isinstance(data, dict):
+        return content
+    output = data.get("output")
+    if not isinstance(output, str):
+        return content
+    head = _coerce_int(profile.get("head_lines"), 50)
+    tail = _coerce_int(profile.get("tail_lines"), 100)
+    if head <= 0 and tail <= 0:
+        return content
+    lines = output.split("\n")
+    if len(lines) <= head + tail:
+        return content
+    omitted = len(lines) - head - tail
+    spill_path = data.get("full_output_path")
+    suffix = f" full output: {spill_path}" if isinstance(spill_path, str) and spill_path else ""
+    note = _middle_note(
+        "{omitted} lines of output omitted by the relevance filter",
+        omitted,
+        suffix=suffix,
+    )
+    data["output"] = "\n".join(lines[:head] + [note] + lines[-tail:])
+    data["relevance_note"] = f"{omitted} lines trimmed from output"
+    return json.dumps(data, ensure_ascii=False)
+
+
+def apply_tool_result_filter(tool_name: str, content: Any) -> Any:
+    """Relevance-filter a tool result before it enters the agent context.
+
+    Fail-open by design: any error, unknown tool, disabled config, or
+    unparseable result shape returns ``content`` unchanged, so tool
+    execution is never affected by the config.
+    """
+    if not isinstance(content, str):
+        return content
+    try:
+        profiles = get_tool_result_profiles()
+        if not profiles.get("enabled", True):
+            return content
+        profile = profiles.get("tools", {}).get(tool_name)
+        if not isinstance(profile, dict):
+            return content
+        mode = profile.get("mode", "full")
+        if mode == "bounded_matches":
+            return _filter_bounded_matches(content, profile)
+        if mode == "tail_or_head":
+            return _filter_tail_or_head(content, profile)
+        if mode == "summary":
+            return _filter_summary(content, profile)
+        if mode == "smart_tail":
+            return _filter_smart_tail(content, profile)
+    except Exception:
+        pass
+    return content

--- a/tools/tool_result_profiles.py
+++ b/tools/tool_result_profiles.py
@@ -13,9 +13,10 @@ Supported modes (``mode`` per tool in ``tool_result_profiles.tools``):
 - ``full`` — passthrough (the current behavior; also the behavior for any
   tool without a profile). Compatible with existing installs.
 - ``bounded_matches`` — search-like results. Keeps the first N matches and
-  the last N matches (works on both the verbose ``matches`` array and the
-  densified path-grouped ``matches_text`` block), summarizes the middle,
-  re-serializes the JSON envelope.
+  the last N matches of the verbose ``matches`` array (the densified
+  path-grouped ``matches_text`` block is trimmed by *lines*, since it has
+  no per-match boundaries), summarizes the middle, re-serializes the JSON
+  envelope.
 - ``tail_or_head`` — large read_file pages. Keeps the head and tail lines
   (function defs at the top, the answer near the bottom), drops the middle.
   Small reads pass through untouched (``full_if_under_chars``).
@@ -35,9 +36,12 @@ Design invariants:
 - **Complement, not replacement.** The mode filter runs before the size
   caps and persistence thresholds, so it can only *shrink* what enters
   context — never raise it above what ``tool_output`` already allows.
-- **Full output stays available where it already is.** Persist spill files
-  and ``full_output_path`` references are written before the filter runs
-  and are untouched by it.
+- **Full output stays available where it already is.** Tools that write
+  their own spill references (e.g. the terminal tool's
+  ``full_output_path``) do so before the result reaches the filter and
+  are untouched by it. Executor-level persistence runs *after* the filter,
+  so a result that still exceeds ``tool_output`` thresholds is spilled in
+  its filtered form.
 - **Process-lifetime cache.** Profiles are read from config once and cached
   (same pattern as ``tools/tool_output_limits.py``); tests reset the cache
   via ``_reset_tool_result_profiles_cache()``.
@@ -60,6 +64,7 @@ DEFAULT_PROFILES: Dict[str, Any] = {
             "first_matches": 5,
             "last_matches": 5,
             "middle_summary": "{omitted} additional matches omitted — use a narrower pattern or offset to page through them",
+            "middle_summary_lines": "{omitted} additional lines omitted — use a narrower pattern or offset to page through them",
         },
         "read_file": {
             "mode": "tail_or_head",
@@ -69,9 +74,13 @@ DEFAULT_PROFILES: Dict[str, Any] = {
         },
         "patch": {
             "mode": "summary",
+            "keep_keys": [],
+            "deny_keys": [],
         },
         "write_file": {
             "mode": "summary",
+            "keep_keys": [],
+            "deny_keys": [],
         },
         "terminal": {
             "mode": "smart_tail",
@@ -124,6 +133,18 @@ def _coerce_bool(value: Any, default: bool) -> bool:
         return bool(value)
     except Exception:
         return default
+
+
+def _coerce_str_list(value: Any) -> list[str]:
+    """Return ``value`` as a list of strings, dropping non-string entries.
+
+    Used for per-tool ``keep_keys``/``deny_keys`` overrides. Anything that
+    is not a list (or a list with garbage in it) resolves to ``[]`` — a
+    config typo must never raise during profile resolution.
+    """
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
 
 
 def _middle_note(template: str, omitted: int, suffix: str = "") -> str:
@@ -186,6 +207,20 @@ def get_tool_result_profiles() -> Dict[str, Any]:
                     "{omitted} additional matches omitted — use a narrower pattern or offset to page through them",
                 )
             )
+            profile["middle_summary_lines"] = str(
+                raw_profile.get("middle_summary_lines")
+                or defaults.get(
+                    "middle_summary_lines",
+                    "{omitted} additional lines omitted — use a narrower pattern or offset to page through them",
+                )
+            )
+        elif mode == "summary":
+            # Per-tool keep/deny escapes: ``keep_keys`` are preserved in
+            # addition to the default set; ``deny_keys`` are dropped even
+            # if a default would keep them. Lets new result fields surface
+            # (or legacy ones be hidden) without a code change.
+            profile["keep_keys"] = _coerce_str_list(raw_profile.get("keep_keys"))
+            profile["deny_keys"] = _coerce_str_list(raw_profile.get("deny_keys"))
         elif mode in ("tail_or_head", "smart_tail"):
             defaults = DEFAULT_PROFILES["tools"].get(tool_name, {})
             profile["head_lines"] = _coerce_int(
@@ -223,6 +258,9 @@ def _filter_bounded_matches(content: str, profile: Dict[str, Any]) -> str:
     if first_n <= 0 and last_n <= 0:
         return content
     middle_summary = profile.get("middle_summary", "")
+    middle_summary_lines = profile.get("middle_summary_lines", "")
+    if not middle_summary_lines:
+        middle_summary_lines = middle_summary
 
     payload = content
     hint = ""
@@ -258,12 +296,15 @@ def _filter_bounded_matches(content: str, profile: Dict[str, Any]) -> str:
         lines = matches_text.split("\n")
         if len(lines) > first_n + last_n:
             omitted = len(lines) - first_n - last_n
-            note = _middle_note(middle_summary, omitted)
+            note = _middle_note(middle_summary_lines, omitted)
             data["matches_text"] = "\n".join(
                 lines[:first_n] + [note] + lines[-last_n:]
             )
             data["truncated"] = True
-            data["_relevance"] = {"mode": "bounded_matches", "omitted": omitted}
+            data["_relevance"] = {
+                "mode": "bounded_matches",
+                "omitted_lines": omitted,
+            }
             changed = True
 
     if not changed:
@@ -300,7 +341,12 @@ def _filter_tail_or_head(content: str, profile: Dict[str, Any]) -> str:
 
 
 def _filter_summary(content: str, profile: Dict[str, Any]) -> str:
-    """patch/write_file: keep the compact JSON envelope, drop diffs."""
+    """patch/write_file: keep the compact JSON envelope, drop diffs.
+
+    The keep/deny sets are the built-in defaults plus any per-tool
+    ``keep_keys``/``deny_keys`` from config, so new result fields can
+    surface without a code change (and noisy ones can be suppressed).
+    """
     if not _looks_like_json(content):
         return content
     try:
@@ -309,8 +355,11 @@ def _filter_summary(content: str, profile: Dict[str, Any]) -> str:
         return content
     if not isinstance(data, dict):
         return content
-    keep = {k: v for k, v in data.items() if k in _SUMMARY_KEEP_KEYS}
-    dropped = sorted(set(data.keys()) - _SUMMARY_KEEP_KEYS)
+    keep_set = set(_SUMMARY_KEEP_KEYS)
+    keep_set |= set(profile.get("keep_keys") or ())
+    keep_set -= set(profile.get("deny_keys") or ())
+    keep = {k: v for k, v in data.items() if k in keep_set}
+    dropped = sorted(set(data.keys()) - keep_set)
     if not dropped:
         return content
     keep["_relevance"] = {"mode": "summary", "dropped_keys": dropped}

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -764,6 +764,7 @@ tool_result_profiles:
       first_matches: 5
       last_matches: 5
       middle_summary: "{omitted} additional matches omitted — use a narrower pattern or offset to page through them"
+      middle_summary_lines: "{omitted} additional lines omitted — use a narrower pattern or offset to page through them"
     read_file:
       mode: tail_or_head        # large pages: head + tail, middle summarized
       head_lines: 50
@@ -771,8 +772,12 @@ tool_result_profiles:
       full_if_under_chars: 4000 # small reads pass through untouched
     patch:
       mode: summary             # compact envelope; diff bodies dropped
+      keep_keys: []             # extra keys to preserve (on top of defaults)
+      deny_keys: []             # default-kept keys to drop
     write_file:
       mode: summary
+      keep_keys: []
+      deny_keys: []
     terminal:
       mode: smart_tail          # head + tail of output; metadata kept
       head_lines: 50
@@ -782,25 +787,36 @@ tool_result_profiles:
 Per-tool modes:
 
 - **`bounded_matches`** (`search_files`) — keeps the first `first_matches`
-  and last `last_matches` matches (both the verbose `matches` array and the
-  densified path-grouped text are supported), marks the result `truncated`,
-  and records the omitted count in `_relevance` so the model can page with
-  `offset` for the middle.
+  and last `last_matches` matches of the verbose `matches` array and marks
+  the result `truncated`, recording the omitted count in `_relevance` so
+  the model can page with `offset` for the middle. The densified
+  path-grouped `matches_text` block has no per-match boundaries, so it is
+  trimmed by *lines* (`middle_summary_lines` renders that note; the
+  omitted count is recorded as `omitted_lines`).
 - **`tail_or_head`** (`read_file`) — for pages larger than
   `full_if_under_chars`, keeps the first `head_lines` and last `tail_lines`
   (function definitions near the top, the answer near the bottom) and
   inserts an omitted-lines notice. Small reads pass through untouched.
 - **`summary`** (`patch`, `write_file`) — keeps the compact JSON envelope
   (success/error, `files_modified`, `resolved_path`, warnings) and drops
-  verbose diff bodies the agent already knows about.
+  verbose diff bodies the agent already knows about. Concise by default,
+  but an escape hatch exists: `keep_keys` preserves additional result
+  fields (so new fields surface without a code change) and `deny_keys`
+  drops fields the built-in keep-list would preserve.
 - **`smart_tail`** (`terminal`) — trims the `output` field to the head and
   tail (banner/version at the top, errors at the bottom) while leaving all
   other result metadata (`exit_code`, spill paths, truncation notes) intact,
   and records the trimmed count in `relevance_note`.
 
 The filter is fail-open: malformed output, unknown tools, unparseable JSON,
-or a disabled section all pass results through unchanged. To disable the
-system entirely, set `tool_result_profiles.enabled: false`.
+or a disabled section all pass results through unchanged. The filter runs
+before the size caps and context-persistence thresholds, so an oversized
+result is relevance-filtered first and only then spilled or truncated if it
+still exceeds the `tool_output` limits. Profiles are read once per process
+and cached (the same pattern as the `tool_output` limits), so changes to
+`tool_result_profiles` in `config.yaml` require restarting the agent to
+take effect. To disable the system entirely, set
+`tool_result_profiles.enabled: false`.
 
 ## Global Toolset Disable
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -745,6 +745,63 @@ tool_output:
   max_lines: 500
 ```
 
+## Tool-Result Relevance Profiles
+
+Where `tool_output` caps tool output by **size**, `tool_result_profiles`
+filters by **relevance**: each tool type declares which portion of its result
+the agent is likely to need, and Hermes keeps only that portion when the
+result is injected into the agent context. The filter runs before the size
+caps and context-persistence thresholds, so it can only shrink what enters
+context — never raise it above what `tool_output` allows. Tools without a
+profile keep the current behavior.
+
+```yaml
+tool_result_profiles:
+  enabled: true
+  tools:
+    search_files:
+      mode: bounded_matches     # keep first N + last N matches
+      first_matches: 5
+      last_matches: 5
+      middle_summary: "{omitted} additional matches omitted — use a narrower pattern or offset to page through them"
+    read_file:
+      mode: tail_or_head        # large pages: head + tail, middle summarized
+      head_lines: 50
+      tail_lines: 100
+      full_if_under_chars: 4000 # small reads pass through untouched
+    patch:
+      mode: summary             # compact envelope; diff bodies dropped
+    write_file:
+      mode: summary
+    terminal:
+      mode: smart_tail          # head + tail of output; metadata kept
+      head_lines: 50
+      tail_lines: 100
+```
+
+Per-tool modes:
+
+- **`bounded_matches`** (`search_files`) — keeps the first `first_matches`
+  and last `last_matches` matches (both the verbose `matches` array and the
+  densified path-grouped text are supported), marks the result `truncated`,
+  and records the omitted count in `_relevance` so the model can page with
+  `offset` for the middle.
+- **`tail_or_head`** (`read_file`) — for pages larger than
+  `full_if_under_chars`, keeps the first `head_lines` and last `tail_lines`
+  (function definitions near the top, the answer near the bottom) and
+  inserts an omitted-lines notice. Small reads pass through untouched.
+- **`summary`** (`patch`, `write_file`) — keeps the compact JSON envelope
+  (success/error, `files_modified`, `resolved_path`, warnings) and drops
+  verbose diff bodies the agent already knows about.
+- **`smart_tail`** (`terminal`) — trims the `output` field to the head and
+  tail (banner/version at the top, errors at the bottom) while leaving all
+  other result metadata (`exit_code`, spill paths, truncation notes) intact,
+  and records the trimmed count in `relevance_note`.
+
+The filter is fail-open: malformed output, unknown tools, unparseable JSON,
+or a disabled section all pass results through unchanged. To disable the
+system entirely, set `tool_result_profiles.enabled: false`.
+
 ## Global Toolset Disable
 
 To suppress specific toolsets across the CLI and every gateway platform in one


### PR DESCRIPTION
## Summary

Implements the profile system proposed in #85288: tool results are relevance-filtered **before** they are injected into the agent context, per tool type. The existing `tool_output` size caps stay as a hard backstop — this complements them by filling the allowed size with the parts of a result the tool's semantics imply are needed, instead of a raw blob.

## What's inside

New config section `tool_result_profiles` (fail-open, disabled by default means current behavior):

| Mode | Tools | Effect |
|---|---|---|
| `bounded_matches` | `search_files` | Keep first N + last N matches (works on both the verbose `matches` array and the densified path-grouped `matches_text`), mark `truncated`, record `_relevance.omitted` so the model pages with `offset` |
| `tail_or_head` | `read_file` | Pages bigger than `full_if_under_chars` keep head + tail with an omitted-lines notice; small reads pass through |
| `summary` | `patch`, `write_file` | Keep the compact JSON envelope (success/error, `files_modified`, `resolved_path`, warnings), drop diff bodies |
| `smart_tail` | `terminal` | Trim only the `output` field to head + tail; all other metadata (`exit_code`, spill paths, truncation notes) intact; records `relevance_note` |

## Integration points

- `agent/tool_executor.py` — the single choke point where tool results become `role: "tool"` context messages. Filter runs **after** `maybe_persist_tool_result` (so full outputs are still spilled/persisted on-demand) and **before** subdir-hint injection (so appended AGENTS.md payloads are never trimmed mid-result). Covers concurrent, sequential, and segmented paths (segmented delegates to the first two).
- `tools/tool_result_profiles.py` — filter engine, mirrors the `tools/tool_output_limits.py` pattern (config read once, process-lifetime cache, never raises).
- `hermes_cli/config_defaults.py` — `tool_result_profiles` section with built-in defaults.
- Docs (`website/docs/user-guide/configuration.md`) + desktop settings list (`apps/desktop/.../constants.ts`).

## Design invariants (per AGENTS.md)

- **Fail-open**: unknown tools, disabled config, non-string/malformed output, unparseable JSON all pass through unchanged. No tool result can ever be broken by the config.
- **Shrink-only**: the filter runs before the size caps, so it never raises context above what `tool_output` already allows.
- **Prompt-cache safe**: only new tool messages are affected; past context is untouched.
- No new deps, no env vars, no new core tools.

## Tests

`tests/tools/test_tool_result_profiles.py` — 32 tests:
- config resolution, coercion, disabled/unknown-mode fallbacks, DEFAULT_CONFIG sync
- per-mode behavior (verbose + densified search output, hint-suffix preservation, error-JSON passthrough, head/tail bounds, summary keep-list, terminal metadata preservation)
- fail-open contract over garbage inputs
- **executor wiring E2E**: real `execute_tool_calls_sequential` surface with a mocked dispatch — asserts a 20-match search result lands in the context message bounded to 4 matches, and that disabling the system leaves it untouched

All green locally: `scripts/run_tests.sh tests/tools/test_tool_result_profiles.py` (32/32), plus regression sweeps over tool-output limits, config validation, tool-result storage, dispatch helpers, batch segmentation, incremental persistence, and terminal truncation suites (all pass). Ruff: clean.

Closes #85288