### PR TITLE
feat(skills): add metadata-only topology routing and audit

### DIFF
--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -75,9 +75,11 @@ def _category(fm: dict[str, Any], skill_md: Path) -> str:
 
 
 def _iter_skill_files(roots: list[tuple[str, Path]]):
+    from agent.skill_utils import iter_skill_index_files
+
     for source, root in roots:
         if root.exists():
-            for path in root.rglob("SKILL.md"):
+            for path in iter_skill_index_files(root, "SKILL.md"):
                 yield source, path
 
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -26,9 +26,11 @@ from agent.skill_utils import (
     extract_skill_conditions,
     extract_skill_description,
     get_all_skills_dirs,
+    get_central_private_skill_roots,
     get_disabled_skill_names,
     iter_skill_index_files,
     org_id_of_path,
+    path_is_within_roots,
     parse_frontmatter,
     read_active_org_id,
     skill_matches_environment,
@@ -1480,9 +1482,10 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-# v2: entries gained org provenance fields (org_id/org_author/rel_dir) for M2
+# v3: snapshots bind to the configured MCP-authority boundary. Entries gained
+# org provenance fields (org_id/org_author/rel_dir) for M2 in v2.
 # org-shared skills; older snapshots are discarded and rebuilt.
-_SKILLS_SNAPSHOT_VERSION = 2
+_SKILLS_SNAPSHOT_VERSION = 3
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1500,7 +1503,10 @@ def clear_skills_system_prompt_cache(*, clear_snapshot: bool = False) -> None:
             logger.debug("Could not remove skills prompt snapshot: %s", e)
 
 
-def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
+def _build_skills_manifest(
+    skills_dir: Path,
+    authority_roots: tuple[Path, ...],
+) -> dict[str, list[int]]:
     """Build an mtime/size manifest of all SKILL.md and DESCRIPTION.md files.
 
     Org mirrors (M2): only the ACTIVE org's mirror participates, and the
@@ -1508,6 +1514,8 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
     invalidates the snapshot even when no SKILL.md changed.
     """
     manifest: dict[str, list[int]] = {}
+    if path_is_within_roots(skills_dir, authority_roots):
+        return manifest
     skills_dir_str = str(skills_dir)
     base = os.path.join(skills_dir_str, "")
     prefix_len = len(base)
@@ -1522,6 +1530,10 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
     except OSError:
         pass
     for root, dirs, files in os.walk(skills_dir_str, followlinks=True):
+        root_path = Path(root)
+        if path_is_within_roots(root_path, authority_roots):
+            dirs[:] = []
+            continue
         has_skill_md = "SKILL.md" in files
         if root == skills_dir_str and ORG_MIRROR_DIR_NAME in dirs and active_org is None:
             dirs.remove(ORG_MIRROR_DIR_NAME)
@@ -1532,6 +1544,7 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
             for d in dirs
             if d not in EXCLUDED_SKILL_DIRS
             and not (has_skill_md and d in SKILL_SUPPORT_DIRS)
+            and not path_is_within_roots(root_path / d, authority_roots)
         ]
         for filename in ("SKILL.md", "DESCRIPTION.md"):
             if filename not in files:
@@ -1545,7 +1558,7 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
     return manifest
 
 
-def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
+def _load_skills_snapshot(skills_dir: Path, authority_boundary) -> Optional[dict]:
     """Load the disk snapshot if it exists and its manifest still matches."""
     snapshot_path = _skills_prompt_snapshot_path()
     if not snapshot_path.exists():
@@ -1558,7 +1571,11 @@ def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
         return None
     if snapshot.get("version") != _SKILLS_SNAPSHOT_VERSION:
         return None
-    if snapshot.get("manifest") != _build_skills_manifest(skills_dir):
+    if snapshot.get("authority_signature") != list(authority_boundary.signature[1:]):
+        return None
+    if snapshot.get("manifest") != _build_skills_manifest(
+        skills_dir, authority_boundary.roots
+    ):
         return None
     return snapshot
 
@@ -1568,11 +1585,13 @@ def _write_skills_snapshot(
     manifest: dict[str, list[int]],
     skill_entries: list[dict],
     category_descriptions: dict[str, str],
+    authority_boundary,
 ) -> None:
     """Persist skill metadata to disk for fast cold-start reuse."""
     payload = {
         "version": _SKILLS_SNAPSHOT_VERSION,
         "manifest": manifest,
+        "authority_signature": list(authority_boundary.signature[1:]),
         "skills": skill_entries,
         "category_descriptions": category_descriptions,
     }
