### PR TITLE
fix(camofox): scroll via /evaluate instead of the inert mouse wheel

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -115,6 +115,69 @@ class TestCamofoxNavigate:
 
 
 # ---------------------------------------------------------------------------
+# Scroll
+# ---------------------------------------------------------------------------
+
+
+class TestCamofoxScroll:
+    def test_no_session_returns_error(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        result = json.loads(camofox_scroll("down", task_id="no_such_task"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_scrolls_via_evaluate_not_the_wheel(self, mock_post, monkeypatch):
+        """The wheel endpoint is inert in headless Firefox; /evaluate is not."""
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab1", "url": "https://example.com"})
+        camofox_navigate("https://example.com", task_id="t_scroll")
+
+        mock_post.reset_mock()
+        mock_post.return_value = _mock_response(
+            json_data={"result": {"ok": True, "via": "document", "y": 2500, "max": 9000}}
+        )
+
+        result = json.loads(camofox_scroll("down", task_id="t_scroll", amount=2500))
+        assert result["success"] is True
+        assert result["at"] == 2500
+        assert result["height"] == 9000
+        assert result.get("at_end") is not True
+
+        url, payload = mock_post.call_args.args[0], mock_post.call_args.kwargs["json"]
+        assert url.endswith("/evaluate")
+        assert "2500" in payload["expression"]
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_up_scrolls_by_a_negative_delta(self, mock_post, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab1", "url": "https://example.com"})
+        camofox_navigate("https://example.com", task_id="t_scroll_up")
+
+        mock_post.return_value = _mock_response(json_data={"result": {"ok": True, "y": 0, "max": 9000}})
+        camofox_scroll("up", task_id="t_scroll_up", amount=500)
+
+        assert "-500" in mock_post.call_args.kwargs["json"]["expression"]
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_reaching_the_end_is_success_not_failure(self, mock_post, monkeypatch):
+        """Already at the bottom is a normal outcome — flagging it as an error
+        would teach agents to retry a scroll that is already done."""
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab1", "url": "https://example.com"})
+        camofox_navigate("https://example.com", task_id="t_scroll_end")
+
+        mock_post.return_value = _mock_response(
+            json_data={"result": {"ok": False, "via": "none", "y": 9000, "max": 9000}}
+        )
+
+        result = json.loads(camofox_scroll("down", task_id="t_scroll_end"))
+        assert result["success"] is True
+        assert result["at_end"] is True
+        assert result["at"] == 9000
+
+
+# ---------------------------------------------------------------------------
 # Snapshot
 # ---------------------------------------------------------------------------
 

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -718,18 +718,109 @@ def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
         return tool_error(redact_browser_typed_text_for_display(str(e), text), success=False)
 
 
-def camofox_scroll(direction: str, task_id: Optional[str] = None) -> str:
-    """Scroll the page via Camofox."""
+# Scroll by script rather than by wheel. Camofox's POST /tabs/:id/scroll calls
+# page.mouse.wheel() with the mouse wherever Playwright last left it, which is
+# (0,0) on a fresh tab, and in this headless Firefox that wheel event moves
+# nothing at all. Measured on both a plain document (Wikipedia) and a
+# JS-rendered app page: scrollY stayed 0 for amount=500 and amount=2500 alike,
+# while scrollTo(0, 1234) read back 1234 -- so the page and the measurement
+# were both fine and the wheel was simply inert.
+#
+# It is not free, either: it blocks for about as long as the travel would take
+# (1.8s at 500px, 6.5s at 2500px) and can reach camofox's 30s handler timeout
+# under load. /evaluate does the same job in 3-10ms.
+#
+# There is no mouse-move endpoint to aim the wheel with, so this is fixed on
+# the client side.
+_SCROLL_JS = """
+(() => {
+  const delta = %d;
+
+  // 1. The ordinary case: the document scrolls.
+  const se = document.scrollingElement || document.documentElement;
+  if (se) {
+    const before = se.scrollTop;
+    se.scrollBy(0, delta);
+    if (se.scrollTop !== before) {
+      return {ok: true, via: 'document', y: se.scrollTop, max: se.scrollHeight};
+    }
+  }
+
+  // 2. Otherwise the page scrolls an inner pane, and the document stays pinned
+  //    at 0 no matter what you do to it. Take the largest genuinely-scrollable
+  //    element.
+  let best = null, bestArea = 0;
+  for (const el of document.querySelectorAll('*')) {
+    if (el.scrollHeight - el.clientHeight < 50) continue;
+    const oy = getComputedStyle(el).overflowY;
+    if (oy !== 'auto' && oy !== 'scroll') continue;
+    const r = el.getBoundingClientRect();
+    const area = r.width * r.height;
+    if (area > bestArea) { best = el; bestArea = area; }
+  }
+  if (best) {
+    const before = best.scrollTop;
+    best.scrollBy(0, delta);
+    if (best.scrollTop !== before) {
+      return {ok: true, via: 'container', y: best.scrollTop, max: best.scrollHeight};
+    }
+  }
+
+  // 3. Genuinely nowhere to go -- already at the end, or nothing scrollable.
+  return {ok: false, via: 'none', y: se ? se.scrollTop : null,
+          max: se ? se.scrollHeight : null};
+})()
+"""
+
+
+def camofox_scroll(
+    direction: str, task_id: Optional[str] = None, amount: Optional[int] = None
+) -> str:
+    """Scroll the page via Camofox.
+
+    ``amount`` is the pixel distance (default 500, matching camofox's own
+    default for the wheel endpoint this replaces). See _SCROLL_JS above for why
+    this goes through /evaluate.
+
+    The returned payload carries ``at`` (the resulting scroll offset) and
+    ``height``, and adds ``at_end: True`` when nothing moved -- so "the page did
+    not scroll" is something the caller can see rather than infer. That case
+    stays ``success: True`` on purpose: reaching the bottom of a page is a
+    normal outcome, not a failure, and flagging it as one would teach agents to
+    retry a scroll that is already done.
+    """
     try:
         session = _get_session(task_id)
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
-        _post(
-            f"/tabs/{session['tab_id']}/scroll",
-            {"userId": session["user_id"], "direction": direction},
+        pixels = int(amount) if amount is not None else 500
+        delta = -pixels if direction == "up" else pixels
+
+        data = _post(
+            f"/tabs/{session['tab_id']}/evaluate",
+            {"userId": session["user_id"], "expression": _SCROLL_JS % delta},
         )
-        return json.dumps({"success": True, "scrolled": direction})
+        result = data.get("result") or {}
+
+        if not result.get("ok"):
+            # Not an error: the common cause is already being at the bottom.
+            return json.dumps({
+                "success": True,
+                "scrolled": direction,
+                "at_end": True,
+                "at": result.get("y"),
+                "height": result.get("max"),
+                "note": "Page did not move -- already at the end of the "
+                        "scrollable area, or nothing on the page scrolls.",
+            })
+
+        return json.dumps({
+            "success": True,
+            "scrolled": direction,
+            "at": result.get("y"),
+            "height": result.get("max"),
+        })
     except Exception as e:
         return tool_error(str(e), success=False)
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3666,14 +3666,33 @@ def browser_scroll(direction: str, task_id: Optional[str] = None) -> str:
     # ~500px is roughly half a viewport of travel.
     _SCROLL_PIXELS = 500
 
+    # Camofox's own default is also 500px per request, and the old loop issued
+    # five of them; keep that total travel in the single request below.
+    _CAMOFOX_SCROLL_NOTCHES = 5
+
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_scroll
-        # Camofox REST API doesn't support pixel args; use repeated calls
-        _SCROLL_REPEATS = 5
-        result = None
-        for _ in range(_SCROLL_REPEATS):
-            result = camofox_scroll(direction, task_id)
-        return result
+        # This used to be `for _ in range(5): result = camofox_scroll(...)`, on
+        # the belief that the camofox REST API took no pixel argument. It does --
+        # its POST /tabs/:id/scroll destructures `amount` -- so the loop bought
+        # nothing and cost three things:
+        #   * five HTTP round trips per tool call, each able to block for
+        #     camofox's full 30s handler timeout, so one "scroll down" could
+        #     take 150s;
+        #   * intermediate results were overwritten, so a failure anywhere but
+        #     the last iteration was reported as success, and a success after a
+        #     failure hid the failure;
+        #   * no early exit, so it kept scrolling after a request had already
+        #     failed.
+        # Observed in the wild: 79.5s of wall clock for one scroll, containing
+        # two 500s, one of them masked.
+        # The distance is preserved deliberately -- five wheel notches at
+        # camofox's 500px default -- so agents that scroll N times to reach
+        # content behave as before rather than suddenly needing five times as
+        # many calls.
+        return camofox_scroll(
+            direction, task_id, amount=_SCROLL_PIXELS * _CAMOFOX_SCROLL_NOTCHES
+        )
 
     effective_task_id = _last_session_key(task_id or "default")
 


### PR DESCRIPTION
## What does this PR do?

`browser_scroll` in Camofox mode doesn't scroll. Two independent problems on the same call path.

### 1. The wheel is inert in headless Firefox

Camofox's `POST /tabs/:id/scroll` calls `page.mouse.wheel()` with the mouse wherever Playwright last left it — **(0,0) on a fresh tab**. In this headless Firefox that wheel event moves nothing.

Measured on a plain document (Wikipedia) and on a JS-rendered app page:

| call | resulting `scrollY` |
|---|---|
| `POST /scroll amount=500` | `0` |
| `POST /scroll amount=2500` | `0` |
| `scrollTo(0, 1234)` via `/evaluate` | `1234` |

So the page and the measurement were both fine — the wheel was simply not doing anything. It isn't free either: it blocks for roughly as long as the travel would take (1.8s at 500px, 6.5s at 2500px) and can reach camofox's 30s handler timeout under load. `/evaluate` does the same job in 3–10ms.

There is no mouse-move endpoint to aim the wheel with, so this is fixed on the client side.

### 2. `browser_scroll` issued five calls per scroll

```python
# Camofox REST API doesn't support pixel args; use repeated calls
_SCROLL_REPEATS = 5
result = None
for _ in range(_SCROLL_REPEATS):
    result = camofox_scroll(direction, task_id)
return result
```

The premise is wrong — camofox's scroll handler destructures `amount`. So the loop bought nothing and cost three things:

- **five HTTP round trips** per tool call, each able to block for the full 30s handler timeout, so one `browser_scroll` could take 150s;
- **intermediate results were overwritten**, so a failure in any iteration but the last was reported as success, and a success after a failure hid the failure;
- **no early exit** — it kept scrolling after a request had already failed.

Observed in the wild: 79.5s of wall clock for a single scroll, containing two 500s, one of them masked by a later success.

## Related Issue

No existing issue found; searched open and closed PRs for `camofox scroll`, `scroll wheel`, `mouse.wheel`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tools/browser_camofox.py`**
  - `_SCROLL_JS` — scrolls the document, falling back to the largest genuinely-scrollable container for pages that pin the document at 0, and reporting whether anything moved.
  - `camofox_scroll` gains an optional `amount` (default 500, matching camofox's own default) and goes through `/evaluate`.
  - The payload now carries `at` and `height`, plus `at_end: True` when nothing moved. **Reaching the bottom stays `success: True`** on purpose — it is a normal outcome, and reporting it as an error teaches agents to retry a scroll that is already done.
- **`tools/browser_tool.py`** — one call passing `amount` instead of the five-call loop. Total travel is preserved deliberately (five notches × camofox's 500px default), so agents that scroll N times to reach content behave exactly as before rather than suddenly needing five times as many calls.
- **`tests/tools/test_browser_camofox.py`** — a `TestCamofoxScroll` class (there was none; `camofox_scroll` was imported by two test modules and exercised by neither).

## How to Test

1. `pytest tests/tools/test_browser_camofox.py -q` → 24 passed.
2. Revert both tool files and re-run `-k Scroll`: 3 of the 4 new tests fail. They are real regression tests.
3. Against a live Camofox, on any long page:
   ```
   browser_navigate("https://en.wikipedia.org/wiki/Scrolling")
   browser_scroll("down")
   browser_snapshot()
   ```
   Before: the snapshot is unchanged and the call takes seconds. After: the page has moved and `at`/`height` report where it is.

## Note on #54890

That open PR adds a 404 guard to `camofox_scroll` (among seven other functions). This PR rewrites the body of the same function, so they will conflict textually. The two changes are independent in substance and I'm happy to rebase whichever lands second.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 26.04 (LXC), Python 3.14

> **On the full suite:** all 64 tests across the seven `test_browser_camofox*.py` files pass. I could not run `pytest tests/ -q` in full — unrelated modules fail to *collect* in my environment for missing optional deps (`aiohttp`, `httpx`, `mcp`, `rich`, `websockets`), which this change doesn't touch.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments) — the rationale lives next to `_SCROLL_JS`
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A, no platform-specific code
- [x] Tool descriptions/schemas — N/A. `browser_scroll`'s own signature and description are unchanged; `amount` is added to the internal `camofox_scroll` helper, not to the agent-facing tool.
