### PR TITLE
fix(aux): stop leaking OpenAI `response_format` onto the Anthropic Messages API

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1945,6 +1945,16 @@ class AsyncCodexAuxiliaryClient:
         self._real_client = sync_wrapper._real_client
 
 
+# Caller-supplied ``extra_body`` keys that must never reach the Anthropic
+# Messages API. These are OpenAI chat.completions request fields with no
+# Messages-API equivalent; strict endpoints (Bedrock) reject unknown body keys
+# outright rather than ignoring them, turning a best-effort hint into a hard
+# HTTP 400. ``reasoning`` is additionally translated into the native
+# ``thinking`` field by build_anthropic_kwargs, so forwarding it would
+# double-specify reasoning.
+_ANTHROPIC_UNSUPPORTED_EXTRA_BODY_KEYS = frozenset({"reasoning", "response_format"})
+
+
 class _AnthropicCompletionsAdapter:
     """OpenAI-client-compatible adapter for Anthropic Messages API."""
 
@@ -2045,18 +2055,30 @@ class _AnthropicCompletionsAdapter:
         # form is the documented Anthropic SDK passthrough for non-standard
         # request body keys; merge on top of whatever build_anthropic_kwargs
         # already produced (e.g. fast-mode ``speed``) so call-time settings
-        # survive. Two exclusions:
+        # survive. Three exclusions:
         #   - ``reasoning``: the OpenAI-shaped config dict is TRANSLATED into
         #     the native ``thinking`` field above (build_anthropic_kwargs);
         #     forwarding the raw field alongside would double-specify
         #     reasoning and 400 on strict gateways.
+        #   - ``response_format``: OpenAI chat.completions-only. The Messages
+        #     API expresses structured output through tools/prefill and has no
+        #     such field, so forwarding it is never useful and is actively
+        #     fatal on strict endpoints — Bedrock rejects unknown body keys
+        #     with ``response_format: Extra inputs are not permitted``, which
+        #     made every ``title_generation`` call fail on Bedrock/Anthropic
+        #     (title_generator sends a json_schema format unconditionally).
+        #     Callers already tolerate an unconstrained reply: the title
+        #     prompt demands a bare JSON object and ``_extract_title_text``
+        #     falls back to a loose JSON scan, so dropping the hint degrades
+        #     gracefully instead of failing the request.
         #   - ``_``-prefixed keys: private Hermes plumbing (_reasoning_config
         #     et al.), never wire fields.
         caller_extra_body = kwargs.get("extra_body")
         if caller_extra_body and isinstance(caller_extra_body, dict):
             passthrough = {
                 k: v for k, v in caller_extra_body.items()
-                if k != "reasoning" and not str(k).startswith("_")
+                if k not in _ANTHROPIC_UNSUPPORTED_EXTRA_BODY_KEYS
+                and not str(k).startswith("_")
             }
             if passthrough:
                 existing = anthropic_kwargs.get("extra_body") or {}

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2080,6 +2080,26 @@ class _AnthropicCompletionsAdapter:
                 if k not in _ANTHROPIC_UNSUPPORTED_EXTRA_BODY_KEYS
                 and not str(k).startswith("_")
             }
+            # Make the degradation observable. Dropping ``response_format``
+            # silently weakens a caller's contract from schema-enforced to
+            # best-effort prompt compliance; a future caller that cannot
+            # tolerate that should be able to see it in the log rather than
+            # discover it from a malformed reply. Debug level: for the known
+            # callers (title generation, plugin json_mode) this is expected
+            # and would otherwise be per-call warning noise.
+            if logger.isEnabledFor(logging.DEBUG):
+                dropped = sorted(
+                    _ANTHROPIC_UNSUPPORTED_EXTRA_BODY_KEYS
+                    & set(caller_extra_body.keys())
+                )
+                if dropped:
+                    logger.debug(
+                        "Anthropic Messages API: dropped unsupported "
+                        "extra_body keys %s for model %s (no Messages-API "
+                        "equivalent; structured output degrades to prompt "
+                        "compliance)",
+                        dropped, model,
+                    )
             if passthrough:
                 existing = anthropic_kwargs.get("extra_body") or {}
                 if not isinstance(existing, dict):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2386,6 +2386,35 @@ class TestAuxiliaryTaskExtraBody:
             "thinking": {"type": "disabled"}, "metadata": {"user_id": "u1"},
         }
 
