### PR TITLE
feat(freemaxxing): opt-in multi-provider free routing plugin

### DIFF
--- a/plugins/model-providers/freemaxxing/README.md
+++ b/plugins/model-providers/freemaxxing/README.md
@@ -1,0 +1,146 @@
+# Freemaxxing
+
+An **opt-in Hermes model-provider plugin**. It exposes one authenticated local
+OpenAI-compatible endpoint and selects eligible free routes behind the stable
+`provider: freemaxxing`, `model: freemaxxing` identity. All implementation lives
+in this directory. No core loader, transport, session, dependency, or global
+configuration patch is required.
+
+## Activation
+
+Before launching Hermes, explicitly set `FREEMAXXING_ENABLED=1`. Leave it unset
+(or `0`) to keep the plugin inactive. Inactive discovery registers metadata only;
+it opens no socket and reads no upstream credential or catalog. Select the
+Freemaxxing provider/model in Hermes after activation. Restart after changing
+enrollment or listener settings; the listener capability is immutable.
+
+OpenCode Free is keyless. An existing `OPENROUTER_API_KEY` adds OpenRouter Free.
+No real bearer is sent to OpenCode. The local endpoint always requires its own
+random process-local bearer; it binds only to `127.0.0.1` on an ephemeral port.
+The existing provider resolver receives the actual endpoint and local bearer.
+
+For additional accounts, set `FREEMAXXING_FREE_TIER_PROVIDERS` to a comma-separated
+subset of `nous-portal,groq,gemini,mistral` **only after disabling paid use/overage
+at those accounts**. This is an explicit operator assertion, not automatic
+billing verification. A credential alone does not enroll an allowance account.
+
+Nous uses the existing Hermes OAuth resolver (or `NOUS_API_KEY`) and admits only
+models with fresh, unambiguous zero input/output pricing in the authenticated
+catalog. The old DeepSeek Flash allowlist is removed. Groq uses `GROQ_API_KEY`,
+Gemini uses `GEMINI_API_KEY` or `GOOGLE_API_KEY`, and Mistral uses `MISTRAL_API_KEY`.
+Missing, expired, contradictory, or nonzero price evidence cannot authorize a
+Nous route. Catalog evidence is bound to the exact endpoint and credential;
+authentication refresh cannot reuse another credential's grant.
+
+An optional local fallback accepts `FREEMAXXING_LOCAL_BASE_URL`, for example
+`http://127.0.0.1:11434/v1`. Only numeric loopback is accepted, not remote hosts or
+`localhost` DNS aliases. `FREEMAXXING_LOCAL_MODELS` can seed comma-separated local
+model IDs; otherwise the local catalog is discovered. Hardware and electricity
+are not free, but the local route incurs no hosted token charge.
+
+## Spending boundary
+
+OpenRouter routes require `:free` or `openrouter/free`, reject contradictory
+pricing, and receive a zero `provider.max_price` cap at dispatch. Explicit model
+IDs undergo the same admission check as automatic selection. Caller-supplied
+paid extensions, upstream fallback lists, and server-executed tools are refused.
+Only client-executed function tools are accepted; the plugin never executes them.
+
+OpenCode discovery admits supported Chat Completions free SKUs, not arbitrary
+`-free` model names. Responses/Messages-only models are excluded rather than sent
+to the wrong endpoint. Authenticated providers never redirect credentials.
+
+A cached catalog is not a provider-side spending lock. For Nous and allowance
+providers, the configured free-only account boundary remains essential; this
+plugin cannot inspect or change an external billing configuration. Promotions,
+quotas, and provider availability can change. It never intentionally substitutes
+a paid model. Global Hermes fallbacks and non-model tools configured outside
+Freemaxxing remain outside this plugin's spending boundary.
+
+## Recovery and latency
+
+Catalog refresh runs in bounded, single-flight background workers. Safe known
+OpenCode/OpenRouter IDs remain usable during catalog outages. Empty catalogs are
+cached too. Refresh errors do not poison a healthy inference route. Connections
+are pooled, scheduling is local (no extra LLM routing call), and successful
+session affinity is retained in a bounded in-memory cache.
+
+Model failures and account failures are distinct. A missing/broken model can
+fall through to another model, while an account-wide 429 respects its complete
+`Retry-After` rather than retrying every model under the same exhausted quota.
+Authentication refresh is serialized against the actual failed credential.
+Request concurrency, attempts, catalogs, response bytes, and stream events are
+bounded. Optional `FREEMAXXING_REQUEST_TIMEOUT` (default 90 seconds),
+`FREEMAXXING_MAX_ATTEMPTS` (12), and `FREEMAXXING_CONCURRENCY` (8) tune the recovery
+budget. Transport idle timeout is 25 seconds and connection timeout is 5 seconds;
+the recovery deadline is checked between I/O operations, with an in-flight read
+bounded by its already-assigned timeout.
+
+**Streaming uses atomic replay.** The router buffers and validates one complete
+upstream stream before committing downstream HTTP 200. Keepalives, malformed
+JSON, incomplete tool arguments, and missing terminal completion do not commit a
+response. An interruption anywhere upstream can therefore fail over without
+splicing generations or leaking partial tool calls. Exactly one complete winning
+stream is replayed. This deliberately increases time to first visible token; it
+is not a zero-latency claim or live token-by-token passthrough.
+
+When no eligible free route remains, the endpoint returns a typed retryable 503
+with `Retry-After`, never a fabricated assistant completion or `[DONE]`. The
+plugin does not delete sessions, alter their transcripts, execute/replay tools,
+or own durable turn recovery. It does not promise that all providers remain
+available, that an exhausted turn completes, or that a process crash is recovered
+without the host's existing session facilities. Multiplex-profile runtimes are
+refused before upstream credential resolution.
+
+Authenticated `GET /healthz` exposes bounded route health; public
+`GET /v1/healthz` contains only a liveness marker. `GET /v1/models` is metadata-only.
+Error responses contain no upstream credentials or raw provider error text.
+
+## Free MoA with the existing Hermes engine
+
+`examples/free-moa.yaml` supplies a disabled-by-default named preset for the
+existing Hermes MoA runtime. It does not introduce another agent loop. All three
+advisors and the acting aggregator use Freemaxxing, so their requests traverse
+the same free-route boundary. The qualified selectors
+`opencode-free::freemaxxing`, `openrouter::freemaxxing`, and
+`nous-portal::freemaxxing` keep advisor provider pools distinct while discovering
+models dynamically. They are provider diversity, not a guarantee of distinct
+underlying model families. Exact `provider-name::model-id` pins also work.
+
+Fan-out occurs once per user turn, not every tool iteration; advisor output and
+time are bounded, and failed advisors are disclosed by the existing host policy.
+The plugin does not automatically install or activate the preset, guarantee an
+ensemble quality improvement, or reserve future provider quota for its aggregator.
+
+## Verification
+
+From a complete repository checkout:
+
+```sh
+scripts/run_tests.sh tests/plugins/model_providers/test_freemaxxing_proxy.py tests/plugins/model_providers/test_freemaxxing_registration.py -q
+```
+
+The loopback suite drives the real HTTP handler, pool, transport, and stream
+validator with disposable upstream HTTP servers; no external model inference or
+account mutation is performed. Registration fixtures isolate the host API; the
+native-loader tests additionally exercise real Hermes provider discovery and
+credential resolution in fresh subprocesses when the full checkout is present.
+The native tests explicitly skip in a standalone plugin-only test workspace.
+
+## Provider references and interlocks
+
+Provider contracts checked on 2026-09-05; discovery does not assume they remain
+unchanged indefinitely:
+
+- OpenCode free model endpoints: https://opencode.ai/docs/zen/
+- OpenRouter price limits: https://openrouter.ai/docs/guides/routing/provider-selection
+- Nous model pricing: https://portal.nousresearch.com/models
+- Groq free limits: https://console.groq.com/docs/rate-limits
+- Gemini pricing: https://ai.google.dev/gemini-api/docs/pricing
+- Mistral account billing: https://docs.mistral.ai/admin/billing-usage/usage-limits
+
+Canonical implementation: https://github.com/NousResearch/hermes-agent/pull/85631
+Adjacent, not duplicated: OpenCode model hygiene #101448 and fallback API-mode
+preservation #102229/#102148. Their core files are not changed here. OpenCode
+Chat Completions qualification remains plugin-local; unsupported protocols do not
+become a new core router or a second implementation of those fixes.

--- a/plugins/model-providers/freemaxxing/__init__.py
+++ b/plugins/model-providers/freemaxxing/__init__.py
@@ -1,0 +1,203 @@
+"""Optional Freemaxxing model-provider plugin; no core registration patches.
+
+FREEMAXXING_ENABLED=1 is explicit activation. Discovery otherwise registers only
+static metadata: no listener, credential lookup, catalog request, or worker.
+"""
+from __future__ import annotations
+
+import os
+import secrets
+import threading
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+from .policy import Limits, _OPENCODE_CHAT_MODELS, validate_url
+from .proxy import Backend, pool, spawn_proxy, stop_proxy as _stop_proxy
+
+_LOCAL_TOKEN = secrets.token_urlsafe(32)
+_listener = None
+_listener_lock = threading.RLock()
+_NOUS_BASE_URL = 'https://inference-api.nousresearch.com/v1'
+
+
+def _enabled():
+    value = os.environ.get('FREEMAXXING_ENABLED', '').strip().lower()
+    if value not in {'', '0', 'false', 'no', 'off', '1', 'true', 'yes', 'on'}:
+        raise ValueError('FREEMAXXING_ENABLED must be a boolean')
+    return value in {'1', 'true', 'yes', 'on'}
+
+
+def _multiplex_active():
+    try:
+        from agent.secret_scope import is_multiplex_active
+        return bool(is_multiplex_active())
+    except Exception:
+        # Unknown scope authority is not permission to read process credentials.
+        return True
+
+
+def _assert_single_profile_runtime():
+    if _multiplex_active():
+        raise RuntimeError('Freemaxxing does not support gateway.multiplex_profiles')
+
+
+def _resolve_key(names):
+    _assert_single_profile_runtime()
+    from agent.secret_scope import current_secret_scope, get_secret
+    if current_secret_scope() is not None:
+        for name in names:
+            value = get_secret(name)
+            if value and str(value).strip():
+                return str(value).strip()
+        return ''  # A scoped miss cannot widen to dotenv or the process environment.
+    from hermes_cli.config import get_env_value_prefer_dotenv
+    for name in names:
+        value = get_env_value_prefer_dotenv(name)
+        if value and str(value).strip():
+            return str(value).strip()
+    return ''
+
+
+def _resolve_nous_credentials():
+    _assert_single_profile_runtime()
+    from hermes_cli.auth import resolve_nous_runtime_credentials
+    try:
+        credentials = resolve_nous_runtime_credentials()
+        key = str(credentials.get('api_key') or '').strip()
+        base = str(credentials.get('base_url') or _NOUS_BASE_URL).rstrip('/')
+        validate_url(base)
+        if key:
+            return base, key
+    except Exception:
+        pass
+    return _NOUS_BASE_URL, _resolve_key(('NOUS_API_KEY',))
+
+
+def _build_pool():
+    _assert_single_profile_runtime()
+    # Validate the complete configuration before retiring a working generation.
+    allowed = {item.strip() for item in os.environ.get(
+        'FREEMAXXING_FREE_TIER_PROVIDERS', '').split(',') if item.strip()}
+    providers = {
+        'groq': ('https://api.groq.com/openai/v1', ('GROQ_API_KEY',)),
+        'gemini': ('https://generativelanguage.googleapis.com/v1beta/openai',
+                   ('GEMINI_API_KEY', 'GOOGLE_API_KEY')),
+        'mistral': ('https://api.mistral.ai/v1', ('MISTRAL_API_KEY',)),
+    }
+    if allowed - (providers.keys() | {'nous-portal'}):
+        raise ValueError('unknown free-tier provider; no account was enrolled')
+    local = os.environ.get('FREEMAXXING_LOCAL_BASE_URL', '').strip()
+    if local:
+        validate_url(local, local=True)
+    backends = []
+    # Nous prices can change and its API has no documented zero-price cap.
+    # Enrollment therefore requires the operator's separate free-only account
+    # assertion, plus fresh zero pricing for every admitted model.
+    if 'nous-portal' in allowed:
+        backends.append(Backend('nous-portal', _NOUS_BASE_URL,
+                                refresh=_resolve_nous_credentials, tier=0,
+                                free_tier_only=True))
+    key = _resolve_key(('OPENROUTER_API_KEY',))
+    if key:
+        backend = Backend('openrouter', 'https://openrouter.ai/api/v1', api_key=key, tier=1)
+        backend.set_cached_models(['openrouter/free'], ttl=0)
+        backends.append(backend)
+    backend = Backend('opencode-free', 'https://opencode.ai/zen/v1', tier=0,
+                      default_model='mimo-v2.5-free')
+    backend.set_cached_models(sorted(_OPENCODE_CHAT_MODELS), ttl=0)
+    backends.append(backend)
+    # A key alone never enrolls an allowance-based account in automatic routing.
+    for name in sorted(allowed & providers.keys()):
+        base, names = providers[name]
+        key = _resolve_key(names)
+        if key:
+            backends.append(Backend(name, base, api_key=key, tier=2, free_tier_only=True))
+    if local:
+        backend = Backend('local', local, tier=3)
+        models = [m.strip() for m in os.environ.get('FREEMAXXING_LOCAL_MODELS', '').split(',') if m.strip()]
+        if models:
+            backend.set_cached_models(models, ttl=0)
+        backends.append(backend)
+    pool.clear()
+    for backend in backends:
+        pool.add(backend)
+
+
+def local_token():
+    return _LOCAL_TOKEN
+
+
+def _configured_port():
+    port = int(os.environ.get('FREEMAXXING_PORT', '0'))
+    if not 0 <= port <= 65535:
+        raise ValueError('invalid FREEMAXXING_PORT')
+    return port
+
+
+def ensure_proxy():
+    global _listener
+    _assert_single_profile_runtime()
+    if not _enabled():
+        raise RuntimeError('Freemaxxing is disabled; set FREEMAXXING_ENABLED=1 explicitly')
+    with _listener_lock:
+        _listener = spawn_proxy(port=_configured_port(), token=_LOCAL_TOKEN,
+                                pool_initializer=_build_pool,
+                                runtime_guard=_assert_single_profile_runtime)
+        return f'http://127.0.0.1:{_listener.server_address[1]}/v1'
+
+
+def stop_proxy():
+    global _listener
+    with _listener_lock:
+        _stop_proxy(_listener)
+        _listener = None
+
+
+class _LocalCapabilityEnvVars(tuple):
+    def __new__(cls):
+        return super().__new__(cls, ('FREEMAXXING_API_KEY',))
+
+    def __iter__(self):
+        if not _enabled() or _multiplex_active():
+            return iter(())
+        return super().__iter__()
+
+
+class FreemaxxingProfile(ProviderProfile):
+    def fetch_models(self, **_kwargs):
+        return ['freemaxxing']
+
+    def build_extra_body(self, *, session_id=None, **_context):
+        return {'freemaxxing_session': str(session_id)} if session_id else {}
+
+
+def _register():
+    base = 'http://127.0.0.1:11435/v1'  # Inactive metadata only.
+    if _enabled():
+        pool.limits = Limits(
+            total=float(os.environ.get('FREEMAXXING_REQUEST_TIMEOUT', '90')),
+            attempts=int(os.environ.get('FREEMAXXING_MAX_ATTEMPTS', '12')),
+            concurrency=int(os.environ.get('FREEMAXXING_CONCURRENCY', '8')),
+        )
+        base = ensure_proxy()
+        os.environ['FREEMAXXING_API_KEY'] = _LOCAL_TOKEN
+    register_provider(FreemaxxingProfile(
+        name='freemaxxing', aliases=('fm', 'freemaxxing-auto'),
+        display_name='Freemaxxing',
+        description='Optional free-only provider pool with atomic completion recovery',
+        env_vars=('FREEMAXXING_API_KEY',), base_url=base, auth_type='api_key',
+        api_mode='chat_completions', supports_health_check=False,
+        supports_vision=False, default_aux_model='freemaxxing',
+        fallback_models=('freemaxxing',),
+    ))
+    # Existing plugin-side generic resolver bridge. No monkeypatch of provider
+    # discovery, transport, session handling, or import-parent namespaces.
+    from hermes_cli.auth import PROVIDER_REGISTRY, ProviderConfig
+    runtime = ProviderConfig(id='freemaxxing', name='Freemaxxing', auth_type='api_key',
+                             inference_base_url=base, api_key_env_vars=_LocalCapabilityEnvVars())
+    for alias in ('freemaxxing', 'fm', 'freemaxxing-auto'):
+        PROVIDER_REGISTRY[alias] = runtime
+
+
+_register()

