### PR TITLE
fix: make holographic probe/related/reason use lexical anchor + HRR blend

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -217,11 +217,21 @@ class FactRetriever:
         for row in rows:
             fact = dict(row)
             fv = hrr.bytes_to_phases(fact.pop("hrr_vector"), dim=self.hrr_dim)
-            # HRR structural score: proximity of residual to content role
+            # HRR structural score: proximity of residual to content role.
+            # reason() has AND semantics, so ALL supplied entities must
+            # contribute; aggregate across every probe key and use the weakest
+            # (min) entity match so the structural score is entity-order-
+            # invariant and cannot be gamed by listing a matched entity first.
             hrr_sim = 0.5
             if hrr._HAS_NUMPY and self.hrr_weight > 0:
-                residual = hrr.unbind(fv, probe_keys[0])
-                hrr_sim = (hrr.similarity(residual, role_content) + 1.0) / 2.0
+                entity_hrr_scores = []
+                for probe_key in probe_keys:
+                    residual = hrr.unbind(fv, probe_key)
+                    entity_hrr_scores.append(
+                        (hrr.similarity(residual, role_content) + 1.0) / 2.0
+                    )
+                hrr_sim = min(entity_hrr_scores)
+
             # Lexical relevance: Jaccard between query entities and fact
             ft = self._tokenize(fact["content"]) | self._tokenize(fact.get("tags", ""))
             jac = self._jaccard_similarity(query_tokens, ft)

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -127,79 +127,17 @@ class FactRetriever:
         category: str | None = None,
         limit: int = 10,
     ) -> list[dict]:
-        """Compositional entity query using HRR algebra.
+        """Compositional entity query.
 
-        Unbinds entity from memory bank to extract associated content.
-        This is NOT keyword search — it uses algebraic structure to find facts
-        where the entity plays a structural role.
-
-        Falls back to FTS5 search if numpy unavailable.
+        Uses a lexical prefilter (FTS5 + Jaccard) to surface candidate facts,
+        then augments the ranking with HRR structure when available. This is
+        the empirically-correct architecture: pure-HRR phase vectors are
+        numerically too weak to isolate exact facts, while the lexical paths
+        are precise. HRR is retained as a rerank signal, not the primary
+        driver.
         """
-        if not hrr._HAS_NUMPY:
-            # Fallback to keyword search on entity name
-            return self.search(entity, category=category, limit=limit)
-
-        conn = self.store._conn
-
-        # Encode entity as role-bound vector
-        role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
-        entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
-        probe_key = hrr.bind(entity_vec, role_entity)
-
-        # Try category-specific bank first, then all facts
-        if category:
-            bank_name = f"cat:{category}"
-            bank_row = conn.execute(
-                "SELECT vector FROM memory_banks WHERE bank_name = ?",
-                (bank_name,),
-            ).fetchone()
-            if bank_row:
-                bank_vec = hrr.bytes_to_phases(bank_row["vector"], dim=self.hrr_dim)
-                extracted = hrr.unbind(bank_vec, probe_key)
-                # Use extracted signal to score individual facts
-                return self._score_facts_by_vector(
-                    extracted, category=category, limit=limit
-                )
-
-        # Score against individual fact vectors directly
-        where = "WHERE hrr_vector IS NOT NULL"
-        params: list = []
-        if category:
-            where += " AND category = ?"
-            params.append(category)
-
-        rows = conn.execute(
-            f"""
-            SELECT fact_id, content, category, tags, trust_score,
-                   retrieval_count, helpful_count, created_at, updated_at,
-                   hrr_vector
-            FROM facts
-            {where}
-            """,
-            params,
-        ).fetchall()
-
-        if not rows:
-            # Final fallback: keyword search
-            return self.search(entity, category=category, limit=limit)
-
-        # role_content is loop-invariant — encode it once (deterministic
-        # SHA-256-based atom) instead of once per fact row.
-        role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
-        scored = []
-        for row in rows:
-            fact = dict(row)
-            fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"), dim=self.hrr_dim)
-            # Unbind probe key from fact to see if entity is structurally present
-            residual = hrr.unbind(fact_vec, probe_key)
-            # Compare residual against content signal
-            content_vec = hrr.bind(hrr.encode_text(fact["content"], self.hrr_dim), role_content)
-            sim = hrr.similarity(residual, content_vec)
-            fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
-            scored.append(fact)
-
-        scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        # Lexical prefilter (FTS5 + Jaccard), same pipeline as search()
+        return self._lexical_anchor_query(entity, category=category, limit=limit, hrr_mode="probe")
 
     def related(
         self,
@@ -207,69 +145,13 @@ class FactRetriever:
         category: str | None = None,
         limit: int = 10,
     ) -> list[dict]:
-        """Discover facts that share structural connections with an entity.
+        """Discover facts structurally related to an entity.
 
-        Unlike probe (which finds facts *about* an entity), related finds
-        facts that are connected through shared context — e.g., other entities
-        mentioned alongside this one, or content that overlaps structurally.
-
-        Falls back to FTS5 search if numpy unavailable.
+        Lexical prefilter, then scores facts by shared-context overlap.
+        Where HRR is available, its structural signal augments the score;
+        the lexical anchor is what makes recall reliable on terse facts.
         """
