### PR TITLE
fix(relay): use canonical managed operation names

### DIFF
--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -22,6 +22,19 @@ _PROVIDER_MESSAGE_EXTENSION_KEYS = frozenset(
 _RELAY_INTERNAL_PROVIDER_HEADERS = frozenset(
     {"x-dynamo-parent-session-id", "x-dynamo-session-id"}
 )
+_RELAY_OPERATION_BY_API_MODE = {
+    "chat_completions": "openai.chat_completions",
+    "codex_responses": "openai.responses",
+    "anthropic_messages": "anthropic.messages",
+}
+
+
+def _relay_operation_name(provider_name: str, metadata: dict[str, Any] | None) -> str:
+    """Return Relay's canonical operation name when Hermes knows the API mode."""
+    api_mode = (metadata or {}).get("api_mode")
+    if not isinstance(api_mode, str):
+        return provider_name
+    return _RELAY_OPERATION_BY_API_MODE.get(api_mode, provider_name)
 
 
 def execute(
@@ -83,7 +96,7 @@ def execute(
             runtime.run_in_session_async(
                 session,
                 runtime.relay.llm.execute,
-                name,
+                _relay_operation_name(name, metadata),
                 relay_request,
                 invoke,
                 handle=parent,
@@ -177,7 +190,7 @@ async def execute_async(
         managed = await runtime.run_in_session_async(
             session,
             runtime.relay.llm.execute,
-            name,
+            _relay_operation_name(name, metadata),
             relay_request,
             invoke,
             handle=parent,
@@ -528,7 +541,7 @@ class ManagedLlmStream(Iterator[Any]):
                 runtime.run_in_session_async(
                     session,
                     runtime.relay.llm.stream_execute,
-                    name,
+                    _relay_operation_name(name, metadata),
                     relay_request,
                     provider_stream,
                     observe_chunk,

--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -8,6 +8,7 @@ import inspect
 import json
 import logging
 from collections.abc import Callable, Iterator
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
 
@@ -22,19 +23,51 @@ _PROVIDER_MESSAGE_EXTENSION_KEYS = frozenset(
 _RELAY_INTERNAL_PROVIDER_HEADERS = frozenset(
     {"x-dynamo-parent-session-id", "x-dynamo-session-id"}
 )
-_RELAY_OPERATION_BY_API_MODE = {
-    "chat_completions": "openai.chat_completions",
-    "codex_responses": "openai.responses",
-    "anthropic_messages": "anthropic.messages",
+@dataclass(frozen=True, slots=True)
+class _RelayProtocol:
+    operation: str
+    codec_class: str
+
+
+_RELAY_PROTOCOL_BY_API_MODE = {
+    "chat_completions": _RelayProtocol(
+        operation="openai.chat_completions",
+        codec_class="OpenAIChatCodec",
+    ),
+    "codex_responses": _RelayProtocol(
+        operation="openai.responses",
+        codec_class="OpenAIResponsesCodec",
+    ),
+    "anthropic_messages": _RelayProtocol(
+        operation="anthropic.messages",
+        codec_class="AnthropicMessagesCodec",
+    ),
 }
+
+
+def _relay_protocol(metadata: dict[str, Any] | None) -> _RelayProtocol | None:
+    """Return Relay's operation and codec descriptor for an API mode."""
+    api_mode = (metadata or {}).get("api_mode")
+    if not isinstance(api_mode, str):
+        return None
+    return _RELAY_PROTOCOL_BY_API_MODE.get(api_mode)
 
 
 def _relay_operation_name(provider_name: str, metadata: dict[str, Any] | None) -> str:
     """Return Relay's canonical operation name when Hermes knows the API mode."""
-    api_mode = (metadata or {}).get("api_mode")
-    if not isinstance(api_mode, str):
-        return provider_name
-    return _RELAY_OPERATION_BY_API_MODE.get(api_mode, provider_name)
+    protocol = _relay_protocol(metadata)
+    return protocol.operation if protocol is not None else provider_name
+
+
+def _relay_metadata(
+    provider_name: str, metadata: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Preserve the physical provider when the operation name is canonicalized."""
+    relay_metadata = _jsonable(metadata or {})
+    if not isinstance(relay_metadata, dict):
+        relay_metadata = {}
+    relay_metadata.setdefault("hermes.provider", provider_name)
+    return relay_metadata
 
 
 def execute(
@@ -100,7 +133,7 @@ def execute(
                 relay_request,
                 invoke,
                 handle=parent,
-                metadata=_jsonable(metadata or {}),
+                metadata=_relay_metadata(name, metadata),
                 model_name=model_name,
                 codec=_codec(runtime.relay, metadata),
                 response_codec=_codec(runtime.relay, metadata),
@@ -194,7 +227,7 @@ async def execute_async(
             relay_request,
             invoke,
             handle=parent,
-            metadata=_jsonable(metadata or {}),
+            metadata=_relay_metadata(name, metadata),
             model_name=model_name,
             codec=_codec(runtime.relay, metadata),
             response_codec=_codec(runtime.relay, metadata),
@@ -547,7 +580,7 @@ class ManagedLlmStream(Iterator[Any]):
                     observe_chunk,
                     relay_finalizer,
                     handle=parent,
-                    metadata=_jsonable(metadata or {}),
+                    metadata=_relay_metadata(name, metadata),
                     model_name=model_name,
                     codec=_codec(runtime.relay, metadata),
                     response_codec=_codec(runtime.relay, metadata),
@@ -1199,18 +1232,11 @@ def _provider_request_body(
 
 
 def _codec(relay: Any, metadata: dict[str, Any] | None) -> Any:
-    api_mode = str((metadata or {}).get("api_mode") or "")
+    protocol = _relay_protocol(metadata)
     codecs = getattr(relay, "codecs", None)
-    if codecs is None:
+    if protocol is None or codecs is None:
         return None
-    if api_mode == "chat_completions":
-        codec = getattr(codecs, "OpenAIChatCodec", None)
-    elif api_mode == "anthropic_messages":
-        codec = getattr(codecs, "AnthropicMessagesCodec", None)
-    elif api_mode == "codex_responses":
-        codec = getattr(codecs, "OpenAIResponsesCodec", None)
-    else:
-        codec = None
+    codec = getattr(codecs, protocol.codec_class, None)
     return codec() if callable(codec) else None
 
 

--- a/plugins/observability/nemo_relay/README.md
+++ b/plugins/observability/nemo_relay/README.md
@@ -209,6 +209,25 @@ create a second LLM or tool lifecycle. `tool_parallelism.mode = "observe_only"`
 keeps tool scheduling observational while still intercepting the core-managed
 execution boundary.
 
+### Managed LLM Operation Names
+
+Hermes identifies managed LLM operations by provider wire protocol, not by the
+physical service routing the request. This keeps Relay middleware and codec
+selection stable when providers such as OpenRouter or Nous expose an
+OpenAI-compatible API:
+
+| Hermes API mode | Relay operation |
+| --- | --- |
+| `chat_completions` | `openai.chat_completions` |
+| `codex_responses` | `openai.responses` |
+| `anthropic_messages` | `anthropic.messages` |
+
+Middleware written against earlier Hermes builds might match physical provider
+names such as `openrouter`, `nous`, or `anthropic` as the operation. Match the
+canonical operation instead. Hermes retains the original provider in the
+managed invocation metadata field `hermes.provider`. Unknown or custom API
+modes continue to use the physical provider name as their operation.
+
 ### Dynamic Plugins
 
 Hermes uses the dynamic-plugin activation API available in NeMo Relay 0.6 and

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -39,6 +39,98 @@ def relay_turn(tmp_path, monkeypatch):
         relay_runtime._reset_for_tests()
 
 
+def test_sync_execution_uses_canonical_relay_operation_name(relay_turn, monkeypatch):
+    relay, _turn = relay_turn
+    observed_names = []
+    original_execute = relay.llm.execute
+
+    async def capture_name(name, *args, **kwargs):
+        observed_names.append(name)
+        return await original_execute(name, *args, **kwargs)
+
+    monkeypatch.setattr(relay.llm, "execute", capture_name)
+    monkeypatch.setattr(relay_llm, "_codec", lambda *_args, **_kwargs: None)
+
+    result = relay_llm.execute(
+        {"model": "test-model", "messages": []},
+        lambda _request: {"content": "done"},
+        session_id="session-1",
+        name="custom",
+        model_name="test-model",
+        metadata={"api_mode": "chat_completions"},
+    )
+
+    assert result == {"content": "done"}
+    assert observed_names == ["openai.chat_completions"]
+
+
+@pytest.mark.asyncio
+async def test_async_execution_uses_canonical_relay_operation_name(
+    relay_turn, monkeypatch
+):
+    relay, _turn = relay_turn
+    observed_names = []
+    original_execute = relay.llm.execute
+
+    async def capture_name(name, *args, **kwargs):
+        observed_names.append(name)
+        return await original_execute(name, *args, **kwargs)
+
+    async def provider(_request):
+        return {"content": "done"}
+
+    monkeypatch.setattr(relay.llm, "execute", capture_name)
+    monkeypatch.setattr(relay_llm, "_codec", lambda *_args, **_kwargs: None)
+
+    result = await relay_llm.execute_async(
+        {"model": "test-model", "input": "hello"},
+        provider,
+        session_id="session-1",
+        name="custom",
+        model_name="test-model",
+        metadata={"api_mode": "codex_responses"},
+    )
+
+    assert result == {"content": "done"}
+    assert observed_names == ["openai.responses"]
+
+
+def test_stream_execution_uses_canonical_relay_operation_name(relay_turn, monkeypatch):
+    relay, _turn = relay_turn
+    observed_names = []
+    original_stream_execute = relay.llm.stream_execute
+
+    async def capture_name(name, *args, **kwargs):
+        observed_names.append(name)
+        return await original_stream_execute(name, *args, **kwargs)
+
+    monkeypatch.setattr(relay.llm, "stream_execute", capture_name)
+    monkeypatch.setattr(relay_llm, "_codec", lambda *_args, **_kwargs: None)
+
+    stream = relay_llm.stream(
+        {"model": "test-model", "messages": []},
+        lambda _request: iter([{"delta": "done"}]),
+        session_id="session-1",
+        name="custom",
+        model_name="test-model",
+        finalizer=lambda: {"content": "done"},
+        metadata={"api_mode": "anthropic_messages"},
+    )
+
+    try:
+        assert list(stream) == [{"delta": "done"}]
+    finally:
+        stream.close()
+    assert observed_names == ["anthropic.messages"]
+
+
+def test_unknown_api_mode_preserves_provider_name():
+    assert (
+        relay_llm._relay_operation_name("custom-provider", {"api_mode": "future_api"})
+        == "custom-provider"
+    )
+
+
 def test_stream_uses_rewritten_request_and_post_intercept_chunks(relay_turn):
     relay, turn = relay_turn
     captured_requests = []

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -131,6 +131,36 @@ def test_unknown_api_mode_preserves_provider_name():
     )
 
 
+@pytest.mark.parametrize(
+    ("api_mode", "operation", "codec_class"),
+    [
+        ("chat_completions", "openai.chat_completions", "OpenAIChatCodec"),
+        ("codex_responses", "openai.responses", "OpenAIResponsesCodec"),
+        ("anthropic_messages", "anthropic.messages", "AnthropicMessagesCodec"),
+    ],
+)
+def test_relay_protocol_drives_operation_and_codec(
+    api_mode, operation, codec_class
+):
+    codec_type = type(codec_class, (), {})
+    codecs = SimpleNamespace(**{codec_class: codec_type})
+    relay = SimpleNamespace(codecs=codecs)
+    metadata = {"api_mode": api_mode}
+
+    assert relay_llm._relay_operation_name("custom-provider", metadata) == operation
+    assert isinstance(relay_llm._codec(relay, metadata), codec_type)
+
+
+def test_relay_metadata_preserves_provider_name():
+    metadata = {"api_mode": "chat_completions", "hermes.provider": "explicit"}
+
+    assert relay_llm._relay_metadata("openrouter", metadata) == metadata
+    assert relay_llm._relay_metadata("openrouter", {"api_mode": "chat_completions"}) == {
+        "api_mode": "chat_completions",
+        "hermes.provider": "openrouter",
+    }
+
+
 def test_stream_uses_rewritten_request_and_post_intercept_chunks(relay_turn):
     relay, turn = relay_turn
     captured_requests = []

--- a/tests/agent/test_relay_nested_execution.py
+++ b/tests/agent/test_relay_nested_execution.py
@@ -171,7 +171,7 @@ def test_main_turn_llm_call_stays_managed(relay_turn):
         host.relay.llm.execute = original_execute
 
     assert out is not None
-    assert "main-prov" in managed_llm_names
+    assert "openai.chat_completions" in managed_llm_names
 
 
 def test_guard_resets_after_managed_callback_returns(relay_turn):
@@ -219,7 +219,7 @@ def test_guard_resets_after_managed_callback_returns(relay_turn):
     finally:
         host.relay.llm.execute = original_execute
 
-    assert "after-prov" in managed_llm_names
+    assert "openai.chat_completions" in managed_llm_names
 
 
 def test_resolve_execution_context_bypasses_inside_guard(relay_turn):


### PR DESCRIPTION
## What does this PR do?

Uses NeMo Relay's canonical managed LLM operation names based on Hermes's API mode: `openai.chat_completions`, `openai.responses`, and `anthropic.messages`. Unknown API modes retain the provider-supplied name.

Relay middleware and dynamic plugins can dispatch on operation names. Passing arbitrary Hermes provider labels prevented general middleware from reliably identifying the underlying provider protocol.

This focused fix is extracted from #77915 so it can be reviewed and merged independently. #77915 will drop the duplicated commits after this lands.

## Related Issue

Relates to #77915

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a single API-mode-to-operation-name mapping in `agent/relay_llm.py`.
- Apply canonical names to synchronous, asynchronous, and streaming managed calls.
- Preserve custom provider names for unknown or absent API modes.
- Update direct and nested managed-execution tests.

## How to Test

1. Run the focused canonical-name tests in `tests/agent/test_relay_llm.py`.
2. Run `tests/agent/test_relay_nested_execution.py`.
3. Run Ruff on the changed files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python mapping and tests
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused canonical operation-name and nested-execution tests passed. Ruff passed on all changed files.
