### PR TITLE
fix(usage): cost display honesty — sub-cent labels, cost buckets, included notes

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -1000,6 +1000,29 @@ class InsightsEngine:
         lines.append(f"  Avg msgs/session:  {o['avg_messages_per_session']:.1f}")
         lines.append("")
 
+        # Cost breakdown — surface the three buckets so subscription-included
+        # and unknown-cost sessions are visible instead of silently collapsing
+        # to $0. See #77223.
+        est_cost = o.get("estimated_cost", 0.0)
+        included_sessions = o.get("included_cost_sessions", 0)
+        unknown_sessions = o.get("unknown_cost_sessions", 0)
+        if est_cost > 0 or included_sessions > 0 or unknown_sessions > 0:
+            lines.append("  💰 Cost")
+            lines.append("  " + "─" * 56)
+            if est_cost > 0:
+                lines.append(f"  Estimated:         ~${est_cost:.2f}")
+            if included_sessions > 0:
+                lines.append(
+                    f"  Included:           {included_sessions} session(s) "
+                    f"(subscription — no provider invoice)"
+                )
+            if unknown_sessions > 0:
+                lines.append(
+                    f"  Unknown:            {unknown_sessions} session(s) "
+                    f"(no pricing data)"
+                )
+            lines.append("")
+
         # Model breakdown
         if report["models"]:
             lines.append("  🤖 Models Used")
@@ -1113,6 +1136,21 @@ class InsightsEngine:
         if o["total_hours"] > 0:
             lines.append(f"**Active time:** ~{format_duration_compact(o['total_hours'] * 3600)} | **Avg session:** ~{format_duration_compact(o['avg_session_duration'])}")
         lines.append("")
+
+        # Cost breakdown — surface buckets so included/unknown are visible
+        est_cost = o.get("estimated_cost", 0.0)
+        included = o.get("included_cost_sessions", 0)
+        unknown = o.get("unknown_cost_sessions", 0)
+        cost_parts: list[str] = []
+        if est_cost > 0:
+            cost_parts.append(f"~${est_cost:.2f} estimated")
+        if included > 0:
+            cost_parts.append(f"{included} included (subscription)")
+        if unknown > 0:
+            cost_parts.append(f"{unknown} unknown")
+        if cost_parts:
+            lines.append(f"**Cost:** {' | '.join(cost_parts)}")
+            lines.append("")
 
         # Models (top 5)
         if report["models"]:

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -1022,7 +1022,7 @@ class InsightsEngine:
             lines.append("  💰 Cost")
             lines.append("  " + "─" * 56)
             if est_cost > 0:
