### PR TITLE
fix(kanban): make workspace provenance explicit

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2098,8 +2098,17 @@ def _cmd_claim(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
-        workspace = kb.resolve_workspace(task)
-        kb.set_workspace_path(conn, task.id, str(workspace))
+        if task.workspace_kind == "worktree":
+            workspace, resolved_branch_name = kb._resolve_worktree_workspace(task)
+        else:
+            workspace = kb.resolve_workspace(task)
+            resolved_branch_name = task.branch_name
+        kb.set_workspace_path(
+            conn,
+            task.id,
+            str(workspace),
+            branch_name=resolved_branch_name,
+        )
     print(f"Claimed {task.id}")
     print(f"Workspace: {workspace}")
     return 0

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1572,6 +1572,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             created_by=args.created_by or _profile_author(),
             workspace_kind=ws_kind,
             workspace_path=ws_path,
+            requested_workspace=requested_workspace,
             branch_name=branch_name,
             project_id=getattr(args, "project", None),
             tenant=args.tenant,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -333,7 +333,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
     p_create.add_argument("--parent", action="append", default=[],
                           help="Parent task id (repeatable)")
-    p_create.add_argument("--workspace", default="scratch",
+    p_create.add_argument("--workspace", default=None,
                           help="scratch | worktree | worktree:<path> | dir:<path> "
                                "(default: scratch)")
     p_create.add_argument("--branch", default=None,
@@ -1541,7 +1541,8 @@ def _cmd_assignees(args: argparse.Namespace) -> int:
 
 def _cmd_create(args: argparse.Namespace) -> int:
     try:
-        ws_kind, ws_path = _parse_workspace_flag(args.workspace)
+        requested_workspace = args.workspace
+        ws_kind, ws_path = _parse_workspace_flag(requested_workspace or "scratch")
         branch_name = _parse_branch_flag(getattr(args, "branch", None))
     except argparse.ArgumentTypeError as exc:
         print(f"kanban: {exc}", file=sys.stderr)
@@ -1588,6 +1589,11 @@ def _cmd_create(args: argparse.Namespace) -> int:
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
+    from hermes_cli.kanban_workspace import supersession_warning
+
+    workspace_warning = supersession_warning(requested_workspace, task)
+    if workspace_warning:
+        print(f"kanban: warning: {workspace_warning}", file=sys.stderr)
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
     else:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1590,9 +1590,10 @@ def _cmd_create(args: argparse.Namespace) -> int:
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
+        created_requested_workspace = kb.get_created_requested_workspace(conn, task_id)
     from hermes_cli.kanban_workspace import supersession_warning
 
-    workspace_warning = supersession_warning(requested_workspace, task)
+    workspace_warning = supersession_warning(created_requested_workspace, task)
     if workspace_warning:
         print(f"kanban: warning: {workspace_warning}", file=sys.stderr)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3127,6 +3127,7 @@ def create_task(
     created_by: Optional[str] = None,
     workspace_kind: str = "scratch",
     workspace_path: Optional[str] = None,
+    requested_workspace: Optional[str] = None,
     branch_name: Optional[str] = None,
     tenant: Optional[str] = None,
     priority: int = 0,
@@ -3507,6 +3508,10 @@ def create_task(
                         "status": task_status,
                         "parents": list(parents),
                         "tenant": tenant,
+                        # Preserve the caller's pre-normalization request as
+                        # separate creation provenance. The established fields
+                        # below remain the normalized creation state.
+                        "requested_workspace": requested_workspace,
                         "workspace_kind": workspace_kind,
                         "workspace_path": workspace_path,
                         "branch_name": branch_name,
@@ -7771,13 +7776,59 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
 
 
 def set_workspace_path(
-    conn: sqlite3.Connection, task_id: str, path: Path | str
-) -> None:
+    conn: sqlite3.Connection,
+    task_id: str,
+    path: Path | str,
+    *,
+    branch_name: Optional[str] = None,
+) -> bool:
+    """Persist a claim-resolved workspace and its provenance atomically.
+
+    Emit ``workspace_resolved`` only when resolution changes the persisted
+    path. The row update and event share one transaction, so history cannot
+    claim a resolution whose task update rolled back. Returns whether the path
+    changed.
+    """
+    resolved_path = str(path)
     with write_txn(conn):
+        row = conn.execute(
+            "SELECT workspace_path, branch_name, current_run_id "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"unknown task: {task_id}")
+
+        previous_path = row["workspace_path"]
+        resolved_branch = branch_name if branch_name is not None else row["branch_name"]
+        if previous_path == resolved_path:
+            if branch_name is not None and branch_name != row["branch_name"]:
+                conn.execute(
+                    "UPDATE tasks SET branch_name = ? WHERE id = ?",
+                    (branch_name, task_id),
+                )
+            return False
+
         conn.execute(
-            "UPDATE tasks SET workspace_path = ? WHERE id = ?",
-            (str(path), task_id),
+            "UPDATE tasks SET workspace_path = ?, branch_name = ? WHERE id = ?",
+            (resolved_path, resolved_branch, task_id),
         )
+        _append_event(
+            conn,
+            task_id,
+            "workspace_resolved",
+            {
+                "previous_path": previous_path,
+                "resolved_path": resolved_path,
+                "branch_name": resolved_branch,
+            },
+            run_id=(
+                int(row["current_run_id"])
+                if row["current_run_id"] is not None
+                else None
+            ),
+        )
+    return True
 
 
 def set_branch_name(
@@ -9839,10 +9890,22 @@ def _dispatch_once_locked(
             if auto:
                 result.auto_blocked.append(claimed.id)
             continue
-        # Persist the resolved workspace path so the worker can cd there.
-        set_workspace_path(conn, claimed.id, str(workspace))
-        if claimed.workspace_kind == "worktree":
-            set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+        # Persist the resolved workspace and branch together with the provenance
+        # event so readers never observe a path/branch pair from different
+        # claim-resolution states.
+        resolved_branch = (
+            resolved_branch_name
+            or (claimed.branch_name or "").strip()
+            or f"wt/{claimed.id}"
+            if claimed.workspace_kind == "worktree"
+            else None
+        )
+        set_workspace_path(
+            conn,
+            claimed.id,
+            str(workspace),
+            branch_name=resolved_branch,
+        )
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
@@ -9966,10 +10029,22 @@ def _dispatch_once_locked(
             if auto:
                 result.auto_blocked.append(claimed.id)
             continue
-        # Persist the resolved workspace path so the worker can cd there.
-        set_workspace_path(conn, claimed.id, str(workspace))
-        if claimed.workspace_kind == "worktree":
-            set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+        # Persist the resolved workspace and branch together with the provenance
+        # event so readers never observe a path/branch pair from different
+        # claim-resolution states.
+        resolved_branch = (
+            resolved_branch_name
+            or (claimed.branch_name or "").strip()
+            or f"wt/{claimed.id}"
+            if claimed.workspace_kind == "worktree"
+            else None
+        )
+        set_workspace_path(
+            conn,
+            claimed.id,
+            str(workspace),
+            branch_name=resolved_branch,
+        )
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         # Force-load the sdlc-review skill for review agents — it carries
         # the review logic (AC verification, merge, etc.). The mandatory

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4265,6 +4265,33 @@ def list_events(conn: sqlite3.Connection, task_id: str) -> list[Event]:
     return out
 
 
+def get_created_requested_workspace(
+    conn: sqlite3.Connection, task_id: str
+) -> Optional[str]:
+    """Return the immutable workspace request recorded at task creation.
+
+    Legacy or malformed ``created`` events may not carry the additive field;
+    those are treated like an omitted request. Reading the durable event (not
+    the current create invocation) keeps idempotent retries from inventing or
+    suppressing a supersession warning for the pre-existing task they return.
+    """
+    row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'created' ORDER BY created_at ASC, id ASC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row is None or not row["payload"]:
+        return None
+    try:
+        payload = json.loads(row["payload"])
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    requested = payload.get("requested_workspace")
+    return requested if isinstance(requested, str) else None
+
+
 def _append_event(
     conn: sqlite3.Connection,
     task_id: str,
@@ -7785,9 +7812,9 @@ def set_workspace_path(
     """Persist a claim-resolved workspace and its provenance atomically.
 
     Emit ``workspace_resolved`` only when resolution changes the persisted
-    path. The row update and event share one transaction, so history cannot
-    claim a resolution whose task update rolled back. Returns whether the path
-    changed.
+    path or branch. The row update and event share one transaction, so history
+    cannot claim a resolution whose task update rolled back. Returns whether
+    either resolved value changed.
     """
     resolved_path = str(path)
     with write_txn(conn):
@@ -7800,13 +7827,9 @@ def set_workspace_path(
             raise ValueError(f"unknown task: {task_id}")
 
         previous_path = row["workspace_path"]
-        resolved_branch = branch_name if branch_name is not None else row["branch_name"]
-        if previous_path == resolved_path:
-            if branch_name is not None and branch_name != row["branch_name"]:
-                conn.execute(
-                    "UPDATE tasks SET branch_name = ? WHERE id = ?",
-                    (branch_name, task_id),
-                )
+        previous_branch = row["branch_name"]
+        resolved_branch = branch_name if branch_name is not None else previous_branch
+        if previous_path == resolved_path and previous_branch == resolved_branch:
             return False
 
         conn.execute(
@@ -7820,6 +7843,9 @@ def set_workspace_path(
             {
                 "previous_path": previous_path,
                 "resolved_path": resolved_path,
+                "previous_branch_name": previous_branch,
+                "resolved_branch_name": resolved_branch,
+                # Backward-compatible alias retained for existing consumers.
                 "branch_name": resolved_branch,
             },
             run_id=(

--- a/hermes_cli/kanban_workspace.py
+++ b/hermes_cli/kanban_workspace.py
@@ -1,0 +1,36 @@
+"""User-facing descriptions of Kanban workspace normalization."""
+
+from __future__ import annotations
+
+from typing import Optional, Protocol
+
+
+class _TaskWorkspace(Protocol):
+    workspace_kind: str
+    workspace_path: Optional[str]
+    project_id: Optional[str]
+
+
+def workspace_spec(kind: str, path: Optional[str] = None) -> str:
+    """Return the CLI-style representation of a workspace selection."""
+    return f"{kind}:{path}" if path else kind
+
+
+def supersession_warning(
+    requested_workspace: Optional[str], task: _TaskWorkspace
+) -> Optional[str]:
+    """Describe an explicit workspace replaced by project normalization.
+
+    ``None`` means the caller omitted the workspace and intentionally receives
+    the project convention silently.  A project link is required so ordinary
+    normalization does not produce a misleading warning.
+    """
+    if requested_workspace != "scratch" or not task.project_id:
+        return None
+    selected = workspace_spec(task.workspace_kind, task.workspace_path)
+    if task.workspace_kind != "worktree":
+        return None
+    return (
+        f"requested workspace {requested_workspace!r} was superseded by "
+        f"project-linked workspace {selected!r}"
+    )

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -2922,6 +2922,7 @@
     const defaultWorkspacePath = props.defaultWorkspacePath || "";
     const [workspaceKind, setWorkspaceKind] = useState(defaultWorkspaceKind);
     const [workspacePath, setWorkspacePath] = useState(defaultWorkspacePath);
+    const [workspaceTouched, setWorkspaceTouched] = useState(false);
     // Goal-mode: when on, the dispatched worker runs the Ralph-style /goal
     // loop — a judge re-checks the card after each turn and the worker keeps
     // going in the same session until done, or the turn budget runs out
@@ -2948,14 +2949,18 @@
         .map(function (s) { return s.trim(); })
         .filter(function (s) { return s.length > 0; });
       if (skillList.length > 0) body.skills = skillList;
-      // Always send the selected kind. In particular, an explicit switch to
-      // scratch on a project-bound board must remain distinguishable from an
-      // omitted workspace so the API can preserve and warn on supersession.
+      // Always send the visible board-derived values so they remain the
+      // normalization inputs. Preserve whether the user actually changed the
+      // controls separately: untouched defaults are implicit, while an
+      // explicit switch to scratch can be preserved and warned on.
       if (workspaceKind) {
         body.workspace_kind = workspaceKind;
       }
-      const wpTrim = workspacePath.trim();
+      // Scratch is pathless. Ignore any hidden board-default path left in
+      // state after switching from dir/worktree to scratch.
+      const wpTrim = workspaceKind === "scratch" ? "" : workspacePath.trim();
       if (wpTrim) body.workspace_path = wpTrim;
+      body.workspace_explicit = workspaceTouched;
       // Goal-mode toggle. Only send the keys when enabled so the request
       // shape stays small and old dispatchers ignore it cleanly.
       if (goalMode) {
@@ -2966,6 +2971,7 @@
       props.onSubmit(body);
       setTitle(""); setAssignee(""); setPriority(0); setParent(""); setSkills("");
       setWorkspaceKind(defaultWorkspaceKind); setWorkspacePath(defaultWorkspacePath);
+      setWorkspaceTouched(false);
       setGoalMode(false); setGoalMaxTurns("");
     };
 
@@ -3062,7 +3068,10 @@
                 value: workspaceKind,
                 title: "Choose whether task files are temporary or preserved after completion.",
                 className: "h-8 text-sm flex-1",
-              }, selectChangeHandler(setWorkspaceKind)),
+              }, selectChangeHandler(function (value) {
+                setWorkspaceKind(value);
+                setWorkspaceTouched(true);
+              })),
                 h(SelectOption, { value: "scratch" },
                   tx(t, "workspaceScratch", "Temporary — deleted on completion")),
                 h(SelectOption, { value: "worktree" },
@@ -3072,7 +3081,10 @@
               ),
               showPathInput ? h(Input, {
                 value: workspacePath,
-                onChange: function (e) { setWorkspacePath(e.target.value); },
+                onChange: function (e) {
+                  setWorkspacePath(e.target.value);
+                  setWorkspaceTouched(true);
+                },
                 placeholder: pathPlaceholder,
                 className: "h-8 text-sm flex-1",
               }) : null,

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -2948,9 +2948,10 @@
         .map(function (s) { return s.trim(); })
         .filter(function (s) { return s.length > 0; });
       if (skillList.length > 0) body.skills = skillList;
-      // Only send workspace_kind when it's non-default. Keeps the request
-      // shape small and interoperable with older dispatcher versions.
-      if (workspaceKind && workspaceKind !== "scratch") {
+      // Always send the selected kind. In particular, an explicit switch to
+      // scratch on a project-bound board must remain distinguishable from an
+      // omitted workspace so the API can preserve and warn on supersession.
+      if (workspaceKind) {
         body.workspace_kind = workspaceKind;
       }
       const wpTrim = workspacePath.trim();

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -603,6 +603,12 @@ class CreateTaskBody(BaseModel):
     priority: int = 0
     workspace_kind: Optional[str] = None
     workspace_path: Optional[str] = None
+    # The dashboard always submits its visible board-derived workspace values
+    # so creation keeps the selected normalization inputs.  Track whether the
+    # user actually changed those controls separately: an untouched default is
+    # inherited, not an explicit request that should warn when a project link
+    # normalizes it.
+    workspace_explicit: Optional[bool] = None
     parents: list[str] = Field(default_factory=list)
     triage: bool = False
     idempotency_key: Optional[str] = None
@@ -627,9 +633,21 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
     try:
         from hermes_cli.kanban_workspace import workspace_spec
 
+        workspace_explicit = (
+            payload.workspace_kind is not None
+            if payload.workspace_explicit is None
+            else payload.workspace_explicit
+        )
+        # Scratch is pathless. In particular, the dashboard may still hold a
+        # hidden board-default path after the user switches the kind to
+        # scratch; never let that stale value alter provenance or project
+        # normalization.
+        workspace_path = (
+            None if payload.workspace_kind == "scratch" else payload.workspace_path
+        )
         requested_workspace = (
-            workspace_spec(payload.workspace_kind, payload.workspace_path)
-            if payload.workspace_kind is not None
+            workspace_spec(payload.workspace_kind, workspace_path)
+            if workspace_explicit and payload.workspace_kind is not None
             else None
         )
         task_id = kanban_db.create_task(
@@ -639,7 +657,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             assignee=payload.assignee,
             created_by="dashboard",
             workspace_kind=payload.workspace_kind or "scratch",
-            workspace_path=payload.workspace_path,
+            workspace_path=workspace_path,
             requested_workspace=requested_workspace,
             tenant=payload.tenant,
             priority=payload.priority,
@@ -657,11 +675,14 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             board=board,
         )
         task = kanban_db.get_task(conn, task_id)
+        created_requested_workspace = kanban_db.get_created_requested_workspace(
+            conn, task_id
+        )
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
         from hermes_cli.kanban_workspace import supersession_warning
 
         workspace_warning = supersession_warning(
-            requested_workspace,
+            created_requested_workspace,
             task,
         ) if task else None
         if workspace_warning:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -601,7 +601,7 @@ class CreateTaskBody(BaseModel):
     assignee: Optional[str] = None
     tenant: Optional[str] = None
     priority: int = 0
-    workspace_kind: str = "scratch"
+    workspace_kind: Optional[str] = None
     workspace_path: Optional[str] = None
     parents: list[str] = Field(default_factory=list)
     triage: bool = False
@@ -631,7 +631,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             body=payload.body,
             assignee=payload.assignee,
             created_by="dashboard",
-            workspace_kind=payload.workspace_kind,
+            workspace_kind=payload.workspace_kind or "scratch",
             workspace_path=payload.workspace_path,
             tenant=payload.tenant,
             priority=payload.priority,
@@ -650,6 +650,18 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
         )
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
+        from hermes_cli.kanban_workspace import supersession_warning, workspace_spec
+
+        workspace_warning = supersession_warning(
+            (
+                workspace_spec(payload.workspace_kind, payload.workspace_path)
+                if payload.workspace_kind is not None
+                else None
+            ),
+            task,
+        ) if task else None
+        if workspace_warning:
+            body["warning"] = workspace_warning
         # Surface a dispatcher-presence warning so the UI can show a
         # banner when a `ready` task would otherwise sit idle because no
         # gateway is running (or dispatch_in_gateway=false). Only emit
@@ -667,7 +679,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
                 running, message = _check_dispatcher_presence(
                     hermes_home=get_hermes_home()
                 )
-                if not running and message:
+                if not running and message and "warning" not in body:
                     body["warning"] = message
             except Exception:
                 # Probe failure must never block the create itself.

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -625,6 +625,13 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
+        from hermes_cli.kanban_workspace import workspace_spec
+
+        requested_workspace = (
+            workspace_spec(payload.workspace_kind, payload.workspace_path)
+            if payload.workspace_kind is not None
+            else None
+        )
         task_id = kanban_db.create_task(
             conn,
             title=payload.title,
@@ -633,6 +640,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             created_by="dashboard",
             workspace_kind=payload.workspace_kind or "scratch",
             workspace_path=payload.workspace_path,
+            requested_workspace=requested_workspace,
             tenant=payload.tenant,
             priority=payload.priority,
             parents=payload.parents,
@@ -650,14 +658,10 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
         )
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
-        from hermes_cli.kanban_workspace import supersession_warning, workspace_spec
+        from hermes_cli.kanban_workspace import supersession_warning
 
         workspace_warning = supersession_warning(
-            (
-                workspace_spec(payload.workspace_kind, payload.workspace_path)
-                if payload.workspace_kind is not None
-                else None
-            ),
+            requested_workspace,
             task,
         ) if task else None
         if workspace_warning:

--- a/tests/hermes_cli/test_kanban_project_link.py
+++ b/tests/hermes_cli/test_kanban_project_link.py
@@ -9,6 +9,7 @@ import pytest
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import projects_db as pdb
+from hermes_cli.kanban_workspace import supersession_warning
 
 
 @pytest.fixture
@@ -38,6 +39,36 @@ def test_project_linked_task_gets_deterministic_worktree_and_branch(kanban_conn)
     # Deterministic branch: <slug>/<task-id>-<title-slug>. NOT a random wt/...
     assert task.branch_name == f"{proj.slug}/{tid}-add-login"
     assert not task.branch_name.startswith("wt/")
+
+
+def test_explicit_scratch_supersession_reports_requested_and_selected_workspace(
+    kanban_conn,
+):
+    proj = _make_project()
+    tid = kb.create_task(
+        kanban_conn,
+        title="Add login",
+        project_id=proj.slug,
+        workspace_kind="scratch",
+    )
+
+    task = kb.get_task(kanban_conn, tid)
+    assert supersession_warning("scratch", task) == (
+        "requested workspace 'scratch' was superseded by project-linked "
+        f"workspace 'worktree:{task.workspace_path}'"
+    )
+
+
+def test_omitted_workspace_inherits_project_worktree_without_warning(kanban_conn):
+    proj = _make_project()
+    tid = kb.create_task(
+        kanban_conn,
+        title="Add login",
+        project_id=proj.slug,
+    )
+
+    task = kb.get_task(kanban_conn, tid)
+    assert supersession_warning(None, task) is None
 
 
 def test_explicit_branch_overrides_project_default(kanban_conn):

--- a/tests/hermes_cli/test_kanban_project_link.py
+++ b/tests/hermes_cli/test_kanban_project_link.py
@@ -71,6 +71,39 @@ def test_omitted_workspace_inherits_project_worktree_without_warning(kanban_conn
     assert supersession_warning(None, task) is None
 
 
+def test_explicit_directory_preserved_without_warning(kanban_conn, tmp_path):
+    proj = _make_project()
+    assert proj is not None
+    requested_path = tmp_path / "explicit-workspace"
+    tid = kb.create_task(
+        kanban_conn,
+        title="Use existing directory",
+        project_id=proj.slug,
+        workspace_kind="dir",
+        workspace_path=str(requested_path),
+    )
+
+    task = kb.get_task(kanban_conn, tid)
+    assert task is not None
+    assert task.workspace_kind == "dir"
+    assert task.workspace_path == str(requested_path)
+    assert supersession_warning(f"dir:{requested_path}", task) is None
+
+
+def test_explicit_scratch_on_unlinked_task_does_not_warn(kanban_conn):
+    tid = kb.create_task(
+        kanban_conn,
+        title="Unlinked scratch",
+        workspace_kind="scratch",
+    )
+
+    task = kb.get_task(kanban_conn, tid)
+    assert task is not None
+    assert task.project_id is None
+    assert task.workspace_kind == "scratch"
+    assert supersession_warning("scratch", task) is None
+
+
 def test_explicit_branch_overrides_project_default(kanban_conn):
     proj = _make_project()
     tid = kb.create_task(

--- a/tests/hermes_cli/test_kanban_workspace_provenance.py
+++ b/tests/hermes_cli/test_kanban_workspace_provenance.py
@@ -125,10 +125,13 @@ def test_changed_workspace_resolution_updates_row_and_emits_payload_atomically(
         )
 
         task = kb.get_task(conn, task_id)
-        events = _event(conn, task_id, "workspace_resolved")
+        history = kb.list_events(conn, task_id)
+        events = [event for event in history if event.kind == "workspace_resolved"]
         created_after = _event(conn, task_id, "created")[0]
 
     assert changed is True
+    assert [event.kind for event in history] == ["created", "workspace_resolved"]
+    assert history[0].id < history[1].id
     assert task.workspace_path == str(resolved)
     assert task.branch_name == "wt/resolved"
     assert len(events) == 1

--- a/tests/hermes_cli/test_kanban_workspace_provenance.py
+++ b/tests/hermes_cli/test_kanban_workspace_provenance.py
@@ -178,6 +178,7 @@ def test_claim_heals_legacy_worktree_path_and_records_resolution(
         task = kb.get_task(conn, task_id)
         created_after = _event(conn, task_id, "created")[0]
         resolved_events = _event(conn, task_id, "workspace_resolved")
+        events = kb.list_events(conn, task_id)
 
     expected_path = repo / ".worktrees" / task_id
     assert task is not None
@@ -191,6 +192,11 @@ def test_claim_heals_legacy_worktree_path_and_records_resolution(
             "branch_name": f"wt/{task_id}",
         }
     ]
+    event_kinds = [event.kind for event in events]
+    assert event_kinds.index("created") < event_kinds.index("claimed")
+    assert event_kinds.index("claimed") < event_kinds.index("workspace_resolved")
+    claimed = next(event for event in events if event.kind == "claimed")
+    assert resolved_events[0].run_id == claimed.run_id
 
 
 def test_repeated_resolution_does_not_duplicate_event(kanban_home: Path) -> None:

--- a/tests/hermes_cli/test_kanban_workspace_provenance.py
+++ b/tests/hermes_cli/test_kanban_workspace_provenance.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import subprocess
+from argparse import Namespace
 from pathlib import Path
 
 import pytest
 
+from hermes_cli import kanban
 from hermes_cli import kanban_db as kb
 
 
@@ -138,6 +141,56 @@ def test_legacy_claim_time_healing_is_visible_without_rewriting_created_event(
         "resolved_path": str(resolved),
         "branch_name": "wt/legacy-child",
     }
+
+
+def test_claim_heals_legacy_worktree_path_and_records_resolution(
+    kanban_home: Path,
+) -> None:
+    repo = kanban_home / "repo"
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "Test User"],
+        check=True,
+    )
+    (repo / "README.md").write_text("fixture\n")
+    subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-qm", "fixture"], check=True
+    )
+    legacy_path = repo
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="legacy worktree child",
+            assignee="coding",
+            workspace_kind="worktree",
+            workspace_path=str(legacy_path),
+        )
+        created_before = _event(conn, task_id, "created")[0]
+
+    assert kanban._cmd_claim(Namespace(task_id=task_id, ttl=60)) == 0
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        created_after = _event(conn, task_id, "created")[0]
+        resolved_events = _event(conn, task_id, "workspace_resolved")
+
+    expected_path = repo / ".worktrees" / task_id
+    assert task is not None
+    assert task.workspace_path == str(expected_path)
+    assert created_after.id == created_before.id
+    assert created_after.payload == created_before.payload
+    assert [event.payload for event in resolved_events] == [
+        {
+            "previous_path": str(legacy_path),
+            "resolved_path": str(expected_path),
+            "branch_name": f"wt/{task_id}",
+        }
+    ]
 
 
 def test_repeated_resolution_does_not_duplicate_event(kanban_home: Path) -> None:

--- a/tests/hermes_cli/test_kanban_workspace_provenance.py
+++ b/tests/hermes_cli/test_kanban_workspace_provenance.py
@@ -1,0 +1,182 @@
+"""Workspace provenance event contracts for Kanban tasks."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _event(conn, task_id: str, kind: str):
+    return [event for event in kb.list_events(conn, task_id) if event.kind == kind]
+
+
+def test_created_event_preserves_requested_and_normalized_workspace(kanban_home: Path) -> None:
+    requested_path = kanban_home / "repo"
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="explicit workspace",
+            workspace_kind="dir",
+            workspace_path=str(requested_path),
+            requested_workspace=f"dir:{requested_path}",
+        )
+
+        created = _event(conn, task_id, "created")
+
+    assert len(created) == 1
+    assert created[0].payload["requested_workspace"] == f"dir:{requested_path}"
+    assert created[0].payload["workspace_kind"] == "dir"
+    assert created[0].payload["workspace_path"] == str(requested_path)
+
+
+def test_created_event_records_null_when_workspace_was_omitted(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="implicit workspace")
+
+        created = _event(conn, task_id, "created")
+
+    assert len(created) == 1
+    assert "requested_workspace" in created[0].payload
+    assert created[0].payload["requested_workspace"] is None
+    assert created[0].payload["workspace_kind"] == "scratch"
+    assert created[0].payload["workspace_path"] is None
+
+
+def test_unchanged_workspace_resolution_emits_no_event(kanban_home: Path) -> None:
+    path = kanban_home / "workspace"
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="already resolved", workspace_kind="dir", workspace_path=str(path)
+        )
+
+        changed = kb.set_workspace_path(conn, task_id, path, branch_name=None)
+
+        assert changed is False
+        assert _event(conn, task_id, "workspace_resolved") == []
+
+
+def test_changed_workspace_resolution_updates_row_and_emits_payload_atomically(
+    kanban_home: Path,
+) -> None:
+    previous = kanban_home / "requested"
+    resolved = kanban_home / "repo" / ".worktrees" / "task"
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="resolved elsewhere",
+            workspace_kind="worktree",
+            workspace_path=str(previous),
+            branch_name="old/branch",
+        )
+        created_before = _event(conn, task_id, "created")[0]
+
+        changed = kb.set_workspace_path(
+            conn, task_id, resolved, branch_name="wt/resolved"
+        )
+
+        task = kb.get_task(conn, task_id)
+        events = _event(conn, task_id, "workspace_resolved")
+        created_after = _event(conn, task_id, "created")[0]
+
+    assert changed is True
+    assert task.workspace_path == str(resolved)
+    assert task.branch_name == "wt/resolved"
+    assert len(events) == 1
+    assert events[0].payload == {
+        "previous_path": str(previous),
+        "resolved_path": str(resolved),
+        "branch_name": "wt/resolved",
+    }
+    assert created_after.id == created_before.id
+    assert created_after.payload == created_before.payload
+
+
+def test_legacy_claim_time_healing_is_visible_without_rewriting_created_event(
+    kanban_home: Path,
+) -> None:
+    previous = kanban_home / "legacy-parent-worktree"
+    resolved = kanban_home / "repo" / ".worktrees" / "legacy-child"
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="legacy child",
+            workspace_kind="worktree",
+            workspace_path=str(previous),
+        )
+        legacy_payload = {"workspace_kind": "worktree", "workspace_path": str(previous)}
+        conn.execute(
+            "UPDATE task_events SET payload = ? WHERE task_id = ? AND kind = 'created'",
+            (json.dumps(legacy_payload), task_id),
+        )
+        conn.commit()
+
+        kb.set_workspace_path(conn, task_id, resolved, branch_name="wt/legacy-child")
+
+        created = _event(conn, task_id, "created")
+        resolved_events = _event(conn, task_id, "workspace_resolved")
+
+    assert len(created) == 1
+    assert created[0].payload == legacy_payload
+    assert len(resolved_events) == 1
+    assert resolved_events[0].payload == {
+        "previous_path": str(previous),
+        "resolved_path": str(resolved),
+        "branch_name": "wt/legacy-child",
+    }
+
+
+def test_repeated_resolution_does_not_duplicate_event(kanban_home: Path) -> None:
+    first = kanban_home / "first"
+    resolved = kanban_home / "resolved"
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="repeat claim", workspace_kind="worktree", workspace_path=str(first)
+        )
+
+        assert kb.set_workspace_path(conn, task_id, resolved, branch_name="wt/repeat") is True
+        assert kb.set_workspace_path(conn, task_id, resolved, branch_name="wt/repeat") is False
+
+        assert len(_event(conn, task_id, "workspace_resolved")) == 1
+
+
+def test_resolution_event_failure_rolls_back_task_row(kanban_home: Path) -> None:
+    previous = kanban_home / "previous"
+    resolved = kanban_home / "resolved"
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="atomic resolution", workspace_kind="dir", workspace_path=str(previous)
+        )
+        conn.execute(
+            """
+            CREATE TRIGGER reject_workspace_resolution
+            BEFORE INSERT ON task_events
+            WHEN NEW.kind = 'workspace_resolved'
+            BEGIN
+                SELECT RAISE(ABORT, 'reject resolution event');
+            END
+            """
+        )
+        conn.commit()
+
+        with pytest.raises(sqlite3.IntegrityError, match="reject resolution event"):
+            kb.set_workspace_path(conn, task_id, resolved)
+
+        task = kb.get_task(conn, task_id)
+
+    assert task is not None
+    assert task.workspace_path == str(previous)

--- a/tests/hermes_cli/test_kanban_workspace_provenance.py
+++ b/tests/hermes_cli/test_kanban_workspace_provenance.py
@@ -74,6 +74,37 @@ def test_unchanged_workspace_resolution_emits_no_event(kanban_home: Path) -> Non
         assert _event(conn, task_id, "workspace_resolved") == []
 
 
+def test_branch_only_workspace_resolution_emits_provenance(kanban_home: Path) -> None:
+    path = kanban_home / "workspace"
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="branch healed",
+            workspace_kind="worktree",
+            workspace_path=str(path),
+            branch_name="old/branch",
+        )
+
+        changed = kb.set_workspace_path(
+            conn, task_id, path, branch_name="resolved/branch"
+        )
+        task = kb.get_task(conn, task_id)
+        events = _event(conn, task_id, "workspace_resolved")
+
+    assert changed is True
+    assert task is not None
+    assert task.branch_name == "resolved/branch"
+    assert [event.payload for event in events] == [
+        {
+            "previous_path": str(path),
+            "resolved_path": str(path),
+            "previous_branch_name": "old/branch",
+            "resolved_branch_name": "resolved/branch",
+            "branch_name": "resolved/branch",
+        }
+    ]
+
+
 def test_changed_workspace_resolution_updates_row_and_emits_payload_atomically(
     kanban_home: Path,
 ) -> None:
@@ -104,6 +135,8 @@ def test_changed_workspace_resolution_updates_row_and_emits_payload_atomically(
     assert events[0].payload == {
         "previous_path": str(previous),
         "resolved_path": str(resolved),
+        "previous_branch_name": "old/branch",
+        "resolved_branch_name": "wt/resolved",
         "branch_name": "wt/resolved",
     }
     assert created_after.id == created_before.id
@@ -140,6 +173,8 @@ def test_legacy_claim_time_healing_is_visible_without_rewriting_created_event(
     assert resolved_events[0].payload == {
         "previous_path": str(previous),
         "resolved_path": str(resolved),
+        "previous_branch_name": None,
+        "resolved_branch_name": "wt/legacy-child",
         "branch_name": "wt/legacy-child",
     }
 
@@ -190,6 +225,8 @@ def test_claim_heals_legacy_worktree_path_and_records_resolution(
         {
             "previous_path": str(legacy_path),
             "resolved_path": str(expected_path),
+            "previous_branch_name": None,
+            "resolved_branch_name": f"wt/{task_id}",
             "branch_name": f"wt/{task_id}",
         }
     ]
@@ -271,6 +308,8 @@ def test_project_normalization_and_claim_resolution_keep_all_provenance_stages(
         {
             "previous_path": str(repo),
             "resolved_path": str(normalized_path),
+            "previous_branch_name": created_payload["branch_name"],
+            "resolved_branch_name": created_payload["branch_name"],
             "branch_name": created_payload["branch_name"],
         }
     ]

--- a/tests/hermes_cli/test_kanban_workspace_provenance.py
+++ b/tests/hermes_cli/test_kanban_workspace_provenance.py
@@ -12,6 +12,7 @@ import pytest
 
 from hermes_cli import kanban
 from hermes_cli import kanban_db as kb
+from hermes_cli import projects_db as pdb
 
 
 @pytest.fixture
@@ -197,6 +198,86 @@ def test_claim_heals_legacy_worktree_path_and_records_resolution(
     assert event_kinds.index("claimed") < event_kinds.index("workspace_resolved")
     claimed = next(event for event in events if event.kind == "claimed")
     assert resolved_events[0].run_id == claimed.run_id
+
+
+def test_project_normalization_and_claim_resolution_keep_all_provenance_stages(
+    kanban_home: Path,
+) -> None:
+    repo = kanban_home / "project-repo"
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "Test User"],
+        check=True,
+    )
+    (repo / "README.md").write_text("fixture\n")
+    subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-qm", "fixture"], check=True
+    )
+    with pdb.connect_closing() as project_conn:
+        project_id = pdb.create_project(
+            project_conn, name="Provenance Fixture", folders=[str(repo)]
+        )
+        project = pdb.get_project(project_conn, project_id)
+    assert project is not None
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="prove workspace provenance",
+            assignee="coding",
+            project_id=project.id,
+            workspace_kind="scratch",
+            requested_workspace="scratch",
+        )
+        created_before_claim = _event(conn, task_id, "created")[0]
+        created_payload = created_before_claim.payload
+        normalized_path = repo / ".worktrees" / task_id
+
+        assert created_payload is not None
+        assert created_payload["requested_workspace"] == "scratch"
+        assert created_payload["workspace_kind"] == "worktree"
+        assert created_payload["workspace_path"] == str(normalized_path)
+
+        # Reproduce a legacy pre-resolution row while leaving the immutable
+        # creation record intact. Claim-time healing must append provenance,
+        # not overwrite either the request or normalized creation state.
+        conn.execute(
+            "UPDATE tasks SET workspace_path = ? WHERE id = ?", (str(repo), task_id)
+        )
+        conn.commit()
+
+    assert kanban._cmd_claim(Namespace(task_id=task_id, ttl=60)) == 0
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        events = kb.list_events(conn, task_id)
+        created_after_claim = _event(conn, task_id, "created")[0]
+        resolved = _event(conn, task_id, "workspace_resolved")
+
+    assert task is not None
+    assert task.workspace_path == str(normalized_path)
+    created_events = [event for event in events if event.kind == "created"]
+    claimed_events = [event for event in events if event.kind == "claimed"]
+    assert created_events == [created_after_claim]
+    assert len(claimed_events) == 1
+    assert created_after_claim.id == created_before_claim.id
+    assert created_after_claim.payload == created_before_claim.payload
+    assert [event.payload for event in resolved] == [
+        {
+            "previous_path": str(repo),
+            "resolved_path": str(normalized_path),
+            "branch_name": created_payload["branch_name"],
+        }
+    ]
+    assert resolved[0].run_id == claimed_events[0].run_id
+    event_kinds = [event.kind for event in events]
+    assert event_kinds.index("created") < event_kinds.index("claimed")
+    assert event_kinds.index("claimed") < event_kinds.index("workspace_resolved")
 
 
 def test_repeated_resolution_does_not_duplicate_event(kanban_home: Path) -> None:

--- a/tests/hermes_cli/test_kanban_workspace_warning.py
+++ b/tests/hermes_cli/test_kanban_workspace_warning.py
@@ -43,13 +43,20 @@ def test_cli_prints_explicit_workspace_supersession_to_stderr(monkeypatch, capsy
         status="todo",
         assignee=None,
     )
+    captured_kwargs = {}
+
+    def create_task(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return "t_123"
+
     monkeypatch.setattr(kanban.kb, "connect_closing", lambda: nullcontext(object()))
-    monkeypatch.setattr(kanban.kb, "create_task", lambda *args, **kwargs: "t_123")
+    monkeypatch.setattr(kanban.kb, "create_task", create_task)
     monkeypatch.setattr(kanban.kb, "get_task", lambda *args, **kwargs: task)
 
     assert kanban._cmd_create(_create_args()) == 0
 
     captured = capsys.readouterr()
+    assert captured_kwargs["requested_workspace"] == "scratch"
     assert "requested workspace 'scratch'" in captured.err
     assert "project-linked workspace 'worktree:/repo/.worktrees/t_123'" in captured.err
 
@@ -62,10 +69,17 @@ def test_cli_omitted_workspace_inherits_silently(monkeypatch, capsys):
         status="todo",
         assignee=None,
     )
+    captured_kwargs = {}
+
+    def create_task(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return "t_123"
+
     monkeypatch.setattr(kanban.kb, "connect_closing", lambda: nullcontext(object()))
-    monkeypatch.setattr(kanban.kb, "create_task", lambda *args, **kwargs: "t_123")
+    monkeypatch.setattr(kanban.kb, "create_task", create_task)
     monkeypatch.setattr(kanban.kb, "get_task", lambda *args, **kwargs: task)
 
     assert kanban._cmd_create(_create_args(workspace=None)) == 0
 
     assert capsys.readouterr().err == ""
+    assert captured_kwargs["requested_workspace"] is None

--- a/tests/hermes_cli/test_kanban_workspace_warning.py
+++ b/tests/hermes_cli/test_kanban_workspace_warning.py
@@ -52,6 +52,9 @@ def test_cli_prints_explicit_workspace_supersession_to_stderr(monkeypatch, capsy
     monkeypatch.setattr(kanban.kb, "connect_closing", lambda: nullcontext(object()))
     monkeypatch.setattr(kanban.kb, "create_task", create_task)
     monkeypatch.setattr(kanban.kb, "get_task", lambda *args, **kwargs: task)
+    monkeypatch.setattr(
+        kanban.kb, "get_created_requested_workspace", lambda *args: "scratch"
+    )
 
     assert kanban._cmd_create(_create_args()) == 0
 
@@ -78,8 +81,51 @@ def test_cli_omitted_workspace_inherits_silently(monkeypatch, capsys):
     monkeypatch.setattr(kanban.kb, "connect_closing", lambda: nullcontext(object()))
     monkeypatch.setattr(kanban.kb, "create_task", create_task)
     monkeypatch.setattr(kanban.kb, "get_task", lambda *args, **kwargs: task)
+    monkeypatch.setattr(
+        kanban.kb, "get_created_requested_workspace", lambda *args: None
+    )
 
     assert kanban._cmd_create(_create_args(workspace=None)) == 0
 
     assert capsys.readouterr().err == ""
     assert captured_kwargs["requested_workspace"] is None
+
+
+def test_cli_retry_warning_uses_immutable_created_request(monkeypatch, capsys):
+    task = SimpleNamespace(
+        workspace_kind="worktree",
+        workspace_path="/repo/.worktrees/t_123",
+        project_id="project-id",
+        status="todo",
+        assignee=None,
+    )
+    monkeypatch.setattr(kanban.kb, "connect_closing", lambda: nullcontext(object()))
+    monkeypatch.setattr(kanban.kb, "create_task", lambda *args, **kwargs: "t_123")
+    monkeypatch.setattr(kanban.kb, "get_task", lambda *args, **kwargs: task)
+    monkeypatch.setattr(
+        kanban.kb, "get_created_requested_workspace", lambda *args: "scratch"
+    )
+
+    assert kanban._cmd_create(_create_args(workspace=None)) == 0
+
+    assert "requested workspace 'scratch'" in capsys.readouterr().err
+
+
+def test_cli_retry_does_not_invent_warning_from_current_request(monkeypatch, capsys):
+    task = SimpleNamespace(
+        workspace_kind="worktree",
+        workspace_path="/repo/.worktrees/t_123",
+        project_id="project-id",
+        status="todo",
+        assignee=None,
+    )
+    monkeypatch.setattr(kanban.kb, "connect_closing", lambda: nullcontext(object()))
+    monkeypatch.setattr(kanban.kb, "create_task", lambda *args, **kwargs: "t_123")
+    monkeypatch.setattr(kanban.kb, "get_task", lambda *args, **kwargs: task)
+    monkeypatch.setattr(
+        kanban.kb, "get_created_requested_workspace", lambda *args: None
+    )
+
+    assert kanban._cmd_create(_create_args(workspace="scratch")) == 0
+
+    assert capsys.readouterr().err == ""

--- a/tests/hermes_cli/test_kanban_workspace_warning.py
+++ b/tests/hermes_cli/test_kanban_workspace_warning.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+from hermes_cli import kanban
+
+
+def _create_args(**overrides):
+    values = {
+        "workspace": "scratch",
+        "branch": None,
+        "max_runtime": None,
+        "max_retries": None,
+        "title": "Explicit workspace",
+        "body": None,
+        "assignee": None,
+        "created_by": "test",
+        "project": "project-id",
+        "tenant": None,
+        "priority": 0,
+        "parent": [],
+        "triage": False,
+        "idempotency_key": None,
+        "skills": [],
+        "model_override": None,
+        "provider_override": None,
+        "goal_mode": False,
+        "goal_max_turns": None,
+        "initial_status": "running",
+        "json": False,
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def test_cli_prints_explicit_workspace_supersession_to_stderr(monkeypatch, capsys):
+    task = SimpleNamespace(
+        workspace_kind="worktree",
+        workspace_path="/repo/.worktrees/t_123",
+        project_id="project-id",
+        status="todo",
+        assignee=None,
+    )
+    monkeypatch.setattr(kanban.kb, "connect_closing", lambda: nullcontext(object()))
+    monkeypatch.setattr(kanban.kb, "create_task", lambda *args, **kwargs: "t_123")
+    monkeypatch.setattr(kanban.kb, "get_task", lambda *args, **kwargs: task)
+
+    assert kanban._cmd_create(_create_args()) == 0
+
+    captured = capsys.readouterr()
+    assert "requested workspace 'scratch'" in captured.err
+    assert "project-linked workspace 'worktree:/repo/.worktrees/t_123'" in captured.err
+
+
+def test_cli_omitted_workspace_inherits_silently(monkeypatch, capsys):
+    task = SimpleNamespace(
+        workspace_kind="worktree",
+        workspace_path="/repo/.worktrees/t_123",
+        project_id="project-id",
+        status="todo",
+        assignee=None,
+    )
+    monkeypatch.setattr(kanban.kb, "connect_closing", lambda: nullcontext(object()))
+    monkeypatch.setattr(kanban.kb, "create_task", lambda *args, **kwargs: "t_123")
+    monkeypatch.setattr(kanban.kb, "get_task", lambda *args, **kwargs: task)
+
+    assert kanban._cmd_create(_create_args(workspace=None)) == 0
+
+    assert capsys.readouterr().err == ""

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -246,6 +246,18 @@ def test_dashboard_markdown_html_is_sanitized_before_render():
     assert "dangerouslySetInnerHTML: { __html: renderMarkdown(props.source || \"\") }" not in js
 
 
+def test_dashboard_submits_explicit_scratch_workspace_kind():
+    """The UI must not collapse explicit scratch into an omitted workspace."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text(encoding="utf-8")
+
+    assert 'if (workspaceKind) {' in js
+    assert 'body.workspace_kind = workspaceKind;' in js
+    assert 'if (workspaceKind && workspaceKind !== "scratch") {' not in js
+
+
 # ---------------------------------------------------------------------------
 # GET /tasks/:id returns body + comments + events + links
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -20,6 +20,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hermes_cli import kanban_db as kb
+from hermes_cli import projects_db as pdb
 
 
 # ---------------------------------------------------------------------------
@@ -114,6 +115,43 @@ def test_create_task_appears_on_board(client):
     assert ready["tasks"][0]["id"] == task_id
     assert "acme" in data["tenants"]
     assert "researcher" in data["assignees"]
+
+
+def test_explicit_workspace_supersession_is_returned_as_api_warning(
+    client, tmp_path
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pdb.connect_closing() as conn:
+        project_id = pdb.create_project(conn, name="API Project", folders=[str(repo)])
+
+    kb.write_board_metadata("default", project_id=project_id)
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Explicit scratch", "workspace_kind": "scratch"},
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["warning"] == (
+        "requested workspace 'scratch' was superseded by project-linked "
+        f"workspace 'worktree:{data['task']['workspace_path']}'"
+    )
+
+
+def test_omitted_workspace_inherits_project_without_api_warning(client, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pdb.connect_closing() as conn:
+        project_id = pdb.create_project(conn, name="API Project", folders=[str(repo)])
+
+    kb.write_board_metadata("default", project_id=project_id)
+    response = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "Implicit workspace"}
+    )
+
+    assert response.status_code == 200, response.text
+    assert "warning" not in response.json()
 
 
 def test_patch_board_sets_project_directory(client, tmp_path):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -137,6 +137,16 @@ def test_explicit_workspace_supersession_is_returned_as_api_warning(
         "requested workspace 'scratch' was superseded by project-linked "
         f"workspace 'worktree:{data['task']['workspace_path']}'"
     )
+    with kb.connect_closing() as conn:
+        created = next(
+            event
+            for event in kb.list_events(conn, data["task"]["id"])
+            if event.kind == "created"
+        )
+    assert created.payload is not None
+    assert created.payload["requested_workspace"] == "scratch"
+    assert created.payload["workspace_kind"] == "worktree"
+    assert created.payload["workspace_path"] == data["task"]["workspace_path"]
 
 
 def test_omitted_workspace_inherits_project_without_api_warning(client, tmp_path):
@@ -150,8 +160,16 @@ def test_omitted_workspace_inherits_project_without_api_warning(client, tmp_path
         "/api/plugins/kanban/tasks", json={"title": "Implicit workspace"}
     )
 
-    assert response.status_code == 200, response.text
-    assert "warning" not in response.json()
+    data = response.json()
+    assert "warning" not in data
+    with kb.connect_closing() as conn:
+        created = next(
+            event
+            for event in kb.list_events(conn, data["task"]["id"])
+            if event.kind == "created"
+        )
+    assert created.payload is not None
+    assert created.payload["requested_workspace"] is None
 
 
 def test_patch_board_sets_project_directory(client, tmp_path):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -149,6 +149,40 @@ def test_explicit_workspace_supersession_is_returned_as_api_warning(
     assert created.payload["workspace_path"] == data["task"]["workspace_path"]
 
 
+def test_explicit_scratch_ignores_hidden_dashboard_default_path(client, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pdb.connect_closing() as conn:
+        project_id = pdb.create_project(conn, name="API Project", folders=[str(repo)])
+
+    kb.write_board_metadata("default", project_id=project_id)
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "Explicit scratch",
+            "workspace_kind": "scratch",
+            "workspace_path": str(repo),
+            "workspace_explicit": True,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["warning"] == (
+        "requested workspace 'scratch' was superseded by project-linked "
+        f"workspace 'worktree:{data['task']['workspace_path']}'"
+    )
+    assert data["task"]["workspace_path"] != str(repo)
+    with kb.connect_closing() as conn:
+        created = next(
+            event
+            for event in kb.list_events(conn, data["task"]["id"])
+            if event.kind == "created"
+        )
+    assert created.payload is not None
+    assert created.payload["requested_workspace"] == "scratch"
+
+
 def test_omitted_workspace_inherits_project_without_api_warning(client, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -170,6 +204,78 @@ def test_omitted_workspace_inherits_project_without_api_warning(client, tmp_path
         )
     assert created.payload is not None
     assert created.payload["requested_workspace"] is None
+
+
+def test_untouched_dashboard_default_is_normalized_without_api_warning(
+    client, tmp_path
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pdb.connect_closing() as conn:
+        project_id = pdb.create_project(conn, name="API Project", folders=[str(repo)])
+
+    kb.write_board_metadata("default", project_id=project_id)
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "Untouched dashboard default",
+            "workspace_kind": "scratch",
+            "workspace_explicit": False,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert "warning" not in data
+    assert data["task"]["workspace_kind"] == "worktree"
+    with kb.connect_closing() as conn:
+        created = next(
+            event
+            for event in kb.list_events(conn, data["task"]["id"])
+            if event.kind == "created"
+        )
+    assert created.payload is not None
+    assert created.payload["requested_workspace"] is None
+    assert created.payload["workspace_kind"] == "worktree"
+    assert created.payload["workspace_path"] == data["task"]["workspace_path"]
+
+
+def test_api_idempotent_retry_warning_uses_original_created_request(client, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pdb.connect_closing() as conn:
+        project_id = pdb.create_project(conn, name="API Project", folders=[str(repo)])
+    kb.write_board_metadata("default", project_id=project_id)
+
+    implicit = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Implicit", "idempotency_key": "implicit-key"},
+    ).json()
+    explicit_retry = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "Retry",
+            "idempotency_key": "implicit-key",
+            "workspace_kind": "scratch",
+        },
+    ).json()
+    assert explicit_retry["task"]["id"] == implicit["task"]["id"]
+    assert "warning" not in explicit_retry
+
+    explicit = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "Explicit",
+            "idempotency_key": "explicit-key",
+            "workspace_kind": "scratch",
+        },
+    ).json()
+    omitted_retry = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Retry", "idempotency_key": "explicit-key"},
+    ).json()
+    assert omitted_retry["task"]["id"] == explicit["task"]["id"]
+    assert omitted_retry["warning"] == explicit["warning"]
 
 
 def test_patch_board_sets_project_directory(client, tmp_path):
@@ -247,7 +353,7 @@ def test_dashboard_markdown_html_is_sanitized_before_render():
 
 
 def test_dashboard_submits_explicit_scratch_workspace_kind():
-    """The UI must not collapse explicit scratch into an omitted workspace."""
+    """The UI distinguishes a changed workspace from its visible default."""
 
     repo_root = Path(__file__).resolve().parents[2]
     bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
@@ -255,6 +361,10 @@ def test_dashboard_submits_explicit_scratch_workspace_kind():
 
     assert 'if (workspaceKind) {' in js
     assert 'body.workspace_kind = workspaceKind;' in js
+    assert 'body.workspace_explicit = workspaceTouched;' in js
+    assert 'workspaceKind === "scratch" ? "" : workspacePath.trim()' in js
+    assert 'setWorkspaceTouched(true);' in js
+    assert 'setWorkspaceTouched(false);' in js
     assert 'if (workspaceKind && workspaceKind !== "scratch") {' not in js
 
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -853,6 +853,55 @@ def test_create_records_omitted_workspace_request_as_null(worker_env):
     assert created.payload["requested_workspace"] is None
 
 
+def test_create_returns_warning_for_explicit_project_workspace_supersession(
+    worker_env, tmp_path
+):
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import projects_db as pdb
+    from tools import kanban_tools as kt
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pdb.connect_closing() as conn:
+        project_id = pdb.create_project(conn, name="Tool Project", folders=[str(repo)])
+    kb.write_board_metadata("default", project_id=project_id)
+
+    out = json.loads(
+        kt._handle_create(
+            {
+                "title": "explicit project scratch",
+                "assignee": "peer",
+                "workspace_kind": "scratch",
+            }
+        )
+    )
+
+    assert out["warning"] == (
+        "requested workspace 'scratch' was superseded by project-linked "
+        f"workspace 'worktree:{out['workspace_path']}'"
+    )
+
+
+def test_create_omitted_project_workspace_inherits_without_warning(worker_env, tmp_path):
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import projects_db as pdb
+    from tools import kanban_tools as kt
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pdb.connect_closing() as conn:
+        project_id = pdb.create_project(conn, name="Tool Project", folders=[str(repo)])
+    kb.write_board_metadata("default", project_id=project_id)
+
+    out = json.loads(
+        kt._handle_create({"title": "implicit project workspace", "assignee": "peer"})
+    )
+
+    assert out["workspace_kind"] == "worktree"
+    assert out["workspace_path"].startswith(str(repo / ".worktrees"))
+    assert out["warning"] is None
+
+
 def _list_subs_for_task(task_id):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -809,6 +809,50 @@ def test_board_param_none_falls_back_to_env(worker_env):
 #   even when the session has a delivery channel.
 # ---------------------------------------------------------------------------
 
+
+def test_create_records_explicit_workspace_request(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    out = json.loads(
+        kt._handle_create(
+            {
+                "title": "explicit directory",
+                "assignee": "peer",
+                "workspace_kind": "dir",
+                "workspace_path": "/tmp/explicit-directory",
+            }
+        )
+    )
+
+    with kb.connect_closing() as conn:
+        created = next(
+            event
+            for event in kb.list_events(conn, out["task_id"])
+            if event.kind == "created"
+        )
+    assert created.payload is not None
+    assert created.payload["requested_workspace"] == "dir:/tmp/explicit-directory"
+
+
+def test_create_records_omitted_workspace_request_as_null(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    out = json.loads(
+        kt._handle_create({"title": "implicit scratch", "assignee": "peer"})
+    )
+
+    with kb.connect_closing() as conn:
+        created = next(
+            event
+            for event in kb.list_events(conn, out["task_id"])
+            if event.kind == "created"
+        )
+    assert created.payload is not None
+    assert created.payload["requested_workspace"] is None
+
+
 def _list_subs_for_task(task_id):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -902,6 +902,54 @@ def test_create_omitted_project_workspace_inherits_without_warning(worker_env, t
     assert out["warning"] is None
 
 
+def test_create_idempotent_retry_warning_uses_original_request(worker_env, tmp_path):
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import projects_db as pdb
+    from tools import kanban_tools as kt
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pdb.connect_closing() as conn:
+        project_id = pdb.create_project(conn, name="Tool Project", folders=[str(repo)])
+    kb.write_board_metadata("default", project_id=project_id)
+
+    implicit = json.loads(
+        kt._handle_create(
+            {"title": "implicit", "assignee": "peer", "idempotency_key": "implicit"}
+        )
+    )
+    explicit_retry = json.loads(
+        kt._handle_create(
+            {
+                "title": "retry",
+                "assignee": "peer",
+                "idempotency_key": "implicit",
+                "workspace_kind": "scratch",
+            }
+        )
+    )
+    assert explicit_retry["task_id"] == implicit["task_id"]
+    assert explicit_retry["warning"] is None
+
+    explicit = json.loads(
+        kt._handle_create(
+            {
+                "title": "explicit",
+                "assignee": "peer",
+                "idempotency_key": "explicit",
+                "workspace_kind": "scratch",
+            }
+        )
+    )
+    omitted_retry = json.loads(
+        kt._handle_create(
+            {"title": "retry", "assignee": "peer", "idempotency_key": "explicit"}
+        )
+    )
+    assert omitted_retry["task_id"] == explicit["task_id"]
+    assert omitted_retry["warning"] == explicit["warning"]
+
+
 def _list_subs_for_task(task_id):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1386,6 +1386,7 @@ def _handle_create(args: dict, **kw) -> str:
     # preserving the repository/branch convention without sharing a checkout.
     workspace_kind = args.get("workspace_kind")
     workspace_path = args.get("workspace_path")
+    requested_workspace_kind = workspace_kind
     project_id = args.get("project") or args.get("project_id")
     project_source_task_id = None
     _inherit_project = workspace_kind is None and workspace_path is None
@@ -1464,6 +1465,16 @@ def _handle_create(args: dict, **kw) -> str:
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
+            from hermes_cli.kanban_workspace import supersession_warning, workspace_spec
+
+            workspace_warning = supersession_warning(
+                (
+                    workspace_spec(str(requested_workspace_kind), workspace_path)
+                    if requested_workspace_kind is not None
+                    else None
+                ),
+                new_task,
+            ) if new_task else None
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,
@@ -1471,6 +1482,7 @@ def _handle_create(args: dict, **kw) -> str:
                 workspace_path=new_task.workspace_path if new_task else None,
                 project_id=new_task.project_id if new_task else None,
                 subscribed=subscribed,
+                warning=workspace_warning,
             )
         finally:
             conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1434,6 +1434,11 @@ def _handle_create(args: dict, **kw) -> str:
                     if _self_task is not None and _self_task.project_id:
                         project_id = _self_task.project_id
                         project_source_task_id = _self_task.id
+            from hermes_cli.kanban_workspace import (
+                supersession_warning,
+                workspace_spec,
+            )
+
             new_tid = kb.create_task(
                 conn,
                 title=str(title).strip(),
@@ -1444,6 +1449,11 @@ def _handle_create(args: dict, **kw) -> str:
                 priority=int(priority) if priority is not None else 0,
                 workspace_kind=str(workspace_kind),
                 workspace_path=workspace_path,
+                requested_workspace=(
+                    workspace_spec(str(requested_workspace_kind), workspace_path)
+                    if requested_workspace_kind is not None
+                    else None
+                ),
                 project_id=project_id,
                 project_source_task_id=project_source_task_id,
                 triage=triage,

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1474,15 +1474,12 @@ def _handle_create(args: dict, **kw) -> str:
                 session_id=session_id,
             )
             new_task = kb.get_task(conn, new_tid)
+            created_requested_workspace = kb.get_created_requested_workspace(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
-            from hermes_cli.kanban_workspace import supersession_warning, workspace_spec
+            from hermes_cli.kanban_workspace import supersession_warning
 
             workspace_warning = supersession_warning(
-                (
-                    workspace_spec(str(requested_workspace_kind), workspace_path)
-                    if requested_workspace_kind is not None
-                    else None
-                ),
+                created_requested_workspace,
                 new_task,
             ) if new_task else None
             return _ok(

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -1124,6 +1124,14 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | `completed` | `{result_len, summary?}` | Worker wrote `--result` / `--summary` and task hit `done`. `summary` is the first-line handoff (400-char cap); full version lives on the run row. If `complete_task` is called on a never-claimed task with handoff fields, a zero-duration run is synthesized so `run_id` still points at something. |
 | `blocked` | `{reason, kind, recurrences}` | Worker or human flipped the task to `blocked`. `kind` is the typed block reason (`needs_input`, `capability`, `transient`, or `null` for a generic block); `recurrences` is the unblock-loop counter. Synthesizes a zero-duration run when called on a never-claimed task with `--reason`. |
 | `dependency_wait` | `{reason, kind}` | Worker blocked with `kind=dependency` — the task is only waiting on another task, so it routes to `todo` (parent-gated, auto-promoted) instead of `blocked`. No human needed. |
+
+Workspace provenance is additive and backward-compatible. Readers must accept older `created`
+events without `requested_workspace`; in that case the explicit pre-normalization request is
+unknown, while the existing workspace fields still describe creation-time state. The absence of a
+later `workspace_resolved` event means only that no recorded post-creation path change exists. The
+kernel does not backfill or rewrite older events. When a project binding supersedes an explicitly
+requested `scratch` workspace, creation succeeds and the CLI/API returns a warning naming both the
+request and selected project worktree; omitted/default project inheritance remains silent.
 | `block_loop_detected` | `{reason, kind, recurrences, limit}` | A task was unblocked and re-blocked for the same reason `BLOCK_RECURRENCE_LIMIT` times (default 2). Instead of landing in `blocked` again — where a cron would keep unblocking it — it routes to `triage` for a human decision, breaking the unblock↔re-block loop. |
 | `unblocked` | — | `blocked → ready` (or `todo` if parents are still open), either manually or via `/unblock`. Resets the dispatcher's `consecutive_failures` but deliberately preserves `block_recurrences` so the loop breaker keeps its memory. `run_id` is `NULL`. |
 | `archived` | — | Hidden from the default board. If the task was still running, carries the `run_id` of the run that was reclaimed as a side effect. |

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -1120,7 +1120,7 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | `created` | `{assignee, status, parents, tenant, requested_workspace, workspace_kind, workspace_path, branch_name, project_id, …}` | Task inserted. `requested_workspace` is the caller's pre-normalization workspace string (or `null` when omitted); `workspace_kind` and `workspace_path` are the normalized creation state. This event is immutable and its `run_id` is `NULL`. |
 | `promoted` | — | `todo → ready` because all parents hit `done`. `run_id` is `NULL`. |
 | `claimed` | `{lock, expires, run_id}` | Dispatcher atomically claimed a `ready` task for spawn. |
-| `workspace_resolved` | `{previous_path, resolved_path, branch_name}` | Claim-time workspace resolution changed the persisted path. The task-row update and event are atomic; repeated resolution to the same path emits no duplicate event. |
+| `workspace_resolved` | `{previous_path, resolved_path, previous_branch_name, resolved_branch_name, branch_name}` | Claim-time workspace resolution changed the persisted path or branch. The task-row update and event are atomic; repeated resolution to the same path and branch emits no duplicate event. `branch_name` remains a backward-compatible alias for `resolved_branch_name`. |
 | `completed` | `{result_len, summary?}` | Worker wrote `--result` / `--summary` and task hit `done`. `summary` is the first-line handoff (400-char cap); full version lives on the run row. If `complete_task` is called on a never-claimed task with handoff fields, a zero-duration run is synthesized so `run_id` still points at something. |
 | `blocked` | `{reason, kind, recurrences}` | Worker or human flipped the task to `blocked`. `kind` is the typed block reason (`needs_input`, `capability`, `transient`, or `null` for a generic block); `recurrences` is the unblock-loop counter. Synthesizes a zero-duration run when called on a never-claimed task with `--reason`. |
 | `dependency_wait` | `{reason, kind}` | Worker blocked with `kind=dependency` — the task is only waiting on another task, so it routes to `todo` (parent-gated, auto-promoted) instead of `blocked`. No human needed. |
@@ -1131,7 +1131,7 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 Workspace provenance is additive and backward-compatible. Readers must accept older `created`
 events without `requested_workspace`; in that case the explicit pre-normalization request is
 unknown, while the existing workspace fields still describe creation-time state. The absence of a
-later `workspace_resolved` event means only that no recorded post-creation path change exists. The
+later `workspace_resolved` event means only that no recorded post-creation path or branch change exists. The
 kernel does not backfill or rewrite older events. When a project binding supersedes an explicitly
 requested `scratch` workspace, creation succeeds and the CLI/API returns a warning naming both the
 request and selected project worktree; omitted/default project inheritance remains silent.

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -1117,9 +1117,10 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 
 | Kind | Payload | When |
 |---|---|---|
-| `created` | `{assignee, status, parents, tenant}` | Task inserted. `run_id` is `NULL`. |
+| `created` | `{assignee, status, parents, tenant, requested_workspace, workspace_kind, workspace_path, branch_name, project_id, …}` | Task inserted. `requested_workspace` is the caller's pre-normalization workspace string (or `null` when omitted); `workspace_kind` and `workspace_path` are the normalized creation state. This event is immutable and its `run_id` is `NULL`. |
 | `promoted` | — | `todo → ready` because all parents hit `done`. `run_id` is `NULL`. |
 | `claimed` | `{lock, expires, run_id}` | Dispatcher atomically claimed a `ready` task for spawn. |
+| `workspace_resolved` | `{previous_path, resolved_path, branch_name}` | Claim-time workspace resolution changed the persisted path. The task-row update and event are atomic; repeated resolution to the same path emits no duplicate event. |
 | `completed` | `{result_len, summary?}` | Worker wrote `--result` / `--summary` and task hit `done`. `summary` is the first-line handoff (400-char cap); full version lives on the run row. If `complete_task` is called on a never-claimed task with handoff fields, a zero-duration run is synthesized so `run_id` still points at something. |
 | `blocked` | `{reason, kind, recurrences}` | Worker or human flipped the task to `blocked`. `kind` is the typed block reason (`needs_input`, `capability`, `transient`, or `null` for a generic block); `recurrences` is the unblock-loop counter. Synthesizes a zero-duration run when called on a never-claimed task with `--reason`. |
 | `dependency_wait` | `{reason, kind}` | Worker blocked with `kind=dependency` — the task is only waiting on another task, so it routes to `todo` (parent-gated, auto-promoted) instead of `blocked`. No human needed. |

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -1124,6 +1124,9 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | `completed` | `{result_len, summary?}` | Worker wrote `--result` / `--summary` and task hit `done`. `summary` is the first-line handoff (400-char cap); full version lives on the run row. If `complete_task` is called on a never-claimed task with handoff fields, a zero-duration run is synthesized so `run_id` still points at something. |
 | `blocked` | `{reason, kind, recurrences}` | Worker or human flipped the task to `blocked`. `kind` is the typed block reason (`needs_input`, `capability`, `transient`, or `null` for a generic block); `recurrences` is the unblock-loop counter. Synthesizes a zero-duration run when called on a never-claimed task with `--reason`. |
 | `dependency_wait` | `{reason, kind}` | Worker blocked with `kind=dependency` — the task is only waiting on another task, so it routes to `todo` (parent-gated, auto-promoted) instead of `blocked`. No human needed. |
+| `block_loop_detected` | `{reason, kind, recurrences, limit}` | A task was unblocked and re-blocked for the same reason `BLOCK_RECURRENCE_LIMIT` times (default 2). Instead of landing in `blocked` again — where a cron would keep unblocking it — it routes to `triage` for a human decision, breaking the unblock↔re-block loop. |
+| `unblocked` | — | `blocked → ready` (or `todo` if parents are still open), either manually or via `/unblock`. Resets the dispatcher's `consecutive_failures` but deliberately preserves `block_recurrences` so the loop breaker keeps its memory. `run_id` is `NULL`. |
+| `archived` | — | Hidden from the default board. If the task was still running, carries the `run_id` of the run that was reclaimed as a side effect. |
 
 Workspace provenance is additive and backward-compatible. Readers must accept older `created`
 events without `requested_workspace`; in that case the explicit pre-normalization request is
@@ -1132,9 +1135,6 @@ later `workspace_resolved` event means only that no recorded post-creation path 
 kernel does not backfill or rewrite older events. When a project binding supersedes an explicitly
 requested `scratch` workspace, creation succeeds and the CLI/API returns a warning naming both the
 request and selected project worktree; omitted/default project inheritance remains silent.
-| `block_loop_detected` | `{reason, kind, recurrences, limit}` | A task was unblocked and re-blocked for the same reason `BLOCK_RECURRENCE_LIMIT` times (default 2). Instead of landing in `blocked` again — where a cron would keep unblocking it — it routes to `triage` for a human decision, breaking the unblock↔re-block loop. |
-| `unblocked` | — | `blocked → ready` (or `todo` if parents are still open), either manually or via `/unblock`. Resets the dispatcher's `consecutive_failures` but deliberately preserves `block_recurrences` so the loop breaker keeps its memory. `run_id` is `NULL`. |
-| `archived` | — | Hidden from the default board. If the task was still running, carries the `run_id` of the run that was reclaimed as a side effect. |
 
 **Edits** (human-driven changes that aren't transitions):
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -826,9 +826,10 @@ hermes kanban runs t_abcd
 
 | 类型 | 有效载荷 | 时机 |
 |---|---|---|
-| `created` | `{assignee, status, parents, tenant}` | 任务插入。`run_id` 为 `NULL`。 |
+| `created` | `{assignee, status, parents, tenant, requested_workspace, workspace_kind, workspace_path, branch_name, project_id, …}` | 任务插入。`requested_workspace` 是调用方在归一化之前提供的工作区字符串（省略时为 `null`）；`workspace_kind` 和 `workspace_path` 是创建时归一化后的状态。该事件不可变，`run_id` 为 `NULL`。 |
 | `promoted` | — | 因所有父任务达到 `done` 而 `todo → ready`。`run_id` 为 `NULL`。 |
 | `claimed` | `{lock, expires, run_id}` | 调度器原子性认领 `ready` 任务以启动。 |
+| `workspace_resolved` | `{previous_path, resolved_path, branch_name}` | 认领时的工作区解析改变了持久化路径。任务行更新与事件写入是原子的；重复解析到同一路径不会产生重复事件。 |
 | `completed` | `{result_len, summary?}` | Worker 写入 `--result` / `--summary` 且任务达到 `done`。`summary` 是第一行交接（400 字符上限）；完整版本存在于运行行上。如果在从未认领的任务上调用 `complete_task` 并带有交接字段，则合成零持续时间运行，以便 `run_id` 仍然指向某处。 |
 | `blocked` | `{reason}` | Worker 或人类将任务翻转为 `blocked`。在带有 `--reason` 的从未认领任务上调用时合成零持续时间运行。 |
 | `unblocked` | — | `blocked → ready`，手动或通过 `/unblock`。`run_id` 为 `NULL`。 |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -829,14 +829,14 @@ hermes kanban runs t_abcd
 | `created` | `{assignee, status, parents, tenant, requested_workspace, workspace_kind, workspace_path, branch_name, project_id, …}` | 任务插入。`requested_workspace` 是调用方在归一化之前提供的工作区字符串（省略时为 `null`）；`workspace_kind` 和 `workspace_path` 是创建时归一化后的状态。该事件不可变，`run_id` 为 `NULL`。 |
 | `promoted` | — | 因所有父任务达到 `done` 而 `todo → ready`。`run_id` 为 `NULL`。 |
 | `claimed` | `{lock, expires, run_id}` | 调度器原子性认领 `ready` 任务以启动。 |
-| `workspace_resolved` | `{previous_path, resolved_path, branch_name}` | 认领时的工作区解析改变了持久化路径。任务行更新与事件写入是原子的；重复解析到同一路径不会产生重复事件。 |
+| `workspace_resolved` | `{previous_path, resolved_path, previous_branch_name, resolved_branch_name, branch_name}` | 认领时的工作区解析改变了持久化路径或分支。任务行更新与事件写入是原子的；重复解析到相同路径和分支不会产生重复事件。`branch_name` 作为 `resolved_branch_name` 的向后兼容别名保留。 |
 | `completed` | `{result_len, summary?}` | Worker 写入 `--result` / `--summary` 且任务达到 `done`。`summary` 是第一行交接（400 字符上限）；完整版本存在于运行行上。如果在从未认领的任务上调用 `complete_task` 并带有交接字段，则合成零持续时间运行，以便 `run_id` 仍然指向某处。 |
 | `blocked` | `{reason}` | Worker 或人类将任务翻转为 `blocked`。在带有 `--reason` 的从未认领任务上调用时合成零持续时间运行。 |
 | `unblocked` | — | `blocked → ready`，手动或通过 `/unblock`。`run_id` 为 `NULL`。 |
 | `archived` | — | 从默认看板中隐藏。如果任务仍在运行，携带作为副作用被回收的运行的 `run_id`。 |
 
 工作区来源信息采用增量、向后兼容的格式。读取方必须接受不含
-`requested_workspace` 的旧 `created` 事件；此时无法得知归一化前的显式请求，而原有工作区字段仍表示创建时状态。缺少后续 `workspace_resolved` 事件仅表示没有记录到创建后的路径变更。内核不会回填或重写旧事件。当项目绑定取代显式请求的 `scratch` 工作区时，创建仍会成功，CLI/API 会返回同时列出请求值和所选项目工作树的警告；省略工作区或使用默认项目继承时保持静默。
+`requested_workspace` 的旧 `created` 事件；此时无法得知归一化前的显式请求，而原有工作区字段仍表示创建时状态。缺少后续 `workspace_resolved` 事件仅表示没有记录到创建后的路径或分支变更。内核不会回填或重写旧事件。当项目绑定取代显式请求的 `scratch` 工作区时，创建仍会成功，CLI/API 会返回同时列出请求值和所选项目工作树的警告；省略工作区或使用默认项目继承时保持静默。
 
 **编辑**（不是转换的人类驱动变更）：
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -833,10 +833,10 @@ hermes kanban runs t_abcd
 | `completed` | `{result_len, summary?}` | Worker 写入 `--result` / `--summary` 且任务达到 `done`。`summary` 是第一行交接（400 字符上限）；完整版本存在于运行行上。如果在从未认领的任务上调用 `complete_task` 并带有交接字段，则合成零持续时间运行，以便 `run_id` 仍然指向某处。 |
 | `blocked` | `{reason}` | Worker 或人类将任务翻转为 `blocked`。在带有 `--reason` 的从未认领任务上调用时合成零持续时间运行。 |
 | `unblocked` | — | `blocked → ready`，手动或通过 `/unblock`。`run_id` 为 `NULL`。 |
+| `archived` | — | 从默认看板中隐藏。如果任务仍在运行，携带作为副作用被回收的运行的 `run_id`。 |
 
 工作区来源信息采用增量、向后兼容的格式。读取方必须接受不含
 `requested_workspace` 的旧 `created` 事件；此时无法得知归一化前的显式请求，而原有工作区字段仍表示创建时状态。缺少后续 `workspace_resolved` 事件仅表示没有记录到创建后的路径变更。内核不会回填或重写旧事件。当项目绑定取代显式请求的 `scratch` 工作区时，创建仍会成功，CLI/API 会返回同时列出请求值和所选项目工作树的警告；省略工作区或使用默认项目继承时保持静默。
-| `archived` | — | 从默认看板中隐藏。如果任务仍在运行，携带作为副作用被回收的运行的 `run_id`。 |
 
 **编辑**（不是转换的人类驱动变更）：
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -833,6 +833,9 @@ hermes kanban runs t_abcd
 | `completed` | `{result_len, summary?}` | Worker 写入 `--result` / `--summary` 且任务达到 `done`。`summary` 是第一行交接（400 字符上限）；完整版本存在于运行行上。如果在从未认领的任务上调用 `complete_task` 并带有交接字段，则合成零持续时间运行，以便 `run_id` 仍然指向某处。 |
 | `blocked` | `{reason}` | Worker 或人类将任务翻转为 `blocked`。在带有 `--reason` 的从未认领任务上调用时合成零持续时间运行。 |
 | `unblocked` | — | `blocked → ready`，手动或通过 `/unblock`。`run_id` 为 `NULL`。 |
+
+工作区来源信息采用增量、向后兼容的格式。读取方必须接受不含
+`requested_workspace` 的旧 `created` 事件；此时无法得知归一化前的显式请求，而原有工作区字段仍表示创建时状态。缺少后续 `workspace_resolved` 事件仅表示没有记录到创建后的路径变更。内核不会回填或重写旧事件。当项目绑定取代显式请求的 `scratch` 工作区时，创建仍会成功，CLI/API 会返回同时列出请求值和所选项目工作树的警告；省略工作区或使用默认项目继承时保持静默。
 | `archived` | — | 从默认看板中隐藏。如果任务仍在运行，携带作为副作用被回收的运行的 `run_id`。 |
 
 **编辑**（不是转换的人类驱动变更）：


### PR DESCRIPTION
## Summary
- preserve the caller's requested workspace separately from normalized creation state
- record atomic `workspace_resolved` events when claim-time resolution changes the path
- warn across CLI, dashboard API, and `kanban_create` when project binding supersedes an explicit workspace
- preserve explicit dashboard `scratch` selections and document the public event contract

## Verification
- `./scripts/run_tests.sh -j 6 tests/hermes_cli/test_kanban_workspace_provenance.py tests/hermes_cli/test_kanban_project_link.py tests/hermes_cli/test_kanban_workspace_warning.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_dispatch_lock.py tests/hermes_cli/test_kanban_default_assignee.py tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_review_lifecycle.py tests/plugins/test_kanban_dashboard_plugin.py tests/tools/test_kanban_tools.py -q` — 131 passed, 1 Windows-only skip
- final provenance/project/warning lane — 15 passed
- `uv run ruff check <changed Python files>` — passed
- `git diff --check origin/main...HEAD` — passed
- fresh independent exact-head review of `7c993d6850030c7c55a15fbab2842c3e22b17f0a` after the documentation correction — APPROVED, no blockers

## Notes
- `created` remains immutable; legacy history is not backfilled.
- The broader repository suite completed non-green with 99 failures and 11 ACP collection-error files in unrelated optional-dependency/environment/base areas; no changed provenance test failed.
- GitHub currently reports no CI checks for this PR; an empty rollup is not a pass.

Kanban: `t_f75e9710`
