### PR TITLE
fix(termux): native install and update chain

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -178,3 +178,28 @@ jobs:
 
       - name: Run footgun checker
         run: python scripts/check-windows-footguns.py --all
+
+
+  termux-footguns:
+    # Android/Bionic-specific static guardrails that normal Linux runners do
+    # not exercise: host package managers, fake wheel tags, accidental Electron
+    # execution, unsafe Termux:X11 Chromium flags, and non-loopback Desktop binds.
+    name: Termux footguns (blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          version: "0.9.28"
+
+      - name: Set up Python 3.11
+        uses: ./.github/actions/retry
+        with:
+          command: uv python install 3.11
+
+      - name: Run Termux footgun checker
+        run: python scripts/check-termux-footguns.py --all

--- a/.github/workflows/termux-regression.yml
+++ b/.github/workflows/termux-regression.yml
@@ -1,0 +1,70 @@
+name: Termux regression
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/termux-regression.yml"
+      - ".github/workflows/lint.yml"
+      - "hermes_cli/android_wheels.py"
+      - "hermes_cli/main.py"
+      - "hermes_cli/psutil_android.py"
+      - "hermes_cli/termux_wheelhouse.py"
+      - "hermes_cli/update_cmd.py"
+      - "pyproject.toml"
+      - "constraints-termux.txt"
+      - "scripts/check-termux-footguns.py"
+      - "scripts/install-termux.sh"
+      - "scripts/install.sh"
+      - "scripts/install_android_wheels.py"
+      - "scripts/prepare_termux_wheelhouse.py"
+      - "scripts/run-termux-regression.sh"
+      - "scripts/termux_requirements.py"
+      - "tests/hermes_cli/test_android_wheels.py"
+      - "tests/hermes_cli/test_psutil_android_wheel_tag.py"
+      - "tests/hermes_cli/test_termux_wheelhouse.py"
+      - "tests/scripts/test_termux_footguns.py"
+      - "tests/test_install_termux_native.py"
+      - "tests/test_termux_requirements.py"
+      - "uv.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: termux-regression-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native-termux-aarch64:
+    name: Native Termux aarch64 install/update
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 55
+    env:
+      TERMUX_IMAGE: termux/termux-docker@sha256:3aed9c7fbcf9195a9919deaad418da006232864a779fb4f322d68a34887a2e15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Make the checked-out PR addressable to the native installer
+        shell: bash
+        run: git branch -f termux-ci "$GITHUB_SHA"
+
+      - name: Pull pinned native Termux aarch64 image
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(uname -m)" = "aarch64"
+          docker pull "$TERMUX_IMAGE"
+          test "$(docker image inspect --format '{{.Architecture}}' "$TERMUX_IMAGE")" = "arm64"
+
+      - name: Run native installer/update regression gates
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          docker run --rm \
+            -v "$PWD:/workspace:ro" \
+            "$TERMUX_IMAGE" \
+            bash /workspace/scripts/run-termux-regression.sh

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The installer handles everything: uv, Python 3.11, Node.js, ripgrep, ffmpeg, **a
 
 If you already have Git installed, the installer detects it and uses that instead. Otherwise a ~45MB MinGit download is all you need — it won't touch or interfere with any system Git.
 
-> **Android / Termux:** The tested manual path is documented in the [Termux guide](https://hermes-agent.nousresearch.com/docs/getting-started/termux). On Termux, Hermes installs a curated `.[termux]` extra because the full `.[all]` extra currently pulls Android-incompatible voice dependencies.
+> **Android / Termux:** The one-line command dispatches to a dedicated native `uv` installer that automatically selects or installs the SHA-256-pinned Python 3.13.14 aarch64 runtime. Python 3.11/3.12 remain available only through an explicit compatibility selection. On the normal CPython 3.13 arm64 path it verifies and installs a pinned immutable Android wheelhouse with `--only-binary :all:`, avoiding on-device C and Rust compilation; unsupported Python/architecture combinations retain a compatibility build fallback. See the [Termux guide](https://hermes-agent.nousresearch.com/docs/getting-started/termux) for options and limitations.
 >
 > **Windows:** Native Windows is fully supported — the PowerShell one-liner above installs everything. If you'd rather use WSL2, the Linux command works there too. Native Windows install lives under `%LOCALAPPDATA%\hermes`; WSL2 installs under `~/.hermes` as on Linux.
 

--- a/contributors/emails/adybag14@gmail.com
+++ b/contributors/emails/adybag14@gmail.com
@@ -1,0 +1,2 @@
+adybag14-cyber
+# PR #67163 (fix(termux): repair the complete native install chain)

--- a/hermes_cli/android_wheels.py
+++ b/hermes_cli/android_wheels.py
@@ -1,0 +1,220 @@
+"""Safe helpers for building CPython extension wheels on Android/Termux.
+
+Setuptools normally labels a native Termux build as ``linux_<arch>`` even
+though Android/Bionic is not ABI-compatible with glibc Linux. The functions
+here apply a package-local ``bdist_wheel.plat_name`` override so the build gets
+a PEP 738 Android tag without exporting ``_PYTHON_HOST_PLATFORM`` into uv.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import re
+import shutil
+import stat
+import tarfile
+import urllib.request
+import zipfile
+from pathlib import Path, PurePosixPath
+
+DEFAULT_ANDROID_API_LEVEL = 24
+ANDROID_ABI_BY_MACHINE = {
+    "aarch64": "arm64_v8a",
+    "arm64": "arm64_v8a",
+    "armv7l": "armeabi_v7a",
+    "armv8l": "armeabi_v7a",
+    "arm": "armeabi_v7a",
+    "x86_64": "x86_64",
+    "amd64": "x86_64",
+    "i386": "x86",
+    "i486": "x86",
+    "i586": "x86",
+    "i686": "x86",
+    "x86": "x86",
+}
+_BDIST_WHEEL_SECTION_RE = re.compile(
+    r"(?ms)^\[bdist_wheel\]\s*\n(?P<body>.*?)(?=^\[|\Z)"
+)
+_PLAT_NAME_RE = re.compile(r"(?m)^plat_name\s*=.*$")
+
+
+class AndroidWheelError(RuntimeError):
+    """Raised when an Android source build cannot be prepared safely."""
+
+
+def canonicalize_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def android_wheel_platform_tag(
+    *, api_level: int | str | None = None, machine: str | None = None
+) -> str:
+    raw_level = api_level if api_level is not None else DEFAULT_ANDROID_API_LEVEL
+    try:
+        level = int(raw_level)
+    except (TypeError, ValueError) as exc:
+        raise AndroidWheelError(f"Invalid Android API level: {raw_level!r}") from exc
+    if not 21 <= level <= 99:
+        raise AndroidWheelError(
+            f"Android API level must be between 21 and 99, got {level}"
+        )
+
+    normalized_machine = (machine or platform.machine()).strip().lower()
+    abi = ANDROID_ABI_BY_MACHINE.get(normalized_machine)
+    if abi is None:
+        raise AndroidWheelError(
+            f"Unsupported Android architecture: {normalized_machine or '<empty>'}"
+        )
+    return f"android_{level}_{abi}"
+
+
+def configure_setuptools_android_tag(src_root: Path, platform_tag: str) -> None:
+    """Write a package-scoped wheel platform override into ``setup.cfg``."""
+    setup_cfg = src_root / "setup.cfg"
+    try:
+        content = setup_cfg.read_text(encoding="utf-8") if setup_cfg.exists() else ""
+    except OSError as exc:
+        raise AndroidWheelError(f"Failed to read {setup_cfg}") from exc
+
+    section = _BDIST_WHEEL_SECTION_RE.search(content)
+    if section is None:
+        separator = "" if not content else "" if content.endswith("\n\n") else "\n"
+        if content and not content.endswith("\n"):
+            separator = "\n\n"
+        elif content and content.endswith("\n") and not content.endswith("\n\n"):
+            separator = "\n"
+        updated = f"{content}{separator}[bdist_wheel]\nplat_name = {platform_tag}\n"
+    else:
+        body = section.group("body")
+        if _PLAT_NAME_RE.search(body):
+            new_body = _PLAT_NAME_RE.sub(f"plat_name = {platform_tag}", body, count=1)
+        else:
+            new_body = f"plat_name = {platform_tag}\n{body}"
+        updated = (
+            content[: section.start("body")] + new_body + content[section.end("body") :]
+        )
+
+    try:
+        setup_cfg.write_text(updated, encoding="utf-8")
+    except OSError as exc:
+        raise AndroidWheelError(f"Failed to write {setup_cfg}") from exc
+
+
+def _safe_parts(name: str) -> tuple[str, ...]:
+    path = PurePosixPath(name)
+    parts = tuple(part for part in path.parts if part not in ("", "."))
+    if path.is_absolute() or not parts or ".." in parts:
+        raise AndroidWheelError(f"Unsafe archive member path: {name!r}")
+    return parts
+
+
+def _extract_tar(archive: Path, destination: Path) -> None:
+    with tarfile.open(archive, "r:*") as tf:
+        for member in tf.getmembers():
+            target = destination.joinpath(*_safe_parts(member.name))
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                raise AndroidWheelError(
+                    f"Unsupported archive member type: {member.name}"
+                )
+            target.parent.mkdir(parents=True, exist_ok=True)
+            source = tf.extractfile(member)
+            if source is None:
+                raise AndroidWheelError(f"Cannot read archive member: {member.name}")
+            with source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+            try:
+                target.chmod(member.mode & 0o777)
+            except OSError:
+                pass
+
+
+def _extract_zip(archive: Path, destination: Path) -> None:
+    with zipfile.ZipFile(archive) as zf:
+        for info in zf.infolist():
+            target = destination.joinpath(*_safe_parts(info.filename))
+            mode = (info.external_attr >> 16) & 0xFFFF
+            if stat.S_ISLNK(mode):
+                raise AndroidWheelError(
+                    f"Archive symlink is not allowed: {info.filename}"
+                )
+            if info.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(info) as source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+
+
+def safe_extract_sdist(archive: Path, destination: Path) -> Path:
+    destination.mkdir(parents=True, exist_ok=True)
+    if zipfile.is_zipfile(archive):
+        _extract_zip(archive, destination)
+    elif tarfile.is_tarfile(archive):
+        _extract_tar(archive, destination)
+    else:
+        raise AndroidWheelError(f"Unsupported sdist archive: {archive.name}")
+
+    roots = sorted(path for path in destination.iterdir() if path.is_dir())
+    if len(roots) != 1:
+        raise AndroidWheelError(
+            f"Expected one source directory in {archive.name}, found {len(roots)}"
+        )
+    return roots[0]
+
+
+def pypi_sdist(name: str, version: str, destination: Path) -> Path:
+    """Download an exact PyPI sdist and verify its repository SHA-256."""
+    api_url = f"https://pypi.org/pypi/{name}/{version}/json"
+    try:
+        with urllib.request.urlopen(api_url, timeout=60) as response:  # noqa: S310
+            metadata = json.load(response)
+    except Exception as exc:
+        raise AndroidWheelError(
+            f"Failed to read PyPI metadata for {name}=={version}"
+        ) from exc
+
+    candidates = [
+        item for item in metadata.get("urls", []) if item.get("packagetype") == "sdist"
+    ]
+    if not candidates:
+        raise AndroidWheelError(f"PyPI has no sdist for {name}=={version}")
+    candidate = candidates[0]
+    url = candidate.get("url")
+    expected = (candidate.get("digests") or {}).get("sha256")
+    filename = candidate.get("filename") or f"{name}-{version}.tar.gz"
+    if not url or not expected:
+        raise AndroidWheelError(f"Incomplete PyPI sdist metadata for {name}=={version}")
+
+    destination.mkdir(parents=True, exist_ok=True)
+    archive = destination / filename
+    try:
+        urllib.request.urlretrieve(url, archive)  # noqa: S310
+    except Exception as exc:
+        raise AndroidWheelError(f"Failed to download {name}=={version} sdist") from exc
+    actual = hashlib.sha256(archive.read_bytes()).hexdigest()
+    if actual != expected:
+        archive.unlink(missing_ok=True)
+        raise AndroidWheelError(
+            f"SHA-256 mismatch for {name}=={version}: expected {expected}, got {actual}"
+        )
+    return archive
+
+
+def patch_psutil_android_detection(src_root: Path) -> None:
+    common = src_root / "psutil" / "_common.py"
+    marker = 'LINUX = sys.platform.startswith("linux")'
+    replacement = 'LINUX = sys.platform.startswith(("linux", "android"))'
+    try:
+        content = common.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise AndroidWheelError("psutil sdist is missing psutil/_common.py") from exc
+    if replacement in content:
+        return
+    if marker not in content:
+        raise AndroidWheelError("psutil Android compatibility marker not found")
+    common.write_text(content.replace(marker, replacement), encoding="utf-8")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8625,6 +8625,18 @@ def _install_python_dependencies_with_optional_fallback(
     copies (Windows blocks REPLACE on a running .exe but allows RENAME). See
     ``_quarantine_running_hermes_exe`` for the rationale.
     """
+    if group == "termux-all" and _is_termux_env(env) and _is_android_python():
+        if _install_termux_dependencies_from_wheelhouse(
+            install_cmd_prefix,
+            env=env,
+        ):
+            return
+        print(
+            "  WARNING: Immutable wheels do not support this Python/architecture; "
+            "using the native-build compatibility fallback..."
+        )
+        _install_psutil_android_compat(install_cmd_prefix, env=env)
+
     scripts_dir = _venv_scripts_dir() if _is_windows() else None
 
     def _install(args: list[str]) -> None:
@@ -8998,6 +9010,393 @@ def _is_windows_npm_path(npm_path: str) -> bool:
         or low.startswith("/mnt/")
         or "\\" in npm_path
     )
+
+
+def _termux_wheelhouse_cache_root(env: dict[str, str] | None = None) -> Path:
+    values = env or os.environ
+    home = values.get("HERMES_HOME")
+    root = Path(home).expanduser() if home else Path.home() / ".hermes"
+    return root / "cache" / "termux-wheelhouse"
+
+
+def _install_termux_dependencies_from_wheelhouse(
+    install_cmd_prefix: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> bool:
+    """Resolve and install the Termux graph from the pinned binary wheelhouse.
+
+    Returns ``False`` only when the interpreter/architecture is outside the
+    published CPython 3.13 arm64 target. Integrity, download, or dependency-pin
+    failures raise and therefore never silently fall back to local compilation.
+    """
+    if len(install_cmd_prefix) < 2 or install_cmd_prefix[1] != "pip":
+        return False
+
+    from hermes_cli.termux_wheelhouse import (
+        TermuxWheelhouseUnsupported,
+        binary_install_options,
+        ensure_wheelhouse,
+        validate_runtime,
+    )
+
+    uv_bin = install_cmd_prefix[0]
+    target_python = _resolve_install_target_python(install_cmd_prefix, env)
+    if target_python is None:
+        return False
+
+    probe = (
+        "import json, platform, sys; "
+        "g=getattr(sys, 'getandroidapilevel', None); "
+        "print(json.dumps({'platform':sys.platform,'version':list(sys.version_info[:2]),"
+        "'machine':platform.machine(),'api':g() if callable(g) else None,'full_version':platform.python_version()}))"
+    )
+    result = subprocess.run(
+        [str(target_python), "-c", probe],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    details = json.loads(result.stdout)
+    try:
+        validate_runtime(
+            python_version=tuple(details["version"]),
+            machine=str(details["machine"]),
+            android_api=details["api"],
+            sys_platform=str(details["platform"]),
+        )
+    except TermuxWheelhouseUnsupported:
+        return False
+
+    work = _termux_wheelhouse_cache_root(env).parent / "termux-update"
+    work.mkdir(parents=True, exist_ok=True)
+    direct = work / "direct.in"
+    lock_constraints = work / "lock-constraints.txt"
+    resolved = work / "resolved.txt"
+    run_env = {**os.environ, **(env or {})}
+    run_env.pop("PYTHONPATH", None)
+    run_env.pop("PYTHONHOME", None)
+    run_env["UV_NO_CONFIG"] = "1"
+    run_env["UV_LINK_MODE"] = "copy"
+    run_env["UV_PYTHON"] = str(target_python)
+    run_env["UV_DEFAULT_INDEX"] = "https://pypi.org/simple"
+    run_env["UV_INDEX_STRATEGY"] = "first-index"
+    for key in (
+        "UV_INDEX",
+        "UV_EXTRA_INDEX_URL",
+        "PIP_INDEX_URL",
+        "PIP_EXTRA_INDEX_URL",
+    ):
+        run_env.pop(key, None)
+
+    _run_install_with_heartbeat(
+        [uv_bin, "pip", "install", "--python", str(target_python), "packaging==26.0"],
+        env=run_env,
+    )
+    subprocess.run(
+        [
+            str(target_python),
+            str(PROJECT_ROOT / "scripts" / "termux_requirements.py"),
+            "--pyproject",
+            str(PROJECT_ROOT / "pyproject.toml"),
+            "--lock",
+            str(PROJECT_ROOT / "uv.lock"),
+            "--requirements",
+            str(direct),
+            "--constraints",
+            str(lock_constraints),
+            "--python-version",
+            str(details["full_version"]),
+        ],
+        cwd=PROJECT_ROOT,
+        check=True,
+        env=run_env,
+    )
+    subprocess.run(
+        [
+            uv_bin,
+            "pip",
+            "compile",
+            str(direct),
+            "--python",
+            str(target_python),
+            "--constraint",
+            str(lock_constraints),
+            "--output-file",
+            str(resolved),
+            "--no-annotate",
+        ],
+        cwd=PROJECT_ROOT,
+        check=True,
+        env=run_env,
+    )
+    wheelhouse = ensure_wheelhouse(
+        _termux_wheelhouse_cache_root(run_env),
+        requirements=resolved,
+        uv_lock=PROJECT_ROOT / "uv.lock",
+        check_runtime=False,
+    )
+    print(f"  Using immutable Termux wheelhouse: {wheelhouse.name}")
+    _run_install_with_heartbeat(
+        [
+            uv_bin,
+            "pip",
+            "install",
+            "--python",
+            str(target_python),
+            "--requirements",
+            str(resolved),
+            "--constraint",
+            str(PROJECT_ROOT / "constraints-termux.txt"),
+            *binary_install_options(wheelhouse),
+        ],
+        env=run_env,
+    )
+    _run_install_with_heartbeat(
+        [
+            uv_bin,
+            "pip",
+            "install",
+            "--python",
+            str(target_python),
+            "--no-deps",
+            "--editable",
+            ".",
+        ],
+        env=run_env,
+    )
+    subprocess.run(
+        [uv_bin, "pip", "check", "--python", str(target_python)],
+        cwd=PROJECT_ROOT,
+        check=True,
+        env=run_env,
+    )
+    smoke = (
+        "import importlib; "
+        "[importlib.import_module(m) for m in "
+        "('cffi','cryptography','jiter','markupsafe','PIL.Image','psutil',"
+        "'pydantic_core','yaml','rpds','_ruamel_yaml')]; "
+        "print('immutable Termux native imports ok')"
+    )
+    subprocess.run(
+        [str(target_python), "-c", smoke],
+        cwd=PROJECT_ROOT,
+        check=True,
+        env=run_env,
+    )
+    return True
+
+
+def _termux_post_pull_wheelhouse_gate(
+    git_cmd: list[str],
+    pre_pull_sha: str | None,
+) -> None:
+    """Reject a pulled Termux update unless its complete graph is binary-only.
+
+    The verifier runs in a child process so it loads the newly pulled release
+    constants instead of this process's pre-pull module cache. After the
+    immutable wheel release is verified, uv performs a dry-run of the freshly
+    resolved Termux graph with source distributions disabled. Any pin,
+    checksum, download, or binary-coverage failure rolls the checkout back.
+    """
+    if not (_is_termux_env() and _is_android_python()):
+        return
+
+    def reject(detail: str) -> None:
+        print("Updated checkout failed the immutable Termux wheel gate:")
+        print(
+            f"  {detail.splitlines()[-1] if detail else 'unknown wheelhouse failure'}"
+        )
+        if pre_pull_sha:
+            rollback = subprocess.run(
+                git_cmd + ["reset", "--hard", pre_pull_sha],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if rollback.returncode == 0:
+                print(
+                    f"  Rolled back to {pre_pull_sha[:10]}; "
+                    "the existing install is unchanged"
+                )
+            else:
+                print(f"  Recover manually: git reset --hard {pre_pull_sha}")
+        raise SystemExit(1)
+
+    uv_bin = _ensure_uv_for_termux([sys.executable, "-m", "pip"])
+    if not uv_bin:
+        reject("Termux uv is unavailable; reinstall the Termux uv package")
+
+    target_python = _resolve_install_target_python(
+        [uv_bin, "pip"],
+        {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")},
+    ) or Path(sys.executable)
+    verifier = [
+        str(target_python),
+        str(PROJECT_ROOT / "scripts" / "prepare_termux_wheelhouse.py"),
+        "--cache-root",
+        str(_termux_wheelhouse_cache_root()),
+        "--uv-lock",
+        str(PROJECT_ROOT / "uv.lock"),
+    ]
+    result = subprocess.run(
+        verifier,
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 2:
+        print(
+            "  WARNING: Updated checkout is outside the immutable "
+            "arm64/Python 3.13 target"
+        )
+        return
+    if result.returncode != 0:
+        reject(
+            (result.stderr or result.stdout or "wheelhouse verification failed").strip()
+        )
+
+    work = _termux_wheelhouse_cache_root().parent / "termux-update-gate"
+    work.mkdir(parents=True, exist_ok=True)
+    direct = work / "direct.in"
+    lock_constraints = work / "lock-constraints.txt"
+    resolved = work / "resolved.txt"
+    run_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+    run_env.pop("PYTHONPATH", None)
+    run_env.pop("PYTHONHOME", None)
+    run_env["UV_NO_CONFIG"] = "1"
+    run_env["UV_LINK_MODE"] = "copy"
+    run_env["UV_PYTHON"] = str(target_python)
+    run_env["UV_DEFAULT_INDEX"] = "https://pypi.org/simple"
+    run_env["UV_INDEX_STRATEGY"] = "first-index"
+    for key in (
+        "UV_INDEX",
+        "UV_EXTRA_INDEX_URL",
+        "PIP_INDEX_URL",
+        "PIP_EXTRA_INDEX_URL",
+    ):
+        run_env.pop(key, None)
+
+    version_probe = subprocess.run(
+        [
+            str(target_python),
+            "-c",
+            "import platform; print(platform.python_version())",
+        ],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=run_env,
+    )
+    if version_probe.returncode != 0:
+        reject((version_probe.stderr or "target Python version probe failed").strip())
+    full_version = version_probe.stdout.strip()
+
+    try:
+        subprocess.run(
+            [
+                str(target_python),
+                str(PROJECT_ROOT / "scripts" / "termux_requirements.py"),
+                "--pyproject",
+                str(PROJECT_ROOT / "pyproject.toml"),
+                "--lock",
+                str(PROJECT_ROOT / "uv.lock"),
+                "--requirements",
+                str(direct),
+                "--constraints",
+                str(lock_constraints),
+                "--python-version",
+                full_version,
+            ],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+            env=run_env,
+        )
+        subprocess.run(
+            [
+                uv_bin,
+                "pip",
+                "compile",
+                str(direct),
+                "--python",
+                str(target_python),
+                "--constraint",
+                str(lock_constraints),
+                "--output-file",
+                str(resolved),
+                "--no-annotate",
+            ],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+            env=run_env,
+        )
+    except subprocess.CalledProcessError as exc:
+        reject((exc.stderr or exc.stdout or str(exc)).strip())
+
+    graph_verifier = [*verifier, "--requirements", str(resolved)]
+    graph_result = subprocess.run(
+        graph_verifier,
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=run_env,
+    )
+    if graph_result.returncode != 0:
+        reject(
+            (
+                graph_result.stderr or graph_result.stdout or "dependency pin mismatch"
+            ).strip()
+        )
+    output_lines = [
+        line.strip() for line in graph_result.stdout.splitlines() if line.strip()
+    ]
+    if not output_lines:
+        reject("wheelhouse verifier returned no cache path")
+    wheelhouse = Path(output_lines[-1])
+
+    binary_probe = subprocess.run(
+        [
+            uv_bin,
+            "pip",
+            "install",
+            "--dry-run",
+            "--reinstall",
+            "--python",
+            str(target_python),
+            "--requirements",
+            str(resolved),
+            "--constraint",
+            str(PROJECT_ROOT / "constraints-termux.txt"),
+            "--find-links",
+            str(wheelhouse),
+            "--only-binary",
+            ":all:",
+        ],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=run_env,
+    )
+    if binary_probe.returncode != 0:
+        reject(
+            (
+                binary_probe.stderr
+                or binary_probe.stdout
+                or "resolved graph requires an unavailable source build"
+            ).strip()
+        )
+    print("  Immutable Termux wheel update gate passed (binary-only graph)")
 
 
 def _resolve_node_runtime_npm() -> str | None:

--- a/hermes_cli/psutil_android.py
+++ b/hermes_cli/psutil_android.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import platform
+import re
 import shutil
 import tarfile
 from pathlib import Path, PurePosixPath
@@ -17,18 +19,70 @@ PSUTIL_URL = (
 MARKER = 'LINUX = sys.platform.startswith("linux")'
 REPLACEMENT = 'LINUX = sys.platform.startswith(("linux", "android"))'
 
+_DEFAULT_ANDROID_API_LEVEL = 24
+_ANDROID_ABI_BY_MACHINE = {
+    "aarch64": "arm64_v8a",
+    "arm64": "arm64_v8a",
+    "armv7l": "armeabi_v7a",
+    "armv8l": "armeabi_v7a",
+    "arm": "armeabi_v7a",
+    "x86_64": "x86_64",
+    "amd64": "x86_64",
+    "i386": "x86",
+    "i486": "x86",
+    "i586": "x86",
+    "i686": "x86",
+    "x86": "x86",
+}
+_BDIST_WHEEL_SECTION_RE = re.compile(
+    r"(?ms)^\[bdist_wheel\]\s*\n(?P<body>.*?)(?=^\[|\Z)"
+)
+_PLAT_NAME_RE = re.compile(r"(?m)^plat_name\s*=.*$")
+
 
 class PsutilAndroidInstallError(RuntimeError):
     """Raised when the pinned psutil sdist is missing or unsafe."""
+
+
+def android_wheel_platform_tag(
+    *,
+    api_level: int | str | None = None,
+    machine: str | None = None,
+) -> str:
+    """Return the PEP 738 wheel platform tag for the current Termux target.
+
+    Termux packages target Android API 24 even when the phone itself runs a
+    newer Android release. Using the runtime API (for example 36) makes uv
+    reject a locally built wheel because its interpreter target is API 24.
+    Callers that intentionally target another API must pass ``api_level``.
+    """
+    raw_api_level = api_level if api_level is not None else _DEFAULT_ANDROID_API_LEVEL
+    try:
+        normalized_api_level = int(raw_api_level)
+    except (TypeError, ValueError) as exc:
+        raise PsutilAndroidInstallError(
+            f"Invalid Android API level for wheel tag: {raw_api_level!r}"
+        ) from exc
+    if normalized_api_level < 21:
+        raise PsutilAndroidInstallError(
+            f"Android API level must be 21 or newer, got {normalized_api_level}"
+        )
+
+    normalized_machine = (machine or platform.machine()).strip().lower()
+    abi = _ANDROID_ABI_BY_MACHINE.get(normalized_machine)
+    if abi is None:
+        raise PsutilAndroidInstallError(
+            "Unsupported Android architecture for wheel tag: "
+            f"{normalized_machine or '<empty>'}"
+        )
+    return f"android_{normalized_api_level}_{abi}"
 
 
 def _normalize_member_parts(member_name: str) -> tuple[str, ...]:
     path = PurePosixPath(member_name)
     parts = tuple(part for part in path.parts if part not in ("", "."))
     if path.is_absolute() or ".." in parts or not parts:
-        raise PsutilAndroidInstallError(
-            f"Unsafe archive member path: {member_name!r}"
-        )
+        raise PsutilAndroidInstallError(f"Unsafe archive member path: {member_name!r}")
     return parts
 
 
@@ -64,13 +118,57 @@ def _safe_extract_tar_gz(archive: Path, destination: Path) -> None:
                 pass
 
 
-def prepare_patched_psutil_sdist(archive: Path, destination: Path) -> Path:
-    """Safely extract the pinned psutil sdist and patch it for Android."""
+def _configure_android_wheel_tag(src_root: Path, platform_tag: str) -> None:
+    """Make setuptools emit an Android wheel without leaking env into uv.
+
+    Exporting ``_PYTHON_HOST_PLATFORM`` around ``uv pip`` changes the platform
+    uv sees while inspecting the interpreter, which fails with ``Unknown
+    operating system: android_...``. A package-local ``bdist_wheel`` setting
+    affects only the wheel build and leaves uv's interpreter probe untouched.
+    """
+    setup_cfg = src_root / "setup.cfg"
+    try:
+        content = setup_cfg.read_text(encoding="utf-8") if setup_cfg.exists() else ""
+    except OSError as exc:
+        raise PsutilAndroidInstallError("Failed to read psutil setup.cfg") from exc
+
+    section_match = _BDIST_WHEEL_SECTION_RE.search(content)
+    if section_match is None:
+        separator = "" if not content else "\n" if content.endswith("\n") else "\n\n"
+        updated = f"{content}{separator}[bdist_wheel]\nplat_name = {platform_tag}\n"
+    else:
+        body = section_match.group("body")
+        if _PLAT_NAME_RE.search(body):
+            updated_body = _PLAT_NAME_RE.sub(
+                f"plat_name = {platform_tag}", body, count=1
+            )
+        else:
+            updated_body = f"plat_name = {platform_tag}\n{body}"
+        updated = (
+            content[: section_match.start("body")]
+            + updated_body
+            + content[section_match.end("body") :]
+        )
+
+    try:
+        setup_cfg.write_text(updated, encoding="utf-8")
+    except OSError as exc:
+        raise PsutilAndroidInstallError("Failed to write psutil setup.cfg") from exc
+
+
+def prepare_patched_psutil_sdist(
+    archive: Path,
+    destination: Path,
+    *,
+    platform_tag: str | None = None,
+) -> Path:
+    """Safely extract psutil and patch Android detection and wheel metadata."""
     _safe_extract_tar_gz(archive, destination)
 
     src_roots = sorted(
         (
-            path for path in destination.iterdir()
+            path
+            for path in destination.iterdir()
             if path.is_dir() and path.name.startswith("psutil-")
         ),
         key=lambda path: path.name,
@@ -105,4 +203,9 @@ def prepare_patched_psutil_sdist(archive: Path, destination: Path) -> Path:
         raise PsutilAndroidInstallError(
             f"Failed to write {common_py.relative_to(src_root)!s}"
         ) from exc
+
+    _configure_android_wheel_tag(
+        src_root,
+        platform_tag or android_wheel_platform_tag(),
+    )
     return src_root

--- a/hermes_cli/termux_wheelhouse.py
+++ b/hermes_cli/termux_wheelhouse.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Pinned immutable Android wheelhouse support for native Termux installs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+RELEASE_REPOSITORY = "adybag14-cyber/termux-hermes"
+RELEASE_TAG = "wheelhouse-cp313-android24-arm64-20260719.1"
+RELEASE_COMMIT = "b042ce9e662f14794ef6b5664c9ae711330df31b"
+RELEASE_BASE_URL = (
+    f"https://github.com/{RELEASE_REPOSITORY}/releases/download/{RELEASE_TAG}"
+)
+SHA256SUMS_SHA256 = "916ff13af7e5283f75952b810fb6b7eef86ab3422bc5004c1ee1440d5163ade5"
+MIN_ANDROID_API = 24
+SUPPORTED_PYTHON = (3, 13)
+SUPPORTED_ARCHES = frozenset({"aarch64", "arm64"})
+
+LOCKED_WHEELS: dict[str, tuple[str, str, str]] = {
+    "cffi": (
+        "2.0.0",
+        "cffi-2.0.0-cp313-cp313-android_24_arm64_v8a.whl",
+        "2dc0a19762e92645cebc0d466221aeb1b77757f4e8f0daab33caa4cfa3f25db7",
+    ),
+    "cryptography": (
+        "46.0.7",
+        "cryptography-46.0.7-cp313-abi3-android_24_arm64_v8a.whl",
+        "dd2cfdc605e647a5795479d3060d909a25e54ccd1bab4ac56de7c9827cfd859f",
+    ),
+    "jiter": (
+        "0.13.0",
+        "jiter-0.13.0-cp313-cp313-android_24_arm64_v8a.whl",
+        "240eb59a6105e47f82ce9ce97e219958e9bd3871b390da31af75171a2b82dcc7",
+    ),
+    "markupsafe": (
+        "3.0.3",
+        "markupsafe-3.0.3-cp313-cp313-android_24_arm64_v8a.whl",
+        "17d4ae49861da832cbb8d6d5211c23c65e047eb67fdb20f41e5ab9a6539a35e2",
+    ),
+    "pillow": (
+        "12.2.0",
+        "pillow-12.2.0-cp313-cp313-android_24_arm64_v8a.whl",
+        "f0c0d2256e05318958d88db9740717a59b88e1906d423111c4e5e62ee7d5ef5f",
+    ),
+    "psutil": (
+        "7.2.2",
+        "psutil-7.2.2-cp36-abi3-android_24_arm64_v8a.whl",
+        "c9d6df3d4595b302afd1aadb97d88fe24d0d1e47456573302ae50eb387ca0a5a",
+    ),
+    "pydantic-core": (
+        "2.46.4",
+        "pydantic_core-2.46.4-cp313-cp313-android_24_arm64_v8a.whl",
+        "5c14345f4e6bf7d6cb6fd18ed3fa6828fc093f24182eaca3ed48131b5814f46a",
+    ),
+    "pyyaml": (
+        "6.0.3",
+        "pyyaml-6.0.3-cp313-cp313-android_24_arm64_v8a.whl",
+        "e6f4bd9aa8f87d5868fcf7a73304b51a885f332713e8067bbf21107b9a6788b2",
+    ),
+    "rpds-py": (
+        "0.30.0",
+        "rpds_py-0.30.0-cp313-cp313-android_24_arm64_v8a.whl",
+        "6a4c73b9ad80e2f95b5b33716dde1fe11068ebb86ea6efcd9b8332657205a5a2",
+    ),
+    "ruamel-yaml-clib": (
+        "0.2.15",
+        "ruamel_yaml_clib-0.2.15-cp313-cp313-android_24_arm64_v8a.whl",
+        "114e76d80a60a6e35bb02ab89443e585e37eb3189928485db4de380db3312652",
+    ),
+}
+
+_REQ_RE = re.compile(r"^([A-Za-z0-9_.-]+)==([^\s;]+)")
+
+
+class TermuxWheelhouseError(RuntimeError):
+    """Base failure for a supported target or immutable release."""
+
+
+class TermuxWheelhouseUnsupported(TermuxWheelhouseError):
+    """The runtime cannot consume this CPython/Android/ARM64 wheel set."""
+
+
+class TermuxWheelhouseMismatch(TermuxWheelhouseError):
+    """Hermes dependency pins no longer match the immutable wheel release."""
+
+
+def canonicalize_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def locked_versions() -> dict[str, str]:
+    return {name: metadata[0] for name, metadata in LOCKED_WHEELS.items()}
+
+
+def _check_versions(actual: dict[str, set[str]], *, source: str) -> None:
+    problems: list[str] = []
+    for name, expected in locked_versions().items():
+        versions = actual.get(name, set())
+        if versions != {expected}:
+            rendered = ", ".join(sorted(versions)) if versions else "missing"
+            problems.append(f"{name}: expected {expected}, found {rendered}")
+    if problems:
+        raise TermuxWheelhouseMismatch(
+            f"{source} is incompatible with immutable Termux wheelhouse {RELEASE_TAG}: "
+            + "; ".join(problems)
+        )
+
+
+def validate_requirements_text(text: str, *, source: str = "requirements") -> None:
+    actual: dict[str, set[str]] = {}
+    for raw in text.splitlines():
+        match = _REQ_RE.match(raw.strip())
+        if not match:
+            continue
+        name = canonicalize_name(match.group(1))
+        actual.setdefault(name, set()).add(match.group(2))
+    _check_versions(actual, source=source)
+
+
+def validate_requirements_file(path: Path) -> None:
+    validate_requirements_text(path.read_text(encoding="utf-8"), source=str(path))
+
+
+def validate_uv_lock_text(text: str, *, source: str = "uv.lock") -> None:
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        raise TermuxWheelhouseMismatch(f"Could not parse {source}: {exc}") from exc
+    actual: dict[str, set[str]] = {}
+    for package in data.get("package", []):
+        raw_name = package.get("name")
+        version = package.get("version")
+        if not raw_name or not version:
+            continue
+        name = canonicalize_name(str(raw_name))
+        if name in LOCKED_WHEELS:
+            actual.setdefault(name, set()).add(str(version))
+    _check_versions(actual, source=source)
+
+
+def validate_uv_lock(path: Path) -> None:
+    validate_uv_lock_text(path.read_text(encoding="utf-8"), source=str(path))
+
+
+def _android_api_level() -> int | None:
+    getter = getattr(sys, "getandroidapilevel", None)
+    if callable(getter):
+        try:
+            return int(getter())
+        except (TypeError, ValueError, OSError):
+            return None
+    return None
+
+
+def validate_runtime(
+    *,
+    python_version: tuple[int, int] | None = None,
+    machine: str | None = None,
+    android_api: int | None = None,
+    sys_platform: str | None = None,
+) -> None:
+    version = python_version or (sys.version_info.major, sys.version_info.minor)
+    arch = (machine or platform.machine()).lower()
+    platform_name = sys_platform or sys.platform
+    api = _android_api_level() if android_api is None else android_api
+    if platform_name != "android":
+        raise TermuxWheelhouseUnsupported(
+            f"immutable Termux wheels require Android Python, not {platform_name}"
+        )
+    if version != SUPPORTED_PYTHON:
+        raise TermuxWheelhouseUnsupported(
+            f"immutable Termux wheels require CPython 3.13 (current: {version[0]}.{version[1]})"
+        )
+    if arch not in SUPPORTED_ARCHES:
+        raise TermuxWheelhouseUnsupported(
+            f"immutable Termux wheels require arm64/aarch64, not {arch}"
+        )
+    if api is None:
+        raise TermuxWheelhouseUnsupported("could not determine the Android API level")
+    if api < MIN_ANDROID_API:
+        raise TermuxWheelhouseUnsupported(
+            f"immutable Termux wheels require Android API {MIN_ANDROID_API}+, not {api}"
+        )
+
+
+def parse_sha256sums(text: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for raw in text.splitlines():
+        if not raw.strip():
+            continue
+        try:
+            digest, filename = raw.split(maxsplit=1)
+        except ValueError as exc:
+            raise TermuxWheelhouseError(f"invalid SHA256SUMS line: {raw!r}") from exc
+        digest = digest.lower()
+        filename = filename.strip().lstrip("*")
+        if (
+            len(digest) != 64
+            or any(ch not in "0123456789abcdef" for ch in digest)
+            or Path(filename).name != filename
+            or filename in parsed
+        ):
+            raise TermuxWheelhouseError(f"invalid SHA256SUMS line: {raw!r}")
+        parsed[filename] = digest
+    return parsed
+
+
+def _release_marker() -> dict[str, object]:
+    return {
+        "repository": RELEASE_REPOSITORY,
+        "tag": RELEASE_TAG,
+        "commit": RELEASE_COMMIT,
+        "sha256sums_sha256": SHA256SUMS_SHA256,
+        "wheels": sorted(metadata[1] for metadata in LOCKED_WHEELS.values()),
+    }
+
+
+def verify_wheelhouse(path: Path) -> None:
+    sums_path = path / "SHA256SUMS"
+    marker_path = path / "release.json"
+    if not sums_path.is_file() or not marker_path.is_file():
+        raise TermuxWheelhouseError("wheelhouse metadata is incomplete")
+    if sha256_file(sums_path) != SHA256SUMS_SHA256:
+        raise TermuxWheelhouseError(
+            "SHA256SUMS digest does not match the pinned release"
+        )
+    try:
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TermuxWheelhouseError("wheelhouse release marker is invalid") from exc
+    if marker != _release_marker():
+        raise TermuxWheelhouseError("wheelhouse release marker does not match the pin")
+    sums = parse_sha256sums(sums_path.read_text(encoding="utf-8"))
+    for _name, (_version, filename, expected) in LOCKED_WHEELS.items():
+        if sums.get(filename) != expected:
+            raise TermuxWheelhouseError(
+                f"release checksum manifest mismatch: {filename}"
+            )
+        wheel = path / filename
+        if not wheel.is_file() or sha256_file(wheel) != expected:
+            raise TermuxWheelhouseError(f"wheel checksum mismatch: {filename}")
+
+
+def _download(curl: str, url: str, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            curl,
+            "-fL",
+            "--retry",
+            "3",
+            "--retry-all-errors",
+            "--proto",
+            "=https",
+            url,
+            "-o",
+            str(destination),
+        ],
+        check=True,
+    )
+
+
+def ensure_wheelhouse(
+    cache_root: Path,
+    *,
+    requirements: Path | None = None,
+    uv_lock: Path | None = None,
+    curl: str | None = None,
+    check_runtime: bool = True,
+) -> Path:
+    if requirements is not None:
+        validate_requirements_file(requirements)
+    if uv_lock is not None:
+        validate_uv_lock(uv_lock)
+    if check_runtime:
+        validate_runtime()
+
+    cache_root = cache_root.expanduser().resolve()
+    final = cache_root / RELEASE_TAG
+    try:
+        verify_wheelhouse(final)
+        return final
+    except TermuxWheelhouseError:
+        pass
+
+    curl_path = curl or shutil.which("curl")
+    if not curl_path:
+        raise TermuxWheelhouseError(
+            "curl is required to download immutable Termux wheels"
+        )
+
+    cache_root.mkdir(parents=True, exist_ok=True)
+    stage = cache_root / f".{RELEASE_TAG}.tmp-{os.getpid()}"
+    backup = cache_root / f".{RELEASE_TAG}.previous"
+    shutil.rmtree(stage, ignore_errors=True)
+    stage.mkdir()
+    try:
+        sums_path = stage / "SHA256SUMS"
+        _download(curl_path, f"{RELEASE_BASE_URL}/SHA256SUMS", sums_path)
+        if sha256_file(sums_path) != SHA256SUMS_SHA256:
+            raise TermuxWheelhouseError(
+                "downloaded SHA256SUMS does not match the immutable release pin"
+            )
+        sums = parse_sha256sums(sums_path.read_text(encoding="utf-8"))
+        for _name, (_version, filename, expected) in LOCKED_WHEELS.items():
+            if sums.get(filename) != expected:
+                raise TermuxWheelhouseError(
+                    f"immutable release manifest does not contain the pinned {filename}"
+                )
+            wheel = stage / filename
+            _download(curl_path, f"{RELEASE_BASE_URL}/{filename}", wheel)
+            if sha256_file(wheel) != expected:
+                raise TermuxWheelhouseError(
+                    f"downloaded wheel checksum mismatch: {filename}"
+                )
+        (stage / "release.json").write_text(
+            json.dumps(_release_marker(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        verify_wheelhouse(stage)
+
+        shutil.rmtree(backup, ignore_errors=True)
+        if final.exists():
+            final.rename(backup)
+        try:
+            stage.rename(final)
+        except BaseException:
+            if backup.exists() and not final.exists():
+                backup.rename(final)
+            raise
+        shutil.rmtree(backup, ignore_errors=True)
+        return final
+    except BaseException:
+        shutil.rmtree(stage, ignore_errors=True)
+        raise
+
+
+def binary_install_options(wheelhouse: Path) -> list[str]:
+    return ["--find-links", str(wheelhouse), "--only-binary", ":all:"]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cache-root", type=Path, required=True)
+    parser.add_argument("--requirements", type=Path)
+    parser.add_argument("--uv-lock", type=Path)
+    parser.add_argument("--curl")
+    args = parser.parse_args(argv)
+    try:
+        path = ensure_wheelhouse(
+            args.cache_root,
+            requirements=args.requirements,
+            uv_lock=args.uv_lock,
+            curl=args.curl,
+        )
+    except TermuxWheelhouseUnsupported as exc:
+        print(f"unsupported immutable wheel target: {exc}", file=sys.stderr)
+        return 2
+    except (TermuxWheelhouseError, subprocess.CalledProcessError, OSError) as exc:
+        print(f"immutable Termux wheelhouse failed: {exc}", file=sys.stderr)
+        return 1
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_cli/termux_wheelhouse.py
+++ b/hermes_cli/termux_wheelhouse.py
@@ -16,12 +16,12 @@ import tomllib
 from pathlib import Path
 
 RELEASE_REPOSITORY = "adybag14-cyber/termux-hermes"
-RELEASE_TAG = "wheelhouse-cp313-android24-arm64-20260719.1"
-RELEASE_COMMIT = "b042ce9e662f14794ef6b5664c9ae711330df31b"
+RELEASE_TAG = "wheelhouse-cp313-android24-arm64-20260811.1"
+RELEASE_COMMIT = "5184b2059257918e9a98993186b57f6aaf9037b9"
 RELEASE_BASE_URL = (
     f"https://github.com/{RELEASE_REPOSITORY}/releases/download/{RELEASE_TAG}"
 )
-SHA256SUMS_SHA256 = "916ff13af7e5283f75952b810fb6b7eef86ab3422bc5004c1ee1440d5163ade5"
+SHA256SUMS_SHA256 = "435f23524d76cf061bf658c48bbee7439a85bf39e3a3b0b292d54db38669d079"
 MIN_ANDROID_API = 24
 SUPPORTED_PYTHON = (3, 13)
 SUPPORTED_ARCHES = frozenset({"aarch64", "arm64"})
@@ -33,9 +33,9 @@ LOCKED_WHEELS: dict[str, tuple[str, str, str]] = {
         "2dc0a19762e92645cebc0d466221aeb1b77757f4e8f0daab33caa4cfa3f25db7",
     ),
     "cryptography": (
-        "46.0.7",
-        "cryptography-46.0.7-cp313-abi3-android_24_arm64_v8a.whl",
-        "dd2cfdc605e647a5795479d3060d909a25e54ccd1bab4ac56de7c9827cfd859f",
+        "50.0.0",
+        "cryptography-50.0.0-cp313-abi3-android_24_arm64_v8a.whl",
+        "7580a6de25b86680389c1083b72d5eb27f20b2d588c1aa51600784864d7739de",
     ),
     "jiter": (
         "0.13.0",
@@ -48,9 +48,9 @@ LOCKED_WHEELS: dict[str, tuple[str, str, str]] = {
         "17d4ae49861da832cbb8d6d5211c23c65e047eb67fdb20f41e5ab9a6539a35e2",
     ),
     "pillow": (
-        "12.2.0",
-        "pillow-12.2.0-cp313-cp313-android_24_arm64_v8a.whl",
-        "f0c0d2256e05318958d88db9740717a59b88e1906d423111c4e5e62ee7d5ef5f",
+        "12.3.0",
+        "pillow-12.3.0-cp313-cp313-android_24_arm64_v8a.whl",
+        "7a2d796d96f9b2a9061a78306d5585b0eaa65a93e16e645c887f87dd55eacd67",
     ),
     "psutil": (
         "7.2.2",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4328,6 +4328,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print(f"    cd {_m().PROJECT_ROOT} && git reflog && git reset --hard <prev-sha>")
                 sys.exit(1)
 
+            # Termux updates must prove the freshly pulled lock is still fully
+            # satisfiable from the immutable Android wheelhouse before the new
+            # checkout is accepted. The helper rolls back to pre_pull_sha on
+            # integrity, pin, download, or binary-coverage failure.
+            _m()._termux_post_pull_wheelhouse_gate(git_cmd, pre_pull_sha)
+
             update_succeeded = True
         finally:
             if auto_stash_ref is not None:

--- a/scripts/check-termux-footguns.py
+++ b/scripts/check-termux-footguns.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Fast static guard for Hermes' native Termux/Android support.
+
+This complements the normal Python/TypeScript tests with cheap checks for
+regressions that are easy to introduce on a Linux CI host but fail immediately
+in Android/Bionic Termux: Linux distribution package managers, leaked fake
+Python platform tags, fragile CI shell quoting, privileged regression containers,
+and drift in the curated Android dependency/install contract.
+
+Usage:
+    python scripts/check-termux-footguns.py             # staged files
+    python scripts/check-termux-footguns.py --all       # full repository audit
+    python scripts/check-termux-footguns.py --diff main # files changed vs main
+    python scripts/check-termux-footguns.py path ...    # explicit files/dirs
+
+Intentional matches can be suppressed on the same line with:
+    # termux-footgun: ok - <reason>
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SUPPRESS_MARKER = re.compile(r"#\s*termux-footgun\s*:\s*ok\b", re.IGNORECASE)
+TEXT_SUFFIXES = {".py", ".sh", ".ts", ".tsx", ".js", ".mjs", ".json", ".yml", ".yaml"}
+EXCLUDED_DIRS = {
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    "dist",
+    "build",
+    "release",
+    "__pycache__",
+    ".pytest_cache",
+}
+EXCLUDED_FILES = {"scripts/check-termux-footguns.py"}
+
+
+@dataclass(frozen=True)
+class Footgun:
+    name: str
+    paths: tuple[str, ...]
+    pattern: re.Pattern[str]
+    message: str
+    fix: str
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    line: int
+    text: str
+    name: str
+    message: str
+    fix: str
+
+
+FOOTGUNS: tuple[Footgun, ...] = (
+    Footgun(
+        name="host Linux package manager in native Termux installer",
+        paths=("scripts/install-termux.sh",),
+        pattern=re.compile(r"^\s*(?:sudo\s+|apt(?:-get)?\s+|systemctl\s+)", re.IGNORECASE),
+        message=(
+            "Native Termux has no sudo/apt/systemd host layer. Installing host-Linux "
+            "packages here makes the native Android path silently depend on proot."
+        ),
+        fix="Use `pkg`/`apt` only through Termux's package environment, normally `pkg install ...`.",
+    ),
+    Footgun(
+        name="fake _PYTHON_HOST_PLATFORM assignment",
+        paths=("scripts/install-termux.sh",),
+        pattern=re.compile(r"^\s*(?:export\s+)?_PYTHON_HOST_PLATFORM\s*="),
+        message=(
+            "Forcing _PYTHON_HOST_PLATFORM makes resolvers select non-Android wheel tags. "
+            "The native installer must derive Android/Bionic tags from the interpreter."
+        ),
+        fix="Remove the assignment; explicitly `unset _PYTHON_HOST_PLATFORM` before resolution.",
+    ),
+    Footgun(
+        name="fragile inline quoted Termux regression shell",
+        paths=(".github/workflows/termux-regression.yml",),
+        pattern=re.compile(r"bash\s+-lc\s+['\"]"),
+        message=(
+            "The native Termux regression body must live in a checked-in shell script, "
+            "not a large bash -lc quoted string whose embedded quotes can escape unexpectedly."
+        ),
+        fix="Execute scripts/run-termux-regression.sh directly inside the Termux container.",
+    ),
+    Footgun(
+        name="privileged Termux PR regression container",
+        paths=(".github/workflows/termux-regression.yml",),
+        pattern=re.compile(r"(?:^|\s)--privileged(?:\s|$)|--security-opt(?:=|\s+)seccomp=unconfined"),
+        message=(
+            "PR-controlled Termux regression code must not run in a privileged or "
+            "seccomp-disabled Docker container on the GitHub runner."
+        ),
+        fix="Use an unprivileged container and add only a narrowly justified capability if a real gate proves it is necessary.",
+    ),
+)
+
+
+def _repo_rel(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def should_scan_file(path: Path) -> bool:
+    rel = _repo_rel(path)
+    if rel in EXCLUDED_FILES or path.suffix.lower() not in TEXT_SUFFIXES:
+        return False
+    return not any(part in EXCLUDED_DIRS for part in Path(rel).parts)
+
+
+def iter_files(paths: Iterable[Path]) -> Iterable[Path]:
+    seen: set[Path] = set()
+    for raw in paths:
+        path = raw if raw.is_absolute() else REPO_ROOT / raw
+        if path.is_file():
+            if should_scan_file(path) and path not in seen:
+                seen.add(path)
+                yield path
+            continue
+        if not path.is_dir():
+            continue
+        for root, dirs, files in os.walk(path):
+            dirs[:] = [d for d in dirs if d not in EXCLUDED_DIRS]
+            for name in files:
+                candidate = Path(root) / name
+                if candidate not in seen and should_scan_file(candidate):
+                    seen.add(candidate)
+                    yield candidate
+
+
+def _line_code(line: str) -> str:
+    stripped = line.lstrip()
+    if stripped.startswith("#"):
+        return ""
+    # Shell/Python comments are enough for the narrow policy rules above. Keep
+    # URL fragments in strings intact by treating ` #` as the comment boundary.
+    marker = line.find(" #")
+    return line if marker < 0 else line[:marker]
+
+
+def scan_file(path: Path) -> list[Finding]:
+    rel = _repo_rel(path)
+    applicable = [rule for rule in FOOTGUNS if rel in rule.paths]
+    if not applicable:
+        return []
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    findings: list[Finding] = []
+    for number, line in enumerate(text.splitlines(), 1):
+        if SUPPRESS_MARKER.search(line):
+            continue
+        code = _line_code(line)
+        for rule in applicable:
+            if rule.pattern.search(code):
+                findings.append(
+                    Finding(path, number, line.rstrip(), rule.name, rule.message, rule.fix)
+                )
+    return findings
+
+
+def _function_source(path: Path, name: str) -> tuple[str, int] | None:
+    try:
+        text = path.read_text(encoding="utf-8")
+        tree = ast.parse(text)
+    except (OSError, SyntaxError, UnicodeError):
+        return None
+    lines = text.splitlines()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            end = getattr(node, "end_lineno", node.lineno)
+            return "\n".join(lines[node.lineno - 1 : end]), node.lineno
+    return None
+
+
+def invariant_findings(selected: set[str]) -> list[Finding]:
+    """Validate cross-file contracts that a one-line regex cannot express."""
+    findings: list[Finding] = []
+
+    req_rel = "scripts/termux_requirements.py"
+    if req_rel in selected:
+        path = REPO_ROOT / req_rel
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            source = ""
+        required = ('"uvicorn": {"standard"}', '"python-telegram-bot": {"webhooks"}')
+        if any(token not in source for token in required):
+            findings.append(
+                Finding(
+                    path,
+                    1,
+                    "DROP_EXTRAS",
+                    "Android-native optional dependency filter weakened",
+                    "Desktop/server extras can pull unsupported native packages into the Termux resolver graph.",
+                    "Retain the curated uvicorn[standard] and Telegram webhook-extra stripping in DROP_EXTRAS.",
+                )
+            )
+
+    installer_rel = "scripts/install-termux.sh"
+    if installer_rel in selected:
+        path = REPO_ROOT / installer_rel
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            source = ""
+        if not source.startswith("#!/data/data/com.termux/files/usr/bin/bash"):
+            findings.append(
+                Finding(
+                    path,
+                    1,
+                    source.splitlines()[0] if source else "<missing>",
+                    "native Termux installer lost its Termux shebang",
+                    "The installer entrypoint must resolve the Termux bash, not a host/proot shell.",
+                    "Restore #!/data/data/com.termux/files/usr/bin/bash.",
+                )
+            )
+        if not re.search(r"unset(?:[^\n]*\\\n)*[^\n]*_PYTHON_HOST_PLATFORM", source):
+            findings.append(
+                Finding(
+                    path,
+                    1,
+                    "_PYTHON_HOST_PLATFORM cleanup",
+                    "native installer no longer scrubs fake Python host tags",
+                    "Inherited _PYTHON_HOST_PLATFORM values can poison Android wheel selection.",
+                    "Unset _PYTHON_HOST_PLATFORM before uv resolution/install.",
+                )
+            )
+
+    return findings
+
+
+def _git_names(args: Sequence[str]) -> list[Path]:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if proc.returncode != 0:
+        return []
+    return [REPO_ROOT / line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def staged_paths() -> list[Path]:
+    return _git_names(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+
+
+def diff_paths(base: str) -> list[Path]:
+    return _git_names(["diff", "--name-only", "--diff-filter=ACMR", f"{base}...HEAD"])
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", type=Path)
+    parser.add_argument("--all", action="store_true", dest="all_files", help="scan the full repository")
+    parser.add_argument("--diff", metavar="BASE", help="scan files changed from BASE...HEAD")
+    parser.add_argument("--list", action="store_true", help="print files that will be scanned")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if sum(bool(x) for x in (args.paths, args.all_files, args.diff)) > 1:
+        raise SystemExit("choose exactly one of explicit paths, --all, or --diff")
+
+    if args.all_files:
+        roots = [REPO_ROOT]
+    elif args.diff:
+        roots = diff_paths(args.diff)
+    elif args.paths:
+        roots = list(args.paths)
+    else:
+        roots = staged_paths()
+
+    files = sorted(iter_files(roots), key=_repo_rel)
+    if args.list:
+        for path in files:
+            print(_repo_rel(path))
+        return 0
+
+    selected = {_repo_rel(path) for path in files}
+    findings = [finding for path in files for finding in scan_file(path)]
+    findings.extend(invariant_findings(selected))
+    findings.sort(key=lambda item: (_repo_rel(item.path), item.line, item.name))
+
+    if not findings:
+        print(f"Termux footgun check passed ({len(files)} file(s) scanned).")
+        return 0
+
+    print(f"Termux footgun check found {len(findings)} issue(s):", file=sys.stderr)
+    for finding in findings:
+        rel = _repo_rel(finding.path)
+        print(f"\n{rel}:{finding.line}: {finding.name}", file=sys.stderr)
+        print(f"  {finding.text.strip()}", file=sys.stderr)
+        print(f"  Why: {finding.message}", file=sys.stderr)
+        print(f"  Fix: {finding.fix}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install-termux.sh
+++ b/scripts/install-termux.sh
@@ -1,0 +1,559 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# Native Android/Termux installer for Hermes Agent.
+# This path intentionally uses Termux packages + uv directly; it does not use
+# proot, Ubuntu, pip, or a global third-party Python package index.
+set -euo pipefail
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+INSTALL_DIR="${HERMES_INSTALL_DIR:-$HERMES_HOME/hermes-agent}"
+BRANCH="main"
+INSTALL_COMMIT=""
+RUN_SETUP=true
+SKIP_BROWSER=false
+NO_SKILLS=false
+NON_INTERACTIVE=false
+USE_VENV=true
+PYTHON_BIN=""
+ANDROID_BUILD_API=24
+REPO_URL="${HERMES_REPO_URL:-https://github.com/NousResearch/hermes-agent.git}"
+# The fallback is locked by both release coordinates and content digest. A
+# replaced or corrupted release asset is rejected before package extraction.
+readonly PINNED_PYTHON_VERSION="3.13.14"
+readonly PINNED_PYTHON_RELEASE="termux-aarch64-20260719.9.1"
+readonly PINNED_PYTHON_ASSET="python_3.13.14_aarch64.deb"
+readonly PINNED_PYTHON_SHA256="42376a2a47e50048cb7eca2d0f442fc1895fbca2aee2dee3d2fd82728ea1bd80"
+readonly PINNED_PYTHON_URL="https://github.com/adybag14-cyber/termux-python/releases/download/${PINNED_PYTHON_RELEASE}/${PINNED_PYTHON_ASSET}"
+
+log() { printf '\033[0;36m→\033[0m %s\n' "$*"; }
+ok() { printf '\033[0;32m✓\033[0m %s\n' "$*"; }
+warn() { printf '\033[0;33m⚠\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[0;31m✗\033[0m %s\n' "$*" >&2; exit 1; }
+
+is_termux() {
+    [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
+}
+
+usage() {
+    cat <<'USAGE'
+Hermes Agent native Termux installer
+
+Usage: install-termux.sh [OPTIONS]
+  --branch NAME          Git branch to install (default: main)
+  --commit SHA           Pin the checkout to an exact commit
+  --dir PATH             Installation directory
+  --hermes-home PATH     Hermes data directory
+  --python PATH          CPython 3.11, 3.12, or 3.13 interpreter
+  --android-api-level N  Android wheel build target (default: 24)
+  --skip-setup           Skip API/provider setup
+  --skip-browser         Skip optional Node browser dependency install
+  --no-skills            Do not seed bundled skills
+  --non-interactive      Never prompt
+  --no-venv              Unsupported on native Termux (isolated venv required)
+  -h, --help             Show this help
+USAGE
+}
+
+parse_args() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --branch|-Branch)
+                [ "$#" -ge 2 ] || die "$1 requires a value"
+                BRANCH="$2"
+                shift 2
+                ;;
+            --commit|-Commit)
+                [ "$#" -ge 2 ] || die "$1 requires a value"
+                INSTALL_COMMIT="$2"
+                shift 2
+                ;;
+            --dir)
+                [ "$#" -ge 2 ] || die "$1 requires a value"
+                INSTALL_DIR="$2"
+                shift 2
+                ;;
+            --hermes-home)
+                [ "$#" -ge 2 ] || die "$1 requires a value"
+                HERMES_HOME="$2"
+                shift 2
+                ;;
+            --python)
+                [ "$#" -ge 2 ] || die "$1 requires a value"
+                PYTHON_BIN="$2"
+                shift 2
+                ;;
+            --android-api-level)
+                [ "$#" -ge 2 ] || die "$1 requires a value"
+                ANDROID_BUILD_API="$2"
+                shift 2
+                ;;
+            --skip-setup) RUN_SETUP=false; shift ;;
+            --skip-browser|--no-playwright) SKIP_BROWSER=true; shift ;;
+            --no-skills) NO_SKILLS=true; shift ;;
+            --non-interactive|-NonInteractive) NON_INTERACTIVE=true; shift ;;
+            --no-venv) USE_VENV=false; shift ;;
+            -h|--help) usage; exit 0 ;;
+            --manifest|-Manifest|--stage|-Stage|--json|-Json|--include-desktop|-IncludeDesktop|--ensure|--postinstall)
+                die "$1 is not supported by the native Termux installer"
+                ;;
+            *) die "Unknown option: $1" ;;
+        esac
+    done
+    [ "$USE_VENV" = true ] || die \
+        "Native Termux installs require an isolated venv; remove --no-venv"
+}
+
+python_is_supported() {
+    local candidate="$1"
+    [ -x "$candidate" ] || return 1
+    "$candidate" -c \
+        'import sys; raise SystemExit(0 if (3, 11) <= sys.version_info < (3, 14) else 1)' \
+        >/dev/null 2>&1
+}
+
+python_is_immutable_target() {
+    local candidate="$1"
+    [ -x "$candidate" ] || return 1
+    "$candidate" -c \
+        'import sys; raise SystemExit(0 if sys.version_info[:2] == (3, 13) else 1)' \
+        >/dev/null 2>&1
+}
+
+find_immutable_python() {
+    local candidate resolved
+    for candidate in python3.13 python; do
+        resolved="$(command -v "$candidate" 2>/dev/null || true)"
+        if [ -n "$resolved" ] && python_is_immutable_target "$resolved"; then
+            printf '%s\n' "$resolved"
+            return 0
+        fi
+    done
+    return 1
+}
+
+find_supported_python() {
+    local candidate resolved
+    if [ -n "$PYTHON_BIN" ]; then
+        resolved="$PYTHON_BIN"
+        command -v "$resolved" >/dev/null 2>&1 && resolved="$(command -v "$resolved")"
+        python_is_supported "$resolved" || die \
+            "--python must point to CPython 3.11, 3.12, or 3.13: $resolved"
+        printf '%s\n' "$resolved"
+        return 0
+    fi
+
+    for candidate in python3.13 python3.12 python3.11 python; do
+        resolved="$(command -v "$candidate" 2>/dev/null || true)"
+        if [ -n "$resolved" ] && python_is_supported "$resolved"; then
+            printf '%s\n' "$resolved"
+            return 0
+        fi
+    done
+    return 1
+}
+
+termux_architecture() {
+    dpkg --print-architecture 2>/dev/null || uname -m
+}
+
+install_pinned_python313() {
+    command -v curl >/dev/null 2>&1 || die "curl is required to download Python"
+    command -v dpkg >/dev/null 2>&1 || die "dpkg is required to inspect Python"
+    command -v dpkg-deb >/dev/null 2>&1 || die "dpkg-deb is required to extract Python"
+    command -v sha256sum >/dev/null 2>&1 || die "sha256sum is required to verify Python"
+
+    local architecture
+    architecture="$(termux_architecture)"
+    case "$architecture" in
+        aarch64|arm64) ;;
+        *) die "The pinned Termux Python build supports aarch64 only, not $architecture" ;;
+    esac
+
+    log "No CPython 3.13 interpreter is available for the immutable wheel target"
+    log "Installing pinned Python $PINNED_PYTHON_VERSION side-by-side"
+
+    local tmp deb staged_prefix package version package_arch
+    tmp="$(mktemp -d "${TMPDIR:-$PREFIX/tmp}/hermes-python313.XXXXXX")"
+    deb="$tmp/$PINNED_PYTHON_ASSET"
+    if ! curl -fL --retry 3 --retry-all-errors \
+        "$PINNED_PYTHON_URL" -o "$deb"; then
+        rm -rf "$tmp"
+        die "Failed to download pinned Python $PINNED_PYTHON_VERSION"
+    fi
+
+    if ! printf '%s  %s\n' "$PINNED_PYTHON_SHA256" "$deb" | sha256sum -c -; then
+        rm -rf "$tmp"
+        die "Pinned Python checksum verification failed"
+    fi
+
+    package="$(dpkg-deb -f "$deb" Package 2>/dev/null || true)"
+    version="$(dpkg-deb -f "$deb" Version 2>/dev/null || true)"
+    package_arch="$(dpkg-deb -f "$deb" Architecture 2>/dev/null || true)"
+    if [ "$package" != "python" ] || \
+       [ "$version" != "$PINNED_PYTHON_VERSION" ] || \
+       [ "$package_arch" != "aarch64" ]; then
+        rm -rf "$tmp"
+        die "Pinned Python package metadata did not match the locked release"
+    fi
+
+    dpkg-deb -x "$deb" "$tmp/root"
+    staged_prefix="$tmp/root$PREFIX"
+    [ -x "$staged_prefix/bin/python3.13" ] || {
+        rm -rf "$tmp"
+        die "Pinned package did not contain $PREFIX/bin/python3.13"
+    }
+
+    # Install only the versioned payload. The package also contains aliases for
+    # python/python3 and related tools; removing them before the copy keeps the
+    # Termux system interpreter untouched.
+    rm -f \
+        "$staged_prefix/bin/python" "$staged_prefix/bin/python3" \
+        "$staged_prefix/bin/python-config" "$staged_prefix/bin/python3-config" \
+        "$staged_prefix/bin/pip" "$staged_prefix/bin/pip3" \
+        "$staged_prefix/bin/idle" "$staged_prefix/bin/idle3" \
+        "$staged_prefix/bin/pydoc" "$staged_prefix/bin/pydoc3" \
+        "$staged_prefix/bin/2to3" \
+        "$staged_prefix/lib/pkgconfig/python3.pc" \
+        "$staged_prefix/lib/pkgconfig/python3-embed.pc" \
+        "$staged_prefix/share/man/man1/python.1.gz" \
+        "$staged_prefix/share/man/man1/python3.1.gz"
+    cp -a "$staged_prefix/." "$PREFIX/"
+    rm -rf "$tmp"
+    hash -r
+    python_is_supported "$PREFIX/bin/python3.13" || die \
+        "Pinned Python $PINNED_PYTHON_VERSION failed its launch check"
+    ok "$($PREFIX/bin/python3.13 --version) installed side-by-side"
+}
+
+install_system_packages() {
+    log "Installing native Termux runtime packages"
+    pkg install -y \
+        git curl ca-certificates coreutils dpkg uv \
+        gdbm libandroid-posix-semaphore libandroid-support libbz2 libcrypt \
+        libexpat libffi liblzma libsqlite ncurses ncurses-ui-libs openssl \
+        readline zlib libjpeg-turbo libpng freetype libwebp openjpeg \
+        littlecms libtiff libyaml nodejs ripgrep ffmpeg >/dev/null
+    ok "Termux runtime and uv are ready"
+}
+
+install_native_build_packages() {
+    log "Installing native compiler fallback for this unsupported wheel target"
+    pkg install -y clang rust make pkg-config binutils patchelf >/dev/null
+    ok "Termux native build toolchain is ready"
+}
+
+prepare_repository() {
+    mkdir -p "$(dirname "$INSTALL_DIR")"
+    if [ -d "$INSTALL_DIR/.git" ]; then
+        log "Updating existing Hermes checkout"
+        local stash_ref=""
+        if [ -n "$(git -C "$INSTALL_DIR" status --porcelain 2>/dev/null)" ]; then
+            git -C "$INSTALL_DIR" stash push --include-untracked -m \
+                "hermes-termux-installer-$(date -u +%Y%m%dT%H%M%SZ)" >/dev/null
+            stash_ref="$(git -C "$INSTALL_DIR" stash list -1 --format='%gd')"
+            warn "Local changes were stashed as $stash_ref"
+        fi
+        git -C "$INSTALL_DIR" fetch origin "$BRANCH"
+        git -C "$INSTALL_DIR" checkout "$BRANCH" 2>/dev/null || \
+            git -C "$INSTALL_DIR" checkout -B "$BRANCH" "origin/$BRANCH"
+        git -C "$INSTALL_DIR" merge --ff-only "origin/$BRANCH"
+        if [ -n "$stash_ref" ]; then
+            if git -C "$INSTALL_DIR" stash pop >/dev/null; then
+                ok "Restored local checkout changes"
+            else
+                warn "Could not automatically restore $stash_ref; it remains in git stash"
+            fi
+        fi
+    elif [ -e "$INSTALL_DIR" ]; then
+        local backup="${INSTALL_DIR}.broken-$(date -u +%Y%m%d-%H%M%S)"
+        warn "Moving non-git install aside to $backup"
+        mv "$INSTALL_DIR" "$backup"
+        git clone --branch "$BRANCH" "$REPO_URL" "$INSTALL_DIR"
+    else
+        log "Cloning Hermes Agent"
+        git clone --branch "$BRANCH" "$REPO_URL" "$INSTALL_DIR"
+    fi
+
+    if [ -n "$INSTALL_COMMIT" ]; then
+        git -C "$INSTALL_DIR" fetch origin "$INSTALL_COMMIT" || true
+        git -C "$INSTALL_DIR" checkout --detach "$INSTALL_COMMIT"
+    fi
+    ok "Repository ready at $INSTALL_DIR"
+}
+
+create_venv() {
+    local python="$1"
+    local backup=""
+    cd "$INSTALL_DIR"
+    if [ -d venv ]; then
+        backup="venv.pre-native-termux-$(date -u +%Y%m%d-%H%M%S)"
+        mv venv "$backup"
+        warn "Preserved previous venv as $INSTALL_DIR/$backup until validation succeeds"
+    fi
+
+    if ! uv venv --python "$python" venv; then
+        [ -n "$backup" ] && [ -d "$backup" ] && mv "$backup" venv
+        die "uv failed to create the Hermes virtual environment"
+    fi
+    VENV_BACKUP="$backup"
+    export VENV_BACKUP
+    ok "Virtual environment ready: $(venv/bin/python --version)"
+}
+
+install_python_dependencies() {
+    cd "$INSTALL_DIR"
+    local venv_python="$INSTALL_DIR/venv/bin/python"
+    local work="$HERMES_HOME/cache/termux-install"
+    local direct="$work/direct.in"
+    local lock_constraints="$work/lock-constraints.txt"
+    local resolved="$work/resolved.txt"
+    local wheelhouse_cache="$HERMES_HOME/cache/termux-wheelhouse"
+    local cargo_home="$HERMES_HOME/cache/cargo-termux"
+    mkdir -p "$work" "$cargo_home" "$HERMES_HOME/cache/uv-termux" "$wheelhouse_cache"
+
+    export UV_NO_CONFIG=1
+    export UV_LINK_MODE=copy
+    export UV_PYTHON="$venv_python"
+    export UV_CACHE_DIR="$HERMES_HOME/cache/uv-termux"
+    export UV_CONCURRENT_BUILDS=1
+    export UV_CONCURRENT_INSTALLS=1
+    export UV_CONCURRENT_DOWNLOADS=4
+    export CARGO_BUILD_JOBS=1
+    export CARGO_HOME="$cargo_home"
+    export ANDROID_API_LEVEL="$ANDROID_BUILD_API"
+    export UV_DEFAULT_INDEX="https://pypi.org/simple"
+    export UV_INDEX_STRATEGY=first-index
+    unset UV_INDEX UV_EXTRA_INDEX_URL PIP_INDEX_URL PIP_EXTRA_INDEX_URL \
+        _PYTHON_HOST_PLATFORM
+
+    log "Installing the dependency resolver prerequisite"
+    uv pip install --python "$venv_python" 'packaging==26.0'
+
+    "$venv_python" scripts/termux_requirements.py \
+        --pyproject pyproject.toml \
+        --lock uv.lock \
+        --requirements "$direct" \
+        --constraints "$lock_constraints" \
+        --python-version "$($venv_python -c \
+            'import platform; print(platform.python_version())')"
+
+    log "Resolving the Android-safe Termux dependency graph"
+    uv pip compile "$direct" \
+        --python "$venv_python" \
+        --constraint "$lock_constraints" \
+        --output-file "$resolved" \
+        --no-annotate
+
+    local wheelhouse wheelhouse_rc
+    set +e
+    wheelhouse="$("$venv_python" scripts/prepare_termux_wheelhouse.py \
+        --cache-root "$wheelhouse_cache" \
+        --requirements "$resolved" \
+        --uv-lock uv.lock \
+        --curl "$(command -v curl)")"
+    wheelhouse_rc=$?
+    set -e
+
+    if [ "$wheelhouse_rc" -eq 0 ]; then
+        log "Installing with immutable CPython 3.13 Android ARM64 wheels"
+        uv pip install --python "$venv_python" \
+            --requirements "$resolved" \
+            --constraint constraints-termux.txt \
+            --find-links "$wheelhouse" \
+            --only-binary :all:
+        ok "Verified immutable wheelhouse $wheelhouse"
+    elif [ "$wheelhouse_rc" -eq 2 ]; then
+        warn "This Python/architecture is outside the published immutable wheel target"
+        warn "Falling back to one-time native builds for compatibility"
+        install_native_build_packages
+        uv pip install --python "$venv_python" \
+            'setuptools>=77,<83' wheel packaging cython pycparser
+
+        log "Prebuilding setuptools extensions with Android wheel tags"
+        "$venv_python" scripts/install_android_wheels.py \
+            --uv "$(command -v uv)" \
+            --python "$venv_python" \
+            --requirements "$resolved" \
+            --android-api-level "$ANDROID_BUILD_API"
+
+        install_resolved_from_source() {
+            uv pip install --python "$venv_python" --requirements "$resolved" \
+                --constraint constraints-termux.txt
+        }
+
+        log "Installing resolved dependencies with serial native builds"
+        if ! install_resolved_from_source; then
+            local broken_cargo="${cargo_home}.broken-$(date -u +%Y%m%d-%H%M%S)"
+            warn "Native dependency build failed; retrying with a fresh Cargo registry"
+            [ -d "$cargo_home" ] && mv "$cargo_home" "$broken_cargo"
+            mkdir -p "$cargo_home"
+            install_resolved_from_source || die \
+                "Hermes dependency installation failed on the clean Cargo retry"
+            rm -rf "$broken_cargo"
+        fi
+    else
+        die "The pinned immutable Termux wheelhouse could not be verified or downloaded"
+    fi
+
+    log "Installing Hermes editable entrypoints with uv"
+    uv pip install --python "$venv_python" --no-deps --editable .
+    uv pip check --python "$venv_python"
+
+    "$venv_python" - <<'PY'
+import importlib
+
+required = [
+    "hermes_cli",
+    "psutil",
+    "yaml",
+    "cffi",
+    "PIL",
+    "pydantic_core",
+    "cryptography",
+    "jiter",
+    "rpds",
+]
+for module in required:
+    importlib.import_module(module)
+print("Hermes native dependency smoke test passed")
+PY
+    ok "Python dependencies installed"
+}
+
+install_launcher() {
+    local launcher="$PREFIX/bin/hermes"
+    local venv_python="$INSTALL_DIR/venv/bin/python"
+    local venv_hermes="$INSTALL_DIR/venv/bin/hermes"
+    [ -x "$venv_hermes" ] || die \
+        "Hermes console entrypoint was not generated: $venv_hermes"
+    cat > "$launcher" <<EOF_LAUNCHER
+#!$PREFIX/bin/bash
+unset PYTHONPATH
+unset PYTHONHOME
+export UV_LINK_MODE=copy
+case "\${1:-}" in
+    --version|-V|version)
+        exec "$venv_python" -c 'from hermes_cli import __release_date__, __version__; import sys; print(f"Hermes Agent v{__version__} ({__release_date__})"); print(f"Install directory: $INSTALL_DIR"); print(f"Python: {sys.version.split()[0]}")'
+        ;;
+esac
+exec "$venv_hermes" "\$@"
+EOF_LAUNCHER
+    chmod 755 "$launcher"
+    hash -r
+    ok "Installed launcher at $launcher"
+}
+
+configure_hermes() {
+    mkdir -p "$HERMES_HOME"/{cron,sessions,logs,pairing,hooks,image_cache,audio_cache,memories,skills}
+    if [ ! -f "$HERMES_HOME/.env" ]; then
+        if [ -f "$INSTALL_DIR/.env.example" ]; then
+            cp "$INSTALL_DIR/.env.example" "$HERMES_HOME/.env"
+        else
+            touch "$HERMES_HOME/.env"
+        fi
+    fi
+    chmod 600 "$HERMES_HOME/.env"
+    if [ ! -f "$HERMES_HOME/config.yaml" ] && \
+       [ -f "$INSTALL_DIR/cli-config.yaml.example" ]; then
+        cp "$INSTALL_DIR/cli-config.yaml.example" "$HERMES_HOME/config.yaml"
+    fi
+    if [ ! -f "$HERMES_HOME/SOUL.md" ]; then
+        printf '%s\n' \
+            'You are Hermes Agent, an intelligent AI assistant created by Nous Research.' \
+            > "$HERMES_HOME/SOUL.md"
+    fi
+
+    if [ "$NO_SKILLS" = true ]; then
+        printf '%s\n' 'Bundled skill seeding disabled by --no-skills.' \
+            > "$HERMES_HOME/.no-bundled-skills"
+    elif [ -f "$INSTALL_DIR/tools/skills_sync.py" ]; then
+        "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" || \
+            warn "Bundled skill sync failed"
+    fi
+    ok "Hermes configuration directory is ready"
+}
+
+install_optional_node_tools() {
+    [ "$SKIP_BROWSER" = false ] || return 0
+    command -v npm >/dev/null 2>&1 || {
+        warn "npm unavailable; skipping browser tools"
+        return 0
+    }
+    log "Installing optional browser command dependencies"
+    if (
+        cd "$INSTALL_DIR"
+        npm install --workspaces=false --silent --no-fund --no-audit --progress=false
+    ); then
+        ok "Browser command dependencies installed"
+    else
+        warn "Browser command dependency install failed; core Hermes remains usable"
+    fi
+}
+
+run_setup() {
+    [ "$RUN_SETUP" = true ] || return 0
+    [ "$NON_INTERACTIVE" = false ] || return 0
+    if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+        "$PREFIX/bin/hermes" setup </dev/tty >/dev/tty || \
+            warn "Setup wizard did not complete"
+    else
+        warn "No interactive terminal is available; run 'hermes setup' later"
+    fi
+}
+
+main() {
+    parse_args "$@"
+    is_termux || die "This installer is only for native Termux/Android"
+    [ -n "${PREFIX:-}" ] || die "PREFIX is not set; launch this from Termux"
+    case "$ANDROID_BUILD_API" in
+        ''|*[!0-9]*) die "--android-api-level must be numeric" ;;
+    esac
+    [ "$ANDROID_BUILD_API" -ge 21 ] && [ "$ANDROID_BUILD_API" -le 99 ] || \
+        die "Android build API must be between 21 and 99"
+
+    unset PYTHONPATH PYTHONHOME
+    install_system_packages
+
+    local python architecture
+    if [ -n "$PYTHON_BIN" ]; then
+        # An explicit 3.11/3.12 request is supported through the source-build
+        # compatibility path. Automatic installs prefer the immutable cp313 set.
+        python="$(find_supported_python || true)"
+    else
+        python="$(find_immutable_python || true)"
+        if [ -z "$python" ]; then
+            architecture="$(termux_architecture)"
+            case "$architecture" in
+                aarch64|arm64)
+                    install_pinned_python313
+                    python="$PREFIX/bin/python3.13"
+                    ;;
+                *)
+                    python="$(find_supported_python || true)"
+                    ;;
+            esac
+        fi
+    fi
+    [ -n "$python" ] || die \
+        "No supported CPython 3.11-3.13 interpreter is available for this architecture"
+    ok "Using $($python --version) at $python"
+
+    prepare_repository
+    create_venv "$python"
+    install_python_dependencies
+    install_launcher
+    configure_hermes
+    install_optional_node_tools
+
+    "$PREFIX/bin/hermes" --version
+    echo "git" > "$INSTALL_DIR/.install_method"
+    if [ -n "${VENV_BACKUP:-}" ] && [ -d "$INSTALL_DIR/$VENV_BACKUP" ]; then
+        rm -rf "$INSTALL_DIR/$VENV_BACKUP"
+    fi
+    run_setup
+    ok "Hermes Agent is installed natively in Termux"
+    printf '%s\n' "Run: hermes"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # Hermes Agent Installer
 # ============================================================================
 # Installation script for Linux, macOS, and Android/Termux.
