### PR TITLE
fix(hooks): version outbound webhook envelope and fail closed on invalid config

### DIFF
--- a/agent/outbound_webhooks.py
+++ b/agent/outbound_webhooks.py
@@ -14,17 +14,25 @@ changes; outbound tells the world when Hermes does something.
 Design notes
 ------------
 * Delivery is fire-and-forget through a bounded in-process queue and a
-  single daemon worker thread.  ``invoke_hook()`` runs inside the agent
+  single daemon worker thread. ``invoke_hook()`` runs inside the agent
   loop, so callbacks must never block on network I/O — they serialize,
-  enqueue, and return ``None`` immediately.  Outbound targets can never
+  enqueue, and return ``None`` immediately. Outbound targets can never
   block a tool call, inject context, or otherwise influence agent flow.
-* Payloads are signed with HMAC-SHA256 (GitHub-style
-  ``X-Hermes-Signature-256: sha256=<hexdigest>`` over the raw body) when
-  a secret is configured.  Receivers verify exactly like they verify
-  GitHub webhooks.
+* The version-1 body is signed with HMAC-SHA256 when a secret reference
+  resolves. ``X-Hermes-Signature-256`` remains for compatibility;
+  ``X-Hermes-Signature-V2`` binds the raw ``X-Hermes-Timestamp`` value,
+  a literal ``.`` byte, and the exact raw body.
+* A configured ``secret_ref`` or compatibility ``secret_env`` is
+  fail-closed. An empty, malformed, unscoped, or unresolved reference
+  disables that target; Hermes never silently downgrades it to unsigned
+  delivery. Unsigned delivery is possible only when neither reference
+  field is present.
+* Inline plaintext ``secret`` values are no longer accepted. Move the
+  value to the environment or active profile secret scope and configure
+  its name through ``secret_ref`` (preferred) or ``secret_env``.
 * No consent prompt: unlike shell hooks, an outbound target executes no
   code on this machine — it POSTs JSON to a URL the user themselves put
-  in config.  ``HERMES_SAFE_MODE=1`` still skips registration, matching
+  in config. ``HERMES_SAFE_MODE=1`` still skips registration, matching
   plugins / MCP / shell hooks.
 * Registration is idempotent — safe to invoke from both the CLI entry
   point and the gateway entry point.
@@ -35,16 +43,17 @@ Config schema (``~/.hermes/config.yaml``)::
       outbound:
         - url: https://ci.example.com/hermes-events
           events: [on_session_end, subagent_stop]
