### PR TITLE
feat(desktop): add quick workspace path change to statusbar

### DIFF
--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -95,7 +95,8 @@ export const StatusbarSurface = memo(function StatusbarSurface({
     openCommandCenterSection: actions.openCommandCenterSection,
     requestGateway: actions.requestGateway,
     statusSnapshot,
-    toggleCommandCenter: actions.toggleCommandCenter
+    toggleCommandCenter: actions.toggleCommandCenter,
+    changeSessionCwd: actions.changeSessionCwd
   })
 
   return <StatusbarControls items={statusbarItems} leftItems={leftStatusbarItems} />

--- a/apps/desktop/src/app/contrib/types.ts
+++ b/apps/desktop/src/app/contrib/types.ts
@@ -67,6 +67,8 @@ export interface WiringActions extends SidebarActions, ChatActions {
   requestGateway: GatewayRequester
   selectModel: ComponentProps<typeof ModelMenuPanel>['onSelectModel']
   toggleCommandCenter: () => void
+  /** Change the workspace directory for the current conversation only. */
+  changeSessionCwd: (cwd: string, sessionId?: string) => Promise<void>
 }
 
 /** The four wired surfaces the controller publishes; `WiredPane` renders one by

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -272,9 +272,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     useSessionListActions({ profileScope })
 
   const updateActiveSessionRuntimeInfo = useCallback(
-    (info: { branch?: string; cwd?: string }) => {
-      const sessionId = activeSessionIdRef.current
-
+    (sessionId: string, info: { branch?: string; cwd?: string }) => {
       if (!sessionId) {
         return
       }
@@ -285,10 +283,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         cwd: info.cwd ?? state.cwd
       }))
     },
-    [activeSessionIdRef, updateSessionState]
+    [updateSessionState]
   )
 
-  const { refreshProjectBranch } = useCwdActions({
+  const { changeSessionCwd, refreshProjectBranch } = useCwdActions({
     activeSessionIdRef,
     onSessionRuntimeInfo: updateActiveSessionRuntimeInfo,
     requestGateway
@@ -928,7 +926,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     openCommandCenterSection,
     requestGateway,
     selectModel,
-    toggleCommandCenter
+    toggleCommandCenter,
+    changeSessionCwd
   }
 
   if (actionsRef.current) {

--- a/apps/desktop/src/app/session/hooks/use-cwd-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-cwd-actions.ts
@@ -13,7 +13,7 @@ import type { SessionRuntimeInfo } from '@/types/hermes'
 
 interface CwdActionsOptions {
   activeSessionIdRef: MutableRefObject<string | null>
-  onSessionRuntimeInfo?: (info: Pick<SessionRuntimeInfo, 'branch' | 'cwd'>) => void
+  onSessionRuntimeInfo?: (sessionId: string, info: Pick<SessionRuntimeInfo, 'branch' | 'cwd'>) => void
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
 
@@ -46,18 +46,19 @@ export function useCwdActions({ activeSessionIdRef, onSessionRuntimeInfo, reques
   )
 
   const changeSessionCwd = useCallback(
-    async (cwd: string) => {
+    async (cwd: string, sessionIdOverride?: string) => {
       const trimmed = cwd.trim()
 
       if (!trimmed) {
         return
       }
 
-      // Ref, not the closure-captured prop: this hook's consumers are memoized
-      // on a stable actions object, so the prop can still name the previously
-      // focused chat. Re-anchoring the wrong session's workspace would point
-      // that agent's terminal/file tools at another conversation's project.
-      const sessionId = activeSessionIdRef.current
+      // Prefer the caller's target session (the statusbar operates on the
+      // FOCUSED session — a tile, or the primary), falling back to the ref so
+      // existing primary-scoped callers keep working. The ref alone would
+      // re-anchor the primary's workspace even when the statusbar is
+      // describing a focused tile (mis-associating session state).
+      const sessionId = sessionIdOverride ?? activeSessionIdRef.current
 
       if (!sessionId) {
         setCurrentCwd(trimmed)
@@ -98,7 +99,7 @@ export function useCwdActions({ activeSessionIdRef, onSessionRuntimeInfo, reques
 
         setCurrentCwd(info.cwd || trimmed)
         setCurrentBranch(info.branch || '')
-        onSessionRuntimeInfo?.({ branch: info.branch || '', cwd: info.cwd || trimmed })
+        onSessionRuntimeInfo?.(sessionId, { branch: info.branch || '', cwd: info.cwd || trimmed })
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
 

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -9,6 +9,7 @@ import { $paneVisible, togglePaneVisible } from '@/components/pane-shell/tree/st
 import { Codicon } from '@/components/ui/codicon'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
+import { selectDesktopPaths } from '@/lib/desktop-fs'
 import { displayPath, pathLeaf } from '@/lib/display-path'
 import { Activity, AlertCircle, Clock, Command, FolderOpen, Globe, Hash, Loader2, Terminal } from '@/lib/icons'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
@@ -66,6 +67,8 @@ interface StatusbarItemsOptions {
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
   statusSnapshot: StatusResponse | null
   toggleCommandCenter: () => void
+  /** Change the workspace directory for the current conversation only. */
+  changeSessionCwd?: (cwd: string, sessionId?: string) => Promise<void>
 }
 
 export function useStatusbarItems({
@@ -80,7 +83,8 @@ export function useStatusbarItems({
   openCommandCenterSection,
   requestGateway,
   statusSnapshot,
-  toggleCommandCenter
+  toggleCommandCenter,
+  changeSessionCwd
 }: StatusbarItemsOptions) {
   const { t } = useI18n()
   const copy = t.shell.statusbar
@@ -216,6 +220,27 @@ export function useStatusbarItems({
   // the tree changes; null (no named project) falls back to the cwd leaf below.
   const projectTree = useStore($projectTree)
   const projectName = useMemo(() => projectNameForCwd(currentCwd), [currentCwd, projectTree])
+
+  // Open the workspace folder picker, switch the focused conversation's cwd.
+  // selectDesktopPaths is the remote-aware seam: a remote gateway browses the
+  // backend filesystem where sessions run; local mode opens the native dialog.
+  const pickAndChangeWorkspaceCwd = useCallback(async () => {
+    const [selected] = await selectDesktopPaths({
+      directories: true,
+      multiple: false,
+      title: fileMenu.changeCwdTitle
+    })
+
+    if (!selected?.trim()) {
+      return
+    }
+
+    // Target the FOCUSED session (a tile, else the primary) — the same scope
+    // the statusbar's cwd readout describes. changeSessionCwd falls back to
+    // the primary ref when no override is passed, so existing callers (and
+    // the no-session draft path) are unaffected.
+    await changeSessionCwd?.(selected, activeSessionId ?? undefined)
+  }, [activeSessionId, changeSessionCwd, fileMenu.changeCwdTitle])
 
   const sessionStartedAt = primaryFocused
     ? primarySessionStartedAt
@@ -424,6 +449,12 @@ export function useStatusbarItems({
         menuItems: currentCwd
           ? [
               {
+                id: 'change-workspace-path',
+                label: fileMenu.changeCwdTitle,
+                onSelect: () => void pickAndChangeWorkspaceCwd(),
+                title: displayPath(currentCwd)
+              },
+              {
                 id: 'copy-workspace-path',
                 label: fileMenu.copyPath,
                 onSelect: () => void copyFilePath(currentCwd),
@@ -496,6 +527,7 @@ export function useStatusbarItems({
       connectionItem,
       copy,
       currentCwd,
+      fileMenu.changeCwdTitle,
       fileMenu.copyPath,
       fileMenu.revealFileManager,
       fileMenu.revealInSidebar,
@@ -506,6 +538,7 @@ export function useStatusbarItems({
       inferenceReady,
       inferenceStatus?.reason,
       openAgents,
+      pickAndChangeWorkspaceCwd,
       projectName,
       subagentsFailed,
       subagentsRunning,

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -52,7 +52,8 @@ export const ar = defineLocale({
     renameLabel: 'الاسم الجديد',
     deleteTitle: name => `حذف ${name}؟`,
     deleteBody: 'سيتم نقله إلى سلة المهملات — يمكنك استعادته من هناك.',
-    pathCopied: 'تم نسخ المسار'
+    pathCopied: 'تم نسخ المسار',
+    changeCwdTitle: 'تغيير المسار'
   },
   boot: {
     ready: 'Hermes Desktop جاهز',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -58,7 +58,8 @@ export const en: Translations = {
     renameLabel: 'New name',
     deleteTitle: name => `Delete ${name}?`,
     deleteBody: 'It will be moved to the Trash — you can restore it from there.',
-    pathCopied: 'Path copied'
+    pathCopied: 'Path copied',
+    changeCwdTitle: 'Change path'
   },
 
   boot: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -58,7 +58,8 @@ export const ja = defineLocale({
     renameLabel: '新しい名前',
     deleteTitle: name => `${name} を削除しますか？`,
     deleteBody: 'ゴミ箱に移動します。そこから復元できます。',
-    pathCopied: 'パスをコピーしました'
+    pathCopied: 'パスをコピーしました',
+    changeCwdTitle: 'パスを変更'
   },
 
   boot: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -105,6 +105,7 @@ export interface Translations {
     deleteTitle: (name: string) => string
     deleteBody: string
     pathCopied: string
+    changeCwdTitle: string
   }
 
   boot: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -58,7 +58,8 @@ export const zhHant = defineLocale({
     renameLabel: '新名稱',
     deleteTitle: name => `刪除 ${name}？`,
     deleteBody: '將移至垃圾桶，你可以從那裡還原。',
-    pathCopied: '已複製路徑'
+    pathCopied: '已複製路徑',
+    changeCwdTitle: '更改路徑'
   },
 
   boot: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -58,7 +58,8 @@ export const zh: Translations = {
     renameLabel: '新名称',
     deleteTitle: name => `删除 ${name}？`,
     deleteBody: '将移至废纸篓，你可以从那里恢复。',
-    pathCopied: '已复制路径'
+    pathCopied: '已复制路径',
+    changeCwdTitle: '更改路径'
   },
 
   boot: {


### PR DESCRIPTION
## Summary

Adds a quick "Change path" action to the workspace-cwd statusbar item in the bottom-left corner of the Hermes desktop app, making it convenient to switch the current conversation's working directory directly from the statusbar.

## Motivation

Previously, changing a conversation's workspace directory required navigating through the right sidebar file tree or using the CLI. This PR adds a native folder picker entry point in the statusbar — the most natural place users look for workspace context — making the workflow more intuitive.

## Changes

- **Workspace-cwd statusbar item** now has a "Change path" menu item in its dropdown
- Clicking it opens the OS-native folder picker (via `window.hermesDesktop.selectPaths`)
- The selected path becomes the current conversation's working directory via the existing `changeSessionCwd` wiring
- No new buttons or redundant UI — only a single text-only menu item, consistent with the existing "Copy path" / "Reveal in Finder" pattern

### Files modified

- `apps/desktop/src/app/contrib/types.ts` — add `changeSessionCwd` to `WiringActions`
- `apps/desktop/src/app/contrib/wiring.tsx` — expose `changeSessionCwd` from `useCwdActions`
- `apps/desktop/src/app/contrib/surfaces.tsx` — pass `changeSessionCwd` to `useStatusbarItems`
- `apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx` — add `pickAndChangeWorkspaceCwd` callback and menu item
- `apps/desktop/src/i18n/types.ts` — add `changeCwdTitle` key to `fileMenu`
- `apps/desktop/src/i18n/en.ts`, `zh.ts`, `ja.ts`, `ar.ts`, `zh-hant.ts` — localized `changeCwdTitle` values

### Design decisions

- **No icon** — consistent with other workspace-cwd menu items (text-only)
- **No separate statusbar button** — lives in the existing dropdown
- **No new infrastructure** — reuses `selectPaths` preload API and `changeSessionCwd`
- **Conversation-scoped** — affects only the focused conversation; the sidebar project grouping and session history are untouched

## Test Plan

- [ ] Manual: click workspace-cwd statusbar item → "Change path" → pick folder → verify cwd updates
- [ ] TypeScript compilation passes (`tsc --noEmit`)
- [ ] Vite build succeeds (`vite build`)
- [ ] No regressions in existing workspace-cwd menu items

## Screenshots

![Change path menu item in workspace-cwd statusbar](https://files.catbox.moe/w1omf3.png)

The "Change path" menu item in the workspace-cwd dropdown (bottom-left statusbar).

## Notes for Reviewers

- `changeSessionCwd` already existed in `use-cwd-actions.ts` — this PR only wires it through to the statusbar
- `selectPaths` was already available in the preload — no electron main process changes needed
- Tested on Windows 11