### PR TITLE
fix(tui): support narrow Termux terminals

### DIFF
--- a/scripts/smoke-termux-tui.py
+++ b/scripts/smoke-termux-tui.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Native narrow-terminal startup smoke for the Hermes TUI.
+
+Runs the installed ``hermes`` launcher inside a real PTY, at a phone-like
+terminal size, long enough to catch import/gateway/layout startup failures.
+The smoke intentionally does not need model credentials: an onboarding/setup
+screen is a valid interactive state. It fails only when the process crashes,
+produces a known fatal startup signature, or never paints anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import select
+import shutil
+import signal
+import struct
+import subprocess
+import sys
+import time
+
+if os.name != "posix":
+    raise SystemExit("smoke-termux-tui.py requires a POSIX/Termux runtime")
+
+import fcntl  # noqa: E402
+import pty  # noqa: E402
+import termios  # noqa: E402
+
+FATAL_MARKERS = (
+    b"Traceback (most recent call last)",
+    b"Cannot find module",
+    b"ERR_MODULE_NOT_FOUND",
+    b"SyntaxError:",
+    # This smoke creates the child on pty.openpty() and wires stdin/out/err to
+    # the slave. ENOTTY therefore means startup code tried a terminal ioctl on
+    # a non-TTY fd; it is not an expected property of a healthy Termux PTY.
+    b"ENOTTY",
+    b"gateway.start_timeout",
+)
+FIRST_RUN_SETUP_MARKERS = (
+    b"No inference provider is configured yet",
+    b"Set up a provider now?",
+)
+
+
+def _resize(fd: int, cols: int, rows: int) -> None:
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+
+
+def _signal_process_group(proc: subprocess.Popen[bytes], sig: int) -> None:
+    kill_group = getattr(os, "killpg", None)
+    if callable(kill_group):
+        kill_group(proc.pid, sig)
+    else:  # Defensive fallback if the script is ever imported on a non-POSIX host.
+        proc.terminate()
+
+
+def _drain(master: int, proc: subprocess.Popen[bytes], deadline: float) -> bytes:
+    chunks: list[bytes] = []
+    while time.monotonic() < deadline:
+        ready, _, _ = select.select([master], [], [], 0.1)
+        if ready:
+            try:
+                chunk = os.read(master, 65536)
+            except OSError:
+                break
+            if not chunk:
+                break
+            chunks.append(chunk)
+        if proc.poll() is not None and not ready:
+            break
+    return b"".join(chunks)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--command", default="hermes")
+    parser.add_argument("--cols", type=int, default=48)
+    parser.add_argument("--rows", type=int, default=18)
+    parser.add_argument("--observe-seconds", type=float, default=6.0)
+    args = parser.parse_args(argv)
+
+    executable = shutil.which(args.command)
+    if not executable:
+        raise SystemExit(f"TUI smoke command not found: {args.command}")
+    if args.cols < 20 or args.rows < 8:
+        raise SystemExit("TUI smoke dimensions are unrealistically small")
+
+    master, slave = pty.openpty()
+    _resize(slave, args.cols, args.rows)
+    env = os.environ.copy()
+    env.update(
+        {
+            "TERM": "xterm-256color",
+            "COLORTERM": "truecolor",
+            "HERMES_TUI_DISABLE_MOUSE": "1",
+            "HERMES_TUI_STARTUP_TIMEOUT_MS": "12000",
+        }
+    )
+    proc = subprocess.Popen(
+        [executable],
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        env=env,
+        start_new_session=True,
+    )
+    os.close(slave)
+    output = b""
+    try:
+        output += _drain(master, proc, time.monotonic() + args.observe_seconds)
+        early_rc = proc.poll()
+        if early_rc is not None:
+            raise RuntimeError(f"Hermes TUI exited during startup with code {early_rc}")
+        if len(output) < 32:
+            raise RuntimeError("Hermes TUI did not paint meaningful terminal output")
+        for marker in FATAL_MARKERS:
+            if marker in output:
+                raise RuntimeError(f"Hermes TUI emitted fatal startup marker: {marker.decode(errors='replace')}")
+
+        # A fresh install without credentials deliberately hands off from the
+        # painted TUI into an interactive provider-onboarding prompt.  That
+        # prompt catches KeyboardInterrupt and treats Ctrl-C as "skip setup",
+        # so using Ctrl-C immediately would test onboarding semantics instead
+        # of the TUI exit path. Decline onboarding explicitly, then exercise
+        # Ctrl-C once the normal interactive surface owns the terminal again.
+        if any(marker in output for marker in FIRST_RUN_SETUP_MARKERS):
+            os.write(master, b"n\n")
+            output += _drain(master, proc, time.monotonic() + 2.0)
+            if proc.poll() is not None:
+                raise RuntimeError(
+                    f"Hermes exited after declining first-run setup with code {proc.returncode}"
+                )
+
+        # Ctrl-C on an idle non-dashboard TUI is the normal exit hotkey.  Give
+        # the Node parent enough time to reap its gateway child; gracefulExit's
+        # own failsafe is four seconds, so the smoke grace must be longer than
+        # that rather than racing it at the same deadline.
+        os.write(master, b"\x03")
+        output += _drain(master, proc, time.monotonic() + 5.5)
+        try:
+            rc = proc.wait(timeout=1.0)
+        except subprocess.TimeoutExpired as exc:
+            _signal_process_group(proc, signal.SIGTERM)
+            proc.wait(timeout=3.0)
+            raise RuntimeError("Hermes TUI did not exit after onboarding was dismissed and Ctrl-C was sent") from exc
+        if rc not in (0, 130, -signal.SIGINT):
+            raise RuntimeError(f"Hermes TUI did not shut down cleanly after Ctrl-C (code {rc})")
+    except Exception as exc:
+        preview = output[-8000:].decode("utf-8", errors="replace")
+        print(preview, file=sys.stderr)
+        print(f"termux-tui-smoke failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        if proc.poll() is None:
+            try:
+                _signal_process_group(proc, getattr(signal, "SIGKILL", signal.SIGTERM))
+            except OSError:
+                pass
+        os.close(master)
+
+    print(
+        f"termux-tui-smoke-ok cols={args.cols} rows={args.rows} bytes={len(output)} rc={rc}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ui-tui/src/__tests__/termuxComposerLayout.test.ts
+++ b/ui-tui/src/__tests__/termuxComposerLayout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { stableComposerColumns, transcriptBodyWidth } from '../lib/inputMetrics.js'
+import { stableComposerColumns, terminalFloor, transcriptBodyWidth, transcriptPaneColumns } from '../lib/inputMetrics.js'
 import { composerPromptText } from '../lib/prompt.js'
 
 describe('Termux composer prompt + width guards', () => {
@@ -36,5 +36,29 @@ describe('Termux composer prompt + width guards', () => {
   it('keeps legacy desktop floor outside Termux mode', () => {
     expect(transcriptBodyWidth(24, 'assistant', '>')).toBe(20)
     expect(transcriptBodyWidth(24, 'user', 'upstr >')).toBe(20)
+  })
+
+  it('never widens the real transcript pane past a narrow Termux window', () => {
+    // Regression: TranscriptPane used to apply Math.max(28, ...) after the
+    // Termux-aware message helper had already removed its own width floor.
+    // The contradictory 28-column claim overflowed 18–24 column phone panes
+    // and caused resize/reflow oscillation (visible as UI bouncing).
+    for (const cols of [24, 21, 18, 16, 21, 24]) {
+      const pane = transcriptPaneColumns(cols, 2, 0, false, true)
+      expect(pane).toBe(cols - 2)
+      expect(pane).toBeLessThanOrEqual(cols)
+    }
+  })
+
+  it('keeps the desktop transcript readability floor outside Termux', () => {
+    expect(transcriptPaneColumns(18, 2, 0, false, false)).toBe(28)
+  })
+
+  it('lets every narrow Termux surface honor its physical dimension', () => {
+    for (const available of [24, 18, 12, 8, 1]) {
+      expect(terminalFloor(available, 64, true)).toBe(available)
+    }
+
+    expect(terminalFloor(18, 64, false)).toBe(64)
   })
 })

--- a/ui-tui/src/components/activeSessionSwitcher.tsx
+++ b/ui-tui/src/components/activeSessionSwitcher.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useInput, useStdout } from '@hermes/ink'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
 import { sessionScopedModelArg } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type {
@@ -11,6 +12,7 @@ import type {
   SessionListItem,
   SessionListResponse
 } from '../gatewayTypes.js'
+import { terminalFloor } from '../lib/inputMetrics.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
@@ -324,9 +326,9 @@ export function ActiveSessionSwitcher({
   const historyDisplayRef = useRef<SessionListItem[]>([])
   const { stdout } = useStdout()
   // Optional maxWidth lets grid layouts hand the switcher its cell budget.
-  const preferredWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
+  const preferredWidth = terminalFloor(Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6), MIN_WIDTH, TERMUX_TUI_MODE)
   const width = clampOverlayWidth(preferredWidth, maxWidth)
-  const promptColumns = Math.max(20, width - 11)
+  const promptColumns = terminalFloor(width - 11, 20, TERMUX_TUI_MODE)
 
   // Rows are [new][live…][history…]: the "+ new" row is pinned first (index 0,
   // always rendered) and the live+history list is windowed below it. `total`

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -18,7 +18,8 @@ import {
   COMPOSER_PROMPT_GAP_WIDTH,
   composerPromptWidth,
   inputVisualHeight,
-  stableComposerColumns
+  stableComposerColumns,
+  transcriptPaneColumns
 } from '../lib/inputMetrics.js'
 import { PerfPane } from '../lib/perfPane.js'
 import { composerPromptText } from '../lib/prompt.js'
@@ -151,7 +152,15 @@ const TranscriptPane = memo(function TranscriptPane({
   //  - narrow terminals: keep full width and reserve bottom rows instead, so
   //    the newest lines sit above the pet rather than getting cramped.
   const useGutter = !!petBox && composer.cols - railCols - petBox.width >= MIN_GUTTER_BODY_COLS
-  const bodyCols = Math.max(28, (useGutter && petBox ? composer.cols - petBox.width : composer.cols) - railCols)
+
+  const bodyCols = transcriptPaneColumns(
+    composer.cols,
+    railCols,
+    petBox?.width ?? 0,
+    useGutter,
+    TERMUX_TUI_MODE
+  )
+
   const petBandRows = petBox && !useGutter ? petBox.height : 0
 
   // LiveTodoPanel rides as a child of the latest user-message row so it

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -6,6 +6,8 @@ import { useGateway } from '../app/gatewayContext.js'
 import type { AppOverlaysProps } from '../app/interfaces.js'
 import { $overlayState, hasFloatingPanel, patchOverlayState } from '../app/overlayStore.js'
 import { $uiSessionId, $uiTheme } from '../app/uiStore.js'
+import { TERMUX_TUI_MODE } from '../config/env.js'
+import { terminalFloor } from '../lib/inputMetrics.js'
 
 import { ActiveSessionSwitcher } from './activeSessionSwitcher.js'
 import { FloatBox } from './appChrome.js'
@@ -331,7 +333,7 @@ export function FloatingOverlays({
               surface painting its own background, which is why it could
               disagree with every other overlay). Only the ACTIVE row carries
               a selection chip, mirroring the session switcher. */}
-          <Box flexDirection="column" width={Math.max(28, cols - 6)}>
+          <Box flexDirection="column" width={terminalFloor(cols - 6, 28, TERMUX_TUI_MODE)}>
             {(() => {
               const visible = completions.slice(start, start + viewportSize)
               // Two-column grid: the name track auto-sizes to the widest

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -3,7 +3,9 @@ import { useEffect, useState } from 'react'
 import unicodeSpinners from 'unicode-animations'
 
 import { artWidth, caduceus, CADUCEUS_WIDTH, logo, LOGO_WIDTH } from '../banner.js'
+import { TERMUX_TUI_MODE } from '../config/env.js'
 import { mix } from '../lib/color.js'
+import { terminalFloor } from '../lib/inputMetrics.js'
 import { flat } from '../lib/text.js'
 import type { Theme } from '../theme.js'
 import type { PanelSection, SessionInfo } from '../types.js'
@@ -80,7 +82,7 @@ const ruleIn = (label: string, w: number) => {
 
 function CompactBanner({ cols, t }: { cols: number; t: Theme }) {
   // -4 keeps a margin so exact-edge rows don't trip terminal pending-wrap.
-  const w = Math.max(28, cols - 4)
+  const w = terminalFloor(cols - 4, 28, TERMUX_TUI_MODE)
 
   // No `opaque` (see ArtLines): the dashed rules are glyphs and the tagline's
   // centering spaces carry the text's own fg style, so every cell paints with
@@ -211,12 +213,12 @@ const TOOLSETS_MAX = 8
 
 export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
   const term = useStdout().stdout?.columns ?? 100
-  const cols = Math.max(20, Math.min(term, maxWidth ?? term))
+  const cols = terminalFloor(Math.min(term, maxWidth ?? term), 20, TERMUX_TUI_MODE)
   const heroLines = caduceus(t.color, t.bannerHero || undefined)
   const leftW = Math.min((artWidth(heroLines) || CADUCEUS_WIDTH) + 4, Math.floor(cols * 0.4))
   const wide = cols >= 90 && leftW + 40 < cols
-  const w = Math.max(20, wide ? cols - leftW - 14 : cols - 12)
-  const lineBudget = Math.max(12, w - 2)
+  const w = terminalFloor(wide ? cols - leftW - 14 : cols - 12, 20, TERMUX_TUI_MODE)
+  const lineBudget = terminalFloor(w - 2, 12, TERMUX_TUI_MODE)
   const strip = (s: string) => (s.endsWith('_tools') ? s.slice(0, -6) : s)
 
   // Hierarchy: labels lead in the label tone; member lists recede in the

--- a/ui-tui/src/components/gridTestOverlay.tsx
+++ b/ui-tui/src/components/gridTestOverlay.tsx
@@ -1,5 +1,7 @@
 import { Box, Text } from '@hermes/ink'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
+import { terminalFloor } from '../lib/inputMetrics.js'
 import type { GridAreaCell, GridTrackSize } from '../lib/widgetGrid.js'
 import type { GridTestState } from '../sdk/apps/gridTestState.js'
 import type { Theme } from '../theme.js'
@@ -23,7 +25,7 @@ const MINI_CELL_HEIGHT = 3
 const showsNestedPreview = (row: number, col: number) => row % 2 === 0 && col % 2 === 0
 
 export function GridTestOverlay({ cols, state, t }: GridTestOverlayProps) {
-  const gridCols = Math.max(12, cols)
+  const gridCols = terminalFloor(cols, 12, TERMUX_TUI_MODE)
   const activeIdx = state.activeRow * state.cols + state.activeCol
   const activeLabel = `c${activeIdx + 1}`
 

--- a/ui-tui/src/components/journey.tsx
+++ b/ui-tui/src/components/journey.tsx
@@ -1,8 +1,10 @@
 import { Box, NoSelect, ScrollBox, type ScrollBoxHandle, Text, useInput, useStdout } from '@hermes/ink'
 import { useEffect, useRef, useState } from 'react'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import { openInEditor } from '../lib/editor.js'
+import { terminalFloor } from '../lib/inputMetrics.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import { deriveStarmapPalette, fadeHex, fadeInk, type StarmapPalette } from '../lib/starmapPalette.js'
 import type { Theme } from '../theme.js'
@@ -135,10 +137,10 @@ function ListRow({ active, cells, t }: { active: boolean; cells: Cell[]; t: Them
 
 export function Journey({ gw, onClose, t }: JourneyProps) {
   const { stdout } = useStdout()
-  const cols = Math.max(40, (stdout?.columns ?? 90) - 3)
-  const rows = Math.max(16, (stdout?.rows ?? 30) - 2)
-  const chartRows = Math.max(5, Math.min(MAX_CHART_ROWS, Math.floor(rows * 0.32)))
-  const page = Math.max(4, rows - 6)
+  const cols = terminalFloor((stdout?.columns ?? 90) - 3, 40, TERMUX_TUI_MODE)
+  const rows = terminalFloor((stdout?.rows ?? 30) - 2, 16, TERMUX_TUI_MODE)
+  const chartRows = terminalFloor(Math.min(MAX_CHART_ROWS, Math.floor(rows * 0.32)), 5, TERMUX_TUI_MODE)
+  const page = terminalFloor(rows - 6, 4, TERMUX_TUI_MODE)
 
   const palette = deriveStarmapPalette(t.color.primary, t.color.text)
 
@@ -448,7 +450,7 @@ export function Journey({ gw, onClose, t }: JourneyProps) {
   const axisGap = Math.max(1, cols - 2 - data.axis.start.length - data.axis.end.length)
   const dataGrid = data.frames.at(-1)?.grid.filter(r => !rowText(r).trimStart().startsWith('trajectory')) ?? []
   const chartGrid = dataGrid.slice(-MAX_CHART_ROWS)
-  const listH = Math.max(3, rows - chartGrid.length - (data.categories?.length ? 11 : 10))
+  const listH = terminalFloor(rows - chartGrid.length - (data.categories?.length ? 11 : 10), 3, TERMUX_TUI_MODE)
   const start = windowStart(cursor, tree.length, listH)
 
   return (

--- a/ui-tui/src/components/maskedPrompt.tsx
+++ b/ui-tui/src/components/maskedPrompt.tsx
@@ -1,6 +1,8 @@
 import { Box, Text } from '@hermes/ink'
 import { useState } from 'react'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
+import { terminalFloor } from '../lib/inputMetrics.js'
 import type { Theme } from '../theme.js'
 
 import { TextInput } from './textInput.js'
@@ -20,7 +22,7 @@ export function MaskedPrompt({ cols = 80, icon, label, onSubmit, sub, t }: Maske
         <Text color={t.color.label}>{'> '}</Text>
         <TextInput
           color={t.color.text}
-          columns={Math.max(20, cols - 6)}
+          columns={terminalFloor(cols - 6, 20, TERMUX_TUI_MODE)}
           mask="*"
           onChange={setValue}
           onSubmit={onSubmit}

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -8,7 +8,7 @@ import { splitComposerHighlights } from '../domain/composerHighlights.js'
 import { sectionMode } from '../domain/details.js'
 import { userDisplay } from '../domain/messages.js'
 import { ROLE } from '../domain/roles.js'
-import { transcriptBodyWidth, transcriptGutterWidth } from '../lib/inputMetrics.js'
+import { terminalFloor, transcriptBodyWidth, transcriptGutterWidth } from '../lib/inputMetrics.js'
 import {
   boundedLiveRenderText,
   compactPreview,
@@ -128,7 +128,7 @@ export const MessageLine = memo(function MessageLine({
   }
 
   if (msg.role === 'tool') {
-    const maxChars = Math.max(24, cols - 14)
+    const maxChars = terminalFloor(cols - 14, 24, TERMUX_TUI_MODE)
     const stripped = hasAnsi(msg.text) ? stripAnsi(msg.text) : msg.text
     const safeAnsi = hasAnsi(msg.text) ? sanitizeAnsiForRender(msg.text) : msg.text
     const preview = compactPreview(stripped, maxChars) || '(empty tool result)'

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -1,11 +1,13 @@
 import { Box, Text, useInput, useStdout } from '@hermes/ink'
 import { useEffect, useMemo, useState } from 'react'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
 import { providerDisplayNames } from '../domain/providers.js'
 import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { ModelOptionProvider, ModelOptionsResponse } from '../gatewayTypes.js'
 import { fuzzyRank } from '../lib/fuzzy.js'
+import { terminalFloor } from '../lib/inputMetrics.js'
 import { modelSearchText } from '../lib/model-search-text.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
@@ -62,7 +64,7 @@ export function ModelPicker({
   // model names scroll into view, and so `wrap="truncate-end"` on each row
   // has an actual constraint to truncate against. Optional maxWidth lets
   // grid layouts hand the picker its cell budget.
-  const preferredWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
+  const preferredWidth = terminalFloor(Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6), MIN_WIDTH, TERMUX_TUI_MODE)
   const width = clampOverlayWidth(preferredWidth, maxWidth)
 
   useEffect(() => {

--- a/ui-tui/src/components/petPicker.tsx
+++ b/ui-tui/src/components/petPicker.tsx
@@ -1,7 +1,9 @@
 import { Box, Text, useInput, useStdout } from '@hermes/ink'
 import { useEffect, useMemo, useState } from 'react'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
 import type { GatewayClient } from '../gatewayClient.js'
+import { terminalFloor } from '../lib/inputMetrics.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
@@ -41,7 +43,7 @@ export function PetPicker({ gw, maxWidth, onClose, t }: PetPickerProps) {
 
   const { stdout } = useStdout()
   // Optional maxWidth lets grid layouts hand the picker its cell budget.
-  const preferredWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
+  const preferredWidth = terminalFloor(Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6), MIN_WIDTH, TERMUX_TUI_MODE)
   const width = clampOverlayWidth(preferredWidth, maxWidth)
 
   useEffect(() => {

--- a/ui-tui/src/components/pluginsHub.tsx
+++ b/ui-tui/src/components/pluginsHub.tsx
@@ -1,7 +1,9 @@
 import { Box, Text, useInput, useStdout } from '@hermes/ink'
 import { useEffect, useState } from 'react'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
 import type { GatewayClient } from '../gatewayClient.js'
+import { terminalFloor } from '../lib/inputMetrics.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
@@ -52,7 +54,7 @@ export function PluginsHub({ gw, maxWidth, onClose, t }: PluginsHubProps) {
 
   const { stdout } = useStdout()
   // Optional maxWidth lets grid layouts hand the hub its cell budget.
-  const preferredWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
+  const preferredWidth = terminalFloor(Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6), MIN_WIDTH, TERMUX_TUI_MODE)
   const width = clampOverlayWidth(preferredWidth, maxWidth)
 
   const load = () => {

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -1,6 +1,8 @@
 import { Box, Text, useInput, wrapAnsi } from '@hermes/ink'
 import { useState } from 'react'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
+import { terminalFloor } from '../lib/inputMetrics.js'
 import { isMac } from '../lib/platform.js'
 import type { Theme } from '../theme.js'
 import type { ApprovalReq, ClarifyReq, ConfirmReq } from '../types.js'
@@ -97,7 +99,7 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
   // Wrap long single-line commands to the panel width instead of clipping the
   // tail (mirrors the CLI approval panel fix — the full command must be
   // reviewable before approving). Border + paddingX + inner padding ≈ 8 cols.
-  const innerWidth = Math.max(20, cols - 8)
+  const innerWidth = terminalFloor(cols - 8, 20, TERMUX_TUI_MODE)
 
   const rawLines = req.command
     .split('\n')
@@ -194,7 +196,7 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
           <Text color={t.color.label}>{'> '}</Text>
           <TextInput
             color={t.color.text}
-            columns={Math.max(20, cols - 6)}
+            columns={terminalFloor(cols - 6, 20, TERMUX_TUI_MODE)}
             onChange={setCustom}
             onSubmit={onAnswer}
             value={custom}

--- a/ui-tui/src/components/queuedMessages.tsx
+++ b/ui-tui/src/components/queuedMessages.tsx
@@ -1,5 +1,7 @@
 import { Box, Text } from '@hermes/ink'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
+import { terminalFloor } from '../lib/inputMetrics.js'
 import { compactPreview } from '../lib/text.js'
 import type { Theme } from '../theme.js'
 
@@ -42,7 +44,7 @@ export function QueuedMessages({ cols, queueEditIdx, queued, t }: QueuedMessages
 
         return (
           <Text color={active ? t.color.accent : t.color.muted} dimColor key={`${idx}-${item.slice(0, 16)}`}>
-            {active ? '▸' : ' '} {idx + 1}. {compactPreview(item, Math.max(16, cols - 10))}
+            {active ? '▸' : ' '} {idx + 1}. {compactPreview(item, terminalFloor(cols - 10, 16, TERMUX_TUI_MODE))}
           </Text>
         )
       })}

--- a/ui-tui/src/components/skillsHub.tsx
+++ b/ui-tui/src/components/skillsHub.tsx
@@ -1,7 +1,9 @@
 import { Box, Text, useInput, useStdout } from '@hermes/ink'
 import { useEffect, useState } from 'react'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
 import type { GatewayClient } from '../gatewayClient.js'
+import { terminalFloor } from '../lib/inputMetrics.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
@@ -26,7 +28,7 @@ export function SkillsHub({ gw, maxWidth, onClose, t }: SkillsHubProps) {
 
   const { stdout } = useStdout()
   const terminalWidth = Math.max(1, (stdout?.columns ?? 80) - 6)
-  const preferredWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, terminalWidth))
+  const preferredWidth = terminalFloor(Math.min(MAX_WIDTH, terminalWidth), MIN_WIDTH, TERMUX_TUI_MODE)
   const width = clampOverlayWidth(preferredWidth, maxWidth)
 
   useEffect(() => {

--- a/ui-tui/src/config/env.ts
+++ b/ui-tui/src/config/env.ts
@@ -23,6 +23,8 @@ const parseToggle = (v?: string): boolean | null => {
   return null
 }
 
+// Startup-time constant by design: terminal mode is derived once before the TUI mounts.
+// It is not a reactive setting and must not change during a rendered session.
 export const TERMUX_TUI_MODE = isTermuxTuiMode()
 
 export const STARTUP_RESUME_ID = (process.env.HERMES_TUI_RESUME ?? '').trim()

--- a/ui-tui/src/lib/inputMetrics.ts
+++ b/ui-tui/src/lib/inputMetrics.ts
@@ -1,5 +1,6 @@
 import { stringWidth, wrapAnsi } from '@hermes/ink'
 
+import { TERMUX_TUI_MODE } from '../config/env.js'
 import type { Role } from '../types.js'
 
 export const COMPOSER_PROMPT_GAP_WIDTH = 1
@@ -178,17 +179,41 @@ export function transcriptGutterWidth(role: Role, userPrompt: string) {
   return role === 'user' ? composerPromptWidth(userPrompt) : 3
 }
 
+export function terminalFloor(value: number, minimum: number, termuxMode = TERMUX_TUI_MODE) {
+  const available = Math.max(1, value)
+
+  // In Termux, the physical pane is the hard upper bound. Raising an 8-column
+  // pane to an 8-10+ column "usability floor" cannot create usable space; it
+  // only makes Ink claim cells that do not exist and can restart the resize /
+  // wrap oscillation this helper prevents. Callers may choose to hide a UI at
+  // extreme sizes, but any rendered surface must stay within `available`.
+  return termuxMode ? available : Math.max(minimum, available)
+}
+
 export function transcriptBodyWidth(totalCols: number, role: Role, userPrompt: string, termuxMode = false) {
   const horizontalReserve = termuxMode ? 2 : 4
   const available = Math.max(1, totalCols - transcriptGutterWidth(role, userPrompt) - horizontalReserve)
 
-  if (termuxMode) {
-    // On narrow / unusual aspect-ratio mobile panes, forcing a wide minimum
-    // width causes right-edge clipping and chopped words.
-    return available
-  }
+  // On narrow / unusual aspect-ratio mobile panes, forcing a wide minimum
+  // width causes right-edge clipping and chopped words.
+  return terminalFloor(available, 20, termuxMode)
+}
 
-  return Math.max(20, available)
+export function transcriptPaneColumns(
+  totalCols: number,
+  railCols: number,
+  petWidth = 0,
+  usePetGutter = false,
+  termuxMode = false
+) {
+  const petReserve = usePetGutter ? Math.max(0, petWidth) : 0
+  const available = Math.max(1, totalCols - Math.max(0, railCols) - petReserve)
+
+  // Desktop keeps the historical readability floor. Termux must never claim
+  // more cells than the physical terminal actually owns: Ink otherwise wraps
+  // the over-wide transcript, fires another resize/layout pass, and narrow
+  // Android terminals visibly bounce between two geometries.
+  return terminalFloor(available, 28, termuxMode)
 }
 
 export function stableComposerColumns(totalCols: number, promptWidth: number, termuxMode = false) {

--- a/ui-tui/src/sdk/apps/ticker.tsx
+++ b/ui-tui/src/sdk/apps/ticker.tsx
@@ -1,8 +1,10 @@
-import { Box, Text } from '@hermes/ink'
+import { Box, Text, useStdout } from '@hermes/ink'
 import { useEffect, useState } from 'react'
 
 import { Dialog } from '../../components/overlay.js'
+import { TERMUX_TUI_MODE } from '../../config/env.js'
 import { sparkline } from '../../lib/charts.js'
+import { terminalFloor } from '../../lib/inputMetrics.js'
 import type { Theme } from '../../theme.js'
 import { defineWidgetApp } from '../registry.js'
 import { isCtrl } from '../types.js'
@@ -23,6 +25,10 @@ export interface TickerState {
 }
 
 function Chart({ symbol, t }: { symbol: string; t: Theme }) {
+  const { stdout } = useStdout()
+  const width = terminalFloor(Math.min(POINTS + 6, Math.max(1, (stdout?.columns ?? POINTS + 6) - 2)), 32, TERMUX_TUI_MODE)
+  const chartPoints = Math.max(1, width - 6)
+
   const [series, setSeries] = useState<number[]>(() => {
     const seed = 1.1 + Math.random() * 0.4
     const out = [seed]
@@ -49,7 +55,7 @@ function Chart({ symbol, t }: { symbol: string; t: Theme }) {
   const dir = up ? t.color.ok : t.color.error
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" width={width}>
       <Box columnGap={1} flexDirection="row">
         <Text bold color={t.color.label}>
           {symbol}
@@ -60,7 +66,7 @@ function Chart({ symbol, t }: { symbol: string; t: Theme }) {
           {Math.abs(delta / PIP).toFixed(1)}p
         </Text>
       </Box>
-      <Text color={dir}>{sparkline(series)}</Text>
+      <Text color={dir}>{sparkline(series.slice(-chartPoints))}</Text>
     </Box>
   )
 }
@@ -84,7 +90,7 @@ export const tickerApp = defineWidgetApp<TickerState>({
 
   render({ state, t }) {
     return (
-      <Dialog width={Math.max(32, POINTS + 6)}>
+      <Dialog>
         <Chart symbol={state.symbol} t={t} />
       </Dialog>
     )


### PR DESCRIPTION
## Summary

This is the narrow-terminal TUI slice split out of #67163 at @teknium1's request.

It intentionally contains only the terminal-layout work:
- replace hard minimum geometry floors with terminal-aware widths/heights across the main layout and secondary overlays;
- keep composer/transcript sizing stable on narrow Termux screens;
- add deterministic narrow-layout regression coverage;
- add a real PTY smoke harness for a 48x18 terminal, including first-run onboarding dismissal and clean Ctrl-C shutdown.

There are **no native installer/wheelhouse changes and no Desktop/browser/PTY-web-server changes** in this PR. Those are separate concerns.

## Maintainer scope clarification

Teknium clarified in #86986 that NousResearch accepts light Termux integration and cheap, concrete Termux bug fixes that do not compromise primary platforms. This PR remains exactly that isolated UI bug-fix slice. PR #85606 has since merged the separate APT-managed-install integration; this PR does not alter package distribution or install/update semantics.

## Review follow-up and current rebase (2026-08-18)

Rebased from the old 2026-08-16 base onto current upstream history after #85606 merged. Current PR head: `f6f3423ff7`.

The automated review points were checked against the code rather than applied mechanically:
- **Overlay floors:** no artificial 8-10 column Termux floor was added. Claiming more cells than the physical pane owns is the resize/wrap oscillation this PR fixes. Callers may hide an unusable UI at extreme sizes, but a rendered surface must not exceed the real terminal width.
- **Startup constant:** `TERMUX_TUI_MODE` is explicitly documented as a startup-time, non-reactive constant.
- **Call-site drift:** `terminalFloor()` now defaults to the shared `TERMUX_TUI_MODE` startup constant while existing call sites remain explicit/testable.
- **`ENOTTY` smoke marker:** retained intentionally. The smoke creates a real PTY with `pty.openpty()` and wires stdin/stdout/stderr to its slave; `ENOTTY` therefore indicates a terminal ioctl reached a non-TTY fd, not a normal healthy Termux startup condition. This is documented beside the marker.

## Validation

On the rebased head:
- `npm --workspace ui-tui run typecheck` — pass
- `termuxComposerLayout.test.ts` — **9/9 pass**
- `npm --workspace ui-tui run lint` — **0 errors** (2 unrelated existing hook warnings)
- `python -m py_compile scripts/smoke-termux-tui.py` — pass
- `git diff --check` — pass
- broad Windows workspace run reached **1,654 passing tests**; its 10 failures are existing Unix editor/PATH assumptions in `editor.test.ts`, `terminalParity.test.ts`, and `terminalSetup.test.ts`, none changed by this PR. Fresh GitHub CI is the authoritative cross-platform full suite.

This remains non-draft and ready for focused maintainer review once the fresh post-rebase CI completes.
