### PR TITLE
fix(cron): skip session-only toolset checks

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -292,6 +292,22 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+# These toolsets describe a client/session surface rather than capabilities a
+# scheduled job can use.  They must be removed before schema assembly: the
+# registry evaluates every registered check_fn for every requested toolset, so
+# merely relying on the checks to return False still emits irrelevant warnings
+# on every cron run.  The desktop gateway adds ``desktop_ui`` for desktop-sourced
+# sessions, while Kanban dispatcher workers get ``kanban`` through their worker
+# context.  Neither surface belongs to a cron agent, and keeping this policy
+# scheduler-local leaves those interactive/worker paths unchanged.
+_CRON_SESSION_ONLY_TOOLSETS = frozenset({"desktop_ui", "kanban"})
+
+
+def _filter_cron_session_toolsets(toolsets: list[str]) -> list[str]:
+    """Remove client/worker-only toolsets from a cron toolset allowlist."""
+    return [name for name in toolsets if str(name) not in _CRON_SESSION_ONLY_TOOLSETS]
+
+
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
@@ -300,6 +316,10 @@ def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
       - ``clarify`` — interactive, blocks waiting for user input
       - ``memory`` — cron agents are constructed with ``skip_memory=True``, so
         exposing this tool only gives the model an unbacked tool that fails
+
+    ``desktop_ui`` and ``kanban`` are likewise always disabled: they are a
+    session/client surface and a dispatcher-worker surface respectively, and
+    neither is part of a scheduled run. See ``_CRON_SESSION_ONLY_TOOLSETS``.
 
     ``cronjob`` is policy-denied by default (loop prevention, not a security
     boundary) and config-gated: setting ``cron.allow_agent_scheduling: true``
@@ -317,6 +337,9 @@ def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
         disabled = ["messaging", "clarify", "memory"]
     else:
         disabled = ["cronjob", "messaging", "clarify", "memory"]
+    # Appended after the gate so both branches inherit them: the
+    # allow_agent_scheduling gate governs ``cronjob`` only.
+    disabled.extend(sorted(_CRON_SESSION_ONLY_TOOLSETS))
     agent_cfg = (cfg or {}).get("agent") or {}
     user_disabled = agent_cfg.get("disabled_toolsets") or []
     for name in user_disabled:
