### PR TITLE
feat(tui): clear scrollback without ending the session

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -54,6 +54,7 @@ class CommandDef:
     args_hint: str = ""                # argument placeholder: "<prompt>", "[name]"
     subcommands: tuple[str, ...] = ()  # tab-completable subcommands
     cli_only: bool = False             # only available in CLI
+    tui_only: bool = False             # only available in the Ink TUI
     gateway_only: bool = False         # only available in gateway/messaging
     gateway_config_gate: str | None = None  # config dotpath; when truthy, overrides cli_only for gateway
     # Mid-run (agent busy) gateway behavior.  Drives the Guard-2 dispatcher
@@ -111,7 +112,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("clear", "Clear screen and start a new session", "Session",
                cli_only=True),
     CommandDef("cls", "Clear visible TUI scrollback without ending the session", "Session",
-               cli_only=True),
+               cli_only=True, tui_only=True),
     CommandDef("redraw", "Force a full UI repaint (recovers from terminal drift)", "Session",
                cli_only=True),
     CommandDef("history", "Show conversation history", "Session",
@@ -382,7 +383,7 @@ def _build_description(cmd: CommandDef) -> str:
 # Backwards-compatible flat dict: "/command" -> description
 COMMANDS: dict[str, str] = {}
 for _cmd in COMMAND_REGISTRY:
-    if not _cmd.gateway_only:
+    if not _cmd.gateway_only and not _cmd.tui_only:
         COMMANDS[f"/{_cmd.name}"] = _build_description(_cmd)
         for _alias in _cmd.aliases:
             COMMANDS[f"/{_alias}"] = f"{_cmd.description} (alias for /{_cmd.name})"
@@ -390,7 +391,7 @@ for _cmd in COMMAND_REGISTRY:
 # Backwards-compatible categorized dict
 COMMANDS_BY_CATEGORY: dict[str, dict[str, str]] = {}
 for _cmd in COMMAND_REGISTRY:
-    if not _cmd.gateway_only:
+    if not _cmd.gateway_only and not _cmd.tui_only:
         _cat = COMMANDS_BY_CATEGORY.setdefault(_cmd.category, {})
         _cat[f"/{_cmd.name}"] = COMMANDS[f"/{_cmd.name}"]
         for _alias in _cmd.aliases:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -110,6 +110,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, args_hint="[off|help|session-id]"),
     CommandDef("clear", "Clear screen and start a new session", "Session",
                cli_only=True),
+    CommandDef("cls", "Clear visible TUI scrollback without ending the session", "Session",
+               cli_only=True),
     CommandDef("redraw", "Force a full UI repaint (recovers from terminal drift)", "Session",
                cli_only=True),
     CommandDef("history", "Show conversation history", "Session",

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -108,8 +108,14 @@ class TestDerivedDicts:
         assert "/reload_mcp" in COMMANDS
         assert "/gateway" in COMMANDS
 
+    def test_commands_dict_excludes_tui_only_commands(self):
+        assert resolve_command("cls").tui_only
+        assert "/cls" not in COMMANDS
+
     def test_commands_by_category_covers_all_categories(self):
-        registry_categories = {cmd.category for cmd in COMMAND_REGISTRY if not cmd.gateway_only}
+        registry_categories = {
+            cmd.category for cmd in COMMAND_REGISTRY if not cmd.gateway_only and not cmd.tui_only
+        }
         assert set(COMMANDS_BY_CATEGORY.keys()) == registry_categories
 
 

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -99,6 +99,22 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.sys).toHaveBeenCalledWith('ui redrawn')
   })
 
