### PR TITLE
feat(compression): add keep_history context engine — request-only compaction that preserves the visible chat history

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -233,7 +233,7 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'agent.image_input_mode': ['auto', 'native', 'text'],
   'approvals.mode': ['manual', 'smart', 'off'],
   'code_execution.mode': ['project', 'strict'],
-  'context.engine': ['compressor', 'default', 'custom'],
+  'context.engine': ['compressor', 'keep_history', 'default', 'custom'],
   // '' = inherit the agent's own effort; the rest is the shared scale.
   'delegation.reasoning_effort': ['', ...REASONING_EFFORTS],
   // NOTE: memory.provider is intentionally NOT listed here. Its options are

--- a/plugins/context_engine/keep_history/__init__.py
+++ b/plugins/context_engine/keep_history/__init__.py
@@ -1,0 +1,280 @@
+"""keep_history — Codex-style context engine: compact background context
+(tool logs, terminal dumps, file arrays) in the REQUEST only, never in the
+persisted transcript.
+
+Why this engine exists
+----------------------
+The built-in ``compressor`` engine rewrites the live transcript on
+compaction (``archive_and_compact`` soft-archives every active row and
+re-inserts head + summary + tail). Desktop/gateway UIs render only active
+rows, so a compaction visibly collapses the whole chat into a summary card
+plus the recent tail. ``keep_history`` never rewrites the transcript: it
+prunes old tool-result payloads from the per-request message list via the
+``select_context()`` hook (request-only by contract — the session DB is
+never touched), so the model always sees a bounded, compacted context while
+the UI keeps the full conversation scrollable. This mirrors Codex Desktop's
+behavior (thread stays intact; background tool context is compacted).
+
+Behavior
+--------
+- ``should_compress()`` -> False: the destructive full-compression path
+  (LLM summary + ``archive_and_compact``) is never auto-triggered.
+- ``select_context()``: when the assembled request crosses the token
+  trigger, run the deterministic 3-pass tool-result prune (dedup, one-line
+  summaries for large outputs, tool_call-arg truncation) on a COPY of the
+  request. Returns the pruned list; persisted history is untouched. A
+  rearm watermark (like the built-in proactive prune) keeps cache-breaking
+  prunes episodic, and a hard-ceiling trim guarantees the request still
+  fits the window even in pathological sessions.
+- ``compress()`` (manual ``/compress`` / gateway hygiene): deterministic
+  prune-only compaction — every user/assistant message is preserved
+  verbatim; only old tool-result bodies are shortened. Never produces a
+  summary card and never drops chat turns.
+- ``prune_tool_results_only()`` -> no-op: the loop-level proactive prune
+  commits via ``archive_and_compact`` (a transcript rewrite); this engine
+  does its pruning request-only in ``select_context`` instead.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.context_compressor import (
+    ContextCompressor,
+    _estimate_msg_budget_tokens,
+    resolve_model_threshold,
+)
+
+
+def _load_compression_config() -> Dict[str, Any]:
+    """Read the ``compression`` block from the active profile's config.yaml.
+
+    Plugin engines are constructed with no arguments (the loader calls
+    ``Engine()``), so config values that the built-in engine receives via
+    its constructor must be resolved here. Falls back to built-in-safe
+    defaults when the file is missing/unreadable.
+    """
+    cfg: Dict[str, Any] = {}
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = get_hermes_home()
+        path = os.path.join(home, "config.yaml")
+        if os.path.isfile(path):
+            import yaml
+
+            with open(path, encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+            block = data.get("compression", {})
+            if isinstance(block, dict):
+                cfg = block
+    except Exception:
+        pass
+    return cfg
+
+
+class KeepHistoryContextEngine(ContextCompressor):
+    """Request-only compaction engine that preserves the full transcript.
+
+    The persisted conversation history (and therefore the visible chat
+    timeline in the desktop app) is never rewritten by this engine. All
+    compaction happens on the per-request message list.
+    """
+
+    @property
+    def name(self) -> str:
+        return "keep_history"
+
+    def __init__(self, *args, **kwargs):
+        _cfg = _load_compression_config()
+
+        def _f(key, default):
+            try:
+                v = _cfg.get(key)
+                return default if v is None else v
+            except Exception:
+                return default
+
+        kwargs.setdefault("model", "keep_history")
+        kwargs.setdefault(
+            "threshold_percent", float(_f("threshold", 0.85))
+        )
+        kwargs.setdefault("protect_first_n", int(_f("protect_first_n", 3)))
+        kwargs.setdefault("protect_last_n", int(_f("protect_last_n", 60)))
+        kwargs.setdefault(
+            "summary_target_ratio", float(_f("target_ratio", 0.20))
+        )
+        kwargs.setdefault("quiet_mode", True)
+        kwargs.setdefault(
+            "proactive_prune_tokens", int(_f("proactive_prune_tokens", 0))
+        )
+        kwargs.setdefault(
+            "proactive_prune_min_result_chars",
+            int(_f("proactive_prune_min_result_chars", 2000)),
+        )
+        kwargs.setdefault(
+            "proactive_prune_min_reclaim_tokens",
+            int(_f("proactive_prune_min_reclaim_tokens", 4096)),
+        )
+        kwargs.setdefault(
+            "min_tail_user_messages", int(_f("min_tail_user_messages", 5))
+        )
+        super().__init__(*args, **kwargs)
+        # Watermark: after a committed request-prune, do not prune again
+        # until the transcript regrows a full trigger-sized runway, so
+        # prompt-cache breaks stay episodic (same contract as the built-in
+        # proactive prune's rearm gate).
+        self._select_rearm_tokens: int = 0
+        # Last measured savings from a request prune (for status/logging).
+        self._last_select_prune_savings_tokens: int = 0
+
+    # -- never auto-trigger the destructive full compression ----------------
+
+    def should_compress(self, prompt_tokens: Optional[int] = None) -> bool:
+        """Never auto-fire the LLM-summary + transcript-rewrite path."""
+        return False
+
+    def should_compress_info(
+        self, prompt_tokens: Optional[int] = None
+    ) -> Tuple[bool, Optional[str]]:
+        return False, None
+
+    def should_compress_preflight(self, messages: List[Dict[str, Any]]) -> bool:
+        # The request is compacted every turn via select_context(); there is
+        # no preflight path that should force a transcript rewrite.
+        return False
+
+    def prune_tool_results_only(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: Optional[int] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """No-op: the loop-level proactive prune commits to the session DB
+        (``archive_and_compact``), which this engine never does. Request
+        pruning happens in ``select_context`` instead."""
+        return messages, 0
+
+    # -- request-only compaction -------------------------------------------
+
+    def select_context(
+        self,
+        request_messages: List[Dict[str, Any]],
+        *,
+        conversation_messages: Optional[List[Dict[str, Any]]] = None,
+        incoming_message: Optional[Dict[str, Any]] = None,
+        budget_tokens: int = 0,
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Prune old tool-result payloads from THIS request only.
+
+        Runs every turn, independent of ``should_compress()``. Returns the
+        compacted request list when the request crossed the token trigger
+        and the prune reclaimed meaningful tokens; ``None`` (no-op) keeps
+        the request and the provider-side prompt cache untouched.
+        """
+        if not request_messages:
+            return None
+        ctx = int(self.context_length or budget_tokens or 0)
+        if ctx <= 0:
+            return None
+
+        trigger = (
+            int(self.proactive_prune_tokens)
+            if self.proactive_prune_tokens and self.proactive_prune_tokens > 0
+            else int(ctx * 0.55)
+        )
+        est = sum(_estimate_msg_budget_tokens(m) for m in request_messages)
+        if est < trigger:
+            return None
+        if est < self._select_rearm_tokens:
+            return None
+
+        pruned, n = self._prune_old_tool_results(
+            request_messages,
+            protect_tail_count=self.protect_last_n,
+            protect_tail_tokens=None,
+            min_prune_chars=self.proactive_prune_min_result_chars,
+        )
+        if not n:
+            return None
+
+        after = sum(_estimate_msg_budget_tokens(m) for m in pruned)
+        reclaimed = max(0, est - after)
+        if reclaimed < self.proactive_prune_min_reclaim_tokens:
+            return None
+
+        # Hard ceiling: even after tool-result pruning the request would
+        # still overflow the window (pathological: giant user/assistant
+        # text). Drop the oldest non-head/non-tail messages — request-only,
+        # the persisted transcript is untouched.
+        if after > int(ctx * 0.95):
+            pruned = self._trim_request_to_budget(pruned, int(ctx * 0.85))
+            after = sum(_estimate_msg_budget_tokens(m) for m in pruned)
+            reclaimed = max(0, est - after)
+
+        runway = max(reclaimed, trigger, self.proactive_prune_min_reclaim_tokens)
+        self._select_rearm_tokens = after + runway
+        self._last_select_prune_savings_tokens = reclaimed
+        return pruned
+
+    def _trim_request_to_budget(
+        self, messages: List[Dict[str, Any]], budget_tokens: int
+    ) -> List[Dict[str, Any]]:
+        """Drop the oldest non-head messages until the request fits ``budget_tokens``.
+
+        Request-only fallback for pathological sessions. Never drops the
+        head (system prompt + first exchange) or the recent tail. Orphaned
+        tool results from the cut are cleaned by ``_sanitize_tool_pairs``.
+        """
+        if not messages:
+            return messages
+        head = self._protect_head_size(messages)
+        tail = min(self.protect_last_n, max(3, len(messages) - head))
+        if head + tail >= len(messages):
+            return messages
+        end_kept = len(messages) - tail
+        cut = head
+        total = sum(_estimate_msg_budget_tokens(m) for m in messages)
+        while cut < end_kept and total > budget_tokens:
+            total -= _estimate_msg_budget_tokens(messages[cut])
+            cut += 1
+        if cut <= head:
+            return messages
+        kept = messages[:head] + messages[cut:]
+        return self._sanitize_tool_pairs(kept)
+
+    # -- non-destructive compaction for /compress and hygiene ---------------
+
+    def compress(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: Optional[int] = None,
+        focus_topic: Optional[str] = None,
+        force: bool = False,
+        memory_context: str = "",
+    ) -> List[Dict[str, Any]]:
+        """Deterministic prune-only compaction.
+
+        All user and assistant messages are preserved verbatim; only old
+        tool-result bodies are shortened/deduped and oversized tool_call
+        arguments truncated. No LLM summary is produced and no chat turn is
+        dropped, so even a manual ``/compress`` never collapses the visible
+        history into a summary card.
+        """
+        if not messages:
+            return messages
+        pruned, _n = self._prune_old_tool_results(
+            messages,
+            protect_tail_count=self.protect_last_n,
+            protect_tail_tokens=None,
+            min_prune_chars=self.proactive_prune_min_result_chars,
+        )
+        pruned = self._sanitize_tool_pairs(pruned)
+        self.compression_count += 1
+        return pruned
+
+
+def register(ctx) -> None:
+    """Plugin-style registration hook (also handled by the loader's class
+    scan; kept for general-plugin-system compatibility)."""
+    ctx.register_context_engine(KeepHistoryContextEngine())