@@ -341,7 +364,11 @@ def _merge_mcp_into_per_job_toolsets(per_job: list[str], cfg: dict) -> list[str]
         add nothing further (the user named exactly the servers they want)
       * otherwise -> union in every globally-enabled MCP server
     """
-    result = [t for t in per_job if t != "no_mcp"]
+    result = [
+        t
+        for t in per_job
+        if t != "no_mcp" and str(t) not in _CRON_SESSION_ONLY_TOOLSETS
+    ]
     if "no_mcp" in per_job:
         return result
     # lazy import: avoid heavy hermes_cli import at cron module load (matches
@@ -381,7 +408,9 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
         return _merge_mcp_into_per_job_toolsets(list(per_job), cfg or {})
     try:
         from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
-        return sorted(_get_platform_tools(cfg or {}, "cron"))
+        return _filter_cron_session_toolsets(
+            sorted(_get_platform_tools(cfg or {}, "cron"))
+        )
     except Exception as exc:
         logger.warning(
             "Cron toolset resolution failed, falling back to full default toolset: %s",

--- a/tests/cron/test_agent_scheduling_gate.py
+++ b/tests/cron/test_agent_scheduling_gate.py
@@ -9,6 +9,8 @@ default off) makes that denial opt-out-able:
   - gate on: ``cronjob`` dropped from the base denylist; ``messaging`` and
     ``clarify`` (interactivity constraints) and ``memory`` (cron agents run
     with skip_memory=True) are ALWAYS denied regardless of the gate.
+  - ``desktop_ui`` and ``kanban`` are session/worker-only surfaces and are
+    likewise always denied; the gate governs ``cronjob`` only.
   - user-level ``agent.disabled_toolsets`` still layers on top, so a user who
     denies ``cronjob`` globally keeps it denied even with the gate on
     (per-job enabled_toolsets can never widen past the config denylist).
@@ -29,17 +31,20 @@ class TestGateOffDefault:
     def test_empty_config_denies_cronjob(self):
         assert _resolve_cron_disabled_toolsets({}) == [
             "cronjob", "messaging", "clarify", "memory",
+            "desktop_ui", "kanban",
         ]
 
     def test_none_config_denies_cronjob(self):
         assert _resolve_cron_disabled_toolsets(None) == [
             "cronjob", "messaging", "clarify", "memory",
+            "desktop_ui", "kanban",
         ]
 
     def test_cron_section_present_but_gate_absent(self):
         cfg = {"cron": {"preflight": True}}
         assert _resolve_cron_disabled_toolsets(cfg) == [
             "cronjob", "messaging", "clarify", "memory",
+            "desktop_ui", "kanban",
         ]
 
     def test_explicit_false_matches_default(self):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -14,6 +14,7 @@ from cron.scheduler import (
     _build_job_prompt,
     _deliver_result,
     _merge_mcp_into_per_job_toolsets,
+    _resolve_cron_disabled_toolsets,
     _resolve_cron_enabled_toolsets,
     _resolve_delivery_target,
     _resolve_origin,
@@ -117,6 +118,98 @@ class TestPerJobToolsetMcpMerge:
         # _get_platform_tools args: (cfg, "cron")
         assert m_platform.call_args[0][1] == "cron"
         assert set(result) == set(sentinel)
+
+
+class TestCronToolsetAvailability:
+    """Cron must not request client/session-only toolset gates."""
+
+    def test_resolver_filters_desktop_and_kanban_toolsets(self):
+        cfg = {"platform_toolsets": {"cron": ["file", "skills", "terminal"]}}
+        with patch(
+            "hermes_cli.tools_config._get_platform_tools",
+            return_value={"file", "skills", "terminal", "desktop_ui", "kanban"},
+        ):
+            result = _resolve_cron_enabled_toolsets({}, cfg)
+
+        assert set(result) == {"file", "skills", "terminal"}
+
+    def test_per_job_override_cannot_reenable_session_toolsets(self):
+        result = _resolve_cron_enabled_toolsets(
+            {"enabled_toolsets": ["file", "desktop_ui", "kanban"]},
+            {},
+        )
+
+        assert result == ["file"]
+
+    def test_cron_policy_disables_session_toolsets_even_on_fallback(self):
+        disabled = _resolve_cron_disabled_toolsets({})
+
+        assert {"desktop_ui", "kanban"} <= set(disabled)
+
+    def test_session_toolsets_stay_disabled_under_agent_scheduling_gate(self):
+        """The allow_agent_scheduling gate governs ``cronjob`` only."""
+        disabled = _resolve_cron_disabled_toolsets(
+            {"cron": {"allow_agent_scheduling": True}}
+        )
+
+        assert {"desktop_ui", "kanban"} <= set(disabled)
+        assert "cronjob" not in disabled
+
+    def test_schema_assembly_keeps_core_tools_without_session_gate_probes(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """A cron schema build must not evaluate GUI/Kanban check_fn gates."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        (tmp_path / ".hermes").mkdir()
+
+        from model_tools import _clear_tool_defs_cache, get_tool_definitions
+        from tools.registry import invalidate_check_fn_cache
+
+        _clear_tool_defs_cache()
+        invalidate_check_fn_cache()
+        caplog.set_level(logging.WARNING, logger="tools.registry")
+
+        enabled = _resolve_cron_enabled_toolsets(
+            {}, {"platform_toolsets": {"cron": ["file", "skills", "terminal"]}}
+        )
+        schema = get_tool_definitions(
+            enabled_toolsets=enabled,
+            disabled_toolsets=_resolve_cron_disabled_toolsets({}),
+            quiet_mode=True,
+        )
+        names = {item["function"]["name"] for item in schema}
+
+        assert {"terminal", "process", "read_file", "write_file"} <= names
+        assert not {name for name in names if name.startswith("kanban_")}
+        assert not {
+            name
+            for name in names
+            if name
+            in {
+                "read_terminal",
+                "close_terminal",
+                "open_preview",
+                "read_preview",
+                "read_window_below",
+                "focus_pane",
+                "react_to_message",
+            }
+        }
+
+        irrelevant_check_names = {
+            "check_close_terminal_requirements",
+            "check_focus_pane_requirements",
+            "check_open_preview_requirements",
+            "check_react_requirements",
+            "check_read_preview_requirements",
+            "check_read_terminal_requirements",
+            "_check_kanban_mode",
+            "_check_kanban_orchestrator_mode",
+        }
+        assert not any(
+            any(name in record.getMessage() for name in irrelevant_check_names)
+            for record in caplog.records
+        )
 
 
 class TestResolveOrigin:


### PR DESCRIPTION
Cron-spawned agents were being handed `desktop_ui` and `kanban` in their requested toolset list. Neither belongs to a scheduled run:

- **`desktop_ui`** is a client/session surface the desktop gateway attaches to desktop-sourced sessions.
- **`kanban`** reaches dispatcher workers through their worker context.

