### PR TITLE
fix(cli): honor --in in one-shot mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ models-dev-upstream/
 
 # Local editor / agent tooling (machine-specific; keep in global config, not the repo)
 .codex/
+implementation-notes.md
 .cursor/
 .gemini/
 .zed/

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2177,6 +2177,11 @@ if _config_path.exists():
             }
             for _cfg_key, _env_var in _terminal_env_map.items():
                 if _cfg_key in _terminal_cfg:
+                    if (
+                        _cfg_key == "cwd"
+                        and os.environ.get("HERMES_EXPLICIT_CWD_PIN") == "1"
+                    ):
+                        continue
                     _val = _terminal_cfg[_cfg_key]
                     # Skip cwd placeholder values (".", "auto", "cwd") — the
                     # gateway resolves these to Path.home() later (line ~255).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1873,7 +1873,11 @@ _ensure_ssl_certs()
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
-from hermes_constants import get_hermes_home, get_hermes_home_override
+from hermes_constants import (
+    explicit_cwd_pin_active,
+    get_hermes_home,
+    get_hermes_home_override,
+)
 from utils import atomic_json_write, is_truthy_value
 _hermes_home = get_hermes_home()
 
@@ -2177,10 +2181,7 @@ if _config_path.exists():
             }
             for _cfg_key, _env_var in _terminal_env_map.items():
                 if _cfg_key in _terminal_cfg:
