### PR TITLE
test(webhook): Task 19 real-listener probe — final integration still pending

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# campaign authorship

--- a/tests/e2e/test_webhook_surface.py
+++ b/tests/e2e/test_webhook_surface.py
@@ -1,0 +1,136 @@
+"""Cross-surface webhook validation (Task 19).
+
+Starts the real webhook adapter's aiohttp listener via ``connect()`` on a
+free port with an isolated profile home, then exercises the deployed surface
+end-to-end over real HTTP:
+
+- listener lifecycle (connect/disconnect + liveness endpoint)
+- intake contract (202 accepted, unknown-route 404)
+- same-route delivery retry suppression (idempotency)
+
+This proves the surface an operator actually deploys, not a mocked handler.
+Fan-out (cross-route execute), 409 conflict, and the /ready readiness endpoint
+are covered by their own task PRs' focused tests and land with those PRs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter
+
+
+def _free_port() -> int:
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _github_sig(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+@pytest.fixture
+def adapter(tmp_path, monkeypatch):
+    # Isolate the dynamic-routes home so the test never touches the real
+    # operator's webhook_subscriptions.json.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": _free_port(),
+                "routes": {
+                    "pr": {
+                        "secret": "e2e-secret",
+                        "signature_mode": "github",
+                        "events": ["push"],
+                        "prompt": "PR {x}",
+                        "deliver": "log",
+                    }
+                },
+            },
+        )
+    )
+
+
+class TestCrossSurfaceWebhook:
+    @pytest.mark.asyncio
+    async def test_listener_lifecycle_and_liveness(self, adapter):
+        assert await adapter.connect() is True
+        try:
+            import aiohttp
+            host = adapter._host
+            port = adapter._port
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"http://{host}:{port}/health") as resp:
+                    assert resp.status == 200
+                    data = await resp.json()
+                    assert data["status"] == "ok"
+                    assert data["platform"] == "webhook"
+                    # Never leaks the route secret.
+                    assert "e2e-secret" not in json.dumps(data)
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_intake_contract_over_real_http(self, adapter):
+        assert await adapter.connect() is True
+        try:
+            import aiohttp
+            host = adapter._host
+            port = adapter._port
+            base = f"http://{host}:{port}"
+            body = json.dumps({"x": 1}).encode()
+            sig = _github_sig(body, "e2e-secret")
+            headers = {
+                "Content-Type": "application/json",
+                "X-Hub-Signature-256": sig,
+                "X-GitHub-Event": "push",
+                "X-GitHub-Delivery": "e2e-delivery",
+            }
+            async with aiohttp.ClientSession() as session:
+                # Accepted
+                async with session.post(f"{base}/webhooks/pr", data=body, headers=headers) as resp:
+                    assert resp.status == 202
+                    data = await resp.json()
+                    assert data["status"] == "accepted"
+                # Unknown route -> 404
+                async with session.post(f"{base}/webhooks/nope", data=body, headers=headers) as resp:
+                    assert resp.status == 404
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_same_route_retry_suppressed_over_real_http(self, adapter):
+        assert await adapter.connect() is True
+        try:
+            import aiohttp
+            host = adapter._host
+            port = adapter._port
+            base = f"http://{host}:{port}"
+            body = json.dumps({"x": 1}).encode()
+            sig = _github_sig(body, "e2e-secret")
+            headers = {
+                "Content-Type": "application/json",
+                "X-Hub-Signature-256": sig,
+                "X-GitHub-Event": "push",
+                "X-GitHub-Delivery": "e2e-retry",
+            }
+            async with aiohttp.ClientSession() as session:
+                async with session.post(f"{base}/webhooks/pr", data=body, headers=headers) as resp:
+                    assert resp.status == 202
+                # Retry with the same delivery id -> duplicate (200), not re-run.
+                async with session.post(f"{base}/webhooks/pr", data=body, headers=headers) as resp:
+                    assert resp.status == 200
+                    data = await resp.json()
+                    assert data["status"] == "duplicate"
+        finally:
+            await adapter.disconnect()


### PR DESCRIPTION
Part of #84834 — Webhook Revolution Task 19 evidence lane.

## Current truth

This branch is a useful **real-listener E2E probe** and is **ready for review**, but it is **not yet the Task 19 final integration candidate** defined by the campaign contract.

What this head proves:

- starts the real aiohttp listener via `connect()` on an ephemeral port;
- exercises liveness over real HTTP;
- proves accepted intake and unknown-route behavior;
- proves a same-route retry suppression path.

What it does **not** yet prove or assemble:

- Tasks 1–18 integrated exactly once by stable patch ID;
- Task 5 re-extracted/retargeted against the final integrated topology;
- canonical Task 10 current-main implementation from #90236;
- Task 9 signature/auth composition on top of that exact intake owner;
- Task 12 session/interaction policy (#90304);
- Task 13 terminal-partial fan-out/callback/completion truth;
- Task 15 CLI/REST management integration;
- Task 16 web/desktop parity;
- Task 17 full deployment/readiness contract;
- Task 18 mechanically true docs/recipes;
- complete focused matrix, frontend/doc verification, secret-egress scan, 2,000-line gate, and terminal conquest receipt.

Per the campaign execution model, Task 19 is the **only** lane allowed to assemble Tasks 1–18. Focused tests in sibling PRs are inputs to Task 19, not substitutes for the final integrated proof.

## Required before merge authorization as the final Task 19 candidate

1. Wait for each implementation lane to have an exact published candidate and passing receipt.
2. Rebuild this branch from current `main` as the sole semantic integration topology, consuming verified lanes by stable patch ID rather than replaying stale campaign history.
3. Retarget the Task 5 extraction after all behavior-changing lanes are integrated.
4. Run the complete cross-surface matrix and real-listener probes against that exact tree.
5. Emit and commit the Task 19 dependency ledger + terminal conquest receipt.
6. Only then hand the exact Task 19 SHA to Task 20; Task 20 must not cherry-pick Tasks 1–18 again.

Ready for review now; final integration/merge authority remains gated on those receipts.