### PR TITLE
fix(kanban): gate dispatch on implementation prerequisites

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -68,6 +68,8 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "workspace_kind": t.workspace_kind,
         "workspace_path": t.workspace_path,
         "branch_name": t.branch_name,
+        "base_ref": t.base_ref,
+        "required_paths": list(t.required_paths or []),
         "project_id": t.project_id,
         "created_by": t.created_by,
         "created_at": t.created_at,
@@ -338,6 +340,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "(default: scratch)")
     p_create.add_argument("--branch", default=None,
                           help="Branch name for worktree tasks, e.g. wt/t6-wire")
+    p_create.add_argument("--base-ref", default=None,
+                          help="Git revision from which a new worktree branch must start")
+    p_create.add_argument("--require-path", action="append", default=[],
+                          help="Repository-relative path required before dispatch (repeatable)")
     p_create.add_argument("--project", default=None,
                           help="Link to a project (id or slug). Anchors the task's "
                                "worktree under the project's primary repo with a "
@@ -1572,6 +1578,8 @@ def _cmd_create(args: argparse.Namespace) -> int:
             workspace_kind=ws_kind,
             workspace_path=ws_path,
             branch_name=branch_name,
+            base_ref=getattr(args, "base_ref", None),
+            required_paths=getattr(args, "require_path", None),
             project_id=getattr(args, "project", None),
             tenant=args.tenant,
             priority=args.priority,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7837,10 +7837,19 @@ def _check_implementation_prerequisites(
         )
         if result.returncode != 0:
             return f"task branch does not contain required base revision {task.base_ref!r}"
-    missing = [
-        path for path in task.required_paths or []
-        if not (workspace / path).exists()
-    ]
+    missing = []
+    for path in task.required_paths or []:
+        result = subprocess.run(
+            ["git", "-C", str(workspace), "cat-file", "-e", f"HEAD:{path}"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            check=False,
+        )
+        if result.returncode != 0:
+            missing.append(path)
     if missing:
         return "required implementation path(s) absent: " + ", ".join(missing)
     return None

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6176,7 +6176,7 @@ def block_task(
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
 ) -> bool:
-    """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
+    """Transition ``running``/``ready``/``review`` → a blocked route.
 
     ``kind`` (one of :data:`VALID_BLOCK_KINDS`, or ``None`` for a legacy
     un-typed block) drives routing instead of every block landing in one
@@ -6218,7 +6218,7 @@ def block_task(
         source_status = (
             _retry_status_for_run(conn, task_id)
             if cur_row["status"] == "running"
-            else "ready"
+            else str(cur_row["status"])
         )
         prev_kind = cur_row["block_kind"] if "block_kind" in cur_row.keys() else None
         prev_recurrences = (
@@ -6242,7 +6242,7 @@ def block_task(
                        worker_pid    = NULL,
                        block_kind    = ?
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ('running', 'ready', 'review')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
                 (kind, task_id) if expected_run_id is None
                 else (kind, task_id, int(expected_run_id)),
@@ -6280,9 +6280,10 @@ def block_task(
 
         # Truly-blocked kinds. Increment the unblock-loop counter when this is a
         # re-block for the SAME reason after a prior unblock. block_task only
-        # fires from running/ready (i.e. AFTER an unblock returned the task to
-        # the work pool), so a stored block_kind that matches the incoming kind
-        # means: blocked → unblocked → about-to-re-block for the same cause.
+        # usually fires after an unblock returned the task to the work pool, so
+        # a stored block_kind that matches the incoming kind means: blocked →
+        # unblocked → about-to-re-block for the same cause. Review dispatch can
+        # also block before claim when its implementation prerequisites changed.
         # An un-typed (None) block compares as "same" to a prior un-typed block.
         same_cause = prev_kind == kind
         recurrences = prev_recurrences + 1 if same_cause else 1
@@ -6300,7 +6301,7 @@ def block_task(
                        block_kind    = ?,
                        block_recurrences = ?
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ('running', 'ready', 'review')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
                 (kind, recurrences, task_id) if expected_run_id is None
                 else (kind, recurrences, task_id, int(expected_run_id)),
@@ -6339,7 +6340,7 @@ def block_task(
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
-                       AND status IN ('running', 'ready')
+                       AND status IN ('running', 'ready', 'review')
                     """,
                     (kind, recurrences, task_id),
                 )
@@ -6354,7 +6355,7 @@ def block_task(
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
-                       AND status IN ('running', 'ready')
+                       AND status IN ('running', 'ready', 'review')
                        AND current_run_id = ?
                     """,
                     (kind, recurrences, task_id, int(expected_run_id)),
@@ -9791,6 +9792,37 @@ def _dispatch_once_locked(
             # bucket it as nonspawnable if the profile genuinely isn't
             # there, with the existing diagnostic.
             _default_assignee_resolved = True
+
+    def _preflight_implementation_prerequisites(
+        task_id: str,
+    ) -> tuple[Optional[Path], Optional[str], bool]:
+        candidate = get_task(conn, task_id)
+        if candidate is None or not (candidate.base_ref or candidate.required_paths):
+            return None, None, False
+        try:
+            workspace, branch = _resolve_worktree_workspace(candidate, board=board)
+            prerequisite_error = _check_implementation_prerequisites(
+                candidate, workspace
+            )
+        except Exception as exc:
+            prerequisite_error = str(exc)
+            workspace = None
+            branch = None
+        if not prerequisite_error:
+            return workspace, branch, False
+
+        reason = f"Dispatch prerequisite failed: {prerequisite_error}"
+        if dry_run:
+            result.auto_blocked.append(candidate.id)
+        elif block_task(conn, candidate.id, reason=reason, kind="capability"):
+            with write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+                    (reason[:2000], candidate.id),
+                )
+            result.auto_blocked.append(candidate.id)
+        return None, None, True
+
     for row in ready_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
@@ -9895,6 +9927,11 @@ def _dispatch_once_locked(
                         {"reason": guard_reason},
                     )
             continue
+        prerequisite_workspace, prerequisite_branch, prerequisite_failed = (
+            _preflight_implementation_prerequisites(row["id"])
+        )
+        if prerequisite_failed:
+            continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
             spawned += 1
@@ -9907,29 +9944,6 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
-        prerequisite_workspace: Optional[Path] = None
-        prerequisite_branch: Optional[str] = None
-        candidate = get_task(conn, row["id"])
-        if candidate is not None and (candidate.base_ref or candidate.required_paths):
-            try:
-                prerequisite_workspace, prerequisite_branch = (
-                    _resolve_worktree_workspace(candidate, board=board)
-                )
-                prerequisite_error = _check_implementation_prerequisites(
-                    candidate, prerequisite_workspace
-                )
-            except Exception as exc:
-                prerequisite_error = str(exc)
-            if prerequisite_error:
-                reason = f"Dispatch prerequisite failed: {prerequisite_error}"
-                if block_task(conn, candidate.id, reason=reason, kind="capability"):
-                    with write_txn(conn):
-                        conn.execute(
-                            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
-                            (reason[:2000], candidate.id),
-                        )
-                    result.auto_blocked.append(candidate.id)
-                continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue
@@ -10052,6 +10066,11 @@ def _dispatch_once_locked(
                         {"reason": guard_reason},
                     )
             continue
+        prerequisite_workspace, prerequisite_branch, prerequisite_failed = (
+            _preflight_implementation_prerequisites(row["id"])
+        )
+        if prerequisite_failed:
+            continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
             spawned += 1
@@ -10065,7 +10084,10 @@ def _dispatch_once_locked(
             continue
         try:
             resolved_branch_name = None
-            if claimed.workspace_kind == "worktree":
+            if prerequisite_workspace is not None:
+                workspace = prerequisite_workspace
+                resolved_branch_name = prerequisite_branch
+            elif claimed.workspace_kind == "worktree":
                 workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
             else:
                 workspace = resolve_workspace(claimed, board=board)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1069,6 +1069,8 @@ class Task:
     claim_expires: Optional[int]
     tenant: Optional[str]
     branch_name: Optional[str] = None
+    base_ref: Optional[str] = None
+    required_paths: Optional[list[str]] = None
     project_id: Optional[str] = None
     result: Optional[str] = None
     idempotency_key: Optional[str] = None
@@ -1154,6 +1156,14 @@ class Task:
                     skills_value = [str(s) for s in parsed if s]
             except Exception:
                 skills_value = None
+        required_paths_value: Optional[list[str]] = None
+        if "required_paths" in keys and row["required_paths"]:
+            try:
+                parsed = json.loads(row["required_paths"])
+                if isinstance(parsed, list):
+                    required_paths_value = [str(path) for path in parsed if path]
+            except Exception:
+                required_paths_value = None
         return cls(
             id=row["id"],
             title=row["title"],
@@ -1168,6 +1178,8 @@ class Task:
             workspace_kind=row["workspace_kind"],
             workspace_path=row["workspace_path"],
             branch_name=row["branch_name"] if "branch_name" in keys else None,
+            base_ref=row["base_ref"] if "base_ref" in keys else None,
+            required_paths=required_paths_value,
             project_id=row["project_id"] if "project_id" in keys else None,
             claim_lock=row["claim_lock"],
             claim_expires=row["claim_expires"],
@@ -1344,6 +1356,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     workspace_kind       TEXT NOT NULL DEFAULT 'scratch',
     workspace_path       TEXT,
     branch_name          TEXT,
+    -- Revision from which a newly materialized task branch must start.
+    base_ref             TEXT,
+    -- JSON list of repository-relative paths required before dispatch.
+    required_paths       TEXT,
     -- Optional link to a first-class Project (hermes_cli/projects_db). When set,
     -- the task's worktree is anchored under the project's primary repo with a
     -- deterministic branch name instead of a random wt/<task-id> fallback.
@@ -2503,6 +2519,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(conn, "tasks", "result", "result TEXT")
     if "branch_name" not in cols:
         _add_column_if_missing(conn, "tasks", "branch_name", "branch_name TEXT")
+    if "base_ref" not in cols:
+        _add_column_if_missing(conn, "tasks", "base_ref", "base_ref TEXT")
+    if "required_paths" not in cols:
+        _add_column_if_missing(conn, "tasks", "required_paths", "required_paths TEXT")
     if "project_id" not in cols:
         _add_column_if_missing(conn, "tasks", "project_id", "project_id TEXT")
     if "idempotency_key" not in cols:
@@ -3128,6 +3148,8 @@ def create_task(
     workspace_kind: str = "scratch",
     workspace_path: Optional[str] = None,
     branch_name: Optional[str] = None,
+    base_ref: Optional[str] = None,
+    required_paths: Optional[Iterable[str]] = None,
     tenant: Optional[str] = None,
     priority: int = 0,
     parents: Iterable[str] = (),
@@ -3207,6 +3229,22 @@ def create_task(
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
+    if base_ref is not None:
+        base_ref = str(base_ref).strip() or None
+    if base_ref and workspace_kind != "worktree":
+        raise ValueError("base_ref is only valid for worktree workspaces")
+    required_paths_list: list[str] = []
+    for raw_path in required_paths or ():
+        path = str(raw_path).strip()
+        if not path:
+            continue
+        candidate = Path(path)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise ValueError(f"required path must be repository-relative: {path!r}")
+        if path not in required_paths_list:
+            required_paths_list.append(path)
+    if required_paths_list and workspace_kind != "worktree":
+        raise ValueError("required_paths are only valid for worktree workspaces")
 
     # Inherit the board's scoped project when the caller didn't name one, so a
     # project-scoped board anchors every new task to that project's repo
@@ -3456,12 +3494,13 @@ def create_task(
                     INSERT INTO tasks (
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
-                        branch_name, project_id, tenant, idempotency_key,
+                        branch_name, base_ref, required_paths,
+                        project_id, tenant, idempotency_key,
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
                         goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3475,6 +3514,8 @@ def create_task(
                         workspace_kind,
                         workspace_path,
                         branch_name,
+                        base_ref,
+                        json.dumps(required_paths_list) if required_paths_list else None,
                         project_id,
                         tenant,
                         idempotency_key,
@@ -3510,6 +3551,8 @@ def create_task(
                         "workspace_kind": workspace_kind,
                         "workspace_path": workspace_path,
                         "branch_name": branch_name,
+                        "base_ref": base_ref,
+                        "required_paths": required_paths_list or None,
                         "project_id": project_id,
                         "skills": list(skills_list) if skills_list else None,
                         "goal_mode": bool(goal_mode) or None,
@@ -7589,7 +7632,12 @@ def _repo_root_for_worktree_target(path: Path) -> Optional[Path]:
         current = current.parent
 
 
-def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> None:
+def _ensure_git_worktree(
+    repo_root: Path,
+    target: Path,
+    branch_name: str,
+    base_ref: Optional[str] = None,
+) -> None:
     """Materialize ``target`` as a linked git worktree under ``repo_root``."""
     target = target.expanduser()
     repo_common = _git_common_dir(repo_root)
@@ -7603,7 +7651,7 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
     else:
         cmd = [
             "git", "-C", str(repo_root), "worktree", "add", "-b", branch_name,
-            str(target), "HEAD",
+            str(target), base_ref or "HEAD",
         ]
     result = subprocess.run(
         cmd,
@@ -7659,7 +7707,7 @@ def _resolve_worktree_workspace(
                 f"{board_slug!r} default_workdir {board_default!r} is not inside a git repo"
             )
         target = repo_root / ".worktrees" / task.id
-        _ensure_git_worktree(repo_root, target, branch_name)
+        _ensure_git_worktree(repo_root, target, branch_name, task.base_ref)
         return target, branch_name
 
     requested = Path(task.workspace_path).expanduser()
@@ -7685,7 +7733,7 @@ def _resolve_worktree_workspace(
         if fallback_root is not None:
             fallback = fallback_root / ".worktrees" / task.id
             if fallback.resolve(strict=False) != requested_resolved:
-                _ensure_git_worktree(fallback_root, fallback, branch_name)
+                _ensure_git_worktree(fallback_root, fallback, branch_name, task.base_ref)
                 return fallback.resolve(strict=False), branch_name
         # No repo to anchor a fallback on (or the occupied path IS this
         # task's own canonical worktree): keep the legacy reuse rather
@@ -7695,7 +7743,7 @@ def _resolve_worktree_workspace(
     repo_root = _git_toplevel(requested)
     if repo_root is not None and requested_resolved == repo_root:
         target = repo_root / ".worktrees" / task.id
-        _ensure_git_worktree(repo_root, target, branch_name)
+        _ensure_git_worktree(repo_root, target, branch_name, task.base_ref)
         return target, branch_name
 
     repo_root = _repo_root_for_worktree_target(requested.parent)
@@ -7704,7 +7752,7 @@ def _resolve_worktree_workspace(
             f"task {task.id} worktree path {task.workspace_path!r} is not inside a git repo "
             "and does not point at a git repo root"
         )
-    _ensure_git_worktree(repo_root, requested, branch_name)
+    _ensure_git_worktree(repo_root, requested, branch_name, task.base_ref)
     return requested, branch_name
 
 
@@ -7768,6 +7816,34 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
         p, _branch_name = _resolve_worktree_workspace(task, board=board)
         return p
     raise ValueError(f"unknown workspace_kind: {kind}")
+
+
+def _check_implementation_prerequisites(
+    task: Task, workspace: Path
+) -> Optional[str]:
+    """Return why a worktree task cannot dispatch at its resolved revision."""
+    if task.base_ref:
+        result = subprocess.run(
+            [
+                "git", "-C", str(workspace), "merge-base", "--is-ancestor",
+                task.base_ref, "HEAD",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            check=False,
+        )
+        if result.returncode != 0:
+            return f"task branch does not contain required base revision {task.base_ref!r}"
+    missing = [
+        path for path in task.required_paths or []
+        if not (workspace / path).exists()
+    ]
+    if missing:
+        return "required implementation path(s) absent: " + ", ".join(missing)
+    return None
 
 
 def set_workspace_path(
@@ -9822,12 +9898,38 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row_assignee, 0) + 1
                 )
             continue
+        prerequisite_workspace: Optional[Path] = None
+        prerequisite_branch: Optional[str] = None
+        candidate = get_task(conn, row["id"])
+        if candidate is not None and (candidate.base_ref or candidate.required_paths):
+            try:
+                prerequisite_workspace, prerequisite_branch = (
+                    _resolve_worktree_workspace(candidate, board=board)
+                )
+                prerequisite_error = _check_implementation_prerequisites(
+                    candidate, prerequisite_workspace
+                )
+            except Exception as exc:
+                prerequisite_error = str(exc)
+            if prerequisite_error:
+                reason = f"Dispatch prerequisite failed: {prerequisite_error}"
+                if block_task(conn, candidate.id, reason=reason, kind="capability"):
+                    with write_txn(conn):
+                        conn.execute(
+                            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+                            (reason[:2000], candidate.id),
+                        )
+                    result.auto_blocked.append(candidate.id)
+                continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue
         try:
             resolved_branch_name = None
-            if claimed.workspace_kind == "worktree":
+            if prerequisite_workspace is not None:
+                workspace = prerequisite_workspace
+                resolved_branch_name = prerequisite_branch
+            elif claimed.workspace_kind == "worktree":
                 workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
             else:
                 workspace = resolve_workspace(claimed, board=board)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -39,7 +39,7 @@ def _init_git_repo(repo: Path) -> None:
     subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, capture_output=True, text=True)
 
 
-def test_dispatch_blocks_before_claim_when_required_path_is_absent(
+def test_dispatch_blocks_before_claim_when_required_path_is_only_untracked(
     kanban_home, tmp_path
 ):
     repo = tmp_path / "repo"
@@ -63,6 +63,20 @@ def test_dispatch_blocks_before_claim_when_required_path_is_absent(
             base_ref=base_ref,
             required_paths=["scripts/run-replay.ts"],
         )
+        candidate = kb.get_task(conn, task_id)
+        assert candidate is not None
+        workspace, _branch_name = kb._resolve_worktree_workspace(candidate)
+        (workspace / "scripts").mkdir()
+        (workspace / "scripts" / "run-replay.ts").write_text(
+            "export {};\n", encoding="utf-8"
+        )
+        git_status = subprocess.run(
+            ["git", "-C", str(workspace), "status", "--short"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert "?? scripts/" in git_status
         result = kb.dispatch_once(
             conn, spawn_fn=lambda *_args, **_kwargs: pytest.fail("spawned")
         )
@@ -75,8 +89,9 @@ def test_dispatch_blocks_before_claim_when_required_path_is_absent(
     assert "scripts/run-replay.ts" in (task.last_failure_error or "")
 
 
+@pytest.mark.parametrize("required_path", ["scripts", "scripts/run-replay.ts"])
 def test_dispatch_materializes_declared_base_with_required_path(
-    kanban_home, tmp_path
+    kanban_home, tmp_path, required_path
 ):
     repo = tmp_path / "repo"
     _init_git_repo(repo)
@@ -106,7 +121,7 @@ def test_dispatch_materializes_declared_base_with_required_path(
             workspace_path=str(repo),
             branch_name="docs/replay",
             base_ref=base_ref,
-            required_paths=["scripts/run-replay.ts"],
+            required_paths=[required_path],
         )
         result = kb.dispatch_once(
             conn, spawn_fn=lambda _task, workspace: spawned.append(workspace)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -89,6 +89,41 @@ def test_dispatch_blocks_before_claim_when_required_path_is_only_untracked(
     assert "scripts/run-replay.ts" in (task.last_failure_error or "")
 
 
+def test_dispatch_dry_run_does_not_report_missing_prerequisite_as_spawnable(
+    kanban_home, tmp_path
+):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    base_ref = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    (kanban_home / "profiles" / "alice").mkdir(parents=True)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Document replay command",
+            assignee="alice",
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+            branch_name="docs/replay",
+            base_ref=base_ref,
+            required_paths=["scripts/run-replay.ts"],
+        )
+        result = kb.dispatch_once(conn, dry_run=True)
+        task = kb.get_task(conn, task_id)
+
+    assert task is not None
+    assert task.status == "ready"
+    assert task_id in result.auto_blocked
+    assert task_id not in [
+        spawned_id for spawned_id, _assignee, _path in result.spawned
+    ]
+
+
 @pytest.mark.parametrize("required_path", ["scripts", "scripts/run-replay.ts"])
 def test_dispatch_materializes_declared_base_with_required_path(
     kanban_home, tmp_path, required_path
@@ -109,6 +144,13 @@ def test_dispatch_materializes_declared_base_with_required_path(
         capture_output=True,
         text=True,
     ).stdout.strip()
+    (repo / "after-base.txt").write_text("newer revision\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "add", "after-base.txt"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "advance main"], check=True
+    )
     (kanban_home / "profiles" / "alice").mkdir(parents=True)
     spawned: list[str] = []
 
@@ -130,6 +172,74 @@ def test_dispatch_materializes_declared_base_with_required_path(
     assert len(result.spawned) == 1
     assert len(spawned) == 1
     assert (Path(spawned[0]) / "scripts" / "run-replay.ts").is_file()
+    assert not (Path(spawned[0]) / "after-base.txt").exists()
+
+
+def test_review_dispatch_blocks_when_required_path_was_removed(
+    kanban_home, tmp_path
+):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    (repo / "scripts").mkdir()
+    replay_path = repo / "scripts" / "run-replay.ts"
+    replay_path.write_text("export {};\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "add", "scripts/run-replay.ts"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "add replay"], check=True
+    )
+    base_ref = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    (kanban_home / "profiles" / "alice").mkdir(parents=True)
+    spawned: list[str] = []
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Document replay command",
+            assignee="alice",
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+            branch_name="docs/replay",
+            base_ref=base_ref,
+            required_paths=["scripts/run-replay.ts"],
+        )
+        kb.dispatch_once(
+            conn, spawn_fn=lambda _task, workspace: spawned.append(workspace)
+        )
+        running = kb.get_task(conn, task_id)
+        assert running is not None
+        assert running.status == "running"
+        workspace = Path(spawned[0])
+        (workspace / "scripts" / "run-replay.ts").unlink()
+        subprocess.run(
+            ["git", "-C", str(workspace), "add", "-u"], check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(workspace), "commit", "-m", "remove replay"],
+            check=True,
+        )
+        assert kb.request_review(
+            conn,
+            task_id,
+            summary="Documentation ready",
+            expected_run_id=running.current_run_id,
+        )
+        result = kb.dispatch_once(
+            conn, spawn_fn=lambda *_args, **_kwargs: pytest.fail("spawned")
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.claim_lock is None
+    assert task_id in result.auto_blocked
+    assert "scripts/run-replay.ts" in (task.last_failure_error or "")
 
 
 def test_create_task_rejects_unsafe_required_path(kanban_home, tmp_path):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -39,6 +39,96 @@ def _init_git_repo(repo: Path) -> None:
     subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, capture_output=True, text=True)
 
 
+def test_dispatch_blocks_before_claim_when_required_path_is_absent(
+    kanban_home, tmp_path
+):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    base_ref = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    (kanban_home / "profiles" / "alice").mkdir(parents=True)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Document replay command",
+            assignee="alice",
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+            branch_name="docs/replay",
+            base_ref=base_ref,
+            required_paths=["scripts/run-replay.ts"],
+        )
+        result = kb.dispatch_once(
+            conn, spawn_fn=lambda *_args, **_kwargs: pytest.fail("spawned")
+        )
+        task = kb.get_task(conn, task_id)
+
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.claim_lock is None
+    assert task_id in result.auto_blocked
+    assert "scripts/run-replay.ts" in (task.last_failure_error or "")
+
+
+def test_dispatch_materializes_declared_base_with_required_path(
+    kanban_home, tmp_path
+):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "run-replay.ts").write_text("export {};\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "add", "scripts/run-replay.ts"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "add replay"], check=True
+    )
+    base_ref = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    (kanban_home / "profiles" / "alice").mkdir(parents=True)
+    spawned: list[str] = []
+
+    with kb.connect() as conn:
+        kb.create_task(
+            conn,
+            title="Document replay command",
+            assignee="alice",
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+            branch_name="docs/replay",
+            base_ref=base_ref,
+            required_paths=["scripts/run-replay.ts"],
+        )
+        result = kb.dispatch_once(
+            conn, spawn_fn=lambda _task, workspace: spawned.append(workspace)
+        )
+
+    assert len(result.spawned) == 1
+    assert len(spawned) == 1
+    assert (Path(spawned[0]) / "scripts" / "run-replay.ts").is_file()
+
+
+def test_create_task_rejects_unsafe_required_path(kanban_home, tmp_path):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="repository-relative"):
+            kb.create_task(
+                conn,
+                title="unsafe prerequisite",
+                workspace_kind="worktree",
+                workspace_path=str(tmp_path),
+                required_paths=["../secret"],
+            )
+
+
 # ---------------------------------------------------------------------------
 # Schema / init
 # ---------------------------------------------------------------------------

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1386,6 +1386,8 @@ def _handle_create(args: dict, **kw) -> str:
     # preserving the repository/branch convention without sharing a checkout.
     workspace_kind = args.get("workspace_kind")
     workspace_path = args.get("workspace_path")
+    base_ref = args.get("base_ref")
+    required_paths = args.get("required_paths")
     project_id = args.get("project") or args.get("project_id")
     project_source_task_id = None
     _inherit_project = workspace_kind is None and workspace_path is None
@@ -1443,6 +1445,8 @@ def _handle_create(args: dict, **kw) -> str:
                 priority=int(priority) if priority is not None else 0,
                 workspace_kind=str(workspace_kind),
                 workspace_path=workspace_path,
+                base_ref=base_ref,
+                required_paths=required_paths,
                 project_id=project_id,
                 project_source_task_id=project_source_task_id,
                 triage=triage,
@@ -1469,6 +1473,8 @@ def _handle_create(args: dict, **kw) -> str:
                 status=new_task.status if new_task else None,
                 workspace_kind=new_task.workspace_kind if new_task else None,
                 workspace_path=new_task.workspace_path if new_task else None,
+                base_ref=new_task.base_ref if new_task else None,
+                required_paths=list(new_task.required_paths or []) if new_task else [],
                 project_id=new_task.project_id if new_task else None,
                 subscribed=subscribed,
             )
@@ -2202,6 +2208,21 @@ KANBAN_CREATE_SCHEMA = {
                 "description": (
                     "Absolute path for 'dir' or 'worktree' workspace. "
                     "Relative paths are rejected at dispatch."
+                ),
+            },
+            "base_ref": {
+                "type": "string",
+                "description": (
+                    "Git revision from which the task worktree branch must "
+                    "start. Only valid for worktree tasks."
+                ),
+            },
+            "required_paths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Repository-relative implementation paths that must exist "
+                    "in the resolved task revision before dispatch."
                 ),
             },
             "project": {


### PR DESCRIPTION
## Summary
- add explicit `base_ref` and repository-relative `required_paths` to Kanban worktree tasks
- materialize new task branches from the declared base revision
- fail closed before claim/spawn when the task branch lacks the base revision or a required implementation path
- expose prerequisites through the CLI and `kanban_create` tool

## Verification
- `uv run pytest tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_cli.py -q` (68 passed, 1 skipped)
- `uv run ruff check hermes_cli/kanban_db.py hermes_cli/kanban.py tools/kanban_tools.py tests/hermes_cli/test_kanban_db.py`
- `git diff --check`

Kanban: `t_38b13d82`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks can specify a Git base revision and required repository paths.
  * Task creation commands and tools support base revisions and repeatable required-path options.
  * Workspaces can be created from the selected base revision with required paths restored when available.

* **Bug Fixes**
  * Tasks are blocked before dispatch when required paths or base revisions are unavailable or invalid.
  * Unsafe parent-relative paths are rejected during task creation.
  * Review tasks now follow standard dependency and triage handling when blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->