+    def test_anthropic_aux_strips_response_format(self):
+        """#85624: response_format must never reach the Messages API.
+
+        It is an OpenAI chat.completions-only field. Bedrock rejects unknown
+        body keys with 'response_format: Extra inputs are not permitted',
+        which made every title_generation call fail on Bedrock/Anthropic.
+        """
+        api_kwargs = self._run_anthropic_adapter(
+            call_extra_body={
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {"name": "session_title", "strict": True},
+                },
+            },
+        )
+        # Nothing survived, so no extra_body should be attached at all.
+        assert "response_format" not in (api_kwargs.get("extra_body") or {})
+        assert "extra_body" not in api_kwargs
+
+    def test_anthropic_aux_strips_response_format_keeps_siblings(self):
+        """Stripping response_format must not drop legitimate vendor fields."""
+        api_kwargs = self._run_anthropic_adapter(
+            call_extra_body={
+                "response_format": {"type": "json_object"},
+                "metadata": {"user_id": "u1"},
+            },
+        )
+        assert api_kwargs["extra_body"] == {"metadata": {"user_id": "u1"}}
+
 
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2415,6 +2415,65 @@ class TestAuxiliaryTaskExtraBody:
         )
         assert api_kwargs["extra_body"] == {"metadata": {"user_id": "u1"}}
 
+    def test_anthropic_aux_response_format_top_level_kwarg_not_forwarded(self):
+        """#85626 review: response_format can't leak as a top-level kwarg either.
+
+        The adapter reads a fixed allow-list of OpenAI kwargs (model, messages,
+        tools, tool_choice, max_tokens, temperature, extra_body) and builds the
+        Messages body from scratch, so an unrecognized top-level kwarg is
+        dropped on the floor rather than forwarded. This pins that behaviour so
+        a future refactor to **kwargs-splat forwarding can't silently reopen
+        the leak on a second path.
+        """
+        from agent.auxiliary_client import _AnthropicCompletionsAdapter
+
+        adapter = _AnthropicCompletionsAdapter(
+            MagicMock(), "claude-sonnet-4-6", is_oauth=False,
+        )
+        bak_result = {
+            "model": "claude-sonnet-4-6", "messages": [], "max_tokens": 64,
+        }
+        with patch("agent.anthropic_adapter.build_anthropic_kwargs",
+                   return_value=dict(bak_result)) as mock_bak, \
+             patch("agent.anthropic_adapter.create_anthropic_message") as mock_create, \
+             patch("agent.transports.get_transport") as mock_gt:
+            mock_gt.return_value.normalize_response.return_value = MagicMock(
+                content="ok", tool_calls=None, reasoning=None,
+                finish_reason="stop", usage=None, provider_data=None,
+            )
+            adapter.create(
+                model="claude-sonnet-4-6",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=64,
+                # top-level, NOT nested under extra_body
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {"name": "session_title", "strict": True},
+                },
+            )
+
+        # Never reaches the body builder...
+        assert "response_format" not in mock_bak.call_args.kwargs
+        api_kwargs = mock_create.call_args.args[1]
+        # ...nor the SDK, top-level or smuggled into extra_body.
+        assert "response_format" not in api_kwargs
+        assert "response_format" not in (api_kwargs.get("extra_body") or {})
+
+    def test_anthropic_aux_logs_dropped_response_format(self, caplog):
+        """#85626 review: the degradation is observable, not silent."""
+        with caplog.at_level(logging.DEBUG, logger="agent.auxiliary_client"):
+            self._run_anthropic_adapter(
+                call_extra_body={
+                    "response_format": {"type": "json_object"},
+                    "metadata": {"user_id": "u1"},
+                },
+            )
+        assert any(
+            "dropped unsupported extra_body keys" in r.message
+            and "response_format" in r.getMessage()
+            for r in caplog.records
+        ), caplog.text
+
 
 
 


### PR DESCRIPTION
## Problem

