### PR TITLE
fix(agent): wrap auxiliary clients using explicit_base_url

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6717,7 +6717,17 @@ def resolve_provider_client(
         # Anthropic-wire endpoints (Kimi Coding Plan api.kimi.com/coding,
         # /anthropic-suffixed gateways) so named providers like kimi-coding
         # land on the right transport without needing per-provider branches.
-        client = _wrap_if_needed(client, final_model, raw_base_url, api_key)
+        #
+        # Wrap against the same endpoint the caller targeted. After an
+        # explicit_base_url override, that is the override (un-rewritten so
+        # /anthropic suffixes stay visible) — not the credential-pool stock
+        # URL (#85535).
+        wrap_url = (
+            explicit_base_url.strip().rstrip("/")
+            if explicit_base_url
+            else raw_base_url
+        )
+        client = _wrap_if_needed(client, final_model, wrap_url, api_key)
 
         logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode

--- a/tests/agent/test_auxiliary_explicit_base_anthropic.py
+++ b/tests/agent/test_auxiliary_explicit_base_anthropic.py
@@ -51,6 +51,45 @@ def _client_base_url(client) -> str:
     return ""
 
 
+def test_api_key_provider_wrap_uses_explicit_override_not_stock_creds_url():
+    """#85535: named API-key branch must wrap against explicit_base_url.
+
+    Fallback entries override a built-in provider's endpoint. Wrap used to
+    inspect the credential-pool stock URL, so an Anthropic-only override
+    never triggered the Messages adapter.
+    """
+    from agent.auxiliary_client import resolve_provider_client, AnthropicAuxiliaryClient
+
+    fake_anthropic = MagicMock(name="anthropic_sdk_client")
+    stock_creds = {
+        "provider": "minimax",
+        "api_key": "sk-stock",
+        "base_url": "https://api.minimax.io/v1",
+        "source": "env",
+    }
+    with (
+        patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value=stock_creds,
+        ),
+        patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=fake_anthropic,
+        ) as mock_build,
+    ):
+        client, _model = resolve_provider_client(
+            "minimax",
+            model="claude-opus-4-8",
+            explicit_base_url=_ANTHROPIC_BASE,
+            explicit_api_key="k-override",
+            api_mode="anthropic_messages",
+        )
+
+    assert isinstance(client, AnthropicAuxiliaryClient)
+    mock_build.assert_called_once_with("k-override", _ANTHROPIC_BASE)
+    assert client.base_url == _ANTHROPIC_BASE
+
+
 def test_explicit_base_anthropic_messages_keeps_anthropic_path():
     """api_mode=anthropic_messages must build the Anthropic wrapper on the raw
     ``/anthropic`` base — not the ``/v1``-rewritten one."""


### PR DESCRIPTION
## What breaks

A fallback / auxiliary entry that names a built-in API-key provider (e.g. `minimax`) but overrides `explicit_base_url` to an Anthropic-only gateway never gets `AnthropicAuxiliaryClient`. Side tasks (title, compression, vision) keep talking OpenAI `/chat/completions` at the **stock** provider host, not the override.

This is the leftover call site from the August `/anthropic`↔`/v1` sweep. #85532 / #85466 cover the rewrite policy; they do not fix *which URL* wrap inspects.

## Why

In `resolve_provider_client()`’s `auth_type == "api_key"` branch:

1. The OpenAI client is built with `base_url = _to_openai_base_url(explicit or creds)`.
2. `_wrap_if_needed(...)` was passed `raw_base_url`.

If wrap does not see the override (or sees the pool’s MiniMax/OpenAI stock URL), `_maybe_wrap_anthropic` never matches `/anthropic` / `api_mode=anthropic_messages` for the URL the user actually targeted.

## What this changes

When `explicit_base_url` is set, wrap receives that string **un-rewritten** (so an `/anthropic` suffix stays visible). Otherwise it still uses the credential base.

The client construction / `_to_openai_base_url` host allowlist is unchanged. Dual-surface MiniMax still rewrites the *OpenAI* client to `/v1`; wrap still needs the raw override to decide Messages vs chat.

## Verify

```text
pytest tests/agent/test_auxiliary_explicit_base_anthropic.py::test_api_key_provider_wrap_uses_explicit_override_not_stock_creds_url
# 1 passed
```

Stock creds mocked as MiniMax `/v1`; explicit base is an Anthropic-only proxy. Asserts `AnthropicAuxiliaryClient` and `build_anthropic_client(..., override_url)`.

Fixes #85535
