### PR TITLE
fix(fallback): preserve anthropic_messages api_mode during fallback activation (salvage #79787)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2035,10 +2035,16 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         fb_base_url_hint = (fb.get("base_url") or "").strip() or None
         fb_api_key_hint = resolve_entry_api_key(fb)
         # Determine api_mode from the ORIGINAL base_url (before URL transformation).
-        # resolve_provider_client() calls _to_openai_base_url() which rewrites
-        # /anthropic to /v1, losing the anthropic wire signal. Pre-compute here.
+        # resolve_provider_client() calls _to_openai_base_url() which can rewrite
+        # a dual-surface /anthropic base to /v1, losing the Anthropic wire signal
+        # from the client's post-rewrite base_url. Pre-compute here so detection
+        # sees the URL the user actually configured. (#79787)
+        #
+        # An explicit ``api_mode`` on the fallback entry always wins — including
+        # an explicit "chat_completions" — and suppresses all re-detection below.
+        fb_api_mode_explicit = bool(str(fb.get("api_mode") or "").strip())
         fb_api_mode = "chat_completions"
-        if fb.get("api_mode"):
+        if fb_api_mode_explicit:
             fb_api_mode = str(fb.get("api_mode")).strip()
         elif fb_provider == "anthropic":
             # Provider-name check must not be gated on fb_base_url_hint:
@@ -2082,15 +2088,14 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
-        # If fb_api_mode was already pre-computed from original URL, preserve it
-        if not locals().get('fb_api_mode'):
-            fb_api_mode = "chat_completions"
+        # Re-determine api_mode from provider / resolved base URL / model when
+        # the pre-computed pass above landed on the default and the user did
+        # not pin api_mode explicitly. An explicit fb.api_mode (even
+        # "chat_completions") must never be overridden here.
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        
-        # Only re-determine if not already set from original URL
-        if fb_api_mode == "chat_completions":
+
+        if not fb_api_mode_explicit and fb_api_mode == "chat_completions":
             if fb_provider == "openai-codex":
                 fb_api_mode = "codex_responses"
             elif fb_provider in {"nous", "nous-portal", "nousresearch"}:
@@ -2101,6 +2106,16 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 from hermes_cli.providers import nous_api_mode
 
                 fb_api_mode = nous_api_mode(fb_model)
+            elif (
+                fb_base_url.rstrip("/").lower().endswith("/anthropic")
+                or base_url_hostname(fb_base_url) == "api.anthropic.com"
+            ):
+                # Named custom providers (e.g. cron-anthropic) resolve their
+                # base_url from config rather than the fallback entry, so the
+                # pre-resolve hint check above never sees it. Match the host
+                # the same way determine_api_mode() and _detect_api_mode_for_url()
+                # do on the primary path. (#32243, #49247)
+                fb_api_mode = "anthropic_messages"
             elif _fb_is_azure:
                 # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
                 # support the Responses API. Stay on chat_completions.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2034,6 +2034,26 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
         fb_base_url_hint = (fb.get("base_url") or "").strip() or None
         fb_api_key_hint = resolve_entry_api_key(fb)
+        # Determine api_mode from the ORIGINAL base_url (before URL transformation).
+        # resolve_provider_client() calls _to_openai_base_url() which rewrites
+        # /anthropic to /v1, losing the anthropic wire signal. Pre-compute here.
+        fb_api_mode = "chat_completions"
+        if fb.get("api_mode"):
+            fb_api_mode = str(fb.get("api_mode")).strip()
+        elif fb_provider == "anthropic":
+            # Provider-name check must not be gated on fb_base_url_hint:
+            # an entry that names provider: anthropic without an explicit
+            # base_url uses the provider's default endpoint and must still
+            # resolve to anthropic_messages, not chat_completions.
+            fb_api_mode = "anthropic_messages"
+        elif fb_base_url_hint:
+            _orig_url = fb_base_url_hint.rstrip("/").lower()
+            if (
+                _orig_url.endswith("/anthropic")
+                or base_url_hostname(fb_base_url_hint) == "api.anthropic.com"
+            ):
+                fb_api_mode = "anthropic_messages"
+        
         # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
         # when no explicit key is in the fallback config. Host match
         # (not substring) — see GHSA-76xc-57q6-vm5m.
@@ -2044,7 +2064,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         fb_client, _resolved_fb_model = resolve_provider_client(
             fb_provider, model=fb_model, raw_codex=True,
             explicit_base_url=fb_base_url_hint,
-            explicit_api_key=fb_api_key_hint)
+            explicit_api_key=fb_api_key_hint,
+            api_mode=fb_api_mode)
         if fb_client is None:
             logger.warning(
                 "Fallback to %s failed: provider not configured",
@@ -2062,50 +2083,43 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             )
 
         # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
