### PR TITLE
fix(matrix): install mautrix without the encryption extra

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2,7 +2,8 @@
 
 Connects to any Matrix homeserver (self-hosted or matrix.org) via the
 mautrix Python SDK.  Supports optional end-to-end encryption (E2EE)
-when installed with ``pip install "mautrix[encryption]"``.
+when installed with ``hermes-agent[matrix-e2ee]`` (or
+``pip install "mautrix[encryption]"``).
 
 Environment variables:
     MATRIX_HOMESERVER           Homeserver URL (e.g. https://matrix.example.org)
@@ -608,8 +609,8 @@ _OUTBOUND_MENTION_RE = re.compile(
 )
 
 _E2EE_INSTALL_HINT = (
-    "Install with: pip install 'mautrix[encryption]' asyncpg aiosqlite  "
-    "(requires libolm C library)"
+    "Install with: pip install 'hermes-agent[matrix-e2ee]' "
+    "(or: pip install 'mautrix[encryption]' asyncpg aiosqlite; requires libolm)"
 )
 
 _MATRIX_IMAGE_FILENAME_EXTS = frozenset({

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,12 @@ dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==1.28.1
 messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.30.0", "slack-sdk==3.43.0", "aiohttp==3.14.3"]
-matrix = ["mautrix[encryption]==0.21.1", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0", "aiohttp==3.14.3"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7 (mautrix/aiohttp-socks only cap aiohttp<4 / >=3.10, so pin the patched floor directly)
+# Plain mautrix is a py3-none-any wheel. The [encryption] extra pulls
+# python-olm, which has no wheels on modern macOS / Windows and fails
+# `hermes update` / first connect (#85588 / #64065). E2EE is opt-in via
+# the matrix-e2ee extra (or pip install 'mautrix[encryption]').
+matrix = ["mautrix==0.21.1", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0", "aiohttp==3.14.3"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7 (mautrix/aiohttp-socks only cap aiohttp<4 / >=3.10, so pin the patched floor directly)
+matrix-e2ee = ["hermes-agent[matrix]", "mautrix[encryption]==0.21.1"]
 # WeCom callback-mode adapter — parses untrusted XML POST bodies from
 # WeCom-controlled callback endpoints, so we use defusedxml (drop-in
 # replacement for stdlib xml.etree.ElementTree) to block billion-laughs
@@ -340,12 +345,10 @@ all = [
   #   matrix, slack, honcho, voice (faster-whisper),
   #   dingtalk, feishu, bedrock, tts-premium (elevenlabs)
   #
-  # Why: the matrix extra in particular pulls `mautrix[encryption]`
-  # which depends on `python-olm`. python-olm has Linux-only wheels and
-  # no native build path on Windows or modern macOS. With matrix in
-  # [all], `uv sync --locked` on Windows tried to build it from sdist
-  # and failed on `make`. Lazy-install routes that build to first use,
-  # where the user is expected to have a toolchain available.
+  # Why: the matrix extra used to pull `mautrix[encryption]` / python-olm
+  # (Linux-only wheels; no native build on Windows or modern macOS).
+  # Encryption is now opt-in (`matrix-e2ee`). Lazy-install of the base
+  # extra should succeed without a C toolchain (#85588).
   "hermes-agent[cron]",
   "hermes-agent[pty]",
   "hermes-agent[mcp]",

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -787,6 +787,11 @@ class TestMatrixModuleImport:
 
 class TestMatrixRequirements:
 
+    def test_e2ee_install_hint_names_the_matrix_e2ee_extra(self):
+        from plugins.platforms.matrix.adapter import _E2EE_INSTALL_HINT
+
+        assert "hermes-agent[matrix-e2ee]" in _E2EE_INSTALL_HINT
+        assert "mautrix[encryption]" in _E2EE_INSTALL_HINT
 
     def test_check_requirements_encryption_true_no_e2ee_deps(self, monkeypatch):
         """MATRIX_ENCRYPTION=true should fail if python-olm is not installed."""

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -18,19 +18,20 @@ def _load_package_data():
 
 
 def test_matrix_extra_not_in_all():
-    """The [matrix] extra pulls `mautrix[encryption]` -> `python-olm`,
+    """The [matrix] extra used to pull `mautrix[encryption]` -> `python-olm`,
     which has Linux-only wheels and no native build path on Windows or
     modern macOS (archived libolm, C++ errors with Clang 21+).
 
-    With matrix in [all], `uv sync --locked` on Windows tried to build
-    python-olm from sdist and failed on `make`. As of 2026-05-12 the
-    [matrix] extra is excluded from [all] entirely and routed through
-    `tools/lazy_deps.py` (LAZY_DEPS["platform.matrix"]) — installs at
-    first use, where the user is expected to have a toolchain.
+    As of #85588 the default [matrix] extra is plain `mautrix` (wheel-only);
+    E2EE is the opt-in `matrix-e2ee` extra. [matrix] stays out of [all]
+    and is lazy-installed via tools/lazy_deps.py.
     """
     optional_dependencies = _load_optional_dependencies()
 
     assert "matrix" in optional_dependencies, "[matrix] extra must still exist for `uv sync --extra matrix`"
+    matrix_specs = optional_dependencies["matrix"]
+    assert any(spec.startswith("mautrix==") for spec in matrix_specs), matrix_specs
+    assert not any("[encryption]" in spec for spec in matrix_specs), matrix_specs
     # Must NOT appear in [all] in any form — neither unconditional nor
     # platform-gated. Lazy-install handles it.
     matrix_in_all = [

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -23,6 +23,13 @@ import tools.lazy_deps as ld
 # ---------------------------------------------------------------------------
 
 
+def test_platform_matrix_does_not_require_encryption_extra():
+    """#85588: lazy-install of Matrix must not pull python-olm."""
+    specs = ld.LAZY_DEPS["platform.matrix"]
+    assert any(spec.startswith("mautrix==") for spec in specs)
+    assert not any("[encryption]" in spec for spec in specs)
+
+
 class TestSpecSafety:
     @pytest.mark.parametrize("spec", [
         "mistralai>=2.3.0,<3",

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -224,7 +224,11 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "aiohttp==3.14.3",  # prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
     ),
     "platform.matrix": (
-        "mautrix[encryption]==0.21.1",
+        # No [encryption] extra: python-olm has no wheels on modern macOS /
+        # Windows, so the extra pin left Matrix stuck on 0.21.0 and the
+        # adapter refused to start (#85588). E2EE remains opt-in via
+        # MATRIX_E2EE_MODE / pip install 'mautrix[encryption]'.
+        "mautrix==0.21.1",
         "aiosqlite==0.22.1",
         "asyncpg==0.31.0",
         "aiohttp-socks==0.11.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1689,6 +1689,13 @@ matrix = [
     { name = "aiohttp-socks" },
     { name = "aiosqlite" },
     { name = "asyncpg" },
+    { name = "mautrix" },
+]
+matrix-e2ee = [
+    { name = "aiohttp" },
+    { name = "aiohttp-socks" },
+    { name = "aiosqlite" },
+    { name = "asyncpg" },
     { name = "mautrix", extra = ["encryption"] },
 ]
 mcp = [
@@ -1846,6 +1853,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["homeassistant"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["homeassistant"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'termux'" },
+    { name = "hermes-agent", extras = ["matrix"], marker = "extra == 'matrix-e2ee'" },
     { name = "hermes-agent", extras = ["mcp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["mcp"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["pty"], marker = "extra == 'all'" },
@@ -1863,7 +1871,8 @@ requires-dist = [
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
     { name = "markdown", specifier = "==3.10.2" },
-    { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.1" },
+    { name = "mautrix", marker = "extra == 'matrix'", specifier = "==0.21.1" },
+    { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix-e2ee'", specifier = "==0.21.1" },
     { name = "mcp", marker = "extra == 'computer-use'", specifier = "==1.28.1" },
     { name = "mcp", marker = "extra == 'dev'", specifier = "==1.28.1" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = "==1.28.1" },
@@ -1931,7 +1940,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "matrix-e2ee", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -362,8 +362,8 @@ E2EE requires the `mautrix` library with encryption extras and the `libolm` C li
 # Install mautrix with E2EE support
 pip install 'mautrix[encryption]'
 
-# Or install with hermes extras
-cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
+# Or install the Hermes extra. Plain [matrix] is unencrypted mautrix only.
+cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix-e2ee]"
 ```
 
 You also need `libolm` installed on your system:
@@ -497,7 +497,7 @@ Other Matrix clients (Element, matrix-commander) may cache the old device keys. 
 :::
 
 :::info
-If `mautrix[encryption]` is not installed or `libolm` is missing, the bot falls back to a plain (unencrypted) client automatically. You'll see a warning in the logs.
+If `hermes-agent[matrix-e2ee]` (or `mautrix[encryption]`) is not installed or `libolm` is missing, the bot falls back to a plain (unencrypted) client automatically. You'll see a warning in the logs. Installing only `hermes-agent[matrix]` is not enough for E2EE.
 :::
 
 ## Home Room
@@ -722,7 +722,7 @@ history, so other clients trust it immediately.
 
 ## Proxy Mode (E2EE on macOS)
 
-Matrix E2EE requires `libolm`, which doesn't compile on macOS ARM64 (Apple Silicon). The `hermes-agent[matrix]` extra is gated to Linux only. If you're on macOS, proxy mode lets you run E2EE in a Docker container on a Linux VM while the actual agent runs natively on macOS with full access to your local files, memory, and skills.
+Matrix E2EE requires `libolm`, which doesn't compile on macOS ARM64 (Apple Silicon). The `hermes-agent[matrix-e2ee]` extra pulls `python-olm` and is the Linux path for encryption. If you're on macOS, proxy mode lets you run E2EE in a Docker container on a Linux VM while the actual agent runs natively on macOS with full access to your local files, memory, and skills.
 
 ### How It Works
 
@@ -803,7 +803,7 @@ services:
 FROM python:3.11-slim
 
 RUN apt-get update && apt-get install -y libolm-dev && rm -rf /var/lib/apt/lists/*
-RUN cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
+RUN cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix-e2ee]"
 
 CMD ["hermes", "gateway"]
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
@@ -245,8 +245,8 @@ E2EE 需要带有加密扩展的 `mautrix` 库以及 `libolm` C 库：
 # 安装带 E2EE 支持的 mautrix
 pip install 'mautrix[encryption]'
 
-# 或通过 hermes extras 安装
-cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
+# 或通过 Hermes extra 安装。仅安装 [matrix] 不会带上加密。
+cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix-e2ee]"
 ```
 
 你还需要在系统上安装 `libolm`：
@@ -326,7 +326,7 @@ Hermes 在启动时会检测到此情况并拒绝启用 E2EE，日志显示：`d
 :::
 
 :::info
-如果未安装 `mautrix[encryption]` 或缺少 `libolm`，机器人会自动回退到普通（未加密）客户端。你会在日志中看到警告。
+如果未安装 `hermes-agent[matrix-e2ee]`（或 `mautrix[encryption]`）或缺少 `libolm`，机器人会自动回退到普通（未加密）客户端。你会在日志中看到警告。仅安装 `hermes-agent[matrix]` 不足以启用 E2EE。
 :::
 
 ## 主房间
@@ -508,7 +508,7 @@ cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
 
 ## 代理模式（macOS 上的 E2EE）
 
-Matrix E2EE 需要 `libolm`，而该库无法在 macOS ARM64（Apple Silicon）上编译。`hermes-agent[matrix]` extra 仅限 Linux。如果你在 macOS 上，代理模式允许你在 Linux 虚拟机的 Docker 容器中运行 E2EE，而实际的 agent 在 macOS 上原生运行，可完整访问你的本地文件、记忆和技能。
+Matrix E2EE 需要 `libolm`，而该库无法在 macOS ARM64（Apple Silicon）上编译。`hermes-agent[matrix-e2ee]` extra 会拉取 `python-olm`，这是 Linux 上的加密安装路径。如果你在 macOS 上，代理模式允许你在 Linux 虚拟机的 Docker 容器中运行 E2EE，而实际的 agent 在 macOS 上原生运行，可完整访问你的本地文件、记忆和技能。
 
 ### 工作原理
 
@@ -589,7 +589,7 @@ services:
 FROM python:3.11-slim
 
 RUN apt-get update && apt-get install -y libolm-dev && rm -rf /var/lib/apt/lists/*
-RUN cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
+RUN cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix-e2ee]"
 
 CMD ["hermes", "gateway"]
 ```


### PR DESCRIPTION
## What breaks

On macOS, after `hermes update` bumped the pin to `mautrix[encryption]==0.21.1`, Matrix does not come back. `python-olm` (pulled by the `[encryption]` extra) has no wheels for current Apple clang; the sdist build fails. `mautrix` stays at 0.21.0, the new pin is unsatisfied, and the adapter refuses to start.

Related history: #64065 / excluding `[matrix]` from `[all]` for the same olm build failure.

## Why

Both the `[matrix]` extra and `LAZY_DEPS["platform.matrix"]` required `mautrix[encryption]==0.21.1`. `hermes update` refreshes previously activated lazy features to the new pin, so every Matrix user pays the olm compile — including those with E2EE off (the default).

Plain `mautrix==0.21.1` is a `py3-none-any` wheel. The adapter already treats E2EE as optional (`MATRIX_E2EE_MODE` / `_check_e2ee_deps()`); connect without olm is the normal path.

## What this changes

- `[matrix]` extra and the lazy-deps spec install **`mautrix==0.21.1`** (no extra).
- New **`matrix-e2ee`** extra: `hermes-agent[matrix]` + `mautrix[encryption]==0.21.1` for operators who actually need olm.
- Packaging test now asserts the default extra does not contain `[encryption]`.

E2EE install hint on the adapter is unchanged (`pip install 'mautrix[encryption]' …`).

## Verify

```text
pytest tests/test_project_metadata.py::test_matrix_extra_not_in_all \
       tests/tools/test_lazy_deps.py::test_platform_matrix_does_not_require_encryption_extra
# 2 passed
uv lock   # lockfile updated for the extra change
```

Not installed on a Mac in this session. The wheel vs sdist distinction is from the issue + the existing `[all]` exclusion comment.

Fixes #85588
