### PR TITLE
fix: add deterministic computer-use window targeting

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1455,6 +1455,26 @@ class TestCuaCliFallbackResolution:
             "/Users/example/.local/bin/cua-driver", "call", "click"
         ]
 
+    def test_cli_fallback_nonzero_exit_with_json_fails_closed(self):
+        from tools.computer_use.cua_backend import _AsyncBridge, _CuaDriverSession
+
+        proc = MagicMock(
+            stdout='{"error":"stale target"}',
+            stderr="",
+            returncode=1,
+        )
+        session = _CuaDriverSession(_AsyncBridge())
+        with patch(
+            "tools.computer_use.cua_backend.resolve_cua_driver_cmd",
+            return_value="/Users/example/.local/bin/cua-driver",
+        ), patch("subprocess.run", return_value=proc):
+            out = session._call_tool_via_cli(
+                "hotkey", {"pid": 42, "window_id": 7}, timeout=0.1,
+            )
+
+        assert out["isError"] is True
+        assert out["structuredContent"]["error"] == "stale target"
+
 
 class TestClickButtonPassthrough:
     """Surface 5 (NousResearch/hermes-agent#47072) — `middle_click` must

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1475,6 +1475,23 @@ class TestCuaCliFallbackResolution:
         assert out["isError"] is True
         assert out["structuredContent"]["error"] == "stale target"
 
+    def test_shared_daemon_cli_transport_does_not_append_embedded_socket(self):
+        from tools.computer_use.cua_backend import _AsyncBridge, _CuaDriverSession
+
+        proc = MagicMock(stdout="{}", stderr="", returncode=0)
+        session = _CuaDriverSession(_AsyncBridge())
+        session._embedded_daemon = MagicMock()
+        with patch(
+            "tools.computer_use.cua_backend.resolve_cua_driver_cmd",
+            return_value="/Users/example/.local/bin/cua-driver",
+        ), patch("subprocess.run", return_value=proc) as run:
+            session._call_tool_via_cli(
+                "hotkey", {"pid": 42, "window_id": 7}, timeout=0.1,
+                shared_daemon=True,
+            )
+
+        assert "--socket" not in run.call_args.args[0]
+
 
 class TestClickButtonPassthrough:
     """Surface 5 (NousResearch/hermes-agent#47072) — `middle_click` must

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1473,12 +1473,31 @@ class TestClickButtonPassthrough:
         from tools.computer_use.cua_backend import CuaDriverBackend
         backend = CuaDriverBackend()
         backend._session = MagicMock()
-        backend._session.call_tool.return_value = {
+        action_result = {
             "data": "ok",
             "images": [],
             "structuredContent": None,
             "isError": False,
         }
+
+        def call_tool(name, _args):
+            if name == "list_windows":
+                return {
+                    "data": "",
+                    "images": [],
+                    "structuredContent": {"windows": [{
+                        "app_name": "Test App",
+                        "pid": 111,
+                        "window_id": 222,
+                        "is_on_screen": True,
+                        "title": "Test Window",
+                        "z_index": 1,
+                    }]},
+                    "isError": False,
+                }
+            return action_result
+
+        backend._session.call_tool.side_effect = call_tool
         # Pretend capture() ran and resolved a target.
         backend._active_pid = 111
         backend._active_window_id = 222
@@ -1559,12 +1578,31 @@ class TestKeyboardWindowIdRouting:
         from tools.computer_use.cua_backend import CuaDriverBackend
         backend = CuaDriverBackend()
         backend._session = MagicMock()
-        backend._session.call_tool.return_value = {
+        action_result = {
             "data": "ok",
             "images": [],
             "structuredContent": None,
             "isError": False,
         }
+
+        def call_tool(name, _args):
+            if name == "list_windows":
+                return {
+                    "data": "",
+                    "images": [],
+                    "structuredContent": {"windows": [{
+                        "app_name": "Test App",
+                        "pid": 111,
+                        "window_id": 222,
+                        "is_on_screen": True,
+                        "title": "Test Window",
+                        "z_index": 1,
+                    }]},
+                    "isError": False,
+                }
+            return action_result
+
+        backend._session.call_tool.side_effect = call_tool
         backend._active_pid = 111
         backend._active_window_id = 222
         return backend
@@ -1890,10 +1928,29 @@ class TestElementTokenAttachment:
 
         backend = CuaDriverBackend()
         backend._session = MagicMock()
-        backend._session.call_tool.return_value = {
+        action_result = {
             "data": "ok", "images": [], "image_mime_types": [],
             "structuredContent": None, "isError": False,
         }
+
+        def call_tool(name, _args):
+            if name == "list_windows":
+                return {
+                    "data": "",
+                    "images": [],
+                    "structuredContent": {"windows": [{
+                        "app_name": "Test App",
+                        "pid": 111,
+                        "window_id": 222,
+                        "is_on_screen": True,
+                        "title": "Test Window",
+                        "z_index": 1,
+                    }]},
+                    "isError": False,
+                }
+            return action_result
+
+        backend._session.call_tool.side_effect = call_tool
         # `supports_capability(cap, tool=None)` honors the supplied map.
         def _supports(cap, tool=None):
             if tool is not None:

--- a/tests/tools/test_computer_use_cua_0_9.py
+++ b/tests/tools/test_computer_use_cua_0_9.py
@@ -48,6 +48,19 @@ class _FakeSession:
         self.calls: list[tuple[str, Dict[str, Any]]] = []
 
     def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0):
+        if name == "list_windows":
+            return {
+                "isError": False,
+                "data": {},
+                "structuredContent": {"windows": [{
+                    "app_name": "Test App",
+                    "pid": 42,
+                    "window_id": 7,
+                    "is_on_screen": True,
+                    "title": "Test Window",
+                    "z_index": 1,
+                }]},
+            }
         self.calls.append((name, dict(args)))
         return self.out
 

--- a/tests/tools/test_computer_use_cua_0_9.py
+++ b/tests/tools/test_computer_use_cua_0_9.py
@@ -46,6 +46,7 @@ class _FakeSession:
         self.input_properties = input_properties or {}
         self.tools = tools or {"bring_to_front", *self.input_properties}
         self.calls: list[tuple[str, Dict[str, Any]]] = []
+        self.cli_calls: list[tuple[str, Dict[str, Any], float]] = []
 
     def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0):
         if name == "list_windows":
@@ -62,6 +63,10 @@ class _FakeSession:
                 }]},
             }
         self.calls.append((name, dict(args)))
+        return self.out
+
+    def _call_tool_via_cli(self, name: str, args: Dict[str, Any], timeout: float):
+        self.cli_calls.append((name, dict(args), timeout))
         return self.out
 
     def supports_capability(self, capability: str, tool: Optional[str] = None) -> bool:
@@ -173,12 +178,28 @@ def test_foreground_focus_is_a_separate_call_before_action():
     )
 
     assert result.ok is True
-    assert [name for name, _ in session.calls] == ["bring_to_front", "click"]
+    assert [name for name, _ in session.calls] == ["bring_to_front"]
+    assert [name for name, _, _ in session.cli_calls] == ["click"]
     focus_args = session.calls[0][1]
-    action_args = session.calls[1][1]
+    action_args = session.cli_calls[0][1]
     assert focus_args == {"pid": 42, "window_id": 7}
     assert action_args["delivery_mode"] == "foreground"
     assert "bring_to_front" not in action_args
+
+
+def test_foreground_input_uses_cli_socket_transport_but_background_stays_on_mcp():
+    session = _FakeSession(input_properties={"hotkey": {"delivery_mode"}})
+    backend = _make_backend(session)
+
+    foreground = backend.key("cmd+t", delivery_mode="foreground")
+    background = backend.key("cmd+t", delivery_mode="background")
+
+    assert foreground.ok is True
+    assert background.ok is True
+    assert [name for name, _, _ in session.cli_calls] == ["hotkey"]
+    assert session.cli_calls[0][1]["delivery_mode"] == "foreground"
+    assert [name for name, _ in session.calls] == ["hotkey"]
+    assert "delivery_mode" not in session.calls[0][1]
 
 
 def test_foreground_refuses_only_when_schema_lacks_delivery_property():

--- a/tests/tools/test_computer_use_cua_0_9.py
+++ b/tests/tools/test_computer_use_cua_0_9.py
@@ -65,7 +65,9 @@ class _FakeSession:
         self.calls.append((name, dict(args)))
         return self.out
 
-    def _call_tool_via_cli(self, name: str, args: Dict[str, Any], timeout: float):
+    def _call_tool_via_cli(
+        self, name: str, args: Dict[str, Any], timeout: float, **kwargs: Any,
+    ):
         self.cli_calls.append((name, dict(args), timeout))
         return self.out
 

