### PR TITLE
fix(desktop): keep repo pane aligned with the active session

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -225,6 +225,33 @@ describe('useProjectTree', () => {
     expect(readDir).toHaveBeenLastCalledWith('/b')
   })
 
+  it('keeps a new profile tree when an old same-path request settles last', async () => {
+    let resolveOldProfile: ((value: HermesReadDirResult) => void) | undefined
+    readDir.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveOldProfile = resolve
+        })
+    )
+    readDir.mockResolvedValueOnce(ok([{ name: 'new-profile', path: '/workspace/new-profile', isDirectory: false }]))
+
+    $connection.set({ baseUrl: 'gateway-a', mode: 'local', profile: 'a' } as never)
+    const { result } = renderHook(() => useProjectTree('/workspace'))
+    await waitFor(() => expect(readDir).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      $connection.set({ baseUrl: 'gateway-b', mode: 'local', profile: 'b' } as never)
+    })
+    await waitFor(() => expect(result.current.data[0]?.name).toBe('new-profile'))
+
+    await act(async () => {
+      resolveOldProfile?.(ok([{ name: 'old-profile', path: '/workspace/old-profile', isDirectory: false }]))
+      await Promise.resolve()
+    })
+
+    expect(result.current.data.map(node => node.name)).toEqual(['new-profile'])
+  })
+
   it('falls back to the sanitized workspace dir when the session cwd is gone', async () => {
     const sanitizeWorkspaceCwd = vi.fn(async () => ({ cwd: '/home/me/projects', sanitized: true }))
     readDir.mockImplementation(async path => {

--- a/apps/desktop/src/app/right-sidebar/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.test.tsx
@@ -1,8 +1,14 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesReadDirResult } from '@/global'
-import { $connection, setCurrentCwd } from '@/store/session'
+import {
+  $connection,
+  commitWorkspaceCwdForSelectedSession,
+  releaseWorkspaceCwdOwner,
+  setCurrentCwd,
+  setSelectedStoredSessionId
+} from '@/store/session'
 
 import { resetProjectTreeState } from './files/use-project-tree'
 
@@ -17,6 +23,8 @@ function installBridge() {
 describe('RightSidebarPane', () => {
   beforeEach(() => {
     $connection.set(null)
+    setSelectedStoredSessionId(null)
+    commitWorkspaceCwdForSelectedSession('')
     resetProjectTreeState()
     readDir.mockReset()
     readDir.mockResolvedValue({ entries: [{ isDirectory: false, name: 'README.md', path: '/repo/README.md' }] })
@@ -53,5 +61,71 @@ describe('RightSidebarPane', () => {
 
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull())
     expect(readDir).not.toHaveBeenCalled()
+  })
+
+  it('hides the previous repo while the selected session workspace is unresolved', async () => {
+    setSelectedStoredSessionId('session-a')
+    commitWorkspaceCwdForSelectedSession('/repo-a')
+    readDir.mockResolvedValueOnce({
+      entries: [{ isDirectory: false, name: 'a.txt', path: '/repo-a/a.txt' }]
+    })
+
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith('/repo-a'))
+    expect(screen.getByText('repo-a')).toBeTruthy()
+
+    act(() => {
+      setSelectedStoredSessionId('session-b')
+      releaseWorkspaceCwdOwner()
+    })
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull())
+    expect(screen.queryByText('repo-a')).toBeNull()
+    expect(readDir).toHaveBeenCalledTimes(1)
+  })
+
+  it('follows rapid session switches and ignores an old repo load that settles last', async () => {
+    let resolveFirstA: ((value: HermesReadDirResult) => void) | undefined
+    readDir.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveFirstA = resolve
+        })
+    )
+    readDir.mockResolvedValueOnce({
+      entries: [{ isDirectory: false, name: 'b.txt', path: '/repo-b/b.txt' }]
+    })
+    readDir.mockResolvedValueOnce({
+      entries: [{ isDirectory: false, name: 'latest-a.txt', path: '/repo-a/latest-a.txt' }]
+    })
+
+    setSelectedStoredSessionId('session-a')
+    commitWorkspaceCwdForSelectedSession('/repo-a')
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith('/repo-a'))
+
+    act(() => {
+      setSelectedStoredSessionId('session-b')
+      releaseWorkspaceCwdOwner()
+      commitWorkspaceCwdForSelectedSession('/repo-b')
+    })
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith('/repo-b'))
+    expect(screen.getByText('repo-b')).toBeTruthy()
+
+    act(() => {
+      setSelectedStoredSessionId('session-a')
+      releaseWorkspaceCwdOwner()
+      commitWorkspaceCwdForSelectedSession('/repo-a')
+    })
+    await waitFor(() => expect(readDir.mock.calls.filter(([path]) => path === '/repo-a')).toHaveLength(2))
+    expect(screen.getByText('repo-a')).toBeTruthy()
+
+    await act(async () => {
+      resolveFirstA?.({ entries: [{ isDirectory: false, name: 'stale-a.txt', path: '/repo-a/stale-a.txt' }] })
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('repo-a')).toBeTruthy()
+    expect(screen.queryByText('repo-b')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -13,7 +13,7 @@ import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { openPreview } from '@/store/preview'
-import { $currentCwd } from '@/store/session'
+import { $currentCwd, $selectedStoredSessionId, $workspaceCwdOwner } from '@/store/session'
 
 import { SidebarPanelLabel } from '../shell/sidebar-label'
 
@@ -30,12 +30,16 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
   const r = t.rightSidebar
   const panesFlipped = useStore($panesFlipped)
   const currentCwd = useStore($currentCwd).trim()
+  const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  const workspaceCwdOwner = useStore($workspaceCwdOwner)
 
-  // The file tree is simply "browse the session's working directory". If the
-  // session has a cwd — a repo, a sibling worktree, or any folder — show it. A
-  // bare/detached chat (resolveNewSessionCwd → '') has none, so it shows the
-  // empty hint instead of whatever dir Hermes happens to run from.
-  const hasWorkspace = Boolean(currentCwd)
+  // `$currentCwd` deliberately retains the previous session's path while a
+  // switch settles so keep-alive workspace panes do not lose their cached
+  // state. Only expose it once ownership says it belongs to the visible
+  // session; hidden/background sessions may keep updating their own state but
+  // must never publish a repository into this shared pane.
+  const hasWorkspace =
+    Boolean(currentCwd) && (workspaceCwdOwner ?? null) === (selectedStoredSessionId ?? null)
 
   const {
     collapseAll,


### PR DESCRIPTION
- show the shared Repo pane only when the retained workspace path belongs to the currently selected session
- prevent hidden sessions and stale async directory reads from restoring the previous session's repository
- cover unresolved, rapid A→B→A, and same-path cross-profile session switches

Tests:
- Desktop renderer typecheck
- ESLint on changed files
- 18 focused right-sidebar/project-tree tests
- production Desktop build (implementation subagent)

💘 Generated with Crush