--- a/plugins/model-providers/freemaxxing/examples/free-moa.yaml
+++ b/plugins/model-providers/freemaxxing/examples/free-moa.yaml
@@ -1,0 +1,21 @@
+# Merge this named preset into config.yaml; it does not activate itself.
+# Enable deliberately, then select the freemaxxing preset through Hermes MoA.
+# Nous requires FREEMAXXING_FREE_TIER_PROVIDERS=nous-portal and a free-only account.
+moa:
+  presets:
+    freemaxxing:
+      enabled: false
+      fanout: user_turn
+      reference_timeout: 45
+      reference_max_tokens: 1024
+      degraded_reference_policy: loud
+      reference_models:
+        - provider: freemaxxing
+          model: "opencode-free::freemaxxing"
+        - provider: freemaxxing
+          model: "openrouter::freemaxxing"
+        - provider: freemaxxing
+          model: "nous-portal::freemaxxing"
+      aggregator:
+        provider: freemaxxing
+        model: freemaxxing

--- a/plugins/model-providers/freemaxxing/handler.py
+++ b/plugins/model-providers/freemaxxing/handler.py
@@ -1,0 +1,210 @@
+"""Authenticated loopback API; exhausted routes are typed errors, not fake success."""
+from __future__ import annotations
+
+import hmac
+import json
+import socket
+import time
+from http.server import BaseHTTPRequestHandler
+
+from .policy import (AuthError, Budget, ClientRequestError, ModelNotFoundError,
+                     RateLimitError, TransientError, _MAX_REQUEST_BODY_BYTES,
+                     )
+from .pool import pool
+from .upstream import _forward, _open_stream
+
+
+class ChatCompletionsHandler(BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+    def log_message(self, *_args):
+        pass
+
+    @property
+    def owner(self):
+        return getattr(self.server, 'backend_pool', pool)
+
+    def _send_json(self, code, body, retry_after=None):
+        raw = json.dumps(body, allow_nan=False).encode('utf-8')
+        self.send_response(code)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(raw)))
+        self.send_header('Connection', 'close')
+        if retry_after is not None:
+            self.send_header('Retry-After', str(max(1, int(retry_after))))
+        self.end_headers()
+        self.close_connection = True
+        try:
+            self.wfile.write(raw)
+        except OSError:
+            pass
+
+    def _send_error(self, code, message, error_type='freemaxxing_error', retry_after=None):
+        self._send_json(code, {'error': {'message': message, 'type': error_type,
+                                       'retryable': code in {429, 503},
+                                       'router_state_mutated': False}}, retry_after)
+
+    def _require_auth(self):
+        expected = str(getattr(self.server, 'auth_token', '') or '')
+        supplied = self.headers.get('Authorization', '')
+        # Bytes keep malformed non-ASCII header values from raising TypeError.
+        valid = expected and hmac.compare_digest(supplied.encode('utf-8'),
+                                                  f'Bearer {expected}'.encode('utf-8'))
+        if valid:
+            return True
+        self._send_error(401, 'Unauthorized', 'unauthorized')
+        return False
+
+    def _require_runtime(self):
+        try:
+            guard = getattr(self.server, 'runtime_guard', None)
+            if guard is not None:
+                guard()
+            with self.server.pool_init_lock:
+                if not self.server.pool_ready:
+                    self.server.pool_initializer()
+                    self.server.pool_ready = True
+            return True
+        except RuntimeError:
+            self._send_error(409, 'Freemaxxing requires a single-profile runtime.', 'profile_isolation')
+        except Exception:
+            self._send_error(503, 'Freemaxxing initialization failed; session is unchanged.',
+                             'runtime_unavailable', 5)
+        return False
+
+    def do_GET(self):  # noqa: N802
+        path = self.path.split('?', 1)[0]
+        if path == '/v1/healthz':
+            self._send_json(200, {'service': 'freemaxxing', 'status': 'ok'})
+        elif self._require_auth():
+            if path == '/v1/models':
+                self._send_json(200, {'object': 'list', 'data': self.owner.get_aggregated_models()})
+            elif path == '/healthz':
+                self._send_json(200, {'service': 'freemaxxing', 'health': self.owner.health()})
+            else:
+                self._send_error(404, 'Unknown endpoint')
+
+    def _read_body(self):
+        if self.headers.get('Transfer-Encoding'):
+            raise ClientRequestError('Transfer-Encoding is not supported')
+        lengths = self.headers.get_all('Content-Length', [])
+        if len(lengths) != 1:
+            raise ClientRequestError('exactly one Content-Length is required')
+        try:
+            length = int(lengths[0])
+        except ValueError as exc:
+            raise ClientRequestError('invalid Content-Length') from exc
+        if not 0 < length <= _MAX_REQUEST_BODY_BYTES:
+            self._send_error(413 if length > 0 else 400, 'request body outside allowed bounds')
+            return None
+        raw = self.rfile.read(length)
+        if len(raw) != length:
+            raise ClientRequestError('request body interrupted')
+        def invalid(_value):
+            raise ValueError('non-finite number')
+        try:
+            body = json.loads(raw, parse_constant=invalid)
+        except (ValueError, UnicodeError) as exc:
+            raise ClientRequestError('invalid JSON') from exc
+        if (not isinstance(body, dict) or not isinstance(body.get('messages'), list) or
+                not body['messages'] or any(not isinstance(m, dict) for m in body['messages'])):
+            raise ClientRequestError('messages must be a nonempty array of objects')
+        if 'stream' in body and not isinstance(body['stream'], bool):
+            raise ClientRequestError('stream must be boolean')
+        if body.get('n', 1) != 1 or not isinstance(body.get('model', 'freemaxxing'), str):
+            raise ClientRequestError('one completion and a string model are required')
+        if any(k in body for k in ('models', 'plugins', 'transforms', 'web_search_options')):
+            raise ClientRequestError('upstream fallbacks and paid extensions are not allowed')
+        if 'tools' in body and not isinstance(body['tools'], list):
+            raise ClientRequestError('tools must be an array')
+        return body
+
+    def do_POST(self):  # noqa: N802
+        if self.path.split('?', 1)[0] != '/v1/chat/completions':
+            self._send_error(404, 'Unknown endpoint')
+            return
+        if not self._require_auth():
+            return
+        try:
+            body = self._read_body()
+        except (ClientRequestError, socket.timeout, OSError) as exc:
+            self._send_error(400, str(exc) if isinstance(exc, ClientRequestError) else 'request read timeout',
+                             'invalid_request')
+            return
+        if body is None or not self._require_runtime():
+            return
+        # Acquire before spawning inference work; no unbounded waiting queue.
+        if not self.server.inference_slots.acquire(False):
+            self._send_error(503, 'Freemaxxing is at its concurrency limit.', 'capacity', 1)
+            return
+        try:
+            self._complete(body)
+        except ClientRequestError as exc:
+            self._send_error(400, str(exc), 'invalid_request')
+        except Exception:
+            self._send_error(503, 'Freemaxxing could not complete this attempt; session is unchanged.',
+                             'runtime_unavailable', 5)
+        finally:
+            self.server.inference_slots.release()
+
+    def _complete(self, body):
+        owner, tried = self.owner, set()
+        budget = Budget(owner.limits.total)
+        owner.refresh_catalogs()
+        session = body.pop('freemaxxing_session', None)
+        if session is not None and (not isinstance(session, str) or len(session) > 256):
+            raise ClientRequestError('invalid session affinity')
+        catalog_deadline = time.monotonic() + owner.limits.catalog
+        while len(tried) < owner.limits.attempts:
+            try:
+                budget.remaining()
+            except TransientError:
+                break
+            candidates = [c for c in owner.candidates(body, session) if c.identity not in tried]
+            if not candidates:
+                remaining = catalog_deadline - time.monotonic()
+                if remaining > 0 and owner.catalog_pending():
+                    owner.wait_for_catalog(budget, remaining)
+                    continue
+                break
+            candidate = candidates[0]
+            backend = candidate.backend
+            tried.add(candidate.identity)
+            outgoing = dict(body, model=candidate.model)
+            start = time.monotonic()
+            try:
+                if body.get('stream'):
+                    result = _open_stream(backend, outgoing, budget, owner=owner)
+                else:
+                    result = _forward(backend, outgoing, budget, owner=owner)
+            except RateLimitError as exc:
+                backend.record_failure(exc.retry_after, 'rate_limit')
+                continue
+            except AuthError:
+                backend.record_failure(60, 'auth')
+                continue
+            except ModelNotFoundError:
+                backend.record_failure(300, 'model_unavailable', model=candidate.model)
+                continue
+            except TransientError:
+                backend.record_failure(10, 'transient', model=candidate.model)
+                continue
+            backend.record_success(model=candidate.model, elapsed=time.monotonic() - start)
+            owner.remember(session, candidate.identity)
+            if not body.get('stream'):
+                self._send_json(200, result)
+            else:
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/event-stream')
+                self.send_header('Cache-Control', 'no-cache')
+                self.send_header('Content-Length', str(len(result)))
+                self.send_header('Connection', 'close')
+                self.end_headers()
+                self.close_connection = True
+                try:
+                    self.wfile.write(result)
+                    self.wfile.flush()
+                except OSError:
+                    pass  # Downstream cancellation is not upstream ill-health.
+            return
+        self._send_error(503, owner.exhaustion_detail(), 'free_routes_exhausted', owner.retry_after())

--- a/plugins/model-providers/freemaxxing/plugin.yaml
+++ b/plugins/model-providers/freemaxxing/plugin.yaml
@@ -1,0 +1,8 @@
+name: freemaxxing
+kind: model-provider
+version: "0.3.0"
+description: "Opt-in free-route pooling with authenticated atomic completion recovery"
+author: Axl Ibiza
+license: MIT
+homepage: "https://github.com/NousResearch/hermes-agent"
+tags: [free, failover, routing, local, authenticated]

