### PR TITLE
feat(sessions): expose privacy-safe gateway origins

### DIFF
--- a/hermes_cli/session_origins.py
+++ b/hermes_cli/session_origins.py
@@ -1,0 +1,82 @@
+"""Privacy-safe gateway origin metadata for session list responses."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+
+def _session_origin_text(value: Any, *, max_chars: int = 240) -> str:
+    """Normalize untrusted gateway labels for a compact JSON UI payload."""
+    if value is None:
+        return ""
+    text = str(value).replace("\r\n", "\n").replace("\r", "\n").strip()
+    text = "".join(ch if ch >= " " else " " for ch in text)
+    if len(text) > max_chars:
+        text = text[: max_chars - 3] + "..."
+    return text
+
+
+def session_origin_metadata(row: Dict[str, Any]) -> Optional[Dict[str, str]]:
+    """Project a state.db gateway row into non-secret, UI-ready metadata."""
+    raw = row.get("origin_json")
+    if not raw:
+        return None
+    try:
+        origin = json.loads(raw) if isinstance(raw, str) else raw
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(origin, dict):
+        return None
+
+    platform = _session_origin_text(origin.get("platform") or row.get("source"))
+    if not platform:
+        return None
+    chat_type = _session_origin_text(origin.get("chat_type") or row.get("chat_type")) or "chat"
+    is_dm = chat_type.casefold() == "dm"
+    fallback_kind = "DM" if is_dm else chat_type
+    display_label = f"{platform.title()} {fallback_kind}"
+
+    if not is_dm:
+        identifier_fields = (
+            "chat_id",
+            "chat_id_alt",
+            "guild_id",
+            "message_id",
+            "parent_chat_id",
+            "routing_key",
+            "scope_id",
+            "session_key",
+            "thread_id",
+            "user_id",
+            "user_id_alt",
+            "user_name",
+        )
+        identifiers = set()
+        for key in identifier_fields:
+            for source in (row, origin):
+                value = _session_origin_text(source.get(key))
+                if value:
+                    identifiers.add(value.casefold())
+        for candidate in (row.get("display_name"), origin.get("chat_name")):
+            label = _session_origin_text(candidate)
+            if label and label.casefold() not in identifiers:
+                display_label = label
+                break
+
+    return {"platform": platform, "chat_type": chat_type, "display_label": display_label}
+
+
+def enrich_sessions_with_origins(sessions: List[Dict[str, Any]], db: Any) -> None:
+    """Attach gateway origins from the canonical state.db routing index."""
+    if not sessions:
+        return
+    wanted = [str(session.get("id") or "") for session in sessions]
+    origins: Dict[str, Dict[str, str]] = {}
+    for row in db.get_gateway_session_metadata(wanted).values():
+        session_id = str(row.get("id") or "")
+        metadata = session_origin_metadata(row)
+        if metadata:
+            origins[session_id] = metadata
+    for session in sessions:
+        origin = origins.get(str(session.get("id") or ""))
+        if origin:
+            session["origin"] = origin

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional, Tuple  # noqa: F401
 
 from fastapi import APIRouter, HTTPException, Query  # noqa: F401
 
+from hermes_cli.session_origins import enrich_sessions_with_origins
 from hermes_cli.web_deps import late
 from hermes_cli.web_models import (
     ProfileCreate,
@@ -193,6 +194,7 @@ def get_profiles_sessions(
             )
             total += profile_total
             profile_totals[name] = profile_total
+            enrich_sessions_with_origins(rows, db)
             for s in rows:
                 s["profile"] = name
                 s["is_default_profile"] = name == "default"
@@ -334,6 +336,7 @@ def get_profiles_sessions_sidebar(
             continue
         try:
             profile_rows = _slice(db, exclude=recents_exclude_list, cap=recents_cap)
+            enrich_sessions_with_origins(profile_rows, db)
             # A full window means more rows remain on disk. That is all the
             # sidebar's "load more" needs, and unlike an exact COUNT(*) per
             # profile per refresh it costs nothing beyond the rows already
@@ -346,10 +349,12 @@ def get_profiles_sessions_sidebar(
             # a page, and a total that shrank when you scrolled would be worse
             # than no total at all.
             profile_totals[name] = db.usage_totals()
-            cron_rows.extend(_tag(_slice(db, source="cron", cap=cron_cap), name))
-            messaging_rows.extend(
-                _tag(_slice(db, exclude=messaging_exclude_list, cap=messaging_cap), name)
-            )
+            profile_rows = _slice(db, source="cron", cap=cron_cap)
+            enrich_sessions_with_origins(profile_rows, db)
+            cron_rows.extend(_tag(profile_rows, name))
+            profile_rows = _slice(db, exclude=messaging_exclude_list, cap=messaging_cap)
+            enrich_sessions_with_origins(profile_rows, db)
+            messaging_rows.extend(_tag(profile_rows, name))
         except Exception as exc:
             _warn_profile_read_error(name, exc)
             errors.append({"profile": name, "error": str(exc)})

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -22,6 +22,7 @@ from fastapi import APIRouter, HTTPException, Query, Request  # noqa: F401
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
 
+from hermes_cli.session_origins import enrich_sessions_with_origins
 from hermes_cli.web_deps import late
 from hermes_cli.web_models import (
     BulkDeleteSessions,
@@ -154,6 +155,7 @@ def get_sessions(
                 # SQLite stores the flag as 0/1; expose a real JSON boolean.
                 s["archived"] = bool(s.get("archived"))
                 s["pinned"] = bool(s.get("pinned"))
+            enrich_sessions_with_origins(sessions, db)
             if not full:
                 _strip_session_list_rows(sessions)
             return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4495,6 +4495,37 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             rows = self._conn.execute(query, params).fetchall()
         return [self._session_row_dict(r) for r in rows]
 
+    def get_gateway_session_metadata(
+        self, session_ids: List[str]
+    ) -> Dict[str, Dict[str, Any]]:
+        """Return gateway presentation metadata keyed by requested session ID.
+
+        Unlike :meth:`list_gateway_sessions`, this preserves historical rows
+        that share a routing ``session_key``. Queries are bounded to the
+        requested primary keys and select only the columns presentation
+        consumers need.
+        """
+        ids = list(dict.fromkeys(str(value) for value in session_ids if value))
+        if not ids:
+            return {}
+
+        result: Dict[str, Dict[str, Any]] = {}
+        # Stay comfortably below SQLite's host-parameter limit on older builds.
+        for start in range(0, len(ids), 400):
+            batch = ids[start : start + 400]
+            placeholders = ",".join("?" for _ in batch)
+            query = f"""
+                SELECT id, source, chat_type, display_name, origin_json,
+                       session_key, chat_id, user_id, thread_id
+                FROM sessions
+                WHERE session_key IS NOT NULL
+                  AND id IN ({placeholders})
+            """
+            with self._lock:
+                rows = self._conn.execute(query, batch).fetchall()
+            result.update((row["id"], dict(row)) for row in rows)
+        return result
+
     def find_session_by_origin(
         self,
         *,

--- a/tests/hermes_cli/test_profiles_sidebar_scope.py
+++ b/tests/hermes_cli/test_profiles_sidebar_scope.py
@@ -11,6 +11,8 @@ Two behaviors that only show up with more than one profile on disk:
   coexist in one list.
 """
 
