### PR TITLE
Add stable DeepSeek retry identity

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -46,7 +46,6 @@ from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
 logger = logging.getLogger(__name__)
 _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
-
 # When the fallback chain is fully exhausted on a non-rate-limit failure
 # (e.g. every provider returns a non-retryable client error like HTTP 400),
 # arm a short cooldown so the NEXT turn's restore_primary_runtime stays gated

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -25,6 +25,11 @@ import ssl
 import time
 from typing import Any, Dict, List, Optional
 
+from agent.provider_request_identity import (
+    RequestSecretSnapshot,
+    apply_deepseek_request_identity,
+    load_deepseek_identity_secret,
+)
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.conversation_compression import (
     COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
@@ -2442,6 +2447,9 @@ def run_conversation(
         api_kwargs = None  # Guard against UnboundLocalError in except handler
         api_request_id = f"{turn_id}:api:{api_call_count}"
         agent._current_api_request_id = api_request_id
+        _deepseek_identity_secret_for_request = RequestSecretSnapshot(
+            load_deepseek_identity_secret
+        )
 
         while retry_count < max_retries:
             # ── Nous Portal rate limit guard ──────────────────────
@@ -2697,6 +2705,9 @@ def run_conversation(
                         _use_streaming = False
 
                 def _perform_api_call(next_api_kwargs):
+                    # Execution middleware and transport preflight may rewrite
+                    # the payload. Derive identity only after both so it covers
+                    # the final body and actual agent-bound wire destination.
                     if agent.api_mode == "codex_responses":
                         next_api_kwargs = agent._get_transport().preflight_kwargs(
                             next_api_kwargs,
@@ -2704,6 +2715,14 @@ def run_conversation(
                             is_github_responses=agent._is_copilot_url(),
                             sanitize_harmony_tokens=agent._is_codex_backend(),
                         )
+                    next_api_kwargs = apply_deepseek_request_identity(
+                        next_api_kwargs,
+                        api_request_id=api_request_id,
+                        provider=agent.provider,
+                        model=next_api_kwargs.get("model", agent.model),
+                        base_url=agent.base_url,
+                        identity_secret_loader=_deepseek_identity_secret_for_request,
+                    )
                     if _use_streaming:
                         return agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner

--- a/agent/provider_request_identity.py
+++ b/agent/provider_request_identity.py
@@ -1,0 +1,287 @@
+"""Provider-scoped request identity policy for ambiguous retry recovery."""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import stat
+from enum import Enum
+from pathlib import Path
+from urllib.parse import urlparse
+
+_DEEPSEEK_REQUEST_MODELS = {
+    "homelab/deepseek-v4-flash",
+    "homelab/deepseek-v4-flash-0731",
+    "deepseek-v4-flash",
+    "deepseek-v4-flash-0731",
+}
+logger = logging.getLogger(__name__)
+_SECRET_WARNINGS: set[str] = set()
+_ROUTE_OVERRIDE_KEYS = {"api_base", "base_url", "client", "http_client", "provider"}
+_TRANSPORT_KEYS = {
+    "api_key",
+    "client",
+    "http_client",
+    "max_retries",
+    "timeout",
+}
+_SENSITIVE_OR_TRANSPORT_HEADERS = {
+    "accept",
+    "authorization",
+    "baggage",
+    "content-length",
+    "content-type",
+    "cookie",
+    "idempotency-key",
+    "proxy-authorization",
+    "set-cookie",
+    "traceparent",
+    "tracestate",
+    "user-agent",
+    "x-api-key",
+    "x-amzn-trace-id",
+    "x-request-id",
+}
+
+
+def _semantic_headers(headers: dict) -> dict:
+    semantic = {}
+    for name, value in headers.items():
+        normalized = str(name).lower()
+        if (
+            normalized in _SENSITIVE_OR_TRANSPORT_HEADERS
+            or normalized.startswith("x-b3-")
+            or normalized.startswith("x-ot-")
+            or normalized.startswith("x-trace-")
+        ):
+            continue
+        semantic[normalized] = value
+    return semantic
+
+
+def _canonicalize(value):
+    """Represent supported SDK-body values without process-local repr data."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, bytes):
+        return {"__bytes__": value.hex()}
+    if isinstance(value, Enum):
+        return {
+            "__enum__": f"{type(value).__module__}.{type(value).__qualname__}",
+            "value": _canonicalize(value.value),
+        }
+    if isinstance(value, (datetime.date, datetime.time)):
+        return {
+            "__type__": f"{type(value).__module__}.{type(value).__qualname__}",
+            "value": value.isoformat(),
+        }
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {
+            "__dataclass__": f"{type(value).__module__}.{type(value).__qualname__}",
+            "value": _canonicalize(dataclasses.asdict(value)),
+        }
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return {
+            "__model__": f"{type(value).__module__}.{type(value).__qualname__}",
+            "value": _canonicalize(model_dump(mode="json")),
+        }
+    if isinstance(value, dict):
+        return {str(key): _canonicalize(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_canonicalize(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        items = [_canonicalize(item) for item in value]
+        return {
+            "__set__": sorted(
+                items,
+                key=lambda item: json.dumps(
+                    item, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+                ),
+            )
+        }
+    type_name = f"{type(value).__module__}.{type(value).__qualname__}"
+    try:
+        attrs = vars(value)
+    except TypeError as exc:
+        raise TypeError(f"unsupported canonical value: {type_name}") from exc
+    return {"__type__": type_name, "attrs": _canonicalize(attrs)}
+
+
+def _is_transport_control(key, value) -> bool:
+    normalized = str(key).lower()
+    return (
+        normalized in _TRANSPORT_KEYS
+        or normalized.startswith("_")
+        or normalized.startswith("on_")
+        or normalized.endswith("callback")
+        or normalized.endswith("callbacks")
+        or normalized.endswith("hook")
+        or normalized.endswith("hooks")
+        or callable(value)
+    )
+
+
+def _warn_secret_once(reason: str, message: str) -> None:
+    if reason not in _SECRET_WARNINGS:
+        _SECRET_WARNINGS.add(reason)
+        logger.warning(message)
+
+
+def load_deepseek_identity_secret() -> str | None:
+    """Load a valid dedicated HMAC secret from a protected file."""
+    path = os.environ.get("HERMES_DEEPSEEK_IDEMPOTENCY_SECRET_FILE", "").strip()
+    if not path:
+        return None
+    secret_path = Path(path)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(secret_path, flags)
+        try:
+            info = os.fstat(fd)
+            if (
+                not stat.S_ISREG(info.st_mode)
+                or info.st_uid != os.getuid()
+                or info.st_mode & 0o077
+                or info.st_size > 4096
+            ):
+                _warn_secret_once(
+                    "insecure",
+                    "DeepSeek idempotency secret must be a mode-600 regular file owned by the service user and at most 4096 bytes",
+                )
+                return None
+            with os.fdopen(fd, "r", encoding="utf-8") as handle:
+                fd = -1
+                secret = handle.read(4097).strip()
+        finally:
+            if fd >= 0:
+                os.close(fd)
+    except (OSError, UnicodeError):
+        _warn_secret_once("unreadable", "DeepSeek idempotency secret file could not be read")
+        return None
+    if len(secret) < 32:
+        _warn_secret_once(
+            "too-short",
+            "DeepSeek idempotency secret must contain at least 32 characters",
+        )
+        return None
+    return secret
+
+
+class RequestSecretSnapshot:
+    """Lazily pin one secret for all retries of a logical request."""
+
+    def __init__(self, loader):
+        self._loader = loader
+        self._loaded = False
+        self._value = None
+
+    def __call__(self):
+        if not self._loaded:
+            self._value = self._loader()
+            self._loaded = True
+        return self._value
+
+
+def apply_deepseek_request_identity(
+    api_kwargs: dict, *, api_request_id, provider, model, base_url,
+    identity_secret=None,
+    identity_secret_loader=None,
+) -> dict:
+    """Add stable request and idempotency IDs to homelab DeepSeek calls.
+
+    The effective post-middleware model controls the gate. Idempotency hashes
+    cover semantic body, query, and non-sensitive routing headers. Unsupported
+    values fail open: X-Request-ID remains, while Idempotency-Key is omitted.
+    """
+    try:
+        parsed = urlparse(str(base_url or ""))
+        if not isinstance(api_kwargs, dict):
+            return api_kwargs
+        if any(key in api_kwargs for key in _ROUTE_OVERRIDE_KEYS):
+            return api_kwargs
+        effective_model = api_kwargs.get("model", model)
+        effective_destination = {
+            "scheme": parsed.scheme.lower(),
+            "hostname": parsed.hostname,
+            "port": parsed.port or 443,
+            "path": parsed.path or "/",
+            "query": parsed.query,
+        }
+        if (
+            str(provider or "").lower() != "homelab"
+            or parsed.scheme.lower() != "https"
+            or parsed.hostname != "ai.homelab.samaschke.de"
+            or str(effective_model or "").strip().lower()
+            not in _DEEPSEEK_REQUEST_MODELS
+        ):
+            return api_kwargs
+    except Exception:
+        return api_kwargs
+
+    raw_headers = api_kwargs.get("extra_headers")
+    try:
+        headers = dict(raw_headers) if raw_headers is not None else {}
+    except (TypeError, ValueError):
+        return api_kwargs
+
+    header_names = {str(name).lower() for name in headers}
+    request_id = str(api_request_id)
+    if "x-request-id" not in header_names:
+        if re.fullmatch(r"[A-Za-z0-9._:/-]{1,200}", request_id):
+            headers["X-Request-ID"] = request_id
+        else:
+            headers["X-Request-ID"] = "hermes-" + hashlib.sha256(
+                request_id.encode("utf-8", errors="replace")
+            ).hexdigest()[:32]
+
+    canonical_kwargs = {
+        key: value
+        for key, value in api_kwargs.items()
+        if key != "extra_headers" and not _is_transport_control(key, value)
+    }
+    canonical_kwargs["__destination__"] = effective_destination
+    semantic_headers = _semantic_headers(headers)
+    if semantic_headers:
+        canonical_kwargs["extra_headers"] = semantic_headers
+
+    try:
+        canonical = json.dumps(
+            _canonicalize(canonical_kwargs),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+    except Exception:
+        api_kwargs["extra_headers"] = headers
+        return api_kwargs
+
+    if "idempotency-key" not in header_names:
+        if identity_secret is None and callable(identity_secret_loader):
+            try:
+                identity_secret = identity_secret_loader()
+            except Exception:
+                identity_secret = None
+        if not isinstance(identity_secret, str) or not identity_secret:
+            api_kwargs["extra_headers"] = headers
+            return api_kwargs
+        try:
+            material = request_id.encode("utf-8", errors="replace") + b"\0" + canonical
+            hmac_key = hashlib.sha256(
+                b"hermes-deepseek-idempotency-v1\0"
+                + identity_secret.encode("utf-8", errors="strict")
+            ).digest()
+            headers["Idempotency-Key"] = "hermes-" + hmac.new(
+                hmac_key, material, hashlib.sha256
+            ).hexdigest()
+        except Exception:
+            api_kwargs["extra_headers"] = headers
+            return api_kwargs
+    api_kwargs["extra_headers"] = headers
+    return api_kwargs

--- a/tests/test_deepseek_request_identity.py
+++ b/tests/test_deepseek_request_identity.py
@@ -1,0 +1,320 @@
+from agent.provider_request_identity import (
+    RequestSecretSnapshot,
+    apply_deepseek_request_identity,
+    load_deepseek_identity_secret,
+)
+
+
+URL = "https://ai.homelab.samaschke.de/v1"
+KW = {"model": "deepseek-v4-flash", "messages": [{"role": "user", "content": "hi"}]}
+
+
+def apply(kwargs=KW, **overrides):
+    args = dict(
+        provider="homelab",
+        model="deepseek-v4-flash",
+        base_url=URL,
+        identity_secret="stable-gateway-secret",
+    )
+    args.update(overrides)
+    return apply_deepseek_request_identity(
+        dict(kwargs), api_request_id="turn:api:1", **args
+    )
+
+
+def test_secret_loader_is_lazy_for_nonmatching_requests():
+    calls = []
+
+    result = apply_deepseek_request_identity(
+        dict(KW),
+        api_request_id="turn:api:1",
+        provider="other",
+        model="deepseek-v4-flash",
+        base_url=URL,
+        identity_secret_loader=lambda: calls.append(True) or "x" * 32,
+    )
+    assert result == KW
+    assert calls == []
+
+
+def test_gate_requires_provider_https_exact_host_and_model():
+    for args in (
+        {"provider": "other"},
+        {"base_url": "http://ai.homelab.samaschke.de"},
+        {"base_url": "https://ai.homelab.samaschke.de.evil"},
+        {"base_url": "https://evil.ai.homelab.samaschke.de"},
+    ):
+        original = dict(KW)
+        assert apply(original, **args) == original
+        assert "extra_headers" not in original
+
+    unsupported = {**KW, "model": "deepseek-v3"}
+    assert apply(unsupported) == unsupported
+    assert "extra_headers" not in unsupported
+
+
+def test_destination_fingerprint_preserves_path_and_query_semantics():
+    base = apply(KW, base_url=URL)
+    trailing_slash = apply(KW, base_url=URL + "/")
+    changed_path = apply(KW, base_url="https://ai.homelab.samaschke.de/experimental")
+    first_query_order = apply(KW, base_url=URL + "?route=a&route=b")
+    second_query_order = apply(KW, base_url=URL + "?route=b&route=a")
+    keys = {
+        base["extra_headers"]["Idempotency-Key"],
+        trailing_slash["extra_headers"]["Idempotency-Key"],
+        changed_path["extra_headers"]["Idempotency-Key"],
+        first_query_order["extra_headers"]["Idempotency-Key"],
+        second_query_order["extra_headers"]["Idempotency-Key"],
+    }
+    assert len(keys) == 5
+
+
+def test_route_or_client_overrides_disable_provider_policy():
+    for override in (
+        {"base_url": "https://other.example/v1"},
+        {"api_base": "https://other.example/v1"},
+        {"provider": "other"},
+        {"client": object()},
+        {"http_client": object()},
+    ):
+        result = apply({**KW, **override})
+        assert "extra_headers" not in result
+
+
+def test_post_middleware_payload_model_controls_the_gate():
+    rewritten_away = apply(
+        {**KW, "model": "homelab/gpt-5.6-luna"},
+        model="deepseek-v4-flash",
+    )
+    assert "extra_headers" not in rewritten_away
+
+    rewritten_to_deepseek = apply(
+        {**KW, "model": "homelab/deepseek-v4-flash"},
+        model="homelab/gpt-5.6-luna",
+    )
+    assert "X-Request-ID" in rewritten_to_deepseek["extra_headers"]
+    assert "Idempotency-Key" in rewritten_to_deepseek["extra_headers"]
+
+
+def test_provider_and_payload_model_aliases_are_supported():
+    for model in (
+        "homelab/deepseek-v4-flash",
+        "homelab/deepseek-v4-flash-0731",
+        "deepseek-v4-flash",
+        "deepseek-v4-flash-0731",
+    ):
+        result = apply(
+            {**KW, "model": model},
+            model="homelab/gpt-5.6-luna",
+            provider="HOMELAB",
+        )
+        assert "X-Request-ID" in result["extra_headers"]
+        assert "Idempotency-Key" in result["extra_headers"]
+
+
+def test_existing_headers_are_preserved_case_insensitively():
+    headers = {"x-request-id": "caller-id", "IDEMPOTENCY-KEY": "caller-key", "X-Other": "v"}
+    result = apply({**KW, "extra_headers": headers})
+    assert result["extra_headers"] == headers
+
+
+def test_key_is_stable_across_independent_calls_with_same_service_secret():
+    first = apply({**KW, "functions": [{"name": "one"}]})
+    second = apply({**KW, "functions": [{"name": "one"}]})
+    changed_legacy_body = apply({**KW, "functions": [{"name": "two"}]})
+    assert first["extra_headers"]["Idempotency-Key"] == second["extra_headers"]["Idempotency-Key"]
+    assert first["extra_headers"]["Idempotency-Key"] != changed_legacy_body["extra_headers"]["Idempotency-Key"]
+
+
+def test_dedicated_secret_loader_reads_protected_file(monkeypatch, tmp_path):
+    secret_file = tmp_path / "idempotency.secret"
+    secret_file.write_text("dedicated-secret-with-at-least-32-chars\n")
+    secret_file.chmod(0o600)
+    monkeypatch.setenv(
+        "HERMES_DEEPSEEK_IDEMPOTENCY_SECRET_FILE", str(secret_file)
+    )
+    assert load_deepseek_identity_secret() == "dedicated-secret-with-at-least-32-chars"
+
+
+def test_dedicated_secret_loader_rejects_insecure_special_and_oversized_files(
+    monkeypatch, tmp_path
+):
+    secret_file = tmp_path / "insecure.secret"
+    monkeypatch.setenv(
+        "HERMES_DEEPSEEK_IDEMPOTENCY_SECRET_FILE", str(secret_file)
+    )
+    secret_file.write_text("x" * 32)
+    secret_file.chmod(0o644)
+    assert load_deepseek_identity_secret() is None
+
+    target = tmp_path / "target.secret"
+    target.write_text("y" * 32)
+    target.chmod(0o600)
+    secret_file.unlink()
+    secret_file.symlink_to(target)
+    assert load_deepseek_identity_secret() is None
+
+    secret_file.unlink()
+    secret_file.write_text("z" * 4097)
+    secret_file.chmod(0o600)
+    assert load_deepseek_identity_secret() is None
+
+
+def test_dedicated_secret_loader_recovers_after_transient_failure(monkeypatch, tmp_path):
+    secret_file = tmp_path / "late.secret"
+    monkeypatch.setenv(
+        "HERMES_DEEPSEEK_IDEMPOTENCY_SECRET_FILE", str(secret_file)
+    )
+    assert load_deepseek_identity_secret() is None
+    secret_file.write_text("late-secret-with-at-least-32-characters")
+    secret_file.chmod(0o600)
+    assert load_deepseek_identity_secret() == "late-secret-with-at-least-32-characters"
+
+
+def test_logical_request_snapshot_pins_secret_across_retries():
+    secrets = iter(("a" * 32, "b" * 32))
+    snapshot = RequestSecretSnapshot(lambda: next(secrets))
+    assert snapshot() == "a" * 32
+    assert snapshot() == "a" * 32
+
+
+def test_dedicated_secret_loader_observes_atomic_rotation(monkeypatch, tmp_path):
+    secret_file = tmp_path / "rotated.secret"
+    monkeypatch.setenv(
+        "HERMES_DEEPSEEK_IDEMPOTENCY_SECRET_FILE", str(secret_file)
+    )
+    secret_file.write_text("first-secret-with-at-least-32-characters")
+    secret_file.chmod(0o600)
+    assert load_deepseek_identity_secret().startswith("first-secret")
+    replacement = tmp_path / "replacement.secret"
+    replacement.write_text("second-secret-with-at-least-32-characters")
+    replacement.chmod(0o600)
+    replacement.replace(secret_file)
+    assert load_deepseek_identity_secret().startswith("second-secret")
+
+
+def test_missing_stable_secret_keeps_request_id_but_omits_idempotency():
+    result = apply(KW, identity_secret=None)
+    assert result["extra_headers"]["X-Request-ID"] == "turn:api:1"
+    assert "Idempotency-Key" not in result["extra_headers"]
+
+
+def test_malformed_stable_secret_fails_open():
+    result = apply(KW, identity_secret="bad\ud800secret")
+    assert result["extra_headers"]["X-Request-ID"] == "turn:api:1"
+    assert "Idempotency-Key" not in result["extra_headers"]
+
+
+def test_key_is_stable_for_ordering_and_changes_with_payload():
+    first = apply({**KW, "extra_body": {"b": 2, "a": 1}})
+    second = apply({**KW, "extra_body": {"a": 1, "b": 2}})
+    changed = apply({**KW, "extra_body": {"a": 1, "b": 3}})
+    assert first["extra_headers"]["Idempotency-Key"] == second["extra_headers"]["Idempotency-Key"]
+    assert first["extra_headers"]["Idempotency-Key"] != changed["extra_headers"]["Idempotency-Key"]
+
+
+def test_transport_settings_and_credentials_do_not_change_semantic_key():
+    first = apply({
+        **KW,
+        "timeout": 30,
+        "api_key": "low-entropy-secret-a",
+        "extra_headers": {"Authorization": "Bearer secret-a"},
+    })
+    second = apply({
+        **KW,
+        "timeout": 900,
+        "api_key": "low-entropy-secret-b",
+        "extra_headers": {"Authorization": "Bearer secret-b"},
+    })
+    assert first["extra_headers"]["Idempotency-Key"] == second["extra_headers"]["Idempotency-Key"]
+    assert first["extra_headers"]["Authorization"] == "Bearer secret-a"
+    assert second["extra_headers"]["Authorization"] == "Bearer secret-b"
+
+
+def test_semantic_route_headers_and_query_change_the_key():
+    base = apply({
+        **KW,
+        "extra_headers": {"Authorization": "Bearer secret", "X-Route": "one"},
+        "extra_query": {"provider": "a"},
+    })
+    changed_route = apply({
+        **KW,
+        "extra_headers": {"Authorization": "Bearer other", "X-Route": "two"},
+        "extra_query": {"provider": "a"},
+    })
+    changed_query = apply({
+        **KW,
+        "extra_headers": {"Authorization": "Bearer secret", "X-Route": "one"},
+        "extra_query": {"provider": "b"},
+    })
+    keys = {
+        base["extra_headers"]["Idempotency-Key"],
+        changed_route["extra_headers"]["Idempotency-Key"],
+        changed_query["extra_headers"]["Idempotency-Key"],
+    }
+    assert len(keys) == 3
+
+
+def test_runtime_controls_do_not_change_semantic_key():
+    def first_callback():
+        return None
+
+    def second_callback():
+        return None
+
+    first = apply({**KW, "on_progress": first_callback, "max_retries": 1})
+    second = apply({**KW, "on_progress": second_callback, "max_retries": 9})
+    assert first["extra_headers"]["Idempotency-Key"] == second["extra_headers"]["Idempotency-Key"]
+
+
+def test_semantic_header_names_are_case_insensitive():
+    first = apply({**KW, "extra_headers": {"X-Route": "one"}})
+    second = apply({**KW, "extra_headers": {"x-route": "one"}})
+    assert first["extra_headers"]["Idempotency-Key"] == second["extra_headers"]["Idempotency-Key"]
+
+
+def test_opaque_semantic_value_fails_open_instead_of_collapsing_by_type():
+    class Opaque:
+        __slots__ = ("value",)
+
+        def __init__(self, value):
+            self.value = value
+
+    result = apply({**KW, "metadata": Opaque("distinct")})
+    assert result["extra_headers"]["X-Request-ID"] == "turn:api:1"
+    assert "Idempotency-Key" not in result["extra_headers"]
+
+
+def test_cyclic_semantic_value_keeps_request_id_and_omits_idempotency_key():
+    cyclic = []
+    cyclic.append(cyclic)
+    result = apply({**KW, "metadata": cyclic})
+    assert result["extra_headers"]["X-Request-ID"] == "turn:api:1"
+    assert "Idempotency-Key" not in result["extra_headers"]
+
+
+def test_invalid_header_mapping_is_not_silently_replaced():
+    class InvalidHeaders:
+        def keys(self):
+            raise TypeError("not a mapping")
+
+    kwargs = {**KW, "extra_headers": InvalidHeaders()}
+    result = apply(kwargs)
+    assert result["extra_headers"] is kwargs["extra_headers"]
+
+
+def test_invalid_request_id_uses_safe_deterministic_fallback():
+    result = apply_deepseek_request_identity(
+        dict(KW), api_request_id="bad\nrequest", provider="homelab",
+        model="deepseek-v4-flash", base_url=URL,
+        identity_secret="stable-gateway-secret",
+    )
+    request_id = result["extra_headers"]["X-Request-ID"]
+    assert request_id.startswith("hermes-")
+    assert len(request_id) == len("hermes-") + 32
+
+
+def test_existing_extra_headers_are_retained():
+    result = apply({**KW, "extra_headers": {"X-Custom": "keep"}})
+    assert result["extra_headers"]["X-Custom"] == "keep"
+    assert result["extra_headers"]["X-Request-ID"] == "turn:api:1"


### PR DESCRIPTION
## Summary
- derive stable request and idempotency identity at the final execution boundary for homelab DeepSeek requests
- HMAC the semantic wire request and exact destination with a dedicated protected secret
- pin the secret per logical request across retries while allowing new requests to observe atomic rotation
- reject route/client overrides and fail open without leaking credentials or payload hashes

## Verification
- 44/44 targeted and adjacent current-main tests
- review PASS on current main and production backport
- production backport tests 46/46; deployed-source policy tests 25/25
- dedicated secret is a bounded, regular, owner-only mode-600 file