### PR TITLE
fix(plugins): discover entrypoint capability declarations (salvage #85287)

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -65,6 +65,7 @@ from hermes_cli.config import cfg_get, load_config_readonly
 from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION, VALID_MIDDLEWARE
 from hermes_cli.plugin_capabilities import (  # noqa: F401 — re-exported
     CAPABILITY_REGISTRY,
+    VALID_CAPABILITY_IDS,
     plugin_capability_granted,
 )
 from hermes_cli.plugin_capabilities import (
@@ -391,6 +392,103 @@ SHELL_UNSUPPORTED_HOOKS: Set[str] = {
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"
+ENTRY_POINT_CAPABILITIES_GROUP = "hermes_agent.plugin_capabilities"
+
+
+def _select_entry_point_group(entry_points: Any, group: str) -> list:
+    """Return one metadata entry-point group across supported Python APIs."""
+    if hasattr(entry_points, "select"):
+        return list(entry_points.select(group=group))
+    if isinstance(entry_points, dict):
+        return list(entry_points.get(group, []))
+    return [ep for ep in entry_points if ep.group == group]
+
+
+def discover_entrypoint_manifests() -> List["PluginManifest"]:
+    """Return metadata-only manifests for installed entry-point plugins.
+
+    Composes the full entry-point manifest contract in one place:
+
+    * **Kind classification** — the module source is resolved import-free
+      (``_resolve_module_source``) and scanned for provider markers
+      (``_detect_kind_from_source``), so memory providers (``exclusive``)
+      and model providers (``model-provider``) are routed to their own
+      discovery systems instead of being eagerly imported here.
+    * **Capability declarations** — read from the companion
+      ``hermes_agent.plugin_capabilities`` entry-point group (declarations
+      named ``<plugin-id>.<capability-id>`` pointing at the same object),
+      so consent/introspection is accurate without importing plugin code.
+
+    Failures are isolated per entry point: one malformed distribution must
+    not blank the manifests of every other installed plugin.
+    """
+    manifests: List[PluginManifest] = []
+    try:
+        eps = importlib.metadata.entry_points()
+        group_eps = _select_entry_point_group(eps, ENTRY_POINTS_GROUP)
+        capability_eps = _select_entry_point_group(
+            eps, ENTRY_POINT_CAPABILITIES_GROUP
+        )
+    except Exception as exc:
+        logger.debug("Entry-point scan failed: %s", exc)
+        return manifests
+
+    for ep in group_eps:
+        try:
+            capabilities = []
+            for capability in VALID_CAPABILITY_IDS:
+                declaration_name = f"{ep.name}.{capability}"
+                if any(
+                    declaration.name == declaration_name
+                    and declaration.value == ep.value
+                    for declaration in capability_eps
+                ):
+                    capabilities.append(capability)
+            dist = getattr(ep, "dist", None)
+            metadata = getattr(dist, "metadata", None)
+            manifest = PluginManifest(
+                name=ep.name,
+                version=str(getattr(dist, "version", "") or ""),
+                description=(
+                    str(metadata.get("Summary", "") or "")
+                    if metadata is not None
+                    else ""
+                ),
+                source="entrypoint",
+                path=ep.value,
+                key=ep.name,
+                capabilities=_parse_declared_capabilities(
+                    capabilities, ep.name
+                ),
+            )
+            manifest.kind = _classify_entrypoint_value_kind(ep.value)
+            manifests.append(manifest)
+        except Exception as exc:
+            logger.debug(
+                "Entry-point manifest for %r skipped: %s",
+                getattr(ep, "name", "?"),
+                exc,
+            )
+    return manifests
+
+
+def _classify_entrypoint_value_kind(value: str) -> str:
+    """Classify an entry-point target by import-free source scan.
+
+    Module-level twin of ``PluginManager._classify_entrypoint_kind`` so
+    ``discover_entrypoint_manifests()`` callers outside the manager (the
+    CLI capabilities path) get identical routing. Unresolvable or
+    non-Python modules stay ``standalone``.
+    """
+    try:
+        module_name = str(value).split(":", 1)[0].strip()
+        if not module_name:
+            return "standalone"
+        return _detect_kind_from_source(
+            _resolve_module_source(module_name)
+        ) or "standalone"
+    except Exception:
+        return "standalone"
 
 # System-prompt sections are deliberately more constrained than lifecycle
 # hooks. They become high-trust prompt bytes and are charged on every turn.
@@ -4290,31 +4388,17 @@ class PluginManager:
             return "standalone"
 
     def _scan_entry_points(self) -> List[PluginManifest]:
-        """Check ``importlib.metadata`` for pip-installed plugins."""
-        manifests: List[PluginManifest] = []
-        try:
-            eps = importlib.metadata.entry_points()
-            # Python 3.12+ returns a SelectableGroups; earlier returns dict
-            if hasattr(eps, "select"):
-                group_eps = eps.select(group=ENTRY_POINTS_GROUP)
-            elif isinstance(eps, dict):
-                group_eps = eps.get(ENTRY_POINTS_GROUP, [])
-            else:
-                group_eps = [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
+        """Read installed plugin and companion capability entry points.
 
-            for ep in group_eps:
-                manifest = PluginManifest(
-                    name=ep.name,
-                    source="entrypoint",
-                    path=ep.value,
-                    key=ep.name,
-                )
-                manifest.kind = self._classify_entrypoint_kind(ep)
-                manifests.append(manifest)
-        except Exception as exc:
-            logger.debug("Entry-point scan failed: %s", exc)
-
-        return manifests
+        Delegates to ``discover_entrypoint_manifests()``, which composes
+        kind classification (import-free source scan routing memory/model
+        providers away from the general manager) with capability
+        declarations from the ``hermes_agent.plugin_capabilities`` group.
+        Capability declarations live in distribution metadata so discovery
+        is available before importing untrusted plugin code and does not
+        depend on a package-data ``plugin.yaml`` being present.
+        """
+        return discover_entrypoint_manifests()
 
     # -----------------------------------------------------------------------
     # Loading

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1354,6 +1354,13 @@ def _declared_capabilities_for_key(key: str) -> list:
     for entry in _discover_all_plugins():
         # entry = (name, version, description, source, dir_path, key)
         if entry[5] == key or entry[0] == key:
+            if entry[3] == "entrypoint":
+                from hermes_cli.plugins import discover_entrypoint_manifests
+
+                for manifest in discover_entrypoint_manifests():
+                    if key in (manifest.key, manifest.name):
+                        return list(manifest.capabilities)
+                return []
             dir_path = entry[4]
             if not dir_path:
                 return []

--- a/tests/hermes_cli/test_plugin_capabilities.py
+++ b/tests/hermes_cli/test_plugin_capabilities.py
@@ -7,6 +7,7 @@ and backward compatibility with the legacy ``allow_*`` gates.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -112,6 +113,45 @@ class TestDeclarationParsing:
         )
         assert manifest is not None
         assert manifest.capabilities == []
+
+    def test_entrypoint_companion_metadata_declares_capabilities_without_import(
+        self, monkeypatch
+    ):
+        """Installed plugins can declare consent metadata in dist entry points."""
+        from hermes_cli import plugins as plugins_mod
+        from hermes_cli.plugins import PluginManager
+
+        load = MagicMock(side_effect=AssertionError("plugin code must not be imported"))
+        plugin_ep = SimpleNamespace(
+            name="thread-namer",
+            value="thread_namer.plugin:register",
+            group="hermes_agent.plugins",
+            dist=SimpleNamespace(
+                version="1.2.3",
+                metadata={"Summary": "Names gateway threads"},
+            ),
+            load=load,
+        )
+        capability_ep = SimpleNamespace(
+            name="thread-namer.gateway.platform_actions",
+            value="thread_namer.plugin:register",
+            group="hermes_agent.plugin_capabilities",
+            load=load,
+        )
+        monkeypatch.setattr(
+            plugins_mod.importlib.metadata,
+            "entry_points",
+            lambda: [plugin_ep, capability_ep],
+        )
+
+        manifests = PluginManager()._scan_entry_points()
+
+        assert len(manifests) == 1
+        assert manifests[0].name == "thread-namer"
+        assert manifests[0].version == "1.2.3"
+        assert manifests[0].description == "Names gateway threads"
+        assert manifests[0].capabilities == ["gateway.platform_actions"]
+        load.assert_not_called()
 
 
 # ── Consent grant + persistence ──────────────────────────────────────────────

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -94,3 +94,36 @@ def test_discover_all_plugins_includes_entrypoint_plugins(monkeypatch, tmp_path)
     ]
 
 
+def test_declared_capabilities_for_entrypoint_uses_distribution_metadata(
+    monkeypatch, tmp_path
+):
+    bundled_dir = tmp_path / "bundled"
+    user_dir = tmp_path / "user"
+    bundled_dir.mkdir()
+    user_dir.mkdir()
+    plugin_ep = SimpleNamespace(
+        name="thread-namer",
+        value="thread_namer.plugin:register",
+        group="hermes_agent.plugins",
+        dist=SimpleNamespace(version="1.0", metadata={"Summary": ""}),
+    )
+    capability_ep = SimpleNamespace(
+        name="thread-namer.gateway.platform_actions",
+        value="thread_namer.plugin:register",
+        group="hermes_agent.plugin_capabilities",
+    )
+    monkeypatch.setattr(plugins_cmd, "_plugins_dir", lambda: user_dir)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_bundled_plugins_dir", lambda: bundled_dir
+    )
+    monkeypatch.setattr(
+        plugins_cmd.importlib.metadata,
+        "entry_points",
+        lambda: [plugin_ep, capability_ep],
+    )
+
+    assert plugins_cmd._declared_capabilities_for_key("thread-namer") == [
+        "gateway.platform_actions"
+    ]
+
+

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -253,6 +253,25 @@ config keys (`plugins.entries.<id>.allow_tool_override`, …) still work but
 are deprecated — declare capabilities instead so users get a single,
 auditable consent screen. Capabilities are consent + audit, **not a
 sandbox**: they gate host API surfaces, nothing more.
+
+**Pip-distributed plugins** have no `plugin.yaml` directory once installed,
+so declare capabilities in distribution metadata instead, via the companion
+`hermes_agent.plugin_capabilities` entry-point group. Each declaration is
+named `<plugin-id>.<capability-id>` and points at the same object as your
+`hermes_agent.plugins` entry point:
+
+```toml
+[project.entry-points."hermes_agent.plugins"]
+calculator = "my_pkg:register"
+
+[project.entry-points."hermes_agent.plugin_capabilities"]
+"calculator.tools.override" = "my_pkg:register"
+```
+
+Hermes reads these from installed metadata without importing your code, so
+`hermes plugins capabilities` and the consent flow stay accurate for pip
+installs.
+
 ### Manifest v2 reference
 
 `plugin.yaml` also supports an additive **v2 schema** (#64165). Every field is


### PR DESCRIPTION
## Summary
Pip-installed plugins now report their declared capabilities in `hermes plugins capabilities` and the consent flow, via a companion `hermes_agent.plugin_capabilities` entry-point group read from distribution metadata — no plugin code imported.

Salvage of #85287 (@jeeves-assistant), cherry-picked with authorship preserved, composed with the kind-classification contract that landed in #85527.

## Changes
- `hermes_cli/plugins.py`: `discover_entrypoint_manifests()` composes BOTH contracts — import-free kind classification (from #85527) AND capability declarations — in one function; per-entry exception isolation so one malformed dist can't blank every other plugin's manifest; `_scan_entry_points()` delegates to it
- `hermes_cli/plugins_cmd.py`: `hermes plugins capabilities` resolves entry-point plugins from the manifest scan instead of requiring a directory
- Docs: `hermes_agent.plugin_capabilities` group documented in the plugin developer guide with a pyproject example

## Validation
| Check | Result |
|---|---|
| capability + cmd_list + plugins + memory-discovery + providers tests | 480 passed, 1 skipped |
| 6 hindsight failures | pre-existing on main (missing optional dep), previously verified on clean origin/main |
| Conflict with #85527 | resolved by composition, not override — classification asserted in existing kind tests, capabilities in new ones |

## Infographic

![Plugin capabilities for pip installs](https://files.catbox.moe/53u93g.png)
