### PR TITLE
fix(cron): accept repeat=forever on cronjob create

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1566,6 +1566,35 @@ def _validate_job_mode_invariants(
         )
 
 
+def normalize_repeat_count(repeat):
+    """Coerce a cron ``repeat`` value to ``None`` (forever) or a positive int.
+
+    The tool schema and success payload advertise ``"forever"`` for infinite
+    jobs, but create/update compared the raw value with ``<= 0``. Passing
+    the documented string then raised ``TypeError`` (#85383).
+    """
+    if repeat is None:
+        return None
+    if isinstance(repeat, str):
+        text = repeat.strip().lower()
+        if text in {"", "forever", "infinite", "inf", "none", "null"}:
+            return None
+        try:
+            repeat = int(text)
+        except ValueError:
+            raise ValueError(
+                f"Invalid repeat value {repeat!r}; use a positive integer or 'forever'"
+            ) from None
+    if isinstance(repeat, bool):
+        raise ValueError("repeat must be a count or 'forever', not a boolean")
+    if isinstance(repeat, (int, float)):
+        count = int(repeat)
+        return None if count <= 0 else count
+    raise ValueError(
+        f"Invalid repeat value {repeat!r}; use a positive integer or 'forever'"
+    )
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -1649,9 +1678,8 @@ def create_job(
     """
     parsed_schedule = parse_schedule(schedule)
 
-    # Normalize repeat: treat 0 or negative values as None (infinite)
-    if repeat is not None and repeat <= 0:
-        repeat = None
+    # Normalize repeat: 0 / negative / "forever" → None (infinite)
+    repeat = normalize_repeat_count(repeat)
 
     # Auto-set repeat=1 for one-shot schedules if not specified
     if parsed_schedule["kind"] == "once" and repeat is None:

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -246,6 +246,33 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_create_accepts_repeat_forever_string(self):
+        """Documented 'forever' must not TypeError against <= 0 (#85383)."""
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Run proposal-evaluator.py once.",
+                schedule="30 6 * * *",
+                name="proposal-evaluator",
+                repeat="forever",
+            )
+        )
+        assert created["success"] is True
+        assert created["job"]["repeat"] == "forever"
+
+    def test_create_repeat_numeric_still_works(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Once",
+                schedule="30 6 * * *",
+                name="once-job",
+                repeat=1,
+            )
+        )
+        assert created["success"] is True
+        assert created["job"]["repeat"] != "forever"
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1482,8 +1482,12 @@ def cronjob(
                         )
                 updates["no_agent"] = target_no_agent
             if repeat is not None:
-                # Normalize: treat 0 or negative as None (infinite)
-                normalized_repeat = None if repeat <= 0 else repeat
+                from cron.jobs import normalize_repeat_count
+
+                # 0 / negative / "forever" → None (infinite). The schema
+                # documents "forever"; comparing the raw string with <=
+                # raised TypeError (#85383).
+                normalized_repeat = normalize_repeat_count(repeat)
                 repeat_state = dict(job.get("repeat") or {})
                 repeat_state["times"] = normalized_repeat
                 updates["repeat"] = repeat_state
@@ -1552,8 +1556,12 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
                 "description": "Optional human-friendly name"
             },
             "repeat": {
-                "type": "integer",
-                "description": "Optional repeat count. Omit for defaults (once for one-shot, forever for recurring)."
+                "type": ["integer", "string"],
+                "description": (
+                    "Optional repeat count. Positive integer, or 'forever' "
+                    "for infinite recurrence. Omit for defaults (once for "
+                    "one-shot, forever for recurring)."
+                ),
             },
             "deliver": {
                 "type": "string",


### PR DESCRIPTION
## What breaks

`cronjob(action='create', …, repeat='forever')` raises:

```
TypeError: '<=' not supported between instances of 'str' and 'int'
```

Omitting `repeat` succeeds and the tool then *returns* `"repeat": "forever"`. `repeat=1` also works. So the documented sentinel is what the API itself prints, but it cannot be passed back in.

## Why

`create_job()` and the update path did:

```python
if repeat is not None and repeat <= 0:
    repeat = None
```

`None` is infinite; `<= 0` was only meant for numeric “run forever”. The JSON schema advertised `repeat` as integer, but models (and the tool’s own success payload) use the string `"forever"`. The comparison never ran a type check first.

## What this changes

`cron.jobs.normalize_repeat_count()` accepts:

- `None` / `"forever"` / `"infinite"` / `"inf"` / empty → `None` (infinite)
- `0` or negative → `None`
- a positive int (or numeric string) → that count

Create and update both go through it. The schema is now `integer | string` so the documented value is valid input.

Integer `repeat=1` is unchanged (`"once"` in the formatted job).

## Verify

```text
pytest tests/tools/test_cronjob_tools.py::TestUnifiedCronjobTool::test_create_accepts_repeat_forever_string \
       tests/tools/test_cronjob_tools.py::TestUnifiedCronjobTool::test_create_repeat_numeric_still_works
# 2 passed
```

Not runtime-tested through a live gateway cron tick — the failure was at create time, before the scheduler.

Fixes #85383
