### PR TITLE
fix(state): warn when configured journal_mode=delete is overridden by on-disk WAL

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -571,6 +571,10 @@ _wal_fallback_warned_lock = threading.Lock()
 _wal_reset_bug_warned_paths: set[str] = set()
 _wal_reset_bug_warned_lock = threading.Lock()
 
+# Dedup ERROR for the "configured delete overridden by on-disk WAL" warning.
+_delete_overridden_warned_paths: set[str] = set()
+_delete_overridden_warned_lock = threading.Lock()
+
 def _set_last_init_error(msg: Optional[str]) -> None:
     """Record (or clear) the most recent state.db init failure.
 
@@ -1014,6 +1018,10 @@ def apply_wal_with_fallback(
     # Skipping the set-pragma prevents WAL-init from unlinking files other connections hold open.
     current_mode = _on_disk_journal_mode(conn)
     if current_mode == "wal":
+        if configured == "delete":
+            # Never-live-downgrade keeps this WAL; tell the operator their
+            # configured delete did not apply (see _log_configured_delete_overridden_once).
+            _log_configured_delete_overridden_once(db_label)
         _apply_wal_size_limit(conn)
         _apply_macos_checkpoint_barrier(conn)
         _enforce_macos_synchronous_full(conn)
@@ -1181,9 +1189,15 @@ def _apply_delete_for_wal_reset_bug(
     current = _on_disk_journal_mode(conn)
 
     if current == "wal":
-        # Do not TRUNCATE / journal_mode=DELETE while other processes may
-        # still hold this WAL DB open — same safety rule as the NFS path.
         _log_wal_reset_bug_once(db_label, kept_wal=True)
+        if require_delete:
+            # The vulnerability warning above suggests upgrading SQLite, which
+            # does not help on a WAL-incompatible filesystem; surface that the
+            # configured delete is not in effect (see _log_configured_delete_overridden_once).
+            # Emitted last so the actionable message is the final one in the log.
+            _log_configured_delete_overridden_once(db_label)
+        # Do not TRUNCATE / journal_mode=DELETE while other processes may
+        # still hold this WAL DB open; same safety rule as the NFS path.
         _apply_wal_size_limit(conn)
         _apply_macos_checkpoint_barrier(conn)
         _enforce_macos_synchronous_full(conn)
@@ -1320,6 +1334,37 @@ def _log_wal_fallback_once(db_label: str, exc: Exception) -> None:
         "fires once per process per database.",
         db_label,
         exc,
+    )
+
+
+def _log_configured_delete_overridden_once(db_label: str) -> None:
+    """Log a single ERROR per (process, db_label) when the operator configured
+    ``journal_mode=delete`` but the on-disk DB is already WAL, so the configured
+    mode is not in effect.
+
+    Counterpart to :func:`_log_wal_fallback_once` for the opposite direction:
+    there WAL was refused by the filesystem and we silently fell back to DELETE;
+    here the operator asked for DELETE but an inherited on-disk WAL header means
+    we keep WAL (the never-live-downgrade rule prevents a live downgrade, which
+    causes mixed-mode corruption). The signal matters because otherwise the
+    operator has no indication that ``database.journal_mode: delete`` had no
+    effect and the DB still requires a one-time offline ``PRAGMA
+    journal_mode=DELETE`` (with no open connections) to apply.
+
+    Fires once per process per database.
+    """
+    with _delete_overridden_warned_lock:
+        if db_label in _delete_overridden_warned_paths:
+            return
+        _delete_overridden_warned_paths.add(db_label)
+    logger.error(
+        "%s: database.journal_mode=delete is configured but the on-disk "
+        "database is already WAL; keeping WAL (a live downgrade under open "
+        "connections can corrupt the DB). To apply journal_mode=DELETE, stop "
+        "all connections to this DB and run a one-time offline "
+        "'PRAGMA journal_mode=DELETE' on the file. This message fires once "
+        "per process per database.",
+        db_label,
     )
 
 

--- a/tests/test_journal_mode_config.py
+++ b/tests/test_journal_mode_config.py
@@ -29,6 +29,17 @@ def _disable_vulnerable_gate(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _reset_configured_delete_override_warned_paths():
+    """Reset the configured-delete-override warned-paths set so the
+    once-per-process-per-db_label dedup doesn't leak between tests."""
+    import hermes_state
+
+    hermes_state._delete_overridden_warned_paths.clear()
+    yield
+    hermes_state._delete_overridden_warned_paths.clear()
+
+
 def test_database_journal_mode_has_a_canonical_default():
     from hermes_cli.config import DEFAULT_CONFIG
 
