### PR TITLE
fix(relay): unwrap lazy completed streams

### DIFF
--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -312,11 +312,11 @@ def stream_current(
         defer_logical_completion=defer_logical_completion,
         completed_response_predicate=completed_response_predicate,
     )
-    # In the non-managed path the factory already ran eagerly during __init__,
-    # so a completed response is visible immediately and must surface raw.
-    # In the managed path the factory runs lazily on first pull, so
-    # final_response is still None here and the managed stream is returned.
     if completed_response_predicate is not None:
+        # Relay may defer the provider callback until the first stream pull.
+        # Prime once so adapters that ignore stream=True can still return their
+        # completed response directly. A real first chunk is buffered.
+        managed._prime_completed_response()
         completed = getattr(managed, "final_response", None)
         if completed is not None:
             return completed
@@ -400,6 +400,7 @@ class ManagedLlmStream(Iterator[Any]):
         self._relay_observes_chunks = False
         self._provider_completed = False
         self._raw_chunks: list[tuple[Any, Any]] = []
+        self._prefetched_chunks: list[Any] = []
         self.output_modified = False
         callback_context = contextvars.copy_context()
 
@@ -569,9 +570,20 @@ class ManagedLlmStream(Iterator[Any]):
     def __iter__(self) -> "ManagedLlmStream":
         return self
 
+    def _prime_completed_response(self) -> None:
+        """Advance once while preserving a genuine first chunk."""
+        if self._closed or self._prefetched_chunks:
+            return
+        try:
+            self._prefetched_chunks.append(next(self))
+        except StopIteration:
+            pass
+
     def __next__(self) -> Any:
         if self._closed:
             raise StopIteration
+        if self._prefetched_chunks:
+            return self._prefetched_chunks.pop()
         if self._loop is None:
             try:
                 chunk = next(self._stream)
@@ -684,6 +696,7 @@ class ManagedLlmStream(Iterator[Any]):
         if self._closed:
             return
         self._closed = True
+        self._prefetched_chunks.clear()
         loop = self._loop
         self._loop = None
         if loop is None:

--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -286,6 +286,11 @@ def stream_current(
     own ``hasattr(stream, "choices")`` check handled it (#11732, #55933) —
     without the unwrap the response stays trapped as ``final_response`` on the
     inner ManagedLlmStream and the outer consumer sees an empty stream.
+
+    Determining that return shape requires starting a lazy managed pipeline.
+    The first pull therefore happens before this function returns: a genuine
+    first chunk is buffered, while provider latency and errors surface at the
+    same call boundary as the unmanaged ``stream_factory(request)`` path.
     """
     turn = relay_runtime.active_turn()
     if turn is None:

--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -287,10 +287,11 @@ def stream_current(
     without the unwrap the response stays trapped as ``final_response`` on the
     inner ManagedLlmStream and the outer consumer sees an empty stream.
 
-    Determining that return shape requires starting a lazy managed pipeline.
-    The first pull therefore happens before this function returns: a genuine
-    first chunk is buffered, while provider latency and errors surface at the
-    same call boundary as the unmanaged ``stream_factory(request)`` path.
+    Determining that return shape requires starting the lazy managed pipeline,
+    and Relay may read ahead internally while satisfying that first pull. A
+    genuine first returned chunk remains buffered, while provider work,
+    latency, and pre-first-yield errors may surface before this function
+    returns.
     """
     turn = relay_runtime.active_turn()
     if turn is None:

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -796,6 +796,31 @@ def test_stream_current_streams_iterators_with_predicate(tmp_path, monkeypatch):
         relay_runtime._reset_for_tests()
 
 
+def test_stream_current_primes_lazy_completed_response(relay_turn, monkeypatch):
+    """A lazy Relay stream must run once before Hermes decides its shape."""
+    _relay, _turn = relay_turn
+    completed = _completed_response()
+
+    class LazyCompletedStream:
+        final_response = None
+
+        def _prime_completed_response(self):
+            self.final_response = completed
+
+    lazy_stream = LazyCompletedStream()
+    monkeypatch.setattr(relay_llm, "stream", lambda *args, **kwargs: lazy_stream)
+
+    result = relay_llm.stream_current(
+        {"model": "test-model", "messages": [], "stream": True},
+        lambda request: completed,
+        name="test-provider",
+        model_name="test-model",
+        finalizer=dict,
+        completed_response_predicate=_choices_predicate,
+    )
+
+    assert result is completed
+
 
 def _completed_response(content: str = "done") -> SimpleNamespace:
     return SimpleNamespace(
@@ -833,6 +858,8 @@ def test_stream_managed_traps_direct_completed_response(relay_turn):
         finalizer=lambda: {},
         completed_response_predicate=_choices_predicate,
     )
+    stream._prime_completed_response()
+    assert stream._closed
     assert list(stream) == []
     assert stream.final_response is not None
     assert stream.final_response.choices[0].message.content == "done"

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -822,6 +822,44 @@ def test_stream_current_primes_lazy_completed_response(relay_turn, monkeypatch):
     assert result is completed
 
 
+def test_stream_current_preserves_real_relay_interceptor_chunks(relay_turn):
+    """Priming a real managed pipeline must retain its transformed first chunk."""
+    relay, _turn = relay_turn
+
+    def rewrite_stream(request, next_call):
+        async def generate():
+            upstream = await next_call(request)
+            async for chunk in upstream:
+                yield {**chunk, "delta": chunk["delta"].upper()}
+
+        return generate()
+
+    relay.intercepts.register_llm_stream_execution(
+        "hermes-test-prime-stream",
+        1,
+        rewrite_stream,
+    )
+    try:
+        result = relay_llm.stream_current(
+            {"model": "test-model", "messages": [], "stream": True},
+            lambda _request: iter([{"delta": "a"}, {"delta": "b"}]),
+            name="test-provider",
+            model_name="test-model",
+            finalizer=lambda: {"content": "AB"},
+            completed_response_predicate=_choices_predicate,
+        )
+
+        assert list(result) == [
+            SimpleNamespace(delta="A"),
+            SimpleNamespace(delta="B"),
+        ]
+        assert result.output_modified is True
+    finally:
+        relay.intercepts.deregister_llm_stream_execution(
+            "hermes-test-prime-stream"
+        )
+
+
 def _completed_response(content: str = "done") -> SimpleNamespace:
     return SimpleNamespace(
         model="test-model",

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -822,6 +822,36 @@ def test_stream_current_primes_lazy_completed_response(relay_turn, monkeypatch):
     assert result is completed
 
 
+def test_stream_current_unwraps_completed_response_with_real_interceptor(relay_turn):
+    """A real stream interceptor makes Relay lazy; completion still unwraps."""
+    relay, _turn = relay_turn
+    completed = _completed_response()
+
+    async def identity_stream(request, next_call):
+        return await next_call(request)
+
+    relay.intercepts.register_llm_stream_execution(
+        "hermes-test-prime-completed",
+        1,
+        identity_stream,
+    )
+    try:
+        result = relay_llm.stream_current(
+            {"model": "test-model", "messages": [], "stream": True},
+            lambda _request: completed,
+            name="test-provider",
+            model_name="test-model",
+            finalizer=lambda: completed,
+            completed_response_predicate=_choices_predicate,
+        )
+
+        assert result is completed
+    finally:
+        relay.intercepts.deregister_llm_stream_execution(
+            "hermes-test-prime-completed"
+        )
+
+
 def test_stream_current_preserves_real_relay_interceptor_chunks(relay_turn):
     """Priming a real managed pipeline must retain its transformed first chunk."""
     relay, _turn = relay_turn

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -860,6 +860,23 @@ def test_stream_current_preserves_real_relay_interceptor_chunks(relay_turn):
         )
 
 
+def test_stream_current_surfaces_managed_factory_error_before_return(relay_turn):
+    """Shape detection preserves the unmanaged factory-error boundary."""
+
+    def fail_factory(_request):
+        raise RuntimeError("provider failed before streaming")
+
+    with pytest.raises(RuntimeError, match="provider failed before streaming"):
+        relay_llm.stream_current(
+            {"model": "test-model", "messages": [], "stream": True},
+            fail_factory,
+            name="test-provider",
+            model_name="test-model",
+            finalizer=dict,
+            completed_response_predicate=_choices_predicate,
+        )
+
+
 def _completed_response(content: str = "done") -> SimpleNamespace:
     return SimpleNamespace(
         model="test-model",


### PR DESCRIPTION
## What does this PR do?

Correctly unwraps a completed provider response when Relay defers a nominal streaming callback until the first pull. A genuine first stream chunk is prefetched and returned normally; a completed response is surfaced directly and its stream resources are closed.

Some provider adapters ignore `stream=True` and return a completed response. On the managed path Relay starts the callback lazily, so Hermes previously checked `final_response` before the callback ran and returned an apparently empty stream.

This focused fix is extracted from #77915 and ported onto current `main` while preserving its newer stream-cleanup and operation-lease behavior. #77915 will drop the duplicated commits after this lands.

## Related Issue

Relates to #77915

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Prime one lazy managed-stream step before deciding whether the result is streaming or complete.
- Buffer and preserve a genuine first chunk.
- Clear prefetched chunks during close and finish completed responses during priming.
- Add regressions for lazy completed responses and real iterators.

## How to Test

1. Run the lazy completed-response tests in `tests/agent/test_relay_llm.py`.
2. Verify a genuine stream still returns its first prefetched chunk.
3. Run Ruff on `agent/relay_llm.py` and its tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python iterator lifecycle
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Three focused completed-response and iterator regressions passed. Ruff passed on all changed files.
