### PR TITLE
fix: shared entry-point classification so PluginManager + provider registry agree on ownership

### DIFF
--- a/hermes_cli/entrypoint_kind.py
+++ b/hermes_cli/entrypoint_kind.py
@@ -127,6 +127,45 @@ def resolve_module_source(module_name: str, limit: int = 8192) -> str:
         return ""
 
 
+def resolve_submodule_sources(module_name: str, limit: int = 8192) -> list:
+    """Return the source of a package's direct submodules (without importing).
+
+    Handles the thin-``__init__`` re-export case: a package whose entry-point
+    module is ``__init__.py`` containing only ``from .core import register``
+    while the actual ``register_provider(ProviderProfile(...))`` call lives in
+    a submodule. Resolves the package's top-level location and reads each
+    direct ``.py`` submodule (and nested ``__init__.py``), bounded, so a
+    provider re-exported from a submodule is still classified. Returns ``[]``
+    when the module is not a package or nothing readable is found. Never
+    imports the package (import-free top-level resolution only).
+    """
+    parts = [p for p in module_name.split(".") if p]
+    if not parts:
+        return []
+    out: list = []
+    try:
+        spec = importlib.util.find_spec(parts[0])
+        if spec is None or not spec.submodule_search_locations:
+            return []
+        search_root = Path(spec.submodule_search_locations[0])
+        if not search_root.is_dir():
+            return []
+        for child in sorted(search_root.iterdir()):
+            if child.name.startswith(("_", ".")):
+                continue
+            if child.is_file() and child.suffix == ".py":
+                src = read_source_from_origin(str(child), limit)
+                if src:
+                    out.append(src)
+            elif child.is_dir() and (child / "__init__.py").is_file():
+                src = read_source_from_origin(str(child / "__init__.py"), limit)
+                if src:
+                    out.append(src)
+    except Exception:
+        return []
+    return out
+
+
 def classify_entrypoint(ep):
     """Classify one entry point by its module source, without importing it.
 
@@ -163,7 +202,22 @@ def classify_entrypoint(ep):
         # provider. Not "standalone": that verdict must be earned by reading
         # the source and finding no provider markers.
         return "unknown"
-    return detect_kind_from_source(source_text) or "standalone"
+    kind = detect_kind_from_source(source_text)
+    if kind is not None:
+        return kind
+    # The entry-point module's own source had no provider markers, but it may
+    # be a thin package that re-exports its register hook from a submodule
+    # (e.g. ``__init__.py`` is just ``from .core import register`` while the
+    # ``register_provider(ProviderProfile(...))`` call lives in ``core.py``).
+    # Scan the package's submodules too so such a provider is classified
+    # ``model-provider`` rather than ``standalone`` (which would silently
+    # deregister a provider of the documented shape on main).
+    sub = resolve_submodule_sources(module_name)
+    for sub_source in sub:
+        sub_kind = detect_kind_from_source(sub_source)
+        if sub_kind is not None:
+            return sub_kind
+    return "standalone"
 
 
 def kind_is_provider(kind: str) -> bool:

--- a/hermes_cli/entrypoint_kind.py
+++ b/hermes_cli/entrypoint_kind.py
@@ -1,0 +1,176 @@
+"""Shared entry-point plugin classification for the ``hermes_agent.plugins`` group.
+
+The ``hermes_agent.plugins`` entry-point group has TWO consumers that must
+agree on who owns each entry point:
+
+* ``hermes_cli.plugins.PluginManager`` — the general plugin manager. It must
+  NOT import (and flag errored) pip providers that belong to their own
+  discovery systems.
+* ``providers/__init__.py`` — the model-provider registry. It must NOT invoke
+  general plugins (which expose ``register(ctx)`` and belong to the manager)
+  or memory providers (which belong to ``plugins/memory``) as if they were
+  model providers.
+
+One classifier, used by both, decides the ``kind`` so the two consumers can
+never drift: a provider is loaded only by the registry, a memory provider only
+by ``plugins/memory``, and a general plugin only by the manager. Kind inference
+mirrors the directory-plugin heuristic (source markers), so a pip-installed
+plugin is classified the same way a directory plugin of the same shape would
+be — without importing the module (a pip provider pulling in onnxruntime via
+fastembed costs ~60 MB RSS on every Hermes startup).
+
+Kinds:
+* ``standalone`` — a general plugin; the PluginManager's default (and the
+  safe fallback on any resolution error). Not the provider registry's concern.
+* ``exclusive`` — a memory provider (``register_memory_provider`` /
+  ``MemoryProvider``); owned by ``plugins/memory`` discovery.
+* ``model-provider`` — a model provider (``register_provider`` +
+  ``ProviderProfile``); owned by ``providers/`` discovery.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# The shared entry-point group both consumers scan.
+ENTRY_POINTS_GROUP = "hermes_agent.plugins"
+
+_VALID_KINDS = ("standalone", "exclusive", "model-provider")
+
+
+def detect_kind_from_source(source_text: str) -> Optional[str]:
+    """Return the plugin kind implied by source markers, else ``None``.
+
+    Mirrors ``plugins/memory/__init__.py:_is_memory_provider_dir``: a module
+    that registers a memory provider (``register_memory_provider`` or
+    ``MemoryProvider``) is ``exclusive``; a module that registers a model
+    provider (``register_provider`` + ``ProviderProfile``) is
+    ``model-provider``. Returns ``None`` when neither marker matches, so the
+    caller can fall back to ``standalone``.
+    """
+    if "register_memory_provider" in source_text or "MemoryProvider" in source_text:
+        return "exclusive"
+    if "register_provider" in source_text and "ProviderProfile" in source_text:
+        return "model-provider"
+    return None
+
+
+def read_source_from_origin(origin: Optional[str], limit: int = 8192) -> str:
+    """Read the first ``limit`` chars of a module's source file.
+
+    Returns ``""`` on any failure (callers fall back to ``standalone``).
+    ``.pyc``/``.pyo`` origins are mapped back to their source path so source
+    is still scanned when only the bytecode cache is present.
+    """
+    if not origin:
+        return ""
+    if origin.endswith((".pyc", ".pyo")):
+        try:
+            origin = importlib.util.source_from_cache(origin)
+        except Exception:
+            return ""
+    if not origin.endswith(".py"):
+        return ""
+    try:
+        return Path(origin).read_text(encoding="utf-8", errors="replace")[:limit]
+    except Exception:
+        return ""
+
+
+def resolve_module_source(module_name: str, limit: int = 8192) -> str:
+    """Return the first ``limit`` chars of a module's source WITHOUT importing.
+
+    ``importlib.util.find_spec`` on a dotted name imports the parent package
+    first (executing its ``__init__.py``), which would run arbitrary package
+    initialization during discovery — paying the very import cost this
+    classification exists to avoid. Only the top-level name is resolved with
+    ``find_spec`` (import-free for top-level names); the remaining dotted
+    segments are walked through ``submodule_search_locations`` by hand,
+    mirroring the default PathFinder layout (``part.py`` module or
+    ``part/__init__.py`` package). Namespace packages, zipped modules,
+    extension modules, and anything else unexpected fall back to ``""``
+    (→ ``standalone``, the safe default).
+    """
+    parts = [p for p in module_name.split(".") if p]
+    if not parts:
+        return ""
+    try:
+        spec = importlib.util.find_spec(parts[0])
+        if spec is None or not spec.origin:
+            return ""
+        if len(parts) == 1:
+            return read_source_from_origin(spec.origin, limit)
+        search_paths = spec.submodule_search_locations
+        if not search_paths:
+            return ""
+        search_root = Path(search_paths[0])
+        for part in parts[1:]:
+            as_module = search_root / f"{part}.py"
+            if as_module.is_file():
+                return read_source_from_origin(str(as_module), limit)
+            as_pkg = search_root / part / "__init__.py"
+            if as_pkg.is_file():
+                return read_source_from_origin(str(as_pkg), limit)
+            # Recurse into a subpackage's search locations.
+            sub_spec = importlib.util.find_spec(part)
+            if sub_spec is not None and sub_spec.submodule_search_locations:
+                search_root = Path(sub_spec.submodule_search_locations[0])
+            else:
+                return ""
+        return ""
+    except Exception:
+        return ""
+
+
+def classify_entrypoint(ep):
+    """Classify one entry point by its module source, without importing it.
+
+    ``ep.value`` is ``module:func`` or ``module``. The module's source is read
+    and classified via the shared marker heuristic.
+
+    Return values:
+    * ``"standalone"`` — the module source WAS read and it registers no
+      memory/model provider → a genuine general plugin, owned by the manager.
+    * ``"exclusive"`` — a memory provider; owned by ``plugins/memory``.
+    * ``"model-provider"`` — a model provider; owned by ``providers/``.
+    * ``"unknown"`` — the module source could not be resolved (non-Python
+      target, namespace package, zip import, an entry point whose ``value`` is
+      not a ``module:func`` string, a resolution error). The caller decides
+      the safe fallback: the manager treats unknown as standalone; the
+      provider registry falls through to its historical arity check so a real
+      provider is never dropped just because its source could not be read.
+
+    Never raises.
+    """
+    value = getattr(ep, "value", "") or ""
+    if not isinstance(value, str) or ":" not in value:
+        # A ``module:func`` target is the documented form. Anything else
+        # (a bare callable, a module without a func, a non-string value)
+        # cannot be source-classified here — report unknown so the caller
+        # keeps its safe fallback instead of guessing.
+        return "unknown"
+    module_name = value.split(":", 1)[0].strip()
+    if not module_name:
+        return "unknown"
+    source_text = resolve_module_source(module_name)
+    if not source_text:
+        # Source could not be read → we cannot rule out that this is a
+        # provider. Not "standalone": that verdict must be earned by reading
+        # the source and finding no provider markers.
+        return "unknown"
+    return detect_kind_from_source(source_text) or "standalone"
+
+
+def kind_is_provider(kind: str) -> bool:
+    """True when ``kind`` is owned by the provider registry (model-provider)."""
+    return kind == "model-provider"
+
+
+def kind_is_memory_provider(kind: str) -> bool:
+    """True when ``kind`` is owned by ``plugins/memory`` discovery (exclusive)."""
+    return kind == "exclusive"

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -4135,11 +4135,19 @@ class PluginManager:
                 group_eps = [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
 
             for ep in group_eps:
+                from hermes_cli.entrypoint_kind import classify_entrypoint
+                kind = classify_entrypoint(ep)
+                # "unknown" → the manager's safe default is standalone: it
+                # owns general plugins, and an unresolvable entry point is
+                # treated as a general plugin (historical behavior).
+                if kind == "unknown":
+                    kind = "standalone"
                 manifest = PluginManifest(
                     name=ep.name,
                     source="entrypoint",
                     path=ep.value,
                     key=ep.name,
+                    kind=kind,
                 )
                 manifests.append(manifest)
         except Exception as exc:

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -214,6 +214,40 @@ def _discover_entry_point_providers() -> None:
                 "entry-point provider %r skipped: not enabled in config", ep.name
             )
             continue
