### PR TITLE
fix(delegation): preflight coding runtimes and cancel process groups

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,6 +11,7 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
+import subprocess
 import threading
 import time
 import types
@@ -132,11 +133,34 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertNotIn("max_spawn_depth", overrides["description"])
 
 class TestChildSystemPrompt(unittest.TestCase):
-    def test_goal_only(self):
+    @patch(
+        "tools.delegate_tool._coding_runtime_preflight",
+        return_value="Claude CLI (not authenticated); Codex CLI (authenticated).",
+    )
+    def test_goal_only(self, _preflight):
         prompt = _build_child_system_prompt("Fix the tests")
         self.assertIn("Fix the tests", prompt)
         self.assertIn("YOUR TASK", prompt)
         self.assertNotIn("CONTEXT", prompt)
+        self.assertIn("EXTERNAL CODING RUNTIME PREFLIGHT", prompt)
+        self.assertIn("Codex CLI (authenticated)", prompt)
+
+    @patch("tools.delegate_tool.subprocess.run")
+    @patch("tools.delegate_tool.shutil.which")
+    def test_coding_runtime_preflight_rejects_logged_out_cli(self, which, run):
+        from tools import delegate_tool
+
+        which.side_effect = lambda name: f"/usr/bin/{name}"
+        run.side_effect = [
+            subprocess.CompletedProcess([], 1),
+            subprocess.CompletedProcess([], 0),
+        ]
+
+        result = delegate_tool._coding_runtime_preflight()
+
+        self.assertIn("Claude CLI (not authenticated)", result)
+        self.assertIn("Codex CLI (authenticated)", result)
+        self.assertEqual(run.call_count, 2)
 
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2,11 +2,14 @@
 
 import json
 import os
+import shlex
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
+from pathlib import Path
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -1097,6 +1100,54 @@ class TestKillProcess:
             assert ("terminate", 424242) in terminate_calls
         finally:
             registry._running.pop(s.id, None)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+@pytest.mark.live_system_guard_bypass
+def test_kill_process_terminates_descendant_after_wrapper_exits(registry):
+    """Cancellation reaches group children even after their shell exits."""
+    child_pid_file = Path(tempfile.mkstemp(prefix="hermes-child-pid-")[1])
+    child_pid_file.unlink()
+    code = (
+        "import os,time,pathlib; "
+        f"pathlib.Path({str(child_pid_file)!r}).write_text(str(os.getpid())); "
+        "devnull=os.open(os.devnull, os.O_WRONLY); "
+        "os.dup2(devnull, 1); os.dup2(devnull, 2); "
+        "time.sleep(30)"
+    )
+    session = registry.spawn_local(
+        f"{shlex.quote(sys.executable)} -c {shlex.quote(code)} &"
+    )
+    try:
+        assert _wait_until(child_pid_file.exists, timeout=5.0)
+        child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+        assert _wait_until(
+            lambda: session.process.poll() is not None,
+            timeout=5.0,
+        ), "wrapper did not exit"
+        assert _wait_until(lambda: session.exited, timeout=5.0)
+
+        result = registry.kill_process(session.id)
+
+        assert result["status"] == "already_exited"
+        import psutil
+
+        assert _wait_until(
+            lambda: not psutil.pid_exists(child_pid)
+            or psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE,
+            timeout=5.0,
+        ), "descendant survived tracked cancellation"
+    finally:
+        child_pid_file.unlink(missing_ok=True)
+        if 'child_pid' in locals():
+            try:
+                import psutil
+
+                child = psutil.Process(child_pid)
+                if child.status() != psutil.STATUS_ZOMBIE:
+                    child.kill()
+            except psutil.NoSuchProcess:
+                pass
 
 
 # =========================================================================

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -22,6 +22,8 @@ import contextvars
 import json
 import logging
 import re
+import shutil
+import subprocess
 
 logger = logging.getLogger(__name__)
 import os
@@ -1058,6 +1060,46 @@ def check_delegate_requirements() -> bool:
     return True
 
 
