### PR TITLE
fix(slack): stop identified peer bots from bypassing sender authorization

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -506,7 +506,18 @@ class GatewayAuthorizationMixin:
         }
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)
-            if allow_bots_var and _platform_gate_env(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
+            # Slack events with a user ID can use the same exact sender
+            # allowlist at both the adapter prefetch gate and this final gate.
+            # Keep the broad allow_bots fallback only for Workflow Builder/app
+            # events that carry no matchable user identity. Other platforms
+            # retain their established class-wide bot grant.
+            allow_class_grant = source.platform != Platform.SLACK or not user_id
+            if (
+                allow_class_grant
+                and allow_bots_var
+                and _platform_gate_env(allow_bots_var, "none").lower().strip()
+                in {"mentions", "all"}
+            ):
                 return True
 
         if not user_id:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5550,6 +5550,7 @@ class SlackAdapter(BasePlatformAdapter):
                 chat_type="dm" if is_dm else "group",
                 user_id=user_id,
                 user_name="",
+                is_bot=sender_is_bot,
             )
             if not _auth_fn(_source):
                 logger.warning(
@@ -6230,11 +6231,10 @@ class SlackAdapter(BasePlatformAdapter):
             user_name=user_name,
             thread_id=thread_ts,
             scope_id=str(team_id) if team_id else None,
-            # Slack Workflow Builder / app posts arrive as
-            # subtype=bot_message with user=None; flag them so the
-            # gateway SLACK_ALLOW_BOTS bypass can authorize them
-            # (they carry no user_id to match against the allowlist).
-            is_bot=bool(event.get("bot_id")) or event.get("subtype") == "bot_message",
+            # Reuse the identity resolved before the early authorization gate.
+            # This includes bot-user events lacking explicit bot_id/subtype
+            # markers, so both authorization boundaries apply one policy.
+            is_bot=sender_is_bot,
         )
 
         # Per-channel ephemeral prompt

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1687,6 +1687,47 @@ class TestIncomingDocumentHandling:
         adapter._app.client.files_info.assert_not_awaited()
         adapter.handle_message.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_bot_identity_is_consistent_at_early_and_final_auth_boundaries(
+        self,
+        adapter,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("SLACK_ALLOW_BOTS", "all")
+        seen_sources = []
+
+        class Runner:
+            def _is_user_authorized(self, source):
+                seen_sources.append(source)
+                return True
+
+            async def handle(self, event):
+                seen_sources.append(event.source)
+
+        runner = Runner()
+        adapter._message_handler = runner.handle
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_slack_message(
+            {
+                "type": "message",
+                "subtype": "bot_message",
+                "bot_id": "B_PEER",
+                "channel": "D123",
+                "channel_type": "im",
+                "user": "U_PEER_BOT",
+                "text": "peer request",
+                "ts": "1234567890.000002",
+            }
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        delivered_source = adapter.handle_message.await_args.args[0].source
+        assert len(seen_sources) == 1
+        assert seen_sources[0].user_id == delivered_source.user_id == "U_PEER_BOT"
+        assert seen_sources[0].is_bot is True
+        assert delivered_source.is_bot is True
+
 
     @pytest.mark.asyncio
     async def test_rich_text_quotes_and_lists_are_extracted(self, adapter):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1728,6 +1728,45 @@ class TestIncomingDocumentHandling:
         assert seen_sources[0].is_bot is True
         assert delivered_source.is_bot is True
 
+    @pytest.mark.asyncio
+    async def test_failed_bot_lookup_is_consistent_at_both_auth_boundaries(
+        self,
+        adapter,
+    ):
+        seen_sources = []
+
+        class Runner:
+            def _is_user_authorized(self, source):
+                seen_sources.append(source)
+                return True
+
+            async def handle(self, _event):
+                return None
+
+        adapter._message_handler = Runner().handle
+        adapter.handle_message = AsyncMock()
+        adapter._resolve_user_name = AsyncMock(return_value="Unknown")
+        adapter._app.client.users_info = AsyncMock(
+            side_effect=RuntimeError("lookup failed")
+        )
+
+        await adapter._handle_slack_message(
+            {
+                "type": "message",
+                "channel": "D123",
+                "channel_type": "im",
+                "user": "U_UNKNOWN",
+                "text": "request",
+                "ts": "1234567890.000003",
+            }
+        )
+
+        adapter._app.client.users_info.assert_awaited_once_with(user="U_UNKNOWN")
+        adapter.handle_message.assert_awaited_once()
+        delivered_source = adapter.handle_message.await_args.args[0].source
+        assert len(seen_sources) == 1
+        assert seen_sources[0].is_bot is delivered_source.is_bot is False
+
 
     @pytest.mark.asyncio
     async def test_rich_text_quotes_and_lists_are_extracted(self, adapter):

--- a/tests/gateway/test_slack_bot_auth_bypass.py
+++ b/tests/gateway/test_slack_bot_auth_bypass.py
@@ -39,13 +39,12 @@ def _make_bare_runner():
     return runner
 
 
-def _make_slack_bot_source():
-    # Workflow Builder / app posts: subtype=bot_message, user=None.
+def _make_slack_bot_source(user_id=None):
     return SessionSource(
         platform=Platform.SLACK,
         chat_id="C0123",
         chat_type="group",
-        user_id=None,
+        user_id=user_id,
         user_name="",
         is_bot=True,
     )
@@ -66,6 +65,18 @@ def test_slack_bot_authorized_when_allow_bots_all(monkeypatch):
     runner = _make_bare_runner()
     monkeypatch.setenv("SLACK_ALLOW_BOTS", "all")
     assert runner._is_user_authorized(_make_slack_bot_source()) is True
+
+
+@pytest.mark.parametrize("allow_bots", ["mentions", "all"])
+def test_identified_slack_bot_still_requires_sender_authorization(
+    monkeypatch, allow_bots
+):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", allow_bots)
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_TRUSTED_BOT")
+
+    assert runner._is_user_authorized(_make_slack_bot_source("U_TRUSTED_BOT")) is True
+    assert runner._is_user_authorized(_make_slack_bot_source("U_OTHER_BOT")) is False
 
 
 def test_slack_human_unaffected_by_bot_bypass(monkeypatch):

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -433,10 +433,10 @@ platforms:
       assistant_thread_titles: true
 
       # Accept messages posted by other Slack bots (default: "none").
-      # "none" ignores bots, "mentions" accepts a bot message only when
-      # that message itself @mentions Hermes, and "all" accepts every
-      # other bot. Hermes always ignores its own bot user to prevent
-      # self-echoes.
+      # "none" ignores bots, "mentions" accepts an authorized bot message
+      # only when that message itself @mentions Hermes, and "all" accepts
+      # every authorized bot. Hermes always ignores its own bot user to
+      # prevent self-echoes.
       allow_bots: "none"
 
       # Continuable-cron delivery surface (default: "thread").
@@ -456,7 +456,7 @@ platforms:
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |
 | `platforms.slack.extra.suggested_prompts` | `[]` | Up to four `{title, message}` prompts for Agent/Assistant DM entry points; accepts either a list or `{title, prompts}`. |
 | `platforms.slack.extra.assistant_thread_titles` | `true` | When `true`, names Agent/Assistant DM threads from the first user message. |
-| `platforms.slack.extra.allow_bots` | `"none"` | Controls messages from other Slack bots: `"none"` ignores them, `"mentions"` accepts a bot message only when **that message itself** @mentions Hermes, and `"all"` accepts all of them. Use `"mentions"` for the safest bot-to-bot collaboration mode. See [Accepting messages from other bots](#accepting-messages-from-other-bots-allow_bots). |
+| `platforms.slack.extra.allow_bots` | `"none"` | Controls messages from other Slack bots: `"none"` ignores them, `"mentions"` accepts an authorized bot message only when **that message itself** @mentions Hermes, and `"all"` accepts all authorized bots. Identified bots must also satisfy sender authorization; app events without a user ID use this bot opt-in directly. Use `"mentions"` for the safest bot-to-bot collaboration mode. See [Accepting messages from other bots](#accepting-messages-from-other-bots-allow_bots). |
 | `platforms.slack.extra.cron_continuable_surface` | `"thread"` | Delivery surface for [continuable cron jobs](../features/cron.md#flat-in-channel-continuation-slack). `"thread"` opens a dedicated thread per delivery (default); `"in_channel"` delivers flat into the channel timeline. Pair `in_channel` with `reply_in_thread: false` (and `require_mention: false`) so a plain channel reply continues the job. |
 
 The equivalent environment variable is `SLACK_ALLOW_BOTS=none|mentions|all`.

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -622,11 +622,19 @@ platforms:
       # "none" (default) — ignore all bot/app-authored messages
       # "mentions"       — accept a bot message only when THAT message
       #                    @mentions this bot
-      # "all"            — accept every bot message (except the bot's own)
+      # "all"            — accept every allowlisted bot message
+      #                    (except the bot's own)
       allow_bots: mentions
 ```
 
 Env equivalent: `SLACK_ALLOW_BOTS=none|mentions|all` (the config key wins when both are set). Unknown values are treated as `none`.
+
+For bot messages that carry a Slack user ID, `allow_bots` controls whether the
+message is considered, while the existing sender authorization still applies:
+add each peer bot's user ID to `SLACK_ALLOWED_USERS` (or use an explicit
+allow-all sender policy). Workflow Builder and app events without a matchable
+user ID continue to use the `allow_bots` opt-in because they cannot be matched
+against the sender allowlist.
 
 How `mentions` mode gates:
 


### PR DESCRIPTION
## What does this PR do?

Slack peer bots with a resolved user ID could be rejected by the adapter's early authorization gate or, once delivered, bypass the exact sender allowlist whenever `SLACK_ALLOW_BOTS` was `mentions` or `all`. This change carries the same resolved bot identity through both authorization boundaries and requires identified bots to pass the existing exact sender allowlist, while preserving the established fallback for identity-less Workflow Builder and app events.

### Symptom

An identified peer bot that was listed in `SLACK_ALLOWED_USERS` could reach the gateway, but an identified peer bot that was not listed could still pass final authorization under `SLACK_ALLOW_BOTS=mentions` or `all`. The early and final gates therefore made different decisions for the same sender identity.

### Impact

Slack operators could not express one consistent peer-bot sender policy: allowed peer bots could be dropped early, while unlisted identified bots could bypass the final sender authorization boundary.

### Bug Cause

**Trigger:** `plugins/platforms/slack/adapter.py` in `SlackAdapter._process_message` and `gateway/authz_mixin.py` in `GatewayAuthorizationMixin._is_user_authorized`

**Causal chain:**
1. The Slack adapter resolved a peer sender as a bot before its early authorization check.
2. The early `SessionSource` omitted that identity, while the final source marked the sender as a bot and the gateway treated `SLACK_ALLOW_BOTS=mentions|all` as a class-wide authorization grant.
3. The two gates disagreed, and identified peer bots either failed early or bypassed the exact sender allowlist at the final boundary.

**Why it is wrong:** `SLACK_ALLOW_BOTS` controls whether bot traffic is considered, but an identified Slack sender can and should be matched against the existing exact sender allowlist at both boundaries.

**Working sibling / contrast:** Identity-less Slack Workflow Builder and app events cannot match an exact sender ID, so they retain the established `SLACK_ALLOW_BOTS` fallback. Non-Slack bot authorization behavior is unchanged.

**Ruled out:** Interactive human actions are not affected because they deliberately construct sources with `is_bot=False` and continue through the human authorization path.

### Fix

Reuse the adapter's resolved `sender_is_bot` value in both the early and delivered `SessionSource`. Restrict Slack's class-wide bot grant to events without a matchable user ID, so identified bots continue through the existing platform and global sender allowlists. Add regression coverage for both authorization boundaries and the identity-less automation fallback.

## Related Issue

Fixes #85614

## Type of Change

- [x] Security fix

## Changes Made

- `plugins/platforms/slack/adapter.py` - propagate the resolved peer-bot identity consistently through early and final event sources.
- `gateway/authz_mixin.py` - require identified Slack bots to pass exact sender authorization while preserving identity-less automation fallback.
- `tests/gateway/test_slack.py` - cover early and final Slack source identity consistency.
- `tests/gateway/test_slack_bot_auth_bypass.py` - cover identified-bot denial and identity-less bot fallback behavior.

## How to Test

1. Configure `SLACK_ALLOW_BOTS=mentions` or `all` and an exact `SLACK_ALLOWED_USERS` list.
2. Verify an identified listed peer bot is admitted at both authorization boundaries and an identified unlisted peer bot is denied at both.
3. Run the affected test files (166 tests passed locally):

```bash
scripts/run_tests.sh tests/gateway/test_slack_bot_auth_bypass.py tests/gateway/test_slack.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is N/A because this change restores the existing authorization contract
- [x] `cli-config.yaml.example` is N/A because no configuration keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the change is platform-scoped to Slack authorization
- [x] Tool descriptions and schemas are N/A because no model tool behavior changed

## Screenshots / Logs

N/A - automated red-to-green authorization tests reproduce and verify both deterministic in-process policy mismatches.