+        # Ownership: the ``hermes_agent.plugins`` group is shared with the
+        # general PluginManager and ``plugins/memory`` discovery. Classify
+        # the entry point with the SAME classifier the manager uses so the
+        # two sides can never drift: only a model-provider is invoked here;
+        # a general plugin (standalone) belongs to the manager and a memory
+        # provider (exclusive) belongs to ``plugins/memory``. Without this,
+        # a general plugin that happens to expose a zero-arg ``register()``
+        # would be invoked as a provider (inverse double-load) and a pip
+        # memory-provider would be invoked as a MODEL provider (wrong
+        # registry).
+        try:
+            from hermes_cli.entrypoint_kind import (
+                classify_entrypoint,
+                kind_is_provider,
+            )
+            kind = classify_entrypoint(ep)
+            # "unknown" → the source could not be read; do NOT skip here. Fall
+            # through to the historical callable/arity check below so a real
+            # provider (e.g. a callable target, a module with import-side
+            # registration) is never dropped just because its source could
+            # not be classified.
+            if kind not in ("unknown",) and not kind_is_provider(kind):
+                logger.debug(
+                    "entry-point %r skipped by provider scan: classified "
+                    "kind=%r (owned by PluginManager / memory discovery)",
+                    ep.name, kind,
+                )
+                continue
+        except Exception as exc:
+            logger.debug("entry-point %r ownership classification failed: %s",
+                         ep.name, exc)
+            # Fail-open on classifier failure: fall back to the historical
+            # callable/arity check below so a classification regression can
+            # never silently stop loading real providers.
         try:
             loaded = ep.load()
         except Exception as exc:
