### PR TITLE
fix: route image.generate through the provider dispatcher

### DIFF
--- a/tui_gateway/methods_images.py
+++ b/tui_gateway/methods_images.py
@@ -97,9 +97,13 @@ def _(rid, params: dict) -> dict:
         cap = 8_000_000
 
     try:
-        from tools.image_generation_tool import image_generate_tool
+        from tools.image_generation_tool import _handle_image_generate
 
-        raw = image_generate_tool(prompt=prompt, aspect_ratio=aspect)
+        # Full provider dispatcher — the same path the model tool takes:
+        # source-image confinement, plugin-registered providers, managed
+        # Krea routing, then the in-tree FAL fallback. Calling the FAL leaf
+        # (image_generate_tool) directly here bypassed configured providers.
+        raw = _handle_image_generate({"prompt": prompt, "aspect_ratio": aspect})
         result = json.loads(raw)
     except Exception as e:
         return _err(rid, 5071, str(e))


### PR DESCRIPTION
## What

Follow-up defect in #85183, reported by a Hermes-Bot-Mode plugin user: the `image.generate` ws handler called the in-tree FAL leaf (`image_generate_tool`) directly instead of `_handle_image_generate`, the dispatcher the model tool uses. Consequence: plugin-registered image providers and managed Krea routing were silently bypassed — a user with a non-FAL provider configured got FAL (or a failure) from the RPC while the model tool honored their provider.

Swapping to the dispatcher also picks up source-image confinement, keeping the RPC's behavior identical to the model tool's.

## Verification

Live registry round-trip with the dispatcher in place: probe `{available: true}`, real generation via the full chain (plugin dispatch → Krea routing → FAL fallback on this config) returned `success: true` + hosted URL + 4.7MB data URL. Dispatcher-first ordering confirmed by reading `_handle_image_generate` (confine → plugin → managed Krea → FAL leaf). Error shapes (`tool_error` JSON) flow through the existing soft-fail branch unchanged.