### PR TITLE
fix(cli): keep Ollama Cloud requests on /v1

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -135,6 +135,26 @@ DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
+
+
+def ensure_ollama_cloud_openai_base_url(base_url: str) -> str:
+    """Keep Ollama Cloud on the OpenAI-compat ``/v1`` surface.
+
+    ``OLLAMA_BASE_URL=https://ollama.com`` (or a host-only override) makes
+    the OpenAI client POST to the marketing homepage and log HTTP 404 with
+    ``<title>Ollama</title>`` (#85417). Chat completions live at ``/v1``.
+    """
+    url = (base_url or "").strip().rstrip("/")
+    if not url:
+        return DEFAULT_OLLAMA_CLOUD_BASE_URL
+    try:
+        host = (urlparse(url).hostname or "").lower().rstrip(".")
+    except Exception:
+        host = ""
+    if host == "ollama.com" or host.endswith(".ollama.com"):
+        if not url.endswith("/v1"):
+            return url + "/v1"
+    return url
 DEFAULT_ACTUAL_BASE_URL = "https://api.actual.inc/v1"
 DEFAULT_ACTUAL_LOCAL_BASE_URL = "http://127.0.0.1:8080/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
@@ -7273,6 +7293,9 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     # otherwise wedges chat inference — #50252).
     if not (isinstance(base_url, str) and base_url.strip()):
         base_url = pconfig.inference_base_url
