### PR TITLE
fix(slack): rebuild AsyncApp and clients on Socket Mode watchdog restart

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -969,6 +969,11 @@ class SlackAdapter(BasePlatformAdapter):
         # Socket Mode self-healing state for silently dropped websockets; the monotonic
         # start time is the grace window for the first ping/pong.
         self._app_token: Optional[str] = None
+        # Bot tokens preserved from connect() so _restart_socket_mode can
+        # rebuild the AsyncApp and per-workspace clients without an auth_test
+        # round-trip (see #85574: zombie aiohttp session self-heal).
+        self._bot_tokens: List[str] = []
+        self._team_tokens: Dict[str, str] = {}  # team_id → token
         self._proxy_url: Optional[str] = None
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
@@ -992,6 +997,230 @@ class SlackAdapter(BasePlatformAdapter):
                 if inspect.isawaitable(result):
                     await result
                 break
+
+    def _register_app_event_handlers(self) -> None:
+        """Register message, slash, and Block Kit action handlers on ``self._app``.
+
+        Extracted from ``connect()`` so ``_restart_socket_mode`` can rebuild a
+        fresh ``AsyncApp`` after a zombie aiohttp session without replaying
+        the full workspace authentication flow (#85574).
+        """
+        assert self._app is not None
+
+        # Register message event handler
+        @self._app.event("message")
+        async def handle_message_event(event, say, body):
+            await self._handle_slack_message(event, body)
+
+        # Handle app_mention explicitly. In some Slack app configurations,
+        # channel mentions arrive only as app_mention events rather than the
+        # generic message event. Forward them into the normal message
+        # pipeline so @mentions reliably produce replies.
+        # NOTE: when Slack fires BOTH message and app_mention for the same
+        # @mention, they share the same event ts — the dedup in
+        # _handle_slack_message (MessageDeduplicator) suppresses the second.
+        @self._app.event("app_mention")
+        async def handle_app_mention(event, say, body):
+            await self._handle_slack_message(event, body)
+
+        @self._app.event("app_home_opened")
+        async def handle_app_home_opened(event, say, body):
+            await self._handle_app_home_opened(event, body)
+
+        @self._app.event("app_context_changed")
+        async def handle_app_context_changed(event, say, body):
+            await self._handle_app_context_changed(event, body)
+
+        # File lifecycle events can arrive around snippet uploads even when
+        # the actual user message is what we care about. Ack them so Slack
+        # doesn't log noisy 404 "unhandled request" warnings.
+        @self._app.event("file_shared")
+        async def handle_file_shared(event, say, body):
+            await self._handle_slack_file_shared(event, body)
+
+        @self._app.event("file_created")
+        async def handle_file_created(event, say):
+            pass
+
+        @self._app.event("file_change")
+        async def handle_file_change(event, say):
+            pass
+
+        # Forward reaction_added events through the normal message
+        # pipeline (see _handle_slack_reaction). Skills that present
+        # confirmation-style proposals ("react 👍 to proceed") then work
+        # end-to-end. Registered explicitly so high-traffic channels do
+        # not fill gateway.error.log with Slack Bolt "Unhandled request"
+        # warnings.
+        @self._app.event("reaction_added")
+        async def handle_reaction_added(event, say):
+            await self._handle_slack_reaction(event)
+
+        @self._app.event("reaction_removed")
+        async def handle_reaction_removed(event, say):
+            await self._handle_slack_reaction(event, removed=True)
+
+        @self._app.event("assistant_thread_started")
+        async def handle_assistant_thread_started(event, say, body):
+            await self._handle_assistant_thread_lifecycle_event(event, body)
+
+        @self._app.event("assistant_thread_context_changed")
+        async def handle_assistant_thread_context_changed(event, say, body):
+            await self._handle_assistant_thread_lifecycle_event(event, body)
+
+        # Catch-all no-op ack for any other subscribed event type that
+        # Hermes has no listener for (e.g. user_change,
+        # user_huddle_changed, member_joined_channel, channel_archive,
+        # pin_added, etc.).
+        #
+        # Two reasons this must exist (issues #6572 and the Event
+        # Subscriptions auto-disable failure mode):
+        #   1. Correctness at scale: without a matching listener,
+        #      slack-bolt returns HTTP 404 for every unhandled event
+        #      envelope and never sends the Socket Mode ack. When the app
+        #      is subscribed to high-volume events (user_change fires on
+        #      every presence/status change for the whole org), the flood
+        #      of un-acked 404s pushes Slack's failure rate past its
+        #      95%/60-min threshold and Slack auto-disables the app's
+        #      Event Subscriptions — silently killing ALL inbound
+        #      delivery until manually re-enabled.
+        #   2. Noise: each unhandled envelope also logs a slack_bolt
+        #      "Unhandled request" WARNING, flooding gateway logs in
+        #      busy channels.
+        #
+        # Registered AFTER every named handler: bolt dispatches to the
+        # first matching listener, so the named handlers above always
+        # win and this only fires for truly unhandled types. The
+        # envelope is acked with 200, keeping the failure rate near 0%
+        # regardless of which events the Slack app manifest subscribes
+        # to. A debug line preserves visibility into unknown event
+        # types without per-message WARNING noise.
+        @self._app.event(re.compile(r".*"))
+        async def handle_unhandled_event(event, body, logger):
+            logger.debug(
+                "[Slack] Ignoring unhandled event type=%s (no listener "
+                "registered; subscribed events not handled by Hermes can "
+                "be removed from the Slack app manifest via "
+                "`hermes slack manifest`)",
+                (event or {}).get(
+                    "type",
+                    (body or {}).get("event", {}).get("type", "unknown"),
+                ),
+            )
+
+        # Register slash command handler(s)
+        #
+        # Every gateway command from COMMAND_REGISTRY is a native Slack
+        # slash, matching Discord and Telegram's model (e.g. /btw, /stop,
+        # /model work directly without /hermes prefix). A single regex
+        # matcher dispatches all of them to one handler so we don't need
+        # N identical @app.command() decorators.
+        #
+        # The slash commands must ALSO be declared in the Slack app
+        # manifest (see `hermes slack manifest`). In Socket Mode, Slack
+        # routes the command event through the socket regardless of the
+        # manifest's request URL, but it will not deliver an event for
+        # a slash command the manifest doesn't declare.
+        from hermes_cli.commands import slack_native_slashes
+
+        _slash_names = [name for name, _d, _h in slack_native_slashes()]
+        if _slash_names:
+            _slash_pattern = re.compile(
+                r"^/(?:" + "|".join(re.escape(n) for n in _slash_names) + r")$"
+            )
+        else:  # pragma: no cover - registry always non-empty
+            _slash_pattern = re.compile(r"^/hermes$")
+
+        @self._app.command(_slash_pattern)
+        async def handle_hermes_command(ack, command):
+            slash = (command.get("command") or "").lstrip("/")
+            await ack(
+                response_type="ephemeral",
+                text=f"Running `/{slash}`…",
+            )
+            await self._handle_slash_command(command)
+
+        # Register Block Kit action handlers for approval buttons
+        for _action_id in (
+            "hermes_approve_once",
+            "hermes_approve_session",
+            "hermes_approve_always",
+            "hermes_deny",
+        ):
+            self._app.action(_action_id)(self._handle_approval_action)
+
+        # Register Block Kit action handlers for slash-confirm buttons
+        # (generic three-option prompts; see tools/slash_confirm.py).
+        for _action_id in (
+            "hermes_confirm_once",
+            "hermes_confirm_always",
+            "hermes_confirm_cancel",
+        ):
+            self._app.action(_action_id)(self._handle_slash_confirm_action)
+
+        self._app.action("hermes_feedback")(self._handle_feedback_action)
+
+        # Register Block Kit action handlers for clarify buttons
+        # (interactive multiple-choice prompts; see tools/clarify_gateway.py).
+        # Choice buttons use indexed action IDs so each ID is unique within
+        # its actions block, as required by Slack's Block Kit schema.
+        self._app.action(
+            re.compile(r"^hermes_clarify_choice_\d+$")
+        )(self._handle_clarify_action)
+        self._app.action("hermes_clarify_other")(self._handle_clarify_action)
+
+        # Register plugin-provided Block Kit action handlers.
+        #
+        # Plugins call ``ctx.register_slack_action_handler(action_id, cb)``
+        # at register() time; the manager queues them and the adapter
+        # wires them into AsyncApp here so slack_bolt's matcher knows
+        # about them before Socket Mode starts dispatching events.
+        #
+        # Each callback is wrapped so a misbehaving plugin can't take
+        # down the gateway: any exception inside the plugin handler is
+        # caught and logged, and slack_bolt still sees a clean ack.
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+            _plugin_handlers = get_plugin_manager().get_slack_action_handlers()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(
+                "[Slack] Could not load plugin action handlers: %s", e,
+            )
+            _plugin_handlers = []
+
+        # Closure factory — keeps the wrapper's signature limited to
+        # ``(ack, body, action)``. slack_bolt inspects listener
+        # signatures via ``inspect.signature`` and passes ``None`` for
+        # any parameter name it doesn't recognise, so capturing loop
+        # vars as default args (``_cb=_cb`` etc.) silently clobbers
+        # them at dispatch time.
+        def _make_wrapper(cb, plugin_name):
+            async def _wrapped(ack, body, action):
+                try:
+                    await cb(ack, body, action)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.error(
+                        "[Slack] Plugin '%s' action handler raised: %s",
+                        plugin_name, exc, exc_info=True,
+                    )
+                    # Best-effort ack so Slack doesn't retry the click.
+                    try:
+                        await ack()
+                    except Exception:
+                        pass
+            return _wrapped
+
+        for _action_id, _cb, _plugin_name in _plugin_handlers:
+            self._app.action(_action_id)(_make_wrapper(_cb, _plugin_name))
+            logger.debug(
+                "[Slack] Registered plugin action handler %s (from %s)",
+                _action_id, _plugin_name,
+            )
+        if _plugin_handlers:
+            logger.info(
+                "[Slack] Wired %d plugin action handler(s)",
+                len(_plugin_handlers),
+            )
 
     @staticmethod
     def _slack_timestamp_sort_key(ts: Any) -> Tuple[int, int, str]:
