### PR TITLE
feat: forward repeat through cron.manage add

### DIFF
--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1653,6 +1653,14 @@ def _(rid, params: dict) -> dict:
                         name=jid,
                         schedule=params.get("schedule", ""),
                         prompt=params.get("prompt", ""),
+                        # Optional repeat cap ("run N times"); None keeps the
+                        # schedule-kind default (once for one-shot, forever
+                        # for recurring).
+                        repeat=(
+                            int(params["repeat"])
+                            if str(params.get("repeat", "")).strip().isdigit()
+                            else None
+                        ),
                     )
                 ),
             )


### PR DESCRIPTION
## What

Companion to #85566 (include_disabled): the `cron.manage` ws handler's add branch drops the `repeat` param that `cronjob(action="create")` has always accepted, so ws-driven UIs (Hermes-Bot-Mode's cronjob dialog) cannot create run-N-times jobs. Forward it — digit strings accepted, anything else resolves to None which keeps the schedule-kind default (once for one-shot, forever for recurring).

One-shot relative schedules (bare `30m` / `2h` → "once in …") already worked through the schedule string; no change needed there.

## Verification

Live registry: created a one-shot (`45m` → `schedule: once in 45m`, correct next_run_at) and a capped recurring job (`every 1d`, `repeat: 5` → `repeat: 5 times`); both listed correctly and were removed after.