+        # If fb_api_mode was already pre-computed from original URL, preserve it
+        if not locals().get('fb_api_mode'):
+            fb_api_mode = "chat_completions"
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
-            fb_api_mode = "codex_responses"
-        elif fb_provider in {"nous", "nous-portal", "nousresearch"}:
-            # Portal is dual-wire: anthropic/* must land on /v1/messages.
-            # resolve_provider_client still returns an OpenAI client for
-            # Nous; the anthropic_messages branch below rebuilds the native
-            # client from that credential + base_url.
-            from hermes_cli.providers import nous_api_mode
+        
+        # Only re-determine if not already set from original URL
+        if fb_api_mode == "chat_completions":
+            if fb_provider == "openai-codex":
+                fb_api_mode = "codex_responses"
+            elif fb_provider in {"nous", "nous-portal", "nousresearch"}:
+                # Portal is dual-wire: anthropic/* must land on /v1/messages.
+                # resolve_provider_client still returns an OpenAI client for
+                # Nous; the anthropic_messages branch below rebuilds the native
+                # client from that credential + base_url.
+                from hermes_cli.providers import nous_api_mode
 
-            fb_api_mode = nous_api_mode(fb_model)
-        elif (
-            fb_provider == "anthropic"
-            or fb_base_url.rstrip("/").lower().endswith("/anthropic")
-            or base_url_hostname(fb_base_url) == "api.anthropic.com"
-        ):
-            # Custom providers (e.g. cron-anthropic) point at the native
-            # api.anthropic.com host with no "/anthropic" path suffix, so the
-            # name/suffix checks above miss them and they default to
-            # chat_completions → POST /v1/chat/completions → 404. Match the
-            # host the same way determine_api_mode() and _detect_api_mode_for_url()
-            # do on the primary path. (#32243, #49247)
-            fb_api_mode = "anthropic_messages"
-        elif _fb_is_azure:
-            # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
-            # support the Responses API. Stay on chat_completions.
-            fb_api_mode = "chat_completions"
-        elif agent._is_direct_openai_url(fb_base_url):
-            fb_api_mode = "codex_responses"
-        elif agent._provider_model_requires_responses_api(
-            fb_model,
-            provider=fb_provider,
-        ):
-            # GPT-5.x models usually need Responses API, but keep
-            # provider-specific exceptions like Copilot gpt-5-mini on
-            # chat completions.
-            fb_api_mode = "codex_responses"
-        elif fb_provider == "bedrock" or (
-            base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
-            and base_url_host_matches(fb_base_url, "amazonaws.com")
-        ):
-            fb_api_mode = "bedrock_converse"
+                fb_api_mode = nous_api_mode(fb_model)
+            elif _fb_is_azure:
+                # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
+                # support the Responses API. Stay on chat_completions.
+                fb_api_mode = "chat_completions"
+            elif agent._is_direct_openai_url(fb_base_url):
+                fb_api_mode = "codex_responses"
+            elif agent._provider_model_requires_responses_api(
+                fb_model,
+                provider=fb_provider,
+            ):
+                # GPT-5.x models usually need Responses API, but keep
+                # provider-specific exceptions like Copilot gpt-5-mini on
+                # chat completions.
+                fb_api_mode = "codex_responses"
+            elif fb_provider == "bedrock" or (
+                base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
+                and base_url_host_matches(fb_base_url, "amazonaws.com")
+            ):
+                fb_api_mode = "bedrock_converse"
 
         old_model = agent.model
         old_provider = agent.provider

