### PR TITLE
feat(models): add google/gemini-3.7-flash to nous + openrouter catalogs, drop gemini-3.6-flash

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -67,7 +67,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("openai/gpt-5.4-mini",                    ""),
     # Google
     ("google/gemini-3.1-pro-preview",          ""),
-    ("google/gemini-3.6-flash",                ""),
+    ("google/gemini-3.7-flash",                ""),
     # xAI
     ("x-ai/grok-4.6",                          ""),
     # DeepSeek
@@ -241,7 +241,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.4-mini",
         # Google
         "google/gemini-3.1-pro-preview",
-        "google/gemini-3.6-flash",
+        "google/gemini-3.7-flash",
         # xAI
         "x-ai/grok-4.6",
         # DeepSeek

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -244,7 +244,7 @@ openrouter = OpenRouterProfile(
         "anthropic/claude-sonnet-4.6",
         "openai/gpt-5.4",
         "deepseek/deepseek-chat",
-        "google/gemini-3.6-flash",
+        "google/gemini-3.7-flash",
         "qwen/qwen3-plus",
     ),
 )

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-12T17:23:25Z",
+  "updated_at": "2026-08-13T18:19:29Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -81,7 +81,7 @@
           "description": ""
         },
         {
-          "id": "google/gemini-3.6-flash",
+          "id": "google/gemini-3.7-flash",
           "description": ""
         },
         {
@@ -223,7 +223,7 @@
           "id": "google/gemini-3.1-pro-preview"
         },
         {
-          "id": "google/gemini-3.6-flash"
+          "id": "google/gemini-3.7-flash"
         },
         {
           "id": "x-ai/grok-4.6"


### PR DESCRIPTION
## Summary
`google/gemini-3.7-flash` is now in the Nous Portal and OpenRouter curated pickers, replacing `google/gemini-3.6-flash` on those two routes.

## Changes
- `hermes_cli/models.py`: swap 3.6-flash → 3.7-flash in `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]` (slotted below gemini-3.1-pro-preview, newest-first)
- `plugins/model-providers/openrouter/__init__.py`: `fallback_models` mirror updated
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py`

## Scope notes
- Scoped to the two named providers: vertex/gemini/gmi curated lists, setup defaults, and aux defaults intentionally still carry 3.6-flash.
- Pricing snapshot skipped: both routes bill via `official_models_api` (live pricing), verified with `resolve_billing_route`.
- Context length resolves via the generic `gemini` fuzzy entry → 1,048,576, matching the live value on both endpoints (no new metadata entry needed).
- Verified live: OpenRouter `/api/v1/models` (ctx 1,048,576, max_out 65,536, $0.375/M in, $1.875/M out — half of 3.6-flash) and Nous Portal `/v1/models` both serve `google/gemini-3.7-flash`.

## Validation
| Check | Result |
|---|---|
| Catalog gate (test_models, picker, gmi lockstep, model_catalog, usage_pricing, minimax) | 105/105 |
| Aux-client catalog/free-model tests | 20/20 |
| Provider plugin suites + live-curated merge | 175/175 |
| E2E temp-HERMES_HOME curated lists (presence, no dupes, ordering, catalog.json) | pass |

## Infographic

![gemini-3.7-flash rollout](https://files.catbox.moe/pfmv5v.png)