--- a/tests/tools/test_computer_use_delivery_ladder.py
+++ b/tests/tools/test_computer_use_delivery_ladder.py
@@ -70,7 +70,9 @@ class _FakeSession:
         self.calls.append((name, dict(args)))
         return self._out
 
-    def _call_tool_via_cli(self, name: str, args: Dict[str, Any], timeout: float):
+    def _call_tool_via_cli(
+        self, name: str, args: Dict[str, Any], timeout: float, **kwargs: Any,
+    ):
         self.last_args = args
         self.cli_calls.append((name, dict(args), timeout))
         return self._out

--- a/tests/tools/test_computer_use_delivery_ladder.py
+++ b/tests/tools/test_computer_use_delivery_ladder.py
@@ -50,6 +50,7 @@ class _FakeSession:
         self._input_properties = input_properties or {}
         self.last_args: Dict[str, Any] = {}
         self.calls = []
+        self.cli_calls = []
 
     def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0):
         if name == "list_windows":
@@ -67,6 +68,11 @@ class _FakeSession:
             }
         self.last_args = args
         self.calls.append((name, dict(args)))
+        return self._out
+
+    def _call_tool_via_cli(self, name: str, args: Dict[str, Any], timeout: float):
+        self.last_args = args
+        self.cli_calls.append((name, dict(args), timeout))
         return self._out
 
     def supports_capability(self, capability: str, tool: Optional[str] = None) -> bool:
@@ -204,7 +210,8 @@ def test_foreground_sent_when_schema_property_present():
     sess = _FakeSession(out, input_properties={"click": {"delivery_mode"}})
     be = _make_backend(sess)
     res = be.click(element=1, delivery_mode="foreground", bring_to_front=True)
-    assert [name for name, _ in sess.calls] == ["bring_to_front", "click"]
+    assert [name for name, _ in sess.calls] == ["bring_to_front"]
+    assert [name for name, _, _ in sess.cli_calls] == ["click"]
     assert sess.calls[0][1] == {"pid": 4242, "window_id": 7}
     assert sess.last_args.get("delivery_mode") == "foreground"
     assert "bring_to_front" not in sess.last_args

--- a/tests/tools/test_computer_use_delivery_ladder.py
+++ b/tests/tools/test_computer_use_delivery_ladder.py
@@ -52,6 +52,19 @@ class _FakeSession:
         self.calls = []
 
     def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0):
+        if name == "list_windows":
+            return {
+                "isError": False,
+                "data": {},
+                "structuredContent": {"windows": [{
+                    "app_name": "Test App",
+                    "pid": 4242,
+                    "window_id": 7,
+                    "is_on_screen": True,
+                    "title": "Test Window",
+                    "z_index": 1,
+                }]},
+            }
         self.last_args = args
         self.calls.append((name, dict(args)))
         return self._out