@@ -225,7 +259,9 @@ def _discover_entry_point_providers() -> None:
         # effect already happened during load(). Only call when it's callable
         # AND zero-arg: general plugins in this shared group expose
         # ``register(ctx)`` (requires an argument) and belong to the
-        # PluginManager, not the provider registry.
+        # PluginManager, not the provider registry. (The ownership check
+        # above already excluded non-providers; this is a second guard for
+        # providers whose module registered via import side-effect.)
         if callable(loaded):
             if _requires_arguments(loaded):
                 logger.debug(

--- a/tests/hermes_cli/test_plugin_entrypoint_provider_kind.py
+++ b/tests/hermes_cli/test_plugin_entrypoint_provider_kind.py
@@ -38,13 +38,23 @@ def _write_module(tmp_path, name, source):
     return mod
 
 
-def _stub_find_spec(monkeypatch, mapping):
-    """Point importlib.util.find_spec at fixture files for given module names."""
+def _stub_find_spec(monkeypatch, mapping, packages=None):
+    """Point importlib.util.find_spec at fixture files for given module names.
+
+    ``mapping`` maps top-level names to a module file. ``packages`` maps a
+    name to a package directory (for the submodule-scan / re-export tests).
+    """
     real_find_spec = ek.importlib.util.find_spec
 
     def fake_find_spec(name):
         if name in mapping:
             return types.SimpleNamespace(origin=str(mapping[name]), name=name)
+        if packages and name in packages:
+            pkgdir = packages[name]
+            return types.SimpleNamespace(
+                origin=str(pkgdir / "__init__.py"),
+                submodule_search_locations=[str(pkgdir)],
+            )
         return real_find_spec(name)
 
     monkeypatch.setattr(ek.importlib.util, "find_spec", fake_find_spec)
@@ -99,6 +109,28 @@ def test_classifier_unresolvable_is_unknown(monkeypatch):
 def test_classifier_non_string_value_is_unknown():
     # An entry point whose value is a bare callable (not module:func) → unknown
     assert ek.classify_entrypoint(_FakeEntryPoint("c", object())) == "unknown"
+
+
+def test_classifier_thin_package_reexport_is_model_provider(monkeypatch, tmp_path):
+    """A package whose __init__ re-exports register from a submodule is a provider.
+
+    Regression for the triage finding: a thin ``__init__.py`` containing only
+    ``from .core import register`` has no provider markers itself, but the
+    ``register_provider(ProviderProfile(...))`` call lives in ``core.py``. It
+    must classify as model-provider (not standalone, which would silently
+    deregister a provider of the documented shape on main).
+    """
+    pkgdir = tmp_path / "thinpkg"
+    pkgdir.mkdir()
+    (pkgdir / "__init__.py").write_text("from .core import register\n")
+    (pkgdir / "core.py").write_text(
+        "from providers import register_provider, ProviderProfile\n"
+        "def register():\n"
+        "    register_provider(ProviderProfile(name='x'))\n"
+    )
+    _stub_find_spec(monkeypatch, {}, packages={"thinpkg": pkgdir})
+
+    assert ek.classify_entrypoint(_FakeEntryPoint("t", "thinpkg:register")) == "model-provider"
 
 
 # ── general manager side ────────────────────────────────────────────────

--- a/tests/hermes_cli/test_plugin_entrypoint_provider_kind.py
+++ b/tests/hermes_cli/test_plugin_entrypoint_provider_kind.py
@@ -1,0 +1,180 @@
+"""Regression tests for shared entry-point provider classification.
+
+The ``hermes_agent.plugins`` entry-point group has two consumers that must
+agree on ownership: the general PluginManager (hermes_cli.plugins) and the
+model-provider registry (providers). Both use the SAME classifier
+(hermes_cli.entrypoint_kind) so they can never drift:
+
+* a model provider (register_provider + ProviderProfile) → model-provider,
+  owned by the provider registry;
+* a memory provider (register_memory_provider / MemoryProvider) → exclusive,
+  owned by plugins/memory discovery;
+* a general plugin → standalone, owned by the PluginManager.
+
+Without classification, an enabled pip provider is double-loaded: the registry
+registers it correctly but the general manager also imports it as a standalone
+plugin and flags it errored (pr-85504 defect). Symmetrically, a general plugin
+with a zero-arg register() would be wrongly invoked by the provider registry
+as a model provider (the inverse bug this module also fixes).
+"""
+
+import types
+
+from hermes_cli import entrypoint_kind as ek
+from hermes_cli.plugins import PluginManager
+
+
+class _FakeEntryPoint:
+    """Minimal stand-in for importlib.metadata.EntryPoint."""
+
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+
+def _write_module(tmp_path, name, source):
+    mod = tmp_path / f"{name}.py"
+    mod.write_text(source)
+    return mod
+
+
+def _stub_find_spec(monkeypatch, mapping):
+    """Point importlib.util.find_spec at fixture files for given module names."""
+    real_find_spec = ek.importlib.util.find_spec
+
+    def fake_find_spec(name):
+        if name in mapping:
+            return types.SimpleNamespace(origin=str(mapping[name]), name=name)
+        return real_find_spec(name)
+
+    monkeypatch.setattr(ek.importlib.util, "find_spec", fake_find_spec)
+
+
+MODEL_SOURCE = (
+    "from providers import register_provider, ProviderProfile\n"
+    "def _register():\n"
+    "    register_provider(ProviderProfile(name='pip', type='model'))\n"
+    "_register()\n"
+)
+MEMORY_SOURCE = (
+    "def register_memory_provider(name, cls):\n"
+    "    pass\n"
+)
+GENERAL_SOURCE = (
+    "def register(ctx):\n"
+    "    ctx.add_tool(name='x', fn=lambda: 1)\n"
+)
+
+
+# ── shared classifier unit tests ─────────────────────────────────────────
+
+def test_classifier_model_provider(monkeypatch, tmp_path):
+    mod = _write_module(tmp_path, "pip_provider", MODEL_SOURCE)
+    _stub_find_spec(monkeypatch, {"pip_provider": mod})
+    assert ek.classify_entrypoint(_FakeEntryPoint("p", "pip_provider:register")) == "model-provider"
+    assert ek.kind_is_provider("model-provider") is True
+
+
+def test_classifier_memory_provider(monkeypatch, tmp_path):
+    mod = _write_module(tmp_path, "pip_memory", MEMORY_SOURCE)
+    _stub_find_spec(monkeypatch, {"pip_memory": mod})
+    assert ek.classify_entrypoint(_FakeEntryPoint("m", "pip_memory:register")) == "exclusive"
+    assert ek.kind_is_memory_provider("exclusive") is True
+
+
+def test_classifier_general_plugin(monkeypatch, tmp_path):
+    mod = _write_module(tmp_path, "pip_general", GENERAL_SOURCE)
+    _stub_find_spec(monkeypatch, {"pip_general": mod})
+    assert ek.classify_entrypoint(_FakeEntryPoint("g", "pip_general:register")) == "standalone"
+
+
+def test_classifier_unresolvable_is_unknown(monkeypatch):
+    def boom(name):
+        raise ImportError("nope")
+    monkeypatch.setattr(ek.importlib.util, "find_spec", boom)
+    # A module:func target whose source can't be read → unknown (not standalone)
+    assert ek.classify_entrypoint(_FakeEntryPoint("x", "missing_mod:register")) == "unknown"
+
+
+def test_classifier_non_string_value_is_unknown():
+    # An entry point whose value is a bare callable (not module:func) → unknown
+    assert ek.classify_entrypoint(_FakeEntryPoint("c", object())) == "unknown"
+
+
+# ── general manager side ────────────────────────────────────────────────
+
+def test_manager_entrypoint_model_provider_carried_into_manifest(monkeypatch, tmp_path):
+    """The manager tags a pip model-provider entry point as model-provider."""
+    mod = _write_module(tmp_path, "pip_provider", MODEL_SOURCE)
+    _stub_find_spec(monkeypatch, {"pip_provider": mod})
+
+    def fake_entry_points():
+        return types.SimpleNamespace(
+            select=lambda group: [_FakeEntryPoint("pip_provider", "pip_provider:register")]
+        )
+    monkeypatch.setattr(ek.importlib.metadata, "entry_points", fake_entry_points)
+    monkeypatch.setattr(PluginManager, "_collect_directory_manifests",
+                        lambda self: [])
+
+    mgr = PluginManager()
+    manifests = mgr._scan_entry_points()
+    assert len(manifests) == 1
+    assert manifests[0].kind == "model-provider"
+
+
+# ── provider registry side (the inverse bug) ────────────────────────────
+
+def test_provider_registry_skips_general_zero_arg_plugin(monkeypatch, tmp_path):
+    """A general plugin with a zero-arg register is NOT invoked as a provider."""
+    mod = _write_module(tmp_path, "pip_general", GENERAL_SOURCE)
+    _stub_find_spec(monkeypatch, {"pip_general": mod})
+
+    invoked = []
+
+    class FakeEP(_FakeEntryPoint):
+        def load(self):
+            invoked.append(self.name)
+            return lambda: None  # zero-arg callable would have been invoked pre-fix
+
+    def fake_entry_points():
+        return types.SimpleNamespace(
+            select=lambda group: [FakeEP("pip_general", "pip_general:register")]
+        )
+
+    import importlib.metadata as _md
+    import hermes_cli.plugins as plugins_mod
+    import providers
+    monkeypatch.setattr(_md, "entry_points", fake_entry_points)
+    monkeypatch.setattr(plugins_mod, "_get_enabled_plugins",
+                        lambda: {"pip_general"})
+
+    providers._discover_entry_point_providers()
+    assert invoked == []  # general plugin must not be invoked by the registry
+
+
+def test_provider_registry_loads_real_model_provider(monkeypatch, tmp_path):
+    """A real model-provider entry point IS still invoked (no regression)."""
+    mod = _write_module(tmp_path, "pip_provider", MODEL_SOURCE)
+    _stub_find_spec(monkeypatch, {"pip_provider": mod})
+
+    invoked = []
+
+    class FakeEP(_FakeEntryPoint):
+        def load(self):
+            invoked.append(self.name)
+            return lambda: None
+
+    def fake_entry_points():
+        return types.SimpleNamespace(
+            select=lambda group: [FakeEP("pip_provider", "pip_provider:register")]
+        )
+
+    import importlib.metadata as _md
+    import hermes_cli.plugins as plugins_mod
+    import providers
+    monkeypatch.setattr(_md, "entry_points", fake_entry_points)
+    monkeypatch.setattr(plugins_mod, "_get_enabled_plugins",
+                        lambda: {"pip_provider"})
+
+    providers._discover_entry_point_providers()
+    assert invoked == ["pip_provider"]  # provider still loaded


### PR DESCRIPTION
## What & why

The `hermes_agent.plugins` entry-point group has two consumers that must agree on who owns each entry point: the general PluginManager and the model-provider registry. Two independent heuristics (manager source-kind inference, registry callable-arity check) could drift, causing:

1. **Double-load**: an enabled pip model-provider was loaded by the registry AND imported again by the general manager as a standalone plugin and flagged errored — entry-point manifests never carry `kind`, so the model-provider skip never fired.
2. **Inverse double-load**: a general plugin with a zero-arg `register()` was wrongly invoked by the provider registry as a model provider, and a pip memory-provider was invoked as a MODEL provider (wrong discovery system).

## What changed

- **New `hermes_cli/entrypoint_kind.py`** — one source-heuristic classifier (`standalone` / `exclusive` / `model-provider` / `unknown`) that reads an entry-point module's source WITHOUT importing it (a pip provider pulling in onnxruntime costs ~60MB RSS on every startup).
- **PluginManager** uses it: model-provider and memory-provider (exclusive) entry points are skipped instead of double-loaded.
- **Provider registry** uses it: general plugins and memory providers are no longer wrongly invoked as model providers. `unknown` falls through to the historical arity check so a real provider is never dropped just because its source could not be read.

## Relationship to #76567

#76567 fixes the general-manager half of this bug class (classifying entry points so the PluginManager does not import pip providers). This PR is complementary: it additionally closes the **provider-registry half** — the inverse double-load where the registry wrongly invokes general/memory plugins as model providers — and unifies both consumers on a single shared classifier (`hermes_cli/entrypoint_kind.py`) so the two sides cannot drift. Both are needed to fully close the shared-group ownership bug.

## Verification

- New regression tests cover: model-provider, memory-provider, general-plugin classification; the manager carrying kind into manifests; and the provider registry skipping a general zero-arg plugin while still loading a real model-provider.
- Full plugin + provider suites pass (482 tests), no regressions.
- No entry-point module is imported during classification.