@@ -112,7 +123,10 @@ def test_configured_delete_validates_vulnerable_sqlite_result(monkeypatch, tmp_p
         conn.close()
 
 
-def test_configured_delete_never_live_downgrades_existing_wal(monkeypatch, tmp_path):
+def test_configured_delete_never_live_downgrades_existing_wal(monkeypatch, tmp_path, caplog):
+    """Keeping WAL is correct, but the operator must be told their configured
+    delete had no effect (otherwise the DB silently stays WAL and the protection
+    they configured never applies)."""
     from hermes_state import apply_wal_with_fallback
 
     _configure_mode(monkeypatch, tmp_path, "delete")
@@ -124,8 +138,96 @@ def test_configured_delete_never_live_downgrades_existing_wal(monkeypatch, tmp_p
             "hermes_state.is_sqlite_wal_reset_vulnerable",
             lambda **kwargs: True,
         )
-        assert apply_wal_with_fallback(conn, db_label="existing-wal.db") == "wal"
+        with caplog.at_level("ERROR", logger="hermes_state"):
+            assert apply_wal_with_fallback(conn, db_label="existing-wal.db") == "wal"
         assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        assert any(
+            "database.journal_mode=delete is configured" in r.message
+            and "on-disk" in r.message
+            for r in caplog.records
+        ), "expected a warning that configured delete was overridden by on-disk WAL"
+    finally:
+        conn.close()
+
+
+def test_configured_delete_overridden_warns_on_non_vulnerable_runtime_too(monkeypatch, tmp_path, caplog):
+    """When the SQLite runtime is NOT WAL-reset-vulnerable (e.g. after a
+    3.51.3+ upgrade), the on-disk WAL + configured-delete case reaches the
+    read-only probe path instead of the vulnerability path. That path used to
+    return WAL with no signal at all; it must emit the same override warning."""
+    from hermes_state import apply_wal_with_fallback
+
+    _configure_mode(monkeypatch, tmp_path, "delete")
+    _disable_vulnerable_gate(monkeypatch)
+    db_path = tmp_path / "existing-wal.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+        with caplog.at_level("ERROR", logger="hermes_state"):
+            assert apply_wal_with_fallback(conn, db_label="existing-wal.db") == "wal"
+            assert apply_wal_with_fallback(conn, db_label="existing-wal.db") == "wal"
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        warnings = [
+            r for r in caplog.records
+            if "database.journal_mode=delete is configured" in r.message
+        ]
+        assert len(warnings) == 1, (
+            "probe path must warn when configured delete is overridden by on-disk WAL, "
+            "and dedup to one per process per db_label"
+        )
+    finally:
+        conn.close()
+
+
+def test_configured_delete_overridden_warning_fires_once_per_db(monkeypatch, tmp_path, caplog):
+    """The override warning is deduped per process per db_label (same discipline
+    as the WAL-fallback warning), so repeated connections don't flood the log."""
+    from hermes_state import apply_wal_with_fallback
+
+    _configure_mode(monkeypatch, tmp_path, "delete")
+    monkeypatch.setattr(
+        "hermes_state.is_sqlite_wal_reset_vulnerable",
+        lambda **kwargs: True,
+    )
+    db_path = tmp_path / "existing-wal.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL").fetchone()
+        with caplog.at_level("ERROR", logger="hermes_state"):
+            assert apply_wal_with_fallback(conn, db_label="once.db") == "wal"
+            assert apply_wal_with_fallback(conn, db_label="once.db") == "wal"
+            assert apply_wal_with_fallback(conn, db_label="once.db") == "wal"
+        warnings = [
+            r for r in caplog.records
+            if "database.journal_mode=delete is configured" in r.message
+        ]
+        assert len(warnings) == 1, "override warning must fire once per process per db_label"
+    finally:
+        conn.close()
+
+
+def test_configured_delete_with_require_wal_and_existing_wal_returns_wal(monkeypatch, tmp_path, caplog):
+    """Pin the require_wal=True + configured=delete + on-disk WAL edge case: the
+    existing-WAL probe branch returns "wal" unconditionally (require_wal only
+    governs the WAL-refusal fallback paths), so the override warning fires and no
+    WalUnsupportedError is raised."""
+    from hermes_state import apply_wal_with_fallback
+
+    _configure_mode(monkeypatch, tmp_path, "delete")
+    _disable_vulnerable_gate(monkeypatch)
+    db_path = tmp_path / "existing-wal.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+        with caplog.at_level("ERROR", logger="hermes_state"):
+            result = apply_wal_with_fallback(
+                conn, db_label="existing-wal.db", require_wal=True
+            )
+        assert result == "wal"
+        assert any(
+            "database.journal_mode=delete is configured" in r.message
+            for r in caplog.records
+        )
     finally:
         conn.close()
 