@@ -1148,7 +1377,21 @@ class SlackAdapter(BasePlatformAdapter):
         return (time.time() - last) > (ping_interval * self._socket_ping_stale_factor)
 
     async def _restart_socket_mode(self, reason: str) -> None:
-        """Reconnect Socket Mode without rebuilding adapter state."""
+        """Reconnect Socket Mode, rebuilding the AsyncApp and its clients.
+
+        When the watchdog detects a wedged/zombie session (ping/pong stale,
+        transport disconnected, or the socket task dying with a closed aiohttp
+        session), the underlying aiohttp ``ClientSession`` inside the
+        ``AsyncApp``'s ``AsyncWebClient`` may be permanently closed.  Simply
+        stopping and restarting the Socket Mode handler reuses the same dead
+        client, so every reconnect attempt fails identically with
+        ``RuntimeError("Session is closed")`` (see #85574: 15,948 failed
+        attempts over 29.5 hours).  This method closes the old handler and
+        clients, builds a fresh ``AsyncApp`` and per-workspace
+        ``AsyncWebClient`` instances from the stored tokens, re-registers all
+        handlers, and starts a new handler — mirroring what a full process
+        restart does but scoped to the Slack adapter.
+        """
         if not self._running:
             return
         async with self._socket_reconnect_lock:
