### PR TITLE
fix(gateway): give Feishu a 90s first-connect budget

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -84,6 +84,12 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 # returns. Leave enough outer budget for initialize/deleteWebhook/start_polling
 # wall deadlines plus readiness; other platforms retain the 30s isolation bound.
 _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT = 180.0
+# Feishu defers `lark_oapi` until connect(); a cold import is ~24s (#68756)
+# and plus the websocket handshake exceeds the 30s isolation bound, so the
+# first boot after update always times out and the bot stays offline until
+# a later in-process retry (or a manual restart if the updater killed the
+# process first). Same class as Telegram's extra budget (#19776 / #85564).
+_FEISHU_CONNECT_TIMEOUT_SECS_DEFAULT = 90.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 # End reasons that mean the USER deliberately closed this thread of work
 # (/new -> session_reset / new_session, an explicit exit, or a /switch).
@@ -7050,6 +7056,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return max(0.0, timeout)
         if platform == Platform.TELEGRAM:
             return _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT
+        if platform == Platform.FEISHU:
+            return _FEISHU_CONNECT_TIMEOUT_SECS_DEFAULT
         return _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
 
     async def _connect_adapter_with_timeout(

--- a/tests/gateway/test_feishu_lazy_import.py
+++ b/tests/gateway/test_feishu_lazy_import.py
@@ -53,3 +53,20 @@ def test_feishu_connect_loads_sdk_on_worker_thread():
         assert asyncio.run(adapter.connect()) is True
 
     to_thread.assert_awaited_once_with(load_sdk)
+
+
+def test_feishu_connect_timeout_exceeds_cold_sdk_import():
+    """First Feishu connect must outlive a cold lark_oapi import (#85564)."""
+    from gateway.config import Platform
+    from gateway.run import (
+        GatewayRunner,
+        _FEISHU_CONNECT_TIMEOUT_SECS_DEFAULT,
+        _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT,
+    )
+
+    timeout = GatewayRunner._platform_connect_timeout_secs(
+        GatewayRunner.__new__(GatewayRunner), Platform.FEISHU
+    )
+    assert timeout == _FEISHU_CONNECT_TIMEOUT_SECS_DEFAULT
+    assert timeout > _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
+    assert timeout >= 90.0


### PR DESCRIPTION
## What breaks

After `hermes update`, Feishu often comes up as:

```
feishu connect timed out after 30s
Gateway started with no connected platforms
```

A later in-process retry connects in ~1s. If the updater *restarts* the gateway process before that retry, there is no cache and the bot stays offline until someone restarts it by hand. Users see “Feishu stopped after update”.

## Why

Two stacked changes:

1. Per-platform connect isolation defaults to **30s**. Only Telegram gets 180s (real `getUpdates` on first connect).
2. `lark_oapi` was deferred into `connect()` via `asyncio.to_thread(_load_lark_oapi)` so an unused Feishu extra does not pay ~24s at import. The SDK is ~49MB / 10k+ modules. Measured cold import on the reporter’s box: **24.3s**. Import + websocket handshake **> 30s** every cold boot.

Once the module is in `sys.modules`, retry is ~1s. The 30s bound is only fatal on the first connect of a fresh process — exactly the post-update path.

`gateway.platform_connect_timeout: 60` already unblocks this (reporter: first connect at 33s). There was no Feishu-specific default.

## What this changes

`GatewayRunner._platform_connect_timeout_secs(Platform.FEISHU)` is **90s**, same idea as Telegram’s extra budget.

`HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT` and `gateway.platform_connect_timeout` still win over that default. If you already set `60` as the #19776 escape hatch, first connect stays capped at 60s after this lands — drop the override to get the 90s budget. Reporter follow-up: Windows 11 / lark-oapi 1.6.8 cold connect ~33s with that 60s cap.

The lazy import is left in place: we do not pull `lark_oapi` back to module scope (that was #57657 / #68756).

## Verify

```text
pytest tests/gateway/test_feishu_lazy_import.py::test_feishu_connect_timeout_exceeds_cold_sdk_import
# 1 passed
```

Existing lazy-import tests still assert the SDK is not loaded at config time. Not re-timed against a real Feishu tenant on this machine.

Fixes #85564
