### PR TITLE
feat(desktop): multiprofile group chats — @mention profiles into one conversation

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-at-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-at-completions.ts
@@ -5,12 +5,13 @@ import { refChipLabel } from '@/components/assistant-ui/directive-text'
 import type { HermesGateway } from '@/hermes'
 import { cachedPathCompletion, hasCachedPathCompletion } from '@/lib/slash-completion-cache'
 import { normalize } from '@/lib/text'
+import { $profiles } from '@/store/profile'
 
 import type { CompletionEntry, CompletionPayload } from './use-live-completion-adapter'
 import { useLiveCompletionAdapter } from './use-live-completion-adapter'
 
-const KIND_RE = /^@(file|folder|url|image|tool|git):(.*)$/
-const REF_STARTERS = new Set(['file', 'folder', 'url', 'image', 'tool', 'git'])
+const KIND_RE = /^@(file|folder|url|image|tool|git|profile):(.*)$/
+const REF_STARTERS = new Set(['file', 'folder', 'url', 'image', 'tool', 'git', 'profile'])
 
 const STARTER_META: Record<string, string> = {
   file: 'Attach a file reference',
@@ -18,7 +19,8 @@ const STARTER_META: Record<string, string> = {
   url: 'Attach a URL reference',
   image: 'Attach an image reference',
   tool: 'Attach a tool reference',
-  git: 'Attach git context'
+  git: 'Attach git context',
+  profile: 'Address an agent profile'
 }
 
 function starterEntries(query: string): CompletionEntry[] {
@@ -31,6 +33,26 @@ function starterEntries(query: string): CompletionEntry[] {
     display: `@${kind}:`,
     meta: STARTER_META[kind] || ''
   }))