@@ -1156,7 +1399,44 @@ class SlackAdapter(BasePlatformAdapter):
                 return
             logger.warning("[Slack] Socket Mode unhealthy (%s); reconnecting", reason)
             await self._stop_socket_mode_handler()
+
+            if not self._bot_tokens:
+                logger.error(
+                    "[Slack] Cannot rebuild Socket Mode app: no bot tokens stored"
+                )
+                return
+
             try:
+                # Close the dead aiohttp sessions owned by the old AsyncApp
+                # and per-workspace clients, then drop them.
+                await self._close_workspace_clients()
+                self._app = None
+                self._team_clients = {}
+
+                # Rebuild the AsyncApp with a fresh primary client/session.
+                primary_token = self._bot_tokens[0]
+                primary_client = AsyncWebClient(
+                    token=primary_token,
+                    user_agent_prefix=_HERMES_SLACK_USER_AGENT_PREFIX,
+                )
+                self._app = AsyncApp(token=primary_token, client=primary_client)
+                _apply_slack_proxy(self._app.client, self._proxy_url)
+
+                # Rebuild per-workspace clients with fresh aiohttp sessions.
+                # We reuse the existing team_id → token mapping from
+                # ``connect()`` so no extra auth_test round-trip is needed;
+                # the bot identity and team metadata are already known.
+                for team_id, token in self._team_tokens.items():
+                    client = AsyncWebClient(
+                        token=token,
+                        user_agent_prefix=_HERMES_SLACK_USER_AGENT_PREFIX,
+                    )
+                    _apply_slack_proxy(client, self._proxy_url)
+                    self._team_clients[team_id] = client
+
+                # Re-register all event/slash/action handlers on the new app.
+                self._register_app_event_handlers()
+
                 self._start_socket_mode_handler()
             except Exception as exc:  # pragma: no cover - defensive logging
                 logger.error("[Slack] Socket Mode reconnect failed: %s", exc, exc_info=True)