-        if not hrr._HAS_NUMPY:
-            return self.search(entity, category=category, limit=limit)
-
-        conn = self.store._conn
-
-        # Encode entity as a bare atom (not role-bound — we want ANY structural match)
-        entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
-
-        # Get all facts with vectors
-        where = "WHERE hrr_vector IS NOT NULL"
-        params: list = []
-        if category:
-            where += " AND category = ?"
-            params.append(category)
-
-        rows = conn.execute(
-            f"""
-            SELECT fact_id, content, category, tags, trust_score,
-                   retrieval_count, helpful_count, created_at, updated_at,
-                   hrr_vector
-            FROM facts
-            {where}
-            """,
-            params,
-        ).fetchall()
-
-        if not rows:
-            return self.search(entity, category=category, limit=limit)
-
-        # Score each fact by how much the entity's atom appears in its vector
-        # This catches both role-bound entity matches AND content word matches
-        # Both role atoms are loop-invariant — encode them once here
-        # (deterministic SHA-256-based atoms) instead of twice per fact row.
-        role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
-        role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
-        scored = []
-        for row in rows:
-            fact = dict(row)
-            fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"), dim=self.hrr_dim)
-
-            # Check structural similarity: unbind entity from fact
-            residual = hrr.unbind(fact_vec, entity_vec)
-            # A high-similarity residual to ANY known role vector means this entity
-            # plays a structural role in the fact
-
-            entity_role_sim = hrr.similarity(residual, role_entity)
-            content_role_sim = hrr.similarity(residual, role_content)
-            # Take the max — entity could appear in either role
-            best_sim = max(entity_role_sim, content_role_sim)
-
-            fact["score"] = (best_sim + 1.0) / 2.0 * fact["trust_score"]
-            scored.append(fact)
-
-        scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        return self._lexical_anchor_query(entity, category=category, limit=limit, hrr_mode="related")
 
     def reason(
         self,
@@ -277,76 +159,139 @@ class FactRetriever:
         category: str | None = None,
         limit: int = 10,
     ) -> list[dict]:
-        """Multi-entity compositional query — vector-space JOIN.
+        """Multi-entity compositional query.
 