--- a/tests/tools/test_computer_use_window_targeting.py
+++ b/tests/tools/test_computer_use_window_targeting.py
@@ -1,0 +1,486 @@
+"""Regression coverage for exact native-window targeting in computer_use."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.computer_use.backend import ActionResult, CaptureResult
+
+
+def _window(
+    window_id: int,
+    *,
+    pid: int = 73384,
+    title: str = "Mission Control",
+    on_screen: bool = True,
+    width: float = 1906,
+    height: float = 960,
+    z_index: int = 45,
+):
+    return {
+        "app_name": "Safari",
+        "pid": pid,
+        "window_id": window_id,
+        "is_on_screen": on_screen,
+        "title": title,
+        "z_index": z_index,
+        "layer": 0,
+        "bounds": {"x": 1, "y": 30, "width": width, "height": height},
+    }
+
+
+def _backend_with_windows(windows):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    session = MagicMock()
+    session.capabilities_discovered = True
+    session._has_tool.return_value = False
+    session.supports_capability.return_value = False
+    session.supports_input_property.return_value = False
+
+    def call_tool(name, args, *unused_args, **unused_kwargs):
+        if name == "list_windows":
+            requested_pid = args.get("pid")
+            listed = [w for w in windows if requested_pid is None or w["pid"] == requested_pid]
+            return {
+                "data": "",
+                "images": [],
+                "structuredContent": {"windows": listed},
+                "isError": False,
+            }
+        if name == "get_window_state":
+            return {
+                "data": '0 elements\n- [0] AXWindow "Mission Control"',
+                "images": [],
+                "structuredContent": {"elements": []},
+                "isError": False,
+            }
+        return {"data": "ok", "images": [], "structuredContent": {}, "isError": False}
+
+    session.call_tool.side_effect = call_tool
+    backend._session = session
+    return backend
+
+
+@pytest.fixture(autouse=True)
+def _reset_tool_backend():
+    from tools.computer_use.tool import reset_backend_for_tests
+
+    reset_backend_for_tests()
+    yield
+    reset_backend_for_tests()
+
+
+def test_capture_result_carries_exact_native_target_in_text_and_multimodal_responses():
+    from tools.computer_use import tool as cu_tool
+
+    cap = CaptureResult(
+        mode="ax",
+        width=100,
+        height=100,
+        app="Safari",
+        window_title="Mission Control",
+        pid=73384,
+        window_id=754,
+    )
+    payload = json.loads(cu_tool._capture_response(cap))
+    assert payload["pid"] == 73384
+    assert payload["window_id"] == 754
+    assert "pid=73384 window_id=754" in payload["summary"]
+
+    cap.mode = "vision"
+    cap.png_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAADUlEQVR4nG"
+        "NgGAUgAAABCAABgukLHQAAAABJRU5ErkJggg=="
+    )
+    with patch.object(cu_tool, "_should_route_through_aux_vision", return_value=False):
+        response = cu_tool._capture_response(cap)
+    assert response["meta"]["pid"] == 73384
+    assert response["meta"]["window_id"] == 754
+    assert "pid=73384 window_id=754" in response["text_summary"]
+
+
+def test_auxiliary_vision_capture_response_carries_exact_native_target(tmp_path):
+    from tools.computer_use import tool as cu_tool
+
+    cap = CaptureResult(
+        mode="vision",
+        width=8,
+        height=8,
+        png_b64=(
+            "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAADUlEQVR4nG"
+            "NgGAUgAAABCAABgukLHQAAAABJRU5ErkJggg=="
+        ),
+        pid=73384,
+        window_id=754,
+    )
+    fake_vision = MagicMock(return_value="<coro>")
+    with patch.object(cu_tool, "_should_route_through_aux_vision", return_value=True), \
+         patch("hermes_constants.get_hermes_dir", return_value=tmp_path), \
+         patch("model_tools._run_async", return_value=json.dumps({"analysis": "synthetic"})), \
+         patch("tools.vision_tools.vision_analyze_tool", new=fake_vision):
+        response = cu_tool._capture_response(cap)
+
+    payload = json.loads(response)
+    assert payload["vision_analysis_routed_via"] == "auxiliary.vision"
+    assert payload["pid"] == 73384
+    assert payload["window_id"] == 754
+
+
+def test_capture_after_uses_successful_action_result_target_over_sticky_target():
+    from tools.computer_use import tool as cu_tool
+
+    class CaptureTrackingBackend:
+        _last_target = {"pid": 73384, "window_id": 754}
+        _last_app = "Safari"
+
+        def __init__(self):
+            self.capture_calls = []
+
+        def capture(self, **kwargs):
+            self.capture_calls.append(kwargs)
+            return CaptureResult(
+                mode=kwargs["mode"],
+                width=100,
+                height=100,
+                pid=kwargs.get("pid"),
+                window_id=kwargs.get("window_id"),
+            )
+
+    backend = CaptureTrackingBackend()
+    result = ActionResult(
+        ok=True,
+        action="key",
+        meta={"pid": 80000, "window_id": 900},
+    )
+
+    cu_tool._maybe_follow_capture(backend, result, True)
+
+    assert backend.capture_calls == [
+        {"mode": cu_tool._capture_after_mode(), "pid": 80000, "window_id": 900}
+    ]
+
+
+def test_approval_summary_names_explicit_native_target():
+    from tools.computer_use import tool as cu_tool
+
+    summary = cu_tool._summarize_action(
+        "key", {"keys": "cmd+t", "pid": 73384, "window_id": 754}
+    )
+
+    assert "pid=73384" in summary
+    assert "window_id=754" in summary
+
+
+def test_capture_dispatch_passes_only_target_keywords_actually_specified():
+    from tools.computer_use import tool as cu_tool
+
+    class PidAwareLegacyBackend:
+        def __init__(self):
+            self.pid = None
+
+        def capture(self, mode="som", app=None, *, pid=None):
+            self.pid = pid
+            return CaptureResult(mode=mode, width=1, height=1)
+
+    backend = PidAwareLegacyBackend()
+    cu_tool._dispatch(
+        backend,
+        "capture",
+        {"action": "capture", "mode": "ax", "pid": 73384},
+    )
+
+    assert backend.pid == 73384
+
+
+def test_dispatch_omits_unspecified_target_keywords_for_legacy_backend():
+    from tools.computer_use import tool as cu_tool
+
+    class LegacyBackend:
+        def key(self, keys, *, delivery_mode=None, bring_to_front=False):
+            return ActionResult(ok=True, action="key", message=keys)
+
+    payload = json.loads(
+        cu_tool._dispatch(LegacyBackend(), "key", {"action": "key", "keys": "cmd+t"})
+    )
+
+    assert payload["ok"] is True
+
+
+def test_public_dispatch_forwards_explicit_target_to_every_native_action():
+    from tools.computer_use import tool as cu_tool
+
+    class TrackingBackend:
+        _last_target = None
+        _last_app = None
+
+        def __init__(self):
+            self.calls = []
+
+        def _record(self, name, **kwargs):
+            self.calls.append((name, kwargs))
+            return ActionResult(ok=True, action=name)
+
+        def click(self, **kwargs):
+            return self._record("click", **kwargs)
+
+        def drag(self, **kwargs):
+            return self._record("drag", **kwargs)
+
+        def scroll(self, **kwargs):
+            return self._record("scroll", **kwargs)
+
+        def type_text(self, text, **kwargs):
+            return self._record("type", text=text, **kwargs)
+
+        def key(self, keys, **kwargs):
+            return self._record("key", keys=keys, **kwargs)
+
+        def set_value(self, value, element=None, **kwargs):
+            return self._record("set_value", value=value, element=element, **kwargs)
+
+        def focus_app(self, app=None, raise_window=False, **kwargs):
+            return self._record(
+                "focus_app", app=app, raise_window=raise_window, **kwargs
+            )
+
+    backend = TrackingBackend()
+    target = {"pid": 73384, "window_id": 754}
+    actions = [
+        {"action": "click", "coordinate": [1, 2]},
+        {
+            "action": "double_click",
+            "coordinate": [1, 2],
+        },
+        {"action": "right_click", "coordinate": [1, 2]},
+        {"action": "middle_click", "coordinate": [1, 2]},
+        {
+            "action": "drag",
+            "from_coordinate": [1, 2],
+            "to_coordinate": [3, 4],
+        },
+        {"action": "scroll", "direction": "down"},
+        {"action": "type", "text": "synthetic"},
+        {"action": "key", "keys": "cmd+t"},
+        {"action": "set_value", "element": 1, "value": "synthetic"},
+        {"action": "focus_app"},
+    ]
+
+    for action in actions:
+        result = cu_tool._dispatch(backend, action["action"], {**action, **target})
+        assert "error" not in json.loads(result), result
+
+    assert len(backend.calls) == len(actions)
+    for _name, kwargs in backend.calls:
+        assert kwargs["pid"] == 73384
+        assert kwargs["window_id"] == 754
+
+
+def test_app_capture_ignores_hidden_and_zero_size_technical_windows():
+    technical = [
+        _window(1331, on_screen=False, width=53, height=48, z_index=78),
+        _window(1296, on_screen=False, width=0, height=0, z_index=75),
+        _window(758, on_screen=False, width=699, height=337, z_index=46),
+    ]
+    backend = _backend_with_windows([*technical, _window(754)])
+
+    cap = backend.capture(mode="ax", app="Safari")
+
+    assert cap.pid == 73384
+    assert cap.window_id == 754
+    assert cap.error is None
+    gws = [c for c in backend._session.call_tool.call_args_list if c.args[0] == "get_window_state"]
+    assert gws[-1].args[1]["window_id"] == 754
+
+
+def test_app_capture_with_two_visible_windows_fails_closed_and_lists_choices():
+    backend = _backend_with_windows([
+        _window(754, title="Mission Control", z_index=45),
+        _window(900, title="Documentation", z_index=44),
+    ])
+
+    cap = backend.capture(mode="ax", app="Safari")
+
+    assert cap.error == "ambiguous_window_target"
+    assert {w["window_id"] for w in cap.available_windows} == {754, 900}
+    assert backend._active_pid is None
+    assert backend._active_window_id is None
+    assert not any(
+        c.args[0] == "get_window_state" for c in backend._session.call_tool.call_args_list
+    )
+
+
+def test_explicit_window_id_wins_and_infers_pid():
+    backend = _backend_with_windows([
+        _window(754, title="Mission Control"),
+        _window(1331, on_screen=False, width=53, height=48, z_index=78),
+    ])
+
+    cap = backend.capture(mode="ax", app="Wrong App Name", window_id=754)
+
+    assert cap.pid == 73384
+    assert cap.window_id == 754
+    assert cap.error is None
+
+
+def test_explicit_hidden_window_id_still_wins_over_visibility_filter():
+    backend = _backend_with_windows([
+        _window(754, title="Mission Control"),
+        _window(1331, on_screen=False, width=53, height=48, z_index=78),
+    ])
+
+    result = backend.key("cmd+t", window_id=1331)
+
+    assert result.ok
+    hotkey_calls = [
+        call
+        for call in backend._session.call_tool.call_args_list
+        if call.args[0] == "hotkey"
+    ]
+    assert hotkey_calls[-1].args[1]["pid"] == 73384
+    assert hotkey_calls[-1].args[1]["window_id"] == 1331
+
+
+def test_stale_explicit_capture_target_fails_without_falling_back():
+    backend = _backend_with_windows([_window(754)])
+
+    cap = backend.capture(mode="ax", pid=73384, window_id=999999)
+
+    assert cap.error == "stale_window_target"
+    assert [w["window_id"] for w in cap.available_windows] == [754]
+    assert backend._active_pid is None
+    assert not any(
+        c.args[0] == "get_window_state" for c in backend._session.call_tool.call_args_list
+    )
+
+
+def test_explicit_action_target_overrides_sticky_capture_target_and_reaches_driver():
+    backend = _backend_with_windows([
+        _window(754, title="Mission Control"),
+        _window(900, title="Documentation", pid=80000),
+    ])
+    backend._active_pid = 73384
+    backend._active_window_id = 754
+
+    result = backend.key("cmd+t", pid=80000, window_id=900)
+
+    assert result.ok
+    hotkey_calls = [c for c in backend._session.call_tool.call_args_list if c.args[0] == "hotkey"]
+    assert hotkey_calls[-1].args[1]["pid"] == 80000
+    assert hotkey_calls[-1].args[1]["window_id"] == 900
+
+
+def test_stale_explicit_action_target_fails_without_native_action_or_retarget():
+    backend = _backend_with_windows([_window(754)])
+    backend._active_pid = 73384
+    backend._active_window_id = 754
+
+    result = backend.key("cmd+t", pid=73384, window_id=999999)
+
+    assert not result.ok
+    assert result.code == "stale_window_target"
+    assert result.meta["available_windows"][0]["window_id"] == 754
+    assert not any(c.args[0] == "hotkey" for c in backend._session.call_tool.call_args_list)
+    assert backend._active_window_id == 754
+
+
+def test_pid_only_action_with_multiple_visible_windows_fails_closed():
+    backend = _backend_with_windows([
+        _window(754, title="Mission Control"),
+        _window(900, title="Documentation"),
+        _window(1331, on_screen=False, width=53, height=48),
+    ])
+
+    result = backend.key("cmd+t", pid=73384)
+
+    assert not result.ok
+    assert result.code == "ambiguous_window_target"
+    assert {w["window_id"] for w in result.meta["available_windows"]} == {754, 900}
+    assert not any(c.args[0] == "hotkey" for c in backend._session.call_tool.call_args_list)
+
+
+def test_sticky_target_is_revalidated_and_closed_window_fails_closed():
+    backend = _backend_with_windows([_window(900, title="Documentation")])
+    backend._active_pid = 73384
+    backend._active_window_id = 754
+
+    result = backend.key("cmd+t")
+
+    assert not result.ok
+    assert result.code == "stale_window_target"
+    assert not any(
+        call.args[0] == "hotkey"
+        for call in backend._session.call_tool.call_args_list
+    )
+    assert any(
+        call.args[0] == "list_windows"
+        for call in backend._session.call_tool.call_args_list
+    )
+
+
+def test_sticky_target_pair_mismatch_fails_closed_after_window_id_recycling():
+    backend = _backend_with_windows([
+        _window(754, pid=80000, title="Recycled Native ID"),
+        _window(900, pid=73384, title="Sibling"),
+    ])
+    backend._active_pid = 73384
+    backend._active_window_id = 754
+
+    result = backend.key("cmd+t")
+
+    assert not result.ok
+    assert result.code == "stale_window_target"
+    assert not any(
+        call.args[0] == "hotkey"
+        for call in backend._session.call_tool.call_args_list
+    )
+
+
+def test_focus_app_explicit_target_performs_one_exact_window_lookup():
+    backend = _backend_with_windows([
+        _window(754, title="Mission Control"),
+        _window(900, title="Documentation"),
+    ])
+
+    result = backend.focus_app(pid=73384, window_id=754)
+
+    assert result.ok
+    list_calls = [
+        call
+        for call in backend._session.call_tool.call_args_list
+        if call.args[0] == "list_windows"
+    ]
+    assert len(list_calls) == 1
+    assert list_calls[0].args[1]["on_screen_only"] is False
+
+
+def test_focus_app_with_multiple_visible_windows_fails_closed():
+    backend = _backend_with_windows([
+        _window(754, title="Mission Control"),
+        _window(900, title="Documentation"),
+        _window(1331, on_screen=False, width=53, height=48),
+    ])
+
+    result = backend.focus_app("Safari")
+
+    assert not result.ok
+    assert result.code == "ambiguous_window_target"
+    assert {w["window_id"] for w in result.meta["available_windows"]} == {754, 900}
+    assert backend._active_window_id is None
+
+
+def test_captured_target_is_reused_exactly_when_followup_omits_target():
+    backend = _backend_with_windows([_window(754)])
+    cap = backend.capture(mode="ax", app="Safari")
+    assert cap.window_id == 754
+
+    result = backend.key("cmd+t")
+
+    assert result.ok
+    hotkey_calls = [c for c in backend._session.call_tool.call_args_list if c.args[0] == "hotkey"]
+    assert hotkey_calls[-1].args[1]["pid"] == 73384
+    assert hotkey_calls[-1].args[1]["window_id"] == 754

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -65,6 +65,14 @@ class CaptureResult:
     # When None, downstream consumers fall back to base64-prefix
     # sniffing for back-compat with older drivers.
     image_mime_type: Optional[str] = None
+    # Exact native target resolved for this capture. Additive for backward
+    # compatibility: non-window backends leave both fields unset.
+    pid: Optional[int] = None
+    window_id: Optional[int] = None
+    # Structured target-resolution failure. Failed captures carry no active
+    # target and may include safe window metadata so callers can choose one.
+    error: Optional[str] = None
+    available_windows: List[Dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
@@ -147,6 +155,8 @@ class ComputerUseBackend(ABC):
         modifiers: Optional[List[str]] = None,
         delivery_mode: Optional[str] = None,   # background (default) | foreground
         bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
     ) -> ActionResult: ...
 
     @abstractmethod
@@ -161,6 +171,8 @@ class ComputerUseBackend(ABC):
         modifiers: Optional[List[str]] = None,
         delivery_mode: Optional[str] = None,
         bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
     ) -> ActionResult: ...
 
     @abstractmethod
@@ -175,16 +187,20 @@ class ComputerUseBackend(ABC):
         modifiers: Optional[List[str]] = None,
         delivery_mode: Optional[str] = None,
         bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
     ) -> ActionResult: ...
 
     # ── Keyboard ────────────────────────────────────────────────────
     @abstractmethod
     def type_text(self, text: str, *, delivery_mode: Optional[str] = None,
-                  bring_to_front: bool = False) -> ActionResult: ...
+                  bring_to_front: bool = False, pid: Optional[int] = None,
+                  window_id: Optional[int] = None) -> ActionResult: ...
 
     @abstractmethod
     def key(self, keys: str, *, delivery_mode: Optional[str] = None,
-            bring_to_front: bool = False) -> ActionResult:
+            bring_to_front: bool = False, pid: Optional[int] = None,
+            window_id: Optional[int] = None) -> ActionResult:
         """Send a key combo, e.g. 'cmd+s', 'ctrl+alt+t', 'return'."""
 
     # ── Introspection ───────────────────────────────────────────────
@@ -201,12 +217,16 @@ class ComputerUseBackend(ABC):
         return []
 
     @abstractmethod
-    def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
+    def focus_app(self, app: Optional[str] = None, raise_window: bool = False, *,
+                  pid: Optional[int] = None,
+                  window_id: Optional[int] = None) -> ActionResult:
         """Route input to `app` (by name or bundle ID). Default: focus without raise."""
 
     # ── Native-value mutation ────────────────────────────────────────
     @abstractmethod
-    def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
+    def set_value(self, value: str, element: Optional[int] = None, *,
+                  pid: Optional[int] = None,
+                  window_id: Optional[int] = None) -> ActionResult:
         """Set a native value on an element (e.g. AXPopUpButton selection).
 
         `element` is the 1-based SOM index returned by a prior capture call.

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1578,6 +1578,7 @@ class _CuaDriverSession:
         attempts = 4
         backoff = 0.5
         parsed: Any = None
