### PR TITLE
fix: forward include_disabled through cron.manage list

### DIFF
--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1633,7 +1633,17 @@ def _(rid, params: dict) -> dict:
         from tools.cronjob_tools import cronjob
 
         if action == "list":
-            return _ok(rid, json.loads(cronjob(action="list")))
+            # Paused jobs are excluded by default, which reads as deletion in
+            # any UI with an enable/disable toggle — forward the flag.
+            return _ok(
+                rid,
+                json.loads(
+                    cronjob(
+                        action="list",
+                        include_disabled=is_truthy_value(params.get("include_disabled", False)),
+                    )
+                ),
+            )
         if action == "add":
             return _ok(
                 rid,


### PR DESCRIPTION
## What

User report against the Hermes-Bot-Mode routines pane: toggling a routine off made it vanish from the list — pause read as silent deletion, making the separate delete affordance look redundant.

Root cause is in the ws layer: `cron.manage`'s list branch calls `cronjob(action="list")` bare, and the tool's `include_disabled` defaults to `False`, so paused jobs are dropped from every refresh. The handler accepted no way to ask for them. Forward `include_disabled` from params (default unchanged).

## Verification

Live registry round-trip: created a probe job, paused it via the RPC — invisible in `{action: list}` (the reported bug), visible with `state: paused` in `{action: list, include_disabled: true}`; removed the probe and confirmed clean list after.

Consumer: the Bot Mode routines pane lists with the flag so paused routines stay visible with their toggle off.