### PR TITLE
fix(desktop): stop sidebar wheel dead-zone on long session lists

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -150,7 +150,7 @@ export function SidebarCronJobsSection({
         </button>
       </div>
       {open && (
-        <SidebarGroupContent className="scrollbar-fade flex max-h-72 flex-col gap-px overflow-x-hidden overflow-y-auto overscroll-contain pb-1.75 compact:max-h-none compact:overflow-visible">
+        <SidebarGroupContent className="scrollbar-fade flex max-h-72 flex-col gap-px overflow-x-hidden overflow-y-auto pb-1.75 compact:max-h-none compact:overflow-visible">
           {shown.map(job => (
             <CronJobSidebarRow
               expanded={peekJobId === job.id}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -162,7 +162,7 @@ import {
 import { WorktreeDialog } from './projects/worktree-dialog'
 import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
 import { buildSessionByAnyId } from './session-index'
-import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
+import { SidebarSessionsSection } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 
 // Non-session groups (messaging platforms) stay compact: show a few rows up
@@ -215,7 +215,8 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
 ]
 
 // Two modes via the `compact` height variant (styles.css):
-//   tall    → each section is shrink-0, capped, its own scroller; Sessions is flex-1.
+//   tall    → pinned/messaging/cron are shrink-0, max-h capped, own small
+//             chainable scrollers; the session stack is one shared scroller.
 //   compact → COMPACT_FLAT drops the caps so the whole stack scrolls as one.
 // Sections stay shrink-0 so none can be squeezed below its content and bleed onto
 // the next — the flexbox `min-height: auto` overlap trap that caused the bug.
@@ -223,7 +224,10 @@ const COMPACT_FLAT = 'compact:max-h-none compact:overflow-visible'
 
 // Vertical scroll only — never a horizontal bar from glow bleed, long titles,
 // etc. The bar itself only shows while the pointer is in the list.
-const SCROLL_Y = 'overflow-y-auto overflow-x-hidden overscroll-contain scrollbar-fade'
+// No overscroll-contain: Chromium latches a wheel gesture to the nearest
+// scroll container, and contain stops the chain even when that container
+// cannot scroll — the mid-list dead-zone while the outer thumb still works.
+const SCROLL_Y = 'overflow-y-auto overflow-x-hidden scrollbar-fade'
 
 // The outer list reserves its bar's width whether or not one is showing, so
 // filtering or collapsing a section doesn't reflow every row sideways. Only the
@@ -402,6 +406,10 @@ export function ChatSidebar({
   // Per-platform count of rows currently revealed (starts at NON_SESSION_INITIAL_ROWS).
   const [messagingVisible, setMessagingVisible] = useState<Record<string, number>>({})
   const searchInputRef = useRef<HTMLInputElement>(null)
+  // Single scroll container for the session stack (search / pinned / recents).
+  // Handed to the virtualizer so a long recents list does not nest a second
+  // overflow-y-auto port inside this one.
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
   const trimmedQuery = searchQuery.trim()
 
   // Hotkey (session.focusSearch) → focus the field once it's mounted.
@@ -1306,11 +1314,9 @@ export function ChatSidebar({
 
   const displayAgentGroups = profileGroups
 
-  // The recents list owns its own (virtualized) scroll container only when it's a
-  // long flat list. In that case it must keep its scroller even in short mode, so
-  // we don't flatten it (flattening would defeat virtualization). Short flat lists
-  // and grouped views (profile groups or the worktree tree) flatten into the
-  // single outer scroll instead.
+  // Recents/search virtualize into the shared session-stack scroller (no nested
+  // overflow port). Grouped views and short lists render in document flow in
+  // that same scroller.
   // Whichever grouping is active, the flat set of repo subtrees on screen — the
   // single source for reconciling repo/worktree order, whether repos hang off
   // the bare tree or are nested under projects.
@@ -1319,17 +1325,7 @@ export function ChatSidebar({
     [agentProjectTree]
   )
 
-  // Mirror the section's own virtualization inputs (the props it receives),
-  // not the raw tree cache: agentProjectTree persists after leaving Project
-  // grouping, and keying on it here while the section keys on projectOverview
-  // (which is nulled the moment grouping changes) left the two disagreeing —
-  // wrapper classes built for a virtualized list around a non-virtual one.
-  // Entered-project content is the third prop that suppresses virtualization.
-  const recentsVirtualizes =
-    !displayAgentGroups?.length &&
-    !projectOverview?.length &&
-    !(inProject && enteredProjectContent) &&
-    displayAgentSessions.length >= VIRTUALIZE_THRESHOLD
+  const getScrollElement = useCallback(() => scrollContainerRef.current, [])
 
   // Keep the persisted parent + worktree orders reconciled with what's on screen:
   // freshly-seen repos/worktrees surface at the top, vanished ones drop out of
@@ -1514,11 +1510,14 @@ export function ChatSidebar({
         )}
 
         {showSessionSections && (
-          <div className={cn('flex min-h-0 flex-1 flex-col pb-1.75', SCROLL_Y, SCROLL_GUTTER)}>
+          <div
+            className={cn('flex min-h-0 flex-1 flex-col pb-1.75', SCROLL_Y, SCROLL_GUTTER)}
+            ref={scrollContainerRef}
+          >
             {trimmedQuery && (
               <SidebarSessionsSection
                 activeSessionId={activeSidebarSessionId}
-                contentClassName={cn('flex min-h-0 flex-1 flex-col gap-px pb-1.75', SCROLL_Y)}
+                contentClassName="flex flex-col gap-px pb-1.75"
                 emptyState={
                   searchPending ? (
                     <SidebarSessionSkeletons />
@@ -1528,6 +1527,7 @@ export function ChatSidebar({
                     </div>
                   )
                 }
+                getScrollElement={getScrollElement}
                 label={s.results}
                 onArchiveSession={onArchiveSession}
                 onBranchSession={onBranchSession}
@@ -1537,7 +1537,7 @@ export function ChatSidebar({
                 onTogglePin={pinSession}
                 open
                 pinned={false}
-                rootClassName="min-h-32 flex-1 overflow-hidden p-0"
+                rootClassName="min-h-32 shrink-0 p-0"
                 sessions={searchResults}
                 showProfileTags={showAllProfiles}
               />
@@ -1575,20 +1575,7 @@ export function ChatSidebar({
                 // the overview previews all render the same card.
                 card={cardRows}
                 collapsible={!inProject}
-                contentClassName={cn(
-                  'flex min-h-0 flex-1 flex-col gap-px pb-1.75',
-                  // The section is the ONE authority on whether the virtual
-                  // list owns scrolling: it neutralizes this wrapper scroller
-                  // itself (overflow-visible) when it virtualizes. Gating
-                  // SCROLL_Y here on index's own parallel guess desynced the
-                  // two — a cached project tree flipped this side but not the
-                  // section's, leaving the list with no scroller at all and
-                  // the recents pane rendering blank under Updated grouping.
-                  SCROLL_Y,
-                  // Flatten into the single scroll when compact — unless this is the
-                  // virtualized long list, which must keep its own scroller.
-                  !recentsVirtualizes && COMPACT_FLAT
-                )}
+                contentClassName="flex flex-col gap-px pb-1.75"
                 dndSensors={dndSensors}
                 emptyState={
                   showSessionSkeletons ? (
@@ -1621,6 +1608,7 @@ export function ChatSidebar({
                   ) : null
                 }
                 forceEmptyState={showSessionSkeletons}
+                getScrollElement={getScrollElement}
                 // Archived is a plain list, and so is a magnitude-ranked one.
                 // Otherwise project lanes stay chronological whatever the flat
                 // list does — only the flat list can swap its dividers for
@@ -1720,10 +1708,7 @@ export function ChatSidebar({
                 projectRepoWorktrees={inProject ? scopedRepoWorktrees : undefined}
                 projectsLoading={worktreeGroupingActive ? projectTreeLoading : false}
                 removedSessionIds={inProject ? removedSessionIds : undefined}
-                rootClassName={cn(
-                  'min-h-32 flex-1 overflow-hidden p-0',
-                  !recentsVirtualizes && 'compact:min-h-0 compact:flex-none compact:overflow-visible'
-                )}
+                rootClassName="min-h-32 shrink-0 p-0 compact:min-h-0"
                 sessions={displayAgentSessions}
                 sortable={!showAllProfiles && agentSessions.length > 1}
               />

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -59,6 +59,10 @@ function generateSessions(count: number): SessionInfo[] {
 
 const noop = () => {}
 
+// Shared-scroll owner required to virtualize (otherwise the section stays
+// flat so it cannot nest an overflow-y-auto port — see #84964).
+const sharedScroll = { getScrollElement: () => null }
+
 describe('SidebarSessionsSection memoization & virtualizer stability', () => {
   it('memoizes flatRows and passes the exact same rows array reference across parent re-renders', () => {
     mockVirtualListPropsHistory.length = 0
@@ -78,6 +82,7 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
         open={true}
         pinned={false}
         sessions={sessions}
+        {...sharedScroll}
       />
     )
 
@@ -99,6 +104,7 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
         open={true}
         pinned={false}
         sessions={sessions}
+        {...sharedScroll}
       />
     )
 
@@ -128,6 +134,7 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
         open={true}
         pinned={false}
         sessions={initialSessions}
+        {...sharedScroll}
       />
     )
 
@@ -148,6 +155,7 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
         open={true}
         pinned={false}
         sessions={initialSessions}
+        {...sharedScroll}
       />
     )
 
@@ -170,6 +178,7 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
         open={true}
         pinned={false}
         sessions={updatedSessions}
+        {...sharedScroll}
       />
     )
 

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -17,7 +17,6 @@ import {
   toSessionRows
 } from '@/lib/session-date-groups'
 import { sessionBucketLabel } from '@/lib/time'
-import { cn } from '@/lib/utils'
 import { sessionPinId } from '@/store/session'
 import { $sessionDotStateById, hasLiveTurn } from '@/store/session-dot-state'
 
@@ -168,6 +167,10 @@ interface SidebarSessionsSectionProps {
   // grouping is active — the flat recents list opts in; dense tree surfaces
   // (pinned, projects, messaging) keep the one-line row.
   card?: boolean
+  /** When provided, the virtualized flat list scrolls in this external
+   *  element (the sidebar's shared scroll container) instead of owning a
+   *  nested scroller. Virtualization only activates in this mode. */
+  getScrollElement?: () => HTMLElement | null
 }
 
 export function SidebarSessionsSection({
@@ -210,7 +213,8 @@ export function SidebarSessionsSection({
   dndSensors,
   showProfileTags = false,
   grouping = 'none',
-  card = false
+  card = false,
+  getScrollElement
 }: SidebarSessionsSectionProps) {
   const { t } = useI18n()
   const dividerLabels = t.sidebar.dateDivider
@@ -356,13 +360,17 @@ export function SidebarSessionsSection({
   // Pinned never virtualizes. Virtualization needs a bounded viewport to
   // measure against, and Pinned deliberately has none — however many chats you
   // pin, all of them render and the sidebar's own scroll carries the length.
+  // Also require a shared scroll element: without one, VirtualSessionList
+  // would own overflow-y-auto + overscroll-contain and latch the wheel
+  // mid-list inside the outer sidebar scroller (#84964).
   const flatVirtualized =
     !pinned &&
     !showEmptyState &&
     !groups?.length &&
     !projectOverview?.length &&
     !projectContent &&
-    sessions.length >= VIRTUALIZE_THRESHOLD
+    sessions.length >= VIRTUALIZE_THRESHOLD &&
+    Boolean(getScrollElement)
 
   // First paint into the grouped view (e.g. the app restoring the Projects tab)
   // has flat recents in `sessions` but no tree yet. Show skeletons rather than
@@ -455,6 +463,7 @@ export function SidebarSessionsSection({
         card={card}
         className={contentClassName}
         dividerAction={dividerAction}
+        getScrollElement={getScrollElement}
         onArchiveSession={onArchiveSession}
         onBranchSession={onBranchSession}
         onDeleteSession={onDeleteSession}
@@ -485,11 +494,11 @@ export function SidebarSessionsSection({
     inner = flatRows.map(row => renderListRow(row, false, dividerAction))
   }
 
-  // The virtualizer owns its own scroller, so suppress the wrapper's overflow
-  // to avoid a double scroll container. Both axes: `overflow-y-visible` next
-  // to the inherited `overflow-x-hidden` computes to `auto` (CSS spec), which
-  // kept a phantom 4px scrollbar gutter and cut every row short on the right.
-  const resolvedContentClassName = cn(contentClassName, flatVirtualized && 'overflow-visible')
+  // flatVirtualized now implies shared-scroll mode: the virtualizer never
+  // owns a scroller here, so the wrapper needs no overflow suppression.
+  // Do not add per-axis overflow classes — a single-axis overflow forces
+  // the other axis from `visible` to `auto` and recreates a nested port.
+  const resolvedContentClassName = contentClassName
 
   return (
     <SidebarGroup className={rootClassName}>

--- a/apps/desktop/src/app/chat/sidebar/tests/sessions-section-scroll.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/tests/sessions-section-scroll.test.tsx
@@ -1,0 +1,118 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from '../sessions-section'
+import type { VirtualSessionListProps } from '../virtual-session-list'
+
+afterEach(cleanup)
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        dateDivider: {
+          earlierThisMonth: 'Earlier this month',
+          lastMonth: 'Last month',
+          lastWeek: 'Last week',
+          older: 'Older',
+          today: 'Today',
+          yesterday: 'Yesterday'
+        }
+      }
+    }
+  })
+}))
+
+const mockVirtualListPropsHistory: VirtualSessionListProps[] = []
+
+vi.mock('../virtual-session-list', () => ({
+  VirtualSessionList: (props: VirtualSessionListProps) => {
+    mockVirtualListPropsHistory.push(props)
+
+    return <div data-testid="virtual-session-list">Virtual List ({props.rows.length} rows)</div>
+  }
+}))
+
+vi.mock('../session-row', () => ({
+  SidebarSessionRow: ({ session }: { session: SessionInfo }) => (
+    <div data-testid={`session-row-${session.id}`}>{session.id}</div>
+  )
+}))
+
+function makeSession(id: string, startedAt = 1000): SessionInfo {
+  return {
+    handoff_platform: null,
+    handoff_state: null,
+    id,
+    last_active: startedAt,
+    profile: 'default',
+    started_at: startedAt
+  } as unknown as SessionInfo
+}
+
+function generateSessions(count: number): SessionInfo[] {
+  return Array.from({ length: count }, (_, i) => makeSession(`session-${i + 1}`, 10000 - i * 100))
+}
+
+const noop = () => {}
+
+describe('SidebarSessionsSection shared-scroll virtualization', () => {
+  it('does not mount an owned virtual scroller without a shared scroll element', () => {
+    mockVirtualListPropsHistory.length = 0
+
+    const { queryByTestId, getByTestId } = render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={<div>Empty</div>}
+        label="Sessions"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        open={true}
+        pinned={false}
+        sessions={generateSessions(VIRTUALIZE_THRESHOLD + 5)}
+      />
+    )
+
+    // A long list without an outer scroll owner must stay in document flow.
+    // Mounting VirtualSessionList here would create the nested overflow-y-auto
+    // + overscroll-contain port that latches the wheel mid-list (#84964).
+    expect(queryByTestId('virtual-session-list')).toBeNull()
+    expect(mockVirtualListPropsHistory).toHaveLength(0)
+    expect(getByTestId('session-row-session-1')).toBeTruthy()
+  })
+
+  it('virtualizes only into a provided shared scroll element', () => {
+    mockVirtualListPropsHistory.length = 0
+
+    const host = { id: 'sidebar-scroll' } as HTMLElement
+    const getScrollElement = () => host
+
+    const { getByTestId } = render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={<div>Empty</div>}
+        getScrollElement={getScrollElement}
+        label="Sessions"
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        open={true}
+        pinned={false}
+        sessions={generateSessions(VIRTUALIZE_THRESHOLD + 5)}
+      />
+    )
+
+    expect(getByTestId('virtual-session-list')).toBeTruthy()
+    expect(mockVirtualListPropsHistory).toHaveLength(1)
+    expect(
+      (mockVirtualListPropsHistory[0] as { getScrollElement?: () => HTMLElement | null }).getScrollElement
+    ).toBe(getScrollElement)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/tests/virtual-session-list-scroll.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/tests/virtual-session-list-scroll.test.tsx
@@ -1,0 +1,116 @@
+import type * as ReactVirtual from '@tanstack/react-virtual'
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+import type { SidebarListRow } from '@/lib/session-date-groups'
+
+import { VirtualSessionList } from '../virtual-session-list'
+
+type VirtualizerOpts = Parameters<typeof ReactVirtual.useVirtualizer>[0]
+
+let lastOpts: undefined | VirtualizerOpts
+
+vi.mock('@tanstack/react-virtual', async importOriginal => {
+  const actual = await importOriginal<typeof ReactVirtual>()
+
+  return {
+    ...actual,
+    useVirtualizer: (opts: VirtualizerOpts) => {
+      lastOpts = opts
+
+      return actual.useVirtualizer(opts)
+    }
+  }
+})
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        dateDivider: {
+          today: 'Today',
+          yesterday: 'Yesterday'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('../chrome', () => ({
+  SidebarDateDivider: () => <div data-testid="date-divider" />
+}))
+
+vi.mock('../session-row', () => ({
+  SidebarSessionRow: () => <div data-testid="session-row" />
+}))
+
+function makeSession(id: string): SessionInfo {
+  return {
+    archived: false,
+    cwd: '/tmp',
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1_000,
+    message_count: 1,
+    model: 'claude',
+    output_tokens: 0,
+    preview: 'preview',
+    source: 'cli',
+    started_at: 1_000,
+    title: id,
+    tool_call_count: 0
+  }
+}
+
+const dividerRow: SidebarListRow = { key: 'today', kind: 'divider', label: 'Today' }
+const sessionRow: SidebarListRow = { entry: { session: makeSession('sess-1') }, kind: 'session' }
+
+const baseProps = {
+  activeSessionId: null,
+  onArchiveSession: () => undefined,
+  onDeleteSession: () => undefined,
+  onResumeSession: () => undefined,
+  onTogglePin: () => undefined,
+  pinned: false,
+  rows: [dividerRow, sessionRow],
+  sortable: false
+}
+
+describe('VirtualSessionList shared-scroll contract', () => {
+  beforeEach(() => {
+    lastOpts = undefined
+  })
+
+  afterEach(cleanup)
+
+  it('does not paint a nested vertical scroller when a shared scroll element is provided', () => {
+    const host = {
+      getBoundingClientRect: () => ({
+        bottom: 0,
+        height: 0,
+        left: 0,
+        right: 0,
+        toJSON: () => ({}),
+        top: 0,
+        width: 0,
+        x: 0,
+        y: 0
+      }),
+      scrollTop: 0
+    } as HTMLElement
+
+    const getScrollElement = () => host
+
+    const { container } = render(
+      <VirtualSessionList {...baseProps} getScrollElement={getScrollElement} />
+    )
+
+    const rootClass = container.firstElementChild?.className ?? ''
+    expect(rootClass).not.toMatch(/overflow-y-auto/)
+    expect(rootClass).not.toMatch(/overscroll-contain/)
+    expect(lastOpts?.getScrollElement?.()).toBe(host)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -2,7 +2,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import type * as React from 'react'
-import { type FC, useCallback, useRef } from 'react'
+import { type FC, useCallback, useLayoutEffect, useRef, useState } from 'react'
 
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -35,6 +35,10 @@ export interface VirtualSessionListProps {
   className?: string
   /** Hover-revealed control for date dividers (the group-level "+"). */
   dividerAction?: React.ReactNode
+  /** When set, the virtualizer scrolls this external element instead of
+   *  owning an overflow port (shared-scroll mode). Required to keep the
+   *  sessions sidebar to one vertical scrollport. */
+  getScrollElement?: () => HTMLElement | null
   rows: SidebarListRow[]
   onArchiveSession: (sessionId: string) => void
   onBranchSession?: (sessionId: string, profile?: string) => void
@@ -52,12 +56,16 @@ const ROW_ESTIMATE_PX = 28
 // self-measurement catches up.
 const CARD_ROW_ESTIMATE_PX = 66
 const OVERSCAN_ROWS = 12
+// The row grid renders with `gap-px`; the virtualizer must be told or every
+// row's start drifts 1px further from reality (N-1 px across the list).
+const ROW_GAP_PX = 1
 
 export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   activeSessionId,
   card = false,
   className,
   dividerAction,
+  getScrollElement: getScrollElementProp,
   rows: listRows,
   onArchiveSession,
   onBranchSession,
@@ -70,26 +78,73 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
 }) => {
   const { t } = useI18n()
   const dividerLabels = t.sidebar.dateDivider
-  const scrollerRef = useRef<HTMLDivElement | null>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const sharedScroll = Boolean(getScrollElementProp)
+  const resolvedGetScrollElement = getScrollElementProp ?? (() => containerRef.current)
+
+  // Shared-scroll offset (TanStack `scrollMargin`): pinned / headers sit
+  // above this list in the same scroller. Re-measured after every commit
+  // because the offset is sibling layout, not a prop of this component.
+  const [sharedScrollMargin, setSharedScrollMargin] = useState(0)
+  const [measureRetry, setMeasureRetry] = useState(0)
+  const retriedRef = useRef(false)
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- sibling layout, not own props
+  useLayoutEffect(() => {
+    if (!sharedScroll) {
+      return
+    }
+
+    const el = containerRef.current
+    const scrollEl = getScrollElementProp?.()
+
+    if (!el || !scrollEl) {
+      // Same-commit mount: ancestor ref is not attached yet. One rAF retry.
+      if (!retriedRef.current) {
+        retriedRef.current = true
+        requestAnimationFrame(() => setMeasureRetry(n => n + 1))
+      }
+
+      return
+    }
+
+    const margin = Math.round(
+      el.getBoundingClientRect().top - scrollEl.getBoundingClientRect().top + scrollEl.scrollTop
+    )
+
+    setSharedScrollMargin(prev => (Math.abs(prev - margin) < 1 ? prev : margin))
+  })
+
+  const scrollMargin = sharedScroll ? sharedScrollMargin : 0
 
   const virtualizer = useVirtualizer({
     count: listRows.length,
     estimateSize: () => (card ? CARD_ROW_ESTIMATE_PX : ROW_ESTIMATE_PX),
+    gap: ROW_GAP_PX,
     getItemKey: index => {
       const row = listRows[index]
 
       return row ? (row.kind === 'divider' ? row.key : row.entry.session.id) : index
     },
-    getScrollElement: () => scrollerRef.current,
+    getScrollElement: resolvedGetScrollElement,
+    // virtual-core scrollToOffset(initialOffset=0) on attach would yank the
+    // shared container to the top on remount. Seed from live scrollTop.
+    initialOffset: () => resolvedGetScrollElement()?.scrollTop ?? 0,
     // jsdom-friendly default; the real rect takes over on first observe.
     initialRect: { height: 600, width: 240 },
-    overscan: OVERSCAN_ROWS
+    overscan: OVERSCAN_ROWS,
+    scrollMargin
   })
+
+  void measureRetry
 
   const virtualItems = virtualizer.getVirtualItems()
   const totalSize = virtualizer.getTotalSize()
-  const paddingTop = virtualItems[0]?.start ?? 0
-  const paddingBottom = Math.max(0, totalSize - (virtualItems[virtualItems.length - 1]?.end ?? 0))
+  // Item start/end include scrollMargin; getTotalSize() does not.
+  const firstStart = (virtualItems[0]?.start ?? scrollMargin) - scrollMargin
+  const lastEnd = (virtualItems[virtualItems.length - 1]?.end ?? scrollMargin) - scrollMargin
+  const paddingTop = Math.max(0, firstStart)
+  const paddingBottom = Math.max(0, totalSize - lastEnd)
 
   const rows = virtualItems.map(virtualItem => {
     const row = listRows[virtualItem.index]
@@ -150,19 +205,23 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   // When sortable, the caller wraps this in a ReorderableList that owns the
   // DndContext + SortableContext (keyed on the same ids); the virtualized rows
   // just consume that context via useSortable.
+  const ownsScroll = !sharedScroll
+
   return (
     <div
-      // scrollbar-fade, NOT scrollbar-overlay: overlay opts out of the themed
-      // thin scrollbar entirely, and on Windows (no native overlay scrollbars)
-      // Chromium then paints the classic always-visible gutter. The themed
-      // fade bar reserves its 4px on every platform but stays invisible until
-      // hover — and the wrapper no longer stacks a second scroller, so the
-      // double-gutter this class change was reaching for is already gone.
+      // Shared-scroll mode must carry NO overflow property at all — not even
+      // overflow-x-hidden. One-axis overflow computes the other axis from
+      // `visible` to `auto` (CSS Overflow 3) and silently recreates the
+      // nested port that latches the wheel. Owned mode keeps the themed
+      // fade bar (not overlay: overlay opts out of the thin scrollbar and
+      // on Windows Chromium paints the classic always-visible gutter).
       className={cn(
-        'scrollbar-fade relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain',
+        'relative min-h-0',
+        ownsScroll &&
+          'scrollbar-fade flex-1 overflow-x-hidden overflow-y-auto overscroll-contain',
         className
       )}
-      ref={scrollerRef}
+      ref={containerRef}
     >
       <div className="grid gap-px" style={{ paddingBottom: `${paddingBottom}px`, paddingTop: `${paddingTop}px` }}>
         {rows}


### PR DESCRIPTION
## What does this PR do?

Stops the Desktop sessions sidebar from eating mouse-wheel input once the recents list virtualizes (25+ sessions). The wheel latched to a nested `overflow-y-auto overscroll-contain` port on `VirtualSessionList` (and a phantom `auto` scroller from one-axis overflow), so mid-list scrolling died while dragging the outer scrollbar still worked.

The session stack now has one shared vertical scrollport. That same node is the visible gutter, the wheel target, and TanStack Virtual's `getScrollElement`. The virtual list only mounts when that owner is provided; without it the long list stays in document flow instead of creating a competing scroller. Capped messaging/cron bodies keep their tall-mode max-height ports but drop `overscroll-contain` so the wheel chains at their edges.

Residual: no packaged Desktop wheel e2e in this change. #77507 (dynamic-sizing jitter) is a separate cause. Open #62529 targets the same nested-scroller class on a stale base.

## Related Issue

Fixes #84964

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx`: optional `getScrollElement`; shared mode carries no overflow classes; `scrollMargin` + `initialOffset` from the shared port; `gap: 1` to match `gap-px`.
- `apps/desktop/src/app/chat/sidebar/sessions-section.tsx`: virtualize only when a shared scroll element is provided; stop adding `overflow-visible` on the wrapper.
- `apps/desktop/src/app/chat/sidebar/index.tsx`: session-stack ref is the single scroller; search and recents receive it; nested `SCROLL_Y` / `overscroll-contain` removed from those sections.
- `apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx`: drop `overscroll-contain` on the capped body so the wheel chains outward.
- `apps/desktop/src/app/chat/sidebar/tests/*scroll.test.tsx` and `sessions-section.test.tsx`: contract that a long list does not own a nested scroller without a shared owner.

## How to Test

1. Open Hermes Desktop with 25+ sessions so Recents virtualizes.
2. Wheel through the mid-list region (not only the scrollbar track). Scrolling should continue through the whole list.
3. Drag the sidebar scrollbar: still works.
4. Expand/collapse Pinned and type in search: the list should not jump to the top.
5. Unit: from `apps/desktop`, `npx vitest run --project ui src/app/chat/sidebar/tests/sessions-section-scroll.test.tsx src/app/chat/sidebar/tests/virtual-session-list-scroll.test.tsx src/app/chat/sidebar/sessions-section.test.tsx` — 5 passed. Full sidebar UI suite: 15 files / 126 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux WSL2 (class repro + vitest); no packaged Desktop wheel e2e here

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
