### PR TITLE
fix(tools): do not adopt a stale cwd after an interrupted command

### DIFF
--- a/tests/tools/test_interrupted_command_cwd.py
+++ b/tests/tools/test_interrupted_command_cwd.py
@@ -1,0 +1,205 @@
+"""An interrupted command must not adopt the shared environment's cwd.
+
+The command wrapper prints the ``__HERMES_CWD_*`` marker AFTER the command
+returns, so a killed / timed-out command emits none and ``env.cwd`` still holds
+whatever the last command to FINISH left there. One local environment is shared
+by every session (``_resolve_container_task_id`` collapses cwd-only overrides to
+``"default"``), so that leftover is routinely ANOTHER session's directory.
+
+Without the ``cwd_observed`` gate, the post-command dual-write stamped that
+foreign directory onto the interrupted session's durable record, and every later
+command in that session ran there — a silent re-home into a directory the user
+never opened.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+import tools.terminal_tool as tt
+from tools.environments.local import LocalEnvironment
+
+
+@pytest.fixture(autouse=True)
+def _clean_store(monkeypatch):
+    monkeypatch.setattr(tt, "_session_cwd", {})
+    monkeypatch.setattr(tt, "_task_env_overrides", {})
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+
+@pytest.fixture
+def env(tmp_path):
+    environment = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+    environment.init_session()
+    yield environment
+    environment.cleanup()
+
+
+def _run(env, session_key, command, timeout=30):
+    """One turn of the terminal tool's per-session cwd handling.
+
+    Mirrors terminal_tool.py: resolve this session's cwd, run, then dual-write
+    the record only when the command reported where it finished.
+    """
+    command_cwd = tt._resolve_command_cwd(
+        workdir=None, default_cwd=env.cwd, session_key=session_key, env_type="local"
+    )
+    result = env.execute(command, cwd=command_cwd, timeout=timeout)
+    if result.get("cwd_observed"):
+        tt.record_session_cwd(session_key, getattr(env, "cwd", None))
+    return result, command_cwd
+
+
+class TestCwdObservedFlag:
+    def test_completed_command_reports_its_cwd(self, env, tmp_path):
+        target = tmp_path / "done"
+        target.mkdir()
+        result, _ = _run(env, "sess", f"cd {target} && pwd")
+        assert result["cwd_observed"] is True
+
+    def test_interrupted_command_reports_no_cwd(self, env, tmp_path):
+        target = tmp_path / "slow"
+        target.mkdir()
+        result, _ = _run(env, "sess", f"cd {target} && sleep 20", timeout=2)
+        # Killed before the wrapper could print the marker.
+        assert not result.get("cwd_observed")
+
+
+class TestInterruptDoesNotStealAnotherSessionsCwd:
+    def test_record_survives_an_interrupt(self, env, tmp_path):
+        mine = tmp_path / "mine"
+        theirs = tmp_path / "theirs"
+        mine.mkdir()
+        theirs.mkdir()
+
+        _run(env, "mine", f"cd {mine} && pwd")
+        assert tt.get_session_cwd("mine") == str(mine)
+
+        # Another chat finishes a command; the shared env now points at it.
+        _run(env, "theirs", f"cd {theirs} && pwd")
+        assert os.path.realpath(env.cwd) == os.path.realpath(str(theirs))
+
+        # My command is interrupted. My record must not adopt their directory.
+        _run(env, "mine", f"cd {mine} && sleep 20", timeout=2)
+        assert tt.get_session_cwd("mine") == str(mine)
+
+    def test_next_command_still_runs_in_my_directory(self, env, tmp_path):
+        mine = tmp_path / "mine"
+        theirs = tmp_path / "theirs"
+        mine.mkdir()
+        theirs.mkdir()
+
+        _run(env, "mine", f"cd {mine} && pwd")
+        _run(env, "theirs", f"cd {theirs} && pwd")
+        _run(env, "mine", f"cd {mine} && sleep 20", timeout=2)
+
+        result, _ = _run(env, "mine", "pwd")
+        assert os.path.realpath(result["output"].strip()) == os.path.realpath(str(mine))
+
+    def test_single_session_keeps_its_own_prior_directory(self, env, tmp_path):
+        """No second session needed: a lone session must not re-home either."""
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+
+        _run(env, "solo", f"cd {first} && pwd")
+        # Move the shared env elsewhere the way any other consumer would.
+        env.execute(f"cd {second} && pwd", cwd=str(second))
+
+        _run(env, "solo", f"cd {first} && sleep 20", timeout=2)
+        assert tt.get_session_cwd("solo") == str(first)
+
+
+class TestEchoIsGatedToo:
+    def test_interrupted_command_does_not_echo_a_foreign_cwd(self, env, tmp_path):
+        """The echo tells the model where it ended up; it must not lie."""
+        mine = tmp_path / "mine"
+        theirs = tmp_path / "theirs"
+        mine.mkdir()
+        theirs.mkdir()
+
+        _run(env, "mine", f"cd {mine} && pwd")
+        _run(env, "theirs", f"cd {theirs} && pwd")
+
+        result, command_cwd = _run(env, "mine", f"cd {mine} && sleep 20", timeout=2)
+
+        # The echo block in terminal_tool reads env.cwd only when observed.
+        post_cwd = getattr(env, "cwd", None) if result.get("cwd_observed") else None
+        echoed = (
+            str(post_cwd)
+            if post_cwd
+            and command_cwd
+            and os.path.realpath(str(post_cwd)) != os.path.realpath(str(command_cwd))
+            else None
+        )
+        assert echoed is None
+
+
+class TestTerminalToolReadsTheFlag:
+    """Drive ``tt.terminal_tool`` itself, not a reimplementation of its gate.
+
+    The classes above prove that the ENVIRONMENT produces ``cwd_observed``
+    correctly. These tests prove that the terminal tool CONSUMES it: the
+    record write and the cwd echo. Without them, reverting either call site
+    to the ungated read passes every other test in this file (verified by
+    mutation during review).
+    """
+
+    def _tool(self, monkeypatch, env, command, task_id, timeout=None):
+        import json
+
+        # One shared env for every session, like the real local backend
+        # (_resolve_container_task_id collapses cwd-only sessions to "default").
+        monkeypatch.setattr(tt, "_active_environments", {"default": env})
+        monkeypatch.setattr(tt, "_last_activity", {})
+        monkeypatch.setattr(
+            tt, "_get_env_config",
+            lambda: {"env_type": "local", "cwd": env.cwd, "timeout": 60,
+                     "lifetime_seconds": 3600},
+        )
+        monkeypatch.setattr(
+            tt, "_check_all_guards",
+            lambda command, env_type, **kwargs: {"approved": True},
+        )
+        return json.loads(
+            tt.terminal_tool(command=command, task_id=task_id, timeout=timeout)
+        )
+
+    def test_interrupt_keeps_record_and_echoes_no_cwd(self, env, tmp_path, monkeypatch):
+        mine = tmp_path / "mine"
+        theirs = tmp_path / "theirs"
+        mine.mkdir()
+        theirs.mkdir()
+
+        # My session establishes its directory through the real tool.
+        result = self._tool(monkeypatch, env, f"cd {mine} && pwd", "mine")
+        assert result["exit_code"] == 0
+        assert tt.get_session_cwd("mine") == str(mine)
+
+        # Another session finishes a command; the shared env moves to it.
+        result = self._tool(monkeypatch, env, f"cd {theirs} && pwd", "theirs")
+        assert result["exit_code"] == 0
+        assert os.path.realpath(env.cwd) == os.path.realpath(str(theirs))
+
+        # My command is interrupted. The tool must not write the record
+        # (terminal_tool.py record write) ...
+        result = self._tool(
+            monkeypatch, env, f"cd {mine} && sleep 20", "mine", timeout=2
+        )
+        assert tt.get_session_cwd("mine") == str(mine)
+        # ... and must not echo the foreign directory to the model
+        # (terminal_tool.py cwd echo). Ungated, env.cwd (theirs) differs from
+        # my command_cwd (mine), so the echo would fire with THEIR directory.
+        assert "cwd" not in result or result.get("cwd") is None
+
+    def test_completed_command_still_records_and_echoes(self, env, tmp_path, monkeypatch):
+        """The gate must not break the observed path: cd still round-trips."""
+        target = tmp_path / "target"
+        target.mkdir()
+
+        result = self._tool(monkeypatch, env, f"cd {target} && pwd", "sess")
+        assert result["exit_code"] == 0
+        assert tt.get_session_cwd("sess") == str(target)
+        assert os.path.realpath(result["cwd"]) == os.path.realpath(str(target))

--- a/tests/tools/test_session_cwd_store.py
+++ b/tests/tools/test_session_cwd_store.py
@@ -73,9 +73,10 @@ class TestPostCommandDualWrite:
             env = {}
             cwd = "/start"
             def execute(self, command, **kwargs):
-                # Simulate the env's own post-command tracking (marker parse).
+                # Simulate the env's own post-command tracking (marker parse):
+                # the marker is what moves cwd AND what flags the observation.
                 self.cwd = "/new/dir"
-                return {"output": "", "returncode": 0}
+                return {"output": "", "returncode": 0, "cwd_observed": True}
 
         result = self._run(monkeypatch, "sess-a", FakeEnv())
         assert result["exit_code"] == 0
@@ -154,6 +155,47 @@ class TestDelegateSeedsChildRecord:
         assert tt.get_session_cwd("child-1") == "/child/scratch"
 
 
+class TestReapedEnvFallbackIsFillOnly:
+    """file_tools' reaped-env rescue (#26211) must not overwrite the record.
+
+    The cached file_ops' ``cwd`` is a snapshot of the SHARED env, so it can
+    belong to another session — the same class of error as the
+    interrupted-command bug (#85658). The rescue may only fill an ABSENT
+    record.
+    """
+
+    def _reap(self, monkeypatch, tmp_path, task_id, stale_cwd):
+        import tools.file_tools as ft
+
+        class _StaleFileOps:
+            cwd = stale_cwd
+
+        # Cached file_ops whose env was reaped: cache entry present,
+        # _active_environments empty. The cache is keyed by the COLLAPSED
+        # container id ("default" for plain sessions) — that collapse is
+        # exactly why the snapshot can belong to another session.
+        container_id = tt._resolve_container_task_id(task_id)
+        monkeypatch.setattr(ft, "_file_ops_cache", {container_id: _StaleFileOps()})
+        monkeypatch.setattr(tt, "_active_environments", {})
+        monkeypatch.setattr(tt, "_last_activity", {})
+        monkeypatch.setattr(
+            tt, "_get_env_config",
+            lambda: {"env_type": "local", "cwd": str(tmp_path), "timeout": 60,
+                     "lifetime_seconds": 3600},
+        )
+        ft._get_file_ops(task_id)
+
+    def test_existing_record_survives_the_rescue(self, tmp_path, monkeypatch):
+        tt.record_session_cwd("sess-a", "/my/worktree")
+        self._reap(monkeypatch, tmp_path, "sess-a", "/other/sessions/dir")
+        assert tt.get_session_cwd("sess-a") == "/my/worktree"
+
+    def test_absent_record_is_filled(self, tmp_path, monkeypatch):
+        """#26211 stays fixed: a recordless session still gets the rescue."""
+        self._reap(monkeypatch, tmp_path, "sess-b", "/last/known/dir")
+        assert tt.get_session_cwd("sess-b") == "/last/known/dir"
+
+
 class TestCommandCwdReadsTheRecord:
     """_resolve_command_cwd: workdir > session record > default. Nothing else."""
 
@@ -187,6 +229,8 @@ class TestCommandCwdReadsTheRecord:
                 self.last_cwd_arg = kwargs.get("cwd")
                 if command.startswith("cd "):
                     self.cwd = command[3:]
+                    # A completed cd emits the cwd marker; the parse sets both.
+                    return {"output": "", "returncode": 0, "cwd_observed": True}
                 return {"output": "", "returncode": 0}
 
         fake = FakeEnv()

--- a/tests/tools/test_vercel_sandbox_environment.py
+++ b/tests/tools/test_vercel_sandbox_environment.py
@@ -337,7 +337,8 @@ class TestFileSync:
 
         result = env.execute("echo hello")
 
-        assert result == {"output": "hello\n", "returncode": 0}
+        assert result["output"] == "hello\n"
+        assert result["returncode"] == 0
         assert vercel_sdk.current.write_files_calls[-1] == [
             {
                 "path": "/home/vercel/.hermes/credentials/token.txt",
@@ -480,7 +481,8 @@ class TestExecute:
 
         result = env.execute("echo hello")
 
-        assert result == {"output": "hello\n", "returncode": 0}, label
+        assert result["output"] == "hello\n", label
+        assert result["returncode"] == 0, label
         assert original.closed == 1
         assert vercel_sdk.current is replacement
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1340,6 +1340,13 @@ class BaseEnvironment(ABC):
 
         Updates self.cwd and strips the marker from result["output"].
         Used by remote backends (Docker, SSH, Modal, Daytona, Singularity).
+
+        Sets ``result["cwd_observed"]`` when the marker yielded a directory for
+        THIS command. The wrapper prints the marker after the command returns,
+        so a killed / timed-out command never emits one and ``self.cwd`` keeps
+        whatever the previous command left there. That environment is shared by
+        every session, so callers must not attribute an unobserved cwd to the
+        session that ran this command (see terminal_tool's session-cwd record).
         """
         output = result.get("output", "")
         marker = self._cwd_marker
@@ -1356,6 +1363,7 @@ class BaseEnvironment(ABC):
         cwd_path = output[first + len(marker) : last].strip()
         if cwd_path:
             self.cwd = cwd_path
+            result["cwd_observed"] = True
 
         # Strip the marker line AND the \n we injected before it.
         # The wrapper emits: printf '\n__MARKER__%s__MARKER__\n'

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1665,7 +1665,10 @@ class LocalEnvironment(BaseEnvironment):
             else:
                 # Stale / non-existent path — keep previous cwd; _run_bash
                 # will resolve a safe fallback on the next call if needed.
+                # The rollback restores a value this command did not observe,
+                # so it is not attributable to this command's session either.
                 self.cwd = prev_cwd
+                result.pop("cwd_observed", None)
 
     def cleanup(self):
         """Clean up temp files."""

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1437,11 +1437,21 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 # (fixes #26211: silent file-creation failures in long-running
                 # conversations). Usually a no-op: every completed command
                 # already recorded its cwd.
+                #
+                # Fill-only: ``cached.cwd`` is a snapshot of the SHARED env's
+                # cwd at cache-build time, so it is not attributable to this
+                # session (same class as the interrupted-command bug, #85658).
+                # Rescue a session that has no record, but never overwrite a
+                # record the session wrote for itself.
                 old_cwd = getattr(cached, "cwd", None)
                 if old_cwd:
                     try:
-                        from tools.terminal_tool import record_session_cwd
-                        record_session_cwd(raw_task_id, old_cwd)
+                        from tools.terminal_tool import (
+                            get_session_cwd,
+                            record_session_cwd,
+                        )
+                        if get_session_cwd(raw_task_id) is None:
+                            record_session_cwd(raw_task_id, old_cwd)
                     except Exception:
                         pass
                 with _file_ops_lock:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3311,7 +3311,14 @@ def terminal_tool(
             # (docstring: "Working directory for this command"). Recording it
             # would hijack the session's durable cwd for every later command
             # that doesn't pass ``workdir``. Skip the dual-write in that case.
-            if not workdir:
+            #
+            # AND only when the command actually reported its cwd. The marker
+            # is printed after the command returns, so an interrupted / killed
+            # / timed-out command emits none and env.cwd still holds whatever
+            # the last command to FINISH left there — on a shared env, that is
+            # another session's directory. Recording it silently re-homes this
+            # session into a directory the user never opened.
+            if not workdir and (result or {}).get("cwd_observed"):
                 record_session_cwd(session_key, getattr(env, "cwd", None))
 
             # Extract output
@@ -3418,8 +3425,13 @@ def terminal_tool(
             # defensive 'cd X && ' prefix because the model can't see cwd
             # state; echoing it on change removes the guesswork (pattern
             # borrowed from crush's <cwd> injection).
+            #
+            # Gated on the same observation flag as the record above: without
+            # it, an interrupted command echoes the shared env's leftover cwd
+            # and tells the model it moved to a directory another session
+            # opened.
             try:
-                post_cwd = getattr(env, "cwd", None)
+                post_cwd = getattr(env, "cwd", None) if (result or {}).get("cwd_observed") else None
                 if post_cwd and command_cwd and os.path.realpath(str(post_cwd)) != os.path.realpath(str(command_cwd)):
                     result_dict["cwd"] = str(post_cwd)
             except Exception:


### PR DESCRIPTION
## What does this PR do?

A chat adopted the working directory of a different chat, and every later
command in that chat ran there.

The command wrapper prints the `__HERMES_CWD_*` marker after the command
returns (`tools/environments/base.py:924`). A killed or timed-out command never
prints it, so `env.cwd` still holds the directory of the last command that
FINISHED. One local environment serves every session, because
`_resolve_container_task_id` (`tools/terminal_tool.py:1384`) collapses cwd-only
overrides to `"default"`. That leftover directory is therefore routinely
another session's.

Three call sites trusted a directory that the command never reported:

- The post-command dual-write (`tools/terminal_tool.py:3315`) copied `env.cwd`
  into the interrupted session's durable record.
- The cwd echo (`tools/terminal_tool.py:3422`) read the same value and told
  the model that it had moved.
- The reaped-environment rescue (`tools/file_tools.py:1443`) copied a cached
  snapshot of the same shared value into the session record. Review found
  this sibling after the first version of this PR.

This PR reports the observation instead of inferring it. The marker parse sets
`result["cwd_observed"]`, and the two terminal-tool call sites read that flag.
The file-tools rescue becomes fill-only: it writes the snapshot when the
session has no record, and it never overwrites a record that the session wrote
for itself. When a command reports no directory, the session keeps the
directory that it already had.

This approach is correct because the marker is the only evidence that a command
finished somewhere. The parse already knows whether it found one, so the flag
adds no new state and no new resolver. It also removes the last reads of the
shared `env.cwd` on the session-record path, which the comment at
`tools/terminal_tool.py:1180` asks for.

## Related Issue

Fixes #85658

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/base.py` — `_extract_cwd_from_output` sets
  `result["cwd_observed"]` when the marker gives a directory for this command.
  The docstring states why an unobserved cwd belongs to no session.
- `tools/environments/local.py` — the local override clears the flag when it
  rolls back a path that does not exist. The restored value is also unobserved.
- `tools/terminal_tool.py` — the record write (line 3315) and the cwd echo
  (line 3422) both read the flag.
- `tools/file_tools.py` — the rescue for a reaped environment (#26211) writes
  the cached snapshot only when the session has no record. The snapshot comes
  from the shared environment, so it is not attributable to the session.
- `tests/tools/test_interrupted_command_cwd.py` — new. Eight tests against a
  real `LocalEnvironment`. Two of them drive `terminal_tool` itself through an
  interrupt, so the gates at the call sites have direct coverage.
- `tests/tools/test_session_cwd_store.py` — two fakes simulate the marker
  parse. They moved `cwd` but did not report the observation, so they no longer
  modelled a completed command. They now return the flag. Two new tests pin the
  fill-only contract of the file-tools rescue.
- `tests/tools/test_vercel_sandbox_environment.py` — two assertions compared the
  whole result dictionary against a literal. They now read the two fields that
  they test.

## How to Test

1. Run the changed test files. All 22 pass:

   ```bash
   scripts/run_tests.sh tests/tools/test_interrupted_command_cwd.py tests/tools/test_session_cwd_store.py -q
   ```

2. Prove that the tests detect each fault. Each row reverts one change, runs
   the tests, and fails. I ran all four:

   | Mutation | Result |
   |---|---|
   | Delete `result["cwd_observed"] = True` in `base.py` | 6 of 8 fail in `test_interrupted_command_cwd.py` |
   | Revert the record write to `if not workdir:` | 1 of 8 fails (`test_interrupt_keeps_record_and_echoes_no_cwd`) |
   | Revert the echo to the ungated `getattr(env, "cwd", None)` | 1 of 8 fails (`test_interrupt_keeps_record_and_echoes_no_cwd`) |
   | Remove the `get_session_cwd(...) is None` guard in `file_tools.py` | 1 of 14 fails (`test_existing_record_survives_the_rescue`) |

   The first version of this PR gated the two terminal-tool call sites but
   tested them through a copy of the gate inside the test file. Review showed
   that a revert of either call site passed every test. The two
   `TestTerminalToolReadsTheFlag` tests close that gap: they call
   `tt.terminal_tool()` itself.

3. Reproduce the original defect with the script in #85658. Before the change
   the record holds the other chat's directory. After the change it holds its
   own.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — see the detail below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS, Linux 7.1.0

Test detail: I ran the directories that this change touches, not the whole
suite. CI owns the full run.

- `tests/tools/` reports 27 failures. I ran the same directory on `ac9b9f54c`
  in a clean worktree and compared the failure names. The sets are identical,
  so this branch adds no failure. One of the 27 needs the network
  (`test_web_providers.py`, "DNS resolution failed").
- `tests/tui_gateway/` reports 421 passed and 0 failed.
- The changed test files report 22 passed
  (`test_interrupted_command_cwd.py`: 8, `test_session_cwd_store.py`: 14).
- `tests/tools/test_file_tools_cwd_resolution.py` and
  `tests/tools/test_file_tools.py` report 56 passed and 2 skipped, so the
  fill-only rescue does not regress the #26211 paths.

I started a full `scripts/run_tests.sh` run and stopped it before it finished,
so I make no claim about the directories that I did not run.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the
  docstrings of the changed functions state the new contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

Cross-platform detail: the flag rides the result dictionary, so it is
independent of the host. `scripts/check-windows-footguns.py --diff origin/main`
reports nothing on the lines that this PR adds. The Windows-specific path is
the local override in `local.py`, which clears the flag on a rollback. The
rollback exists for the MSYS path normalization that Git Bash needs.

## Screenshots / Logs

The defect, before the change:

```
shared env.cwd after other chat: /tmp/…/otherchat_4tfd78l7
my interrupted command: {'out': '[Command timed out after 2s]', 'exit': 124}
   my record became   : /tmp/…/otherchat_4tfd78l7      <-- the other chat
   (repo was          : /tmp/…/repo_217_imog )
```

The same sequence, after the change:

```
A: my chat cds into its repo   : {'exit': 0, 'cwd': '/tmp/…/repo_jwnktgnz'}
   my record: True /tmp/…/repo_jwnktgnz

B: OTHER chat works elsewhere  : {'exit': 0, 'cwd': '/tmp/…/otherchat__i3317hp'}
   shared env.cwd is now other : True

C: my chat's command INTERRUPTED: {'exit': 124}
   my record after interrupt   : /tmp/…/repo_jwnktgnz
   STILL MINE (not other)?     : True

D: my next plain command runs in: /tmp/…/repo_jwnktgnz
```

## Notes for review

This PR adds one key to the `execute()` result dictionary. A test that compares
that dictionary against a literal will see it. Two such tests are in this diff.

This PR corrects one of two defects behind the original report. The second
defect is separate. `_completion_cwd` (`tui_gateway/server.py:2411`) gives a
detached desktop session the value of `TERMINAL_CWD`, which the app pins to the
home directory. The database row correctly records no workspace, but the prompt
and the terminal disagree with it. That correction touches a different resolver
and a race in the renderer, so it belongs in its own PR.