--- a/plugins/context_engine/keep_history/__init__.py
+++ b/plugins/context_engine/keep_history/__init__.py
@@ -25,7 +25,10 @@ Behavior
   request. Returns the pruned list; persisted history is untouched. A
   rearm watermark (like the built-in proactive prune) keeps cache-breaking
   prunes episodic, and a hard-ceiling trim guarantees the request still
-  fits the window even in pathological sessions.
+  fits the window even in pathological sessions — note that this trim CAN
+  drop mid-conversation messages from the request the model sees
+  (request-level drop only; the persisted transcript — and therefore the
+  visible chat history — still keeps every turn).
 - ``compress()`` (manual ``/compress`` / gateway hygiene): deterministic
   prune-only compaction — every user/assistant message is preserved
   verbatim; only old tool-result bodies are shortened. Never produces a
@@ -37,7 +40,7 @@ Behavior
 
 from __future__ import annotations
 
-import os
+import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.context_compressor import (
@@ -46,32 +49,39 @@ from agent.context_compressor import (
     resolve_model_threshold,
 )
 
+logger = logging.getLogger(__name__)
+
+# Request-prune trigger as a fraction of the context window when
+# ``proactive_prune_tokens`` is not configured.
+_REQUEST_PRUNE_TRIGGER_RATIO = 0.55
+
+# Safety-valve window when neither the model's context length nor the
+# request's ``budget_tokens`` is known (call sites that skip the budget):
+# request compaction must never silently disable itself and let requests
+# grow past the provider window unbounded.
+_FALLBACK_CONTEXT_TOKENS = 128_000
+
 
 def _load_compression_config() -> Dict[str, Any]:
-    """Read the ``compression`` block from the active profile's config.yaml.
+    """Read the ``compression`` block via the standard config loader.
 
     Plugin engines are constructed with no arguments (the loader calls
     ``Engine()``), so config values that the built-in engine receives via
-    its constructor must be resolved here. Falls back to built-in-safe
-    defaults when the file is missing/unreadable.
+    its constructor must be resolved here. Going through
+    ``hermes_cli.config.load_config`` (instead of a direct YAML read)
+    keeps env overrides, managed scope and profile switches consistent
+    with the rest of the app. Falls back to built-in-safe defaults when
+    the config subsystem is unavailable.
     """
-    cfg: Dict[str, Any] = {}
     try:
-        from hermes_constants import get_hermes_home
+        from hermes_cli.config import load_config
 
-        home = get_hermes_home()
-        path = os.path.join(home, "config.yaml")
-        if os.path.isfile(path):
-            import yaml
-
-            with open(path, encoding="utf-8") as f:
-                data = yaml.safe_load(f) or {}
-            block = data.get("compression", {})
-            if isinstance(block, dict):
-                cfg = block
-    except Exception:
-        pass
-    return cfg
+        cfg = load_config()
+        block = cfg.get("compression") if isinstance(cfg, dict) else None
+        return block if isinstance(block, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load compression config: %s", exc)
+        return {}
 
 
 class KeepHistoryContextEngine(ContextCompressor):
@@ -97,14 +107,10 @@ class KeepHistoryContextEngine(ContextCompressor):
                 return default
 
         kwargs.setdefault("model", "keep_history")
-        kwargs.setdefault(
-            "threshold_percent", float(_f("threshold", 0.85))
-        )
+        kwargs.setdefault("threshold_percent", float(_f("threshold", 0.85)))
         kwargs.setdefault("protect_first_n", int(_f("protect_first_n", 3)))
         kwargs.setdefault("protect_last_n", int(_f("protect_last_n", 60)))
-        kwargs.setdefault(
-            "summary_target_ratio", float(_f("target_ratio", 0.20))
-        )
+        kwargs.setdefault("summary_target_ratio", float(_f("target_ratio", 0.20)))
         kwargs.setdefault("quiet_mode", True)
         kwargs.setdefault(
             "proactive_prune_tokens", int(_f("proactive_prune_tokens", 0))
@@ -176,12 +182,14 @@ class KeepHistoryContextEngine(ContextCompressor):
             return None
         ctx = int(self.context_length or budget_tokens or 0)
         if ctx <= 0:
-            return None
+            # Safety valve: compaction must never silently disable itself
+            # just because the call site didn't pass a budget.
+            ctx = _FALLBACK_CONTEXT_TOKENS
 
         trigger = (
             int(self.proactive_prune_tokens)
             if self.proactive_prune_tokens and self.proactive_prune_tokens > 0
-            else int(ctx * 0.55)
+            else int(ctx * _REQUEST_PRUNE_TRIGGER_RATIO)
         )
         est = sum(_estimate_msg_budget_tokens(m) for m in request_messages)
         if est < trigger:

--- a/plugins/context_engine/keep_history/plugin.yaml
+++ b/plugins/context_engine/keep_history/plugin.yaml
@@ -1,0 +1,6 @@
+name: keep_history
+description: >-
+  Codex-style request-only compaction. Prunes old tool logs, terminal
+  dumps and file arrays from what is sent to the model while keeping the
+  full conversation transcript (and the visible chat history) intact.
+version: 1.0.0

--- a/tests/agent/test_keep_history_engine.py
+++ b/tests/agent/test_keep_history_engine.py
@@ -1,0 +1,140 @@
+"""Tests for the keep_history context engine (request-only compaction).
+
+``keep_history`` never rewrites the persisted transcript: it compacts
+background tool context (tool logs, terminal dumps, file arrays) only in
+the per-request message list via ``select_context()``, so the visible chat
+history in UIs that render the session DB stays fully intact while the
+model still receives a bounded, compacted context.
+"""
+
+import copy
+
+import pytest
+
+from plugins.context_engine import discover_context_engines, load_context_engine
+
+
+@pytest.fixture()
+def engine():
+    eng = load_context_engine("keep_history")
+    assert eng is not None, "keep_history engine must be discoverable"
+    eng.update_model(
+        model="deepseek/deepseek-v4-flash-0731",
+        context_length=1_048_576,
+        provider="nous",
+    )
+    return eng
+
+
+def _bulky_session(n_dumps: int = 20, dump_chars: int = 150_000):
+    """System + user + N terminal tool_call/tool_result pairs + chat tail."""
+    msgs = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "Set up the proxy stack"},
+    ]
+    big = "y" * dump_chars
+    for i in range(n_dumps):
+        msgs.append(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": f"c{i}",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"command":"ls -la"}',
+                        },
+                    }
+                ],
+            }
+        )
+        msgs.append({"role": "tool", "tool_call_id": f"c{i}", "content": big})
+    msgs += [
+        {"role": "assistant", "content": "All green"},
+        {"role": "user", "content": "Ship it"},
+        {"role": "assistant", "content": "Done, released v2"},
+    ]
+    return msgs
+
+
+def test_engine_discoverable_and_named():
+    names = [name for name, _desc, _avail in discover_context_engines()]
+    assert "keep_history" in names
+    assert load_context_engine("keep_history").name == "keep_history"
+
+
+def test_never_triggers_destructive_compression(engine):
+    # The whole point: the LLM-summary + archive_and_compact path must
+    # never auto-fire, even with a nearly full context.
+    assert engine.should_compress(999_999) is False
+    assert engine.should_compress_info(999_999) == (False, None)
+    assert engine.should_compress_preflight([]) is False
+
+
+def test_loop_proactive_prune_is_noop(engine):
+    # prune_tool_results_only commits to the session DB via
+    # archive_and_compact; keep_history must not participate.
+    msgs = _bulky_session()
+    passed = copy.deepcopy(msgs)
+    out, n = engine.prune_tool_results_only(passed, current_tokens=900_000)
+    assert out is passed  # input object returned unchanged (no-op contract)
+    assert n == 0
+
+
+def test_select_context_prunes_request_only(engine):
+    msgs = _bulky_session()
+    orig = copy.deepcopy(msgs)
+
+    selected = engine.select_context(copy.deepcopy(msgs), budget_tokens=1_048_576)
+
+    assert selected is not None
+    assert selected is not msgs  # replacement list, never in-place mutation
+    # Chat turns (user/assistant text) survive verbatim.
+    chat = [(m["role"], m.get("content", "")) for m in selected if m["role"] in ("user", "assistant")]
+    assert chat[0] == ("user", "Set up the proxy stack")
+    assert chat[-1] == ("assistant", "Done, released v2")
+    # Bulk tool results are replaced with one-line summaries. The dedup
+    # pass is intentionally lossless: the NEWEST full copy survives while
+    # older duplicates become short back-references, so at most one tool
+    # result keeps its full payload and the rest collapse.
+    tool_lens = sorted(len(m.get("content", "")) for m in selected if m.get("role") == "tool")
+    assert tool_lens
+    assert sum(1 for l in tool_lens if l <= 200) >= len(tool_lens) - 1
+    assert tool_lens[0] <= 200
+    # Persisted transcript is untouched (request-only contract).
+    assert msgs == orig
+
+
+def test_select_context_small_request_noop(engine):
+    small = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+    assert engine.select_context(copy.deepcopy(small), budget_tokens=1_048_576) is None
+
+
+def test_select_context_rearm_gate(engine):
+    # After a committed prune, an immediate re-call must no-op so prompt
+    # cache breaks stay episodic (same contract as the built-in rearm).
+    msgs = _bulky_session()
+    first = engine.select_context(copy.deepcopy(msgs), budget_tokens=1_048_576)
+    assert first is not None
+    second = engine.select_context(copy.deepcopy(first), budget_tokens=1_048_576)
+    assert second is None
+
+
+def test_compress_preserves_all_chat_turns(engine):
+    msgs = _bulky_session()
+    out = engine.compress(copy.deepcopy(msgs))
+    roles = [m["role"] for m in out if m["role"] in ("user", "assistant")]
+    # 2 user turns + 20 tool-call assistant rows + 2 chat assistant turns
+    # — every chat turn survives; nothing is summarized away.
+    assert roles.count("user") == 2
+    assert roles.count("assistant") == 22
+    # No summary card is produced.
+    joined = " ".join(str(m.get("content", "")) for m in out)
+    assert "CONTEXT COMPACTION" not in joined
+    assert "Earlier turns were compacted" not in joined
+    # Tool bulk is still deterministically pruned (dedup back-references).
+    tool_lens = sorted(len(m.get("content", "")) for m in out if m.get("role") == "tool")
+    assert tool_lens
+    assert tool_lens[0] <= 200

--- a/tests/agent/test_keep_history_engine.py
+++ b/tests/agent/test_keep_history_engine.py
@@ -34,22 +34,20 @@ def _bulky_session(n_dumps: int = 20, dump_chars: int = 150_000):
     ]
     big = "y" * dump_chars
     for i in range(n_dumps):
-        msgs.append(
-            {
-                "role": "assistant",
-                "content": "",
-                "tool_calls": [
-                    {
-                        "id": f"c{i}",
-                        "type": "function",
-                        "function": {
-                            "name": "terminal",
-                            "arguments": '{"command":"ls -la"}',
-                        },
-                    }
-                ],
-            }
-        )
+        msgs.append({
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": f"c{i}",
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command":"ls -la"}',
+                    },
+                }
+            ],
+        })
         msgs.append({"role": "tool", "tool_call_id": f"c{i}", "content": big})
     msgs += [
         {"role": "assistant", "content": "All green"},
@@ -92,14 +90,20 @@ def test_select_context_prunes_request_only(engine):
     assert selected is not None
     assert selected is not msgs  # replacement list, never in-place mutation
     # Chat turns (user/assistant text) survive verbatim.
-    chat = [(m["role"], m.get("content", "")) for m in selected if m["role"] in ("user", "assistant")]
+    chat = [
+        (m["role"], m.get("content", ""))
+        for m in selected
+        if m["role"] in ("user", "assistant")
+    ]
     assert chat[0] == ("user", "Set up the proxy stack")
     assert chat[-1] == ("assistant", "Done, released v2")
     # Bulk tool results are replaced with one-line summaries. The dedup
     # pass is intentionally lossless: the NEWEST full copy survives while
     # older duplicates become short back-references, so at most one tool
     # result keeps its full payload and the rest collapse.
-    tool_lens = sorted(len(m.get("content", "")) for m in selected if m.get("role") == "tool")
+    tool_lens = sorted(
+        len(m.get("content", "")) for m in selected if m.get("role") == "tool"
+    )
     assert tool_lens
     assert sum(1 for l in tool_lens if l <= 200) >= len(tool_lens) - 1
     assert tool_lens[0] <= 200
@@ -108,8 +112,28 @@ def test_select_context_prunes_request_only(engine):
 
 
 def test_select_context_small_request_noop(engine):
-    small = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+    small = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
     assert engine.select_context(copy.deepcopy(small), budget_tokens=1_048_576) is None
+
+
+def test_select_context_falls_back_when_budget_missing(engine):
+    # Safety valve: a call site that supplies neither a model context
+    # length nor budget_tokens must not silently disable request
+    # compaction — the engine falls back to a conservative default window.
+    engine.context_length = 0
+    msgs = _bulky_session()
+    selected = engine.select_context(copy.deepcopy(msgs), budget_tokens=0)
+    assert selected is not None
+    # Fallback window is far below the ~1M-token session bulk, so the
+    # hard-ceiling trim must also have engaged and bounded the request.
+    est = sum(
+        len(str(m.get("content", ""))) // 4 + len(str(m.get("tool_calls", ""))) // 4
+        for m in selected
+    )
+    assert est < 128_000
 
 
 def test_select_context_rearm_gate(engine):
@@ -135,6 +159,8 @@ def test_compress_preserves_all_chat_turns(engine):
     assert "CONTEXT COMPACTION" not in joined
     assert "Earlier turns were compacted" not in joined
     # Tool bulk is still deterministically pruned (dedup back-references).
-    tool_lens = sorted(len(m.get("content", "")) for m in out if m.get("role") == "tool")
+    tool_lens = sorted(
+        len(m.get("content", "")) for m in out if m.get("role") == "tool"
+    )
     assert tool_lens
     assert tool_lens[0] <= 200

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -34,6 +34,52 @@ Configure via `hermes plugins` → Provider Plugins → Context Engine, or edit 
 
 For building a context engine plugin, see [Context Engine Plugins](/developer-guide/context-engine-plugin).
 
+## keep_history engine: request-only compaction (chat history always visible)
+
+The built-in `compressor` rewrites the live transcript on compaction: the
+summarized middle is swapped in and the pre-compaction turns are
+soft-archived (`active=0, compacted=1` in the session store). UIs that
+render the session store (desktop app, dashboard) show only active rows, so
+after a compaction the visible timeline collapses to a summary card plus the
+recent tail.
+
+The bundled `keep_history` engine takes the opposite approach: **the
+persisted transcript is never rewritten**. It compacts *background* context
+— old tool logs, terminal dumps, file arrays, search results — only in the
+per-request message list via the `select_context()` hook (request-only by
+contract), so:
+
+- The model always receives a bounded, compacted context within token limits.
+- The session DB — and therefore the visible chat history — keeps **every**
+  user/assistant turn, fully scrollable at all times.
+
+```yaml
+context:
+  engine: "keep_history"    # compact background context, keep full chat history
+```
+
+Behavior:
+
+- `should_compress()` always returns `False` — the destructive
+  LLM-summary + `archive_and_compact` path is never auto-triggered.
+- `select_context()` prunes old tool results deterministically (dedup,
+  one-line summaries for large outputs, tool_call-arg truncation) when the
+  request crosses the token trigger, with a rearm watermark so
+  prompt-cache breaks stay episodic. A hard-ceiling trim guarantees the
+  request still fits the window in pathological sessions (request-only —
+  the stored transcript is untouched).
+- `compress()` (manual `/compress`, gateway hygiene) performs the same
+  deterministic prune — every user/assistant message survives verbatim and
+  no summary card is produced.
+
+The engine honors the same `compression.*` config block
+(`threshold`, `protect_last_n`, `min_tail_user_messages`,
+`proactive_prune_tokens`, `proactive_prune_min_result_chars`,
+`proactive_prune_min_reclaim_tokens`). Note that the destructive
+full-compression trigger (`threshold`) is effectively advisory for this
+engine since auto-compression never fires; it is still used for the
+request-prune trigger calculations.
+
 ## Dual Compression System
 
 Hermes has two separate compression layers that operate independently:

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -66,8 +66,10 @@ Behavior:
   one-line summaries for large outputs, tool_call-arg truncation) when the
   request crosses the token trigger, with a rearm watermark so
   prompt-cache breaks stay episodic. A hard-ceiling trim guarantees the
-  request still fits the window in pathological sessions (request-only —
-  the stored transcript is untouched).
+  request still fits the window in pathological sessions; in those cases
+  the trim may drop mid-chat turns **from the request the model sees**
+  (request-level drop only — the stored transcript still keeps every
+  turn, so the visible history is unaffected).
 - `compress()` (manual `/compress`, gateway hygiene) performs the same
   deterministic prune — every user/assistant message survives verbatim and
   no summary card is produced.
@@ -75,10 +77,11 @@ Behavior:
 The engine honors the same `compression.*` config block
 (`threshold`, `protect_last_n`, `min_tail_user_messages`,
 `proactive_prune_tokens`, `proactive_prune_min_result_chars`,
-`proactive_prune_min_reclaim_tokens`). Note that the destructive
-full-compression trigger (`threshold`) is effectively advisory for this
-engine since auto-compression never fires; it is still used for the
-request-prune trigger calculations.
+`proactive_prune_min_reclaim_tokens`). The request-prune trigger is driven
+by `proactive_prune_tokens` (fallback: ~55% of the context window);
+`threshold` is accepted for compatibility but is not consulted, since the
+destructive full-compression path it configures never fires for this
+engine.
 
 ## Dual Compression System
 


### PR DESCRIPTION
## Problem

When auto-compression triggers, the entire visible chat history disappears from the UI. Everything from the beginning of the conversation is wiped out and replaced with just a summary card — the user can no longer scroll up to review the original past messages.

### Root cause

The built-in `ContextCompressor.compress()` rewrites the live transcript on every compaction: `archive_and_compact()` soft-archives **every** active row (`active=0, compacted=1`) and re-inserts head + LLM summary + tail as fresh rows. UIs that render the session store (desktop app, dashboard, web) show only `active=1` rows, so after a compaction the visible timeline collapses to a summary card plus the recent tail.

Real-world evidence from a desktop session (`20260813_065425_b72b43`): 1503 stored messages, only 197 active — 1044 rows soft-archived by repeated compressions. The archived rows are still in the DB (searchable via `session_search`), but the UI cannot show them.

Related: #45117 (make pre-compression history discoverable/resumable), #82462, #78484.

## Fix

Adds a bundled **`keep_history`** context engine that takes the Codex-Desktop approach: compact *background* context (tool logs, terminal dumps, file arrays) only in the **per-request** message list via the existing `select_context()` hook, which is request-only by contract — the persisted transcript is never rewritten, so the visible chat history stays fully intact and scrollable at all times while the model still receives a bounded, compacted context.

- `should_compress()` always returns `False` — the destructive LLM-summary + `archive_and_compact` path never auto-fires.
- `select_context()` deterministically prunes old tool results (dedup, one-line summaries for large outputs, tool_call-arg truncation) when the request crosses the token trigger, with a rearm watermark so prompt-cache breaks stay episodic, plus a hard-ceiling trim so the request still fits the window in pathological sessions.
- `compress()` (manual `/compress`, gateway hygiene) performs the same deterministic prune — every user/assistant message survives verbatim and no summary card is produced.
- Honors the existing `compression.*` config block (`threshold`, `protect_last_n`, `min_tail_user_messages`, `proactive_prune_tokens`, `proactive_prune_min_result_chars`, `proactive_prune_min_reclaim_tokens`).
- Exposed in the desktop Settings → Context Engine dropdown; documented in the developer guide.

Opt-in, additive: the default `compressor` engine is untouched. Select via:

```yaml
context:
  engine: "keep_history"
```

## Tests

`tests/agent/test_keep_history_engine.py` — 8 tests covering discovery, never-triggering destructive compression, loop-prune no-op, request-only pruning (transcript untouched), small-request no-op, rearm gating, and `compress()` preserving every chat turn.

```
23 passed (engine tests + existing context-engine/prune suites)
```