+  it('clears visible scrollback without changing the active session', async () => {
+    patchUiState({ sid: 'sid-abc' })
+    const ctx = buildCtx()
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    expect(createSlashHandler(ctx)('/cls')).toBe(true)
+    expect(ctx.transcript.setHistoryItems).toHaveBeenCalledWith([])
+    expect(ctx.session.newSession).not.toHaveBeenCalled()
+    expect(ctx.session.resetVisibleHistory).not.toHaveBeenCalled()
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+    expect(getUiState().sid).toBe('sid-abc')
+
+    await Promise.resolve()
+    expect(write).toHaveBeenCalledWith(expect.stringContaining('\u001B[3J'))
+  })
+
   it('opens the editor locally for /prompt without slash worker fallback', () => {
     const ctx = buildCtx()
 

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -115,6 +115,18 @@ describe('createSlashHandler', () => {
     expect(write).toHaveBeenCalledWith(expect.stringContaining('\u001B[3J'))
   })
 
+  it('keeps live turn output visible instead of claiming to clear it', () => {
+    patchUiState({ busy: true, sid: 'sid-abc' })
+    const ctx = buildCtx()
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    expect(createSlashHandler(ctx)('/cls')).toBe(true)
+    expect(ctx.transcript.setHistoryItems).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('cannot clear scrollback while a turn is running')
+    expect(write).not.toHaveBeenCalled()
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
   it('opens the editor locally for /prompt without slash worker fallback', () => {
     const ctx = buildCtx()
 

--- a/ui-tui/src/__tests__/slashParity.test.ts
+++ b/ui-tui/src/__tests__/slashParity.test.ts
@@ -21,6 +21,7 @@ const MUTATING_COMMANDS = [
   'browser',
   'busy',
   'clear',
+  'cls',
   'compress',
   'fast',
   'model',

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -221,6 +221,10 @@ export const coreCommands: SlashCommand[] = [
     help: 'clear visible scrollback without ending the session',
     name: 'cls',
     run: (_arg, ctx) => {
+      if (ctx.ui.busy) {
+        return ctx.transcript.sys('cannot clear scrollback while a turn is running')
+      }
+
       ctx.transcript.setHistoryItems([])
       queueMicrotask(() => {
         process.stdout.write(CLEAR_SCREEN_AND_SCROLLBACK)

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -75,6 +75,7 @@ const mouseModeFromArg = (arg: string, current: MouseTrackingMode): MouseTrackin
 
 const RESET_WORDS = new Set(['reset', 'clear', 'default'])
 const CYCLE_WORDS = new Set(['cycle', 'toggle'])
+const CLEAR_SCREEN_AND_SCROLLBACK = '\u001B[2J\u001B[3J\u001B[H'
 
 const DETAILS_USAGE =
   'usage: /details [hidden|collapsed|expanded|cycle]  or  /details <section> [hidden|collapsed|expanded|reset]'
@@ -212,6 +213,18 @@ export const coreCommands: SlashCommand[] = [
           onConfirm: commit,
           title: isNew ? 'Start a new session?' : 'Clear the current session?'
         }
+      })
+    }
+  },
+
+  {
+    help: 'clear visible scrollback without ending the session',
+    name: 'cls',
+    run: (_arg, ctx) => {
+      ctx.transcript.setHistoryItems([])
+      queueMicrotask(() => {
+        process.stdout.write(CLEAR_SCREEN_AND_SCROLLBACK)
+        forceRedraw(process.stdout)
       })
     }
   },


### PR DESCRIPTION
## What does this PR do?

Adds a TUI-local `/cls` command that clears the visible transcript and terminal scrollback without starting a new session or discarding backend conversation context. This gives users a way to remove sensitive or noisy output from the visible terminal while continuing the same conversation.

### Motivation

The existing `/clear` command starts a new session, so it cannot be used when a user needs to clear visible output but retain the active conversation. Terminal-native clearing also does not remove Ink's rendered transcript history.

### Behavior

`/cls` clears Ink history and emits the terminal clear-screen and clear-scrollback sequences while preserving the current session ID and backend state. If a turn is running, it leaves live output intact and reports that scrollback cannot be cleared yet. The command is exposed to the Ink TUI catalog but remains hidden from the classic CLI.

### Implementation

The canonical command registry now marks TUI-only commands explicitly. The Ink slash handler clears only presentation state, schedules a terminal scrollback reset, and redraws the UI without invoking session lifecycle or gateway RPC paths. Tests cover session preservation, the busy-turn guard, classic CLI exclusion, and slash-command parity.

## Related Issue

Closes #85516

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/commands.py` - register `/cls` as a TUI-only command without exposing it to classic CLI help or completion.
- `ui-tui/src/app/slash/commands/core.ts` - clear visible transcript and terminal scrollback while retaining the active session.
- `tests/hermes_cli/test_commands.py` - verify TUI-only commands stay out of classic CLI command maps.
- `ui-tui/src/__tests__/createSlashHandler.test.ts` - verify session preservation and safe handling during active turns.
- `ui-tui/src/__tests__/slashParity.test.ts` - include `/cls` in local mutating-command parity coverage.

## How to Test

1. Start `hermes --tui`, submit a prompt, then run `/cls` after the turn completes.
2. Confirm the visible transcript and terminal scrollback are cleared, then continue the conversation and verify prior context is retained.
3. Run the focused automated checks:

```bash
npm --prefix ui-tui test -- --run src/__tests__/createSlashHandler.test.ts src/__tests__/slashParity.test.ts
npm --prefix ui-tui run typecheck
scripts/run_tests.sh tests/hermes_cli/test_commands.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant Python tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; the command is discoverable through the canonical TUI command catalog
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - terminal sequences are standard ANSI clear-screen and clear-scrollback controls
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool changed

## Screenshots / Logs

N/A - focused automated tests verify transcript clearing, session preservation, busy-turn behavior, command parity, and classic CLI isolation.
