### PR TITLE
fix(agent): jitter backoff waits across retry sites to break synchronized storms

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1346,7 +1346,8 @@ def try_recover_primary_transport(
                 shared=True,
             )
 
-        wait_time = min(3 + retry_count, 8)
+        from agent.error_classifier import jittered_wait
+        wait_time = min(jittered_wait(3 + retry_count), 8)
         agent._vprint(
             f"{agent.log_prefix}🔁 Transient {error_type} on {agent.provider} — "
             f"rebuilt client, waiting {wait_time}s before one last primary attempt.",

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9304,7 +9304,8 @@ def _call_llm_impl(
             _max_transient_retries = _transient_retry_count()
             _last_transient = transient_err
             for _attempt in range(1, _max_transient_retries + 1):
-                _backoff = min(_TRANSIENT_RETRY_BACKOFF_BASE * (2.0 ** (_attempt - 1)), 8.0)
+                from agent.error_classifier import jittered_wait
+                _backoff = min(jittered_wait(_TRANSIENT_RETRY_BACKOFF_BASE * (2.0 ** (_attempt - 1))), 8.0)
                 logger.info(
                     "Auxiliary %s: transient transport error (attempt %d/%d); "
                     "retrying same provider after %.1fs before fallback: %s",

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1949,6 +1949,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             backoff_count = getattr(agent, "_rate_limit_backoff_count", 0)
             agent._rate_limit_backoff_count = backoff_count + 1
             backoff_seconds = min(60 * (2 ** backoff_count), 14400)
+            # S1-04 jitter: de-synchronize retry storms; floor preserved.
+            from agent.error_classifier import jittered_wait
+            backoff_seconds = int(jittered_wait(backoff_seconds))
             agent._rate_limited_until = time.monotonic() + backoff_seconds
             logging.info(
                 "Rate-limit backoff level %d: cooldown %d s (%.1f min, backoff#%d)",

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -13,10 +13,33 @@ from __future__ import annotations
 
 import enum
 import logging
+import random
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def jittered_wait(seconds: float) -> float:
+    """Multiplicative jitter for retry/cooldown waits.
+
+    Deterministic exponential backoff is a synchronized-retry-storm hazard:
+    N concurrent sessions hitting the same provider 429 at once all compute
+    the same wait and re-collide on the next attempt (the aider #5165 class).
+    A uniform(0.75, 1.25) spread keeps the backoff's intent (floor preserved)
+    while de-synchronizing storms. Bounded - never below 0.75x, never above
+    1.25x - so a cooldown can't be jittered to near-zero and defeat itself.
+
+    The BASE is clamped to [0, 3600] before jittering: a pathological
+    server-influenced base (negative Retry-After, absurd float) must not
+    produce a negative or huge sleep. time.sleep(negative) raises and a
+    huge sleep is a self-DoS.
+    """
+    try:
+        base = max(0.0, min(float(seconds), 3600.0))
+        return base * random.uniform(0.75, 1.25)
+    except Exception:
+        return seconds
 
 
 # ── Error taxonomy ──────────────────────────────────────────────────────

--- a/tests/agent/test_jittered_wait.py
+++ b/tests/agent/test_jittered_wait.py
@@ -1,0 +1,76 @@
+"""Tests for agent.error_classifier.jittered_wait — bounded multiplicative jitter.
+
+S1-04: deterministic exponential backoff is a synchronized-retry-storm hazard
+(aider #5165 class). jittered_wait spreads waits by a uniform(0.75, 1.25)
+factor after clamping the base to [0, 3600] (JW-3). These tests assert the
+BOUNDS and the CLAMP only — no sleeps, deterministic, fast.
+"""
+
+import time
+
+import pytest
+
+from agent.error_classifier import jittered_wait
+
+
+SAMPLES = 500
+
+
+def _sample(base, n=SAMPLES):
+    return [jittered_wait(base) for _ in range(n)]
+
+
+# ── Bounds ────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("base", [0.01, 1.0, 60.0, 3600.0])
+def test_stays_within_jitter_bounds(base):
+    samples = _sample(base)
+    lo, hi = 0.75 * base, 1.25 * base
+    assert all(lo <= s <= hi for s in samples)
+
+
+def test_never_zero_for_positive_base():
+    assert all(s > 0 for s in _sample(1.0))
+
+
+# ── Clamp (JW-3) ──────────────────────────────────────────────────────────
+
+def test_high_base_clamped_to_3600():
+    samples = _sample(1e9)
+    assert all(2700.0 <= s <= 4500.0 for s in samples)
+
+
+@pytest.mark.parametrize("base", [0.0, -5.0, float("-inf")])
+def test_nonpositive_base_clamped_to_zero(base):
+    assert _sample(base) == [0.0] * SAMPLES
+
+
+# ── Statistical shape ─────────────────────────────────────────────────────
+
+def test_mean_tracks_base():
+    samples = _sample(100.0, n=2000)
+    assert 97.0 <= sum(samples) / len(samples) <= 103.0
+
+
+def test_spread_is_real():
+    samples = _sample(60.0)
+    assert len({round(s, 6) for s in samples}) > 1
+
+
+# ── No sleeps ─────────────────────────────────────────────────────────────
+
+def test_no_sleep_in_wait_path():
+    start = time.monotonic()
+    _sample(0.5, n=200)
+    assert time.monotonic() - start < 2.0
+
+
+# ── Call-site bound (transport recovery: min(jittered_wait(3+retry), 8)) ──
+
+def test_transport_call_site_bounds():
+    for retry_count in range(5):
+        base = 3 + retry_count
+        lo, hi = min(0.75 * base, 8.0), min(1.25 * base, 8.0)
+        for _ in range(200):
+            wait = min(jittered_wait(base), 8.0)
+            assert lo <= wait <= hi


### PR DESCRIPTION
## What does this PR do?

Adds bounded multiplicative jitter to the agent's retry/cooldown wait sites so that N concurrent sessions hitting the same provider failure at the same moment no longer compute identical waits and re-collide (the synchronized-retry-storm class, e.g. aider#5165).

- New `jittered_wait(seconds)` in `agent/error_classifier.py`: `uniform(0.75, 1.25)` spread with the base clamped to `[0, 3600]` (a pathological server-influenced base must not produce a negative or self-DoS sleep).
- Applied at the three retry/cooldown call sites:
  - transport-recovery wait (`agent/agent_runtime_helpers.py`): `min(3 + retry_count, 8)` → `min(jittered_wait(3 + retry_count), 8)`
  - auxiliary transient-retry exponential backoff (`agent/auxiliary_client.py`)
  - rate-limit cooldown (`agent/chat_completion_helpers.py`)
- Tests: `tests/agent/test_jittered_wait.py` — bounds, clamp edge cases (0 / negative / inf), mean convergence, spread (never collapses to constant), no-sleep guard, call-site bound.

## Related Issue

No upstream issue exists for this. This extends the same de-synchronization principle already merged for gateway WS reconnects in #77654 to provider retry waits.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py` — add `jittered_wait()` (docstring carries the full rationale)
- `agent/agent_runtime_helpers.py` — jitter the transport-recovery wait
- `agent/auxiliary_client.py` — jitter transient-retry exponential backoff
- `agent/chat_completion_helpers.py` — jitter the rate-limit cooldown
- `tests/agent/test_jittered_wait.py` — new test suite (13 cases)

## How to Test

```
bash scripts/run_tests.sh tests/agent/test_jittered_wait.py -v
bash scripts/run_tests.sh tests/agent/test_error_classifier.py -v
```

Both pass on this branch (per-file isolation, CI-parity env via the canonical runner).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected scope (`tests/agent/test_jittered_wait.py` + `tests/agent/test_error_classifier.py`) through the canonical runner; full-suite run pending CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (AWS EC2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — full rationale in the `jittered_wait` docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — stdlib `random.uniform` only, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Wire-level evidence from a loopback-failure harness against this patch (fixture emits 503/503/200, `Retry-After: 0.1` on 429):

```
429-PROBE REQUESTS=3 GAPS_S=['0.223', '0.222']      # exactly 3 requests (api_max_retries bound); bounded sub-second waits
503-PROBE REQUESTS=3 GAPS_S=['2.435', '4.825']      # exactly 3 requests; jittered ±25% of bases 3/4 — never exact-ms, never unbounded
jittered_wait(0.1) min=0.0752 max=0.1248            # 200 samples within exact [0.75x, 1.25x] bounds
jittered_wait(3.0) min=2.2511 max=3.7482            # spread never collapses to a constant
```