+        parsed_returncode = 0
         last_err = ""
         try:
             for attempt in range(attempts):
@@ -1603,6 +1604,7 @@ class _CuaDriverSession:
                         candidate = None
                     if candidate is not None:
                         parsed = candidate
+                        parsed_returncode = int(proc.returncode or 0)
                         break
                 # No JSON (EAGAIN warning / empty) — retry with backoff.
                 if attempt < attempts - 1:
@@ -1624,12 +1626,16 @@ class _CuaDriverSession:
             images: List[str] = []
             data: Any = None
             structured: Optional[Dict] = parsed if isinstance(parsed, dict) else None
-            is_error = False
+            is_error = parsed_returncode != 0
             if isinstance(parsed, dict):
                 # Current cua-driver CLI responses may report logical failures
                 # in-band even when the subprocess itself exits successfully.
                 # Preserve that bit so stateful callers can fail closed.
-                is_error = parsed.get("isError") is True or parsed.get("is_error") is True
+                is_error = (
+                    is_error
+                    or parsed.get("isError") is True
+                    or parsed.get("is_error") is True
+                )
                 shot = parsed.get("screenshot_png_b64")
                 if not shot:
                     # Screenshot was routed to a file (ours or the daemon's choice).
@@ -2759,7 +2765,18 @@ class CuaDriverBackend(ComputerUseBackend):
             )
             if not focused.ok:
                 return focused
-        result = self._action(action, args)
+        # Foreground input is an explicit escalation for native apps that do
+        # not accept background delivery. Route that one rung over the
+        # driver's direct CLI/socket transport: the persistent stdio MCP
+        # bridge can acknowledge macOS global-input delivery without the
+        # event reaching the target, while `cua-driver call` uses the daemon's
+        # native socket and delivers the same exact pid/window-bound payload.
+        # Background input remains on MCP and retains the no-focus contract.
+        result = self._action(
+            action,
+            args,
+            cli_transport=delivery_mode == "foreground",
+        )
         if args.get("pid") is not None:
             result.meta.setdefault("pid", args["pid"])
         if args.get("window_id") is not None:
@@ -3430,6 +3447,7 @@ class CuaDriverBackend(ComputerUseBackend):
         args: Dict[str, Any],
         *,
         inject_session: bool = True,
+        cli_transport: bool = False,
     ) -> ActionResult:
         # Attach the snapshot's element_token whenever the call carries
         # an element_index and the target tool advertises support.
@@ -3441,7 +3459,10 @@ class CuaDriverBackend(ComputerUseBackend):
         if inject_session:
             args.setdefault("session", self._session_id)
         try:
-            out = self._session.call_tool(name, args)
+            if cli_transport:
+                out = self._session._call_tool_via_cli(name, args, 30.0)
+            else:
+                out = self._session.call_tool(name, args)
         except Exception as e:
             logger.exception("cua-driver %s call failed", name)
             return ActionResult(ok=False, action=name, message=f"cua-driver error: {e}")

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1526,7 +1526,14 @@ class _CuaDriverSession:
         self._start_lifecycle_locked()
         self._started = True
 
-    def _call_tool_via_cli(self, name: str, args: Dict[str, Any], timeout: float) -> Dict[str, Any]:
+    def _call_tool_via_cli(
+        self,
+        name: str,
+        args: Dict[str, Any],
+        timeout: float,
+        *,
+        shared_daemon: bool = False,
+    ) -> Dict[str, Any]:
         """Fallback transport: invoke ``cua-driver call <tool> <json>`` as a
         subprocess instead of going through the stdio MCP bridge.
 
@@ -1564,7 +1571,7 @@ class _CuaDriverSession:
         child_env = cua_driver_child_env()
         socket_args: List[str] = []
         embedded_daemon = getattr(self, "_embedded_daemon", None)
-        if embedded_daemon is not None:
+        if embedded_daemon is not None and not shared_daemon:
             driver_command = embedded_daemon.proxy_invocation()[0]
             child_env = embedded_daemon.child_env()
             socket_args = ["--socket", embedded_daemon.socket_path]
@@ -3460,7 +3467,9 @@ class CuaDriverBackend(ComputerUseBackend):
             args.setdefault("session", self._session_id)
         try:
             if cli_transport:
-                out = self._session._call_tool_via_cli(name, args, 30.0)
+                out = self._session._call_tool_via_cli(
+                    name, args, 30.0, shared_daemon=True,
+                )
             else:
                 out = self._session.call_tool(name, args)
         except Exception as e:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -341,11 +341,13 @@ def _select_capture_target(
     """
     candidates = [w for w in windows if not w["off_screen"]]
     pool = candidates
