### PR TITLE
fix(camofox): treat 410 Gone as a dead tab so navigate can recover

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -3,6 +3,9 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+import requests
+
 
 from tools.browser_camofox import (
     camofox_back,
@@ -112,6 +115,57 @@ class TestCamofoxNavigate:
         result = json.loads(camofox_navigate("https://example.com", task_id="t_err"))
         assert result["success"] is False
         assert "Cannot connect" in result["error"]
+
+    @pytest.mark.parametrize("gone_status", [404, 410])
+    @patch("tools.browser_camofox.requests.post")
+    def test_recovers_when_tab_is_gone(self, mock_post, monkeypatch, gone_status):
+        """A tab that stops existing is reopened, not retried forever.
+
+        404 is a garbage-collected tab; 410 is one the browser destroyed or
+        took down with it on a restart. Both leave a stale tab_id in the
+        session, and navigate is the only call that can replace it.
+        """
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        task_id = f"t_gone_{gone_status}"
+
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab1", "url": "https://example.com"})
+        assert json.loads(camofox_navigate("https://example.com", task_id=task_id))["success"] is True
+
+        gone = _mock_response(status=gone_status, json_data={"error": "Tab was destroyed."})
+        gone.raise_for_status.side_effect = requests.HTTPError(f"{gone_status} Error", response=gone)
+
+        def _post_side_effect(url, **kwargs):
+            # The dead tab refuses; opening a new one succeeds.
+            if url.endswith("/tabs"):
+                return _mock_response(json_data={"tabId": "tab2", "url": "https://example.com"})
+            return gone
+
+        mock_post.side_effect = _post_side_effect
+
+        result = json.loads(camofox_navigate("https://example.com", task_id=task_id))
+        assert result["success"] is True
+        assert any(c.args[0].endswith("/tabs") for c in mock_post.call_args_list[1:]), (
+            "expected a fresh tab to be created after the old one was gone"
+        )
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_other_http_errors_do_not_open_a_new_tab(self, mock_post, monkeypatch):
+        """Only 404/410 mean "gone" — a 500 is a real failure, not a dead tab."""
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        task_id = "t_server_error"
+
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab1", "url": "https://example.com"})
+        assert json.loads(camofox_navigate("https://example.com", task_id=task_id))["success"] is True
+
+        boom = _mock_response(status=500, json_data={"error": "internal"})
+        boom.raise_for_status.side_effect = requests.HTTPError("500 Error", response=boom)
+        mock_post.reset_mock()
+        mock_post.return_value = boom
+        mock_post.side_effect = None
+
+        result = json.loads(camofox_navigate("https://example.com", task_id=task_id))
+        assert result["success"] is False
+        assert not any(c.args[0].endswith("/tabs") for c in mock_post.call_args_list)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -421,6 +421,30 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
     return session
 
 
+# Camofox reports a tab we still hold an id for as gone with two different
+# status codes, and they mean the same thing to us:
+#
+#   404  no such tab -- garbage collected, or an id this server never issued
+#   410  the tab was ours and the browser took it away. server.js returns this
+#        for `tab_destroyed`, `page_crashed` and `browser_restarted`, each with
+#        an explicit `recovery: "create_new_tab"` in the body
+#
+# 410 is the one that costs a whole run, because it is what a browser restart
+# looks like: every tab dies at once, so the session's cached tab_id is stale
+# and `navigate` -- the only call that can open a replacement -- was raising
+# instead of recovering. The agent then retries navigate, which fails the same
+# way, for as long as it is willing to keep trying.
+_TAB_GONE_STATUSES = (404, 410)
+
+
+def _is_tab_gone(exc: BaseException) -> bool:
+    """True when exc is Camofox saying the tab we hold no longer exists."""
+    if not isinstance(exc, requests.HTTPError):
+        return False
+    resp = getattr(exc, "response", None)
+    return resp is not None and resp.status_code in _TAB_GONE_STATUSES
+
+
 def _drop_session(task_id: Optional[str]) -> Optional[Dict[str, Any]]:
     """Remove and return session info."""
     task_id = task_id or "default"
@@ -503,7 +527,8 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
             session = _ensure_tab(task_id, browser_url)
             data = {"ok": True, "url": browser_url}
         else:
-            # Navigate existing tab — recover from stale tab 404
+            # Navigate existing tab — recover from a tab that is gone, whether
+            # it was garbage collected (404) or destroyed with the browser (410)
             try:
                 data = _post(
                     f"/tabs/{session['tab_id']}/navigate",
@@ -511,11 +536,11 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
                     timeout=60,
                 )
             except requests.HTTPError as e:
-                if e.response is not None and e.response.status_code == 404:
+                if _is_tab_gone(e):
                     logger.warning(
-                        "Camofox tab %s returned 404 — tab was garbage collected. "
-                        "Creating a fresh tab.",
+                        "Camofox tab %s is gone (HTTP %s). Creating a fresh tab.",
                         session["tab_id"],
+                        getattr(e.response, "status_code", "?"),
                     )
                     session["tab_id"] = None
                     session = _ensure_tab(task_id, browser_url)


### PR DESCRIPTION
## What does this PR do?

Camofox reports a tab that no longer exists with **two** status codes, and they mean the same thing to the client:

| status | when | body |
|---|---|---|
| `404` | no such tab — garbage collected, or an id this server never issued | `{"error": "Tab not found"}` |
| `410` | the tab was ours and the browser took it away | `{"code": "tab_destroyed" \| "page_crashed" \| "browser_restarted", "recovery": "create_new_tab"}` |

`camofox_navigate` recovered from `404` only (added in #54729), so `410` raised instead.

That is the case that costs a whole run rather than a single call. A browser restart kills **every** tab at once, so the session is left holding a stale `tab_id` — and `navigate` is the only call that can open a replacement. The agent retries `navigate`, hits the same 410 against the same cached id, and never gets a working tab back. In the run that turned this up, the browser was killed by the host's OOM killer part-way through a batch and the agent burned nine navigate attempts before giving up with "no way to spawn a new tab". The server was healthy and idle the whole time.

Worth noting that camofox is already telling us what to do here — `recovery: "create_new_tab"` is in the 410 body — and nothing was reading it.

## Related Issue

No existing issue found. Adjacent open PR: **#54890** (see below).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tools/browser_camofox.py`**
  - New `_TAB_GONE_STATUSES = (404, 410)` and `_is_tab_gone(exc)` predicate, with a comment recording what camofox returns and when.
  - `camofox_navigate` uses the predicate instead of its inline `status_code == 404` check. The log line now names the status it saw.
  - Behaviour for every other status is unchanged: a 500 still propagates and does **not** open a new tab.
- **`tests/tools/test_browser_camofox.py`** — three tests (parametrized over 404/410, plus a 500 case).

## Relationship to #54890

**#54890** fixes the sibling operations (`snapshot`, `click`, `type`, `scroll`, `back`, `press`, `get_images`, `vision`), which leave a stale `tab_id` and return a raw error. This PR deliberately does **not** touch those functions, so there is no overlap — it only changes `camofox_navigate`, which #54890 leaves alone.

The two are complementary, and the ordering doesn't matter:

- If **#54890** merges first, its `_clear_stale_tab()` should switch from `status_code == 404` to the `_is_tab_gone()` predicate added here — otherwise those eight functions still trap the session on a browser restart, which is the common case. Happy to send that as a follow-up, or the author can pick it up; I've left a note on that PR.
- If **this** merges first, #54890 can use `_is_tab_gone()` directly instead of adding its own 404 check.

## How to Test

1. `pytest tests/tools/test_browser_camofox.py -q` → 23 passed.
2. Revert `tools/browser_camofox.py` and re-run: `test_recovers_when_tab_is_gone[410]` fails with `assert False is True`, `[404]` still passes. The test is a real regression test, not a tautology.
3. Against a live Camofox: navigate a tab, restart the browser (or `docker restart` the container), then navigate again on the same `task_id`. Before, every retry returns `Navigation failed: 410 Client Error: Gone`; after, the first retry opens a fresh tab and succeeds.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — found #54890, scoped this to not overlap it (above)
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 26.04 (LXC), Python 3.14

> **On the full suite:** all 63 tests across the seven `test_browser_camofox*.py` files pass. I could not run `pytest tests/ -q` in full — unrelated modules fail to *collect* in my environment for missing optional deps (`aiohttp`, `httpx`, `mcp`, `rich`, `websockets`), which this change doesn't touch.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments) — the new constant carries the explanation
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A, pure status-code handling
- [x] Tool descriptions/schemas — N/A, no schema or signature change