-          # secret literal (discouraged) or env var name (preferred):
-          secret_env: HERMES_OUTBOUND_WEBHOOK_SECRET
-          # optional regex, honored for pre/post_tool_call only:
-          matcher: "terminal|delegate_task"
+          # Name of a secret in the active profile scope or environment.
+          secret_ref: HERMES_OUTBOUND_WEBHOOK_SECRET
+          # ``secret_env`` is accepted as a compatibility alias.
+          matcher: "terminal|delegate_task"  # pre/post_tool_call only
           timeout: 10       # per-attempt seconds, clamped to [1, 60]
           name: ci-notify   # optional label for logs / `hermes hooks list`
 
 Wire format (POST body)::
 
     {
+        "schema_version":  1,
         "hook_event_name": "on_session_end",
         "tool_name":       null,
         "tool_input":      null,
@@ -58,10 +67,25 @@ Wire format (POST body)::
 Headers::
 
     Content-Type:            application/json
-    User-Agent:              Hermes-Agent-Outbound-Webhook
+    User-Agent:              Hermes-Agent-Outbound-Webhook/1
     X-Hermes-Event:          <hook event name>
     X-Hermes-Delivery:       <delivery_id>
-    X-Hermes-Signature-256:  sha256=<hmac hexdigest>   # only when secret set
+    X-Hermes-Schema-Version: 1
+    X-Hermes-Timestamp:      <unix seconds>
+    X-Hermes-Signature-256:  sha256=<HMAC(raw body)>  # compatibility
+    X-Hermes-Signature-V2:   sha256=<HMAC(timestamp + b"." + raw body)>
+
+Receiver verification contract
+------------------------------
+``X-Hermes-Signature-V2`` makes replay checks possible; the receiver must
+complete them before performing side effects. Parse ``X-Hermes-Timestamp``
+as integer Unix seconds and reject requests outside a bounded freshness
+window (300 seconds is the recommended default, with clock skew included).
+Compute HMAC-SHA256 over the exact timestamp header bytes, ``b"."``, and
+the untouched request body, then compare the full ``sha256=...`` value with
+``hmac.compare_digest``. Finally, accept each ``X-Hermes-Delivery`` value at
+most once for at least the freshness window. A valid HMAC without freshness
+and delivery-ID deduplication is authenticated but still replayable.
 """
 
 from __future__ import annotations
@@ -71,7 +95,6 @@ import hashlib
 import hmac
 import json
 import logging
-import os
 import queue
 import re
 import threading
@@ -83,6 +106,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib import error as urlerror
 from urllib import request as urlrequest
+
+from agent.secret_scope import UnscopedSecretError, get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +122,17 @@ _TOOL_SCOPED_EVENTS = {"pre_tool_call", "post_tool_call"}
 
 # kwargs promoted to top-level payload keys (mirrors shell hooks wire).
 _TOP_LEVEL_PAYLOAD_KEYS = {"tool_name", "args", "session_id", "parent_session_id"}
+
+_KNOWN_FIELDS = frozenset({
+    "url",
+    "events",
+    "name",
+    "secret_ref",
+    "secret_env",
+    "matcher",
+    "timeout",
+})
+_SECRET_REFERENCE_FIELDS = ("secret_ref", "secret_env")
 
 # (event, url) pairs already wired to the plugin manager in this process.
 _registered: Set[Tuple[str, str]] = set()
@@ -156,7 +192,7 @@ class WebhookTarget:
 def register_from_config(cfg: Optional[Dict[str, Any]]) -> List[WebhookTarget]:
     """Register every configured outbound webhook on the plugin manager.
 
-    ``cfg`` is the full parsed config dict.  Missing, empty, or malformed
+    ``cfg`` is the full parsed config dict. Missing, empty, or malformed
     ``hooks.outbound`` is treated as zero targets — config parsing never
     raises, because a broken webhook entry must not crash the agent.
 
@@ -220,7 +256,7 @@ def iter_configured_targets(cfg: Optional[Dict[str, Any]]) -> List[WebhookTarget
 
 def flush(timeout: float = 5.0) -> bool:
     """Block until all queued deliveries are done (or *timeout* elapses).
-    Returns ``True`` when the queue fully drained.  Test/shutdown helper."""
+    Returns ``True`` when the queue fully drained. Test/shutdown helper."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         with _delivery_queue.all_tasks_done:
@@ -232,7 +268,7 @@ def flush(timeout: float = 5.0) -> bool:
 
 
 def reset_for_tests() -> None:
-    """Clear the idempotence set and drain the queue.  Test-only helper."""
+    """Clear the idempotence set and drain the queue. Test-only helper."""
     with _registered_lock:
         _registered.clear()
     try:
@@ -273,6 +309,27 @@ def _parse_single_target(index: int, raw: Any) -> Optional[WebhookTarget]:
             "hooks.outbound[%d] must be a mapping with 'url' and 'events' "
             "keys; got %s", index, type(raw).__name__,
         )
+        return None
+
+    unknown = sorted(set(raw) - _KNOWN_FIELDS)
+    if unknown:
+        if "secret" in unknown:
+            logger.error(
+                "hooks.outbound[%d].secret contains unsupported inline "
+                "plaintext. Move the value to the environment or active "
+                "profile secret scope and set secret_ref (preferred) or "
+                "secret_env to that name — target disabled",
+                index,
+            )
+        other_unknown = [field for field in unknown if field != "secret"]
+        if other_unknown:
+            logger.warning(
+                "hooks.outbound[%d] has unknown field(s) %s. Known fields: %s "
+                "— target disabled",
+                index,
+                ", ".join(other_unknown),
+                ", ".join(sorted(_KNOWN_FIELDS)),
+            )
         return None
 
     url = raw.get("url")
@@ -339,7 +396,9 @@ def _parse_single_target(index: int, raw: Any) -> Optional[WebhookTarget]:
         timeout = DEFAULT_TIMEOUT_SECONDS
     timeout = max(1, min(timeout, MAX_TIMEOUT_SECONDS))
 
-    secret = _resolve_secret(index, raw)
+    secret, usable = _resolve_secret(index, raw)
+    if not usable:
+        return None
 
     name = raw.get("name")
     if not isinstance(name, str):
@@ -355,22 +414,62 @@ def _parse_single_target(index: int, raw: Any) -> Optional[WebhookTarget]:
     )
 
 
