### PR TITLE
fix(tui): reschedule WS orphan reap while a turn is still running

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3856,6 +3856,52 @@ def test_ws_orphan_reap_releases_resume_lock_before_slow_teardown(monkeypatch):
     assert not thread.is_alive()
 
 
+def test_ws_orphan_reap_reschedules_while_mid_turn_then_reaps(monkeypatch):
+    """A detached session that is still running must keep the reap timer (#85578)."""
+    callbacks = []
+    torn_down = []
+
+    class _Timer:
+        def __init__(self, _delay, callback):
+            callbacks.append(callback)
+            self.daemon = False
+
+        def start(self):
+            return None
+
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(
+        server,
+        "_teardown_session",
+        lambda session, *, end_reason="tui_close": torn_down.append(
+            (session, end_reason)
+        ),
+    )
+    live = _session(
+        transport=server._detached_ws_transport,
+        running=True,
+    )
+    server._sessions["midturn-sid"] = live
+
+    try:
+        server._schedule_ws_orphan_reap("midturn-sid")
+        callbacks.pop(0)()
+
+        assert "midturn-sid" in server._sessions
+        assert len(callbacks) == 1
+        assert torn_down == []
+
+        live["running"] = False
+        callbacks.pop(0)()
+
+        assert "midturn-sid" not in server._sessions
+        assert len(torn_down) == 1
+        assert torn_down[0][1] == "ws_orphan_reap"
+    finally:
+        server._sessions.pop("midturn-sid", None)
+
+
 def test_ws_orphan_reap_waits_for_active_delegation_then_reaps(monkeypatch):
     from tools import async_delegation
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1088,9 +1088,21 @@ def _schedule_ws_orphan_reap(sid: str) -> None:
         session = None
         with _session_resume_lock:
             current = _sessions.get(sid)
-            if not _ws_session_is_orphaned(current):
+            # Mid-turn detached sessions are not yet orphaned (_running
+            # short-circuits _ws_session_is_orphaned). If we return here
+            # the single Timer is gone and the session is immortal until
+            # the 6h TTL — which also skips running (#85578). Reschedule
+            # like the active-delegation branch below.
+            if (
+                current
+                and not current.get("_finalized")
+                and current.get("running")
+                and current.get("transport") is _detached_ws_transport
+            ):
+                reschedule = True
+            elif not _ws_session_is_orphaned(current):
                 return
-            if _session_has_active_delegations(sid, current):
+            elif _session_has_active_delegations(sid, current):
                 reschedule = True
             else:
                 session = _pop_session_by_id(sid)


### PR DESCRIPTION
## What breaks

Desktop / TUI: disconnect while a turn is still running. The session stays in `_sessions` forever (`ended_at` NULL, no error). The in-memory agent is never released. Seen on v0.20.0, Linux/Docker. Config timeouts (`gateway_timeout`, `session_stall_timeout`, `max_live_sessions`) do not help — every eviction path skips `running`.

This is an eighth leak next to the family in #84047 (closest is F, but distinct).

## Why

`handle_ws` detach points the session at `_detached_ws_transport` and arms **one** `threading.Timer` (`_schedule_ws_orphan_reap`, default 20s).

`_ws_session_is_orphaned()` is:

```python
if session.get("running"):
    return False
return session.get("transport") is _detached_ws_transport
```

If the timer fires mid-turn, `_reap()` hits `not orphaned` and **returns**. The active-delegation branch one line below correctly calls `_schedule_ws_orphan_reap` again; the running branch did not. After that, nothing re-arms the timer. The 6h TTL reaper also treats `running` as non-evictable. If the turn never clears from the leak’s point of view, the session is immortal.

## What this changes

A detached session that is still `running` reschedules the same grace timer (same as delegations). When the turn later clears, the next fire sees a real orphan and tears down.

Live transports and finalized sessions still return immediately (no reschedule loop).

## Verify

```text
pytest tests/test_tui_gateway_server.py::test_ws_orphan_reap_reschedules_while_mid_turn_then_reaps
# 1 passed
```

Fake Timer, session starts `running=True` + detached transport: first fire keeps it and arms again; after `running=False`, second fire teardowns with `ws_orphan_reap`.

Fixes #85578
