### PR TITLE
fix(kanban): prevent false completion of undelivered code

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2389,6 +2389,15 @@ DEFAULT_CONFIG = {
         # decomposer prompt, model, or skills; configure that LLM path under
         # auxiliary.kanban_decomposer.
         "orchestrator_profile": "",
+        # Dispatcher-worker completion safety. Dirty local Git worktrees are
+        # rejected by default so an implementation cannot disappear behind a
+        # successful summary while files remain uncommitted. The merged-PR
+        # root gate is opt-in because not every board uses GitHub or assigns
+        # its orchestration root to a delivery role.
+        "completion_guard": {
+            "reject_dirty_worktrees": True,
+            "require_merged_pr_for_code_roots": False,
+        },
         # Where a child task lands if the orchestrator can't match an
         # assignee to any installed profile. When unset, falls back to the
         # default profile. A task never ends up with assignee=None.

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -132,6 +132,117 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_complete_rejects_dirty_worktree(monkeypatch, tmp_path):
+    """A worker must not report done while its implementation is uncommitted."""
+    import subprocess
+    from pathlib import Path as _Path
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=repo, check=True)
+    (repo / "tracked.txt").write_text("uncommitted\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "coder")
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="implement feature",
+            assignee="coder",
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+        )
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+
+    out = json.loads(kt._handle_complete({
+        "summary": "implemented and tested",
+        "metadata": {"changed_files": ["tracked.txt"]},
+    }))
+
+    assert "error" in out
+    assert "uncommitted changes" in out["error"]
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "running"
+    finally:
+        conn.close()
+
+
+def test_complete_rejects_code_delivery_root_without_merge_approval(monkeypatch, tmp_path):
+    """An opted-in orchestrator root cannot turn child code into a false done."""
+    from pathlib import Path as _Path
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "kanban:\n"
+        "  orchestrator_profile: architect\n"
+        "  completion_guard:\n"
+        "    require_merged_pr_for_code_roots: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "architect")
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        child = kb.create_task(conn, title="implement", assignee="coder")
+        kb.claim_task(conn, child)
+        assert kb.complete_task(
+            conn,
+            child,
+            summary="implementation ready",
+            metadata={"changed_files": ["src/feature.py"], "commit_sha": "abc123"},
+        )
+        root = kb.create_task(conn, title="deliver feature", assignee="architect")
+        kb.link_tasks(conn, child, root)
+        kb.recompute_ready(conn)
+        kb.claim_task(conn, root)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", root)
+
+    rejected = json.loads(kt._handle_complete({
+        "summary": "all children completed",
+        "metadata": {"outcome": "completed_via_child_pipeline"},
+    }))
+    assert "error" in rejected
+    assert "merged PR evidence" in rejected["error"]
+
+    approved = json.loads(kt._handle_complete({
+        "summary": "PR merged after human review",
+        "metadata": {
+            "pr_url": "https://github.com/example/repo/pull/42",
+            "pr_state": "MERGED",
+            "merge_commit": "def456",
+            "human_approval": True,
+        },
+    }))
+    assert approved.get("ok") is True
+
+
 def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
     """After a phantom rejection, retrying kanban_complete with
     created_cards=[] (the documented escape hatch) must complete the

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import subprocess
 from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
@@ -652,6 +653,84 @@ def _handle_list(args: dict, **kw) -> str:
         return tool_error(f"kanban_list: {e}")
 
 
+def _dirty_worktree_completion_error(task: Any, cfg: dict) -> Optional[str]:
+    """Return an actionable error when a local worker worktree is dirty.
+
+    Remote/container workspace paths are deliberately fail-open: only a local
+    path that Git positively identifies as a dirty worktree is rejected.
+    """
+    if not cfg_get(
+        cfg, "kanban", "completion_guard", "reject_dirty_worktrees", default=True,
+    ):
+        return None
+    if not task or task.workspace_kind != "worktree" or not task.workspace_path:
+        return None
+    try:
+        proc = subprocess.run(
+            ["git", "-C", task.workspace_path, "status", "--porcelain", "--untracked-files=all"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    preview = ", ".join(line.strip() for line in proc.stdout.splitlines()[:5])
+    return (
+        "completion blocked: this Git worktree has uncommitted changes "
+        f"({preview}). Commit the intended files and include commit_sha in "
+        "metadata, or block the task with an explicit recovery handoff."
+    )
+
+
+def _code_delivery_root_error(kb: Any, conn: Any, task: Any, metadata: Any, cfg: dict) -> Optional[str]:
+    """Require merged-PR evidence for an opted-in orchestrator delivery root."""
+    if not cfg_get(
+        cfg,
+        "kanban",
+        "completion_guard",
+        "require_merged_pr_for_code_roots",
+        default=False,
+    ):
+        return None
+    orchestrator = str(cfg_get(cfg, "kanban", "orchestrator_profile", default="architect"))
+    if not task or task.assignee != orchestrator:
+        return None
+    parents = kb.parent_ids(conn, task.id)
+    # A delivery root is a dependency sink. Review/remediation cards can have
+    # code-producing parents too, but still feed another task and must not be
+    # mistaken for the final user-facing delivery boundary.
+    if not parents or kb.child_ids(conn, task.id):
+        return None
+    has_code_evidence = False
+    for parent_id in parents:
+        run = kb.latest_run(conn, parent_id)
+        run_metadata = run.metadata if run and isinstance(run.metadata, dict) else {}
+        if any(run_metadata.get(key) for key in ("changed_files", "commit_sha", "key_files")):
+            has_code_evidence = True
+            break
+    if not has_code_evidence:
+        return None
+    handoff = metadata if isinstance(metadata, dict) else {}
+    pr_url = str(handoff.get("pr_url") or "").strip()
+    human_approval = handoff.get("human_approval") is True
+    merged = (
+        str(handoff.get("pr_state") or "").upper() == "MERGED"
+        or bool(handoff.get("merged_at"))
+    )
+    merge_commit = str(handoff.get("merge_commit") or "").strip()
+    if pr_url and "/pull/" in pr_url and human_approval and merged and merge_commit:
+        return None
+    return (
+        "completion blocked: this code-delivery root requires merged PR evidence. "
+        "Keep it in the human-review gate until the user confirms the merge, then "
+        "retry with metadata containing pr_url, pr_state='MERGED' (or merged_at), "
+        "merge_commit, and human_approval=true."
+    )
+
+
 def _handle_complete(args: dict, **kw) -> str:
     """Mark the current task done with a structured handoff."""
     delegated_err = _reject_delegated_child_mutation("kanban_complete")
@@ -752,6 +831,14 @@ def _handle_complete(args: dict, **kw) -> str:
             # Only enforce when a judge is actually reachable — see
             # _goal_judge_available for why an unavailable judge fails open.
             task = kb.get_task(conn, tid)
+            cfg = load_config()
+            guard_error = _dirty_worktree_completion_error(task, cfg)
+            if guard_error is None:
+                guard_error = _code_delivery_root_error(
+                    kb, conn, task, metadata, cfg,
+                )
+            if guard_error is not None:
+                return tool_error(guard_error)
             rejection = _goal_mode_handoff_rejection(
                 task,
                 (summary or result or "").strip(),

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -610,6 +610,8 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `auto_decompose` | `true` | Dispatcher auto-runs the decomposer every tick. |
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
+| `completion_guard.reject_dirty_worktrees` | `true` | Reject dispatcher-worker completion when a local Git worktree has tracked or untracked changes. The task stays running until the worker commits or blocks with a recovery handoff. |
+| `completion_guard.require_merged_pr_for_code_roots` | `false` | Opt-in: when the orchestrator owns a dependency-sink root whose parents report code changes, require `pr_url`, merged state, merge commit, and explicit human approval in completion metadata. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
 


### PR DESCRIPTION
## Summary
- reject dispatcher-worker completion when a local Git worktree is dirty
- add an opt-in merged-PR gate for orchestrator-owned code delivery roots
- document both completion guards and their defaults

## Root cause
Kanban trusted worker completion summaries without checking Git state. A coder could pass tests against uncommitted files, a reviewer could inspect that dirty sibling worktree, and the orchestrator could mark the root done although no commit, push, or PR existed.

## Test plan
- RED confirmed: both new regression tests completed the tasks before the fix
- `tests/tools/test_kanban_tools.py`: 31 passed
- Kanban DB + review lifecycle + tool tests: 82 passed, 1 skipped
- Ruff: passed
- compileall: passed
- git diff --check: passed

## Compatibility
- dirty local worktree rejection defaults on for dispatcher workers
- merged-PR root enforcement is opt-in for boards that use GitHub delivery
- manual human CLI/dashboard completion remains available