--- a/plugins/model-providers/freemaxxing/policy.py
+++ b/plugins/model-providers/freemaxxing/policy.py
@@ -1,0 +1,207 @@
+"""Freemaxxing's request, resource, and spending boundaries.
+
+A model name is not spending authority. Admission is checked again at dispatch;
+unknown providers and contradictory catalog prices are never implicitly free.
+"""
+from __future__ import annotations
+
+import email.utils
+import math
+import time
+from dataclasses import dataclass
+from datetime import timezone
+from decimal import Decimal, InvalidOperation
+from typing import Any
+from urllib.parse import urlsplit
+
+_MAX_REQUEST_BODY_BYTES = 1_000_000
+_MAX_RESPONSE_BODY_BYTES = 10_000_000
+_MAX_CATALOG_BODY_BYTES = 2_000_000
+_MAX_SSE_LINE_BYTES = 1_000_000
+_MAX_SSE_EVENT_BYTES = 2_000_000
+_CATALOG_TTL_SECONDS = 120.0
+_ROUTER_MODELS = frozenset({'freemaxxing', 'fm', 'freemaxxing-auto'})
+# Only chat-completions SKUs documented by OpenCode. A new SKU with explicit
+# compatible endpoint metadata can also be admitted; a '-free' suffix alone
+# must not cause a Responses/Messages model to be sent to the wrong API.
+_OPENCODE_CHAT_MODELS = frozenset({
+    'big-pickle', 'mimo-v2.5-free', 'ling-3.0-flash-fin-free',
+    'nemotron-3-ultra-free', 'nemotron-3.5-lightning-free',
+    'laguna-s-2.1-free',
+})
+_PRICE_PAIRS = (('prompt', 'completion'), ('input', 'output'),
+                ('input_cost_per_token', 'output_cost_per_token'))
+
+
+class TransientError(Exception):
+    """Retryable upstream transport or completion-integrity failure."""
+
+
+class ModelNotFoundError(Exception):
+    """Route-local model/capability failure; do not poison the provider."""
+
+
+class AuthError(Exception):
+    """An account credential was rejected."""
+
+
+class ClientRequestError(Exception):
+    """Invalid caller request; do not replay it to other providers."""
+
+
+class FreePolicyError(ClientRequestError):
+    """The exact dispatch does not satisfy this plugin's free-only policy."""
+
+
+class RateLimitError(Exception):
+    def __init__(self, message: str, retry_after: float = 30.0):
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+@dataclass(frozen=True)
+class Limits:
+    connect: float = 5.0
+    read: float = 25.0
+    total: float = 90.0
+    catalog: float = 4.0
+    attempts: int = 12
+    concurrency: int = 8
+
+    def __post_init__(self):
+        for value in (self.connect, self.read, self.total, self.catalog):
+            if not math.isfinite(value) or not 0 < value <= 600:
+                raise ValueError('timeouts must be finite and between 0 and 600 seconds')
+        if not 1 <= self.attempts <= 64 or not 1 <= self.concurrency <= 32:
+            raise ValueError('invalid Freemaxxing attempt/concurrency bound')
+
+
+class Budget:
+    def __init__(self, seconds: float):
+        self.deadline = time.monotonic() + seconds
+
+    def remaining(self) -> float:
+        remaining = self.deadline - time.monotonic()
+        if remaining <= 0:
+            raise TransientError('Freemaxxing recovery deadline exhausted')
+        return remaining
+
+
+def _is_router_model(model: str) -> bool:
+    return str(model or '').strip().lower() in _ROUTER_MODELS
+
+
+def _parse_retry_after(headers: Any) -> float:
+    raw = headers.get('Retry-After') if headers is not None else None
+    if raw is None:
+        return 30.0
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        try:
+            date = email.utils.parsedate_to_datetime(str(raw))
+            if date.tzinfo is None:
+                date = date.replace(tzinfo=timezone.utc)
+            value = date.timestamp() - time.time()
+        except (TypeError, ValueError, OverflowError):
+            return 30.0
+    # Do not shorten a daily/account quota reset into a five-minute retry storm.
+    return max(0.0, value) if math.isfinite(value) else 30.0
+
+
+def is_loopback(url: str) -> bool:
+    try:
+        parts = urlsplit(url)
+        return (parts.scheme in {'http', 'https'} and
+                parts.hostname in {'127.0.0.1', '::1'} and
+                not parts.username and not parts.password and
+                not parts.query and not parts.fragment and parts.port != 0)
+    except ValueError:
+        return False
+
+
+def validate_url(url: str, *, local: bool = False) -> None:
+    parts = urlsplit(url)
+    if (not parts.hostname or parts.username or parts.password or parts.query or
+            parts.fragment or (parts.scheme != 'https' and not is_loopback(url))):
+        raise FreePolicyError('upstream URL must be HTTPS or an explicit numeric loopback')
+    if local and not is_loopback(url):
+        raise FreePolicyError('local free routes must use numeric loopback, not a remote host')
+
+
+def _zero(value: Any) -> bool:
+    if isinstance(value, bool) or value is None:
+        return False
+    try:
+        number = Decimal(str(value))
+        return number.is_finite() and number == 0
+    except (InvalidOperation, TypeError, ValueError):
+        return False
+
+
+def free_price(row: dict) -> bool:
+    pricing = row.get('pricing')
+    if not isinstance(pricing, dict):
+        return False
+    # Nous exposes pre-discount prices as pricing.original (display metadata).
+    pricing = {key: value for key, value in pricing.items() if key != 'original'}
+    return (any(all(key in pricing for key in pair) for pair in _PRICE_PAIRS)
+            and bool(pricing) and all(_zero(value) for value in pricing.values()))
+
+
+def conflicting_price(row: dict) -> bool:
+    pricing = row.get('pricing')
+    if isinstance(pricing, dict):
+        pricing = {key: value for key, value in pricing.items() if key != 'original'}
+    return pricing is not None and (not isinstance(pricing, dict) or
+                                   not pricing or not all(_zero(v) for v in pricing.values()))
+
+
+def _accept_catalog_id(backend: Any, model_id: str, row: dict | None = None) -> bool:
+    model = str(model_id or '').strip()
+    if not model or model.startswith('~') or model.endswith(':batch'):
+        return False
+    row = row or {}
+    if conflicting_price(row):
+        return False
+    kind = backend.kind
+    if kind == 'openrouter':
+        return model.endswith(':free') or model == 'openrouter/free'
+    if kind == 'opencode-free':
+        mode = row.get('api_mode')
+        endpoints = row.get('supported_endpoints', [])
+        if not isinstance(endpoints, list):
+            return False
+        chat = (mode == 'chat_completions' or 'chat/completions' in endpoints or
+                (mode is None and not endpoints and model in _OPENCODE_CHAT_MODELS))
+        return chat and (model.endswith('-free') or model == 'big-pickle')
+    if kind == 'nous-portal':
+        # No static paid/previously-promotional model escape hatch.
+        return backend.free_tier_only and free_price(row)
+    if kind == 'local':
+        return is_loopback(backend.base_url)
+    return kind in {'groq', 'gemini', 'mistral'} and backend.free_tier_only
+
+
+def guard_body(backend: Any, body: dict, row: dict) -> dict:
+    """Apply policy to aliases AND explicit models at the last pre-I/O boundary."""
+    if not _accept_catalog_id(backend, str(body.get('model', '')), row):
+        raise FreePolicyError('selected model has no current free-route authority')
+    outgoing = dict(body)
+    for tool in outgoing.get('tools') or []:
+        if not isinstance(tool, dict) or tool.get('type') != 'function':
+            raise ClientRequestError('only client-executed function tools are allowed')
+    # These can install paid services or independent routing policies upstream.
+    if any(key in outgoing for key in ('models', 'plugins', 'transforms', 'web_search_options')):
+        raise ClientRequestError('upstream fallbacks and paid extensions are not allowed')
+    if 'provider' in outgoing and backend.kind != 'openrouter':
+        raise ClientRequestError('provider-routing overrides are not allowed')
+    if backend.kind == 'openrouter':
+        requested = outgoing.get('provider', {})
+        if not isinstance(requested, dict):
+            raise ClientRequestError('provider must be an object')
+        # Never inherit an upstream caller's paid fallback/BYOK routing policy.
+        outgoing['provider'] = {'max_price': {'prompt': 0, 'completion': 0,
+                                            'image': 0, 'request': 0},
+                                'require_parameters': True}
+    return outgoing

--- a/plugins/model-providers/freemaxxing/pool.py
+++ b/plugins/model-providers/freemaxxing/pool.py
@@ -1,0 +1,331 @@
+"""Bounded model-level scheduling and single-flight catalog refresh."""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from dataclasses import dataclass
+
+from .policy import (Budget, Limits, TransientError, _CATALOG_TTL_SECONDS,
+                     _MAX_CATALOG_BODY_BYTES,
+                     _accept_catalog_id, _is_router_model)
+from .transport import Transport, read_bounded
+
+
+class Backend:
+    def __init__(self, name, base_url, api_key='', tier=0, refresh=None,
+                 default_model='', *, kind=None, free_tier_only=False):
+        self.name, self.base_url = name, base_url.rstrip('/')
+        self.api_key, self.tier = api_key, int(tier)
+        self.kind = kind or name
+        self.refresh, self.default_model = refresh, default_model
+        self.free_tier_only = free_tier_only
+        self.refresh_lock = threading.RLock()
+        self.catalog_lock = threading.Lock()
+        self._state_lock = threading.RLock()
+        self.cooldown_until = 0.0
+        self.last_success = 0.0
+        self.last_error_class = None
+        self.cached_models = None
+        self.cached_models_until = 0.0
+        self.rows = {}
+        self.model_cooldowns = {}
+        self.latencies = {}
+        self.closed = False
+        self.catalog_retry_until = 0.0
+        self.catalog_credentials = (self.base_url, self.api_key)
+
+    def credential_snapshot(self):
+        with self.refresh_lock:
+            return self.base_url, self.api_key
+
+    def is_available(self):
+        with self._state_lock:
+            return not self.closed and time.monotonic() >= self.cooldown_until
+
+    def record_failure(self, retry_after=30.0, error_class='transient', *, model=None):
+        with self._state_lock:
+            until = time.monotonic() + max(0.0, retry_after)
+            if model:
+                self.model_cooldowns[model] = max(self.model_cooldowns.get(model, 0), until)
+            else:
+                self.cooldown_until = max(self.cooldown_until, until)
+            self.last_error_class = error_class
+
+    def record_success(self, *, model=None, elapsed=None):
+        with self._state_lock:
+            self.last_success = time.time()
+            self.last_error_class = None
+            # A concurrent success cannot erase a newer account-wide 429.
+            if model and elapsed is not None:
+                old = self.latencies.get(model, elapsed)
+                self.latencies[model] = 0.8 * old + 0.2 * elapsed
+
+    def set_catalog(self, rows, ttl=_CATALOG_TTL_SECONDS, *, credentials=None):
+        accepted, rejected = {}, set()
+        for row in rows:
+            if not isinstance(row, dict) or not isinstance(row.get('id'), str):
+                continue
+            model = row['id']
+            if _accept_catalog_id(self, model, row):
+                accepted[model] = dict(row)
+            else:
+                rejected.add(model)
+        # An ambiguous duplicate never wins by order or last-writer-wins.
+        for model in rejected:
+            accepted.pop(model, None)
+        with self.refresh_lock, self._state_lock:
+            if self.closed or (credentials is not None and credentials != (self.base_url, self.api_key)):
+                return
+            self.catalog_credentials = credentials or (self.base_url, self.api_key)
+            self.rows = accepted
+            self.cached_models = list(accepted)
+            self.cached_models_until = time.monotonic() + ttl
+            self.model_cooldowns = {k: v for k, v in self.model_cooldowns.items()
+                                    if k in accepted and v > time.monotonic()}
+            self.latencies = {k: v for k, v in self.latencies.items() if k in accepted}
+
+    def set_cached_models(self, models, ttl=_CATALOG_TTL_SECONDS):
+        self.set_catalog([{'id': model} for model in models], ttl)
+
+    def get_cached_models(self):
+        return list(self.available_rows())
+
+    def available_rows(self):
+        with self._state_lock:
+            if not self.is_available() or self.catalog_credentials != (self.base_url, self.api_key):
+                return {}
+            now = time.monotonic()
+            # Expired prices cannot establish spend authority. Keyless/local and
+            # OpenRouter's server-enforced zero cap can safely use stale IDs.
+            if now >= self.cached_models_until and self.kind not in {
+                'opencode-free', 'openrouter', 'local',
+            }:
+                return {}
+            return {key: dict(row) for key, row in self.rows.items()
+                    if self.model_cooldowns.get(key, 0) <= now}
+
+    def supports_model(self, model):
+        return model in self.available_rows()
+
+    def health(self):
+        with self._state_lock:
+            return {'name': self.name, 'tier': self.tier, 'available': self.is_available(),
+                    'retry_after': max(0, self.cooldown_until - time.monotonic()),
+                    'last_success': self.last_success, 'last_error_class': self.last_error_class,
+                    'models_cached': len(self.rows), 'eligible_models': len(self.available_rows())}
+
+
+@dataclass(frozen=True)
+class Candidate:
+    backend: Backend
+    model: str
+    row: dict
+
+    @property
+    def identity(self):
+        return self.backend.name, self.model
+
+
+class BackendPool:
+    def __init__(self, limits=None):
+        self.limits = limits or Limits()
+        self.backends = []
+        self._lock = threading.RLock()
+        self._index = 0
+        self._transport = None
+        self._changed = threading.Event()
+        self._workers = set()
+        self._affinity = {}
+
+    @property
+    def transport(self):
+        with self._lock:
+            if self._transport is None:
+                self._transport = Transport(self.limits)
+            return self._transport
+
+    def add(self, backend):
+        with self._lock:
+            if len(self.backends) >= 8 or any(b.name == backend.name for b in self.backends):
+                raise ValueError('duplicate backend or backend bound exceeded')
+            self.backends.append(backend)
+
+    def snapshot(self):
+        with self._lock:
+            return list(self.backends)
+
+    def count(self):
+        return len(self.snapshot())
+
+    def clear(self):
+        with self._lock:
+            old, self.backends = self.backends, []
+            for backend in old:
+                with backend._state_lock:
+                    backend.closed = True
+            transport, self._transport = self._transport, None
+            self._index = 0
+            self._affinity.clear()
+        if transport is not None:
+            transport.close()
+        self._changed.set()
+
+    def next(self, requested_model='', exclude=None):
+        available = [b for b in self.snapshot() if b.is_available() and
+                     b.name not in (exclude or set()) and
+                     (_is_router_model(requested_model) or b.supports_model(requested_model))]
+        if not available:
+            return None
+        tier = min(b.tier for b in available)
+        group = [b for b in available if b.tier == tier]
+        with self._lock:
+            selected = group[self._index % len(group)]
+            self._index += 1
+        return selected
+
+    def _fetch_models(self, backend, budget, transport=None):
+        if backend.closed:
+            raise TransientError('catalog generation retired')
+        observed = backend.credential_snapshot()
+        if not observed[1] and backend.refresh is not None:
+            _refresh_backend_credentials(backend, require_new=False, observed=observed)
+        observed = backend.credential_snapshot()
+        response = (transport or self.transport).request(backend, 'GET', '/models', budget,
+                                                         catalog=True, credentials=observed)
+        raw = read_bounded(response, budget, _MAX_CATALOG_BODY_BYTES)
+        try:
+            payload = json.loads(raw)
+            rows = payload if isinstance(payload, list) else payload['data']
+            if not isinstance(rows, list):
+                raise ValueError('not a list')
+            return rows, observed
+        except (ValueError, TypeError, KeyError) as exc:
+            raise TransientError('invalid upstream catalog') from exc
+
+    def refresh_catalogs(self):
+        for backend in self.snapshot():
+            with backend._state_lock:
+                due = (backend.cached_models_until <= time.monotonic() + 15 and
+                       backend.catalog_retry_until <= time.monotonic())
+            if not due or not backend.is_available() or not backend.catalog_lock.acquire(False):
+                continue
+            transport = self.transport
+            def worker(target=backend, transport=transport):
+                try:
+                    rows, credentials = self._fetch_models(target, Budget(self.limits.catalog), transport)
+                    target.set_catalog(rows, credentials=credentials)
+                except Exception:
+                    # Negative-cache cold failures and back off refresh of stale
+                    # lists, without renewing expired price evidence.
+                    with target._state_lock:
+                        cold = target.cached_models is None
+                    # set_catalog acquires credential then state; never call it
+                    # while holding state or a concurrent auth refresh can deadlock.
+                    if cold:
+                        target.set_catalog([], ttl=15)
+                    with target._state_lock:
+                        target.catalog_retry_until = time.monotonic() + 15
+                finally:
+                    target.catalog_lock.release()
+                    self._changed.set()
+                    with self._lock:
+                        self._workers.discard(threading.current_thread())
+            thread = threading.Thread(target=worker, name='freemaxxing-catalog', daemon=True)
+            with self._lock:
+                self._workers.add(thread)
+            thread.start()
+
+    def candidates(self, body, session=None):
+        requested = str(body.get('model') or 'freemaxxing')
+        selector, separator, selected = requested.partition('::')
+        scoped_auto = bool(separator and _is_router_model(selected))
+        groups = []
+        for backend in sorted(self.snapshot(), key=lambda b: b.tier):
+            if scoped_auto and backend.name != selector:
+                continue
+            group = []
+            for model, row in backend.available_rows().items():
+                qualified = f'{backend.name}::{model}'
+                if not _is_router_model(requested) and not scoped_auto and requested not in {model, qualified}:
+                    continue
+                parameters = row.get('supported_parameters')
+                if body.get('tools') and isinstance(parameters, list) and 'tools' not in parameters:
+                    continue
+                if body.get('response_format') and isinstance(parameters, list) and 'response_format' not in parameters:
+                    continue
+                group.append(Candidate(backend, model, row))
+            group.sort(key=lambda c: (c.model != backend.default_model,
+                                     backend.latencies.get(c.model, float('inf'))))
+            if group:
+                groups.append(group)
+        # Try another provider before cycling through all models on one provider.
+        candidates = [group[i] for i in range(max(map(len, groups), default=0))
+                      for group in groups if i < len(group)]
+        if session and _is_router_model(requested):
+            with self._lock:
+                preferred = self._affinity.get(session)
+            candidates.sort(key=lambda c: c.identity != preferred)
+        return candidates
+
+    def remember(self, session, identity):
+        if not session:
+            return
+        with self._lock:
+            self._affinity.pop(session, None)
+            if len(self._affinity) >= 1024:
+                self._affinity.pop(next(iter(self._affinity)))
+            self._affinity[session] = identity
+
+    def catalog_pending(self):
+        with self._lock:
+            return bool(self._workers)
+
+    def wait_for_catalog(self, budget, timeout=None):
+        self._changed.wait(min(timeout or self.limits.catalog, budget.remaining()))
+        self._changed.clear()
+
+    def get_aggregated_models(self):
+        # Picker/catalog calls are metadata-only and cannot spend quota.
+        return [{'id': 'freemaxxing', 'object': 'model', 'owned_by': 'freemaxxing'}]
+
+    def health(self):
+        return {'backends': [b.health() for b in self.snapshot()]}
+
+    def exhaustion_detail(self):
+        return 'No eligible free route; session state has not been modified.'
+
+    def retry_after(self):
+        return max(1, min((b.health()['retry_after'] for b in self.snapshot()
+                           if not b.is_available()), default=5))
+
+
+pool = BackendPool()
+
+
+def _resolve_auto_model(backend):
+    rows = backend.available_rows()
+    return backend.default_model if backend.default_model in rows else next(iter(rows), '')
+
+
+def _refresh_backend_credentials(backend, *, require_new, observed=None):
+    if backend.refresh is None:
+        return False
+    with backend.refresh_lock:
+        current = backend.base_url, backend.api_key
+        if observed is not None and current != observed:
+            return True
+        base, key = backend.refresh()
+        base, key = str(base or current[0]).rstrip('/'), str(key or '').strip()
+        if not key or (require_new and (base, key) == current):
+            return False
+        with backend._state_lock:
+            backend.base_url, backend.api_key = base, key
+            if (base, key) != current:
+                # Price/capability evidence from another credential cannot authorize
+                # a refreshed endpoint, even when its model names happen to match.
+                backend.rows = {}
+                backend.cached_models = None
+                backend.cached_models_until = 0
+                backend.catalog_retry_until = 0
+        return True