@@ -1590,6 +1870,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._team_clients[team_id] = client
         self._team_bot_user_ids[team_id] = bot_user_id
         self._team_bot_names[team_id] = bot_name
+        self._team_tokens[team_id] = token  # for _restart_socket_mode rebuild (#85574)
         if self._bot_user_id is None:
             self._bot_user_id = bot_user_id
         if self._bot_display_name is None:
@@ -1649,6 +1930,10 @@ class SlackAdapter(BasePlatformAdapter):
             # Reset so a reconnect with dropped/rotated tokens carries no stale identities.
             self._bot_user_id = self._bot_display_name = None
             self._team_clients, self._team_bot_user_ids, self._team_bot_names = {}, {}, {}
+            # Preserve bot tokens so _restart_socket_mode can rebuild the AsyncApp
+            # and per-workspace clients without an auth_test round-trip (#85574).
+            self._bot_tokens = list(bot_tokens)
+            self._team_tokens = {}
             self._app = AsyncApp(
                 token=bot_tokens[0], client=self._new_web_client(bot_tokens[0], proxy_url),
                 before_authorize=_slack_per_request_proxy_middleware(proxy_url))
@@ -1748,6 +2033,7 @@ class SlackAdapter(BasePlatformAdapter):
         await self._stop_socket_mode_handler()
         await self._close_workspace_clients()
         self._app = self._app_token = self._proxy_url = self._bot_user_id = None
+        self._bot_tokens, self._team_tokens = [], {}
         self._team_clients, self._team_bot_user_ids = {}, {}
         self._channel_team, self._dm_conversation_cache = {}, {}
         self._release_platform_lock()

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1123,7 +1123,7 @@ class SlackAdapter(BasePlatformAdapter):
         # routes the command event through the socket regardless of the
         # manifest's request URL, but it will not deliver an event for
         # a slash command the manifest doesn't declare.
-        from hermes_cli.commands import slack_native_slashes
+        from hermes_cli.commands_platforms import slack_native_slashes
 
         _slash_names = [name for name, _d, _h in slack_native_slashes()]
         if _slash_names:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -974,6 +974,8 @@ class SlackAdapter(BasePlatformAdapter):
         # round-trip (see #85574: zombie aiohttp session self-heal).
         self._bot_tokens: List[str] = []
         self._team_tokens: Dict[str, str] = {}  # team_id → token