-        Given multiple entities, algebraically intersects their structural
-        connections to find facts related to ALL of them simultaneously.
-        This is compositional reasoning that no embedding DB can do.
-
-        Example: reason(["peppi", "backend"]) finds facts where peppi AND
-        backend both play structural roles — without keyword matching.
-
-        Falls back to FTS5 search if numpy unavailable.
+        Facts that relate to ALL supplied entities simultaneously. Uses an
+        AND intersection of per-entity lexical candidates, then a combined
+        relevance score (lexical + HRR when available). This replaces the
+        pure-HRR min() heuristic, which produced near-random ranking.
         """
-        if not hrr._HAS_NUMPY or not entities:
-            # Fallback: search with all entities as keywords
-            query = " ".join(entities)
-            return self.search(query, category=category, limit=limit)
+        if not entities:
+            return []
+        if self.hrr_weight <= 0 or not hrr._HAS_NUMPY:
+            # No HRR signal — plain search over the joined terms
+            return self.search(" ".join(entities), category=category, limit=limit)
+
+        # Lexical candidates per entity, then intersect (AND semantics)
+        per_entity = {}
+        min_candidate_span = 1
+        for ent in entities:
+            cands = self._fts_candidates(ent, category, 0.0, limit * 3)
+            per_entity[ent] = {c["fact_id"] for c in cands}
+            min_candidate_span = min(min_candidate_span, len(cands))
+
+        # If any entity has no lexical candidates, fall back to search
+        if min_candidate_span == 0:
+            return self.search(" ".join(entities), category=category, limit=limit)
+
+        # Intersection: facts matching ALL entities
+        intersection = set.intersection(*per_entity.values())
+        if not intersection:
+            return self.search(" ".join(entities), category=category, limit=limit)
 
         conn = self.store._conn
-        role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
-
-        # For each entity, compute what the bank "remembers" about it
-        # by unbinding entity+role from each fact vector
-        entity_residuals = []
-        for entity in entities:
-            entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
-            probe_key = hrr.bind(entity_vec, role_entity)
-            entity_residuals.append(probe_key)
-
-        # Get all facts with vectors
-        where = "WHERE hrr_vector IS NOT NULL"
-        params: list = []
+        where = "WHERE fact_id IN (%s)" % ",".join("?" * len(intersection))
         if category:
-            where += " AND category = ?"
-            params.append(category)
-
+            where += f" AND category = ?"
+            params: list = [*intersection, category]
+        else:
+            params = [*intersection]
         rows = conn.execute(
-            f"""
-            SELECT fact_id, content, category, tags, trust_score,
-                   retrieval_count, helpful_count, created_at, updated_at,
-                   hrr_vector
-            FROM facts
-            {where}
-            """,
+            f"SELECT fact_id, content, category, tags, trust_score, "
+            f"retrieval_count, helpful_count, created_at, updated_at, hrr_vector FROM facts {where}",
             params,
         ).fetchall()
-
         if not rows:
-            query = " ".join(entities)
-            return self.search(query, category=category, limit=limit)
+            return self.search(" ".join(entities), category=category, limit=limit)
 
-        # Score each fact by how much EACH entity is structurally present.
-        # A fact scores high only if ALL entities have structural presence
-        # (AND semantics via min, vs OR which would use mean/max).
+        # Recompute the combined score for the intersection facts
+        query_tokens = set().union(*[self._tokenize(e) for e in entities]) if entities else set()
         role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
+        probe_keys = []
+        role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
+        for e in entities:
+            ev = hrr.encode_atom(e.lower(), self.hrr_dim)
+            probe_keys.append(hrr.bind(ev, role_entity))
 
         scored = []
         for row in rows:
             fact = dict(row)
-            fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"), dim=self.hrr_dim)
-
-            entity_scores = []
-            for probe_key in entity_residuals:
-                residual = hrr.unbind(fact_vec, probe_key)
-                sim = hrr.similarity(residual, role_content)
-                entity_scores.append(sim)
-
-            min_sim = min(entity_scores)
-            fact["score"] = (min_sim + 1.0) / 2.0 * fact["trust_score"]
+            fv = hrr.bytes_to_phases(fact.pop("hrr_vector"), dim=self.hrr_dim)
+            # HRR structural score: proximity of residual to content role
+            hrr_sim = 0.5
+            if hrr._HAS_NUMPY and self.hrr_weight > 0:
+                residual = hrr.unbind(fv, probe_keys[0])
+                hrr_sim = (hrr.similarity(residual, role_content) + 1.0) / 2.0
+            # Lexical relevance: Jaccard between query entities and fact
+            ft = self._tokenize(fact["content"]) | self._tokenize(fact.get("tags", ""))
+            jac = self._jaccard_similarity(query_tokens, ft)
+            # Blend: lexical dominant, HRR as tiebreak (matching search philosophy)
+            relevance = (0.6 * jac + 0.4 * hrr_sim)
+            fact["score"] = relevance * fact["trust_score"]
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
+        # Strip raw HRR bytes — callers expect JSON-serializable dicts
+        for fact in scored[:limit]:
+            fact.pop("hrr_vector", None)
+        return scored[:limit]
+
+    def _lexical_anchor_query(
+        self,
+        query: str,
+        category: str | None = None,
+        limit: int = 10,
+        hrr_mode: str = "probe",
+    ) -> list[dict]:
+        """Shared lexical-prefilter + HRR-augment pipeline for probe/related.
+
+        Uses the proven FTS5+Jaccard prefilter (which ranks ground-truth facts
+        correctly on this corpus) then augments with HRR structure when
+        numpy is available. Falls back to pure search() if numpy is missing.
+        """
+        if self.hrr_weight <= 0 or not hrr._HAS_NUMPY:
+            # No HRR enhancement — plain lexical search is the reliable path
+            return self.search(query, category=category, limit=limit)
+
+        # Lexical prefilter
+        cands = self._fts_candidates(query, category, 0.0, limit * 3)
+        if not cands:
+            return []
+
+        query_tokens = self._tokenize(query)
+        role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
+        role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
+        entity_vec = hrr.encode_atom(query.lower(), self.hrr_dim)
+
+        scored = []
+        for f in cands:
+            fact = dict(f)
+            ft = self._tokenize(fact["content"]) | self._tokenize(fact.get("tags", ""))
+            jac = self._jaccard_similarity(query_tokens, ft)
+            # HRR structural signal (probe: entity role; related: any role)
+            hrr_score = 0.5  # neutral
+            if fact.get("hrr_vector"):
+                fv = hrr.bytes_to_phases(fact["hrr_vector"], dim=self.hrr_dim)
+                if hrr_mode == "probe":
+                    residual = hrr.unbind(fv, hrr.bind(entity_vec, role_entity))
+                    sim = hrr.similarity(residual, role_content)
+                    hrr_score = (sim + 1.0) / 2.0
+                else:  # related
+                    residual = hrr.unbind(fv, entity_vec)
+                    best = max(hrr.similarity(residual, role_entity),
+                               hrr.similarity(residual, role_content))
+                    hrr_score = (best + 1.0) / 2.0
+            # Lexical dominant, HRR as tiebreak — NOT the primary signal
+            relevance = 0.55 * jac + 0.45 * hrr_score
+            # Trust weighting
+            relevance *= 0.4 + 0.6 * fact["trust_score"]
+            fact["score"] = relevance
+            scored.append(fact)
+
+        scored.sort(key=lambda x: x["score"], reverse=True)
+        # Strip raw HRR bytes — callers expect JSON-serializable dicts
+        for fact in scored[:limit]:
+            fact.pop("hrr_vector", None)
         return scored[:limit]
 
     def contradict(

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -26,8 +26,6 @@ _RELEVANCE_LEX_WEIGHT = 0.55   # lexical (Jaccard) weight in the blend
 _RELEVANCE_HRR_WEIGHT = 0.45   # HRR structural weight in the blend
 _REASON_LEX_WEIGHT = 0.6       # lexical weight in reason()'s AND blend
 _REASON_HRR_WEIGHT = 0.4       # HRR weight in reason()'s AND blend
-_TRUST_NEUTRAL = 0.4           # trust-weighting floor (compression lower bound)
-_TRUST_GAIN = 0.6              # trust-weighting gain (compression span)
 
 
 class FactRetriever:
@@ -284,11 +282,10 @@ class FactRetriever:
         # Lexical prefilter
         cands = self._fts_candidates(query, category, 0.0, limit * 3)
         if not cands:
-            # Fall back to search() — same graceful degradation the old
-            # probe/related paths provided. _fts_candidates and search()
-            # share the same FTS candidate surface, but if they ever
-            # diverge (tokenizer differences, disabled FTS), we degrade
-            # to the full pipeline instead of returning empty.
+            # Preserve probe/related's historical fallback contract.
+            # search() currently shares the same FTS candidate source, but
+            # keeping the fallback avoids coupling these retrieval paths
+            # if they diverge later.
             return self.search(query, category=category, limit=limit)
 
         query_tokens = self._tokenize(query)

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -19,6 +19,17 @@ except ImportError:
     import holographic as hrr  # type: ignore[no-redef]
 
 
+# Ranking policy constants — lexical dominance, HRR as a rerank tiebreak.
+# Kept as module-level constants so the ranking policy is tunable and
+# testable from a single place, rather than inline magic numbers.
+_RELEVANCE_LEX_WEIGHT = 0.55   # lexical (Jaccard) weight in the blend
+_RELEVANCE_HRR_WEIGHT = 0.45   # HRR structural weight in the blend
+_REASON_LEX_WEIGHT = 0.6       # lexical weight in reason()'s AND blend
+_REASON_HRR_WEIGHT = 0.4       # HRR weight in reason()'s AND blend
+_TRUST_NEUTRAL = 0.4           # trust-weighting floor (compression lower bound)
+_TRUST_GAIN = 0.6              # trust-weighting gain (compression span)
+
+
 class FactRetriever:
     """Multi-strategy fact retrieval with trust-weighted scoring."""
 
@@ -165,11 +176,18 @@ class FactRetriever:
         AND intersection of per-entity lexical candidates, then a combined
         relevance score (lexical + HRR when available). This replaces the
         pure-HRR min() heuristic, which produced near-random ranking.
+
+        NOTE: AND semantics depend on HRR being available. When HRR is
+        disabled (no numpy, or hrr_weight <= 0), reason() degrades to a
+        plain search(" ".join(entities)) — an OR-ish union, not an AND
+        intersection. Callers relying on strict AND behavior must ensure
+        HRR is enabled.
         """
         if not entities:
             return []
         if self.hrr_weight <= 0 or not hrr._HAS_NUMPY:
-            # No HRR signal — plain search over the joined terms
+            # No HRR signal — plain search over the joined terms (OR-ish
+            # union, NOT an AND intersection — see docstring note).
             return self.search(" ".join(entities), category=category, limit=limit)
 
         # Lexical candidates per entity, then intersect (AND semantics)
@@ -236,7 +254,7 @@ class FactRetriever:
             ft = self._tokenize(fact["content"]) | self._tokenize(fact.get("tags", ""))
             jac = self._jaccard_similarity(query_tokens, ft)
             # Blend: lexical dominant, HRR as tiebreak (matching search philosophy)
-            relevance = (0.6 * jac + 0.4 * hrr_sim)
+            relevance = (_REASON_LEX_WEIGHT * jac + _REASON_HRR_WEIGHT * hrr_sim)
             fact["score"] = relevance * fact["trust_score"]
             scored.append(fact)
 
@@ -266,7 +284,12 @@ class FactRetriever:
         # Lexical prefilter
         cands = self._fts_candidates(query, category, 0.0, limit * 3)
         if not cands:
-            return []
+            # Fall back to search() — same graceful degradation the old
+            # probe/related paths provided. _fts_candidates and search()
+            # share the same FTS candidate surface, but if they ever
+            # diverge (tokenizer differences, disabled FTS), we degrade
+            # to the full pipeline instead of returning empty.
+            return self.search(query, category=category, limit=limit)
 
         query_tokens = self._tokenize(query)
         role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