@@ -1741,6 +1760,7 @@ def build_skills_system_prompt(
     """
     skills_dir = get_skills_dir()
     external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
+    authority_boundary = get_central_private_skill_roots()
 
     if not skills_dir.exists() and not external_dirs:
         return ""
@@ -1753,6 +1773,8 @@ def build_skills_system_prompt(
     cache_key = (
         str(skills_dir),
         tuple(str(d) for d in external_dirs),
+        authority_boundary.signature,
+        tuple(str(root) for root in authority_boundary.roots),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
@@ -1766,7 +1788,7 @@ def build_skills_system_prompt(
             return cached
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
-    snapshot = _load_skills_snapshot(skills_dir)
+    snapshot = _load_skills_snapshot(skills_dir, authority_boundary)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
@@ -1863,9 +1885,10 @@ def build_skills_system_prompt(
 
         _write_skills_snapshot(
             skills_dir,
-            _build_skills_manifest(skills_dir),
+            _build_skills_manifest(skills_dir, authority_boundary.roots),
             skill_entries,
             category_descriptions,
+            authority_boundary,
         )
 
     # ── External skill directories ─────────────────────────────────────

--- a/agent/skill_topology.py
+++ b/agent/skill_topology.py
@@ -462,9 +462,11 @@ def plan_skill_route(
         }
 
     selected: list[str] = []
+    selected_tier_score: int | None = None
     roles: dict[str, str] = {}
     scores: dict[str, int] = {}
     reasons_by_name: dict[str, list[str]] = {}
+
     def dependency_closure(
         root: Mapping[str, Any],
     ) -> tuple[list[str], list[dict[str, Any]], list[dict[str, Any]]]:
@@ -578,11 +580,14 @@ def plan_skill_route(
         )
 
     for negative_score, _, _, root, root_reasons in ranked:
+        root_score = -negative_score
+        if selected_tier_score is not None and root_score != selected_tier_score:
+            break
         root_name = _record_name(root)
         root_key = _name_key(root_name)
         if root_name in selected:
             roles[root_key] = "root"
-            scores[root_key] = -negative_score
+            scores[root_key] = root_score
             reasons_by_name[root_key] = root_reasons
             continue
 
@@ -630,12 +635,13 @@ def plan_skill_route(
             )
             continue
 
+        selected_tier_score = root_score
         selected.extend(new_names)
         for name in closure:
             key = _name_key(name)
             if key == root_key:
                 roles[key] = "root"
-                scores[key] = -negative_score
+                scores[key] = root_score
                 reasons_by_name[key] = root_reasons
             elif key not in roles:
                 roles[key] = "required"

--- a/agent/skill_topology.py
+++ b/agent/skill_topology.py
@@ -1,0 +1,708 @@
+"""Pure parsing, auditing, and local route planning for skill topology.
+
+This module deliberately has no profile, CLI, tool-registry, or execution
+dependencies.  Callers supply metadata for skills that already passed Hermes'
+normal platform, environment, disabled-skill, and permission gates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import re
+from typing import Any, Iterable, Mapping, Sequence
+
+
+TOPOLOGY_LIST_FIELDS = (
+    "domains",
+    "inputs",
+    "outputs",
+    "requires",
+    "follows",
+    "precedes",
+    "conflicts",
+    "permissions",
+)
+TOPOLOGY_FIELDS = (*TOPOLOGY_LIST_FIELDS, "lifecycle")
+LIFECYCLES = ("experimental", "candidate", "stable", "deprecated")
+REFERENCE_FIELDS = ("requires", "follows", "precedes", "conflicts")
+ROUTE_ARTIFACT_VERSION = 1
+DEFAULT_ROUTE_LIMIT = 5
+DEFAULT_ROUTE_BUDGET_CHARS = 24_000
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def _normalize_values(value: Any) -> tuple[str, ...]:
+    """Normalize a scalar/list into stable, lowercase, de-duplicated values."""
+    if value is None:
+        return ()
+    if isinstance(value, (set, frozenset)):
+        values = sorted(value, key=lambda item: str(item).casefold())
+    else:
+        values = value if isinstance(value, (list, tuple)) else (value,)
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in values:
+        if item is None or isinstance(item, Mapping):
+            continue
+        normalized = str(item).strip().casefold()
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            result.append(normalized)
+    return tuple(result)
+
+
+@dataclass(frozen=True)
+class SkillTopology:
+    """Normalized optional ``metadata.hermes.topology`` manifest."""
+
+    domains: tuple[str, ...] = ()
+    inputs: tuple[str, ...] = ()
+    outputs: tuple[str, ...] = ()
+    requires: tuple[str, ...] = ()
+    follows: tuple[str, ...] = ()
+    precedes: tuple[str, ...] = ()
+    conflicts: tuple[str, ...] = ()
+    permissions: tuple[str, ...] = ()
+    lifecycle: str | None = None
+    declared: bool = False
+    invalid_lifecycle: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return only the public V1 schema, with stable keys and list values."""
+        return {
+            "domains": list(self.domains),
+            "inputs": list(self.inputs),
+            "outputs": list(self.outputs),
+            "requires": list(self.requires),
+            "follows": list(self.follows),
+            "precedes": list(self.precedes),
+            "conflicts": list(self.conflicts),
+            "permissions": list(self.permissions),
+            "lifecycle": self.lifecycle,
+        }
+
+
+def parse_topology(value: Any) -> SkillTopology:
+    """Parse optional topology metadata without invalidating the skill.
+
+    Unknown keys and malformed container values are ignored.  An invalid
+    lifecycle is retained separately so graph audits can diagnose it while the
+    containing SKILL.md remains loadable and backward compatible.
+    """
+    if isinstance(value, SkillTopology):
+        return value
+    if not isinstance(value, Mapping):
+        return SkillTopology()
+
+    normalized = {
+        field: _normalize_values(value.get(field)) for field in TOPOLOGY_LIST_FIELDS
+    }
+    lifecycle_values = _normalize_values(value.get("lifecycle"))
+    lifecycle_value = lifecycle_values[0] if lifecycle_values else None
+    lifecycle = lifecycle_value if lifecycle_value in LIFECYCLES else None
+    invalid_lifecycle = lifecycle_value if lifecycle_value and lifecycle is None else None
+    return SkillTopology(
+        **normalized,
+        lifecycle=lifecycle,
+        declared=True,
+        invalid_lifecycle=invalid_lifecycle,
+    )
+
+
+def _record_topology(record: Mapping[str, Any]) -> SkillTopology:
+    value = record.get("topology")
+    return parse_topology(value)
+
+
+def _record_name(record: Mapping[str, Any]) -> str:
+    return str(record.get("name") or "").strip()
+
+
+def _name_key(value: str) -> str:
+    return value.strip().casefold()
+
+
+def _diagnostic(code: str, message: str, **details: Any) -> dict[str, Any]:
+    item = {"code": code, "message": message}
+    item.update({key: value for key, value in details.items() if value is not None})
+    return item
+
+
+def _sort_diagnostics(items: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    unique: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in items:
+        marker = repr(sorted(item.items(), key=lambda pair: pair[0]))
+        if marker not in seen:
+            seen.add(marker)
+            unique.append(item)
+    return sorted(
+        unique,
+        key=lambda item: (
+            str(item.get("code", "")),
+            str(item.get("skill", "")),
+            str(item.get("reference", "")),
+            str(item.get("message", "")),
+        ),
+    )
+
+
+def _canonical_cycle(cycle: Sequence[str]) -> tuple[str, ...]:
+    """Rotate a closed cycle to a deterministic representation."""
+    nodes = list(cycle[:-1])
+    if not nodes:
+        return tuple(cycle)
+    rotations = [nodes[index:] + nodes[:index] for index in range(len(nodes))]
+    best = min(rotations, key=lambda values: tuple(_name_key(item) for item in values))
+    return tuple([*best, best[0]])
+
+
+def _dependency_cycles(
+    ordered_records: Sequence[Mapping[str, Any]],
+    by_name: Mapping[str, Mapping[str, Any]],
+) -> list[list[str]]:
+    cycles: set[tuple[str, ...]] = set()
+    visited: set[str] = set()
+    active: list[str] = []
+    active_set: set[str] = set()
+
+    def visit(key: str) -> None:
+        if key in active_set:
+            index = active.index(key)
+            names = [_record_name(by_name[item]) for item in active[index:]]
+            names.append(names[0])
+            cycles.add(_canonical_cycle(names))
+            return
+        if key in visited:
+            return
+        visited.add(key)
+        active.append(key)
+        active_set.add(key)
+        for reference in _record_topology(by_name[key]).requires:
+            ref_key = _name_key(reference)
+            if ref_key in by_name:
+                visit(ref_key)
+        active.pop()
+        active_set.remove(key)
+
+    for record in ordered_records:
+        visit(_name_key(_record_name(record)))
+    return [list(cycle) for cycle in sorted(cycles)]
+
+
+def audit_topology(skills: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Audit a supplied installed-skill graph without executing any skill."""
+    ordered = sorted(
+        skills,
+        key=lambda item: (
+            _name_key(_record_name(item)),
+            str(item.get("category") or ""),
+        ),
+    )
+    by_name: dict[str, Mapping[str, Any]] = {}
+    diagnostics: list[dict[str, Any]] = []
+    for record in ordered:
+        name = _record_name(record)
+        key = _name_key(name)
+        if key and key not in by_name:
+            by_name[key] = record
+
+    lifecycle_counts = {value: 0 for value in LIFECYCLES}
+    lifecycle_counts.update({"unspecified": 0, "invalid": 0})
+    manifests_declared = 0
+    conflict_pairs: set[tuple[str, str]] = set()
+
+    for record in ordered:
+        name = _record_name(record)
+        key = _name_key(name)
+        topology = _record_topology(record)
+        if topology.declared:
+            manifests_declared += 1
+        if topology.invalid_lifecycle:
+            lifecycle_counts["invalid"] += 1
+            diagnostics.append(
+                _diagnostic(
+                    "invalid_lifecycle",
+                    f"Skill '{name}' declares unsupported lifecycle "
+                    f"'{topology.invalid_lifecycle}'.",
+                    skill=name,
+                    value=topology.invalid_lifecycle,
+                )
+            )
+        elif topology.lifecycle:
+            lifecycle_counts[topology.lifecycle] += 1
+        else:
+            lifecycle_counts["unspecified"] += 1
+
+        for field in REFERENCE_FIELDS:
+            for reference in getattr(topology, field):
+                ref_key = _name_key(reference)
+                if ref_key == key:
+                    diagnostics.append(
+                        _diagnostic(
+                            "self_reference",
+                            f"Skill '{name}' references itself in topology.{field}.",
+                            skill=name,
+                            field=field,
+                            reference=reference,
+                        )
+                    )
+                elif ref_key not in by_name:
+                    diagnostics.append(
+                        _diagnostic(
+                            "missing_reference",
+                            f"Skill '{name}' references missing skill '{reference}' "
+                            f"in topology.{field}.",
+                            skill=name,
+                            field=field,
+                            reference=reference,
+                        )
+                    )
+                elif field == "conflicts":
+                    other_name = _record_name(by_name[ref_key])
+                    conflict_pairs.add(tuple(sorted((name, other_name), key=_name_key)))
+
+    cycles = _dependency_cycles(ordered, by_name)
+    for cycle in cycles:
+        diagnostics.append(
+            _diagnostic(
+                "dependency_cycle",
+                f"Dependency cycle detected: {' -> '.join(cycle)}.",
+                cycle=cycle,
+            )
+        )
+    conflicts = [
+        list(pair)
+        for pair in sorted(
+            conflict_pairs, key=lambda pair: tuple(map(_name_key, pair))
+        )
+    ]
+    for left, right in conflicts:
+        diagnostics.append(
+            _diagnostic(
+                "conflict",
+                f"Skills '{left}' and '{right}' declare a conflict.",
+                skills=[left, right],
+            )
+        )
+
+    count = len(ordered)
+    coverage = round((manifests_declared / count * 100), 2) if count else 0.0
+    sorted_diagnostics = _sort_diagnostics(diagnostics)
+    return {
+        "version": ROUTE_ARTIFACT_VERSION,
+        "status": "issues" if sorted_diagnostics else "ok",
+        "summary": {
+            "skill_count": count,
+            "manifests_declared": manifests_declared,
+            "manifest_coverage_percent": coverage,
+            "lifecycle_counts": lifecycle_counts,
+        },
+        "cycles": cycles,
+        "conflicts": conflicts,
+        "diagnostics": sorted_diagnostics,
+    }
+
+
+def _canonical_phrase(value: str) -> str:
+    return " ".join(_WORD_RE.findall(value.casefold()))
+
+
+def _tokens(value: Any) -> set[str]:
+    return set(_WORD_RE.findall(str(value or "").casefold()))
+
+
+def _score_record(record: Mapping[str, Any], query: str) -> tuple[int, list[str]]:
+    query_phrase = _canonical_phrase(query)
+    query_tokens = _tokens(query)
+    if not query_phrase or not query_tokens:
+        return 0, []
+
+    name = _record_name(record)
+    topology = _record_topology(record)
+    fields: list[tuple[str, Sequence[str], int, int]] = [
+        ("tag", _normalize_values(record.get("tags")), 600, 80),
+        ("domain", topology.domains, 500, 70),
+        ("input", topology.inputs, 350, 60),
+        ("output", topology.outputs, 300, 50),
+        ("category", _normalize_values(record.get("category")), 200, 30),
+    ]
+    score = 0
+    reasons: list[str] = []
+    if _canonical_phrase(name) == query_phrase:
+        score += 1000
+        reasons.append("matched exact name")
+    else:
+        overlap = query_tokens & _tokens(name)
+        if overlap:
+            score += 100 * len(overlap)
+            reasons.append("matched name terms")
+
+    for label, values, exact_weight, token_weight in fields:
+        exact_values = [
+            value for value in values if _canonical_phrase(value) == query_phrase
+        ]
+        if exact_values:
+            score += exact_weight
+            reasons.append(f"matched exact {label} '{exact_values[0]}'")
+            continue
+        overlap_values = [value for value in values if query_tokens & _tokens(value)]
+        if overlap_values:
+            overlap_count = len(
+                set().union(
+                    *(_tokens(value) & query_tokens for value in overlap_values)
+                )
+            )
+            score += token_weight * overlap_count
+            reasons.append(f"matched {label} terms")
+
+    description_overlap = query_tokens & _tokens(record.get("description"))
+    if description_overlap:
+        score += 10 * len(description_overlap)
+        reasons.append("matched description terms")
+    return score, reasons
+
+
+def _cost(record: Mapping[str, Any], field: str) -> int:
+    try:
+        return max(0, int(record.get(field) or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _route_conflicts(
+    names: Sequence[str], by_name: Mapping[str, Mapping[str, Any]]
+) -> list[list[str]]:
+    pairs: set[tuple[str, str]] = set()
+    keys = {_name_key(name) for name in names}
+    for name in names:
+        topology = _record_topology(by_name[_name_key(name)])
+        for reference in topology.conflicts:
+            ref_key = _name_key(reference)
+            if ref_key in keys and ref_key != _name_key(name):
+                other = _record_name(by_name[ref_key])
+                pairs.add(tuple(sorted((name, other), key=_name_key)))
+    return [
+        list(pair)
+        for pair in sorted(pairs, key=lambda pair: tuple(map(_name_key, pair)))
+    ]
+
+
+def plan_skill_route(
+    skills: Sequence[Mapping[str, Any]],
+    query: str,
+    *,
+    max_skills: int,
+    budget_chars: int,
+) -> dict[str, Any]:
+    """Select a deterministic, dependency-ordered local skill neighborhood."""
+    digest = hashlib.sha256(str(query).encode("utf-8")).hexdigest()
+    diagnostics: list[dict[str, Any]] = []
+    if max_skills < 1 or budget_chars < 1:
+        if max_skills < 1:
+            diagnostics.append(_diagnostic("invalid_limit", "max_skills must be at least 1."))
+        if budget_chars < 1:
+            diagnostics.append(_diagnostic("invalid_budget", "budget_chars must be at least 1."))
+        return {
+            "version": ROUTE_ARTIFACT_VERSION,
+            "status": "blocked",
+            "query_digest": digest,
+            "limits": {"max_skills": max_skills, "budget_chars": budget_chars},
+            "route": [],
+            "total_cost_chars": 0,
+            "total_cost_bytes": 0,
+            "diagnostics": _sort_diagnostics(diagnostics),
+        }
+
+    ordered = sorted(
+        skills,
+        key=lambda item: (
+            _name_key(_record_name(item)),
+            str(item.get("category") or ""),
+        ),
+    )
+    by_name: dict[str, Mapping[str, Any]] = {}
+    for record in ordered:
+        key = _name_key(_record_name(record))
+        if key and key not in by_name:
+            by_name[key] = record
+
+    ranked: list[tuple[int, str, str, Mapping[str, Any], list[str]]] = []
+    for record in ordered:
+        score, reasons = _score_record(record, str(query))
+        if score:
+            ranked.append(
+                (
+                    -score,
+                    _name_key(_record_name(record)),
+                    str(record.get("category") or "").casefold(),
+                    record,
+                    reasons,
+                )
+            )
+    ranked.sort(key=lambda item: item[:3])
+
+    if not ranked:
+        diagnostics.append(
+            _diagnostic(
+                "no_match", "No installed skill metadata matched the query."
+            )
+        )
+        return {
+            "version": ROUTE_ARTIFACT_VERSION,
+            "status": "no_match",
+            "query_digest": digest,
+            "limits": {"max_skills": max_skills, "budget_chars": budget_chars},
+            "route": [],
+            "total_cost_chars": 0,
+            "total_cost_bytes": 0,
+            "diagnostics": diagnostics,
+        }
+
+    selected: list[str] = []
+    roles: dict[str, str] = {}
+    scores: dict[str, int] = {}
+    reasons_by_name: dict[str, list[str]] = {}
+    def dependency_closure(
+        root: Mapping[str, Any],
+    ) -> tuple[list[str], list[dict[str, Any]], list[dict[str, Any]]]:
+        closure: list[str] = []
+        blockers: list[dict[str, Any]] = []
+        findings: list[dict[str, Any]] = []
+        visiting: list[str] = []
+        done: set[str] = set()
+
+        def visit(record: Mapping[str, Any]) -> None:
+            name = _record_name(record)
+            key = _name_key(name)
+            if key in visiting:
+                index = visiting.index(key)
+                cycle_keys = visiting[index:] + [key]
+                cycle = [_record_name(by_name[item]) for item in cycle_keys]
+                blockers.append(
+                    _diagnostic(
+                        "dependency_cycle",
+                        f"Dependency cycle blocks skill '{_record_name(root)}': {' -> '.join(cycle)}.",
+                        skill=_record_name(root),
+                        cycle=cycle,
+                    )
+                )
+                return
+            if key in done:
+                return
+            topology = _record_topology(record)
+            if topology.invalid_lifecycle:
+                blockers.append(
+                    _diagnostic(
+                        "invalid_lifecycle",
+                        f"Skill '{name}' has invalid lifecycle '{topology.invalid_lifecycle}'.",
+                        skill=name,
+                        value=topology.invalid_lifecycle,
+                    )
+                )
+                return
+            visiting.append(key)
+            for field in ("follows", "precedes", "conflicts"):
+                for reference in getattr(topology, field):
+                    ref_key = _name_key(reference)
+                    if ref_key == key:
+                        blockers.append(
+                            _diagnostic(
+                                "self_reference",
+                                f"Skill '{name}' references itself in "
+                                f"topology.{field}.",
+                                skill=name,
+                                field=field,
+                                reference=reference,
+                            )
+                        )
+                    elif ref_key not in by_name:
+                        findings.append(
+                            _diagnostic(
+                                "missing_reference",
+                                f"Skill '{name}' references missing skill "
+                                f"'{reference}' in topology.{field}.",
+                                skill=name,
+                                field=field,
+                                reference=reference,
+                            )
+                        )
+            for reference in topology.requires:
+                ref_key = _name_key(reference)
+                if ref_key == key:
+                    blockers.append(
+                        _diagnostic(
+                            "self_reference",
+                            f"Skill '{name}' requires itself.",
+                            skill=name,
+                            reference=reference,
+                        )
+                    )
+                    continue
+                dependency = by_name.get(ref_key)
+                if dependency is None:
+                    blockers.append(
+                        _diagnostic(
+                            "missing_required_skill",
+                            f"Skill '{name}' requires missing skill '{reference}'.",
+                            skill=name,
+                            reference=reference,
+                        )
+                    )
+                    continue
+                visit(dependency)
+            visiting.pop()
+            done.add(key)
+            closure.append(name)
+
+        visit(root)
+        if blockers:
+            return [], blockers, [*findings, *blockers]
+        conflicts = _route_conflicts(closure, by_name)
+        for left, right in conflicts:
+            blockers.append(
+                _diagnostic(
+                    "route_conflict",
+                    f"Route for '{_record_name(root)}' contains conflicting "
+                    f"skills '{left}' and '{right}'.",
+                    skill=_record_name(root),
+                    skills=[left, right],
+                )
+            )
+        return (
+            [] if blockers else closure,
+            blockers,
+            [*findings, *blockers],
+        )
+
+    for negative_score, _, _, root, root_reasons in ranked:
+        root_name = _record_name(root)
+        root_key = _name_key(root_name)
+        if root_name in selected:
+            roles[root_key] = "root"
+            scores[root_key] = -negative_score
+            reasons_by_name[root_key] = root_reasons
+            continue
+
+        closure, blockers, findings = dependency_closure(root)
+        diagnostics.extend(findings)
+        if blockers:
+            continue
+        new_names = [name for name in closure if name not in selected]
+        combined_names = [*selected, *new_names]
+        existing_conflicts = _route_conflicts(combined_names, by_name)
+        if existing_conflicts:
+            for left, right in existing_conflicts:
+                diagnostics.append(
+                    _diagnostic(
+                        "route_conflict",
+                        f"Omitted '{root_name}' because it conflicts with the selected route.",
+                        skill=root_name,
+                        skills=[left, right],
+                    )
+                )
+            continue
+        if len(combined_names) > max_skills:
+            diagnostics.append(
+                _diagnostic(
+                    "limit_omission",
+                    f"Omitted '{root_name}' because its dependency closure exceeds the skill limit.",
+                    skill=root_name,
+                    required_skill_count=len(combined_names),
+                )
+            )
+            continue
+        projected_cost = sum(
+            _cost(by_name[_name_key(name)], "cost_chars")
+            for name in combined_names
+        )
+        if projected_cost > budget_chars:
+            diagnostics.append(
+                _diagnostic(
+                    "budget_omission",
+                    f"Omitted '{root_name}' because its dependency closure "
+                    "exceeds the character budget.",
+                    skill=root_name,
+                    required_cost_chars=projected_cost,
+                )
+            )
+            continue
+
+        selected.extend(new_names)
+        for name in closure:
+            key = _name_key(name)
+            if key == root_key:
+                roles[key] = "root"
+                scores[key] = -negative_score
+                reasons_by_name[key] = root_reasons
+            elif key not in roles:
+                roles[key] = "required"
+                scores[key] = 0
+                parents = sorted(
+                    (
+                        candidate
+                        for candidate in closure
+                        if key
+                        in {
+                            _name_key(reference)
+                            for reference in _record_topology(
+                                by_name[_name_key(candidate)]
+                            ).requires
+                        }
+                    ),
+                    key=_name_key,
+                )
+                reasons_by_name[key] = [f"required by {parent}" for parent in parents]
+
+    route: list[dict[str, Any]] = []
+    cumulative_chars = 0
+    cumulative_bytes = 0
+    for name in selected:
+        key = _name_key(name)
+        record = by_name[key]
+        cost_chars = _cost(record, "cost_chars")
+        cost_bytes = _cost(record, "cost_bytes")
+        cumulative_chars += cost_chars
+        cumulative_bytes += cost_bytes
+        topology = _record_topology(record)
+        route.append(
+            {
+                "name": name,
+                "category": record.get("category"),
+                "graph_role": roles[key],
+                "score": scores[key],
+                "reasons": reasons_by_name[key],
+                "cost_chars": cost_chars,
+                "cost_bytes": cost_bytes,
+                "cumulative_cost_chars": cumulative_chars,
+                "cumulative_cost_bytes": cumulative_bytes,
+                "topology": topology.to_dict() if topology.declared else {},
+            }
+        )
+
+    status = "ok" if route else "blocked"
+    return {
+        "version": ROUTE_ARTIFACT_VERSION,
+        "status": status,
+        "query_digest": digest,
+        "limits": {"max_skills": max_skills, "budget_chars": budget_chars},
+        "route": route,
+        "total_cost_chars": cumulative_chars,
+        "total_cost_bytes": cumulative_bytes,
+        "diagnostics": _sort_diagnostics(diagnostics),
+    }
+
+
+__all__ = [
+    "DEFAULT_ROUTE_BUDGET_CHARS",
+    "DEFAULT_ROUTE_LIMIT",
+    "LIFECYCLES",
+    "ROUTE_ARTIFACT_VERSION",
+    "SkillTopology",
+    "TOPOLOGY_FIELDS",
+    "audit_topology",
+    "parse_topology",
+    "plan_skill_route",
+]

--- a/agent/skill_topology.py
+++ b/agent/skill_topology.py
@@ -491,18 +491,18 @@ def plan_skill_route(
         for records in collisions.values()
         for record in records
     )
+    if ambiguous_match:
+        return {
+            "version": ROUTE_ARTIFACT_VERSION,
+            "status": "blocked",
+            "query_digest": digest,
+            "limits": {"max_skills": max_skills, "budget_chars": budget_chars},
+            "route": [],
+            "total_cost_chars": 0,
+            "total_cost_bytes": 0,
+            "diagnostics": _sort_diagnostics(diagnostics),
+        }
     if not ranked:
-        if ambiguous_match:
-            return {
-                "version": ROUTE_ARTIFACT_VERSION,
-                "status": "blocked",
-                "query_digest": digest,
-                "limits": {"max_skills": max_skills, "budget_chars": budget_chars},
-                "route": [],
-                "total_cost_chars": 0,
-                "total_cost_bytes": 0,
-                "diagnostics": _sort_diagnostics(diagnostics),
-            }
         diagnostics.append(
             _diagnostic(
                 "no_match", "No installed skill metadata matched the query."

--- a/agent/skill_topology.py
+++ b/agent/skill_topology.py
@@ -124,10 +124,61 @@ def _name_key(value: str) -> str:
     return value.strip().casefold()
 
 
+def _index_records(
+    skills: Sequence[Mapping[str, Any]],
+) -> tuple[
+    list[Mapping[str, Any]],
+    dict[str, Mapping[str, Any]],
+    dict[str, tuple[Mapping[str, Any], ...]],
+]:
+    """Index records by canonical name without choosing across collisions."""
+    ordered = sorted(
+        skills,
+        key=lambda item: (
+            _name_key(_record_name(item)),
+            _record_name(item),
+            str(item.get("category") or "").casefold(),
+            str(item.get("category") or ""),
+        ),
+    )
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for record in ordered:
+        key = _name_key(_record_name(record))
+        if key:
+            grouped.setdefault(key, []).append(record)
+
+    by_name: dict[str, Mapping[str, Any]] = {}
+    collisions: dict[str, tuple[Mapping[str, Any], ...]] = {}
+    for key in sorted(grouped):
+        records = grouped[key]
+        if len(records) == 1:
+            by_name[key] = records[0]
+        else:
+            collisions[key] = tuple(records)
+    return ordered, by_name, collisions
+
+
 def _diagnostic(code: str, message: str, **details: Any) -> dict[str, Any]:
     item = {"code": code, "message": message}
     item.update({key: value for key, value in details.items() if value is not None})
     return item
+
+
+def _collision_diagnostic(
+    canonical_name: str, records: Sequence[Mapping[str, Any]]
+) -> dict[str, Any]:
+    names = sorted(
+        (_record_name(record) for record in records),
+        key=lambda name: (name.casefold(), name),
+    )
+    return _diagnostic(
+        "canonical_name_collision",
+        f"Canonical skill name '{canonical_name}' is ambiguous across "
+        f"{len(records)} installed records.",
+        canonical_name=canonical_name,
+        names=names,
+        record_count=len(records),
+    )
 
 
 def _sort_diagnostics(items: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -194,20 +245,11 @@ def _dependency_cycles(
 
 def audit_topology(skills: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     """Audit a supplied installed-skill graph without executing any skill."""
-    ordered = sorted(
-        skills,
-        key=lambda item: (
-            _name_key(_record_name(item)),
-            str(item.get("category") or ""),
-        ),
-    )
-    by_name: dict[str, Mapping[str, Any]] = {}
-    diagnostics: list[dict[str, Any]] = []
-    for record in ordered:
-        name = _record_name(record)
-        key = _name_key(name)
-        if key and key not in by_name:
-            by_name[key] = record
+    ordered, by_name, collisions = _index_records(skills)
+    diagnostics = [
+        _collision_diagnostic(key, records)
+        for key, records in collisions.items()
+    ]
 
     lifecycle_counts = {value: 0 for value in LIFECYCLES}
     lifecycle_counts.update({"unspecified": 0, "invalid": 0})
@@ -236,6 +278,8 @@ def audit_topology(skills: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
         else:
             lifecycle_counts["unspecified"] += 1
 
+        if key in collisions:
+            continue
         for field in REFERENCE_FIELDS:
             for reference in getattr(topology, field):
                 ref_key = _name_key(reference)
@@ -249,6 +293,8 @@ def audit_topology(skills: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
                             reference=reference,
                         )
                     )
+                elif ref_key in collisions:
+                    continue
                 elif ref_key not in by_name:
                     diagnostics.append(
                         _diagnostic(
@@ -264,7 +310,8 @@ def audit_topology(skills: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
                     other_name = _record_name(by_name[ref_key])
                     conflict_pairs.add(tuple(sorted((name, other_name), key=_name_key)))
 
-    cycles = _dependency_cycles(ordered, by_name)
+    unique_records = [by_name[key] for key in sorted(by_name)]
+    cycles = _dependency_cycles(unique_records, by_name)
     for cycle in cycles:
         diagnostics.append(
             _diagnostic(
@@ -288,7 +335,7 @@ def audit_topology(skills: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
             )
         )
 
-    count = len(ordered)
+    count = len(skills)
     coverage = round((manifests_declared / count * 100), 2) if count else 0.0
     sorted_diagnostics = _sort_diagnostics(diagnostics)
     return {
@@ -346,7 +393,7 @@ def _score_record(record: Mapping[str, Any], query: str) -> tuple[int, list[str]
         ]
         if exact_values:
             score += exact_weight
-            reasons.append(f"matched exact {label} '{exact_values[0]}'")
+            reasons.append(f"matched exact {label}")
             continue
         overlap_values = [value for value in values if query_tokens & _tokens(value)]
         if overlap_values:
@@ -373,15 +420,16 @@ def _cost(record: Mapping[str, Any], field: str) -> int:
 
 
 def _route_conflicts(
-    names: Sequence[str], by_name: Mapping[str, Mapping[str, Any]]
+    keys: Sequence[str], by_name: Mapping[str, Mapping[str, Any]]
 ) -> list[list[str]]:
     pairs: set[tuple[str, str]] = set()
-    keys = {_name_key(name) for name in names}
-    for name in names:
-        topology = _record_topology(by_name[_name_key(name)])
+    selected_keys = set(keys)
+    for key in keys:
+        name = _record_name(by_name[key])
+        topology = _record_topology(by_name[key])
         for reference in topology.conflicts:
             ref_key = _name_key(reference)
-            if ref_key in keys and ref_key != _name_key(name):
+            if ref_key in selected_keys and ref_key != key:
                 other = _record_name(by_name[ref_key])
                 pairs.add(tuple(sorted((name, other), key=_name_key)))
     return [
@@ -416,21 +464,15 @@ def plan_skill_route(
             "diagnostics": _sort_diagnostics(diagnostics),
         }
 
-    ordered = sorted(
-        skills,
-        key=lambda item: (
-            _name_key(_record_name(item)),
-            str(item.get("category") or ""),
-        ),
+    _, by_name, collisions = _index_records(skills)
+    diagnostics.extend(
+        _collision_diagnostic(key, records)
+        for key, records in collisions.items()
     )
-    by_name: dict[str, Mapping[str, Any]] = {}
-    for record in ordered:
-        key = _name_key(_record_name(record))
-        if key and key not in by_name:
-            by_name[key] = record
 
     ranked: list[tuple[int, str, str, Mapping[str, Any], list[str]]] = []
-    for record in ordered:
+    for key in sorted(by_name):
+        record = by_name[key]
         score, reasons = _score_record(record, str(query))
         if score:
             ranked.append(
@@ -444,7 +486,23 @@ def plan_skill_route(
             )
     ranked.sort(key=lambda item: item[:3])
 
+    ambiguous_match = any(
+        _score_record(record, str(query))[0]
+        for records in collisions.values()
+        for record in records
+    )
     if not ranked:
+        if ambiguous_match:
+            return {
+                "version": ROUTE_ARTIFACT_VERSION,
+                "status": "blocked",
+                "query_digest": digest,
+                "limits": {"max_skills": max_skills, "budget_chars": budget_chars},
+                "route": [],
+                "total_cost_chars": 0,
+                "total_cost_bytes": 0,
+                "diagnostics": _sort_diagnostics(diagnostics),
+            }
         diagnostics.append(
             _diagnostic(
                 "no_match", "No installed skill metadata matched the query."
@@ -458,7 +516,7 @@ def plan_skill_route(
             "route": [],
             "total_cost_chars": 0,
             "total_cost_bytes": 0,
-            "diagnostics": diagnostics,
+            "diagnostics": _sort_diagnostics(diagnostics),
         }
 
     selected: list[str] = []
@@ -520,6 +578,8 @@ def plan_skill_route(
                                 reference=reference,
                             )
                         )
+                    elif ref_key in collisions:
+                        continue
                     elif ref_key not in by_name:
                         findings.append(
                             _diagnostic(
@@ -544,6 +604,11 @@ def plan_skill_route(
                     )
                     continue
                 dependency = by_name.get(ref_key)
+                if ref_key in collisions:
+                    blockers.append(
+                        _collision_diagnostic(ref_key, collisions[ref_key])
+                    )
+                    continue
                 if dependency is None:
                     blockers.append(
                         _diagnostic(
@@ -557,7 +622,7 @@ def plan_skill_route(
                 visit(dependency)
             visiting.pop()
             done.add(key)
-            closure.append(name)
+            closure.append(key)
 
         visit(root)
         if blockers:
@@ -585,7 +650,7 @@ def plan_skill_route(
             break
         root_name = _record_name(root)
         root_key = _name_key(root_name)
-        if root_name in selected:
+        if root_key in selected:
             roles[root_key] = "root"
             scores[root_key] = root_score
             reasons_by_name[root_key] = root_reasons
@@ -595,9 +660,9 @@ def plan_skill_route(
         diagnostics.extend(findings)
         if blockers:
             continue
-        new_names = [name for name in closure if name not in selected]
-        combined_names = [*selected, *new_names]
-        existing_conflicts = _route_conflicts(combined_names, by_name)
+        new_keys = [key for key in closure if key not in selected]
+        combined_keys = [*selected, *new_keys]
+        existing_conflicts = _route_conflicts(combined_keys, by_name)
         if existing_conflicts:
             for left, right in existing_conflicts:
                 diagnostics.append(
@@ -609,19 +674,18 @@ def plan_skill_route(
                     )
                 )
             continue
-        if len(combined_names) > max_skills:
+        if len(combined_keys) > max_skills:
             diagnostics.append(
                 _diagnostic(
                     "limit_omission",
                     f"Omitted '{root_name}' because its dependency closure exceeds the skill limit.",
                     skill=root_name,
-                    required_skill_count=len(combined_names),
+                    required_skill_count=len(combined_keys),
                 )
             )
             continue
         projected_cost = sum(
-            _cost(by_name[_name_key(name)], "cost_chars")
-            for name in combined_names
+            _cost(by_name[key], "cost_chars") for key in combined_keys
         )
         if projected_cost > budget_chars:
             diagnostics.append(
@@ -636,9 +700,8 @@ def plan_skill_route(
             continue
 
         selected_tier_score = root_score
-        selected.extend(new_names)
-        for name in closure:
-            key = _name_key(name)
+        selected.extend(new_keys)
+        for key in closure:
             if key == root_key:
                 roles[key] = "root"
                 scores[key] = root_score
@@ -654,20 +717,26 @@ def plan_skill_route(
                         in {
                             _name_key(reference)
                             for reference in _record_topology(
-                                by_name[_name_key(candidate)]
+                                by_name[candidate]
                             ).requires
                         }
                     ),
-                    key=_name_key,
+                    key=lambda candidate: (
+                        _name_key(_record_name(by_name[candidate])),
+                        _record_name(by_name[candidate]),
+                    ),
                 )
-                reasons_by_name[key] = [f"required by {parent}" for parent in parents]
+                reasons_by_name[key] = [
+                    f"required by {_record_name(by_name[parent])}"
+                    for parent in parents
+                ]
 
     route: list[dict[str, Any]] = []
     cumulative_chars = 0
     cumulative_bytes = 0
-    for name in selected:
-        key = _name_key(name)
+    for key in selected:
         record = by_name[key]
+        name = _record_name(record)
         cost_chars = _cost(record, "cost_chars")
         cost_bytes = _cost(record, "cost_bytes")
         cumulative_chars += cost_chars

--- a/agent/skill_topology.py
+++ b/agent/skill_topology.py
@@ -8,7 +8,6 @@ normal platform, environment, disabled-skill, and permission gates.
 from __future__ import annotations
 
 from dataclasses import dataclass
-import hashlib
 import re
 from typing import Any, Iterable, Mapping, Sequence
 
@@ -446,7 +445,6 @@ def plan_skill_route(
     budget_chars: int,
 ) -> dict[str, Any]:
     """Select a deterministic, dependency-ordered local skill neighborhood."""
-    digest = hashlib.sha256(str(query).encode("utf-8")).hexdigest()
     diagnostics: list[dict[str, Any]] = []
     if max_skills < 1 or budget_chars < 1:
         if max_skills < 1:
@@ -456,7 +454,6 @@ def plan_skill_route(
         return {
             "version": ROUTE_ARTIFACT_VERSION,
             "status": "blocked",
-            "query_digest": digest,
             "limits": {"max_skills": max_skills, "budget_chars": budget_chars},
             "route": [],
             "total_cost_chars": 0,
@@ -469,6 +466,35 @@ def plan_skill_route(
         _collision_diagnostic(key, records)
         for key, records in collisions.items()
     )
+
+    unreadable_matches = []
+    for record in skills:
+        if record.get("inventory_error") != "skill_content_unavailable":
+            continue
+        score, _ = _score_record(record, str(query))
+        if score:
+            unreadable_matches.append(record)
+    if unreadable_matches:
+        for record in sorted(
+            unreadable_matches,
+            key=lambda item: (_name_key(_record_name(item)), _record_name(item)),
+        ):
+            diagnostics.append(
+                _diagnostic(
+                    "skill_content_unavailable",
+                    f"Skill '{_record_name(record)}' cannot be safely read for route planning.",
+                    skill=_record_name(record),
+                )
+            )
+        return {
+            "version": ROUTE_ARTIFACT_VERSION,
+            "status": "blocked",
+            "limits": {"max_skills": max_skills, "budget_chars": budget_chars},
+            "route": [],
+            "total_cost_chars": 0,
+            "total_cost_bytes": 0,
+            "diagnostics": _sort_diagnostics(diagnostics),
+        }
 
     ranked: list[tuple[int, str, str, Mapping[str, Any], list[str]]] = []
     for key in sorted(by_name):
@@ -495,7 +521,6 @@ def plan_skill_route(
         return {
             "version": ROUTE_ARTIFACT_VERSION,
             "status": "blocked",
-            "query_digest": digest,
             "limits": {"max_skills": max_skills, "budget_chars": budget_chars},
             "route": [],
             "total_cost_chars": 0,
@@ -511,7 +536,6 @@ def plan_skill_route(
         return {
             "version": ROUTE_ARTIFACT_VERSION,
             "status": "no_match",
-            "query_digest": digest,
             "limits": {"max_skills": max_skills, "budget_chars": budget_chars},
             "route": [],
             "total_cost_chars": 0,
@@ -761,7 +785,6 @@ def plan_skill_route(
     return {
         "version": ROUTE_ARTIFACT_VERSION,
         "status": status,
-        "query_digest": digest,
         "limits": {"max_skills": max_skills, "budget_chars": budget_chars},
         "route": route,
         "total_cost_chars": cumulative_chars,

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -122,7 +122,10 @@ def is_excluded_skill_path(path, *, root: Optional[Path] = None) -> bool:
     # Some older callers own their own directory walk. Keep the authority
     # boundary in this common predicate as a final fail-closed guard while
     # callers migrate to ``iter_skill_index_files`` for subtree pruning.
-    return is_central_private_skill_path(path)
+    candidate = Path(path)
+    if root is not None and not candidate.is_absolute():
+        candidate = Path(root) / candidate
+    return is_central_private_skill_path(candidate)
 
 
 def is_skill_support_path(path, *, root: Optional[Path] = None) -> bool:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -9,8 +9,9 @@ import logging
 import os
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from hermes_constants import get_config_path, get_skills_dir, is_termux
 
@@ -114,9 +115,14 @@ def is_excluded_skill_path(path, *, root: Optional[Path] = None) -> bool:
     except AttributeError:
         from pathlib import PurePath
         parts = PurePath(str(path)).parts
-    return any(part in EXCLUDED_SKILL_DIRS for part in parts) or is_skill_support_path(
+    if any(part in EXCLUDED_SKILL_DIRS for part in parts) or is_skill_support_path(
         path, root=root
-    )
+    ):
+        return True
+    # Some older callers own their own directory walk. Keep the authority
+    # boundary in this common predicate as a final fail-closed guard while
+    # callers migrate to ``iter_skill_index_files`` for subtree pruning.
+    return is_central_private_skill_path(path)
 
 
 def is_skill_support_path(path, *, root: Optional[Path] = None) -> bool:
@@ -398,14 +404,14 @@ def _raw_config_cache_clear() -> None:
     _RAW_CONFIG_CACHE.clear()
 
 
-def _load_raw_config() -> Dict[str, Any]:
+def _load_raw_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
     """Read config.yaml with a shared mtime+size keyed cache.
 
     This module intentionally avoids importing ``hermes_cli.config`` on the
     skill prompt/build path. A tiny local cache gives the same repeated-read
     win without pulling the heavier CLI config stack into startup.
     """
-    config_path = get_config_path()
+    config_path = config_path or get_config_path()
     if not config_path.exists():
         return {}
     try:
@@ -488,12 +494,157 @@ def _normalize_string_set(values) -> Set[str]:
 # each trigger a category lookup during banner construction (10+ seconds
 # of pure waste).
 _EXTERNAL_DIRS_CACHE: Dict[Tuple[str, int], List[Path]] = {}
+_CENTRAL_PRIVATE_ROOTS_CACHE: Dict[Tuple[str, int, int], "CentralPrivateSkillRoots"] = {}
+
+
+@dataclass(frozen=True)
+class CentralPrivateSkillRoots:
+    """Resolved native-scan exclusions for MCP-authoritative skill corpora.
+
+    The configured roots are never surfaced to model-facing artifacts. Invalid
+    entries still contribute a best-effort resolved guard so a symlink or a
+    transient permissions failure cannot turn into an inventory bypass.
+    """
+
+    roots: Tuple[Path, ...]
+    diagnostics: Tuple[str, ...]
+    signature: Tuple[str, int, int]
 
 
 def _external_dirs_cache_clear() -> None:
     """Test hook — drop the in-process cache."""
     _EXTERNAL_DIRS_CACHE.clear()
+    _CENTRAL_PRIVATE_ROOTS_CACHE.clear()
     _raw_config_cache_clear()
+
+
+def _safe_resolve_skill_path(path: Path) -> Path:
+    """Resolve aliases for boundary checks without propagating path failures."""
+    try:
+        return path.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError):
+        return path.expanduser().absolute()
+
+
+def _contains_symlink_component(path: Path) -> bool:
+    """Return whether an absolute configured path traverses a symlink."""
+    if not path.is_absolute():
+        return False
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        try:
+            if current.is_symlink():
+                return True
+        except OSError:
+            return True
+    return False
+
+
+def _config_signature(config_path: Path) -> Tuple[str, int, int]:
+    try:
+        stat = config_path.stat()
+        return (str(config_path), stat.st_mtime_ns, stat.st_size)
+    except OSError:
+        return (str(config_path), 0, 0)
+
+
+def get_central_private_skill_roots(
+    config_path: Optional[Path] = None,
+) -> CentralPrivateSkillRoots:
+    """Read strict ``skills.central_private_roots`` exclusions.
+
+    This is an explicit authority boundary, not a directory-name heuristic.
+    Entries must be absolute, non-symlink, readable directories. A malformed
+    entry is diagnosed without ever including its configured path in logs; when
+    it can still be resolved, that location remains guarded fail-closed.
+    """
+    config_path = config_path or get_config_path()
+    signature = _config_signature(config_path)
+    cached = _CENTRAL_PRIVATE_ROOTS_CACHE.get(signature)
+    if cached is not None:
+        return cached
+
+    diagnostics: list[str] = []
+    parsed = _load_raw_config(config_path)
+    skills_cfg = parsed.get("skills") if isinstance(parsed, dict) else None
+    raw_roots = skills_cfg.get("central_private_roots") if isinstance(skills_cfg, dict) else None
+    if raw_roots is None:
+        result = CentralPrivateSkillRoots((), (), signature)
+        _CENTRAL_PRIVATE_ROOTS_CACHE[signature] = result
+        return result
+    entries = raw_roots
+    if not isinstance(entries, list):
+        # A scalar absolute path is still enough information to reserve a
+        # subtree. Treat it as malformed config *and* guard it rather than
+        # allowing the shape error to reveal a private corpus.
+        diagnostics.append("central_private_root_invalid")
+        entries = [entries] if isinstance(entries, str) else []
+
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    for entry in entries:
+        if not isinstance(entry, str) or not entry.strip():
+            diagnostics.append("central_private_root_invalid")
+            continue
+        declared = Path(entry)
+        if not declared.is_absolute():
+            diagnostics.append("central_private_root_invalid")
+            continue
+        resolved = _safe_resolve_skill_path(declared)
+        invalid = (
+            _contains_symlink_component(declared)
+            or not declared.is_dir()
+            or not os.access(declared, os.R_OK | os.X_OK)
+        )
+        if invalid:
+            diagnostics.append("central_private_root_invalid")
+        if resolved in seen:
+            diagnostics.append("central_private_root_ambiguous")
+            continue
+        seen.add(resolved)
+        roots.append(resolved)
+
+    for index, root in enumerate(roots):
+        for other in roots[index + 1 :]:
+            if path_is_within_roots(root, (other,)) or path_is_within_roots(other, (root,)):
+                diagnostics.append("central_private_root_ambiguous")
+                break
+
+    unique_diagnostics = tuple(sorted(set(diagnostics)))
+    if unique_diagnostics:
+        logger.warning(
+            "Configured MCP authority roots include invalid or ambiguous entries; "
+            "affected paths remain excluded from native skill discovery."
+        )
+    result = CentralPrivateSkillRoots(tuple(roots), unique_diagnostics, signature)
+    _CENTRAL_PRIVATE_ROOTS_CACHE.clear()
+    _CENTRAL_PRIVATE_ROOTS_CACHE[signature] = result
+    return result
+
+
+def path_is_within_roots(path: Path, roots: Iterable[Path]) -> bool:
+    """Return whether *path* is in a resolved authority subtree."""
+    candidate = _safe_resolve_skill_path(Path(path))
+    for root in roots:
+        try:
+            candidate.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def is_central_private_skill_path(
+    path: Path,
+    *,
+    config_path: Optional[Path] = None,
+) -> bool:
+    """Whether a candidate is reserved for its configured MCP authority."""
+    return path_is_within_roots(
+        path,
+        get_central_private_skill_roots(config_path).roots,
+    )
 
 
 def get_external_skills_dirs() -> List[Path]:
@@ -874,7 +1025,12 @@ def is_skill_description_truncated_for_prompt(frontmatter: Dict[str, Any]) -> bo
 # ── File iteration ────────────────────────────────────────────────────────
 
 
-def iter_skill_index_files(skills_dir: Path, filename: str):
+def iter_skill_index_files(
+    skills_dir: Path,
+    filename: str,
+    *,
+    excluded_roots: Optional[Iterable[Path]] = None,
+):
     """Walk skills_dir yielding sorted paths matching *filename*.
 
     Excludes Hermes metadata, VCS, virtualenv/dependency, cache, and skill
@@ -890,10 +1046,19 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     without any manual cleanup.
     """
     skills_dir_str = str(skills_dir)
+    if excluded_roots is None:
+        excluded_roots = get_central_private_skill_roots().roots
+    excluded_roots = tuple(_safe_resolve_skill_path(Path(root)) for root in excluded_roots)
+    if path_is_within_roots(skills_dir, excluded_roots):
+        return
     active_org = read_active_org_id(skills_dir)
     org_root = os.path.join(skills_dir_str, ORG_MIRROR_DIR_NAME)
     matches: list[str] = []
     for root, dirs, files in os.walk(skills_dir_str, followlinks=True):
+        root_path = Path(root)
+        if path_is_within_roots(root_path, excluded_roots):
+            dirs[:] = []
+            continue
         has_skill_md = "SKILL.md" in files
         if root == skills_dir_str and ORG_MIRROR_DIR_NAME in dirs and active_org is None:
             dirs.remove(ORG_MIRROR_DIR_NAME)
@@ -905,6 +1070,7 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
             for d in dirs
             if d not in EXCLUDED_SKILL_DIRS
             and not (has_skill_md and d in SKILL_SUPPORT_DIRS)
+            and not path_is_within_roots(root_path / d, excluded_roots)
         ]
         if filename in files:
             matches.append(os.path.join(root, filename))

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -847,6 +847,13 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # MCP-authoritative skill corpus roots. These must be exact absolute,
+  # non-symlink directories. Hermes excludes them from all native discovery,
+  # listing, routing, topology, and loading. Keep a thin local adapter skill
+  # outside the roots; it should direct the model to the configured MCP tools.
+  # central_private_roots:
+  #   - /absolute/path/to/mcp-authority-root
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/docs/plans/2026-07-31-skill-protocol-topology-v1-design.md
+++ b/docs/plans/2026-07-31-skill-protocol-topology-v1-design.md
@@ -19,8 +19,9 @@ without a query it will follow the existing code path unchanged.
 
 Two read-only CLI actions will share the same planner. `skills route` plans
 against currently eligible skills, while `skills topology` audits the same
-local graph. JSON is deterministically serialized and includes only the query's
-SHA-256 digest, never the raw query. Human output shows route order, reasons,
+local graph. JSON is deterministically serialized, identifies the query with a
+SHA-256 digest, and has no dedicated raw-query field. Selected skill metadata
+may naturally repeat query terms. Human output shows route order, reasons,
 costs, and diagnostics. No route event is persisted because V1 has no concrete
 reader for a separate event log.
 

--- a/docs/plans/2026-07-31-skill-protocol-topology-v1-design.md
+++ b/docs/plans/2026-07-31-skill-protocol-topology-v1-design.md
@@ -1,0 +1,35 @@
+# Skill Protocol Topology V1 Design
+
+Hermes will treat skill topology as optional advisory metadata, parsed from
+`metadata.hermes.topology`. A new import-light `agent.skill_topology` module
+will own normalization, validation, graph auditing, deterministic scoring,
+dependency expansion, budget enforcement, and privacy-safe route artifacts.
+It will accept plain skill metadata dictionaries rather than reading profiles
+or registering tools, keeping the planner testable and reusable by both CLI and
+model-tool adapters. Existing platform, environment, disabled-skill, and tool
+permission gates remain upstream of the planner; topology never executes a
+skill or grants permission.
+
+The existing skill scanner will gain an opt-in rich-metadata mode. Default
+calls keep their current minimal dictionaries and serialized `skills_list()`
+shape. Rich mode reads the complete SKILL.md so `cost_chars` and `cost_bytes`
+come from the real content, and exposes tags plus normalized topology to the
+planner. `skills_list(query=...)` will use this mode and return a route artifact;
+without a query it will follow the existing code path unchanged.
+
+Two read-only CLI actions will share the same planner. `skills route` plans
+against currently eligible skills, while `skills topology` audits the same
+local graph. JSON is deterministically serialized and includes only the query's
+SHA-256 digest, never the raw query. Human output shows route order, reasons,
+costs, and diagnostics. No route event is persisted because V1 has no concrete
+reader for a separate event log.
+
+Ranking uses explicit weighted field matches: exact name first, then exact
+tags/domains, then inputs/outputs/category, with loose name and description
+tokens last. Ties resolve by canonical name and category. A route greedily
+considers ranked roots, expands transitive `requires` depth-first so
+prerequisites precede dependents, and omits candidates that exceed count or
+character budgets. Missing requirements, dependency cycles, self references,
+invalid lifecycle values, and active conflicts produce explicit diagnostics;
+when every match is unusable the result is `blocked`, and when nothing matches
+it is `no_match`.

--- a/docs/plans/2026-07-31-skill-protocol-topology-v1-design.md
+++ b/docs/plans/2026-07-31-skill-protocol-topology-v1-design.md
@@ -17,13 +17,31 @@ come from the real content, and exposes tags plus normalized topology to the
 planner. `skills_list(query=...)` will use this mode and return a route artifact;
 without a query it will follow the existing code path unchanged.
 
-Two read-only CLI actions will share the same planner. `skills route` plans
-against currently eligible skills, while `skills topology` audits the same
-local graph. JSON is deterministically serialized, identifies the query with a
-SHA-256 digest, and has no dedicated raw-query field. Selected skill metadata
-may naturally repeat query terms. Human output shows route order, reasons,
-costs, and diagnostics. No route event is persisted because V1 has no concrete
-reader for a separate event log.
+Two read-only CLI actions and the `skills_list(query=...)` model-tool path
+share one rich installed-inventory builder. `skills route` plans against
+currently eligible local, external, and registered plugin skills, while
+`skills topology` audits that same installed inventory with disabled and
+runtime-ineligible records included for diagnosis. Plugin costs come from the
+complete registered `SKILL.md` with the same UTF-8-sig decoding and byte/character
+accounting as local rich scanning; an unreadable registered file blocks a
+matching route without exposing its path or contents. Ordinary no-query
+`skills_list()` keeps its historical local/external-only listing and does not
+trigger plugin discovery.
+
+JSON is deterministically serialized but contains no query fingerprint: an
+unsalted digest is dictionary-guessable for low-entropy queries and has no
+required V1 reader. Route artifacts contain neither raw queries, local paths,
+nor skill bodies. Selected skill metadata may naturally repeat query terms.
+Human output shows route order, reasons, costs, and diagnostics. No route event
+is persisted because V1 has no concrete reader for a separate event log.
+
+Topology has an intentionally narrow authority boundary. Hermes routes only
+skills installed into the active local tree, configured external directories,
+or registered plugins. A central private MCP skill library is represented by
+one installed thin adapter skill; the adapter owns discovery, routing, and
+loading inside that library. Hermes must not crawl or ingest the library's
+catalog as a second installed inventory, and this design adds no dependency on
+the private library.
 
 Ranking uses explicit weighted field matches: exact name first, then exact
 tags/domains, then inputs/outputs/category, with loose name and description

--- a/docs/plans/2026-07-31-skill-protocol-topology-v1-design.md
+++ b/docs/plans/2026-07-31-skill-protocol-topology-v1-design.md
@@ -39,9 +39,14 @@ Topology has an intentionally narrow authority boundary. Hermes routes only
 skills installed into the active local tree, configured external directories,
 or registered plugins. A central private MCP skill library is represented by
 one installed thin adapter skill; the adapter owns discovery, routing, and
-loading inside that library. Hermes must not crawl or ingest the library's
-catalog as a second installed inventory, and this design adds no dependency on
-the private library.
+loading inside that library. `skills.central_private_roots` supplies exact
+absolute non-symlink corpus roots; native scans prune them before traversal and
+native exact loads reject them after alias resolution. The boundary is included
+in profile-scoped scan and prompt-cache signatures, so a profile or config
+change cannot retain a prior inventory. Invalid or ambiguous entries are
+diagnosed without paths and remain excluded wherever resolvable. Hermes must
+not crawl or ingest the library's catalog as a second installed inventory, and
+this design adds no dependency on the private library or its MCP package.
 
 Ranking uses explicit weighted field matches: exact name first, then exact
 tags/domains, then inputs/outputs/category, with loose name and description

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3182,14 +3182,18 @@ def _check_unavailable_skill(command_name: str) -> str | None:
     normalized = command_name.lower().replace("_", "-")
     try:
         from tools.skills_tool import _get_disabled_skill_names
-        from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+        from agent.skill_utils import (
+            get_all_skills_dirs,
+            is_excluded_skill_path,
+            iter_skill_index_files,
+        )
         disabled = _get_disabled_skill_names()
 
         # Check disabled skills across all dirs (local + external)
         for skills_dir in get_all_skills_dirs():
             if not skills_dir.exists():
                 continue
-            for skill_md in skills_dir.rglob("SKILL.md"):
+            for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
                 if is_excluded_skill_path(skill_md):
                     continue
                 slug, declared_name = _skill_slug_from_frontmatter(skill_md)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1870,6 +1870,10 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # Exact absolute directories owned by an MCP authority. Hermes never
+        # scans, lists, routes, audits, costs, or loads skills beneath them.
+        # Keep a thin local adapter skill outside these roots for MCP routing.
+        "central_private_roots": [],
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -16,7 +16,11 @@ from pathlib import Path
 from hermes_cli.config import get_hermes_home, get_env_path, get_project_root, load_config
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import (
+    get_central_private_skill_roots,
+    is_excluded_skill_path,
+    iter_skill_index_files,
+)
 
 
 def _dotenv_key_names() -> set[str]:
@@ -146,8 +150,13 @@ def _count_skills(hermes_home: Path) -> int:
     skills_dir = hermes_home / "skills"
     if not skills_dir.is_dir():
         return 0
+    authority_boundary = get_central_private_skill_roots(hermes_home / "config.yaml")
     count = 0
-    for item in skills_dir.rglob("SKILL.md"):
+    for item in iter_skill_index_files(
+        skills_dir,
+        "SKILL.md",
+        excluded_roots=authority_boundary.roots,
+    ):
         if is_excluded_skill_path(item):
             continue
         count += 1

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11387,6 +11387,10 @@ def cmd_skills(args):
         from hermes_cli.skills_config import skills_command as skills_config_command
 
         skills_config_command(args)
+    elif getattr(args, "skills_action", None) in {"route", "topology"}:
+        from hermes_cli.skills_topology import skills_topology_command
+
+        skills_topology_command(args)
     else:
         from hermes_cli.skills_hub import skills_command
 

--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -34,7 +34,11 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli import profiles as profiles_mod
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import (
+    get_central_private_skill_roots,
+    is_excluded_skill_path,
+    iter_skill_index_files,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -107,8 +111,13 @@ def _collect_skills(profile_dir: Path) -> list[str]:
     skills_dir = profile_dir / "skills"
     if not skills_dir.is_dir():
         return []
+    authority_boundary = get_central_private_skill_roots(profile_dir / "config.yaml")
     names: list[str] = []
-    for md in skills_dir.rglob("SKILL.md"):
+    for md in iter_skill_index_files(
+        skills_dir,
+        "SKILL.md",
+        excluded_roots=authority_boundary.roots,
+    ):
         if is_excluded_skill_path(md):
             continue
         try:
@@ -198,10 +207,17 @@ def describe_profile(
 
     skill_names = _collect_skills(profile_dir)
     skill_list = "\n".join(f"  - {n}" for n in skill_names) or "  (no skills installed)"
+    skills_dir = profile_dir / "skills"
+    authority_boundary = get_central_private_skill_roots(profile_dir / "config.yaml")
     skill_count = sum(
-        1 for _ in (profile_dir / "skills").rglob("SKILL.md")
-        if not is_excluded_skill_path(_)
-    ) if (profile_dir / "skills").is_dir() else 0
+        1
+        for skill_md in iter_skill_index_files(
+            skills_dir,
+            "SKILL.md",
+            excluded_roots=authority_boundary.roots,
+        )
+        if not is_excluded_skill_path(skill_md)
+    ) if skills_dir.is_dir() else 0
 
     # Read model + provider from the profile's config.
     try:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -33,7 +33,11 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, List, Optional, Tuple
 
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import (
+    get_central_private_skill_roots,
+    is_excluded_skill_path,
+    iter_skill_index_files,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -745,7 +749,7 @@ def _check_gateway_running(profile_dir: Path) -> bool:
 # renders "全部智能体 0". We cache the count keyed by the skills dir, invalidated
 # when the dir tree's signature (skills_dir + immediate category dirs mtimes)
 # changes (catches skill add/remove) or after a short TTL (catches deep edits).
-_SKILL_COUNT_CACHE: dict[str, tuple[float, float, int]] = {}
+_SKILL_COUNT_CACHE: dict[str, tuple[object, float, int]] = {}
 _SKILL_COUNT_TTL_SECONDS = 30.0
 
 
@@ -783,7 +787,8 @@ def _count_skills(profile_dir: Path) -> int:
         return 0
 
     key = str(skills_dir)
-    signature = _skills_dir_signature(skills_dir)
+    authority_boundary = get_central_private_skill_roots(profile_dir / "config.yaml")
+    signature = (_skills_dir_signature(skills_dir), authority_boundary.signature)
     now = time.time()
     cached = _SKILL_COUNT_CACHE.get(key)
     if (
@@ -794,7 +799,11 @@ def _count_skills(profile_dir: Path) -> int:
         return cached[2]
 
     count = 0
-    for md in skills_dir.rglob("SKILL.md"):
+    for md in iter_skill_index_files(
+        skills_dir,
+        "SKILL.md",
+        excluded_roots=authority_boundary.roots,
+    ):
         if is_excluded_skill_path(md):
             continue
         count += 1

--- a/hermes_cli/skills_topology.py
+++ b/hermes_cli/skills_topology.py
@@ -9,12 +9,11 @@ from agent.skill_topology import audit_topology, plan_skill_route
 
 
 def _load_skill_records(*, include_disabled: bool) -> list[dict[str, Any]]:
-    """Load rich records through the canonical skill scanner."""
-    from tools.skills_tool import _find_all_skills
+    """Load the same rich installed inventory as the model-tool topology path."""
+    from tools.skills_tool import build_installed_skill_inventory
 
-    return _find_all_skills(
+    return build_installed_skill_inventory(
         skip_disabled=include_disabled,
-        include_topology=True,
         include_ineligible=include_disabled,
     )
 
@@ -33,7 +32,6 @@ def _print_diagnostics(diagnostics: list[dict[str, Any]]) -> None:
 
 def _print_route(artifact: dict[str, Any]) -> None:
     print(f"Skill route: {artifact['status']}")
-    print(f"Query digest: {artifact['query_digest']}")
     print(
         f"Budget: {artifact['total_cost_chars']}/"
         f"{artifact['limits']['budget_chars']} characters; "

--- a/hermes_cli/skills_topology.py
+++ b/hermes_cli/skills_topology.py
@@ -1,0 +1,103 @@
+"""Read-only CLI adapter for local skill topology routing and audits."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent.skill_topology import audit_topology, plan_skill_route
+
+
+def _load_skill_records(*, include_disabled: bool) -> list[dict[str, Any]]:
+    """Load rich records through the canonical skill scanner."""
+    from tools.skills_tool import _find_all_skills
+
+    return _find_all_skills(
+        skip_disabled=include_disabled,
+        include_topology=True,
+        include_ineligible=include_disabled,
+    )
+
+
+def _print_json(artifact: dict[str, Any]) -> None:
+    print(json.dumps(artifact, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def _print_diagnostics(diagnostics: list[dict[str, Any]]) -> None:
+    if not diagnostics:
+        return
+    print("Diagnostics:")
+    for diagnostic in diagnostics:
+        print(f"  - [{diagnostic['code']}] {diagnostic['message']}")
+
+
+def _print_route(artifact: dict[str, Any]) -> None:
+    print(f"Skill route: {artifact['status']}")
+    print(f"Query digest: {artifact['query_digest']}")
+    print(
+        f"Budget: {artifact['total_cost_chars']}/"
+        f"{artifact['limits']['budget_chars']} characters; "
+        f"{len(artifact['route'])}/{artifact['limits']['max_skills']} skills"
+    )
+    for index, item in enumerate(artifact["route"], start=1):
+        print(
+            f"{index}. {item['name']} [{item['graph_role']}] "
+            f"score={item['score']} cost={item['cost_chars']} "
+            f"cumulative={item['cumulative_cost_chars']}"
+        )
+        print(f"   Why: {', '.join(item['reasons'])}")
+    _print_diagnostics(artifact["diagnostics"])
+
+
+def _print_audit(artifact: dict[str, Any]) -> None:
+    summary = artifact["summary"]
+    counts = summary["lifecycle_counts"]
+    print(f"Skill topology: {artifact['status']}")
+    print(
+        "Manifest coverage: "
+        f"{summary['manifests_declared']}/{summary['skill_count']} "
+        f"({summary['manifest_coverage_percent']:.2f}%)"
+    )
+    print(
+        "Lifecycle: "
+        + ", ".join(f"{name}={count}" for name, count in counts.items())
+    )
+    print(
+        f"Graph findings: missing/self/invalid diagnostics="
+        f"{sum(1 for item in artifact['diagnostics'] if item['code'] not in {'dependency_cycle', 'conflict'})}, "
+        f"cycles={len(artifact['cycles'])}, conflicts={len(artifact['conflicts'])}"
+    )
+    _print_diagnostics(artifact["diagnostics"])
+
+
+def skills_topology_command(args) -> dict[str, Any]:
+    """Dispatch ``hermes skills route|topology`` and return its artifact."""
+    action = getattr(args, "skills_action", None)
+    if action == "route":
+        query = " ".join(args.query)
+        records = _load_skill_records(include_disabled=False)
+        artifact = plan_skill_route(
+            records,
+            query,
+            max_skills=args.limit,
+            budget_chars=args.budget_chars,
+        )
+        if args.json:
+            _print_json(artifact)
+        else:
+            _print_route(artifact)
+        return artifact
+
+    if action == "topology":
+        records = _load_skill_records(include_disabled=True)
+        artifact = audit_topology(records)
+        if args.json:
+            _print_json(artifact)
+        else:
+            _print_audit(artifact)
+        return artifact
+
+    raise ValueError(f"Unsupported local skills action: {action}")
+
+
+__all__ = ["skills_topology_command"]

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -93,7 +93,9 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         "route", help="Plan a small local skill route for a query"
     )
     skills_route.add_argument(
-        "query", nargs="+", help="Local routing query (never stored or emitted in JSON)"
+        "query",
+        nargs="+",
+        help="Local routing query (not stored; JSON has no dedicated query field)",
     )
     skills_route.add_argument(
         "--limit",

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -6,7 +6,17 @@ Handler injected to avoid importing ``main``.
 
 from __future__ import annotations
 
+import argparse
 from typing import Callable
+
+from agent.skill_topology import DEFAULT_ROUTE_BUDGET_CHARS, DEFAULT_ROUTE_LIMIT
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
 
 
 def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
@@ -77,6 +87,38 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
             "minimax",
         ],
         help="Filter by source or provider (e.g. nvidia, openai)",
+    )
+
+    skills_route = skills_subparsers.add_parser(
+        "route", help="Plan a small local skill route for a query"
+    )
+    skills_route.add_argument(
+        "query", nargs="+", help="Local routing query (never stored or emitted in JSON)"
+    )
+    skills_route.add_argument(
+        "--limit",
+        type=_positive_int,
+        default=DEFAULT_ROUTE_LIMIT,
+        help=f"Maximum skills including requirements (default: {DEFAULT_ROUTE_LIMIT})",
+    )
+    skills_route.add_argument(
+        "--budget-chars",
+        type=_positive_int,
+        default=DEFAULT_ROUTE_BUDGET_CHARS,
+        help=(
+            "Maximum cumulative SKILL.md characters "
+            f"(default: {DEFAULT_ROUTE_BUDGET_CHARS})"
+        ),
+    )
+    skills_route.add_argument(
+        "--json", action="store_true", help="Output a stable JSON route artifact"
+    )
+
+    skills_topology = skills_subparsers.add_parser(
+        "topology", help="Audit the installed local skill topology graph"
+    )
+    skills_topology.add_argument(
+        "--json", action="store_true", help="Output a stable JSON audit artifact"
     )
     skills_search.add_argument("--limit", type=int, default=25, help="Max results")
     skills_search.add_argument(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13903,10 +13903,12 @@ def _disable_unselected_skills(profile_dir: Path, keep: List[str]) -> int:
     disabled_count = 0
     token = set_hermes_home_override(str(profile_dir))
     try:
+        from agent.skill_utils import iter_skill_index_files
+
         installed: List[str] = []
         skills_root = profile_dir / "skills"
         if skills_root.is_dir():
-            for md in skills_root.rglob("SKILL.md"):
+            for md in iter_skill_index_files(skills_root, "SKILL.md"):
                 installed.append(md.parent.name)
         cfg = load_config()
         disabled = get_disabled_skills(cfg)

--- a/skills/software-development/plan/SKILL.md
+++ b/skills/software-development/plan/SKILL.md
@@ -9,6 +9,12 @@ metadata:
   hermes:
     tags: [planning, plan-mode, implementation, workflow, design, documentation]
     related_skills: [subagent-driven-development, test-driven-development, requesting-code-review]
+    topology:
+      domains: [software-development, planning]
+      inputs: [requirements, design]
+      outputs: [implementation-plan]
+      precedes: [test-driven-development, systematic-debugging]
+      lifecycle: stable
 ---
 
 # Plan Mode

--- a/skills/software-development/requesting-code-review/SKILL.md
+++ b/skills/software-development/requesting-code-review/SKILL.md
@@ -9,6 +9,13 @@ metadata:
   hermes:
     tags: [code-review, security, verification, quality, pre-commit, auto-fix]
     related_skills: [subagent-driven-development, plan, test-driven-development, github-code-review]
+    topology:
+      domains: [software-development, code-review]
+      inputs: [tested-implementation, tested-fix, code-diff]
+      outputs: [review-findings, verified-change]
+      requires: [test-driven-development]
+      follows: [test-driven-development, systematic-debugging]
+      lifecycle: stable
 ---
 
 # Pre-Commit Code Verification

--- a/skills/software-development/systematic-debugging/SKILL.md
+++ b/skills/software-development/systematic-debugging/SKILL.md
@@ -9,6 +9,13 @@ metadata:
   hermes:
     tags: [debugging, troubleshooting, problem-solving, root-cause, investigation]
     related_skills: [test-driven-development, plan, subagent-driven-development]
+    topology:
+      domains: [software-development, debugging]
+      inputs: [bug-report, failing-test, unexpected-behavior]
+      outputs: [root-cause, tested-fix]
+      follows: [plan]
+      precedes: [requesting-code-review]
+      lifecycle: stable
 ---
 
 # Systematic Debugging

--- a/skills/software-development/test-driven-development/SKILL.md
+++ b/skills/software-development/test-driven-development/SKILL.md
@@ -9,6 +9,13 @@ metadata:
   hermes:
     tags: [testing, tdd, development, quality, red-green-refactor]
     related_skills: [systematic-debugging, plan, subagent-driven-development]
+    topology:
+      domains: [software-development, testing]
+      inputs: [requirements, implementation-plan, bug-report]
+      outputs: [failing-test, tested-implementation]
+      follows: [plan]
+      precedes: [requesting-code-review]
+      lifecycle: stable
 ---
 
 # Test-Driven Development (TDD)

--- a/tests/agent/test_skill_topology.py
+++ b/tests/agent/test_skill_topology.py
@@ -67,7 +67,7 @@ def test_parse_topology_absent_is_valid_and_invalid_lifecycle_is_retained_for_au
     assert invalid.invalid_lifecycle == "preview"
 
 
-def test_exact_name_and_taxonomy_matches_beat_description_words():
+def test_route_selects_only_the_highest_scoring_root_tier():
     skills = [
         skill("testing", description="Loose testing helper"),
         skill("other", topology={"domains": ["testing"], "lifecycle": "stable"}),
@@ -76,9 +76,124 @@ def test_exact_name_and_taxonomy_matches_beat_description_words():
 
     route = plan_skill_route(skills, "testing", max_skills=3, budget_chars=1000)
 
-    assert [item["name"] for item in route["route"]] == ["testing", "third", "other"]
-    assert route["route"][0]["score"] > route["route"][1]["score"]
-    assert route["route"][1]["score"] > route["route"][2]["score"]
+    assert [item["name"] for item in route["route"]] == ["testing"]
+
+
+def test_ranking_is_exact_name_then_exact_tag_then_exact_domain_then_description():
+    query = "testing"
+    records = [
+        skill("testing"),
+        skill("tag-match", tags=["testing"]),
+        skill("domain-match", topology={"domains": ["testing"]}),
+        skill("description-match", description="Testing helper"),
+    ]
+
+    scores = [
+        plan_skill_route(records[index:], query, max_skills=4, budget_chars=1000)[
+            "route"
+        ][0]["score"]
+        for index in range(len(records))
+    ]
+
+    assert scores[0] > scores[1] > scores[2] > scores[3]
+
+
+def test_route_excludes_weak_description_root_after_review_tier_is_selected():
+    skills = [
+        skill(
+            "github-code-review",
+            tags=["code-review"],
+            description="Review pull requests",
+        ),
+        skill(
+            "requesting-code-review",
+            tags=["code-review"],
+            description="Review completed work",
+        ),
+        skill(
+            "ads-creative",
+            category="marketing",
+            description="Review advertising creative",
+        ),
+    ]
+
+    result = plan_skill_route(
+        skills,
+        "code review",
+        max_skills=5,
+        budget_chars=1000,
+    )
+
+    assert [item["name"] for item in result["route"]] == [
+        "github-code-review",
+        "requesting-code-review",
+    ]
+    assert all(
+        diagnostic.get("skill") != "ads-creative"
+        and "ads-creative" not in diagnostic.get("message", "")
+        for diagnostic in result["diagnostics"]
+    )
+
+
+def test_route_falls_back_when_every_root_in_higher_tier_cannot_fit():
+    skills = [
+        skill("budget-heavy", tags=["testing"], cost=200),
+        skill("limit-heavy", tags=["testing"], topology={"requires": "dependency"}),
+        skill("dependency", cost=50),
+        skill("fallback", description="Testing helper", cost=50),
+    ]
+
+    result = plan_skill_route(
+        skills,
+        "testing",
+        max_skills=1,
+        budget_chars=100,
+    )
+
+    assert [item["name"] for item in result["route"]] == ["fallback"]
+    assert diagnostic_codes(result) == ["budget_omission", "limit_omission"]
+
+
+def test_route_falls_back_after_higher_tier_graph_fault_and_keeps_diagnostic():
+    result = plan_skill_route(
+        [
+            skill("broken", tags=["testing"], topology={"requires": "missing"}),
+            skill("fallback", description="Testing helper"),
+        ],
+        "testing",
+        max_skills=2,
+        budget_chars=1000,
+    )
+
+    assert [item["name"] for item in result["route"]] == ["fallback"]
+    assert diagnostic_codes(result) == ["missing_required_skill"]
+
+
+@pytest.mark.parametrize(
+    ("max_skills", "budget_chars", "second_topology", "expected_code"),
+    [
+        (1, 1000, None, "limit_omission"),
+        (3, 100, None, "budget_omission"),
+        (3, 1000, {"conflicts": "alpha"}, "route_conflict"),
+    ],
+)
+def test_tied_root_omission_is_explicit_without_lower_tier_diagnostics(
+    max_skills, budget_chars, second_topology, expected_code
+):
+    result = plan_skill_route(
+        [
+            skill("alpha", tags=["testing"], cost=60),
+            skill("beta", tags=["testing"], topology=second_topology, cost=60),
+            skill("weak", description="Testing helper", cost=1001),
+        ],
+        "testing",
+        max_skills=max_skills,
+        budget_chars=budget_chars,
+    )
+
+    assert [item["name"] for item in result["route"]] == ["alpha"]
+    assert [diagnostic["skill"] for diagnostic in result["diagnostics"]] == ["beta"]
+    assert diagnostic_codes(result) == [expected_code]
 
 
 def test_ranking_ties_are_deterministic_by_name_then_category():

--- a/tests/agent/test_skill_topology.py
+++ b/tests/agent/test_skill_topology.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import json
 
 import pytest
@@ -491,7 +490,7 @@ def test_budget_and_limit_omissions_are_explicit():
     assert "limit_omission" in diagnostic_codes(limited)
 
 
-def test_no_match_is_explicit_and_json_artifact_never_contains_raw_query():
+def test_no_match_is_explicit_and_json_artifact_contains_no_query_fingerprint():
     query = "private phrase 8675309"
     result = plan_skill_route(
         [skill("testing", description="Write tests")],
@@ -502,7 +501,7 @@ def test_no_match_is_explicit_and_json_artifact_never_contains_raw_query():
 
     encoded = json.dumps(result, sort_keys=True)
     assert result["status"] == "no_match"
-    assert result["query_digest"] == hashlib.sha256(query.encode("utf-8")).hexdigest()
+    assert "query_digest" not in result
     assert query not in encoded
     assert "8675309" not in encoded
 

--- a/tests/agent/test_skill_topology.py
+++ b/tests/agent/test_skill_topology.py
@@ -98,6 +98,30 @@ def test_ranking_is_exact_name_then_exact_tag_then_exact_domain_then_description
     assert scores[0] > scores[1] > scores[2] > scores[3]
 
 
+@pytest.mark.parametrize(
+    ("label", "record_kwargs"),
+    [
+        ("tag", {"tags": ["private phrase 8675309"]}),
+        ("domain", {"topology": {"domains": ["private phrase 8675309"]}}),
+        ("input", {"topology": {"inputs": ["private phrase 8675309"]}}),
+        ("output", {"topology": {"outputs": ["private phrase 8675309"]}}),
+        ("category", {"category": "private phrase 8675309"}),
+    ],
+)
+def test_exact_taxonomy_reasons_do_not_echo_the_matched_value(label, record_kwargs):
+    query = "private phrase 8675309"
+    record = skill(f"helper for {query}", **record_kwargs)
+
+    result = plan_skill_route(
+        [record], query, max_skills=1, budget_chars=1000
+    )
+
+    assert result["route"][0]["name"] == f"helper for {query}"
+    assert f"matched exact {label}" in result["route"][0]["reasons"]
+    assert all(query not in reason for reason in result["route"][0]["reasons"])
+    assert "query" not in result
+
+
 def test_route_excludes_weak_description_root_after_review_tier_is_selected():
     skills = [
         skill(
@@ -207,6 +231,114 @@ def test_ranking_ties_are_deterministic_by_name_then_category():
 
     assert [item["name"] for item in first["route"]] == ["alpha", "zeta"]
     assert first == second
+
+
+def test_collision_only_query_fails_closed_without_duplicate_route_or_budget():
+    records = [
+        skill("Review", tags=["review"], cost=100),
+        skill("review", tags=["review"], cost=700),
+    ]
+
+    result = plan_skill_route(
+        records, "review", max_skills=5, budget_chars=1000
+    )
+
+    assert result["status"] == "blocked"
+    assert result["route"] == []
+    assert result["total_cost_chars"] == 0
+    assert result["total_cost_bytes"] == 0
+    assert diagnostic_codes(result) == ["canonical_name_collision"]
+    assert result["diagnostics"][0]["canonical_name"] == "review"
+    assert result["diagnostics"][0]["names"] == ["Review", "review"]
+
+
+def test_unrelated_unique_skill_routes_when_another_name_is_ambiguous():
+    result = plan_skill_route(
+        [
+            skill("Review", tags=["review"]),
+            skill("review", tags=["review"]),
+            skill("testing", cost=75),
+        ],
+        "testing",
+        max_skills=5,
+        budget_chars=1000,
+    )
+
+    assert result["status"] == "ok"
+    assert [item["name"] for item in result["route"]] == ["testing"]
+    assert result["total_cost_chars"] == 75
+    assert diagnostic_codes(result) == ["canonical_name_collision"]
+
+
+def test_ambiguous_required_dependency_blocks_root_as_collision_not_missing():
+    result = plan_skill_route(
+        [
+            skill("Review"),
+            skill("review"),
+            skill(
+                "publish",
+                topology={"requires": "review", "follows": "review"},
+            ),
+        ],
+        "publish",
+        max_skills=5,
+        budget_chars=1000,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["route"] == []
+    assert "canonical_name_collision" in diagnostic_codes(result)
+    assert "missing_required_skill" not in diagnostic_codes(result)
+    assert "missing_reference" not in diagnostic_codes(result)
+
+
+def test_collision_route_and_audit_artifacts_are_input_order_independent():
+    records = [
+        skill("Review", tags=["review"], cost=100),
+        skill("review", tags=["review"], cost=700),
+        skill("testing", topology={"lifecycle": "stable"}, cost=75),
+    ]
+
+    collision_route = plan_skill_route(
+        records, "review", max_skills=5, budget_chars=1000
+    )
+    reversed_collision_route = plan_skill_route(
+        list(reversed(records)), "review", max_skills=5, budget_chars=1000
+    )
+    unique_route = plan_skill_route(
+        records, "testing", max_skills=5, budget_chars=1000
+    )
+    reversed_unique_route = plan_skill_route(
+        list(reversed(records)), "testing", max_skills=5, budget_chars=1000
+    )
+    audit = audit_topology(records)
+    reversed_audit = audit_topology(list(reversed(records)))
+
+    assert json.dumps(collision_route, sort_keys=True) == json.dumps(
+        reversed_collision_route, sort_keys=True
+    )
+    assert json.dumps(unique_route, sort_keys=True) == json.dumps(
+        reversed_unique_route, sort_keys=True
+    )
+    assert json.dumps(audit, sort_keys=True) == json.dumps(
+        reversed_audit, sort_keys=True
+    )
+    assert diagnostic_codes(audit) == ["canonical_name_collision"]
+
+
+def test_exact_case_duplicate_records_also_fail_closed_once():
+    duplicate = skill("review", tags=["review"], cost=100)
+
+    route = plan_skill_route(
+        [duplicate, dict(duplicate)], "review", max_skills=5, budget_chars=1000
+    )
+    audit = audit_topology([duplicate, dict(duplicate)])
+
+    assert route["route"] == []
+    assert route["total_cost_chars"] == 0
+    assert diagnostic_codes(route) == ["canonical_name_collision"]
+    assert diagnostic_codes(audit) == ["canonical_name_collision"]
+    assert audit["diagnostics"][0]["record_count"] == 2
 
 
 def test_transitive_requirements_are_ordered_before_the_matching_root():

--- a/tests/agent/test_skill_topology.py
+++ b/tests/agent/test_skill_topology.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from agent.skill_topology import (
+    TOPOLOGY_FIELDS,
+    audit_topology,
+    parse_topology,
+    plan_skill_route,
+)
+
+
+def skill(
+    name: str,
+    *,
+    description: str = "",
+    category: str = "software-development",
+    tags=(),
+    topology=None,
+    cost: int = 100,
+):
+    return {
+        "name": name,
+        "description": description,
+        "category": category,
+        "tags": list(tags),
+        "topology": topology,
+        "cost_chars": cost,
+        "cost_bytes": cost,
+    }
+
+
+def diagnostic_codes(artifact):
+    return [item["code"] for item in artifact["diagnostics"]]
+
+
+def test_parse_topology_normalizes_scalars_lists_and_duplicates():
+    topology = parse_topology(
+        {
+            "domains": " Testing ",
+            "inputs": ["requirements", " requirements ", None, {"bad": "shape"}],
+            "requires": "plan",
+            "permissions": ["terminal", 7],
+            "lifecycle": " STABLE ",
+        }
+    )
+
+    assert topology.declared is True
+    assert topology.domains == ("testing",)
+    assert topology.inputs == ("requirements",)
+    assert topology.requires == ("plan",)
+    assert topology.permissions == ("terminal", "7")
+    assert topology.lifecycle == "stable"
+    assert set(topology.to_dict()) == set(TOPOLOGY_FIELDS)
+
+
+def test_parse_topology_absent_is_valid_and_invalid_lifecycle_is_retained_for_audit():
+    absent = parse_topology(None)
+    invalid = parse_topology({"lifecycle": "preview"})
+
+    assert absent.declared is False
+    assert absent.lifecycle is None
+    assert invalid.lifecycle is None
+    assert invalid.invalid_lifecycle == "preview"
+
+
+def test_exact_name_and_taxonomy_matches_beat_description_words():
+    skills = [
+        skill("testing", description="Loose testing helper"),
+        skill("other", topology={"domains": ["testing"], "lifecycle": "stable"}),
+        skill("third", tags=["testing"], description="Unrelated"),
+    ]
+
+    route = plan_skill_route(skills, "testing", max_skills=3, budget_chars=1000)
+
+    assert [item["name"] for item in route["route"]] == ["testing", "third", "other"]
+    assert route["route"][0]["score"] > route["route"][1]["score"]
+    assert route["route"][1]["score"] > route["route"][2]["score"]
+
+
+def test_ranking_ties_are_deterministic_by_name_then_category():
+    skills = [
+        skill("zeta", tags=["testing"]),
+        skill("alpha", tags=["testing"]),
+    ]
+
+    first = plan_skill_route(skills, "testing", max_skills=2, budget_chars=1000)
+    second = plan_skill_route(list(reversed(skills)), "testing", max_skills=2, budget_chars=1000)
+
+    assert [item["name"] for item in first["route"]] == ["alpha", "zeta"]
+    assert first == second
+
+
+def test_transitive_requirements_are_ordered_before_the_matching_root():
+    skills = [
+        skill("plan", topology={"lifecycle": "stable"}),
+        skill("tdd", topology={"requires": "plan", "lifecycle": "stable"}),
+        skill("review", topology={"requires": "tdd", "lifecycle": "stable"}),
+    ]
+
+    result = plan_skill_route(skills, "review", max_skills=3, budget_chars=1000)
+
+    assert result["status"] == "ok"
+    assert [item["name"] for item in result["route"]] == ["plan", "tdd", "review"]
+    assert [item["graph_role"] for item in result["route"]] == ["required", "required", "root"]
+    assert result["route"][-1]["cumulative_cost_chars"] == 300
+
+
+@pytest.mark.parametrize(
+    ("topology", "expected_code"),
+    [
+        ({"requires": "missing"}, "missing_reference"),
+        ({"requires": "root"}, "self_reference"),
+        ({"lifecycle": "preview"}, "invalid_lifecycle"),
+    ],
+)
+def test_audit_reports_manifest_errors(topology, expected_code):
+    audit = audit_topology([skill("root", topology=topology)])
+
+    assert expected_code in diagnostic_codes(audit)
+    assert audit["status"] == "issues"
+
+
+def test_audit_reports_dependency_cycles_and_declared_conflicts():
+    skills = [
+        skill("a", topology={"requires": "b", "conflicts": "b"}),
+        skill("b", topology={"requires": "a"}),
+    ]
+
+    audit = audit_topology(skills)
+
+    assert "dependency_cycle" in diagnostic_codes(audit)
+    assert "conflict" in diagnostic_codes(audit)
+    assert audit["cycles"] == [["a", "b", "a"]]
+    assert audit["conflicts"] == [["a", "b"]]
+
+
+def test_route_is_blocked_when_matching_skill_has_missing_requirement():
+    result = plan_skill_route(
+        [skill("review", topology={"requires": "missing"})],
+        "review",
+        max_skills=3,
+        budget_chars=1000,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["route"] == []
+    assert "missing_required_skill" in diagnostic_codes(result)
+
+
+def test_route_reports_non_dependency_reference_faults_without_guessing():
+    result = plan_skill_route(
+        [
+            skill(
+                "review",
+                topology={"follows": "missing", "precedes": "review"},
+            )
+        ],
+        "review",
+        max_skills=2,
+        budget_chars=1000,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["route"] == []
+    assert "missing_reference" in diagnostic_codes(result)
+    assert "self_reference" in diagnostic_codes(result)
+
+
+def test_route_is_blocked_by_dependency_cycle_and_conflict():
+    cycle = plan_skill_route(
+        [
+            skill("a", topology={"requires": "b"}),
+            skill("b", topology={"requires": "a"}),
+        ],
+        "a",
+        max_skills=3,
+        budget_chars=1000,
+    )
+    conflict = plan_skill_route(
+        [
+            skill("a", topology={"requires": "b", "conflicts": "b"}),
+            skill("b"),
+        ],
+        "a",
+        max_skills=3,
+        budget_chars=1000,
+    )
+
+    assert cycle["status"] == "blocked"
+    assert "dependency_cycle" in diagnostic_codes(cycle)
+    assert conflict["status"] == "blocked"
+    assert "route_conflict" in diagnostic_codes(conflict)
+
+
+def test_budget_and_limit_omissions_are_explicit():
+    skills = [
+        skill("large", tags=["testing"], cost=500),
+        skill("small", tags=["testing"], cost=80),
+    ]
+
+    budgeted = plan_skill_route(skills, "testing", max_skills=2, budget_chars=100)
+    limited = plan_skill_route(
+        [skill("root", topology={"requires": "dep"}), skill("dep")],
+        "root",
+        max_skills=1,
+        budget_chars=1000,
+    )
+
+    assert [item["name"] for item in budgeted["route"]] == ["small"]
+    assert "budget_omission" in diagnostic_codes(budgeted)
+    assert limited["status"] == "blocked"
+    assert "limit_omission" in diagnostic_codes(limited)
+
+
+def test_no_match_is_explicit_and_json_artifact_never_contains_raw_query():
+    query = "private phrase 8675309"
+    result = plan_skill_route(
+        [skill("testing", description="Write tests")],
+        query,
+        max_skills=3,
+        budget_chars=1000,
+    )
+
+    encoded = json.dumps(result, sort_keys=True)
+    assert result["status"] == "no_match"
+    assert result["query_digest"] == hashlib.sha256(query.encode("utf-8")).hexdigest()
+    assert query not in encoded
+    assert "8675309" not in encoded
+
+
+def test_audit_reports_coverage_and_lifecycle_counts():
+    audit = audit_topology(
+        [
+            skill("stable", topology={"lifecycle": "stable"}),
+            skill("old", topology={"lifecycle": "deprecated"}),
+            skill("plain"),
+        ]
+    )
+
+    assert audit["summary"]["skill_count"] == 3
+    assert audit["summary"]["manifests_declared"] == 2
+    assert audit["summary"]["manifest_coverage_percent"] == pytest.approx(66.67)
+    assert audit["summary"]["lifecycle_counts"] == {
+        "experimental": 0,
+        "candidate": 0,
+        "stable": 1,
+        "deprecated": 1,
+        "unspecified": 1,
+        "invalid": 0,
+    }

--- a/tests/agent/test_skill_topology.py
+++ b/tests/agent/test_skill_topology.py
@@ -252,20 +252,48 @@ def test_collision_only_query_fails_closed_without_duplicate_route_or_budget():
     assert result["diagnostics"][0]["names"] == ["Review", "review"]
 
 
-def test_unrelated_unique_skill_routes_when_another_name_is_ambiguous():
+def test_matching_collision_blocks_before_lower_scoring_unique_roots_deterministically():
+    records = [
+        skill("Review", tags=["review"], cost=100),
+        skill("review", tags=["review"], cost=700),
+        skill("github-code-review", description="Review pull requests"),
+        skill("requesting-code-review", description="Review completed work"),
+        skill("deploy", cost=75),
+    ]
+
+    artifacts = [
+        plan_skill_route(order, "review", max_skills=5, budget_chars=2000)
+        for order in (records, list(reversed(records)))
+    ]
+    encoded = [
+        json.dumps(artifact, sort_keys=True, separators=(",", ":"))
+        for artifact in artifacts
+    ]
+
+    assert encoded[0] == encoded[1]
+    result = artifacts[0]
+    assert result["status"] == "blocked"
+    assert result["route"] == []
+    assert result["total_cost_chars"] == 0
+    assert result["total_cost_bytes"] == 0
+    assert diagnostic_codes(result) == ["canonical_name_collision"]
+
+
+def test_unrelated_unique_deploy_routes_when_composed_review_collision_scores_zero():
+    records = [
+        skill("Review", tags=["review"]),
+        skill("review", tags=["review"]),
+        skill("github-code-review", description="Review pull requests"),
+        skill("requesting-code-review", description="Review completed work"),
+        skill("deploy", cost=75),
+    ]
+
     result = plan_skill_route(
-        [
-            skill("Review", tags=["review"]),
-            skill("review", tags=["review"]),
-            skill("testing", cost=75),
-        ],
-        "testing",
-        max_skills=5,
-        budget_chars=1000,
+        records, "deploy", max_skills=5, budget_chars=1000
     )
 
     assert result["status"] == "ok"
-    assert [item["name"] for item in result["route"]] == ["testing"]
+    assert [item["name"] for item in result["route"]] == ["deploy"]
     assert result["total_cost_chars"] == 75
     assert diagnostic_codes(result) == ["canonical_name_collision"]
 

--- a/tests/agent/test_skill_topology_builtins.py
+++ b/tests/agent/test_skill_topology_builtins.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+from agent.skill_topology import (
+    DEFAULT_ROUTE_BUDGET_CHARS,
+    audit_topology,
+    parse_topology,
+    plan_skill_route,
+)
+from agent.skill_utils import parse_frontmatter
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAIN = (
+    "plan",
+    "test-driven-development",
+    "systematic-debugging",
+    "requesting-code-review",
+)
+
+
+def _load_chain():
+    records = []
+    for name in CHAIN:
+        skill_md = REPO_ROOT / "skills" / "software-development" / name / "SKILL.md"
+        raw = skill_md.read_bytes()
+        content = raw.decode("utf-8")
+        frontmatter, _ = parse_frontmatter(content)
+        hermes = frontmatter["metadata"]["hermes"]
+        records.append(
+            {
+                "name": frontmatter["name"],
+                "description": frontmatter["description"],
+                "category": "software-development",
+                "tags": hermes["tags"],
+                "topology": parse_topology(hermes.get("topology")),
+                "cost_chars": len(content),
+                "cost_bytes": len(raw),
+            }
+        )
+    return records
+
+
+def test_builtin_planning_tdd_debugging_review_topology_is_valid():
+    records = _load_chain()
+
+    audit = audit_topology(records)
+
+    assert audit["status"] == "ok"
+    assert audit["summary"]["manifests_declared"] == 4
+
+
+def test_builtin_review_route_loads_tdd_first_without_plan_mode_instructions():
+    records = _load_chain()
+    route = plan_skill_route(
+        records,
+        "review",
+        max_skills=2,
+        budget_chars=DEFAULT_ROUTE_BUDGET_CHARS,
+    )
+
+    assert route["status"] == "ok"
+    assert [item["name"] for item in route["route"]] == [
+        "test-driven-development",
+        "requesting-code-review",
+    ]
+    assert route["total_cost_chars"] <= DEFAULT_ROUTE_BUDGET_CHARS

--- a/tests/hermes_cli/test_skills_topology_cli.py
+++ b/tests/hermes_cli/test_skills_topology_cli.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.skill_topology import parse_topology
+from hermes_cli.subcommands.skills import build_skills_parser
+
+
+def _parser():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_skills_parser(subparsers, cmd_skills=lambda args: None)
+    return parser
+
+
+def _record(name, *, topology=None, tags=(), description="", cost=100):
+    return {
+        "name": name,
+        "description": description,
+        "category": "software-development",
+        "tags": list(tags),
+        "topology": parse_topology(topology),
+        "cost_chars": cost,
+        "cost_bytes": cost,
+    }
+
+
+def test_route_parser_accepts_multiword_query_and_budget_options():
+    args = _parser().parse_args(
+        [
+            "skills",
+            "route",
+            "review",
+            "this",
+            "change",
+            "--limit",
+            "3",
+            "--budget-chars",
+            "9000",
+            "--json",
+        ]
+    )
+
+    assert args.skills_action == "route"
+    assert args.query == ["review", "this", "change"]
+    assert args.limit == 3
+    assert args.budget_chars == 9000
+    assert args.json is True
+
+
+def test_topology_parser_is_read_only_and_supports_json():
+    args = _parser().parse_args(["skills", "topology", "--json"])
+
+    assert args.skills_action == "topology"
+    assert args.json is True
+    assert not hasattr(args, "deep")
+
+
+def test_topology_loader_requests_the_full_installed_graph(monkeypatch):
+    from hermes_cli import skills_topology
+    from tools import skills_tool
+
+    captured = {}
+
+    def fake_find_all_skills(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(skills_tool, "_find_all_skills", fake_find_all_skills)
+
+    skills_topology._load_skill_records(include_disabled=True)
+
+    assert captured == {
+        "skip_disabled": True,
+        "include_topology": True,
+        "include_ineligible": True,
+    }
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["skills", "route", "query", "--limit", "0"],
+        ["skills", "route", "query", "--budget-chars", "-1"],
+    ],
+)
+def test_route_parser_rejects_nonpositive_limits(argv):
+    with pytest.raises(SystemExit):
+        _parser().parse_args(argv)
+
+
+def test_route_json_is_stable_and_omits_raw_query(monkeypatch, capsys):
+    from hermes_cli import skills_topology
+
+    records = [
+        _record("plan", topology={"lifecycle": "stable"}),
+        _record(
+            "review-private-8675309",
+            topology={"requires": "plan", "lifecycle": "candidate"},
+        ),
+    ]
+    monkeypatch.setattr(skills_topology, "_load_skill_records", lambda **kwargs: records)
+    args = SimpleNamespace(
+        skills_action="route",
+        query=["review", "private-8675309"],
+        limit=2,
+        budget_chars=1000,
+        json=True,
+    )
+
+    first = skills_topology.skills_topology_command(args)
+    first_output = capsys.readouterr().out
+    second = skills_topology.skills_topology_command(args)
+    second_output = capsys.readouterr().out
+
+    payload = json.loads(first_output)
+    assert first == second
+    assert first_output == second_output
+    assert payload["query_digest"] == hashlib.sha256(
+        b"review private-8675309"
+    ).hexdigest()
+    assert [item["name"] for item in payload["route"]] == [
+        "plan",
+        "review-private-8675309",
+    ]
+    assert "review private-8675309" not in first_output
+
+
+def test_route_human_output_shows_order_reasons_and_budget(monkeypatch, capsys):
+    from hermes_cli import skills_topology
+
+    records = [
+        _record("plan", cost=75),
+        _record("review", topology={"requires": "plan"}, cost=125),
+    ]
+    monkeypatch.setattr(skills_topology, "_load_skill_records", lambda **kwargs: records)
+    args = SimpleNamespace(
+        skills_action="route",
+        query=["review"],
+        limit=2,
+        budget_chars=500,
+        json=False,
+    )
+
+    skills_topology.skills_topology_command(args)
+    output = capsys.readouterr().out
+
+    assert "1. plan [required]" in output
+    assert "2. review [root]" in output
+    assert "Why: required by review" in output
+    assert "Budget: 200/500 characters" in output
+
+
+def test_topology_json_reports_coverage_lifecycle_and_faults(monkeypatch, capsys):
+    from hermes_cli import skills_topology
+
+    records = [
+        _record("a", topology={"requires": "missing", "lifecycle": "stable"}),
+        _record("plain"),
+    ]
+    monkeypatch.setattr(skills_topology, "_load_skill_records", lambda **kwargs: records)
+    args = SimpleNamespace(skills_action="topology", json=True)
+
+    artifact = skills_topology.skills_topology_command(args)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload == artifact
+    assert payload["summary"]["manifests_declared"] == 1
+    assert payload["summary"]["lifecycle_counts"]["stable"] == 1
+    assert payload["diagnostics"][0]["code"] == "missing_reference"
+
+
+@pytest.mark.parametrize("action", ["route", "topology"])
+def test_main_dispatches_local_topology_actions_before_remote_hub(
+    action, monkeypatch
+):
+    import hermes_cli.main as main_module
+    from hermes_cli import skills_hub, skills_topology
+
+    calls = []
+    monkeypatch.setattr(
+        skills_topology,
+        "skills_topology_command",
+        lambda args: calls.append(("local", args.skills_action)),
+    )
+    monkeypatch.setattr(
+        skills_hub,
+        "skills_command",
+        lambda args: calls.append(("hub", args.skills_action)),
+    )
+
+    main_module.cmd_skills(SimpleNamespace(skills_action=action))
+
+    assert calls == [("local", action)]

--- a/tests/hermes_cli/test_skills_topology_cli.py
+++ b/tests/hermes_cli/test_skills_topology_cli.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -80,23 +79,22 @@ def test_topology_parser_is_read_only_and_supports_json():
     assert not hasattr(args, "deep")
 
 
-def test_topology_loader_requests_the_full_installed_graph(monkeypatch):
+def test_topology_loader_uses_the_shared_installed_inventory(monkeypatch):
     from hermes_cli import skills_topology
     from tools import skills_tool
 
     captured = {}
 
-    def fake_find_all_skills(**kwargs):
+    def fake_inventory(**kwargs):
         captured.update(kwargs)
         return []
 
-    monkeypatch.setattr(skills_tool, "_find_all_skills", fake_find_all_skills)
+    monkeypatch.setattr(skills_tool, "build_installed_skill_inventory", fake_inventory)
 
     skills_topology._load_skill_records(include_disabled=True)
 
     assert captured == {
         "skip_disabled": True,
-        "include_topology": True,
         "include_ineligible": True,
     }
 
@@ -194,7 +192,7 @@ def test_route_parser_rejects_nonpositive_limits(argv):
         _parser().parse_args(argv)
 
 
-def test_route_json_is_stable_and_omits_raw_query(monkeypatch, capsys):
+def test_route_json_is_stable_and_omits_query_and_fingerprint(monkeypatch, capsys):
     from hermes_cli import skills_topology
 
     records = [
@@ -221,9 +219,7 @@ def test_route_json_is_stable_and_omits_raw_query(monkeypatch, capsys):
     payload = json.loads(first_output)
     assert first == second
     assert first_output == second_output
-    assert payload["query_digest"] == hashlib.sha256(
-        b"review private-8675309"
-    ).hexdigest()
+    assert "query_digest" not in payload
     assert [item["name"] for item in payload["route"]] == [
         "plan",
         "review-private-8675309",

--- a/tests/hermes_cli/test_skills_topology_cli.py
+++ b/tests/hermes_cli/test_skills_topology_cli.py
@@ -116,10 +116,23 @@ def test_scanned_collision_blocks_cli_route_and_audit_deterministically(
     external_b.mkdir()
     _write_skill(local_dir, "local-review", "review")
     _write_skill(external_a, "external-review", external_name)
+    _write_skill(external_b, "github-code-review", "github-code-review")
+    _write_skill(
+        external_b,
+        "requesting-code-review",
+        "requesting-code-review",
+    )
     _write_skill(external_b, "deploy", "deploy")
     route_args = SimpleNamespace(
         skills_action="route",
         query=["review"],
+        limit=5,
+        budget_chars=10_000,
+        json=True,
+    )
+    deploy_args = SimpleNamespace(
+        skills_action="route",
+        query=["deploy"],
         limit=5,
         budget_chars=10_000,
         json=True,
@@ -139,14 +152,16 @@ def test_scanned_collision_blocks_cli_route_and_audit_deterministically(
             skills_tool._SKILLS_CACHE.clear()
             route = skills_topology.skills_topology_command(route_args)
             route_output = capsys.readouterr().out
+            deploy_route = skills_topology.skills_topology_command(deploy_args)
+            deploy_output = capsys.readouterr().out
             audit = skills_topology.skills_topology_command(audit_args)
             audit_output = capsys.readouterr().out
-        artifacts.append((route, audit))
-        outputs.append((route_output, audit_output))
+        artifacts.append((route, deploy_route, audit))
+        outputs.append((route_output, deploy_output, audit_output))
 
     assert outputs[0] == outputs[1]
     assert artifacts[0] == artifacts[1]
-    route, audit = artifacts[0]
+    route, deploy_route, audit = artifacts[0]
     assert route["status"] == "blocked"
     assert route["route"] == []
     assert route["total_cost_chars"] == 0
@@ -158,9 +173,12 @@ def test_scanned_collision_blocks_cli_route_and_audit_deterministically(
     assert [item["code"] for item in audit["diagnostics"]] == [
         "canonical_name_collision"
     ]
-    for route_output, audit_output in outputs:
+    assert deploy_route["status"] == "ok"
+    assert [item["name"] for item in deploy_route["route"]] == ["deploy"]
+    for route_output, deploy_output, audit_output in outputs:
         for root in (local_dir, external_a, external_b):
             assert str(root) not in route_output
+            assert str(root) not in deploy_output
             assert str(root) not in audit_output
 
 

--- a/tests/hermes_cli/test_skills_topology_cli.py
+++ b/tests/hermes_cli/test_skills_topology_cli.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -28,6 +30,23 @@ def _record(name, *, topology=None, tags=(), description="", cost=100):
         "cost_chars": cost,
         "cost_bytes": cost,
     }
+
+
+def _write_skill(root: Path, directory: str, name: str) -> None:
+    skill_dir = root / directory
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        f"description: Description for {name}.\n"
+        "metadata:\n"
+        "  hermes:\n"
+        "    topology:\n"
+        "      lifecycle: stable\n"
+        "---\n\n"
+        f"# {name}\n",
+        encoding="utf-8",
+    )
 
 
 def test_route_parser_accepts_multiword_query_and_budget_options():
@@ -80,6 +99,69 @@ def test_topology_loader_requests_the_full_installed_graph(monkeypatch):
         "include_topology": True,
         "include_ineligible": True,
     }
+
+
+@pytest.mark.parametrize("external_name", ["review", "Review"])
+def test_scanned_collision_blocks_cli_route_and_audit_deterministically(
+    external_name, tmp_path, capsys
+):
+    from hermes_cli import skills_topology
+    from tools import skills_tool
+
+    local_dir = tmp_path / "local"
+    external_a = tmp_path / "external-a"
+    external_b = tmp_path / "external-b"
+    local_dir.mkdir()
+    external_a.mkdir()
+    external_b.mkdir()
+    _write_skill(local_dir, "local-review", "review")
+    _write_skill(external_a, "external-review", external_name)
+    _write_skill(external_b, "deploy", "deploy")
+    route_args = SimpleNamespace(
+        skills_action="route",
+        query=["review"],
+        limit=5,
+        budget_chars=10_000,
+        json=True,
+    )
+    audit_args = SimpleNamespace(skills_action="topology", json=True)
+
+    outputs = []
+    artifacts = []
+    for external_dirs in ([external_a, external_b], [external_b, external_a]):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch(
+                "agent.skill_utils.get_external_skills_dirs",
+                return_value=external_dirs,
+            ),
+        ):
+            skills_tool._SKILLS_CACHE.clear()
+            route = skills_topology.skills_topology_command(route_args)
+            route_output = capsys.readouterr().out
+            audit = skills_topology.skills_topology_command(audit_args)
+            audit_output = capsys.readouterr().out
+        artifacts.append((route, audit))
+        outputs.append((route_output, audit_output))
+
+    assert outputs[0] == outputs[1]
+    assert artifacts[0] == artifacts[1]
+    route, audit = artifacts[0]
+    assert route["status"] == "blocked"
+    assert route["route"] == []
+    assert route["total_cost_chars"] == 0
+    assert route["total_cost_bytes"] == 0
+    assert [item["code"] for item in route["diagnostics"]] == [
+        "canonical_name_collision"
+    ]
+    assert audit["status"] == "issues"
+    assert [item["code"] for item in audit["diagnostics"]] == [
+        "canonical_name_collision"
+    ]
+    for route_output, audit_output in outputs:
+        for root in (local_dir, external_a, external_b):
+            assert str(root) not in route_output
+            assert str(root) not in audit_output
 
 
 @pytest.mark.parametrize(

--- a/tests/hermes_cli/test_skills_topology_cli.py
+++ b/tests/hermes_cli/test_skills_topology_cli.py
@@ -197,3 +197,34 @@ def test_main_dispatches_local_topology_actions_before_remote_hub(
     main_module.cmd_skills(SimpleNamespace(skills_action=action))
 
     assert calls == [("local", action)]
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_status"),
+    [
+        (["skills", "route", "testing", "--json"], "ok"),
+        (["skills", "topology", "--json"], "ok"),
+    ],
+)
+def test_full_hermes_cli_invocation_parses_and_dispatches_topology_actions(
+    argv, expected_status, monkeypatch, capsys
+):
+    import sys
+
+    import hermes_cli.main as main_module
+    from hermes_cli import skills_topology
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(
+        skills_topology,
+        "_load_skill_records",
+        lambda **kwargs: [_record("testing")],
+    )
+    monkeypatch.setattr(main_module, "_prepare_agent_startup", lambda args: None)
+    monkeypatch.setattr(config_module, "get_container_exec_info", lambda: None)
+    monkeypatch.setattr(sys, "argv", ["hermes", *argv])
+
+    main_module.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == expected_status

--- a/tests/hermes_cli/test_web_server_skills_profiles.py
+++ b/tests/hermes_cli/test_web_server_skills_profiles.py
@@ -64,6 +64,30 @@ def _load_cfg(home):
 
 class TestProfileScopedSkills:
 
+    def test_profile_builder_does_not_write_authority_skill_to_disabled_state(
+        self, isolated_profiles
+    ):
+        """The profile setup path only disables skills it is allowed to enumerate."""
+        pytest.importorskip("fastapi")
+        from hermes_cli.web_server import _disable_unselected_skills
+
+        worker_home = isolated_profiles["worker_alpha"]
+        skills_root = worker_home / "skills"
+        _write_skill(skills_root, "public-skill")
+        private = skills_root / "private" / "canonical-private-workflow-8675309"
+        _write_skill(private.parent, private.name)
+        (worker_home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {"skills": {"central_private_roots": [str(private)]}}
+            ),
+            encoding="utf-8",
+        )
+
+        assert _disable_unselected_skills(worker_home, keep=[]) == 2
+        disabled = _load_cfg(worker_home)["skills"]["disabled"]
+        assert set(disabled) == {"worker-skill", "public-skill"}
+        assert "canonical-private-workflow-8675309" not in disabled
+
 
     def test_toggle_writes_into_target_profile_only(self, client, isolated_profiles):
         resp = client.put(

--- a/tests/tools/test_blueprints.py
+++ b/tests/tools/test_blueprints.py
@@ -5,6 +5,7 @@ the create-job bridge, and the export round-trip without touching the real
 cron store.
 """
 
+import os
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -63,6 +64,39 @@ metadata:
 """
 
 
+def _write_blueprint(
+    root: Path,
+    directory: str,
+    *,
+    name: str,
+    schedule: str,
+    body: str = "body",
+) -> Path:
+    skill_dir = root / directory
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "metadata:\n"
+        "  hermes:\n"
+        "    blueprint:\n"
+        f'      schedule: "{schedule}"\n'
+        "---\n\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _write_authority_config(home: Path, roots: tuple[Path, ...]) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    lines = ["skills:"]
+    if roots:
+        lines.append("  central_private_roots:")
+        lines.extend(f"    - {root}" for root in roots)
+    (home / "config.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 class TestParseBlueprint:
     def test_parses_full_blueprint(self):
         spec = parse_blueprint(BLUEPRINT_SKILL)
@@ -103,6 +137,96 @@ class TestBlueprintSpecForInstalled:
         (d / "SKILL.md").write_text(PLAIN_SKILL, encoding="utf-8")
         with patch("tools.skills_hub.SKILLS_DIR", skills_dir):
             assert blueprint_spec_for_installed("not-a-blueprint") is None
+
+
+    @pytest.mark.parametrize("boundary", ["equal", "nested", "containing", "symlink_alias"])
+    def test_mcp_authority_boundary_blocks_guessed_blueprint_names(
+        self, tmp_path, monkeypatch, caplog, boundary
+    ):
+        from agent import skill_utils
+
+        home = tmp_path / "home"
+        skills_dir = home / "skills"
+        private_body = "PRIVATE BLUEPRINT BODY 8675309"
+        private = _write_blueprint(
+            skills_dir,
+            "private/canonical-private-workflow-8675309",
+            name="canonical-private-workflow-8675309",
+            schedule="0 1 * * *",
+            body=private_body,
+        )
+        _write_blueprint(
+            skills_dir,
+            "adapter",
+            name="adapter",
+            schedule="0 2 * * *",
+        )
+        if boundary == "equal":
+            authority = private
+        elif boundary == "nested":
+            authority = private.parent
+        elif boundary == "containing":
+            authority = skills_dir
+        else:
+            authority = tmp_path / "authority-alias"
+            authority.symlink_to(private, target_is_directory=True)
+        _write_authority_config(home, (authority,))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        skill_utils._external_dirs_cache_clear()
+
+        with patch("tools.skills_hub.SKILLS_DIR", skills_dir):
+            assert blueprint_spec_for_installed("canonical-private-workflow-8675309") is None
+            if boundary != "containing":
+                adapter = blueprint_spec_for_installed("adapter")
+                assert adapter is not None
+                assert adapter.schedule == "0 2 * * *"
+
+        assert "canonical-private-workflow-8675309" not in caplog.text
+        assert private_body not in caplog.text
+        assert str(private) not in caplog.text
+
+
+    def test_colliding_blueprint_directories_use_sorted_native_index_order(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        _write_blueprint(skills_dir, "z-last/collision", name="collision", schedule="0 9 * * *")
+        _write_blueprint(skills_dir, "a-first/collision", name="collision", schedule="0 7 * * *")
+
+        with patch("tools.skills_hub.SKILLS_DIR", skills_dir):
+            spec = blueprint_spec_for_installed("collision")
+
+        assert spec is not None
+        assert spec.schedule == "0 7 * * *"
+
+
+    def test_authority_config_cache_tracks_edits_and_profile_switches(self, tmp_path, monkeypatch):
+        from agent import skill_utils
+
+        first_home = tmp_path / "first-home"
+        skills_dir = first_home / "skills"
+        private = _write_blueprint(
+            skills_dir,
+            "private/profile-private",
+            name="profile-private",
+            schedule="0 1 * * *",
+        )
+        _write_authority_config(first_home, (private,))
+        monkeypatch.setenv("HERMES_HOME", str(first_home))
+        skill_utils._external_dirs_cache_clear()
+
+        with patch("tools.skills_hub.SKILLS_DIR", skills_dir):
+            assert blueprint_spec_for_installed("profile-private") is None
+
+            _write_authority_config(first_home, ())
+            config = first_home / "config.yaml"
+            stat = config.stat()
+            os.utime(config, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1))
+            visible = blueprint_spec_for_installed("profile-private")
+            assert visible is not None
+
+            second_home = tmp_path / "second-home"
+            _write_authority_config(second_home, (private,))
+            monkeypatch.setenv("HERMES_HOME", str(second_home))
+            assert blueprint_spec_for_installed("profile-private") is None
 
 
 class TestCreateBlueprintJob:

--- a/tests/tools/test_skills_mcp_authority_boundary.py
+++ b/tests/tools/test_skills_mcp_authority_boundary.py
@@ -131,6 +131,68 @@ def test_symlink_aliases_cannot_bypass_authority_exclusion(authority_env, tmp_pa
     }
 
 
+@pytest.mark.parametrize(
+    "boundary", ["equal", "nested", "containing", "symlink_alias"]
+)
+def test_relative_exclusion_resolves_candidate_under_scan_root(
+    authority_env, tmp_path, boundary
+):
+    scan_root = tmp_path / "scan-root"
+    if boundary == "symlink_alias":
+        authority = tmp_path / "authority"
+        private_dir = _write_skill(authority, "canonical", PRIVATE_ID)
+        scan_root.mkdir()
+        (scan_root / "private").symlink_to(authority, target_is_directory=True)
+        candidate = scan_root / "private" / "canonical" / "SKILL.md"
+    else:
+        private_dir = _write_skill(scan_root, f"private/{PRIVATE_ID}", PRIVATE_ID)
+        candidate = private_dir / "SKILL.md"
+        if boundary == "equal":
+            authority = scan_root
+        elif boundary == "nested":
+            authority = private_dir
+        else:
+            authority = tmp_path
+    _write_config(authority_env, authority_roots=[authority])
+
+    relative_candidate = candidate.relative_to(scan_root)
+
+    assert skill_utils.is_excluded_skill_path(relative_candidate, root=scan_root)
+
+
+def test_sync_relative_scans_exclude_authority_skills(authority_env, tmp_path):
+    from tools.skills_sync import _discover_bundled_skills, _optional_skill_index
+
+    scan_root = tmp_path / "official-skills"
+    _write_skill(scan_root, "public", "public-skill")
+    authority = scan_root / "private"
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    _write_config(authority_env, authority_roots=[authority])
+
+    discovered = _discover_bundled_skills(scan_root)
+    with patch("tools.skills_sync._get_optional_dir", return_value=scan_root):
+        optional_index = _optional_skill_index()
+
+    assert [name for name, _path in discovered] == ["public-skill"]
+    assert set(optional_index) == {"public", "public-skill"}
+
+
+def test_hub_relative_scans_exclude_authority_skills(authority_env, tmp_path):
+    from tools.skills_hub import OptionalSkillSource
+
+    scan_root = tmp_path / "optional-skills"
+    public = _write_skill(scan_root, "public", "public-skill")
+    authority = scan_root / "private"
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    _write_config(authority_env, authority_roots=[authority])
+    source = OptionalSkillSource()
+    source._optional_dir = scan_root
+
+    assert [meta.name for meta in source._scan_all()] == ["public-skill"]
+    assert source._find_skill_dir("public") == public
+    assert source._find_skill_dir("canonical") is None
+
+
 def test_authority_boundary_cache_tracks_profile_switch_and_config_mtime(authority_env, tmp_path, monkeypatch):
     external = tmp_path / "external"
     first_root = external / "first"

--- a/tests/tools/test_skills_mcp_authority_boundary.py
+++ b/tests/tools/test_skills_mcp_authority_boundary.py
@@ -371,3 +371,74 @@ def test_mcp_configuration_is_not_a_native_skill_source(authority_env, tmp_path)
     assert _names(skills_list()) == {"mcp-adapter"}
     assert json.loads(skill_view("mcp-adapter"))["success"] is True
     assert load_config()["mcp_servers"]["canonical"]["command"] == "example-mcp"
+
+
+@pytest.mark.parametrize("boundary", ["equal", "nested", "containing", "symlink_alias"])
+def test_sync_status_and_opt_out_inventory_never_enumerate_authority_skills(
+    authority_env, tmp_path, monkeypatch, boundary
+):
+    """Sync status and opt-out discovery share the native authority boundary."""
+    from tools import skills_sync_client as sync_client
+
+    skills_root = authority_env / "skills"
+    org_root = skills_root / "_org" / "org-1"
+    _write_skill(skills_root, "mcp-adapter", "mcp-adapter")
+    _write_skill(org_root, "public", "public-skill")
+    private_dir = _write_skill(org_root, f"private/{PRIVATE_ID}", PRIVATE_ID)
+    (skills_root / "_org" / ".active_org").write_text("org-1\n", encoding="utf-8")
+
+    if boundary == "equal":
+        authority = org_root
+    elif boundary == "nested":
+        authority = private_dir
+    elif boundary == "containing":
+        authority = skills_root / "_org"
+    else:
+        authority = tmp_path / "authority-alias"
+        authority.symlink_to(private_dir, target_is_directory=True)
+    _write_config(authority_env, authority_roots=[authority])
+
+    monkeypatch.setattr(sync_client, "resolve_identity", lambda: {"owner": "owner"})
+    monkeypatch.setattr(
+        sync_client,
+        "resolve_org_identity",
+        lambda: {"org_id": "org-1", "org_role": "MEMBER"},
+    )
+    monkeypatch.setattr(sync_client, "list_locally_modified_org_skills", lambda _org_id: [])
+
+    status = sync_client.sync_status()
+    local_names = sync_client._all_local_skill_names()
+
+    assert PRIVATE_ID not in "\n".join(status["org_skills"])
+    assert PRIVATE_ID not in local_names
+    assert "mcp-adapter" in local_names
+    if boundary == "nested" or boundary == "symlink_alias":
+        assert status["org_skills"] == ["public"]
+    else:
+        assert status["org_skills"] == []
+
+
+def test_sync_local_enumeration_tracks_authority_config_and_profile_switch(
+    authority_env, tmp_path, monkeypatch
+):
+    """Authority roots are reloaded when config changes or the profile changes."""
+    from tools import skills_sync_client as sync_client
+
+    private_dir = _write_skill(authority_env / "skills", PRIVATE_ID, PRIVATE_ID)
+    _write_skill(authority_env / "skills", "mcp-adapter", "mcp-adapter")
+    _write_config(authority_env, authority_roots=[private_dir])
+    assert PRIVATE_ID not in sync_client._all_local_skill_names()
+
+    _write_config(authority_env, authority_roots=[])
+    config_path = authority_env / "config.yaml"
+    stat = config_path.stat()
+    os.utime(config_path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1))
+    assert PRIVATE_ID in sync_client._all_local_skill_names()
+
+    other_home = tmp_path / "other-profile"
+    other_private_dir = _write_skill(other_home / "skills", "other-private", "other-private")
+    _write_skill(other_home / "skills", "other-adapter", "other-adapter")
+    _write_config(other_home, authority_roots=[other_private_dir])
+    monkeypatch.setenv("HERMES_HOME", str(other_home))
+
+    assert sync_client._all_local_skill_names() == ["other-adapter"]

--- a/tests/tools/test_skills_mcp_authority_boundary.py
+++ b/tests/tools/test_skills_mcp_authority_boundary.py
@@ -1,0 +1,373 @@
+"""Regression coverage for the MCP-authority skills boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent import skill_utils
+from tools import skills_tool
+from tools.skills_tool import (
+    _find_all_skills,
+    build_installed_skill_inventory,
+    skill_view,
+    skills_list,
+)
+
+
+PRIVATE_ID = "canonical-private-workflow-8675309"
+
+
+def _write_skill(root: Path, directory: str, name: str, body: str = "Use this skill.") -> Path:
+    skill_dir = root / directory
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        f"description: Description for {name}.\n"
+        "---\n\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+@pytest.fixture
+def authority_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    skill_utils._external_dirs_cache_clear()
+    skills_tool._SKILLS_CACHE.clear()
+    yield home
+    skill_utils._external_dirs_cache_clear()
+    skills_tool._SKILLS_CACHE.clear()
+
+
+def _write_config(home: Path, *, external_dirs=(), authority_roots=(), extra: str = "") -> None:
+    lines = ["skills:"]
+    if external_dirs:
+        lines.append("  external_dirs:")
+        lines.extend(f"    - {path}" for path in external_dirs)
+    if authority_roots:
+        lines.append("  central_private_roots:")
+        lines.extend(f"    - {path}" for path in authority_roots)
+    if extra:
+        lines.extend(extra.splitlines())
+    (home / "config.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _names(raw: str) -> set[str]:
+    return {item["name"] for item in json.loads(raw)["skills"]}
+
+
+def test_external_dir_equal_to_authority_root_exposes_no_canonical_records(authority_env, tmp_path):
+    authority = tmp_path / "authority"
+    authority.mkdir()
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    _write_skill(authority_env / "skills", "mcp-adapter", "mcp-adapter")
+    _write_config(authority_env, external_dirs=[authority], authority_roots=[authority])
+
+    listed = skills_list()
+    inventory = build_installed_skill_inventory()
+    route = skills_list(query=PRIVATE_ID)
+    denied = skill_view(PRIVATE_ID)
+
+    assert _names(listed) == {"mcp-adapter"}
+    assert [record["name"] for record in inventory] == ["mcp-adapter"]
+    assert json.loads(route)["route"] == []
+    assert json.loads(denied)["success"] is False
+
+
+def test_authority_subtree_is_pruned_but_external_siblings_remain_visible(authority_env, tmp_path):
+    external = tmp_path / "external"
+    authority = external / "private"
+    _write_skill(external, "public", "public-skill")
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    _write_config(authority_env, external_dirs=[external], authority_roots=[authority])
+
+    assert _names(skills_list()) == {"public-skill"}
+    assert json.loads(skill_view("public-skill"))["success"] is True
+    assert json.loads(skill_view(PRIVATE_ID))["success"] is False
+    assert json.loads(skill_view("private/canonical")) == {
+        "success": False,
+        "error": "This skill is available only through its configured MCP authority.",
+    }
+
+
+def test_external_dir_nested_inside_authority_root_is_excluded(authority_env, tmp_path):
+    authority = tmp_path / "authority"
+    external = authority / "published"
+    _write_skill(external, "canonical", PRIVATE_ID)
+    _write_config(authority_env, external_dirs=[external], authority_roots=[authority])
+
+    assert json.loads(skills_list())["skills"] == []
+    assert _find_all_skills(include_topology=True) == []
+
+
+@pytest.mark.parametrize("alias_kind", ["external_alias", "nested_alias"])
+def test_symlink_aliases_cannot_bypass_authority_exclusion(authority_env, tmp_path, alias_kind):
+    authority = tmp_path / "authority"
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    external = tmp_path / "external"
+    external.mkdir()
+    if alias_kind == "external_alias":
+        external.rmdir()
+        external.symlink_to(authority, target_is_directory=True)
+    else:
+        (external / "alias").symlink_to(authority, target_is_directory=True)
+    _write_config(authority_env, external_dirs=[external], authority_roots=[authority])
+
+    assert json.loads(skills_list())["skills"] == []
+    denied = json.loads(skill_view(PRIVATE_ID))
+    assert denied == {
+        "success": False,
+        "error": "This skill is available only through its configured MCP authority.",
+    }
+
+
+def test_authority_boundary_cache_tracks_profile_switch_and_config_mtime(authority_env, tmp_path, monkeypatch):
+    external = tmp_path / "external"
+    first_root = external / "first"
+    second_root = external / "second"
+    _write_skill(first_root, "private", "first-private")
+    _write_skill(second_root, "private", "second-private")
+    _write_skill(external, "public", "public-skill")
+    _write_config(authority_env, external_dirs=[external], authority_roots=[])
+
+    assert _names(skills_list()) == {"public-skill", "first-private", "second-private"}
+
+    config = authority_env / "config.yaml"
+    _write_config(authority_env, external_dirs=[external], authority_roots=[first_root])
+    stat = config.stat()
+    os.utime(config, (stat.st_atime + 10, stat.st_mtime + 10))
+    assert _names(skills_list()) == {"public-skill", "second-private"}
+
+    other_home = tmp_path / "other-home"
+    other_home.mkdir()
+    _write_skill(other_home / "skills", "adapter", "other-profile-adapter")
+    _write_config(other_home, authority_roots=[])
+    monkeypatch.setenv("HERMES_HOME", str(other_home))
+    assert _names(skills_list()) == {"other-profile-adapter"}
+
+
+def test_native_artifacts_do_not_leak_private_inventory_details(authority_env, tmp_path):
+    external = tmp_path / "external"
+    authority = external / "private"
+    _write_skill(authority, "canonical", PRIVATE_ID, body="x" * 431)
+    _write_skill(authority_env / "skills", "mcp-adapter", "mcp-adapter")
+    _write_config(authority_env, external_dirs=[external], authority_roots=[authority])
+
+    assert skill_utils.is_excluded_skill_path(authority / "canonical" / "SKILL.md")
+
+    from hermes_cli import skills_topology
+
+    outputs = [
+        skills_list(),
+        skills_list(query=PRIVATE_ID),
+        skill_view(PRIVATE_ID),
+    ]
+    with patch("builtins.print") as printed:
+        skills_topology.skills_topology_command(
+            type("Args", (), {"skills_action": "topology", "json": True})()
+        )
+    outputs.extend(str(call.args[0]) for call in printed.call_args_list)
+
+    for output in outputs:
+        assert PRIVATE_ID not in output
+        assert str(authority) not in output
+        assert "query_digest" not in output
+        assert "431" not in output
+
+
+def test_native_prompt_and_slash_scans_exclude_mcp_authority_roots(authority_env, tmp_path):
+    external = tmp_path / "external"
+    authority = external / "private"
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    _write_skill(external, "public", "public-skill")
+    _write_config(authority_env, external_dirs=[external], authority_roots=[authority])
+
+    from agent.prompt_builder import build_skills_system_prompt, clear_skills_system_prompt_cache
+    from agent.skill_commands import scan_skill_commands
+
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    prompt = build_skills_system_prompt()
+    commands = scan_skill_commands()
+
+    assert PRIVATE_ID not in prompt
+    assert "public-skill" in prompt
+    assert f"/{PRIVATE_ID}" not in commands
+    assert "/public-skill" in commands
+
+
+def test_native_management_and_gateway_scans_do_not_index_authority_skills(authority_env, tmp_path):
+    external = tmp_path / "external"
+    authority = external / "private"
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    _write_config(authority_env, external_dirs=[external], authority_roots=[authority])
+
+    from gateway.run import _check_unavailable_skill
+    from tools.skill_manager_tool import _find_skill
+    from tools.skills_sync import _build_external_skill_index
+
+    assert _find_skill("canonical") is None
+    assert _check_unavailable_skill(PRIVATE_ID) is None
+    assert PRIVATE_ID not in _build_external_skill_index()
+
+
+def test_native_learning_graph_does_not_ingest_authority_skills(authority_env, tmp_path):
+    external = tmp_path / "external"
+    authority = external / "private"
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    _write_skill(external, "public", "public-skill")
+    _write_config(authority_env, external_dirs=[external], authority_roots=[authority])
+
+    from agent.learning_graph import build_skill_nodes
+
+    nodes = build_skill_nodes([("external", external)])
+
+    assert PRIVATE_ID not in nodes
+    assert "public-skill" in nodes
+
+
+def test_native_usage_audit_excludes_authority_subtree(authority_env):
+    local_skills = authority_env / "skills"
+    authority = local_skills / "private"
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    _write_skill(local_skills, "public", "public-skill")
+    _write_config(authority_env, authority_roots=[authority])
+
+    from tools.skill_usage import usage_report
+
+    assert {row["name"] for row in usage_report()} == {"public-skill"}
+
+
+def test_profile_reporting_does_not_count_or_describe_authority_skills(authority_env):
+    local_skills = authority_env / "skills"
+    authority = local_skills / "private"
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    _write_skill(local_skills, "public", "public-skill")
+    _write_config(authority_env, authority_roots=[authority])
+
+    from hermes_cli.dump import _count_skills as count_dump_skills
+    from hermes_cli.profile_describer import _collect_skills
+    from hermes_cli.profiles import _count_skills as count_profile_skills
+
+    assert count_profile_skills(authority_env) == 1
+    assert count_dump_skills(authority_env) == 1
+    assert _collect_skills(authority_env) == ["public"]
+
+
+def test_local_adapter_and_noncentral_plugin_continue_to_route_and_load(authority_env, tmp_path, monkeypatch):
+    authority = tmp_path / "authority"
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    adapter = _write_skill(
+        authority_env / "skills",
+        "mcp-adapter",
+        "mcp-adapter",
+        body="Use the configured MCP tools for canonical workflows.",
+    )
+    plugin_skill = _write_skill(tmp_path / "plugin", "plugin-skill", "plugin-skill") / "SKILL.md"
+    _write_config(authority_env, external_dirs=[authority], authority_roots=[authority])
+
+    class Manager:
+        def list_plugin_skill_metadata(self):
+            return [
+                {"name": "demo:plugin-skill", "description": "Plugin skill.", "path": plugin_skill},
+                {"name": "authority:canonical", "description": "Private skill.", "path": authority / "canonical" / "SKILL.md"},
+            ]
+
+        def find_plugin_skill(self, name):
+            if name == "demo:plugin-skill":
+                return plugin_skill
+            if name == "authority:canonical":
+                return authority / "canonical" / "SKILL.md"
+            return None
+
+        def list_plugin_skills(self, namespace):
+            if namespace == "demo":
+                return ["plugin-skill"]
+            if namespace == "authority":
+                return ["canonical"]
+            return []
+
+    from hermes_cli import plugins
+
+    monkeypatch.setattr(plugins, "discover_plugins", lambda: None)
+    monkeypatch.setattr(plugins, "get_plugin_manager", lambda: Manager())
+    adapter_route = json.loads(skills_list(query="mcp-adapter", limit=3, budget_chars=10_000))
+    plugin_route = json.loads(skills_list(query="plugin-skill", limit=3, budget_chars=10_000))
+
+    assert json.loads(skill_view("mcp-adapter"))["success"] is True
+    assert json.loads(skill_view("demo:plugin-skill"))["success"] is True
+    assert json.loads(skill_view("authority:canonical")) == {
+        "success": False,
+        "error": "This skill is available only through its configured MCP authority.",
+    }
+    assert json.loads(skill_view("authority:unknown")) == {
+        "success": False,
+        "error": "This skill is available only through its configured MCP authority.",
+    }
+    assert [item["name"] for item in adapter_route["route"]] == ["mcp-adapter"]
+    assert [item["name"] for item in plugin_route["route"]] == ["demo:plugin-skill"]
+    assert adapter.exists()
+
+
+def test_malformed_authority_root_fails_closed_without_path_diagnostic(authority_env, tmp_path, caplog):
+    authority = tmp_path / "authority"
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    alias = tmp_path / "authority-alias"
+    alias.symlink_to(authority, target_is_directory=True)
+    _write_config(authority_env, external_dirs=[authority], authority_roots=[alias])
+
+    with caplog.at_level("WARNING"):
+        roots = skill_utils.get_central_private_skill_roots()
+        listing = skills_list()
+
+    assert roots.diagnostics == ("central_private_root_invalid",)
+    assert roots.roots == (authority.resolve(),)
+    assert json.loads(listing)["skills"] == []
+    assert str(alias) not in caplog.text
+    assert str(authority) not in caplog.text
+
+
+def test_scalar_authority_root_is_malformed_but_remains_excluded(authority_env, tmp_path, caplog):
+    authority = tmp_path / "authority"
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    (authority_env / "config.yaml").write_text(
+        "skills:\n"
+        f"  external_dirs:\n    - {authority}\n"
+        f"  central_private_roots: {authority}\n",
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("WARNING"):
+        roots = skill_utils.get_central_private_skill_roots()
+
+    assert roots.diagnostics == ("central_private_root_invalid",)
+    assert roots.roots == (authority.resolve(),)
+    assert json.loads(skills_list())["skills"] == []
+    assert str(authority) not in caplog.text
+
+
+def test_mcp_configuration_is_not_a_native_skill_source(authority_env, tmp_path):
+    authority = tmp_path / "authority"
+    _write_skill(authority, "canonical", PRIVATE_ID)
+    _write_skill(authority_env / "skills", "mcp-adapter", "mcp-adapter")
+    _write_config(
+        authority_env,
+        external_dirs=[authority],
+        authority_roots=[authority],
+        extra="mcp_servers:\n  canonical:\n    command: example-mcp",
+    )
+
+    from hermes_cli.config import load_config
+
+    assert _names(skills_list()) == {"mcp-adapter"}
+    assert json.loads(skill_view("mcp-adapter"))["success"] is True
+    assert load_config()["mcp_servers"]["canonical"]["command"] == "example-mcp"

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 import tools.skills_tool as skills_tool_module
+from agent.skill_topology import audit_topology
 from tools.skills_tool import (
     SKILLS_LIST_SCHEMA,
     _get_required_environment_variables,
@@ -317,6 +318,107 @@ class TestSkillsList:
                 "description": "Description for skill-a.",
                 "category": None,
             }
+        ]
+
+    def test_exact_duplicate_rich_discovery_blocks_route_and_audit(
+        self, tmp_path
+    ):
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+        _make_skill(local_dir, "review")
+        _make_skill(external_dir, "review")
+        _make_skill(external_dir, "deploy")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch(
+                "agent.skill_utils.get_external_skills_dirs",
+                return_value=[external_dir],
+            ),
+        ):
+            skills_tool_module._SKILLS_CACHE.clear()
+            legacy_raw = skills_list()
+            route_raw = skills_list(
+                query="review", limit=5, budget_chars=10_000
+            )
+            unique_raw = skills_list(
+                query="deploy", limit=5, budget_chars=10_000
+            )
+            installed = _find_all_skills(
+                skip_disabled=True,
+                include_topology=True,
+                include_ineligible=True,
+            )
+
+        legacy = json.loads(legacy_raw)
+        route = json.loads(route_raw)
+        unique_route = json.loads(unique_raw)
+        audit = audit_topology(installed)
+
+        assert legacy["skills"] == [
+            {
+                "name": "deploy",
+                "description": "Description for deploy.",
+                "category": None,
+            },
+            {
+                "name": "review",
+                "description": "Description for review.",
+                "category": None,
+            },
+        ]
+        assert [record["name"] for record in installed].count("review") == 2
+        assert route["status"] == "blocked"
+        assert route["route"] == []
+        assert route["total_cost_chars"] == 0
+        assert route["total_cost_bytes"] == 0
+        assert [item["code"] for item in route["diagnostics"]] == [
+            "canonical_name_collision"
+        ]
+        assert audit["status"] == "issues"
+        assert [item["code"] for item in audit["diagnostics"]] == [
+            "canonical_name_collision"
+        ]
+        assert unique_route["status"] == "ok"
+        assert [item["name"] for item in unique_route["route"]] == ["deploy"]
+        for raw in (route_raw, json.dumps(audit, sort_keys=True)):
+            assert str(local_dir) not in raw
+            assert str(external_dir) not in raw
+
+    def test_case_variant_scanner_collision_blocks_queried_tool(self, tmp_path):
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+        _make_skill(local_dir, "review")
+        external_skill = _make_skill(external_dir, "external-review")
+        skill_md = external_skill / "SKILL.md"
+        skill_md.write_text(
+            skill_md.read_text(encoding="utf-8").replace(
+                "name: external-review", "name: Review"
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch(
+                "agent.skill_utils.get_external_skills_dirs",
+                return_value=[external_dir],
+            ),
+        ):
+            skills_tool_module._SKILLS_CACHE.clear()
+            raw = skills_list(query="review", limit=5, budget_chars=10_000)
+
+        route = json.loads(raw)
+        assert route["status"] == "blocked"
+        assert route["route"] == []
+        assert route["total_cost_chars"] == 0
+        assert route["total_cost_bytes"] == 0
+        assert [item["code"] for item in route["diagnostics"]] == [
+            "canonical_name_collision"
         ]
 
     def test_unqueried_empty_category_keeps_legacy_listing_shape(self, tmp_path):

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -401,6 +401,9 @@ class TestSkillsList:
             ),
             encoding="utf-8",
         )
+        _make_skill(external_dir, "github-code-review")
+        _make_skill(external_dir, "requesting-code-review")
+        _make_skill(external_dir, "deploy")
 
         with (
             patch("tools.skills_tool.SKILLS_DIR", local_dir),
@@ -411,8 +414,12 @@ class TestSkillsList:
         ):
             skills_tool_module._SKILLS_CACHE.clear()
             raw = skills_list(query="review", limit=5, budget_chars=10_000)
+            deploy_raw = skills_list(
+                query="deploy", limit=5, budget_chars=10_000
+            )
 
         route = json.loads(raw)
+        deploy_route = json.loads(deploy_raw)
         assert route["status"] == "blocked"
         assert route["route"] == []
         assert route["total_cost_chars"] == 0
@@ -420,6 +427,11 @@ class TestSkillsList:
         assert [item["code"] for item in route["diagnostics"]] == [
             "canonical_name_collision"
         ]
+        assert deploy_route["status"] == "ok"
+        assert [item["name"] for item in deploy_route["route"]] == ["deploy"]
+        for payload in (raw, deploy_raw):
+            assert str(local_dir) not in payload
+            assert str(external_dir) not in payload
 
     def test_unqueried_empty_category_keeps_legacy_listing_shape(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -9,6 +9,7 @@ import pytest
 
 import tools.skills_tool as skills_tool_module
 from tools.skills_tool import (
+    SKILLS_LIST_SCHEMA,
     _get_required_environment_variables,
     _parse_frontmatter,
     _parse_tags,
@@ -294,6 +295,131 @@ class TestSkillsList:
         assert result["count"] == 1
         assert result["categories"] == ["linked"]
         assert result["skills"][0]["name"] == "knowledge-brain"
+
+    def test_unqueried_payload_keeps_minimal_skill_shape(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "skill-a",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    tags: [testing]\n"
+                    "    topology:\n"
+                    "      domains: [quality]\n"
+                ),
+            )
+            result = json.loads(skills_list())
+
+        assert result["skills"] == [
+            {
+                "name": "skill-a",
+                "description": "Description for skill-a.",
+                "category": None,
+            }
+        ]
+
+    def test_unqueried_empty_category_keeps_legacy_listing_shape(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "skill-a", category="devops")
+            result = json.loads(skills_list(category="missing"))
+
+        assert result == {
+            "success": True,
+            "skills": [],
+            "categories": [],
+            "count": 0,
+            "hint": "Use skill_view(name) to see full content, tags, and linked files",
+        }
+
+    def test_rich_discovery_computes_actual_character_and_byte_costs(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(
+                tmp_path,
+                "review",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    tags: [quality]\n"
+                    "    topology:\n"
+                    "      domains: [code-review]\n"
+                    "      lifecycle: stable\n"
+                ),
+                body="Review the change. 🧪",
+            )
+            record = _find_all_skills(include_topology=True)[0]
+
+        content = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+        assert record["cost_chars"] == len(content)
+        assert record["cost_bytes"] == len(content.encode("utf-8"))
+        assert record["cost_bytes"] > record["cost_chars"]
+        assert record["tags"] == ["quality"]
+        assert record["topology"].domains == ("code-review",)
+
+    def test_topology_audit_discovery_can_include_runtime_ineligible_skills(
+        self, tmp_path
+    ):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "windows-only",
+                frontmatter_extra=(
+                    "platforms: [windows]\n"
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    topology:\n"
+                    "      lifecycle: stable\n"
+                ),
+            )
+            eligible = _find_all_skills(include_topology=True)
+            installed = _find_all_skills(
+                skip_disabled=True,
+                include_topology=True,
+                include_ineligible=True,
+            )
+
+        assert eligible == []
+        assert [record["name"] for record in installed] == ["windows-only"]
+
+    def test_query_mode_returns_route_without_raw_query(self, tmp_path):
+        query = "review private-8675309"
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "review-private-8675309",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    topology:\n"
+                    "      lifecycle: stable\n"
+                ),
+            )
+            raw = skills_list(query=query, limit=1, budget_chars=10000)
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["mode"] == "route"
+        assert result["status"] == "ok"
+        assert result["route"][0]["name"] == "review-private-8675309"
+        assert query not in raw
+
+    def test_query_mode_does_not_create_a_missing_skills_directory(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            result = json.loads(skills_list(query="testing"))
+
+        assert result["status"] == "no_match"
+        assert not skills_dir.exists()
+
+    def test_schema_adds_only_optional_route_parameters(self):
+        properties = SKILLS_LIST_SCHEMA["parameters"]["properties"]
+
+        assert SKILLS_LIST_SCHEMA["parameters"]["required"] == []
+        assert "query" in SKILLS_LIST_SCHEMA["description"]
+        assert properties["query"]["type"] == "string"
+        assert properties["limit"]["minimum"] == 1
+        assert properties["budget_chars"]["minimum"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -260,6 +260,261 @@ class TestFindAllSkills:
 
 
 class TestSkillsList:
+    def test_unqueried_listing_does_not_discover_plugin_skills(self, tmp_path, monkeypatch):
+        """The legacy no-query index must remain local/external only."""
+        from hermes_cli import plugins
+
+        calls = []
+        monkeypatch.setattr(plugins, "discover_plugins", lambda: calls.append(True))
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "local")
+            result = json.loads(skills_list())
+
+        assert [item["name"] for item in result["skills"]] == ["local"]
+        assert calls == []
+
+    def test_query_plugin_uses_complete_skill_content_cost_and_environment_gate(
+        self, tmp_path, monkeypatch
+    ):
+        """Plugin candidates use their registered SKILL.md, never a short description."""
+        from hermes_cli import plugins
+
+        plugin_skill = tmp_path / "plugin" / "SKILL.md"
+        plugin_skill.parent.mkdir()
+        plugin_skill.write_bytes(
+            b"\xef\xbb\xbf---\nname: review\ndescription: tiny\n---\n\n" + b"x" * 200
+        )
+        metadata = {
+            "name": "demo:review",
+            "description": "tiny",
+            "category": "plugin",
+            "path": plugin_skill,
+            "frontmatter": {"environments": ["not-a-real-environment"]},
+        }
+        monkeypatch.setattr(plugins, "discover_plugins", lambda: None)
+        monkeypatch.setattr(
+            plugins,
+            "get_plugin_manager",
+            lambda: type("Manager", (), {"list_plugin_skill_metadata": lambda self: [metadata]})(),
+        )
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"):
+            result = json.loads(skills_list(query="review", limit=1, budget_chars=100))
+
+        # Unknown environment tags intentionally fail open; the full 200-char
+        # body must therefore exceed the budget rather than being charged as
+        # the five-character description.
+        assert result["status"] == "blocked"
+        assert [item["code"] for item in result["diagnostics"]] == ["budget_omission"]
+
+    def test_query_plugin_ineligible_environment_is_not_routable(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins
+
+        plugin_skill = tmp_path / "plugin" / "SKILL.md"
+        plugin_skill.parent.mkdir()
+        plugin_skill.write_text("---\nname: review\n---\n\nReview", encoding="utf-8")
+        metadata = {
+            "name": "demo:review",
+            "description": "review",
+            "category": "plugin",
+            "path": plugin_skill,
+            "frontmatter": {"environments": ["docker"]},
+        }
+        monkeypatch.setattr(plugins, "discover_plugins", lambda: None)
+        monkeypatch.setattr(
+            plugins,
+            "get_plugin_manager",
+            lambda: type("Manager", (), {"list_plugin_skill_metadata": lambda self: [metadata]})(),
+        )
+        monkeypatch.setattr(skills_tool_module, "skill_matches_environment", lambda _: False)
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"):
+            result = json.loads(skills_list(query="review"))
+
+        assert result["status"] == "no_match"
+
+    def test_query_plugin_uses_registered_file_frontmatter_over_stale_metadata(
+        self, tmp_path, monkeypatch
+    ):
+        """Eligibility cannot be bypassed by stale registration metadata."""
+        from hermes_cli import plugins
+
+        plugin_skill = tmp_path / "plugin" / "SKILL.md"
+        plugin_skill.parent.mkdir()
+        plugin_skill.write_text(
+            "---\nname: review\nplatforms: [windows]\nenvironments: [docker]\nmetadata:\n"
+            "  hermes:\n    tags: [review]\n---\n\nReview",
+            encoding="utf-8",
+        )
+        metadata = {
+            "name": "demo:worker",
+            "description": "unrelated",
+            "category": "plugin",
+            "path": plugin_skill,
+            # This stale registration data would make the old route path
+            # consider the plugin a review candidate on every environment.
+            "frontmatter": {"metadata": {"hermes": {"tags": ["review"]}}},
+        }
+        monkeypatch.setattr(plugins, "discover_plugins", lambda: None)
+        monkeypatch.setattr(
+            plugins,
+            "get_plugin_manager",
+            lambda: type("Manager", (), {"list_plugin_skill_metadata": lambda self: [metadata]})(),
+        )
+        monkeypatch.setattr(
+            skills_tool_module,
+            "skill_matches_environment",
+            lambda frontmatter: "docker" not in frontmatter.get("environments", []),
+        )
+        monkeypatch.setattr(
+            skills_tool_module,
+            "skill_matches_platform",
+            lambda frontmatter: "windows" not in frontmatter.get("platforms", []),
+        )
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"):
+            result = json.loads(skills_list(query="review"))
+
+        assert result["status"] == "no_match"
+
+    def test_query_plugin_with_unreadable_registered_skill_fails_closed(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import plugins
+
+        metadata = {
+            "name": "demo:review",
+            "description": "review",
+            "category": "plugin",
+            "path": tmp_path / "missing" / "SKILL.md",
+            "frontmatter": {},
+        }
+        monkeypatch.setattr(plugins, "discover_plugins", lambda: None)
+        monkeypatch.setattr(
+            plugins,
+            "get_plugin_manager",
+            lambda: type("Manager", (), {"list_plugin_skill_metadata": lambda self: [metadata]})(),
+        )
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"):
+            result = json.loads(skills_list(query="review"))
+
+        assert result["status"] == "blocked"
+        assert [item["code"] for item in result["diagnostics"]] == [
+            "skill_content_unavailable"
+        ]
+
+    def test_mixed_local_external_and_plugin_route_shares_costs_and_dependencies(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import plugins
+
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        _make_skill(local_dir, "local-helper", body="local")
+        external_plan = _make_skill(external_dir, "plan", body="external-plan")
+        plugin_skill = tmp_path / "plugin" / "SKILL.md"
+        plugin_skill.parent.mkdir()
+        plugin_skill.write_text(
+            "---\nname: review\nmetadata:\n  hermes:\n    tags: [review]\n"
+            "    topology:\n      requires: [plan]\n---\n\nplugin-review-body",
+            encoding="utf-8",
+        )
+        metadata = {
+            "name": "demo:review",
+            "description": "short",
+            "category": "plugin",
+            "path": plugin_skill,
+            "frontmatter": {
+                "metadata": {
+                    "hermes": {"tags": ["review"], "topology": {"requires": ["plan"]}}
+                }
+            },
+        }
+        monkeypatch.setattr(plugins, "discover_plugins", lambda: None)
+        monkeypatch.setattr(
+            plugins,
+            "get_plugin_manager",
+            lambda: type("Manager", (), {"list_plugin_skill_metadata": lambda self: [metadata]})(),
+        )
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[external_dir]),
+        ):
+            skills_tool_module._SKILLS_CACHE.clear()
+            result = json.loads(skills_list(query="review", limit=2, budget_chars=10_000))
+
+        assert [item["name"] for item in result["route"]] == ["plan", "demo:review"]
+        assert result["total_cost_chars"] == (
+            len((external_plan / "SKILL.md").read_text(encoding="utf-8"))
+            + len(plugin_skill.read_text(encoding="utf-8-sig"))
+        )
+        assert result["route"][1]["graph_role"] == "root"
+
+    def test_mixed_plugin_collision_blocks_route_without_paths(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins
+
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        _make_skill(external_dir, "plugin-copy", body="external")
+        external_md = external_dir / "plugin-copy" / "SKILL.md"
+        external_md.write_text(
+            external_md.read_text(encoding="utf-8").replace(
+                "name: plugin-copy", "name: demo:review"
+            ),
+            encoding="utf-8",
+        )
+        plugin_skill = tmp_path / "plugin" / "SKILL.md"
+        plugin_skill.parent.mkdir()
+        plugin_skill.write_text("---\nname: review\n---\n\nplugin", encoding="utf-8")
+        metadata = {
+            "name": "demo:review",
+            "description": "review",
+            "category": "plugin",
+            "path": plugin_skill,
+            "frontmatter": {},
+        }
+        monkeypatch.setattr(plugins, "discover_plugins", lambda: None)
+        monkeypatch.setattr(
+            plugins,
+            "get_plugin_manager",
+            lambda: type("Manager", (), {"list_plugin_skill_metadata": lambda self: [metadata]})(),
+        )
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[external_dir]),
+        ):
+            skills_tool_module._SKILLS_CACHE.clear()
+            result = json.loads(skills_list(query="review"))
+
+        assert result["status"] == "blocked"
+        assert [item["code"] for item in result["diagnostics"]] == [
+            "canonical_name_collision"
+        ]
+        assert str(external_dir) not in json.dumps(result)
+        assert str(plugin_skill) not in json.dumps(result)
+
+    def test_rich_inventory_cache_does_not_cross_live_profile_skill_directories(
+        self, tmp_path, monkeypatch
+    ):
+        alpha_home = tmp_path / "alpha"
+        beta_home = tmp_path / "beta"
+        _make_skill(alpha_home / "skills", "alpha")
+        _make_skill(beta_home / "skills", "beta")
+        active_home = [alpha_home]
+        monkeypatch.setattr(skills_tool_module, "get_hermes_home", lambda: active_home[0])
+        skills_tool_module._SKILLS_CACHE.clear()
+
+        alpha = _find_all_skills(include_topology=True)
+        active_home[0] = beta_home
+        beta = _find_all_skills(include_topology=True)
+
+        assert [record["name"] for record in alpha] == ["alpha"]
+        assert [record["name"] for record in beta] == ["beta"]
+
     def test_empty_creates_directory(self, tmp_path):
         skills_dir = tmp_path / "skills"
         with patch("tools.skills_tool.SKILLS_DIR", skills_dir):

--- a/tools/blueprints.py
+++ b/tools/blueprints.py
@@ -144,18 +144,26 @@ def parse_blueprint(skill_md_text: str) -> Optional[BlueprintSpec]:
 def blueprint_spec_for_installed(skill_name: str) -> Optional[BlueprintSpec]:
     """Locate an installed skill's SKILL.md and parse its blueprint block.
 
-    Searches the standard skills tree for ``<skill_name>/SKILL.md``. Returns
-    None if the skill isn't found or isn't a blueprint.
+    Searches the native, authority-filtered skills index for
+    ``<skill_name>/SKILL.md``. Returns None if the skill isn't found or isn't
+    a blueprint.
     """
     try:
+        from agent.skill_utils import (
+            is_central_private_skill_path,
+            iter_skill_index_files,
+        )
         from tools.skills_hub import SKILLS_DIR
     except Exception:  # pragma: no cover - import guard
         return None
 
     base = Path(SKILLS_DIR)
-    # Skills live at skills/<category>/<name>/SKILL.md or skills/<name>/SKILL.md.
-    candidates = list(base.glob(f"**/{skill_name}/SKILL.md"))
-    for path in candidates:
+    # The shared index prunes MCP-authoritative roots and yields sorted paths.
+    # Retain the explicit predicate as a final guard for any future iterator
+    # implementation change: blueprint discovery must never bypass authority.
+    for path in iter_skill_index_files(base, "SKILL.md"):
+        if path.parent.name != skill_name or is_central_private_skill_path(path):
+            continue
         try:
             text = path.read_text(encoding="utf-8")
         except OSError:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -650,11 +650,15 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+    from agent.skill_utils import (
+        get_all_skills_dirs,
+        is_excluded_skill_path,
+        iter_skill_index_files,
+    )
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
+        for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
             if skill_md.parent.name == name:
@@ -793,7 +797,19 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
         if not skills_dir.is_dir():
             continue
         try:
-            for skill_md in skills_dir.rglob("SKILL.md"):
+            from agent.skill_utils import (
+                get_central_private_skill_roots,
+                iter_skill_index_files,
+            )
+
+            authority_boundary = get_central_private_skill_roots(
+                skills_dir.parent / "config.yaml"
+            )
+            for skill_md in iter_skill_index_files(
+                skills_dir,
+                "SKILL.md",
+                excluded_roots=authority_boundary.roots,
+            ):
                 if is_excluded_skill_path(skill_md):
                     continue
                 if skill_md.parent.name == name:

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -34,7 +34,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
-from agent.skill_utils import is_excluded_skill_path, is_external_skill_path
+from agent.skill_utils import (
+    is_excluded_skill_path,
+    is_external_skill_path,
+    iter_skill_index_files,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -356,7 +360,7 @@ def list_agent_created_skill_names() -> List[str]:
 
     names: List[str] = []
     # Top-level SKILL.md files (flat layout) AND nested category/skill/SKILL.md
-    for skill_md in base.rglob("SKILL.md"):
+    for skill_md in iter_skill_index_files(base, "SKILL.md"):
         # Skip Hermes metadata, VCS, virtualenv/dependency, and cache dirs
         if is_excluded_skill_path(skill_md):
             continue
@@ -548,7 +552,7 @@ def list_unmanaged_skill_names() -> List[str]:
     usage = load_usage()
 
     names: List[str] = []
-    for skill_md in base.rglob("SKILL.md"):
+    for skill_md in iter_skill_index_files(base, "SKILL.md"):
         if is_excluded_skill_path(skill_md) or is_external_skill_path(skill_md):
             continue
         try:
@@ -1232,7 +1236,7 @@ def _find_external_skill_dir(skill_name: str) -> Optional[Path]:
     for base in get_all_skills_dirs()[1:]:
         if not base.exists():
             continue
-        for skill_md in base.rglob("SKILL.md"):
+        for skill_md in iter_skill_index_files(base, "SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
             if _read_skill_name(skill_md, fallback=skill_md.parent.name) == skill_name:
@@ -1315,7 +1319,7 @@ def usage_report() -> List[Dict[str, Any]]:
     data = load_usage()
     rows: List[Dict[str, Any]] = []
     seen: set = set()
-    for skill_md in base.rglob("SKILL.md"):
+    for skill_md in iter_skill_index_files(base, "SKILL.md"):
         if is_excluded_skill_path(skill_md):
             continue
         name = _read_skill_name(skill_md, fallback=skill_md.parent.name)

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -88,7 +88,11 @@ def _build_external_skill_index() -> Set[str]:
     Used to prevent sync_skills from shadowing externally-delegated skills.
     """
     try:
-        from agent.skill_utils import get_external_skills_dirs, _external_dirs_cache_clear
+        from agent.skill_utils import (
+            _external_dirs_cache_clear,
+            get_external_skills_dirs,
+            iter_skill_index_files,
+        )
     except ImportError:
         return set()
 
@@ -97,7 +101,7 @@ def _build_external_skill_index() -> Set[str]:
 
     external_names: Set[str] = set()
     for ext_dir in get_external_skills_dirs():
-        for skill_md in ext_dir.rglob("SKILL.md"):
+        for skill_md in iter_skill_index_files(ext_dir, "SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
             skill_dir = skill_md.parent

--- a/tools/skills_sync_client.py
+++ b/tools/skills_sync_client.py
@@ -530,7 +530,9 @@ def _all_local_skill_names() -> List[str]:
     try:
         if not root.exists():
             return []
-        for skill_md in root.rglob("SKILL.md"):
+        from agent.skill_utils import iter_skill_index_files
+
+        for skill_md in iter_skill_index_files(root, "SKILL.md"):
             if skill_md.is_symlink():
                 continue
             name: Optional[str] = None
@@ -1702,7 +1704,7 @@ def list_org_skill_names() -> List[str]:
     """Skill names present in the local org mirror (empty when none pulled)."""
     names: List[str] = []
     try:
-        from agent.skill_utils import read_active_org_id
+        from agent.skill_utils import iter_skill_index_files, read_active_org_id
 
         org_id = read_active_org_id(_skills_dir())
         if not org_id:
@@ -1710,7 +1712,7 @@ def list_org_skill_names() -> List[str]:
         root = _org_dir() / org_id
         if not root.is_dir():
             return names
-        for skill_md in root.rglob("SKILL.md"):
+        for skill_md in iter_skill_index_files(root, "SKILL.md"):
             rel = skill_md.parent.relative_to(root)
             if rel.parts:
                 names.append(str(rel).replace("\\", "/"))

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -104,7 +104,7 @@ _SKILLS_CACHE_KEY_DISABLED = "with_disabled"
 _SKILLS_CACHE_KEY_FILTERED = "filtered"
 
 
-def _skills_scan_signature(dirs_to_scan, disabled) -> tuple:
+def _skills_scan_signature(dirs_to_scan, disabled, authority_boundary) -> tuple:
     """Cheap change-signature for the skill scan inputs.
 
     O(#dirs + #categories) stat calls, not a recursive walk. Includes the
@@ -134,7 +134,13 @@ def _skills_scan_signature(dirs_to_scan, disabled) -> tuple:
         except OSError:
             pass
         sig.append((str(d), m))
-    return (tuple(sig), frozenset(disabled), platform)
+    return (
+        tuple(sig),
+        frozenset(disabled),
+        platform,
+        authority_boundary.signature,
+        tuple(str(root) for root in authority_boundary.roots),
+    )
 
 
 # All skills live in ~/.hermes/skills/ (seeded from bundled skills/ on install).
@@ -697,7 +703,12 @@ def _find_all_skills(
     signature changes (dir/category mtimes or the disabled-set) and expires
     after a short TTL to bound staleness from in-place SKILL.md edits.
     """
-    from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+    from agent.skill_utils import (
+        get_central_private_skill_roots,
+        get_external_skills_dirs,
+        path_is_within_roots,
+        iter_skill_index_files,
+    )
 
     base_cache_key = (
         _SKILLS_CACHE_KEY_DISABLED if skip_disabled else _SKILLS_CACHE_KEY_FILTERED
@@ -716,8 +727,9 @@ def _find_all_skills(
     if active_skills_dir.exists():
         dirs_to_scan.append(active_skills_dir)
     dirs_to_scan.extend(get_external_skills_dirs())
+    authority_boundary = get_central_private_skill_roots()
 
-    signature = _skills_scan_signature(dirs_to_scan, disabled)
+    signature = _skills_scan_signature(dirs_to_scan, disabled, authority_boundary)
     now = time.monotonic()
 
     cached = _SKILLS_CACHE.get(cache_key)
@@ -737,7 +749,13 @@ def _find_all_skills(
     # Scan local dir first, then external dirs (local takes precedence) —
     # dirs_to_scan already resolved above for the signature.
     for scan_dir in dirs_to_scan:
-        for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
+        if path_is_within_roots(scan_dir, authority_boundary.roots):
+            continue
+        for skill_md in iter_skill_index_files(
+            scan_dir,
+            "SKILL.md",
+            excluded_roots=authority_boundary.roots,
+        ):
             if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
                 continue
 
@@ -840,6 +858,7 @@ def _plugin_topology_records(*, include_ineligible: bool) -> List[Dict[str, Any]
     planner reports only its qualified name, never the path or file content.
     """
     from agent.skill_topology import parse_topology
+    from agent.skill_utils import is_central_private_skill_path
     from hermes_cli.plugins import discover_plugins, get_plugin_manager
 
     records: List[Dict[str, Any]] = []
@@ -865,6 +884,8 @@ def _plugin_topology_records(*, include_ineligible: bool) -> List[Dict[str, Any]
         try:
             registered_path = plugin_skill.get("path") or manager.find_plugin_skill(name)
             path = Path(registered_path)
+            if is_central_private_skill_path(path):
+                continue
             raw_content = path.read_bytes()
             content = raw_content.decode("utf-8-sig")
             parsed_frontmatter, _ = _parse_frontmatter(content)
@@ -1269,6 +1290,13 @@ def skill_view(
                 ensure_ascii=False,
             )
 
+        from agent.skill_utils import (
+            get_central_private_skill_roots,
+            get_external_skills_dirs,
+            path_is_within_roots,
+        )
+        authority_boundary = get_central_private_skill_roots()
+
         local_category_name: str | None = None
         # ── Qualified name dispatch (plugin skills) ──────────────────
         # Names containing ':' are routed to the plugin skill registry.
@@ -1329,6 +1357,14 @@ def skill_view(
                     )
 
             if plugin_skill_md is not None:
+                if path_is_within_roots(plugin_skill_md, authority_boundary.roots):
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "error": "This skill is available only through its configured MCP authority.",
+                        },
+                        ensure_ascii=False,
+                    )
                 if not plugin_skill_md.exists():
                     # Stale registry entry — file deleted out of band
                     pm.remove_plugin_skill(name)
@@ -1356,6 +1392,17 @@ def skill_view(
             # Plugin exists but this specific skill is missing?
             available = pm.list_plugin_skills(namespace)
             if available:
+                # A plugin registry can retain candidates that are physically
+                # under an MCP-authority root. Do not turn a qualified miss
+                # into an enumeration of that private corpus.
+                if authority_boundary.roots:
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "error": "This skill is available only through its configured MCP authority.",
+                        },
+                        ensure_ascii=False,
+                    )
                 return json.dumps(
                     {
                         "success": False,
@@ -1371,8 +1418,6 @@ def skill_view(
             # on-disk `category/skill` path during the local scan below.
             if bare:
                 local_category_name = f"{namespace}/{bare}"
-
-        from agent.skill_utils import get_external_skills_dirs
 
         # The categorized fall-through form (namespace/bare) joins onto each
         # search dir too; re-validate it since `bare` is not namespace-checked.
@@ -1429,10 +1474,14 @@ def skill_view(
             candidates.append((sd, smd))
 
         for search_dir in all_dirs:
+            if path_is_within_roots(search_dir, authority_boundary.roots):
+                continue
             # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
             # at the top of the dir).
             direct_path = search_dir / name
             if (
+                not path_is_within_roots(direct_path, authority_boundary.roots)
+                and
                 not _is_skill_support_path(direct_path)
                 and direct_path.is_dir()
                 and (direct_path / "SKILL.md").exists()
@@ -1449,6 +1498,8 @@ def skill_view(
             if local_category_name:
                 categorized_path = search_dir / local_category_name
                 if (
+                    not path_is_within_roots(categorized_path, authority_boundary.roots)
+                    and
                     not _is_skill_support_path(categorized_path)
                     and categorized_path.is_dir()
                     and (categorized_path / "SKILL.md").exists()
@@ -1466,7 +1517,11 @@ def skill_view(
             # plus frontmatter `name:` lookup. `skills_list()` exposes the
             # frontmatter name, so `skill_view(name)` must accept it too even
             # when the on-disk directory is a shorter category/alias.
-            for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
+            for found_skill_md in iter_skill_index_files(
+                search_dir,
+                "SKILL.md",
+                excluded_roots=authority_boundary.roots,
+            ):
                 if found_skill_md.parent.name == name:
                     _record(found_skill_md.parent, found_skill_md)
                     continue
@@ -1482,7 +1537,11 @@ def skill_view(
             # Exclude skill support docs: references/templates/assets/scripts
             # are loaded through skill_view(skill, file_path=...) and must not
             # shadow or collide with real skills that share the same basename.
-            for found_md in search_dir.rglob(f"{name}.md"):
+            for found_md in iter_skill_index_files(
+                search_dir,
+                f"{name}.md",
+                excluded_roots=authority_boundary.roots,
+            ):
                 if found_md.name != "SKILL.md" and not _is_skill_support_path(
                     found_md
                 ):
@@ -1517,6 +1576,14 @@ def skill_view(
 
         if not skill_md or not skill_md.exists():
             available = [s["name"] for s in _sort_skills(_find_all_skills())[:20]]
+            if authority_boundary.roots:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": "This skill is available only through its configured MCP authority.",
+                    },
+                    ensure_ascii=False,
+                )
             return json.dumps(
                 {
                     "success": False,

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -830,6 +830,107 @@ def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
 
 
+def _plugin_topology_records(*, include_ineligible: bool) -> List[Dict[str, Any]]:
+    """Return rich records for registered plugin skills without exposing paths.
+
+    Plugin skills are registered outside the local/external scan tree.  Route
+    planning must nevertheless account for exactly the same complete
+    ``SKILL.md`` representation as a rich local scan.  A registered file that
+    cannot be decoded is retained as a matching fail-closed sentinel; the
+    planner reports only its qualified name, never the path or file content.
+    """
+    from agent.skill_topology import parse_topology
+    from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
+    records: List[Dict[str, Any]] = []
+    try:
+        discover_plugins()
+        manager = get_plugin_manager()
+        plugin_skills = manager.list_plugin_skill_metadata()
+    except Exception:
+        logger.debug("Plugin skill discovery failed", exc_info=True)
+        return records
+
+    for metadata in plugin_skills:
+        plugin_skill = dict(metadata)
+        registered_frontmatter = plugin_skill.pop("frontmatter", {})
+        if not isinstance(registered_frontmatter, dict):
+            registered_frontmatter = {}
+        name = str(plugin_skill.get("name") or "")
+        if not name:
+            continue
+        inventory_error = None
+        raw_content = b""
+        content = ""
+        try:
+            registered_path = plugin_skill.get("path") or manager.find_plugin_skill(name)
+            path = Path(registered_path)
+            raw_content = path.read_bytes()
+            content = raw_content.decode("utf-8-sig")
+            parsed_frontmatter, _ = _parse_frontmatter(content)
+            # The registered file is authoritative.  Keep registration-time
+            # metadata only for older plugins whose file has no parseable
+            # frontmatter at all.
+            frontmatter = parsed_frontmatter or registered_frontmatter
+        except (KeyError, OSError, UnicodeDecodeError, TypeError, ValueError):
+            # Do not propagate exception strings: they can contain private
+            # local paths.  The route planner treats this matching candidate
+            # as blocked rather than undercharging it from its description.
+            inventory_error = "skill_content_unavailable"
+            frontmatter = registered_frontmatter
+        if not include_ineligible:
+            if not skill_matches_platform(frontmatter):
+                continue
+            if not skill_matches_environment(frontmatter):
+                continue
+            if _is_skill_disabled(name):
+                continue
+
+        metadata_block = frontmatter.get("metadata")
+        hermes_meta = (
+            metadata_block.get("hermes", {})
+            if isinstance(metadata_block, dict)
+            and isinstance(metadata_block.get("hermes"), dict)
+            else {}
+        )
+        record = {
+            "name": name,
+            "description": str(
+                frontmatter.get("description") or plugin_skill.get("description", "")
+            ),
+            "category": str(plugin_skill.get("category") or "plugin"),
+            "tags": _parse_tags(
+                hermes_meta.get("tags") or frontmatter.get("tags", "")
+            ),
+            "topology": parse_topology(hermes_meta.get("topology")),
+        }
+        if inventory_error:
+            record["inventory_error"] = inventory_error
+        else:
+            record["cost_chars"] = len(content)
+            record["cost_bytes"] = len(raw_content)
+        records.append(record)
+    return records
+
+
+def build_installed_skill_inventory(
+    *, skip_disabled: bool = False, include_ineligible: bool = False
+) -> List[Dict[str, Any]]:
+    """Build the one rich installed inventory used by route and audit paths.
+
+    Ordinary ``skills_list()`` listings deliberately do not use this builder:
+    preserving their legacy local/external-only shape also avoids plugin
+    discovery unless callers explicitly request topology-aware work.
+    """
+    records = _find_all_skills(
+        skip_disabled=skip_disabled,
+        include_topology=True,
+        include_ineligible=include_ineligible,
+    )
+    records.extend(_plugin_topology_records(include_ineligible=include_ineligible))
+    return records
+
+
 def skills_list(
     category: str = None,
     task_id: str = None,
@@ -856,68 +957,19 @@ def skills_list(
     try:
         active_skills_dir = _skills_dir()
         if not active_skills_dir.exists():
-            if query is not None:
-                from agent.skill_topology import (
-                    DEFAULT_ROUTE_BUDGET_CHARS,
-                    DEFAULT_ROUTE_LIMIT,
-                    plan_skill_route,
-                )
+            # A topology query may still route a registered plugin skill even
+            # when this profile has no local skills directory yet.  Keep the
+            # legacy no-query side effect (creating the directory) unchanged.
+            if query is None:
+                active_skills_dir.mkdir(parents=True, exist_ok=True)
 
-                artifact = plan_skill_route(
-                    [],
-                    query,
-                    max_skills=(DEFAULT_ROUTE_LIMIT if limit is None else limit),
-                    budget_chars=(
-                        DEFAULT_ROUTE_BUDGET_CHARS
-                        if budget_chars is None
-                        else budget_chars
-                    ),
-                )
-                return json.dumps(
-                    {"success": True, "mode": "route", **artifact},
-                    ensure_ascii=False,
-                )
-            active_skills_dir.mkdir(parents=True, exist_ok=True)
-
-        # Find all skills. Query mode requests the richer topology/cost shape;
-        # the ordinary listing preserves the legacy minimal metadata contract.
-        all_skills = _find_all_skills(include_topology=query is not None)
-        try:
-            from hermes_cli.plugins import discover_plugins, get_plugin_manager
-
-            discover_plugins()
-            for plugin_skill in get_plugin_manager().list_plugin_skill_metadata():
-                plugin_skill = dict(plugin_skill)
-                frontmatter = plugin_skill.pop("frontmatter", {})
-                if not skill_matches_platform(frontmatter):
-                    continue
-                if _is_skill_disabled(plugin_skill["name"]):
-                    continue
-                if query is not None:
-                    from agent.skill_topology import parse_topology
-
-                    metadata = frontmatter.get("metadata")
-                    hermes_meta = (
-                        metadata.get("hermes", {})
-                        if isinstance(metadata, dict)
-                        and isinstance(metadata.get("hermes"), dict)
-                        else {}
-                    )
-                    description = str(plugin_skill.get("description", ""))
-                    plugin_skill.update(
-                        {
-                            "tags": _parse_tags(
-                                hermes_meta.get("tags")
-                                or frontmatter.get("tags", "")
-                            ),
-                            "topology": parse_topology(hermes_meta.get("topology")),
-                            "cost_chars": len(description),
-                            "cost_bytes": len(description.encode("utf-8")),
-                        }
-                    )
-                all_skills.append(plugin_skill)
-        except Exception:
-            logger.debug("Plugin skill listing failed", exc_info=True)
+        # Topology query mode uses the shared rich inventory.  The ordinary
+        # listing must preserve its historical local/external-only behavior.
+        all_skills = (
+            build_installed_skill_inventory()
+            if query is not None
+            else _find_all_skills()
+        )
 
         if query is not None:
             from agent.skill_topology import (

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -670,13 +670,24 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         return False
 
 
-def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
+def _find_all_skills(
+    *,
+    skip_disabled: bool = False,
+    include_topology: bool = False,
+    include_ineligible: bool = False,
+) -> List[Dict[str, Any]]:
     """Recursively find all skills in ~/.hermes/skills/ and external dirs.
 
     Args:
         skip_disabled: If True, return ALL skills regardless of disabled
             state (used by ``hermes skills`` config UI). Default False
             filters out disabled skills.
+        include_topology: If True, include normalized topology, tags, and
+            actual SKILL.md character/byte costs for local route planning.
+            Default False preserves the minimal metadata shape.
+        include_ineligible: If True, include skills gated from the current
+            platform/environment. Used only by the read-only installed-graph
+            topology audit; routes keep the gates enforced.
 
     Returns:
         List of skill metadata dicts (name, description, category).
@@ -687,7 +698,10 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     """
     from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
 
-    cache_key = _SKILLS_CACHE_KEY_DISABLED if skip_disabled else _SKILLS_CACHE_KEY_FILTERED
+    base_cache_key = (
+        _SKILLS_CACHE_KEY_DISABLED if skip_disabled else _SKILLS_CACHE_KEY_FILTERED
+    )
+    cache_key = (base_cache_key, include_topology, include_ineligible)
 
     # Load disabled set once (not per-skill). Part of the cache signature:
     # disabling a skill is a config change with no filesystem mtime bump.
@@ -729,13 +743,20 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
             skill_dir = skill_md.parent
 
             try:
-                content = skill_md.read_text(encoding="utf-8-sig", errors="replace")[:4000]
+                if include_topology:
+                    raw_content = skill_md.read_bytes()
+                    content = raw_content.decode("utf-8-sig")
+                else:
+                    raw_content = b""
+                    content = skill_md.read_text(
+                        encoding="utf-8-sig", errors="replace"
+                    )[:4000]
                 frontmatter, body = _parse_frontmatter(content)
 
-                if not skill_matches_platform(frontmatter):
+                if not include_ineligible and not skill_matches_platform(frontmatter):
                     continue
 
-                if not skill_matches_environment(frontmatter):
+                if not include_ineligible and not skill_matches_environment(frontmatter):
                     continue
 
                 name = frontmatter.get("name", skill_dir.name)[:MAX_NAME_LENGTH]
@@ -758,11 +779,33 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 category = _get_category_from_path(skill_md)
 
                 seen_names.add(name)
-                skills.append({
+                skill_record = {
                     "name": name,
                     "description": description,
                     "category": category,
-                })
+                }
+                if include_topology:
+                    from agent.skill_topology import parse_topology
+
+                    metadata = frontmatter.get("metadata")
+                    hermes_meta = (
+                        metadata.get("hermes", {})
+                        if isinstance(metadata, dict)
+                        and isinstance(metadata.get("hermes"), dict)
+                        else {}
+                    )
+                    skill_record.update(
+                        {
+                            "tags": _parse_tags(
+                                hermes_meta.get("tags")
+                                or frontmatter.get("tags", "")
+                            ),
+                            "topology": parse_topology(hermes_meta.get("topology")),
+                            "cost_chars": len(content),
+                            "cost_bytes": len(raw_content),
+                        }
+                    )
+                skills.append(skill_record)
 
             except (UnicodeDecodeError, PermissionError) as e:
                 logger.debug("Failed to read skill file %s: %s", skill_md, e)
@@ -786,7 +829,13 @@ def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
 
 
-def skills_list(category: str = None, task_id: str = None) -> str:
+def skills_list(
+    category: str = None,
+    task_id: str = None,
+    query: str = None,
+    limit: int = None,
+    budget_chars: int = None,
+) -> str:
     """
     List all available skills (progressive disclosure tier 1 - minimal metadata).
 
@@ -796,30 +845,104 @@ def skills_list(category: str = None, task_id: str = None) -> str:
     Args:
         category: Optional category filter (e.g., "mlops")
         task_id: Optional task identifier used to probe the active backend
+        query: Optional local route query. Omit for the legacy minimal listing.
+        limit: Maximum skills in query mode (including requirements).
+        budget_chars: Maximum cumulative SKILL.md characters in query mode.
 
     Returns:
-        JSON string with minimal skill info: name, description, category
+        JSON string with minimal skill info, or a route artifact in query mode.
     """
     try:
         active_skills_dir = _skills_dir()
         if not active_skills_dir.exists():
+            if query is not None:
+                from agent.skill_topology import (
+                    DEFAULT_ROUTE_BUDGET_CHARS,
+                    DEFAULT_ROUTE_LIMIT,
+                    plan_skill_route,
+                )
+
+                artifact = plan_skill_route(
+                    [],
+                    query,
+                    max_skills=(DEFAULT_ROUTE_LIMIT if limit is None else limit),
+                    budget_chars=(
+                        DEFAULT_ROUTE_BUDGET_CHARS
+                        if budget_chars is None
+                        else budget_chars
+                    ),
+                )
+                return json.dumps(
+                    {"success": True, "mode": "route", **artifact},
+                    ensure_ascii=False,
+                )
             active_skills_dir.mkdir(parents=True, exist_ok=True)
 
-        # Find all skills
-        all_skills = _find_all_skills()
+        # Find all skills. Query mode requests the richer topology/cost shape;
+        # the ordinary listing preserves the legacy minimal metadata contract.
+        all_skills = _find_all_skills(include_topology=query is not None)
         try:
             from hermes_cli.plugins import discover_plugins, get_plugin_manager
 
             discover_plugins()
             for plugin_skill in get_plugin_manager().list_plugin_skill_metadata():
+                plugin_skill = dict(plugin_skill)
                 frontmatter = plugin_skill.pop("frontmatter", {})
                 if not skill_matches_platform(frontmatter):
                     continue
                 if _is_skill_disabled(plugin_skill["name"]):
                     continue
+                if query is not None:
+                    from agent.skill_topology import parse_topology
+
+                    metadata = frontmatter.get("metadata")
+                    hermes_meta = (
+                        metadata.get("hermes", {})
+                        if isinstance(metadata, dict)
+                        and isinstance(metadata.get("hermes"), dict)
+                        else {}
+                    )
+                    description = str(plugin_skill.get("description", ""))
+                    plugin_skill.update(
+                        {
+                            "tags": _parse_tags(
+                                hermes_meta.get("tags")
+                                or frontmatter.get("tags", "")
+                            ),
+                            "topology": parse_topology(hermes_meta.get("topology")),
+                            "cost_chars": len(description),
+                            "cost_bytes": len(description.encode("utf-8")),
+                        }
+                    )
                 all_skills.append(plugin_skill)
         except Exception:
             logger.debug("Plugin skill listing failed", exc_info=True)
+
+        if query is not None:
+            from agent.skill_topology import (
+                DEFAULT_ROUTE_BUDGET_CHARS,
+                DEFAULT_ROUTE_LIMIT,
+                plan_skill_route,
+            )
+
+            if category:
+                all_skills = [
+                    s for s in all_skills if s.get("category") == category
+                ]
+            artifact = plan_skill_route(
+                all_skills,
+                query,
+                max_skills=(DEFAULT_ROUTE_LIMIT if limit is None else limit),
+                budget_chars=(
+                    DEFAULT_ROUTE_BUDGET_CHARS
+                    if budget_chars is None
+                    else budget_chars
+                ),
+            )
+            return json.dumps(
+                {"success": True, "mode": "route", **artifact},
+                ensure_ascii=False,
+            )
 
         if not all_skills:
             return json.dumps(
@@ -832,7 +955,9 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                 ensure_ascii=False,
             )
 
-        # Filter by category if specified
+        # Filter by category if specified. Keep this after the all-skills
+        # emptiness check: legacy callers receive a normal empty filtered
+        # listing, not the "no skills installed" message.
         if category:
             all_skills = [s for s in all_skills if s.get("category") == category]
 
@@ -1888,14 +2013,32 @@ if __name__ == "__main__":
 
 SKILLS_LIST_SCHEMA = {
     "name": "skills_list",
-    "description": "List available skills (name + description). Use skill_view(name) to load full content.",
+    "description": (
+        "List available skills (name + description). Optionally pass query for "
+        "a small local route with reasons and topology. Use skill_view(name) "
+        "to load full content."
+    ),
     "parameters": {
         "type": "object",
         "properties": {
             "category": {
                 "type": "string",
                 "description": "Optional category filter to narrow results",
-            }
+            },
+            "query": {
+                "type": "string",
+                "description": "Optional query for a small deterministic local skill route",
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Maximum skills in query mode, including required skills",
+            },
+            "budget_chars": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Maximum cumulative SKILL.md characters in query mode",
+            },
         },
         "required": [],
     },
@@ -1925,7 +2068,11 @@ registry.register(
     toolset="skills",
     schema=SKILLS_LIST_SCHEMA,
     handler=lambda args, **kw: skills_list(
-        category=args.get("category"), task_id=kw.get("task_id")
+        category=args.get("category"),
+        task_id=kw.get("task_id"),
+        query=args.get("query"),
+        limit=args.get("limit"),
+        budget_chars=args.get("budget_chars"),
     ),
     check_fn=check_skills_requirements,
     emoji="📚",

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -682,9 +682,10 @@ def _find_all_skills(
         skip_disabled: If True, return ALL skills regardless of disabled
             state (used by ``hermes skills`` config UI). Default False
             filters out disabled skills.
-        include_topology: If True, include normalized topology, tags, and
-            actual SKILL.md character/byte costs for local route planning.
-            Default False preserves the minimal metadata shape.
+        include_topology: If True, include normalized topology, tags, actual
+            SKILL.md character/byte costs, and every physical record needed
+            for collision-safe local route planning. Default False preserves
+            exact-name precedence and the minimal metadata shape.
         include_ineligible: If True, include skills gated from the current
             platform/environment. Used only by the read-only installed-graph
             topology audit; routes keep the gates enforced.
@@ -760,7 +761,7 @@ def _find_all_skills(
                     continue
 
                 name = frontmatter.get("name", skill_dir.name)[:MAX_NAME_LENGTH]
-                if name in seen_names:
+                if name in seen_names and not include_topology:
                     continue
                 if name in disabled:
                     continue

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -309,6 +309,7 @@ def _(rid, params: dict) -> dict:
         try:
             from hermes_cli.config import load_config
             from hermes_cli.skills_config import get_disabled_skills
+            from agent.skill_utils import iter_skill_index_files
 
             cfg = load_config() or {}
             disabled = {s.lower() for s in get_disabled_skills(cfg)}
@@ -316,7 +317,7 @@ def _(rid, params: dict) -> dict:
             installed = []
             skills_root = profile_dir / "skills"
             if skills_root.is_dir():
-                for md in sorted(skills_root.rglob("SKILL.md")):
+                for md in iter_skill_index_files(skills_root, "SKILL.md"):
                     skill_name = md.parent.name
                     installed.append(
                         {"name": skill_name, "enabled": skill_name.lower() not in disabled}

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -145,15 +145,23 @@ hermes skills route "review this change" --limit 4 --budget-chars 24000 --json
 The planner ranks existing name, category, description, tags, domains, inputs,
 and outputs deterministically, then places transitive requirements before the
 matching root while respecting both limits. It never executes a skill. Route
-JSON contains a SHA-256 query digest, selection reasons, costs, and diagnostics,
-but no dedicated raw-query field. Selected skill metadata may naturally repeat
-query terms. Route decisions are returned to the caller and are not persisted
-in V1.
+JSON contains selection reasons, costs, and diagnostics, but no query, query
+fingerprint, local path, or skill body. Selected skill metadata may naturally
+repeat query terms. Route decisions are returned to the caller and are not
+persisted in V1.
 
 The existing `skills_list` model tool accepts optional `query`, `limit`, and
 `budget_chars` parameters for the same local planner. With no `query`, its
 legacy minimal listing shape is unchanged. Query mode alone includes route
-reasons and normalized topology.
+reasons and normalized topology. Route and topology inventory includes eligible
+registered plugin skills as well as local and configured external skills; route
+budgets always use the full registered `SKILL.md`, not a plugin description.
+
+Topology only knows about installed Hermes skills: local, configured external,
+and registered plugin skills. To connect a central private MCP skill library,
+install one thin adapter skill and let that adapter route and load its own
+canonical library. Hermes does not import that library's full catalog into the
+installed topology inventory.
 
 ### Platform-Specific Skills
 

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -57,6 +57,16 @@ metadata:
   hermes:
     tags: [Category, Subcategory, Keywords]
     related_skills: [other-skill-name]
+    topology:                           # Optional local route metadata (V1)
+      domains: [software-development]
+      inputs: [requirements]
+      outputs: [tested-change]
+      requires: [prerequisite-skill]
+      follows: [earlier-handoff]
+      precedes: [later-handoff]
+      conflicts: [incompatible-skill]
+      permissions: [filesystem-write]
+      lifecycle: candidate
     requires_toolsets: [web]            # Optional — only show when these toolsets are active
     requires_tools: [web_search]        # Optional — only show when these tools are available
     fallback_for_toolsets: [browser]    # Optional — hide when these toolsets are active
@@ -97,6 +107,52 @@ Known failure modes and how to handle them.
 ## Verification
 How the agent confirms it worked.
 ```
+
+### Skill Topology and Local Routing
+
+Skills may declare compact, optional routing metadata under
+`metadata.hermes.topology`. Skills without it remain valid and continue to
+appear through the normal discovery paths.
+
+| Field | V1 meaning |
+|-------|------------|
+| `domains` | Task areas used for high-confidence local matching. |
+| `inputs` / `outputs` | Named artifacts or states the skill consumes and produces. |
+| `requires` | Skill dependencies. The route planner includes them transitively before the dependent. |
+| `follows` / `precedes` | Directed handoff hints for graph inspection; they do not force inclusion in V1. |
+| `conflicts` | Skills that must not coexist in one planned route. |
+| `permissions` | Descriptive permission needs. This field never grants access or bypasses tool, platform, environment, or approval gates. |
+| `lifecycle` | One of `experimental`, `candidate`, `stable`, or `deprecated`. Other values are reported by the topology audit. |
+
+Every scalar field that accepts multiple values may be written as one string or
+a YAML list. Hermes normalizes values and computes `cost_chars` and
+`cost_bytes` from the actual complete SKILL.md; authors do not maintain a cost
+estimate.
+
+`related_skills` and topology edges serve different contracts:
+`related_skills` is an undirected discovery hint shown when browsing a skill.
+Topology `requires`, `follows`, and `precedes` are directed planning/handoff
+edges. Use `requires` only for a true prerequisite; broad affinity belongs in
+`related_skills`.
+
+Inspect or plan against the local graph with:
+
+```bash
+hermes skills topology --json
+hermes skills route "review this change" --limit 4 --budget-chars 24000 --json
+```
+
+The planner ranks existing name, category, description, tags, domains, inputs,
+and outputs deterministically, then places transitive requirements before the
+matching root while respecting both limits. It never executes a skill. Route
+JSON contains a SHA-256 query digest, selection reasons, costs, and diagnostics,
+but never the raw query. Route decisions are returned to the caller and are not
+persisted in V1.
+
+The existing `skills_list` model tool accepts optional `query`, `limit`, and
+`budget_chars` parameters for the same local planner. With no `query`, its
+legacy minimal listing shape is unchanged. Query mode alone includes route
+reasons and normalized topology.
 
 ### Platform-Specific Skills
 

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -146,8 +146,9 @@ The planner ranks existing name, category, description, tags, domains, inputs,
 and outputs deterministically, then places transitive requirements before the
 matching root while respecting both limits. It never executes a skill. Route
 JSON contains a SHA-256 query digest, selection reasons, costs, and diagnostics,
-but never the raw query. Route decisions are returned to the caller and are not
-persisted in V1.
+but no dedicated raw-query field. Selected skill metadata may naturally repeat
+query terms. Route decisions are returned to the caller and are not persisted
+in V1.
 
 The existing `skills_list` model tool accepts optional `query`, `limit`, and
 `budget_chars` parameters for the same local planner. With no `query`, its

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -160,8 +160,11 @@ budgets always use the full registered `SKILL.md`, not a plugin description.
 Topology only knows about installed Hermes skills: local, configured external,
 and registered plugin skills. To connect a central private MCP skill library,
 install one thin adapter skill and let that adapter route and load its own
-canonical library. Hermes does not import that library's full catalog into the
-installed topology inventory.
+canonical library. Configure its filesystem locations under
+`skills.central_private_roots`; Hermes does not import, enumerate, cost, route,
+audit, or exact-load that library through the installed topology inventory.
+The adapter remains an ordinary local skill outside the configured roots and
+points to the independently configured MCP tools.
 
 ### Platform-Specific Skills
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1181,7 +1181,7 @@ hermes skills opt-in --sync            # undo: remove marker and re-seed now
 
 Notes:
 - `route` is local and read-only; unlike `search`, it never queries remote registries. `--limit` counts required skills and `--budget-chars` uses actual complete SKILL.md character counts.
-- Route JSON omits the raw query and includes only its SHA-256 digest. V1 returns the artifact without persisting a route event.
+- Route JSON has no dedicated raw-query field and identifies the query with a SHA-256 digest; selected skill metadata may naturally repeat query terms. V1 returns the artifact without persisting a route event.
 - `topology` is a graph/manifest audit and is distinct from the security-focused `skills audit` command.
 - `--force` can override non-dangerous policy blocks for third-party/community skills.
 - `--force` does not override a `dangerous` scan verdict.

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1136,6 +1136,8 @@ Subcommands:
 |------------|-------------|
 | `browse` | Paginated browser for skill registries. |
 | `search` | Search skill registries. |
+| `route <query>` | Plan a deterministic, budgeted route through eligible local skills. |
+| `topology` | Audit local topology coverage, lifecycle values, references, cycles, and conflicts. |
 | `install` | Install a skill. |
 | `inspect` | Preview a skill without installing it. |
 | `list` | List installed skills. |
@@ -1158,6 +1160,9 @@ hermes skills browse
 hermes skills browse --source official
 hermes skills search react --source skills-sh
 hermes skills search https://mintlify.com/docs --source well-known
+hermes skills route "review this change" --limit 4 --budget-chars 24000
+hermes skills route "debug failing tests" --json
+hermes skills topology --json
 hermes skills inspect official/security/1password
 hermes skills inspect skills-sh/vercel-labs/json-render/json-render-react
 hermes skills install official/migration/openclaw-migration
@@ -1175,6 +1180,9 @@ hermes skills opt-in --sync            # undo: remove marker and re-seed now
 ```
 
 Notes:
+- `route` is local and read-only; unlike `search`, it never queries remote registries. `--limit` counts required skills and `--budget-chars` uses actual complete SKILL.md character counts.
+- Route JSON omits the raw query and includes only its SHA-256 digest. V1 returns the artifact without persisting a route event.
+- `topology` is a graph/manifest audit and is distinct from the security-focused `skills audit` command.
 - `--force` can override non-dangerous policy blocks for third-party/community skills.
 - `--force` does not override a `dangerous` scan verdict.
 - `--source skills-sh` searches the public `skills.sh` directory.

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1180,8 +1180,9 @@ hermes skills opt-in --sync            # undo: remove marker and re-seed now
 ```
 
 Notes:
-- `route` is local and read-only; unlike `search`, it never queries remote registries. `--limit` counts required skills and `--budget-chars` uses actual complete SKILL.md character counts.
-- Route JSON has no dedicated raw-query field and identifies the query with a SHA-256 digest; selected skill metadata may naturally repeat query terms. V1 returns the artifact without persisting a route event.
+- `route` is local and read-only; unlike `search`, it never queries remote registries. `--limit` counts required skills and `--budget-chars` uses actual complete SKILL.md character counts, including registered plugin skills.
+- Route JSON contains neither a raw query nor a query fingerprint. It never includes local paths or skill bodies; selected skill metadata may naturally repeat query terms. V1 returns the artifact without persisting a route event.
+- `route` and `topology` use the installed Hermes inventory: local skills, configured external directories, and registered plugins. A central private MCP skill library belongs behind one installed thin adapter skill; Hermes does not ingest that library's catalog directly.
 - `topology` is a graph/manifest audit and is distinct from the security-focused `skills audit` command.
 - `--force` can override non-dangerous policy blocks for third-party/community skills.
 - `--force` does not override a `dangerous` scan verdict.

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -165,7 +165,7 @@ Tools for driving desktop [Projects](../user-guide/cli.md) — named, multi-fold
 |------|-------------|----------------------|
 | `skill_manage` | Manage skills (create, update, delete). Skills are your procedural memory — reusable approaches for recurring task types. New skills go to ~/.hermes/skills/; existing skills can be modified wherever they live. Actions: create (full SKILL.m… | — |
 | `skill_view` | Skills allow for loading information about specific tasks and workflows, as well as scripts and templates. Load a skill's full content or access its linked files (references, templates, scripts). First call returns SKILL.md content plus a… | — |
-| `skills_list` | List available skills (name + description). Use skill_view(name) to load full content. | — |
+| `skills_list` | List available skills (name + description). Optional `query`, `limit`, and `budget_chars` plan a small local route with reasons and topology; no query preserves the minimal legacy shape. Use `skill_view(name)` to load full content. | — |
 
 ## `terminal` toolset
 
@@ -287,5 +287,4 @@ Registered only on the `hermes-yuanbao` platform toolset. Yuanbao is Tencent's c
 | `yb_send_dm` | Send a private/direct message to a user in a group, with optional media files. | Yuanbao credentials |
 | `yb_search_sticker` | Search the built-in Yuanbao sticker (TIM face) catalogue by keyword. | Yuanbao credentials |
 | `yb_send_sticker` | Send a built-in sticker to the current Yuanbao chat. | Yuanbao credentials |
-
 

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -165,7 +165,7 @@ Tools for driving desktop [Projects](../user-guide/cli.md) — named, multi-fold
 |------|-------------|----------------------|
 | `skill_manage` | Manage skills (create, update, delete). Skills are your procedural memory — reusable approaches for recurring task types. New skills go to ~/.hermes/skills/; existing skills can be modified wherever they live. Actions: create (full SKILL.m… | — |
 | `skill_view` | Skills allow for loading information about specific tasks and workflows, as well as scripts and templates. Load a skill's full content or access its linked files (references, templates, scripts). First call returns SKILL.md content plus a… | — |
-| `skills_list` | List available skills (name + description). Optional `query`, `limit`, and `budget_chars` plan a small local route with reasons and topology; no query preserves the minimal legacy shape. Use `skill_view(name)` to load full content. | — |
+| `skills_list` | List available skills (name + description). Optional `query`, `limit`, and `budget_chars` plan a small route across installed local/external/eligible-plugin skills with reasons and topology; no query preserves the minimal legacy local/external-only shape. Route artifacts omit queries, query fingerprints, paths, and skill bodies. Use `skill_view(name)` to load full content. | — |
 
 ## `terminal` toolset
 
@@ -287,4 +287,3 @@ Registered only on the `hermes-yuanbao` platform toolset. Yuanbao is Tencent's c
 | `yb_send_dm` | Send a private/direct message to a user in a group, with optional media files. | Yuanbao credentials |
 | `yb_search_sticker` | Search the built-in Yuanbao sticker (TIM face) catalogue by keyword. | Yuanbao credentials |
 | `yb_send_sticker` | Send a built-in sticker to the current Yuanbao chat. | Yuanbao credentials |
-

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -647,6 +647,25 @@ hermes config set skills.config.myplugin.path ~/myplugin-data
 
 For details on declaring config settings in your own skills, see [Creating Skills — Config Settings](/developer-guide/creating-skills#config-settings-configyaml).
 
+### MCP-authoritative skill roots
+
+When a private canonical skill corpus is served through MCP, configure its
+filesystem roots explicitly so Hermes never treats it as a native skill source:
+
+```yaml
+skills:
+  central_private_roots:
+    - /absolute/path/to/canonical-corpus
+```
+
+Each entry must be an existing, readable, absolute directory that is not a
+symlink. Hermes excludes matching paths (including aliases that resolve there)
+from native discovery, prompts, slash commands, listings, routes, topology
+audits, cost accounting, and `skill_view`. Keep one small adapter `SKILL.md`
+outside these roots; the adapter can instruct the model to use the separately
+configured MCP tools. This setting does not configure or invoke MCP servers;
+use the existing `mcp_servers` configuration for that.
+
 ### Guard on agent-created skill writes
 
 When the agent uses `skill_manage` to create, edit, patch, or delete a skill, Hermes can optionally scan the new/updated content for dangerous keyword patterns (credential harvesting, obvious prompt injection, exfil instructions). The scanner is **off by default** — real agent workflows that legitimately touch `~/.ssh/` or mention `$OPENAI_API_KEY` were tripping the heuristic too often. Turn it back on if you want the scanner to prompt you before the agent's skill writes land:

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -347,6 +347,28 @@ skills:
 
 Paths support `~` expansion and `${VAR}` environment variable substitution.
 
+### MCP-authoritative corpora
+
+An external directory can contain a private corpus that belongs exclusively to
+an MCP server. Mark that corpus with `skills.central_private_roots` rather than
+relying on a directory name:
+
+```yaml
+skills:
+  external_dirs:
+    - /absolute/path/to/external-skills
+  central_private_roots:
+    - /absolute/path/to/external-skills/mcp-authority-subtree
+```
+
+Roots must be existing, readable, absolute non-symlink directories. Hermes
+prunes the configured subtree even when it is nested inside an external
+directory or reached through a symlink alias. It does not list, load, route,
+audit, or count those skills. Put a thin local adapter skill outside the root
+to guide the model to the separately configured MCP server. Invalid authority
+entries are handled fail-closed where they can be resolved and produce only a
+privacy-safe diagnostic.
+
 ### How it works
 
 - **Create locally, update in place**: New agent-created skills are written to `~/.hermes/skills/`. Existing skills are modified where they are found, including skills under `external_dirs`, when the agent uses `skill_manage` actions such as `patch`, `edit`, `write_file`, `remove_file`, or `delete`.


### PR DESCRIPTION
## Summary
- add deterministic metadata-only routing and audit for installed Hermes skills
- support topology metadata for local, external, and plugin-provided skills
- fail closed on ambiguous collisions and unreadable matching plugin records
- preserve legacy `skills_list()` output when no routing query is supplied
- omit raw queries and stable query fingerprints from route artifacts
- document the authority boundary for a central private route-first MCP library

## Verification
- 211 focused tests passed, 2 skipped
- Python compile and Ruff checks passed for the changed surface
- independent release review is running against exact SHA `63037c3c2c22d469eb8530b36bf1e5d5d863605b`

## Release gate
This remains a draft until exact-SHA independent review clears it.