-    if not exact_target and not app_requested and sys.platform == "linux":
+    # Desktop/shell helper exclusion is cross-platform. The optional X11
+    # active-window tie-break remains Linux-only.
+    if not exact_target and not app_requested:
         real_apps = [w for w in candidates if _is_real_app_window(w)]
         if real_apps:
             pool = real_apps
-        if pool and _z_index_uninformative(pool):
+        if sys.platform == "linux" and pool and _z_index_uninformative(pool):
             active_id = _linux_x11_active_window_id()
             if active_id is not None:
                 for w in pool:
@@ -2076,7 +2078,10 @@ class CuaDriverBackend(ComputerUseBackend):
         self._last_target = None
         self._snapshot_tokens = {}
 
-    def _failed_capture(self, mode: str, message: str = "") -> CaptureResult:
+    def _failed_capture(
+        self, mode: str, message: str = "", *, error: Optional[str] = None,
+        available_windows: Optional[List[Dict[str, Any]]] = None,
+    ) -> CaptureResult:
         """Return an empty capture after disarming any prior target context."""
         self._clear_active_target()
         return CaptureResult(
@@ -2088,7 +2093,108 @@ class CuaDriverBackend(ComputerUseBackend):
             app="",
             window_title=message,
             png_bytes_len=0,
+            error=error,
+            available_windows=available_windows or [],
         )
+
+    @staticmethod
+    def _visible_window(window: Dict[str, Any]) -> bool:
+        """Exclude hidden and zero-area helper windows from app ambiguity."""
+        if window.get("is_on_screen") is False or window.get("off_screen") is True:
+            return False
+        bounds = window.get("bounds") or {}
+        width = bounds.get("width")
+        height = bounds.get("height")
+        return not (width is not None and height is not None
+                    and (float(width) <= 0 or float(height) <= 0))
+
+    def _resolve_exact_target(
+        self, *, pid: Optional[int], window_id: Optional[int], action: str,
+    ) -> Tuple[
+        Optional[Dict[str, Any]],
+        List[Dict[str, Any]],
+        Optional[str],
+    ]:
+        """Validate native IDs and refuse a PID that still names >1 window."""
+        del action  # retained in the signature for diagnostics/call-site clarity
+        # Exact IDs are allowed to name an off-screen/background window. App
+        # and PID-only resolution still filter to visible top-level windows.
+        windows = self._load_windows(on_screen_only=False)
+        visible = [window for window in windows if self._visible_window(window)]
+        wanted_pid = _positive_int(pid) if pid is not None else None
+        wanted_window = _positive_int(window_id) if window_id is not None else None
+        if ((pid is not None and wanted_pid is None)
+                or (window_id is not None and wanted_window is None)):
+            return None, visible, "stale_window_target"
+
+        # A native window ID is the strongest identity. If a PID accompanies
+        # it, both values must still describe the same live window. This is the
+        # strongest identity macOS exposes here: CGWindowID can theoretically
+        # be recycled quickly to a new window owned by the same PID, and
+        # list_windows provides no generation token to distinguish that case.
+        # We therefore guarantee current pair existence, but cannot detect
+        # same-PID/same-CGWindowID recycling without an OS-provided generation.
+        if wanted_window is not None:
+            matches = [
+                window for window in windows
+                if window["window_id"] == wanted_window
+                and (wanted_pid is None or window["pid"] == wanted_pid)
+            ]
+            return (
+                matches[0] if matches else None,
+                visible,
+                None if matches else "stale_window_target",
+            )
+
+        # PID-only targeting is safe only when exactly one visible window is
+        # owned by that process. Hidden helper windows do not create ambiguity.
+        matches = [window for window in visible if window["pid"] == wanted_pid]
+        if len(matches) > 1:
+            return None, matches, "ambiguous_window_target"
+        return (
+            matches[0] if matches else None,
+            visible,
+            None if matches else "stale_window_target",
+        )
+
+    def _action_target(
+        self, action: str, pid: Optional[int], window_id: Optional[int],
+    ) -> Tuple[Optional[int], Optional[int], Optional[ActionResult]]:
+        explicit = pid is not None or window_id is not None
+        if explicit:
+            target, windows, target_error = self._resolve_exact_target(
+                pid=pid, window_id=window_id, action=action,
+            )
+        else:
+            if self._active_pid is None or self._active_window_id is None:
+                return None, None, ActionResult(
+                    ok=False, action=action,
+                    message="No active window — call capture() first.",
+                )
+            # Revalidate the exact sticky pair immediately before every native
+            # mutation. This detects a closed ID and cross-process ID recycling
+            # without ever resolving by PID to a sibling window.
+            target, windows, target_error = self._resolve_exact_target(
+                pid=self._active_pid,
+                window_id=self._active_window_id,
+                action=action,
+            )
+            if target is None:
+                self._clear_active_target()
+
+        if target is None:
+            code = target_error or "stale_window_target"
+            message = (
+                "The process owns more than one visible top-level window; "
+                "provide window_id."
+                if code == "ambiguous_window_target"
+                else "The exact native window target is no longer available."
+            )
+            return None, None, ActionResult(
+                ok=False, action=action, code=code, message=message,
+                meta={"available_windows": windows},
+            )
+        return target["pid"], target["window_id"], None
 
     def _call_capture_tool(self, name: str, args: Dict[str, Any]) -> Dict[str, Any]:
         """Call a capture-stage tool and disarm state on transport or logical failure."""
@@ -2106,7 +2212,7 @@ class CuaDriverBackend(ComputerUseBackend):
             )
         return out
 
-    def _load_windows(self) -> List[Dict[str, Any]]:
+    def _load_windows(self, *, on_screen_only: bool = True) -> List[Dict[str, Any]]:
         """Load normalized visible windows, with the shared CLI recovery path.
 
         Windows are sorted by ``z_index`` **descending**: CUA Driver
@@ -2118,7 +2224,7 @@ class CuaDriverBackend(ComputerUseBackend):
         """
         out = self._call_capture_tool(
             "list_windows",
-            {"on_screen_only": True, "session": self._session_id},
+            {"on_screen_only": on_screen_only, "session": self._session_id},
         )
         windows = _ingest_windows(_windows_from_tool_result(out))
         windows.sort(key=lambda w: w["z_index"], reverse=True)
@@ -2132,7 +2238,7 @@ class CuaDriverBackend(ComputerUseBackend):
         try:
             cli_out = self._session._call_tool_via_cli(
                 "list_windows",
-                {"on_screen_only": True, "session": self._session_id},
+                {"on_screen_only": on_screen_only, "session": self._session_id},
                 20.0,
             )
         except Exception as exc:
@@ -2249,24 +2355,21 @@ class CuaDriverBackend(ComputerUseBackend):
         # An exact pid/window pair is both the stable capture_after target and
         # the escape hatch when app/window discovery is unavailable on X11.
         if pid is not None or window_id is not None:
-            if pid is None or window_id is None:
+            target, available, target_error = self._resolve_exact_target(
+                pid=pid, window_id=window_id, action="capture",
+            )
+            if target is None:
                 return self._failed_capture(
-                    mode, "<capture targeting requires both pid and window_id>",
+                    mode,
+                    (
+                        "<process owns multiple visible windows; pass window_id>"
+                        if target_error == "ambiguous_window_target"
+                        else "<explicit native window target is stale>"
+                    ),
+                    error=target_error or "stale_window_target",
+                    available_windows=available,
                 )
-            target_pid = _positive_int(pid)
-            target_window_id = _positive_int(window_id)
-            if target_pid is None or target_window_id is None:
-                return self._failed_capture(
-                    mode, "<capture targeting requires positive integer pid and window_id>",
-                )
-            windows = [{
-                "app_name": app or "",
-                "pid": target_pid,
-                "window_id": target_window_id,
-                "off_screen": False,
-                "title": "",
-                "z_index": 0,
-            }]
+            windows = [target]
         else:
             try:
                 windows = self._load_windows()
@@ -2318,6 +2421,7 @@ class CuaDriverBackend(ComputerUseBackend):
             )
         elif pid is None and window_id is None and app:
             filtered = self._match_windows_for_app(windows, app)
+            filtered = [w for w in filtered if self._visible_window(w)]
             if not filtered:
                 return self._failed_capture(
                     mode,
@@ -2328,6 +2432,11 @@ class CuaDriverBackend(ComputerUseBackend):
                         f"instead of 'Calculator'; some Linux/Qt apps only "
                         f"resolve via list_apps metadata)>"
                     ),