-def _resolve_secret(index: int, raw: Dict[str, Any]) -> Optional[str]:
-    """``secret_env`` (env var name, preferred) wins over inline ``secret``."""
-    secret_env = raw.get("secret_env")
-    if isinstance(secret_env, str) and secret_env.strip():
-        value = os.environ.get(secret_env.strip(), "")
-        if value:
-            return value
-        logger.warning(
-            "hooks.outbound[%d].secret_env=%r is not set in the environment "
-            "— deliveries will be UNSIGNED", index, secret_env.strip(),
+def _resolve_secret(
+    index: int, raw: Dict[str, Any],
+) -> Tuple[Optional[str], bool]:
+    """Resolve one optional secret reference.
+
+    Returns ``(secret, usable)``. ``(None, True)`` means no secret field was
+    configured and unsigned delivery was intentionally requested.
+    ``(None, False)`` means a reference was configured but could not be used,
+    so the caller must disable the target rather than downgrade it.
+    """
+    configured = [field for field in _SECRET_REFERENCE_FIELDS if field in raw]
+    if not configured:
+        return None, True
+    if len(configured) != 1:
+        logger.error(
+            "hooks.outbound[%d] configures both secret_ref and secret_env. "
+            "Configure exactly one reference field — target disabled",
+            index,
         )
-        return None
-    secret = raw.get("secret")
-    if isinstance(secret, str) and secret:
-        return secret
-    return None
+        return None, False
+
+    field_name = configured[0]
+    reference = raw.get(field_name)
+    if not isinstance(reference, str) or not reference.strip():
+        logger.error(
+            "hooks.outbound[%d].%s must be a non-empty secret name — target "
+            "disabled; Hermes will not send this webhook unsigned",
+            index,
+            field_name,
+        )
+        return None, False
+    reference = reference.strip()
+
+    try:
+        value = get_secret(reference, "")
+    except UnscopedSecretError as exc:
+        logger.error(
+            "hooks.outbound[%d] secret reference %r cannot be resolved "
+            "without an active profile secret scope (%s) — target disabled; "
+            "no process-environment fallback was attempted",
+            index,
+            reference,
+            exc,
+        )
+        return None, False
+
+    if value:
+        return str(value), True
+
+    logger.error(
+        "hooks.outbound[%d] secret reference %r did not resolve — target "
+        "disabled; Hermes will not send this webhook unsigned",
+        index,
+        reference,
+    )
+    return None, False
 
 
 # ---------------------------------------------------------------------------
@@ -404,12 +503,13 @@ def _make_callback(event: str, target: WebhookTarget):
 def _serialize_payload(
     event: str, kwargs: Dict[str, Any], delivery_id: str,
 ) -> bytes:
-    """Render the POST body.  Same top-level shape as shell hooks' stdin
-    (documented in :mod:`agent.shell_hooks`), plus delivery metadata.
+    """Render the version-1 POST body.
 
-    ``delivery_id`` is shared with the ``X-Hermes-Delivery`` header so
-    receivers can dedupe on either — and since it (plus ``timestamp``)
-    lives inside the HMAC-signed body, it doubles as replay protection.
+    The shape mirrors shell hooks' stdin (documented in
+    :mod:`agent.shell_hooks`) plus delivery metadata. ``delivery_id`` is shared
+    with ``X-Hermes-Delivery`` so receivers can deduplicate. Replay protection
+    is complete only when the receiver also validates the V2 timestamp and
+    rejects a delivery ID it has already accepted.
     """
     extras = {k: v for k, v in kwargs.items() if k not in _TOP_LEVEL_PAYLOAD_KEYS}
     try:
@@ -417,6 +517,7 @@ def _serialize_payload(
     except OSError:
         cwd = ""
     payload = {
+        "schema_version": 1,
         "hook_event_name": event,
         "tool_name": kwargs.get("tool_name"),
         "tool_input": kwargs.get("args") if isinstance(kwargs.get("args"), dict) else None,
@@ -434,17 +535,28 @@ def _serialize_payload(
 def _build_delivery(
     event: str, target: WebhookTarget, body: bytes, delivery_id: str,
 ) -> Dict[str, Any]:
+    timestamp = str(int(time.time()))
     headers = {
         "Content-Type": "application/json",
-        "User-Agent": "Hermes-Agent-Outbound-Webhook",
+        "User-Agent": "Hermes-Agent-Outbound-Webhook/1",
         "X-Hermes-Event": event,
         "X-Hermes-Delivery": delivery_id,
+        "X-Hermes-Schema-Version": "1",
+        "X-Hermes-Timestamp": timestamp,
     }
     if target.secret:
-        digest = hmac.new(
+        # Compatibility header for existing receivers.
+        legacy = hmac.new(
             target.secret.encode("utf-8"), body, hashlib.sha256
         ).hexdigest()
-        headers["X-Hermes-Signature-256"] = f"sha256={digest}"
+        headers["X-Hermes-Signature-256"] = f"sha256={legacy}"
+
+        # V2 binds time + body so receivers can enforce bounded freshness.
+        signed = timestamp.encode("ascii") + b"." + body
+        digest = hmac.new(
+            target.secret.encode("utf-8"), signed, hashlib.sha256
+        ).hexdigest()
+        headers["X-Hermes-Signature-V2"] = f"sha256={digest}"
     return {
         "url": target.url,
         "label": target.label,
@@ -480,7 +592,7 @@ def _ensure_worker() -> None:
         # The worker is a daemon thread, so a short-lived process (a `-q`
         # CLI run, a cron session) can exit right after enqueuing the
         # final events — silently dropping on_session_end, the headline
-        # use case.  Drain the queue at interpreter shutdown, bounded so
+        # use case. Drain the queue at interpreter shutdown, bounded so
         # a dead endpoint can only delay exit, never hang it.
         atexit.register(flush, timeout=5.0)
 
@@ -506,7 +618,7 @@ class _NoRedirectHandler(urlrequest.HTTPRedirectHandler):
 
     urllib's default handler converts a redirected POST into a body-less
     GET — the signed payload would be silently dropped and the headers
-    re-sent to a location the user never configured.  Treat any 3xx as a
+    re-sent to a location the user never configured. Treat any 3xx as a
     delivery failure instead (surfaced as HTTPError by returning None).
     """
 
