### PR TITLE
fix(desktop): profiles unusable over a global SSH remote — don't dial doomed per-profile sockets

### DIFF
--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The global-remote share (backend routing case 3): every profile is served
+// by the PRIMARY backend over one host, and getConnection() tags the shared
+// descriptor with `profile`. Dialing a second WebSocket at that descriptor
+// used to fail over SSH (per-backend tunnel/ticket) and poison the active
+// gateway with a closed socket — "Hermes gateway is not connected" for every
+// profile except the primary. These tests pin the fix: a profile routed to
+// the shared primary activates the primary socket instead of dialing.
+
+vi.mock('@/hermes', () => ({
+  HermesGateway: class {
+    connectionState = 'closed'
+    connect = vi.fn(async () => {
+      throw new Error('dialed a socket for a shared-primary profile')
+    })
+    onEvent = vi.fn(() => () => {})
+    onState = vi.fn(() => () => {})
+  }
+}))
+vi.mock('@/store/session', () => ({ setGatewayState: vi.fn() }))
+vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
+
+const { $gateway, configureGatewayRegistry, ensureGatewayForProfile, setPrimaryGateway } = await import('./gateway')
+
+type DesktopStub = { getConnection: ReturnType<typeof vi.fn> }
+
+function installDesktop(stub: DesktopStub): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = stub
+}
+
+function makePrimary(): { connectionState: string } {
+  // Only connectionState is consulted by setActive/isOpen for these paths.
+  return { connectionState: 'open' }
+}
+
+beforeEach(() => {
+  configureGatewayRegistry({
+    onEvent: vi.fn(),
+    primaryProfile: 'default'
+  } as never)
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('ensureGatewayForProfile under a shared global remote', () => {
+  it('activates the primary socket for a profile tagged onto the shared descriptor', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    installDesktop({
+      // Shared descriptor: primary connection tagged with the profile.
+      getConnection: vi.fn(async () => ({ port: 4242, profile: 'venture', token: 't' }))
+    })
+
+    await ensureGatewayForProfile('venture')
+
+    expect($gateway.get()).toBe(primary)
+  })
+
+  it('still pools a socket for profiles with their own descriptor (untagged)', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    installDesktop({
+      // Own descriptor: no profile tag → normal pooled path (dial attempted).
+      getConnection: vi.fn(async () => ({ port: 5151, token: 't2' }))
+    })
+
+    await ensureGatewayForProfile('worker')
+
+    // The pooled path dialed (our stub throws, so the socket stays closed and
+    // reconnect is scheduled) — the important part is it did NOT silently
+    // reuse the primary.
+    expect($gateway.get()).not.toBe(primary)
+  })
+})

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -247,6 +247,29 @@ function createSecondary(profile: string): Secondary {
   return entry
 }
 
+// True when `profile`'s backend route resolves to the SHARED primary backend
+// (global-remote case 3 in resolveProfileBackendRoute): the descriptor comes
+// back as the primary connection tagged with `profile`. Own-remote-override
+// and local pooled descriptors are never tagged. Dialing a second socket at
+// that descriptor is wrong — over SSH the second dial fails (tunnel/token are
+// per-backend) and the closed socket poisons the active gateway with
+// "not connected" even though the primary is open right next to it.
+async function sharedPrimaryRoute(profile: string): Promise<boolean> {
+  const desktop = window.hermesDesktop
+
+  if (!desktop) {
+    return false
+  }
+
+  try {
+    const conn = await desktop.getConnection(profile)
+
+    return Boolean(conn && typeof conn === 'object' && (conn as { profile?: string }).profile)
+  } catch {
+    return false
+  }
+}
+
 // Open `profile`'s socket WITHOUT making it active — the hover-intent pre-warm
 // (store/profile). Runs the same spawn + connect chain as a real switch, so by
 // click time ensureGatewayForProfile finds an open socket and just activates
@@ -257,6 +280,11 @@ export async function openGatewayForProfile(profile: string): Promise<void> {
   const key = normKey(profile)
 
   if (key === g.primaryProfile) {
+    return
+  }
+
+  if (await sharedPrimaryRoute(key)) {
+    // Served by the primary backend — there is no per-profile socket to warm.
     return
   }
 
@@ -275,6 +303,17 @@ export async function ensureGatewayForProfile(profile: string): Promise<void> {
 
   if (key === g.primaryProfile) {
     setActive(key)
+
+    return
+  }
+
+  // Global-remote share (routing case 3): one remote host serves every
+  // profile through the PRIMARY socket, scoped per request. Activate the
+  // primary instead of dialing a doomed duplicate socket at the same
+  // descriptor — $activeGatewayProfile still moves to `key`, so request
+  // scoping and profile-aware surfaces behave identically.
+  if (await sharedPrimaryRoute(key)) {
+    setActive(g.primaryProfile)
 
     return
   }


### PR DESCRIPTION
## What

Fixes "Hermes gateway is not connected" when clicking into any non-primary profile while connected to a global SSH/remote gateway.

Reported by a Bot Mode user (@signalbydel): the roster (primary socket) shows all agents, but opening any of them lands on the gateway-disconnected screen.

## Root cause

`ensureGatewayForProfile()` / `openGatewayForProfile()` unconditionally dial a per-profile secondary WebSocket for any non-primary profile. Under a global remote, the electron routing table (`resolveProfileBackendRoute`, case 3) routes every profile to the SHARED primary backend — one host, scoped per request; the descriptor `getConnection()` returns is the primary connection tagged with `profile`. There is no per-profile backend to dial: over SSH the tunnel/ticket belong to the primary connection, so the duplicate dial fails and the CLOSED socket becomes the active gateway. Every RPC then throws "Hermes gateway is not connected" even though the healthy primary socket is right there. The renderer's socket registry was contradicting the routing table it sits on top of.

## Fix

Detect the shared-primary route (descriptor tagged with `profile` — only the global-remote share does this; own-remote-override and local pooled descriptors are never tagged) and activate the primary socket instead of dialing a duplicate. `$activeGatewayProfile` still moves to the clicked profile, so `?profile=` request scoping and profile-aware surfaces behave identically. The hover pre-warm becomes a no-op on this route for the same reason.

Local multi-profile (pooled backends) and per-profile remote overrides are untouched — pinned by the second test.

## Verification

- New `gateway-shared-remote.test.ts`: shared descriptor → primary socket activated, no dial; untagged descriptor → pooled path still dials. 2/2 pass.
- Existing behavior unchanged for the primary profile fast path.