+                )
+            if len(filtered) > 1:
+                return self._failed_capture(
+                    mode, "<multiple visible windows matched app; pass window_id>",
+                    error="ambiguous_window_target", available_windows=filtered,
                 )
             windows = filtered
 
@@ -2559,6 +2668,8 @@ class CuaDriverBackend(ComputerUseBackend):
             window_title=window_title,
             png_bytes_len=png_bytes_len,
             image_mime_type=image_mime_type,
+            pid=self._active_pid,
+            window_id=self._active_window_id,
         )
 
     # ── Pointer ────────────────────────────────────────────────────
@@ -2632,7 +2743,9 @@ class CuaDriverBackend(ComputerUseBackend):
                     delivery_mode="foreground",
                     message="The connected cua-driver does not advertise the standalone bring_to_front tool.",
                 )
-            if self._active_pid is None or self._active_window_id is None:
+            target_pid = _positive_int(args.get("pid"))
+            target_window_id = _positive_int(args.get("window_id"))
+            if target_pid is None or target_window_id is None:
                 return ActionResult(
                     ok=False,
                     action=action,
@@ -2641,12 +2754,16 @@ class CuaDriverBackend(ComputerUseBackend):
                     message="Capture an exact target before requesting persistent foreground focus.",
                 )
             focused = self.bring_to_front(
-                pid=self._active_pid,
-                window_id=self._active_window_id,
+                pid=target_pid,
+                window_id=target_window_id,
             )
             if not focused.ok:
                 return focused
         result = self._action(action, args)
+        if args.get("pid") is not None:
+            result.meta.setdefault("pid", args["pid"])
+        if args.get("window_id") is not None:
+            result.meta.setdefault("window_id", args["window_id"])
         if bring_to_front:
             result.meta["foreground_focus"] = {
                 "invoked": True,
@@ -2665,11 +2782,12 @@ class CuaDriverBackend(ComputerUseBackend):
         modifiers: Optional[List[str]] = None,
         delivery_mode: Optional[str] = None,
         bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
     ) -> ActionResult:
-        pid = self._active_pid
-        if pid is None:
-            return ActionResult(ok=False, action="click",
-                                message="No active window — call capture() first.")
+        pid, target_window_id, target_error = self._action_target("click", pid, window_id)
+        if target_error:
+            return target_error
 
         # Choose tool by click_count only — single-vs-double — and pass the
         # button through to `click`'s `button` enum (Surface 5 of
@@ -2687,18 +2805,18 @@ class CuaDriverBackend(ComputerUseBackend):
 
         args: Dict[str, Any] = {"pid": pid, "button": button_norm}
         if element is not None:
-            if self._active_window_id is None:
+            if target_window_id is None:
                 return ActionResult(ok=False, action=tool,
                                     message="No active window_id for element_index click.")
             args["element_index"] = element
-            args["window_id"] = self._active_window_id
+            args["window_id"] = target_window_id
         elif x is not None and y is not None:
-            if self._active_window_id is None:
+            if target_window_id is None:
                 return ActionResult(ok=False, action=tool,
                                     message="No active window_id for coordinate click.")
             args["x"] = x
             args["y"] = y
-            args["window_id"] = self._active_window_id
+            args["window_id"] = target_window_id
         else:
             return ActionResult(ok=False, action=tool,
                                 message="click requires element= or x/y.")
@@ -2718,26 +2836,27 @@ class CuaDriverBackend(ComputerUseBackend):
         modifiers: Optional[List[str]] = None,
         delivery_mode: Optional[str] = None,
         bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
     ) -> ActionResult:
-        pid = self._active_pid
-        if pid is None:
-            return ActionResult(ok=False, action="drag",
-                                message="No active window — call capture() first.")
+        pid, target_window_id, target_error = self._action_target("drag", pid, window_id)
+        if target_error:
+            return target_error
         args: Dict[str, Any] = {"pid": pid}
         if from_element is not None and to_element is not None:
-            if self._active_window_id is None:
+            if target_window_id is None:
                 return ActionResult(ok=False, action="drag",
                                     message="No active window_id for element-based drag.")
             args["from_element"] = from_element
             args["to_element"] = to_element
-            args["window_id"] = self._active_window_id
+            args["window_id"] = target_window_id
         elif from_xy is not None and to_xy is not None:
-            if self._active_window_id is None:
+            if target_window_id is None:
                 return ActionResult(ok=False, action="drag",
                                     message="No active window_id for coordinate drag.")
             args["from_x"], args["from_y"] = int(from_xy[0]), int(from_xy[1])
             args["to_x"], args["to_y"] = int(to_xy[0]), int(to_xy[1])
-            args["window_id"] = self._active_window_id
+            args["window_id"] = target_window_id
         else:
             return ActionResult(ok=False, action="drag",
                                 message="drag requires from_element/to_element or from_coordinate/to_coordinate.")
@@ -2754,21 +2873,22 @@ class CuaDriverBackend(ComputerUseBackend):
         modifiers: Optional[List[str]] = None,
         delivery_mode: Optional[str] = None,
         bring_to_front: bool = False,
+        pid: Optional[int] = None,
+        window_id: Optional[int] = None,
     ) -> ActionResult:
-        pid = self._active_pid
-        if pid is None:
-            return ActionResult(ok=False, action="scroll",
-                                message="No active window — call capture() first.")
+        pid, target_window_id, target_error = self._action_target("scroll", pid, window_id)
+        if target_error:
+            return target_error
         args: Dict[str, Any] = {
             "pid": pid,
             "direction": direction,
             "amount": max(1, min(50, amount)),
         }
-        if element is not None and self._active_window_id is not None:
+        if element is not None and target_window_id is not None:
             args["element_index"] = element
-            args["window_id"] = self._active_window_id
+            args["window_id"] = target_window_id
         elif x is not None and y is not None:
-            if self._active_window_id is None:
+            if target_window_id is None:
                 return ActionResult(ok=False, action="scroll",
                                     message="No active window_id for coordinate scroll.")
             # CUA Driver 0.7.1 Linux schema rejects x/y on scroll. Only
@@ -2782,27 +2902,27 @@ class CuaDriverBackend(ComputerUseBackend):
             ):
                 args["x"] = x
                 args["y"] = y
-            args["window_id"] = self._active_window_id
+            args["window_id"] = target_window_id
+        elif target_window_id is not None:
+            args["window_id"] = target_window_id
         return self._run_input_action("scroll", args, delivery_mode, bring_to_front)
 
     # ── Keyboard ───────────────────────────────────────────────────
     def type_text(self, text: str, *, delivery_mode: Optional[str] = None,
-                  bring_to_front: bool = False) -> ActionResult:
-        pid = self._active_pid
-        window_id = self._active_window_id
-        if pid is None or window_id is None:
-            return ActionResult(ok=False, action="type_text",
-                                message="No active window — call capture() first.")
+                  bring_to_front: bool = False, pid: Optional[int] = None,
+                  window_id: Optional[int] = None) -> ActionResult:
+        pid, window_id, target_error = self._action_target("type_text", pid, window_id)
+        if target_error:
+            return target_error
         args: Dict[str, Any] = {"pid": pid, "window_id": window_id, "text": text}
         return self._run_input_action("type_text", args, delivery_mode, bring_to_front)
 
     def key(self, keys: str, *, delivery_mode: Optional[str] = None,
-            bring_to_front: bool = False) -> ActionResult:
-        pid = self._active_pid
-        window_id = self._active_window_id
-        if pid is None or window_id is None:
-            return ActionResult(ok=False, action="key",
-                                message="No active window — call capture() first.")
+            bring_to_front: bool = False, pid: Optional[int] = None,
+            window_id: Optional[int] = None) -> ActionResult:
+        pid, window_id, target_error = self._action_target("key", pid, window_id)
+        if target_error:
+            return target_error
 
         key_name, modifiers = _parse_key_combo(keys)
         if not key_name:
@@ -2819,13 +2939,13 @@ class CuaDriverBackend(ComputerUseBackend):
             return self._run_input_action("press_key", args, delivery_mode, bring_to_front)
 
     # ── Value setter ────────────────────────────────────────────────
-    def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
+    def set_value(self, value: str, element: Optional[int] = None, *,
+                  pid: Optional[int] = None,
+                  window_id: Optional[int] = None) -> ActionResult:
         """Set a value on an element. Handles AXPopUpButton selects natively."""
-        pid = self._active_pid
-        window_id = self._active_window_id
-        if pid is None or window_id is None:
-            return ActionResult(ok=False, action="set_value",
-                                message="No active window — call capture() first.")
+        pid, window_id, target_error = self._action_target("set_value", pid, window_id)
+        if target_error:
+            return target_error
         if element is None:
             return ActionResult(ok=False, action="set_value",
                                 message="set_value requires element= (element index).")