@@ -518,7 +630,7 @@ _opener = urlrequest.build_opener(_NoRedirectHandler)
 
 
 def _deliver(delivery: Dict[str, Any]) -> None:
-    """POST with bounded retries.  Retries on connection errors and 5xx;
+    """POST with bounded retries. Retries on connection errors and 5xx;
     4xx is the receiver telling us the request itself is wrong — no retry.
     3xx redirects are never followed (misconfiguration — fix the URL)."""
     last_error = ""

--- a/tests/agent/test_outbound_webhook_contract.py
+++ b/tests/agent/test_outbound_webhook_contract.py
@@ -1,0 +1,141 @@
+"""Strict Task 14 outbound configuration and signature contract."""
+
+import hashlib
+import hmac
+import json
+import logging
+
+import pytest
+
+from agent import outbound_webhooks as ow
+from agent import secret_scope
+
+
+def _cfg(entry):
+    return {"hooks": {"outbound": [entry]}}
+
+
+def _entry(**overrides):
+    entry = {
+        "url": "https://example.com/hook",
+        "events": ["on_session_end"],
+    }
+    entry.update(overrides)
+    return entry
+
+
+def test_unknown_field_rejects_entire_target():
+    assert ow.iter_configured_targets(_cfg(_entry(secrete="typo"))) == []
+
+
+def test_inline_plaintext_secret_reports_migration_and_disables_target(caplog):
+    caplog.set_level(logging.ERROR, logger=ow.__name__)
+
+    assert ow.iter_configured_targets(
+        _cfg(_entry(secret="super-secret-value"))
+    ) == []
+
+    message = caplog.text
+    assert "unsupported inline plaintext" in message
+    assert "secret_ref" in message
+    assert "secret_env" in message
+    assert "target disabled" in message
+    assert "super-secret-value" not in message
+
+
+def test_missing_explicit_secret_reference_fails_closed(monkeypatch, caplog):
+    monkeypatch.delenv("MISSING_WR_SECRET", raising=False)
+    caplog.set_level(logging.ERROR, logger=ow.__name__)
+
+    assert ow.iter_configured_targets(
+        _cfg(_entry(secret_ref="MISSING_WR_SECRET"))
+    ) == []
+
+    assert "target disabled" in caplog.text
+    assert "will not send this webhook unsigned" in caplog.text
+
+
+@pytest.mark.parametrize("value", ["", "   ", None, 7])
+def test_malformed_explicit_secret_reference_never_downgrades_to_unsigned(
+    value, caplog,
+):
+    caplog.set_level(logging.ERROR, logger=ow.__name__)
+
+    assert ow.iter_configured_targets(
+        _cfg(_entry(secret_ref=value))
+    ) == []
+
+    assert "must be a non-empty secret name" in caplog.text
+    assert "will not send this webhook unsigned" in caplog.text
+
+
+def test_multiple_reference_fields_are_rejected(monkeypatch, caplog):
+    monkeypatch.setenv("A", "one")
+    monkeypatch.setenv("B", "two")
+    caplog.set_level(logging.ERROR, logger=ow.__name__)
+
+    assert ow.iter_configured_targets(
+        _cfg(_entry(secret_ref="A", secret_env="B"))
+    ) == []
+
+    assert "exactly one reference field" in caplog.text
+
+
+def test_no_secret_fields_is_the_only_unsigned_configuration():
+    target = ow.iter_configured_targets(_cfg(_entry()))[0]
+    assert target.secret is None
+
+
+def test_unscoped_reference_fails_closed_without_process_env_fallback(
+    monkeypatch, caplog,
+):
+    monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", True)
+    monkeypatch.setenv("PROFILE_ONLY_SECRET", "must-not-leak")
+    caplog.set_level(logging.ERROR, logger=ow.__name__)
+
+    assert ow.iter_configured_targets(
+        _cfg(_entry(secret_ref="PROFILE_ONLY_SECRET"))
+    ) == []
+
+    assert "active profile secret scope" in caplog.text
+    assert "no process-environment fallback was attempted" in caplog.text
+
+
+def test_unexpected_secret_resolver_failure_is_not_swallowed(monkeypatch):
+    def explode(_name, _default):
+        raise RuntimeError("resolver import/state failure")
+
+    monkeypatch.setattr(ow, "get_secret", explode)
+
+    with pytest.raises(RuntimeError, match="resolver import/state failure"):
+        ow.iter_configured_targets(
+            _cfg(_entry(secret_ref="WR_SECRET"))
+        )
+
+
+def test_v2_signature_binds_timestamp_and_body(monkeypatch):
+    monkeypatch.setenv("WR_SECRET", "s3cret")
+    target = ow.iter_configured_targets(
+        _cfg(_entry(secret_ref="WR_SECRET"))
+    )[0]
+    body = json.dumps({"schema_version": 1, "x": 1}).encode()
+    delivery = ow._build_delivery("on_session_end", target, body, "d1")
+    headers = delivery["headers"]
+    timestamp = headers["X-Hermes-Timestamp"]
+
+    expected_v2 = hmac.new(
+        b"s3cret", timestamp.encode("ascii") + b"." + body, hashlib.sha256
+    ).hexdigest()
+    expected_legacy = hmac.new(b"s3cret", body, hashlib.sha256).hexdigest()
+
+    assert headers["X-Hermes-Signature-V2"] == f"sha256={expected_v2}"
+    assert headers["X-Hermes-Signature-256"] == f"sha256={expected_legacy}"
+    assert headers["X-Hermes-Schema-Version"] == "1"
+
+
+def test_receiver_contract_documents_complete_replay_checks():
+    docs = ow.__doc__ or ""
+    assert "300 seconds" in docs
+    assert "hmac.compare_digest" in docs
+    assert "X-Hermes-Delivery" in docs
+    assert "still replayable" in docs

--- a/tests/agent/test_outbound_webhooks.py
+++ b/tests/agent/test_outbound_webhooks.py
@@ -219,21 +219,21 @@ class TestParseConfig:
         )
         assert targets[0].matcher == "terminal|delegate_task"
 
-    def test_secret_env_wins_over_literal(self, monkeypatch):
+    def test_inline_secret_field_rejects_the_target(self, monkeypatch):
         monkeypatch.setenv("MY_HOOK_SECRET", "from-env")
         targets = outbound_webhooks.iter_configured_targets(
             _cfg(
                 {
-                    "url": "https://example.com",
+                    "url": "https://example.com/hook",
                     "events": ["on_session_end"],
                     "secret_env": "MY_HOOK_SECRET",
                     "secret": "literal",
                 }
             )
         )
-        assert targets[0].secret == "from-env"
+        assert targets == []
 
-    def test_unset_secret_env_means_unsigned(self, monkeypatch):
+    def test_unset_secret_reference_skips_target(self, monkeypatch):
         monkeypatch.delenv("MISSING_SECRET_VAR", raising=False)
         targets = outbound_webhooks.iter_configured_targets(
             _cfg(
@@ -244,7 +244,7 @@ class TestParseConfig:
                 }
             )
         )
-        assert targets[0].secret is None
+        assert targets == []
 
 
 # ── matcher behaviour ─────────────────────────────────────────────────────
@@ -300,6 +300,7 @@ class TestPayload:
         assert payload["extra"]["duration_ms"] == 42
         assert payload["delivery_id"] == "did_1234"
         assert payload["timestamp"].endswith("Z")
+        assert payload["schema_version"] == 1
 
     def test_unserialisable_values_stringified(self):
         body = outbound_webhooks._serialize_payload(
@@ -349,13 +350,14 @@ class TestRegistration:
 
 
 class TestDelivery:
-    def test_delivery_with_hmac_signature(self, http_server):
+    def test_delivery_with_hmac_signature(self, http_server, monkeypatch):
         secret = "s3cret"
+        monkeypatch.setenv("WR_OUTBOUND_SECRET", secret)
         cfg = _cfg(
             {
                 "url": _url(http_server),
                 "events": ["on_session_end"],
-                "secret": secret,
+                "secret_ref": "WR_OUTBOUND_SECRET",
                 "name": "e2e",
             }
         )
@@ -376,19 +378,14 @@ class TestDelivery:
 
         assert len(http_server.captured) == 1
         req = http_server.captured[0]
-
         payload = json.loads(req["body"])
-        assert payload["hook_event_name"] == "on_session_end"
-        assert payload["session_id"] == "sess_e2e"
-        assert payload["extra"]["completed"] is True
-        assert payload["extra"]["model"] == "test-model"
-
-        assert req["headers"]["X-Hermes-Event"] == "on_session_end"
-        assert req["headers"]["X-Hermes-Delivery"]
-        expected = hmac.new(
-            secret.encode(), req["body"], hashlib.sha256
+        assert payload["schema_version"] == 1
+        assert req["headers"]["X-Hermes-Schema-Version"] == "1"
+        timestamp = req["headers"]["X-Hermes-Timestamp"]
+        expected_v2 = hmac.new(
+            secret.encode(), timestamp.encode("ascii") + b"." + req["body"], hashlib.sha256
         ).hexdigest()
-        assert req["headers"]["X-Hermes-Signature-256"] == f"sha256={expected}"
+        assert req["headers"]["X-Hermes-Signature-V2"] == f"sha256={expected_v2}"
 
     def test_unsigned_delivery_has_no_signature_header(self, http_server):
         cfg = _cfg({"url": _url(http_server), "events": ["on_session_end"]})
@@ -466,12 +463,13 @@ class TestDelivery:
         assert [c["method"] for c in http_server.captured] == ["POST"]
         assert http_server.captured[0]["path"] == "/hook"
 
-    def test_delivery_id_matches_header_and_body(self, http_server):
+    def test_delivery_id_matches_header_and_body(self, http_server, monkeypatch):
         """The X-Hermes-Delivery header and the signed body's delivery_id
         must be the same value, or receiver-side dedupe breaks."""
+        monkeypatch.setenv("WR_OUTBOUND_SECRET", "s")
         cfg = _cfg(
             {"url": _url(http_server), "events": ["on_session_end"],
-             "secret": "s"}
+             "secret_ref": "WR_OUTBOUND_SECRET"}
         )
         outbound_webhooks.register_from_config(cfg)
 


### PR DESCRIPTION
Part of #84834 — Webhook Feature Package Task 14.

## Current disposition

The outbound-webhook lane is semantically restacked directly onto current `main` as a one-commit/three-file object.

- base: `533886c8b8eb67ff8b389b7f48e7d5e5d9c575b9`
- head: `d136e8562c372dc9cbf1dbacd94d79b2079431d3`
- commits: 1
- files: 3
- mergeable: yes

The restack was proof-preserving: comparison from the previous base to current `main` showed that none of this lane's three owned files changed upstream. The new object overlays the exact previously reviewed production/test blobs onto the exact current-main tree rather than replaying historical campaign topology.

## Owned contract

- versioned outbound webhook envelope (`schema_version: 1`);
- explicit known-field validation; inline plaintext `secret` is rejected with a value-free migration hint;
- exactly one opaque credential reference (`secret_ref`, with `secret_env` compatibility) and no raw environment fallback after the profile secret authority returns a scoped miss;
- unresolved explicit references disable the target rather than silently sending unsigned;
- V2 signs `<timestamp>.<raw body>` and receiver documentation requires freshness, constant-time HMAC verification, and delivery-ID deduplication; timestamp binding alone is not represented as replay prevention;
- redirects are refused and delivery remains bounded/fire-and-forget through the existing worker queue.

This closes the cross-profile authority defect in the old implementation: `agent.secret_scope.get_secret` is the sole credential resolver. `UnscopedSecretError` fails the target closed; unexpected runtime/import failures remain visible instead of being swallowed by a blanket `except Exception`.

## Exact-head verification

All hosted acceptance receipts are attached directly to `d136e8562c372dc9cbf1dbacd94d79b2079431d3`:

- CI `32446033866` — **success**
- Docker `32446033398` — **success**
- Nix `32446033397` — **success**

No status is inherited from the prior head. The former exact-head Windows progress failure belonged to `71c40ca...`; the current-main restack now passes that repository matrix on its own exact object.

## Topology

This remains the Task 14 outbound-hook authority under #84834. It does not absorb inbound webhook intake (#90236/#90995), verifier authority (#85318), session policy (#90304), callback transport (#85675), or final Task 19 integration (#85640).