### PR TITLE
fix(agent): keep prompt caching enabled for Anthropic model aliases (salvage #85512)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2248,8 +2248,11 @@ def anthropic_prompt_cache_policy(
                 capability="prompt_caching",
                 custom_providers=getattr(agent, "_custom_providers", None),
             )
-        except Exception:
-            pass
+        except Exception as _cap_exc:
+            logger.debug(
+                "custom-provider prompt_caching capability lookup failed: %s",
+                _cap_exc,
+            )
     if custom_prompt_caching is not None:
         return custom_prompt_caching, custom_prompt_caching
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2756,6 +2756,13 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     )
 
     # ── Re-evaluate prompt caching ──
+    # Refresh the custom-provider snapshot from the config just loaded above
+    # so the per-model ``prompt_caching`` capability lookup sees the same
+    # live list the context-length resolution used — without this, a flag
+    # added to config.yaml after session start is invisible to a /model
+    # switch (the policy would read the stale init-time snapshot).
+    if _sm_custom_providers is not None:
+        agent._custom_providers = _sm_custom_providers
     agent._use_prompt_caching, agent._use_native_cache_layout = (
         agent._anthropic_prompt_cache_policy(
             provider=new_provider,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2231,6 +2231,28 @@ def anthropic_prompt_cache_policy(
         and (eff_provider == "anthropic" or base_url_hostname(eff_base_url) == "api.anthropic.com")
     )
 
+    # A custom Anthropic-compatible route may use a bare model alias that is
+    # canonicalized only after Hermes sends the request. In that case model
+    # spelling cannot prove cache support. Honor an exact route+model
+    # capability declaration instead; explicit false is authoritative too.
+    # This preserves the runtime model id (and therefore request/cache keys)
+    # while avoiding unsafe alias-name guesses.
+    custom_prompt_caching = None
+    if is_anthropic_wire:
+        try:
+            from hermes_cli.config import get_custom_provider_model_capability
+
+            custom_prompt_caching = get_custom_provider_model_capability(
+                model=eff_model,
+                base_url=eff_base_url,
+                capability="prompt_caching",
+                custom_providers=getattr(agent, "_custom_providers", None),
+            )
+        except Exception:
+            pass
+    if custom_prompt_caching is not None:
+        return custom_prompt_caching, custom_prompt_caching
+
     # MiniMax-M3 rides MiniMax's server-side automatic prefix cache on the
     # Anthropic wire (content-keyed, no marker needed); explicit cache_control
     # is documented for M2.7/M2.5/M2.1/M2 only, so markers on M3 are dead

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1799,6 +1799,12 @@ def get_custom_provider_model_capability(
         return None
     if custom_providers is None:
         try:
+            if config is None:
+                # Read-only path: this helper never mutates the entries it
+                # scans, and get_compatible_custom_providers shallow-copies
+                # each entry before normalizing, so the no-deepcopy cache is
+                # safe here (~135us saved per call on the blank-stub paths).
+                config = load_config_readonly()
             custom_providers = get_compatible_custom_providers(config)
         except Exception:
             return None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1782,6 +1782,51 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_custom_provider_model_capability(
+    model: str,
+    base_url: str,
+    capability: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[bool]:
+    """Return an explicit boolean capability for one custom-provider model.
+
+    Matching is scoped to the normalized route and exact runtime model id so
+    aliases can declare capabilities without changing the id sent upstream.
+    Missing or non-boolean declarations return ``None``.
+    """
+    if not model or not base_url or not capability:
+        return None
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            return None
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_url = normalize_route_base_url(base_url)
+    if not target_url:
+        return None
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = normalize_route_base_url(entry.get("base_url"))
+        if not entry_url or entry_url != target_url:
+            continue
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            continue
+        model_cfg = models.get(model)
+        if not isinstance(model_cfg, dict):
+            continue
+        value = model_cfg.get(capability)
+        if isinstance(value, bool):
+            return value
+    return None
+
+
 def _coerce_config_version(value: Any) -> int:
     """Return a safe integer config version, treating invalid values as legacy."""
     if isinstance(value, bool):

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from hermes_cli.config import get_custom_provider_context_length
+from hermes_cli.config import (
+    get_custom_provider_context_length,
+    get_custom_provider_model_capability,
+)
 
 
 class TestGetCustomProviderContextLength:
@@ -47,6 +50,53 @@ class TestGetCustomProviderContextLength:
         assert get_custom_provider_context_length("m", "", [{"base_url": "", "models": {"m": {"context_length": 1}}}]) is None
         assert get_custom_provider_context_length("m", "http://x", None) is None
         assert get_custom_provider_context_length("m", "http://x", []) is None
+
+
+class TestGetCustomProviderModelCapability:
+    def test_matches_exact_model_on_normalized_route(self):
+        custom = [
+            {
+                "base_url": "https://example.invalid/anthropic/",
+                "models": {"fable": {"prompt_caching": True}},
+            }
+        ]
+
+        assert get_custom_provider_model_capability(
+            "fable",
+            "https://example.invalid/anthropic",
+            "prompt_caching",
+            custom,
+        ) is True
+        assert get_custom_provider_model_capability(
+            "opus",
+            "https://example.invalid/anthropic",
+            "prompt_caching",
+            custom,
+        ) is None
+
+    def test_false_is_preserved_and_non_boolean_is_ignored(self):
+        custom = [
+            {
+                "base_url": "https://example.invalid/anthropic",
+                "models": {
+                    "disabled": {"prompt_caching": False},
+                    "invalid": {"prompt_caching": "true"},
+                },
+            }
+        ]
+
+        assert get_custom_provider_model_capability(
+            "disabled",
+            "https://example.invalid/anthropic",
+            "prompt_caching",
+            custom,
+        ) is False
+        assert get_custom_provider_model_capability(
+            "invalid",
+            "https://example.invalid/anthropic",
+            "prompt_caching",
+            custom,
+        ) is None
 
 
 

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -98,6 +98,27 @@ class TestGetCustomProviderModelCapability:
             custom,
         ) is None
 
+    def test_capability_is_route_isolated(self):
+        """A declaration for one route must not apply to another route.
+
+        Guards normalize_route_base_url matching: if the URL comparison ever
+        regresses to a model-only (or hostname-only) shortcut, this pins the
+        failure.
+        """
+        custom = [
+            {
+                "base_url": "https://other.example.invalid/anthropic",
+                "models": {"fable": {"prompt_caching": True}},
+            }
+        ]
+
+        assert get_custom_provider_model_capability(
+            "fable",
+            "https://example.invalid/anthropic",
+            "prompt_caching",
+            custom,
+        ) is None
+
 
 
 class TestGetModelContextLengthHonorsOverride:

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -231,6 +231,68 @@ class TestThirdPartyAnthropicGateway:
 
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
+    def test_operator_cache_disable_beats_explicit_capability_true(self):
+        """prompt_caching.cache_ttl disable (agent._cache_disabled) is a
+        global operator kill-switch — it must win over a per-model
+        prompt_caching: true declaration (#33555 semantics)."""
+        agent = _make_agent(
+            provider="custom:anthropic-proxy",
+            base_url="https://gateway.example.com/anthropic",
+            api_mode="anthropic_messages",
+            model="fable",
+        )
+        agent._custom_providers = [
+            {
+                "name": "anthropic-proxy",
+                "base_url": "https://gateway.example.com/anthropic",
+                "models": {"fable": {"prompt_caching": True}},
+            }
+        ]
+        agent._cache_disabled = True
+
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_modern_providers_yaml_through_real_loader(self, tmp_path, monkeypatch):
+        """Production path: a real config.yaml in the modern ``providers:``
+        dict shape, loaded through the real normalizer chain — including the
+        init-order fallback where ``_custom_providers`` is NOT yet set on the
+        agent and the policy loads config itself."""
+        import textwrap
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            textwrap.dedent(
+                """
+                providers:
+                  anthropic-proxy:
+                    api: https://gateway.example.com/anthropic
+                    transport: anthropic_messages
+                    models:
+                      fable:
+                        context_length: 1000000
+                        prompt_caching: true
+                      opus:
+                        prompt_caching: false
+                """
+            )
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        # load_config's cache is keyed by resolved config path, so pointing
+        # HERMES_HOME at a fresh tempdir needs no cache invalidation.
+        agent = _make_agent(
+            provider="custom:anthropic-proxy",
+            base_url="https://gateway.example.com/anthropic",
+            api_mode="anthropic_messages",
+            model="fable",
+        )
+        # No agent._custom_providers — exercises the config fallback the
+        # init-time call (agent_init before the snapshot assignment) hits.
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+        agent.model = "opus"
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
 
 class TestMiniMaxAnthropicWire:
     """MiniMax's own model family on its Anthropic-compatible endpoint.

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -161,6 +161,58 @@ class TestThirdPartyAnthropicGateway:
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
 
+    def test_bare_alias_with_explicit_prompt_caching_capability_caches(self):
+        agent = _make_agent(
+            provider="custom:anthropic-proxy",
+            base_url="https://gateway.example.com/anthropic",
+            api_mode="anthropic_messages",
+            model="fable",
+        )
+        agent._custom_providers = [
+            {
+                "name": "anthropic-proxy",
+                "base_url": "https://gateway.example.com/anthropic",
+                "models": {"fable": {"prompt_caching": True}},
+            }
+        ]
+
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_explicit_prompt_caching_false_is_authoritative(self):
+        agent = _make_agent(
+            provider="custom:anthropic-proxy",
+            base_url="https://gateway.example.com/anthropic",
+            api_mode="anthropic_messages",
+            model="claude-fable-5",
+        )
+        agent._custom_providers = [
+            {
+                "name": "anthropic-proxy",
+                "base_url": "https://gateway.example.com/anthropic",
+                "models": {"claude-fable-5": {"prompt_caching": False}},
+            }
+        ]
+
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_bare_alias_without_capability_stays_conservative(self):
+        agent = _make_agent(
+            provider="custom:anthropic-proxy",
+            base_url="https://gateway.example.com/anthropic",
+            api_mode="anthropic_messages",
+            model="fable",
+        )
+        agent._custom_providers = [
+            {
+                "name": "anthropic-proxy",
+                "base_url": "https://gateway.example.com/anthropic",
+                "models": {"fable": {"context_length": 1_000_000}},
+            }
+        ]
+
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+
 class TestMiniMaxAnthropicWire:
     """MiniMax's own model family on its Anthropic-compatible endpoint.
 

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -212,6 +212,25 @@ class TestThirdPartyAnthropicGateway:
 
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
+    def test_capability_on_other_route_does_not_apply(self):
+        """prompt_caching declared for a DIFFERENT base_url must not enable
+        caching for this agent's route — route isolation at the policy level."""
+        agent = _make_agent(
+            provider="custom:anthropic-proxy",
+            base_url="https://gateway.example.com/anthropic",
+            api_mode="anthropic_messages",
+            model="fable",
+        )
+        agent._custom_providers = [
+            {
+                "name": "other-proxy",
+                "base_url": "https://other.example.com/anthropic",
+                "models": {"fable": {"prompt_caching": True}},
+            }
+        ]
+
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
 
 class TestMiniMaxAnthropicWire:
     """MiniMax's own model family on its Anthropic-compatible endpoint.

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -185,6 +185,26 @@ providers:
 
 With discovery off, the model picker (`hermes model`, `/model`) shows the configured list instead of a live probe.
 
+For an Anthropic-compatible gateway that resolves a bare model alias only
+after receiving the request, opt the alias into native prompt-cache markers
+with the per-model `prompt_caching` capability:
+
+```yaml
+providers:
+  anthropic-proxy:
+    api: https://gateway.example.com/anthropic
+    transport: anthropic_messages
+    models:
+      fable:
+        context_length: 1000000
+        prompt_caching: true
+```
+
+Hermes matches this declaration to the exact provider route and runtime model
+id, without rewriting the alias. Set `prompt_caching: false` to explicitly
+disable cache markers for a model; when omitted, Hermes keeps its normal
+provider and model capability detection.
+
 :::note Legacy format
 Older configs used a top-level `custom_providers:` list (with `base_url` instead of `api`). It still works and is auto-migrated to the `providers:` dict on `hermes update` (config v12).
 :::


### PR DESCRIPTION
## Summary

Custom Anthropic-wire providers (`api_mode: anthropic_messages`) can now declare `prompt_caching: true|false` per model, so a bare runtime alias (e.g. `fable`, canonicalized to `claude-fable-5` by a downstream router) gets `cache_control` breakpoints instead of silently losing prompt caching.

Root cause: `anthropic_prompt_cache_policy()` gates third-party Anthropic-wire caching on `"claude" in model_lower`, so an alias that a downstream gateway canonicalizes after Hermes sends the request always resolved to `(False, False)` — no breakpoints, zero cache reads/writes on every turn (one reported session: 88 calls, 28.6M uncached input tokens).

Salvage of #85512 by @fangliquanflq — cherry-picked with authorship preserved, plus two follow-up commits addressing review findings and @StanleyStetson's feedback on the original PR.

**Scope note (per review feedback):** this implements issue #85464's option 2 — an explicit per-model opt-in. Existing alias configs that only declare `context_length` stay uncached until the operator adds `prompt_caching: true`; there is no automatic alias resolution. The issue's end-to-end acceptance signal (second-turn `cache_read_input_tokens > 0`) requires a live cache-capable upstream and is out of unit-test scope.

Closes #85512. Closes #85464.

## Changes

Commit 1 (cherry-picked, @fangliquanflq):
- `hermes_cli/config.py`: new `get_custom_provider_model_capability()` — exact route+model match, boolean-only, `None` for missing/non-boolean declarations
- `agent/agent_runtime_helpers.py`: `anthropic_prompt_cache_policy()` honors the declaration on the Anthropic wire; explicit `false` is authoritative; undeclared providers unchanged; runtime model ID (and therefore request/cache keys) never rewritten
- Tests + docs (`website/docs/user-guide/configuring-models.md`)

Commit 2 (review findings):
- `logger.debug` breadcrumb instead of a bare `except Exception: pass` (a swallowed failure silently downgraded an explicit `prompt_caching: true` with zero trace)
- `load_config_readonly()` for the None-fallback (read-only helper; skips the ~135µs defensive deepcopy on the agent-init and MoA/auxiliary blank-stub paths)
- Route-isolation regression tests at both levels; mutation-checked (both fail when the URL match is disabled)

Commit 3 (@StanleyStetson's original-PR feedback):
- `/model` switch now refreshes `agent._custom_providers` from the config loaded during the switch before re-evaluating cache policy — previously a `prompt_caching` flag added to config.yaml after session start was invisible to a mid-session switch (the policy read the stale init-time snapshot while context-length resolution used the live list)
- Production-path test: real `config.yaml` in the modern `providers:` dict shape through the real loader chain, exercising the init-order fallback (no `_custom_providers` attr) for both the `fable` opt-in and the `opus` explicit opt-out
- Pinned operator kill-switch precedence: `_cache_disabled` (`prompt_caching.cache_ttl` falsy) beats an explicit per-model `prompt_caching: true`

## Related work

This is a third caching knob next to in-flight #76336 (`model.cache_control_mode`) and #79621 (`ProviderProfile.prompt_cache_policy()`). It is deliberately the narrowest of the three (per-model, custom-route-scoped, exact-match). Whichever of the broader mechanisms lands later should consume `get_custom_provider_model_capability()` rather than adding another per-model flag.

## Validation

| Check | Result |
|---|---|
| Targeted suites (policy + custom-provider) | 49 passed |
| `-k 'switch or cache'` + model-switch custom-provider suites | green (29 + 48 passed) |
| Broader `-k cache` / `-k custom_provider` sweeps (pre-follow-up) | 240 passed, 0 failed |
| Mutation checks | original-fix tests fail on pre-fix code; route-isolation tests fail with URL match disabled |
| 10-scenario side-by-side probe (main vs branch, clean subprocesses) | only the 2 intended scenarios change; native Anthropic, OpenRouter Claude/Kimi, MiniMax-M3 exclusion, `_cache_disabled` override all byte-identical |
| E2E with real config.yaml (v12 `providers:` dict AND legacy `custom_providers:` list) | opt-in/opt-out both work; route isolation holds; no unknown-key warning |
| ruff on all touched files | clean |

Docs example verified against the real schema (`api:`/`transport:` accepted aliases) and semantics cross-checked against Anthropic's prompt-caching documentation.

## Credit

Based on #85512 by @fangliquanflq — commit cherry-picked to preserve authorship. Review feedback by @StanleyStetson addressed in commit 3.