@@ -2835,7 +2955,10 @@ class CuaDriverBackend(ComputerUseBackend):
             "element_index": element,
             "value": value,
         }
-        return self._action("set_value", args)
+        result = self._action("set_value", args)
+        result.meta.setdefault("pid", pid)
+        result.meta.setdefault("window_id", window_id)
+        return result
 
     # ── Introspection ──────────────────────────────────────────────
     def list_apps(self) -> List[Dict[str, Any]]:
@@ -2877,7 +3000,9 @@ class CuaDriverBackend(ComputerUseBackend):
     def list_windows(self) -> List[Dict[str, Any]]:
         return self._load_windows()
 
-    def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
+    def focus_app(self, app: Optional[str] = None, raise_window: bool = False, *,
+                  pid: Optional[int] = None,
+                  window_id: Optional[int] = None) -> ActionResult:
         """Target an app, optionally invoking standalone foreground focus.
 
         cua-driver background-automation never needs to bring a window to the
@@ -2891,13 +3016,49 @@ class CuaDriverBackend(ComputerUseBackend):
         separately approved by the Hermes adapter, and uses cua-driver's
         standalone ``bring_to_front`` tool rather than an action property.
         """
-        try:
-            windows = self._load_windows()
-        except Exception:
-            self._clear_active_target()
-            raise
-
-        matched = self._match_windows_for_app(windows, app)
+        explicit_target = pid is not None or window_id is not None
+        if explicit_target:
+            target, available, target_error = self._resolve_exact_target(
+                pid=pid, window_id=window_id, action="focus_app",
+            )
+            if target is None:
+                self._clear_active_target()
+                code = target_error or "stale_window_target"
+                return ActionResult(
+                    ok=False,
+                    action="focus_app",
+                    code=code,
+                    message=(
+                        "The process owns more than one visible top-level window; "
+                        "provide window_id."
+                        if code == "ambiguous_window_target"
+                        else "The explicit native window target is no longer available."
+                    ),
+                    meta={"available_windows": available},
+                )
+            matched = [target]
+        else:
+            try:
+                windows = self._load_windows()
+            except Exception:
+                self._clear_active_target()
+                raise
+            matched = [
+                window for window in self._match_windows_for_app(windows, app or "")
+                if self._visible_window(window)
+            ]
+            if len(matched) > 1:
+                self._clear_active_target()
+                return ActionResult(
+                    ok=False,
+                    action="focus_app",
+                    code="ambiguous_window_target",
+                    message=(
+                        "The app owns more than one visible top-level window; "
+                        "provide window_id."
+                    ),
+                    meta={"available_windows": matched},
+                )
         # Don't silently fall back to the frontmost window when the filter
         # matches nothing — that hides the real failure (often a localized
         # macOS app name mismatch, e.g. caller passed "Calculator" but
@@ -2907,7 +3068,7 @@ class CuaDriverBackend(ComputerUseBackend):
             self._active_pid = target["pid"]
             self._active_window_id = target["window_id"]
             self._snapshot_tokens = {}
-            self._last_app = target["app_name"] or app  # retained for back-compat diagnostics
+            self._last_app = target["app_name"] or app or ""  # retained for back-compat diagnostics
             self._last_target = {
                 "pid": self._active_pid,
                 "window_id": self._active_window_id,
@@ -2933,6 +3094,7 @@ class CuaDriverBackend(ComputerUseBackend):
                 ok=True, action="focus_app",
                 message=f"Targeted {target['app_name']} (pid {self._active_pid}, "
                         f"window {self._active_window_id}) without raising window.",
+                meta={"pid": self._active_pid, "window_id": self._active_window_id},
             )
         self._clear_active_target()
         return ActionResult(ok=False, action="focus_app",

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -94,16 +94,19 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
             "pid": {
                 "type": "integer",
                 "description": (
-                    "Optional exact process target for action='capture'. Pair "
-                    "with window_id when discovery cannot resolve an X11 app."
+                    "Optional exact process target for capture and native "
+                    "window actions. Pair with window_id when known; window_id "
+                    "alone can resolve its owning pid through list_windows."
                 ),
             },
             "window_id": {
                 "type": "integer",
                 "description": (
-                    "Optional exact native window target for action='capture'. "
-                    "Pair with pid when an external cua-driver list_windows "
-                    "lookup has already identified the window."
+                    "Optional exact native window target for capture, click, "
+                    "double/right/middle click, drag, scroll, type, key, "
+                    "set_value, and focus_app. Explicit window_id always wins. "
+                    "Capture responses expose pid/window_id for reuse. A stale "
+                    "or closed id fails without selecting another window."
                 ),
             },
             "max_elements": {

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -424,12 +424,13 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
         self.calls.append(("list_windows", {}))
         return []
 
-    def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
-        self.calls.append(("focus_app", {"app": app, "raise": raise_window}))
+    def focus_app(self, app: Optional[str] = None, raise_window: bool = False,
+                  **kw) -> ActionResult:
+        self.calls.append(("focus_app", {"app": app, "raise": raise_window, **kw}))
         return ActionResult(ok=True, action="focus_app")
 
-    def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
-        self.calls.append(("set_value", {"value": value, "element": element}))
+    def set_value(self, value: str, element: Optional[int] = None, **kw) -> ActionResult:
+        self.calls.append(("set_value", {"value": value, "element": element, **kw}))
         return ActionResult(ok=True, action="set_value")
 
 
@@ -564,42 +565,56 @@ def _request_approval(action: str, args: Dict[str, Any],
 def _summarize_action(action: str, args: Dict[str, Any]) -> str:
     fg = " [FOREGROUND — briefly raises the window / changes focus]" \
         if args.get("delivery_mode") == "foreground" else ""
+    target_parts = [
+        f"{key}={args[key]}"
+        for key in ("pid", "window_id")
+        if args.get(key) is not None
+    ]
+    target = f" [target {' '.join(target_parts)}]" if target_parts else ""
     if action in {"click", "double_click", "right_click", "middle_click"}:
         if args.get("element") is not None:
-            return f"{action} element #{args['element']}{fg}"
-        coord = args.get("coordinate")
-        if coord:
-            return f"{action} at {tuple(coord)}{fg}"
-        return action + fg
-    if action == "drag":
+            summary = f"{action} element #{args['element']}"
+        elif coord := args.get("coordinate"):
+            summary = f"{action} at {tuple(coord)}"
+        else:
+            summary = action
+    elif action == "drag":
         src = args.get("from_element") or args.get("from_coordinate")
         dst = args.get("to_element") or args.get("to_coordinate")
-        return f"drag {src} → {dst}{fg}"
-    if action == "scroll":
-        return f"scroll {args.get('direction', '?')} x{args.get('amount', 3)}{fg}"
-    if action == "type":
+        summary = f"drag {src} → {dst}"
+    elif action == "scroll":
+        summary = f"scroll {args.get('direction', '?')} x{args.get('amount', 3)}"
+    elif action == "type":
         text = args.get("text", "")
-        return f"type {text[:60]!r}" + ("..." if len(text) > 60 else "") + fg
-    if action == "key":
-        return f"key {args.get('keys', '')!r}{fg}"
-    if action == "focus_app":
-        return f"focus {args.get('app', '')!r}" + (" (raise)" if args.get("raise_window") else "")
-    return action + fg
+        summary = f"type {text[:60]!r}" + ("..." if len(text) > 60 else "")
+    elif action == "key":
+        summary = f"key {args.get('keys', '')!r}"
+    elif action == "focus_app":
+        summary = f"focus {args.get('app', '')!r}" + (
+            " (raise)" if args.get("raise_window") else ""
+        )
+    else:
+        summary = action
+    return summary + target + fg
 
 
 def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) -> Any:
     capture_after = bool(args.get("capture_after"))
+    target_kwargs = {
+        key: args[key]
+        for key in ("pid", "window_id")
+        if args.get(key) is not None
+    }
 
     if action == "capture":
         mode = str(args.get("mode", "som"))
         if mode not in {"som", "vision", "ax"}:
             return json.dumps({"error": f"bad mode {mode!r}; use som|vision|ax"})
-        capture_kwargs: Dict[str, Any] = {"mode": mode, "app": args.get("app")}
-        if args.get("pid") is not None or args.get("window_id") is not None:
-            capture_kwargs.update({
-                "pid": args.get("pid"),
-                "window_id": args.get("window_id"),
-            })
+        capture_kwargs: Dict[str, Any] = {
+            "mode": mode,
+            "app": args.get("app"),
+            **target_kwargs,
+        }
         cap = backend.capture(**capture_kwargs)
         return _capture_response(cap, max_elements=_coerce_max_elements(args.get("max_elements")))
 
@@ -618,9 +633,11 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
 
     if action == "focus_app":
         app = args.get("app")
-        if not app:
+        if not app and args.get("pid") is None and args.get("window_id") is None:
             return json.dumps({"error": "focus_app requires `app`"})
-        res = backend.focus_app(app, raise_window=bool(args.get("raise_window")))
+        res = backend.focus_app(
+            app, raise_window=bool(args.get("raise_window")), **target_kwargs,
+        )
         return _maybe_follow_capture(backend, res, capture_after)
 
     # cua-driver's typed browser surface is namespaced inside the existing
@@ -734,6 +751,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             x=x, y=y, button=button or "left", click_count=click_count,
             modifiers=args.get("modifiers"),
             delivery_mode=delivery_mode, bring_to_front=bring_to_front,
+            **target_kwargs,
         )
         return _maybe_follow_capture(backend, res, capture_after)
 
@@ -752,6 +770,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             button=args.get("button", "left"),
             modifiers=args.get("modifiers"),
             delivery_mode=delivery_mode, bring_to_front=bring_to_front,
+            **target_kwargs,
         )
         return _maybe_follow_capture(backend, res, capture_after)
 