+import json
+
 import pytest
 
 
@@ -84,6 +86,32 @@ def _seed_session(home, session_id, *, source, cwd=None, tokens=None, cost=None)
         conn.close()
 
 
+def _seed_gateway_session(home, session_id, *, source, chat_type, display_name):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=home / "state.db")
+    try:
+        db.create_session(session_id, source=source)
+        db.record_gateway_session_peer(
+            session_id,
+            source=source,
+            session_key=f"agent:main:{source}:{chat_type}:{session_id}",
+            chat_id=f"chat-{session_id}",
+            chat_type=chat_type,
+            display_name=display_name,
+            origin_json=json.dumps(
+                {
+                    "platform": source,
+                    "chat_type": chat_type,
+                    "chat_id": f"chat-{session_id}",
+                }
+            ),
+        )
+        db.append_message(session_id=session_id, role="user", content="hi")
+    finally:
+        db.close()
+
+
 def _seed_project(home, name, folder):
     from hermes_cli import projects_db
 
@@ -96,6 +124,57 @@ def _slice_ids(payload, slice_name):
 
 
 class TestSidebarScope:
+
+    def test_recent_cron_and_messaging_rows_include_canonical_origins(
+        self, profiles_on_disk
+    ):
+        worker_home = profiles_on_disk["worker"]
+        _seed_gateway_session(
+            worker_home,
+            "worker-recent",
+            source="telegram",
+            chat_type="group",
+            display_name="Recent room",
+        )
+        _seed_gateway_session(
+            worker_home,
+            "worker-cron",
+            source="cron",
+            chat_type="job",
+            display_name="Nightly job",
+        )
+        _seed_gateway_session(
+            worker_home,
+            "worker-messaging",
+            source="discord",
+            chat_type="channel",
+            display_name="Release room",
+        )
+
+        from hermes_cli.web_routers.profiles import get_profiles_sessions_sidebar
+
+        payload = get_profiles_sessions_sidebar(
+            recents_profile="worker",
+            recents_exclude="cron,discord",
+            messaging_exclude="cron,telegram",
+        )
+
+        assert payload["errors"] == []
+        assert payload["recents"]["sessions"][0]["origin"] == {
+            "platform": "telegram",
+            "chat_type": "group",
+            "display_label": "Recent room",
+        }
+        assert payload["cron"]["sessions"][0]["origin"] == {
+            "platform": "cron",
+            "chat_type": "job",
+            "display_label": "Nightly job",
+        }
+        assert payload["messaging"]["sessions"][0]["origin"] == {
+            "platform": "discord",
+            "chat_type": "channel",
+            "display_label": "Release room",
+        }
 
     def test_concrete_profile_sees_only_its_own_slices(self, client, profiles_on_disk):
         _seed_session(profiles_on_disk["default"], "default-chat", source="cli")