--- a/plugins/model-providers/freemaxxing/protocol.py
+++ b/plugins/model-providers/freemaxxing/protocol.py
@@ -1,0 +1,177 @@
+"""Completion validation and atomic SSE replay: partial tool calls never escape."""
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from .policy import (Budget, TransientError, _MAX_RESPONSE_BODY_BYTES,
+                     _MAX_SSE_EVENT_BYTES, _MAX_SSE_LINE_BYTES)
+
+
+def loads(raw):
+    def invalid(_value):
+        raise ValueError('non-finite JSON value')
+    try:
+        return json.loads(raw, parse_constant=invalid)
+    except (ValueError, UnicodeError, TypeError) as exc:
+        raise TransientError('invalid upstream JSON') from exc
+
+
+def validate_completion(payload):
+    if not isinstance(payload, dict) or 'error' in payload:
+        raise TransientError('upstream returned an error envelope')
+    choices = payload.get('choices')
+    if not isinstance(choices, list) or len(choices) != 1 or not isinstance(choices[0], dict):
+        raise TransientError('upstream returned no single completion')
+    choice = choices[0]
+    message = choice.get('message')
+    if not isinstance(message, dict) or message.get('role', 'assistant') != 'assistant':
+        raise TransientError('upstream returned an invalid assistant message')
+    if choice.get('finish_reason') not in {'stop', 'length', 'tool_calls', 'content_filter'}:
+        raise TransientError('upstream completion has no terminal reason')
+    tools = message.get('tool_calls', [])
+    if tools is None:
+        tools = []
+    if not isinstance(tools, list):
+        raise TransientError('invalid tool-call envelope')
+    seen = set()
+    for tool in tools:
+        if not isinstance(tool, dict):
+            raise TransientError('invalid tool call')
+        function = tool.get('function')
+        identity = tool.get('id')
+        if (not isinstance(identity, str) or not identity or identity in seen or
+                tool.get('type') != 'function' or not isinstance(function, dict) or
+                not isinstance(function.get('name'), str) or not function['name'] or
+                not isinstance(function.get('arguments'), str) or
+                not isinstance(loads(function['arguments']), dict)):
+            raise TransientError('incomplete or invalid tool call')
+        seen.add(identity)
+    content = message.get('content') or message.get('refusal')
+    if not tools and (not isinstance(content, str) or not content.strip()):
+        raise TransientError('upstream returned no usable final content')
+    if tools and choice.get('finish_reason') not in {'tool_calls', 'stop'}:
+        raise TransientError('upstream truncated a tool-call response')
+    return payload
+
+
+class StreamValidator:
+    def __init__(self):
+        self.message = {'role': 'assistant', 'content': ''}
+        self.tools = {}
+        self.finish = None
+        self.done = False
+        self.identity = None
+
+    def event(self, data):
+        if data.strip() == b'[DONE]':
+            self.message['tool_calls'] = [self.tools[i] for i in sorted(self.tools)]
+            validate_completion({'choices': [{'message': self.message,
+                                              'finish_reason': self.finish}]})
+            self.done = True
+            return
+        chunk = loads(data)
+        if not isinstance(chunk, dict) or 'error' in chunk:
+            raise TransientError('upstream SSE error')
+        choices = chunk.get('choices')
+        if choices == [] and 'usage' in chunk:
+            return
+        if not isinstance(choices, list) or len(choices) != 1 or not isinstance(choices[0], dict):
+            raise TransientError('invalid SSE choices')
+        identity = chunk.get('id')
+        if identity:
+            if self.identity and self.identity != identity:
+                raise TransientError('completion identity changed mid-stream')
+            self.identity = identity
+        choice = choices[0]
+        if choice.get('index', 0) != 0:
+            raise TransientError('unexpected SSE choice index')
+        delta = choice.get('delta')
+        if not isinstance(delta, dict):
+            raise TransientError('invalid SSE delta')
+        if self.finish is not None and any(delta.get(k) for k in ('content', 'tool_calls', 'refusal')):
+            raise TransientError('content appeared after terminal SSE event')
+        for field in ('content', 'refusal'):
+            value = delta.get(field)
+            if value is not None:
+                if not isinstance(value, str):
+                    raise TransientError('invalid SSE text')
+                self.message[field] = self.message.get(field, '') + value
+        calls = delta.get('tool_calls', [])
+        if calls is None:
+            calls = []
+        if not isinstance(calls, list):
+            raise TransientError('invalid streamed tool calls')
+        for call in calls:
+            if not isinstance(call, dict) or type(call.get('index')) is not int or not 0 <= call['index'] < 128:
+                raise TransientError('invalid streamed tool index')
+            tool = self.tools.setdefault(call['index'], {'id': '', 'type': 'function',
+                                                        'function': {'name': '', 'arguments': ''}})
+            for field in ('id', 'type'):
+                if call.get(field):
+                    if not isinstance(call[field], str):
+                        raise TransientError('invalid streamed tool identity')
+                    if field == 'id' and tool['id'] and tool['id'] != call[field]:
+                        raise TransientError('tool identity changed mid-stream')
+                    tool[field] = call[field]
+            function = call.get('function', {})
+            if not isinstance(function, dict):
+                raise TransientError('invalid streamed function')
+            for field in ('name', 'arguments'):
+                value = function.get(field)
+                if value is not None:
+                    if not isinstance(value, str):
+                        raise TransientError('invalid streamed function field')
+                    tool['function'][field] += value
+        if choice.get('finish_reason') is not None:
+            if self.finish is not None and self.finish != choice['finish_reason']:
+                raise TransientError('conflicting SSE termination')
+            self.finish = choice['finish_reason']
+
+
+def read_stream(response, budget: Budget):
+    """Return one complete validated stream or fail before downstream HTTP 200.
+
+    Atomic replay intentionally trades first-token latency for transparent
+    failover after any upstream interruption. It does not splice generations.
+    """
+    validator = StreamValidator()
+    raw, pending, event = bytearray(), bytearray(), []
+    event_size = 0
+    try:
+        for chunk in response.iter_raw():
+            budget.remaining()
+            if len(raw) + len(chunk) > _MAX_RESPONSE_BODY_BYTES:
+                raise TransientError('SSE response exceeds total byte bound')
+            raw.extend(chunk)
+            pending.extend(chunk)
+            offset = 0
+            while (newline := pending.find(b'\n', offset)) >= 0:
+                line = pending[offset:newline]
+                offset = newline + 1
+                if len(line) > _MAX_SSE_LINE_BYTES:
+                    raise TransientError('SSE line exceeds byte bound')
+                line = line.rstrip(b'\r')
+                if not line:
+                    if event:
+                        validator.event(b'\n'.join(event))
+                    event, event_size = [], 0
+                    if validator.done:
+                        # Do not forward bytes following the terminal event in
+                        # the same network chunk (a second generation/error).
+                        return bytes(raw[:len(raw) - len(pending) + offset])
+                else:
+                    event_size += len(line)
+                    if event_size > _MAX_SSE_EVENT_BYTES:
+                        raise TransientError('SSE event exceeds byte bound')
+                    if line.startswith(b'data:'):
+                        event.append(bytes(line[5:]).lstrip(b' '))
+            del pending[:offset]
+            if len(pending) > _MAX_SSE_LINE_BYTES:
+                raise TransientError('unterminated SSE line exceeds byte bound')
+        raise TransientError('upstream stream ended without valid terminal completion')
+    except (httpx.HTTPError, OSError) as exc:
+        raise TransientError('upstream stream interrupted') from exc
+    finally:
+        response.close()

--- a/plugins/model-providers/freemaxxing/proxy.py
+++ b/plugins/model-providers/freemaxxing/proxy.py
@@ -1,0 +1,6 @@
+"""Freemaxxing's backwards-compatible public composition surface."""
+from .router import *  # noqa: F403
+from .router import __all__ as _router_all
+from .server import ChatCompletionsHandler, spawn_proxy, stop_proxy
+
+__all__ = [*_router_all, 'ChatCompletionsHandler', 'spawn_proxy', 'stop_proxy']

--- a/plugins/model-providers/freemaxxing/router.py
+++ b/plugins/model-providers/freemaxxing/router.py
@@ -1,0 +1,15 @@
+"""Stable public backend-policy namespace; implementation stays in this plugin."""
+from .policy import (AuthError, ClientRequestError, FreePolicyError, ModelNotFoundError,
+                     RateLimitError, TransientError, _MAX_CATALOG_BODY_BYTES,
+                     _MAX_REQUEST_BODY_BYTES, _MAX_RESPONSE_BODY_BYTES,
+                     _MAX_SSE_EVENT_BYTES, _MAX_SSE_LINE_BYTES,
+                     _accept_catalog_id, _parse_retry_after)
+from .pool import Backend, BackendPool, _resolve_auto_model, pool
+from .upstream import _exhausted_message, _forward, _open_stream
+
+__all__ = ['AuthError', 'Backend', 'BackendPool', 'ClientRequestError', 'FreePolicyError',
+           'ModelNotFoundError', 'RateLimitError', 'TransientError',
+           '_MAX_CATALOG_BODY_BYTES', '_MAX_REQUEST_BODY_BYTES', '_MAX_RESPONSE_BODY_BYTES',
+           '_MAX_SSE_EVENT_BYTES', '_MAX_SSE_LINE_BYTES', '_accept_catalog_id',
+           '_parse_retry_after', '_resolve_auto_model', '_exhausted_message',
+           '_forward', '_open_stream', 'pool']