@@ -765,24 +784,35 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             y=coord[1] if coord and coord[1] is not None else None,
             modifiers=args.get("modifiers"),
             delivery_mode=delivery_mode, bring_to_front=bring_to_front,
+            **target_kwargs,
         )
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "type":
-        res = backend.type_text(args.get("text", ""),
-                                delivery_mode=delivery_mode, bring_to_front=bring_to_front)
+        res = backend.type_text(
+            args.get("text", ""),
+            delivery_mode=delivery_mode,
+            bring_to_front=bring_to_front,
+            **target_kwargs,
+        )
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "key":
-        res = backend.key(args.get("keys", ""),
-                          delivery_mode=delivery_mode, bring_to_front=bring_to_front)
+        res = backend.key(
+            args.get("keys", ""),
+            delivery_mode=delivery_mode,
+            bring_to_front=bring_to_front,
+            **target_kwargs,
+        )
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "set_value":
         value = args.get("value")
         if value is None:
             return json.dumps({"error": "set_value requires `value`"})
-        res = backend.set_value(value=str(value), element=args.get("element"))
+        res = backend.set_value(
+            value=str(value), element=args.get("element"), **target_kwargs,
+        )
         return _maybe_follow_capture(backend, res, capture_after)
 
     return json.dumps({"error": f"unknown action {action!r}"})
@@ -1018,7 +1048,9 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
     summary_lines = [
         f"capture mode={cap.mode} {response_width}x{response_height}"
         + (f" app={cap.app}" if cap.app else "")
-        + (f" window={cap.window_title!r}" if cap.window_title else ""),
+        + (f" window={cap.window_title!r}" if cap.window_title else "")
+        + (f" pid={cap.pid} window_id={cap.window_id}"
+           if cap.pid is not None or cap.window_id is not None else ""),
         f"{total_elements} interactable element(s):",
     ]
     if bounds_note:
@@ -1088,6 +1120,10 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
                 "summary": "\n".join(summary_lines),
                 "vision_unavailable": True,
             }
+            if cap.pid is not None:
+                payload["pid"] = cap.pid
+            if cap.window_id is not None:
+                payload["window_id"] = cap.window_id
             if truncated_elements:
                 payload["truncated_elements"] = truncated_elements
             if elements_file:
@@ -1118,6 +1154,8 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
             "text_summary": summary,
             "meta": {"mode": cap.mode, "width": response_width, "height": response_height,
                      "elements": total_elements, "png_bytes": cap.png_bytes_len,
+                     **({"pid": cap.pid} if cap.pid is not None else {}),
+                     **({"window_id": cap.window_id} if cap.window_id is not None else {}),
                      **({"elements_file": elements_file} if elements_file else {}),
                      **({"bounds_scale": bounds_scale} if bounds_scale else {})},
         }
@@ -1139,6 +1177,14 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
         "total_elements": total_elements,
         "summary": summary,
     }
+    if cap.pid is not None:
+        payload["pid"] = cap.pid
+    if cap.window_id is not None:
+        payload["window_id"] = cap.window_id
+    if cap.error is not None:
+        payload["error"] = cap.error
+    if cap.available_windows:
+        payload["available_windows"] = cap.available_windows
     if truncated_elements:
         payload["truncated_elements"] = truncated_elements
     if elements_file:
@@ -1369,6 +1415,10 @@ def _route_capture_through_aux_vision(
         "vision_analysis": analysis_text,
         "vision_analysis_routed_via": "auxiliary.vision",
     }
+    if cap.pid is not None:
+        payload["pid"] = cap.pid
+    if cap.window_id is not None:
+        payload["window_id"] = cap.window_id
     if truncated_elements:
         payload["truncated_elements"] = truncated_elements
     if elements_file:
@@ -1387,12 +1437,16 @@ def _maybe_follow_capture(
     if not res.ok:
         return _text_response(res)
     try:
-        # Preserve the exact selected window when possible. Linux may expose a
-        # generic app name for several unrelated windows, so app-only recapture
-        # can silently switch targets after a successful action.
-        target = getattr(backend, "_last_target", None) or {}
-        pid = target.get("pid")
-        window_id = target.get("window_id")
+        # Prefer the exact target confirmed by the successful action. An
+        # explicit action may override the backend's prior sticky capture
+        # target, so consulting only ``_last_target`` can recapture a sibling.
+        action_meta = res.meta if isinstance(res.meta, dict) else {}
+        pid = action_meta.get("pid")
+        window_id = action_meta.get("window_id")
+        if pid is None or window_id is None:
+            target = getattr(backend, "_last_target", None) or {}
+            pid = target.get("pid")
+            window_id = target.get("window_id")
         mode = _capture_after_mode()
         if pid is not None and window_id is not None:
             cap = backend.capture(mode=mode, pid=pid, window_id=window_id)


### PR DESCRIPTION
## Root Cause

`computer_use` retained an app/PID-oriented sticky target after capture. When one process owned multiple windows, follow-up native actions or `capture_after` could resolve a sibling window, and stale native IDs were not consistently revalidated immediately before mutation.

## Implementation

- Expose the resolved `pid` and native `window_id` on all capture response paths.
- Accept explicit native targets for capture and every native input/focus action.
- Resolve `window_id` as the strongest identity, validate optional PID/window pairs, and fail closed for stale targets.
- Reject ambiguous app/PID-only selection when multiple visible top-level windows remain, while ignoring hidden and zero-area helper windows for ambiguity checks.
- Revalidate sticky target pairs immediately before every mutation and never fall back to another window.
- Prefer the successful action's exact target for `capture_after`.
- Preserve existing hardguards, approval boundaries, background-no-focus behavior, and legacy backends when target kwargs are omitted.

## TDD RED / GREEN

RED: added regression coverage for ambiguous multi-window apps, stale and recycled IDs, explicit target propagation, capture response identity, approval summaries, legacy backend dispatch, and exact `capture_after` routing. These tests reproduced the prior sibling-retargeting and missing-identity behavior before the implementation.

GREEN: the focused targeting suite now passes 20 tests; the complete `computer_use` test set passes 206 tests with 2 platform skips.

## Tests

- `scripts/run_tests.sh tests/tools/test_computer_use_window_targeting.py -q` — 20 passed
- `scripts/run_tests.sh tests/tools/test_computer_use*.py -q` — 206 passed, 2 skipped
- `.venv/bin/ruff check <changed Python files>` — passed
- `.venv/bin/python -m compileall -q <changed Python files>` — passed
- `git diff --check` — passed
- `ty` production-file baseline comparison — 6 existing diagnostics before and after; no new diagnostic class or count

## Independent Review

A separate read-only Codex CLI context reviewed the full implementation for spec, security, and quality, including the six corrected finding classes, hardguards/approvals, background-no-focus behavior, legacy backend compatibility, and macOS/Linux/native-Windows behavior.

Verdict: **PASS** — no Critical or Important findings.

## Compatibility

The backend interface additions are optional and additive. Dispatch omits unspecified `pid`/`window_id` kwargs, preserving legacy backend implementations. Exact resolution uses the existing cross-platform `list_windows` contract; Linux-only X11 active-window probing remains Linux-gated, and native Windows/macOS paths receive only normalized integer IDs supported by the existing driver schema. Foreground delivery and `bring_to_front` capability checks remain unchanged and separately approved.

## Residual Limitation

A same-process window that closes and is immediately replaced with the same macOS `CGWindowID` cannot be distinguished from the original target because the OS/driver supplies no generation token. The implementation detects closed IDs and cross-PID ID recycling, but same-PID/same-`CGWindowID` recycling remains theoretically possible.