+def _coding_runtime_preflight() -> str:
+    """Describe authenticated external coding CLIs available to a child."""
+    checks = (
+        ("Claude CLI", "claude", ["auth", "status"]),
+        ("Codex CLI", "codex", ["login", "status"]),
+    )
+    available: List[str] = []
+    unavailable: List[str] = []
+    for label, binary, args in checks:
+        executable = shutil.which(binary)
+        if not executable:
+            unavailable.append(f"{label} (not installed)")
+            continue
+        try:
+            result = subprocess.run(
+                [executable, *args],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            unavailable.append(f"{label} (authentication check failed)")
+            continue
+        if result.returncode == 0:
+            available.append(f"{label} (authenticated)")
+        else:
+            unavailable.append(f"{label} (not authenticated)")
+
+    selection = (
+        f"Authenticated external runtimes: {', '.join(available)}."
+        if available
+        else "No authenticated external coding CLI is available."
+    )
+    if unavailable:
+        selection += f" Do not launch: {', '.join(unavailable)}."
+    return selection
+
+
 def _build_child_system_prompt(
     goal: str,
     context: Optional[str] = None,
@@ -1101,6 +1143,12 @@ def _build_child_system_prompt(
         "points over paragraphs, and don't replay your whole process. Your "
         "response is returned to the parent agent as a summary, and overlong "
         "summaries crowd out the parent's context window."
+    )
+    parts.append(
+        "\nEXTERNAL CODING RUNTIME PREFLIGHT:\n"
+        f"{_coding_runtime_preflight()} "
+        "Use an authenticated runtime listed above or continue with native "
+        "Hermes tools; do not launch an unavailable runtime to rediscover the failure."
     )
     if role == "orchestrator":
         child_note = (

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -371,6 +371,7 @@ class ProcessSession:
     task_id: str = ""                           # Task/sandbox isolation key
     session_key: str = ""                       # Gateway session key (for reset protection)
     pid: Optional[int] = None                   # OS process ID
+    process_group_id: Optional[int] = None     # Owned POSIX group captured at spawn
     process: Optional[subprocess.Popen] = None  # Popen handle (local only)
     env_ref: Any = None                         # Reference to the environment object
     cwd: Optional[str] = None                   # Working directory
@@ -948,6 +949,70 @@ class ProcessRegistry:
             except (psutil.AccessDenied, OSError):
                 pass
 
+    @classmethod
+    def _terminate_owned_process_group(
+        cls,
+        pid: int,
+        process_group_id: Optional[int],
+        expected_start: Optional[int] = None,
+    ) -> bool:
+        """Terminate one process group created by ``spawn_local``.
+
+        Capturing the group at spawn avoids the race where the shell exits and
+        its descendants are reparented before a later process-tree walk. The
+        leader identity is revalidated, and Hermes' own group is never touched.
+        """
+        if _IS_WINDOWS or not process_group_id:
+            return False
+        if expected_start is not None and not cls._host_pid_is_ours(pid, expected_start):
+            # A reaped group leader is expected when a wrapper exits before its
+            # children. A live PID with the same number is a reuse hazard and
+            # must fail closed; an absent leader cannot own a newly reused group.
+            try:
+                os.getpgid(pid)  # windows-footgun: ok — guarded above
+            except ProcessLookupError:
+                pass
+            except (PermissionError, OSError):
+                return False
+            else:
+                return False
+        try:
+            if process_group_id == os.getpgrp():
+                logger.error(
+                    "Refusing to terminate process group %d because Hermes belongs to it",
+                    process_group_id,
+                )
+                return False
+        except OSError:
+            return False
+
+        def _group_alive() -> bool:
+            try:
+                os.killpg(process_group_id, 0)  # windows-footgun: ok — guarded above
+                return True
+            except ProcessLookupError:
+                return False
+            except PermissionError:
+                return True
+
+        try:
+            os.killpg(process_group_id, signal.SIGTERM)  # windows-footgun: ok — guarded above
+        except ProcessLookupError:
+            return True
+        except (PermissionError, OSError):
+            return False
+
+        grace = cls._daemon_term_grace_seconds()
+        deadline = time.monotonic() + grace
+        while grace > 0 and time.monotonic() < deadline and _group_alive():
+            time.sleep(0.05)
+        if grace > 0 and _group_alive():
+            try:
+                os.killpg(process_group_id, signal.SIGKILL)  # windows-footgun: ok — guarded above
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+        return True
+
     # ----- Spawn -----
 
     @staticmethod
@@ -1152,6 +1217,11 @@ class ProcessRegistry:
         session.process = proc
         session.pid = proc.pid
         session.host_start_time = self._safe_host_start_time(session.pid)
+        if not _IS_WINDOWS:
+            try:
+                session.process_group_id = os.getpgid(proc.pid)
+            except ProcessLookupError:
+                session.process_group_id = None
 
         try:
             # Start output reader thread
@@ -2038,6 +2108,12 @@ class ProcessRegistry:
             # unit cleanup).  Stop the scope to reap any survivors.
             if session.systemd_unit:
                 _stop_systemd_unit(session.systemd_unit)
+            elif session.process_group_id:
+                self._terminate_owned_process_group(
+                    session.pid or session.process_group_id,
+                    session.process_group_id,
+                    session.host_start_time,
+                )
             with session._lock:
                 result = {
                     "status": "already_exited",
@@ -2066,7 +2142,12 @@ class ProcessRegistry:
                 # Local process -- kill the process tree. On Windows this
                 # must be taskkill /T /F; Popen.terminate() only kills the
                 # shell wrapper and leaves Git Bash descendants behind.
-                self._terminate_host_pid(session.process.pid, session.host_start_time)
+                if not self._terminate_owned_process_group(
+                    session.process.pid,
+                    session.process_group_id,
+                    session.host_start_time,
+                ):
+                    self._terminate_host_pid(session.process.pid, session.host_start_time)
             elif session.env_ref and session.pid:
                 # Non-local -- kill inside sandbox
                 session.env_ref.execute(f"kill {session.pid} 2>/dev/null", timeout=5)


### PR DESCRIPTION
## Problem
Delegated writers could select an installed but unauthenticated Claude CLI, and tracked process cancellation could miss descendants after the shell wrapper exited.

## Fix
- Probe Claude and Codex CLI authentication before constructing delegated child prompts, and direct children to an authenticated runtime or native Hermes tools.
- Capture the POSIX process group created for each local background process and cancel that owned group, including the already-exited-wrapper path.
- Preserve PID reuse and Hermes-own-group guards; Windows keeps the existing tree-kill path.

## Verification
- `.venv/bin/python -m pytest tests/tools/test_delegate.py tests/tools/test_process_registry.py -q` — 139 passed, 5 skipped
- `.venv/bin/ruff check tools/delegate_tool.py tools/process_registry.py tests/tools/test_delegate.py tests/tools/test_process_registry.py`
- `git diff --check`
- Real local auth state reproduced: Claude `auth status` exit 1 / loggedIn false; Codex `login status` exit 0.

No CCM behavior, data, schema, API, deployment, or live-trading changes.