### PR TITLE
fix: isolate agent browser research from visible Chrome

### DIFF
--- a/agent/browser_interaction_policy.py
+++ b/agent/browser_interaction_policy.py
@@ -1,0 +1,77 @@
+"""Central policy for agent-driven visible browser interaction.
+
+Routine agent work is isolated/headless by default.  A human-owned foreground
+session may opt into visible browser control by setting
+``HERMES_BROWSER_INTERACTION=visible``.  Dispatcher workers and delegated
+children always fail closed, even if they inherit that process setting.
+
+Artifact presentation remains outside this policy: desktop/TUI user gestures
+and ``open_preview`` do not call these helpers.
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import Optional
+
+_POLICY_ENV = "HERMES_BROWSER_INTERACTION"
+_VISIBLE_VALUES = frozenset({"visible", "interactive", "headed"})
+
+
+def _is_unattended_context() -> bool:
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        return True
+    try:
+        from agent.delegation_context import (
+            is_delegated_child_process_context,
+            is_dispatcher_owned_worker_context,
+        )
+
+        if is_delegated_child_process_context():
+            return True
+        # Cron runs spawned in-process from a worker are marked non-owner.
+        if os.environ.get("HERMES_KANBAN_TASK") and not is_dispatcher_owned_worker_context():
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def visible_browser_allowed() -> bool:
+    """Whether this execution may control or launch a visible browser."""
+    if _is_unattended_context():
+        return False
+    return os.environ.get(_POLICY_ENV, "isolated").strip().lower() in _VISIBLE_VALUES
+
+
+_BROWSER_EXECUTABLE = re.compile(
+    r"(?:^|[;&|]\s*|\b(?:env|command|nohup)\s+)(?:[^\n;&|]*\s+)?"
+    r"(?:google-chrome|chrome|chromium|chromium-browser|brave|msedge|firefox)"
+    r"(?:\.exe)?(?:\s|$)",
+    re.IGNORECASE,
+)
+_OS_OPENER_URL = re.compile(
+    r"(?:^|[;&|]\s*)(?:open|xdg-open|start)(?:\s+-a\s+[^\n;&|]+)?\s+"
+    r"(?:['\"])?https?://",
+    re.IGNORECASE,
+)
+_PYTHON_WEBBROWSER = re.compile(
+    r"\bpython(?:3(?:\.\d+)?)?\s+-m\s+webbrowser\b", re.IGNORECASE
+)
+_HEADLESS_FLAG = re.compile(r"--headless(?:=\S+)?\b", re.IGNORECASE)
+
+
+def blocked_visible_browser_command(command: str) -> Optional[str]:
+    """Return a refusal reason for obvious GUI-browser shell launches.
+
+    This is defense in depth at the generic terminal boundary.  Network CLI
+    clients and browser processes carrying an explicit ``--headless`` flag are
+    unaffected.
+    """
+    if visible_browser_allowed() or not isinstance(command, str):
+        return None
+    if _PYTHON_WEBBROWSER.search(command) or _OS_OPENER_URL.search(command):
+        return "Visible browser launch blocked by the isolated research policy."
+    if _BROWSER_EXECUTABLE.search(command) and not _HEADLESS_FLAG.search(command):
+        return "Headed browser launch blocked by the isolated research policy."
+    return None

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2334,6 +2334,8 @@ class CLICommandsMixin:
                 print()
                 return
 
+            # /browser connect is the explicit, foreground opt-in boundary.
+            os.environ["HERMES_BROWSER_INTERACTION"] = "visible"
             os.environ["BROWSER_CDP_URL"] = cdp_url
             # Eagerly start the CDP supervisor so pending_dialogs + frame_tree
             # show up in the next browser_snapshot.  No-op if already started.
@@ -2365,6 +2367,7 @@ class CLICommandsMixin:
         elif sub == "disconnect":
             if current:
                 os.environ.pop("BROWSER_CDP_URL", None)
+                os.environ.pop("HERMES_BROWSER_INTERACTION", None)
                 try:
                     from tools.browser_tool import cleanup_all_browsers, _stop_cdp_supervisor
                     _stop_cdp_supervisor("default")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10335,6 +10335,11 @@ def _default_spawn(
     from gateway.session_context import _VAR_MAP
     for key in _VAR_MAP:
         env.pop(key, None)
+    # Board workers are unattended. Never inherit a foreground session's
+    # headed-browser or operator-CDP capability.
+    env["HERMES_BROWSER_INTERACTION"] = "isolated"
+    env.pop("AGENT_BROWSER_HEADED", None)
+    env.pop("BROWSER_CDP_URL", None)
 
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
     # (fallback_providers, toolsets, agent settings, etc.) instead of the root

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -83,6 +83,9 @@ agent:
     assert pid == 4242
     assert captured["env"]["HERMES_HOME"] == str(profile)
     assert captured["env"]["HERMES_KANBAN_TASK"] == "t_spawn_tools"
+    assert captured["env"]["HERMES_BROWSER_INTERACTION"] == "isolated"
+    assert "AGENT_BROWSER_HEADED" not in captured["env"]
+    assert "BROWSER_CDP_URL" not in captured["env"]
     assert "--toolsets" in captured["cmd"]
     pinned = captured["cmd"][captured["cmd"].index("--toolsets") + 1].split(",")
     for required in ("terminal", "web", "file", "skills", "code_execution", "delegation"):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -13394,6 +13394,7 @@ def test_browser_manage_connect_sets_env_and_cleans_twice(monkeypatch):
         "Chromium-family browser is already listening at http://127.0.0.1:9222"
     ]
     assert os.environ.get("BROWSER_CDP_URL") == "http://127.0.0.1:9222"
+    assert os.environ.get("HERMES_BROWSER_INTERACTION") == "visible"
     # First cleanup runs against the OLD env (none here), second against the NEW.
     assert cleanup_calls == ["", "http://127.0.0.1:9222"]
 

--- a/tests/tools/test_browser_headed_mode.py
+++ b/tests/tools/test_browser_headed_mode.py
@@ -20,9 +20,15 @@ def _reset_headed_cache():
 
 @pytest.fixture(autouse=True)
 def _clean_headed_cache():
+    previous = os.environ.get("HERMES_BROWSER_INTERACTION")
+    os.environ["HERMES_BROWSER_INTERACTION"] = "visible"
     _reset_headed_cache()
     yield
     _reset_headed_cache()
+    if previous is None:
+        os.environ.pop("HERMES_BROWSER_INTERACTION", None)
+    else:
+        os.environ["HERMES_BROWSER_INTERACTION"] = previous
 
 
 # ---------------------------------------------------------------------------
@@ -40,14 +46,27 @@ class TestIsHeadedMode:
     def test_config_true(self):
         from tools.browser_tool import _is_headed_mode
         cfg = {"browser": {"headed": True}}
-        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+        with patch("hermes_cli.config.load_config", return_value=cfg):
             assert _is_headed_mode() is True
+
+    def test_managed_false_wins_over_raw_profile_true(self):
+        from tools.browser_tool import _is_headed_mode
+        resolved = {"browser": {"headed": False}}
+        with patch("hermes_cli.config.load_config", return_value=resolved):
+            assert _is_headed_mode() is False
+
+    def test_isolated_policy_forces_false(self, monkeypatch):
+        from tools.browser_tool import _is_headed_mode
+        monkeypatch.delenv("HERMES_BROWSER_INTERACTION", raising=False)
+        resolved = {"browser": {"headed": True}}
+        with patch("hermes_cli.config.load_config", return_value=resolved):
+            assert _is_headed_mode() is False
 
 
     def test_caching(self):
         from tools.browser_tool import _is_headed_mode
         cfg = {"browser": {"headed": True}}
-        with patch("hermes_cli.config.read_raw_config", return_value=cfg) as mock_read:
+        with patch("hermes_cli.config.load_config", return_value=cfg) as mock_read:
             assert _is_headed_mode() is True
             assert _is_headed_mode() is True
             assert mock_read.call_count == 1

--- a/tests/tools/test_browser_interaction_policy.py
+++ b/tests/tools/test_browser_interaction_policy.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+
+
+def test_default_policy_is_isolated(monkeypatch):
+    monkeypatch.delenv("HERMES_BROWSER_INTERACTION", raising=False)
+    from agent.browser_interaction_policy import visible_browser_allowed
+
+    assert visible_browser_allowed() is False
+
+
+def test_explicit_visible_policy_allows_foreground_session(monkeypatch):
+    monkeypatch.setenv("HERMES_BROWSER_INTERACTION", "visible")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from agent.browser_interaction_policy import visible_browser_allowed
+
+    assert visible_browser_allowed() is True
+
+
+def test_delegated_child_cannot_inherit_visible_policy(monkeypatch):
+    monkeypatch.setenv("HERMES_BROWSER_INTERACTION", "visible")
+    from agent.browser_interaction_policy import visible_browser_allowed
+    from agent.delegation_context import delegated_child_context
+
+    with delegated_child_context("child-session"):
+        assert visible_browser_allowed() is False
+
+
+def test_kanban_worker_cannot_inherit_visible_policy(monkeypatch):
+    monkeypatch.setenv("HERMES_BROWSER_INTERACTION", "visible")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_policy")
+    from agent.browser_interaction_policy import visible_browser_allowed
+
+    assert visible_browser_allowed() is False
+
+
+def test_computer_use_browser_actions_refused_without_visible_policy(monkeypatch):
+    monkeypatch.delenv("HERMES_BROWSER_INTERACTION", raising=False)
+    from tools.computer_use.tool import handle_computer_use
+
+    result = json.loads(handle_computer_use({"action": "cua_browser_prepare", "pid": 42}))
+    assert result["code"] == "visible_browser_policy"
+
+
+def test_terminal_blocks_gui_browser_launch_but_allows_fetch_and_headless(monkeypatch):
+    monkeypatch.delenv("HERMES_BROWSER_INTERACTION", raising=False)
+    from agent.browser_interaction_policy import blocked_visible_browser_command
+
+    assert blocked_visible_browser_command("open https://example.com")
+    assert blocked_visible_browser_command("open -a 'Google Chrome' https://example.com")
+    assert blocked_visible_browser_command("google-chrome https://example.com")
+    assert blocked_visible_browser_command("python -m webbrowser https://example.com")
+    assert blocked_visible_browser_command("curl -fsSL https://example.com") is None
+    assert blocked_visible_browser_command("chromium --headless https://example.com") is None

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -302,12 +302,19 @@ class TestLegacyCloudMigration:
         assert _is_provider_active(cli_row, dict(self._LEGACY)) is False
 
 
+@pytest.fixture(autouse=True)
+def _visible_browser_policy_for_legacy_contracts(monkeypatch):
+    """Existing Browser Use tests exercise the explicit foreground contract."""
+    monkeypatch.setenv("HERMES_BROWSER_INTERACTION", "visible")
+
+
 class TestBackendCdpResolution:
     """browser_exec routes through the configured browser backend by reusing
     the legacy stack's provider session machinery (_get_session_info)."""
 
     def _env(self):
         return {}