--- a/plugins/model-providers/freemaxxing/server.py
+++ b/plugins/model-providers/freemaxxing/server.py
@@ -1,0 +1,97 @@
+"""Immutable loopback capability and bounded HTTP worker lifetime."""
+from __future__ import annotations
+
+import atexit
+import hmac
+import threading
+from http.server import ThreadingHTTPServer
+
+from .handler import ChatCompletionsHandler
+from .pool import pool
+
+_proxy_server = None
+_proxy_lock = threading.RLock()
+
+
+class BoundedServer(ThreadingHTTPServer):
+    daemon_threads = True
+    block_on_close = False
+    request_queue_size = 16
+
+    def get_request(self):
+        request, address = super().get_request()
+        request.settimeout(10)
+        return request, address
+
+    def process_request(self, request, address):
+        if not self.http_slots.acquire(False):
+            # Do not allocate another handler thread for a slow/malicious client.
+            self.shutdown_request(request)
+            return
+        try:
+            super().process_request(request, address)
+        except BaseException:
+            self.http_slots.release()
+            raise
+
+    def process_request_thread(self, request, address):
+        try:
+            super().process_request_thread(request, address)
+        finally:
+            self.http_slots.release()
+
+
+def spawn_proxy(*, port, token, pool_initializer=None, runtime_guard=None, backend_pool=None):
+    global _proxy_server
+    if not isinstance(token, str) or not token.strip():
+        raise ValueError('freemaxxing proxy requires a non-empty token')
+    with _proxy_lock:
+        if _proxy_server is not None:
+            existing = _proxy_server
+            if not hmac.compare_digest(token.encode(), existing.auth_token.encode()):
+                raise RuntimeError('existing Freemaxxing listener has different authority')
+            if pool_initializer is not None and existing.pool_initializer is not pool_initializer:
+                raise RuntimeError('existing Freemaxxing listener has a different initializer')
+            if backend_pool is not None and existing.backend_pool is not backend_pool:
+                raise RuntimeError('existing Freemaxxing listener has a different pool')
+            if runtime_guard is not None and existing.runtime_guard is not runtime_guard:
+                raise RuntimeError('existing Freemaxxing listener has a different runtime guard')
+            if port and port != existing.server_address[1]:
+                raise RuntimeError('existing Freemaxxing listener has a different port')
+            if not existing.worker_thread.is_alive():
+                raise RuntimeError('Freemaxxing listener stopped; explicit restart required')
+            return existing
+        owner = backend_pool or pool
+        server = BoundedServer(('127.0.0.1', int(port)), ChatCompletionsHandler)
+        server.auth_token = token
+        server.backend_pool = owner
+        server.pool_initializer = pool_initializer
+        server.pool_ready = pool_initializer is None
+        server.runtime_guard = runtime_guard
+        server.pool_init_lock = threading.Lock()
+        server.inference_slots = threading.BoundedSemaphore(owner.limits.concurrency)
+        server.http_slots = threading.BoundedSemaphore(owner.limits.concurrency + 4)
+        thread = threading.Thread(target=server.serve_forever, kwargs={'poll_interval': 0.05},
+                                  name='freemaxxing-proxy', daemon=True)
+        server.worker_thread = thread
+        _proxy_server = server
+        thread.start()
+        return server
+
+
+def stop_proxy(server=None):
+    global _proxy_server
+    with _proxy_lock:
+        target = server or _proxy_server
+        if target is None:
+            return
+        target.shutdown()
+        target.server_close()
+        if target.worker_thread is not threading.current_thread():
+            target.worker_thread.join(timeout=2)
+        target.backend_pool.clear()
+        if target is _proxy_server:
+            _proxy_server = None
+
+
+atexit.register(stop_proxy)

--- a/plugins/model-providers/freemaxxing/transport.py
+++ b/plugins/model-providers/freemaxxing/transport.py
@@ -1,0 +1,95 @@
+"""Reusable HTTP transport; no redirects, no credential-bearing ambient headers."""
+from __future__ import annotations
+
+import httpx
+
+from .policy import (AuthError, Budget, ClientRequestError, Limits,
+                     ModelNotFoundError, RateLimitError, TransientError,
+                     _parse_retry_after, validate_url)
+
+
+class Transport:
+    def __init__(self, limits: Limits):
+        self.limits = limits
+        self.client = httpx.Client(
+            follow_redirects=False,
+            limits=httpx.Limits(max_connections=limits.concurrency,
+                               max_keepalive_connections=limits.concurrency),
+        )
+
+    def close(self):
+        self.client.close()
+
+    def request(self, backend, method, path, budget: Budget, *, body=None, catalog=False, credentials=None):
+        base, key = credentials or backend.credential_snapshot()
+        validate_url(base, local=backend.kind == 'local')
+        if backend.kind not in {'opencode-free', 'local'} and not key:
+            raise AuthError('missing upstream credential')
+        remaining = budget.remaining()
+        read = min(self.limits.catalog if catalog else self.limits.read, remaining)
+        headers = {'Accept': 'application/json', 'Accept-Encoding': 'identity',
+                   'User-Agent': 'HermesAgent/Freemaxxing'}
+        if backend.kind != 'opencode-free' and key:
+            headers['Authorization'] = f'Bearer {key}'
+        if backend.kind == 'opencode-free':
+            headers.update({'HTTP-Referer': 'https://hermes-agent.nousresearch.com',
+                            'X-Title': 'Hermes Agent'})
+        timeout = httpx.Timeout(connect=min(self.limits.connect, remaining),
+                                read=read, write=read, pool=min(1.0, remaining))
+        try:
+            request = self.client.build_request(method, base.rstrip('/') + path,
+                                                headers=headers, json=body, timeout=timeout)
+            response = self.client.send(request, stream=True)
+        except (httpx.HTTPError, OSError) as exc:
+            raise TransientError('upstream connection failed') from exc
+        code = response.status_code
+        if response.headers.get('Content-Encoding', 'identity').lower() not in {'', 'identity'}:
+            response.close()
+            raise TransientError('compressed upstream response refused at byte-boundary')
+        if 200 <= code < 300:
+            return response
+        try:
+            if code == 429:
+                raise RateLimitError('upstream rate limit', _parse_retry_after(response.headers))
+            if code in {401, 403}:
+                raise AuthError('upstream credential rejected')
+            if code == 404:
+                raise ModelNotFoundError('model unavailable')
+            if 300 <= code < 400:
+                raise TransientError('upstream redirect refused')
+            # Inspect only a bounded error body; do not publish provider text/secrets.
+            raw = bytearray()
+            for chunk in response.iter_raw():
+                budget.remaining()
+                raw.extend(chunk[:16_384 - len(raw)])
+                if len(raw) >= 16_384:
+                    break
+            text = raw.decode('utf-8', errors='replace').lower()
+            if code in {400, 413, 422} and any(word in text for word in (
+                'context length', 'context_length', 'context window', 'maximum context',
+                'model not found', 'invalid model', 'unknown model', 'not support',
+                'unsupported', 'not available',
+            )):
+                raise ModelNotFoundError('route lacks requested model/capability/context')
+            if 400 <= code < 500:
+                raise ClientRequestError(f'upstream rejected request (HTTP {code})')
+            raise TransientError(f'upstream unavailable (HTTP {code})')
+        except (httpx.HTTPError, OSError) as exc:
+            raise TransientError('upstream error response interrupted') from exc
+        finally:
+            response.close()
+
+
+def read_bounded(response, budget: Budget, limit: int):
+    raw = bytearray()
+    try:
+        for chunk in response.iter_raw():
+            budget.remaining()
+            if len(raw) + len(chunk) > limit:
+                raise TransientError('upstream response exceeded the byte limit')
+            raw.extend(chunk)
+        return bytes(raw)
+    except (httpx.HTTPError, OSError) as exc:
+        raise TransientError('upstream response interrupted') from exc
+    finally:
+        response.close()

--- a/plugins/model-providers/freemaxxing/upstream.py
+++ b/plugins/model-providers/freemaxxing/upstream.py
@@ -1,0 +1,73 @@
+"""One free-only dispatch boundary for main, auxiliary, explicit, and MoA calls."""
+from __future__ import annotations
+
+from .policy import (AuthError, Budget, ModelNotFoundError,
+                     _MAX_RESPONSE_BODY_BYTES, _is_router_model, guard_body)
+from .pool import _refresh_backend_credentials, _resolve_auto_model, pool
+from .protocol import loads, read_stream, validate_completion
+from .transport import read_bounded
+
+
+def _exhausted_message(last_error=None):
+    return 'No eligible free route. Retry is safe for inference; no tool was executed by this router.'
+
+
+def _open_response(backend, body, budget=None, *, owner=None):
+    owner = owner or pool
+    budget = budget or Budget(owner.limits.total)
+    outgoing = dict(body)
+    model = str(outgoing.get('model') or 'freemaxxing')
+    if _is_router_model(model):
+        model = _resolve_auto_model(backend)
+    elif model.startswith(backend.name + '::'):
+        model = model.split('::', 1)[1]
+    outgoing['model'] = model
+
+    def attempt(snapshot):
+        with backend.refresh_lock:
+            if backend.credential_snapshot() != snapshot:
+                raise ModelNotFoundError('upstream credential changed before dispatch')
+            row = backend.available_rows().get(model)
+            if row is None:
+                raise ModelNotFoundError('model has no current eligible free route')
+            secured = guard_body(backend, outgoing, row)
+        budget.remaining()
+        return owner.transport.request(backend, 'POST', '/chat/completions', budget,
+                                       body=secured, credentials=snapshot)
+
+    observed = backend.credential_snapshot()
+    if not observed[1] and backend.refresh is not None:
+        _refresh_backend_credentials(backend, require_new=False, observed=observed)
+        observed = backend.credential_snapshot()
+    try:
+        return attempt(observed)
+    except AuthError:
+        if not _refresh_backend_credentials(backend, require_new=True, observed=observed):
+            raise
+        # Network I/O is outside the credential lock. All waiters compare the
+        # actual failed credential, not a later snapshot, so one refresh wins.
+        # A new credential must earn its own catalog; never replay an old
+        # account's price/capability grant after refreshing authentication.
+        if not backend.catalog_lock.acquire(timeout=budget.remaining()):
+            raise ModelNotFoundError('catalog refresh deadline exhausted')
+        try:
+            if model not in backend.available_rows():
+                rows, credentials = owner._fetch_models(backend, budget)
+                backend.set_catalog(rows, credentials=credentials)
+        finally:
+            backend.catalog_lock.release()
+        return attempt(backend.credential_snapshot())
+
+
+def _forward(backend, body, budget=None, *, owner=None):
+    owner = owner or pool
+    budget = budget or Budget(owner.limits.total)
+    response = _open_response(backend, dict(body, stream=False), budget, owner=owner)
+    return validate_completion(loads(read_bounded(response, budget, _MAX_RESPONSE_BODY_BYTES)))
+
+
+def _open_stream(backend, body, budget=None, *, owner=None):
+    owner = owner or pool
+    budget = budget or Budget(owner.limits.total)
+    response = _open_response(backend, dict(body, stream=True), budget, owner=owner)
+    return read_stream(response, budget)

