### PR TITLE
chore: release v0.20.1 (2026.8.13)

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.20.0"
-__release_date__ = "2026.8.3"
+__version__ = "0.20.1"
+__release_date__ = "2026.8.13"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "hermes-agent"
-version = "0.20.0"
+version = "0.20.1"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/uv.lock
+++ b/uv.lock
@@ -1563,7 +1563,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
Release v0.20.1 (v2026.8.13) — rollup patch tag for the ~656 PRs merged since v0.20.0, giving downstream consumers (Docker images, hosted deployments) a stable tagged release. Full curated notes for this window ship with v0.21.0.

## Changes
- `hermes_cli/__init__.py`: `__version__` 0.20.0 → 0.20.1, `__release_date__` 2026.8.3 → 2026.8.13
- `pyproject.toml`: version 0.20.1
- `uv.lock`: regenerated (`uv lock --check` clean)

## Validation
| Gate | Result |
|---|---|
| `uv lock --check` | clean |
| Anchored stale-version grep (0.20.0) | zero hits |
| Bootstrap-file rewrite scan (install.sh/ps1) | no rewrite-shaped commits |

## Infographic

![hermes-v0.20.1-rollup](https://files.catbox.moe/qddml7.png)
