### PR TITLE
fix(gateway): align /resume numbered list with /sessions (unnamed sessions no longer consume the limit window)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4367,12 +4367,25 @@ class GatewaySlashCommandsMixin:
         async def _list_titled_sessions() -> list[dict]:
             user_source = source.platform.value if source.platform else None
             widen = allow_all and self._resume_caller_is_admin(source)
-            sessions = await self._session_db.list_sessions_rich(
+            from hermes_cli.session_listing import query_session_listing
+            current_entry = await self.async_session_store.get_or_create_session(source)
+            # Use the same over-fetching listing helper as /sessions so the
+            # numbered /resume list matches /sessions exactly: unnamed/empty
+            # sessions near the top of the recent window no longer squeeze
+            # titled sessions out of the limit-10 fetch (they consumed the
+            # window, making /resume <N> indexes disagree with /sessions).
+            sessions = await asyncio.to_thread(
+                query_session_listing,
+                getattr(self._session_db, "_db", self._session_db),
                 source=user_source,
                 session_key=None if widen else session_key,
+                current_session_id=current_entry.session_id,
+                include_all_sources=widen,
+                include_unnamed=False,
                 limit=10,
+                exclude_sources=["tool"],
             )
-            return [s for s in sessions if s.get("title")][:10]
+            return sessions
 
         if not name:
             # List recent titled sessions for this user/platform


### PR DESCRIPTION
## Problem

The gateway `/resume` command (no args) listed **fewer** sessions than `/sessions`, so the numeric indexes disagreed between the two surfaces. In the reporter's case `/sessions` showed 7 titled sessions but `/resume 6` failed with `Resume index 6 is out of range.`

**Root cause:** `_list_titled_sessions` in `gateway/slash_commands.py` fetched only the 10 most recent sessions (`list_sessions_rich(limit=10)`) and then filtered to titled ones. Empty/placeholder gateway sessions (0 messages, no title) near the top of the recent window consumed the limit, so the titled list came back shorter than `/sessions`, which over-fetches (`fetch_limit = max(limit*4, limit)` in `query_session_listing`) before filtering.

## Fix

Make `/resume` use the **same** `query_session_listing` helper as `/sessions` (fetch 40 → filter titled → cap at 10). Both surfaces now render the identical numbered list, so `/resume <N>` indexes always match the `/sessions` display.

Verified against a real session store: previously `/resume` returned 6 titled sessions while `/sessions` showed 9; after the fix both return the same 9 entries in the same order.

## Tests

`tests/gateway/test_resume_command.py` — 25 passed (including `test_bare_resume_lists_exact_lane_before_limit`, `test_numeric_resume_fallback_uses_exact_lane_candidates`, `test_sessions_search_finds_older_titled_session`).