### PR TITLE
fix: exclude launchd-managed gateway from orphan reaper on macOS

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1555,6 +1555,16 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     own = {os.getpid()}
     if extra_exclude:
         own |= extra_exclude
+    # On macOS, exclude the launchd-managed gateway PID so the orphan reaper
+    # doesn't kill a supervised gateway when Hermes Desktop opens (the serve
+    # process calls this on startup).  supports_systemd_services() returns
+    # False on macOS, so without this the launchd gateway looks like an
+    # unsupervised orphan and gets SIGTERM'd, causing launchd to restart it.
+    if is_macos():
+        try:
+            own |= _get_service_pids()
+        except Exception:
+            pass
     try:
         # find_gateway_pids() includes no-supervisor `gateway restart` runtimes
         # for the current profile when no systemd supervisor is present.

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -427,6 +427,74 @@ class TestStopProfileGateway:
         assert killed_pid in reap_extra_excludes[0]
 
 
+class TestReapUnsupervisedGatewayOrphansMacOS:
+    """Tests that the orphan reaper excludes launchd-managed PIDs on macOS.
+
+    Regression guard: without the ``is_macos()`` exclusion of
+    ``_get_service_pids()``, the reaper would SIGTERM the launchd-supervised
+    gateway every time Hermes Desktop opens (``hermes serve`` calls
+    ``_reap_unsupervised_gateway_orphans`` during startup).
+    """
+
+    def test_macos_excludes_launchd_pid_from_kill(self, monkeypatch):
+        """A launchd-managed PID must not appear in the orphan kill list."""
+        launchd_pid = 52615
+
+        # Pretend we're on macOS — supports_systemd_services() returns False
+        # so the function does NOT short-circuit and proceeds to the scan.
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+
+        # _get_service_pids returns the launchd-managed gateway PID.
+        monkeypatch.setattr(gateway, "_get_service_pids", lambda: {launchd_pid})
+
+        # find_gateway_pids returns the launchd PID plus a real orphan.
+        # The reaper should only kill the orphan, not the launchd PID.
+        orphan_pid = 99998
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [p for p in [launchd_pid, orphan_pid] if p not in (exclude_pids or set())],
+        )
+
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        monkeypatch.setattr("time.monotonic", lambda: 1.0)
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert result is True  # at least one orphan was reaped
+        killed = [pid for pid, _ in killed_pids]
+        assert orphan_pid in killed       # the real orphan was killed
+        assert launchd_pid not in killed  # the launchd PID was NOT killed
+
+    def test_macos_no_orphans_when_only_launchd_gateway_running(self, monkeypatch):
+        """If the only gateway PID is launchd-managed, reaper returns False."""
+        launchd_pid = 52615
+
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "_get_service_pids", lambda: {launchd_pid})
+
+        # find_gateway_pids would return the launchd PID, but it's excluded.
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [p for p in [launchd_pid] if p not in (exclude_pids or set())],
+        )
+
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert result is False  # no orphans reaped
+        assert killed_pids == []  # nothing was killed
+
+
 def test_module_has_logger():
     """Verify module has a logger instance (regression guard for #27154)."""
     assert hasattr(gateway, "logger")


### PR DESCRIPTION
## Problem

`_reap_unsupervised_gateway_orphans()` in `hermes_cli/gateway.py` short-circuits on Linux hosts with systemd via `supports_systemd_services()`. On macOS there is no systemd, so the function returns `False` and the orphan reaper runs unconditionally — treating the launchd-managed gateway as an unsupervised orphan and SIGTERM-ing it.

When Hermes Desktop opens, `hermes serve` calls this function during startup (`web_server.py` ~line 251, gated on `HERMES_DESKTOP == "1"`). The launchd-managed gateway is killed, launchd restarts it via `KeepAlive: true`, and the user sees a spurious gateway restart every time they reopen the Desktop app.

## Fix

Exclude PIDs managed by launchd (`_get_service_pids()` already returns launchd-managed PIDs on macOS) from the orphan scan — the same pattern used for systemd on Linux.

```python
# On macOS, exclude the launchd-managed gateway PID so the orphan reaper
# doesn't kill a supervised gateway when Hermes Desktop opens.
if is_macos():
    try:
        own |= _get_service_pids()
    except Exception:
        pass
```

## Testing

Tested on macOS 26.5 (Tahoe) with Hermes Desktop 0.16+ and a launchd-managed gateway (`ai.hermes.gateway` plist with `KeepAlive: true`).

**Before:** Quitting and reopening Hermes Desktop restarted the gateway every time (visible in `~/.hermes/logs/gateway.log` — "Starting Hermes Gateway..." on every Desktop open).

**After:** Gateway stays running across Desktop quit/reopen cycles. No spurious restart.