### PR TITLE
fix(delegate): inherit parent session workspace context

### DIFF
--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -12,9 +12,10 @@ contextvar; CLI/cron fall through to `TERMINAL_CWD`/launch cwd.
 
 import logging
 import os
+from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,21 @@ def set_session_cwd(cwd: str | None) -> Token:
 
 def clear_session_cwd() -> None:
     _SESSION_CWD.set("")
+
+
+@contextmanager
+def scoped_session_cwd(cwd: str | None) -> Iterator[None]:
+    """Temporarily pin the logical cwd for an isolated agent execution.
+
+    Delegated children execute in worker threads that share the host process's
+    ``os.getcwd()``.  Scope their inherited workspace through this ContextVar
+    instead of changing process-wide cwd or relying on ``TERMINAL_CWD``.
+    """
+    token = set_session_cwd(cwd)
+    try:
+        yield
+    finally:
+        _SESSION_CWD.reset(token)
 
 
 def _session_cwd_override() -> str:

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -10,6 +10,7 @@ from agent.runtime_cwd import (
     clear_session_cwd,
     resolve_agent_cwd,
     resolve_context_cwd,
+    scoped_session_cwd,
     set_session_cwd,
 )
 
@@ -76,6 +77,19 @@ class TestSessionCwdOverride:
         try:
             clear_session_cwd()
             assert resolve_agent_cwd() == tmp_path
+        finally:
+            rt._SESSION_CWD.reset(token)
+
+    def test_scoped_session_cwd_restores_prior_context(self, tmp_path):
+        original = tmp_path / "original"
+        delegated = tmp_path / "delegated"
+        original.mkdir()
+        delegated.mkdir()
+        token = set_session_cwd(str(original))
+        try:
+            with scoped_session_cwd(str(delegated)):
+                assert resolve_context_cwd() == delegated
+            assert resolve_context_cwd() == original
         finally:
             rt._SESSION_CWD.reset(token)
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,6 +11,7 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
+import tempfile
 import threading
 import time
 import types
