### PR TITLE
Suggestion pills wait for finished words, and the MCP directory more than doubles

### DIFF
--- a/apps/desktop/src/lib/mcp-brands.tsx
+++ b/apps/desktop/src/lib/mcp-brands.tsx
@@ -7,12 +7,17 @@
  * a favicon service for it would leak that hostname off-box.
  */
 import {
+  SiAirtable,
+  SiAsana,
   SiAtlassian,
   SiDatadog,
   SiFigma,
   SiGithub,
   SiGitlab,
+  SiHuggingface,
+  SiIntercom,
   SiLinear,
+  SiNetlify,
   SiNotion,
   SiPaypal,
   SiPostgresql,
@@ -21,6 +26,7 @@ import {
   SiStripe,
   SiSupabase,
   SiVercel,
+  SiWebflow,
   SiZapier
 } from '@icons-pack/react-simple-icons'
 import type { ComponentType, SVGProps } from 'react'
@@ -35,12 +41,18 @@ export interface McpBrand {
 }
 
 export const MCP_BRAND_ICONS: Record<string, McpBrand> = {
+  airtable: { Icon: SiAirtable, color: '#18BFFF' },
+  asana: { Icon: SiAsana, color: '#F06A6A' },
   atlassian: { Icon: SiAtlassian, color: '#0052CC' },
   datadog: { Icon: SiDatadog, color: '#632CA6' },
   figma: { Icon: SiFigma, color: '#F24E1E' },
   github: { Icon: SiGithub, color: '#181717', monochrome: true },
   gitlab: { Icon: SiGitlab, color: '#FC6D26' },
+  hugging_face: { Icon: SiHuggingface, color: '#FFD21E' },
+  huggingface: { Icon: SiHuggingface, color: '#FFD21E' },
+  intercom: { Icon: SiIntercom, color: '#6AFDEF' },
   linear: { Icon: SiLinear, color: '#5E6AD2' },
+  netlify: { Icon: SiNetlify, color: '#00C7B7' },
   notion: { Icon: SiNotion, color: '#000000', monochrome: true },
   paypal: { Icon: SiPaypal, color: '#003087' },
   postgres: { Icon: SiPostgresql, color: '#4169E1' },
@@ -50,6 +62,7 @@ export const MCP_BRAND_ICONS: Record<string, McpBrand> = {
   stripe: { Icon: SiStripe, color: '#635BFF' },
   supabase: { Icon: SiSupabase, color: '#3FCF8E' },
   vercel: { Icon: SiVercel, color: '#000000', monochrome: true },
+  webflow: { Icon: SiWebflow, color: '#146EF5' },
   zapier: { Icon: SiZapier, color: '#FF4A00' }
 }
 

--- a/apps/desktop/src/lib/mcp-directory.ts
+++ b/apps/desktop/src/lib/mcp-directory.ts
@@ -99,6 +99,93 @@ export const MCP_DIRECTORY: McpDirectoryEntry[] = [
     keywords: ['stripe'],
     name: 'stripe',
     url: 'https://mcp.stripe.com'
+  },
+  {
+    description: 'Deployments, logs, and projects via Vercel’s hosted MCP.',
+    docs: 'https://vercel.com/docs/mcp',
+    // No `vercel.app` on purpose (same rule as GitHub): pasted deploy-preview
+    // links are about the site being previewed, not about managing Vercel.
+    hosts: ['vercel.com'],
+    keywords: ['vercel'],
+    name: 'vercel',
+    url: 'https://mcp.vercel.com'
+  },
+  {
+    description: 'Database, auth, and storage from your Supabase projects.',
+    docs: 'https://supabase.com/docs/guides/ai-tools/mcp',
+    hosts: ['supabase.com', 'supabase.co'],
+    keywords: ['supabase'],
+    name: 'supabase',
+    url: 'https://mcp.supabase.com/mcp'
+  },
+  {
+    description: 'Sites, deploys, and env vars via Netlify’s hosted MCP.',
+    docs: 'https://docs.netlify.com/build/build-with-ai/agent-setup-guides/agent-setup-overview/',
+    // No `netlify.app` for the same deploy-preview reason as vercel.app.
+    hosts: ['netlify.com'],
+    keywords: ['netlify'],
+    name: 'netlify',
+    url: 'https://netlify-mcp.netlify.app/mcp'
+  },
+  {
+    description: 'Models, datasets, Spaces, and papers from the Hugging Face Hub.',
+    docs: 'https://huggingface.co/docs/hub/agents-mcp',
+    hosts: ['huggingface.co', 'hf.co'],
+    keywords: ['hugging face', 'huggingface'],
+    // Underscored so prettyName renders "Hugging Face", not "Huggingface".
+    name: 'hugging_face',
+    url: 'https://huggingface.co/mcp'
+  },
+  {
+    description: 'Tasks, projects, and goals from your Asana workspace.',
+    docs: 'https://developers.asana.com/docs/using-asanas-mcp-server',
+    hosts: ['asana.com'],
+    keywords: ['asana'],
+    name: 'asana',
+    url: 'https://mcp.asana.com/sse'
+  },
+  {
+    description: 'Conversations, tickets, and customer data from Intercom.',
+    docs: 'https://developers.intercom.com/docs/guides/mcp',
+    hosts: ['intercom.com', 'intercom.io'],
+    keywords: ['intercom'],
+    name: 'intercom',
+    url: 'https://mcp.intercom.com/mcp'
+  },
+  {
+    description: 'Bases, tables, and records from your Airtable workspace.',
+    docs: 'https://support.airtable.com/articles/9897799762-using-the-airtable-mcp-server',
+    hosts: ['airtable.com'],
+    keywords: ['airtable'],
+    name: 'airtable',
+    url: 'https://mcp.airtable.com/mcp'
+  },
+  {
+    description: 'Sites, CMS collections, and pages via Webflow’s hosted MCP.',
+    docs: 'https://developers.webflow.com/mcp/reference/getting-started',
+    // No `webflow.io` — that's published staging sites, not Webflow intent.
+    hosts: ['webflow.com'],
+    keywords: ['webflow'],
+    name: 'webflow',
+    url: 'https://mcp.webflow.com/mcp'
+  },
+  {
+    description: 'Payments, invoices, and subscriptions via PayPal’s hosted MCP.',
+    docs: 'https://developer.paypal.com/tools/mcp-server/',
+    hosts: ['developer.paypal.com'],
+    keywords: ['paypal'],
+    name: 'paypal',
+    url: 'https://mcp.paypal.com/sse'
+  },
+  {
+    description: 'Catalog, orders, and payments via Square’s hosted MCP.',
+    docs: 'https://developer.squareup.com/docs/mcp',
+    hosts: ['squareup.com'],
+    // "square" the English word is everywhere ("square brackets", "square
+    // corners") — only the unambiguous brand form triggers.
+    keywords: ['squareup'],
+    name: 'square',
+    url: 'https://mcp.squareup.com/sse'
   }
 ]
 

--- a/apps/desktop/src/store/suggestion-providers/mcp.test.ts
+++ b/apps/desktop/src/store/suggestion-providers/mcp.test.ts
@@ -75,4 +75,21 @@ describe('matchSuggestions', () => {
       { keyword: 'sentry.io', server: 'sentry' }
     ])
   })
