### PR TITLE
fix(tui_gateway): restore openrouter provider on session resume (salvage #57593)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3125,10 +3125,11 @@ def test_session_cwd_set_profile_session_updates_profile_db(monkeypatch, tmp_pat
 
 
 def test_stored_session_runtime_overrides_skips_bare_billing_provider():
-    """A bare billing bucket ("custom"/"auto"/"openrouter") must not be restored as the
-    provider identity on resume. A custom endpoint that never used `/model` persists only
+    """A bare billing bucket ("custom"/"auto") must not be restored as the provider
+    identity on resume. A custom endpoint that never used `/model` persists only
     `billing_provider="custom"`; restoring that broke `session.resume` with "No LLM provider
-    configured" (agent_init treats it as non-routable). A real provider, or an explicit
+    configured" (agent_init treats it as non-routable). ``"openrouter"`` is NOT a bare bucket
+    — it is a fully routable provider; see #57588. A real provider, or an explicit
     `model_config.provider`, is still restored.
     """
     # Bare "custom" bucket, no explicit model_config.provider: no provider override restored.
@@ -3136,7 +3137,7 @@ def test_stored_session_runtime_overrides_skips_bare_billing_provider():
     assert "provider_override" not in ov
     assert ov["model_override"]["provider"] is None
 
-    for bare in ("auto", "openrouter", "custom"):
+    for bare in ("auto", "custom"):
         ov = server._stored_session_runtime_overrides({"model": "m", "billing_provider": bare})
         assert "provider_override" not in ov
 
@@ -3163,6 +3164,33 @@ def test_stored_session_runtime_overrides_restores_explicit_normal_tier():
 
     assert "service_tier_override" in overrides
     assert overrides["service_tier_override"] == ""
+
+
+def test_openrouter_session_resume_restores_provider():
+    """OpenRouter is a fully routable provider — sessions that used OpenRouter must
+    restore the "openrouter" provider override on resume, not fall through to whatever
+    the current global model is.  (#57588)
+    """
+    # OpenRouter session with no explicit model_config.provider (the common case
+    # for sessions that never used /model): billing_provider="openrouter" should
+    # be restored as the provider override.
+    ov = server._stored_session_runtime_overrides(
+        {"model": "anthropic/claude-opus-4.8", "billing_provider": "openrouter"}
+    )
+    assert ov["provider_override"] == "openrouter"
+    assert ov["model_override"]["provider"] == "openrouter"
+    assert ov["model_override"]["model"] == "anthropic/claude-opus-4.8"
+
+    # When an explicit model_config.provider exists, it takes precedence over
+    # billing_provider (this path was already correct).
+    ov = server._stored_session_runtime_overrides(
+        {
+            "model": "anthropic/claude-opus-4.8",
+            "billing_provider": "openrouter",
+            "model_config": {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1"},
+        }
+    )
+    assert ov["provider_override"] == "openrouter"
 
 
 def test_persist_live_session_runtime_preserves_resume_metadata(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3768,7 +3768,12 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
 
 # Bare billing buckets are not routable provider identities (kept in parity with the
 # provider gate in agent_init). Restoring one as a session provider override breaks resume.
-_BARE_BILLING_PROVIDERS = {"auto", "openrouter", "custom"}
+# ``openrouter`` is deliberately excluded — it is a fully routable provider with its own
+# API key and base_url.  Sessions that used OpenRouter store
+# ``billing_provider="openrouter"``; dropping it forces resume to the current global
+# model (e.g. a custom endpoint), which is the wrong provider for the stored model.
+#  See #57588.
+_BARE_BILLING_PROVIDERS = {"auto", "custom"}
 
 
 def _stored_session_runtime_overrides(row: dict | None) -> dict:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3766,13 +3766,15 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
     return model, None
 
 
-# Bare billing buckets are not routable provider identities (kept in parity with the
-# provider gate in agent_init). Restoring one as a session provider override breaks resume.
-# ``openrouter`` is deliberately excluded — it is a fully routable provider with its own
-# API key and base_url.  Sessions that used OpenRouter store
-# ``billing_provider="openrouter"``; dropping it forces resume to the current global
-# model (e.g. a custom endpoint), which is the wrong provider for the stored model.
-#  See #57588.
+# Bare billing buckets are not routable provider identities; restoring one as a
+# session provider override breaks resume. (agent_init's fail-fast gate is a
+# DIFFERENT set that also skips "openrouter" — there it means "default route,
+# don't fail fast", not "unroutable".)
+# ``openrouter`` is deliberately excluded here — it is a fully routable provider
+# with its own API key and base_url. Sessions that used OpenRouter store
+# ``billing_provider="openrouter"``; dropping it forces resume to the current
+# global model (e.g. a custom endpoint), which is the wrong provider for the
+# stored model. See #57588.
 _BARE_BILLING_PROVIDERS = {"auto", "custom"}
 
 


### PR DESCRIPTION
## Summary
Resuming an OpenRouter session after switching the global default to a custom endpoint now restores OpenRouter as the session's provider instead of routing the stored model to the new endpoint (which failed with a bogus "context window of 2,048 tokens" error).

Salvage of #57593 by @liuhao1024 onto current main (original branch is ~7,900 commits stale). Cherry-picked with authorship preserved.

Root cause: `_BARE_BILLING_PROVIDERS` in `tui_gateway/server.py` treated `"openrouter"` as a non-routable billing bucket (alongside `"auto"`/`"custom"`), so `_stored_session_runtime_overrides` dropped the provider on resume and the session fell through to the ambient default endpoint. Unlike bare `"custom"`/`"auto"`, `"openrouter"` IS a fully routable provider identity — restoring it is safe: `_make_agent` re-resolves credentials via the normal provider resolution (no api_key is persisted), and `resolve_billing_route()` only writes `billing_provider="openrouter"` when the turn actually routed via openrouter (provider name or openrouter.ai host).

## Changes
- `tui_gateway/server.py`: remove `"openrouter"` from `_BARE_BILLING_PROVIDERS` (`auto`/`custom` remain filtered)
- `tests/test_tui_gateway_server.py`: regression test `test_openrouter_session_resume_restores_provider` + updated bare-bucket loop

## Validation
| | Before | After |
|---|---|---|
| Resume OpenRouter session with custom endpoint as global default | provider dropped → resume hits custom endpoint with OpenRouter slug → context-window error | `provider_override="openrouter"` restored, resume routes correctly |
| Resume bare `custom`/`auto` rows (#44022) | filtered | still filtered |
| `tests/test_tui_gateway_server.py` | — | 552 passed |

E2E: real-import run against isolated `HERMES_HOME` with a custom-endpoint ambient config confirmed the #57588 row shape restores `openrouter`, bare buckets stay filtered, and explicit `model_config.provider` precedence is intact.

Fixes #57588
Closes #57593

Credit: @liuhao1024 (commit cherry-picked, authorship preserved). #57597 by @Ahmett101 implemented the same fix and is already closed as duplicate.
