### PR TITLE
fix(providers): support custom opencode-go-* provider routing and grok models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4184,12 +4184,18 @@ def normalize_opencode_model_id(provider_id: Optional[str], model_id: Optional[s
     """Normalize OpenCode config IDs to the bare model slug used in API requests."""
     provider = normalize_provider(provider_id)
     current = str(model_id or "").strip()
-    if not current or provider not in {"opencode-zen", "opencode-go"}:
+    is_opencode = provider in {"opencode-zen", "opencode-go"} or (
+        isinstance(provider_id, str) and provider_id.lower().startswith("opencode-go")
+    )
+    if not current or not is_opencode:
         return current
 
-    prefix = f"{provider}/"
-    if current.lower().startswith(prefix):
+    prefix = f"{provider_id}/" if provider_id else f"{provider}/"
+    if current.lower().startswith(prefix.lower()):
         return current[len(prefix):]
+    fallback_prefix = f"{provider}/"
+    if current.lower().startswith(fallback_prefix.lower()):
+        return current[len(fallback_prefix):]
     return current
 
 
@@ -4198,8 +4204,8 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
 
     OpenCode routes different models behind different API surfaces:
 
-    - GPT-5 / Codex models on Zen use ``/v1/responses``
-    - GPT models on Go (gpt-5.6-luna) use ``/v1/responses``
+    - GPT-5 / Codex / Grok models on Zen use ``/v1/responses``
+    - GPT / Grok models on Go (gpt-5.6-luna, grok-4.5) use ``/v1/responses``
     - Claude models on Zen use ``/v1/messages``
     - MiniMax and Qwen models on Go use ``/v1/messages``
     - GLM / Kimi / DeepSeek / MiMo on Go use ``/v1/chat/completions``
@@ -4215,9 +4221,12 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
     if not normalized:
         return "chat_completions"
 
-    if provider == "opencode-go":
-        if normalized.startswith("gpt-"):
-            # GPT models on Go (gpt-5.6-luna) are served via /v1/responses
+    is_opencode_go = provider == "opencode-go" or (
+        isinstance(provider_id, str) and provider_id.lower().startswith("opencode-go")
+    )
+    if is_opencode_go:
+        if normalized.startswith("gpt-") or normalized.startswith("grok-"):
+            # GPT and Grok models on Go (gpt-5.6-luna, grok-4.5) are served via /v1/responses
             # per the published Go endpoint table, same as GPT on Zen:
             # https://opencode.ai/docs/go/#endpoints
             return "codex_responses"
@@ -4232,7 +4241,7 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
     if provider == "opencode-zen":
         if normalized.startswith("claude-"):
             return "anthropic_messages"
-        if normalized.startswith("gpt-"):
+        if normalized.startswith("gpt-") or normalized.startswith("grok-"):
             return "codex_responses"
         if normalized.startswith("qwen"):
             # Qwen models on Zen moved to /v1/messages per the published
@@ -4268,7 +4277,10 @@ def normalize_opencode_base_url(
     if not url:
         return url
     provider = normalize_provider(provider_id)
-    if provider not in {"opencode-zen", "opencode-go"}:
+    is_opencode = provider in {"opencode-zen", "opencode-go"} or (
+        isinstance(provider_id, str) and provider_id.lower().startswith("opencode-go")
+    )
+    if not is_opencode:
         return url
 
     import re as _re

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4185,7 +4185,7 @@ def normalize_opencode_model_id(provider_id: Optional[str], model_id: Optional[s
     provider = normalize_provider(provider_id)
     current = str(model_id or "").strip()
     is_opencode = provider in {"opencode-zen", "opencode-go"} or (
-        isinstance(provider_id, str) and provider_id.lower().startswith("opencode-go")
+        isinstance(provider_id, str) and provider_id.lower().startswith(("opencode-go", "opencode-zen"))
     )
     if not current or not is_opencode:
         return current
@@ -4238,7 +4238,10 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
             return "anthropic_messages"
         return "chat_completions"
 
-    if provider == "opencode-zen":
+    is_opencode_zen = provider == "opencode-zen" or (
+        isinstance(provider_id, str) and provider_id.lower().startswith("opencode-zen")
+    )
+    if is_opencode_zen:
         if normalized.startswith("claude-"):
             return "anthropic_messages"
         if normalized.startswith("gpt-") or normalized.startswith("grok-"):
@@ -4278,7 +4281,7 @@ def normalize_opencode_base_url(
         return url
     provider = normalize_provider(provider_id)
     is_opencode = provider in {"opencode-zen", "opencode-go"} or (
-        isinstance(provider_id, str) and provider_id.lower().startswith("opencode-go")
+        isinstance(provider_id, str) and provider_id.lower().startswith(("opencode-go", "opencode-zen"))
     )
     if not is_opencode:
         return url

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -543,7 +543,10 @@ def _resolve_runtime_from_pool_entry(
             if cfg_base_url:
                 base_url = cfg_base_url
         configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-        if provider in {"opencode-zen", "opencode-go"}:
+        is_opencode_provider = provider in {"opencode-zen", "opencode-go"} or (
+            isinstance(provider, str) and provider.startswith("opencode-go")
+        )
+        if is_opencode_provider:
             # Re-derive api_mode from the effective model rather than the
             # persisted api_mode: the opencode providers serve both
             # anthropic_messages and chat_completions models, so the previous
@@ -564,7 +567,10 @@ def _resolve_runtime_from_pool_entry(
     # symmetrically: strip /v1 for anthropic_messages, re-append it for
     # chat_completions / codex_responses (heals a stripped URL persisted to
     # model.base_url by an earlier switch into an anthropic-routed model).
-    if provider in {"opencode-zen", "opencode-go"}:
+    is_opencode_provider = provider in {"opencode-zen", "opencode-go"} or (
+        isinstance(provider, str) and provider.startswith("opencode-go")
+    )
+    if is_opencode_provider:
         from hermes_cli.models import normalize_opencode_base_url
 
         base_url = normalize_opencode_base_url(provider, api_mode, base_url)
@@ -2244,7 +2250,10 @@ def resolve_runtime_provider(
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             # Only honor persisted api_mode when it belongs to the same provider family.
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if provider in {"opencode-zen", "opencode-go"}:
+            is_opencode_provider = provider in {"opencode-zen", "opencode-go"} or (
+                isinstance(provider, str) and provider.startswith("opencode-go")
+            )
+            if is_opencode_provider:
                 # opencode-zen/go must always re-derive api_mode from the
                 # target model (not the stale persisted api_mode), because
                 # the same provider serves both anthropic_messages
@@ -2266,7 +2275,10 @@ def resolve_runtime_provider(
                     provider, base_url, target_model or model_cfg.get("default", "")
                 )
         # Normalize the /v1 suffix for OpenCode by API mode (see comment above).
-        if provider in {"opencode-zen", "opencode-go"}:
+        is_opencode_provider = provider in {"opencode-zen", "opencode-go"} or (
+            isinstance(provider, str) and provider.startswith("opencode-go")
+        )
+        if is_opencode_provider:
             from hermes_cli.models import normalize_opencode_base_url
             base_url = normalize_opencode_base_url(provider, api_mode, base_url)
         if provider == "lmstudio":

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -544,7 +544,7 @@ def _resolve_runtime_from_pool_entry(
                 base_url = cfg_base_url
         configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
         is_opencode_provider = provider in {"opencode-zen", "opencode-go"} or (
-            isinstance(provider, str) and provider.startswith("opencode-go")
+            isinstance(provider, str) and provider.lower().startswith(("opencode-go", "opencode-zen"))
         )
         if is_opencode_provider:
             # Re-derive api_mode from the effective model rather than the
@@ -568,7 +568,7 @@ def _resolve_runtime_from_pool_entry(
     # chat_completions / codex_responses (heals a stripped URL persisted to
     # model.base_url by an earlier switch into an anthropic-routed model).
     is_opencode_provider = provider in {"opencode-zen", "opencode-go"} or (
-        isinstance(provider, str) and provider.startswith("opencode-go")
+        isinstance(provider, str) and provider.lower().startswith(("opencode-go", "opencode-zen"))
     )
     if is_opencode_provider:
         from hermes_cli.models import normalize_opencode_base_url
@@ -2251,7 +2251,7 @@ def resolve_runtime_provider(
             # Only honor persisted api_mode when it belongs to the same provider family.
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
             is_opencode_provider = provider in {"opencode-zen", "opencode-go"} or (
-                isinstance(provider, str) and provider.startswith("opencode-go")
+                isinstance(provider, str) and provider.lower().startswith(("opencode-go", "opencode-zen"))
             )
             if is_opencode_provider:
                 # opencode-zen/go must always re-derive api_mode from the
@@ -2276,7 +2276,7 @@ def resolve_runtime_provider(
                 )
         # Normalize the /v1 suffix for OpenCode by API mode (see comment above).
         is_opencode_provider = provider in {"opencode-zen", "opencode-go"} or (
-            isinstance(provider, str) and provider.startswith("opencode-go")
+            isinstance(provider, str) and provider.lower().startswith(("opencode-go", "opencode-zen"))
         )
         if is_opencode_provider:
             from hermes_cli.models import normalize_opencode_base_url

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -272,6 +272,14 @@ class TestCopilotNormalization:
         # GPT models on Go are Responses-only (Go endpoint table).
         assert opencode_model_api_mode("opencode-go", "gpt-5.6-luna") == "codex_responses"
         assert opencode_model_api_mode("opencode-go", "opencode-go/gpt-5.6-luna") == "codex_responses"
+        # Grok models on Go are Responses-only.
+        assert opencode_model_api_mode("opencode-go", "grok-4.5") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/grok-4.5") == "codex_responses"
+        # Custom opencode-go-* providers route according to opencode-go rules.
+        assert opencode_model_api_mode("opencode-go-bridge", "grok-4.5") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go-bridge", "opencode-go-bridge/grok-4.5") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go-bridge", "minimax-m2.5") == "anthropic_messages"
+        assert opencode_model_api_mode("opencode-go-bridge", "deepseek-v4-flash") == "chat_completions"
 
 
 class TestNormalizeOpencodeBaseUrl:

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -280,6 +280,14 @@ class TestCopilotNormalization:
         assert opencode_model_api_mode("opencode-go-bridge", "opencode-go-bridge/grok-4.5") == "codex_responses"
         assert opencode_model_api_mode("opencode-go-bridge", "minimax-m2.5") == "anthropic_messages"
         assert opencode_model_api_mode("opencode-go-bridge", "deepseek-v4-flash") == "chat_completions"
+        # Case-insensitive provider ID handling (e.g. OpenCode-Go-Bridge).
+        assert opencode_model_api_mode("OpenCode-Go-Bridge", "grok-4.5") == "codex_responses"
+        assert opencode_model_api_mode("OpenCode-Go-Bridge", "minimax-m2.5") == "anthropic_messages"
+        # Custom opencode-zen-* providers route according to opencode-zen rules.
+        assert opencode_model_api_mode("opencode-zen-custom", "claude-3-5-sonnet") == "anthropic_messages"
+        assert opencode_model_api_mode("opencode-zen-custom", "gpt-5") == "codex_responses"
+        assert opencode_model_api_mode("opencode-zen-custom", "grok-4.5") == "codex_responses"
+        assert opencode_model_api_mode("OpenCode-Zen-Custom", "claude-3-7-sonnet") == "anthropic_messages"
 
 
 class TestNormalizeOpencodeBaseUrl:


### PR DESCRIPTION
## What does this PR do?

Custom provider configurations whose names start with `opencode-go-` (e.g., `opencode-go-bridge` pointing to `https://opencode.ai/zen/go/v1`) were previously normalized as generic `custom` providers. This caused models requiring the `/v1/responses` endpoint (such as `grok-4.5` and `gpt-5.6-luna`) to incorrectly fall back to `/v1/chat/completions`, failing with HTTP 503 Endpoint Unavailable.

This PR:
1. Recognizes `grok-*` models on `opencode-go` and `opencode-zen` as `codex_responses`.
2. Extends `normalize_opencode_model_id`, `opencode_model_api_mode`, and `normalize_opencode_base_url` to match custom `opencode-go-*` provider names.
3. Correctly re-derives `api_mode` and base URL normalization in `hermes_cli/runtime_provider.py` for providers matching `opencode-go-*`.
4. Adds regression unit tests covering `grok-*` models and custom `opencode-go-bridge` provider routing.

## Related Issue

Fixes #85589

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`:
  - Added `grok-*` mapping to `codex_responses` for `opencode-go` and `opencode-zen`.
  - Updated `normalize_opencode_model_id`, `opencode_model_api_mode`, and `normalize_opencode_base_url` to recognize custom `opencode-go-*` providers.
- `hermes_cli/runtime_provider.py`:
  - Enabled dynamic API mode resolution and base URL normalization for `opencode-go-*` custom providers.
- `tests/hermes_cli/test_model_validation.py`:
  - Added unit test assertions in `test_opencode_go_api_modes_match_docs` for `grok-4.5` and `opencode-go-bridge`.

## How to Test

1. Run unit test suite:
   ```bash
   pytest tests/hermes_cli/test_model_validation.py -v
   ```
   Confirm all 29 tests pass cleanly.
2. Verify `opencode_model_api_mode("opencode-go-bridge", "grok-4.5")` resolves to `"codex_responses"`.
3. Verify `opencode_model_api_mode("opencode-go-bridge", "minimax-m2.5")` resolves to `"anthropic_messages"`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A