-                lines.append(f"  Estimated:         {_fmt_est_cost(est_cost)}")
+                lines.append(f"  Estimated:          {_fmt_est_cost(est_cost)}")
             if included_sessions > 0:
                 lines.append(
                     f"  Included:           {included_sessions} session(s) "

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -21,14 +21,26 @@ import sqlite3
 import time
 from collections import Counter, defaultdict
 from datetime import datetime
+from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
 from agent.usage_pricing import (
     CanonicalUsage,
     estimate_usage_cost,
+    format_cost_label,
     format_duration_compact,
     has_known_pricing,
 )
+
+
+def _fmt_est_cost(est_cost: float) -> str:
+    """Format an aggregate estimated cost via the shared cost-label helper.
+
+    Routes through ``format_cost_label`` so sub-cent aggregates render at
+    4dp instead of collapsing to "~$0.00" (#79220 bug class — the same
+    dishonesty this module's cost buckets exist to fix, #77223).
+    """
+    return format_cost_label(Decimal(str(est_cost)))
 
 
 
@@ -1010,7 +1022,7 @@ class InsightsEngine:
             lines.append("  💰 Cost")
             lines.append("  " + "─" * 56)
             if est_cost > 0:
-                lines.append(f"  Estimated:         ~${est_cost:.2f}")
+                lines.append(f"  Estimated:         {_fmt_est_cost(est_cost)}")
             if included_sessions > 0:
                 lines.append(
                     f"  Included:           {included_sessions} session(s) "
@@ -1143,7 +1155,7 @@ class InsightsEngine:
         unknown = o.get("unknown_cost_sessions", 0)
         cost_parts: list[str] = []
         if est_cost > 0:
-            cost_parts.append(f"~${est_cost:.2f} estimated")
+            cost_parts.append(f"{_fmt_est_cost(est_cost)} estimated")
         if included > 0:
             cost_parts.append(f"{included} included (subscription)")
         if unknown > 0:

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -23,22 +23,30 @@ _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 _SUBCENT_THRESHOLD = Decimal("0.01")
 
 
-def _format_cost_label(amount: Decimal) -> str:
+def format_cost_label(amount: Decimal) -> str:
     """Format a cost amount as a display label.
 
     Scales precision to magnitude:
     - Zero → "$0.00"
-    - Sub-cent (< $0.01) → "~$0.0046" (4 dp, always non-zero)
+    - Sub-cent (< $0.01) → "~$0.0046" (4 dp; below $0.00005 falls back
+      to "~$<0.0001" so the label never reads as zero)
     - Normal → "~$1.23" (2 dp)
 
     This fixes #79220 where sub-cent per-turn costs on cheap models
     (DeepSeek, etc.) rendered as "$0.00" despite amount_usd carrying
     full Decimal precision.
+
+    Shared by per-response cost labels (estimate_usage_cost) and the
+    insights cost-bucket formatters — keep both surfaces on this one
+    implementation so sub-cent honesty can't regress on one of them.
     """
     if amount == _ZERO:
         return "$0.00"
     if amount < _SUBCENT_THRESHOLD:
-        return f"~${amount:.4f}"
+        label = f"~${amount:.4f}"
+        # 4dp truncation of a positive amount below $0.00005 would render
+        # "~$0.0000" — a zero-looking label, the exact #79220 dishonesty.
+        return label if label != "~$0.0000" else "~$<0.0001"
     return f"~${amount:.2f}"
 
 CostStatus = Literal["actual", "estimated", "included", "unknown"]
@@ -1402,7 +1410,7 @@ def estimate_usage_cost(
         amount += Decimal(usage.request_count) * entry.request_cost
 
     status: CostStatus = "estimated"
-    label = _format_cost_label(amount)
+    label = format_cost_label(amount)
     if entry.source == "none" and amount == _ZERO:
         status = "included"
         label = "included"

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -22,14 +22,20 @@ _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 # the display is non-zero (e.g. $0.0046 instead of $0.00). See #79220.
 _SUBCENT_THRESHOLD = Decimal("0.01")
 
+# Attached to every CostResult with status="included" so consumers can
+# distinguish "free because subscription" from "free because $0 pricing".
+_INCLUDED_NOTE = "subscription-included; no provider invoice for usage"
+
 
 def format_cost_label(amount: Decimal) -> str:
     """Format a cost amount as a display label.
 
     Scales precision to magnitude:
     - Zero → "$0.00"
-    - Sub-cent (< $0.01) → "~$0.0046" (4 dp; below $0.00005 falls back
-      to "~$<0.0001" so the label never reads as zero)
+    - Sub-cent (< $0.01) → "~$0.0046" (4 dp; amounts that ROUND to
+      0.0000 at 4 dp — i.e. at or below $0.00005 under banker's
+      rounding — fall back to "~$<0.0001" so the label never reads
+      as zero)
     - Normal → "~$1.23" (2 dp)
 
     This fixes #79220 where sub-cent per-turn costs on cheap models
@@ -44,8 +50,11 @@ def format_cost_label(amount: Decimal) -> str:
         return "$0.00"
     if amount < _SUBCENT_THRESHOLD:
         label = f"~${amount:.4f}"
-        # 4dp truncation of a positive amount below $0.00005 would render
+        # A positive amount that rounds to 0.0000 at 4 dp would render
         # "~$0.0000" — a zero-looking label, the exact #79220 dishonesty.
+        # Comparing the rendered label checks the truth directly (a naive
+        # `< 0.00005` threshold misses the exact boundary under
+        # ROUND_HALF_EVEN).
         return label if label != "~$0.0000" else "~$<0.0001"
     return f"~${amount:.2f}"
 
@@ -1365,7 +1374,7 @@ def estimate_usage_cost(
             source="none",
             label="included",
             pricing_version="included-route",
-            notes=("subscription-included; no provider invoice for usage",),
+            notes=(_INCLUDED_NOTE,),
         )
 
     entry = get_pricing_entry(model_name, provider=provider, base_url=base_url, api_key=api_key)
@@ -1414,6 +1423,7 @@ def estimate_usage_cost(
     if entry.source == "none" and amount == _ZERO:
         status = "included"
         label = "included"
+        notes.append(_INCLUDED_NOTE)
 
     if route.provider == "openrouter":
         notes.append("OpenRouter cost is estimated from the models API until reconciled.")

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -18,6 +18,29 @@ _ZERO = Decimal("0")
 _ONE_MILLION = Decimal("1000000")
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 
+# Sub-cent cost threshold: below $0.01, render at 4 decimal places so
+# the display is non-zero (e.g. $0.0046 instead of $0.00). See #79220.
+_SUBCENT_THRESHOLD = Decimal("0.01")
+
+
+def _format_cost_label(amount: Decimal) -> str:
+    """Format a cost amount as a display label.
+
+    Scales precision to magnitude:
+    - Zero → "$0.00"
+    - Sub-cent (< $0.01) → "~$0.0046" (4 dp, always non-zero)
+    - Normal → "~$1.23" (2 dp)
+
+    This fixes #79220 where sub-cent per-turn costs on cheap models
+    (DeepSeek, etc.) rendered as "$0.00" despite amount_usd carrying
+    full Decimal precision.
+    """
+    if amount == _ZERO:
+        return "$0.00"
+    if amount < _SUBCENT_THRESHOLD:
+        return f"~${amount:.4f}"
+    return f"~${amount:.2f}"
+
 CostStatus = Literal["actual", "estimated", "included", "unknown"]
 CostSource = Literal[
     "provider_cost_api",
@@ -1334,6 +1357,7 @@ def estimate_usage_cost(
             source="none",
             label="included",
             pricing_version="included-route",
+            notes=("subscription-included; no provider invoice for usage",),
         )
 
     entry = get_pricing_entry(model_name, provider=provider, base_url=base_url, api_key=api_key)
@@ -1378,7 +1402,7 @@ def estimate_usage_cost(
         amount += Decimal(usage.request_count) * entry.request_cost
 
     status: CostStatus = "estimated"
-    label = f"~${amount:.2f}"
+    label = _format_cost_label(amount)
     if entry.source == "none" and amount == _ZERO:
         status = "included"
         label = "included"

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -545,8 +545,8 @@ class TestTerminalFormatting:
 
 
 
-    def test_terminal_format_hides_cost_for_custom_models(self, db):
-        """Cost display is hidden entirely — custom models no longer show 'N/A' either."""
+    def test_terminal_format_unknown_bucket_for_custom_models(self, db):
+        """Custom models with no pricing surface as the Unknown bucket (#77223)."""
         db.create_session(session_id="s1", source="cli", model="my-custom-model")
         db.update_token_counts("s1", input_tokens=1000, output_tokens=500)
         db._conn.commit()
@@ -557,9 +557,11 @@ class TestTerminalFormatting:
 
         assert "N/A" not in text
         assert "custom/self-hosted" not in text
-        # Cost section now surfaces unknown-cost sessions (#77223) instead
-        # of hiding them — a custom model with no pricing data should show
-        # "Unknown: 1 session(s)" rather than silently reporting $0.
+        # Cost section surfaces unknown-cost sessions (#77223) instead of
+        # hiding them — a custom model with no pricing data shows in the
+        # Unknown bucket rather than silently reporting $0.
+        assert "Unknown" in text
+        assert "no pricing data" in text
 
 
 class TestGatewayFormatting:
@@ -572,7 +574,7 @@ class TestGatewayFormatting:
         assert len(gateway_text) < len(terminal_text)
 
 
-    def test_gateway_format_hides_cost(self, populated_db):
+    def test_gateway_format_hides_cache_details(self, populated_db):
         """Gateway format omits internal cache details.
 
         Dollar figures now appear when there are estimated/included/unknown
@@ -705,6 +707,30 @@ class TestEdgeCases:
         assert "included" in text.lower()
         assert "subscription" in text.lower()
 
+    def test_sub_cent_aggregate_estimated_cost_not_zero(self, db):
+        """A sub-cent aggregate must not render 'Estimated: ~$0.00' (#79220).
+
+        The insights formatters share format_cost_label with per-response
+        labels; a cheap-model period totaling $0.0046 shows 4dp, not $0.00.
+        """
+        db.create_session(session_id="est", source="cli", model="model-a")
+        db.update_token_counts(
+            "est", input_tokens=100, model="model-a",
+            billing_provider="custom",
+            estimated_cost_usd=0.0046, actual_cost_usd=0.0,
+            cost_status="estimated", cost_source="provider", api_call_count=1,
+        )
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        terminal_text = engine.format_terminal(report)
+        gateway_text = engine.format_gateway(report)
+
+        assert "~$0.00\n" not in terminal_text
+        assert "~$0.0046" in terminal_text
+        assert "~$0.00 estimated" not in gateway_text
+        assert "~$0.0046 estimated" in gateway_text
+
     def test_cost_buckets_displayed_in_gateway_format(self, db):
         """#77223: included/estimated/unknown cost buckets surface in gateway."""
         db.create_session(session_id="est", source="cli", model="model-a")
@@ -730,7 +756,7 @@ class TestEdgeCases:
         assert "~$2.25" in text
         assert "included" in text.lower()
 
-    def test_no_cost_section_when_all_zero(self, db):
+    def test_unknown_bucket_shown_for_costless_session(self, db):
         """A session with no model still shows unknown cost bucket (#77223).
 
         The unknown bucket is surfaced so users can see they have sessions

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -557,7 +557,9 @@ class TestTerminalFormatting:
 
         assert "N/A" not in text
         assert "custom/self-hosted" not in text
-        assert "Cost" not in text
+        # Cost section now surfaces unknown-cost sessions (#77223) instead
+        # of hiding them — a custom model with no pricing data should show
+        # "Unknown: 1 session(s)" rather than silently reporting $0.
 
 
 class TestGatewayFormatting:
@@ -571,12 +573,16 @@ class TestGatewayFormatting:
 
 
     def test_gateway_format_hides_cost(self, populated_db):
-        """Gateway format omits dollar figures and internal cache details."""
+        """Gateway format omits internal cache details.
+
+        Dollar figures now appear when there are estimated/included/unknown
+        cost buckets (#77223) — the old assertion that '$' is absent is no
+        longer correct because surfacing cost buckets is the fix.
+        """
         engine = InsightsEngine(populated_db)
         report = engine.generate(days=30)
         text = engine.format_gateway(report)
 
-        assert "$" not in text
         assert "cache" not in text.lower()
 
 
@@ -668,5 +674,76 @@ class TestEdgeCases:
         text = engine.format_terminal(report)
         # (it still shows platforms section if there's only cli and nothing else)
         # Actually the condition is > 1 platforms OR non-cli, so single cli won't show
+
+
+    def test_cost_buckets_displayed_in_terminal_format(self, db):
+        """#77223: included/estimated/unknown cost buckets surface in terminal."""
+        # Estimated cost session
+        db.create_session(session_id="est", source="cli", model="model-a")
+        db.update_token_counts(
+            "est", input_tokens=100, model="model-a",
+            billing_provider="custom",
+            estimated_cost_usd=1.50, actual_cost_usd=1.0,
+            cost_status="estimated", cost_source="provider", api_call_count=1,
+        )
+        # Included cost session (subscription)
+        db.create_session(session_id="inc", source="cli", model="gpt-5.4-mini")
+        db.update_token_counts(
+            "inc", input_tokens=200, model="gpt-5.4-mini",
+            billing_provider="openai-codex",
+            estimated_cost_usd=0.0, actual_cost_usd=0.0,
+            cost_status="included", cost_source="none", api_call_count=1,
+        )
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        text = engine.format_terminal(report)
+
+        # The cost section should appear with all three buckets
+        assert "💰 Cost" in text
+        assert "~$1.50" in text  # estimated
+        assert "included" in text.lower()
+        assert "subscription" in text.lower()
+
+    def test_cost_buckets_displayed_in_gateway_format(self, db):
+        """#77223: included/estimated/unknown cost buckets surface in gateway."""
+        db.create_session(session_id="est", source="cli", model="model-a")
+        db.update_token_counts(
+            "est", input_tokens=100, model="model-a",
+            billing_provider="custom",
+            estimated_cost_usd=2.25, actual_cost_usd=0.0,
+            cost_status="estimated", cost_source="provider", api_call_count=1,
+        )
+        db.create_session(session_id="inc", source="cli", model="gpt-5.4-mini")
+        db.update_token_counts(
+            "inc", input_tokens=200, model="gpt-5.4-mini",
+            billing_provider="openai-codex",
+            estimated_cost_usd=0.0, actual_cost_usd=0.0,
+            cost_status="included", cost_source="none", api_call_count=1,
+        )
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        text = engine.format_gateway(report)
+
+        assert "**Cost:**" in text
+        assert "~$2.25" in text
+        assert "included" in text.lower()
+
+    def test_no_cost_section_when_all_zero(self, db):
+        """A session with no model still shows unknown cost bucket (#77223).
+
+        The unknown bucket is surfaced so users can see they have sessions
+        with no pricing data, rather than silently reporting $0.
+        """
+        db.create_session(session_id="s1", source="cli", model="test")
+        db._conn.commit()
+
+        engine = InsightsEngine(db)
+        report = engine.generate(days=30)
+        text = engine.format_terminal(report)
+        # The session has no cost data, so it falls in the "unknown" bucket.
+        assert "💰 Cost" in text
+        assert "Unknown" in text
 
 

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -701,7 +701,8 @@ class TestEdgeCases:
         report = engine.generate(days=30)
         text = engine.format_terminal(report)
 
-        # The cost section should appear with all three buckets
+        # The cost section should appear with the buckets this DB has
+        # (estimated + included; no unknown-cost session is created here)
         assert "💰 Cost" in text
         assert "~$1.50" in text  # estimated
         assert "included" in text.lower()

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -2,11 +2,13 @@ from types import SimpleNamespace
 
 from agent.usage_pricing import (
     CanonicalUsage,
+    _format_cost_label,
     estimate_usage_cost,
     get_pricing_entry,
     normalize_usage,
     resolve_billing_route,
 )
+from decimal import Decimal
 
 
 
@@ -370,3 +372,77 @@ def test_normalize_usage_native_anthropic_no_cache_observability(caplog):
     assert result.input_tokens == 100
     assert result.cache_read_tokens == 50
     assert result.cache_write_tokens == 10
+
+
+# ---------------------------------------------------------------------------
+# Cost label formatting (#79220: sub-cent costs render as $0.00)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCostLabel:
+    """Tests for magnitude-scaled cost label formatting."""
+
+    def test_zero_renders_as_dollar_zero(self):
+        assert _format_cost_label(Decimal("0")) == "$0.00"
+
+    def test_sub_cent_renders_4dp(self):
+        """Costs below $0.01 render at 4 decimal places (#79220)."""
+        label = _format_cost_label(Decimal("0.004640"))
+        assert label == "~$0.0046"
+        # Must NOT be $0.00
+        assert "$0.00" != label
+
+    def test_exactly_one_cent_renders_2dp(self):
+        """$0.01 renders at 2dp."""
+        assert _format_cost_label(Decimal("0.01")) == "~$0.01"
+
+    def test_normal_cost_renders_2dp(self):
+        assert _format_cost_label(Decimal("1.23")) == "~$1.23"
+
+    def test_large_cost_renders_2dp(self):
+        assert _format_cost_label(Decimal("42.50")) == "~$42.50"
+
+    def test_very_small_sub_cent(self):
+        """Even very small costs render non-zero."""
+        label = _format_cost_label(Decimal("0.0001"))
+        assert label == "~$0.0001"
+        assert label != "$0.00"
+
+    def test_sub_cent_deepseek_scenario(self):
+        """Reproduce the #79220 reproduction: DeepSeek at $0.004640."""
+        # DeepSeek V4 Pro: 8K input + 1.2K output + 32K cache read
+        # = $0.004640 per turn
+        amount = Decimal("0.004640")
+        label = _format_cost_label(amount)
+        assert "0.0046" in label
+        assert label != "$0.00"
+        assert label != "~$0.00"
+
+
+# ---------------------------------------------------------------------------
+# Subscription-included cost notes
+# ---------------------------------------------------------------------------
+
+
+class TestSubscriptionIncludedNotes:
+    """Subscription-included costs should carry a note clarifying no invoice."""
+
+    def test_included_cost_has_note(self):
+        """estimate_usage_cost for subscription-included route includes a note."""
+        # openai-codex is subscription_included
+        usage = CanonicalUsage(
+            input_tokens=1000,
+            output_tokens=500,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+            reasoning_tokens=0,
+        )
+        result = estimate_usage_cost(
+            "gpt-5.4-mini",
+            usage,
+            provider="openai-codex",
+        )
+        assert result.status == "included"
+        assert result.amount_usd == Decimal("0")
+        assert len(result.notes) > 0
+        assert any("subscription" in note.lower() for note in result.notes)

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 from agent.usage_pricing import (
     CanonicalUsage,
-    _format_cost_label,
+    format_cost_label,
     estimate_usage_cost,
     get_pricing_entry,
     normalize_usage,
@@ -383,37 +383,47 @@ class TestFormatCostLabel:
     """Tests for magnitude-scaled cost label formatting."""
 
     def test_zero_renders_as_dollar_zero(self):
-        assert _format_cost_label(Decimal("0")) == "$0.00"
+        assert format_cost_label(Decimal("0")) == "$0.00"
 
     def test_sub_cent_renders_4dp(self):
         """Costs below $0.01 render at 4 decimal places (#79220)."""
-        label = _format_cost_label(Decimal("0.004640"))
+        label = format_cost_label(Decimal("0.004640"))
         assert label == "~$0.0046"
         # Must NOT be $0.00
         assert "$0.00" != label
 
     def test_exactly_one_cent_renders_2dp(self):
         """$0.01 renders at 2dp."""
-        assert _format_cost_label(Decimal("0.01")) == "~$0.01"
+        assert format_cost_label(Decimal("0.01")) == "~$0.01"
 
     def test_normal_cost_renders_2dp(self):
-        assert _format_cost_label(Decimal("1.23")) == "~$1.23"
+        assert format_cost_label(Decimal("1.23")) == "~$1.23"
 
     def test_large_cost_renders_2dp(self):
-        assert _format_cost_label(Decimal("42.50")) == "~$42.50"
+        assert format_cost_label(Decimal("42.50")) == "~$42.50"
 
     def test_very_small_sub_cent(self):
         """Even very small costs render non-zero."""
-        label = _format_cost_label(Decimal("0.0001"))
+        label = format_cost_label(Decimal("0.0001"))
         assert label == "~$0.0001"
         assert label != "$0.00"
+
+    def test_below_4dp_floor_never_reads_zero(self):
+        """Amounts below $0.00005 must not render as '~$0.0000' (#79220).
+
+        4dp truncation of a positive amount would produce a zero-looking
+        label — the exact dishonesty the formatter exists to fix.
+        """
+        label = format_cost_label(Decimal("0.00004"))
+        assert label == "~$<0.0001"
+        assert "0.0000" not in label.replace("<0.0001", "")
 
     def test_sub_cent_deepseek_scenario(self):
         """Reproduce the #79220 reproduction: DeepSeek at $0.004640."""
         # DeepSeek V4 Pro: 8K input + 1.2K output + 32K cache read
         # = $0.004640 per turn
         amount = Decimal("0.004640")
-        label = _format_cost_label(amount)
+        label = format_cost_label(amount)
         assert "0.0046" in label
         assert label != "$0.00"
         assert label != "~$0.00"

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -416,7 +416,9 @@ class TestFormatCostLabel:
         """
         label = format_cost_label(Decimal("0.00004"))
         assert label == "~$<0.0001"
-        assert "0.0000" not in label.replace("<0.0001", "")
+        # Exact boundary: $0.00005 rounds to 0.0000 under ROUND_HALF_EVEN
+        # and must also take the fallback.
+        assert format_cost_label(Decimal("0.00005")) == "~$<0.0001"
 
     def test_sub_cent_deepseek_scenario(self):
         """Reproduce the #79220 reproduction: DeepSeek at $0.004640."""


### PR DESCRIPTION
## Summary

Three cost-display honesty fixes. Small, cheap, kills a real confusion class.

### 1. Sub-cent cost label rendering (#79220)

**Problem:** cost labels formatted at 2 decimal places, so for models priced under ~$1/Mtok (DeepSeek, etc.) a normal turn costing $0.004640 rendered `~$0.00` despite `amount_usd` carrying full Decimal precision.

**Fix:** `format_cost_label(amount)` scales precision to magnitude:
- Zero → `$0.00`
- Sub-cent (< $0.01) → `~$0.0046` (4 dp)
- Below $0.00005 → `~$<0.0001` (never a zero-looking 4dp truncation)
- Normal → `~$1.23` (2 dp, unchanged)

Shared by per-response labels (`estimate_usage_cost`) AND the insights aggregate formatters, so sub-cent honesty can't regress on one surface while fixed on the other.

### 2. Cost bucket surfacing in insights (#77223)

**Problem:** aggregate cost views summed `estimated_cost_usd` and reported a single number. Sessions with `cost_status = 'included'` (subscription-included providers like openai-codex) contribute zero — correct per-session, but invisible in the overview. In the reporter's DB, 315 of 473 sessions were `included` and didn't show at all.

**Fix:** both formatters now display three buckets:

```
  💰 Cost
  ────────────────────────────────────────────────────────
  Estimated:         ~$3.75
  Included:           315 session(s) (subscription — no provider invoice)
  Unknown:            3 session(s) (no pricing data)
```

Gateway: `**Cost:** ~$3.75 estimated | 315 included (subscription) | 3 unknown`

### 3. Subscription-included cost notes

`estimate_usage_cost` attaches a `"subscription-included; no provider invoice for usage"` note to `CostResult` for subscription-included routes, so consumers can distinguish "free because subscription" from "free because $0 pricing".

## Validation

| Check | Result |
|---|---|
| tests/agent/test_usage_pricing.py + test_insights.py | 62 passed / 0 failed |
| E2E probe: sub-cent label via real `estimate_usage_cost` route | PASS (`~$0.0046` observed) |
| E2E probe: all 7 `estimate_usage_cost` callers tolerate the note | PASS (none parse `.label`) |
| E2E probe: repo-wide grep for 2dp-label consumers | PASS (no hits — nothing breaks on 4dp) |
| Mutation check: reverting the formatter routing makes the sub-cent aggregate guard fail | PASS |
| ruff | clean |

Fixes #79220
Fixes #77223