+
+    if provider_id == "ollama-cloud":
+        base_url = ensure_ollama_cloud_openai_base_url(base_url)
 
     if not api_key and provider_id == "actual" and is_actual_local_base_url(base_url):
         api_key = ACTUAL_LOCAL_NOAUTH_PLACEHOLDER

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -582,6 +582,14 @@ def _resolve_runtime_from_pool_entry(
     if provider == "lmstudio":
         base_url = auth_mod._normalize_lmstudio_runtime_base_url(base_url)
 
+    # After pool / config.yaml / env have all had a chance to overwrite
+    # the URL: a host-only model.base_url (https://ollama.com) must not
+    # re-drop /v1 once we have already healed the pool entry (#85417).
+    if provider == "ollama-cloud":
+        from hermes_cli.auth import ensure_ollama_cloud_openai_base_url
+
+        base_url = ensure_ollama_cloud_openai_base_url(base_url)
+
     return {
         "provider": provider,
         "api_mode": api_mode,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -460,6 +460,10 @@ def _resolve_runtime_from_pool_entry(
     # config.default was still a Claude model.
     effective_model = (target_model or model_cfg.get("default") or "")
     base_url = (getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or "").rstrip("/")
+    if provider == "ollama-cloud":
+        from hermes_cli.auth import ensure_ollama_cloud_openai_base_url
+
+        base_url = ensure_ollama_cloud_openai_base_url(base_url)
     api_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
     api_mode = "chat_completions"
     if provider == "openai-codex":
@@ -1649,6 +1653,11 @@ def _resolve_explicit_runtime(
 
         if provider == "actual" and not api_key and is_actual_local_base_url(base_url):
             api_key = ACTUAL_LOCAL_NOAUTH_PLACEHOLDER
+
+        if provider == "ollama-cloud":
+            from hermes_cli.auth import ensure_ollama_cloud_openai_base_url
+
+            base_url = ensure_ollama_cloud_openai_base_url(base_url)
 
         return {
             "provider": provider,

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -28,7 +28,7 @@ class TestOllamaCloudProviderRegistry:
 
 PROVIDER_ENV_VARS = (
     "OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
-    "GOOGLE_API_KEY", "GEMINI_API_KEY", "OLLAMA_API_KEY",
+    "GOOGLE_API_KEY", "GEMINI_API_KEY", "OLLAMA_API_KEY", "OLLAMA_BASE_URL",
     "GLM_API_KEY", "ZAI_API_KEY", "KIMI_API_KEY",
     "MINIMAX_API_KEY", "DEEPSEEK_API_KEY",
 )
@@ -78,6 +78,16 @@ class TestOllamaCloudCredentials:
         assert result["provider"] == "ollama-cloud"
         assert result["api_mode"] == "chat_completions"
         assert result["api_key"] == "ollama-key"
+        assert result["base_url"] == "https://ollama.com/v1"
+
+    def test_host_only_ollama_base_url_keeps_v1(self, monkeypatch):
+        """OLLAMA_BASE_URL=https://ollama.com must not drop /v1 (#85417)."""
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama-secret")
+        monkeypatch.setenv("OLLAMA_BASE_URL", "https://ollama.com")
+        creds = resolve_api_key_provider_credentials("ollama-cloud")
+        assert creds["base_url"] == "https://ollama.com/v1"
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="ollama-cloud")
         assert result["base_url"] == "https://ollama.com/v1"
 
 

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -90,6 +90,34 @@ class TestOllamaCloudCredentials:
         result = resolve_runtime_provider(requested="ollama-cloud")
         assert result["base_url"] == "https://ollama.com/v1"
 
+    def test_pool_then_host_only_config_base_url_keeps_v1(self, monkeypatch):
+        """Config model.base_url=https://ollama.com after a default pool URL (#85417)."""
+        from types import SimpleNamespace
+
+        from hermes_cli.runtime_provider import _resolve_runtime_from_pool_entry
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_model_config",
+            lambda: {
+                "provider": "ollama-cloud",
+                "base_url": "https://ollama.com",
+                "default": "deepseek-v4-pro",
+            },
+        )
+        entry = SimpleNamespace(
+            runtime_base_url="https://ollama.com/v1",
+            base_url="https://ollama.com/v1",
+            runtime_api_key="pool-key",
+            access_token="",
+            source="pool",
+        )
+        result = _resolve_runtime_from_pool_entry(
+            provider="ollama-cloud",
+            entry=entry,
+            requested_provider="ollama-cloud",
+        )
+        assert result["base_url"] == "https://ollama.com/v1"
+
 
 # ── Model Catalog (dynamic — no static list) ──
 


### PR DESCRIPTION
## What breaks

```yaml
model:
  provider: ollama-cloud
  base_url: https://ollama.com/v1   # ignored for this named provider
```

or `OLLAMA_BASE_URL=https://ollama.com` (host only, common env). Every call fails:

```
provider=ollama-cloud base_url=https://ollama.com  HTTP 404
```

Body is the ollama.com **marketing HTML** (`<title>Ollama</title>`), not the API. `curl https://ollama.com/v1/chat/completions` with the same key works. Workaround: `provider: custom` + explicit `/v1`.

## Why

The registry default is already `https://ollama.com/v1`. Named-provider resolution prefers `OLLAMA_BASE_URL` when set. That env is often the **origin** (`https://ollama.com`) because native Ollama docs talk about the host, not the OpenAI mount.

The OpenAI client then POSTs `{base}/chat/completions` → `https://ollama.com/chat/completions` → homepage 404.

`model.base_url` in config.yaml is not applied for this named provider (same as other registry providers); the env / pool entry wins. The credential-pool path (`_resolve_runtime_from_pool_entry`) also returned the stored URL as-is, so a host-only pool entry stayed broken even after the generic api_key branch was fixed.

Stripping `/v1` inside `detect_local_server_type` is only for **probes** (`/api/tags`); it is not this bug. Do not reuse probe roots as the chat client base.

## What this changes

`ensure_ollama_cloud_openai_base_url()`: if the host is `ollama.com` (or a subdomain) and the path does not already end in `/v1`, append it.

Applied in:

- `resolve_api_key_provider_credentials` (what `hermes` / aux see from env)
- generic api_key runtime resolution
- `_resolve_runtime_from_pool_entry` (the path that actually fired in the repro)

Non-ollama.com URLs are untouched (local `http://127.0.0.1:11434` stays as-is).

## Verify

```text
pytest tests/hermes_cli/test_ollama_cloud_provider.py::TestOllamaCloudCredentials
# 3 passed
```

Includes `OLLAMA_BASE_URL=https://ollama.com` → runtime `https://ollama.com/v1`. Not live-called against Ollama Cloud from this session.

Fixes #85417
