### PR TITLE
fix(telegram): rebind TypeHandler after lazy install

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -415,7 +415,7 @@ def check_telegram_requirements() -> bool:
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
-    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global CommandHandler, CallbackQueryHandler, TypeHandler, TelegramMessageHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -434,6 +434,7 @@ def check_telegram_requirements() -> bool:
         from telegram.ext import (
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
+            TypeHandler as _TH,
             MessageHandler as _MH,
             ContextTypes as _CT, filters as _filters,
         )
@@ -450,6 +451,7 @@ def check_telegram_requirements() -> bool:
     Application = _App
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
+    TypeHandler = _TH
     TelegramMessageHandler = _MH
     ContextTypes = _CT
     filters = _filters

--- a/tests/gateway/test_telegram_connect.py
+++ b/tests/gateway/test_telegram_connect.py
@@ -6,6 +6,8 @@ background reconnection (#31049).
 """
 
 import sys
+import types
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -54,3 +56,107 @@ class TestTelegramUnconfiguredNonRetryable:
         assert adapter.fatal_error_retryable is False
         assert adapter.fatal_error_code == "missing_dependency"
 
+
+def test_lazy_telegram_dependency_rebinds_type_handler(monkeypatch):
+    """Lazy PTB install must rebind every symbol used by handler registration."""
+
+    class FakeUpdate:
+        ALL_TYPES = object()
+
+    class FakeBot:
+        pass
+
+    class FakeMessage:
+        pass
+
+    class FakeInlineKeyboardButton:
+        pass
+
+    class FakeInlineKeyboardMarkup:
+        pass
+
+    class FakeLinkPreviewOptions:
+        pass
+
+    class FakeApplication:
+        pass
+
+    class FakeCommandHandler:
+        pass
+
+    class FakeCallbackQueryHandler:
+        pass
+
+    class FakeMessageHandler:
+        pass
+
+    class FakeTypeHandler:
+        pass
+
+    class FakeHTTPXRequest:
+        pass
+
+    telegram_pkg = types.ModuleType("telegram")
+    telegram_pkg.Update = FakeUpdate
+    telegram_pkg.Bot = FakeBot
+    telegram_pkg.Message = FakeMessage
+    telegram_pkg.InlineKeyboardButton = FakeInlineKeyboardButton
+    telegram_pkg.InlineKeyboardMarkup = FakeInlineKeyboardMarkup
+    telegram_pkg.LinkPreviewOptions = FakeLinkPreviewOptions
+
+    ext_mod = types.ModuleType("telegram.ext")
+    ext_mod.Application = FakeApplication
+    ext_mod.CommandHandler = FakeCommandHandler
+    ext_mod.CallbackQueryHandler = FakeCallbackQueryHandler
+    ext_mod.MessageHandler = FakeMessageHandler
+    ext_mod.TypeHandler = FakeTypeHandler
+    ext_mod.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=object)
+    ext_mod.filters = types.SimpleNamespace()
+
+    constants_mod = types.ModuleType("telegram.constants")
+    constants_mod.ParseMode = types.SimpleNamespace(MARKDOWN_V2="MarkdownV2")
+    constants_mod.ChatType = types.SimpleNamespace(
+        GROUP="group",
+        SUPERGROUP="supergroup",
+        CHANNEL="channel",
+        PRIVATE="private",
+    )
+
+    request_mod = types.ModuleType("telegram.request")
+    request_mod.HTTPXRequest = FakeHTTPXRequest
+
+    for name, module in {
+        "telegram": telegram_pkg,
+        "telegram.ext": ext_mod,
+        "telegram.constants": constants_mod,
+        "telegram.request": request_mod,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    from tools import lazy_deps
+
+    monkeypatch.setattr(lazy_deps, "ensure", lambda key, prompt=False: None)
+
+    monkeypatch.setattr(telegram_mod, "TELEGRAM_AVAILABLE", False)
+    monkeypatch.setattr(telegram_mod, "Update", Any)
+    monkeypatch.setattr(telegram_mod, "Bot", Any)
+    monkeypatch.setattr(telegram_mod, "Message", Any)
+    monkeypatch.setattr(telegram_mod, "InlineKeyboardButton", Any)
+    monkeypatch.setattr(telegram_mod, "InlineKeyboardMarkup", Any)
+    monkeypatch.setattr(telegram_mod, "LinkPreviewOptions", None)
+    monkeypatch.setattr(telegram_mod, "Application", Any)
+    monkeypatch.setattr(telegram_mod, "CommandHandler", Any)
+    monkeypatch.setattr(telegram_mod, "CallbackQueryHandler", Any)
+    monkeypatch.setattr(telegram_mod, "TypeHandler", Any)
+    monkeypatch.setattr(telegram_mod, "TelegramMessageHandler", Any)
+    monkeypatch.setattr(telegram_mod, "ContextTypes", Any)
+    monkeypatch.setattr(telegram_mod, "filters", None)
+    monkeypatch.setattr(telegram_mod, "ParseMode", None)
+    monkeypatch.setattr(telegram_mod, "ChatType", None)
+    monkeypatch.setattr(telegram_mod, "HTTPXRequest", Any)
+
+    assert telegram_mod.check_telegram_requirements() is True
+    assert telegram_mod.TELEGRAM_AVAILABLE is True
+    assert telegram_mod.TypeHandler is FakeTypeHandler
+    assert telegram_mod.Update is FakeUpdate
+    assert telegram_mod.TelegramMessageHandler is FakeMessageHandler


### PR DESCRIPTION
## What does this PR do?

Fixes Telegram gateway startup after the `python-telegram-bot` dependency is installed through Hermes' lazy dependency path.

When `plugins.platforms.telegram.adapter` is imported before `python-telegram-bot` is available, the fallback import path assigns Telegram SDK symbols to placeholders. `TypeHandler` becomes `typing.Any`.

`check_telegram_requirements()` can later lazy-install and re-import Telegram dependencies, but it was not rebinding `TypeHandler`. The gateway then reaches `_register_handlers()` and tries to instantiate `typing.Any`:

```text
TypeError: Any cannot be instantiated
```

This PR rebinds `telegram.ext.TypeHandler` alongside the other Telegram SDK globals after lazy install succeeds, and adds a regression test for that exact import-state transition.

## Related Issue

No linked issue. I searched existing issues/PRs for the exact Telegram `TypeHandler` / `Any cannot be instantiated` lazy-install failure and did not find a duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - Import and rebind `telegram.ext.TypeHandler` inside `check_telegram_requirements()` after lazy dependency installation succeeds.
- `tests/gateway/test_telegram_connect.py`
  - Add a regression test that simulates Telegram being unavailable at module import time, then available after lazy install, and verifies `TypeHandler` is rebound from the placeholder.

## How to Test

Reproduce the bug before this fix:

1. Start from an environment where `python-telegram-bot` is not installed when `plugins.platforms.telegram.adapter` is first imported. A lean Hermes install that relies on lazy platform dependency installation is enough.
2. Configure the Telegram platform with a valid bot token.
3. Start the gateway and observe Telegram startup/reconnect logs.

Before this fix, startup fails with:

```text
Platform 'Telegram' dependencies missing - attempting install...
[Telegram] Failed to connect to Telegram: Any cannot be instantiated
Gateway started with no connected platforms...
```

After this fix, `TypeHandler` is rebound after lazy install and Telegram can register handlers normally.

Test commands run:

```text
scripts/run_tests.sh tests/gateway/test_telegram_connect.py -q
.venv/bin/ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_connect.py
```

Both passed locally on macOS.

I also attempted the broader suite:

```text
scripts/run_tests.sh tests/ -q
```

It was interrupted after unrelated environment failures, including missing optional `acp` / `anthropic` packages and sandbox-blocked local socket binds (`PermissionError: [Errno 1] Operation not permitted`). The targeted Telegram regression test passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — import-only change, expected cross-platform
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Observed failure log before the fix:

```text
[Telegram] Failed to connect to Telegram: Any cannot be instantiated
Gateway started with no connected platforms...
```