### PR TITLE
fix(state): surface /new (session_reset) child sessions + stop resume hijack

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8974,6 +8974,30 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if row is not None:
                     best = current
 
+                # Only follow children of sessions that ENDED in compression
+                # (`end_reason='compression'`). A `/new`/`/reset` chain ends the
+                # parent with `end_reason='session_reset'` — a deliberate new
+                # conversation whose parent transcript stays its own history.
+                # Following it hijacks resume/transcript loads to the newest
+                # reset descendant (desktop: clicking a parent session showed
+                # the newest session's messages instead). This mirrors
+                # `get_compression_tip()`, which already gates on the parent's
+                # end_reason. See #84284.
+                try:
+                    parent_row = self._conn.execute(
+                        "SELECT end_reason FROM sessions WHERE id = ?",
+                        (current,),
+                    ).fetchone()
+                except Exception:
+                    return session_id
+                if parent_row is None:
+                    break
+                parent_reason = (
+                    parent_row["end_reason"] if hasattr(parent_row, "keys") else parent_row[0]
+                )
+                if parent_reason != "compression":
+                    break
+
                 # Walk to the most-recently-started child — but skip explicit
                 # branch (`_branched_from`), delegate/subagent (`_delegate_from`),
                 # and tool children. They also carry a ``parent_session_id`` yet

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -86,7 +86,7 @@ _BRANCH_CHILD_SQL = (
     "json_extract(COALESCE({a}.model_config, '{{}}'), '$._branched_from') IS NOT NULL"
     " OR EXISTS (SELECT 1 FROM sessions p"
     "            WHERE p.id = {a}.parent_session_id"
-    "            AND p.end_reason = 'branched'"
+    "            AND p.end_reason IN ('branched', 'session_reset')"
     "            AND {a}.started_at >= p.ended_at)"
 )
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1993,6 +1993,125 @@ class TestCompressionChainProjection:
         assert db.get_compression_tip("mid1") == "tip1"
         assert db.get_compression_tip("tip1") == "tip1"
 
+    def test_resolve_resume_session_id_does_not_follow_new_reset_chain(self, db):
+        """A /new (session_reset) chain must NOT redirect resume/transcript
+        loads to the newest descendant: each reset is a deliberate new
+        conversation, and the parent's own transcript stays its history.
+        Regression for the desktop bug where clicking a parent session
+        showed the newest session's messages (#84284)."""
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("parent", "cli")
+        db._conn.execute("UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?", (t0, t0 + 100, "session_reset", "parent"))
+        db.append_message("parent", "user", "parent history")
+
+        db.create_session("child", "cli", parent_session_id="parent")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 200, "child"))
+        db.append_message("child", "user", "child conversation")
+        db._conn.commit()
+
+        assert db.resolve_resume_session_id("parent") == "parent"
+        assert db.resolve_resume_session_id("child") == "child"
+
+    def test_resolve_resume_session_id_follows_compression_chain(self, db):
+        """Compression continuations are still followed: the descendant that
+        holds the live messages is the resume target."""
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("rootc", "cli")
+        db.append_message("rootc", "user", "pre-compression")
+        db._conn.execute("UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?", (t0, t0 + 100, "compression", "rootc"))
+
+        db.create_session("contc", "cli", parent_session_id="rootc")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 200, "contc"))
+        db.append_message("contc", "user", "continuation")
+        db._conn.commit()
+
+        assert db.resolve_resume_session_id("rootc") == "contc"
+
+    def test_resolve_resume_session_id_compression_empty_head_walk(self, db):
+        """Compression parent with no flushed messages still walks to the
+        child that holds the content (legacy empty-head case)."""
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("rootempty", "cli")
+        db._conn.execute("UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?", (t0, t0 + 100, "compression", "rootempty"))
+
+        db.create_session("childfull", "cli", parent_session_id="rootempty")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 200, "childfull"))
+        db.append_message("childfull", "user", "only content here")
+        db._conn.commit()
+
+        assert db.resolve_resume_session_id("rootempty") == "childfull"
+
+    def test_list_sessions_rich_includes_session_reset_children(self, db):
+        """A /new chain (parent ended with session_reset) must be visible in
+        session lists. Regression: the listability filter only allowed
+        branch children, so the current session of a /new chain never
+        appeared in the desktop sidebar while being perfectly functional."""
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("reset_parent", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?",
+            (t0, t0 + 100, "session_reset", "reset_parent"),
+        )
+        db.create_session("reset_child", "cli", parent_session_id="reset_parent")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 200, "reset_child"))
+        db.append_message("reset_child", "user", "current conversation")
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        ids = [s["id"] for s in sessions]
+        assert "reset_parent" in ids
+        assert "reset_child" in ids  # visible even though parent ended with session_reset
+
+    def test_list_sessions_rich_excludes_delegate_children(self, db):
+        """Transient delegate/subagent children (parent ended with
+        agent_close) stay hidden: the widened filter must not surface
+        every child, only deliberate /new conversations."""
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("delegate_parent", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?",
+            (t0, t0 + 100, "agent_close", "delegate_parent"),
+        )
+        db.create_session("delegate_child", "subagent", parent_session_id="delegate_parent")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 200, "delegate_child"))
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        ids = [s["id"] for s in sessions]
+        assert "delegate_parent" in ids
+        assert "delegate_child" not in ids
+
+    def test_list_sessions_rich_still_includes_branch_children(self, db):
+        """Branch children (parent ended with branched) remain visible —
+        no regression from widening the filter."""
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("branch_parent", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?",
+            (t0, t0 + 100, "branched", "branch_parent"),
+        )
+        db.create_session("branch_child", "cli", parent_session_id="branch_parent")
+        db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 200, "branch_child"))
+        db.append_message("branch_child", "user", "branch content")
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(source="cli", limit=20)
+        ids = [s["id"] for s in sessions]
+        assert "branch_parent" in ids
+        assert "branch_child" in ids
+
 
 
     def test_list_surfaces_tip_for_compressed_root(self, db):


### PR DESCRIPTION
## Summary

Two related session-lineage fixes for `/new` chains (the desktop app showed wrong/incomplete session lists):

1. **list_sessions_rich** — `_BRANCH_CHILD_SQL` only listed children whose parent ended with `end_reason='branched'`. `/new` ends the parent with `'session_reset'`, so the **current session of every `/new` chain was missing** from sidebar/desktop session lists while remaining fully functional. This widens the filter to also accept `'session_reset'` parents (deliberate new conversations), while keeping transient delegate/subagent children hidden.

2. **resolve_resume_session_id** — the legacy walk followed `/new` descendants, hijacking transcript loads to the newest reset child: clicking a parent session in the desktop app showed the **newest session's messages** instead. The walk is now gated on the parent's `end_reason` being `'compression'` only, mirroring `get_compression_tip()`. **Fixes #84284.**

## Test Plan

- 6 new unit tests in `TestCompressionChainProjection`:
  - 3 resume-walk cases (reset chain not followed / compression chain followed / empty-head compression walk)
  - 3 listability cases (session_reset child visible / delegate child still hidden / branch child still visible)
- Verified locally: `pytest tests/test_hermes_state.py -k "list or session_reset or compression or resolve"` → **37 passed**
- Live verification on our instance: after the fix, the previously missing `/new` chain sessions appeared in the dashboard session list.
