### PR TITLE
feat(desktop): bind messaging topics to projects

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -28,7 +28,7 @@ import { useI18n } from '@/i18n'
 import { comboTokens } from '@/lib/keybinds/combo'
 import { resolveProfileColor } from '@/lib/profile-color'
 import { sessionMatchesSearch } from '@/lib/session-search'
-import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
+import { normalizeSessionSource } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
 import { $cronJobs } from '@/store/cron'
 import { $bindings } from '@/store/keybinds'
@@ -138,6 +138,7 @@ import type { SidebarNavItem } from '../../types'
 import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarFilterMenu } from './filter-menu'
 import { SidebarLoadMoreRow } from './load-more-row'
+import { buildMessagingGroups, type MessagingConversationGroup, sessionConversationIdentity } from './messaging-groups'
 import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
 import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
@@ -1147,50 +1148,49 @@ export function ChatSidebar({
       return []
     }
 
-    const bySource = new Map<string, SessionInfo[]>()
+    const visibleSessions: SessionInfo[] = []
     // Rows this platform owns that the Pinned section is showing instead. The
     // backend's per-platform total counts them, so discount it or "load more"
     // promises rows that will never appear.
-    const pinnedBySource = new Map<string, number>()
+    const pinnedByPlatform: Record<string, number> = {}
 
     for (const session of messagingSessions) {
-      const sourceId = normalizeSessionSource(session.source)
-
-      if (!sourceId) {
-        continue
-      }
-
-      if (isPinnedSession(session)) {
-        pinnedBySource.set(sourceId, (pinnedBySource.get(sourceId) ?? 0) + 1)
+      if (!isPinnedSession(session)) {
+        visibleSessions.push(session)
 
         continue
       }
 
-      const list = bySource.get(sourceId) ?? []
-      list.push(session)
-      bySource.set(sourceId, list)
+      const sourceId = sessionConversationIdentity(session)?.platform ?? normalizeSessionSource(session.source)
+
+      if (sourceId) {
+        pinnedByPlatform[sourceId] = (pinnedByPlatform[sourceId] ?? 0) + 1
+      }
     }
 
-    return [...bySource.entries()]
-      .map(([sourceId, list]) => {
-        const ordered = [...list].sort((a, b) => sessionTime(b) - sessionTime(a))
-        const known = messagingPlatformTotals[sourceId]
-        const unpinnedKnown = known == null ? null : Math.max(0, known - (pinnedBySource.get(sourceId) ?? 0))
-        const total = Math.max(ordered.length, unpinnedKnown ?? 0)
+    const visiblePlatformTotals = Object.fromEntries(
+      Object.entries(messagingPlatformTotals).map(([sourceId, total]) => [
+        sourceId,
+        Math.max(0, total - (pinnedByPlatform[sourceId] ?? 0))
+      ])
+    )
 
-        return {
-          // Known exact total → more exist iff total exceeds loaded; otherwise
-          // the seed fetch was capped, so assume more until a per-platform load
-          // resolves the count.
-          hasMore: unpinnedKnown != null ? unpinnedKnown > ordered.length : messagingTruncated,
-          label: sessionSourceLabel(sourceId) ?? sourceId,
-          sessions: ordered,
-          sourceId,
-          total
-        }
-      })
-      .sort((a, b) => sessionTime(b.sessions[0]) - sessionTime(a.sessions[0]))
-  }, [messagingSessions, messagingPlatformTotals, messagingTruncated, isPinnedSession])
+    return buildMessagingGroups({
+      platformTotals: visiblePlatformTotals,
+      projectProfile: showAllProfiles ? null : normalizeProfileKey(profileScope),
+      projects,
+      sessions: visibleSessions,
+      truncated: messagingTruncated
+    })
+  }, [
+    messagingSessions,
+    messagingPlatformTotals,
+    messagingTruncated,
+    projects,
+    profileScope,
+    showAllProfiles,
+    isPinnedSession
+  ])
 
   // Grouping by profile: one collapsible group per profile, color on the header
   // (not on every row). Default profile floats to the top, the rest alpha.