@@ -27,6 +28,7 @@ from tools.delegate_tool import (
     _build_child_agent,
     _build_child_progress_callback,
     _build_child_system_prompt,
+    _resolve_workspace_hint,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
@@ -54,6 +56,90 @@ def _make_mock_parent(depth=0):
     parent.tool_progress_callback = None
     parent.thinking_callback = None
     return parent
+
+
+class TestDelegatedWorkspaceContext(unittest.TestCase):
+    def test_workspace_hint_prefers_parent_session_cwd_over_process_env(self):
+        """A child inherits the parent session's live workspace, not gateway cwd."""
+        from tools.terminal_tool import clear_session_cwd, record_session_cwd
+
+        parent = _make_mock_parent()
+        parent._current_task_id = "parent-workspace-context"
+        with tempfile.TemporaryDirectory() as session_dir, tempfile.TemporaryDirectory() as gateway_dir:
+            record_session_cwd(parent._current_task_id, session_dir)
+            try:
+                with patch.dict(os.environ, {"TERMINAL_CWD": gateway_dir}):
+                    assert _resolve_workspace_hint(parent) == session_dir
+            finally:
+                clear_session_cwd(parent._current_task_id)
+
+    def test_child_construction_scopes_session_workspace_and_loads_context_files(self):
+        """Prompt construction sees the inherited workspace before AIAgent init."""
+        from agent.runtime_cwd import resolve_context_cwd
+        from tools.terminal_tool import clear_session_cwd, record_session_cwd
+
+        parent = _make_mock_parent()
+        parent._current_task_id = "parent-child-construction-workspace"
+        with tempfile.TemporaryDirectory() as session_dir, tempfile.TemporaryDirectory() as gateway_dir:
+            record_session_cwd(parent._current_task_id, session_dir)
+            captured = {}
+
+            def make_child(**kwargs):
+                captured["context_cwd"] = resolve_context_cwd()
+                captured.update(kwargs)
+                child = MagicMock()
+                child.session_id = "child-session"
+                return child
+
+            try:
+                with (
+                    patch.dict(os.environ, {"TERMINAL_CWD": gateway_dir}),
+                    patch("run_agent.AIAgent", side_effect=make_child),
+                ):
+                    child = _build_child_agent(
+                        task_index=0,
+                        goal="Inspect the inherited workspace",
+                        context=None,
+                        toolsets=None,
+                        model=None,
+                        max_iterations=10,
+                        parent_agent=parent,
+                        task_count=1,
+                    )
+            finally:
+                clear_session_cwd(parent._current_task_id)
+
+        self.assertEqual(str(captured["context_cwd"]), os.path.abspath(session_dir))
+        self.assertFalse(captured["skip_context_files"])
+        self.assertEqual(getattr(child, "_delegated_workspace_cwd"), os.path.abspath(session_dir))
+
+    def test_worker_thread_scopes_child_workspace_during_run(self):
+        """The daemon worker preserves the construction workspace for tool execution."""
+        from agent.runtime_cwd import resolve_context_cwd
+        from tools.delegate_tool import _run_single_child
+
+        parent = _make_mock_parent()
+        child = MagicMock()
+        child.session_id = "child-session"
+        child._delegated_workspace_cwd = None
+        captured = {}
+
+        with tempfile.TemporaryDirectory() as workspace:
+            child._delegated_workspace_cwd = workspace
+
+            def run(**_kwargs):
+                captured["context_cwd"] = resolve_context_cwd()
+                return {"final_response": "done", "completed": True, "api_calls": 1}
+
+            child.run_conversation.side_effect = run
+            _run_single_child(
+                task_index=0,
+                goal="Inspect workspace in worker",
+                child=child,
+                parent_agent=parent,
+            )
+
+        self.assertEqual(str(captured["context_cwd"]), workspace)
 
 
 class TestDelegateRequirements(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1143,7 +1143,21 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
     teaching subagents a fake container path while still helping them avoid
     guessing `/workspace/...` for local repo tasks.
     """
+    # The terminal session record is the canonical live workspace: it tracks
+    # explicit workspace registration and subsequent `cd` commands per task.
+    # Consult it before process-wide env/agent hints, which can point at the
+    # gateway's launch directory rather than the conversation's repository.
+    session_cwd = None
+    try:
+        from tools.terminal_tool import get_session_cwd
+
+        session_cwd = get_session_cwd(
+            getattr(parent_agent, "_current_task_id", None)
+        )
+    except Exception:
+        logger.debug("Could not read parent session cwd for delegated child", exc_info=True)
     candidates = [
+        session_cwd,
         os.getenv("TERMINAL_CWD"),
         getattr(
             getattr(parent_agent, "_subdirectory_hints", None), "working_dir", None
@@ -1773,8 +1787,12 @@ def _build_child_agent(
         child_optional_kwargs["max_tokens"] = child_max_tokens
 
     from agent.delegation_context import delegated_child_context
+    from agent.runtime_cwd import scoped_session_cwd
 
-    with delegated_child_context():
+    # Construction builds the system prompt and discovers project instructions.
+    # Scope the child's inherited workspace now; the host process cwd may be an
+    # unrelated gateway/service directory shared by every concurrent child.
+    with delegated_child_context(), scoped_session_cwd(workspace_hint):
         child = AIAgent(
             base_url=effective_base_url,
             api_key=effective_api_key,
@@ -1794,7 +1812,10 @@ def _build_child_agent(
             ephemeral_system_prompt=child_prompt,
             log_prefix=f"[subagent-{task_index}]",
             platform="subagent",
-            skip_context_files=True,
+            # Only load project instructions when we resolved an inherited
+            # workspace. Without one, falling back to process cwd could inject
+            # unrelated gateway/service context.
+            skip_context_files=not bool(workspace_hint),
             skip_memory=True,
             clarify_callback=None,
             thinking_callback=child_thinking_cb,
@@ -1830,6 +1851,9 @@ def _build_child_agent(
     child._subagent_id = subagent_id
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
+    # Keep the construction-time workspace for the child's worker-thread run.
+    # ContextVars do not survive the hand-off to DaemonThreadPoolExecutor.
+    setattr(child, "_delegated_workspace_cwd", workspace_hint)
     child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
     # Ownership chain for the model-facing control plane (action=list/steer/
     # stop): a parent may only control agents whose weakref chain reaches it.
@@ -2519,6 +2543,10 @@ def _run_single_child(
                     from tools.terminal_tool import record_session_cwd as _rsc
 
                     _rsc(child_task_id, _worktree_info["path"])
+                    # Match the terminal record: subsequent child turns run in
+                    # this isolated worktree, not the parent workspace used to
+                    # construct the child prompt.
+                    setattr(child, "_delegated_workspace_cwd", _worktree_info["path"])
                 except Exception as e:
                     logger.debug("worktree cwd seed failed: %s", e)
                 # The child's context is already built; carry the isolation
@@ -2568,8 +2596,12 @@ def _run_single_child(
         def _run_with_thread_capture():
             _worker_thread_holder["t"] = threading.current_thread()
             from agent.delegation_context import delegated_child_context
+            from agent.runtime_cwd import scoped_session_cwd
 
-            with delegated_child_context(str(getattr(child, "session_id", "") or "")):
+            with (
+                delegated_child_context(str(getattr(child, "session_id", "") or "")),
+                scoped_session_cwd(getattr(child, "_delegated_workspace_cwd", None)),
+            ):
                 return child.run_conversation(
                     user_message=goal,
                     task_id=child_task_id,


### PR DESCRIPTION
## Summary
- resolve delegated workspace from the parent task's canonical session cwd before process-wide `TERMINAL_CWD`
- scope that workspace through child construction and the daemon worker without `os.chdir()` or global environment mutation
- load project instructions only when an inherited workspace was actually resolved
- keep worktree-isolated children scoped to their newly created worktree during execution

## Regression coverage
- session workspace wins when it differs from service `TERMINAL_CWD`
- child construction sees the inherited workspace before project-context discovery
- daemon worker sees the scoped workspace while `run_conversation()` executes
- scoped cwd restores the parent ContextVar afterward

## Validation
- `uv run --extra dev pytest tests/tools/test_delegate.py tests/tools/test_delegate_kanban_isolation.py tests/tools/test_subagent_worktree.py tests/agent/test_runtime_cwd.py -q` (94 passed)
- `uv run --extra dev pytest tests/tools/test_async_delegation.py tests/tools/test_delegate_output_schema.py tests/tools/test_delegate_toolset_scope.py -q` (49 passed)
- `uv run --extra dev ruff check agent/runtime_cwd.py tools/delegate_tool.py tests/tools/test_delegate.py tests/agent/test_runtime_cwd.py`
- `git diff --check`; diff secret scan

Fixes the workspace-context handoff gap exposed when the service process runs outside the user's repository.