+        # One-shot: empty token cache must not ERROR on every watchdog tick.
+        self._socket_rebuild_skipped_no_tokens = False
         self._proxy_url: Optional[str] = None
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
@@ -1386,60 +1388,80 @@ class SlackAdapter(BasePlatformAdapter):
         stopping and restarting the Socket Mode handler reuses the same dead
         client, so every reconnect attempt fails identically with
         ``RuntimeError("Session is closed")`` (see #85574: 15,948 failed
-        attempts over 29.5 hours).  This method closes the old handler and
-        clients, builds a fresh ``AsyncApp`` and per-workspace
-        ``AsyncWebClient`` instances from the stored tokens, re-registers all
-        handlers, and starts a new handler — mirroring what a full process
-        restart does but scoped to the Slack adapter.
+        attempts over 29.5 hours).  New clients are constructed first; the
+        old handler and sessions are torn down only after that succeeds, so a
+        construct failure cannot leave ``_app is None`` and disable every
+        later watchdog retry.
         """
         if not self._running:
             return
         async with self._socket_reconnect_lock:
             if not self._running or not self._app or not self._app_token:
                 return
-            logger.warning("[Slack] Socket Mode unhealthy (%s); reconnecting", reason)
-            await self._stop_socket_mode_handler()
 
             if not self._bot_tokens:
-                logger.error(
-                    "[Slack] Cannot rebuild Socket Mode app: no bot tokens stored"
-                )
+                if not self._socket_rebuild_skipped_no_tokens:
+                    logger.warning(
+                        "[Slack] Cannot rebuild Socket Mode app: no bot tokens "
+                        "stored; skipping until connect() succeeds"
+                    )
+                    self._socket_rebuild_skipped_no_tokens = True
                 return
 
-            try:
-                # Close the dead aiohttp sessions owned by the old AsyncApp
-                # and per-workspace clients, then drop them.
-                await self._close_workspace_clients()
-                self._app = None
-                self._team_clients = {}
+            logger.warning("[Slack] Socket Mode unhealthy (%s); reconnecting", reason)
 
-                # Rebuild the AsyncApp with a fresh primary client/session.
+            try:
+                # Build replacements before touching the live app so a
+                # construct failure keeps the current ``_app`` reference.
+                # The old aiohttp session may already be dead; keeping the
+                # object is what lets the next watchdog tick retry.
                 primary_token = self._bot_tokens[0]
                 primary_client = AsyncWebClient(
                     token=primary_token,
                     user_agent_prefix=_HERMES_SLACK_USER_AGENT_PREFIX,
                 )
-                self._app = AsyncApp(token=primary_token, client=primary_client)
-                _apply_slack_proxy(self._app.client, self._proxy_url)
+                new_app = AsyncApp(token=primary_token, client=primary_client)
+                _apply_slack_proxy(new_app.client, self._proxy_url)
 
-                # Rebuild per-workspace clients with fresh aiohttp sessions.
-                # We reuse the existing team_id → token mapping from
-                # ``connect()`` so no extra auth_test round-trip is needed;
-                # the bot identity and team metadata are already known.
+                # Reuse the team_id → token mapping from ``connect()`` so no
+                # extra auth_test round-trip is needed.
+                new_team_clients: Dict[str, Any] = {}
                 for team_id, token in self._team_tokens.items():
                     client = AsyncWebClient(
                         token=token,
                         user_agent_prefix=_HERMES_SLACK_USER_AGENT_PREFIX,
                     )
                     _apply_slack_proxy(client, self._proxy_url)
-                    self._team_clients[team_id] = client
+                    new_team_clients[team_id] = client
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.error(
+                    "[Slack] Socket Mode rebuild failed; keeping current app: %s",
+                    exc,
+                    exc_info=True,
+                )
+                return
 
-                # Re-register all event/slash/action handlers on the new app.
+            if len(self._team_tokens) != len(self._bot_tokens):
+                logger.debug(
+                    "[Slack] Socket Mode rebuild using %d/%d workspace tokens "
+                    "(tokens that failed auth_test in connect() are omitted)",
+                    len(self._team_tokens),
+                    len(self._bot_tokens),
+                )
+
+            await self._stop_socket_mode_handler()
+            await self._close_workspace_clients()
+            self._app = new_app
+            self._team_clients = new_team_clients
+            try:
                 self._register_app_event_handlers()
-
                 self._start_socket_mode_handler()
             except Exception as exc:  # pragma: no cover - defensive logging
-                logger.error("[Slack] Socket Mode reconnect failed: %s", exc, exc_info=True)
+                logger.error(
+                    "[Slack] Socket Mode reconnect failed after rebuild: %s",
+                    exc,
+                    exc_info=True,
+                )
 
     async def _socket_watchdog_loop(self) -> None:
         """Monitor Socket Mode and reconnect if the task/transport dies.
@@ -1934,6 +1956,7 @@ class SlackAdapter(BasePlatformAdapter):
             # and per-workspace clients without an auth_test round-trip (#85574).
             self._bot_tokens = list(bot_tokens)
             self._team_tokens = {}
+            self._socket_rebuild_skipped_no_tokens = False
             self._app = AsyncApp(
                 token=bot_tokens[0], client=self._new_web_client(bot_tokens[0], proxy_url),
                 before_authorize=_slack_per_request_proxy_middleware(proxy_url))

--- a/tests/gateway/test_slack_socket_reconnect_heal.py
+++ b/tests/gateway/test_slack_socket_reconnect_heal.py
@@ -378,17 +378,44 @@ class TestSocketModeAppRebuild:
 
     @pytest.mark.asyncio
     async def test_restart_skips_without_stored_tokens(self, adapter):