+}
+
+/** `@profile:` completions come from the renderer's own profile cache — the
+ *  list is already in `$profiles` (refreshed by the rail), so unlike paths
+ *  there is no gateway round trip and no debounce to pay. */
+function profileEntries(query: string): CompletionEntry[] {
+  const q = normalize(query)
+
+  return $profiles
+    .get()
+    .filter(profile => {
+      const name = normalize(profile.name)
+
+      return name !== 'default' && (!q || name.startsWith(q) || name.includes(q))
+    })
+    .map(profile => ({
+      text: `@profile:${profile.name}`,
+      display: profile.name,
+      meta: 'Profile'
+    }))
 }
 
 interface AtItemMetadata extends Record<string, string> {
@@ -100,6 +122,17 @@ export function useAtCompletions(options: {
     async (query: string): Promise<CompletionPayload> => {
       const starters = starterEntries(query)
 
+      // Profile refs never touch the gateway: `@profile:` (or a partial name
+      // after it) resolves against the local $profiles cache synchronously.
+      if (query === 'profile' || query.startsWith('profile:')) {
+        const partial = query.startsWith('profile:') ? query.slice('profile:'.length) : ''
+        const profiles = profileEntries(partial)
+
+        if (profiles.length > 0) {
+          return { items: profiles, query }
+        }
+      }
+
       if (!gateway) {
         return { items: starters, query }
       }
@@ -127,7 +160,14 @@ export function useAtCompletions(options: {
 
         const items = result.items ?? []
 
-        return { items: items.length > 0 ? items : starters, query }
+        // A bare `@bab` should offer the babe profile alongside path hits —
+        // addressing a profile is typed like any chat mention, not via the
+        // `@profile:` starter. Profiles lead: a name match is near-certain
+        // intent, path noise for 4-letter queries is not.
+        const profileMatches = query && !query.includes(':') && !query.includes('/') ? profileEntries(query) : []
+        const merged = profileMatches.length > 0 ? [...profileMatches, ...items] : items
+
+        return { items: merged.length > 0 ? merged : starters, query }
       } catch {
         return { items: starters, query }
       }

--- a/apps/desktop/src/app/chat/group-member-strip.tsx
+++ b/apps/desktop/src/app/chat/group-member-strip.tsx
@@ -1,0 +1,63 @@
+/**
+ * Member strip: the room's roster, rendered as ProfileGlyphs beside the
+ * session's own ProfileTag once a chat has become a group. Invisible until
+ * then — a plain chat pays one store read and renders nothing.
+ *
+ * Each glyph carries the per-member actions on its context menu (mute /
+ * remove), mirroring ProfileSquare in the rail — the square/glyph IS the home
+ * for per-profile actions everywhere in the app.
+ */
+
+import { useStore } from '@nanostores/react'
+import type { FC } from 'react'
+
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
+import { ProfileGlyph } from '@/components/ui/profile-glyph'
+import { Tip } from '@/components/ui/tooltip'
+import { resolveProfileColor } from '@/lib/profile-color'
+import { cn } from '@/lib/utils'
+import { $groupChats, removeGroupMember, setMemberMuted } from '@/store/group-chat'
+import { $profileColors } from '@/store/profile'
+
+export const GroupMemberStrip: FC<{ sessionId: null | string }> = ({ sessionId }) => {
+  const groups = useStore($groupChats)
+  const colors = useStore($profileColors)
+
+  const groupId = sessionId ? `session:${sessionId}` : null
+  const group = groupId ? groups[groupId] : null
+  const members = group ? group.members.filter(member => !member.host) : []
+
+  if (!groupId || members.length === 0) {
+    return null
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1" data-slot="group-member-strip">
+      {members.map(member => (
+        <ContextMenu key={member.profile}>
+          <ContextMenuTrigger asChild>
+            <span className={cn('inline-flex', member.muted && 'opacity-40')}>
+              <Tip label={member.muted ? `${member.profile} (muted)` : member.profile}>
+                <ProfileGlyph
+                  aria-label={member.profile}
+                  color={resolveProfileColor(member.profile, colors)}
+                  isDefault={false}
+                  name={member.profile}
+                  role="img"
+                />
+              </Tip>
+            </span>
+          </ContextMenuTrigger>
+          <ContextMenuContent>
+            <ContextMenuItem onSelect={() => setMemberMuted(groupId, member.profile, !member.muted)}>
+              {member.muted ? 'Unmute' : 'Mute'}
+            </ContextMenuItem>
+            <ContextMenuItem onSelect={() => removeGroupMember(groupId, member.profile)}>
+              Remove from chat
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      ))}
+    </span>
+  )
+}

--- a/apps/desktop/src/app/chat/group-typing-line.tsx
+++ b/apps/desktop/src/app/chat/group-typing-line.tsx
@@ -1,0 +1,47 @@
+/**
+ * Working-members line for a normal chat that has become a room: "builder is
+ * typing…" dots above the composer, tinted per profile. Renders nothing for
+ * plain (non-group) sessions — the overwhelmingly common case costs one
+ * store read.
+ */
+
+import { useStore } from '@nanostores/react'
+import type { FC } from 'react'
+
+import { profileColorSoft, resolveProfileColor } from '@/lib/profile-color'
+import { $groupTyping } from '@/store/group-chat'
+import { $profileColors } from '@/store/profile'
+
+export const GroupTypingLine: FC<{ sessionId: null | string }> = ({ sessionId }) => {
+  const typing = useStore($groupTyping)
+  const overrides = useStore($profileColors)
+
+  const working = sessionId ? (typing[`session:${sessionId}`] ?? []) : []
+
+  if (working.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex items-center gap-3 px-4 pb-1" data-slot="group-typing-line">
+      {working.map(profile => {
+        const color = resolveProfileColor(profile, overrides) ?? 'var(--ui-text-secondary)'
+
+        return (
+          <span
+            className="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium"
+            key={profile}
+            style={{ backgroundColor: profileColorSoft(color, 12), color }}
+          >
+            {profile}
+            <span className="inline-flex gap-0.5">
+              <span className="size-1 animate-bounce rounded-full bg-current [animation-delay:0ms]" />
+              <span className="size-1 animate-bounce rounded-full bg-current [animation-delay:120ms]" />
+              <span className="size-1 animate-bounce rounded-full bg-current [animation-delay:240ms]" />
+            </span>
+          </span>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -56,6 +56,8 @@ import { requestComposerInsert } from './composer/focus'
 import { droppedFileInlineRefs } from './composer/inline-refs'
 import { useComposerScope } from './composer/scope'
 import type { ChatBarState } from './composer/types'
+import { GroupMemberStrip } from './group-member-strip'
+import { GroupTypingLine } from './group-typing-line'
 import { type DroppedFile, partitionDroppedFiles } from './hooks/use-composer-actions'
 import { type DragKind, useFileDropZone } from './hooks/use-file-drop-zone'
 import { ProfileTag } from './profile-tag'
@@ -149,6 +151,7 @@ function ChatHeader({
         }}
       >
         {showProfileTag && <ProfileTag className="pointer-events-auto mr-1.5" profile={activeStoredSession?.profile} />}
+        <GroupMemberStrip sessionId={selectedSessionId || activeSessionId} />
         <SessionActionsMenu
           align="start"
           onDelete={selectedSessionId ? onDeleteSelectedSession : undefined}
@@ -605,6 +608,7 @@ export const ChatView = memo(function ChatView({
             states stay mounted here, so dock⇄float never remounts the editor. */}
         {showChatBar && (
           <Suspense fallback={<ChatBarFallback />}>
+            <GroupTypingLine sessionId={activeSessionId} />
             <ChatBar
               busy={busy}
               cwd={currentCwd}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -35,6 +35,7 @@ import { $billingSettingsRequest } from '@/store/billing-block'
 import { $desktopBoot } from '@/store/boot'
 import { requestVoiceConversationStart } from '@/store/composer'
 import { setCronFocusJobId } from '@/store/cron'
+import { tapGroupChatEvents } from '@/store/group-chat-events'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { $previewTarget } from '@/store/preview'
 import {
@@ -688,6 +689,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const handleGatewayEventWithPlugins = useCallback(
     (event: Parameters<typeof handleDesktopGatewayEvent>[0]) => {
       emitGatewayEvent(event)
+
+      // Group chats tap completed member turns here — the one point every
+      // profile socket's events pass through (tap, not filter).
+      tapGroupChatEvents(event)
 
       if (event.type === 'wake.detected') {
         const payload = event.payload as { profile?: null | string; start_new_session?: boolean } | undefined

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -18,6 +18,7 @@ import {
   type ComposerAttachment,
   terminalContextBlocksFromDraft
 } from '@/store/composer'
+import { maybeRouteGroupMentions, prepareGroupSubmit } from '@/store/group-chat'
 import { $hudMode } from '@/store/hud'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
@@ -616,9 +617,16 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         rewriteOptimistic(liveSessionId)
         const text = buildContextText(syncedAttachments)
 
+        // Group upgrade, pre-submit half: mentioning another profile turns
+        // this chat into a room NOW, and the returned note rides this very
+        // submit as model-input-only context — so the host agent knows about
+        // the room on the invite turn itself, not one turn late.
+        const groupNote = prepareGroupSubmit(liveSessionId, text)
+
         const submitParams = (targetId: string) => ({
           session_id: targetId,
           text,
+          ...(groupNote && { group_note: groupNote }),
           ...(interrupted && { interrupted }),
           // Typed into the floating HUD, so the user is looking at another app
           // rather than at Hermes. The gateway turns this into a per-turn hint
@@ -681,6 +689,12 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         if (usingComposerAttachments) {
           scope.clearAttachments()
         }
+
+        // Group upgrade: a user message that addresses another profile turns
+        // this chat into a room (idempotent) and fans out their turns. After
+        // the submit above so the host's own turn is already in flight — the
+        // router skips the host for user messages for exactly that reason.
+        maybeRouteGroupMentions(sessionId, text)
 
         // Submit landed — the turn now runs (busy stays true), but the submit
         // window is closed, so release the lock for the next (sequential) send.

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -2,7 +2,8 @@
 
 import type { Unstable_DirectiveFormatter, Unstable_DirectiveSegment, Unstable_TriggerItem } from '@assistant-ui/core'
 import type { TextMessagePartComponent, TextMessagePartProps } from '@assistant-ui/react'
-import type { FC } from 'react'
+import { useStore } from '@nanostores/react'
+import type { CSSProperties, FC } from 'react'
 import { Fragment, useEffect, useMemo, useState } from 'react'
 
 import { ZoomableImage } from '@/components/chat/zoomable-image'
@@ -11,9 +12,11 @@ import { extractEmbeddedImages } from '@/lib/embedded-images'
 import { openExternalLink } from '@/lib/external-link'
 import { triggerHaptic } from '@/lib/haptics'
 import { gatewayMediaDataUrl, isRemoteGateway } from '@/lib/media'
+import { resolveProfileColor } from '@/lib/profile-color'
 import { useSessionLinkTitle } from '@/lib/session-link-title'
 import { parseSessionRefValue, sessionRefFallbackLabel } from '@/lib/session-refs'
 import { cn } from '@/lib/utils'
+import { $profileColors } from '@/store/profile'
 
 import { referenceKind, referenceRe, referenceStyle, WIRE_REFERENCE_KINDS } from './reference-kinds'
 
@@ -355,6 +358,8 @@ export function DirectiveContent({ text }: { text: string }) {
           <Fragment key={`t-${index}`}>{segment.text}</Fragment>
         ) : segment.type === 'image' ? null : segment.type === 'session' ? (
           <SessionRefChip key={`m-${index}-${segment.id}`} label={segment.label} value={segment.id} />
+        ) : segment.type === 'profile' ? (
+          <ProfileRefChip key={`m-${index}-${segment.id}`} label={segment.label} value={segment.id} />
         ) : segment.type === 'skill' ? (
           <SlashChip key={`m-${index}-${segment.id}`} kind="skill" label={segment.label} value={segment.id} />
         ) : (
@@ -493,6 +498,31 @@ export const SessionRefChip: FC<{
   const resolved = useSessionLinkTitle(value, label)
 
   return <DirectiveChip id={value} label={resolved} onClick={() => openSessionRef(value)} type="session" />
+}
+
+/** A `@profile:<name>` reference — a profile addressed in a sent message.
+ *  Tinted with the profile's rail color (override, else deterministic hue) so
+ *  `@babe` reads as the same identity everywhere; the CSS accent is the
+ *  fallback when the name resolves to no color (e.g. `default`). */
+export const ProfileRefChip: FC<{
+  label?: string
+  value: string
+}> = ({ label, value }) => {
+  const overrides = useStore($profileColors)
+  const color = resolveProfileColor(value, overrides)
+
+  return (
+    <span
+      {...refAttrs('profile', 'wrap-anywhere')}
+      data-directive-id={value}
+      data-slot="aui_directive-chip"
+      style={color ? ({ '--ref-color': color } as CSSProperties) : undefined}
+      title={value}
+    >
+      <DirectiveIcon type="profile" />
+      {label || value}
+    </span>
+  )
 }
 
 /** A `@session:` reference in assistant markdown (`#session/` links rewritten

--- a/apps/desktop/src/components/assistant-ui/reference-kinds.ts
+++ b/apps/desktop/src/components/assistant-ui/reference-kinds.ts
@@ -23,6 +23,7 @@ export type ReferenceKind =
   | 'line'
   | 'terminal'
   | 'session'
+  | 'profile'
   | 'git'
   | 'diff'
   | 'staged'
@@ -100,6 +101,14 @@ export const REFERENCE_STYLES: Record<ReferenceKind, ReferenceStyle> = {
     paths: ['M4 4h16v2.172a2 2 0 0 1 -.586 1.414l-4.414 4.414v7l-6 2v-8.5l-4.48 -4.928a2 2 0 0 1 -.52 -1.345v-2.227'],
     label: 'Sessions'
   },
+  profile: {
+    codicon: 'account',
+    paths: [
+      'M8 7a4 4 0 1 0 8 0a4 4 0 0 0 -8 0',
+      'M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2'
+    ],
+    label: 'Profiles'
+  },
   git: { codicon: 'git-branch', paths: ['M7 18l0 -12', 'M7 8a2 2 0 1 0 0 -4a2 2 0 0 0 0 4'], label: 'Git' },
   diff: { codicon: 'diff', paths: ['M12 5l0 14', 'M5 12l14 0'], label: 'Changes' },
   staged: { codicon: 'diff-added', paths: ['M12 5l0 14', 'M5 12l14 0'], label: 'Staged' },
@@ -135,7 +144,17 @@ export function referenceStyle(type: string | undefined): ReferenceStyle {
  * above: `command`/`skill`/`theme` arrive via `/`, and `diff`/`staged`/`emoji`
  * have no value to carry.
  */
-export const WIRE_REFERENCE_KINDS = ['file', 'folder', 'url', 'image', 'tool', 'line', 'terminal', 'session'] as const
+export const WIRE_REFERENCE_KINDS = [
+  'file',
+  'folder',
+  'url',
+  'image',
+  'tool',
+  'line',
+  'terminal',
+  'session',
+  'profile'
+] as const
 
 /**
  * The one pattern that recognises a reference in text.
@@ -144,7 +163,7 @@ export const WIRE_REFERENCE_KINDS = ['file', 'folder', 'url', 'image', 'tool', '
  * a space — so the quoted forms are tried BEFORE bare `\S+`, or a quoted value
  * would end at the first space and strand the rest as prose.
  */
-const REFERENCE_PATTERN = /@(file|folder|url|image|tool|line|terminal|session):(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)/
+const REFERENCE_PATTERN = /@(file|folder|url|image|tool|line|terminal|session|profile):(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)/
 
 /**
  * A fresh matcher for every surface that has to find references in text: the

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -1,4 +1,5 @@
 import { ActionBarPrimitive, BranchPickerPrimitive, MessagePrimitive, useAuiState } from '@assistant-ui/react'
+import { useStore } from '@nanostores/react'
 import { type FC, type ReactNode, useCallback, useRef, useState } from 'react'
 
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
@@ -12,9 +13,16 @@ import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { StopFilled } from '@/lib/icons'
+import { profileColorSoft, resolveProfileColor } from '@/lib/profile-color'
 import { cn } from '@/lib/utils'
+import { $profileColors, $profiles } from '@/store/profile'
 import { notifyThreadEditOpen } from '@/store/thread-scroll'
 import { isWatchWindow } from '@/store/windows'
+
+/** Matches a group-chat fan-in message: `[name]: body`. The name must be a
+ *  KNOWN profile before we re-attribute the bubble — a human typing a literal
+ *  `[foo]: bar` about some log format keeps their own bubble. */
+const MEMBER_MESSAGE_RE = /^\[([\w.-]{1,64})\]:\s([\s\S]*)$/
 
 /** True when the user has a live text highlight (drag-select / triple-click). */
 export function hasTextSelection(): boolean {
@@ -153,6 +161,12 @@ export const UserMessage: FC<{
     return messageAttachmentRefs(custom.attachmentRefs)
   })
 
+  // Group-chat attribution inputs (hooks — must run unconditionally). The
+  // profile list doubles as the allow-list for `[name]:` re-attribution.
+  const knownProfiles = useStore($profiles)
+  const colorOverrides = useStore($profileColors)
+  const memberProfiles = knownProfiles.map(profile => profile.name)
+
   const [pickerOpen, setPickerOpen] = useState(false)
   const { enabled: reactionsEnabled, react, reactions: shownReactions } = useMessageReactions(messageId, 'user')
 
@@ -225,6 +239,37 @@ export const UserMessage: FC<{
         data-slot="aui_user-message-root"
       >
         <ProcessNotificationNote text={messageText.trim()} />
+      </MessagePrimitive.Root>
+    )
+  }
+
+  // Group-chat fan-in: `[name]: …` from a KNOWN profile is that member
+  // speaking, not the user — left-aligned, name-labeled, rail-tinted. Wire
+  // role stays `user` (that's the cache-safe transport), only the costume
+  // changes. Checked after hooks for the same reason as the branch above.
+  const memberMatch = MEMBER_MESSAGE_RE.exec(messageText.trim())
+  const memberName = memberMatch ? memberMatch[1]!.toLowerCase() : null
+  const isMemberMessage =
+    memberName !== null && memberProfiles.some(profile => profile.toLowerCase() === memberName)
+
+  if (isMemberMessage && memberMatch) {
+    const color = resolveProfileColor(memberMatch[1]!, colorOverrides) ?? 'var(--ui-text-secondary)'
+
+    return (
+      <MessagePrimitive.Root
+        className="flex w-full min-w-0 flex-col items-start gap-0.5"
+        data-role="user"
+        data-slot="aui_member-message-root"
+      >
+        <span className="px-1 text-[11px] font-medium" style={{ color }}>
+          {memberMatch[1]}
+        </span>
+        <div
+          className="max-w-[85%] rounded-2xl px-3 py-1.5 text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground/95"
+          style={{ backgroundColor: profileColorSoft(color, 10) }}
+        >
+          <UserMessageText className="wrap-anywhere" text={memberMatch[2] ?? ''} />
+        </div>
       </MessagePrimitive.Root>
     )
   }

--- a/apps/desktop/src/lib/profile-mentions.ts
+++ b/apps/desktop/src/lib/profile-mentions.ts
@@ -1,0 +1,123 @@
+/**
+ * Pure `@profile` mention semantics for group chats — Buzz-derived rules,
+ * collapsed to local profiles (no pubkeys, no network):
+ *
+ *   - `@` counts only at start-of-string or after whitespace (never emails,
+ *     never mid-word), matching buzz-sdk's extract_at_names.
+ *   - Mentions inside code fences/spans are ignored (strip_code_regions).
+ *   - Known names match longest-first so `babe-work` wins over `babe` when
+ *     both exist; bare-name matches require a word boundary after the name.
+ *   - Self-mentions are dropped by callers (a profile never wakes itself).
+ *   - ADDRESSED vs NARRATIVE: only a mention that leads the message (or leads
+ *     a line) addresses the profile — "waiting on @morgan" mid-sentence is
+ *     narrative and must not fire a turn. Buzz shipped this rule after a loop
+ *     spammed a member with false notifications.
+ *
+ * The composer's canonical wire form `@profile:babe` is also recognized, and
+ * is ALWAYS addressed — picking a chip is deliberate.
+ */
+
+export interface ProfileMentions {
+  /** Profiles this message addresses — these get a full turn. */
+  addressed: string[]
+  /** Profiles named mid-prose — context only, never a trigger. */
+  narrative: string[]
+}
+
+const WIRE_PROFILE_RE = /(?<![\w/])@profile:(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)/g
+
+/** Fenced/inline code carries literal `@`s (decorators, scoped npm packages);
+ *  blank the regions out, preserving offsets, before any mention scan. */
+export function stripCodeRegions(text: string): string {
+  return text
+    .replace(/```[\s\S]*?(?:```|$)/g, region => ' '.repeat(region.length))
+    .replace(/`[^`\n]*`/g, region => ' '.repeat(region.length))
+}
+
+function unquote(raw: string): string {
+  const head = raw[0]
+  const tail = raw[raw.length - 1]
+
+  if (raw.length >= 2 && head === tail && (head === '`' || head === '"' || head === "'")) {
+    return raw.slice(1, -1)
+  }
+
+  return raw.replace(/[,.;:!?)\]}]+$/, '')
+}
+
+/**
+ * Extract profile mentions from message text.
+ *
+ * `knownNames` scopes bare `@name` matching to real profiles (longest-first),
+ * so `@8pm` in prose can't invent a member. Wire refs (`@profile:x`) resolve
+ * even when unknown — the composer inserted them deliberately.
+ */
+export function extractProfileMentions(text: string, knownNames: readonly string[]): ProfileMentions {
+  const addressed = new Set<string>()
+  const narrative = new Set<string>()
+
+  if (!text || !text.includes('@')) {
+    return { addressed: [], narrative: [] }
+  }
+
+  const scan = stripCodeRegions(text)
+
+  // Wire form first: always addressed, wherever it sits. A chip is a choice.
+  for (const match of scan.matchAll(WIRE_PROFILE_RE)) {
+    const name = unquote(match[1] ?? '').trim().toLowerCase()
+
+    if (name) {
+      addressed.add(name)
+    }
+  }
+
+  // Bare `@name` against known profiles, longest name first so a profile
+  // whose name prefixes another can't steal its mentions.
+  const byLength = [...knownNames].filter(name => name && name !== 'default').sort((a, b) => b.length - a.length)
+
+  for (const known of byLength) {
+    const lower = known.toLowerCase()
+    let from = 0
+
+    for (;;) {
+      const at = scan.toLowerCase().indexOf(`@${lower}`, from)
+
+      if (at === -1) {
+        break
+      }
+
+      from = at + 1
+
+      const before = at === 0 ? '' : scan[at - 1]
+      const afterIndex = at + 1 + lower.length
+      const after = afterIndex >= scan.length ? '' : scan[afterIndex]
+
+      // `@` must sit at a whitespace boundary; the name must end at one too
+      // (or at punctuation), or `@babe` would match inside `@babe-work`.
+      if ((before && !/\s/.test(before)) || (after && /[\w-]/.test(after))) {
+        continue
+      }
+
+      if (addressed.has(lower)) {
+        continue
+      }
+
+      // Addressed = the mention LEADS: first non-whitespace of the message or
+      // of its line. Anything mid-prose is narrative.
+      const lineStart = scan.lastIndexOf('\n', at) + 1
+      const leading = scan.slice(lineStart, at).trim() === ''
+
+      if (leading) {
+        addressed.add(lower)
+      } else {
+        narrative.add(lower)
+      }
+    }
+  }
+
+  for (const name of addressed) {
+    narrative.delete(name)
+  }
+
+  return { addressed: [...addressed], narrative: [...narrative] }
+}

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -133,6 +133,22 @@ export function activeGateway(): HermesGateway | null {
   return g.secondaries.get(g.activeKey)?.gateway ?? g.primaryGateway
 }
 
+/** The open socket for a specific profile — primary or secondary — or null.
+ *  Unlike activeGateway() this never falls back to the primary: a group-chat
+ *  turn for `babe` must reach babe's backend or fail visibly, not silently
+ *  run against whichever profile happens to be active. */
+export function gatewayForProfileKey(profile: string): HermesGateway | null {
+  const key = normKey(profile)
+
+  if (key === g.primaryProfile) {
+    return g.primaryGateway
+  }
+
+  const entry = g.secondaries.get(key)
+
+  return entry && isOpen(entry.gateway) ? entry.gateway : null
+}
+
 // Mirror a backend's connection state into the global composer state, but only
 // when that backend is the one the user is currently looking at. Lets the
 // composer reflect the active profile's socket without a background reconnect

--- a/apps/desktop/src/store/group-chat-events.ts
+++ b/apps/desktop/src/store/group-chat-events.ts
@@ -1,0 +1,49 @@
+/**
+ * Bridge: gateway events → group-chat store.
+ *
+ * Every profile socket funnels through the ONE registry `onEvent` in
+ * wiring.tsx. This hook lets the group store claim `message.complete` events
+ * whose session id belongs to a group member, fanning the finished turn back
+ * into the room (routeGroupMessage → next member's turn). Non-member events
+ * pass through untouched; group events STILL pass through, so the member's
+ * own session view (open in a tab, say) stays live too.
+ */
+
+import type { GatewayEvent } from '@hermes/shared'
+
+import { $groupChats, handleGroupGatewayEvent } from '@/store/group-chat'
+
+/** session_id → { groupId, profile } for every live group member session. */
+function memberBySessionId(sessionId: string): { groupId: string; profile: string } | null {
+  const groups = $groupChats.get()
+
+  for (const key of Object.keys(groups)) {
+    const group = groups[key]
+
+    if (!group) {
+      continue
+    }
+
+    for (const member of group.members) {
+      if (member.sessionId && member.sessionId === sessionId) {
+        return { groupId: group.id, profile: member.profile }
+      }
+    }
+  }
+
+  return null
+}
+
+/** Call from the registry event path. Returns the event unchanged (tap, not
+ *  filter) — group fan-in must never eat an event the session view needs. */
+export function tapGroupChatEvents(event: GatewayEvent): void {
+  if (event.type !== 'message.complete' || !event.session_id) {
+    return
+  }
+
+  const hit = memberBySessionId(event.session_id)
+
+  if (hit) {
+    handleGroupGatewayEvent(hit.groupId, hit.profile, event)
+  }
+}

--- a/apps/desktop/src/store/group-chat.ts
+++ b/apps/desktop/src/store/group-chat.ts
@@ -1,0 +1,562 @@
+/**
+ * Group chat: N profiles + the user in one room.
+ *
+ * ── Architecture ────────────────────────────────────────────────────────────
+ * Each profile is its own backend process; the ONLY party connected to all of
+ * them at once is this renderer (the multi-profile socket registry in
+ * store/gateway.ts). So the room lives here: a group is a routing overlay over
+ * N ordinary per-profile sessions — each member keeps its own transcript,
+ * memory, and cache prefix (profiles stay islands, by design), and the desktop
+ * composites the conversation. No new backend surface: fan-out is
+ * `prompt.submit` on the member's socket, fan-in is its `message.complete`.
+ *
+ * ── Camp-1 rules (Buzz-derived, see /tmp/buzz audit) ───────────────────────
+ * There is no speaker-selection referee. Addressing decides who speaks:
+ *   - The user's message fires a turn for each ADDRESSED profile; everyone
+ *     else receives it as context on their next turn (fan-in batch).
+ *   - A member's reply fires a turn only for profiles it @-addresses
+ *     (mention-gated agent↔agent, Buzz's require_mention default).
+ *   - Narrative mentions ("waiting on @morgan") never trigger.
+ * What IS centralized — the two things Buzz proves you need, which their
+ * relay-race topology couldn't build and ours can:
+ *   - SERIALIZATION: one in-flight turn per member per room. Messages that
+ *     arrive mid-turn batch into the member's next prompt (queue-and-batch),
+ *     so a busy profile never runs concurrent turns over one transcript.
+ *   - CIRCUIT BREAKER: after AGENT_CHAIN_LIMIT consecutive agent-authored
+ *     turns with no user message, agent→agent triggers stop routing (context
+ *     still fans in). Any user message resets the chain. Deliberately high —
+ *     a low cap truncates legitimate coordination; a too-aggressive breaker
+ *     manufactures silent failures (Buzz's welcome-kickoff postmortem).
+ */
+
+import { atom } from 'nanostores'
+
+import type { GatewayEvent } from '@hermes/shared'
+import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
+import { extractProfileMentions } from '@/lib/profile-mentions'
+import { readJson, writeJson } from '@/lib/storage'
+import { ensureGatewayForProfile, gatewayForProfileKey, openGatewayForProfile } from '@/store/gateway'
+import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
+
+/** Unbroken agent-authored turns before agent→agent triggers stop routing.
+ *  A user message resets the chain. */
+export const AGENT_CHAIN_LIMIT = 8
+
+export interface GroupMember {
+  profile: string
+  /** The member's own backend session inside this group. Created lazily on
+   *  its first turn; stable thereafter — it IS the member's transcript. */
+  sessionId: string | null
+  /** Mention-gated by default (Buzz require_mention). `all` = free responder:
+   *  every user message fires a turn. Agent messages stay mention-gated even
+   *  for `all` — a free-responder pair would loop by construction. */
+  respondTo: 'mentions' | 'all'
+  /** Muted: stays in the room, keeps receiving context, never fires turns. */
+  muted: boolean
+  /** The chat this room grew out of. The host's session IS the room's home
+   *  surface: the normal composer path owns its user-message turns (so we
+   *  never double-fire them), and member replies land in it as `[name]:`
+   *  prompts — which is how they both appear in the transcript and reach the
+   *  host agent. */
+  host?: boolean
+}
+
+export interface GroupTurnRequest {
+  /** Room-visible author of the triggering message: 'user' or a profile. */
+  author: string
+  text: string
+}
+
+interface MemberRuntime {
+  /** In-flight turn guard — the serialization rule. */
+  running: boolean
+  /** Messages that arrived while running (or before triggering); drained
+   *  into ONE batched prompt on the member's next turn. */
+  pending: GroupTurnRequest[]
+  /** True when a pending entry addresses this member (a turn is owed). */
+  turnOwed: boolean
+  /** Host only: room rules delivered (they ride the first fan-in prompt —
+   *  the host's session predates the room, so there's no join preamble). */
+  briefed: boolean
+}
+
+export interface GroupChat {
+  id: string
+  members: GroupMember[]
+  /** Consecutive agent-authored turns since the last user message. */
+  agentChain: number
+  /** Set when the breaker fired; cleared by the next user message. */
+  breakerTripped: boolean
+}
+
+export const $groupChats = atom<Record<string, GroupChat>>(loadPersistedGroups())
+
+// ── Persistence ─────────────────────────────────────────────────────────────
+// Rooms survive an app restart: membership + member session ids persist per
+// window (scope declared in the key). Ephemeral runtime (in-flight guards,
+// pending batches, typing) deliberately does NOT persist — a restart clears
+// in-flight state by definition. Transcripts don't persist either: the room
+// view rebuilds from the HOST session's stored history, which already carries
+// every [name]: message durably (backend-authoritative, renderer is a cache).
+const GROUPS_STORAGE_KEY = 'hermes.desktop.groupChats.v1'
+
+function loadPersistedGroups(): Record<string, GroupChat> {
+  const raw = readJson<Record<string, GroupChat>>(GROUPS_STORAGE_KEY)
+
+  if (!raw || typeof raw !== 'object') {
+    return {}
+  }
+
+  // Chains/breaker reset on load: a restart is a human-scale interruption,
+  // and resuming a tripped breaker from storage would silently keep agents
+  // paused with no visible cause.
+  const groups: Record<string, GroupChat> = {}
+
+  for (const key of Object.keys(raw)) {
+    const group = raw[key]
+
+    if (group && Array.isArray(group.members)) {
+      groups[key] = { ...group, agentChain: 0, breakerTripped: false }
+    }
+  }
+
+  return groups
+}
+
+$groupChats.subscribe(groups => writeJson(GROUPS_STORAGE_KEY, groups))
+
+/** Profiles with a turn in flight, per group — the composer's typing dots. */
+export const $groupTyping = atom<Record<string, string[]>>({})
+
+function setTyping(groupId: string, profile: string, typing: boolean): void {
+  const all = $groupTyping.get()
+  const current = all[groupId] ?? []
+  const next = typing ? (current.includes(profile) ? current : [...current, profile]) : current.filter(p => p !== profile)
+
+  if (next !== current) {
+    $groupTyping.set({ ...all, [groupId]: next })
+  }
+}
+
+const runtimes = new Map<string, Map<string, MemberRuntime>>()
+
+function runtimeFor(groupId: string, profile: string): MemberRuntime {
+  let group = runtimes.get(groupId)
+
+  if (!group) {
+    group = new Map()
+    runtimes.set(groupId, group)
+  }
+
+  let member = group.get(profile)
+
+  if (!member) {
+    member = { running: false, pending: [], turnOwed: false, briefed: false }
+    group.set(profile, member)
+  }
+
+  return member
+}
+
+function patchGroup(groupId: string, patch: (group: GroupChat) => GroupChat): void {
+  const groups = $groupChats.get()
+  const group = groups[groupId]
+
+  if (group) {
+    $groupChats.set({ ...groups, [groupId]: patch(group) })
+  }
+}
+
+/** Mention-as-invite: adding a member is idempotent, quiet, and prewarms the
+ *  profile's backend so its first turn doesn't pay a cold boot. */
+export function addGroupMember(groupId: string, profile: string): void {
+  patchGroup(groupId, group =>
+    group.members.some(member => member.profile === profile)
+      ? group
+      : {
+          ...group,
+          members: [...group.members, { profile, sessionId: null, respondTo: 'mentions', muted: false }]
+        }
+  )
+  void openGatewayForProfile(profile)
+}
+
+/** Shared resolution for both submit halves: the room id, whether it exists,
+ *  and which OTHER profiles this text addresses. The self-mention guard lives
+ *  here — `@builder` typed in builder's own chat addresses the HOST, which is
+ *  already present; "inviting" it tells the model it just summoned itself
+ *  (observed: "you pinged me, here i am!" + confabulation about the feature). */
+function resolveGroupMentions(
+  sessionId: string,
+  text: string
+): { addressed: string[]; existing: GroupChat | undefined; groupId: string; hostProfile: string } | null {
+  if (!text.includes('@')) {
+    return null
+  }
+
+  const hostProfile = normalizeProfileKey($activeGatewayProfile.get())
+  const known = $profiles
+    .get()
+    .map(profile => profile.name)
+    .filter(name => name && normalizeProfileKey(name) !== hostProfile)
+
+  const groupId = `session:${sessionId}`
+  const existing = $groupChats.get()[groupId]
+  const memberNames = existing ? existing.members.map(member => member.profile) : []
+  const mentions = extractProfileMentions(text, [...new Set([...known, ...memberNames])])
+  const addressed = mentions.addressed.filter(name => name !== hostProfile.toLowerCase())
+
+  return addressed.length === 0 && !existing ? null : { addressed, existing, groupId, hostProfile }
+}
+
+/**
+ * Pre-submit half of the in-chat upgrade: if `text` addresses other profiles,
+ * upgrade the session to a room, add the mentioned members NOW, and return a
+ * `group_note` for the submit — the model-input-only note that tells the HOST
+ * agent, on this very turn, that the room exists and who's in it. Without it
+ * the host's invite turn predates its own room and the agent "helpfully"
+ * explains the feature doesn't exist. Returns '' for plain messages.
+ */
+export function prepareGroupSubmit(sessionId: string, text: string): string {
+  const resolved = resolveGroupMentions(sessionId, text)
+
+  if (!resolved) {
+    return ''
+  }
+
+  const { addressed, existing, groupId, hostProfile } = resolved
+  const memberNames = existing ? existing.members.map(member => member.profile) : []
+  const invited = addressed.filter(name => !memberNames.some(member => member.toLowerCase() === name))
+
+  ensureSessionGroup(sessionId, hostProfile)
+
+  for (const name of addressed) {
+    addGroupMember(groupId, name)
+  }
+
+  const roster = ($groupChats.get()[groupId]?.members ?? [])
+    .filter(member => !member.host)
+    .map(member => member.profile)
+
+  const lines = [
+    `[Group chat: this conversation is a room shared with the user and other agent profiles (${roster.join(', ') || 'none yet'}).`
+  ]
+
+  if (invited.length > 0) {
+    lines.push(
+      `The user's message just invited ${invited.join(', ')} — they are being woken now and their reply will arrive as a [name]: message. Do not claim you cannot invite profiles; it already happened.`
+    )
+  }
+
+  lines.push(
+    'Messages prefixed [name] are other participants speaking. Address one with @name to hand them the floor. You may end a turn without replying when you have nothing to add.]'
+  )
+
+  return lines.join('\n')
+}
+
+/**
+ * Post-submit half: fan the user's message out to the addressed members.
+ * Membership was already handled by prepareGroupSubmit; this only routes
+ * (addGroupMember is idempotent, so a direct call without prepare also
+ * works — the note is just skipped).
+ */
+export function maybeRouteGroupMentions(sessionId: string, text: string): void {
+  const resolved = resolveGroupMentions(sessionId, text)
+
+  if (!resolved) {
+    return // plain message in a plain chat — the common case, zero cost
+  }
+
+  ensureSessionGroup(sessionId, resolved.hostProfile)
+
+  for (const name of resolved.addressed) {
+    addGroupMember(resolved.groupId, name)
+  }
+
+  routeGroupMessage(resolved.groupId, { author: 'user', text })
+}
+
+/**
+ * The in-chat upgrade: ANY session becomes a room the first time its user
+ * message addresses another profile. The session's own agent joins as the
+ * `host` member (its session already exists — the chat itself); mentioned
+ * profiles join as ordinary mention-gated members. Idempotent per session.
+ */
+export function ensureSessionGroup(sessionId: string, hostProfile: string): string {
+  const groupId = `session:${sessionId}`
+
+  if (!$groupChats.get()[groupId]) {
+    $groupChats.set({
+      ...$groupChats.get(),
+      [groupId]: {
+        id: groupId,
+        members: [{ profile: hostProfile, sessionId, respondTo: 'all', muted: false, host: true }],
+        agentChain: 0,
+        breakerTripped: false
+      }
+    })
+  }
+
+  return groupId
+}
+
+export function removeGroupMember(groupId: string, profile: string): void {
+  patchGroup(groupId, group => ({
+    ...group,
+    members: group.members.filter(member => member.profile !== profile)
+  }))
+  runtimes.get(groupId)?.delete(profile)
+}
+
+export function setMemberMuted(groupId: string, profile: string, muted: boolean): void {
+  patchGroup(groupId, group => ({
+    ...group,
+    members: group.members.map(member => (member.profile === profile ? { ...member, muted } : member))
+  }))
+}
+
+/**
+ * Route one room message. The single choke point every trigger passes
+ * through — which is what makes the breaker a guarantee instead of a hope.
+ *
+ * Returns the profiles whose turns fired (for the surface's typing dots).
+ */
+export function routeGroupMessage(groupId: string, message: GroupTurnRequest): string[] {
+  const group = $groupChats.get()[groupId]
+
+  if (!group) {
+    return []
+  }
+
+  const fromUser = message.author === 'user'
+  const names = group.members.map(member => member.profile)
+  const { addressed } = extractProfileMentions(message.text, names)
+
+  // The chain counts turns, not messages: bump/reset BEFORE routing so the
+  // breaker decision below sees the message's own contribution.
+  if (fromUser) {
+    patchGroup(groupId, current => ({ ...current, agentChain: 0, breakerTripped: false }))
+  }
+
+  const breakerOpen = !fromUser && group.agentChain + 1 >= AGENT_CHAIN_LIMIT
+
+  const fired: string[] = []
+
+  for (const member of group.members) {
+    if (member.profile === message.author || member.muted) {
+      continue // self-drop: a profile never triggers itself (Buzz ignore_self)
+    }
+
+    // The host session hears user messages natively — the composer already
+    // submitted this text as the chat's own turn. Routing it again would
+    // double-fire the host.
+    if (member.host && fromUser) {
+      continue
+    }
+
+    const isAddressed = addressed.includes(member.profile.toLowerCase())
+
+    // The host is the room's home surface: a member's reply MUST reach its
+    // session (that's how it appears in the chat and reaches the host agent),
+    // so the host always takes the turn. Everyone else: user messages fire
+    // addressed/free-responder members; agent messages are strictly
+    // mention-gated (Buzz require_mention).
+    const wantsTurn = member.host
+      ? true
+      : fromUser
+        ? isAddressed || member.respondTo === 'all'
+        : isAddressed
+
+    const runtime = runtimeFor(groupId, member.profile)
+    runtime.pending.push(message)
+
+    if (!wantsTurn) {
+      continue // context only — drains into the next owed turn's batch
+    }
+
+    if (!fromUser && !member.host && breakerOpen) {
+      // Breaker: drop the TRIGGER, keep the context. Logged loudly because
+      // the false-positive is the case that needs a human eye (Buzz doc).
+      console.warn(
+        `[group ${groupId}] agent↔agent breaker open (chain ≥ ${AGENT_CHAIN_LIMIT}): ` +
+          `suppressing ${message.author} → ${member.profile}; a user message resets it`
+      )
+      patchGroup(groupId, current => ({ ...current, breakerTripped: true }))
+      continue
+    }
+
+    runtime.turnOwed = true
+    fired.push(member.profile)
+
+    if (!runtime.running) {
+      void runMemberTurn(groupId, member.profile)
+    }
+    // Already running → queue-and-batch: the owed turn starts from
+    // runMemberTurn's finally when the current one completes.
+  }
+
+  if (!fromUser) {
+    patchGroup(groupId, current => ({ ...current, agentChain: current.agentChain + 1 }))
+  }
+
+  return fired
+}
+
+/** Drain a member's pending room messages into one sender-prefixed batch —
+ *  the shared_multi_user_session wire shape, so the profile's own transcript
+ *  stays an ordinary user/assistant alternation and its cache prefix holds. */
+function drainPendingPrompt(groupId: string, profile: string): string {
+  const runtime = runtimeFor(groupId, profile)
+  const batch = runtime.pending
+  runtime.pending = []
+  runtime.turnOwed = false
+
+  return batch.map(entry => `[${entry.author === 'user' ? 'user' : entry.author}]: ${entry.text}`).join('\n\n')
+}
+
+async function runMemberTurn(groupId: string, profile: string): Promise<void> {
+  const runtime = runtimeFor(groupId, profile)
+
+  if (runtime.running) {
+    return
+  }
+
+  runtime.running = true
+  setTyping(groupId, profile, true)
+
+  try {
+    const prompt = drainPendingPrompt(groupId, profile)
+
+    if (!prompt) {
+      return
+    }
+
+    await submitToProfile(groupId, profile, prompt)
+  } finally {
+    runtime.running = false
+    setTyping(groupId, profile, false)
+
+    // Queue-and-batch drain: messages that addressed us mid-turn owe us
+    // exactly one more turn, over the whole accumulated batch.
+    if (runtime.turnOwed) {
+      void runMemberTurn(groupId, profile)
+    }
+  }
+}
+
+/** The room's rules + roster — leads a member's first prompt (quiet join)
+ *  and the host's first fan-in. Prompt-level norms are Buzz's, verbatim where
+ *  it counts: no bare acks, silence is success, narrative mentions drop the @. */
+const GROUP_JOIN_PREAMBLE = (groupId: string, self: string, others: string[]) =>
+  [
+    `[You are "${self}", a participant in a group chat with the user and other agent profiles (${others.join(', ')}).`,
+    'Messages arrive prefixed with [sender]. Address a participant with @name; it fires a turn for them.',
+    'Rules of the room:',
+    '- Speak only when you add information the thread does not have. Ending your turn WITHOUT replying is a normal, successful outcome — reply with an empty message to stay silent.',
+    '- Never send bare acknowledgements ("Got it", "Standing by", "Will do") — they re-trigger everyone you mention. If you are tempted to announce you are done replying, that is the message not to send.',
+    '- Mention someone only when you need them to act. Naming someone while talking about them ("waiting on @vera") is narrative — drop the @.]'
+  ].join('\n')
+
+/** The transport leg — the gateway is resolved per call so a member's socket
+ *  can drop and reconnect between turns without the room noticing. */
+async function submitToProfile(groupId: string, profile: string, text: string): Promise<void> {
+  await ensureGatewayForProfile(profile)
+
+  const group = $groupChats.get()[groupId]
+  const member = group?.members.find(entry => entry.profile === profile)
+
+  if (!member) {
+    return
+  }
+
+  const gateway = gatewayForProfileKey(profile)
+
+  if (!gateway) {
+    console.warn(`[group ${groupId}] no open socket for ${profile}; dropping turn`)
+
+    return
+  }
+
+  let sessionId = member.sessionId
+  let prompt = text
+  const runtime = runtimeFor(groupId, profile)
+
+  if (member.host) {
+    // Host session predates the room — no session.create, and the rules ride
+    // its first fan-in prompt instead of a join preamble.
+    if (!sessionId) {
+      return
+    }
+
+    if (!runtime.briefed) {
+      runtime.briefed = true
+      const others = group.members.map(entry => entry.profile).filter(name => name !== profile)
+      prompt = `${GROUP_JOIN_PREAMBLE(groupId, profile, ['user', ...others])}\n\n${text}`
+    }
+  } else if (!sessionId) {
+    const created = await gateway.request<{ session_id?: string }>('session.create', {
+      title: `group:${groupId}`
+    })
+    sessionId = created.session_id ?? null
+
+    if (!sessionId) {
+      return
+    }
+
+    patchGroup(groupId, current => ({
+      ...current,
+      members: current.members.map(entry => (entry.profile === profile ? { ...entry, sessionId } : entry))
+    }))
+
+    // Quiet join: the room's rules + roster lead the member's FIRST prompt —
+    // per-session state can't live in the (byte-stable) system prompt, and a
+    // late joiner gets the room's recent tail batched here by the caller
+    // rather than a replay of the whole backlog.
+    const others = group.members.map(entry => entry.profile).filter(name => name !== profile)
+    prompt = `${GROUP_JOIN_PREAMBLE(groupId, profile, ['user', ...others])}\n\n${text}`
+  }
+
+  await gateway.request(
+    'prompt.submit',
+    { session_id: sessionId, text: prompt },
+    PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+  )
+}
+
+/**
+ * Fan a completed member turn back into the room. The surface calls this from
+ * its message.complete handler (it already receives every member socket's
+ * events through the shared handleGatewayEvent path).
+ *
+ * Empty/whitespace replies are a SUCCESS, not a gap — the turn contract says
+ * a profile that has nothing to add ends its turn silently (Buzz base
+ * prompt: "silence is usually correct").
+ */
+export function onMemberTurnComplete(groupId: string, profile: string, text: string): string[] {
+  const reply = (text || '').trim()
+
+  if (!reply) {
+    return []
+  }
+
+  return routeGroupMessage(groupId, { author: profile, text: reply })
+}
+
+/** Handle a gateway event from ANY profile socket. The surface routes events
+ *  here when the session id belongs to a group member. */
+export function handleGroupGatewayEvent(groupId: string, profile: string, event: GatewayEvent): void {
+  if (event.type !== 'message.complete') {
+    return
+  }
+
+  const payload = (event.payload ?? {}) as { status?: string; text?: string }
+
+  // An errored turn is not speech — surface it as the member's session error,
+  // never as a room message that could re-trigger other members.
+  if (payload.status === 'error') {
+    return
+  }
+
+  onMemberTurnComplete(groupId, profile, typeof payload.text === 'string' ? payload.text : '')
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -641,7 +641,8 @@
 }
 
 [data-ref='command'],
-[data-ref='tool'] {
+[data-ref='tool'],
+[data-ref='profile'] {
   --ref-color: color-mix(in srgb, var(--ui-accent) 82%, var(--foreground));
 }
 

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -118,6 +118,13 @@ def _(rid, params: dict) -> dict:
     # in turn: a stale "hud" would tell the model the user is still floating
     # over another app when they are back in Hermes.
     session["client_surface"] = "hud" if params.get("surface") == "hud" else ""
+    # Per-turn group-chat note (desktop rooms): context the model needs about
+    # the room THIS turn — who was invited, who the members are. Same channel
+    # as reaction notes: model input only, never persisted, so the transcript
+    # stays clean and the cached prefix survives. Rewritten (not setdefault)
+    # every submit so a stale note can't outlive the room state it described.
+    _group_note = params.get("group_note")
+    session["group_note"] = _group_note.strip() if isinstance(_group_note, str) else ""
     if truncate_user_ordinal is not None and isinstance(text, str):
         # A rewind/regenerate replays a turn from what the transcript shows. A
         # skill turn shows its invocation, so re-expand it here — otherwise

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9961,6 +9961,11 @@ def _run_prompt_submit(
             # Reactions the user added since the last turn.
             run_message = _prepend_note(run_message, _pending_reaction_notes(session))
 
+            # Desktop group-chat room note (who's in the room / who was just
+            # invited) — per-turn state, so it cannot live in the (byte-stable)
+            # system prompt. Consumed on read: one submit, one note.
+            run_message = _prepend_note(run_message, str(session.pop("group_note", "") or ""))
+
             # Which window the message was typed into. HUD mode is per-turn
             # state, so it cannot live in the (byte-stable) system prompt.
             run_message = _prepend_note(run_message, _hud_surface_note(session))


### PR DESCRIPTION
## Summary

Multiprofile group chats: `@mention` another profile in any chat and it joins the conversation — its backend wakes, it takes a real turn on its own isolated session, and its reply lands back in the chat as an attributed message the host agent reads and can answer. Two agents and the user can talk in one room; profiles stay islands (own memory, own cache prefix, own HERMES_HOME) and the room is a routing overlay in the renderer, which is the only party connected to every profile's socket at once (the existing multi-profile gateway registry).

- **`@profile` references**: new composer reference kind — completions from the renderer's cached profile list (no gateway round trip), bare `@nam` matches float profiles above path hits, chips tint with the profile's rail color.
- **Addressing decides who speaks** — no speaker-selection referee. Leading bare mentions and `@profile:` chips address; mid-prose mentions ("waiting on @vera") are narrative and never trigger; agent→agent replies are strictly mention-gated; the host never self-invites.
- **Loop safety at one choke point**: one in-flight turn per member per room (mid-turn arrivals batch into the next prompt), plus a consecutive agent↔agent turn breaker (8 turns, any user message resets, logged when it fires). Room-rules prompt block bans bare acknowledgements and makes ending a turn silently a normal outcome.
- **Cache-safe by construction**: fan-in messages arrive as `[name]:`-prefixed prompts (the existing `shared_multi_user_session` wire shape), the per-turn `group_note` rides the same model-input-only `_prepend_note` channel as reaction notes, and no already-sent message is ever rewritten.
- **Presence UI**: member replies render as that profile speaking (name label + rail-tinted bubble), working members show typing pills above the composer, and the chat header carries a roster strip with mute/remove. Rooms persist across restart.

Design notes: mention grammar (whitespace-boundary `@`, code-region stripping, longest-known-name-first) and the layered loop-prevention stack follow the mechanics proven in production multi-agent chat rooms; the turn breaker closes the documented gap those systems still have — feasible here because every trigger passes through a single router.

Related: #76221 (multi-session collaboration RFC — the fan-out/fan-in seam here covers its cross-session messaging gaps for the desktop case); #83707 (per-profile turns route on `gatewayForProfileKey`, which never falls back to another profile's socket).

## Test plan

- [ ] `@profile:` and bare-name completions appear in the composer; picked chips render tinted
- [ ] Mentioning a second profile from a default-profile chat wakes it; its reply lands as an attributed bubble; the host agent responds to it
- [ ] Host's invite turn acknowledges the room (group_note) instead of denying the feature
- [ ] Self-mention of the hosting profile is inert (no room, no note)
- [ ] Two profiles mention-ping each other → breaker pauses them at 8 unbroken turns; a user message resumes
- [ ] Mute/remove via the header roster strip; room survives app restart