### PR DESCRIPTION
Closes #85608.

## What

When `database.journal_mode: delete` is configured but the on-disk DB is already WAL, `apply_wal_with_fallback()` honors the never-live-downgrade rule and keeps WAL. That is correct (a live downgrade under open connections causes mixed-mode corruption), but the operator has no signal that their configured mode had no effect, and on a WAL-incompatible filesystem (virtiofs/NFS/SMB) the DB then corrupts on the next crash/sleep — exactly what they configured to prevent.

> **Real-world trigger:** we hit this during the v0.20.0 (v2026.8.3) upgrade. Setting `journal_mode=delete` on inherited-WAL `state.db` files right after the bounce left them silently still in WAL (no signal), and one agent's `state.db` then corrupted on the next Mac sleep. The corruption cause is the pre-existing WAL-on-virtiofs vulnerability, not the upgrade; the upgrade was the crash/sleep trigger at the moment the new `resolve_journal_mode()` knob (#68912) had us set `delete`. See #85608.

This PR adds a once-per-process-per-db_label ERROR telling the operator the config did not apply and they must convert the DB header offline (`PRAGMA journal_mode=DELETE` with no open connections). See #85608 for the full motivation and the two affected code paths.

## Changes

- New `_log_configured_delete_overridden_once(db_label)` helper (mirrors the existing `_log_wal_fallback_once` / `_log_wal_reset_bug_once` idiom: module-level set + lock, deduped per process per db_label, ERROR level).
- Emit it at **both** return-WAL paths when the configured mode is `delete`:
  1. The WAL-reset-vulnerable path (`_apply_delete_for_wal_reset_bug`): previously warned only about the vulnerability with an "upgrade SQLite" remedy that does not help when the cause is the filesystem. The new warning fires AFTER that one, so the actionable message is last.
  2. The read-only probe path (non-vulnerable runtime): previously returned WAL with no signal at all.
- The never-live-downgrade behavior is **unchanged** (return values, exceptions, side effects identical to main; this is log-only).

## Tests

All behavioral (real `sqlite3` on tmp files, `caplog` assertions), no mocks at the boundary:
- `test_configured_delete_never_live_downgrades_existing_wal` (updated): vulnerable path keeps WAL AND warns.
- `test_configured_delete_overridden_warns_on_non_vulnerable_runtime_too`: probe path also warns (the previously fully-silent case), with dedup.
- `test_configured_delete_overridden_warning_fires_once_per_db`: dedup to one per process per db_label.
- `test_configured_delete_with_require_wal_and_existing_wal_returns_wal`: pins the `require_wal=True` + configured=delete + on-disk WAL edge (returns wal, warns, no `WalUnsupportedError`).
- Autouse fixture resets the dedup set so tests are order-independent.

Full WAL test suites pass (`test_journal_mode_config.py`, `test_hermes_state_wal_fallback.py`, `test_sqlite_wal_reset_gate.py`) in both run orders.

## Notes

- This is a follow-up to #68545 / PR #68912, which centralized journal_mode but left inherited on-disk WAL DBs silently un-protected when an operator later sets `delete`.
- The never-live-downgrade rule is intentionally preserved; the PR is purely the operator-facing signal that the configured and on-disk modes disagree.
- Happy to add a `hermes doctor` check or a `hermes db` migration helper as a follow-up if maintainers want either (mentioned in #85608), but kept this PR minimal.