-        """If bot tokens were never stored, _restart_socket_mode gives up safely."""
+        """Empty token cache leaves the live app/handler alone and warns once."""
         adapter._bot_tokens = []
+        adapter._app_token = "xapp-fake"
+        old_app = adapter._app
+
+        adapter._stop_socket_mode_handler = AsyncMock()
+        adapter._close_workspace_clients = AsyncMock()
+        adapter._start_socket_mode_handler = MagicMock()
+
+        with patch.object(_slack_mod.logger, "warning") as warn:
+            await adapter._restart_socket_mode("ping/pong stale")
+            await adapter._restart_socket_mode("ping/pong stale")
+
+        adapter._stop_socket_mode_handler.assert_not_awaited()
+        adapter._close_workspace_clients.assert_not_awaited()
+        adapter._start_socket_mode_handler.assert_not_called()
+        assert adapter._app is old_app
+        assert adapter._socket_rebuild_skipped_no_tokens is True
+        assert warn.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_restart_keeps_app_when_construct_fails(self, adapter):
+        """A failed AsyncApp construct must not null _app or stop the handler."""
+        old_app = adapter._app
+        adapter._bot_tokens = ["xoxb-primary"]
+        adapter._team_tokens = {"T1": "xoxb-primary"}
         adapter._app_token = "xapp-fake"
 
         adapter._stop_socket_mode_handler = AsyncMock()
         adapter._close_workspace_clients = AsyncMock()
         adapter._start_socket_mode_handler = MagicMock()
 
-        await adapter._restart_socket_mode("ping/pong stale")
+        with patch.object(_slack_mod, "AsyncApp", side_effect=RuntimeError("boom")):
+            with patch.object(_slack_mod, "AsyncWebClient", return_value=MagicMock()):
+                await adapter._restart_socket_mode("ping/pong stale")
 
-        adapter._stop_socket_mode_handler.assert_awaited_once()
+        assert adapter._app is old_app
+        adapter._stop_socket_mode_handler.assert_not_awaited()
         adapter._close_workspace_clients.assert_not_awaited()
         adapter._start_socket_mode_handler.assert_not_called()
 

--- a/tests/gateway/test_slack_socket_reconnect_heal.py
+++ b/tests/gateway/test_slack_socket_reconnect_heal.py
@@ -295,3 +295,118 @@ class TestSocketModeRestart:
         await adapter._socket_watchdog_loop()
 
         assert reasons == ["transport disconnected"]
