### PR TITLE
fix(kanban): preserve notify subscriptions across task reopen + GC stale done-task subs (salvage #84230)

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -255,8 +255,35 @@ class GatewayKanbanWatchersMixin:
         # Initial delay so the gateway can finish wiring adapters.
         await asyncio.sleep(5)
 
+        # Stale done-sub GC cadence. Subscriptions survive ``done`` (it is
+        # reversible), so boards that never archive would otherwise
+        # accumulate rows scanned on every 5s tick forever. The sweep is a
+        # single DELETE per board, gated to once per watcher startup and at
+        # most once per hour thereafter — cheap relative to the tick's own
+        # per-sub claims. Retention is kanban.done_sub_retention_days in
+        # config.yaml (default 30; 0 disables), re-read at each sweep so a
+        # config change applies without a restart.
+        _GC_INTERVAL_SECONDS = 3600.0
+        _gc_next_at = 0.0  # 0 → sweep on the first tick after startup
+
         while self._running:
             try:
+                _gc_due = time.monotonic() >= _gc_next_at
+                _gc_retention_days = 30
+                if _gc_due:
+                    _gc_next_at = time.monotonic() + _GC_INTERVAL_SECONDS
+                    try:
+                        from hermes_cli.config import load_config as _load_cfg
+
+                        _kanban_cfg = (_load_cfg() or {}).get("kanban") or {}
+                        _gc_retention_days = int(
+                            _kanban_cfg.get("done_sub_retention_days", 30)
+                        )
+                    except Exception:
+                        # Fail safe on the shipped default; the sweep itself
+                        # treats <= 0 as disabled.
+                        _gc_retention_days = 30
+
                 def _collect():
                     deliveries: list[dict] = []
                     include_unowned = self._owns_kanban_dispatcher_lock()
@@ -346,6 +373,28 @@ class GatewayKanbanWatchersMixin:
                             logger.debug("kanban notifier: cannot open board %s: %s", slug, exc)
                             continue
                         try:
+                            if _gc_due:
+                                # Hourly (plus once at startup) stale-sub GC:
+                                # drop subscriptions for tasks that have been
+                                # ``done`` untouched past the retention
+                                # window. Best-effort — a failed sweep never
+                                # blocks delivery; the next hourly gate
+                                # retries it.
+                                try:
+                                    _purged = _kb.purge_stale_done_notify_subs(
+                                        conn,
+                                        max_age_days=_gc_retention_days,
+                                    )
+                                    if _purged:
+                                        logger.info(
+                                            "kanban notifier: purged %d stale done-task subscription(s) on board %s (retention %dd)",
+                                            _purged, slug, _gc_retention_days,
+                                        )
+                                except Exception as _gc_exc:
+                                    logger.debug(
+                                        "kanban notifier: stale-sub GC failed for board %s: %s",
+                                        slug, _gc_exc,
+                                    )
                             # `connect()` runs the schema + idempotent migration
                             # on first open per process, so an explicit
                             # `init_db()` here would be redundant. Worse:

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -185,9 +185,10 @@ class GatewayKanbanWatchersMixin:
         ``review_requested``, ``block_loop_detected``). Sends one
         message per new event to ``(platform, chat_id, thread_id)``,
         then advances the cursor. The subscription is removed only when the
-        task reaches a truly final *status* (``done`` / ``archived``), not on
-        any terminal event kind — so review cycles and re-block loops keep
-        notifying.
+        task is ``archived``. A ``done`` task can be reopened for review or
+        continuation, so its subscription and origin-session ownership must
+        survive completion. Cursor advancement prevents old events replaying
+        when that happens.
 
         Runs in the gateway event loop; all SQLite work is pushed to a
         thread via ``asyncio.to_thread`` so the loop never blocks on the
@@ -214,11 +215,13 @@ class GatewayKanbanWatchersMixin:
         # writes — surface those transitions to subscribers too.
         # ``review_requested`` wakes the origin subscriber like a block does,
         # but is not a block (see kanban_db.request_review); the task is not