--- a/contributors/emails/sjungwon03@gmail.com
+++ b/contributors/emails/sjungwon03@gmail.com
@@ -1,0 +1,1 @@
+sjungwon03

--- a/tests/run_agent/test_fallback_api_mode_preservation.py
+++ b/tests/run_agent/test_fallback_api_mode_preservation.py
@@ -1,0 +1,182 @@
+"""Fallback activation must preserve the Anthropic wire signal (PR #79787).
+
+Three behaviors salvaged from PR #79787:
+
+1. An explicit ``api_mode`` on the fallback entry is honored — and always
+   wins, including an explicit ``chat_completions`` that would otherwise be
+   overridden by codex_responses / bedrock re-detection.
+2. ``fb_api_mode`` is detected from the ORIGINAL ``base_url`` hint before
+   ``resolve_provider_client`` / ``_to_openai_base_url`` can rewrite a
+   dual-surface ``/anthropic`` base to ``/v1``.
+3. ``api_mode`` is passed into ``resolve_provider_client`` at the fallback
+   call site so the resolver keeps the Anthropic wire for custom bases.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_agent(fallback_model=None):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fallback_model,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+def _mock_client(base_url="https://openrouter.ai/api/v1", api_key="fb-key"):
+    mock = MagicMock()
+    mock.base_url = base_url
+    mock.api_key = api_key
+    return mock
+
+
+def _activate(agent, resolved_base_url, resolved_model, build_anthropic=None):
+    """Run _try_activate_fallback with the standard mock stack.
+
+    Returns the mock for resolve_provider_client so callers can assert on
+    the api_mode kwarg passed at the fallback call site.
+    """
+    patches = [
+        patch(
+            "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+            return_value=None,
+        ),
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(
+                _mock_client(base_url=resolved_base_url),
+                resolved_model,
+            ),
+        ),
+        patch(
+            "hermes_cli.model_normalize.normalize_model_for_provider",
+            side_effect=lambda m, p: m,
+        ),
+        patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            side_effect=build_anthropic
+            or (lambda api_key, base_url, timeout=None, **kw: MagicMock()),
+        ),
+    ]
+    with patches[0], patches[1] as mock_rpc, patches[2], patches[3]:
+        assert agent._try_activate_fallback() is True
+    return mock_rpc
+
+
+class TestExplicitApiModeHonored:
+    def test_explicit_anthropic_messages_honored(self):
+        fbs = [{
+            "provider": "custom",
+            "model": "claude-opus-4-6",
+            "base_url": "https://gateway.example.com/v1",
+            "api_key": "k",
+            "api_mode": "anthropic_messages",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        mock_rpc = _activate(agent, "https://gateway.example.com/v1", "claude-opus-4-6")
+        assert agent.api_mode == "anthropic_messages"
+        # Behavior (3): api_mode forwarded to the resolver.
+        assert mock_rpc.call_args.kwargs["api_mode"] == "anthropic_messages"
+
+    def test_explicit_chat_completions_not_overridden_by_redetection(self):
+        """An explicit chat_completions must survive re-detection.
+
+        api.openai.com would normally re-detect to codex_responses via
+        _is_direct_openai_url; the explicit config field must win.
+        """
+        fbs = [{
+            "provider": "custom",
+            "model": "gpt-5.2",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "k",
+            "api_mode": "chat_completions",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        _activate(agent, "https://api.openai.com/v1", "gpt-5.2")
+        assert agent.api_mode == "chat_completions"
+
+    def test_explicit_chat_completions_not_overridden_by_bedrock_redetection(self):
+        fbs = [{
+            "provider": "bedrock",
+            "model": "anthropic.claude-3-5-sonnet",
+            "api_key": "k",
+            "api_mode": "chat_completions",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        _activate(
+            agent,
+            "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "anthropic.claude-3-5-sonnet",
+        )
+        assert agent.api_mode == "chat_completions"
+
+
+class TestOriginalUrlDetection:
+    def test_anthropic_suffix_hint_survives_rewrite(self):
+        """Dual-surface /anthropic base rewritten to /v1 by the resolver:
+        detection must run on the ORIGINAL hint, not the rewritten client URL.
+        """
+        fbs = [{
+            "provider": "custom",
+            "model": "MiniMax-M2.5",
+            "base_url": "https://api.minimax.io/anthropic",
+            "api_key": "k",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        mock_rpc = _activate(agent, "https://api.minimax.io/v1", "MiniMax-M2.5")
+        assert agent.api_mode == "anthropic_messages"
+        assert mock_rpc.call_args.kwargs["api_mode"] == "anthropic_messages"
+
+    def test_anthropic_host_hint_detected(self):
+        fbs = [{
+            "provider": "custom",
+            "model": "claude-opus-4-6",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "k",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        _activate(agent, "https://api.anthropic.com", "claude-opus-4-6")
+        assert agent.api_mode == "anthropic_messages"
+
+    def test_provider_anthropic_without_base_url(self):
+        """provider: anthropic with no explicit base_url must still resolve
+        to anthropic_messages (follow-up commit 38303343 in PR #79787)."""
+        fbs = [{"provider": "anthropic", "model": "claude-opus-4-6", "api_key": "k"}]
+        agent = _make_agent(fallback_model=fbs)
+        mock_rpc = _activate(agent, "https://api.anthropic.com", "claude-opus-4-6")
+        assert agent.api_mode == "anthropic_messages"
+        assert mock_rpc.call_args.kwargs["api_mode"] == "anthropic_messages"
+
+
+class TestPlainFallbackUnchanged:
+    def test_plain_openrouter_fallback_stays_chat_completions(self):
+        fbs = [{
+            "provider": "openrouter",
+            "model": "z-ai/glm-5",
+            "api_key": "k",
+        }]
+        agent = _make_agent(fallback_model=fbs)
+        mock_rpc = _activate(agent, "https://openrouter.ai/api/v1", "z-ai/glm-5")
+        assert agent.api_mode == "chat_completions"
+        assert mock_rpc.call_args.kwargs["api_mode"] == "chat_completions"
+
+    def test_post_resolve_anthropic_host_still_detected(self):
+        """Named custom providers resolve api.anthropic.com from config, not
+        the fallback entry — post-resolve detection must still catch it
+        (#32243, #49247)."""
+        fbs = [{"provider": "cron-anthropic", "model": "claude-opus-4-6", "api_key": "k"}]
+        agent = _make_agent(fallback_model=fbs)
+        _activate(agent, "https://api.anthropic.com/v1", "claude-opus-4-6")
+        assert agent.api_mode == "anthropic_messages"


### PR DESCRIPTION
## Summary
Fallback activation now preserves the Anthropic wire format. Reduced-scope salvage of #79787 by @sjungwon03 onto current main, authorship preserved.

All three gaps re-verified live post-#85532: the resolver was called without `api_mode` at the fallback site; wire detection ran on the post-rewrite URL (dual-surface hosts still lose the signal); and an explicit `fb.api_mode` config field was honored nowhere.

## Changes
- `agent/chat_completion_helpers.py` (@sjungwon03, cherry-picked): `fb_api_mode` detected from the ORIGINAL `fb_base_url_hint` before any rewrite; explicit `fb.api_mode` config honored; `api_mode` passed into `resolve_provider_client` at the fallback call site
- **Fixup (ours):** explicit `api_mode` now ALWAYS wins — the PR's version let codex_responses/bedrock re-detection override an explicit `chat_completions`; also replaced the `locals().get()` dead-code hack
- **Dropped:** the auxiliary_client explicit-custom hunk (redundant with #85466)
- New fallback-activation regression test file (8 tests)

## Validation
| | Before | After |
|---|---|---|
| /anthropic fallback via provider custom | wire signal lost in resolver | anthropic_messages preserved |
| explicit fb.api_mode: chat_completions | overridden by re-detection (PR bug) | always wins |
| targeted tests | — | 33/33, sabotage-verified |

Supersedes #79787 (closed with credit).

## Infographic

![fallback wire format](https://files.catbox.moe/jp3k8y.png)