+
+
+class TestSocketModeAppRebuild:
+    """Regression for #85574: _restart_socket_mode must rebuild the AsyncApp.
+
+    When the aiohttp ClientSession inside the AsyncApp's AsyncWebClient is
+    closed, simply stopping/starting the Socket Mode handler reuses the same
+    dead client. The restart path must drop the old app/clients and build fresh
+    ones from the stored tokens.
+    """
+
+    @pytest.mark.asyncio
+    async def test_restart_rebuilds_app_and_clients(self, adapter):
+        """_restart_socket_mode creates a new AsyncApp and per-workspace clients."""
+        old_app = adapter._app
+        old_team_clients = {"T1": MagicMock(), "T2": MagicMock()}
+        adapter._team_clients = dict(old_team_clients)
+        adapter._bot_tokens = ["xoxb-primary", "xoxb-second"]
+        adapter._team_tokens = {"T1": "xoxb-primary", "T2": "xoxb-second"}
+        adapter._app_token = "xapp-fake"
+        adapter._proxy_url = None
+
+        created_apps: list = []
+        created_clients: list = []
+
+        def _fake_async_app(*, token: str, client):
+            app = MagicMock()
+            app.token = token
+            app.client = client
+            created_apps.append((token, client))
+            return app
+
+        def _fake_async_web_client(*, token: str, user_agent_prefix: str):
+            client = MagicMock()
+            client.token = token
+            client.user_agent_prefix = user_agent_prefix
+            created_clients.append((token, user_agent_prefix))
+            return client
+
+        # Avoid actually starting a socket task in the test.
+        start_calls: list = []
+
+        def _fake_start():
+            start_calls.append(adapter._app)
+            adapter._socket_mode_task = MagicMock()
+            adapter._socket_mode_task.done.return_value = False
+
+        adapter._stop_socket_mode_handler = AsyncMock()
+        adapter._close_workspace_clients = AsyncMock()
+        adapter._register_app_event_handlers = MagicMock()
+        adapter._start_socket_mode_handler = _fake_start
+
+        with patch.object(_slack_mod, "AsyncApp", side_effect=_fake_async_app):
+            with patch.object(_slack_mod, "AsyncWebClient", side_effect=_fake_async_web_client):
+                await adapter._restart_socket_mode("ping/pong stale")
+
+        # The old app and team clients should have been discarded.
+        assert adapter._app is not old_app, "AsyncApp was not rebuilt"
+        assert adapter._team_clients is not old_team_clients, "team_clients dict not replaced"
+        assert set(adapter._team_clients.keys()) == {"T1", "T2"}, "team workspaces lost"
+
+        # One AsyncApp plus one AsyncWebClient per bot token were created
+        # (the primary is the first bot token, which is also the T1 client).
+        assert len(created_apps) == 1
+        assert len(created_clients) == 3  # primary + T1 + T2
+        # Primary token is the first bot token.
+        app_token, app_client = created_apps[0]
+        assert app_token == "xoxb-primary"
+        assert app_client.user_agent_prefix == _slack_mod._HERMES_SLACK_USER_AGENT_PREFIX
+
+        # Per-workspace clients use the stored team_id → token mapping.
+        client_tokens = {c[0] for c in created_clients}
+        assert client_tokens == {"xoxb-primary", "xoxb-second"}
+
+        # Clean-up and handler wiring were performed in order.
+        adapter._stop_socket_mode_handler.assert_awaited_once()
+        adapter._close_workspace_clients.assert_awaited_once()
+        adapter._register_app_event_handlers.assert_called_once()
+        assert len(start_calls) == 1
+        assert start_calls[0] is adapter._app
+
+    @pytest.mark.asyncio
+    async def test_restart_skips_without_stored_tokens(self, adapter):
+        """If bot tokens were never stored, _restart_socket_mode gives up safely."""
+        adapter._bot_tokens = []
+        adapter._app_token = "xapp-fake"
+
+        adapter._stop_socket_mode_handler = AsyncMock()
+        adapter._close_workspace_clients = AsyncMock()
+        adapter._start_socket_mode_handler = MagicMock()
+
+        await adapter._restart_socket_mode("ping/pong stale")
+
+        adapter._stop_socket_mode_handler.assert_awaited_once()
+        adapter._close_workspace_clients.assert_not_awaited()
+        adapter._start_socket_mode_handler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_clears_stored_tokens(self, adapter):
+        """disconnect() drops the token cache so a later restart cannot build a stale app."""
+        adapter._bot_tokens = ["xoxb-fake"]
+        adapter._team_tokens = {"T1": "xoxb-fake"}
+
+        # Avoid stopping/cleanup side effects and platform lock release.
+        adapter._stop_socket_mode_handler = AsyncMock()
+        adapter._close_workspace_clients = AsyncMock()
+        adapter._seal_stream = AsyncMock()
+        adapter._stop_native_task_card_stream = AsyncMock()
+        adapter._release_platform_lock = MagicMock()
+
+        # _release_platform_lock normally checks _running; make it a no-op.
+        await adapter.disconnect()
+
+        assert adapter._bot_tokens == []
+        assert adapter._team_tokens == {}


### PR DESCRIPTION
## What does this PR do?

When the Slack Socket Mode watchdog detects a zombie session, it previously just tried to reconnect the existing AsyncApp. A zombie session often means the AsyncApp's internal state is corrupt, so reconnecting the same app doesn't help.

This PR rebuilds the AsyncApp and its web/socket clients from stored bot tokens on watchdog restart. A construct failure keeps the old app alive for future watchdog retries.

## Related Issue

Fixes #85574

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `plugins/platforms/slack/adapter.py`: `_restart_socket_mode` rebuilds AsyncApp and clients from `_bot_tokens`; added `_bot_tokens`/`_team_tokens` state; guard for missing tokens; construct failure preserves old app.

## Non-competing PRs

- #83693, #88991, #91630, #96478, #100597 are all about different Socket Mode aspects (orphaned tasks, teardown, transient disconnects, reconnect tasks) — none rebuild the AsyncApp and clients.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_slack_adapter.py` — Slack adapter tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing