### PR TITLE
feat(webhook): run route completion scripts after the agent run (Webhook Feature Package)

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,2 +1,1 @@
 andrexibiza
-# campaign authorship

--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# campaign authorship

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -919,6 +919,7 @@ class WebhookAdapter(BasePlatformAdapter):
             "deliver_extra": self._render_delivery_extra(
                 route_config.get("deliver_extra", {}), payload
             ),
+            "completion_script": route_config.get("completion_script"),
         }
         self._delivery_info[session_chat_id] = deliver_config
         self._delivery_info_created[session_chat_id] = now
@@ -994,6 +995,35 @@ class WebhookAdapter(BasePlatformAdapter):
         row, so this never clobbers a ``compression``/``agent_close`` reason.
         """
         await self._end_webhook_session(event, event.source.chat_id)
+        await self._run_completion_script(event.source.chat_id, outcome)
+
+    async def _run_completion_script(self, session_chat_id: str, outcome: Any) -> None:
+        """Run a route's ``completion_script`` (if configured) after the run.
+
+        Uses the SAME sandboxed script runner as transform scripts
+        (profile scripts root, timeout, redacted output, no-shell Python
+        subprocess). The script receives the outcome envelope on stdin; its
+        return value is ignored — completion scripts are fire-and-forget
+        hooks, not a second delivery path (#80531).
+        """
+        delivery = self._delivery_info.get(session_chat_id, {})
+        script = delivery.get("completion_script")
+        if not script:
+            return
+        try:
+            envelope = {
+                "chat_id": session_chat_id,
+                "outcome": str(outcome)[:2000] if outcome is not None else None,
+            }
+            await asyncio.to_thread(
+                self._route_processor.run_route_script, script, envelope
+            )
+        except Exception:
+            # Completion scripts are best-effort; a failure must never break
+            # the already-finished run or its session closeout.
+            logger.exception(
+                "[webhook] completion_script failed for %s", session_chat_id
+            )
 
     async def _end_webhook_session(
         self, event: "MessageEvent", session_chat_id: str

--- a/tests/gateway/test_webhook_completion_scripts.py
+++ b/tests/gateway/test_webhook_completion_scripts.py
@@ -1,0 +1,59 @@
+"""Completion-script hook tests (Task 13, #80531).
+
+A route's ``completion_script`` runs after the agent run finishes (the true
+end of the run), using the same sandboxed script runner as transform scripts.
+Its return value is ignored — it is a fire-and-forget hook, never a second
+delivery path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from unittest.mock import MagicMock
+
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter
+
+
+def _adapter(routes, **extra):
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"host": "127.0.0.1", "port": 0, "routes": routes, **extra},
+        )
+    )
+
+
+class TestCompletionScript:
+    def test_no_script_is_noop(self):
+        adapter = _adapter({"r": {"secret": "s", "prompt": "p"}})
+        adapter._delivery_info["webhook:r:d1"] = {}
+        # Should not raise and should not invoke the script runner.
+        adapter._route_processor = MagicMock()
+        import asyncio
+        asyncio.run(adapter._run_completion_script("webhook:r:d1", "done"))
+        adapter._route_processor.run_route_script.assert_not_called()
+
+    def test_script_is_invoked_with_envelope(self):
+        adapter = _adapter({"r": {"secret": "s", "prompt": "p"}})
+        adapter._delivery_info["webhook:r:d1"] = {"completion_script": "hook.py"}
+        adapter._route_processor = MagicMock()
+        adapter._route_processor.run_route_script = MagicMock(return_value=(True, {}))
+        import asyncio
+        asyncio.run(adapter._run_completion_script("webhook:r:d1", "done"))
+        adapter._route_processor.run_route_script.assert_called_once()
+        args = adapter._route_processor.run_route_script.call_args[0]
+        assert args[0] == "hook.py"
+        assert args[1]["chat_id"] == "webhook:r:d1"
+
+    def test_script_failure_is_best_effort(self):
+        adapter = _adapter({"r": {"secret": "s", "prompt": "p"}})
+        adapter._delivery_info["webhook:r:d1"] = {"completion_script": "hook.py"}
+        adapter._route_processor = MagicMock()
+        adapter._route_processor.run_route_script = MagicMock(
+            side_effect=RuntimeError("boom")
+        )
+        import asyncio
+        # Must not raise.
+        asyncio.run(adapter._run_completion_script("webhook:r:d1", "done"))


### PR DESCRIPTION
Part of #84834 — Webhook Feature Package completion-script lane. Related #80531.

## Owned contract

A route's `completion_script` runs from the true end-of-run `on_processing_complete` seam, using the same sandboxed route-script runner as transform scripts: profile scripts root, bounded timeout, redacted output, no-shell Python subprocess. Its return value is ignored; failure is best-effort and must not break an already-finished run or session closeout.

This lane owns the true-completion script seam. It does **not** own callback transport (#85675) or final Task 19 composition (#85640).

## Current review disposition

The old profile-allowlist finding was valid for an earlier extraction snapshot but is stale against current `main`. Current `gateway/platforms/webhook.py` owns `_resolve_request_profile` inline and passes `multiplex_profile_allowlist` into `profiles_to_serve`; this PR's effective feature is completion-script storage/execution, not profile admission.

The live head is already narrow: `gateway/platforms/webhook.py`, `tests/gateway/test_webhook_completion_scripts.py`, plus the contributor mapping inherited from the old merge base. The contributor blob is byte-identical to current main (`01c4cfb74a35b5a11ea890f9d67ae52d2c17aeec`) and is not feature ownership.

## Exact-head verification

At `52b636c944d3d381d4791fa76797f3fc5efad8dc`:

- CI `32393390874` — **success**
- Docker `32393389962` — **success**
- Nix `32393389953` — **success**

These receipts are attached directly to this head.

## Topology

Canonical composition remains:

`#85002 → #90236 → #85318 → #90304 → #85644 → #85638 → #85640`

#85645 and #85675 are verified side authorities consumed by #85640 rather than alternate Task 19 owners. Final composition should preserve the route-config → `_delivery_info` → completion-runner ownership and keep callback transport separate.