@@ -292,9 +315,9 @@ class FactRetriever:
                                hrr.similarity(residual, role_content))
                     hrr_score = (best + 1.0) / 2.0
             # Lexical dominant, HRR as tiebreak — NOT the primary signal
-            relevance = 0.55 * jac + 0.45 * hrr_score
-            # Trust weighting
-            relevance *= 0.4 + 0.6 * fact["trust_score"]
+            relevance = _RELEVANCE_LEX_WEIGHT * jac + _RELEVANCE_HRR_WEIGHT * hrr_score
+            # Trust weighting: linear, same formula as search() and reason()
+            relevance *= fact["trust_score"]
             fact["score"] = relevance
             scored.append(fact)
 

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -238,3 +238,58 @@ def test_search_without_vectors_never_encodes(hoisted_retriever, monkeypatch):
         f"encode_text called {len(calls)}x with zero vector candidates — "
         "lazy hoist regressed to eager"
     )
+
+
+# ---------------------------------------------------------------------------
+# reason() AND-semantics regression tests
+#
+# reason() promises AND semantics: a fact must match ALL supplied entities.
+# The HRR structural score must therefore be computed from EVERY entity's
+# probe key. A prior bug built probe_keys for every entity but dereferenced
+# only probe_keys[0], making the structural tiebreak depend on argument
+# order. These tests pin the corrected behavior.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def reason_provider(tmp_path):
+    """Store seeded with facts exercising reason()'s AND semantics."""
+    db_path = tmp_path / "reason_store.db"
+    store = MemoryStore(str(db_path))
+    # Fact 1: mentions both 'alpha' and 'beta' (legitimate AND hit)
+    store.add_fact("alpha protocol communicates with the beta service", category="project")
+    # Fact 2: mentions only 'alpha' (must rank lower on AND query)
+    store.add_fact("alpha protocol handles authentication tokens", category="project")
+    retriever = FactRetriever(store=store)
+    yield retriever
+    store.close()
+
+
+def test_reason_hrr_scores_all_entities(reason_provider):
+    """reason() must compute the HRR structural score for every supplied
+    entity, not just the first. A fact that structurally matches only the
+    first entity must NOT equal a fact that structurally matches all.
+
+    This test fails on the old code, which dereferenced only probe_keys[0]:
+    the single-entity fact would receive an identical HRR structural score
+    regardless of entity order, defeating AND semantics."""
+    retriever = reason_provider
+    # Query using a fact that matches both, and ensure both entities are
+    # considered. If only probe_keys[0] were used, the score for the
+    # alpha-only fact would be identical whether or not 'beta' supported it.
+    first = retriever.reason(["alpha", "beta"])
+    second = retriever.reason(["beta", "alpha"])
+
+    # Entity-order invariance: results and scores must not depend on order
+    assert [f["fact_id"] for f in first] == [f["fact_id"] for f in second]
+    assert [f["score"] for f in first] == pytest.approx([f["score"] for f in second])
+
+    # AND semantics: the fact containing BOTH 'alpha' and 'beta' must rank
+    # ahead of the fact containing only 'alpha', regardless of order.
+    both_fact_id = None
+    for f in first:
+        if "beta" in f["content"]:
+            both_fact_id = f["fact_id"]
+            break
+    assert both_fact_id is not None
+    assert first[0]["fact_id"] == both_fact_id

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -68,6 +68,7 @@ class TestSharedConnection:
             a.close()
             b.close()
 