@@ -1734,6 +1734,21 @@ export function ChatSidebar({
               messagingGroups.map(group => {
                 const visible = messagingVisible[group.sourceId] ?? NON_SESSION_INITIAL_ROWS
                 const shownSessions = group.sessions.slice(0, visible)
+                const shownSessionIds = new Set(shownSessions.map(session => session.id))
+
+                const shownConversations = group.conversations
+                  .map(conversation => ({
+                    ...conversation,
+                    topics: conversation.topics
+                      .map(topic => ({
+                        ...topic,
+                        sessions: topic.sessions.filter(session => shownSessionIds.has(session.id))
+                      }))
+                      .filter(topic => topic.sessions.length > 0)
+                  }))
+                  .filter(conversation => conversation.topics.length > 0)
+
+                const shownFlatSessions = group.flatSessions.filter(session => shownSessionIds.has(session.id))
                 // More to show if rows are hidden behind the cap, or the backend
                 // still has older threads on disk.
                 const canRevealMore = visible < group.sessions.length || group.hasMore
@@ -1761,6 +1776,8 @@ export function ChatSidebar({
                         platformName={group.label}
                       />
                     }
+                    labelMeta={String(shownSessions.length)}
+                    messagingConversations={shownConversations}
                     onArchiveSession={onArchiveSession}
                     onDeleteSession={onDeleteSession}
                     onResumeSession={onResumeSession}
@@ -1768,8 +1785,9 @@ export function ChatSidebar({
                     onTogglePin={pinSession}
                     open={messagingOpenIds.includes(group.sourceId)}
                     pinned={false}
+                    projects={projects}
                     rootClassName="shrink-0 p-0"
-                    sessions={shownSessions}
+                    sessions={shownFlatSessions}
                   />
                 )
               })}
@@ -1804,6 +1822,8 @@ export function ChatSidebar({
 interface MessagingSection {
   sourceId: string
   label: string
+  conversations: MessagingConversationGroup[]
+  flatSessions: SessionInfo[]
   sessions: SessionInfo[]
   total: number
   hasMore: boolean

--- a/apps/desktop/src/app/chat/sidebar/messaging-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/messaging-groups.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ConversationBindingInfo, ProjectInfo, SessionInfo } from '@/types/hermes'
+
+import { buildMessagingGroups, sessionConversationIdentity } from './messaging-groups'
+
+const session = (over: Partial<SessionInfo> & Pick<SessionInfo, 'id'>): SessionInfo =>
+  ({
+    ended_at: null,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 0,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: 'telegram',
+    started_at: 0,
+    title: null,
+    tool_call_count: 0,
+    ...over
+  }) as SessionInfo
+
+const binding: ConversationBindingInfo = {
+  alias: 'Bound alias',
+  created_at: 0,
+  project_id: 'p_1',
+  target_ref: 'opaque-topic',
+  updated_at: 0
+}
+
+const project = (): ProjectInfo =>
+  ({
+    archived: false,
+    board_slug: null,
+    color: null,
+    conversation_bindings: [binding],
+    created_at: 0,
+    description: null,
+    folders: [],
+    icon: null,
+    id: 'p_1',
+    name: 'Project',
+    primary_path: null,
+    slug: 'project'
+  }) as ProjectInfo
+
+const origin: NonNullable<SessionInfo['origin']> = {
+  platform: 'telegram',
+  display_label: 'Engineering',
+  topic_label: 'Deployments',
+  conversation_ref: 'opaque-chat',
+  target_ref: 'opaque-topic'
+}
+
+describe('opaque messaging grouping', () => {
+  it('uses only opaque refs and privacy-safe labels', () => {
+    expect(sessionConversationIdentity(session({ id: 's1', source: 'desktop', origin }))).toMatchObject({
+      platform: 'telegram',
+      conversationLabel: 'Engineering',
+      conversationRef: 'opaque-chat',
+      targetRef: 'opaque-topic',
+      topicLabel: 'Deployments'
+    })
+  })
+
+  it('groups messaging and Desktop continuations under one bound topic', () => {
+    const groups = buildMessagingGroups({
+      projects: [project()],
+      projectProfile: 'default',
+      platformTotals: {},
+      truncated: false,
+      sessions: [
+        session({ id: 'message', last_active: 1, origin }),
+        session({ id: 'continuation', last_active: 2, origin, source: 'desktop' })
+      ]
+    })
+
+    expect(groups[0].conversations[0].topics[0].label).toBe('Bound alias')
+    expect(groups[0].conversations[0].topics[0].sessions.map(row => row.id)).toEqual(['continuation', 'message'])
+  })
+
+  it('keeps legacy rows flat and refuses peer-profile mutation', () => {
+    const groups = buildMessagingGroups({
+      projects: [project()],
+      projectProfile: 'default',
+      platformTotals: {},
+      truncated: false,
+      sessions: [
+        session({ id: 'legacy' }),
+        session({ id: 'default', profile: 'default', origin }),
+        session({ id: 'work', profile: 'work', origin })
+      ]
+    })
+
+    const topics = groups[0].conversations.flatMap(conversation => conversation.topics)
+
+    expect(groups[0].flatSessions.map(row => row.id)).toEqual(['legacy'])
+    expect(topics.find(topic => topic.identity.profile === 'default')?.binding?.alias).toBe('Bound alias')
+    expect(topics.find(topic => topic.identity.profile === 'work')).toMatchObject({
+      binding: null,
+      canManageBinding: false
+    })
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/messaging-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/messaging-groups.ts
@@ -1,0 +1,157 @@
+import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
+import type { ConversationBindingInfo, ProjectInfo, SessionInfo } from '@/types/hermes'
+
+export interface SessionConversationIdentity {
+  profile: string
+  platform: string
+  targetRef: string
+  conversationRef: string
+  conversationLabel: string
+  topicLabel: null | string
+}
+
+export interface MessagingTopicGroup {
+  id: string
+  identity: SessionConversationIdentity
+  label: string
+  binding: ConversationBindingInfo | null
+  canManageBinding: boolean
+  sessions: SessionInfo[]
+}
+
+export interface MessagingConversationGroup {
+  id: string
+  label: string
+  topics: MessagingTopicGroup[]
+}
+
+export interface MessagingPlatformGroup {
+  sourceId: string
+  label: string
+  conversations: MessagingConversationGroup[]
+  flatSessions: SessionInfo[]
+  sessions: SessionInfo[]
+  total: number
+  hasMore: boolean
+}
+
+const text = (value: null | string | undefined): string => (value ?? '').trim()
+const profileKey = (session: SessionInfo): string => text(session.profile) || 'default'
+
+export function sessionConversationIdentity(session: SessionInfo): null | SessionConversationIdentity {
+  const origin = session.origin
+  const platform = normalizeSessionSource(text(origin?.platform))
+  const targetRef = text(origin?.target_ref)
+  const conversationRef = text(origin?.conversation_ref) || targetRef
+
+  if (!platform || !targetRef || !conversationRef) {return null}
+
+  return {
+    profile: profileKey(session),
+    platform,
+    targetRef,
+    conversationRef,
+    conversationLabel: text(origin?.display_label) || 'Conversation',
+    topicLabel: text(origin?.topic_label) || null
+  }
+}
+
+function bindingMap(projects: readonly ProjectInfo[]): Map<string, ConversationBindingInfo> {
+  const bindings = new Map<string, ConversationBindingInfo>()
+
+  for (const project of projects) {
+    for (const binding of project.conversation_bindings ?? []) {bindings.set(binding.target_ref, binding)}
+  }
+
+  return bindings
+}
+
+const sessionTime = (session: SessionInfo): number => session.last_active || session.started_at || 0
+
+const topicTime = (topic: MessagingTopicGroup | undefined): number =>
+  topic?.sessions[0] ? sessionTime(topic.sessions[0]) : 0
+
+export function buildMessagingGroups(params: {
+  sessions: readonly SessionInfo[]
+  projects: readonly ProjectInfo[]
+  projectProfile: null | string
+  platformTotals: Record<string, number>
+  truncated: boolean
+}): MessagingPlatformGroup[] {
+  const bindings = bindingMap(params.projects)
+  const byPlatform = new Map<string, { identified: SessionInfo[]; flat: SessionInfo[] }>()
+
+  for (const session of params.sessions) {
+    const identity = sessionConversationIdentity(session)
+    const sourceId = identity?.platform ?? normalizeSessionSource(session.source)
+
+    if (!sourceId) {continue}
+    const bucket = byPlatform.get(sourceId) ?? { identified: [], flat: [] }
+    bucket[identity ? 'identified' : 'flat'].push(session)
+    byPlatform.set(sourceId, bucket)
+  }
+
+  return [...byPlatform.entries()]
+    .map(([sourceId, bucket]) => {
+      const conversations = new Map<string, MessagingConversationGroup>()
+
+      for (const session of bucket.identified) {
+        const identity = sessionConversationIdentity(session)
+
+        if (!identity) {continue}
+        const conversationId = `${identity.profile}:${identity.conversationRef}`
+        const topicId = `${identity.profile}:${identity.targetRef}`
+
+        const conversation = conversations.get(conversationId) ?? {
+          id: conversationId,
+          label: identity.conversationLabel,
+          topics: []
+        }
+
+        let topic = conversation.topics.find(item => item.id === topicId)
+
+        if (!topic) {
+          const canManageBinding = params.projectProfile !== null && identity.profile === params.projectProfile
+          const binding = canManageBinding ? (bindings.get(identity.targetRef) ?? null) : null
+          topic = {
+            id: topicId,
+            identity,
+            binding,
+            canManageBinding,
+            label: binding?.alias || identity.topicLabel || identity.conversationLabel,
+            sessions: []
+          }
+          conversation.topics.push(topic)
+        }
+
+        topic.sessions.push(session)
+        conversations.set(conversationId, conversation)
+      }
+
+      for (const conversation of conversations.values()) {
+        for (const topic of conversation.topics) {
+          topic.sessions.sort((a, b) => sessionTime(b) - sessionTime(a) || a.id.localeCompare(b.id))
+        }
+
+        conversation.topics.sort((a, b) => topicTime(b) - topicTime(a) || a.label.localeCompare(b.label))
+      }
+
+      const nested = [...conversations.values()].sort(
+        (a, b) => topicTime(b.topics[0]) - topicTime(a.topics[0]) || a.label.localeCompare(b.label)
+      )
+
+      const sessions = [...bucket.identified, ...bucket.flat].sort((a, b) => sessionTime(b) - sessionTime(a))
+      const known = params.platformTotals[sourceId]
+
+      return {
+        sourceId,
+        label: sessionSourceLabel(sourceId) ?? sourceId,
+        conversations: nested,
+        flatSessions: bucket.flat.sort((a, b) => sessionTime(b) - sessionTime(a)),
+        sessions,
+        total: Math.max(sessions.length, known ?? 0),
+        hasMore: known != null ? known > sessions.length : params.truncated
+      }
+    })
+    .sort((a, b) => sessionTime(b.sessions[0]) - sessionTime(a.sessions[0]))
+}

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -66,7 +66,7 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
   const leadingIcon = (
     <Codicon
       className="shrink-0 text-(--ui-text-tertiary)"
-      name={group.isKanban ? 'checklist' : group.isHome ? 'home' : 'git-branch'}
+      name={group.isConversation ? 'comment' : group.isKanban ? 'checklist' : group.isHome ? 'home' : 'git-branch'}
       size="0.75rem"
     />
   )
@@ -106,7 +106,7 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
   // Profile groups start a fresh session in that profile but keep the
   // all-profiles browse view; workspace groups seed the new session's cwd.
   // Main checkout lanes are branch-targeted.
-  const addButton = (onNewSession || isProfileGroup) && (
+  const addButton = !group.isConversation && (onNewSession || isProfileGroup) && (
     <WorkspaceAddButton label={s.newSessionIn(group.label)} onClick={() => void handleNewSession()} />
   )
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -28,6 +28,8 @@ export interface SidebarSessionGroup {
   // worktrees (`<repo>/.worktrees/t_*`) into one row, so a heavy board doesn't
   // spray hundreds of throwaway branch lanes across the sidebar.
   isKanban?: boolean
+  // Messaging conversation/topic lane owned by an explicit Project binding.
+  isConversation?: boolean
   mode?: 'profile' | 'source' | 'workspace'
   sourceId?: string
 }

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -1,8 +1,19 @@
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { SessionInfo } from '@/hermes'
+import type { ProjectInfo, SessionInfo } from '@/hermes'
+
+const { bindConversationToProject, unbindConversationFromProject } = vi.hoisted(() => ({
+  bindConversationToProject: vi.fn(async () => undefined),
+  unbindConversationFromProject: vi.fn(async () => undefined)
+}))
+
+vi.mock('@/store/projects', async importOriginal => ({
+  ...((await importOriginal()) as object),
+  bindConversationToProject,
+  unbindConversationFromProject
+}))
 
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import type { VirtualSessionListProps } from './virtual-session-list'
@@ -12,6 +23,7 @@ afterEach(cleanup)
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
     t: {
+      common: { close: 'Close' },
       sidebar: {
         dateDivider: {
           earlierThisMonth: 'Earlier this month',
@@ -20,6 +32,16 @@ vi.mock('@/i18n', () => ({
           older: 'Older',
           today: 'Today',
           yesterday: 'Yesterday'
+        },
+        projects: {
+          topicBindAction: 'Bind to Project',
+          topicManageAction: 'Manage Project binding',
+          topicProjectDescription: 'Keep this topic in one Project.',
+          topicProjectPlaceholder: 'Choose a Project',
+          topicAliasPlaceholder: 'Optional local alias',
+          topicBind: 'Bind to Project',
+          topicSave: 'Save binding',
+          topicUnbind: 'Unbind'
         }
       }
     }
@@ -175,5 +197,80 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
 
     const thirdRowsRef = mockVirtualListPropsHistory[2].rows
     expect(thirdRowsRef).not.toBe(secondRowsRef)
+  })
+
+  it('opens the inline topic binding dialog and binds the canonical identity', async () => {
+    bindConversationToProject.mockClear()
+    const topicSession = makeSession('topic-session')
+
+    const projects = [
+      {
+        archived: false,
+        board_slug: null,
+        color: null,
+        created_at: 0,
+        description: null,
+        folders: [],
+        icon: null,
+        id: 'p_project',
+        name: 'Operations',
+        primary_path: null,
+        slug: 'operations'
+      } as ProjectInfo
+    ]
+
+    render(
+      <SidebarSessionsSection
+        activeSessionId={null}
+        emptyState={<div>Empty</div>}
+        label="Telegram"
+        messagingConversations={[
+          {
+            id: 'telegram:chat',
+            label: 'Engineering',
+            topics: [
+              {
+                binding: null,
+                canManageBinding: true,
+                id: 'telegram:chat:topic',
+                identity: {
+                  conversationLabel: 'Engineering',
+                  conversationRef: 'opaque-chat',
+                  platform: 'telegram',
+                  profile: 'default',
+                  targetRef: 'opaque-topic',
+                  topicLabel: 'Deployments'
+                },
+                label: 'Deployments',
+                sessions: [topicSession]
+              }
+            ]
+          }
+        ]}
+        onArchiveSession={noop}
+        onDeleteSession={noop}
+        onResumeSession={noop}
+        onToggle={noop}
+        onTogglePin={noop}
+        open={true}
+        pinned={false}
+        projects={projects}
+        sessions={[]}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bind to Project' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Optional local alias' }), {
+      target: { value: 'Deploys' }
+    })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Bind to Project' }).at(-1)!)
+
+    await waitFor(() =>
+      expect(bindConversationToProject).toHaveBeenCalledWith({
+        alias: 'Deploys',
+        projectId: 'p_project',
+        targetRef: 'opaque-topic'
+      })
+    )
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -1,13 +1,26 @@
 import type { useSensors } from '@dnd-kit/core'
 import { useStore } from '@nanostores/react'
 import type * as React from 'react'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useId, useMemo, useState } from 'react'
 
 import { SidebarPanelLabel } from '@/app/shell/sidebar-label'
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
+import { Tip } from '@/components/ui/tooltip'
 import type { HermesGitWorktree } from '@/global'
-import type { SessionInfo } from '@/hermes'
+import type { ProjectInfo, SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { flattenSessionsWithBranches } from '@/lib/session-branch-tree'
 import {
@@ -18,10 +31,12 @@ import {
 } from '@/lib/session-date-groups'
 import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
+import { bindConversationToProject, unbindConversationFromProject } from '@/store/projects'
 import { sessionPinId } from '@/store/session'
 import { $sessionDotStateById, hasLiveTurn } from '@/store/session-dot-state'
 
 import { SidebarDateDivider, SidebarSectionMeta } from './chrome'
+import type { MessagingConversationGroup, MessagingTopicGroup } from './messaging-groups'
 import { orderRowsWithinGroups, reorderableRowIds } from './order'
 import {
   EnteredProjectContent,
@@ -113,6 +128,8 @@ interface SidebarSessionsSectionProps {
   headerAction?: React.ReactNode
   footer?: React.ReactNode
   groups?: SidebarSessionGroup[]
+  messagingConversations?: MessagingConversationGroup[]
+  projects?: ProjectInfo[]
   tree?: SidebarWorkspaceTree[]
   // Project overview: when present, render a drill-in list of project rows
   // instead of sessions. Clicking a row enters that project (onEnterProject),
@@ -190,6 +207,8 @@ export function SidebarSessionsSection({
   headerAction,
   footer,
   groups,
+  messagingConversations,
+  projects = [],
   projectOverview,
   projectOverviewPreviews,
   projectsLoading = false,
@@ -218,6 +237,11 @@ export function SidebarSessionsSection({
   const dotStates = useStore($sessionDotStateById)
   const sectionOpen = collapsible ? open : true
   const hasGroupedSessions = Boolean(groups?.some(group => group.sessions.length > 0))
+
+  const hasMessagingConversations = Boolean(
+    messagingConversations?.some(conversation => conversation.topics.some(topic => topic.sessions.length > 0))
+  )
+
   // A defined project list is itself content (even an empty project should
   // render as a drill-in row so the user can see it exists).
   const hasProjectOverview = Boolean(projectOverview?.length)
@@ -231,7 +255,12 @@ export function SidebarSessionsSection({
   )
 
   const showEmptyState =
-    forceEmptyState || (!hasGroupedSessions && !hasProjectOverview && !hasProjectContent && sessions.length === 0)
+    forceEmptyState ||
+    (!hasGroupedSessions &&
+      !hasMessagingConversations &&
+      !hasProjectOverview &&
+      !hasProjectContent &&
+      sessions.length === 0)
 
   // The flat recents/pinned list is the only place sessions reorder by hand;
   // grouped/tree views always sort by creation date and never drag.
@@ -360,6 +389,7 @@ export function SidebarSessionsSection({
     !pinned &&
     !showEmptyState &&
     !groups?.length &&
+    !messagingConversations?.length &&
     !projectOverview?.length &&
     !projectContent &&
     sessions.length >= VIRTUALIZE_THRESHOLD
@@ -369,7 +399,12 @@ export function SidebarSessionsSection({
   // flashing the flat session list until the overview/content/groups resolve. A
   // background refresh keeps the prior tree, so this only fires when empty.
   const showProjectsSkeleton =
-    projectsLoading && !hasProjectOverview && !hasProjectContent && !projectContent && !groups?.length
+    projectsLoading &&
+    !hasProjectOverview &&
+    !hasProjectContent &&
+    !projectContent &&
+    !groups?.length &&
+    !messagingConversations?.length
 
   let inner: React.ReactNode
 
@@ -436,6 +471,20 @@ export function SidebarSessionsSection({
         ) : (
           rows
         )}
+      </>
+    )
+  } else if (messagingConversations?.length) {
+    inner = (
+      <>
+        {messagingConversations.map(conversation => (
+          <MessagingConversationTree
+            conversation={conversation}
+            key={conversation.id}
+            projects={projects}
+            renderRows={renderRows}
+          />
+        ))}
+        {renderRows(sessions)}
       </>
     )
   } else if (groups?.length) {
@@ -509,6 +558,190 @@ export function SidebarSessionsSection({
         </SidebarGroupContent>
       )}
     </SidebarGroup>
+  )
+}
+
+interface MessagingConversationTreeProps {
+  conversation: MessagingConversationGroup
+  projects: ProjectInfo[]
+  renderRows: (sessions: SessionInfo[]) => React.ReactNode
+}
+
+function MessagingConversationTree({ conversation, projects, renderRows }: MessagingConversationTreeProps) {
+  const [open, setOpen] = useState(true)
+  const contentId = useId()
+
+  return (
+    <div className="grid gap-px">
+      <button
+        aria-controls={contentId}
+        aria-expanded={open}
+        className="group/conversation flex min-h-[1.625rem] min-w-0 items-center gap-1.5 rounded-md bg-transparent pl-2 pr-1 text-left"
+        onClick={() => setOpen(value => !value)}
+        type="button"
+      >
+        <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="comment-discussion" size="0.75rem" />
+        <span className="min-w-0 flex-1 truncate text-[0.8125rem] leading-none text-(--ui-text-secondary)">
+          {conversation.label}
+        </span>
+        <DisclosureCaret
+          className="text-(--ui-text-tertiary) opacity-0 transition group-hover/conversation:opacity-100"
+          open={open}
+        />
+      </button>
+      {open ? (
+        <div className="grid gap-px pl-3" id={contentId}>
+          {conversation.topics.map(topic => (
+            <MessagingTopicTree key={topic.id} projects={projects} renderRows={renderRows} topic={topic} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+interface MessagingTopicTreeProps {
+  projects: ProjectInfo[]
+  renderRows: (sessions: SessionInfo[]) => React.ReactNode
+  topic: MessagingTopicGroup
+}
+
+function MessagingTopicTree({ projects, renderRows, topic }: MessagingTopicTreeProps) {
+  const { t } = useI18n()
+  const strings = t.sidebar.projects
+  const [open, setOpen] = useState(true)
+  const contentId = useId()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const firstActiveProject = projects.find(project => !project.archived)?.id ?? ''
+  const [projectId, setProjectId] = useState(topic.binding?.project_id ?? firstActiveProject)
+  const [alias, setAlias] = useState(topic.binding?.alias ?? topic.label)
+  const [saving, setSaving] = useState(false)
+  const projectName = projects.find(project => project.id === topic.binding?.project_id)?.name
+  const actionLabel = topic.binding ? strings.topicManageAction : strings.topicBindAction
+
+  const openDialog = () => {
+    setProjectId(topic.binding?.project_id ?? firstActiveProject)
+    setAlias(topic.binding?.alias ?? topic.label)
+    setDialogOpen(true)
+  }
+
+  const save = async () => {
+    if (!projectId) {
+      return
+    }
+
+    setSaving(true)
+
+    try {
+      await bindConversationToProject({
+        alias,
+        projectId,
+        targetRef: topic.identity.targetRef
+      })
+      setDialogOpen(false)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const unlink = async () => {
+    setSaving(true)
+
+    try {
+      await unbindConversationFromProject({
+        projectId: topic.binding?.project_id,
+        targetRef: topic.identity.targetRef
+      })
+      setDialogOpen(false)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="grid gap-px">
+      <div className="group/topic grid min-h-[1.625rem] grid-cols-[minmax(0,1fr)_auto] items-stretch rounded-md">
+        <button
+          aria-controls={contentId}
+          aria-expanded={open}
+          className="flex h-full min-w-0 items-center gap-1.5 bg-transparent pl-2 pr-1 text-left"
+          onClick={() => setOpen(value => !value)}
+          type="button"
+        >
+          <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="comment" size="0.75rem" />
+          <span className="min-w-0 flex-1 truncate text-[0.8125rem] leading-none text-(--ui-text-secondary)">
+            {topic.label}
+          </span>
+          {projectName ? (
+            <span className="max-w-20 truncate text-[0.6875rem] font-medium text-(--ui-text-quaternary)">
+              {projectName}
+            </span>
+          ) : null}
+          <DisclosureCaret
+            className="text-(--ui-text-tertiary) opacity-0 transition group-hover/topic:opacity-100"
+            open={open}
+          />
+        </button>
+        {topic.canManageBinding ? (
+          <Tip label={actionLabel}>
+            <Button
+              aria-label={actionLabel}
+              className="self-center"
+              onClick={openDialog}
+              size="icon-xs"
+              variant="ghost"
+            >
+              <Codicon name={topic.binding ? 'link' : 'link-external'} />
+            </Button>
+          </Tip>
+        ) : null}
+      </div>
+      {open ? (
+        <div className="grid gap-px pl-3" id={contentId}>
+          {renderRows(topic.sessions)}
+        </div>
+      ) : null}
+      <Dialog onOpenChange={setDialogOpen} open={topic.canManageBinding && dialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{actionLabel}</DialogTitle>
+            <DialogDescription>{strings.topicProjectDescription}</DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-3">
+            <Select onValueChange={setProjectId} value={projectId}>
+              <SelectTrigger aria-label={strings.topicProjectPlaceholder}>
+                <SelectValue placeholder={strings.topicProjectPlaceholder} />
+              </SelectTrigger>
+              <SelectContent>
+                {projects
+                  .filter(project => !project.archived)
+                  .map(project => (
+                    <SelectItem key={project.id} value={project.id}>
+                      {project.name}
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
+            <Input
+              aria-label={strings.topicAliasPlaceholder}
+              onChange={event => setAlias(event.target.value)}
+              placeholder={strings.topicAliasPlaceholder}
+              value={alias}
+            />
+          </div>
+          <DialogFooter>
+            {topic.binding ? (
+              <Button disabled={saving} onClick={() => void unlink()} type="button" variant="text">
+                {strings.topicUnbind}
+              </Button>
+            ) : null}
+            <Button disabled={!projectId || saving} onClick={() => void save()} type="button">
+              {topic.binding ? strings.topicSave : strings.topicBind}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
   )
 }
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -146,6 +146,7 @@ export type {
   ComputerUseStatus,
   ConfigFieldSchema,
   ConfigSchemaResponse,
+  ConversationBindingInfo,
   CronDeliveryTarget,
   CronJob,
   CronJobCreatePayload,

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1629,7 +1629,15 @@ export const ar = defineLocale({
       enter: label => `فتح ${label}`,
       reorder: label => `إعادة ترتيب ${label}`,
       toggle: (label, open) => `${open ? 'إظهار' : 'إخفاء'} جلسات ${label}`,
-      back: 'كل المشاريع'
+      back: 'كل المشاريع',
+      topicBindAction: 'ربط بالمشروع',
+      topicManageAction: 'إدارة ربط المشروع',
+      topicProjectDescription: 'احتفظ بموضوع المراسلة ومتابعات سطح المكتب أو TUI في مشروع واحد.',
+      topicProjectPlaceholder: 'اختر مشروعًا',
+      topicAliasPlaceholder: 'اسم محلي اختياري',
+      topicBind: 'ربط بالمشروع',
+      topicSave: 'حفظ الربط',
+      topicUnbind: 'إلغاء الربط'
     },
     newSessionIn: label => `جلسة جديدة في ${label}`,
     showMoreIn: (count, label) => `إظهار ${count} أخرى في ${label}`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1959,7 +1959,15 @@ export const en: Translations = {
       enter: label => `Open ${label}`,
       reorder: label => `Reorder ${label}`,
       toggle: (label, open) => `${open ? 'Show' : 'Hide'} ${label} sessions`,
-      back: 'All projects'
+      back: 'All projects',
+      topicBindAction: 'Bind to Project',
+      topicManageAction: 'Manage Project binding',
+      topicProjectDescription: 'Keep this messaging topic and its Desktop or TUI continuations in one Project.',
+      topicProjectPlaceholder: 'Choose a Project',
+      topicAliasPlaceholder: 'Optional local alias',
+      topicBind: 'Bind to Project',
+      topicSave: 'Save binding',
+      topicUnbind: 'Unbind'
     },
     newSessionIn: label => `New session in ${label}`,
     showMoreIn: (count, label) => `Show ${count} more in ${label}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1776,7 +1776,15 @@ export const ja = defineLocale({
       removeWorktreeDirty:
         'このワークツリーにはコミットされていない変更があります。強制削除（変更を破棄）するか、レーンを隠してディスク上に残します。',
       forceRemove: '強制削除',
-      enter: label => `${label} を開く`
+      enter: label => `${label} を開く`,
+      topicBindAction: 'プロジェクトに関連付ける',
+      topicManageAction: 'プロジェクトの関連付けを管理',
+      topicProjectDescription: 'このメッセージトピックと Desktop/TUI の続きの会話を同じプロジェクトにまとめます。',
+      topicProjectPlaceholder: 'プロジェクトを選択',
+      topicAliasPlaceholder: '任意のローカル別名',
+      topicBind: 'プロジェクトに関連付ける',
+      topicSave: '関連付けを保存',
+      topicUnbind: '関連付けを解除'
     },
     newSessionIn: label => `${label} で新しいセッション`,
     showMoreIn: (count, label) => `${label} でさらに ${count} 件を表示`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1647,6 +1647,14 @@ export interface Translations {
       reorder: (label: string) => string
       toggle: (label: string, open: boolean) => string
       back: string
+      topicBindAction: string
+      topicManageAction: string
+      topicProjectDescription: string
+      topicProjectPlaceholder: string
+      topicAliasPlaceholder: string
+      topicBind: string
+      topicSave: string
+      topicUnbind: string
     }
     newSessionIn: (label: string) => string
     showMoreIn: (count: number, label: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1718,7 +1718,15 @@ export const zhHant = defineLocale({
         '從 git 中移除（刪除工作樹目錄，但保留分支），或僅從側邊欄隱藏該軌道並將工作樹保留在磁碟上。',
       removeWorktreeDirty: '此工作樹有未提交的變更。強制移除（捨棄這些變更），或僅隱藏軌道並保留在磁碟上。',
       forceRemove: '強制移除',
-      enter: label => `開啟 ${label}`
+      enter: label => `開啟 ${label}`,
+      topicBindAction: '綁定到專案',
+      topicManageAction: '管理專案綁定',
+      topicProjectDescription: '將此訊息主題及其 Desktop 或 TUI 延續工作階段歸入同一專案。',
+      topicProjectPlaceholder: '選擇專案',
+      topicAliasPlaceholder: '選填本機別名',
+      topicBind: '綁定到專案',
+      topicSave: '儲存綁定',
+      topicUnbind: '解除綁定'
     },
     newSessionIn: label => `在 ${label} 中新建工作階段`,
     showMoreIn: (count, label) => `在 ${label} 中再顯示 ${count} 個`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2148,7 +2148,15 @@ export const zh: Translations = {
       enter: label => `打开 ${label}`,
       reorder: label => `重新排序 ${label}`,
       toggle: (label, open) => `${open ? '展开' : '收起'} ${label} 会话`,
-      back: '全部项目'
+      back: '全部项目',
+      topicBindAction: '绑定到项目',
+      topicManageAction: '管理项目绑定',
+      topicProjectDescription: '将此消息主题及其 Desktop 或 TUI 延续会话归入同一项目。',
+      topicProjectPlaceholder: '选择项目',
+      topicAliasPlaceholder: '可选本地别名',
+      topicBind: '绑定到项目',
+      topicSave: '保存绑定',
+      topicUnbind: '解除绑定'
     },
     newSessionIn: label => `在 ${label} 中新建会话`,
     showMoreIn: (count, label) => `在 ${label} 中再显示 ${count} 个`,

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -8,6 +8,7 @@ import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaul
 
 import {
   $activeProjectId,
+  $projects,
   $projectScope,
   $projectsRpcAvailable,
   $projectTree,
@@ -16,6 +17,7 @@ import {
   $worktreeRefreshToken,
   ALL_PROJECTS,
   beginSessionMutation,
+  bindConversationToProject,
   createProject,
   endSessionMutation,
   enterProject,
@@ -29,7 +31,8 @@ import {
   refreshWorktrees,
   resolveNewSessionCwd,
   scanAndRecordRepos,
-  tombstoneSessions
+  tombstoneSessions,
+  unbindConversationFromProject
 } from './projects'
 
 vi.mock('@/i18n', () => ({
@@ -551,5 +554,94 @@ describe('tombstone pruning', () => {
     await refreshProjectTree()
 
     expect($removedSessionIds.get().has('sess-1')).toBe(false)
+  })
+})
+
+describe('conversation binding mutations', () => {
+  const projects = [
+    {
+      archived: false,
+      board_slug: null,
+      color: null,
+      conversation_bindings: [],
+      created_at: 0,
+      description: null,
+      folders: [],
+      icon: null,
+      id: 'p_first',
+      name: 'First',
+      primary_path: null,
+      slug: 'first'
+    },
+    {
+      archived: false,
+      board_slug: null,
+      color: null,
+      conversation_bindings: [],
+      created_at: 0,
+      description: null,
+      folders: [],
+      icon: null,
+      id: 'p_second',
+      name: 'Second',
+      primary_path: null,
+      slug: 'second'
+    }
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    $projects.set(projects)
+  })
+
+  it('moves a canonical target to exactly one project optimistically', async () => {
+    const request = vi.fn(async (method: string) =>
+      method === 'projects.bind_messaging_target'
+        ? { binding: {} }
+        : { active_id: null, projects: $projects.get(), scoped_session_ids: [] }
+    )
+
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await bindConversationToProject({
+      alias: 'Alias',
+      projectId: 'p_second',
+      targetRef: 'opaque-topic'
+    })
+
+    expect($projects.get().find(project => project.id === 'p_first')?.conversation_bindings).toEqual([])
+    expect($projects.get().find(project => project.id === 'p_second')?.conversation_bindings).toEqual([
+      expect.objectContaining({ alias: 'Alias', target_ref: 'opaque-topic' })
+    ])
+    expect(request).toHaveBeenCalledWith(
+      'projects.bind_messaging_target',
+      expect.objectContaining({ id: 'p_second', target_ref: 'opaque-topic' })
+    )
+  })
+
+  it('removes the local binding after explicit unbind', async () => {
+    $projects.set([
+      {
+        ...projects[0],
+        conversation_bindings: [
+          {
+            alias: null,
+            created_at: 0,
+            project_id: 'p_first',
+            target_ref: 'opaque-topic',
+            updated_at: 0
+          }
+        ]
+      }
+    ])
+    const request = vi.fn(async () => ({ removed: true }))
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+
+    await unbindConversationFromProject({
+      projectId: 'p_first',
+      targetRef: 'opaque-topic'
+    })
+
+    expect($projects.get()[0].conversation_bindings).toEqual([])
   })
 })

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -24,7 +24,7 @@ import {
   setSessions,
   workspaceCwdForNewSession
 } from '@/store/session'
-import type { ProjectInfo, ProjectsPayload } from '@/types/hermes'
+import type { ConversationBindingInfo, ProjectInfo, ProjectsPayload } from '@/types/hermes'
 
 // First-class, per-profile Projects (named, multi-folder workspaces). State is
 // served by the live gateway's `projects.*` JSON-RPC methods, which wrap the
@@ -1004,6 +1004,66 @@ export async function deleteProject(id: string): Promise<void> {
 export async function setActiveProject(id: null | string): Promise<void> {
   const res = await gatewayRequest<{ active_id: null | string }>('projects.set_active', { id })
   $activeProjectId.set(res.active_id ?? null)
+}
+
+export interface BindConversationInput {
+  projectId: string
+  targetRef: string
+  alias?: null | string
+}
+
+export async function bindConversationToProject(input: BindConversationInput): Promise<void> {
+  const snap = snapshotProjects()
+  const targetRef = input.targetRef.trim()
+
+  const optimistic: ConversationBindingInfo = {
+    alias: input.alias?.trim() || null,
+    created_at: 0,
+    project_id: input.projectId,
+    target_ref: targetRef,
+    updated_at: 0
+  }
+
+  $projects.set(
+    snap.projects.map(project => {
+      const withoutTarget = (project.conversation_bindings ?? []).filter(binding => binding.target_ref !== targetRef)
+
+      return project.id === input.projectId
+        ? { ...project, conversation_bindings: [...withoutTarget, optimistic] }
+        : { ...project, conversation_bindings: withoutTarget }
+    })
+  )
+
+  await persistOrRollback(snap, () =>
+    gatewayRequest('projects.bind_messaging_target', {
+      id: input.projectId,
+      target_ref: targetRef,
+      alias: input.alias ?? null
+    })
+  )
+  reconcileProjects()
+}
+
+export async function unbindConversationFromProject(
+  input: Omit<BindConversationInput, 'alias' | 'projectId'> & { projectId?: null | string }
+): Promise<void> {
+  const snap = snapshotProjects()
+  const targetRef = input.targetRef.trim()
+
+  $projects.set(
+    snap.projects.map(project => ({
+      ...project,
+      conversation_bindings: (project.conversation_bindings ?? []).filter(binding => binding.target_ref !== targetRef)
+    }))
+  )
+
+  await persistOrRollback(snap, () =>
+    gatewayRequest('projects.unbind_messaging_target', {
+      id: input.projectId ?? null,
+      target_ref: targetRef
+    })
+  )
+  reconcileProjects()
 }
 
 // ── Project management dialog ────────────────────────────────────────────────

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -463,6 +463,16 @@ export interface SessionCreateResponse {
 
 export interface SessionInfo {
   archived?: boolean
+  /** Privacy-safe messaging identity produced by the session-origin seam in
+   *  #85601. Optional for older backends and local-only sessions. */
+  origin?: null | {
+    platform?: null | string
+    chat_type?: null | string
+    display_label?: null | string
+    topic_label?: null | string
+    target_ref?: null | string
+    conversation_ref?: null | string
+  }
   cwd?: null | string
   /** Git branch checked out in {@link cwd} when the session started/resumed.
    *  The sidebar groups main-checkout sessions by this so feature-branch work
@@ -920,6 +930,14 @@ export interface ProjectFolder {
   added_at: number
 }
 
+export interface ConversationBindingInfo {
+  project_id: string
+  target_ref: string
+  alias: null | string
+  created_at: number
+  updated_at: number
+}
+
 export interface ProjectInfo {
   id: string
   slug: string
@@ -932,6 +950,7 @@ export interface ProjectInfo {
   archived: boolean
   created_at: number
   folders: ProjectFolder[]
+  conversation_bindings?: ConversationBindingInfo[]
 }
 
 export interface ProjectsPayload {

--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -80,6 +80,22 @@ CREATE TABLE IF NOT EXISTS project_folders (
 CREATE INDEX IF NOT EXISTS idx_project_folders_path
     ON project_folders(path);
 
+CREATE TABLE IF NOT EXISTS project_conversation_bindings (
+    project_id  TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    platform    TEXT NOT NULL,
+    chat_id     TEXT NOT NULL,
+    thread_id   TEXT,
+    alias       TEXT,
+    created_at  INTEGER NOT NULL,
+    updated_at  INTEGER NOT NULL,
+    PRIMARY KEY (project_id, platform, chat_id, thread_id),
+    UNIQUE (platform, chat_id, thread_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_project_conversation_bindings_threadless
+    ON project_conversation_bindings(platform, chat_id)
+    WHERE thread_id IS NULL;
+
 CREATE TABLE IF NOT EXISTS project_meta (
     key    TEXT PRIMARY KEY,
     value  TEXT
@@ -233,6 +249,28 @@ class ProjectFolder:
 
 
 @dataclass
+class ConversationBinding:
+    project_id: str
+    platform: str
+    chat_id: str
+    thread_id: Optional[str] = None
+    alias: Optional[str] = None
+    created_at: int = 0
+    updated_at: int = 0
+
+    def to_private_dict(self) -> dict:
+        return {
+            "project_id": self.project_id,
+            "platform": self.platform,
+            "chat_id": self.chat_id,
+            "thread_id": self.thread_id,
+            "alias": self.alias,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass
 class Project:
     id: str
     slug: str
@@ -245,6 +283,7 @@ class Project:
     primary_path: Optional[str] = None
     archived: bool = False
     folders: List[ProjectFolder] = field(default_factory=list)
+    conversation_bindings: List[ConversationBinding] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return {
@@ -260,6 +299,13 @@ class Project:
             "created_at": self.created_at,
             "folders": [f.to_dict() for f in self.folders],
         }
+
+    def to_private_dict(self) -> dict:
+        payload = self.to_dict()
+        payload["conversation_bindings"] = [
+            binding.to_private_dict() for binding in self.conversation_bindings
+        ]
+        return payload
 
 
 def _project_from_row(row: sqlite3.Row) -> Project:
@@ -297,7 +343,44 @@ def _load_folders(conn: sqlite3.Connection, project_id: str) -> List[ProjectFold
 
 def _attach_folders(conn: sqlite3.Connection, project: Project) -> Project:
     project.folders = _load_folders(conn, project.id)
+    project.conversation_bindings = _load_conversation_bindings(conn, project.id)
     return project
+
+
+def _binding_from_row(row: sqlite3.Row) -> ConversationBinding:
+    return ConversationBinding(
+        project_id=row["project_id"],
+        platform=row["platform"],
+        chat_id=row["chat_id"],
+        thread_id=row["thread_id"],
+        alias=row["alias"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _load_conversation_bindings(
+    conn: sqlite3.Connection, project_id: str
+) -> List[ConversationBinding]:
+    return list_conversation_bindings(conn, project_id=project_id)
+
+
+def normalize_thread_id(thread_id: Optional[str]) -> Optional[str]:
+    value = str(thread_id).strip() if thread_id is not None else ""
+    return value or None
+
+
+def normalize_conversation_target(
+    platform: str, chat_id: str, thread_id: Optional[str] = None
+) -> tuple[str, str, Optional[str]]:
+    normalized_platform = str(platform or "").strip().lower()
+    normalized_chat = str(chat_id or "").strip()
+    normalized_thread = normalize_thread_id(thread_id)
+    if not normalized_platform:
+        raise ValueError("platform required")
+    if not normalized_chat:
+        raise ValueError("chat_id required")
+    return normalized_platform, normalized_chat, normalized_thread
 
 
 # ---------------------------------------------------------------------------
@@ -572,6 +655,10 @@ def archive_project(conn: sqlite3.Connection, project_id: str) -> bool:
         cur = conn.execute(
             "UPDATE projects SET archived = 1 WHERE id = ?", (project_id,)
         )
+        conn.execute(
+            "DELETE FROM project_conversation_bindings WHERE project_id = ?",
+            (project_id,),
+        )
     return cur.rowcount > 0
 
 
@@ -584,10 +671,142 @@ def restore_project(conn: sqlite3.Connection, project_id: str) -> bool:
 
 
 def delete_project(conn: sqlite3.Connection, project_id: str) -> bool:
-    """Hard-delete a project and its folders (cascade)."""
+    """Hard-delete a project, its folders, and conversation bindings."""
     with write_txn(conn):
         cur = conn.execute("DELETE FROM projects WHERE id = ?", (project_id,))
     return cur.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# Messaging conversation bindings
+# ---------------------------------------------------------------------------
+
+
+def bind_conversation(
+    conn: sqlite3.Connection,
+    project_id: str,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    alias: Optional[str] = None,
+) -> ConversationBinding:
+    """Bind one canonical messaging target to exactly one active project.
+
+    Rebinding the target moves it deterministically. Rebinding to the current
+    project updates the optional local alias while preserving ``created_at``.
+    """
+    project = get_project(conn, project_id)
+    if project is None:
+        raise ValueError(f"no such project: {project_id}")
+    if project.archived:
+        raise ValueError(f"cannot bind conversation to archived project: {project_id}")
+
+    platform, chat_id, thread_id = normalize_conversation_target(
+        platform, chat_id, thread_id
+    )
+    clean_alias = str(alias).strip() if alias is not None else None
+    clean_alias = clean_alias or None
+    now = _now()
+    existing = get_conversation_binding(
+        conn, platform=platform, chat_id=chat_id, thread_id=thread_id
+    )
+    created_at = existing.created_at if existing else now
+
+    with write_txn(conn):
+        if thread_id is None:
+            conn.execute(
+                "DELETE FROM project_conversation_bindings "
+                "WHERE platform = ? AND chat_id = ? AND thread_id IS NULL",
+                (platform, chat_id),
+            )
+        else:
+            conn.execute(
+                "DELETE FROM project_conversation_bindings "
+                "WHERE platform = ? AND chat_id = ? AND thread_id = ?",
+                (platform, chat_id, thread_id),
+            )
+        conn.execute(
+            "INSERT INTO project_conversation_bindings "
+            "(project_id, platform, chat_id, thread_id, alias, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (project_id, platform, chat_id, thread_id, clean_alias, created_at, now),
+        )
+
+    binding = get_conversation_binding(
+        conn, platform=platform, chat_id=chat_id, thread_id=thread_id
+    )
+    assert binding is not None
+    return binding
+
+
+def unbind_conversation(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    project_id: Optional[str] = None,
+) -> bool:
+    platform, chat_id, thread_id = normalize_conversation_target(
+        platform, chat_id, thread_id
+    )
+    params: list[object] = [platform, chat_id]
+    sql = (
+        "DELETE FROM project_conversation_bindings "
+        "WHERE platform = ? AND chat_id = ?"
+    )
+    if thread_id is None:
+        sql += " AND thread_id IS NULL"
+    else:
+        sql += " AND thread_id = ?"
+        params.append(thread_id)
+    if project_id:
+        sql += " AND project_id = ?"
+        params.append(project_id)
+    with write_txn(conn):
+        cur = conn.execute(sql, params)
+    return cur.rowcount > 0
+
+
+def get_conversation_binding(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+) -> Optional[ConversationBinding]:
+    platform, chat_id, thread_id = normalize_conversation_target(
+        platform, chat_id, thread_id
+    )
+    sql = (
+        "SELECT project_id, platform, chat_id, thread_id, alias, created_at, updated_at "
+        "FROM project_conversation_bindings "
+        "WHERE platform = ? AND chat_id = ?"
+    )
+    params: list[object] = [platform, chat_id]
+    if thread_id is None:
+        sql += " AND thread_id IS NULL"
+    else:
+        sql += " AND thread_id = ?"
+        params.append(thread_id)
+    row = conn.execute(sql, params).fetchone()
+    return _binding_from_row(row) if row else None
+
+
+def list_conversation_bindings(
+    conn: sqlite3.Connection, *, project_id: Optional[str] = None
+) -> List[ConversationBinding]:
+    sql = (
+        "SELECT project_id, platform, chat_id, thread_id, alias, created_at, updated_at "
+        "FROM project_conversation_bindings"
+    )
+    params: list[object] = []
+    if project_id:
+        sql += " WHERE project_id = ?"
+        params.append(project_id)
+    sql += " ORDER BY platform ASC, chat_id ASC, COALESCE(thread_id, '') ASC"
+    return [_binding_from_row(row) for row in conn.execute(sql, params).fetchall()]
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/session_origins.py
+++ b/hermes_cli/session_origins.py
@@ -1,0 +1,82 @@
+"""Privacy-safe gateway origin metadata for session list responses."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+
+def _session_origin_text(value: Any, *, max_chars: int = 240) -> str:
+    """Normalize untrusted gateway labels for a compact JSON UI payload."""
+    if value is None:
+        return ""
+    text = str(value).replace("\r\n", "\n").replace("\r", "\n").strip()
+    text = "".join(ch if ch >= " " else " " for ch in text)
+    if len(text) > max_chars:
+        text = text[: max_chars - 3] + "..."
+    return text
+
+
+def session_origin_metadata(row: Dict[str, Any]) -> Optional[Dict[str, str]]:
+    """Project a state.db gateway row into non-secret, UI-ready metadata."""
+    raw = row.get("origin_json")
+    if not raw:
+        return None
+    try:
+        origin = json.loads(raw) if isinstance(raw, str) else raw
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(origin, dict):
+        return None
+
+    platform = _session_origin_text(origin.get("platform") or row.get("source"))
+    if not platform:
+        return None
+    chat_type = _session_origin_text(origin.get("chat_type") or row.get("chat_type")) or "chat"
+    is_dm = chat_type.casefold() == "dm"
+    fallback_kind = "DM" if is_dm else chat_type
+    display_label = f"{platform.title()} {fallback_kind}"
+
+    if not is_dm:
+        identifier_fields = (
+            "chat_id",
+            "chat_id_alt",
+            "guild_id",
+            "message_id",
+            "parent_chat_id",
+            "routing_key",
+            "scope_id",
+            "session_key",
+            "thread_id",
+            "user_id",
+            "user_id_alt",
+            "user_name",
+        )
+        identifiers = set()
+        for key in identifier_fields:
+            for source in (row, origin):
+                value = _session_origin_text(source.get(key))
+                if value:
+                    identifiers.add(value.casefold())
+        for candidate in (row.get("display_name"), origin.get("chat_name")):
+            label = _session_origin_text(candidate)
+            if label and label.casefold() not in identifiers:
+                display_label = label
+                break
+
+    return {"platform": platform, "chat_type": chat_type, "display_label": display_label}
+
+
+def enrich_sessions_with_origins(sessions: List[Dict[str, Any]], db: Any) -> None:
+    """Attach gateway origins from the canonical state.db routing index."""
+    if not sessions:
+        return
+    wanted = [str(session.get("id") or "") for session in sessions]
+    origins: Dict[str, Dict[str, str]] = {}
+    for row in db.get_gateway_session_metadata(wanted).values():
+        session_id = str(row.get("id") or "")
+        metadata = session_origin_metadata(row)
+        if metadata:
+            origins[session_id] = metadata
+    for session in sessions:
+        origin = origins.get(str(session.get("id") or ""))
+        if origin:
+            session["origin"] = origin

--- a/hermes_cli/session_origins.py
+++ b/hermes_cli/session_origins.py
@@ -62,7 +62,14 @@ def session_origin_metadata(row: Dict[str, Any]) -> Optional[Dict[str, str]]:
                 display_label = label
                 break
 
-    return {"platform": platform, "chat_type": chat_type, "display_label": display_label}
+    topic_label = ""
+    if not is_dm and row.get("thread_id") not in (None, ""):
+        topic_label = _session_origin_text(origin.get("chat_topic")) or "Topic"
+
+    result = {"platform": platform, "chat_type": chat_type, "display_label": display_label}
+    if topic_label:
+        result["topic_label"] = topic_label
+    return result
 
 
 def enrich_sessions_with_origins(sessions: List[Dict[str, Any]], db: Any) -> None:
@@ -75,6 +82,18 @@ def enrich_sessions_with_origins(sessions: List[Dict[str, Any]], db: Any) -> Non
         session_id = str(row.get("id") or "")
         metadata = session_origin_metadata(row)
         if metadata:
+            target_ref = db.gateway_target_ref(
+                platform=row.get("source"),
+                chat_id=row.get("chat_id"),
+                thread_id=row.get("thread_id"),
+            )
+            conversation_ref = db.gateway_conversation_ref(
+                platform=row.get("source"), chat_id=row.get("chat_id")
+            ) or target_ref
+            if target_ref:
+                metadata["target_ref"] = target_ref
+            if conversation_ref:
+                metadata["conversation_ref"] = conversation_ref
             origins[session_id] = metadata
     for session in sessions:
         origin = origins.get(str(session.get("id") or ""))

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional, Tuple  # noqa: F401
 
 from fastapi import APIRouter, HTTPException, Query  # noqa: F401
 
+from hermes_cli.session_origins import enrich_sessions_with_origins
 from hermes_cli.web_deps import late
 from hermes_cli.web_models import (
     ProfileCreate,
@@ -193,6 +194,7 @@ def get_profiles_sessions(
             )
             total += profile_total
             profile_totals[name] = profile_total
+            enrich_sessions_with_origins(rows, db)
             for s in rows:
                 s["profile"] = name
                 s["is_default_profile"] = name == "default"
@@ -334,6 +336,7 @@ def get_profiles_sessions_sidebar(
             continue
         try:
             profile_rows = _slice(db, exclude=recents_exclude_list, cap=recents_cap)
+            enrich_sessions_with_origins(profile_rows, db)
             # A full window means more rows remain on disk. That is all the
             # sidebar's "load more" needs, and unlike an exact COUNT(*) per
             # profile per refresh it costs nothing beyond the rows already
@@ -346,10 +349,12 @@ def get_profiles_sessions_sidebar(
             # a page, and a total that shrank when you scrolled would be worse
             # than no total at all.
             profile_totals[name] = db.usage_totals()
-            cron_rows.extend(_tag(_slice(db, source="cron", cap=cron_cap), name))
-            messaging_rows.extend(
-                _tag(_slice(db, exclude=messaging_exclude_list, cap=messaging_cap), name)
-            )
+            profile_rows = _slice(db, source="cron", cap=cron_cap)
+            enrich_sessions_with_origins(profile_rows, db)
+            cron_rows.extend(_tag(profile_rows, name))
+            profile_rows = _slice(db, exclude=messaging_exclude_list, cap=messaging_cap)
+            enrich_sessions_with_origins(profile_rows, db)
+            messaging_rows.extend(_tag(profile_rows, name))
         except Exception as exc:
             _warn_profile_read_error(name, exc)
             errors.append({"profile": name, "error": str(exc)})

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -22,6 +22,7 @@ from fastapi import APIRouter, HTTPException, Query, Request  # noqa: F401
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
 
+from hermes_cli.session_origins import enrich_sessions_with_origins
 from hermes_cli.web_deps import late
 from hermes_cli.web_models import (
     BulkDeleteSessions,
@@ -154,6 +155,7 @@ def get_sessions(
                 # SQLite stores the flag as 0/1; expose a real JSON boolean.
                 s["archived"] = bool(s.get("archived"))
                 s["pinned"] = bool(s.get("pinned"))
+            enrich_sessions_with_origins(sessions, db)
             if not full:
                 _strip_session_list_rows(sessions)
             return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4495,6 +4495,37 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             rows = self._conn.execute(query, params).fetchall()
         return [self._session_row_dict(r) for r in rows]
 
+    def get_gateway_session_metadata(
+        self, session_ids: List[str]
+    ) -> Dict[str, Dict[str, Any]]:
+        """Return gateway presentation metadata keyed by requested session ID.
+
+        Unlike :meth:`list_gateway_sessions`, this preserves historical rows
+        that share a routing ``session_key``. Queries are bounded to the
+        requested primary keys and select only the columns presentation
+        consumers need.
+        """
+        ids = list(dict.fromkeys(str(value) for value in session_ids if value))
+        if not ids:
+            return {}
+
+        result: Dict[str, Dict[str, Any]] = {}
+        # Stay comfortably below SQLite's host-parameter limit on older builds.
+        for start in range(0, len(ids), 400):
+            batch = ids[start : start + 400]
+            placeholders = ",".join("?" for _ in batch)
+            query = f"""
+                SELECT id, source, chat_type, display_name, origin_json,
+                       session_key, chat_id, user_id, thread_id
+                FROM sessions
+                WHERE session_key IS NOT NULL
+                  AND id IN ({placeholders})
+            """
+            with self._lock:
+                rows = self._conn.execute(query, batch).fetchall()
+            result.update((row["id"], dict(row)) for row in rows)
+        return result
+
     def find_session_by_origin(
         self,
         *,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4526,6 +4526,61 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             result.update((row["id"], dict(row)) for row in rows)
         return result
 
+    def resolve_gateway_target(self, target_ref: str) -> Optional[Dict[str, Any]]:
+        """Resolve an opaque session id to its canonical messaging target."""
+        if not target_ref:
+            return None
+        with self._lock:
+            row = self._conn.execute(
+                """SELECT source, chat_id, thread_id
+                   FROM sessions
+                   WHERE id = ? AND session_key IS NOT NULL
+                     AND source IS NOT NULL AND chat_id IS NOT NULL""",
+                (str(target_ref),),
+            ).fetchone()
+        if row is None or not str(row["source"] or "").strip() or not str(row["chat_id"] or "").strip():
+            return None
+        return {
+            "platform": str(row["source"]).strip().lower(),
+            "chat_id": str(row["chat_id"]).strip(),
+            "thread_id": str(row["thread_id"]).strip() if row["thread_id"] not in (None, "") else None,
+        }
+
+    def gateway_target_ref(
+        self, *, platform: str, chat_id: str, thread_id: Optional[str] = None
+    ) -> Optional[str]:
+        """Return a deterministic opaque session id for a canonical target."""
+        platform = str(platform or "").strip().lower()
+        chat_id = str(chat_id or "").strip()
+        thread_id = str(thread_id).strip() if thread_id not in (None, "") else None
+        if not platform or not chat_id:
+            return None
+        sql = """SELECT MIN(id) AS target_ref FROM sessions
+                 WHERE session_key IS NOT NULL AND LOWER(source) = ? AND chat_id = ?"""
+        params: list[Any] = [platform, chat_id]
+        if thread_id is None:
+            sql += " AND (thread_id IS NULL OR thread_id = '')"
+        else:
+            sql += " AND thread_id = ?"
+            params.append(thread_id)
+        with self._lock:
+            row = self._conn.execute(sql, params).fetchone()
+        return str(row["target_ref"]) if row and row["target_ref"] else None
+
+    def gateway_conversation_ref(self, *, platform: str, chat_id: str) -> Optional[str]:
+        """Return a deterministic opaque session id shared by all chat topics."""
+        platform = str(platform or "").strip().lower()
+        chat_id = str(chat_id or "").strip()
+        if not platform or not chat_id:
+            return None
+        with self._lock:
+            row = self._conn.execute(
+                """SELECT MIN(id) AS target_ref FROM sessions
+                   WHERE session_key IS NOT NULL AND LOWER(source) = ? AND chat_id = ?""",
+                (platform, chat_id),
+            ).fetchone()
+        return str(row["target_ref"]) if row and row["target_ref"] else None
+
     def find_session_by_origin(
         self,
         *,

--- a/tests/hermes_cli/test_profiles_sidebar_scope.py
+++ b/tests/hermes_cli/test_profiles_sidebar_scope.py
@@ -164,16 +164,22 @@ class TestSidebarScope:
             "platform": "telegram",
             "chat_type": "group",
             "display_label": "Recent room",
+            "target_ref": "worker-recent",
+            "conversation_ref": "worker-recent",
         }
         assert payload["cron"]["sessions"][0]["origin"] == {
             "platform": "cron",
             "chat_type": "job",
             "display_label": "Nightly job",
+            "target_ref": "worker-cron",
+            "conversation_ref": "worker-cron",
         }
         assert payload["messaging"]["sessions"][0]["origin"] == {
             "platform": "discord",
             "chat_type": "channel",
             "display_label": "Release room",
+            "target_ref": "worker-messaging",
+            "conversation_ref": "worker-messaging",
         }
 
     def test_concrete_profile_sees_only_its_own_slices(self, client, profiles_on_disk):

--- a/tests/hermes_cli/test_profiles_sidebar_scope.py
+++ b/tests/hermes_cli/test_profiles_sidebar_scope.py
@@ -11,6 +11,8 @@ Two behaviors that only show up with more than one profile on disk:
   coexist in one list.
 """
 
+import json
+
 import pytest
 
 
@@ -84,6 +86,32 @@ def _seed_session(home, session_id, *, source, cwd=None, tokens=None, cost=None)
         conn.close()
 
 
+def _seed_gateway_session(home, session_id, *, source, chat_type, display_name):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=home / "state.db")
+    try:
+        db.create_session(session_id, source=source)
+        db.record_gateway_session_peer(
+            session_id,
+            source=source,
+            session_key=f"agent:main:{source}:{chat_type}:{session_id}",
+            chat_id=f"chat-{session_id}",
+            chat_type=chat_type,
+            display_name=display_name,
+            origin_json=json.dumps(
+                {
+                    "platform": source,
+                    "chat_type": chat_type,
+                    "chat_id": f"chat-{session_id}",
+                }
+            ),
+        )
+        db.append_message(session_id=session_id, role="user", content="hi")
+    finally:
+        db.close()
+
+
 def _seed_project(home, name, folder):
     from hermes_cli import projects_db
 
@@ -96,6 +124,57 @@ def _slice_ids(payload, slice_name):
 
 
 class TestSidebarScope:
+
+    def test_recent_cron_and_messaging_rows_include_canonical_origins(
+        self, profiles_on_disk
+    ):
+        worker_home = profiles_on_disk["worker"]
+        _seed_gateway_session(
+            worker_home,
+            "worker-recent",
+            source="telegram",
+            chat_type="group",
+            display_name="Recent room",
+        )
+        _seed_gateway_session(
+            worker_home,
+            "worker-cron",
+            source="cron",
+            chat_type="job",
+            display_name="Nightly job",
+        )
+        _seed_gateway_session(
+            worker_home,
+            "worker-messaging",
+            source="discord",
+            chat_type="channel",
+            display_name="Release room",
+        )
+
+        from hermes_cli.web_routers.profiles import get_profiles_sessions_sidebar
+
+        payload = get_profiles_sessions_sidebar(
+            recents_profile="worker",
+            recents_exclude="cron,discord",
+            messaging_exclude="cron,telegram",
+        )
+
+        assert payload["errors"] == []
+        assert payload["recents"]["sessions"][0]["origin"] == {
+            "platform": "telegram",
+            "chat_type": "group",
+            "display_label": "Recent room",
+        }
+        assert payload["cron"]["sessions"][0]["origin"] == {
+            "platform": "cron",
+            "chat_type": "job",
+            "display_label": "Nightly job",
+        }
+        assert payload["messaging"]["sessions"][0]["origin"] == {
+            "platform": "discord",
+            "chat_type": "channel",
+            "display_label": "Release room",
+        }
 
     def test_concrete_profile_sees_only_its_own_slices(self, client, profiles_on_disk):
         _seed_session(profiles_on_disk["default"], "default-chat", source="cli")

--- a/tests/hermes_cli/test_projects_db.py
+++ b/tests/hermes_cli/test_projects_db.py
@@ -101,3 +101,103 @@ def test_per_profile_isolation(tmp_path):
         b.close()
 
 
+def test_conversation_binding_is_unique_moves_and_unbinds(conn):
+    first = pdb.create_project(conn, name="First")
+    second = pdb.create_project(conn, name="Second")
+
+    original = pdb.bind_conversation(
+        conn,
+        first,
+        platform=" Telegram ",
+        chat_id=" chat-1 ",
+        thread_id=" topic-1 ",
+        alias="Operations",
+    )
+    moved = pdb.bind_conversation(
+        conn,
+        second,
+        platform="telegram",
+        chat_id="chat-1",
+        thread_id="topic-1",
+        alias="Incidents",
+    )
+
+    assert moved.project_id == second
+    assert moved.created_at == original.created_at
+    assert moved.alias == "Incidents"
+    assert pdb.list_conversation_bindings(conn, project_id=first) == []
+    assert [binding.project_id for binding in pdb.list_conversation_bindings(conn)] == [second]
+
+    # A stale dialog scoped to the old project cannot remove the moved binding.
+    assert pdb.unbind_conversation(
+        conn,
+        project_id=first,
+        platform="telegram",
+        chat_id="chat-1",
+        thread_id="topic-1",
+    ) is False
+    assert pdb.unbind_conversation(
+        conn,
+        project_id=second,
+        platform="telegram",
+        chat_id="chat-1",
+        thread_id="topic-1",
+    ) is True
+    assert pdb.list_conversation_bindings(conn) == []
+
+
+def test_threadless_binding_normalizes_empty_thread_and_rejects_archive(conn):
+    project_id = pdb.create_project(conn, name="Messages")
+    binding = pdb.bind_conversation(
+        conn,
+        project_id,
+        platform="slack",
+        chat_id="C123",
+        thread_id="",
+    )
+
+    assert binding.thread_id is None
+    assert pdb.get_conversation_binding(
+        conn, platform="slack", chat_id="C123", thread_id=None
+    ) == binding
+
+    pdb.archive_project(conn, project_id)
+    with pytest.raises(ValueError, match="archived project"):
+        pdb.bind_conversation(
+            conn,
+            project_id,
+            platform="slack",
+            chat_id="C456",
+        )
+    assert pdb.list_conversation_bindings(conn, project_id=project_id) == []
+
+
+def test_public_project_payload_never_serializes_private_routing_keys(conn):
+    project_id = pdb.create_project(conn, name="Messages")
+    pdb.bind_conversation(conn, project_id, platform="telegram", chat_id="secret-chat", thread_id="secret-topic")
+
+    payload = pdb.get_project(conn, project_id).to_dict()
+
+    assert "conversation_bindings" not in payload
+    assert "secret-chat" not in repr(payload)
+    assert "secret-topic" not in repr(payload)
+
+
+def test_conversation_bindings_are_profile_local(tmp_path):
+    first = pdb.connect(db_path=tmp_path / "first" / "projects.db")
+    second = pdb.connect(db_path=tmp_path / "second" / "projects.db")
+    try:
+        project_id = pdb.create_project(first, name="First profile")
+        pdb.bind_conversation(
+            first,
+            project_id,
+            platform="discord",
+            chat_id="channel-1",
+            thread_id="thread-1",
+        )
+
+        assert len(pdb.list_conversation_bindings(first)) == 1
+        assert pdb.list_conversation_bindings(second) == []
+    finally:
+        first.close()
+        second.close()

--- a/tests/hermes_cli/test_session_origins.py
+++ b/tests/hermes_cli/test_session_origins.py
@@ -1,0 +1,58 @@
+import json
+
+from hermes_cli.session_origins import enrich_sessions_with_origins, session_origin_metadata
+from hermes_state import SessionDB
+
+
+def test_session_origin_metadata_keeps_dm_labels_private():
+    metadata = session_origin_metadata(
+        {
+            "source": "telegram",
+            "chat_type": "dm",
+            "display_name": "+4712345678",
+            "origin_json": json.dumps({"platform": "telegram", "chat_type": "dm", "chat_name": "Alice"}),
+        }
+    )
+
+    assert metadata == {"platform": "telegram", "chat_type": "dm", "display_label": "Telegram DM"}
+
+
+def test_session_origin_metadata_uses_non_identifier_room_label():
+    metadata = session_origin_metadata(
+        {
+            "source": "discord",
+            "chat_type": "channel",
+            "display_name": "Production",
+            "chat_id": "123",
+            "origin_json": json.dumps({"platform": "discord", "chat_type": "channel", "chat_id": "123"}),
+        }
+    )
+
+    assert metadata == {"platform": "discord", "chat_type": "channel", "display_label": "Production"}
+
+
+def test_enrich_sessions_reads_gateway_origins_from_state_db(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("gateway-session", "telegram")
+        db.record_gateway_session_peer(
+            "gateway-session",
+            source="telegram",
+            session_key="agent:main:telegram:group:42",
+            chat_id="42",
+            chat_type="group",
+            display_name="Lighting crew",
+            origin_json=json.dumps({"platform": "telegram", "chat_type": "group", "chat_id": "42"}),
+        )
+        sessions = [{"id": "gateway-session"}, {"id": "local-session"}]
+
+        enrich_sessions_with_origins(sessions, db)
+
+        assert sessions[0]["origin"] == {
+            "platform": "telegram",
+            "chat_type": "group",
+            "display_label": "Lighting crew",
+        }
+        assert "origin" not in sessions[1]
+    finally:
+        db.close()

--- a/tests/hermes_cli/test_session_origins.py
+++ b/tests/hermes_cli/test_session_origins.py
@@ -1,7 +1,30 @@
 import json
+import re
+from pathlib import Path
 
 from hermes_cli.session_origins import enrich_sessions_with_origins, session_origin_metadata
 from hermes_state import SessionDB
+
+
+def test_desktop_origin_and_binding_types_expose_only_opaque_identity():
+    source = (Path(__file__).parents[2] / "apps/desktop/src/types/hermes.ts").read_text()
+    session_origin = re.search(r"origin\?: null \| \{(?P<body>.*?)\n  \}", source, re.S)
+    binding = re.search(
+        r"export interface ConversationBindingInfo \{(?P<body>.*?)\n\}", source, re.S
+    )
+
+    assert session_origin and binding
+    exposed = session_origin.group("body") + binding.group("body")
+    for forbidden in (
+        "chat_id",
+        "thread_id",
+        "conversation_id",
+        "topic_id",
+        "routing_key",
+        "session_key",
+    ):
+        assert forbidden not in exposed
+    assert "target_ref" in exposed
 
 
 def test_session_origin_metadata_keeps_dm_labels_private():
@@ -52,7 +75,10 @@ def test_enrich_sessions_reads_gateway_origins_from_state_db(tmp_path):
             "platform": "telegram",
             "chat_type": "group",
             "display_label": "Lighting crew",
+            "target_ref": "gateway-session",
+            "conversation_ref": "gateway-session",
         }
+        assert not ({"chat_id", "thread_id", "session_key", "routing_key"} & sessions[0]["origin"].keys())
         assert "origin" not in sessions[1]
     finally:
         db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1819,6 +1819,34 @@ class TestListSessionsRich:
     def test_get_gateway_session_metadata_empty_request(self, db):
         assert db.get_gateway_session_metadata([]) == {}
 
+    def test_opaque_gateway_target_resolution_is_canonical_and_fails_closed(self, db):
+        for session_id, thread_id in (
+            ("later", "topic"),
+            ("earlier", "topic"),
+            ("other", "other"),
+        ):
+            db.create_session(session_id, source="telegram")
+            db.record_gateway_session_peer(
+                session_id,
+                source="telegram",
+                session_key=f"private:{session_id}",
+                chat_id="secret-chat",
+                thread_id=thread_id,
+            )
+
+        assert db.resolve_gateway_target("earlier") == {
+            "platform": "telegram",
+            "chat_id": "secret-chat",
+            "thread_id": "topic",
+        }
+        assert db.resolve_gateway_target("missing") is None
+        assert db.gateway_target_ref(
+            platform="telegram", chat_id="secret-chat", thread_id="topic"
+        ) == "earlier"
+        assert db.gateway_conversation_ref(
+            platform="telegram", chat_id="secret-chat"
+        ) == "earlier"
+
     def test_order_by_last_active_surfaces_recently_touched_older_session_first(self, db):
         t0 = 1709500000.0
         db.create_session("old", "cli")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1779,6 +1779,46 @@ class TestListSessionsRich:
         activity = db.get_session_activity("gw-1")
         assert activity["last_activity_description"] == "compressing context"
 
+    def test_get_gateway_session_metadata_preserves_same_key_history(self, db):
+        shared_key = "agent:main:telegram:dm:c1"
+        for session_id, display_name in (
+            ("gw-history-old", "Earlier chat"),
+            ("gw-history-new", "Latest chat"),
+        ):
+            db.create_session(session_id, "telegram")
+            db.record_gateway_session_peer(
+                session_id,
+                source="telegram",
+                session_key=shared_key,
+                chat_id="private-chat-id",
+                chat_type="dm",
+                display_name=display_name,
+                origin_json=json.dumps({"platform": "telegram", "chat_type": "dm"}),
+            )
+        db.create_session("not-gateway", "cli")
+
+        rows = db.get_gateway_session_metadata(
+            ["gw-history-old", "missing", "gw-history-new", "gw-history-old", "not-gateway"]
+        )
+
+        assert set(rows) == {"gw-history-old", "gw-history-new"}
+        assert rows["gw-history-old"]["display_name"] == "Earlier chat"
+        assert rows["gw-history-new"]["display_name"] == "Latest chat"
+        assert set(rows["gw-history-old"]) == {
+            "id",
+            "source",
+            "chat_type",
+            "display_name",
+            "origin_json",
+            "session_key",
+            "chat_id",
+            "user_id",
+            "thread_id",
+        }
+
+    def test_get_gateway_session_metadata_empty_request(self, db):
+        assert db.get_gateway_session_metadata([]) == {}
+
     def test_order_by_last_active_surfaces_recently_touched_older_session_first(self, db):
         t0 = 1709500000.0
         db.create_session("old", "cli")

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -42,6 +42,16 @@ def _project(pid, name, folders, **over):
     return row
 
 
+def _binding(project_id, *, platform="telegram", chat_id="chat", thread_id="topic", alias=None):
+    return {
+        "project_id": project_id,
+        "platform": platform,
+        "chat_id": chat_id,
+        "thread_id": thread_id,
+        "alias": alias,
+    }
+
+
 def _resolver(mapping):
     """Build a resolve() from {cwd: (repo_root, worktree_root)}."""
 
@@ -546,6 +556,80 @@ def test_home_bucket_leads_the_tree_and_is_lossless():
         cwdless["id"],
         junked["id"],
     }
+
+
+def test_conversation_binding_claims_topic_and_desktop_continuation():
+    project = _project(
+        "p_topic",
+        "Topic Project",
+        [],
+        conversation_bindings=[_binding("p_topic", alias="Operations")],
+    )
+    target = {
+        "platform": "telegram",
+        "chat_id": "chat",
+        "thread_id": "topic",
+        "target_ref": "opaque-topic",
+        "conversation_ref": "opaque-chat",
+        "display_label": "Engineering",
+        "topic_label": "Deployments",
+    }
+    messaging = _session(None, source="telegram", _messaging_target=target)
+    continuation = _session(None, source="desktop", _messaging_target=target)
+    unbound = _session(
+        None,
+        source="telegram",
+        _messaging_target={**target, "thread_id": "other", "target_ref": "opaque-other", "topic_label": "Other"},
+    )
+
+    tree = pt.build_tree(
+        [project], [messaging, continuation, unbound], [], hydrate=True
+    )
+    node = next(item for item in tree["projects"] if item["id"] == "p_topic")
+    group = node["repos"][0]["groups"][0]
+
+    assert node["sessionCount"] == 2
+    assert group["label"] == "Operations"
+    assert {row["id"] for row in group["sessions"]} == {
+        messaging["id"],
+        continuation["id"],
+    }
+    assert unbound["id"] in _home_session_ids(tree)
+
+
+def test_conversation_binding_overrides_filesystem_project_without_duplication():
+    folder_project = _project("p_folder", "Folder", ["/repo"])
+    topic_project = _project(
+        "p_topic",
+        "Topic",
+        [],
+        conversation_bindings=[_binding("p_topic")],
+    )
+    session = _session(
+        "/repo",
+        source="desktop",
+        _messaging_target={
+            "platform": "telegram",
+            "chat_id": "chat",
+            "thread_id": "topic",
+            "target_ref": "opaque-topic",
+            "conversation_ref": "opaque-chat",
+        },
+    )
+
+    tree = pt.build_tree(
+        [folder_project, topic_project],
+        [session],
+        [],
+        resolve=lambda _cwd: None,
+        hydrate=True,
+    )
+    by_id = {project["id"]: project for project in tree["projects"]}
+
+    assert by_id["p_folder"]["sessionCount"] == 0
+    assert by_id["p_topic"]["sessionCount"] == 1
+    assert [row["id"] for row in _sessions_of(by_id["p_topic"])] == [session["id"]]
+    assert all("_messaging_target" not in row for row in _sessions_of(by_id["p_topic"]))
 
 
 def test_colliding_repo_basenames_disambiguate_labels():

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -54,6 +54,8 @@ def test_methods_registered():
         "projects.set_primary",
         "projects.archive",
         "projects.set_active",
+        "projects.bind_messaging_target",
+        "projects.unbind_messaging_target",
         "projects.for_cwd",
     ):
         assert m in server._methods
@@ -272,6 +274,87 @@ def test_update_and_archive(tmp_path):
     assert all(p["id"] != pid or p["archived"] for p in payload["projects"])
 
 
+def test_bind_move_unbind_conversation_roundtrip(monkeypatch, tmp_path):
+    from hermes_state import SessionDB
+
+    state = SessionDB(db_path=tmp_path / "state.db")
+    state.create_session("opaque-target", source="telegram")
+    state.record_gateway_session_peer(
+        "opaque-target", source="telegram", session_key="private", chat_id="chat-1", thread_id="topic-1"
+    )
+    monkeypatch.setattr(server, "_db", state)
+    first = _call("projects.create", {"name": "First"})["project"]["id"]
+    second = _call("projects.create", {"name": "Second"})["project"]["id"]
+
+    bound = _call(
+        "projects.bind_messaging_target",
+        {
+            "id": first,
+            "target_ref": "opaque-target",
+            "alias": "Ops",
+        },
+    )
+    moved = _call(
+        "projects.bind_messaging_target",
+        {
+            "id": second,
+            "target_ref": "opaque-target",
+        },
+    )
+
+    assert bound["projects"]
+    assert moved["projects"]
+    listing = _call("projects.list")["projects"]
+    assert next(p for p in listing if p["id"] == first)["conversation_bindings"] == []
+    assert len(next(p for p in listing if p["id"] == second)["conversation_bindings"]) == 1
+    assert "chat-1" not in repr(listing)
+    assert "topic-1" not in repr(listing)
+
+    assert _call(
+        "projects.unbind_messaging_target",
+        {
+            "id": second,
+            "target_ref": "opaque-target",
+        },
+    )["removed"] is True
+    state.close()
+
+
+def test_bind_conversation_refuses_archived_project(monkeypatch, tmp_path):
+    from hermes_state import SessionDB
+
+    state = SessionDB(db_path=tmp_path / "state.db")
+    state.create_session("opaque-target", source="slack")
+    state.record_gateway_session_peer("opaque-target", source="slack", session_key="private", chat_id="C1")
+    monkeypatch.setattr(server, "_db", state)
+    project_id = _call("projects.create", {"name": "Archived"})["project"]["id"]
+    _call("projects.archive", {"id": project_id})
+
+    response = server._methods["projects.bind_messaging_target"](
+        1,
+        {"id": project_id, "target_ref": "opaque-target"},
+    )
+
+    assert response["error"]["message"] == "cannot bind conversation to archived project: " + project_id
+    state.close()
+
+
+def test_unknown_target_ref_fails_closed_without_mutating(monkeypatch, tmp_path):
+    from hermes_state import SessionDB
+
+    state = SessionDB(db_path=tmp_path / "state.db")
+    monkeypatch.setattr(server, "_db", state)
+    project_id = _call("projects.create", {"name": "Safe"})["project"]["id"]
+
+    response = server._methods["projects.bind_messaging_target"](
+        1, {"id": project_id, "target_ref": "stale-or-invented"}
+    )
+
+    assert response["error"]["message"] == "unknown or stale target_ref"
+    assert _call("projects.list")["projects"][-1]["conversation_bindings"] == []
+    state.close()
+
+
 def test_get_unknown_returns_error():
     resp = server._methods["projects.get"](1, {"id": "nope"})
     assert "error" in resp
@@ -458,5 +541,3 @@ def test_nondefault_policy_rejects_stale_or_legacy_results(monkeypatch, tmp_path
     assert stale["accepted"] is False
     assert accepted["accepted"] is True
     assert any(item["root"] == str(root) for item in accepted["repos"])
-
-

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -500,6 +500,157 @@ def _project_for_session(session: dict, index: _FolderIndex, resolve: Optional[R
     return best
 
 
+def _normalize_text(value: Any) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+def _normalize_thread(value: Any) -> Optional[str]:
+    return _normalize_text(value) or None
+
+
+def _session_origin(session: dict) -> dict:
+    """Return server-private canonical metadata used only during tree build."""
+    origin = session.get("_messaging_target")
+    return origin if isinstance(origin, dict) else {}
+
+
+def _origin_value(origin: dict, *names: str) -> str:
+    for name in names:
+        value = _normalize_text(origin.get(name))
+        if value:
+            return value
+    return ""
+
+
+def _session_conversation_target(
+    session: dict,
+) -> Optional[tuple[str, str, Optional[str]]]:
+    origin = _session_origin(session)
+    conversation_id = _origin_value(origin, "chat_id")
+    if not conversation_id:
+        return None
+    platform = _origin_value(origin, "platform").lower()
+    if not platform:
+        platform = _normalize_text(session.get("source")).lower()
+    if not platform:
+        return None
+    topic_id = _normalize_thread(_origin_value(origin, "thread_id"))
+    return platform, conversation_id, topic_id
+
+
+def _conversation_key(
+    platform: str, conversation_id: str, topic_id: Optional[str]
+) -> tuple[str, str, Optional[str]]:
+    return platform.lower(), conversation_id, topic_id
+
+
+class _ConversationBindingIndex:
+    def __init__(self, projects: list[dict]) -> None:
+        self._by_target: dict[tuple[str, str, Optional[str]], dict] = {}
+        self._binding_by_project_target: dict[
+            tuple[str, tuple[str, str, Optional[str]]], dict
+        ] = {}
+        for project in projects:
+            for binding in project.get("conversation_bindings") or []:
+                platform = _normalize_text(binding.get("platform")).lower()
+                conversation_id = _normalize_text(binding.get("chat_id"))
+                if not platform or not conversation_id:
+                    continue
+                key = _conversation_key(
+                    platform,
+                    conversation_id,
+                    _normalize_thread(binding.get("thread_id")),
+                )
+                self._by_target[key] = project
+                self._binding_by_project_target[(project["id"], key)] = binding
+
+    def match(self, session: dict) -> Optional[dict]:
+        target = _session_conversation_target(session)
+        return self._by_target.get(_conversation_key(*target)) if target else None
+
+    def binding_for(self, project_id: str, session: dict) -> Optional[dict]:
+        target = _session_conversation_target(session)
+        if target is None:
+            return None
+        return self._binding_by_project_target.get(
+            (project_id, _conversation_key(*target))
+        )
+
+
+def _conversation_label(session: dict, binding: Optional[dict], *, topic: bool) -> str:
+    alias = _normalize_text((binding or {}).get("alias"))
+    if alias:
+        return alias
+    origin = _session_origin(session)
+    if topic:
+        label = _origin_value(origin, "topic_label")
+        return label or "Topic"
+    label = _origin_value(origin, "display_label")
+    return label or "Conversation"
+
+
+def _build_conversation_repos(
+    project_id: str,
+    sessions: list[dict],
+    binding_index: _ConversationBindingIndex,
+    hydrate: bool,
+) -> list[dict]:
+    repos: dict[str, dict] = {}
+    for session in sessions:
+        target = _session_conversation_target(session)
+        binding = binding_index.binding_for(project_id, session)
+        if target is None or binding is None:
+            continue
+        origin = _session_origin(session)
+        repo_ref = _origin_value(origin, "conversation_ref", "target_ref")
+        target_ref = _origin_value(origin, "target_ref")
+        if not repo_ref or not target_ref:
+            continue
+        repo_id = f"conversation::{repo_ref}"
+        group_id = f"{repo_id}::target::{target_ref}"
+        repo = repos.setdefault(
+            repo_id,
+            {
+                "id": repo_id,
+                "label": _conversation_label(session, None, topic=False),
+                "path": None,
+                "groups": [],
+                "sessionCount": 0,
+            },
+        )
+        group = next((item for item in repo["groups"] if item["id"] == group_id), None)
+        if group is None:
+            group = {
+                "id": group_id,
+                "label": _conversation_label(session, binding, topic=True),
+                "path": None,
+                "isConversation": True,
+                "sessions": [],
+            }
+            repo["groups"].append(group)
+        group["sessions"].append(session)
+        repo["sessionCount"] += 1
+
+    for repo in repos.values():
+        for group in repo["groups"]:
+            group["sessions"].sort(key=_session_time, reverse=True)
+        repo["groups"].sort(
+            key=lambda group: (
+                -max(
+                    (_session_time(session) for session in group["sessions"]),
+                    default=0.0,
+                ),
+                group["label"].lower(),
+            )
+        )
+        if not hydrate:
+            for group in repo["groups"]:
+                group["sessions"] = []
+    return sorted(
+        repos.values(), key=lambda repo: (-repo["sessionCount"], repo["label"].lower())
+    )
+
+
 # ---------------------------------------------------------------------------
 # Public builder
 # ---------------------------------------------------------------------------
@@ -586,11 +737,17 @@ def build_tree(
     _junk_cwd = is_junk_cwd or (lambda _cwd: False)
     _exists = exists or (lambda _path: True)
     folder_index = _FolderIndex(active_projects)
+    binding_index = _ConversationBindingIndex(active_projects)
 
     by_project: dict[str, list[dict]] = {}
     unowned: list[dict] = []
     for session in sessions:
-        owner = _project_for_session(session, folder_index, resolve)
+        # An explicit conversation binding is stronger than filesystem
+        # placement. This is what keeps a Desktop/TUI continuation under the
+        # messaging topic's chosen Project even when it later gains a cwd.
+        owner = binding_index.match(session) or _project_for_session(
+            session, folder_index, resolve
+        )
         if owner:
             by_project.setdefault(owner["id"], []).append(session)
         else:
@@ -612,9 +769,25 @@ def build_tree(
     # Tier 1: explicit, user-created projects (always shown, even with 0 sessions).
     for project in active_projects:
         psessions = by_project.get(project["id"], [])
+        conversation_sessions: list[dict] = []
+        filesystem_sessions: list[dict] = []
+        for session in psessions:
+            target = (
+                conversation_sessions
+                if binding_index.binding_for(project["id"], session) is not None
+                else filesystem_sessions
+            )
+            target.append(session)
         scoped_ids.extend(s["id"] for s in psessions if s.get("id"))
         repos = _seed_folder_repos(
-            _build_repos(psessions, resolve, hydrate), project.get("folders") or [], resolve
+            _build_repos(filesystem_sessions, resolve, hydrate),
+            project.get("folders") or [],
+            resolve,
+        )
+        repos.extend(
+            _build_conversation_repos(
+                project["id"], conversation_sessions, binding_index, hydrate
+            )
         )
         result.append(
             _project_node(
@@ -783,4 +956,8 @@ def build_tree(
             ),
         )
 
+    # Canonical routing metadata is build-only authority. Returned project-tree
+    # rows are Desktop/TUI transport and must never expose it.
+    for session in sessions:
+        session.pop("_messaging_target", None)
     return {"projects": result, "scoped_session_ids": scoped_ids}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11614,8 +11614,32 @@ class _NoProject(Exception):
 def _projects_payload(conn) -> dict:
     from hermes_cli import projects_db as pdb
 
+    def public_project(project) -> dict:
+        payload = project.to_dict()
+        safe_bindings = []
+        state_db = _get_db()
+        if state_db is not None:
+            for binding in project.conversation_bindings:
+                target_ref = state_db.gateway_target_ref(
+                    platform=binding.platform,
+                    chat_id=binding.chat_id,
+                    thread_id=binding.thread_id,
+                )
+                if target_ref:
+                    safe_bindings.append(
+                        {
+                            "project_id": binding.project_id,
+                            "target_ref": target_ref,
+                            "alias": binding.alias,
+                            "created_at": binding.created_at,
+                            "updated_at": binding.updated_at,
+                        }
+                    )
+        payload["conversation_bindings"] = safe_bindings
+        return payload
+
     return {
-        "projects": [p.to_dict() for p in pdb.list_projects(conn, include_archived=True)],
+        "projects": [public_project(p) for p in pdb.list_projects(conn, include_archived=True)],
         "active_id": pdb.get_active_id(conn),
     }
 
@@ -11745,6 +11769,48 @@ def _(rid, params, pdb, conn) -> dict:
 def _(rid, params, pdb, conn) -> dict:
     pdb.set_active(conn, _require_project(pdb, conn, params).id if params.get("id") else None)
     return _ok(rid, {"active_id": pdb.get_active_id(conn)})
+
+
+def _resolve_project_target_ref(params: dict) -> dict:
+    target_ref = str(params.get("target_ref") or "").strip()
+    state_db = _get_db()
+    target = state_db.resolve_gateway_target(target_ref) if state_db is not None else None
+    if target is None:
+        raise ValueError("unknown or stale target_ref")
+    return target
+
+
+@_projects_method("projects.bind_messaging_target")
+def _(rid, params, pdb, conn) -> dict:
+    project = _require_project(pdb, conn, params)
+    target = _resolve_project_target_ref(params)
+    pdb.bind_conversation(
+        conn,
+        project.id,
+        platform=target["platform"],
+        chat_id=target["chat_id"],
+        thread_id=target["thread_id"],
+        alias=params.get("alias"),
+    )
+    return _ok(rid, _projects_payload(conn))
+
+
+@_projects_method("projects.unbind_messaging_target")
+def _(rid, params, pdb, conn) -> dict:
+    project_id = str(params.get("id") or "").strip() or None
+    if project_id and pdb.get_project(conn, project_id) is None:
+        raise _NoProject
+    target = _resolve_project_target_ref(params)
+    removed = pdb.unbind_conversation(
+        conn,
+        platform=target["platform"],
+        chat_id=target["chat_id"],
+        thread_id=target["thread_id"],
+        project_id=project_id,
+    )
+    payload = _projects_payload(conn)
+    payload["removed"] = removed
+    return _ok(rid, payload)
 
 
 @_projects_method("projects.for_cwd")
@@ -12027,6 +12093,30 @@ def _project_tree_inputs(
         compact_rows=True,
     )
     sessions = [_project_tree_row(r) for r in rows]
+    metadata = db.get_gateway_session_metadata([session["id"] for session in sessions])
+    from hermes_cli.session_origins import session_origin_metadata
+
+    for session in sessions:
+        row = metadata.get(session["id"])
+        if row:
+            safe_origin = session_origin_metadata(row) or {}
+            session["_messaging_target"] = {
+                "platform": str(row.get("source") or "").strip().lower(),
+                "chat_id": str(row.get("chat_id") or "").strip(),
+                "thread_id": str(row.get("thread_id")).strip()
+                if row.get("thread_id") not in (None, "")
+                else None,
+                "target_ref": db.gateway_target_ref(
+                    platform=row.get("source"),
+                    chat_id=row.get("chat_id"),
+                    thread_id=row.get("thread_id"),
+                ),
+                "conversation_ref": db.gateway_conversation_ref(
+                    platform=row.get("source"), chat_id=row.get("chat_id")
+                ),
+                "display_label": safe_origin.get("display_label") or "Conversation",
+                "topic_label": safe_origin.get("topic_label") or "Topic",
+            }
     # Parallel-warm the git cache so build_tree's resolver reads it instead of
     # cold-probing each cwd in sequence (matters on the drill-in path, which
     # skips the discovery warm-up below).
@@ -12043,7 +12133,7 @@ def _project_tree_inputs(
                 policy_key,
                 preserve_unversioned=_repo_discovery_policy_is_default(policy),
             )
-        projects = [p.to_dict() for p in pdb.list_projects(conn)]
+        projects = [p.to_private_dict() for p in pdb.list_projects(conn)]
         active_id = pdb.get_active_id(conn)
         # backfill stays off the hot tree path — grouping uses the live resolver.
         discovered = (
@@ -12109,6 +12199,8 @@ def _build_project_tree(
         is_junk_cwd=_is_session_cwd_junk,
         exists=_dir_exists_cached,
     )
+    for session in sessions:
+        session.pop("_messaging_target", None)
     return tree, active_id
 
 


### PR DESCRIPTION
## Summary

Current-main recut of #67555 that preserves the virtualized Desktop sidebar while allowing a messaging topic/conversation to be bound, moved, aliased, or unbound from exactly one Project.

This recut replaces the rejected raw-identifier design with opaque canonical references:

- Desktop receives only privacy-safe labels plus `target_ref` / `conversation_ref`.
- Bind/unbind RPCs send only the opaque `target_ref`; they never send `chat_id`, `thread_id`, `conversation_id`, `topic_id`, `session_key`, or routing keys.
- The gateway resolves the opaque ref against the active profile's canonical `state.db` and keeps raw routing fields private in `projects.db`.
- Public Project payloads expose only the opaque ref, alias, project ID, and timestamps.
- Explicit topic ownership overrides cwd/folder grouping for later Desktop/TUI continuations.
- Legacy rows without origin refs remain in the existing flat sidebar path.
- Existing virtualization threshold, session row identity/memoization, pins, paging, source grouping, project tree, and load-more behavior are preserved.

## Dependency

**Depends on #85601.** The first commit in this stacked branch is a rebased copy of #85601's privacy-safe session-origin seam. Its stable patch ID exactly matches commit `3f8d460cf04366142a5249fe5aadfe0650404e17`:

```text
3c793fc939d070e879706eddc6bbfa9a248a58fb
```

Please merge #85601 first, then rebase/drop the duplicate dependency commit before landing this PR.

## Verification

After rebasing onto current `main` (`2ae96939f53b0cc0aa82868fc9a44702f3dd6c09`):

- Focused Python acceptance: **78 passed, 1 third-party deprecation warning**
- Focused Desktop Vitest: **66 passed across 5 files**
- Renderer TypeScript: `tsc -p . --noEmit` passed
- Changed Python Ruff: passed
- Changed Python `py_compile`: passed
- `git diff --check origin/main...HEAD`: passed
- Working tree clean

Privacy and refusal coverage includes:

- unknown/stale opaque ref fails closed without mutation;
- archived Project rejects binding;
- moving a target removes the old Project binding;
- public Project payload excludes raw chat/thread IDs;
- cross-profile/all-profile views cannot mutate another profile's binding;
- build-only raw routing metadata is stripped from Project-tree session rows;
- explicit conversation binding outranks cwd ownership.

## Scope

No deployment, runtime restart, credential/config mutation, or live environment change is included.