-        # done/archived, so the subscription stays alive and later review
+        # archived, so the subscription stays alive and later review
         # cycles keep notifying.
         TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected", "review_requested")
-        # Subscriptions are removed only when the task reaches a truly final
-        # status (done / archived). We used to also unsub on any terminal
+        # Subscriptions are removed only when the task reaches the irreversible
+        # archived status. ``done`` is reversible in review/controller flows,
+        # so removing its subscription would silence a later reopen. We used
+        # to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
         # silently dropped the user out of the loop whenever the dispatcher
         # respawned the task: a worker that crashes, gets reclaimed, runs
@@ -226,7 +229,7 @@ class GatewayKanbanWatchersMixin:
         # crash because the subscription was deleted after the first event.
         # Same shape as the reblock-after-unblock cycle that PR #22941
         # fixed for `blocked`. Keeping the subscription alive until the
-        # task is genuinely done lets the cursor (advanced atomically by
+        # task is archived lets the cursor (advanced atomically by
         # claim_unseen_events_for_sub) handle dedup, and any retry-loop
         # event reaches the user.
         # Per-subscription send-failure counter. Adapter.send raising
@@ -706,7 +709,7 @@ class GatewayKanbanWatchersMixin:
                         #   advances after it succeeds — a failure rewinds the
                         #   claim exactly like a failed send() above, so the
                         #   next tick retries.