Session auto-titling fails on **every** call when the `title_generation` auxiliary task resolves to an Anthropic-wire provider (Bedrock, or any Anthropic-compatible gateway):

```
WARNING agent.title_generator: Title generation failed: Error code: 400 -
  {'message': 'response_format: Extra inputs are not permitted'}
```

Sessions keep their truncated derived title forever (`title_source` stays `derived`). This is the **default configuration** for anyone running Hermes on Bedrock, since `auxiliary.title_generation.provider: auto` resolves to the main provider.

Fixes #85624.

## Root cause

Two correct-in-isolation behaviours combine into a guaranteed failure:

1. `agent/title_generator.py:404` unconditionally sends the OpenAI structured-output field:
   ```python
   extra_body={"response_format": _TITLE_RESPONSE_FORMAT},   # json_schema, strict
   ```
2. `_AnthropicCompletionsAdapter.create()` forwarded caller `extra_body` verbatim into the Messages API body, excluding only `reasoning` and `_`-prefixed keys.

The Anthropic Messages API has **no** `response_format` field — structured output is expressed through tools/prefill — and Bedrock's endpoint rejects unknown body keys rather than ignoring them. So the field didn't degrade; it failed the whole request.

The adapter already excluded `reasoning` for precisely this reason ("forwarding the raw field alongside would double-specify reasoning and 400 on strict gateways"). `response_format` is the same class of OpenAI-shaped key and was simply missed.

## Fix

Strip `response_format` alongside `reasoning`, via a named frozenset so the intent is documented in one place and future OpenAI-only keys have an obvious home:

```python
_ANTHROPIC_UNSUPPORTED_EXTRA_BODY_KEYS = frozenset({"reasoning", "response_format"})
```

Degrading is safe rather than lossy: the title prompt already demands a bare JSON object and `_extract_title_text()` falls back to a loose JSON scan, so an unconstrained reply still titles correctly.

## Why not fix it in `title_generator` instead

The two open PRs for the neighbouring `json_schema`-rejection reports (#82751, #83186) retry with a **looser response_format**. That approach cannot fix this case — on Bedrock the looser rung 400s identically, because the problem is the field's *existence*, not its value:

```
400 FAIL  response_format json_schema   (what title_generator sends)
400 FAIL  response_format json_object   (#82751's retry rung)
200 OK    thinking: {"type":"disabled"}  (#83186's other retry key)
200 OK    no extra_body                 (control)
```

(Raw `AnthropicBedrock` against `us.anthropic.claude-opus-5`, `us-west-2`, one axis varied.)

Fixing it at the adapter also covers a second caller: `agent/plugin_llm.py:868,1011` (`_json_response_format()` for `json_mode`/`json_schema`) routes through the same `call_llm` path, so plugin structured-output calls were broken on Anthropic-wire providers too.

## Verification

**Real path, live Bedrock, on this branch** (`us.anthropic.claude-opus-5`, `us-west-2`):

```
strip set  : ['reasoning', 'response_format']
call_llm OK: '{"title":"Debugging AWS Bedrock 400 Error"}'
generate_title(): 'Bedrock 400 error on title generation'
```

Before the change the same call raised `400 response_format: Extra inputs are not permitted`. A fresh session now records `title_source = llm` instead of `derived`.

**Tests** — two regression cases added to the existing `_run_anthropic_adapter` harness in `tests/agent/test_auxiliary_client.py`:

- `test_anthropic_aux_strips_response_format` — the key never reaches the SDK
- `test_anthropic_aux_strips_response_format_keeps_siblings` — stripping it does not drop legitimate vendor fields (`metadata` survives)

```
$ pytest tests/agent/test_auxiliary_client.py -k "strips_response_format or extra_body_passthrough"
3 passed, 180 deselected
```

The pre-existing `test_anthropic_aux_extra_body_passthrough` still passes, confirming legitimate vendor passthrough (`thinking`, `metadata`) is unaffected.

## Follow-up (not in this PR)

A richer fix would *translate* `response_format` into the Messages API's native structured-output mechanism (a forced single-tool call, or assistant prefill), giving Anthropic-wire providers real schema enforcement instead of best-effort prompt compliance. Happy to do that as a separate PR if wanted — this one restores titling with the minimal change.