--- a/tests/plugins/model_providers/test_freemaxxing_proxy.py
+++ b/tests/plugins/model_providers/test_freemaxxing_proxy.py
@@ -1,0 +1,592 @@
+"""Real loopback dispatch contracts; no external inference or account mutation."""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import threading
+import time
+import types
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_DIR = ROOT / 'plugins' / 'model-providers' / 'freemaxxing'
+# Test the packaged implementation directly. Registration/loader composition is
+# covered separately through Hermes' actual provider loader, not a core patch.
+NAME = '_freemaxxing_contract'
+package = types.ModuleType(NAME)
+package.__path__ = [str(PLUGIN_DIR)]
+sys.modules.setdefault(NAME, package)
+POLICY = importlib.import_module(NAME + '.policy')
+POOL = importlib.import_module(NAME + '.pool')
+SERVER = importlib.import_module(NAME + '.server')
+PROTOCOL = importlib.import_module(NAME + '.protocol')
+UPSTREAM = importlib.import_module(NAME + '.upstream')
+TRANSPORT = importlib.import_module(NAME + '.transport')
+TOKEN = 'test-only-freemaxxing-capability'
+
+
+def completion(text='ok', **message):
+    return {'id': 'completion-1', 'object': 'chat.completion', 'model': 'test-model',
+            'choices': [{'index': 0, 'finish_reason': 'stop',
+                         'message': {'role': 'assistant', 'content': text, **message}}]}
+
+
+def event(delta=None, finish=None, **extra):
+    return b'data: ' + json.dumps({'id': 'completion-1', 'choices': [
+        {'index': 0, 'delta': delta or {}, 'finish_reason': finish}], **extra}).encode() + b'\n\n'
+
+
+def valid_stream(text='ok'):
+    return [event({'role': 'assistant'}), event({'content': text}),
+            event(finish='stop'), b'data: [DONE]\n\n']
+
+
+class Mock:
+    def __init__(self, *, status=200, raw=None, stream=None, rows=None,
+                 retry_after='1', delay=0, catalog_status=200, responder=None):
+        self.status, self.raw, self.stream = status, raw, stream
+        self.rows = rows if rows is not None else [{'id': 'test-model'}]
+        self.retry_after, self.delay = retry_after, delay
+        self.catalog_status, self.responder = catalog_status, responder
+        self.calls, self.gets = [], 0
+        self.port_ids = []
+        outer = self
+
+        class H(BaseHTTPRequestHandler):
+            protocol_version = 'HTTP/1.1'
+
+            def log_message(self, *_args):
+                pass
+
+            def do_GET(self):  # noqa: N802
+                outer.gets += 1
+                data = json.dumps({'data': outer.rows}).encode()
+                self.send_response(outer.catalog_status)
+                self.send_header('Content-Length', str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get('Content-Length', 0))
+                body = json.loads(self.rfile.read(length))
+                outer.calls.append((body, dict(self.headers)))
+                outer.port_ids.append(self.client_address[1])
+                status, raw, chunks = outer.status, outer.raw, outer.stream
+                if outer.responder:
+                    status, raw, chunks = outer.responder(body, dict(self.headers))
+                if status == 0:
+                    self.close_connection = True
+                    return
+                if outer.delay:
+                    time.sleep(outer.delay)
+                try:
+                    self.send_response(status)
+                    if status == 429:
+                        self.send_header('Retry-After', outer.retry_after)
+                    if 300 <= status < 400:
+                        self.send_header('Location', 'http://127.0.0.1:1/stolen')
+                    if chunks is not None:
+                        self.send_header('Content-Type', 'text/event-stream')
+                        self.send_header('Connection', 'close')
+                        self.end_headers()
+                        for chunk in chunks:
+                            self.wfile.write(chunk)
+                            self.wfile.flush()
+                        self.close_connection = True
+                    else:
+                        if raw is None:
+                            raw = json.dumps(completion()).encode()
+                        self.send_header('Content-Type', 'application/json')
+                        self.send_header('Content-Length', str(len(raw)))
+                        self.end_headers()
+                        self.wfile.write(raw)
+                except OSError:
+                    pass
+
+        self.server = ThreadingHTTPServer(('127.0.0.1', 0), H)
+        self.server.daemon_threads = True
+        self.thread = threading.Thread(target=self.server.serve_forever,
+                                       kwargs={'poll_interval': 0.02}, daemon=True)
+        self.thread.start()
+
+    @property
+    def url(self):
+        return f'http://127.0.0.1:{self.server.server_address[1]}'
+
+    def close(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(1)
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setenv('NO_PROXY', '127.0.0.1,::1')
+    owner = POOL.BackendPool(POLICY.Limits(connect=.3, read=.4, total=3, catalog=.3))
+    mocks = []
+    SERVER.stop_proxy()
+
+    def add(*, name=None, kind='local', rows=None, key='key', tier=0, **kwargs):
+        mock = Mock(rows=rows, **kwargs)
+        mocks.append(mock)
+        backend = POOL.Backend(name or f'backend-{len(mocks)}', mock.url,
+                               api_key=key, kind=kind, tier=tier, free_tier_only=(kind == 'nous-portal'))
+        backend.set_catalog(mock.rows, ttl=3600)
+        owner.add(backend)
+        return mock, backend
+
+    server = SERVER.spawn_proxy(port=0, token=TOKEN, backend_pool=owner)
+    yield types.SimpleNamespace(owner=owner, server=server, add=add)
+    SERVER.stop_proxy(server)
+    for mock in mocks:
+        mock.close()
+
+
+def request(env, body=None, *, token=TOKEN, path='/v1/chat/completions'):
+    headers = {} if token is None else {'Authorization': f'Bearer {token}'}
+    if body is None:
+        body = {'model': 'freemaxxing', 'messages': [{'role': 'user', 'content': 'hi'}]}
+    raw = json.dumps(body).encode()
+    req = urllib.request.Request(f'http://127.0.0.1:{env.server.server_address[1]}{path}',
+                                 data=raw, headers={'Content-Type': 'application/json', **headers})
+    return urllib.request.urlopen(req, timeout=5)
+
+
+def body(**extra):
+    return {'model': 'freemaxxing', 'messages': [{'role': 'user', 'content': 'hi'}], **extra}
+
+
+def test_authenticated_public_dispatch(env):
+    mock, _ = env.add()
+    with request(env) as result:
+        assert json.load(result)['choices'][0]['message']['content'] == 'ok'
+    assert len(mock.calls) == 1
+
+
+@pytest.mark.parametrize('token', [None, '', 'wrong', 'é'])
+def test_unauthorized_cannot_call_upstream(env, token):
+    mock, _ = env.add()
+    with pytest.raises(urllib.error.HTTPError) as error:
+        request(env, token=token)
+    assert error.value.code == 401
+    assert not mock.calls and not mock.gets
+
+
+def test_minimal_health_and_authenticated_metadata_do_not_initialize(env):
+    env.server.pool_ready = False
+    env.server.pool_initializer = lambda: pytest.fail('metadata cannot initialize credentials')
+    for path, token in [('/v1/healthz', None), ('/v1/models', TOKEN)]:
+        headers = {'Authorization': f'Bearer {token}'} if token else {}
+        req = urllib.request.Request(f'http://127.0.0.1:{env.server.server_address[1]}{path}', headers=headers)
+        with urllib.request.urlopen(req) as response:
+            data = json.load(response)
+        assert ('health' not in data)
+    assert not env.server.pool_ready
+
+
+def test_runtime_guard_rechecked_after_initialization(env):
+    mock, _ = env.add()
+    env.server.runtime_guard = lambda: (_ for _ in ()).throw(RuntimeError('multiplex'))
+    with pytest.raises(urllib.error.HTTPError) as error:
+        request(env)
+    assert error.value.code == 409 and not mock.calls
+
+
+@pytest.mark.parametrize('status', [0, 429, 500, 503, 307])
+def test_transport_failures_recover_on_another_provider(env, status):
+    first, _ = env.add(status=status)
+    second, _ = env.add()
+    with request(env) as response:
+        assert json.load(response)['id'] == 'completion-1'
+    assert len(first.calls) == len(second.calls) == 1
+
+
+@pytest.mark.parametrize('raw', [b'{bad', b'\xff', b'[]', b'{}', b'{"error": {"code": 500}}',
+                                b'{"choices": []}', b'{"x": NaN}'])
+def test_invalid_http_200_cannot_end_turn(env, raw):
+    first, _ = env.add(raw=raw)
+    second, _ = env.add()
+    with request(env) as response:
+        assert json.load(response)['id'] == 'completion-1'
+    assert first.calls and second.calls
+
+
+def test_model_failure_does_not_discard_other_models(env):
+    rows = [{'id': 'bad'}, {'id': 'good'}]
+    def responder(payload, _headers):
+        return (404, b'{}', None) if payload['model'] == 'bad' else (200, None, None)
+    mock, backend = env.add(rows=rows, responder=responder)
+    with request(env) as response:
+        json.load(response)
+    assert [c[0]['model'] for c in mock.calls] == ['bad', 'good']
+    assert backend.is_available()
+    assert 'bad' not in backend.available_rows()
+
+
+def test_account_429_does_not_try_other_models_in_same_quota(env):
+    mock, backend = env.add(status=429, retry_after='86400', rows=[{'id': 'a'}, {'id': 'b'}])
+    env.add()
+    with request(env) as response:
+        json.load(response)
+    assert len(mock.calls) == 1
+    assert backend.health()['retry_after'] > 86390
+    backend.record_success(model='a', elapsed=1)
+    assert not backend.is_available()
+
+
+def test_caller_error_is_not_replayed(env):
+    first, _ = env.add(status=400, raw=b'{"error":"bad messages"}')
+    second, _ = env.add()
+    with pytest.raises(urllib.error.HTTPError) as error:
+        request(env)
+    assert error.value.code == 400 and len(first.calls) == 1 and not second.calls
+
+
+@pytest.mark.parametrize('text', ['unsupported tool_choice', 'context length exceeded', 'invalid model'])
+def test_route_capability_errors_fail_over(env, text):
+    env.add(status=400, raw=json.dumps({'error': text}).encode())
+    second, _ = env.add()
+    with request(env) as response:
+        json.load(response)
+    assert second.calls
+
+
+def test_keyless_opencode_never_receives_real_key(env):
+    mock, _ = env.add(kind='opencode-free', key='must-not-leak', rows=[{'id': 'mimo-v2.5-free'}])
+    with request(env) as response:
+        json.load(response)
+    assert 'Authorization' not in mock.calls[0][1]
+    assert mock.calls[0][1]['X-Title'] == 'Hermes Agent'
+
+
+@pytest.mark.parametrize('model', ['paid/model', 'deepseek/deepseek-v4-flash-0731'])
+def test_explicit_paid_model_cannot_bypass_admission(env, model):
+    mock, _ = env.add(kind='openrouter', rows=[{'id': 'free/model:free'}, {'id': model}])
+    with pytest.raises(urllib.error.HTTPError) as error:
+        request(env, body(model=model))
+    assert error.value.code == 503 and not mock.calls
+
+
+def test_openrouter_zero_price_guard_replaces_caller_routing(env):
+    mock, _ = env.add(kind='openrouter', rows=[{'id': 'model:free'}])
+    with request(env, body(provider={'max_price': {'prompt': 20}, 'order': ['paid']})) as response:
+        json.load(response)
+    routing = mock.calls[0][0]['provider']
+    assert set(routing['max_price'].values()) == {0}
+    assert 'order' not in routing and routing['require_parameters']
+
+
+def test_nous_requires_current_zero_price_not_old_model_name(env):
+    rows = [{'id': 'deepseek/deepseek-v4-flash-0731'},
+            {'id': 'free-model', 'pricing': {'prompt': '0', 'completion': '0'}}]
+    mock, backend = env.add(kind='nous-portal', rows=rows)
+    with request(env) as response:
+        json.load(response)
+    assert mock.calls[0][0]['model'] == 'free-model'
+    backend.cached_models_until = 0
+    assert not backend.available_rows()
+
+
+@pytest.mark.parametrize('value', ['0.01', '-1', 'nan', 'Infinity', None, True, 'unknown'])
+def test_ambiguous_or_nonzero_prices_are_excluded(value):
+    backend = POOL.Backend('nous-portal', 'https://example.invalid', free_tier_only=True)
+    backend.set_catalog([{'id': 'x', 'pricing': {'prompt': value, 'completion': '0'}}])
+    assert not backend.available_rows()
+
+
+def test_conflicting_duplicate_catalog_is_order_independent():
+    backend = POOL.Backend('nous-portal', 'https://example.invalid', free_tier_only=True)
+    free = {'id': 'x', 'pricing': {'prompt': 0, 'completion': 0}}
+    paid = {'id': 'x', 'pricing': {'prompt': 1, 'completion': 1}}
+    for rows in ([free, paid], [paid, free]):
+        backend.set_catalog(rows)
+        assert not backend.available_rows()
+
+
+@pytest.mark.parametrize('field', ['models', 'plugins', 'transforms', 'web_search_options'])
+def test_paid_extension_rejected_before_effect(env, field):
+    mock, _ = env.add()
+    with pytest.raises(urllib.error.HTTPError) as error:
+        request(env, body(**{field: ['anything']}))
+    assert error.value.code == 400 and not mock.calls
+
+
+@pytest.mark.parametrize('chunks', [[], [b': keepalive\n\n'], [b'data: not-json\n\n'],
+    [event({'content': 'uncommitted'})], [event({'role': 'assistant'}), b'data: [DONE]\n\n'],
+    [event({'content': 'uncommitted'}), b'data: {"error":{"code":503}}\n\n'],
+    [event({'tool_calls': [{'index': 0, 'id': 't', 'type': 'function',
+                           'function': {'name': 'write', 'arguments': '{'}}]}),
+     event(finish='tool_calls'), b'data: [DONE]\n\n']])
+def test_any_upstream_stream_failure_recovers_before_commit(env, chunks):
+    first, _ = env.add(stream=chunks)
+    second, _ = env.add(stream=valid_stream('winner'))
+    with request(env, body(stream=True)) as response:
+        raw = response.read()
+    assert b'winner' in raw and b'uncommitted' not in raw
+    assert b'write' not in raw and raw.count(b'data: [DONE]') == 1
+    assert len(first.calls) == len(second.calls) == 1
+
+
+def test_fragmented_multiline_sse_with_tool_only_output(env):
+    tool = {'index': 0, 'id': 't', 'type': 'function', 'function': {'name': 'read', 'arguments': '{'}}
+    raw = (event({'tool_calls': [tool]}) +
+           event({'tool_calls': [{'index': 0, 'function': {'arguments': '"path":"x"}'}}]}) +
+           event(finish='tool_calls') + b'data: [DONE]\n\n')
+    env.add(stream=[raw[i:i+7] for i in range(0, len(raw), 7)])
+    with request(env, body(stream=True)) as response:
+        assert response.read() == raw
+
+
+def test_stream_stops_exactly_at_terminal_event(env):
+    raw = b''.join(valid_stream())
+    env.add(stream=[raw + b'data: {"error":"later-generation"}\n\n'])
+    with request(env, body(stream=True)) as response:
+        assert response.read() == raw
+
+
+def test_sse_total_limit_applies_to_keepalives(env, monkeypatch):
+    monkeypatch.setattr(PROTOCOL, '_MAX_RESPONSE_BODY_BYTES', 1024)
+    env.add(stream=[b':' + b'a' * 2000 + b'\n\n'])
+    env.add(stream=valid_stream())
+    with request(env, body(stream=True)) as response:
+        assert b'data: [DONE]' in response.read()
+
+
+def test_complete_tool_call_is_preserved(env):
+    tool = {'id': 'read-1', 'type': 'function', 'function': {'name': 'read', 'arguments': '{"path":"x"}'}}
+    env.add(raw=json.dumps(completion(None, tool_calls=[tool])).encode())
+    with request(env) as response:
+        assert json.load(response)['choices'][0]['message']['tool_calls'] == [tool]
+
+
+def test_tool_argument_truncation_does_not_escape(env):
+    tool = {'id': 'write-1', 'type': 'function', 'function': {'name': 'write', 'arguments': '{'}}
+    env.add(raw=json.dumps(completion(None, tool_calls=[tool])).encode())
+    env.add()
+    with request(env) as response:
+        assert json.load(response)['choices'][0]['message']['content'] == 'ok'
+
+
+def test_empty_catalog_is_cached_without_refetch_loop(env):
+    mock, backend = env.add(rows=[])
+    for _ in range(5):
+        env.owner.refresh_catalogs()
+    assert backend.cached_models == [] and mock.gets == 0
+
+
+def test_catalog_failure_does_not_disable_known_safe_routes(env):
+    mock, backend = env.add(kind='openrouter', rows=[{'id': 'model:free'}], catalog_status=503)
+    backend.cached_models_until = 0
+    env.owner.refresh_catalogs()
+    for _ in range(100):
+        if backend.catalog_retry_until:
+            break
+        time.sleep(.01)
+    assert backend.is_available() and 'model:free' in backend.available_rows()
+    assert mock.gets == 1
+
+
+def test_catalog_refresh_singleflight(env):
+    mock, backend = env.add()
+    backend.cached_models_until = 0
+    threads = [threading.Thread(target=env.owner.refresh_catalogs) for _ in range(20)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    env.owner.wait_for_catalog(POLICY.Budget(1))
+    assert mock.gets == 1
+
+
+def test_connection_reuse(env):
+    mock, _ = env.add()
+    for _ in range(3):
+        with request(env) as response:
+            response.read()
+    assert len(set(mock.port_ids)) == 1
+
+
+def test_session_affinity_is_bounded_and_never_forwarded(env):
+    first, _ = env.add()
+    with request(env, body(freemaxxing_session='session-a')) as response:
+        response.read()
+    assert 'freemaxxing_session' not in first.calls[0][0]
+    for i in range(1500):
+        env.owner.remember(f's-{i}', ('b', 'm'))
+    assert len(env.owner._affinity) == 1024
+
+
+def test_capacity_exhaustion_is_typed_not_queued(env):
+    for _ in range(env.owner.limits.concurrency):
+        env.server.inference_slots.acquire()
+    try:
+        with pytest.raises(urllib.error.HTTPError) as error:
+            request(env)
+        assert error.value.code == 503
+        assert json.load(error.value)['error']['type'] == 'capacity'
+    finally:
+        for _ in range(env.owner.limits.concurrency):
+            env.server.inference_slots.release()
+
+
+def test_exhaustion_returns_retryable_error_never_done_marker(env):
+    with pytest.raises(urllib.error.HTTPError) as error:
+        request(env, body(stream=True))
+    assert error.value.code == 503
+    result = json.load(error.value)
+    assert result['error']['retryable'] and not result['error']['router_state_mutated']
+    assert 'choices' not in result
+
+
+def test_same_listener_cannot_change_capability_or_pool(env):
+    with pytest.raises(ValueError):
+        SERVER.spawn_proxy(port=0, token=' ')
+    with pytest.raises(RuntimeError):
+        SERVER.spawn_proxy(port=0, token='other')
+    with pytest.raises(RuntimeError):
+        SERVER.spawn_proxy(port=0, token=TOKEN, backend_pool=POOL.BackendPool())
+
+
+@pytest.mark.parametrize('raw,expected', [('nan',30),('inf',30),('-10',0),('9999',9999),('86400',86400)])
+def test_retry_after_does_not_shorten_provider_reset(raw, expected):
+    assert POLICY._parse_retry_after({'Retry-After': raw}) == expected
+
+
+@pytest.mark.parametrize('url', ['https://example.com', 'http://localhost:1234',
+                                 'http://127.0.0.1.evil.test', 'http://127.0.0.1@evil.test'])
+def test_local_provider_cannot_be_remote(url):
+    with pytest.raises(POLICY.FreePolicyError):
+        POLICY.validate_url(url, local=True)
+
+
+def test_untrusted_provider_is_not_implicitly_free():
+    backend = POOL.Backend('unknown', 'https://example.com')
+    assert not POLICY._accept_catalog_id(backend, 'free-model')
+
+
+def test_native_responses_opencode_sku_is_not_misrouted():
+    backend = POOL.Backend('opencode-free', 'https://opencode.ai/zen/v1')
+    assert not POLICY._accept_catalog_id(backend, 'muse-spark-1.3-contributor-free')
+    assert not POLICY._accept_catalog_id(backend, 'mimo-v2.5-free', {'api_mode': 'responses'})
+    assert POLICY._accept_catalog_id(backend, 'new-free', {'api_mode': 'chat_completions'})
+
+
+def test_nous_promotional_original_price_is_not_current_price():
+    backend = POOL.Backend('nous-portal', 'https://example.invalid', free_tier_only=True)
+    row = {'id': 'promotional', 'pricing': {'prompt': '0', 'completion': '0',
+                                          'original': {'prompt': '1', 'completion': '2'}}}
+    backend.set_catalog([row])
+    assert backend.get_cached_models() == ['promotional']
+
+
+def test_nous_catalog_price_without_account_boundary_is_not_authority():
+    backend = POOL.Backend('nous-portal', 'https://example.invalid')
+    backend.set_catalog([{'id': 'x', 'pricing': {'prompt': 0, 'completion': 0}}])
+    assert not backend.available_rows()
+
+
+def test_scoped_auto_selector_keeps_moa_advisors_on_distinct_providers(env):
+    first, _ = env.add(name='first')
+    second, _ = env.add(name='second')
+    with request(env, body(model='second::freemaxxing')) as response:
+        json.load(response)
+    assert not first.calls and len(second.calls) == 1
+
+
+def test_stale_catalog_cannot_publish_after_credential_rotation(env):
+    _, backend = env.add()
+    old = backend.credential_snapshot()
+    backend.refresh = lambda: (backend.base_url, 'new-key')
+    assert POOL._refresh_backend_credentials(backend, require_new=True, observed=old)
+    backend.set_catalog([{'id': 'old-account-only'}], credentials=old)
+    assert not backend.available_rows()
+
+
+def test_auth_recovery_revalidates_catalog_for_new_credential(env):
+    def responder(_body, headers):
+        return (401, b'{}', None) if headers.get('Authorization') == 'Bearer old' else (200, None, None)
+    mock, backend = env.add(key='old', responder=responder)
+    calls = []
+    def refresh():
+        calls.append(1)
+        return mock.url, 'new'
+    backend.refresh = refresh
+    with request(env) as response:
+        json.load(response)
+    assert len(calls) == 1 and mock.gets == 1
+    assert [call[1]['Authorization'] for call in mock.calls] == ['Bearer old', 'Bearer new']
+
+
+def test_refresh_waiters_reuse_the_actual_failed_credential_receipt(env):
+    _, backend = env.add()
+    old = backend.credential_snapshot()
+    calls = []
+    backend.refresh = lambda: (calls.append(1) or backend.base_url, 'new-key')
+    threads = [threading.Thread(target=POOL._refresh_backend_credentials,
+                               args=(backend,), kwargs={'require_new': True, 'observed': old})
+               for _ in range(12)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize('bad', [{}, '', 0, False])
+def test_malformed_empty_tool_call_container_is_not_valid(bad):
+    with pytest.raises(POLICY.TransientError):
+        PROTOCOL.validate_completion(completion('text', tool_calls=bad))
+
+
+@pytest.mark.parametrize('bad', [{}, '', 0, False])
+def test_malformed_empty_streamed_tool_call_container_is_not_valid(bad):
+    with pytest.raises(POLICY.TransientError):
+        PROTOCOL.StreamValidator().event(json.dumps({'choices': [
+            {'delta': {'tool_calls': bad}, 'finish_reason': None}]}).encode())
+
+
+def test_server_executed_tools_cannot_spend_outside_free_model(env):
+    mock, _ = env.add()
+    with pytest.raises(urllib.error.HTTPError) as error:
+        request(env, body(tools=[{'type': 'web_search'}]))
+    assert error.value.code == 400 and not mock.calls
+
+
+def test_unknown_opencode_endpoint_metadata_fails_closed():
+    backend = POOL.Backend('opencode-free', 'https://opencode.ai/zen/v1')
+    for endpoints in (None, 12, {}, 'chat/completions'):
+        assert not POLICY._accept_catalog_id(backend, 'mimo-v2.5-free', {'supported_endpoints': endpoints})
+
+
+def test_listener_guard_cannot_be_replaced(env):
+    with pytest.raises(RuntimeError, match='runtime guard'):
+        SERVER.spawn_proxy(port=0, token=TOKEN, runtime_guard=lambda: None)
+
+
+def test_catalog_failure_does_not_invert_credential_and_state_locks(env, monkeypatch):
+    _, backend = env.add()
+    backend.cached_models = None
+    backend.cached_models_until = 0
+    entered = threading.Event()
+    original = backend.set_catalog
+    def set_catalog(*args, **kwargs):
+        entered.set()
+        return original(*args, **kwargs)
+    def fail(*_args):
+        raise POLICY.TransientError('catalog unavailable')
+    monkeypatch.setattr(backend, 'set_catalog', set_catalog)
+    monkeypatch.setattr(env.owner, '_fetch_models', fail)
+    with backend.refresh_lock:
+        env.owner.refresh_catalogs()
+        assert entered.wait(1)
+        acquired = backend._state_lock.acquire(timeout=.2)
+        if acquired:
+            backend._state_lock.release()
+    assert acquired, 'catalog failure held state while waiting for credential authority'

--- a/tests/plugins/model_providers/test_freemaxxing_registration.py
+++ b/tests/plugins/model_providers/test_freemaxxing_registration.py
@@ -1,0 +1,183 @@
+"""Plugin lifecycle contracts plus native-loader composition in full checkouts."""
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+PLUGIN = ROOT / 'plugins' / 'model-providers' / 'freemaxxing'
+
+
+@pytest.fixture
+def plugin(monkeypatch):
+    """Isolated host-API fixture; native host integration is tested below."""
+    profiles, runtime = {}, {}
+    class Record:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+    bindings = {
+        'providers': {'register_provider': lambda p: profiles.update({p.name: p})},
+        'providers.base': {'ProviderProfile': Record},
+        'agent.secret_scope': {'is_multiplex_active': lambda: False,
+                               'current_secret_scope': lambda: None,
+                               'get_secret': lambda _name: None},
+        'hermes_cli.auth': {'PROVIDER_REGISTRY': runtime, 'ProviderConfig': Record,
+                           'resolve_nous_runtime_credentials': lambda: {}},
+        'hermes_cli.config': {'get_env_value_prefer_dotenv': lambda name: os.environ.get(name, '')},
+    }
+    for name, values in bindings.items():
+        module = types.ModuleType(name)
+        module.__dict__.update(values)
+        monkeypatch.setitem(sys.modules, name, module)
+    for key in list(os.environ):
+        if key.startswith('FREEMAXXING_') or key.endswith('_API_KEY'):
+            monkeypatch.delenv(key, raising=False)
+    name = '_freemaxxing_registration_contract'
+    spec = importlib.util.spec_from_file_location(name, PLUGIN / '__init__.py',
+                                                 submodule_search_locations=[str(PLUGIN)])
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    yield module, profiles, runtime
+    module.stop_proxy()
+    for key in list(sys.modules):
+        if key.startswith(name + '.'):
+            sys.modules.pop(key, None)
+
+
+def test_discovery_is_disabled_and_metadata_only(plugin):
+    module, profiles, runtime = plugin
+    assert module._listener is None and module.pool.count() == 0
+    assert profiles['freemaxxing'].fetch_models() == ['freemaxxing']
+    assert list(runtime['freemaxxing'].api_key_env_vars) == []
+    assert 'FREEMAXXING_API_KEY' not in os.environ
+
+
+def test_enabled_plugin_registers_only_its_local_capability(plugin, monkeypatch):
+    module, profiles, runtime = plugin
+    monkeypatch.setenv('FREEMAXXING_ENABLED', '1')
+    monkeypatch.setenv('FREEMAXXING_PORT', '0')
+    module._register()
+    assert profiles['freemaxxing'].base_url.startswith('http://127.0.0.1:')
+    assert os.environ['FREEMAXXING_API_KEY'] == module.local_token()
+    assert list(runtime['fm'].api_key_env_vars) == ['FREEMAXXING_API_KEY']
+    assert module.pool.count() == 0  # No credentials/catalog during registration.
+
+
+def test_multiplex_refuses_before_credentials_or_listener(plugin, monkeypatch):
+    module, _, runtime = plugin
+    monkeypatch.setenv('FREEMAXXING_ENABLED', '1')
+    monkeypatch.setattr(sys.modules['agent.secret_scope'], 'is_multiplex_active', lambda: True)
+    with pytest.raises(RuntimeError, match='multiplex_profiles'):
+        module.ensure_proxy()
+    with pytest.raises(RuntimeError, match='multiplex_profiles'):
+        module._build_pool()
+    assert module._listener is None and module.pool.count() == 0
+    assert list(runtime['fm'].api_key_env_vars) == []
+
+
+def test_unknown_scope_is_not_permission_to_initialize(plugin, monkeypatch):
+    module, _, _ = plugin
+    def fail():
+        raise RuntimeError('scope probe failed')
+    monkeypatch.setattr(sys.modules['agent.secret_scope'], 'is_multiplex_active', fail)
+    with pytest.raises(RuntimeError):
+        module._build_pool()
+    assert module.pool.count() == 0
+
+
+def test_scoped_secret_miss_never_inherits_process_key(plugin, monkeypatch):
+    module, _, _ = plugin
+    monkeypatch.setenv('OPENROUTER_API_KEY', 'other-profile-secret')
+    monkeypatch.setattr(sys.modules['agent.secret_scope'], 'current_secret_scope', lambda: {})
+    assert module._resolve_key(('OPENROUTER_API_KEY',)) == ''
+
+
+def test_keys_do_not_auto_enroll_allowance_accounts(plugin, monkeypatch):
+    module, _, _ = plugin
+    for provider in ('GROQ', 'GEMINI', 'MISTRAL', 'NOUS'):
+        monkeypatch.setenv(provider + '_API_KEY', 'not-free-proof')
+    module._build_pool()
+    assert [backend.name for backend in module.pool.snapshot()] == ['opencode-free']
+
+
+def test_explicit_account_enrollment_and_local_boundary(plugin, monkeypatch):
+    module, _, _ = plugin
+    monkeypatch.setenv('FREEMAXXING_FREE_TIER_PROVIDERS', 'nous-portal,groq,gemini,mistral')
+    for provider in ('OPENROUTER', 'GROQ', 'GEMINI', 'MISTRAL'):
+        monkeypatch.setenv(provider + '_API_KEY', 'test-only')
+    monkeypatch.setenv('FREEMAXXING_LOCAL_BASE_URL', 'http://127.0.0.1:11434/v1')
+    monkeypatch.setenv('FREEMAXXING_LOCAL_MODELS', 'local-test')
+    module._build_pool()
+    assert {b.name for b in module.pool.snapshot()} == {
+        'nous-portal', 'openrouter', 'opencode-free', 'groq', 'gemini', 'mistral', 'local'}
+    nous = next(b for b in module.pool.snapshot() if b.name == 'nous-portal')
+    assert nous.get_cached_models() == [] and nous.api_key == ''
+
+
+def test_invalid_config_does_not_retire_previous_pool(plugin, monkeypatch):
+    module, _, _ = plugin
+    module._build_pool()
+    previous = module.pool.snapshot()
+    monkeypatch.setenv('FREEMAXXING_FREE_TIER_PROVIDERS', 'paid-provider')
+    with pytest.raises(ValueError):
+        module._build_pool()
+    assert module.pool.snapshot() == previous and not previous[0].closed
+
+
+def test_packaged_moa_preset_is_explicit_and_has_no_paid_slot():
+    data = yaml.safe_load((PLUGIN / 'examples' / 'free-moa.yaml').read_text(encoding='utf-8'))
+    preset = data['moa']['presets']['freemaxxing']
+    assert preset['enabled'] is False and preset['fanout'] == 'user_turn'
+    assert all(slot['provider'] == 'freemaxxing' for slot in
+               preset['reference_models'] + [preset['aggregator']])
+    assert len({s['model'] for s in preset['reference_models']}) == 3
+
+
+@pytest.mark.skipif(not (ROOT / 'providers' / '__init__.py').is_file(),
+                    reason='native Hermes host modules require a complete repository checkout')
+@pytest.mark.parametrize('enabled,auth_first', [('0', False), ('1', False), ('1', True)])
+def test_native_provider_loader_and_generic_credentials(tmp_path, enabled, auth_first):
+    # New interpreter and disposable profile prevent test-collection mutation of
+    # the real provider registry. The production loader owns module identity.
+    script = '''
+import importlib, json, os, sys, urllib.request
+import httpx
+httpx.Client.send = lambda *a, **k: (_ for _ in ()).throw(AssertionError("no upstream request allowed"))
+if os.environ["FM_AUTH_FIRST"] == "1":
+    import hermes_cli.auth
+from providers import get_provider_profile
+p = get_provider_profile("freemaxxing")
+assert p is not None
+m = sys.modules[type(p).__module__]
+assert p.fetch_models() == ["freemaxxing"] and m.pool.count() == 0
+if os.environ["FREEMAXXING_ENABLED"] == "1":
+    from hermes_cli.auth import resolve_api_key_provider_credentials
+    resolved = resolve_api_key_provider_credentials("freemaxxing")
+    assert resolved["api_key"] == m.local_token()
+    assert resolved["base_url"] == p.base_url
+    req = urllib.request.Request(p.base_url + "/models", headers={"Authorization": "Bearer " + m.local_token()})
+    with urllib.request.urlopen(req, timeout=3) as response:
+        assert json.load(response)["data"][0]["id"] == "freemaxxing"
+    assert m.pool.count() == 0
+else:
+    assert m._listener is None
+    assert "FREEMAXXING_API_KEY" not in os.environ
+m.stop_proxy()
+'''
+    env = dict(os.environ)
+    for key in list(env):
+        if key.startswith('FREEMAXXING_'):
+            env.pop(key)
+    env.update(HERMES_HOME=str(tmp_path), FREEMAXXING_ENABLED=enabled, FREEMAXXING_PORT='0',
+               FM_AUTH_FIRST='1' if auth_first else '0', NO_PROXY='127.0.0.1,localhost')
+    result = subprocess.run([sys.executable, '-c', script], cwd=ROOT, env=env,
+                            text=True, encoding='utf-8', capture_output=True, timeout=45)
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
<img width="1448" height="1086" alt="Freemaxxing provider" src="https://github.com/user-attachments/assets/106813d8-714f-48c3-b189-0946b93ec95f"/>

## Freemaxxing

Freemaxxing is an **opt-in Hermes model-provider plugin** that turns multiple free inference sources into one stable `provider: freemaxxing`, `model: freemaxxing` route. It is designed for high-volume Hermes use without silently falling through to paid inference, while making provider/model failures recoverable inside the routing layer.

**Plugin-only. Disabled by default. No additions to Hermes core.** The free Mixture-of-Agents (MoA) example uses Hermes' existing MoA engine rather than introducing another agent runtime.

## Implementation

Current implementation: [`18e41e88c4b0e00157865a5fc4316af00e214615`](https://github.com/NousResearch/hermes-agent/commit/18e41e88c4b0e00157865a5fc4316af00e214615), based on [`9dd6634c5635321cf38840cc30e9b51226689128`](https://github.com/NousResearch/hermes-agent/commit/9dd6634c5635321cf38840cc30e9b51226689128).

The PR is one coherent implementation commit: **15 files, 2,364 additions, no deletions**. All production code is under [`plugins/model-providers/freemaxxing/`](https://github.com/NousResearch/hermes-agent/tree/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing), plus two focused files under `tests/plugins/model_providers/`.

There are **no modifications to `providers/`, `agent/`, `hermes_cli/`, gateway/session code, dependencies, workflows, or global configuration**. Existing provider discovery and generic credential resolution are the host integration points. The plugin does not patch the core loader.

The previous five-commit implementation head `5557b2ea43b6225551e9aad64f926213740741bd` is preserved at `archive/85631-pre-plugin-only-5557b2ea`. The restack removed the earlier core-loader modification from this proposal while retaining #85631 as the canonical carrier.

## Complete change map

| Files | Responsibility |
|---|---|
| [`plugin.yaml`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/plugin.yaml), [`__init__.py`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/__init__.py) | Model-provider manifest, static discovery metadata, explicit activation, existing-host registration bridge, local capability, provider enrollment, scoped credential resolution, multiplex refusal, and optional local fallback. |
| [`policy.py`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/policy.py) | Provider/model admission, current-price validation, zero-price dispatch policy, typed failures, URL restrictions, retry-reset parsing, and resource limits. |
| [`pool.py`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/pool.py) | Model-level candidates, account/model cooldown separation, background single-flight catalog refresh, credential-bound catalog grants, negative caching, bounded session affinity, and credential-refresh serialization. |
| [`transport.py`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/transport.py), [`upstream.py`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/upstream.py) | Reusable HTTP connections, bounded reads/timeouts, redirect refusal, upstream status classification, final pre-I/O admission, and catalog revalidation after authentication refresh. |
| [`protocol.py`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/protocol.py) | JSON completion validation, incremental SSE parsing, complete tool-call validation, terminal-event checks, and atomic replay of exactly one accepted generation. |
| [`server.py`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/server.py), [`handler.py`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/handler.py) | Immutable loopback listener authority, bounded HTTP/inference concurrency, bearer authentication, lazy pool initialization, per-request runtime guard, request validation, failover, health/metadata endpoints, and typed exhaustion. |
| [`router.py`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/router.py), [`proxy.py`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/proxy.py) | Plugin-local public composition and compatibility exports. |
| [`README.md`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/README.md), [`examples/free-moa.yaml`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/examples/free-moa.yaml) | Activation, provider/billing qualifications, recovery behavior, operational limits, verification instructions, references, and the disabled existing-engine MoA preset. |
| [`test_freemaxxing_proxy.py`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/tests/plugins/model_providers/test_freemaxxing_proxy.py) | Real loopback HTTP contracts, disposable upstreams, failover/policy/race regressions, resource limits, and positive controls. |
| [`test_freemaxxing_registration.py`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/tests/plugins/model_providers/test_freemaxxing_registration.py) | Registration/enrollment/profile tests, preset assertions, and fresh-subprocess native-host integration cases. |

## Provider coverage

Set `FREEMAXXING_ENABLED=1` before launching Hermes, then select the Freemaxxing provider/model. Leaving it unset or setting it to `0` keeps discovery metadata-only: no listener, upstream credential resolution, catalog request, or worker. Restart after changing enrollment or listener configuration.

When active, the endpoint binds to `127.0.0.1` and uses an ephemeral port by default. A random process-local bearer protects inference and authenticated metadata; upstream API keys are never reused as the local listener capability.

| Route | Enrollment and admission |
|---|---|
| **OpenCode Free** | Keyless supported Chat Completions free routes. No real upstream bearer is sent. Responses/Messages-only SKUs are excluded rather than sent to the wrong API. |
| **OpenRouter Free** | Existing `OPENROUTER_API_KEY`; `:free` routes or `openrouter/free`; contradictory pricing rejected; every dispatch receives a zero `provider.max_price` cap. |
| **Nous Portal Free** | Explicit free-only account enrollment; existing Hermes OAuth resolver or `NOUS_API_KEY`; fresh authenticated zero input/output pricing. The old static DeepSeek Flash allowlist is removed. |
| **Groq** | Explicit free-tier enrollment plus `GROQ_API_KEY`. |
| **Gemini** | Explicit free-tier enrollment plus `GEMINI_API_KEY` or `GOOGLE_API_KEY`. |
| **Mistral** | Explicit free-tier enrollment plus `MISTRAL_API_KEY`. |
| **Local fallback** | Explicit numeric-loopback `FREEMAXXING_LOCAL_BASE_URL`, with optional comma-separated `FREEMAXXING_LOCAL_MODELS`. |

Additional hosted accounts are enrolled with a comma-separated subset in `FREEMAXXING_FREE_TIER_PROVIDERS`, for example `nous-portal,groq`. A provider credential alone does not enroll an allowance-based account.

For Nous and allowance providers, this enrollment is an operator assertion that paid use/overage is disabled at the provider account. The plugin cannot inspect or configure external billing. Promotions, allowances, and provider availability can change; the router therefore combines account-level enrollment with route-level admission rather than treating a model name as spending authority.

## Free-only dispatch boundary

Automatic aliases, explicit model IDs, qualified provider/model selections, auxiliary calls, and MoA calls routed through Freemaxxing converge on the same final dispatch guard.

Unknown providers are not implicitly free. Nous routes require fresh, unambiguous zero input/output pricing; missing, expired, malformed, contradictory, or nonzero evidence cannot authorize dispatch. Conflicting duplicate catalog entries are excluded rather than resolved by arrival order.

OpenRouter dispatch replaces caller routing overrides with the plugin's zero-price policy. Upstream fallback lists, paid extensions, and server-executed tools are refused. Client-executed function tools remain supported, but Freemaxxing never executes them. Global Hermes fallbacks and non-model services configured outside Freemaxxing remain outside this plugin's spending boundary.

Catalog authority belongs to the exact endpoint and credential that obtained it. Credential rotation invalidates the prior catalog grant; late publication from an older credential cannot authorize the replacement generation. Authentication refresh is serialized against the actual failed credential so concurrent waiters reuse the completed refresh rather than independently rotating authority.

Scoped secret misses do not widen to unrelated process credentials. Multiplex-profile runtimes are refused before upstream credential resolution, and unknown scope state fails closed. The runtime guard is checked again on inference requests.

## Reliability and failover

Freemaxxing routes locally without spending another model call on routing. HTTP connections are pooled, successful route affinity is retained in a bounded cache, and catalogs refresh in bounded single-flight background workers.

Model-local and account-wide failures are separate coordinates. A broken/missing/incompatible model can fall through to another eligible model. An account-wide 429 cools down the account and respects its complete `Retry-After`, rather than repeatedly attempting other models under the same exhausted quota. Concurrent success cannot erase a newer account cooldown.

Capability/context failures can fail over. Invalid caller requests are not blindly replayed across providers. Catalog failures do not automatically poison healthy inference routes. Empty catalogs and refresh failures are negatively cached/backed off, while expired pricing cannot silently renew spending authority.

The catalog/auth lock-order regression is explicitly covered: catalog-failure handling cannot hold backend state while waiting for credential authority.

### Operational bounds

| Control | Default / bound |
|---|---|
| Recovery budget | `FREEMAXXING_REQUEST_TIMEOUT=90` seconds |
| Candidate attempts | `FREEMAXXING_MAX_ATTEMPTS=12` |
| Concurrent inference | `FREEMAXXING_CONCURRENCY=8` |
| Connection / read-idle / catalog budget | 5 / 25 / 4 seconds |
| Listener port | `FREEMAXXING_PORT=0` (ephemeral) |
| Request / response / catalog bytes | 1,000,000 / 10,000,000 / 2,000,000 |
| SSE line / event bytes | 1,000,000 / 2,000,000 |
| Session-affinity entries | 1,024 |

Capacity exhaustion is refused instead of entering an unbounded queue. Redirects are refused. Provider credentials and raw upstream error bodies are not returned in plugin error responses. The recovery deadline is checked between I/O operations; in-flight reads remain bounded by their assigned transport timeout.

Public `GET /v1/healthz` exposes liveness only. Authenticated `GET /healthz` exposes route health, while authenticated `GET /v1/models` is metadata-only and does not initialize upstream credentials or catalogs.

## Atomic streaming recovery

Streaming uses **atomic replay**. The router buffers and validates one complete upstream SSE generation before committing downstream HTTP 200. Keepalives, malformed JSON/error envelopes, incomplete tool arguments, missing terminal completion, and changing completion/tool identities cannot commit a successful response.

An interrupted upstream generation can therefore fail over before partial assistant text or tool calls escape. Only the complete accepted stream is replayed, and replay stops at its terminal event instead of forwarding trailing bytes from another generation.

This deliberately trades time to first visible token for transparent pre-publication recovery. It is not live token-by-token passthrough. Recovery remains bounded by available eligible routes and the configured attempt/time budget.

When no eligible free route completes, the endpoint returns a typed retryable `503` with `Retry-After`, never fabricated assistant content or a false `[DONE]`. The plugin does not execute/replay tools or mutate Hermes transcripts/session state.

## Free MoA

[`examples/free-moa.yaml`](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/examples/free-moa.yaml) supplies a named **disabled-by-default** preset for Hermes' existing MoA runtime.

Its reference routes are:

- `opencode-free::freemaxxing`
- `openrouter::freemaxxing`
- `nous-portal::freemaxxing`

The acting aggregator uses `freemaxxing`. All advisor and aggregator calls therefore traverse the same Freemaxxing admission boundary. Qualified selectors keep provider pools distinct while models are discovered dynamically; exact `provider-name::model-id` pins are also supported.

The preset uses once-per-user-turn fan-out, a 45-second reference timeout, a 1,024-token reference output bound, and loud degraded-reference handling. It does not create another agent engine or fan out on every tool iteration. Provider diversity is not represented as proof of distinct underlying model families or as an evaluated quality guarantee.

## Verification

Recorded isolated plugin-workspace verification, Python 3.13.5 / httpx 0.28.1:

```text
100 passed, 3 skipped in 4.74s
86% statement coverage
exit code 0
```

The passing cases exercise real loopback HTTP dispatch with disposable upstream servers, connection reuse, authentication/profile boundaries, automatic and explicit free admission, pricing contradictions, account/model cooldowns, catalog/credential races, complete and interrupted SSE, tool-only positive controls, resource limits, and registration fixtures. No external model inference or provider-account mutation was performed in that run.

The three standalone-workspace skips are native-host subprocess cases that exercise Hermes provider discovery, both import orders, generic credential resolution, and authenticated local `/models` when run from a complete repository checkout.

The implementation pass also recorded clean `compileall`, staged `git diff --check`, the under-2,000-line file gate, and comparisons of uploaded plugin/test blob SHAs with the locally tested files.

Focused full-checkout command:

```sh
scripts/run_tests.sh tests/plugins/model_providers/test_freemaxxing_proxy.py tests/plugins/model_providers/test_freemaxxing_registration.py -q
```

Exact-head workflow receipts:

- [Canonical CI 33976743286](https://github.com/NousResearch/hermes-agent/actions/runs/33976743286)
- [Docker Build, Test, and Publish 33976742799](https://github.com/NousResearch/hermes-agent/actions/runs/33976742799)
- [Nix flake check 33976742782](https://github.com/NousResearch/hermes-agent/actions/runs/33976742782)

## Interlocks

Related repository work remains intentionally separate:

- [#101448 — OpenCode model hygiene](https://github.com/NousResearch/hermes-agent/pull/101448), currently changing `hermes_cli/models.py`.
- [#102229 — fallback API-mode preservation](https://github.com/NousResearch/hermes-agent/pull/102229), currently changing `agent/chat_completion_helpers.py`.
- [#102148 — fallback API-mode issue](https://github.com/NousResearch/hermes-agent/issues/102148).

Those core paths are not part of this plugin PR. Freemaxxing keeps its supported Chat Completions qualification and free-route policy plugin-local rather than duplicating those core repairs.

Provider contracts, activation details, billing qualifications, recovery semantics, and source references are documented in the [plugin README](https://github.com/NousResearch/hermes-agent/blob/18e41e88c4b0e00157865a5fc4316af00e214615/plugins/model-providers/freemaxxing/README.md).