### PR TITLE
feat(desktop): route requests by applied profile gateway

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -23,6 +23,7 @@ import {
   cookiesHaveLiveSession,
   cookiesHavePrivySession,
   cookiesHaveSession,
+  createAppliedConnectionConfig,
   gatewayTicketFailure,
   gatewayWsUrlIpcResult,
   isGatewayAuthRejection,
@@ -32,7 +33,9 @@ import {
   normalizeSshConfig,
   normAuthMode,
   pathWithGlobalRemoteProfile,
+  profileConnectionState,
   profileHasRemoteConnection,
+  profileLocalOverride,
   profileRemoteOverride,
   profileSshOverride,
   resolveAuthMode,
@@ -40,7 +43,8 @@ import {
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,
-  tokenPreview
+  tokenPreview,
+  updateProfileConnectionEntries
 } from './connection-config'
 
 // --- connectionScopeKey / normAuthMode ---
@@ -219,6 +223,32 @@ test('saved SSH drafts are inactive and explicit overrides take precedence', () 
   assert.equal(profileHasRemoteConnection(config, 'coder'), true)
 })
 
+test('named Local and Inherit remain distinct persisted states', () => {
+  const local = { profiles: { work: { mode: 'local' } } }
+
+  assert.equal(profileLocalOverride(local, 'work'), true)
+  assert.deepEqual(profileConnectionState(local, 'work'), { inherited: false, profileOverride: true })
+
+  const inherited = {
+    ...local,
+    profiles: updateProfileConnectionEntries(local.profiles, 'work', null, true)
+  }
+
+  assert.equal(profileLocalOverride(inherited, 'work'), false)
+  assert.deepEqual(profileConnectionState(inherited, 'work'), { inherited: true, profileOverride: false })
+})
+
+test('staged persistence does not change live routing until Apply promotes it', () => {
+  const live = createAppliedConnectionConfig({ mode: 'remote', profiles: {} })
+  const staged = { mode: 'remote', profiles: { work: { mode: 'local' } } }
+
+  assert.equal(profileLocalOverride(live.current(), 'work'), false)
+  assert.equal(profileLocalOverride(staged, 'work'), true)
+
+  live.promote(staged)
+  assert.equal(profileLocalOverride(live.current(), 'work'), true)
+})
+
 // --- resolveProfileBackendRoute ---
 
 const ROUTES = [
@@ -250,6 +280,12 @@ const ROUTES = [
     name: 'a profile with its own remote override gets a pooled descriptor for that host',
     profile: 'coder',
     opts: { primaryProfile: 'default', globalRemote: true, profileRemoteOverride: true },
+    expected: { backend: 'pool', descriptorProfile: null, scopePath: false }
+  },
+  {
+    name: 'an explicit local profile bypasses the app-global remote',
+    profile: 'coder',
+    opts: { primaryProfile: 'default', globalRemote: true, profileLocalOverride: true },
     expected: { backend: 'pool', descriptorProfile: null, scopePath: false }
   },
   {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -376,6 +376,7 @@ function profileRemoteOverride(config, profile) {
 export interface ProfileRouteOptions {
   globalRemote?: boolean
   primaryProfile?: null | string
+  profileLocalOverride?: boolean
   profileRemoteOverride?: boolean
 }
 
@@ -390,6 +391,59 @@ export interface ProfileBackendRoute {
   descriptorProfile: null | string
   /** Whether REST paths on this route must carry `?profile=` to be scoped. */
   scopePath: boolean
+}
+
+/** True when a named profile is explicitly pinned to its local backend. */
+function profileLocalOverride(config, profile) {
+  const key = connectionScopeKey(profile)
+  const entry = key ? config?.profiles?.[key] : null
+
+  return Boolean(entry && typeof entry === 'object' && entry.mode === 'local')
+}
+
+/** Describe whether a named profile has its own saved connection entry. */
+function profileConnectionState(config, profile) {
+  const key = connectionScopeKey(profile)
+  const profiles = config?.profiles
+  const entry = key && profiles && typeof profiles === 'object' ? profiles[key] : null
+  const profileOverride = Boolean(entry && typeof entry === 'object')
+
+  return {
+    inherited: Boolean(key && !profileOverride),
+    profileOverride
+  }
+}
+
+/** Update one profile entry, deleting it only for the explicit inherit choice. */
+function updateProfileConnectionEntries(existingProfiles, profile, entry, inherit = false) {
+  const profiles = { ...(existingProfiles || {}) }
+
+  if (inherit) {
+    delete profiles[profile]
+  } else {
+    profiles[profile] = entry
+  }
+
+  return profiles
+}
+
+/**
+ * Hold the process-lifetime connection config used by live routing. Persisting
+ * a staged config does not touch this boundary; Apply promotes it explicitly.
+ */
+function createAppliedConnectionConfig<T>(initialConfig: T) {
+  let appliedConfig = initialConfig
+
+  return {
+    current(): T {
+      return appliedConfig
+    },
+    promote(config: T): T {
+      appliedConfig = config
+
+      return appliedConfig
+    }
+  }
 }
 
 /**
@@ -416,7 +470,7 @@ function resolveProfileBackendRoute(profile, opts: ProfileRouteOptions = {}): Pr
     return { backend: 'primary', descriptorProfile: null, scopePath: false }
   }
 
-  if (opts.profileRemoteOverride) {
+  if (opts.profileRemoteOverride || opts.profileLocalOverride) {
     return { backend: 'pool', descriptorProfile: null, scopePath: false }
   }
 
@@ -566,6 +620,7 @@ export {
   cookiesHaveLiveSession,
   cookiesHavePrivySession,
   cookiesHaveSession,
+  createAppliedConnectionConfig,
   gatewayTicketFailure,
   gatewayWsUrlIpcResult,
   hostLabelFromBaseUrl,
@@ -577,7 +632,9 @@ export {
   normAuthMode,
   pathWithGlobalRemoteProfile,
   PRIVY_SESSION_COOKIE_VARIANTS,
+  profileConnectionState,
   profileHasRemoteConnection,
+  profileLocalOverride,
   profileRemoteOverride,
   profileSshOverride,
   resolveAuthMode,
@@ -585,5 +642,6 @@ export {
   resolveTestWsUrl,
   RT_COOKIE_VARIANTS,
   savedProfileSsh,
-  tokenPreview
+  tokenPreview,
+  updateProfileConnectionEntries
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -63,6 +63,7 @@ import {
   cookiesHaveLiveSession,
   cookiesHavePrivySession,
   cookiesHaveSession,
+  createAppliedConnectionConfig,
   gatewayTicketFailure,
   gatewayWsUrlIpcResult,
   hostLabelFromBaseUrl,
@@ -72,14 +73,16 @@ import {
   normalizeSshConfig,
   normAuthMode,
   pathWithGlobalRemoteProfile,
+  profileConnectionState,
   profileHasRemoteConnection,
+  profileLocalOverride,
   profileRemoteOverride,
   profileSshOverride,
   resolveAuthMode,
-  resolveProfileBackendRoute,
   resolveTestWsUrl,
   savedProfileSsh,
-  tokenPreview
+  tokenPreview,
+  updateProfileConnectionEntries
 } from './connection-config'
 import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
@@ -174,6 +177,15 @@ import { createKeepAwake } from './power-save'
 import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
+import {
+  type BackendRouteIdentity,
+  connectionApplyAffectsPoolProfile,
+  createProfileAsyncQueue,
+  type EnsureBackendOptions,
+  ensureCompatiblePoolEntry,
+  gatewayRequestForcesLocal,
+  selectBackendSelection
+} from './profile-request-routing'
 import { fetchPrimaryProfileSessions } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
@@ -1096,7 +1108,8 @@ let softRehomeInProgress = false
 // backends spawned lazily when a session belongs to a different profile. A user
 // with no named profiles never populates this map, so their experience is
 // byte-for-byte the single-backend behavior.
-const backendPool = new Map() // profile -> { process, port, token, connectionPromise, lastActiveAt }
+const backendPool = new Map() // profile -> { process, port, token, connectionPromise, lastActiveAt, routeIdentity }
+const profileBackendQueue = createProfileAsyncQueue()
 // Keep the pool light: cap concurrent profile backends (LRU eviction) and reap
 // idle ones. A user idles at exactly the primary backend; pool backends only
 // exist while a non-primary profile is actively being chatted through.
@@ -6859,6 +6872,14 @@ function writeDesktopConnectionConfig(config) {
   connectionConfigCacheMtime = fs.statSync(DESKTOP_CONNECTION_CONFIG_PATH).mtimeMs
 }
 
+// Persisted config can be staged by Save/Test. Live routing changes only when
+// Apply promotes a new snapshot at this explicit boundary.
+const appliedConnectionConfig = createAppliedConnectionConfig(readDesktopConnectionConfig())
+
+function readAppliedDesktopConnectionConfig() {
+  return appliedConnectionConfig.current()
+}
+
 // Returns the desktop's chosen profile name, or null when unset. "default" is
 // a valid stored value (pins the root HERMES_HOME explicitly); null means "no
 // preference" and preserves the legacy launch (no --profile flag).
@@ -6910,6 +6931,7 @@ async function sanitizeDesktopConnectionConfig(config = readDesktopConnectionCon
   const authMode = normAuthMode(block.authMode)
   const remoteUrl = envOverride ? String(process.env.HERMES_DESKTOP_REMOTE_URL || '') : String(block.url || '')
   const mode = envOverride ? 'remote' : savedMode === 'ssh' ? 'ssh' : modeIsRemoteLike(savedMode) ? savedMode : 'local'
+  const connectionState = profileConnectionState(config, key)
 
   // Whether the OS keyring (safeStorage) can encrypt the saved token. When
   // false the renderer knows to offer the plain-text opt-in in Settings →
@@ -6948,6 +6970,7 @@ async function sanitizeDesktopConnectionConfig(config = readDesktopConnectionCon
     mode,
     // Echo the scope back so the UI knows which profile (if any) this reflects.
     profile: key,
+    ...connectionState,
     remoteAuthMode: authMode,
     remoteOauthConnected,
     remoteUrl,
@@ -7008,6 +7031,14 @@ function coerceDesktopConnectionConfig(input: any = {}, existing = readDesktopCo
   const mode = input.mode === 'ssh' ? 'ssh' : modeIsRemoteLike(input.mode) ? input.mode : 'local'
   const remoteLike = modeIsRemoteLike(mode)
 
+  if (key && input.inherit === true) {
+    return {
+      mode: existing.mode === 'ssh' || modeIsRemoteLike(existing.mode) ? existing.mode : 'local',
+      remote: existing.remote || {},
+      profiles: updateProfileConnectionEntries(existing.profiles, key, null, true)
+    }
+  }
+
   // The block being edited: a per-profile entry or the global remote block.
   const rawExistingBlock = key ? existing.profiles?.[key] || {} : existing.remote || {}
   // Leaving a CLOUD connection unselects it: a cloud block's url/org/token
@@ -7059,22 +7090,12 @@ function coerceDesktopConnectionConfig(input: any = {}, existing = readDesktopCo
   }
 
   if (key) {
-    // Per-profile scope: a remote/cloud entry pins this profile to its own
-    // backend; a local entry clears the override so the profile inherits the
-    // default. The mode tag (remote vs cloud) is preserved on the entry.
-    const profiles = { ...(existing.profiles || {}) }
-
-    if (remoteLike) {
-      profiles[key] = { mode, ...buildRemoteBlock(remoteUrl, authMode, nextToken, cloudOrg) }
-    } else {
-      const localEntry = localProfileEntry(rawExistingBlock)
-
-      if (localEntry) {
-        profiles[key] = localEntry
-      } else {
-        delete profiles[key]
-      }
-    }
+    // A named local entry is explicit and terminal; only `inherit: true`
+    // deletes it. Preserve an inactive SSH draft when switching to local.
+    const entry = remoteLike
+      ? { mode, ...buildRemoteBlock(remoteUrl, authMode, nextToken, cloudOrg) }
+      : localProfileEntry(rawExistingBlock) || { mode: 'local' }
+    const profiles = updateProfileConnectionEntries(existing.profiles, key, entry)
 
     return {
       mode: existing.mode === 'ssh' || modeIsRemoteLike(existing.mode) ? existing.mode : 'local',
@@ -7290,7 +7311,7 @@ async function teardownSshConnection(profile) {
 // terminal must NOT fall through to a global SSH host.
 function activeSshTerminalTarget() {
   const profile = primaryProfileKey()
-  const config = readDesktopConnectionConfig()
+  const config = readAppliedDesktopConnectionConfig()
 
   if (profileSshOverride(config, profile)) {
     const scope = sshScopeKey(profile)
@@ -7499,8 +7520,12 @@ function persistSshConnectionToken(profile, source, token) {
 //   3. global remote (connection.json `mode: 'remote'`)
 // A null/empty profile resolves the env/global remote, so legacy callers and
 // the connection test (which pass no profile) are unchanged.
-async function resolveRemoteBackend(profile) {
-  const config = readDesktopConnectionConfig()
+async function resolveRemoteBackend(profile, options: { ignoreLocalOverride?: boolean } = {}) {
+  const config = readAppliedDesktopConnectionConfig()
+
+  if (!options.ignoreLocalOverride && profileLocalOverride(config, profile)) {
+    return null
+  }
 
   // 1. Per-profile override — "a profile with its own remote host". Wins even
   //    over the env override so an explicitly-configured profile always
@@ -7579,11 +7604,15 @@ async function resolveRemoteBackend(profile) {
 // not the local-disk fast path. These three helpers drive that (see
 // interceptSessionReadForRemote).
 function profileHasRemoteOverride(profile) {
-  return profileHasRemoteConnection(readDesktopConnectionConfig(), profile)
+  return profileHasRemoteConnection(readAppliedDesktopConnectionConfig(), profile)
+}
+
+function profileHasLocalOverride(profile) {
+  return profileLocalOverride(readAppliedDesktopConnectionConfig(), profile)
 }
 
 function configuredRemoteProfileNames() {
-  const config = readDesktopConnectionConfig()
+  const config = readAppliedDesktopConnectionConfig()
 
   return Object.keys(config.profiles || {}).filter(name => profileHasRemoteConnection(config, name))
 }
@@ -7597,7 +7626,7 @@ function globalRemoteActive() {
     return true
   }
 
-  const mode = readDesktopConnectionConfig().mode
+  const mode = readAppliedDesktopConnectionConfig().mode
 
   return modeIsRemoteLike(mode) || mode === 'ssh'
 }
@@ -7609,6 +7638,10 @@ function globalRemoteActive() {
 // latch — transient, must stay retryable) vs local (latch to break install
 // loops) BEFORE the throwing resolve/mint runs.
 function primaryBackendIsRemote() {
+  if (profileHasLocalOverride(primaryProfileKey())) {
+    return false
+  }
+
   return Boolean(profileHasRemoteOverride(primaryProfileKey())) || globalRemoteActive()
 }
 
@@ -7969,55 +8002,79 @@ function primaryProfileKey() {
   return readActiveDesktopProfile() || 'default'
 }
 
-// Options describing the current connection setup for `resolveProfileBackendRoute`.
+// Options describing the current applied connection setup for request paths.
 function profileRouteOptions(profile) {
   return {
     globalRemote: globalRemoteActive(),
     primaryProfile: primaryProfileKey(),
+    profileLocalOverride: Boolean(profileHasLocalOverride(profile)),
     profileRemoteOverride: Boolean(profileHasRemoteOverride(profile))
   }
 }
 
-// Resolve a backend connection for the given profile, per the routing table in
-// resolveProfileBackendRoute(). An empty / unknown profile resolves to the
-// primary, so legacy callers are unchanged.
-async function ensureBackend(profile) {
-  const key = profile && String(profile).trim() ? String(profile).trim() : primaryProfileKey()
-  const route = resolveProfileBackendRoute(key, profileRouteOptions(key))
-
-  if (route.backend === 'primary') {
-    const connection = await startHermes()
-
-    // A shared backend still owes the caller its profile scope, so renderer-side
-    // WebSocket, filesystem, and cache routing target the selected profile.
-    return route.descriptorProfile ? { ...connection, profile: route.descriptorProfile } : connection
-  }
-
-  const existing = backendPool.get(key)
-
-  if (existing) {
-    existing.lastActiveAt = Date.now()
-
-    return existing.connectionPromise
-  }
-
-  evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
-
-  const entry = {
-    process: null,
-    port: null,
-    token: null,
-    connectionPromise: null,
-    lastActiveAt: Date.now(),
-    remoteBaseUrl: null
-  }
-
-  entry.connectionPromise = spawnPoolBackend(key, entry).catch(error => {
-    backendPool.delete(key)
-    throw error
+function desiredBackendSelection(profile, forceLocal = false) {
+  return selectBackendSelection({
+    explicitLocal: profileHasLocalOverride(profile),
+    explicitRemote: profileHasRemoteOverride(profile),
+    forceLocal,
+    globalRemote: globalRemoteActive(),
+    primaryProfile: primaryProfileKey(),
+    profile
   })
-  backendPool.set(key, entry)
-  startPoolIdleReaper()
+}
+
+async function ensureBackend(profile, options: EnsureBackendOptions = {}) {
+  const key = profile && String(profile).trim() ? String(profile).trim() : primaryProfileKey()
+
+  return profileBackendQueue.run(key, async () => {
+    const selection = options.selection ?? desiredBackendSelection(key)
+
+    if (selection.target === 'primary') {
+      const connection = await startHermes()
+
+      return selection.route === 'remote-global' && key !== primaryProfileKey()
+        ? { ...connection, profile: key }
+        : connection
+    }
+
+    return ensurePoolBackend(key, selection.route)
+  })
+}
+
+async function ensurePoolBackend(key: string, route: BackendRouteIdentity) {
+  const entry = await ensureCompatiblePoolEntry({
+    create: () => {
+      evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
+
+      const created: any = {
+        process: null,
+        port: null,
+        token: null,
+        connectionPromise: null,
+        lastActiveAt: Date.now(),
+        remoteBaseUrl: null,
+        routeIdentity: route
+      }
+
+      created.connectionPromise = spawnPoolBackend(key, created, route).catch(error => {
+        if (backendPool.get(key) === created) {
+          backendPool.delete(key)
+        }
+
+        throw error
+      })
+      backendPool.set(key, created)
+      startPoolIdleReaper()
+
+      return created
+    },
+    get: () => backendPool.get(key),
+    route,
+    teardown: existing => teardownPoolBackendAndWaitUnlocked(key, existing),
+    touch: existing => {
+      existing.lastActiveAt = Date.now()
+    }
+  })
 
   return entry.connectionPromise
 }
@@ -8096,14 +8153,14 @@ function startPoolIdleReaper() {
 // Spawn an additional dashboard backend pinned to a named profile. Mirrors the
 // local-spawn portion of startHermes() but without the boot-progress UI,
 // bootstrap, or remote handling (those belong to the primary backend only).
-async function spawnPoolBackend(profile, entry) {
+async function spawnPoolBackend(profile, entry, routeIdentity: BackendRouteIdentity) {
   // A profile may point at its OWN remote backend (connection.json
   // `profiles[name]`), or inherit the app-wide remote (env / global settings).
   // In either case there is no local child to spawn — we just verify the
   // remote is reachable and hand back its connection descriptor. The pool
   // entry keeps `entry.process === null`, which stopPoolBackend/evict already
   // tolerate.
-  const remote = await resolveRemoteBackend(profile)
+  const remote = routeIdentity === 'local' ? null : await resolveRemoteBackend(profile)
 
   if (remote) {
     await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode)
@@ -8270,10 +8327,10 @@ function stopPoolBackend(profile) {
   stopBackendChild(entry.process)
 }
 
-async function teardownPoolBackendAndWait(profile) {
+async function teardownPoolBackendAndWaitUnlocked(profile, expectedEntry = null) {
   const entry = backendPool.get(profile)
 
-  if (!entry) {
+  if (!entry || (expectedEntry && entry !== expectedEntry)) {
     return
   }
 
@@ -8282,6 +8339,27 @@ async function teardownPoolBackendAndWait(profile) {
   stopBackendChild(entry.process)
 
   await waitForBackendExit(entry.process)
+}
+
+function teardownPoolBackendAndWait(profile, expectedEntry = null) {
+  return profileBackendQueue.run(profile, () => teardownPoolBackendAndWaitUnlocked(profile, expectedEntry))
+}
+
+async function teardownPoolBackendsForConnectionApply(appliedProfile) {
+  const config = readAppliedDesktopConnectionConfig()
+  const primary = primaryProfileKey()
+  const affected = [...backendPool.keys()].filter(profile =>
+    connectionApplyAffectsPoolProfile({
+      appliedProfile,
+      hasExplicitProfileRoute: Boolean(
+        profileLocalOverride(config, profile) || profileHasRemoteConnection(config, profile)
+      ),
+      primaryProfile: primary,
+      profile
+    })
+  )
+
+  await Promise.all(affected.map(profile => teardownPoolBackendAndWait(profile)))
 }
 
 function stopAllPoolBackends() {
@@ -10492,9 +10570,18 @@ ipcMain.handle('hermes:connection-config:save', async (_event, payload) => {
 ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
   const config = coerceDesktopConnectionConfig(payload)
   writeDesktopConnectionConfig(config)
+  appliedConnectionConfig.promote(config)
 
   const key = connectionScopeKey(payload?.profile)
   const scope = key || ''
+  const primary = primaryProfileKey()
+  const primaryMode = profileLocalOverride(config, primary)
+    ? 'local'
+    : profileHasRemoteConnection(config, primary)
+      ? 'remote'
+      : config.mode
+
+  await teardownPoolBackendsForConnectionApply(key)
 
   await applyConnectionChange({
     cancelAndWait: value => sshBootstrapCoordinator.cancelAndWait(value),
@@ -10506,7 +10593,7 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
           // the local-install latch so unsupported/failure escape paths can re-home.
           bootstrapFailure = null
         },
-        mode: config.mode,
+        mode: primaryMode,
         notifyConnectionApplied: sendConnectionApplied,
         resumeFirstRunRemote: abandonFirstRunSetupChoiceForRemoteApply,
         teardownPrimaryBackend: teardownPrimaryBackendAndWait
@@ -10809,11 +10896,15 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
 }
 
 ipcMain.handle('hermes:api', async (_event, request) => {
+  // Validate exact request targets before any profile-delete or lifecycle side
+  // effect. Omission preserves ambient routing; only `local` is supported.
+  const forceLocal = gatewayRequestForcesLocal(request?.gatewayId)
+
   // Remote-profile session requests would otherwise hit the local primary off
   // each profile's on-disk state.db — fine for local profiles, but a remote
   // profile's sessions live on its remote host, so the UI's IDs 404 (or mutations
   // no-op) the moment they run there. Route reads + mutations to the remote.
-  const rerouted = await interceptSessionRequestForRemote(request)
+  const rerouted = forceLocal ? undefined : await interceptSessionRequestForRemote(request)
 
   if (rerouted !== undefined) {
     return rerouted
@@ -10827,10 +10918,22 @@ ipcMain.handle('hermes:api', async (_event, request) => {
   // backend calls ensure_hermes_home() which recreates the profile directory,
   // defeating the deletion and leaving a zombie process.
   const routeProfile = resolveRouteProfile(tornDownProfile, profile)
-  const connection = await ensureBackend(routeProfile)
+  const effectiveProfile = routeProfile || primaryProfileKey()
+  const selection = selectBackendSelection({
+    explicitLocal: profileHasLocalOverride(effectiveProfile),
+    explicitRemote: profileHasRemoteOverride(effectiveProfile),
+    forceLocal,
+    globalRemote: globalRemoteActive(),
+    primaryProfile: primaryProfileKey(),
+    profile: effectiveProfile
+  })
+  const connection = await ensureBackend(effectiveProfile, { selection })
   const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
-  const requestPath = pathWithGlobalRemoteProfile(request.path, profile, profileRouteOptions(profile))
+  const requestPath = pathWithGlobalRemoteProfile(request.path, profile, {
+    ...profileRouteOptions(profile),
+    globalRemote: !forceLocal && globalRemoteActive()
+  })
 
   const url = `${connection.baseUrl}${requestPath}`
 

--- a/apps/desktop/electron/profile-request-routing.test.ts
+++ b/apps/desktop/electron/profile-request-routing.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  connectionApplyAffectsPoolProfile,
+  createProfileAsyncQueue,
+  ensureCompatiblePoolEntry,
+  gatewayRequestForcesLocal,
+  selectBackendSelection
+} from './profile-request-routing'
+
+describe('profile request routing', () => {
+  it('makes gatewayId=local authoritative over ambient remote routing', () => {
+    expect(gatewayRequestForcesLocal('local')).toBe(true)
+    expect(
+      selectBackendSelection({
+        explicitRemote: true,
+        forceLocal: gatewayRequestForcesLocal('local'),
+        globalRemote: true,
+        primaryProfile: 'default',
+        profile: 'default'
+      })
+    ).toEqual({ route: 'local', target: 'pool' })
+  })
+
+  it('fails closed for unsupported gateway ids', () => {
+    expect(() => gatewayRequestForcesLocal('invented-peer')).toThrow('Unknown gateway target: invented-peer')
+  })
+
+  it('keeps omitted targets on current ambient primary routing', () => {
+    expect(gatewayRequestForcesLocal(undefined)).toBe(false)
+    expect(
+      selectBackendSelection({ globalRemote: true, primaryProfile: 'default', profile: 'default' })
+    ).toEqual({ route: 'remote-global', target: 'primary' })
+    expect(
+      selectBackendSelection({ globalRemote: true, primaryProfile: 'default', profile: 'work' })
+    ).toEqual({ route: 'remote-global', target: 'primary' })
+  })
+
+  it('keeps an explicit Local primary on primary and isolates non-primary overrides', () => {
+    expect(
+      selectBackendSelection({
+        explicitLocal: true,
+        globalRemote: true,
+        primaryProfile: 'work',
+        profile: 'work'
+      })
+    ).toEqual({ route: 'local', target: 'primary' })
+    expect(
+      selectBackendSelection({
+        explicitLocal: true,
+        globalRemote: true,
+        primaryProfile: 'default',
+        profile: 'work'
+      })
+    ).toEqual({ route: 'local', target: 'pool' })
+    expect(
+      selectBackendSelection({
+        explicitRemote: true,
+        globalRemote: true,
+        primaryProfile: 'default',
+        profile: 'work'
+      })
+    ).toEqual({ route: 'remote-profile', target: 'pool' })
+  })
+
+  it('reuses compatible routes and replaces incompatible pool entries', async () => {
+    type Entry = { id: string; routeIdentity: 'local' | 'remote-global' }
+    let current: Entry | undefined = { id: 'stale', routeIdentity: 'remote-global' }
+    const teardown = vi.fn(async (entry: Entry) => {
+      if (current === entry) {
+        current = undefined
+      }
+    })
+    const create = vi.fn(() => (current = { id: 'replacement', routeIdentity: 'local' }))
+
+    const replacement = await ensureCompatiblePoolEntry({ create, get: () => current, route: 'local', teardown })
+    const reused = await ensureCompatiblePoolEntry({ create, get: () => current, route: 'local', teardown })
+
+    expect(replacement).toBe(reused)
+    expect(teardown).toHaveBeenCalledOnce()
+    expect(create).toHaveBeenCalledOnce()
+  })
+
+  it('reuses a compatible replacement installed while stale teardown awaits', async () => {
+    type Entry = { id: string; routeIdentity: 'local' | 'remote-global' }
+    let current: Entry | undefined = { id: 'stale', routeIdentity: 'remote-global' }
+    let releaseTeardown!: () => void
+    const teardownGate = new Promise<void>(resolve => {
+      releaseTeardown = resolve
+    })
+    let teardownStarted!: () => void
+    const started = new Promise<void>(resolve => {
+      teardownStarted = resolve
+    })
+    const create = vi.fn(() => (current = { id: 'replacement', routeIdentity: 'local' }))
+    const teardown = vi.fn(async (entry: Entry) => {
+      if (current === entry) {
+        current = undefined
+      }
+
+      teardownStarted()
+      await teardownGate
+    })
+
+    const first = ensureCompatiblePoolEntry({ create, get: () => current, route: 'local', teardown })
+    await started
+    const second = await ensureCompatiblePoolEntry({ create, get: () => current, route: 'local', teardown })
+    releaseTeardown()
+
+    expect(await first).toBe(second)
+    expect(create).toHaveBeenCalledOnce()
+    expect(teardown).toHaveBeenCalledOnce()
+  })
+
+  it('serializes Apply teardown before a same-profile replacement is created', async () => {
+    const queue = createProfileAsyncQueue()
+    const events: string[] = []
+    let release!: () => void
+    const waiting = new Promise<void>(resolve => {
+      release = resolve
+    })
+    const apply = queue.run('work', async () => {
+      events.push('apply:start')
+      await waiting
+      events.push('apply:end')
+    })
+    const request = queue.run('work', () => {
+      events.push('request:create')
+    })
+
+    await Promise.resolve()
+    expect(events).toEqual(['apply:start'])
+    release()
+    await Promise.all([apply, request])
+    expect(events).toEqual(['apply:start', 'apply:end', 'request:create'])
+  })
+
+  it('invalidates only pool routes affected by Apply', () => {
+    const affected = (profile: string, appliedProfile: null | string, explicit = false) =>
+      connectionApplyAffectsPoolProfile({
+        appliedProfile,
+        hasExplicitProfileRoute: explicit,
+        primaryProfile: 'default',
+        profile
+      })
+
+    expect(affected('work', 'work', true)).toBe(true)
+    expect(affected('review', 'work', true)).toBe(false)
+    expect(affected('work', null, false)).toBe(true)
+    expect(affected('work', null, true)).toBe(false)
+  })
+})

--- a/apps/desktop/electron/profile-request-routing.ts
+++ b/apps/desktop/electron/profile-request-routing.ts
@@ -1,0 +1,122 @@
+/** Electron-free profile routing and lifecycle coordination. */
+
+export type BackendRouteIdentity = 'local' | 'remote-global' | 'remote-profile'
+export type BackendTarget = 'pool' | 'primary'
+
+export interface BackendSelection {
+  route: BackendRouteIdentity
+  target: BackendTarget
+}
+
+export interface EnsureBackendOptions {
+  selection?: BackendSelection
+}
+
+/** `local` is the only exact gateway target until Desktop has a registry. */
+export function gatewayRequestForcesLocal(gatewayId?: string): boolean {
+  const target = String(gatewayId || '').trim()
+
+  if (!target) {
+    return false
+  }
+
+  if (target === 'local') {
+    return true
+  }
+
+  throw new Error(`Unknown gateway target: ${target}`)
+}
+
+export function selectBackendSelection(options: {
+  explicitLocal?: boolean
+  explicitRemote?: boolean
+  forceLocal?: boolean
+  globalRemote?: boolean
+  primaryProfile: string
+  profile: string
+}): BackendSelection {
+  const route: BackendRouteIdentity =
+    options.forceLocal || options.explicitLocal
+      ? 'local'
+      : options.explicitRemote
+        ? 'remote-profile'
+        : options.globalRemote
+          ? 'remote-global'
+          : 'local'
+
+  const isPrimary = options.profile === options.primaryProfile
+  const target: BackendTarget = isPrimary
+    ? options.forceLocal
+      ? 'pool'
+      : 'primary'
+    : options.explicitLocal || options.explicitRemote || !options.globalRemote
+      ? 'pool'
+      : 'primary'
+
+  return { route, target }
+}
+
+export function createProfileAsyncQueue() {
+  const tails = new Map<string, Promise<void>>()
+
+  return {
+    run<T>(profile: string, operation: () => Promise<T> | T): Promise<T> {
+      const previous = tails.get(profile) ?? Promise.resolve()
+      let release!: () => void
+      const current = new Promise<void>(resolve => {
+        release = resolve
+      })
+
+      tails.set(profile, current)
+
+      return previous.then(operation).finally(() => {
+        release()
+
+        if (tails.get(profile) === current) {
+          tails.delete(profile)
+        }
+      })
+    }
+  }
+}
+
+export async function ensureCompatiblePoolEntry<T extends { routeIdentity: BackendRouteIdentity }>(options: {
+  create: () => T
+  get: () => T | undefined
+  route: BackendRouteIdentity
+  teardown: (entry: T) => Promise<void>
+  touch?: (entry: T) => void
+}): Promise<T> {
+  while (true) {
+    const existing = options.get()
+
+    if (!existing) {
+      return options.create()
+    }
+
+    if (existing.routeIdentity === options.route) {
+      options.touch?.(existing)
+
+      return existing
+    }
+
+    await options.teardown(existing)
+  }
+}
+
+export function connectionApplyAffectsPoolProfile(options: {
+  appliedProfile: null | string
+  hasExplicitProfileRoute: boolean
+  primaryProfile: string
+  profile: string
+}): boolean {
+  if (options.profile === options.primaryProfile) {
+    return true
+  }
+
+  if (options.appliedProfile) {
+    return options.profile === options.appliedProfile
+  }
+
+  return !options.hasExplicitProfileRoute
+}

--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -5,7 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ProfileInfo } from '@/types/hermes'
 
 const getConnectionConfig = vi.fn()
+const applyConnectionConfig = vi.fn()
 const saveConnectionConfig = vi.fn()
+const rehomeSecondaryGateway = vi.fn(async () => undefined)
 const profiles = atom<ProfileInfo[]>([])
 
 vi.mock('@/store/profile', () => ({
@@ -13,15 +15,26 @@ vi.mock('@/store/profile', () => ({
   refreshActiveProfile: vi.fn()
 }))
 
+vi.mock('@/store/gateway', () => ({ rehomeSecondaryGateway }))
+
 const localConnection = {
   cloudOrg: '',
   envOverride: false,
+  inherited: false,
   mode: 'local',
+  profileOverride: false,
   remoteAuthMode: 'token',
   remoteOauthConnected: false,
   remoteTokenPreview: null,
   remoteTokenSet: false,
-  remoteUrl: ''
+  remoteUrl: '',
+  secureTokenStorage: true,
+  sshHost: '',
+  sshKeyPath: '',
+  sshPort: null,
+  sshRemoteHermesPath: '',
+  sshRemoteProfile: '',
+  sshUser: ''
 }
 
 beforeEach(() => {
@@ -46,10 +59,11 @@ beforeEach(() => {
     }
   ])
   getConnectionConfig.mockResolvedValue(localConnection)
+  applyConnectionConfig.mockResolvedValue(localConnection)
   saveConnectionConfig.mockResolvedValue(localConnection)
   Object.defineProperty(window, 'hermesDesktop', {
     configurable: true,
-    value: { getConnectionConfig, saveConnectionConfig }
+    value: { applyConnectionConfig, getConnectionConfig, saveConnectionConfig }
   })
 })
 
@@ -59,7 +73,12 @@ afterEach(() => {
 })
 
 describe('GatewaySettings', () => {
-  it('labels local mode as default inheritance for a named profile', async () => {
+  it('renders Local and Inherit as distinct named-profile choices', async () => {
+    getConnectionConfig.mockImplementation(async profile =>
+      profile === 'work'
+        ? { ...localConnection, inherited: true, profile: 'work', profileOverride: false }
+        : localConnection
+    )
     const { GatewaySettings } = await import('./gateway-settings')
 
     render(<GatewaySettings />)
@@ -73,9 +92,18 @@ describe('GatewaySettings', () => {
     await waitFor(() => expect(getConnectionConfig).toHaveBeenLastCalledWith('work'))
     expect(await screen.findByText('Use default gateway')).toBeTruthy()
     expect(screen.getByText("Remove this profile's override and use the default connection.")).toBeTruthy()
-    expect(
-      screen.queryByText('Start a private Hermes backend on localhost. This is the default and works offline.')
-    ).toBeNull()
+    expect(screen.getByText('Local gateway')).toBeTruthy()
+    expect(screen.getByText('Start a private Hermes backend on localhost. This is the default and works offline.')).toBeTruthy()
+
+    const inheritCard = screen.getByRole('button', { name: /Use default gateway/ })
+
+    fireEvent.click(inheritCard)
+    await waitFor(() => expect(inheritCard.className).toContain('border-primary'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save for next restart' }))
+
+    await waitFor(() =>
+      expect(saveConnectionConfig).toHaveBeenCalledWith(expect.objectContaining({ inherit: true, profile: 'work' }))
+    )
   })
 
   it('shows and clears an SSH remote-profile mapping for a named Desktop profile', async () => {
@@ -117,5 +145,37 @@ describe('GatewaySettings', () => {
         })
       )
     )
+  })
+
+  it('applies and rehomes only the selected profile socket', async () => {
+    getConnectionConfig.mockImplementation(async profile =>
+      profile === 'work'
+        ? { ...localConnection, inherited: true, profile: 'work', profileOverride: false }
+        : localConnection
+    )
+    applyConnectionConfig.mockResolvedValue({
+      ...localConnection,
+      inherited: false,
+      profile: 'work',
+      profileOverride: true
+    })
+    const { GatewaySettings } = await import('./gateway-settings')
+
+    render(<GatewaySettings />)
+    fireEvent.click(await screen.findByRole('button', { name: 'work' }))
+    await waitFor(() => expect(getConnectionConfig).toHaveBeenLastCalledWith('work'))
+    const localCard = await screen.findByRole('button', { name: /Local gateway/ })
+
+    fireEvent.click(localCard)
+    await waitFor(() => expect(localCard.className).toContain('border-primary'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save and reconnect' }))
+
+    await waitFor(() =>
+      expect(applyConnectionConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: 'local', profile: 'work' })
+      )
+    )
+    expect(applyConnectionConfig.mock.calls[0]?.[0]).not.toHaveProperty('inherit')
+    await waitFor(() => expect(rehomeSecondaryGateway).toHaveBeenCalledWith('work'))
   })
 })

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -6,7 +6,13 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tip } from '@/components/ui/tooltip'
-import type { DesktopAuthProvider, DesktopCloudAgent, DesktopCloudOrg, DesktopConnectionProbeResult } from '@/global'
+import type {
+  DesktopAuthProvider,
+  DesktopCloudAgent,
+  DesktopCloudOrg,
+  DesktopConnectionConfig,
+  DesktopConnectionProbeResult
+} from '@/global'
 import { useI18n } from '@/i18n'
 import { ExternalLink } from '@/lib/external-link'
 import {
@@ -25,6 +31,7 @@ import {
 import { coerceRemoteUrlScheme } from '@/lib/remote-url'
 import { selectableCardClass } from '@/lib/selectable-card'
 import { cn } from '@/lib/utils'
+import { rehomeSecondaryGateway } from '@/store/gateway'
 import { notify, notifyError, readableError } from '@/store/notifications'
 import { $profiles, refreshActiveProfile } from '@/store/profile'
 
@@ -40,7 +47,9 @@ type CloudDiscoverStatus = 'idle' | 'loading' | 'done' | 'error'
 
 interface GatewaySettingsState {
   envOverride: boolean
+  inherited: boolean
   mode: Mode
+  profileOverride: boolean
   remoteAuthMode: AuthMode
   remoteOauthConnected: boolean
   remoteTokenPreview: string | null
@@ -65,7 +74,9 @@ const SSH_HOST_CUSTOM = '__custom__'
 
 const EMPTY_STATE: GatewaySettingsState = {
   envOverride: false,
+  inherited: false,
   mode: 'local',
+  profileOverride: false,
   remoteAuthMode: 'token',
   remoteOauthConnected: false,
   remoteTokenPreview: null,
@@ -176,9 +187,15 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
   const contextSeq = useRef(0)
   const [connectedCloudUrl, setConnectedCloudUrl] = useState('')
 
-  const acceptSavedConfig = (config: GatewaySettingsState) => {
-    setState(config)
-    setConnectedCloudUrl(savedCloudConnectionUrl(config))
+  const acceptSavedConfig = (config: DesktopConnectionConfig) => {
+    const next = {
+      ...config,
+      inherited: Boolean(config.inherited),
+      profileOverride: Boolean(config.profileOverride)
+    }
+
+    setState(next)
+    setConnectedCloudUrl(savedCloudConnectionUrl(next))
   }
 
   // When set, the plain-text opt-in dialog is open; `apply` remembers whether
@@ -455,6 +472,7 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
   }, [authMode, oauthConnected, remoteToken, state.remoteTokenSet, trimmedUrl])
 
   const payload = (allowPlainTextToken?: boolean) => ({
+    ...(scope !== null && state.inherited ? { inherit: true } : {}),
     mode: state.mode,
     profile: scope ?? undefined,
     remoteAuthMode: authMode,
@@ -489,6 +507,10 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
       const next = apply
         ? await window.hermesDesktop.applyConnectionConfig(payload(allowPlainTextToken))
         : await window.hermesDesktop.saveConnectionConfig(payload(allowPlainTextToken))
+
+      if (apply && scope !== null) {
+        await rehomeSecondaryGateway(scope)
+      }
 
       if (seq !== saveSeq.current) {
         return
@@ -895,6 +917,10 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
         cloudOrg: cloudOrgRef.current ?? undefined
       })
 
+      if (scope !== null) {
+        await rehomeSecondaryGateway(scope)
+      }
+
       if (seq !== contextSeq.current) {
         return
       }
@@ -1108,39 +1134,57 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
         <div className="text-[length:var(--conversation-caption-font-size)] font-medium text-(--ui-text-secondary)">
           {g.modeTitle}
         </div>
-        <div className="grid auto-rows-fr grid-cols-1 gap-2 sm:grid-cols-2 min-[72rem]:grid-cols-4">
+        <div className="grid auto-rows-fr grid-cols-1 gap-2 sm:grid-cols-2 min-[72rem]:grid-cols-5">
+          {scope !== null ? (
+            <ModeCard
+              active={state.inherited}
+              description={g.inheritDesc}
+              disabled={state.envOverride}
+              icon={RefreshCw}
+              onSelect={() => setState(current => ({ ...current, inherited: true, profileOverride: false }))}
+              title={g.inheritTitle}
+            />
+          ) : null}
           <ModeCard
-            active={state.mode === 'local'}
-            description={scope === null ? g.localDesc : g.inheritDesc}
+            active={state.mode === 'local' && (scope === null || state.profileOverride)}
+            description={g.localDesc}
             disabled={state.envOverride}
             icon={Monitor}
-            onSelect={() => setState(current => ({ ...current, mode: 'local' }))}
-            title={scope === null ? g.localTitle : g.inheritTitle}
+            onSelect={() =>
+              setState(current => ({ ...current, inherited: false, mode: 'local', profileOverride: true }))
+            }
+            title={g.localTitle}
           />
           <ModeCard
-            active={state.mode === 'cloud'}
+            active={state.mode === 'cloud' && (scope === null || state.profileOverride)}
             description={g.cloudDesc}
             disabled={state.envOverride}
             icon={Cloud}
-            onSelect={() => setState(current => ({ ...current, mode: 'cloud' }))}
+            onSelect={() =>
+              setState(current => ({ ...current, inherited: false, mode: 'cloud', profileOverride: true }))
+            }
             title={g.cloudTitle}
           />
           <ModeCard
-            active={state.mode === 'remote'}
+            active={state.mode === 'remote' && (scope === null || state.profileOverride)}
             description={g.remoteDesc}
             disabled={state.envOverride}
             hint={g.remoteAuthHint}
             icon={Globe}
-            onSelect={() => setState(current => ({ ...current, mode: 'remote' }))}
+            onSelect={() =>
+              setState(current => ({ ...current, inherited: false, mode: 'remote', profileOverride: true }))
+            }
             title={g.remoteTitle}
           />
           <ModeCard
-            active={state.mode === 'ssh'}
+            active={state.mode === 'ssh' && (scope === null || state.profileOverride)}
             description={g.sshDesc}
             disabled={state.envOverride}
             hint={g.sshTrustHint}
             icon={Terminal}
-            onSelect={() => setState(current => ({ ...current, mode: 'ssh' }))}
+            onSelect={() =>
+              setState(current => ({ ...current, inherited: false, mode: 'ssh', profileOverride: true }))
+            }
             title={g.sshTitle}
           />
         </div>

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -565,6 +565,9 @@ export interface DesktopActiveProfile {
 
 export interface DesktopConnectionConfig {
   envOverride: boolean
+  // Named profile scopes distinguish an explicit entry from inherited global
+  // routing. Global scope always reports false for both fields.
+  inherited?: boolean
   // The saved connection mode. 'cloud' is a Hermes Cloud connection: it carries
   // a remote-shaped block (remoteUrl = the selected agent's dashboardUrl,
   // remoteAuthMode 'oauth') but is remembered as cloud so settings reopens into
@@ -574,6 +577,7 @@ export interface DesktopConnectionConfig {
   // The profile this config describes, or null for the global/default
   // connection. Per-profile entries let a profile point at its own backend.
   profile: null | string
+  profileOverride?: boolean
   remoteAuthMode: 'oauth' | 'token'
   remoteOauthConnected: boolean
   remoteTokenPreview: string | null
@@ -604,6 +608,8 @@ export interface DesktopConnectionConfigInput {
   // When set, the save/apply/test targets this profile's per-profile remote
   // override instead of the global connection.
   profile?: null | string
+  // Remove only this named profile's entry and resume global routing.
+  inherit?: boolean
   remoteAuthMode?: 'oauth' | 'token'
   remoteToken?: string
   // When true and secure (OS-keychain) storage is unavailable, persist the
@@ -819,6 +825,9 @@ export type DesktopBootstrapEvent =
 
 export interface HermesApiRequest {
   path: string
+  // Exact backend target. `local` is supported; unknown ids fail closed.
+  // Omit to preserve the active ambient connection.
+  gatewayId?: string
   method?: string
   body?: unknown
   // Single-file multipart upload (FastAPI UploadFile endpoints). Mutually

--- a/apps/desktop/src/store/gateway.test.ts
+++ b/apps/desktop/src/store/gateway.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const instances: FakeGateway[] = []
+
+class FakeGateway {
+  connectionState = 'closed'
+  close = vi.fn(() => {
+    this.connectionState = 'closed'
+  })
+  connect = vi.fn(async () => {
+    this.connectionState = 'open'
+  })
+  onEvent = vi.fn(() => () => undefined)
+  onState = vi.fn(() => () => undefined)
+
+  constructor() {
+    instances.push(this)
+  }
+}
+
+vi.mock('@hermes/shared', () => ({
+  resolveGatewayWsUrl: vi.fn(async () => 'ws://local.test/api/ws')
+}))
+vi.mock('@/hermes', () => ({ HermesGateway: FakeGateway }))
+vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
+vi.mock('@/store/session', () => ({ setGatewayState: vi.fn() }))
+
+describe('profile gateway rehome', () => {
+  beforeEach(() => {
+    instances.length = 0
+    vi.resetModules()
+  })
+
+  it('discards a stale open racing an exact-profile Apply and keeps the replacement', async () => {
+    let resolveFirst!: (value: { baseUrl: string; mode: 'local'; token: string; wsUrl: string }) => void
+    const firstConnection = new Promise<{ baseUrl: string; mode: 'local'; token: string; wsUrl: string }>(resolve => {
+      resolveFirst = resolve
+    })
+    const getConnection = vi
+      .fn()
+      .mockReturnValueOnce(firstConnection)
+      .mockResolvedValue({ baseUrl: 'http://local.test', mode: 'local', token: 'new', wsUrl: 'ws://new' })
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { getConnection, touchBackend: vi.fn(async () => undefined) }
+    })
+
+    const { openGatewayForProfile, rehomeSecondaryGateway, setPrimaryGateway } = await import('./gateway')
+
+    setPrimaryGateway(new FakeGateway() as never, 'default')
+    const staleOpen = openGatewayForProfile('work')
+    await vi.waitFor(() => expect(getConnection).toHaveBeenCalledTimes(1))
+
+    const rehome = rehomeSecondaryGateway('work')
+    await vi.waitFor(() => expect(getConnection).toHaveBeenCalledTimes(2))
+    resolveFirst({ baseUrl: 'http://stale.test', mode: 'local', token: 'old', wsUrl: 'ws://old' })
+    await Promise.all([staleOpen, rehome])
+
+    const stale = instances[1]
+    const replacement = instances[2]
+
+    expect(stale.connect).not.toHaveBeenCalled()
+    expect(stale.close).toHaveBeenCalledOnce()
+    expect(replacement.connect).toHaveBeenCalledOnce()
+    expect(replacement.close).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -28,6 +28,7 @@ interface RegistryConfig {
 
 // ── Secondary (pool) backends ──────────────────────────────────────────────
 interface Secondary {
+  generation: number
   profile: string
   gateway: HermesGateway
   offEvent: () => void
@@ -169,15 +170,37 @@ function clearTimer(entry: Secondary): void {
 
 async function openSecondary(entry: Secondary): Promise<void> {
   const desktop = window.hermesDesktop
+  const generation = entry.generation
 
   if (!desktop) {
     return
   }
 
   const conn = await desktop.getConnection(entry.profile)
+
+  if (!isCurrentSecondaryOpen(entry, generation)) {
+    return
+  }
+
   const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+
+  if (!isCurrentSecondaryOpen(entry, generation)) {
+    return
+  }
+
   await entry.gateway.connect(wsUrl)
+
+  if (!isCurrentSecondaryOpen(entry, generation)) {
+    entry.gateway.close()
+
+    return
+  }
+
   void desktop.touchBackend?.(entry.profile).catch(() => undefined)
+}
+
+function isCurrentSecondaryOpen(entry: Secondary, generation: number): boolean {
+  return entry.wantOpen && entry.generation === generation && g.secondaries.get(entry.profile) === entry
 }
 
 function scheduleReconnect(entry: Secondary): void {
@@ -220,6 +243,7 @@ function createSecondary(profile: string): Secondary {
   const gateway = new HermesGateway()
 
   const entry: Secondary = {
+    generation: 0,
     profile,
     gateway,
     offEvent: () => {},
@@ -301,6 +325,36 @@ export async function ensureGatewayForProfile(profile: string): Promise<void> {
   setActive(key)
 }
 
+/** Close and reconnect only one named profile after its routing Apply. */
+export async function rehomeSecondaryGateway(profile: string): Promise<void> {
+  const key = normKey(profile)
+
+  if (key === g.primaryProfile) {
+    return
+  }
+
+  const previous = g.secondaries.get(key)
+
+  if (!previous) {
+    return
+  }
+
+  disposeSecondary(previous)
+  g.secondaries.delete(key)
+
+  const replacement = createSecondary(key)
+
+  try {
+    await openSecondary(replacement)
+  } catch {
+    scheduleReconnect(replacement)
+  }
+
+  if (g.activeKey === key) {
+    setActive(key)
+  }
+}
+
 // Reconnect the active gateway after a transient request failure. Primary
 // reconnects are owned by use-gateway-boot, so we only drive secondaries here.
 export async function ensureActiveGatewayOpen(): Promise<HermesGateway | null> {
@@ -350,6 +404,7 @@ export function touchSecondaryGateways(): void {
 // socket. Caller handles removal from the map.
 function disposeSecondary(entry: Secondary): void {
   entry.wantOpen = false
+  entry.generation += 1
   clearTimer(entry)
   entry.offEvent()
   entry.offState()


### PR DESCRIPTION
## Summary
- distinguish per-profile Local from Inherit in Desktop settings
- keep persisted/staged connection config separate from the applied routing snapshot
- route explicit `gatewayId=local` requests through an exact local backend and fail closed for unknown targets
- serialize per-profile backend replacement and rehome only the affected renderer socket

This is the current-main Desktop-routing recut of the relevant seam from #39337. Backend session-origin metadata is intentionally separate in #85601.

## Verification
- Electron focused Vitest: 86 passed
- UI focused Vitest: 4 passed
- full Desktop typecheck: passed
- changed-file ESLint: 0 errors (19 formatting warnings)
- `git diff --check`: passed

No deployment or runtime configuration change was performed.