-                    if (
-                        _cfg_key == "cwd"
-                        and os.environ.get("HERMES_EXPLICIT_CWD_PIN") == "1"
-                    ):
+                    if _cfg_key == "cwd" and explicit_cwd_pin_active():
                         continue
                     _val = _terminal_cfg[_cfg_key]
                     # Skip cwd placeholder values (".", "auto", "cwd") — the

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3392,6 +3392,8 @@ def apply_terminal_config_to_env(
     for cfg_key, env_var in TERMINAL_CONFIG_ENV_MAP.items():
         if cfg_key not in terminal_cfg:
             continue
+        if cfg_key == "cwd" and target.get("HERMES_EXPLICIT_CWD_PIN") == "1":
+            continue
         value = terminal_cfg[cfg_key]
         if cfg_key == "cwd":
             raw_cwd = str(value or "").strip()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3360,6 +3360,8 @@ def apply_terminal_config_to_env(
     and override their matching env values.  Merged defaults only backfill
     missing env vars; they never replace unrelated exported/.env values.
     """
+    from hermes_constants import explicit_cwd_pin_active
+
     target = os.environ if env is None else env
 
     raw_config = read_raw_config()
@@ -3392,7 +3394,7 @@ def apply_terminal_config_to_env(
     for cfg_key, env_var in TERMINAL_CONFIG_ENV_MAP.items():
         if cfg_key not in terminal_cfg:
             continue
-        if cfg_key == "cwd" and target.get("HERMES_EXPLICIT_CWD_PIN") == "1":
+        if cfg_key == "cwd" and explicit_cwd_pin_active(target):
             continue
         value = terminal_cfg[cfg_key]
         if cfg_key == "cwd":

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2798,6 +2798,7 @@ def cmd_chat(args):
     # authoritative site because it runs before tool imports freeze
     # _YOLO_MODE_FROZEN.  This redundant set is a safety net for callers
     # that invoke cmd_chat directly (e.g. subcommand dispatch).
+    _apply_config_isolation(args)
     if getattr(args, "yolo", False):
         os.environ["HERMES_YOLO_MODE"] = "1"
 
@@ -11169,12 +11170,18 @@ def _prepare_agent_startup(args) -> None:
         )
 
 
+def _apply_config_isolation(args) -> None:
+    safe_mode = getattr(args, "safe_mode", False)
+    if getattr(args, "ignore_user_config", False) or safe_mode:
+        os.environ["HERMES_IGNORE_USER_CONFIG"] = "1"
+    if getattr(args, "ignore_rules", False) or safe_mode:
+        os.environ["HERMES_IGNORE_RULES"] = "1"
+
+
 def _apply_safe_mode(args) -> None:
-    if not getattr(args, "safe_mode", False):
-        return
-    os.environ["HERMES_SAFE_MODE"] = "1"
-    os.environ["HERMES_IGNORE_USER_CONFIG"] = "1"
-    os.environ["HERMES_IGNORE_RULES"] = "1"
+    _apply_config_isolation(args)
+    if getattr(args, "safe_mode", False):
+        os.environ["HERMES_SAFE_MODE"] = "1"
 
 
 def _set_chat_arg_defaults(args) -> None:
@@ -11244,6 +11251,7 @@ def _try_fast_chat_launch() -> bool:
     if getattr(args, "command", None) not in {None, "chat"}:
         return False
 
+    _apply_config_isolation(args)
     if getattr(args, "yolo", False):
         os.environ["HERMES_YOLO_MODE"] = "1"
     _prepare_agent_startup(args)
@@ -11305,6 +11313,7 @@ def _try_termux_fast_cli_launch() -> bool:
         _print_version_info(check_updates=False)
         return True
 
+    _apply_config_isolation(args)
     if getattr(args, "oneshot", None):
         _prepare_agent_startup(args)
         _confirm_startup_expensive_model_override(args)
@@ -12983,6 +12992,10 @@ def main():
     if args.version:
         cmd_version(args)
         return
+
+    # Config/rule isolation must precede startup imports so it also applies to
+    # one-shot mode, which dispatches before cmd_chat().
+    _apply_config_isolation(args)
 
     # --yolo: set HERMES_YOLO_MODE *before* plugin discovery.  The call to
     # _prepare_agent_startup() below triggers discover_plugins() → tool

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -134,6 +134,30 @@ def _exit_after_oneshot(rc: object) -> None:
 _oneshot_cleanup_done = False
 
 
+def _apply_in_dir(in_dir: object) -> None:
+    """Validate and enter an explicit workspace."""
+    if not in_dir:
+        return
+
+    # Git Bash / MSYS hands the CLI POSIX-style paths (`--in ~` expands to
+    # `/c/Users/x` before Python ever sees it; MSYS2's path conversion is
+    # disabled for native executables). Translate the MSYS/Cygwin/WSL
+    # drive-root spellings to native Windows form first — no-op elsewhere.
+    from tools.environments.local import _msys_to_windows_path
+
+    target_dir = os.path.abspath(
+        os.path.expanduser(_msys_to_windows_path(str(in_dir)))
+    )
+    if not os.path.isdir(target_dir):
+        print(f"Error: --in directory not found: {in_dir}")
+        sys.exit(1)
+    try:
+        os.chdir(target_dir)
+    except OSError as exc:
+        print(f"Error: cannot enter --in directory {in_dir}: {exc}")
+        sys.exit(1)
+
+
 def _cleanup_oneshot_runtime() -> None:
     """Best-effort process-global cleanup before one-shot hard exit.
 
@@ -180,8 +204,13 @@ def _run_and_exit_oneshot(
     provider: object = None,
     toolsets: object = None,
     usage_file: object = None,
+    in_dir: object = None,
 ) -> None:
     try:
+        target_dir = None
+        if in_dir:
+            _apply_in_dir(in_dir)
+            target_dir = os.getcwd()
         from hermes_cli.oneshot import run_oneshot
 
         rc = run_oneshot(
@@ -190,6 +219,7 @@ def _run_and_exit_oneshot(
             provider=provider,
             toolsets=toolsets,
             usage_file=usage_file,
+            in_dir=target_dir,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -2601,23 +2631,7 @@ def cmd_chat(args):
     # recorded cwd (so the restore step below is skipped).
     in_dir = getattr(args, "in_dir", None)
     if in_dir:
-        # Git Bash / MSYS hands the CLI POSIX-style paths (`--in ~` expands to
-        # `/c/Users/x` before Python ever sees it; MSYS2's path conversion is
-        # disabled for native executables). Translate the MSYS/Cygwin/WSL
-        # drive-root spellings to native Windows form first — no-op elsewhere.
-        from tools.environments.local import _msys_to_windows_path
-
-        _target_dir = os.path.abspath(
-            os.path.expanduser(_msys_to_windows_path(in_dir))
-        )
-        if not os.path.isdir(_target_dir):
-            print(f"Error: --in directory not found: {in_dir}")
-            sys.exit(1)
-        try:
-            os.chdir(_target_dir)
-        except OSError as e:
-            print(f"Error: cannot enter --in directory {in_dir}: {e}")
-            sys.exit(1)
+        _apply_in_dir(in_dir)
         args.no_restore_cwd = True
 
     # --resume latest: keyword for "most recent session" — same resolution
@@ -11242,6 +11256,7 @@ def _try_fast_chat_launch() -> bool:
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            in_dir=getattr(args, "in_dir", None),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -11299,6 +11314,7 @@ def _try_termux_fast_cli_launch() -> bool:
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            in_dir=getattr(args, "in_dir", None),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -12994,6 +13010,7 @@ def main():
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            in_dir=getattr(args, "in_dir", None),
         )
 
     # Handle top-level --resume / --continue as shortcut to chat

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -134,11 +134,8 @@ def _exit_after_oneshot(rc: object) -> None:
 _oneshot_cleanup_done = False
 
 
-def _apply_in_dir(in_dir: object) -> None:
-    """Validate and enter an explicit workspace."""
-    if not in_dir:
-        return
-
+def _resolve_in_dir(in_dir: object) -> str:
+    """Validate ``--in`` and return its absolute path without changing cwd."""
     # Git Bash / MSYS hands the CLI POSIX-style paths (`--in ~` expands to
     # `/c/Users/x` before Python ever sees it; MSYS2's path conversion is
     # disabled for native executables). Translate the MSYS/Cygwin/WSL
@@ -151,6 +148,15 @@ def _apply_in_dir(in_dir: object) -> None:
     if not os.path.isdir(target_dir):
         print(f"Error: --in directory not found: {in_dir}")
         sys.exit(1)
+    return target_dir
+
+
+def _apply_in_dir(in_dir: object) -> None:
+    """Validate and enter an explicit workspace."""
+    if not in_dir:
+        return
+
+    target_dir = _resolve_in_dir(in_dir)
     try:
         os.chdir(target_dir)
     except OSError as exc:
@@ -207,10 +213,7 @@ def _run_and_exit_oneshot(
     in_dir: object = None,
 ) -> None:
     try:
-        target_dir = None
-        if in_dir:
-            _apply_in_dir(in_dir)
-            target_dir = os.getcwd()
+        target_dir = _resolve_in_dir(in_dir) if in_dir else None
         from hermes_cli.oneshot import run_oneshot
 
         rc = run_oneshot(

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -7,7 +7,7 @@ Toolsets = explicit --toolsets when provided, otherwise whatever the user has
 configured for "cli" in `hermes tools`.
 Rules / memory / AGENTS.md / preloaded skills = same as a normal chat turn.
 Approvals = auto-bypassed (HERMES_YOLO_MODE=1 is set for the call).
-Working directory = the user's CWD (AGENTS.md etc. resolve from there as usual).
+Working directory = explicit --in DIR, otherwise the user's launch CWD.
 
 Model / provider selection mirrors `hermes chat`:
     - Both optional. If omitted, use the user's configured default.
@@ -173,6 +173,7 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    in_dir: Optional[str] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -187,6 +188,7 @@ def run_oneshot(
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
             spend per invocation.
+        in_dir: Validated explicit working directory from the CLI dispatcher.
 
     Returns the exit code.  The caller owns process termination.
     """
@@ -248,6 +250,7 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    in_dir=in_dir,
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -325,6 +328,7 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    in_dir: Optional[str] = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -417,6 +421,21 @@ def _run_agent(
         logger=logging.getLogger(__name__),
         single_query=True,
     )
+
+    if in_dir:
+        from tools.terminal_tool import (
+            _get_env_config,
+            record_session_cwd,
+        )
+
+        # --in is a host path. Finish backend resolution before changing the
+        # process cwd, then pin local tools without feeding that host path to
+        # SSH or sandbox backends as a remote cwd.
+        terminal_config = _get_env_config()
+        os.chdir(in_dir)
+        if terminal_config["env_type"] == "local":
+            os.environ["TERMINAL_CWD"] = in_dir
+            record_session_cwd("default", in_dir)
 
     session_db = _create_session_db_for_oneshot()
     # The try spans agent construction (not just ``chat``) so the SQLite store

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import uuid
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Optional
@@ -422,6 +423,8 @@ def _run_agent(
         single_query=True,
     )
 
+    oneshot_task_id = f"oneshot:{uuid.uuid4()}"
+    previous_cwd_pin = None
     if in_dir:
         from tools.terminal_tool import (
             _get_env_config,
@@ -434,8 +437,10 @@ def _run_agent(
         terminal_config = _get_env_config()
         os.chdir(in_dir)
         if terminal_config["env_type"] == "local":
+            previous_cwd_pin = os.environ.get("HERMES_EXPLICIT_CWD_PIN")
             os.environ["TERMINAL_CWD"] = in_dir
-            record_session_cwd("default", in_dir)
+            os.environ["HERMES_EXPLICIT_CWD_PIN"] = "1"
+            record_session_cwd(oneshot_task_id, in_dir)
 
     session_db = _create_session_db_for_oneshot()
     # The try spans agent construction (not just ``chat``) so the SQLite store
@@ -482,7 +487,7 @@ def _run_agent(
         agent.stream_delta_callback = None
         agent.tool_gen_callback = None
 
-        result = agent.run_conversation(prompt)
+        result = agent.run_conversation(prompt, task_id=oneshot_task_id)
         return (result.get("final_response") or "", result)
     finally:
         # Ordering deliberately mirrors gateway/run.py:_cleanup_agent_resources,
@@ -509,6 +514,14 @@ def _run_agent(
                 session_db.close()
             except Exception:
                 logging.debug("oneshot session store cleanup failed", exc_info=True)
+        if in_dir and terminal_config["env_type"] == "local":
+            from tools.terminal_tool import clear_task_env_overrides
+
+            clear_task_env_overrides(oneshot_task_id)
+            if previous_cwd_pin is None:
+                os.environ.pop("HERMES_EXPLICIT_CWD_PIN", None)
+            else:
+                os.environ["HERMES_EXPLICIT_CWD_PIN"] = previous_cwd_pin
 
 
 def _oneshot_clarify_callback(question: str, choices=None, multi_select=False) -> str:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -25,9 +25,9 @@ import logging
 import os
 import sys
 import uuid
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 from gateway.session_context import declare_stateless_channel
 from hermes_cli.fallback_config import get_fallback_chain
@@ -307,6 +307,51 @@ def run_oneshot(
     return 0
 
 
+@contextmanager
+def _oneshot_explicit_cwd(in_dir: Optional[str], task_id: str) -> Iterator[None]:
+    """Enter ``--in`` after backend resolution and pin local tool cwd.
+
+    Restore the pin marker even if task-env cleanup raises. Cleanup failures
+    are logged rather than allowed to mask an error from the one-shot run.
+    """
+    if not in_dir:
+        yield
+        return
+
+    from hermes_constants import (
+        HERMES_EXPLICIT_CWD_PIN,
+        HERMES_EXPLICIT_CWD_PIN_VALUE,
+    )
+    from tools.terminal_tool import _get_env_config, record_session_cwd
+
+    previous_pin = None
+    pinned = False
+    try:
+        # Resolve the backend against the launch cwd first. ``--in`` is a host
+        # path; SSH/Docker keep their configured remote/container cwd.
+        terminal_config = _get_env_config()
+        os.chdir(in_dir)
+        if terminal_config.get("env_type") == "local":
+            previous_pin = os.environ.get(HERMES_EXPLICIT_CWD_PIN)
+            os.environ["TERMINAL_CWD"] = in_dir
+            os.environ[HERMES_EXPLICIT_CWD_PIN] = HERMES_EXPLICIT_CWD_PIN_VALUE
+            pinned = True
+            record_session_cwd(task_id, in_dir)
+        yield
+    finally:
+        if pinned:
+            try:
+                from tools.terminal_tool import clear_task_env_overrides
+
+                clear_task_env_overrides(task_id)
+            except Exception:
+                logging.debug("oneshot task env cleanup failed", exc_info=True)
+            if previous_pin is None:
+                os.environ.pop(HERMES_EXPLICIT_CWD_PIN, None)
+            else:
+                os.environ[HERMES_EXPLICIT_CWD_PIN] = previous_pin
+
+
 def _create_session_db_for_oneshot():
     """Best-effort SessionDB for ``hermes -z`` / oneshot mode.
 
@@ -424,24 +469,6 @@ def _run_agent(
     )
 
     oneshot_task_id = f"oneshot:{uuid.uuid4()}"
-    previous_cwd_pin = None
-    if in_dir:
-        from tools.terminal_tool import (
-            _get_env_config,
-            record_session_cwd,
-        )
-
-        # --in is a host path. Finish backend resolution before changing the
-        # process cwd, then pin local tools without feeding that host path to
-        # SSH or sandbox backends as a remote cwd.
-        terminal_config = _get_env_config()
-        os.chdir(in_dir)
-        if terminal_config["env_type"] == "local":
-            previous_cwd_pin = os.environ.get("HERMES_EXPLICIT_CWD_PIN")
-            os.environ["TERMINAL_CWD"] = in_dir
-            os.environ["HERMES_EXPLICIT_CWD_PIN"] = "1"
-            record_session_cwd(oneshot_task_id, in_dir)
-
     session_db = _create_session_db_for_oneshot()
     # The try spans agent construction (not just ``chat``) so the SQLite store
     # opened above is always closed — including when ``AIAgent(...)`` itself
@@ -449,63 +476,67 @@ def _run_agent(
     # os._exit and skips finalizers, so an un-closed connection here would leak.
     agent = None
     try:
-        # Read the effective fallback chain from profile config so oneshot
-        # workers honour the same merge semantics as interactive CLI and
-        # gateway sessions.
-        _fb = get_fallback_chain(cfg)
+        with _oneshot_explicit_cwd(in_dir, oneshot_task_id):
+            try:
+                # Read the effective fallback chain from profile config so oneshot
+                # workers honour the same merge semantics as interactive CLI and
+                # gateway sessions.
+                _fb = get_fallback_chain(cfg)
 
-        agent = AIAgent(
-            api_key=runtime.get("api_key"),
-            base_url=runtime.get("base_url"),
-            provider=runtime.get("provider"),
-            requested_provider=runtime.get("requested_provider"),
-            api_mode=runtime.get("api_mode"),
-            model=effective_model,
-            enabled_toolsets=toolsets_list,
-            quiet_mode=True,
-            platform="cli",
-            session_db=session_db,
-            credential_pool=runtime.get("credential_pool"),
-            fallback_model=_fb or None,
-            # Interactive callbacks are intentionally NOT wired beyond this
-            # one.  In oneshot mode there's no user sitting at a terminal:
-            #   - clarify  → returns a synthetic "pick a default" instruction
-            #                so the agent continues instead of stalling on
-            #                the tool's built-in "not available" error
-            #   - sudo password prompt → terminal_tool gates on
-            #                HERMES_INTERACTIVE which we never set
-            #   - shell-hook approval → auto-approved via HERMES_ACCEPT_HOOKS=1
-            #                (set above); also falls back to deny on non-tty
-            #   - dangerous-command approval → bypassed via HERMES_YOLO_MODE=1
-            #   - skill secret capture → returns gracefully when no callback set
-            clarify_callback=_oneshot_clarify_callback,
-        )
+                agent = AIAgent(
+                    api_key=runtime.get("api_key"),
+                    base_url=runtime.get("base_url"),
+                    provider=runtime.get("provider"),
+                    requested_provider=runtime.get("requested_provider"),
+                    api_mode=runtime.get("api_mode"),
+                    model=effective_model,
+                    enabled_toolsets=toolsets_list,
+                    quiet_mode=True,
+                    platform="cli",
+                    session_db=session_db,
+                    credential_pool=runtime.get("credential_pool"),
+                    fallback_model=_fb or None,
+                    # Interactive callbacks are intentionally NOT wired beyond this
+                    # one.  In oneshot mode there's no user sitting at a terminal:
+                    #   - clarify  → returns a synthetic "pick a default" instruction
+                    #                so the agent continues instead of stalling on
+                    #                the tool's built-in "not available" error
+                    #   - sudo password prompt → terminal_tool gates on
+                    #                HERMES_INTERACTIVE which we never set
+                    #   - shell-hook approval → auto-approved via HERMES_ACCEPT_HOOKS=1
+                    #                (set above); also falls back to deny on non-tty
+                    #   - dangerous-command approval → bypassed via HERMES_YOLO_MODE=1
+                    #   - skill secret capture → returns gracefully when no callback set
+                    clarify_callback=_oneshot_clarify_callback,
+                )
 
-        # Belt-and-braces: make sure AIAgent doesn't invoke any streaming
-        # display callbacks that would bypass our stdout capture.
-        agent.suppress_status_output = True
-        agent.stream_delta_callback = None
-        agent.tool_gen_callback = None
+                # Belt-and-braces: make sure AIAgent doesn't invoke any streaming
+                # display callbacks that would bypass our stdout capture.
+                agent.suppress_status_output = True
+                agent.stream_delta_callback = None
+                agent.tool_gen_callback = None
 
-        result = agent.run_conversation(prompt, task_id=oneshot_task_id)
-        return (result.get("final_response") or "", result)
+                result = agent.run_conversation(prompt, task_id=oneshot_task_id)
+                return (result.get("final_response") or "", result)
+            finally:
+                # Ordering deliberately mirrors gateway/run.py:_cleanup_agent_resources,
+                # NOT cli.py:_run_cleanup — oneshot has no _active_agent_ref and must
+                # close the agent explicitly because the hard-exit path skips finalizers.
+                # Stay inside the cwd pin until close() returns.
+                if agent is not None:
+                    try:
+                        session_messages = getattr(agent, "_session_messages", None)
+                        if isinstance(session_messages, list):
+                            agent.shutdown_memory_provider(session_messages)
+                        else:
+                            agent.shutdown_memory_provider()
+                    except Exception:
+                        logging.debug("oneshot memory/context cleanup failed", exc_info=True)
+                    try:
+                        agent.close()
+                    except Exception:
+                        logging.debug("oneshot agent cleanup failed", exc_info=True)
     finally:
-        # Ordering deliberately mirrors gateway/run.py:_cleanup_agent_resources,
-        # NOT cli.py:_run_cleanup — oneshot has no _active_agent_ref and must
-        # close the agent explicitly because the hard-exit path skips finalizers.
-        if agent is not None:
-            try:
-                session_messages = getattr(agent, "_session_messages", None)
-                if isinstance(session_messages, list):
-                    agent.shutdown_memory_provider(session_messages)
-                else:
-                    agent.shutdown_memory_provider()
-            except Exception:
-                logging.debug("oneshot memory/context cleanup failed", exc_info=True)
-            try:
-                agent.close()
-            except Exception:
-                logging.debug("oneshot agent cleanup failed", exc_info=True)
         # agent.close() calls session_db.end_session() but leaves the connection
         # open; close it here to checkpoint the WAL before os._exit skips
         # finalizers.
@@ -514,14 +545,6 @@ def _run_agent(
                 session_db.close()
             except Exception:
                 logging.debug("oneshot session store cleanup failed", exc_info=True)
-        if in_dir and terminal_config["env_type"] == "local":
-            from tools.terminal_tool import clear_task_env_overrides
-
-            clear_task_env_overrides(oneshot_task_id)
-            if previous_cwd_pin is None:
-                os.environ.pop("HERMES_EXPLICIT_CWD_PIN", None)
-            else:
-                os.environ["HERMES_EXPLICIT_CWD_PIN"] = previous_cwd_pin
 
 
 def _oneshot_clarify_callback(question: str, choices=None, multi_select=False) -> str:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import stat
 import sys
+from collections.abc import Mapping
 from contextvars import ContextVar, Token
 from pathlib import Path
 
@@ -25,6 +26,17 @@ _HERMES_HOME_OVERRIDE: ContextVar[str | object] = ContextVar(
 # ``ui-tui/src/app/interfaces.ts`` on the frontend side.
 INDICATOR_STYLES: tuple[str, ...] = ("ascii", "emoji", "kaomoji", "unicode")
 DEFAULT_INDICATOR_STYLE: str = "kaomoji"
+
+# CLI ``--in`` outranks config.yaml ``terminal.cwd``. Lazy config→env bridges
+# (including gateway/run.py at import time) skip cwd while this pin is set.
+HERMES_EXPLICIT_CWD_PIN = "HERMES_EXPLICIT_CWD_PIN"
+HERMES_EXPLICIT_CWD_PIN_VALUE = "1"
+
+
+def explicit_cwd_pin_active(env: Mapping[str, str] | None = None) -> bool:
+    """Return True when an explicit CLI ``--in`` cwd pin is in force."""
+    target = os.environ if env is None else env
+    return target.get(HERMES_EXPLICIT_CWD_PIN) == HERMES_EXPLICIT_CWD_PIN_VALUE
 
 
 def set_hermes_home_override(path: str | Path | None) -> Token:

--- a/tests/hermes_cli/test_resume_latest_and_in_dir.py
+++ b/tests/hermes_cli/test_resume_latest_and_in_dir.py
@@ -229,3 +229,97 @@ def test_in_dir_expands_user_home(main_mod, launched, monkeypatch, tmp_path):
         assert os.getcwd() == str((home / "proj").resolve())
     finally:
         os.chdir(start)
+
+
+@pytest.mark.parametrize(
+    ("backend", "configured_cwd"),
+    [
+        ("local", None),
+        ("ssh", "~/remote-project"),
+        ("docker", "/workspace"),
+    ],
+)
+def test_oneshot_in_dir_respects_terminal_backend(
+    main_mod, monkeypatch, tmp_path, backend, configured_cwd
+):
+    import os
+
+    from hermes_cli import oneshot
+    from tools import terminal_tool
+
+    target = tmp_path / "requested"
+    stale = tmp_path / "stale"
+    target.mkdir()
+    stale.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    configured_cwd = configured_cwd or str(stale)
+    (hermes_home / "config.yaml").write_text(
+        f"terminal:\n  backend: {backend}\n  cwd: {configured_cwd}\n",
+        encoding="utf-8",
+    )
+    start = os.getcwd()
+    seen = {}
+
+    class FakeAgent:
+        def __init__(self, **_kwargs):
+            seen["cwd"] = os.getcwd()
+            seen["terminal_cwd"] = os.environ.get("TERMINAL_CWD")
+            seen["tool_cwd"] = terminal_tool._get_env_config()["cwd"]
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+
+        def run_conversation(self, _prompt):
+            return {"final_response": "ok", "failed": False, "partial": False}
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    import hermes_cli.mcp_startup as mcp_startup
+    import hermes_cli.runtime_provider as runtime_provider
+    import hermes_cli.tools_config as tools_config
+    import run_agent
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_CWD", str(stale))
+    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", False)
+    monkeypatch.setattr(run_agent, "AIAgent", FakeAgent)
+    monkeypatch.setattr(oneshot, "_create_session_db_for_oneshot", lambda: None)
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda *_args: set())
+    monkeypatch.setattr(
+        runtime_provider,
+        "resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "key",
+            "base_url": "https://example.test/v1",
+            "provider": "test",
+            "requested_provider": "test",
+            "api_mode": "chat_completions",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(
+        mcp_startup,
+        "ensure_mcp_discovery_before_agent_build",
+        lambda **_kwargs: None,
+    )
+
+    try:
+        response, result = oneshot._run_agent("work here", in_dir=str(target))
+    finally:
+        terminal_tool.clear_session_cwd("default")
+        os.chdir(start)
+
+    assert response == "ok"
+    assert result["failed"] is False
+    assert seen["cwd"] == str(target.resolve())
+    if backend == "local":
+        assert seen["terminal_cwd"] == str(target.resolve())
+        assert seen["tool_cwd"] == str(target.resolve())
+    else:
+        assert seen["terminal_cwd"] == configured_cwd
+        assert seen["tool_cwd"] == configured_cwd

--- a/tests/hermes_cli/test_resume_latest_and_in_dir.py
+++ b/tests/hermes_cli/test_resume_latest_and_in_dir.py
@@ -264,13 +264,15 @@ def test_oneshot_in_dir_respects_terminal_backend(
     class FakeAgent:
         def __init__(self, **_kwargs):
             seen["cwd"] = os.getcwd()
+            import gateway.run  # noqa: F401  -- a real lazy import re-bridges terminal config
             seen["terminal_cwd"] = os.environ.get("TERMINAL_CWD")
             seen["tool_cwd"] = terminal_tool._get_env_config()["cwd"]
             self.suppress_status_output = False
             self.stream_delta_callback = object()
             self.tool_gen_callback = object()
 
-        def run_conversation(self, _prompt):
+        def run_conversation(self, _prompt, task_id=None):
+            seen["task_id"] = task_id
             return {"final_response": "ok", "failed": False, "partial": False}
 
         def shutdown_memory_provider(self):
@@ -317,9 +319,12 @@ def test_oneshot_in_dir_respects_terminal_backend(
     assert response == "ok"
     assert result["failed"] is False
     assert seen["cwd"] == str(target.resolve())
+    assert seen["task_id"].startswith("oneshot:")
+    assert terminal_tool.get_session_cwd(seen["task_id"]) is None
     if backend == "local":
         assert seen["terminal_cwd"] == str(target.resolve())
         assert seen["tool_cwd"] == str(target.resolve())
     else:
         assert seen["terminal_cwd"] == configured_cwd
         assert seen["tool_cwd"] == configured_cwd
+    assert "HERMES_EXPLICIT_CWD_PIN" not in os.environ

--- a/tests/hermes_cli/test_resume_latest_and_in_dir.py
+++ b/tests/hermes_cli/test_resume_latest_and_in_dir.py
@@ -11,6 +11,8 @@ from argparse import Namespace
 
 import pytest
 
+from hermes_constants import HERMES_EXPLICIT_CWD_PIN, HERMES_EXPLICIT_CWD_PIN_VALUE
+
 
 def _args(**overrides):
     base = {
@@ -327,4 +329,245 @@ def test_oneshot_in_dir_respects_terminal_backend(
     else:
         assert seen["terminal_cwd"] == configured_cwd
         assert seen["tool_cwd"] == configured_cwd
-    assert "HERMES_EXPLICIT_CWD_PIN" not in os.environ
+    assert HERMES_EXPLICIT_CWD_PIN not in os.environ
+
+
+def _stub_oneshot_hard_exit(main_mod, monkeypatch):
+    monkeypatch.setattr(main_mod, "_cleanup_oneshot_runtime", lambda: None)
+
+    def fake_exit(rc):
+        raise SystemExit(0 if rc is None else rc)
+
+    monkeypatch.setattr(main_mod, "_exit_after_oneshot", fake_exit)
+
+
+def test_oneshot_explicit_cwd_resolves_backend_before_chdir(monkeypatch, tmp_path):
+    import os
+
+    from hermes_cli.oneshot import _oneshot_explicit_cwd
+    from tools import terminal_tool
+
+    target = tmp_path / "requested"
+    target.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "terminal:\n  backend: local\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv(HERMES_EXPLICIT_CWD_PIN, raising=False)
+    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", False)
+
+    start = os.getcwd()
+    seen = {}
+    real_get = terminal_tool._get_env_config
+
+    def spy_get():
+        seen["cwd_at_resolve"] = os.getcwd()
+        return real_get()
+
+    monkeypatch.setattr(terminal_tool, "_get_env_config", spy_get)
+
+    try:
+        with _oneshot_explicit_cwd(str(target), "oneshot:test"):
+            seen["cwd_inside"] = os.getcwd()
+            assert os.environ.get(HERMES_EXPLICIT_CWD_PIN) == HERMES_EXPLICIT_CWD_PIN_VALUE
+    finally:
+        os.chdir(start)
+
+    assert seen["cwd_at_resolve"] == start
+    assert seen["cwd_inside"] == str(target.resolve())
+    assert HERMES_EXPLICIT_CWD_PIN not in os.environ
+
+
+def test_oneshot_explicit_cwd_preserves_config_error(monkeypatch, tmp_path):
+    import os
+
+    from hermes_cli.oneshot import _oneshot_explicit_cwd
+    from tools import terminal_tool
+
+    target = tmp_path / "requested"
+    target.mkdir()
+    start = os.getcwd()
+    monkeypatch.delenv(HERMES_EXPLICIT_CWD_PIN, raising=False)
+    def boom():
+        raise ValueError("bad terminal config")
+
+    monkeypatch.setattr(terminal_tool, "_get_env_config", boom)
+
+    try:
+        with pytest.raises(ValueError, match="bad terminal config"):
+            with _oneshot_explicit_cwd(str(target), "oneshot:test"):
+                pytest.fail("must not enter after a config error")
+    finally:
+        os.chdir(start)
+
+    assert os.getcwd() == start
+    assert HERMES_EXPLICIT_CWD_PIN not in os.environ
+
+
+def test_oneshot_explicit_cwd_restores_pin_if_record_raises(monkeypatch, tmp_path):
+    import os
+
+    from hermes_cli.oneshot import _oneshot_explicit_cwd
+    from tools import terminal_tool
+
+    target = tmp_path / "requested"
+    target.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "terminal:\n  backend: local\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv(HERMES_EXPLICIT_CWD_PIN, raising=False)
+    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", False)
+
+    def boom(_task_id, _cwd):
+        raise RuntimeError("record boom")
+
+    monkeypatch.setattr(terminal_tool, "record_session_cwd", boom)
+    start = os.getcwd()
+
+    try:
+        with pytest.raises(RuntimeError, match="record boom"):
+            with _oneshot_explicit_cwd(str(target), "oneshot:test"):
+                pytest.fail("must not enter after a record failure")
+    finally:
+        os.chdir(start)
+
+    assert HERMES_EXPLICIT_CWD_PIN not in os.environ
+
+
+def test_oneshot_explicit_cwd_restores_pin_if_cleanup_raises(monkeypatch, tmp_path):
+    import os
+
+    from hermes_cli.oneshot import _oneshot_explicit_cwd
+    from tools import terminal_tool
+
+    target = tmp_path / "requested"
+    target.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "terminal:\n  backend: local\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv(HERMES_EXPLICIT_CWD_PIN, raising=False)
+    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", False)
+
+    def boom(_task_id):
+        raise RuntimeError("cleanup boom")
+
+    monkeypatch.setattr(terminal_tool, "clear_task_env_overrides", boom)
+    start = os.getcwd()
+
+    try:
+        with _oneshot_explicit_cwd(str(target), "oneshot:test"):
+            assert os.environ.get(HERMES_EXPLICIT_CWD_PIN) == HERMES_EXPLICIT_CWD_PIN_VALUE
+    finally:
+        os.chdir(start)
+
+    assert HERMES_EXPLICIT_CWD_PIN not in os.environ
+
+
+def test_oneshot_explicit_cwd_preserves_body_error_if_cleanup_raises(monkeypatch, tmp_path):
+    import os
+
+    from hermes_cli.oneshot import _oneshot_explicit_cwd
+    from tools import terminal_tool
+
+    target = tmp_path / "requested"
+    target.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "terminal:\n  backend: local\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv(HERMES_EXPLICIT_CWD_PIN, raising=False)
+    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", False)
+
+    def boom(_task_id):
+        raise RuntimeError("cleanup boom")
+
+    monkeypatch.setattr(terminal_tool, "clear_task_env_overrides", boom)
+    start = os.getcwd()
+
+    try:
+        with pytest.raises(RuntimeError, match="agent boom"):
+            with _oneshot_explicit_cwd(str(target), "oneshot:test"):
+                raise RuntimeError("agent boom")
+    finally:
+        os.chdir(start)
+
+    assert HERMES_EXPLICIT_CWD_PIN not in os.environ
+
+
+def test_oneshot_dispatch_validates_in_dir_without_chdir(main_mod, monkeypatch, tmp_path):
+    import os
+
+    target = tmp_path / "proj"
+    target.mkdir()
+    start = os.getcwd()
+    seen = {}
+
+    def fake_run_oneshot(*_args, **kwargs):
+        seen["cwd"] = os.getcwd()
+        seen["in_dir"] = kwargs.get("in_dir")
+        return 0
+
+    monkeypatch.setattr("hermes_cli.oneshot.run_oneshot", fake_run_oneshot)
+    _stub_oneshot_hard_exit(main_mod, monkeypatch)
+
+    try:
+        with pytest.raises(SystemExit) as exc:
+            main_mod._run_and_exit_oneshot("hi", in_dir=str(target))
+    finally:
+        os.chdir(start)
+
+    assert exc.value.code == 0
+    assert seen["cwd"] == start
+    assert seen["in_dir"] == str(target.resolve())
+
+
+def test_oneshot_dispatch_missing_in_dir_exits(main_mod, monkeypatch, tmp_path, capsys):
+    _stub_oneshot_hard_exit(main_mod, monkeypatch)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._run_and_exit_oneshot("hi", in_dir=str(tmp_path / "nope"))
+
+    assert exc.value.code == 1
+    assert "--in directory not found" in capsys.readouterr().out
+
+
+def test_oneshot_dispatch_expands_user_home(main_mod, monkeypatch, tmp_path):
+    import os
+
+    home = tmp_path / "home"
+    (home / "proj").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    start = os.getcwd()
+    seen = {}
+
+    def fake_run_oneshot(*_args, **kwargs):
+        seen["cwd"] = os.getcwd()
+        seen["in_dir"] = kwargs.get("in_dir")
+        return 0
+
+    monkeypatch.setattr("hermes_cli.oneshot.run_oneshot", fake_run_oneshot)
+    _stub_oneshot_hard_exit(main_mod, monkeypatch)
+
+    try:
+        with pytest.raises(SystemExit) as exc:
+            main_mod._run_and_exit_oneshot("hi", in_dir="~/proj")
+    finally:
+        os.chdir(start)
+
+    assert exc.value.code == 0
+    assert seen["cwd"] == start
+    assert seen["in_dir"] == str((home / "proj").resolve())

--- a/tests/hermes_cli/test_yolo_startup_order.py
+++ b/tests/hermes_cli/test_yolo_startup_order.py
@@ -55,3 +55,37 @@ def test_top_level_yolo_flag_sets_env_before_startup(monkeypatch):
     )
 
 
+def test_oneshot_config_isolation_flags_precede_startup(monkeypatch):
+    """One-shot must establish config isolation before any startup imports."""
+    import hermes_cli.main as main_mod
+
+    seen = {}
+
+    def spy_prepare_startup(_args):
+        seen["at_startup"] = (
+            os.environ.get("HERMES_IGNORE_USER_CONFIG"),
+            os.environ.get("HERMES_IGNORE_RULES"),
+        )
+
+    def fake_oneshot(*_args, **_kwargs):
+        seen["at_oneshot"] = (
+            os.environ.get("HERMES_IGNORE_USER_CONFIG"),
+            os.environ.get("HERMES_IGNORE_RULES"),
+        )
+
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+    monkeypatch.delenv("HERMES_IGNORE_RULES", raising=False)
+    monkeypatch.setattr(main_mod, "_prepare_agent_startup", spy_prepare_startup)
+    monkeypatch.setattr(main_mod, "_run_and_exit_oneshot", fake_oneshot)
+    monkeypatch.setattr(main_mod, "cmd_chat", lambda _args: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "-z", "hello", "--ignore-user-config", "--ignore-rules"],
+    )
+
+    main_mod.main()
+
+    assert seen["at_startup"] == ("1", "1")
+    assert seen["at_oneshot"] == ("1", "1")
+

--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -85,6 +85,20 @@ def test_explicit_config_key_overrides_matching_env_value(monkeypatch):
     assert config["docker_image"] == "config/image:1"
 
 
+def test_explicit_cwd_pin_survives_config_bridge(monkeypatch, tmp_path):
+    """A one-shot ``--in`` workspace is stronger than persisted terminal.cwd."""
+    requested = tmp_path / "requested"
+    requested.mkdir()
+    _write_config(f"terminal:\n  backend: local\n  cwd: {tmp_path / 'persisted'}\n")
+    monkeypatch.setenv("TERMINAL_CWD", str(requested))
+    monkeypatch.setenv("HERMES_EXPLICIT_CWD_PIN", "1")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["cwd"] == str(requested)
+    assert os.environ["TERMINAL_CWD"] == str(requested)
+
+
 def test_ssh_config_preserves_remote_tilde_cwd(monkeypatch):
     """SSH ``~`` belongs to the remote user, not the Hermes host/container."""
     _write_config("terminal:\n  backend: ssh\n  cwd: '~'\n")

--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -11,7 +11,11 @@ import os
 import pytest
 
 import tools.terminal_tool as terminal_tool
-from hermes_constants import get_hermes_home
+from hermes_constants import (
+    HERMES_EXPLICIT_CWD_PIN,
+    HERMES_EXPLICIT_CWD_PIN_VALUE,
+    get_hermes_home,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -91,12 +95,13 @@ def test_explicit_cwd_pin_survives_config_bridge(monkeypatch, tmp_path):
     requested.mkdir()
     _write_config(f"terminal:\n  backend: local\n  cwd: {tmp_path / 'persisted'}\n")
     monkeypatch.setenv("TERMINAL_CWD", str(requested))
-    monkeypatch.setenv("HERMES_EXPLICIT_CWD_PIN", "1")
+    monkeypatch.setenv(HERMES_EXPLICIT_CWD_PIN, HERMES_EXPLICIT_CWD_PIN_VALUE)
 
     config = terminal_tool._get_env_config()
 
     assert config["cwd"] == str(requested)
     assert os.environ["TERMINAL_CWD"] == str(requested)
+    assert os.environ[HERMES_EXPLICIT_CWD_PIN] == HERMES_EXPLICIT_CWD_PIN_VALUE
 
 
 def test_ssh_config_preserves_remote_tilde_cwd(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`hermes -z ... --in DIR` parsed the flag but dropped it at every one-shot dispatcher, so cwd-sensitive local tools could run in an inherited or configured workspace. I forward the validated host path into one-shot startup and pin it after terminal configuration resolves for the local backend. SSH and Docker keep their configured remote/container cwd.

## Related Issue

Fixes #85495

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: validate and forward `--in` through fast, Termux, and full one-shot dispatch.
- `hermes_cli/oneshot.py`: reassert the host cwd after config startup and pin tool/session cwd only for the local backend.
- `tests/hermes_cli/test_resume_latest_and_in_dir.py`: cover local, SSH, and Docker cwd precedence through the real config bridge.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_resume_latest_and_in_dir.py tests/hermes_cli/test_tui_resume_flow.py tests/hermes_cli/test_oneshot_surrogate.py tests/hermes_cli/test_oneshot_usage_file.py` (25 passed locally).
2. Run `hermes -z "report cwd" --in <dir>` with a stale local `terminal.cwd`; the process, terminal, and file-tool cwd should all resolve to `<dir>`.
3. Repeat with SSH and Docker backends; the host process should enter `<dir>`, while terminal/file tools retain the configured remote/container cwd.

I also ran the full `tests/hermes_cli/` suite: 5,249 passed and 78 skipped. Its two failures reproduce unchanged on clean current `main`: an unavailable optional `acp` module and a macOS-only directory-mode assertion.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is CLI working-directory behavior.
