### PR TITLE
fix(gateway): route the hook event bridge through the leak-safe threadsafe helper

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4773,13 +4773,12 @@ class TurnRunner:
 
     def _event_callback_sync(self, event_type: str, context: dict) -> None:
         ctx = self._ctx
-        try:
-            asyncio.run_coroutine_threadsafe(
-                ctx._hooks_ref.emit(event_type, context),
-                ctx._loop_for_step,
-            )
-        except Exception as _e:
-            logger.debug("event_callback hook error: %s", _e)
+        safe_schedule_threadsafe(
+            ctx._hooks_ref.emit(event_type, context),
+            ctx._loop_for_step,
+            logger=logger,
+            log_message="event_callback hook scheduling error",
+        )
 
     def _attach_session_title_callback(self, agent, ctx) -> None:
         """Wire the platform thread-rename lane onto the agent as `_on_session_title`.

--- a/tests/gateway/test_event_callback_bridge.py
+++ b/tests/gateway/test_event_callback_bridge.py
@@ -1,0 +1,99 @@
+"""Leak-safety of the gateway hook-event bridge (``TurnRunner._event_callback_sync``).
+
+``_event_callback_sync`` is the sync -> async bridge that carries lifecycle hook
+events (notably ``session:compress``, emitted from
+``agent/conversation_compression.py`` and ``agent/codex_runtime.py``) from the
+agent thread onto the gateway's turn loop.  It is wired unconditionally in
+``_run_agent_inner`` -- unlike ``step_callback``, which is only attached when
+hooks are loaded -- so every gateway turn goes through it.
+
+Bridging a coroutine onto a loop that is closing or gone is the shutdown race
+that ``agent.async_utils.safe_schedule_threadsafe`` exists to absorb: a bare
+``asyncio.run_coroutine_threadsafe`` raises before the loop ever takes
+ownership, leaving the ``emit(...)`` coroutine created-but-never-awaited, which
+both drops the hook silently and leaks the coroutine frame with a
+``RuntimeWarning: coroutine ... was never awaited``.
+
+These tests pin the invariant on the loop-closed branch: the coroutine must end
+up *closed*, not merely have its exception swallowed -- swallowing was never
+the missing half.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+from gateway.turn_context import TurnContext
+
+
+class _RecordingHooks:
+    """Stands in for the gateway's hook registry.
+
+    ``emit`` is a real coroutine function, so calling it constructs a coroutine
+    object exactly as the production ``hooks.emit`` does.  The object is kept so
+    a test can inspect whether the bridge disposed of it.
+    """
+
+    def __init__(self) -> None:
+        self.coros: list = []
+        self.emitted: list[tuple[str, dict]] = []
+
+    async def emit(self, event_type: str, context: dict) -> None:
+        self.emitted.append((event_type, context))
+
+
+def _make_runner(ctx: TurnContext):
+    from gateway.run import TurnRunner
+
+    class _StubGatewayRunner:
+        def _adapter_for_source(self, source):
+            return None
+
+    return TurnRunner(_StubGatewayRunner(), ctx)
+
+
+def _bridge_one_event(loop) -> tuple[object, _RecordingHooks]:
+    """Drive one ``session:compress`` event through the bridge onto ``loop``.
+
+    Returns the ``emit()`` coroutine object the bridge was handed, so the caller
+    can assert what happened to it.
+    """
+    hooks = _RecordingHooks()
+    real_emit = hooks.emit
+
+    def _capturing_emit(event_type: str, context: dict):
+        coro = real_emit(event_type, context)
+        hooks.coros.append(coro)
+        return coro
+
+    hooks.emit = _capturing_emit  # type: ignore[method-assign]
+
+    ctx = TurnContext(_hooks_ref=hooks, _loop_for_step=loop)
+    runner = _make_runner(ctx)
+    runner._event_callback_sync("session:compress", {"session_id": "s-1"})
+
+    assert len(hooks.coros) == 1
+    return hooks.coros[0], hooks
+
+
+class TestEventCallbackBridgeLeakSafety:
+    def test_closed_step_loop_closes_the_event_coroutine(self, recwarn):
+        """A loop closed by shutdown must not strand the emit coroutine.
+
+        This is the live race: the compression path fires ``session:compress``
+        from the agent thread while the gateway is tearing its loop down.
+        ``run_coroutine_threadsafe`` raises inside ``call_soon_threadsafe``
+        before the loop adopts the coroutine, so unless the bridge closes it,
+        the hook is dropped *and* the frame leaks.
+        """
+        loop = asyncio.new_event_loop()
+        loop.close()
+
+        coro, hooks = _bridge_one_event(loop)
+
+        assert inspect.getcoroutinestate(coro) == inspect.CORO_CLOSED
+        # The coroutine never ran, so the hook body did not execute -- the
+        # point is that it was disposed of, not that it was delivered.
+        assert hooks.emitted == []
+        assert not [w for w in recwarn.list if "never awaited" in str(w.message)]