-                        task_terminal = task and task.status in {"done", "archived"}
+                        task_terminal = task and task.status == "archived"
                         _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
                         _wake_kinds = (
                             {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
@@ -925,13 +928,11 @@ class GatewayKanbanWatchersMixin:
                             # Nothing left to deliver on this path (the wake,
                             # if any, already succeeded above).
                             sub_fail_counts.pop(sub_key, None)
-                        # Unsubscribe only when the task has reached a truly
-                        # final status (done / archived). For blocked /
-                        # gave_up / crashed / timed_out the subscription is
-                        # kept alive so the user gets notified again if the
-                        # dispatcher respawns the task and it cycles into the
-                        # same state. See the longer comment on TERMINAL_KINDS
-                        # above for the failure mode this prevents.
+                        # Unsubscribe only on archive. Completion (``done``)
+                        # remains reversible: controllers reopen completed
+                        # work for review corrections and continuation. The
+                        # retained cursor prevents replay while preserving the
+                        # original delivery and wake ownership for that cycle.
                         if _is_push_adapter and send_passive and _wake_kinds:
                             # notify+wake: the text ping above was the
                             # delivery and the cursor has advanced; the wake

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2436,6 +2436,14 @@ DEFAULT_CONFIG = {
         # to the TTL/crash/stale recovery paths. Set false to keep orphans
         # frozen for manual forensics.
         "reconcile_orphans": True,
+        # Notify subscriptions survive a task reaching ``done`` (completion
+        # is reversible — controllers reopen done work for review
+        # corrections), and are normally removed on archive. On boards that
+        # never archive, the notifier GC purges subscriptions for tasks
+        # that have been ``done`` with no new activity for this many days,
+        # so stale rows don't accumulate and get scanned on every notifier
+        # tick forever. Set 0 to disable the sweep.
+        "done_sub_retention_days": 30,
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11247,6 +11247,51 @@ def remove_notify_sub(
     return cur.rowcount > 0
 
 
+def purge_stale_done_notify_subs(
+    conn: sqlite3.Connection,
+    *,
+    max_age_days: int = 30,
+) -> int:
+    """Delete notify subscriptions whose task has sat in ``done`` untouched
+    for longer than ``max_age_days``.
+
+    The notifier keeps subscriptions alive through ``done`` because a
+    completed task can be reopened (review corrections, continuation) and
+    the reopened cycle must still notify its origin session. On boards
+    that never archive, that retention would otherwise accumulate
+    subscription rows forever — each one scanned every notifier tick.
+    This GC bounds that: a task that has been ``done`` with no new events
+    for the retention window is treated as settled and its subscriptions
+    are purged. Age is measured from the task's most recent event
+    (falling back to ``completed_at`` then ``created_at``), so ANY
+    activity — including a reopen, which also moves the task off
+    ``done`` — resets or exempts it.
+
+    ``max_age_days <= 0`` disables the sweep entirely. Returns the number
+    of subscription rows deleted.
+    """
+    try:
+        days = int(max_age_days)
+    except (TypeError, ValueError):
+        days = 30
+    if days <= 0:
+        return 0
+    cutoff = int(time.time()) - days * 86400
+    with write_txn(conn):
+        cur = conn.execute(
+            "DELETE FROM kanban_notify_subs WHERE task_id IN ("
+            " SELECT t.id FROM tasks t"
+            " WHERE t.status = 'done'"
+            " AND COALESCE("
+            "  (SELECT MAX(e.created_at) FROM task_events e"
+            "   WHERE e.task_id = t.id),"
+            "  t.completed_at, t.created_at, 0"
+            " ) < ?)",
+            (cutoff,),
+        )
+    return int(cur.rowcount or 0)
+
+
 def unseen_events_for_sub(
     conn: sqlite3.Connection,
     *,

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -354,6 +354,110 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
     assert "crashed" in adapter.sent[1]["text"].lower()
 
 
+def test_notifier_subscription_survives_done_reopen_until_archive(
+    tmp_path, monkeypatch,
+):
+    """Done is reversible; archive alone ends notification ownership."""
+    db_path = tmp_path / "done-reopen-archive.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="review continuation",
+            assignee="worker",
+            session_id="origin-session",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="origin-chat",
+            thread_id="origin-thread",
+            user_id="origin-user",
+            chat_type="group",
+            notifier_profile="reviewer",
+            delivery_mode="notify+wake",
+        )
+        assert kb.complete_task(conn, tid, summary="first completion")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner._active_profile_name = lambda: "reviewer"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert len(adapter.handled) == 1
+    assert adapter.sent[0]["chat_id"] == "origin-chat"
+    assert adapter.sent[0]["metadata"]["thread_id"] == "origin-thread"
+    assert adapter.handled[0].source.thread_id == "origin-thread"
+    assert adapter.handled[0].source.profile == "reviewer"
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+        assert len(subs) == 1, "completion must retain the origin subscription"
+        first_cursor = subs[0]["last_event_id"]
+    finally:
+        conn.close()
+
+    # A quiet tick proves the completed event cannot replay after its cursor
+    # was advanced, even though the subscription now remains present.
+    runner = _make_runner(adapter)
+    runner._active_profile_name = lambda: "reviewer"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert len(adapter.sent) == 1
+    assert len(adapter.handled) == 1
+
+    conn = kb.connect()
+    try:
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (tid,))
+            kb._append_event(conn, tid, "status", {"status": "ready"})
+        assert kb.complete_task(conn, tid, summary="corrected completion")
+    finally:
+        conn.close()
+
+    runner = _make_runner(adapter)
+    runner._active_profile_name = lambda: "reviewer"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    # The reopen status and second completion each deliver once, while only
+    # completion wakes the exact original session/thread.
+    assert len(adapter.sent) == 3
+    assert len(adapter.handled) == 2
+    assert all(item["chat_id"] == "origin-chat" for item in adapter.sent)
+    assert adapter.handled[-1].source.thread_id == "origin-thread"
+    assert adapter.handled[-1].source.profile == "reviewer"
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+        assert len(subs) == 1
+        assert subs[0]["last_event_id"] > first_cursor
+        assert kb.archive_task(conn, tid)
+    finally:
+        conn.close()
+
+    runner = _make_runner(adapter)
+    runner._active_profile_name = lambda: "reviewer"
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    # Archive itself is intentionally silent, but consumes its event and
+    # removes the subscription so no later historical event can replay.
+    assert len(adapter.sent) == 3
+    assert len(adapter.handled) == 2
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
 def test_notifier_wakeup_uses_subscription_chat_type(tmp_path, monkeypatch):
     db_path = tmp_path / "chat-type-wakeup.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -1011,3 +1011,122 @@ def test_create_with_parents_inherits_delivery_metadata(kanban_home):
     finally:
         conn.close()
     _assert_full_inherited_sub(subs)
+
+
+# ---------------------------------------------------------------------------
+# Stale done-subscription GC (purge_stale_done_notify_subs)
+# ---------------------------------------------------------------------------
+
+def _make_done_task_with_sub(kb, conn, *, title, chat_id):
+    tid = kb.create_task(conn, title=title, assignee="worker1")
+    kb.add_notify_sub(
+        conn, task_id=tid, platform="telegram", chat_id=chat_id,
+        notifier_profile="default",
+    )
+    assert kb.complete_task(conn, tid, summary="done")
+    return tid
+
+
+def _backdate_task(kb, conn, tid, *, days):
+    """Push a task's entire event history + completion into the past."""
+    past = int(__import__("time").time()) - days * 86400
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE task_events SET created_at = ? WHERE task_id = ?",
+            (past, tid),
+        )
+        conn.execute(
+            "UPDATE tasks SET completed_at = ?, created_at = ? WHERE id = ?",
+            (past, past, tid),
+        )
+
+
+def test_gc_purges_stale_done_sub_keeps_fresh_one(kanban_home):
+    import hermes_cli.kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        stale = _make_done_task_with_sub(kb, conn, title="old done", chat_id="c-stale")
+        fresh = _make_done_task_with_sub(kb, conn, title="new done", chat_id="c-fresh")
+        _backdate_task(kb, conn, stale, days=45)
+
+        purged = kb.purge_stale_done_notify_subs(conn, max_age_days=30)
+
+        assert purged == 1
+        assert kb.list_notify_subs(conn, stale) == []
+        # A done task inside the retention window keeps its subscription —
+        # it may still be reopened for review corrections.
+        assert len(kb.list_notify_subs(conn, fresh)) == 1
+    finally:
+        conn.close()
+
+
+def test_gc_honors_configured_retention_days(kanban_home):
+    import hermes_cli.kanban_db as kb
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    # The watcher reads kanban.done_sub_retention_days from config; the
+    # shipped default must exist and drive the sweep when passed through.
+    default_days = DEFAULT_CONFIG["kanban"]["done_sub_retention_days"]
+    assert isinstance(default_days, int) and default_days > 0
+
+    conn = kb.connect()
+    try:
+        tid = _make_done_task_with_sub(kb, conn, title="ten days old", chat_id="c-10d")
+        _backdate_task(kb, conn, tid, days=10)
+
+        # Under the shipped default (>= 30d) a 10-day-old done task is fresh.
+        assert kb.purge_stale_done_notify_subs(conn, max_age_days=default_days) == 0
+        assert len(kb.list_notify_subs(conn, tid)) == 1
+
+        # A tighter user-configured retention purges the same row.
+        assert kb.purge_stale_done_notify_subs(conn, max_age_days=7) == 1
+        assert kb.list_notify_subs(conn, tid) == []
+
+        # Zero (and below) disables the sweep entirely.
+        tid2 = _make_done_task_with_sub(kb, conn, title="ancient", chat_id="c-anc")
+        _backdate_task(kb, conn, tid2, days=3650)
+        assert kb.purge_stale_done_notify_subs(conn, max_age_days=0) == 0
+        assert len(kb.list_notify_subs(conn, tid2)) == 1
+    finally:
+        conn.close()
+
+
+def test_gc_spares_reopened_task_even_when_old(kanban_home):
+    import hermes_cli.kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        tid = _make_done_task_with_sub(kb, conn, title="reopened", chat_id="c-reopen")
+        _backdate_task(kb, conn, tid, days=90)
+        # Reopen: the task leaves ``done``, so even with an ancient event
+        # history the GC must not touch its subscription.
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (tid,))
+            kb._append_event(conn, tid, "status", {"status": "ready"})
+        # Backdate the reopen event too — status alone must protect it.
+        _backdate_task(kb, conn, tid, days=90)
+
+        assert kb.purge_stale_done_notify_subs(conn, max_age_days=30) == 0
+        assert len(kb.list_notify_subs(conn, tid)) == 1
+    finally:
+        conn.close()
+
+
+def test_gc_archived_rows_already_removed_by_unsub(kanban_home):
+    import hermes_cli.kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        tid = _make_done_task_with_sub(kb, conn, title="archived", chat_id="c-arch")
+        assert kb.archive_task(conn, tid)
+        # The notifier removes the sub at archive time; the GC targets only
+        # ``done`` tasks, so an archived task contributes nothing to purge.
+        kb.remove_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="c-arch",
+        )
+        _backdate_task(kb, conn, tid, days=365)
+        assert kb.purge_stale_done_notify_subs(conn, max_age_days=30) == 0
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -7,7 +7,7 @@ adapter) and the TUI notification poller only watched process completions.
 ``last_event_id`` stayed 0 forever and no notification was ever delivered.
 
 These tests cover the delivery half that now lives in tui_gateway/server.py:
-``_collect_kanban_notifications`` (cursor claim + formatting + terminal
+``_collect_kanban_notifications`` (cursor claim + formatting + archive-only
 unsubscribe) and ``_format_kanban_event_text``.
 """
 
@@ -65,17 +65,53 @@ class TestCollectKanbanNotifications:
         assert texts == []
         spy_connect.assert_not_called()
 
-    def test_delivers_completed_event_and_unsubscribes(self):
+    def test_done_reopen_notifies_once_per_event_until_archive(self):
         tid = _create_subscribed_task()
         _complete(tid, summary="shipped the fix")
 
-        texts = _collect_kanban_notifications(_session())
+        first = _collect_kanban_notifications(_session())
 
-        assert len(texts) == 1
-        assert tid in texts[0]
-        assert "done" in texts[0]
-        assert "shipped the fix" in texts[0]
-        # Task is at a final status -> subscription removed.
+        assert len(first) == 1
+        assert tid in first[0]
+        assert "done" in first[0]
+        assert "shipped the fix" in first[0]
+        rows = _sub_rows(tid)
+        assert len(rows) == 1, "done must retain the originating session"
+        first_cursor = rows[0]["last_event_id"]
+
+        # The retained subscription must not replay the completed event.
+        assert _collect_kanban_notifications(_session()) == []
+
+        conn = kb.connect()
+        try:
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status = 'ready' WHERE id = ?", (tid,)
+                )
+                kb._append_event(conn, tid, "status", {"status": "ready"})
+            assert kb.complete_task(conn, tid, summary="review corrections")
+        finally:
+            conn.close()
+
+        reopened = _collect_kanban_notifications(_session())
+
+        assert len(reopened) == 2
+        assert "ready" in reopened[0]
+        assert "review corrections" in reopened[1]
+        rows = _sub_rows(tid)
+        assert len(rows) == 1
+        assert rows[0]["chat_id"] == SESSION_KEY
+        assert rows[0]["last_event_id"] > first_cursor
+        assert _collect_kanban_notifications(_session()) == []
+
+        conn = kb.connect()
+        try:
+            assert kb.archive_task(conn, tid)
+        finally:
+            conn.close()
+
+        # Archive is notification-terminal and removes the retained route.
+        assert _collect_kanban_notifications(_session()) == []
         assert _sub_rows(tid) == []
 
     def test_matching_tui_sub_delivers_and_advances_cursor(self):
@@ -189,7 +225,11 @@ class TestCollectKanbanNotifications:
         assert len(texts) == 1
         assert tid in texts[0]
         assert "cross-profile delivery" in texts[0]
-        assert _sub_rows(tid) == []
+        # Completion is reversible, so the shared-board subscription remains
+        # owned by this exact Desktop session until the task is archived.
+        rows = _sub_rows(tid)
+        assert len(rows) == 1
+        assert rows[0]["chat_id"] == SESSION_KEY
 
 
 class TestFormatKanbanEventText:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9257,11 +9257,11 @@ def _collect_kanban_notifications(session: dict) -> list:
                     text = _format_kanban_event_text(sub, task, ev, slug)
                     if text:
                         texts.append(text)
-                # Unsubscribe only at a truly final status (done/archived);
-                # blocked/crashed subs stay live so a respawned task's next
-                # terminal event still reaches the user (same rule as the
-                # gateway notifier).
-                if task and getattr(task, "status", "") in {"done", "archived"}:
+                # Unsubscribe only on archive. ``done`` is reversible in
+                # review/controller flows, so retaining the subscription lets
+                # a later reopen notify the same originating TUI/Desktop
+                # session. The claimed cursor prevents historical replay.
+                if task and getattr(task, "status", "") == "archived":
                     try:
                         _kb.remove_notify_sub(
                             conn,

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -614,6 +614,7 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When `kanban_create` runs inside a persistent gateway/TUI session, terminal events resume that originating agent with a synthetic status turn. Set to `false` for passive completion or to require explicit `kanban_notify-subscribe` calls. Independent of `auto_decompose`. |
+| `done_sub_retention_days` | `30` | Notify subscriptions survive `done` (reopen-safe) and are removed on `archived`. The notifier GC purges subscriptions whose task has been `done` with no new events for this many days, bounding sub-table growth on boards that never archive. `0` disables the sweep. |
 
 And the two auxiliary LLM slots:
 
@@ -886,7 +887,7 @@ bot> ✓ t_9fc1a3 completed by transcriber
      transcribed 42 minutes, saved to podcast/2026-05-04.md
 ```
 
-Subscriptions auto-remove themselves once the task reaches `done` or `archived`. If you script a create with `--json` (machine output) the auto-subscribe is skipped — the assumption is that scripted callers want to manage subscriptions explicitly via `/kanban notify-subscribe`.
+Subscriptions survive a task reaching `done` — completion is reversible (a reviewer or controller can reopen a done task), so the origin session keeps getting notified through reopen cycles. They auto-remove on `archived` (the irreversible end state). On boards that never archive, a GC sweep purges subscriptions for tasks that have sat in `done` with no new activity for `kanban.done_sub_retention_days` days (default 30; set 0 to disable), so stale rows don't accumulate forever. If you script a create with `--json` (machine output) the auto-subscribe is skipped — the assumption is that scripted callers want to manage subscriptions explicitly via `/kanban notify-subscribe`.
 
 A chat-originated auto-subscribe is created in `notify+wake` mode: on a terminal event the destination agent both receives the passive message **and** takes a real turn, so it can read the board context and reply in its own voice. See [Delivery modes](#delivery-modes) below.
 


### PR DESCRIPTION
## Summary
Kanban notify subscriptions now survive task reopen — unsubscribe happens only on `archived`, so a `done → ready → done` review cycle still notifies and wakes the subscriber on the second completion. Salvage of #84230 by @DmytroVolodymyrson onto current main (authorship preserved), paired with a maintainer-authored GC sweep so never-archiving boards don't accumulate subscription rows forever.

## Changes
- `gateway/kanban_watchers.py` + `tui_gateway/server.py` (@DmytroVolodymyrson, cherry-picked): `task_terminal = status == "archived"`; reopened cycles keep origin thread/session/profile
- `hermes_cli/kanban_db.py` (ours): `purge_stale_done_notify_subs()` — deletes subs whose task is `done` with the latest event older than the retention cutoff; reopen exempts by status alone
- Watcher trigger: once at startup + at most hourly (monotonic gate), per board, best-effort
- Config: `kanban.done_sub_retention_days` (default 30, `0` disables) — config.yaml only, no env vars, no version bump needed
- Docs: kanban.md config table + subscriptions section

## Validation
| | Before | After |
|---|---|---|
| done → reopen → done | second completion notifies nobody | notifies + wakes normally |
| never-archiving board | n/a (subs deleted at done) | stale done subs purged after 30d |
| targeted tests | — | 475/475 across 9 suites; both halves sabotage-proven |

Supersedes #84230 (closed with credit).

## Infographic

![subscriptions survive reopen](https://files.catbox.moe/uigy70.png)