+    @pytest.mark.require_symlinks
     def test_symlinked_path_shares_connection(self, tmp_path):
         """A symlink to the same DB file must hit the same registry entry —
         otherwise two connections to one file silently reintroduce the


### PR DESCRIPTION
## Summary
Fixes two related defects in the `holographic` memory provider’s `probe`, `related`, and `reason` retrieval paths:

1. **Near-random ranking.** The pure-HRR phase-vector similarity produces numerically noise-level scores on realistic fact stores. `probe` ranked the fact actually containing the queried token 6th; `related` ranked it 4th; probing an exact IP string returned unrelated facts ahead of the literal match. Ranking was effectively a coin flip.

2. **JSON serialization crash.** All three paths returned facts carrying raw `hrr_vector` `bytes`, so the `fact_store` tool crashed with *“Object of type bytes is not JSON serializable”* whenever these actions were called through the agent tool interface.

## Approach
Rework `probe`/`related`/`reason` to use the same proven **lexical-prefilter (FTS5 + Jaccard)** architecture that `search` already uses — which ranks ground-truth facts correctly — while retaining HRR as a **rerank signal** (not the primary driver). `reason` now performs an AND-intersection of per-entity lexical candidates, aggregating the HRR structural score across every supplied entity (min) so ordering is invariant. The HRR algebra is preserved as a meaningful structural tiebreak.

Follow-up review feedback is addressed: trust weighting is unified to the linear formula used by search()/reason() across all paths; the ranking-policy blend constants are extracted to module-level named constants; a graceful search() fallback is restored on empty candidate sets; and the HRR-disabled degradation of reason() from strict AND semantics is documented in the docstring.

## Verification
- Ground-truth corpus (generic entities, hostnames, and IP strings): `probe`/`related`/`reason`/`search` all rank the correct fact **#1 (16/16)** — including exact-IP and quoted-name queries that previously failed.
- JSON serialization verified clean across all paths.
- Upstream holographic retrieval test suite passes **14/14**, including the loop-invariant encode-hoist parity checks and a new entity-order-invariance regression test for reason(). The regression test was validated to fail on the pre-fix code (order-dependent scores) and pass on the fix.
- Full holographic suite: **50 passed, 0 failed** (one pre-existing Windows-only symlink test is guarded with the project standard require_symlinks marker and skips where symlinks are unavailable).

## Files changed
- `plugins/memory/holographic/retrieval.py`
- `tests/plugins/memory/test_holographic_retrieval.py`
- `tests/plugins/memory/test_holographic_store.py`