### PR TITLE
Show statusbar by default in desktop

### DIFF
--- a/apps/desktop/src/store/statusbar-prefs.ts
+++ b/apps/desktop/src/store/statusbar-prefs.ts
@@ -3,11 +3,10 @@ import { Codecs, persistentAtom } from '@/lib/persisted'
 const STATUSBAR_HIDDEN_STORAGE_KEY = 'hermes.desktop.statusbarHidden'
 const STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible'
 
-// Whole-bar visibility, VS Code's `workbench.statusBar.visible`. Off by default
-// — the bar is opt-in. Hiding it unmounts the bar (its 15s status poll goes with
-// it), so the way back is the `view.toggleStatusbar` keybind or the ⌘K row,
-// never the bar itself.
-export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, false, Codecs.bool)
+// Whole-bar visibility, VS Code's `workbench.statusBar.visible`. On by default.
+// Hiding it unmounts the bar (its 15s status poll goes with it), so the way back
+// is the `view.toggleStatusbar` keybind or the ⌘K row, never the bar itself.
+export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, true, Codecs.bool)
 
 export function toggleStatusbarVisible() {
   $statusbarVisible.set(!$statusbarVisible.get())


### PR DESCRIPTION
Flip `` from `false` to `true` so the status bar appears on first launch instead of being opt-in.

The context-usage meter and other diagnostic items stay hidden via `STATUSBAR_HIDDEN_BY_DEFAULT` — only core status items (gateway health, model pill, command center) show out of the box. The toggle keybind and ⌘K row still let users hide it.