--- a/tests/hermes_cli/test_session_origins.py
+++ b/tests/hermes_cli/test_session_origins.py
@@ -1,0 +1,58 @@
+import json
+
+from hermes_cli.session_origins import enrich_sessions_with_origins, session_origin_metadata
+from hermes_state import SessionDB
+
+
+def test_session_origin_metadata_keeps_dm_labels_private():
+    metadata = session_origin_metadata(
+        {
+            "source": "telegram",
+            "chat_type": "dm",
+            "display_name": "+4712345678",
+            "origin_json": json.dumps({"platform": "telegram", "chat_type": "dm", "chat_name": "Alice"}),
+        }
+    )
+
+    assert metadata == {"platform": "telegram", "chat_type": "dm", "display_label": "Telegram DM"}
+
+
+def test_session_origin_metadata_uses_non_identifier_room_label():
+    metadata = session_origin_metadata(
+        {
+            "source": "discord",
+            "chat_type": "channel",
+            "display_name": "Production",
+            "chat_id": "123",
+            "origin_json": json.dumps({"platform": "discord", "chat_type": "channel", "chat_id": "123"}),
+        }
+    )
+
+    assert metadata == {"platform": "discord", "chat_type": "channel", "display_label": "Production"}
+
+
+def test_enrich_sessions_reads_gateway_origins_from_state_db(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("gateway-session", "telegram")
+        db.record_gateway_session_peer(
+            "gateway-session",
+            source="telegram",
+            session_key="agent:main:telegram:group:42",
+            chat_id="42",
+            chat_type="group",
+            display_name="Lighting crew",
+            origin_json=json.dumps({"platform": "telegram", "chat_type": "group", "chat_id": "42"}),
+        )
+        sessions = [{"id": "gateway-session"}, {"id": "local-session"}]
+
+        enrich_sessions_with_origins(sessions, db)
+
+        assert sessions[0]["origin"] == {
+            "platform": "telegram",
+            "chat_type": "group",
+            "display_label": "Lighting crew",
+        }
+        assert "origin" not in sessions[1]
+    finally:
+        db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1779,6 +1779,46 @@ class TestListSessionsRich:
         activity = db.get_session_activity("gw-1")
         assert activity["last_activity_description"] == "compressing context"
 
+    def test_get_gateway_session_metadata_preserves_same_key_history(self, db):
+        shared_key = "agent:main:telegram:dm:c1"
+        for session_id, display_name in (
+            ("gw-history-old", "Earlier chat"),
+            ("gw-history-new", "Latest chat"),
+        ):
+            db.create_session(session_id, "telegram")
+            db.record_gateway_session_peer(
+                session_id,
+                source="telegram",
+                session_key=shared_key,
+                chat_id="private-chat-id",
+                chat_type="dm",
+                display_name=display_name,
+                origin_json=json.dumps({"platform": "telegram", "chat_type": "dm"}),
+            )
+        db.create_session("not-gateway", "cli")
+
+        rows = db.get_gateway_session_metadata(
+            ["gw-history-old", "missing", "gw-history-new", "gw-history-old", "not-gateway"]
+        )
+
+        assert set(rows) == {"gw-history-old", "gw-history-new"}
+        assert rows["gw-history-old"]["display_name"] == "Earlier chat"
+        assert rows["gw-history-new"]["display_name"] == "Latest chat"
+        assert set(rows["gw-history-old"]) == {
+            "id",
+            "source",
+            "chat_type",
+            "display_name",
+            "origin_json",
+            "session_key",
+            "chat_id",
+            "user_id",
+            "thread_id",
+        }
+
+    def test_get_gateway_session_metadata_empty_request(self, db):
+        assert db.get_gateway_session_metadata([]) == {}
+
     def test_order_by_last_active_surfaces_recently_touched_older_session_first(self, db):
         t0 = 1709500000.0
         db.create_session("old", "cli")


### PR DESCRIPTION
## Summary
- expose privacy-safe gateway origin metadata on session list/sidebar responses
- preserve historical gateway rows sharing a routing key via a bounded SessionDB lookup
- keep DM labels generic while allowing non-identifier room labels

## Verification
- `14 passed` — origin, current sidebar/profile scope, and metadata lookup coverage
- Ruff passed
- `py_compile` passed
- `git diff --check` passed

## Baseline note
- The broader `tests/test_hermes_state.py` run has one deterministic current-main failure at `TestFTS5Search::test_search_projection_skips_context_enrichment_queries`; reproduced unchanged on untouched upstream `bfff32ae8`.

## Scope
- Backend/session metadata only. No Desktop routing, settings, Kanban UI, runtime deployment, or credential changes.
