### PR TITLE
fix(deps): patch build-tool advisories

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -37,7 +37,7 @@ min-release-age-exclude[]=brace-expansion
 # js-yaml 4.3.1 includes fixes for GHSA-5p4m-2wfm-xmqj. remove when > 2wks old (rel 2026-07-31)
 min-release-age-exclude[]=js-yaml
 
-# nanoid 3.3.17 includes fixes for GHSA-2v37-7h3g-55p8. remove when > 2wks old (rel 2026-08-03)
+# nanoid 3.3.18 includes fixes for GHSA-2v37-7h3g-55p8. remove when > 2wks old (rel 2026-08-07)
 min-release-age-exclude[]=nanoid
 
 # mermaid 11.16.1 includes fixes for 5 GHSAs. remove when > 2wks old (rel 2026-08-04)

--- a/contributors/emails/hermes-agent@users.noreply.github.com
+++ b/contributors/emails/hermes-agent@users.noreply.github.com
@@ -1,0 +1,1 @@
+hermes-agent

--- a/package-lock.json
+++ b/package-lock.json
@@ -16482,9 +16482,9 @@
       }
     },
     "node_modules/sanitize-html/node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -16500,9 +16500,9 @@
       }
     },
     "node_modules/sanitize-html/node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -16519,7 +16519,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -18322,9 +18322,9 @@
       }
     },
     "node_modules/vite/node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -18340,9 +18340,9 @@
       }
     },
     "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -18359,7 +18359,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "mermaid": "11.16.1",
     "dompurify": "3.4.13",
     "ip-address": "10.3.1",
-    "nanoid@^3": "3.3.17",
+    "nanoid@^3": "3.3.18",
     "nanoid@^6": "6.0.0",
     "js-yaml@^4": "4.3.1",
     "undici@^6": "6.28.0",
     "undici@^7": "7.29.0",
-    "postcss": "8.5.23",
+    "postcss": "8.5.26",
     "tar": "7.5.22"
   },
   "engines": {


### PR DESCRIPTION
## Summary

- bump the nanoid 3.x override to 3.3.18
- bump the postcss override to 8.5.26
- update the lockfile entries and release-age comment consistently

## Verification

- `npm ci --ignore-scripts --no-audit`
- `npm audit --workspace web --json`: 0 vulnerabilities
- `npm audit --workspace ui-tui --json`: 0 vulnerabilities
- `npm audit --workspace web --omit=dev --json`: 0 vulnerabilities
- `npm audit --workspace ui-tui --omit=dev --json`: 0 vulnerabilities
- web typecheck, test (27 files / 197 tests), and build pass
- ui-tui `build:ink` and typecheck pass
- ui-tui test suite remains flaky/unrelated: 3 failures in the candidate run; baseline origin/main had 5 failures

The installed runtime checkout was not modified by this PR; it remains on the separately managed local `main` hotfix checkout.