### PR TITLE
fix(cli): Support tool-free one-shot runs

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -165,7 +165,7 @@ def build_top_level_parser():
         "-t",
         "--toolsets",
         default=None,
-        help="Comma-separated toolsets to enable for this invocation. Applies to -z/--oneshot and --tui.",
+        help="Comma-separated toolsets to enable for this invocation. Use 'none' for a tool-free one-shot. Applies to -z/--oneshot and --tui.",
     )
     parser.add_argument(
         "--resume",

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -33,7 +33,7 @@ from hermes_cli.fallback_config import get_fallback_chain
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
-    if not toolsets:
+    if toolsets is None or toolsets == "":
         return None
 
     raw_items = [toolsets] if isinstance(toolsets, str) else toolsets
@@ -47,13 +47,18 @@ def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
         else:
             normalized.append(str(item).strip())
 
-    return [item for item in normalized if item] or None
+    cleaned = [item for item in normalized if item]
+    if cleaned:
+        return cleaned
+    return [] if isinstance(toolsets, (list, tuple)) else None
 
 
 def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | None, str | None]:
     normalized = _normalize_toolsets(toolsets)
     if normalized is None:
         return None, None
+    if normalized == ["none"]:
+        return [], None
 
     try:
         from toolsets import validate_toolset
@@ -183,6 +188,7 @@ def run_oneshot(
         provider: Optional provider override. Falls back to config.yaml's
             model.provider, then "auto".
         toolsets: Optional comma-separated string or iterable of toolsets.
+            The sentinel ``none`` explicitly enables zero tools.
         usage_file: Optional path; when set, a JSON usage report (estimated
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for

--- a/model_tools.py
+++ b/model_tools.py
@@ -411,7 +411,8 @@ def _compute_tool_definitions(
     if enabled_toolsets is not None:
         effective_enabled_toolsets = list(enabled_toolsets)
         if (
-            os.environ.get("HERMES_KANBAN_TASK")
+            effective_enabled_toolsets
+            and os.environ.get("HERMES_KANBAN_TASK")
             and not _is_delegated_child_context()
             and _is_dispatcher_owned_worker()
             and "kanban" not in effective_enabled_toolsets

--- a/tests/hermes_cli/test_oneshot_no_tools.py
+++ b/tests/hermes_cli/test_oneshot_no_tools.py
@@ -1,4 +1,5 @@
 from hermes_cli.oneshot import _normalize_toolsets, _validate_explicit_toolsets
+import model_tools
 
 
 def test_none_toolset_is_an_explicit_empty_tool_list():
@@ -10,3 +11,14 @@ def test_none_toolset_is_an_explicit_empty_tool_list():
 def test_explicit_empty_tool_list_survives_agent_construction_normalization():
     assert _normalize_toolsets([]) == []
     assert _normalize_toolsets(None) is None
+
+
+def test_explicit_empty_tool_list_is_not_widened_by_kanban_context(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "tool-free-proof")
+    monkeypatch.setattr(model_tools, "_is_delegated_child_context", lambda: False)
+    monkeypatch.setattr(model_tools, "_is_dispatcher_owned_worker", lambda: True)
+    model_tools._clear_tool_defs_cache()
+    try:
+        assert model_tools.get_tool_definitions(enabled_toolsets=[], quiet_mode=True) == []
+    finally:
+        model_tools._clear_tool_defs_cache()

--- a/tests/hermes_cli/test_oneshot_no_tools.py
+++ b/tests/hermes_cli/test_oneshot_no_tools.py
@@ -1,0 +1,12 @@
+from hermes_cli.oneshot import _normalize_toolsets, _validate_explicit_toolsets
+
+
+def test_none_toolset_is_an_explicit_empty_tool_list():
+    toolsets, error = _validate_explicit_toolsets("none")
+    assert error is None
+    assert toolsets == []
+
+
+def test_explicit_empty_tool_list_survives_agent_construction_normalization():
+    assert _normalize_toolsets([]) == []
+    assert _normalize_toolsets(None) is None


### PR DESCRIPTION
## Summary
- add `--toolsets none` as an explicit zero-tool one-shot sentinel
- preserve an explicit empty tool list through agent construction
- document and test the boundary

## Verification
- 12 focused one-shot/parser tests passed
- real one-shot asked to call terminal under `-t none` completed with zero tool calls
- diff check and secret scan passed