+
 
     def test_existing_bu_env_wins(self, monkeypatch):
         env = {"BU_CDP_WS": "ws://operator-override:9222"}
@@ -351,6 +358,23 @@ class TestBackendCdpResolution:
         env = self._env()
         assert bu_cli._resolve_backend_cdp(env, "t1") is None
         assert "BU_CDP_WS" not in env and "BU_CDP_URL" not in env
+
+    def test_isolated_policy_refuses_operator_cdp(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        monkeypatch.delenv("HERMES_BROWSER_INTERACTION", raising=False)
+        monkeypatch.setattr(bt, "_get_cdp_override", lambda: "http://127.0.0.1:9222")
+        err = bu_cli._resolve_backend_cdp(self._env(), "t1")
+        assert err and "visible browser" in err.lower()
+
+    def test_isolated_policy_refuses_implicit_local_chrome(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        monkeypatch.delenv("HERMES_BROWSER_INTERACTION", raising=False)
+        monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(bt, "_get_cloud_provider", lambda: None)
+        err = bu_cli._resolve_backend_cdp(self._env(), "t1")
+        assert err and "web_search" in err
 
     def test_provider_failure_returns_error(self, monkeypatch):
         import tools.browser_tool as bt

--- a/tests/tools/test_research_browser_isolation_e2e.py
+++ b/tests/tools/test_research_browser_isolation_e2e.py
@@ -1,0 +1,203 @@
+"""End-to-end contracts for isolated agent research and presentation.
+
+These scenarios cross the public tool handlers and dispatcher spawn boundary.
+They intentionally fail if routine research reaches a GUI browser launch path.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+
+
+class _ResearchProvider:
+    name = "contract-provider"
+
+    def supports_search(self):
+        return True
+
+    def supports_extract(self):
+        return True
+
+    def search(self, query, limit):
+        return {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "title": "Isolation contract",
+                        "url": "https://example.test/isolation",
+                        "description": query,
+                        "position": 1,
+                    }
+                ]
+            },
+        }
+
+    async def extract(self, urls, format=None):
+        return [
+            {
+                "url": urls[0],
+                "title": "Isolation contract",
+                "content": "Research stayed on the HTTP provider path.",
+                "error": None,
+            }
+        ]
+
+
+def _forbid_gui_launch(*_args, **_kwargs):
+    raise AssertionError("routine research attempted to launch a browser process")
+
+
+def test_search_page_retrieval_and_multistep_research_never_launch_gui(monkeypatch):
+    """Search -> select -> retrieve stays on API/HTTP providers end to end."""
+    from agent import web_search_registry
+    from tools import desktop_ui, web_tools
+
+    provider = _ResearchProvider()
+    monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(web_tools, "_get_search_backend", lambda: provider.name)
+    monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: provider.name)
+    monkeypatch.setattr(web_search_registry, "get_provider", lambda _name: provider)
+    monkeypatch.setattr(web_search_registry, "get_active_search_provider", lambda: provider)
+    monkeypatch.setattr(web_tools, "async_is_safe_url", lambda _url: asyncio.sleep(0, result=True))
+    preview_events = []
+    desktop_ui.set_emitter(
+        lambda _sid, event, payload: preview_events.append((event, payload))
+    )
+    monkeypatch.setattr(subprocess, "Popen", _forbid_gui_launch)
+    monkeypatch.setattr(subprocess, "run", _forbid_gui_launch)
+
+    try:
+        search = json.loads(web_tools.web_search_tool("headless research contract", limit=3))
+        selected_url = search["data"]["web"][0]["url"]
+        extracted = json.loads(asyncio.run(web_tools.web_extract_tool([selected_url])))
+    finally:
+        desktop_ui.set_emitter(None)
+
+    assert selected_url == "https://example.test/isolation"
+    assert extracted["results"][0]["content"] == "Research stayed on the HTTP provider path."
+    assert preview_events == []
+
+
+def test_default_and_ct106_remote_routing_force_headless_and_ignore_cdp(monkeypatch):
+    """Local defaults and the CT106-style SSH backend share the same policy."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_BROWSER_INTERACTION", raising=False)
+    monkeypatch.setenv("AGENT_BROWSER_HEADED", "true")
+    monkeypatch.setenv("BROWSER_CDP_URL", "http://127.0.0.1:9222")
+
+    from tools import browser_tool
+
+    browser_tool._headed_mode_resolved = False
+    browser_tool._cached_headed_mode = None
+    assert browser_tool._is_headed_mode() is False
+    assert browser_tool._get_cdp_override() == ""
+
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_SSH_HOST", "ct106")
+    browser_tool._headed_mode_resolved = False
+    browser_tool._cached_headed_mode = None
+    assert browser_tool._is_headed_mode() is False
+    assert browser_tool._get_cdp_override() == ""
+
+    monkeypatch.setenv("HERMES_BROWSER_INTERACTION", "visible")
+    browser_tool._headed_mode_resolved = False
+    browser_tool._cached_headed_mode = None
+    assert browser_tool._is_headed_mode() is True
+    assert browser_tool._get_cdp_override() == "http://127.0.0.1:9222"
+
+def test_card_worker_spawn_scrubs_visible_browser_overrides(monkeypatch, tmp_path):
+    """A card worker is isolated even when its dispatcher is foreground-enabled."""
+    from hermes_cli import kanban_db as kb
+
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "researcher"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text("toolsets:\n  - web\n  - browser\n", encoding="utf-8")
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    task = kb.Task(
+        id="t_research",
+        title="research",
+        body=None,
+        assignee="researcher",
+        status="running",
+        priority=0,
+        created_by="test",
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=str(workspace),
+        claim_lock="lock",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=7,
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("HERMES_BROWSER_INTERACTION", "visible")
+    monkeypatch.setenv("AGENT_BROWSER_HEADED", "true")
+    monkeypatch.setenv("BROWSER_CDP_URL", "http://127.0.0.1:9222")
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class _Proc:
+        pid = 4242
+
+    def _capture(_cmd, *args, **kwargs):
+        captured["env"] = kwargs["env"]
+        return _Proc()
+
+    monkeypatch.setattr(subprocess, "Popen", _capture)
+    assert kb._default_spawn(task, str(workspace)) == 4242
+    assert captured["env"]["HERMES_BROWSER_INTERACTION"] == "isolated"
+    assert "AGENT_BROWSER_HEADED" not in captured["env"]
+    assert "BROWSER_CDP_URL" not in captured["env"]
+
+
+def test_explicit_artifact_preview_remains_available_while_research_is_isolated(monkeypatch):
+    """Presentation is an explicit desktop event, not browser research automation."""
+    from tools import desktop_ui
+    from tools.open_preview_tool import open_preview_tool
+
+    monkeypatch.setenv("HERMES_BROWSER_INTERACTION", "isolated")
+    events = []
+    desktop_ui.set_emitter(lambda _sid, event, payload: events.append((event, payload)))
+    try:
+        result = json.loads(open_preview_tool("/tmp/research-report.html", "Research report"))
+    finally:
+        desktop_ui.set_emitter(None)
+
+    assert result["success"] is True
+    assert events == [
+        ("preview.open", {"url": "/tmp/research-report.html", "label": "Research report"})
+    ]
+
+
+def test_browser_docs_explain_research_isolation_presentation_and_migration():
+    docs = Path("website/docs/user-guide/features/browser.md").read_text(encoding="utf-8")
+
+    for required in (
+        "Research is isolated by default",
+        "Artifact presentation is separate",
+        "Opt in to a visible browser",
+        "Migration notes",
+        "Kanban workers",
+        "CT106",
+    ):
+        assert required in docs
+
+    operator_docs = Path("website/docs/developer-guide/browser-supervisor.md").read_text(
+        encoding="utf-8"
+    )
+    for required in (
+        "Agent research isolation",
+        "HERMES_BROWSER_INTERACTION",
+        "HERMES_KANBAN_TASK",
+        "open_preview",
+    ):
+        assert required in operator_docs

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -534,6 +534,11 @@ def _get_cdp_override_raw() -> str:
     "do not execute ``agent-browser --version`` here" rule in
     ``check_browser_requirements``: no side effects during schema build.
     """
+    from agent.browser_interaction_policy import visible_browser_allowed
+
+    if not visible_browser_allowed():
+        return ""
+
     env_override = os.environ.get("BROWSER_CDP_URL", "").strip()
     if env_override:
         return env_override
@@ -1045,6 +1050,10 @@ def _is_headed_mode() -> bool:
     var as fallback.  Result is cached after the first call.
     """
     global _cached_headed_mode, _headed_mode_resolved
+    from agent.browser_interaction_policy import visible_browser_allowed
+
+    if not visible_browser_allowed():
+        return False
     if _headed_mode_resolved:
         return _cached_headed_mode  # type: ignore[return-value]
 
@@ -1052,8 +1061,8 @@ def _is_headed_mode() -> bool:
     _cached_headed_mode = False
 
     try:
-        from hermes_cli.config import read_raw_config
-        cfg = read_raw_config()
+        from hermes_cli.config import load_config
+        cfg = load_config()
         val = cfg.get("browser", {}).get("headed")
         if val is not None:
             _cached_headed_mode = str(val).strip().lower() in ("true", "1", "yes")

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -385,7 +385,15 @@ def _resolve_backend_cdp(env: dict, task_id: Optional[str]) -> Optional[str]:
 
     Returns an error string on provider failure, None on success.
     """
+    from agent.browser_interaction_policy import visible_browser_allowed
+
+    allow_visible = visible_browser_allowed()
     if env.get("BU_CDP_WS") or env.get("BU_CDP_URL"):
+        if not allow_visible:
+            return (
+                "Visible browser/CDP overrides are disabled for isolated agent "
+                "research. Use web_search/web_extract or a configured cloud browser."
+            )
         return None
 
     try:
@@ -403,6 +411,11 @@ def _resolve_backend_cdp(env: dict, task_id: Optional[str]) -> Optional[str]:
     except Exception:
         override = ""
     if override:
+        if not allow_visible:
+            return (
+                "Visible browser/CDP overrides are disabled for isolated agent "
+                "research. Use web_search/web_extract or a configured cloud browser."
+            )
         env["BU_CDP_URL" if override.startswith(("http://", "https://")) else "BU_CDP_WS"] = override
         return None
 
@@ -412,6 +425,13 @@ def _resolve_backend_cdp(env: dict, task_id: Optional[str]) -> Optional[str]:
         logger.debug("Cloud provider lookup failed: %s", e)
         provider = None
     if provider is None:
+        if not allow_visible:
+            return (
+                "No isolated browser backend is configured; refusing Browser Use's "
+                "implicit local Chrome fallback. Use web_search/web_extract, set "
+                "browser.backend: off for Hermes' headless browser, or configure a "
+                "cloud browser provider."
+            )
         return None
 
     # Browser Use direct-API configs: the CLI talks to Browser Use cloud

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -446,6 +446,15 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
     action = (args.get("action") or "").strip().lower()
     if not action:
         return json.dumps({"error": "missing `action`"})
+    if action.startswith("cua_browser_"):
+        from agent.browser_interaction_policy import visible_browser_allowed
+
+        if not visible_browser_allowed():
+            return json.dumps({
+                "error": "Visible desktop browser control is disabled for isolated agent research.",
+                "code": "visible_browser_policy",
+                "hint": "Use web_search/web_extract or the isolated browser toolset.",
+            })
     # Per-run key for approval-state and daemon-mode isolation across
     # concurrent sessions.
     session_id = str(kwargs.get("session_id") or "")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2586,6 +2586,17 @@ def terminal_tool(
                 "status": "error",
             }, ensure_ascii=False)
 
+        from agent.browser_interaction_policy import blocked_visible_browser_command
+
+        browser_refusal = blocked_visible_browser_command(command)
+        if browser_refusal:
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": browser_refusal,
+                "status": "blocked",
+            }, ensure_ascii=False)
+
         # Get configuration
         config = _get_env_config()
         env_type = config["env_type"]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -14425,6 +14425,9 @@ def _browser_connect(rid, params: dict) -> dict:
         # then again AFTER so the default task's cached supervisor
         # is drained against the new URL.
         cleanup_all_browsers()
+        # browser.manage(connect) is an explicit foreground opt-in. Detached
+        # agents cannot reach this UI boundary.
+        os.environ["HERMES_BROWSER_INTERACTION"] = "visible"
         os.environ["BROWSER_CDP_URL"] = normalized
         cleanup_all_browsers()
     except Exception as e:
@@ -14449,6 +14452,7 @@ def _browser_disconnect(rid) -> dict:
 
     reap()
     os.environ.pop("BROWSER_CDP_URL", None)
+    os.environ.pop("HERMES_BROWSER_INTERACTION", None)
     reap()
     return _ok(rid, {"connected": False})
 

--- a/website/docs/developer-guide/browser-supervisor.md
+++ b/website/docs/developer-guide/browser-supervisor.md
@@ -45,6 +45,26 @@ API either way.
 
 Camofox is unsupported — no CDP surface, REST-only.
 
+## Agent research isolation
+
+The supervisor participates only after browser routing selects an allowed CDP endpoint.
+Routine research defaults to the isolated policy in
+`agent/browser_interaction_policy.py`: without an explicit foreground connect action,
+local headed mode and local CDP overrides resolve to disabled. Browser Use must use a
+configured cloud endpoint or fail closed instead of attaching to Chrome.
+
+`HERMES_BROWSER_INTERACTION` is internal, process-scoped policy state. Foreground
+`/browser connect` and desktop `browser.manage(connect)` set it to `visible`; their
+disconnect paths clear it. Do not document it as a user configuration knob. Contexts
+with `HERMES_KANBAN_TASK`, plus delegated child contexts, always deny visible browser
+control even if they inherit a visible value. The Kanban dispatcher additionally sets
+`isolated` and removes `AGENT_BROWSER_HEADED`, `BROWSER_CDP_URL`, `BU_CDP_URL`, and
+`BU_CDP_WS` from each worker environment.
+
+Keep research and presentation separate. `open_preview` emits a desktop renderer event
+to show a requested URL or artifact and intentionally bypasses this browser-automation
+policy. It is exposed only to the owning desktop session, not background card workers.
+
 ## Architecture
 
 ### CDPSupervisor

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -20,6 +20,53 @@ Hermes Agent includes a full browser automation toolset with multiple backend op
 
 In all modes, the agent can navigate websites, interact with page elements, fill forms, and extract information.
 
+## Research is isolated by default
+
+Routine agent research does not use or focus your visible Chrome window. `web_search`
+and `web_extract` use API/HTTP providers, and browser automation uses a cloud or
+headless/isolated browser. If Browser Use has no isolated backend, Hermes refuses its
+implicit local-Chrome fallback rather than opening Chrome. This policy applies to
+normal foreground routing, remote terminal backends such as the CT106 SSH backend,
+delegated agents, and Kanban workers. Card workers also discard inherited headed and
+CDP overrides before they start.
+
+For simple lookup and page retrieval, prefer `web_search` followed by `web_extract`.
+Use browser automation only when the task requires page interaction.
+
+### Artifact presentation is separate
+
+Showing a result is not research automation. In the Hermes desktop app, an explicit
+`open_preview` request can present a URL, local dev server, or generated file in the
+preview pane beside the chat. User-initiated link and artifact actions remain
+available. Background agents do not receive this desktop-only presentation tool and
+do not take over the operator's browser merely to collect information.
+
+### Opt in to a visible browser
+
+A human-owned foreground session can explicitly opt in with `/browser connect` in the
+interactive CLI, or with the desktop browser connect action. That connection permits
+the current foreground session to drive a visible CDP browser until disconnected.
+The opt-in never propagates to delegated children or Kanban workers.
+
+`browser.headed`, `AGENT_BROWSER_HEADED`, `browser.cdp_url`, and `BROWSER_CDP_URL`
+are not standalone opt-ins for routine agent work. They are honored only after the
+foreground visible-browser policy has been enabled by an explicit connect action.
+Operators should not set `HERMES_BROWSER_INTERACTION` directly; it is internal session
+state managed by Hermes.
+
+### Migration notes
+
+- Existing unattended or card-based research that relied on a local Chrome fallback
+  must configure a cloud browser provider, switch to `web_search`/`web_extract`, or
+  select the built-in headless browser with `browser.backend: "off"`.
+- Existing foreground workflows that intentionally control a visible browser should
+  start with `/browser connect` (or the desktop connect action) and disconnect when
+  finished.
+- No dedicated research profile is required. The isolation policy is enforced across
+  profiles and backends, including CT106; a research profile remains optional for
+  choosing narrower toolsets or models.
+- Artifact previews and explicit user-open actions require no migration.
+
 ## Overview
 
 Pages are represented as **accessibility trees** (text-based snapshots), making them ideal for LLM agents. Interactive elements get ref IDs (like `@e1`, `@e2`) that the agent uses for clicking and typing.


### PR DESCRIPTION
## What does this PR do?

Prevents routine agent research from attaching to or launching a user's visible Chrome browser. Browser automation now defaults to an isolated/headless policy across Browser Use, the built-in browser, Kanban workers, computer-use browser controls, and terminal GUI-launch paths. Explicit foreground browser connection remains available when the user intentionally opts in, and desktop artifact preview remains a separate presentation path.

## Related Issue

No public issue; reported through the Hermes Kanban workflow.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a centralized browser interaction policy with isolated and explicit foreground modes.
- Prevent Browser Use and built-in browser routing from implicitly falling through to visible local Chrome/CDP during normal agent work.
- Force isolated mode for Kanban workers and scrub inherited headed/CDP overrides.
- Guard computer-use browser actions and terminal GUI browser launches in isolated agent contexts.
- Preserve explicit `/browser connect` / managed foreground opt-in and desktop-only artifact previews.
- Add end-to-end regression coverage for local research, CT106-style remote routing, Kanban spawning, visible opt-in, and preview separation.
- Document user and operator behavior and migration details.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_research_browser_isolation_e2e.py tests/tools/test_browser_interaction_policy.py tests/tools/test_browser_headed_mode.py tests/tools/test_browser_use_cli.py tests/hermes_cli/test_kanban_worker_spawn_toolsets.py tests/tools/test_terminal_tool.py tests/test_tui_gateway_server.py tests/tools/test_open_preview_tool.py tests/tools/test_desktop_ui.py -q`.
2. Confirm all 669 focused tests pass.
3. Run Ruff on the changed Python files and `git diff --check origin/main...HEAD`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused affected test suite and all 669 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` update is N/A; no config keys were added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] I've considered cross-platform impact; enforcement is platform-neutral and platform-specific launch detection is covered
- [x] Tool behavior documentation and relevant descriptions are updated

## Screenshots / Logs

Focused verification after rebasing onto current `origin/main`:

```text
=== Summary: 9 files, 669 tests passed, 0 failed (100% complete) ===
All checks passed!  # Ruff
git diff --check origin/main...HEAD  # clean
```
