### PR TITLE
fix(auxiliary): only rewrite /anthropic to /v1 for dual-surface hosts (salvage #83782)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1230,14 +1230,29 @@ def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
     return headers
 
 
-def _to_openai_base_url(base_url: str) -> str:
-    """Normalize an Anthropic-style base URL to OpenAI-compatible format.
+# Hosts that expose BOTH an Anthropic-style ``…/anthropic`` path and a sibling
+# OpenAI-compatible ``…/v1`` (or vendor-specific OpenAI path). Unconditional
+# ``/anthropic`` → ``/v1`` rewrites break Anthropic-only gateways such as
+# Alibaba Bailian Token Plan (#83642).
+_DUAL_SURFACE_ANTHROPIC_HOST_MARKERS = (
+    "minimax.io",
+    "minimax.chat",
+    "minimaxi.com",
+    "api.minimax",
+)
 
-    Some providers (MiniMax, MiniMax-CN) expose an ``/anthropic`` endpoint for
-    the Anthropic Messages API and a separate ``/v1`` endpoint for OpenAI chat
-    completions.  The auxiliary client uses the OpenAI SDK, so it must hit the
-    ``/v1`` surface.  Passing the raw ``inference_base_url`` causes requests to
-    land on ``/anthropic/chat/completions`` — a 404.
+
+def _to_openai_base_url(base_url: str) -> str:
+    """Normalize dual-surface Anthropic URLs to OpenAI-compatible format.
+
+    MiniMax (and MiniMax-CN) expose an ``/anthropic`` endpoint for the Anthropic
+    Messages API and a separate ``/v1`` endpoint for OpenAI chat completions.
+    The auxiliary client often uses the OpenAI SDK, so those dual-surface hosts
+    must hit ``/v1``.
+
+    Anthropic-**only** custom gateways (path ends in ``/anthropic`` but has no
+    sibling ``/v1``) must keep their path; rewriting them to ``/v1`` yields 404
+    on compression/vision/title_generation (#83642).
     """
     url = str(base_url or "").strip().rstrip("/")
     if url.endswith("/anthropic"):
@@ -1247,9 +1262,16 @@ def _to_openai_base_url(base_url: str) -> str:
             rewritten = url[: -len("/anthropic")] + "/paas/v4"
             logger.debug("Auxiliary client: rewrote ZAI base URL %s → %s", url, rewritten)
             return rewritten
-        rewritten = url[: -len("/anthropic")] + "/v1"
-        logger.debug("Auxiliary client: rewrote base URL %s → %s", url, rewritten)
-        return rewritten
+        if any(marker in url for marker in _DUAL_SURFACE_ANTHROPIC_HOST_MARKERS):
+            rewritten = url[: -len("/anthropic")] + "/v1"
+            logger.debug("Auxiliary client: rewrote dual-surface base URL %s → %s", url, rewritten)
+            return rewritten
+        # Anthropic-only gateway: leave the /anthropic path alone.
+        logger.debug(
+            "Auxiliary client: keeping Anthropic-only base URL %s (no dual-surface host match)",
+            url,
+        )
+        return url
     if "api.kimi.com" in url and url.endswith("/coding"):
         # Kimi Code uses /coding/v1/messages for Anthropic SDK (appends /v1/messages)
         # but /coding/v1/chat/completions for OpenAI SDK (appends /chat/completions)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1234,12 +1234,30 @@ def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
 # OpenAI-compatible ``…/v1`` (or vendor-specific OpenAI path). Unconditional
 # ``/anthropic`` → ``/v1`` rewrites break Anthropic-only gateways such as
 # Alibaba Bailian Token Plan (#83642).
-_DUAL_SURFACE_ANTHROPIC_HOST_MARKERS = (
+#
+# Matching is anchored to the URL *host* (exact domain or subdomain suffix /
+# ``api.minimax.*`` prefix) — never a substring of the whole URL, so a path
+# that merely contains ``api.minimax`` cannot false-positive.
+_DUAL_SURFACE_ANTHROPIC_HOST_SUFFIXES = (
     "minimax.io",
     "minimax.chat",
     "minimaxi.com",
-    "api.minimax",
 )
+_DUAL_SURFACE_ANTHROPIC_HOST_PREFIXES = ("api.minimax.",)
+
+
+def _is_dual_surface_anthropic_host(url: str) -> bool:
+    """True when the URL's host is a known dual-surface (MiniMax-family) host."""
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return False
+    if not host:
+        return False
+    for suffix in _DUAL_SURFACE_ANTHROPIC_HOST_SUFFIXES:
+        if host == suffix or host.endswith("." + suffix):
+            return True
+    return any(host.startswith(prefix) for prefix in _DUAL_SURFACE_ANTHROPIC_HOST_PREFIXES)
 
 
 def _to_openai_base_url(base_url: str) -> str:
@@ -1262,7 +1280,7 @@ def _to_openai_base_url(base_url: str) -> str:
             rewritten = url[: -len("/anthropic")] + "/paas/v4"
             logger.debug("Auxiliary client: rewrote ZAI base URL %s → %s", url, rewritten)
             return rewritten
-        if any(marker in url for marker in _DUAL_SURFACE_ANTHROPIC_HOST_MARKERS):
+        if _is_dual_surface_anthropic_host(url):
             rewritten = url[: -len("/anthropic")] + "/v1"
             logger.debug("Auxiliary client: rewrote dual-surface base URL %s → %s", url, rewritten)
             return rewritten

--- a/tests/agent/test_auxiliary_explicit_base_anthropic.py
+++ b/tests/agent/test_auxiliary_explicit_base_anthropic.py
@@ -34,6 +34,9 @@ def _clean_env(monkeypatch):
 
 
 _ANTHROPIC_BASE = "https://gateway.example.com/proxy/anthropic"
+# Known dual-surface (MiniMax) host: the only family still auto-rewritten to /v1
+# after the host-anchored policy of #83782 / #83642.
+_DUAL_SURFACE_BASE = "https://api.minimax.io/anthropic"
 
 
 def _client_base_url(client) -> str:
@@ -79,7 +82,9 @@ def test_explicit_base_anthropic_messages_keeps_anthropic_path():
 
 def test_explicit_base_anthropic_messages_openai_fallback_uses_v1():
     """When the anthropic SDK is unavailable, _maybe_wrap_anthropic returns the
-    plain OpenAI client — which must be on the /v1 base, never /anthropic."""
+    plain OpenAI client — for a dual-surface host it must be on the /v1 base.
+    (Anthropic-only gateways keep /anthropic since #83642 — there is no sibling
+    /v1 to fall back to.)"""
     from agent.auxiliary_client import resolve_provider_client, AnthropicAuxiliaryClient
 
     with patch(
@@ -89,7 +94,7 @@ def test_explicit_base_anthropic_messages_openai_fallback_uses_v1():
         client, model = resolve_provider_client(
             "custom",
             model="claude-opus-4-8",
-            explicit_base_url=_ANTHROPIC_BASE,
+            explicit_base_url=_DUAL_SURFACE_BASE,
             explicit_api_key="k",
             api_mode="anthropic_messages",
         )
@@ -97,12 +102,31 @@ def test_explicit_base_anthropic_messages_openai_fallback_uses_v1():
     assert client is not None
     assert not isinstance(client, AnthropicAuxiliaryClient)
     # /anthropic → /v1 so the OpenAI SDK never hits /anthropic/chat/completions.
-    assert _client_base_url(client).rstrip("/").endswith("/proxy/v1")
+    assert _client_base_url(client).rstrip("/").endswith("/v1")
 
 
 def test_explicit_base_without_anthropic_mode_preserves_v1_rewrite():
     """Regression: with no anthropic_messages api_mode, the /anthropic → /v1
-    OpenAI-wire rewrite is preserved (fix is scoped, no behavior change)."""
+    OpenAI-wire rewrite is preserved for known dual-surface hosts."""
+    from agent.auxiliary_client import resolve_provider_client, AnthropicAuxiliaryClient
+
+    client, model = resolve_provider_client(
+        "custom",
+        model="my-model",
+        explicit_base_url=_DUAL_SURFACE_BASE,
+        explicit_api_key="k",
+        api_mode="chat_completions",
+    )
+
+    assert client is not None
+    assert not isinstance(client, AnthropicAuxiliaryClient)
+    assert _client_base_url(client).rstrip("/").endswith("/v1")
+    assert "/anthropic" not in _client_base_url(client)
+
+
+def test_explicit_base_unknown_host_keeps_anthropic_path():
+    """Anthropic-only custom gateways (unknown hosts) keep their /anthropic
+    path even on the OpenAI wire — rewriting to /v1 404s (#83642)."""
     from agent.auxiliary_client import resolve_provider_client, AnthropicAuxiliaryClient
 
     client, model = resolve_provider_client(
@@ -115,4 +139,4 @@ def test_explicit_base_without_anthropic_mode_preserves_v1_rewrite():
 
     assert client is not None
     assert not isinstance(client, AnthropicAuxiliaryClient)
-    assert _client_base_url(client).rstrip("/").endswith("/proxy/v1")
+    assert _client_base_url(client).rstrip("/").endswith("/proxy/anthropic")

--- a/tests/agent/test_minimax_auxiliary_url.py
+++ b/tests/agent/test_minimax_auxiliary_url.py
@@ -24,5 +24,18 @@ class TestToOpenaiBaseUrl:
         url = "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic"
         assert _to_openai_base_url(url) == url
 
+    def test_marker_in_path_does_not_false_positive(self):
+        """Host-anchored matching: a marker in the path must not trigger rewrite."""
+        url = "https://gateway.example.com/api.minimax.io/anthropic"
+        assert _to_openai_base_url(url) == url
+
+    def test_minimax_cn_api_prefix_host_rewritten(self):
+        assert _to_openai_base_url("https://api.minimaxi.com/anthropic") == "https://api.minimaxi.com/v1"
+
+    def test_lookalike_host_suffix_not_matched(self):
+        """evil-minimax.io.example.com must not match the minimax.io suffix."""
+        url = "https://minimax.io.evil.example.com/anthropic"
+        assert _to_openai_base_url(url) == url
+
     def test_none(self):
         assert _to_openai_base_url(None) == ""

--- a/tests/agent/test_minimax_auxiliary_url.py
+++ b/tests/agent/test_minimax_auxiliary_url.py
@@ -16,12 +16,13 @@ class TestToOpenaiBaseUrl:
     def test_minimax_global_anthropic_suffix_replaced(self):
         assert _to_openai_base_url("https://api.minimax.io/anthropic") == "https://api.minimax.io/v1"
 
+    def test_minimax_chat_host_rewritten(self):
+        assert _to_openai_base_url("https://api.minimax.chat/anthropic") == "https://api.minimax.chat/v1"
 
-
-
-
-
-
+    def test_anthropic_only_custom_gateway_kept(self):
+        """Alibaba Bailian Token Plan and similar have no sibling /v1 (#83642)."""
+        url = "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic"
+        assert _to_openai_base_url(url) == url
 
     def test_none(self):
         assert _to_openai_base_url(None) == ""


### PR DESCRIPTION
## Summary
`_to_openai_base_url` now rewrites `/anthropic` → `/v1` ONLY for known dual-surface hosts (MiniMax family; ZAI `/paas/v4` mapping kept) — Anthropic-only gateways like Bailian `/apps/anthropic` keep their path. Salvage of #83782 by @686f6c61 onto current main, authorship preserved. Fixes #83642.

This is the class-wide completion of the #85466 point fix: it reaches the aux-iteration call sites and API-key branch where no `api_mode` is in scope, which per-site guards could not.

## Changes
- `agent/auxiliary_client.py`: rewrite policy inverted to a dual-surface host allowlist; **fixup (ours):** marker matching host-anchored via urlparse (exact/subdomain suffix match) — a URL whose *path* contains `api.minimax` no longer false-positives
- Tests: dual-surface rewrite cases, Bailian path-kept case, path-marker false-positive case, lookalike-suffix host case; `test_auxiliary_explicit_base_anthropic.py` aligned with the new policy
- Dropped from the original PR: an unrelated `test_multiplex_busy_input_mode.py` fixture hunk — already fixed on main via f51aa6a9b5

## Validation
| | Before | After |
|---|---|---|
| Bailian `/apps/anthropic` on aux calls | rewritten to `/apps/v1` → 404 | path kept |
| MiniMax dual-surface | rewritten (works) | rewritten (unchanged) |
| `api.minimax` appearing in a path | would rewrite | no false-positive |
| targeted tests | — | 20/20, 3 sabotage-verified |

Note for merge: unknown dual-surface gateways (e.g. a LiteLLM proxy exposing both wire formats under `/anthropic`) now keep their path on OpenAI-wire aux calls; wrap-detection routes such URLs to the native transport in practice.

## Infographic

![dual-surface rewrite policy](https://files.catbox.moe/vi88x0.png)