+
+  it('a keyword still under the caret does not fire yet', () => {
+    // The debounce elapses mid-thought; the word is only intent once
+    // something follows it.
+    expect(matchSuggestions('can you check linear', INDEX)).toEqual([])
+    expect(matchSuggestions('can you check linear ', INDEX)).toEqual([{ keyword: 'linear', server: 'linear' }])
+    expect(matchSuggestions('can you check linear?', INDEX)).toEqual([{ keyword: 'linear', server: 'linear' }])
+  })
+
+  it('a pasted URL fires even as the last thing in the draft', () => {
+    // Pasting is a deliberate act — the completed-word guard is keyword-only.
+    const index = [{ hosts: ['linear.app'], keywords: ['linear'], server: 'linear' }]
+
+    expect(matchSuggestions('look at https://linear.app/team/issue/ABC-1', index)).toEqual([
+      { keyword: 'linear.app', server: 'linear' }
+    ])
+  })
 })

--- a/apps/desktop/src/store/suggestion-providers/mcp.ts
+++ b/apps/desktop/src/store/suggestion-providers/mcp.ts
@@ -84,11 +84,32 @@ export interface McpMatch {
 
 const MAX_MATCHES = 2
 
+// Whole-word (unicode-aware) keyword hit that the user has FINISHED typing:
+// at least one character must follow the match (the lookahead already
+// guarantees it's a boundary). A hit still under the caret — "figma" as the
+// last thing typed, debounce elapsed mid-thought — is not intent yet, it's
+// eavesdropping on a word in progress; the pill waits for the space/period.
+const keywordHit = (haystack: string, candidate: string): boolean => {
+  const pattern = new RegExp(
+    `(?<![\\p{L}\\p{N}])${candidate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![\\p{L}\\p{N}])`,
+    'gu'
+  )
+
+  for (const match of haystack.matchAll(pattern)) {
+    if (match.index + match[0].length < haystack.length) {
+      return true
+    }
+  }
+
+  return false
+}
+
 /** Pure matcher, exported for tests: pasted-link host hits (the strongest
- *  intent signal) and whole-word (unicode-aware) keyword hits against the
- *  draft, capped at MAX_MATCHES. */
+ *  intent signal) and completed whole-word keyword hits against the draft,
+ *  capped at MAX_MATCHES. Host hits skip the completed-word guard — a paste
+ *  is a deliberate act, and the URL routinely ends the draft. */
 export function matchSuggestions(text: string, index: KeywordEntry[]): McpMatch[] {
-  const haystack = ` ${text.toLowerCase()} `
+  const haystack = text.toLowerCase()
   const hosts = draftHosts(text)
   const matches: McpMatch[] = []
 
@@ -98,14 +119,7 @@ export function matchSuggestions(text: string, index: KeywordEntry[]): McpMatch[
 
     // Whole-word match so "linearly" doesn't suggest Linear. Directory
     // keywords are lowercase; multi-word keywords match as phrases.
-    const keyword =
-      host ??
-      entry.keywords.find(candidate =>
-        new RegExp(
-          `(?<![\\p{L}\\p{N}])${candidate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![\\p{L}\\p{N}])`,
-          'u'
-        ).test(haystack)
-      )
+    const keyword = host ?? entry.keywords.find(candidate => keywordHit(haystack, candidate))
 
     if (keyword) {
       matches.push({ keyword, server: entry.server })

--- a/apps/desktop/src/store/suggestion-providers/skill.test.ts
+++ b/apps/desktop/src/store/suggestion-providers/skill.test.ts
@@ -1,28 +1,64 @@
 import { describe, expect, it } from 'vitest'
 
-import { skillPattern } from './skill'
+import { collidesWithWorkspace, skillHit, skillPattern } from './skill'
 
-describe('skillPattern', () => {
-  it('matches the exact name as a whole word', () => {
-    expect(skillPattern('perf').test('run the perf loop')).toBe(true)
-    expect(skillPattern('perf').test('performance is bad')).toBe(false)
+// skillHit is the provider's real predicate: a whole-word match that the user
+// has finished typing (at least one character follows it).
+const hits = (name: string, draft: string) => skillHit(skillPattern(name), draft.toLowerCase())
+
+describe('skillPattern + skillHit', () => {
+  it('matches the exact name as a completed whole word', () => {
+    expect(hits('perf', 'run the perf loop')).toBe(true)
+    expect(hits('perf', 'performance is bad')).toBe(false)
   })
 
   it('hyphenated names also match spaced phrasing', () => {
-    expect(skillPattern('pr-ready').test('make this pr ready')).toBe(true)
-    expect(skillPattern('pr-ready').test('run pr-ready on it')).toBe(true)
-    expect(skillPattern('pr_ready').test('pr ready please')).toBe(true)
+    expect(hits('pr-ready', 'make this pr ready pls')).toBe(true)
+    expect(hits('pr-ready', 'run pr-ready on it')).toBe(true)
+    expect(hits('pr_ready', 'pr ready please')).toBe(true)
   })
 
   it('never matches inside other words', () => {
-    expect(skillPattern('read').test('i already did')).toBe(false)
-    expect(skillPattern('work').test('reworked the layout')).toBe(false)
+    expect(hits('read', 'i already did')).toBe(false)
+    expect(hits('work', 'reworked the layout')).toBe(false)
     // Suffix boundary includes hyphen: "clean" must not fire inside "clean-up"
     // (a different skill may own that name).
-    expect(skillPattern('clean').test('do a clean-up pass')).toBe(false)
+    expect(hits('clean', 'do a clean-up pass')).toBe(false)
   })
 
   it('is case-insensitive via lowercased input', () => {
-    expect(skillPattern('Clean').test('please clean this diff')).toBe(true)
+    expect(hits('Clean', 'please clean this diff')).toBe(true)
+  })
+
+  it('a name still under the caret is not a hit yet', () => {
+    // The debounce fires while the word is the last thing typed — wait for
+    // the next keystroke to call it intent.
+    expect(hits('perf', 'run perf')).toBe(false)
+    expect(hits('perf', 'run perf ')).toBe(true)
+    expect(hits('perf', 'run perf.')).toBe(true)
+  })
+
+  it('an earlier completed occurrence still counts', () => {
+    expect(hits('perf', 'perf first, then more perf')).toBe(true)
+  })
+})
+
+describe('collidesWithWorkspace', () => {
+  it('suppresses a skill named exactly like the cwd folder', () => {
+    expect(collidesWithWorkspace('hermes-agent', '/Users/b/www/hermes-agent')).toBe(true)
+  })
+
+  it('suppresses inside worktree-suffixed folders too', () => {
+    expect(collidesWithWorkspace('hermes-agent', '/Users/b/www/hermes-agent-suggest')).toBe(true)
+  })
+
+  it('does not suppress on substring-only overlap', () => {
+    // "perf" inside "perfect-app" is not a homonym of the project.
+    expect(collidesWithWorkspace('perf', '/Users/b/www/perfect-app')).toBe(false)
+    expect(collidesWithWorkspace('clean', '/Users/b/www/hermes-agent')).toBe(false)
+  })
+
+  it('never collides when detached (empty cwd)', () => {
+    expect(collidesWithWorkspace('hermes-agent', '')).toBe(false)
   })
 })

--- a/apps/desktop/src/store/suggestion-providers/skill.ts
+++ b/apps/desktop/src/store/suggestion-providers/skill.ts
@@ -2,6 +2,7 @@ import { requestComposerFocus, requestComposerInsert } from '@/app/chat/composer
 import { getSkills } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { type ComposerSuggestion, registerDraftProvider } from '@/store/composer-suggestions'
+import { $currentCwd } from '@/store/session'
 
 /**
  * Skill-match draft provider: the draft names a skill the user has, so offer
@@ -41,7 +42,34 @@ const escape = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 export function skillPattern(name: string): RegExp {
   const flexible = name.toLowerCase().split(/[-_]/).map(escape).join('[-_ ]')
 
-  return new RegExp(`(?<![\\p{L}\\p{N}])${flexible}(?![\\p{L}\\p{N}-])`, 'u')
+  return new RegExp(`(?<![\\p{L}\\p{N}])${flexible}(?![\\p{L}\\p{N}-])`, 'gu')
+}
+
+/** Completed whole-word hit, exported for tests: the match only counts once
+ *  at least one character follows it. The debounce fires mid-sentence, and a
+ *  name still under the caret is a word in progress, not a request — the pill
+ *  waiting for the next keystroke is the difference between "offering" and
+ *  "reading over your shoulder". */
+export function skillHit(pattern: RegExp, haystack: string): boolean {
+  pattern.lastIndex = 0
+
+  for (const match of haystack.matchAll(pattern)) {
+    if (match.index + match[0].length < haystack.length) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/** Workspace homonym guard, exported for tests: a skill named like the
+ *  working directory is the project's name, not a request for the skill.
+ *  Working in `~/www/hermes-agent`, the draft says "hermes-agent" constantly
+ *  — a "Use skill: hermes-agent" pill on every mention is noise (the reported
+ *  annoyance that prompted this guard). Boundary containment, not exact
+ *  segment equality, so worktree dirs (`hermes-agent-suggest`) suppress too. */
+export function collidesWithWorkspace(name: string, cwd: string): boolean {
+  return new RegExp(`(?<![\\p{L}\\p{N}])${escape(name.toLowerCase())}(?![\\p{L}\\p{N}])`, 'u').test(cwd.toLowerCase())
 }
 
 async function loadIndex(): Promise<SkillIndexEntry[]> {
@@ -94,7 +122,10 @@ registerDraftProvider('skill', async ({ text }) => {
   }
 
   const haystack = text.toLowerCase()
+  const cwd = $currentCwd.get()
   const skills = await loadIndex()
 
-  return skills.filter(skill => skill.pattern.test(haystack)).map(skill => toSuggestion(skill.name))
+  return skills
+    .filter(skill => skillHit(skill.pattern, haystack) && !collidesWithWorkspace(skill.name, cwd))
+    .map(skill => toSuggestion(skill.name))
 })


### PR DESCRIPTION
Follow-up to the suggestion-pill work of #85036/#85070/#85091: the pills were firing while the trigger word was still under the caret ("use skill: hermes-agent" appearing because you mentioned the repo you're working in), and the connect directory covered only 8 vendors.

## Precision: two guards on draft-keyword pills

| Situation | Before | Now |
| --- | --- | --- |
| Draft ends `...check linear` (caret after the word, debounce elapses) | "Add Linear" pops mid-thought | quiet until any character follows the word (`linear ` / `linear?`) |
| Pasted `https://linear.app/...` as the last thing in the draft | fires | still fires — pasting is deliberate; host hits skip the guard |
| Skill `hermes-agent` exists, cwd is `~/www/hermes-agent` | "Use skill: hermes-agent" on every repo mention | skill pills whose name appears (word-boundary) in the session cwd never offer |
| cwd is a worktree like `hermes-agent-suggest` | same nag | boundary containment, so suffixed worktree dirs suppress too |

Worked example: typing `can you check linear` → nothing. One more keystroke — `can you check linear board` — and the pill appears. The word finished; now it's intent.

## Breadth: directory grows 8 → 18 official hosted remotes

Vercel, Supabase, Netlify, Hugging Face, Asana, Intercom, Airtable, Webflow, PayPal, Square — all vendor-operated remotes with the docs page linked per entry, same URL-only rule (no local processes, renderer-local, NOT the reviewed install catalog). Ambiguity handled at the trigger: `square` the English word never fires (only `squareup`), and `vercel.app`/`netlify.app` deploy-preview hosts are deliberately absent — a pasted preview link is about the site being previewed, not the platform (same reasoning as GitHub's no-host rule). Brand glyphs wired for every newcomer; Hugging Face is `hugging_face` so prettyName renders the actual brand name.

## Tests

Matcher suites extended: completed-word guard (keyword vs pasted-URL), workspace homonym guard (exact folder, worktree suffix, substring non-collision, detached cwd). 28 passing.