-# Uses uv for desktop/server installs and Python's stdlib venv + pip on Termux.
+# Uses uv for desktop/server installs and a dedicated uv path on Termux.
 #
 # Usage:
 #   curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
@@ -14,6 +14,56 @@
 # ============================================================================
 
 set -e
+
+# Native Termux uses a dedicated uv-based installer. Keep the established
+# Linux/macOS installer below in this file so existing bootstrap integrations
+# retain their established behavior.
+if [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]; then
+    _hermes_script_dir=""
+    _hermes_source="${BASH_SOURCE[0]:-}"
+    if [ -n "$_hermes_source" ] && [ -f "$_hermes_source" ]; then
+        _hermes_script_dir="$(cd "$(dirname "$_hermes_source")" 2>/dev/null && pwd || true)"
+    fi
+
+    if [ -n "$_hermes_script_dir" ] && [ -f "$_hermes_script_dir/install-termux.sh" ]; then
+        exec bash "$_hermes_script_dir/install-termux.sh" "$@"
+    fi
+
+    _hermes_install_ref="main"
+    _hermes_previous=""
+    for _hermes_arg in "$@"; do
+        if [ "$_hermes_previous" = "--branch" ] || [ "$_hermes_previous" = "-Branch" ] || \
+           [ "$_hermes_previous" = "--commit" ] || [ "$_hermes_previous" = "-Commit" ]; then
+            _hermes_install_ref="$_hermes_arg"
+            _hermes_previous=""
+            continue
+        fi
+        case "$_hermes_arg" in
+            --branch|-Branch|--commit|-Commit) _hermes_previous="$_hermes_arg" ;;
+        esac
+    done
+
+    if ! command -v curl >/dev/null 2>&1; then
+        echo "Hermes native Termux installer requires curl" >&2
+        exit 1
+    fi
+
+    _hermes_base="https://raw.githubusercontent.com/NousResearch/hermes-agent/${_hermes_install_ref}/scripts"
+    _hermes_tmp="$(mktemp 2>/dev/null || printf '%s/hermes-install-termux.%s.sh' "${TMPDIR:-/tmp}" "$$")"
+    if ! curl -fsSL "$_hermes_base/install-termux.sh" -o "$_hermes_tmp"; then
+        echo "Failed to download the native Termux installer: $_hermes_base/install-termux.sh" >&2
+        rm -f "$_hermes_tmp"
+        exit 1
+    fi
+
+    if bash "$_hermes_tmp" "$@"; then
+        _hermes_rc=0
+    else
+        _hermes_rc=$?
+    fi
+    rm -f "$_hermes_tmp"
+    exit "$_hermes_rc"
+fi
 
 # Guard against environment leakage when the installer is launched from another
 # Python-driven tool session (e.g. Hermes terminal tool). A pre-set PYTHONPATH

