### PR TITLE
Buzz adapter: honor reply_to_mode instead of always threading replies

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -392,6 +392,15 @@ class BuzzAdapter(BasePlatformAdapter):
             _rm_cfg = _rm_raw
         self.require_mention = str(_rm_cfg).strip().lower() not in ("false", "0", "no", "off")
 
+        # Reply anchoring: "first"/"all" thread the reply onto the parent event
+        # id, "off" posts every reply as a normal top-level channel message.
+        # Mirrors the Discord/Telegram adapters, which already honor this
+        # PlatformConfig field; without it Buzz threaded unconditionally.
+        # Env (BUZZ_REPLY_TO_MODE) overrides config.yaml.
+        _rtm = (os.getenv("BUZZ_REPLY_TO_MODE") or getattr(config, "reply_to_mode", "first")
+                or "first")
+        self._reply_to_mode: str = str(_rtm).strip().lower()
+
         # Inbound transport: "auto" (WebSocket with poll fallback, default),
         # "websocket" (require WS; fail connect when it can't authenticate),
         # or "poll" (CLI polling only). Env (BUZZ_TRANSPORT) overrides
@@ -610,7 +619,7 @@ class BuzzAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
         reply_target = reply_to or (metadata or {}).get("thread_id")
-        if reply_target:
+        if reply_target and self._reply_to_mode != "off":
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=content)
         if code != 0:
@@ -681,7 +690,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
-            if reply_to:
+            if reply_to and self._reply_to_mode != "off":
                 args += ["--reply-to", str(reply_to)]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
@@ -1386,7 +1395,11 @@ async def _standalone_send(
         return {"error": "Buzz standalone send: no target channel (set BUZZ_HOME_CHANNEL)"}
 
     args = ["messages", "send", "--channel", target, "--content", "-"]
-    if thread_id:
+    # Same reply_to_mode gate as the live adapter, so out-of-process cron
+    # delivery (deliver=buzz) doesn't thread when the operator asked for flat.
+    _rtm = (os.getenv("BUZZ_REPLY_TO_MODE")
+            or getattr(pconfig, "reply_to_mode", "first") or "first")
+    if thread_id and str(_rtm).strip().lower() != "off":
         args += ["--reply-to", str(thread_id)]
     for path in media_files or []:
         args += ["--file", str(path)]


### PR DESCRIPTION
## Problem

The Buzz adapter appends `--reply-to` unconditionally, so every agent reply threads onto its parent event id. There is no way to turn that off.

`reply_to_mode` (`off` / `first` / `all`) is already a generic `PlatformConfig` field, parsed for any platform in `gateway/config.py` (`from_dict`: `reply_to_mode=data.get("reply_to_mode", "first")`). Both other chat adapters honor it:

- `plugins/platforms/discord/adapter.py` — reads it in `__init__`, gates in `_reply_reference_for_send` (`if not reply_to or self._reply_to_mode == "off": return None`)
- `plugins/platforms/telegram/adapter.py` — same pattern via `_reply_to_message_id_for_send`

Buzz never reads it, so setting `gateway.platforms.buzz.reply_to_mode: off` is a **silent no-op** — the config is accepted and does nothing, which is worse than it being unsupported.

## Change

Read `reply_to_mode` in `BuzzAdapter.__init__` and skip the `--reply-to` append when it is `off`, at all three send paths:

1. `send()` — the normal reply path
2. `send_image()` — same pattern
3. `_standalone_send()` — the out-of-process path used for `deliver=buzz` cron delivery, which already receives `pconfig`

`BUZZ_REPLY_TO_MODE` overrides `config.yaml`, matching how `require_mention` (`BUZZ_REQUIRE_MENTION`) and `transport` (`BUZZ_TRANSPORT`) already work in this adapter.

**Default is unchanged (`first`), so existing installs keep threading.**

## Why it matters

On a shared channel with several agents, threaded replies collapse under their parent and are easy to miss. Operators who want agents to read as ordinary channel participants currently have no option — the behavior is hardcoded.

## Testing

Verified against a Buzz relay with several agents in one channel:

- Before: agent replies carried an `e` tag (threaded).
- After, with `reply_to_mode: off`: replies carry no `e` tag and render as normal top-level channel messages.
- With the setting absent or set to `first`: threading is unchanged.

## Two follow-ups I'm happy to add to this PR

1. **Document `reply_to_mode` for Buzz** in `website/docs/user-guide/messaging/buzz.md`. The docs currently say only "Replies can thread onto an existing message via its event id", with no mention that the behavior is configurable (because until this change it wasn't).

2. **Document an `enabled` trap that bit me.** `PlatformConfig.from_dict` defaults `enabled` to `False`. So an operator adding a `gateway.platforms.buzz:` block purely to set `reply_to_mode` will silently disable the platform unless they also set `enabled: true`. That is easy to hit for any env-configured install, since Buzz can be enabled entirely through `BUZZ_*` env vars with no `gateway.platforms.buzz` block present at all — adding one to hold a single key flips the platform off. Worth a warning line in the docs, or arguably a different default when a block exists but omits `enabled`.

Let me know if you'd like either folded in here or split out.
