### PR TITLE
fix(desktop): a degenerate model response no longer bricks the workspace

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.overflow.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.overflow.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { MarkdownTextContent } from './markdown-text'
+
+// Regression coverage for the "workspace failed to render / Maximum call stack
+// size exceeded" crash loop (#78000, #85295).
+//
+// Two independent recursions in the markdown pipeline can overflow the JS call
+// stack while React is rendering:
+//
+//   1. Raw inline HTML — `rehype-raw` hands `<unk><unk>…` to parse5, and
+//      `hast-util-from-parse5` recurses once per level of unclosed nesting. A
+//      degenerating model emitting thousands of `<unk>` tokens as reasoning is
+//      the reported trigger, and the payload persists to the session, so the
+//      crash repeats on every reload.
+//   2. Deeply nested block structure — `> > > …` recurses in mdast→hast, which
+//      no HTML guard can prevent.
+//
+// The throw escaping to the workspace boundary is what blanks the whole app, so
+// what matters is that every markdown surface stays up and keeps the text
+// readable. These mount the real production component; a wrapper that silently
+// stopped being applied has to fail here.
+afterEach(cleanup)
+
+// A stack overflow inside React's render logs through console.error; the test
+// asserts on rendered output, not on the noise.
+function renderQuietly(node: Parameters<typeof render>[0]) {
+  const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+  try {
+    return render(node)
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+const DEGENERATE_UNK = `Let${'<unk>'.repeat(16_383)}`
+const DEEP_BLOCKQUOTE = `${'> '.repeat(10_000)}still readable`
+
+describe('markdown surface survives stack-overflow content', () => {
+  it.each([
+    ['degenerate <unk> reasoning run', DEGENERATE_UNK],
+    ['deeply nested blockquotes', DEEP_BLOCKQUOTE]
+  ])('renders %s without throwing, and keeps it readable', (_label, text) => {
+    const { container } = renderQuietly(<MarkdownTextContent isRunning={false} text={text} />)
+
+    expect(container.textContent).toBeTruthy()
+  })
+
+  // The crash is a property of the CONTENT, not of which part carries it: the
+  // same text arrives as an answer, as reasoning, or in a tool result, and all
+  // three render through this component. Guarding only one of them is what let
+  // the bug survive an earlier fix attempt.
+  it.each([
+    ['reasoning (disableArtifacts)', { disableArtifacts: true }],
+    ['assistant answer', {}]
+  ])('survives on the %s path', (_label, surfaceProps) => {
+    const { container } = renderQuietly(
+      <MarkdownTextContent isRunning={false} text={DEGENERATE_UNK} {...surfaceProps} />
+    )
+
+    expect(container.textContent).toBeTruthy()
+  })
+
+  it('still renders while the message is streaming', () => {
+    const { container } = renderQuietly(<MarkdownTextContent isRunning text={DEGENERATE_UNK} />)
+
+    expect(container.textContent).toBeTruthy()
+  })
+
+  it('leaves ordinary markdown on the rich path', async () => {
+    render(<MarkdownTextContent isRunning={false} text={'# Disk report\n\nC: is **full**'} />)
+
+    // A real heading element — the rich renderer ran, rather than degrading
+    // the whole message to plain text.
+    expect(await screen.findByRole('heading', { name: 'Disk report' })).toBeTruthy()
+    expect(screen.getByText('full')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -14,6 +14,7 @@ import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
 import { ZoomableImage } from '@/components/chat/zoomable-image'
+import { ErrorBoundary } from '@/components/error-boundary'
 import { detectArtifact } from '@/lib/artifact-detect'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
@@ -602,23 +603,46 @@ function MarkdownTextSurface({
   }
 
   return (
-    <StreamdownTextPrimitive
-      components={components}
-      containerClassName={cn(MARKDOWN_CONTAINER_CLASS_NAME, containerClassName)}
-      containerProps={containerProps}
-      defer={defer}
-      lineNumbers={false}
-      mode="streaming"
-      // Incomplete-markdown repair runs in preprocessWithTailRepair on the
-      // full accumulated text; the built-in tail-bounded remend is disabled
-      // because a custom parseMarkdownIntoBlocksFn is supplied, and
-      // parseIncompleteMarkdown stays false to avoid a second full-text
-      // remend pass.
-      parseIncompleteMarkdown={false}
-      parseMarkdownIntoBlocksFn={parseMarkdownIntoBlocksCached}
-      plugins={plugins}
-      preprocess={preprocessWithTailRepair}
-    />
+    // Last line of defence for the whole markdown surface — assistant answers,
+    // reasoning, tool output and user bubbles all render through here.
+    //
+    // The pipeline is recursive in several places we don't own (parse5 →
+    // `hast-util-from-parse5` on raw HTML, `mdast-util-to-hast` on nested
+    // block structure), so pathological content can still throw
+    // `RangeError: Maximum call stack size exceeded` from inside Streamdown's
+    // render. `clampHtmlNestingDepth` removes the reachable cause we found;
+    // this catches whatever we haven't. Without it the throw unwinds past
+    // MessageRenderBoundary — which deliberately re-throws anything that isn't
+    // the transient assistant-ui lookup race — and blanks the entire workspace
+    // behind "workspace failed to render", on every reload, because the
+    // offending message is replayed from the session each time.
+    //
+    // Degrading to HugeTextFallback keeps the text readable and the rest of
+    // the transcript alive. The error stays latched for this surface: content
+    // that overflowed the stack will overflow again, and remounting per token
+    // during streaming would cost far more than the plain rendering saves.
+    <ErrorBoundary
+      fallback={() => <HugeTextFallback containerClassName={containerClassName} text={text} />}
+      label="markdown-render"
+    >
+      <StreamdownTextPrimitive
+        components={components}
+        containerClassName={cn(MARKDOWN_CONTAINER_CLASS_NAME, containerClassName)}
+        containerProps={containerProps}
+        defer={defer}
+        lineNumbers={false}
+        mode="streaming"
+        // Incomplete-markdown repair runs in preprocessWithTailRepair on the
+        // full accumulated text; the built-in tail-bounded remend is disabled
+        // because a custom parseMarkdownIntoBlocksFn is supplied, and
+        // parseIncompleteMarkdown stays false to avoid a second full-text
+        // remend pass.
+        parseIncompleteMarkdown={false}
+        parseMarkdownIntoBlocksFn={parseMarkdownIntoBlocksCached}
+        plugins={plugins}
+        preprocess={preprocessWithTailRepair}
+      />
+    </ErrorBoundary>
   )
 }
 

--- a/apps/desktop/src/lib/markdown-html-depth.test.ts
+++ b/apps/desktop/src/lib/markdown-html-depth.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { clampHtmlNestingDepth } from './markdown-html-depth'
+
+// The clamp exists to keep parse5 / hast-util-from-parse5 recursion off the
+// call stack. Its contract is about DEPTH of unclosed elements, so the tests
+// assert that relationship rather than any particular output string.
+describe('clampHtmlNestingDepth', () => {
+  it('returns text without tags unchanged, by identity', () => {
+    const text = 'C:\\Windows\\System32 is 12 GB, and 5 < 7 is true'
+
+    expect(clampHtmlNestingDepth(text)).toBe(text)
+  })
+
+  it('leaves ordinary markup untouched, by identity', () => {
+    const text = '<div class="a"><p>A <b>bold</b> claim</p></div>'
+
+    expect(clampHtmlNestingDepth(text)).toBe(text)
+  })
+
+  it('leaves a wide but shallow tag run untouched — count is not the risk', () => {
+    const text = '<b>x</b>'.repeat(20_000)
+
+    expect(clampHtmlNestingDepth(text)).toBe(text)
+  })
+
+  it('leaves void elements untouched — they never add depth', () => {
+    const text = '<br>'.repeat(20_000)
+
+    expect(clampHtmlNestingDepth(text)).toBe(text)
+  })
+
+  it('leaves self-closing tags untouched — they never add depth', () => {
+    const text = '<custom-el />'.repeat(20_000)
+
+    expect(clampHtmlNestingDepth(text)).toBe(text)
+  })
+
+  it('escapes an unbounded run of unclosed unknown tags', () => {
+    const clamped = clampHtmlNestingDepth('Let' + '<unk>'.repeat(16_383))
+
+    // Nothing is dropped: the text is still all there, just literal. Only the
+    // opening `<` needs escaping — that alone stops parse5 opening an element.
+    expect(clamped).toContain('&lt;unk>')
+    expect(clamped.startsWith('Let<unk>')).toBe(true)
+  })
+
+  it('escapes an unbounded run of unclosed known tags', () => {
+    const clamped = clampHtmlNestingDepth('<div>'.repeat(5_000))
+
+    expect(clamped).toContain('&lt;div>')
+  })
+
+  it('keeps the prefix below the cap parseable and only escapes past it', () => {
+    const clamped = clampHtmlNestingDepth('<unk>'.repeat(5_000))
+    const parseable = clamped.slice(0, clamped.indexOf('&lt;'))
+
+    // Everything before the overflow point is untouched real markup...
+    expect(parseable).toBe('<unk>'.repeat(parseable.length / '<unk>'.length))
+    // ...and it is bounded, which is the entire point.
+    expect(parseable.length).toBeLessThan('<unk>'.repeat(5_000).length)
+  })
+
+  it('does not accumulate depth when tags close, however many there are', () => {
+    const text = '<div>x</div>'.repeat(10_000)
+
+    expect(clampHtmlNestingDepth(text)).toBe(text)
+  })
+})

--- a/apps/desktop/src/lib/markdown-html-depth.ts
+++ b/apps/desktop/src/lib/markdown-html-depth.ts
@@ -1,0 +1,112 @@
+/**
+ * Bound the nesting depth of raw inline HTML before it reaches `rehype-raw`.
+ *
+ * Streamdown parses assistant markdown with `allowDangerousHtml` + `rehype-raw`,
+ * so any `<tag>` run in the text is handed to parse5. `hast-util-from-parse5`
+ * then walks the resulting tree with mutual recursion (`element → one → all`),
+ * one JS frame per level of nesting — so a deeply nested run of UNCLOSED tags
+ * overflows the call stack and throws `RangeError: Maximum call stack size
+ * exceeded` out of the middle of a React render.
+ *
+ * That is not a hypothetical: a degenerating model emits thousands of `<unk>`
+ * tokens as its reasoning, every one of which parse5 opens as another element
+ * that never closes. Measured against our pinned deps, the throw starts at
+ * ~1,750 consecutive unclosed tags and the payload persists to the session, so
+ * every reload re-renders it — the crash repeats until the message is deleted.
+ *
+ * The bound is on DEPTH, not size: 20,000 balanced `<b>x</b>` pairs (160KB) and
+ * 20,000 void `<br>` tags parse fine, because neither drives the tree deeper.
+ * Only unclosed elements accumulate depth, so only they are counted.
+ *
+ * Past the cap the remaining opening tags are escaped (`<` → `&lt;`) rather than
+ * dropped: the text stays visible and readable as literal `<unk>`, which is
+ * exactly what it is. Content under the cap is returned untouched — the common
+ * case pays one scan and no rewrite.
+ */
+
+// parse5 nests only known HTML elements meaningfully, but an unknown tag
+// (`<unk>`) still becomes an element node, so the depth cost is identical.
+// Well under the ~1,750 measured failure point, and far above any nesting real
+// markup uses — a deeply structured HTML document is a few dozen levels.
+const MAX_HTML_DEPTH = 300
+
+// Elements that never take children, so an opening tag adds no depth.
+const VOID_ELEMENTS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr'
+])
+
+// `<tag`, `</tag`, or `<tag/`. Deliberately loose on attributes: we only need
+// the name and whether it opens, closes, or self-closes.
+const TAG_RE = /<(\/?)([a-zA-Z][a-zA-Z0-9-]*)((?:"[^"]*"|'[^']*'|[^>"'])*)>/g
+
+/**
+ * Escape raw HTML tags past `MAX_HTML_DEPTH` levels of unclosed nesting.
+ *
+ * Returns `text` unchanged when the depth never exceeds the cap, so the
+ * identity is preserved for the overwhelming majority of messages (which
+ * matters: the markdown pipeline caches on string identity).
+ */
+export function clampHtmlNestingDepth(text: string): string {
+  // Fast path: no tags at all, nothing to bound.
+  if (!text.includes('<')) {
+    return text
+  }
+
+  const open: string[] = []
+  let depth = 0
+  let firstOverflow = -1
+  let match: RegExpExecArray | null
+
+  TAG_RE.lastIndex = 0
+
+  while ((match = TAG_RE.exec(text)) !== null) {
+    const closing = match[1] === '/'
+    const name = match[2].toLowerCase()
+    const selfClosing = match[3].endsWith('/')
+
+    if (closing) {
+      // Close the nearest matching open element, mirroring parse5's recovery:
+      // an unmatched close tag is ignored rather than unwinding the stack.
+      const index = open.lastIndexOf(name)
+
+      if (index !== -1) {
+        depth = index
+        open.length = index
+      }
+
+      continue
+    }
+
+    if (selfClosing || VOID_ELEMENTS.has(name)) {
+      continue
+    }
+
+    open.push(name)
+    depth += 1
+
+    if (depth > MAX_HTML_DEPTH && firstOverflow === -1) {
+      firstOverflow = match.index
+    }
+  }
+
+  if (firstOverflow === -1) {
+    return text
+  }
+
+  // Everything before the overflow parses at a safe depth and is left exactly
+  // as-is; from there on, opening tags become visible literal text.
+  return text.slice(0, firstOverflow) + text.slice(firstOverflow).replaceAll('<', '&lt;')
+}

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -1,6 +1,7 @@
 import { normalizeMathDelimiters } from '@assistant-ui/react-streamdown'
 
 import { isLikelyProseFence, sanitizeLanguageTag } from '@/lib/markdown-code'
+import { clampHtmlNestingDepth } from '@/lib/markdown-html-depth'
 import { stripPreviewTargets } from '@/lib/preview-targets'
 import { linkifySessionRefs } from '@/lib/session-refs'
 
@@ -510,8 +511,10 @@ export function preprocessMarkdown(text: string): string {
       const trailing = part.match(/\s*$/)?.[0] ?? ''
 
       // Run only on prose segments so `$5` literals and `\(` inside code
-      // blocks stay intact.
-      const transformed = normalizeVisibleProse(stripPreviewTargets(normalizeProseMath(part)))
+      // blocks stay intact. The HTML-depth clamp belongs here for the same
+      // reason: a fenced block renders as code and never reaches rehype-raw,
+      // so escaping tags inside one would corrupt the listing for nothing.
+      const transformed = clampHtmlNestingDepth(normalizeVisibleProse(stripPreviewTargets(normalizeProseMath(part))))
 
       return leading + transformed + trailing
     })


### PR DESCRIPTION
Nemotron-3-ultra degenerates mid-response into thousands of consecutive `<unk>` tokens and emits them as reasoning. Streamdown parses assistant markdown with `allowDangerousHtml`, so that run reaches parse5, and `hast-util-from-parse5` recurses once per level of unclosed nesting until the call stack overflows. The `RangeError` is thrown from inside a React render, `MessageRenderBoundary` re-throws anything that isn't the transient assistant-ui lookup race, and the whole app is replaced by "workspace failed to render". The payload is persisted to the session, so every reload replays it — Retry lands on the same message and fails identically. Three reporters have now hit this on the same model.

Two changes, because there are two independent recursions:

**Bound the raw-HTML depth before `rehype-raw`.** The clamp counts unclosed elements in the prose path and escapes the opening `<` past the cap, so the text stays visible as the literal `<unk>` it always was. The bound is on depth rather than size — 20,000 balanced `<b>x</b>` pairs and 20,000 void `<br>` tags parse fine because neither drives the tree deeper — so ordinary markup is returned unchanged, by identity.

**Contain what the clamp can't reach.** Deeply nested block structure (`> > > …`) recurses in mdast-to-hast, where no HTML guard applies. The boundary sits on `MarkdownTextSurface` rather than on any single caller, because the crash is a property of the content, not of which part carries it: the same payload arrives as an assistant answer, as reasoning, or in tool output, and all three render through that component. A failure degrades to the existing `HugeTextFallback` and the rest of the transcript stays alive.

## Verification

Measured against the pinned dependency graph, the throw starts at ~1,750 consecutive unclosed tags:

| input | before |
|---|---|
| `'<unk>' × 1000` (5 KB) | renders, 10 ms |
| `'<unk>' × 2000` (10 KB) | **RangeError** |
| `'Let' + '<unk>' × 16383` (82 KB, the reported payload) | **RangeError** |
| `'> ' × 10000` | **RangeError** |
| `'<b>x</b>' × 20000` (160 KB) | renders, 110 ms |
| plain 82 KB text | renders, 10 ms |

The regression tests drive the production component. Reverting both halves fails 5 of them with the reported `RangeError`; reverting only the clamp leaves the `<unk>` case passing through the boundary; reverting only the boundary leaves the deep-blockquote case failing. Neither half is redundant. 326 tests pass across `assistant-ui/` and `thread/`.

`MAX_MARKDOWN_CHARS` (200,000) never applied here — the reported payload is 82 KB, and the real threshold is closer to 10 KB.

Supersedes #75844, which had the right instinct but wrapped only `ReasoningTextPart`; the identical payload crashes the answer path with no reasoning involved. Its deep-nesting fixture is kept. Credit to @helix4u.

Also addresses the review note on that PR: the coverage exercises the registered production path, so a wrapper that stopped being applied fails the suite.

Closes #78000
Closes #85295
Supersedes #75844

Not in this PR: the backend could also truncate degenerate `reasoning_content` at persist time. That's worth doing, but it's a separate bug class — the renderer must not depend on the backend behaving.