Relying on their `check_fn` gates to return `False` is not sufficient. The registry evaluates every registered `check_fn` for every **requested** toolset, so each cron run emitted irrelevant warnings before the gates denied the tools anyway:

```
WARNING tools.registry: check_fn _check_kanban_mode returned False; dependent tools will be unavailable this turn
WARNING tools.registry: check_fn _check_kanban_orchestrator_mode returned False; dependent tools will be unavailable this turn
```

This removes both toolsets **before schema assembly** rather than letting the gates reject them afterwards.

The policy is deliberately scheduler-local, so interactive desktop sessions and Kanban dispatcher workers are unaffected — this only changes what a cron agent asks for.

### Interaction with `cron.allow_agent_scheduling`

The session-only denials are appended **after** the `allow_agent_scheduling` gate, so that gate continues to govern `cronjob` only. `desktop_ui` and `kanban` stay denied in both gate states, which `TestGateOn` and a new test both pin.

## Related Issue

No existing issue — found via the `check_fn` warnings on a production cron run. Searched open and closed issues/PRs for `cron desktop_ui`, `cron kanban toolset`, `session-only toolset`, and `disabled_toolsets cron`; no duplicates.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

**`cron/scheduler.py`**

- Added `_CRON_SESSION_ONLY_TOOLSETS` (`frozenset({"desktop_ui", "kanban"})`) and the `_filter_cron_session_toolsets()` helper.
- `_resolve_cron_disabled_toolsets()` — appends the session-only toolsets after the `allow_agent_scheduling` gate, so both branches inherit them.
- `_merge_mcp_into_per_job_toolsets()` — filters them out of a per-job `enabled_toolsets` allowlist, so a per-job override cannot re-enable them.
- `_resolve_cron_enabled_toolsets()` — filters them out of the platform-resolved default list.

**`tests/cron/test_scheduler.py`** — new `TestCronToolsetAvailability` covering all five paths.

**`tests/cron/test_agent_scheduling_gate.py`** — the three exact-equality denylist assertions in `TestGateOffDefault` now include the two new entries; module docstring notes the session-only denials. No assertion was weakened.

## How to Test

1. Confirm the new tests fail without the source change (they pin real behavior, not the implementation):
   ```bash
   git stash -- cron/scheduler.py
   pytest tests/cron/test_scheduler.py::TestCronToolsetAvailability -q   # 5 failed
   git stash pop
   ```
2. Confirm they pass with it, and that the gate contract still holds:
   ```bash
   pytest tests/cron/test_scheduler.py::TestCronToolsetAvailability -q   # 5 passed
   pytest tests/cron/test_agent_scheduling_gate.py -q                    # all pass
   ```
3. Full cron suite:
   ```bash
   pytest tests/cron/ -q
   ```

`test_schema_assembly_keeps_core_tools_without_session_gate_probes` is the end-to-end one: it builds a real cron tool schema and asserts the core tools survive while **no** GUI/Kanban `check_fn` warning is emitted.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected suite — `pytest tests/cron/ -q` → **595 passed**, 1 pre-existing failure (see note)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux 6.8), Python 3.11.15

> **On test scope — stated precisely rather than as a blanket "all pass":**
>
> The change is private to `cron/scheduler.py`. All five touched symbols
> (`_CRON_SESSION_ONLY_TOOLSETS`, `_filter_cron_session_toolsets`,
> `_resolve_cron_disabled_toolsets`, `_resolve_cron_enabled_toolsets`,
> `_merge_mcp_into_per_job_toolsets`) are referenced nowhere outside that module
> and `tests/cron/`, so no test beyond `tests/cron/` can observe this change.
> That suite is green: **595 passed**.
>
> One pre-existing failure remains in it —
> `tests/cron/test_execution_ledger.py::test_restart_marks_interrupted_execution_unknown_without_requeue`
> — which reproduces **identically on unmodified `main`**; it spawns a subprocess
> that doesn't inherit my virtualenv's interpreter path.
>
> I could not get a clean signal from a complete `pytest tests/ -q` locally: the
> run is swamped by e2e teardown noise unrelated to this change (a background
> logging thread writing to `/tmp/hermes_e2e_*/.hermes/logs/agent.log` after the
> temp `HERMES_HOME` is removed — ~1,700 tracebacks). I also confirmed
> `tests/agent/test_auxiliary_main_first.py::TestResolveVisionCustomProvider::test_custom_main_forwards_runtime_endpoint`
> passes in isolation on both branches and fails only in full-suite order on
> **unmodified `main`** too. Happy to rerun anything CI flags.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on both changed functions + the gate test module docstring)
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — pure Python list filtering, no platform-specific primitives
- [x] N/A — no tool descriptions or schemas changed