--- a/tests/gateway/test_event_callback_bridge.py
+++ b/tests/gateway/test_event_callback_bridge.py
@@ -14,15 +14,20 @@ ownership, leaving the ``emit(...)`` coroutine created-but-never-awaited, which
 both drops the hook silently and leaks the coroutine frame with a
 ``RuntimeWarning: coroutine ... was never awaited``.
 
-These tests pin the invariant on the loop-closed branch: the coroutine must end
-up *closed*, not merely have its exception swallowed -- swallowing was never
-the missing half.
+These tests pin the invariant on the two failure branches the helper
+distinguishes: the loop is closed, and the loop is missing entirely.  They
+assert the coroutine ends up *closed*, not merely that no exception escaped --
+swallowing the exception was never the missing half.
 """
 
 from __future__ import annotations
 
 import asyncio
 import inspect
+import threading
+import time
+
+import pytest
 
 from gateway.turn_context import TurnContext
 
@@ -97,3 +102,75 @@ class TestEventCallbackBridgeLeakSafety:
         # point is that it was disposed of, not that it was delivered.
         assert hooks.emitted == []
         assert not [w for w in recwarn.list if "never awaited" in str(w.message)]
+
+    def test_missing_step_loop_closes_the_event_coroutine(self, recwarn):
+        """``_loop_for_step`` can be ``None`` outright, a distinct branch.
+
+        The turn context carries ``_loop_for_step=None`` by default, and the
+        helper handles that without going near asyncio at all.  The bare bridge
+        instead reaches ``None.call_soon_threadsafe`` and leaks the coroutine on
+        the way out.
+        """
+        coro, hooks = _bridge_one_event(None)
+
+        assert inspect.getcoroutinestate(coro) == inspect.CORO_CLOSED
+        assert hooks.emitted == []
+        assert not [w for w in recwarn.list if "never awaited" in str(w.message)]
+
+    def test_live_step_loop_still_delivers_the_event(self):
+        """Invariant guard: the leak-safe path must not change the happy path.
+
+        A running loop still receives and runs the hook coroutine, so routing
+        through the helper is a pure hardening of the failure branches.
+        """
+        loop = asyncio.new_event_loop()
+        thread = None
+        try:
+            ready = threading.Event()
+
+            def _run() -> None:
+                asyncio.set_event_loop(loop)
+                loop.call_soon(ready.set)
+                loop.run_forever()
+
+            thread = threading.Thread(target=_run, daemon=True)
+            thread.start()
+            assert ready.wait(5.0)
+
+            coro, hooks = _bridge_one_event(loop)
+
+            waited = 0.0
+            while not hooks.emitted and waited < 5.0:
+                time.sleep(0.02)
+                waited += 0.02
+
+            assert hooks.emitted == [("session:compress", {"session_id": "s-1"})]
+            assert inspect.getcoroutinestate(coro) == inspect.CORO_CLOSED
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            if thread is not None:
+                thread.join(timeout=5.0)
+            loop.close()
+
+
+@pytest.mark.parametrize("loop_state", ["closed", "missing"])
+def test_bridge_stays_non_raising_and_returns_none(loop_state):
+    """Invariant guard on the bridge's own contract, both failure branches.
+
+    ``_event_callback_sync`` is called from the agent thread and is typed
+    ``-> None``; the ``except Exception`` it replaces already guaranteed the
+    non-raising half, and the helper must keep it while also returning nothing
+    (the future is deliberately not consumed here, matching the sibling
+    ``_step_callback_sync`` bridge).
+    """
+    if loop_state == "closed":
+        loop = asyncio.new_event_loop()
+        loop.close()
+    else:
+        loop = None
+
+    hooks = _RecordingHooks()
+    ctx = TurnContext(_hooks_ref=hooks, _loop_for_step=loop)
+    runner = _make_runner(ctx)
+
+    assert runner._event_callback_sync("session:compress", {"session_id": "s-1"}) is None


### PR DESCRIPTION
## What does this PR do?

`TurnRunner._event_callback_sync` (`gateway/run.py`) is the sync → async bridge that carries lifecycle hook events from the agent thread onto the gateway's turn loop. It called `asyncio.run_coroutine_threadsafe` directly inside a swallowing `except Exception`:

```python
def _event_callback_sync(self, event_type: str, context: dict) -> None:
    ctx = self._ctx
    try:
        asyncio.run_coroutine_threadsafe(
            ctx._hooks_ref.emit(event_type, context),
            ctx._loop_for_step,
        )
    except Exception as _e:
        logger.debug("event_callback hook error: %s", _e)
```

When the loop is closing or gone, `run_coroutine_threadsafe` raises inside `loop.call_soon_threadsafe` **before** the loop takes ownership of the coroutine. Catching the exception is not enough: the `hooks.emit(...)` coroutine is left in `CORO_CREATED`, so the hook silently never fires and its frame leaks with `RuntimeWarning: coroutine ... was never awaited`. This PR routes the bridge through `agent.async_utils.safe_schedule_threadsafe`, which closes the coroutine on both failure branches.

**This is finishing a sweep that already merged, not a new opinion.** Commit `4e89c53082b` — `fix(async): close unscheduled coroutines in all threadsafe bridges (#26584)`, 23 files, 2026-05-15 — introduced `safe_schedule_threadsafe` and converted every threadsafe bridge in the repo. This bridge is not a site that sweep missed; it did not exist yet. `git log -S'_hooks_ref.emit(event_type, context)' -- gateway/run.py` pins its introduction to `e76e7b50730` (`feat(hooks): session:compress event_callback for MemPalace sync`), committed 2026-06-16 — a month after the sweep — and `git merge-base --is-ancestor 4e89c53082b e76e7b50730` confirms the ordering. The invariant was already repo-wide; this one bridge regressed it on arrival.

**The contrast is in-file and one commit wide.** `_step_callback_sync`, twelve lines above, emits onto the same `ctx._loop_for_step` via the same `ctx._hooks_ref.emit(...)` and already goes through the helper with `logger=` / `log_message=`. `git blame` attributes every line of both method bodies to the same commit, `1a3a9de630a` (`refactor(gateway): extract run_sync onto TurnRunner`). This change gives the event bridge the sibling's shape, with an event-specific `log_message` so a scheduling failure stays attributable.

**Why this is a live path, not a paper one.** Unlike `step_callback`, which is attached only when hooks are loaded —

```python
agent.step_callback = ctx._step_callback_sync if ctx._hooks_ref.loaded_hooks else None   # gated
agent.event_callback = ctx._event_callback_sync                                          # unconditional
```

— the event bridge is wired unconditionally, so it is on the production turn path for every gateway turn. Its real emitters are `agent/conversation_compression.py` and `agent/codex_runtime.py`, both firing `session:compress`. So a user-authored compress hook (the introducing commit's own use case is memory sync) is dropped exactly when the gateway is shutting down — the moment persisting that state matters most.

**Sibling sweep.** This is the last raw `asyncio.run_coroutine_threadsafe` left in the Python core (`cli.py`, `hermes_cli/`, `gateway/`, `tui_gateway/`, `utils.py`, `hermes_state*.py`). The only other `*_threadsafe` call in `gateway/run.py` is `loop.call_soon_threadsafe(shutdown_handler, None)`, which passes a plain callable and constructs no coroutine, so it is outside this invariant. Nothing else to widen to.

**Rival disclosure, stated as a checked-N rather than an absence claim:** I checked the diffs of **569 open PRs touching `gateway/run.py`**, enumerated in both `created-asc` and `created-desc` order, and grepped each one's patch for `_event_callback_sync` / `_step_callback_sync` / `agent.event_callback`; 15 carried one of those symbols and every one of them is a hunk-header context anchor or an edit to the callback *wiring* block, not to this method body (7 PRs whose patch was too large for the API were checked with `gh pr diff`). The by-file census is a floor, not a ceiling — dense slices return exactly the API's cap of rows — so I am not claiming "no rivals", only that none of the 569 diffs I read modifies this method.

## Related Issue

No filed issue. This completes the merged sweep in **#26584** (`4e89c53082b`) on a bridge introduced after it; the ancestry is proved above rather than asserted.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — `TurnRunner._event_callback_sync` now schedules through `safe_schedule_threadsafe(..., logger=logger, log_message="event_callback hook scheduling error")` instead of a raw `asyncio.run_coroutine_threadsafe` in a swallowing `except Exception`. The returned future is deliberately left unconsumed, matching `_step_callback_sync`.
- `tests/gateway/test_event_callback_bridge.py` (new) — 5 tests: two regression tests for the failure branches, and three invariant guards.

Three commits, each independently meaningful and green on its own:

1. `fix(gateway):` the production change.
2. `test(gateway):` the loop-closed branch.
3. `test(gateway):` the loop-missing branch plus the happy-path/contract guards.

## How to Test

```
uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_event_callback_bridge.py -v
```

Fail-before / pass-after, verified explicitly by restoring `gateway/run.py` from clean `origin/main` with the new tests in place:

| test | on clean `origin/main` | with this PR |
|---|---|---|
| `test_closed_step_loop_closes_the_event_coroutine` | **FAIL** — `CORO_CREATED != CORO_CLOSED` | pass |
| `test_missing_step_loop_closes_the_event_coroutine` | **FAIL** — `CORO_CREATED != CORO_CLOSED` | pass |
| `test_live_step_loop_still_delivers_the_event` | pass (invariant guard) | pass |
| `test_bridge_stays_non_raising_and_returns_none[closed]` | pass (invariant guard) | pass |
| `test_bridge_stays_non_raising_and_returns_none[missing]` | pass (invariant guard) | pass |

The `origin/main` run also emits `RuntimeWarning: coroutine '_RecordingHooks.emit' was never awaited` at teardown — the user-visible symptom — which disappears with the fix.

The two green-before tests are there on purpose: they prove this is a pure hardening of the failure branches (a live loop still receives *and runs* the hook coroutine; the bridge stays non-raising and still returns `None`), not a behaviour change.

Adjacent suites run green: `tests/gateway/test_turn_context.py`, `tests/gateway/test_session_title_rename_lane.py`, `tests/gateway/test_skip_context_files_wiring.py`, `tests/gateway/test_fallback_chain_reload.py`, `tests/agent/test_async_utils.py`, `tests/gateway/test_shutdown_flush.py`, `tests/gateway/test_13121_shutdown_inflight_transcript_flush.py`, `tests/gateway/test_53175_cleanup_off_loop.py`, `tests/gateway/test_gateway_shutdown.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the focused + adjacent suites listed under "How to Test", not the full tree -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- pure asyncio, no platform-specific code; tests are host-agnostic -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Contract Protected

**Invariant:** a coroutine handed to a threadsafe bridge is always disposed of — scheduled onto the loop, or closed. It is never left in `CORO_CREATED`.

**Known-bad inputs (both now covered):** `ctx._loop_for_step` is a closed loop; `ctx._loop_for_step` is `None`.

**Future-input coverage:** the invariant is enforced by the shared helper rather than by this call site, so a later refactor of the emit payload, the event name, or the hook registry cannot silently reintroduce the leak.

**Negative case:** `test_live_step_loop_still_delivers_the_event` fails if the change ever suppresses delivery on a healthy loop, so the guard cannot be satisfied by simply not emitting.
