### PR TITLE
fix(dashboard): compact language codes in the language switcher

### DIFF
--- a/web/src/components/LanguageSwitcher.tsx
+++ b/web/src/components/LanguageSwitcher.tsx
@@ -80,7 +80,7 @@ export function LanguageSwitcher({ collapsed = false, dropUp = false }: Language
           <Typography
             className="hidden sm:inline text-display tracking-wide text-xs"
           >
-            {locale === "en" ? "EN" : current.name}
+            {current.short}
           </Typography>
         </span>
       </Button>

--- a/web/src/i18n/context.tsx
+++ b/web/src/i18n/context.tsx
@@ -51,24 +51,30 @@ const RTL_LOCALES = new Set<Locale>(["ar"]);
 // countries (English ≠ GB, Portuguese ≠ PT, Spanish ≠ ES, Chinese variants ≠
 // any single jurisdiction). Endonyms are unambiguous and avoid the political
 // mismapping that flag pairings inevitably create.
-export const LOCALE_META: Record<Locale, { name: string }> = {
-  en: { name: "English" },
-  zh: { name: "简体中文" },
-  "zh-hant": { name: "繁體中文" },
-  ja: { name: "日本語" },
-  de: { name: "Deutsch" },
-  es: { name: "Español" },
-  fr: { name: "Français" },
-  tr: { name: "Türkçe" },
-  uk: { name: "Українська" },
-  af: { name: "Afrikaans" },
-  ko: { name: "한국어" },
-  it: { name: "Italiano" },
-  ga: { name: "Gaeilge" },
-  pt: { name: "Português" },
-  ru: { name: "Русский" },
-  hu: { name: "Magyar" },
-  ar: { name: "العربية" },
+//
+// `name` is the full endonym shown in the dropdown; `short` is a compact code
+// used for the trigger button so it stays tidy even in a narrow sidebar
+// column. Latin-script locales use their uppercase ISO 639-1 code (EN, FR,
+// DE…); the two Chinese variants keep a single native glyph because both would
+// otherwise collide as "ZH". Keep `short` short — it must not overflow.
+export const LOCALE_META: Record<Locale, { name: string; short: string }> = {
+  en: { name: "English", short: "EN" },
+  zh: { name: "简体中文", short: "简" },
+  "zh-hant": { name: "繁體中文", short: "繁" },
+  ja: { name: "日本語", short: "JA" },
+  de: { name: "Deutsch", short: "DE" },
+  es: { name: "Español", short: "ES" },
+  fr: { name: "Français", short: "FR" },
+  tr: { name: "Türkçe", short: "TR" },
+  uk: { name: "Українська", short: "UK" },
+  af: { name: "Afrikaans", short: "AF" },
+  ko: { name: "한국어", short: "KO" },
+  it: { name: "Italiano", short: "IT" },
+  ga: { name: "Gaeilge", short: "GA" },
+  pt: { name: "Português", short: "PT" },
+  ru: { name: "Русский", short: "RU" },
+  hu: { name: "Magyar", short: "HU" },
+  ar: { name: "العربية", short: "AR" },
 };
 
 const SUPPORTED_LOCALES = Object.keys(TRANSLATIONS) as Locale[];


### PR DESCRIPTION
## Summary

The dashboard language picker (`LanguageSwitcher`) hard-coded a short code
**only for English**:

```tsx
{locale === "en" ? "EN" : current.name}
```

Every other locale rendered its **full endonym** in the trigger button
(`Français`, `简体中文`, `Українська`, …). When the sidebar column is narrowed,
that long label **overflows / wraps** untidily — the picker is meant to sit in
a compact sidebar, so a long endonym in the trigger is a real UI bug.

This PR adds a `short` code to every `LOCALE_META` entry and uses it for the
trigger button. The dropdown still shows the full endonyms.

## What changed

- `web/src/i18n/context.tsx` — `LOCALE_META` entries now carry a `short` code
  (type: `{ name: string; short: string }`):
  - Latin-script locales use their **uppercase ISO 639-1 code** (`EN`, `FR`,
    `DE`, `ES`, `IT`, `PT`, `TR`, `UK`, `AF`, `KO`, `JA`, `GA`, `RU`, `HU`,
    `AR`).
  - The two Chinese variants use their **distinct native glyph** (`简` / `繁`)
    because both would otherwise collide as `ZH`.
- `web/src/components/LanguageSwitcher.tsx` — the trigger button renders
  `current.short` instead of the `locale === "en" ? "EN" : current.name`
  ternary.

No flags are introduced and no language↔country mappings are added — endonyms
stay in the dropdown, preserving the component's existing design intent.

## Why this approach

The previous special case (`EN`) proves a compact code is the intended look;
it just wasn't extended to the other 16 locales. Putting the code in
`LOCALE_META` keeps one source of truth shared by the trigger and any future
settings page, and keeps the short codes trivially tweakable per language.

## Test plan

- `cd web && npm run build` → success.
- The built bundle contains the short codes (`short:\`FR\``, `short:\`简\``,
  …) and the button reads `current.short`.
- The old `locale === "en" ? "EN"` ternary is absent from the built bundle.