--- a/scripts/install_android_wheels.py
+++ b/scripts/install_android_wheels.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Build and install Android-tagged wheels for known setuptools extensions."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from hermes_cli.android_wheels import (  # noqa: E402
+    DEFAULT_ANDROID_API_LEVEL,
+    AndroidWheelError,
+    android_wheel_platform_tag,
+    canonicalize_name,
+    configure_setuptools_android_tag,
+    patch_psutil_android_detection,
+    pypi_sdist,
+    safe_extract_sdist,
+)
+
+DEFAULT_PACKAGES = (
+    "psutil",
+    "markupsafe",
+    "pyyaml",
+    "cffi",
+    "pillow",
+    "ruamel-yaml-clib",
+)
+_REQ_RE = re.compile(r"^([A-Za-z0-9_.-]+)==([^\s;]+)")
+
+
+def versions_from_requirements(path: Path) -> dict[str, str]:
+    versions: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("-"):
+            continue
+        match = _REQ_RE.match(line)
+        if match:
+            versions[canonicalize_name(match.group(1))] = match.group(2)
+    return versions
+
+
+def installed_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def build_one(
+    *, name: str, version: str, uv: str, python: str, platform_tag: str, work: Path
+) -> Path:
+    package_dir = work / canonicalize_name(name)
+    archive = pypi_sdist(name, version, package_dir / "download")
+    src_root = safe_extract_sdist(archive, package_dir / "src")
+    if canonicalize_name(name) == "psutil":
+        patch_psutil_android_detection(src_root)
+    configure_setuptools_android_tag(src_root, platform_tag)
+
+    out = package_dir / "wheelhouse"
+    out.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["UV_PYTHON"] = python
+    env.pop("_PYTHON_HOST_PLATFORM", None)
+    command = [
+        uv,
+        "build",
+        "--wheel",
+        "--no-build-isolation",
+        "--out-dir",
+        str(out),
+        str(src_root),
+    ]
+    print("  $", " ".join(command), flush=True)
+    subprocess.run(command, check=True, env=env)
+    wheels = sorted(out.glob("*.whl"))
+    if len(wheels) != 1:
+        raise AndroidWheelError(
+            f"Expected one wheel for {name}=={version}, found {len(wheels)}"
+        )
+    wheel = wheels[0]
+    if platform_tag not in wheel.name:
+        raise AndroidWheelError(
+            f"{name} built an incompatible wheel {wheel.name}; expected {platform_tag}"
+        )
+    return wheel
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--uv", required=True)
+    parser.add_argument("--python", required=True)
+    parser.add_argument("--requirements", type=Path, required=True)
+    parser.add_argument(
+        "--android-api-level", type=int, default=DEFAULT_ANDROID_API_LEVEL
+    )
+    parser.add_argument("--package", action="append", dest="packages")
+    parser.add_argument("--work-dir", type=Path)
+    args = parser.parse_args(argv)
+
+    versions = versions_from_requirements(args.requirements)
+    requested = tuple(args.packages or DEFAULT_PACKAGES)
+    platform_tag = android_wheel_platform_tag(api_level=args.android_api_level)
+    owned_temp = None
+    if args.work_dir is None:
+        owned_temp = tempfile.TemporaryDirectory(prefix="hermes-android-wheels-")
+        work = Path(owned_temp.name)
+    else:
+        work = args.work_dir
+        work.mkdir(parents=True, exist_ok=True)
+
+    try:
+        for raw_name in requested:
+            name = canonicalize_name(raw_name)
+            version = versions.get(name)
+            if version is None:
+                print(f"→ {name}: not in resolved Termux requirements; skipping")
+                continue
+            if installed_version(name) == version:
+                print(f"✓ {name}=={version} already installed")
+                continue
+            print(f"→ Building {name}=={version} for {platform_tag}")
+            wheel = build_one(
+                name=name,
+                version=version,
+                uv=args.uv,
+                python=args.python,
+                platform_tag=platform_tag,
+                work=work,
+            )
+            command = [
+                args.uv,
+                "pip",
+                "install",
+                "--python",
+                args.python,
+                "--no-deps",
+                str(wheel),
+            ]
+            print("  $", " ".join(command), flush=True)
+            subprocess.run(command, check=True)
+            print(f"✓ Installed {wheel.name}")
+    except (AndroidWheelError, subprocess.CalledProcessError) as exc:
+        print(f"Android wheel build failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        if owned_temp is not None:
+            owned_temp.cleanup()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare_termux_wheelhouse.py
+++ b/scripts/prepare_termux_wheelhouse.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""CLI bridge for the pinned native Termux wheelhouse."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from hermes_cli.termux_wheelhouse import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-termux-regression.sh
+++ b/scripts/run-termux-regression.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+export TERMUX_VERSION="ci"
+export HERMES_REPO_URL="file:///workspace"
+export HERMES_HOME="$HOME/.hermes-ci"
+export HERMES_INSTALL_DIR="$HOME/hermes-agent-ci"
+# The bootstrap image intentionally has no git yet; Hermes must install it.
+# Pre-authorize the read-only mounted PR checkout through Git environment
+# configuration so the regression wrapper never calls git before install.
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=safe.directory
+export GIT_CONFIG_VALUE_0=/workspace
+
+echo "== native installer =="
+bash /workspace/scripts/install-termux.sh \
+  --branch termux-ci \
+  --dir "$HERMES_INSTALL_DIR" \
+  --hermes-home "$HERMES_HOME" \
+  --skip-setup \
+  --skip-browser \
+  --no-skills \
+  --non-interactive
+
+echo "== CLI smoke =="
+hermes --version
+hermes --help >/dev/null
+"$HERMES_INSTALL_DIR/venv/bin/python" - <<'PY'
+from hermes_cli.main import _is_termux_startup_environment
+assert _is_termux_startup_environment(), "Termux startup detection is false in native image"
+print("native-termux-runtime-contract-ok")
+PY
+
+echo "native-termux-install-regression-ok"

--- a/scripts/termux_requirements.py
+++ b/scripts/termux_requirements.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Generate an Android-safe Hermes requirements set from project metadata.
+
+The regular project metadata intentionally uses desktop/server extras such as
+``uvicorn[standard]`` and Telegram webhooks. On native Termux those extras pull
+native packages that are either unsupported or redundant. This helper expands
+the curated Termux profile, removes only those optional accelerators, and emits
+lock-version constraints without adding TUR as a global package index.
+"""
+
+from __future__ import annotations
+
+import argparse
+import tomllib
+from pathlib import Path
+
+try:
+    from packaging.markers import default_environment
+    from packaging.requirements import Requirement
+    from packaging.utils import canonicalize_name
+except ImportError as exc:  # pragma: no cover - installer supplies packaging first
+    raise SystemExit(
+        "packaging must be installed before generating Termux requirements"
+    ) from exc
+
+SELF_NAME = "hermes-agent"
+DROP_EXTRAS = {
+    "uvicorn": {"standard"},
+    "python-telegram-bot": {"webhooks"},
+}
+
+
+def _android_environment(python_version: str | None = None) -> dict[str, str]:
+    env = default_environment()
+    env.update({
+        "sys_platform": "android",
+        "platform_system": "Android",
+        "os_name": "posix",
+    })
+    if python_version:
+        parts = python_version.split(".")
+        env["python_version"] = ".".join(parts[:2])
+        env["python_full_version"] = python_version
+    return env
+
+
+def _render_requirement(requirement: Requirement, extras: set[str]) -> str:
+    rendered = requirement.name
+    if extras:
+        rendered += "[" + ",".join(sorted(extras)) + "]"
+    if requirement.url:
+        rendered += f" @ {requirement.url}"
+    else:
+        rendered += str(requirement.specifier)
+    if requirement.marker:
+        rendered += f"; {requirement.marker}"
+    return rendered
+
+
+def expand_termux_requirements(
+    pyproject: Path, *, profile: str = "termux-all", python_version: str | None = None
+) -> list[str]:
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    project = data["project"]
+    extras_table = project.get("optional-dependencies", {})
+    pending = list(project.get("dependencies", []))
+    pending.extend(extras_table.get(profile, []))
+    expanded_extras: set[str] = {profile}
+    output: list[str] = []
+    seen: set[str] = set()
+    marker_env = _android_environment(python_version)
+
+    while pending:
+        raw = pending.pop(0)
+        req = Requirement(raw)
+        name = canonicalize_name(req.name)
+        if name == SELF_NAME:
+            for extra in sorted(req.extras):
+                if extra in expanded_extras:
+                    continue
+                expanded_extras.add(extra)
+                pending.extend(extras_table.get(extra, []))
+            continue
+        if req.marker and not req.marker.evaluate(marker_env):
+            continue
+        kept_extras = set(req.extras) - DROP_EXTRAS.get(name, set())
+        rendered = _render_requirement(req, kept_extras)
+        if rendered not in seen:
+            seen.add(rendered)
+            output.append(rendered)
+
+    return sorted(output, key=lambda value: canonicalize_name(Requirement(value).name))
+
+
+def lock_constraints(lockfile: Path) -> list[str]:
+    data = tomllib.loads(lockfile.read_text(encoding="utf-8"))
+    versions: dict[str, set[str]] = {}
+    for package in data.get("package", []):
+        name = package.get("name")
+        version = package.get("version")
+        source = package.get("source") or {}
+        if not name or not version or "registry" not in source:
+            continue
+        versions.setdefault(canonicalize_name(name), set()).add(str(version))
+    # A universal uv.lock may legitimately contain platform forks. A conflicting
+    # multi-version package is left unconstrained rather than emitting an
+    # impossible pair of constraints.
+    return [
+        f"{name}=={next(iter(found))}"
+        for name, found in sorted(versions.items())
+        if len(found) == 1
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pyproject", type=Path, default=Path("pyproject.toml"))
+    parser.add_argument("--lock", type=Path, default=Path("uv.lock"))
+    parser.add_argument("--requirements", type=Path, required=True)
+    parser.add_argument("--constraints", type=Path, required=True)
+    parser.add_argument("--profile", default="termux-all")
+    parser.add_argument("--python-version")
+    args = parser.parse_args(argv)
+
+    requirements = expand_termux_requirements(
+        args.pyproject, profile=args.profile, python_version=args.python_version
+    )
+    constraints = lock_constraints(args.lock)
+    args.requirements.write_text("\n".join(requirements) + "\n", encoding="utf-8")
+    args.constraints.write_text("\n".join(constraints) + "\n", encoding="utf-8")
+    print(
+        f"Generated {len(requirements)} direct Android requirements and "
+        f"{len(constraints)} lock constraints"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_android_wheels.py
+++ b/tests/hermes_cli/test_android_wheels.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from scripts import install_android_wheels
+from hermes_cli.android_wheels import (
+    AndroidWheelError,
+    android_wheel_platform_tag,
+    configure_setuptools_android_tag,
+    safe_extract_sdist,
+)
+
+
+@pytest.mark.parametrize(
+    ("machine", "expected"),
+    [
+        ("aarch64", "android_24_arm64_v8a"),
+        ("armv8l", "android_24_armeabi_v7a"),
+        ("x86_64", "android_24_x86_64"),
+        ("i686", "android_24_x86"),
+    ],
+)
+def test_android_platform_mappings(machine: str, expected: str) -> None:
+    assert android_wheel_platform_tag(machine=machine) == expected
+
+
+def test_explicit_api_override() -> None:
+    assert (
+        android_wheel_platform_tag(machine="aarch64", api_level="26")
+        == "android_26_arm64_v8a"
+    )
+
+
+def test_runtime_android_api_variable_is_not_used(monkeypatch) -> None:
+    monkeypatch.setenv("ANDROID_API_LEVEL", "36")
+    assert android_wheel_platform_tag(machine="aarch64") == "android_24_arm64_v8a"
+
+
+def test_setup_cfg_preserved(tmp_path: Path) -> None:
+    root = tmp_path / "pkg"
+    root.mkdir()
+    cfg = root / "setup.cfg"
+    cfg.write_text(
+        "[metadata]\nname = demo\n\n[bdist_wheel]\nuniversal = 0\n", encoding="utf-8"
+    )
+    configure_setuptools_android_tag(root, "android_24_arm64_v8a")
+    content = cfg.read_text(encoding="utf-8")
+    assert "[metadata]\nname = demo" in content
+    assert "universal = 0" in content
+    assert "plat_name = android_24_arm64_v8a" in content
+
+
+def test_configured_bdist_wheel_filename(tmp_path: Path) -> None:
+    root = tmp_path / "demo"
+    root.mkdir()
+    (root / "setup.py").write_text(
+        "from setuptools import Extension, setup\n"
+        "setup(name='android-tag-demo', version='1.0', py_modules=['demo'], "
+        "ext_modules=[Extension('_demo', sources=['demo.c'])])\n",
+        encoding="utf-8",
+    )
+    (root / "demo.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (root / "demo.c").write_text(
+        "#include <Python.h>\n"
+        'static struct PyModuleDef m={PyModuleDef_HEAD_INIT,"_demo",0,-1,0};\n'
+        "PyMODINIT_FUNC PyInit__demo(void){return PyModule_Create(&m);}\n",
+        encoding="utf-8",
+    )
+    configure_setuptools_android_tag(root, "android_24_arm64_v8a")
+    result = subprocess.run(
+        [sys.executable, "setup.py", "bdist_wheel", "--dist-dir", str(root / "dist")],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 and "invalid command 'bdist_wheel'" in result.stderr:
+        pytest.skip("wheel is not installed in this test interpreter")
+    assert result.returncode == 0, result.stderr
+    wheels = list((root / "dist").glob("*.whl"))
+    assert len(wheels) == 1
+    assert "android_24_arm64_v8a" in wheels[0].name
+
+
+def test_safe_extract_rejects_symlink(tmp_path: Path) -> None:
+    archive = tmp_path / "bad.tar.gz"
+    with tarfile.open(archive, "w:gz") as tf:
+        directory = tarfile.TarInfo("demo-1.0")
+        directory.type = tarfile.DIRTYPE
+        tf.addfile(directory)
+        link = tarfile.TarInfo("demo-1.0/link")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../../outside"
+        tf.addfile(link)
+    with pytest.raises(AndroidWheelError, match="Unsupported archive member type"):
+        safe_extract_sdist(archive, tmp_path / "out")
+
+
+def test_install_script_forwards_explicit_android_api_level(
+    tmp_path: Path, monkeypatch
+) -> None:
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("", encoding="utf-8")
+    captured: dict[str, int] = {}
+
+    def fake_platform_tag(*, api_level: int) -> str:
+        captured["api_level"] = api_level
+        return "android_28_arm64_v8a"
+
+    monkeypatch.setattr(
+        install_android_wheels, "android_wheel_platform_tag", fake_platform_tag
+    )
+    result = install_android_wheels.main([
+        "--uv",
+        "uv",
+        "--python",
+        "python",
+        "--requirements",
+        str(requirements),
+        "--android-api-level",
+        "28",
+        "--package",
+        "not-present",
+        "--work-dir",
+        str(tmp_path / "work"),
+    ])
+
+    assert result == 0
+    assert captured == {"api_level": 28}

--- a/tests/hermes_cli/test_psutil_android_wheel_tag.py
+++ b/tests/hermes_cli/test_psutil_android_wheel_tag.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import io
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.psutil_android import (
+    MARKER,
+    PsutilAndroidInstallError,
+    android_wheel_platform_tag,
+    prepare_patched_psutil_sdist,
+)
+
+
+def _add_dir(tf: tarfile.TarFile, name: str) -> None:
+    info = tarfile.TarInfo(name)
+    info.type = tarfile.DIRTYPE
+    info.mode = 0o755
+    tf.addfile(info)
+
+
+def _add_file(tf: tarfile.TarFile, name: str, content: str) -> None:
+    payload = content.encode()
+    info = tarfile.TarInfo(name)
+    info.size = len(payload)
+    info.mode = 0o644
+    tf.addfile(info, io.BytesIO(payload))
+
+
+def _archive(
+    path: Path,
+    *,
+    setup_cfg: str | None = None,
+    setup_py: str | None = None,
+) -> None:
+    with tarfile.open(path, "w:gz") as tf:
+        _add_dir(tf, "psutil-7.2.2")
+        _add_dir(tf, "psutil-7.2.2/psutil")
+        _add_file(tf, "psutil-7.2.2/psutil/_common.py", f"{MARKER}\n")
+        if setup_cfg is not None:
+            _add_file(tf, "psutil-7.2.2/setup.cfg", setup_cfg)
+        if setup_py is not None:
+            _add_file(tf, "psutil-7.2.2/setup.py", setup_py)
+
+
+@pytest.mark.parametrize(
+    ("machine", "expected_abi"),
+    [
+        ("aarch64", "arm64_v8a"),
+        ("arm64", "arm64_v8a"),
+        ("armv8l", "armeabi_v7a"),
+        ("x86_64", "x86_64"),
+        ("i686", "x86"),
+    ],
+)
+def test_android_wheel_platform_tag_maps_termux_architectures(machine, expected_abi):
+    assert android_wheel_platform_tag(machine=machine) == f"android_24_{expected_abi}"
+
+
+def test_android_wheel_platform_ignores_runtime_android_api(monkeypatch):
+    monkeypatch.setenv("ANDROID_API_LEVEL", "36")
+
+    assert android_wheel_platform_tag(machine="aarch64") == "android_24_arm64_v8a"
+
+
+def test_android_wheel_platform_supports_explicit_build_target():
+    assert (
+        android_wheel_platform_tag(machine="aarch64", api_level=28)
+        == "android_28_arm64_v8a"
+    )
+
+
+def test_android_wheel_platform_rejects_unknown_architecture():
+    with pytest.raises(
+        PsutilAndroidInstallError, match="Unsupported Android architecture"
+    ):
+        android_wheel_platform_tag(machine="mips64")
+
+
+def test_prepare_patched_sdist_adds_android_bdist_wheel_config(tmp_path):
+    archive = tmp_path / "psutil.tar.gz"
+    _archive(archive)
+
+    src = prepare_patched_psutil_sdist(
+        archive,
+        tmp_path / "extract",
+        platform_tag="android_24_arm64_v8a",
+    )
+
+    assert (src / "setup.cfg").read_text() == (
+        "[bdist_wheel]\nplat_name = android_24_arm64_v8a\n"
+    )
+
+
+def test_prepare_patched_sdist_preserves_existing_setup_config(tmp_path):
+    archive = tmp_path / "psutil.tar.gz"
+    _archive(
+        archive,
+        setup_cfg="[metadata]\nlicense_files = LICENSE\n\n[bdist_wheel]\nuniversal = 0\n",
+    )
+
+    src = prepare_patched_psutil_sdist(
+        archive,
+        tmp_path / "extract",
+        platform_tag="android_24_arm64_v8a",
+    )
+    config = (src / "setup.cfg").read_text()
+
+    assert "[metadata]\nlicense_files = LICENSE" in config
+    assert "[bdist_wheel]\nplat_name = android_24_arm64_v8a\nuniversal = 0" in config
+
+
+def test_patched_sdist_builds_an_android_tagged_wheel(tmp_path):
+    archive = tmp_path / "psutil.tar.gz"
+    _archive(
+        archive,
+        setup_py=(
+            "from setuptools import setup\n"
+            "setup(name='psutil', version='7.2.2', packages=['psutil'])\n"
+        ),
+    )
+    src = prepare_patched_psutil_sdist(
+        archive,
+        tmp_path / "extract",
+        platform_tag="android_24_arm64_v8a",
+    )
+
+    subprocess.run(
+        [sys.executable, "setup.py", "bdist_wheel"],
+        cwd=src,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    wheel_names = [wheel.name for wheel in (src / "dist").glob("*.whl")]
+    assert wheel_names == ["psutil-7.2.2-py3-none-android_24_arm64_v8a.whl"]

--- a/tests/hermes_cli/test_termux_wheelhouse.py
+++ b/tests/hermes_cli/test_termux_wheelhouse.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import termux_wheelhouse as tw
+
+
+EXPECTED_NAMES = {
+    "cffi",
+    "cryptography",
+    "jiter",
+    "markupsafe",
+    "pillow",
+    "psutil",
+    "pydantic-core",
+    "pyyaml",
+    "rpds-py",
+    "ruamel-yaml-clib",
+}
+
+
+def _digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def test_current_uv_lock_matches_immutable_release() -> None:
+    root = Path(__file__).resolve().parents[2]
+    tw.validate_uv_lock(root / "uv.lock")
+    assert set(tw.LOCKED_WHEELS) == EXPECTED_NAMES
+    assert tw.RELEASE_TAG == "wheelhouse-cp313-android24-arm64-20260719.1"
+    assert tw.RELEASE_COMMIT == "b042ce9e662f14794ef6b5664c9ae711330df31b"
+
+
+def test_uv_lock_pin_drift_is_rejected() -> None:
+    text = """
+[[package]]
+name = "cffi"
+version = "999.0"
+"""
+    with pytest.raises(tw.TermuxWheelhouseMismatch, match="cffi: expected 2.0.0"):
+        tw.validate_uv_lock_text(text, source="remote uv.lock")
+
+
+def test_resolved_requirements_pin_drift_is_rejected() -> None:
+    requirements = "\n".join(
+        f"{name}=={version}"
+        for name, (version, _filename, _sha) in tw.LOCKED_WHEELS.items()
+    )
+    tw.validate_requirements_text(requirements)
+    with pytest.raises(tw.TermuxWheelhouseMismatch, match="cryptography"):
+        tw.validate_requirements_text(
+            requirements.replace("cryptography==46.0.7", "cryptography==1")
+        )
+
+
+def test_runtime_requires_android_cp313_arm64_api24() -> None:
+    tw.validate_runtime(
+        python_version=(3, 13),
+        machine="aarch64",
+        android_api=35,
+        sys_platform="android",
+    )
+    with pytest.raises(tw.TermuxWheelhouseUnsupported, match="CPython 3.13"):
+        tw.validate_runtime(
+            python_version=(3, 14),
+            machine="aarch64",
+            android_api=35,
+            sys_platform="android",
+        )
+    with pytest.raises(tw.TermuxWheelhouseUnsupported, match="arm64"):
+        tw.validate_runtime(
+            python_version=(3, 13),
+            machine="x86_64",
+            android_api=35,
+            sys_platform="android",
+        )
+
+
+def test_ensure_wheelhouse_verifies_stages_and_reuses_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    files = {
+        "alpha-1-cp313-cp313-android_24_arm64_v8a.whl": b"alpha-wheel",
+        "beta-2-cp313-abi3-android_24_arm64_v8a.whl": b"beta-wheel",
+    }
+    locked = {
+        "alpha": ("1", next(iter(files)), _digest(files[next(iter(files))])),
+        "beta": ("2", list(files)[1], _digest(files[list(files)[1]])),
+    }
+    sums = "".join(
+        f"{_digest(data)}  {name}\n" for name, data in files.items()
+    ).encode()
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    (remote / "SHA256SUMS").write_bytes(sums)
+    for name, data in files.items():
+        (remote / name).write_bytes(data)
+
+    monkeypatch.setattr(tw, "LOCKED_WHEELS", locked)
+    monkeypatch.setattr(tw, "RELEASE_TAG", "test-release")
+    monkeypatch.setattr(tw, "RELEASE_COMMIT", "a" * 40)
+    monkeypatch.setattr(tw, "RELEASE_BASE_URL", "https://example.invalid/test-release")
+    monkeypatch.setattr(tw, "SHA256SUMS_SHA256", _digest(sums))
+    downloads: list[str] = []
+
+    def fake_download(_curl: str, url: str, destination: Path) -> None:
+        downloads.append(url)
+        shutil.copy2(remote / url.rsplit("/", 1)[-1], destination)
+
+    monkeypatch.setattr(tw, "_download", fake_download)
+    cache = tmp_path / "cache"
+    first = tw.ensure_wheelhouse(cache, curl="curl", check_runtime=False)
+    tw.verify_wheelhouse(first)
+    assert len(downloads) == 3
+
+    downloads.clear()
+    second = tw.ensure_wheelhouse(cache, curl="curl", check_runtime=False)
+    assert second == first
+    assert downloads == []
+    assert tw.binary_install_options(first) == [
+        "--find-links",
+        str(first),
+        "--only-binary",
+        ":all:",
+    ]
+
+
+def test_failed_refresh_preserves_previous_verified_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    filename = "alpha-1-cp313-cp313-android_24_arm64_v8a.whl"
+    payload = b"known-good"
+    sums = f"{_digest(payload)}  {filename}\n".encode()
+    monkeypatch.setattr(
+        tw, "LOCKED_WHEELS", {"alpha": ("1", filename, _digest(payload))}
+    )
+    monkeypatch.setattr(tw, "RELEASE_TAG", "test-release")
+    monkeypatch.setattr(tw, "RELEASE_COMMIT", "b" * 40)
+    monkeypatch.setattr(tw, "SHA256SUMS_SHA256", _digest(sums))
+
+    cache = tmp_path / "cache" / "test-release"
+    cache.mkdir(parents=True)
+    (cache / "SHA256SUMS").write_bytes(sums)
+    (cache / filename).write_bytes(payload)
+    (cache / "release.json").write_text(
+        json.dumps(tw._release_marker(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    tw.verify_wheelhouse(cache)
+
+    # Corrupting the cached wheel forces a refresh; a failed staged download
+    # must not rename or delete the existing directory.
+    (cache / filename).write_bytes(b"corrupt-cache")
+
+    def fail_download(_curl: str, _url: str, _destination: Path) -> None:
+        raise OSError("network failed")
+
+    monkeypatch.setattr(tw, "_download", fail_download)
+    with pytest.raises(OSError, match="network failed"):
+        tw.ensure_wheelhouse(tmp_path / "cache", curl="curl", check_runtime=False)
+    assert cache.is_dir()
+    assert (cache / filename).read_bytes() == b"corrupt-cache"
+    assert not list((tmp_path / "cache").glob(".test-release.tmp-*"))
+
+
+def test_post_pull_gate_rolls_back_on_verifier_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hermes_cli import main as hm
+
+    project = tmp_path / "repo"
+    (project / "scripts").mkdir(parents=True)
+    (project / "venv" / "bin").mkdir(parents=True)
+    (project / "venv" / "bin" / "python").write_text("", encoding="utf-8")
+    (project / "scripts" / "prepare_termux_wheelhouse.py").write_text(
+        "", encoding="utf-8"
+    )
+    (project / "uv.lock").write_text("", encoding="utf-8")
+    monkeypatch.setattr(hm, "PROJECT_ROOT", project)
+    monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: True)
+    monkeypatch.setattr(hm, "_is_android_python", lambda: True)
+    monkeypatch.setattr(
+        hm, "_termux_wheelhouse_cache_root", lambda env=None: tmp_path / "cache"
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs):
+        calls.append(command)
+        if "prepare_termux_wheelhouse.py" in " ".join(command):
+            return SimpleNamespace(returncode=1, stdout="", stderr="pin mismatch\n")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hm.subprocess, "run", fake_run)
+    with pytest.raises(SystemExit):
+        hm._termux_post_pull_wheelhouse_gate(["git"], "1" * 40)
+    assert ["git", "reset", "--hard", "1" * 40] in calls
+
+
+def test_post_pull_gate_requires_binary_only_dry_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hermes_cli import main as hm
+
+    project = tmp_path / "repo"
+    scripts = project / "scripts"
+    venv_bin = project / "venv" / "bin"
+    scripts.mkdir(parents=True)
+    venv_bin.mkdir(parents=True)
+    target_python = venv_bin / "python"
+    target_python.write_text("", encoding="utf-8")
+    for relative in (
+        "scripts/prepare_termux_wheelhouse.py",
+        "scripts/termux_requirements.py",
+        "pyproject.toml",
+        "uv.lock",
+        "constraints-termux.txt",
+    ):
+        destination = project / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(hm, "PROJECT_ROOT", project)
+    monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: True)
+    monkeypatch.setattr(hm, "_is_android_python", lambda: True)
+    monkeypatch.setattr(hm.shutil, "which", lambda name: "/termux/bin/uv")
+    monkeypatch.setattr(
+        hm, "_termux_wheelhouse_cache_root", lambda env=None: tmp_path / "cache"
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs):
+        calls.append(command)
+        joined = " ".join(command)
+        if "prepare_termux_wheelhouse.py" in joined:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=str(tmp_path / "cache" / tw.RELEASE_TAG) + "\n",
+                stderr="",
+            )
+        if command[:2] == [str(target_python), "-c"]:
+            return SimpleNamespace(returncode=0, stdout="3.13.14\n", stderr="")
+        if "termux_requirements.py" in joined:
+            Path(command[command.index("--requirements") + 1]).write_text(
+                "cffi==2.0.0\n", encoding="utf-8"
+            )
+            Path(command[command.index("--constraints") + 1]).write_text(
+                "", encoding="utf-8"
+            )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "compile" in command:
+            Path(command[command.index("--output-file") + 1]).write_text(
+                "cffi==2.0.0\n", encoding="utf-8"
+            )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "--dry-run" in command:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hm.subprocess, "run", fake_run)
+    hm._termux_post_pull_wheelhouse_gate(["git"], "1" * 40)
+
+    dry_runs = [command for command in calls if "--dry-run" in command]
+    assert len(dry_runs) == 1
+    assert "--reinstall" in dry_runs[0]
+    assert "--only-binary" in dry_runs[0]
+    assert ":all:" in dry_runs[0]
+    assert "--find-links" in dry_runs[0]
+    assert not any(command[:3] == ["git", "reset", "--hard"] for command in calls)
+
+
+def test_termux_group_uses_wheelhouse_without_psutil_source_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli import main as hm
+
+    calls: list[tuple[list[str], dict[str, str] | None]] = []
+    monkeypatch.setattr(hm, "_is_termux_env", lambda env=None: True)
+    monkeypatch.setattr(hm, "_is_android_python", lambda: True)
+    monkeypatch.setattr(
+        hm,
+        "_install_termux_dependencies_from_wheelhouse",
+        lambda prefix, env=None: calls.append((prefix, env)) or True,
+    )
+    monkeypatch.setattr(
+        hm,
+        "_install_psutil_android_compat",
+        lambda *_args, **_kwargs: pytest.fail("psutil source fallback must not run"),
+    )
+    monkeypatch.setattr(
+        hm,
+        "_run_quarantined_install",
+        lambda *_args, **_kwargs: pytest.fail("generic editable resolver must not run"),
+    )
+
+    env = {"PREFIX": "/data/data/com.termux/files/usr"}
+    hm._install_python_dependencies_with_optional_fallback(
+        ["/data/data/com.termux/files/usr/bin/uv", "pip"],
+        env=env,
+        group="termux-all",
+    )
+
+    assert calls == [(["/data/data/com.termux/files/usr/bin/uv", "pip"], env)]

--- a/tests/hermes_cli/test_termux_wheelhouse.py
+++ b/tests/hermes_cli/test_termux_wheelhouse.py
@@ -33,8 +33,19 @@ def test_current_uv_lock_matches_immutable_release() -> None:
     root = Path(__file__).resolve().parents[2]
     tw.validate_uv_lock(root / "uv.lock")
     assert set(tw.LOCKED_WHEELS) == EXPECTED_NAMES
-    assert tw.RELEASE_TAG == "wheelhouse-cp313-android24-arm64-20260719.1"
-    assert tw.RELEASE_COMMIT == "b042ce9e662f14794ef6b5664c9ae711330df31b"
+    assert tw.RELEASE_TAG == "wheelhouse-cp313-android24-arm64-20260811.1"
+    assert tw.RELEASE_COMMIT == "5184b2059257918e9a98993186b57f6aaf9037b9"
+    assert tw.SHA256SUMS_SHA256 == "435f23524d76cf061bf658c48bbee7439a85bf39e3a3b0b292d54db38669d079"
+    assert tw.LOCKED_WHEELS["cryptography"] == (
+        "50.0.0",
+        "cryptography-50.0.0-cp313-abi3-android_24_arm64_v8a.whl",
+        "7580a6de25b86680389c1083b72d5eb27f20b2d588c1aa51600784864d7739de",
+    )
+    assert tw.LOCKED_WHEELS["pillow"] == (
+        "12.3.0",
+        "pillow-12.3.0-cp313-cp313-android_24_arm64_v8a.whl",
+        "7a2d796d96f9b2a9061a78306d5585b0eaa65a93e16e645c887f87dd55eacd67",
+    )
 
 
 def test_uv_lock_pin_drift_is_rejected() -> None:
@@ -55,7 +66,7 @@ def test_resolved_requirements_pin_drift_is_rejected() -> None:
     tw.validate_requirements_text(requirements)
     with pytest.raises(tw.TermuxWheelhouseMismatch, match="cryptography"):
         tw.validate_requirements_text(
-            requirements.replace("cryptography==46.0.7", "cryptography==1")
+            requirements.replace("cryptography==50.0.0", "cryptography==1")
         )
 
 

--- a/tests/scripts/test_termux_footguns.py
+++ b/tests/scripts/test_termux_footguns.py
@@ -1,0 +1,90 @@
+"""Regression tests for scripts/check-termux-footguns.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LINTER_PATH = REPO_ROOT / "scripts" / "check-termux-footguns.py"
+
+
+def _load_linter_module():
+    spec = importlib.util.spec_from_file_location("check_termux_footguns", LINTER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_termux_footguns"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def linter():
+    return _load_linter_module()
+
+
+def _write(root: Path, rel: str, content: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_flags_host_package_manager_in_native_installer(linter, tmp_path, monkeypatch):
+    monkeypatch.setattr(linter, "REPO_ROOT", tmp_path)
+    path = _write(
+        tmp_path,
+        "scripts/install-termux.sh",
+        "#!/data/data/com.termux/files/usr/bin/bash\nsudo apt-get install python\n",
+    )
+    findings = linter.scan_file(path)
+    assert {item.name for item in findings} == {"host Linux package manager in native Termux installer"}
+
+
+def test_unset_python_host_platform_is_allowed_but_assignment_is_not(linter, tmp_path, monkeypatch):
+    monkeypatch.setattr(linter, "REPO_ROOT", tmp_path)
+    path = _write(
+        tmp_path,
+        "scripts/install-termux.sh",
+        "#!/data/data/com.termux/files/usr/bin/bash\nunset UV_INDEX \\\n    _PYTHON_HOST_PLATFORM\n",
+    )
+    assert not linter.scan_file(path)
+
+    path.write_text(
+        "#!/data/data/com.termux/files/usr/bin/bash\nexport _PYTHON_HOST_PLATFORM=linux_aarch64\n",
+        encoding="utf-8",
+    )
+    assert any(item.name == "fake _PYTHON_HOST_PLATFORM assignment" for item in linter.scan_file(path))
+
+
+def test_termux_regression_rejects_fragile_inline_bash_lc(linter, tmp_path, monkeypatch):
+    monkeypatch.setattr(linter, "REPO_ROOT", tmp_path)
+    path = _write(
+        tmp_path,
+        ".github/workflows/termux-regression.yml",
+        "run: docker run image bash -lc 'echo quoted'\n",
+    )
+    findings = linter.scan_file(path)
+    assert {item.name for item in findings} == {"fragile inline quoted Termux regression shell"}
+
+
+def test_termux_regression_rejects_privileged_or_seccomp_disabled_container(linter, tmp_path, monkeypatch):
+    monkeypatch.setattr(linter, "REPO_ROOT", tmp_path)
+    path = _write(
+        tmp_path,
+        ".github/workflows/termux-regression.yml",
+        "run: docker run --rm --privileged --security-opt seccomp=unconfined image\n",
+    )
+    findings = linter.scan_file(path)
+    assert {item.name for item in findings} == {"privileged Termux PR regression container"}
+
+
+def test_repository_termux_policy_is_clean(linter):
+    files = list(linter.iter_files([REPO_ROOT]))
+    selected = {linter._repo_rel(path) for path in files}
+    findings = [finding for path in files for finding in linter.scan_file(path)]
+    findings.extend(linter.invariant_findings(selected))
+    assert findings == []

--- a/tests/test_install_termux_native.py
+++ b/tests/test_install_termux_native.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL = REPO_ROOT / "scripts" / "install-termux.sh"
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _source_installer(
+    body: str,
+    *,
+    env: dict[str, str] | None = None,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    return subprocess.run(
+        ["bash", "-c", f'source "$1"\n{body}', "bash", str(INSTALL)],
+        env=merged_env,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _python_version_shim(path: Path, version: str) -> None:
+    _write_executable(
+        path,
+        "#!/bin/bash\n"
+        'if [ "${1:-}" = "-c" ]; then\n'
+        '  code="$2"\n'
+        "  exec python3 -c 'import sys; "
+        'sys.version_info=tuple(map(int, sys.argv[2].split("."))); '
+        'exec(sys.argv[1])\' "$code" "' + version + '"\n'
+        "fi\n"
+        f"printf 'Python {version}\\n'\n",
+    )
+
+
+def test_termux_options_are_parsed_as_explicit_installer_inputs(tmp_path: Path) -> None:
+    requested_python = tmp_path / "python3.13"
+    requested_python.touch()
+    result = _source_installer(
+        'parse_args --python "$REQUESTED_PYTHON" --android-api-level 28 '
+        "--skip-setup --skip-browser\n"
+        'printf \'%s|%s|%s|%s\\n\' "$PYTHON_BIN" "$ANDROID_BUILD_API" '
+        '"$RUN_SETUP" "$SKIP_BROWSER"',
+        env={"REQUESTED_PYTHON": str(requested_python)},
+        check=True,
+    )
+    assert result.stdout.strip() == f"{requested_python}|28|false|true"
+
+
+def test_python_support_check_rejects_314_and_accepts_313(tmp_path: Path) -> None:
+    python_313 = tmp_path / "python3.13"
+    python_314 = tmp_path / "python3.14"
+    _python_version_shim(python_313, "3.13.9")
+    _python_version_shim(python_314, "3.14.0")
+
+    result = _source_installer(
+        'if python_is_supported "$PYTHON_314"; then exit 90; fi\n'
+        'python_is_supported "$PYTHON_313"',
+        env={"PYTHON_313": str(python_313), "PYTHON_314": str(python_314)},
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_automatic_python_selection_requires_cp313_for_immutable_wheels(
+    tmp_path: Path,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    python_312 = fake_bin / "python3.12"
+    python_313 = fake_bin / "python3.13"
+    _python_version_shim(python_312, "3.12.11")
+    _python_version_shim(python_313, "3.13.14")
+
+    result = _source_installer(
+        "find_immutable_python",
+        env={"PATH": f"{fake_bin}:{os.environ['PATH']}"},
+        check=True,
+    )
+    assert result.stdout.strip() == str(python_313)
+
+
+def test_automatic_python_selection_does_not_use_312_as_immutable_target(
+    tmp_path: Path,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    python_312 = fake_bin / "python3.12"
+    _python_version_shim(python_312, "3.12.11")
+
+    result = _source_installer(
+        "find_immutable_python",
+        env={"PATH": f"{fake_bin}:{os.environ['PATH']}"},
+    )
+    assert result.returncode != 0
+    assert result.stdout == ""
+
+
+def _pinned_python_toolchain(
+    tmp_path: Path,
+    *,
+    checksum_status: int = 0,
+    package_version: str = "3.13.14",
+) -> tuple[Path, dict[str, str]]:
+    fake_bin = tmp_path / "pinned-bin"
+    fake_bin.mkdir()
+    prefix = tmp_path / "prefix"
+    prefix.mkdir()
+
+    _write_executable(
+        fake_bin / "curl",
+        "#!/bin/bash\n"
+        "set -e\n"
+        "url=''\nout=''\n"
+        'while [ "$#" -gt 0 ]; do\n'
+        '  case "$1" in\n'
+        '    -o) out="$2"; shift 2 ;;\n'
+        "    --retry) shift 2 ;;\n"
+        '    http*) url="$1"; shift ;;\n'
+        "    *) shift ;;\n"
+        "  esac\n"
+        "done\n"
+        'printf \'%s\\n\' "$url" > "$PINNED_URL_LOG"\n'
+        ': > "$out"\n',
+    )
+    _write_executable(
+        fake_bin / "sha256sum",
+        '#!/bin/bash\ncat > "$PINNED_SHA_LOG"\nexit "$PINNED_CHECKSUM_STATUS"\n',
+    )
+    _write_executable(
+        fake_bin / "dpkg",
+        "#!/bin/bash\n"
+        'if [ "${1:-}" = "--print-architecture" ]; then\n'
+        "  printf 'aarch64\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 2\n",
+    )
+    _write_executable(
+        fake_bin / "dpkg-deb",
+        "#!/bin/bash\n"
+        "set -e\n"
+        'case "${1:-}" in\n'
+        "  -f)\n"
+        '    case "${3:-}" in\n'
+        "      Package) printf 'python\\n' ;;\n"
+        "      Version) printf '%s\\n' \"$PINNED_PACKAGE_VERSION\" ;;\n"
+        "      Architecture) printf 'aarch64\\n' ;;\n"
+        "      *) exit 3 ;;\n"
+        "    esac\n"
+        "    ;;\n"
+        "  -x)\n"
+        '    root="$3$PREFIX"\n'
+        '    mkdir -p "$root/bin" "$root/lib/python3.13" "$root/lib/pkgconfig" \
+'
+        '      "$root/share/man/man1"\n'
+        "    cat > \"$root/bin/python3.13\" <<'PYTHON'\n"
+        "#!/bin/bash\n"
+        'if [ "${1:-}" = "-c" ]; then exit 0; fi\n'
+        'if [ "${1:-}" = "--version" ]; then printf \'Python 3.13.14\\n\'; exit 0; fi\n'
+        "exit 0\n"
+        "PYTHON\n"
+        '    chmod 755 "$root/bin/python3.13"\n'
+        '    touch "$root/lib/python3.13/STDLIB"\n'
+        '    touch "$root/lib/pkgconfig/python-3.13.pc" \
+'
+        '      "$root/lib/pkgconfig/python-3.13-embed.pc" \
+'
+        '      "$root/share/man/man1/python3.13.1.gz"\n'
+        '    ln -s python-3.13.pc "$root/lib/pkgconfig/python3.pc"\n'
+        '    ln -s python-3.13-embed.pc "$root/lib/pkgconfig/python3-embed.pc"\n'
+        '    ln -s python3.13.1.gz "$root/share/man/man1/python.1.gz"\n'
+        '    ln -s python3.13.1.gz "$root/share/man/man1/python3.1.gz"\n'
+        "    for alias in python python3 python-config python3-config pip pip3 "
+        "idle idle3 pydoc pydoc3 2to3; do\n"
+        '      ln -s python3.13 "$root/bin/$alias"\n'
+        "    done\n"
+        "    ;;\n"
+        "  *) exit 4 ;;\n"
+        "esac\n",
+    )
+
+    env = {
+        "PREFIX": str(prefix),
+        "TMPDIR": str(tmp_path),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "PINNED_URL_LOG": str(tmp_path / "pinned-url.log"),
+        "PINNED_SHA_LOG": str(tmp_path / "pinned-sha.log"),
+        "PINNED_CHECKSUM_STATUS": str(checksum_status),
+        "PINNED_PACKAGE_VERSION": package_version,
+    }
+    return prefix, env
+
+
+def test_pinned_python_fallback_downloads_and_verifies_exact_release(
+    tmp_path: Path,
+) -> None:
+    prefix, env = _pinned_python_toolchain(tmp_path)
+    result = _source_installer("install_pinned_python313", env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "pinned-url.log").read_text(encoding="utf-8").strip() == (
+        "https://github.com/adybag14-cyber/termux-python/releases/download/"
+        "termux-aarch64-20260719.9.1/python_3.13.14_aarch64.deb"
+    )
+    checksum_parts = (
+        (tmp_path / "pinned-sha.log").read_text(encoding="utf-8").strip().split()
+    )
+    assert checksum_parts[0] == (
+        "42376a2a47e50048cb7eca2d0f442fc1895fbca2aee2dee3d2fd82728ea1bd80"
+    )
+    assert Path(checksum_parts[1]).name == "python_3.13.14_aarch64.deb"
+    assert (prefix / "bin" / "python3.13").is_file()
+    assert (prefix / "lib" / "python3.13" / "STDLIB").is_file()
+    assert (prefix / "lib" / "pkgconfig" / "python-3.13.pc").is_file()
+    assert (prefix / "share" / "man" / "man1" / "python3.13.1.gz").is_file()
+    for alias in (
+        "python",
+        "python3",
+        "python-config",
+        "python3-config",
+        "pip",
+        "pip3",
+        "idle",
+        "idle3",
+        "pydoc",
+        "pydoc3",
+        "2to3",
+    ):
+        assert not (prefix / "bin" / alias).exists()
+    for alias in (
+        prefix / "lib" / "pkgconfig" / "python3.pc",
+        prefix / "lib" / "pkgconfig" / "python3-embed.pc",
+        prefix / "share" / "man" / "man1" / "python.1.gz",
+        prefix / "share" / "man" / "man1" / "python3.1.gz",
+    ):
+        assert not alias.exists()
+
+
+def test_pinned_python_fallback_rejects_checksum_mismatch(tmp_path: Path) -> None:
+    prefix, env = _pinned_python_toolchain(tmp_path, checksum_status=1)
+    result = _source_installer("install_pinned_python313", env=env)
+
+    assert result.returncode != 0
+    assert "checksum verification failed" in result.stderr
+    assert not (prefix / "bin" / "python3.13").exists()
+
+
+def test_pinned_python_fallback_rejects_different_package_version(
+    tmp_path: Path,
+) -> None:
+    prefix, env = _pinned_python_toolchain(tmp_path, package_version="3.13.15")
+    result = _source_installer("install_pinned_python313", env=env)
+
+    assert result.returncode != 0
+    assert "metadata did not match the locked release" in result.stderr
+    assert not (prefix / "bin" / "python3.13").exists()
+
+
+def test_failed_venv_creation_restores_previous_environment(tmp_path: Path) -> None:
+    install_dir = tmp_path / "hermes-agent"
+    old_venv = install_dir / "venv"
+    old_venv.mkdir(parents=True)
+    (old_venv / "keep.txt").write_text("previous environment", encoding="utf-8")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(fake_bin / "uv", "#!/bin/bash\nexit 42\n")
+
+    result = _source_installer(
+        'create_venv "$FAKE_PYTHON"',
+        env={
+            "HERMES_INSTALL_DIR": str(install_dir),
+            "HERMES_HOME": str(tmp_path / "home"),
+            "FAKE_PYTHON": str(tmp_path / "python3.13"),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        },
+    )
+    assert result.returncode != 0
+    assert (install_dir / "venv" / "keep.txt").read_text(encoding="utf-8") == (
+        "previous environment"
+    )
+    assert not list(install_dir.glob("venv.pre-native-termux-*"))
+
+
+def test_launcher_clears_python_environment_and_routes_version(tmp_path: Path) -> None:
+    prefix = tmp_path / "prefix"
+    install_dir = tmp_path / "hermes-agent"
+    bin_dir = prefix / "bin"
+    venv_bin = install_dir / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    venv_bin.mkdir(parents=True)
+    (bin_dir / "bash").symlink_to("/bin/bash")
+    launch_log = tmp_path / "launcher.log"
+
+    _write_executable(
+        venv_bin / "python",
+        "#!/bin/bash\n"
+        "printf 'python|PYTHONPATH=%s|PYTHONHOME=%s|UV_LINK_MODE=%s\\n' "
+        '"${PYTHONPATH-<unset>}" "${PYTHONHOME-<unset>}" '
+        '"${UV_LINK_MODE-<unset>}" >> "$LAUNCH_LOG"\n'
+        "printf 'version-ok\\n'\n",
+    )
+    _write_executable(
+        venv_bin / "hermes",
+        "#!/bin/bash\n"
+        "printf 'hermes|PYTHONPATH=%s|PYTHONHOME=%s|UV_LINK_MODE=%s|args=%s\\n' "
+        '"${PYTHONPATH-<unset>}" "${PYTHONHOME-<unset>}" '
+        '"${UV_LINK_MODE-<unset>}" "$*" >> "$LAUNCH_LOG"\n',
+    )
+
+    _source_installer(
+        "install_launcher",
+        env={
+            "PREFIX": str(prefix),
+            "HERMES_INSTALL_DIR": str(install_dir),
+            "HERMES_HOME": str(tmp_path / "home"),
+            "LAUNCH_LOG": str(launch_log),
+        },
+        check=True,
+    )
+
+    launcher_env = os.environ.copy()
+    launcher_env.update({
+        "PYTHONPATH": "/wrong/python/path",
+        "PYTHONHOME": "/wrong/python/home",
+        "LAUNCH_LOG": str(launch_log),
+    })
+    version = subprocess.run(
+        [str(bin_dir / "hermes"), "version"],
+        env=launcher_env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    subprocess.run(
+        [str(bin_dir / "hermes"), "chat", "--resume"],
+        env=launcher_env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert version.stdout.strip() == "version-ok"
+    lines = launch_log.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == (
+        "python|PYTHONPATH=<unset>|PYTHONHOME=<unset>|UV_LINK_MODE=copy"
+    )
+    assert lines[1] == (
+        "hermes|PYTHONPATH=<unset>|PYTHONHOME=<unset>|UV_LINK_MODE=copy|"
+        "args=chat --resume"
+    )
+
+
+def test_termux_dispatches_to_local_installer_without_network(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    shutil.copy2(INSTALL_SH, scripts / "install.sh")
+    child = scripts / "install-termux.sh"
+    _write_executable(child, "#!/bin/bash\nprintf 'termux:%s\\n' \"$*\"\n")
+
+    env = os.environ.copy()
+    env.update({"TERMUX_VERSION": "0.118", "PREFIX": "/data/data/com.termux/files/usr"})
+    result = subprocess.run(
+        ["bash", str(scripts / "install.sh"), "--skip-setup"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "termux:--skip-setup"
+
+
+def test_streamed_termux_dispatch_honors_requested_ref(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    shutil.copy2(INSTALL_SH, scripts / "install.sh")
+
+    stub = tmp_path / "install-termux.stub.sh"
+    _write_executable(stub, "#!/bin/bash\nprintf 'remote:%s\\n' \"$*\"\n")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_curl = fake_bin / "curl"
+    _write_executable(
+        fake_curl,
+        "#!/bin/bash\n"
+        "url=''\nout=''\n"
+        'while [ "$#" -gt 0 ]; do\n'
+        '  case "$1" in\n'
+        '    -o) out="$2"; shift 2 ;;\n'
+        "    -*) shift ;;\n"
+        '    *) url="$1"; shift ;;\n'
+        "  esac\n"
+        "done\n"
+        'printf \'%s\\n\' "$url" > "$CURL_LOG"\n'
+        'cp "$TERMUX_STUB_SOURCE" "$out"\n',
+    )
+
+    env = os.environ.copy()
+    env.update({
+        "TERMUX_VERSION": "0.118",
+        "PREFIX": "/data/data/com.termux/files/usr",
+        "PATH": f"{fake_bin}:{env['PATH']}",
+        "TERMUX_STUB_SOURCE": str(stub),
+        "CURL_LOG": str(tmp_path / "curl.log"),
+    })
+    result = subprocess.run(
+        [
+            "bash",
+            str(scripts / "install.sh"),
+            "--branch",
+            "feature/native",
+            "--skip-setup",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "remote:--branch feature/native --skip-setup"
+    assert (
+        (tmp_path / "curl.log")
+        .read_text(encoding="utf-8")
+        .strip()
+        .endswith("/feature/native/scripts/install-termux.sh")
+    )

--- a/tests/test_termux_requirements.py
+++ b/tests/test_termux_requirements.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.termux_requirements import expand_termux_requirements, lock_constraints
+
+
+def test_expands_profile_and_removes_native_optional_extras(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "hermes-agent"
+dependencies = [
+  "uvicorn[standard]>=0.24,<1",
+  "basepkg==1",
+  "windows-only==1; sys_platform == 'win32'",
+]
+[project.optional-dependencies]
+termux-all = ["hermes-agent[termux]", "hermes-agent[web]"]
+termux = ["python-telegram-bot[webhooks]==22.6", "hermes-agent[cli]"]
+cli = ["simple-term-menu==1.6.6"]
+web = ["uvicorn[standard]==0.41.0", "fastapi==1.0"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    requirements = expand_termux_requirements(pyproject, python_version="3.11.15")
+    assert "uvicorn<1,>=0.24" in requirements
+    assert "uvicorn==0.41.0" in requirements
+    assert "python-telegram-bot==22.6" in requirements
+    assert "simple-term-menu==1.6.6" in requirements
+    assert all("standard" not in value for value in requirements)
+    assert all("webhooks" not in value for value in requirements)
+    assert all("windows-only" not in value for value in requirements)
+
+
+def test_lock_constraints_skip_platform_forks(tmp_path: Path) -> None:
+    lock = tmp_path / "uv.lock"
+    lock.write_text(
+        """
+version = 1
+[[package]]
+name = "single"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+[[package]]
+name = "forked"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+[[package]]
+name = "forked"
+version = "2.0"
+source = { registry = "https://pypi.org/simple" }
+[[package]]
+name = "local"
+version = "0.1"
+source = { editable = "." }
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    constraints = lock_constraints(lock)
+    assert constraints == ["single==1.2.3"]

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -66,7 +66,7 @@ iex (irm https://hermes-agent.nousresearch.com/install.ps1)
 ```
 
 :::tip Android / Termux
-If you're installing on a phone, see the dedicated [Termux guide](./termux.md) for the tested manual path, supported extras, and current Android-specific limitations.
+If you're installing on a phone, the same command dispatches to the dedicated native `uv` installer. CPython 3.13 arm64 installs use a checksum-pinned immutable Android wheelhouse, so native dependencies do not compile on the phone. The same binary-only path and rollback gate are used by `hermes update`. See the [Termux guide](./termux.md) for the exact target, cache, options, and Android-specific limitations.
 :::
 
 After it finishes, reload your shell:

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -7,247 +7,182 @@ description: "Run Hermes Agent directly on an Android phone with Termux"
 # Hermes on Android with Termux
 
 :::warning Tier 2 platform
-Termux (Android) is a [Tier 2 platform](./platform-support.md#tier-2). The installer script and documentation here are maintained on a best-effort basis only. Commits to `main` may break these packages at any point in time.
+Termux (Android) is a [Tier 2 platform](./platform-support.md#tier-2). The installer and this guide are maintained on a best-effort basis. Changes on `main` may temporarily break Android-specific dependencies.
 :::
 
-Hermes Agent can run directly on an Android phone through [Termux](https://termux.dev/).
+Hermes Agent can run directly on Android through [Termux](https://termux.dev/). The supported path is the dedicated native Termux installer, which uses Termux packages and `uv`; it does not use proot, Ubuntu, a stdlib `venv` plus `pip`, or the desktop `.[all]` dependency set.
 
-It gives you a working local CLI on the phone, plus the core extras that are currently known to install cleanly on Android.
+## What the native installer does
 
-## What is supported in the tested path?
+On Termux, the normal `install.sh` entrypoint dispatches to `scripts/install-termux.sh`. That installer:
 
-The tested Termux bundle installs:
+- installs the native Termux runtime packages with `pkg`; compiler and Rust packages are not installed on the normal arm64 path
+- automatically selects CPython 3.13 on arm64; CPython 3.11/3.12 remain available only through an explicit `--python` compatibility selection, and Python 3.14 is rejected
+- installs a checksum-pinned Python 3.13.14 aarch64 build side-by-side when no CPython 3.13 interpreter exists, without replacing Termux's `python` or `python3` aliases
+- creates the Hermes virtual environment with `uv venv`
+- derives an Android-safe dependency graph from `pyproject.toml` and `uv.lock`
+- verifies that the graph matches the immutable CPython 3.13 Android arm64 wheel release
+- downloads ten native wheels from release `wheelhouse-cp313-android24-arm64-20260719.1`, verifying the pinned `SHA256SUMS` file and every wheel before installation
+- installs the complete graph with `--only-binary :all:` so a supported phone never silently starts a local C or Rust build
+- installs Hermes as an editable package with `--no-deps` and runs dependency/import smoke checks
+- writes a launcher to `$PREFIX/bin/hermes` that clears inherited `PYTHONPATH` and `PYTHONHOME`
+- preserves the previous virtual environment until the new install validates successfully
 
-- the Hermes CLI
-- cron support
-- PTY/background terminal support
-- Telegram gateway support (manual / best-effort background runs)
-- MCP support
-- Honcho memory support
-- ACP support
+The tested mobile dependency set includes the Hermes CLI, cron support, PTY/background terminal support, Telegram gateway support, MCP, Honcho memory, and ACP. The full desktop/server `.[all]` extra is not the Android contract.
 
-Concretely, it maps to:
+## One-line install
+
+Run this inside the current official Termux app:
 
 ```bash
-python -m pip install -e '.[termux]' -c constraints-termux.txt
+pkg update
+pkg install -y curl
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
 ```
 
-## What is not part of the tested path yet?
+After installation:
 
-A few features still need desktop/server-style dependencies that are not published for Android, or have not been validated on phones yet:
+```bash
+hermes version
+hermes doctor
+hermes
+```
 
-- `.[all]` is not supported on Android today
-- the `voice` extra is blocked by `faster-whisper -> ctranslate2`, and `ctranslate2` does not publish Android wheels
-- automatic browser / Playwright bootstrap is skipped in the Termux installer
-- Docker-based terminal isolation is not available inside Termux
-- Android may still suspend Termux background jobs, so gateway persistence is best-effort rather than a normal managed service
+## Installer options
 
-That does not stop Hermes from working well as a phone-native CLI agent — it just means the recommended mobile install is intentionally narrower than the desktop/server install.
+Pass options through `bash -s --` when using the one-line installer:
 
----
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh   | bash -s -- --skip-setup --skip-browser
+```
 
-## Option 1: One-line installer
+Useful options:
 
-Hermes now ships a Termux-aware installer path:
+| Option | Purpose |
+| --- | --- |
+| `--branch NAME` | Install a specific branch |
+| `--commit SHA` | Pin an exact commit |
+| `--dir PATH` | Choose the repository checkout directory |
+| `--hermes-home PATH` | Choose the Hermes data directory |
+| `--python PATH` | Use a specific CPython 3.11-3.13 interpreter |
+| `--android-api-level N` | Override the Android wheel build target; default is 24 |
+| `--skip-setup` | Skip provider/API setup during installation |
+| `--skip-browser` | Skip optional Node/browser command dependencies |
+| `--no-skills` | Do not seed bundled skills |
+| `--non-interactive` | Never prompt |
+
+Configuration such as model/provider settings belongs in `~/.hermes/config.yaml`; credentials belong in `~/.hermes/.env`. The installer does not require new user-facing `HERMES_*` environment controls for Android build behavior.
+
+## Explicit repository install
+
+For a review branch or a locally inspected checkout, use the same native installer directly rather than recreating the process with manual `pip` commands:
+
+```bash
+pkg update
+pkg install -y git curl ca-certificates
+git clone https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+bash scripts/install-termux.sh --skip-setup
+```
+
+To test a branch:
+
+```bash
+bash scripts/install-termux.sh --branch my-branch --skip-setup
+```
+
+This path is intentionally the same installer contract used by the one-line command.
+
+## Updating
+
+Use the normal updater:
+
+```bash
+hermes update
+```
+
+On a supported CPython 3.13 arm64 installation, the update path regenerates the curated Termux graph, revalidates the cached immutable wheelhouse, and performs the dependency update with `--only-binary :all:`. Before changing the environment it also runs `uv pip install --dry-run --reinstall --only-binary :all:` against PyPI plus the wheelhouse, proving that every package in the complete graph has a compatible binary even when an older source-built copy is already installed. It does not invoke the psutil patch builder, Cargo, Clang, or maturin.
+
+Before accepting newly pulled code, the updater executes the wheel verifier from that new checkout in a separate Python process. If the new lockfile no longer matches its pinned immutable wheel release, if a release asset is unavailable, if any SHA-256 differs, or if the binary-only dry run finds a package that would require compilation, the updater resets Git to the previous commit and leaves the existing environment unchanged. This lets a future change advance its dependency pins and wheel-release constants together without using stale verifier code from the running process.
+
+The verified cache is stored under:
+
+```text
+~/.hermes/cache/termux-wheelhouse/wheelhouse-cp313-android24-arm64-20260719.1/
+```
+
+Rerunning the installer remains supported when repairing the repository checkout itself:
 
 ```bash
 curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
 ```
 
-On Termux, the installer automatically:
 
-- uses `pkg` for system packages
-- creates the venv with `python -m venv`
-- attempts the broad `.[termux-all]` extra first and falls back to the smaller `.[termux]` extra (then a base install) — the curl installer matches this order automatically
-- links `hermes` into `$PREFIX/bin` so it stays on your Termux PATH
-- skips the untested browser / WhatsApp bootstrap
-
-If you want the explicit commands or need to debug a failed install, use the manual path below.
-
----
-
-## Option 2: Manual install (fully explicit)
-
-### 1. Update Termux and install system packages
-
-```bash
-pkg update
-pkg install -y git python clang rust make pkg-config libffi openssl nodejs ripgrep ffmpeg
-```
-
-Why these packages?
-
-- `python` — runtime + venv support
-- `git` — clone/update the repo
-- `clang`, `rust`, `make`, `pkg-config`, `libffi`, `openssl` — needed to build a few Python dependencies on Android
-- `nodejs` — optional Node runtime for experiments beyond the tested core path
-- `ripgrep` — fast file search
-- `ffmpeg` — media / TTS conversions
-
-### 2. Clone Hermes
-
-```bash
-git clone https://github.com/NousResearch/hermes-agent.git
-cd hermes-agent
-```
-
-### 3. Create a virtual environment
-
-```bash
-python -m venv venv
-source venv/bin/activate
-export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
-python -m pip install --upgrade pip setuptools wheel
-```
-
-`ANDROID_API_LEVEL` is important for Rust / maturin-based packages such as `jiter`.
-
-### 4. Install the tested Termux bundle
-
-```bash
-python -m pip install -e '.[termux]' -c constraints-termux.txt
-```
-
-If you only want the minimal core agent, this also works:
-
-```bash
-python -m pip install -e '.' -c constraints-termux.txt
-```
-
-### 5. Put `hermes` on your Termux PATH
-
-```bash
-ln -sf "$PWD/venv/bin/hermes" "$PREFIX/bin/hermes"
-```
-
-`$PREFIX/bin` is already on PATH in Termux, so this makes the `hermes` command persist across new shells without re-activating the venv every time.
-
-### 6. Verify the install
-
-```bash
-hermes version
-hermes doctor
-```
-
-### 7. Start Hermes
-
-```bash
-hermes
-```
-
----
-
-## Recommended follow-up setup
-
-### Configure a model
-
-```bash
-hermes model
-```
-
-Or set keys directly in `~/.hermes/.env`.
-
-### Re-run the full interactive setup wizard later
-
-```bash
-hermes setup
-```
-
-### Install optional Node dependencies manually
-
-The tested Termux path skips Node/browser bootstrap on purpose. If you want to experiment with browser tooling later, what you need depends on which backend you use:
-
-- **Cloud browser providers** (Browserbase, Browser Use, Firecrawl) host their own Chromium, so Node.js alone is enough — `agent-browser` resolves lazily via `npx agent-browser` on first use:
-
-  ```bash
-  pkg install nodejs-lts
-  ```
-
-- **Local browser automation** on Termux needs a real `agent-browser` install — the bare npx fallback is deliberately rejected in local mode as too fragile to advertise as ready:
-
-  ```bash
-  pkg install nodejs-lts
-  npm install -g agent-browser && agent-browser install
-  ```
-
-The browser tool automatically includes Termux directories (`/data/data/com.termux/files/usr/bin`) in its PATH search, so `agent-browser` and `npx` are discovered without any extra PATH configuration.
-
-Treat browser / WhatsApp tooling on Android as experimental until documented otherwise.
-
----
+Local changes are stashed before an update and restored afterward when Git can apply them cleanly.
 
 ## Troubleshooting
 
-### `No solution found` when installing `.[all]`
+### Termux currently provides Python 3.14
 
-Use the tested Termux bundle instead:
+Hermes supports Python 3.11 through 3.13, but automatic arm64 installs deliberately use CPython 3.13 so they can consume the immutable wheelhouse. When no CPython 3.13 interpreter is available, including when Termux currently provides only Python 3.14?the native installer stages the exact `python_3.13.14_aarch64.deb` asset from release `termux-aarch64-20260719.9.1` side-by-side without replacing Termux's system aliases. The download is locked to SHA-256 `42376a2a47e50048cb7eca2d0f442fc1895fbca2aee2dee3d2fd82728ea1bd80`; installation stops before extraction if the bytes or package metadata differ. This fallback currently supports aarch64 Termux devices only.
 
-```bash
-python -m pip install -e '.[termux]' -c constraints-termux.txt
-```
-
-The blocker is currently the `voice` extra:
-
-- `voice` pulls `faster-whisper`
-- `faster-whisper` depends on `ctranslate2`
-- `ctranslate2` does not publish Android wheels
-
-### `uv pip install` fails on Android
-
-Use the Termux path with the stdlib venv + `pip` instead:
+A known compatible interpreter can also be selected explicitly. Selecting 3.11 or 3.12 opts into the native-build compatibility path:
 
 ```bash
-python -m venv venv
-source venv/bin/activate
-export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
-python -m pip install --upgrade pip setuptools wheel
-python -m pip install -e '.[termux]' -c constraints-termux.txt
+bash scripts/install-termux.sh --python "$PREFIX/bin/python3.13"
 ```
 
-### `jiter` / `maturin` complains about `ANDROID_API_LEVEL`
+### An immutable wheel download or verification fails
 
-Set the API level explicitly before installing:
+Do not bypass the checksum check or remove `--only-binary :all:`. Rerun the installer or `hermes update`; a partially downloaded staging directory is discarded, while an already verified cache is preserved.
 
 ```bash
-export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
-python -m pip install -e '.[termux]' -c constraints-termux.txt
+bash scripts/install-termux.sh --skip-setup
 ```
 
-### `hermes doctor` says ripgrep or Node is missing
+The immutable release is [`wheelhouse-cp313-android24-arm64-20260719.1`](https://github.com/adybag14-cyber/termux-hermes/releases/tag/wheelhouse-cp313-android24-arm64-20260719.1). Its `SHA256SUMS` asset is itself pinned by Hermes to SHA-256 `916ff13af7e5283f75952b810fb6b7eef86ab3422bc5004c1ee1440d5163ade5`.
 
-Install them with Termux packages:
+CPython 3.11/3.12 or non-arm64 Termux environments cannot consume these CPython 3.13 arm64 wheels. Those unsupported targets retain the older one-time native-build compatibility path and therefore still require the compiler/Rust toolchain.
+
+### A wheel is tagged for the wrong Android API
+
+The immutable release targets Android API 24, which is intentionally independent of the phone's newer runtime Android version. `--android-api-level` only affects the unsupported-target source-build compatibility path; normal CPython 3.13 arm64 installs always use the verified API-24 wheels. Only custom Termux toolchains should override it:
 
 ```bash
-pkg install ripgrep nodejs
+bash scripts/install-termux.sh --android-api-level 28
 ```
 
-### Build failures while installing Python packages
+Do not set the build target from `getprop ro.build.version.sdk`; the phone runtime API may be newer than the interpreter target and can produce wheels that `uv` correctly rejects.
 
-Make sure the build toolchain is installed:
+### The old environment stopped working after an interrupted install
+
+The installer moves an existing `venv` aside before creating the replacement. If `uv venv` fails, the old environment is restored automatically. After a later-stage failure, inspect directories named `venv.pre-native-termux-*` inside the checkout before deleting anything.
+
+### `hermes doctor` reports missing system commands
+
+Rerun the installer, or install the missing Termux package directly. Common packages include:
 
 ```bash
-pkg install clang rust make pkg-config libffi openssl
+pkg install -y ripgrep nodejs ffmpeg
 ```
 
-Then retry:
+### Browser tooling does not work
 
-```bash
-python -m pip install -e '.[termux]' -c constraints-termux.txt
-```
-
----
+Browser and WhatsApp automation remain experimental on Android. The installer can install the optional Node command dependencies, but Android browser availability and background execution differ from desktop Linux. Use `--skip-browser` when only the core CLI is needed.
 
 ## Known limitations on phones
 
-- Docker backend is unavailable
-- local voice transcription via `faster-whisper` is unavailable in the tested path
-- browser automation setup is intentionally skipped by the installer
-- some optional extras may work, but only `.[termux]` and `.[termux-all]` are currently documented as the tested Android bundles
+- Docker terminal isolation is unavailable inside Termux.
+- Local voice transcription through `faster-whisper` is outside the tested dependency graph because `ctranslate2` does not publish Android wheels.
+- Android may suspend Termux background processes, so gateway persistence is best-effort.
+- Browser/WhatsApp automation is experimental.
+- The supported dependency graph is narrower than desktop/server `.[all]`.
 
-If you hit a new Android-specific issue, please open a GitHub issue with:
+When opening an Android-specific issue, include:
 
-- your Android version
+- Android version
 - `termux-info`
 - `python --version`
+- `hermes version`
 - `hermes doctor`
-- the exact install command and full error output
+- the exact installer command and complete error output

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -22,7 +22,7 @@ On Termux, the normal `install.sh` entrypoint dispatches to `scripts/install-ter
 - creates the Hermes virtual environment with `uv venv`
 - derives an Android-safe dependency graph from `pyproject.toml` and `uv.lock`
 - verifies that the graph matches the immutable CPython 3.13 Android arm64 wheel release
-- downloads ten native wheels from release `wheelhouse-cp313-android24-arm64-20260719.1`, verifying the pinned `SHA256SUMS` file and every wheel before installation
+- downloads ten native wheels from release `wheelhouse-cp313-android24-arm64-20260811.1`, verifying the pinned `SHA256SUMS` file and every wheel before installation
 - installs the complete graph with `--only-binary :all:` so a supported phone never silently starts a local C or Rust build
 - installs Hermes as an editable package with `--no-deps` and runs dependency/import smoke checks
 - writes a launcher to `$PREFIX/bin/hermes` that clears inherited `PYTHONPATH` and `PYTHONHOME`
@@ -108,7 +108,7 @@ Before accepting newly pulled code, the updater executes the wheel verifier from
 The verified cache is stored under:
 
 ```text
-~/.hermes/cache/termux-wheelhouse/wheelhouse-cp313-android24-arm64-20260719.1/
+~/.hermes/cache/termux-wheelhouse/wheelhouse-cp313-android24-arm64-20260811.1/
 ```
 
 Rerunning the installer remains supported when repairing the repository checkout itself:
@@ -124,7 +124,7 @@ Local changes are stashed before an update and restored afterward when Git can a
 
 ### Termux currently provides Python 3.14
 
-Hermes supports Python 3.11 through 3.13, but automatic arm64 installs deliberately use CPython 3.13 so they can consume the immutable wheelhouse. When no CPython 3.13 interpreter is available, including when Termux currently provides only Python 3.14?the native installer stages the exact `python_3.13.14_aarch64.deb` asset from release `termux-aarch64-20260719.9.1` side-by-side without replacing Termux's system aliases. The download is locked to SHA-256 `42376a2a47e50048cb7eca2d0f442fc1895fbca2aee2dee3d2fd82728ea1bd80`; installation stops before extraction if the bytes or package metadata differ. This fallback currently supports aarch64 Termux devices only.
+Hermes supports Python 3.11 through 3.13, but automatic arm64 installs deliberately use CPython 3.13 so they can consume the immutable wheelhouse. When no CPython 3.13 interpreter is available, including when Termux currently provides only Python 3.14, the native installer stages the exact `python_3.13.14_aarch64.deb` asset from release `termux-aarch64-20260719.9.1` side-by-side without replacing Termux's system aliases. The download is locked to SHA-256 `42376a2a47e50048cb7eca2d0f442fc1895fbca2aee2dee3d2fd82728ea1bd80`; installation stops before extraction if the bytes or package metadata differ. This fallback currently supports aarch64 Termux devices only.
 
 A known compatible interpreter can also be selected explicitly. Selecting 3.11 or 3.12 opts into the native-build compatibility path:
 
@@ -140,7 +140,7 @@ Do not bypass the checksum check or remove `--only-binary :all:`. Rerun the inst
 bash scripts/install-termux.sh --skip-setup
 ```
 
-The immutable release is [`wheelhouse-cp313-android24-arm64-20260719.1`](https://github.com/adybag14-cyber/termux-hermes/releases/tag/wheelhouse-cp313-android24-arm64-20260719.1). Its `SHA256SUMS` asset is itself pinned by Hermes to SHA-256 `916ff13af7e5283f75952b810fb6b7eef86ab3422bc5004c1ee1440d5163ade5`.
+The immutable release is [`wheelhouse-cp313-android24-arm64-20260811.1`](https://github.com/adybag14-cyber/termux-hermes/releases/tag/wheelhouse-cp313-android24-arm64-20260811.1). Its `SHA256SUMS` asset is itself pinned by Hermes to SHA-256 `435f23524d76cf061bf658c48bbee7439a85bf39e3a3b0b292d54db38669d079`.
 
 CPython 3.11/3.12 or non-arm64 Termux environments cannot consume these CPython 3.13 arm64 wheels. Those unsupported targets retain the older one-time native-build compatibility path and therefore still require the compiler/Rust toolchain.
 


### PR DESCRIPTION
Split from #67163 at Teknium's request. Native install/update scope only. Draft because the current Termux wheel/runtime release pins still need migration to NousResearch-owned CI-built artifacts before merge.