### PR TITLE
docs(a2a): reconcile sanitized caller guidance

### DIFF
--- a/plugins/platforms/a2a/DESIGN.md
+++ b/plugins/platforms/a2a/DESIGN.md
@@ -19,7 +19,7 @@ must not touch core files.** A2A now lives entirely under
 ### Outbound — client tools (`a2a` toolset)
 - `a2a_discover(url)` — fetch + summarize a peer's Agent Card (v1.0
   `supportedInterfaces` aware, tolerates 0.3 cards).
-- `a2a_call(agent, message, context_id?)` — send a JSON-RPC `message/send`
+- `a2a_call(agent, message, context_id?)` — send a JSON-RPC `SendMessage`
   task to a peer, return the reply. Multi-turn via `context_id` (carried
   inside the Message per v1.0). Surfaces `TASK_STATE_INPUT_REQUIRED` so the
   model knows to answer and continue the context.
@@ -44,9 +44,11 @@ Peers resolved from `config.yaml` → `a2a_agents`, or a direct URL.
   `provider`, `capabilities.extendedAgentCard`). **Dynamic**: skills are
   built from the live tool registry at serve time
   (`A2A_ADVERTISED_TOOLSETS` / `extra.advertised_toolsets` restricts them).
-- JSON-RPC methods: `message/send`, `message/stream` (SSE), `tasks/get`,
-  `tasks/list`, `tasks/cancel`, `tasks/subscribe`,
-  `tasks/pushNotificationConfig/create` (legacy `set` names accepted).
+- JSON-RPC methods: v1.0 `SendMessage`, `SendStreamingMessage`, `GetTask`,
+  `ListTasks`, `CancelTask`, `SubscribeToTask`, and push-notification config
+  CRUD. Legacy path aliases (`message/send`, `message/stream`, `tasks/get`,
+  `tasks/list`, `tasks/cancel`, `tasks/subscribe`, and the push-config paths)
+  remain accepted.
 - **Live-session injection (the #11025 insight):** inbound tasks route through
   the normal `MessageEvent` → `handle_message` path keyed by the A2A
   `contextId`, so the agent that answers is the same one serving the user —
@@ -55,19 +57,21 @@ Peers resolved from `config.yaml` → `a2a_agents`, or a direct URL.
   on (per-context FIFO, so concurrent same-context requests can't cross-talk);
   `on_processing_complete` resolves failures/cancellations promptly.
 - **Task store:** every task (including terminal ones, bounded to the last
-  500) stays queryable via `tasks/get` / `tasks/list`, and `tasks/subscribe`
-  reattaches to a running task's stream via store watchers. A watchdog fails
-  orphaned tasks after 5 minutes (idempotent transitions — no double
-  counting in metrics).
+  500) stays queryable via `GetTask` / `ListTasks` (and their legacy aliases),
+  and `SubscribeToTask` reattaches to a running task's stream via store
+  watchers. A watchdog fails orphaned tasks after 5 minutes (idempotent
+  transitions — no double counting in metrics).
 - **input-required:** the platform hint tells the agent to start a reply with
   `[INPUT_REQUIRED]` when it needs clarification; the adapter maps that to
   `TASK_STATE_INPUT_REQUIRED` with the question in `status.message`.
-- **Push notifications:** config accepted inline in `message/send`
-  (`configuration.taskPushNotificationConfig`) or via the create method
-  (returns `configId` + `createdAt`). On terminal transition the callback
-  receives a v1.0 `StreamResponse` (`statusUpdate`) payload, HMAC-SHA256
-  signed (`X-A2A-Signature`, secret `A2A_PUSH_SECRET` falling back to the
-  bearer token), with SSRF-guarded callback URLs.
+- **Push notifications:** config accepted inline in `SendMessage`
+  (`configuration.taskPushNotificationConfig`) or via
+  `CreateTaskPushNotificationConfig` (returns `configId` + `createdAt`). On
+  terminal transition the callback receives a v1.0 `StreamResponse`
+  (`statusUpdate`) payload, HMAC-SHA256 signed (`X-A2A-Signature`, dedicated
+  `A2A_PUSH_SECRET` falling back to the shared bearer credential), with
+  callback URL checks that block unsafe internal destinations. Loopback
+  callbacks are allowed only in localhost-only mode.
 
 ## v1.0 wire format notes
 - Task states / roles are SCREAMING_SNAKE_CASE (TASK_STATE_*, ROLE_*).
@@ -79,15 +83,16 @@ Peers resolved from `config.yaml` → `a2a_agents`, or a direct URL.
   accepts v0.3 (kind) and pre-0.3 (type) shapes from older peers.
   Outbound replies are still text-only — the agent produces text, and
   file/data Parts are for inbound richness.
-- Push notification config: full CRUD — create (inline in message/send
+- Push notification config: full CRUD — create (inline in `SendMessage`
   via configuration.taskPushNotificationConfig, or via the create
   method), get, list, delete. Each config has a configId and createdAt.
   One config per task (v1.0 allows multiple; we keep one).
 - SSE events are StreamResponse objects (statusUpdate / artifactUpdate
   members); stream closure signals the terminal state — no final field.
 - contextId lives inside the Message (legacy top-level accepted inbound).
-- Timestamps are ISO 8601 with millisecond precision; Tasks carry
-  createdAt / lastModified.
+- Task status timestamps are ISO 8601 with millisecond precision. The v1.0
+  Task object does not carry `createdAt` or `lastModified`; push-configuration
+  objects do carry `createdAt`.
 - Error codes: A2A-reserved codes are used only with their spec semantics
   (`-32001` TaskNotFound, `-32002` TaskNotCancelable); custom errors sit at
   `-32050..-32052` (unauthorized / rate-limited / untrusted).
@@ -96,8 +101,8 @@ Peers resolved from `config.yaml` → `a2a_agents`, or a direct URL.
 - **Bind safety:** no token configured (`A2A_BEARER_TOKEN` or
   `A2A_PEER_TOKENS`) ⇒ bind `127.0.0.1` only. A token alone does not widen
   the bind; remote exposure requires token **and** explicit `A2A_HOST`.
-- **Peer identity:** `A2A_PEER_TOKENS="alice:tok1,bob:tok2"` gives each peer
-  its own credential; the matched name is the authenticated identity used
+- **Peer identity:** `A2A_PEER_TOKENS="peer-a:<token-a>,peer-b:<token-b>"`
+  gives each peer its own credential; the matched name is the authenticated identity used
   for rate limiting, the trust gate, message framing, and audit. A shared
   `A2A_BEARER_TOKEN` authenticates as `ip:<addr>`. Nothing in the request
   body can assert identity. Comparisons are constant-time.
@@ -107,14 +112,16 @@ Peers resolved from `config.yaml` → `a2a_agents`, or a direct URL.
   peers can never reach operator slash commands) is defanged (ChatML /
   role-prefix / override patterns → `[filtered]`) and framed with a privacy
   prefix marking it untrusted peer input.
-- **Outbound redaction:** credential-shaped strings (`sk-…`, `ghp_…`, JWTs,
-  bearer tokens, emails) scrubbed before anything leaves.
+- **Outbound redaction:** known credential-shaped strings are scrubbed before
+  anything leaves; this is not a guarantee for arbitrary secrets.
 - **Rate limiting:** sliding window per authenticated identity
   (`A2A_RATE_LIMIT`/min).
 - **Anti-loop:** per-context turn cap (`A2A_MAX_PINGPONG_TURNS`, default 5,
   hard max 20) rejects (v1.0 `TASK_STATE_REJECTED`) runaway agent↔agent
   ping-pong; `tasks/cancel` resets the counter for the task's context.
-- **Audit log:** append-only `~/.hermes/a2a_audit.jsonl` for every exchange.
+- **Audit log:** exchanges are written best-effort to append-only
+  `~/.hermes/a2a_audit.jsonl`; records include a bounded message summary and
+  should be protected as local sensitive data.
 
 ## State placement
 Task store, turn tracker, and rate limiter are **adapter-instance** objects
@@ -145,7 +152,9 @@ them (#11025 requirement). The `a2a_history` tool recalls them by context id.
 ## Deliberately out of scope (future, not this pass)
 - **a2a-sdk / gRPC + HTTP+JSON bindings.** Only the JSONRPC binding is
   served; the card advertises exactly that.
-- **`tenant` field, extended Agent Card, `stateTransitionHistory`.**
+- **Extended Agent Card and `stateTransitionHistory`.** Optional v1.0
+  `tenant` routing is supported; task and push-config queries are scoped to the
+  routed agent/tenant.
 - **True task abort:** `tasks/cancel` marks the task canceled and drops the
   reply, but cannot abort the live session's in-flight turn.
 - **DID / Ed25519 identity, OAuth2 scopes, x402 micropayments** (#14559

--- a/plugins/platforms/a2a/README.md
+++ b/plugins/platforms/a2a/README.md
@@ -24,7 +24,7 @@ gateway:
 a2a_agents:
   researcher:
     url: "http://localhost:9999"
-    auth: { type: bearer, token: "sk-..." }
+    auth: { type: bearer, token: "<peer-token>" }
     timeout: 120
     capabilities: [web_search, research]
 ```
@@ -45,35 +45,51 @@ The agent gets five tools:
 When the `a2a` platform is enabled, Hermes serves a v1.0 Agent Card at
 `http://<host>:<port>/.well-known/agent-card.json` (the legacy
 `/.well-known/agent.json` path is also answered for pre-1.0 clients) and
-accepts JSON-RPC
-`message/send`, `message/stream` (SSE), `tasks/get|list|cancel|subscribe`,
-and push notification configs (inline or via
-`tasks/pushNotificationConfig/create`). Incoming tasks are injected into your
-**live** agent session — the same agent that's talking to you, with full
-memory — and the reply is returned over A2A. Completed tasks stay queryable
-via `tasks/get`.
+accepts JSON-RPC `SendMessage`, `SendStreamingMessage`, `GetTask`, `ListTasks`,
+`CancelTask`, `SubscribeToTask`, and push-notification config CRUD. The
+pre-1.0 path aliases (`message/send`, `message/stream`, `tasks/get`, and so
+on) remain accepted. Incoming tasks are injected into your **live** agent
+session — the same agent that's talking to you, with full memory — and the
+reply is returned over A2A. Completed tasks stay queryable via `GetTask` or
+`tasks/get`.
+
+For a v1.0 `SendMessage` request, the JSON-RPC `result` contains a `task` (or
+`message`) wrapper. Legacy path aliases return the payload without that wrapper.
+The JSON-RPC request id is echoed independently from the server-generated task
+id. `contextId` belongs inside `params.message`; repeat it for a multi-turn
+conversation. If an Agent Card interface advertises a `tenant`, echo that
+value in `params.tenant`.
 
 ## Security
 
 - **No token ⇒ localhost only.** The server binds `127.0.0.1` and refuses to
   widen unless you configure a token *and* set `A2A_HOST`.
-- **Per-peer tokens**: `A2A_PEER_TOKENS="alice:tok1,bob:tok2"` gives each
+- **Per-peer tokens**: `A2A_PEER_TOKENS="peer-a:<token-a>,peer-b:<token-b>"` gives each
   remote agent its own credential; that authenticated name (never anything
   in the request body) drives rate limiting, trust, and audit.
 - Inbound text — including `/`-prefixed text — is run through
   prompt-injection filters and framed as untrusted peer input; remote peers
   cannot invoke operator slash commands.
-- Outbound text is scrubbed of credential-shaped strings.
-- Push callbacks are SSRF-guarded and HMAC-SHA256 signed (`X-A2A-Signature`).
-- Every exchange is logged to `~/.hermes/a2a_audit.jsonl`.
+- Outbound text is scrubbed of known credential-shaped strings; arbitrary
+  secrets are not guaranteed to be removed.
+- Push callbacks are checked for unsafe internal destinations and HMAC-SHA256
+  signed (`X-A2A-Signature`) when a push secret is configured.
+- Exchanges are written best-effort to `~/.hermes/a2a_audit.jsonl`; protect the
+  bounded summaries in that file as sensitive local data.
 - Conversations persist to `~/.hermes/a2a_conversations/` — they survive context
   compaction and restarts (`a2a_history` recalls them).
+
+Streaming uses `SendStreamingMessage`/`message/stream` and emits SSE
+`statusUpdate` or `artifactUpdate` members. v1.0 frames are JSON-RPC-wrapped;
+stream closure, rather than a `final` field or a `done` data event, signals
+completion. `tasks/cancel` is a soft cancel: it drops the A2A reply but cannot
+abort a live agent turn.
 
 ## Env vars
 
 | Var | Default | Meaning |
 |---|---|---|
-| `A2A_PEER_TOKENS` | _(unset)_ | Per-peer credentials `name:token,…` (preferred). |
+| `A2A_PEER_TOKENS` | _(unset)_ | Per-peer credentials `name:<token>,…` (preferred). |
 | `A2A_BEARER_TOKEN` | _(unset)_ | Shared token; identity falls back to caller IP. |
 | `A2A_HOST` | `127.0.0.1` | Bind host. Only widens with a token set. |
 | `A2A_PORT` | `9900` | Inbound port. |
@@ -84,7 +100,7 @@ via `tasks/get`.
 | `A2A_RATE_LIMIT` | `60` | Requests/minute per identity. |
 | `A2A_MAX_PINGPONG_TURNS` | `5` | Anti-loop turn cap per context (max 20). |
 | `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply. |
-| `A2A_PUSH_SECRET` | bearer token | HMAC secret for push signing. |
+| `A2A_PUSH_SECRET` | bearer credential | HMAC secret for push signing; falls back to the shared bearer credential. |
 | `A2A_ADVERTISED_TOOLSETS` | all registered | Restrict skills on the Agent Card. |
 
 See `DESIGN.md` for architecture and the requirement-tracing table.

--- a/plugins/platforms/a2a/__init__.py
+++ b/plugins/platforms/a2a/__init__.py
@@ -74,11 +74,11 @@ def interactive_setup() -> None:
 
     print()
     print_info("Security: with NO token configured the server binds to 127.0.0.1 only.")
-    print_info("Prefer per-peer tokens (A2A_PEER_TOKENS=\"alice:tok1,bob:tok2\") so each")
+    print_info("Prefer per-peer tokens (A2A_PEER_TOKENS=\"peer-a:<token-a>,peer-b:<token-b>\") so each")
     print_info("remote agent has its own authenticated identity.")
     if prompt_yes_no("Configure tokens to allow REMOTE A2A peers?", False):
         peer_tokens = prompt(
-            "Per-peer tokens (name:token, comma-separated; blank to skip)",
+            "Per-peer tokens (name:<token>, comma-separated; blank to skip)",
             default=get_env_value("A2A_PEER_TOKENS") or "",
         )
         if peer_tokens:

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -6,13 +6,15 @@ Design (the #11025 insight, done as a plugin with zero core edits):
     dependency at register() time — avoids the a2a_fleet "register outside a
     loop" bug class).
   - Serves the A2A v1.0 Agent Card at GET /.well-known/agent-card.json (and legacy agent.json).
-  - JSON-RPC at POST /: message/send, message/stream (SSE), tasks/get,
-    tasks/list, tasks/cancel, tasks/subscribe, tasks/pushNotificationConfig/create,
-    tasks/pushNotificationConfig/get, tasks/pushNotificationConfig/list,
-    tasks/pushNotificationConfig/delete.
-  - Push notifications: config accepted inline in message/send
+  - JSON-RPC at POST /: v1.0 SendMessage, SendStreamingMessage (SSE), GetTask,
+    ListTasks, CancelTask, SubscribeToTask, and push-configuration CRUD. Legacy
+    path aliases (message/send, message/stream, tasks/get, tasks/list,
+    tasks/cancel, tasks/subscribe, and the push-configuration paths) are also
+    accepted.
+  - Push notifications: config accepted inline in SendMessage
     (configuration.taskPushNotificationConfig) or via the create method;
-    payloads are v1.0 StreamResponse objects, HMAC-signed.
+    payloads are v1.0 StreamResponse objects, HMAC-signed when a signing
+    secret is configured.
   - Metrics at GET /metrics.
   - Each inbound task is filtered + framed (security.wrap_inbound) and routed
     into the agent's LIVE gateway session via the normal MessageEvent path, so

--- a/plugins/platforms/a2a/plugin.yaml
+++ b/plugins/platforms/a2a/plugin.yaml
@@ -8,8 +8,7 @@ description: >
 
   OUTBOUND (client tools): a2a_discover, a2a_call, a2a_list, a2a_history, and
   a2a_orchestrate let the agent fetch another agent's Agent Card and send it
-  tasks over JSON-RPC — works with any A2A-compliant peer (Hermes, LangChain,
-  CrewAI, Google ADK, OpenClaw, ...).
+  tasks over the A2A v1.0 JSON-RPC binding.
 
   INBOUND (platform adapter): exposes Hermes as an A2A-discoverable agent. An
   Agent Card is served at /.well-known/agent-card.json (v1.0 canonical path;
@@ -31,8 +30,8 @@ author: Nous Research
 requires_env: []
 optional_env:
   - name: A2A_PEER_TOKENS
-    description: "Per-peer bearer tokens ('alice:tok1,bob:tok2'). Each remote agent gets its own credential; the matched name is the authenticated identity used for rate limiting, trust, and audit."
-    prompt: "A2A per-peer tokens (name:token, comma-separated; or empty)"
+    description: "Per-peer bearer tokens ('peer-a:<token-a>,peer-b:<token-b>'). Each remote agent gets its own credential; the matched name is the authenticated identity used for rate limiting, trust, and audit."
+    prompt: "A2A per-peer tokens (name:<token>, comma-separated; or empty)"
     password: true
   - name: A2A_BEARER_TOKEN
     description: "Shared bearer token for inbound A2A calls (identity falls back to caller IP). With no token of any kind => bind to 127.0.0.1 only (no remote access)."

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -4,15 +4,17 @@ and disk-backed conversation persistence.
 
 Wire shape follows A2A Protocol v1.0 (JSON-RPC 2.0 binding over HTTP):
   - Agent Card served at GET /.well-known/agent-card.json (canonical v1.0; legacy agent.json also answers)
-  - Tasks via POST {jsonrpc:"2.0", method:"message/send", params:{...}}
-  - Streaming via ``message/stream`` → SSE; events are StreamResponse objects
+  - Tasks via POST {jsonrpc:"2.0", method:"SendMessage", params:{...}}
+    (the legacy ``message/send`` alias is also accepted)
+  - Streaming via ``SendStreamingMessage`` → SSE (legacy
+    ``message/stream`` is also accepted); events are StreamResponse objects
     discriminated by member presence (``statusUpdate`` / ``artifactUpdate``),
     stream closure signals the terminal state (no ``final`` field in v1.0)
   - Task states / message roles are v1.0 SCREAMING_SNAKE_CASE enums
   - Parts are the v1.0 unified shape ({"text": ..., "mediaType": ...}),
     discriminated by member presence (no ``kind`` field)
   - Push notification configs carry ``configId`` + ``createdAt`` and can be
-    passed inline in ``message/send`` via configuration.taskPushNotificationConfig
+    passed inline in ``SendMessage`` via configuration.taskPushNotificationConfig
 
 We deliberately implement the subset of A2A needed for text task exchange with
 stdlib only (no a2a-sdk). ``extract_text`` stays tolerant of v0.3 peers.

--- a/plugins/platforms/a2a/security.py
+++ b/plugins/platforms/a2a/security.py
@@ -19,7 +19,8 @@ Layers (all opt-out-able only by explicit config, never silently):
   5. Audit log         — append-only JSONL of every inbound + outbound exchange
   6. Trusted peers     — optional allow-list restricting which authenticated
                          identities may run tasks
-  7. Push auth         — HMAC-SHA256 webhook signing + SSRF-safe callback URLs
+  7. Push auth         — optional HMAC-SHA256 webhook signing + SSRF-safe
+                         callback URL checks
 """
 
 from __future__ import annotations
@@ -47,7 +48,8 @@ def get_bearer_token() -> str:
 
 
 def get_peer_tokens() -> dict[str, str]:
-    """Parse A2A_PEER_TOKENS ("alice:tok1,bob:tok2") into {token: peer_name}.
+    """Parse A2A_PEER_TOKENS ("peer-a:<token-a>,peer-b:<token-b>") into
+    {token: peer_name}.
 
     Per-peer tokens give each remote agent its own credential, so the identity
     used for rate limiting, trust, and audit is authenticated — not whatever

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -13,12 +13,13 @@ Peers are resolved from config.yaml under ``a2a_agents``::
     a2a_agents:
       researcher:
         url: "http://localhost:9999"
-        auth: { type: bearer, token: "sk-..." }
+        auth: { type: bearer, token: "<peer-token>" }
         timeout: 120
         capabilities: [web_search, research]
 
 Transport is stdlib urllib (no a2a-sdk dependency). The wire format is the A2A
-v1.0 JSON-RPC ``message/send`` method; replies from v0.3 peers still parse.
+v1.0 JSON-RPC ``SendMessage`` method (legacy ``message/send`` is also
+accepted); replies from v0.3 peers still parse.
 """
 
 from __future__ import annotations

--- a/website/docs/user-guide/messaging/a2a.md
+++ b/website/docs/user-guide/messaging/a2a.md
@@ -1,24 +1,23 @@
 # A2A (Agent-to-Agent)
 
-[A2A](https://a2a-protocol.org) is the open Agent2Agent protocol (v1.0, stewarded by the Linux Foundation) for communication between independent AI agents. The Hermes A2A plugin works in **both directions**: your agent can call other A2A agents as tools, and other agents can send tasks to your Hermes over HTTP.
+[A2A](https://a2a-protocol.org) is an open protocol for communication between
+independent agents. The Hermes A2A plugin works in both directions: your agent
+can call other A2A agents as tools, and other agents can send tasks to Hermes
+over HTTP.
 
-It interoperates with any A2A-compliant peer — another Hermes, LangChain, CrewAI, Google ADK agents, or anything built on the official `a2a-sdk`.
-
-## When to use A2A
-
-- **Hermes ↔ Hermes across machines** — let your desktop agent hand tasks to a Hermes on a server, or vice versa, each with its own memory, tools, and credentials.
-- **Delegating to specialist agents** — a peer that advertises `web_search`/`research`/`coding` skills on its Agent Card can be discovered and called mid-conversation.
-- **Being a callable service** — expose your Hermes so other frameworks' agents can send it tasks.
-
-When you want multiple agents on the **same machine**, prefer [delegation](../features/delegation.md) (in-process subagents) or the [kanban board](../features/kanban.md) (durable multi-profile work queue) — A2A is for crossing process/machine/framework boundaries.
+Use A2A for cross-process, cross-machine, or cross-framework communication. For
+multiple agents on the same machine, prefer [delegation](../features/delegation.md)
+or the [kanban board](../features/kanban.md).
 
 ## Enable
 
+Run the setup flow:
+
 ```bash
-hermes gateway setup      # pick A2A
+hermes gateway setup      # choose A2A
 ```
 
-Or in `~/.hermes/config.yaml`:
+Or enable the inbound platform in `~/.hermes/config.yaml`:
 
 ```yaml
 gateway:
@@ -29,94 +28,287 @@ gateway:
         port: 9900
 ```
 
-The outbound client tools ship as the `a2a` toolset, **off by default** — enable it with `hermes tools`.
+The outbound client tools belong to the `a2a` toolset, which is off by default.
+Enable that toolset with `hermes tools` when the agent should call peers.
 
-## Outbound: calling other agents
+## Outbound: call another agent
 
-With the `a2a` toolset enabled, the agent gets:
+With the `a2a` toolset enabled, Hermes provides:
 
-| Tool | What it does |
+| Tool | Purpose |
 |---|---|
-| `a2a_discover(url)` | Fetch and summarize a peer's Agent Card |
-| `a2a_call(agent, message, context_id?)` | Send a task, get the reply; multi-turn via `context_id` |
-| `a2a_list()` | Configured peers, saved conversations, metrics |
-| `a2a_history(context_id)` | Recall a persisted A2A conversation |
-| `a2a_orchestrate(capability, message, mode?)` | Fan a task out to every peer advertising a capability (`all` / `first` / `best`) |
+| `a2a_discover(url)` | Fetch and summarize a peer's Agent Card. |
+| `a2a_call(agent, message, context_id?)` | Send a task and return the peer's reply. Reuse `context_id` for another turn. |
+| `a2a_list()` | List configured peers, saved conversations, and metrics. |
+| `a2a_history(context_id)` | Recall a persisted A2A conversation. |
+| `a2a_orchestrate(capability, message, mode?)` | Fan a task out to configured peers advertising a capability. Modes are `all`, `first`, and `best`. |
 
-Configure known peers in `config.yaml`:
+Configure named peers in `config.yaml`. The token is a placeholder; keep the
+real credential in the supported secret configuration and out of source files:
 
 ```yaml
 a2a_agents:
   researcher:
-    url: "http://research-box.local:9900"
-    auth: { type: bearer, token: "..." }
+    url: "http://localhost:9999"
+    auth:
+      type: bearer
+      token: "<peer-token>"
     timeout: 120
     capabilities: [web_search, research]
 ```
 
-Then just ask: *"Ask the researcher agent to summarize today's arXiv postings."* Direct URLs work too — `a2a_call` accepts any A2A endpoint.
+The `agent` argument can also be a direct `http(s)` URL. Before sending a task,
+the client prefers the JSON-RPC URL from the peer's `supportedInterfaces[]`
+entry and falls back to the card's legacy top-level `url`.
 
-## Inbound: being callable
+## Caller protocol
 
-With the platform enabled, Hermes serves:
+### Discover the Agent Card
 
-- **Agent Card** at `GET /.well-known/agent-card.json` (canonical v1.0 path; the legacy `agent.json` also answers) — advertises your agent's name, skills (derived from enabled toolsets), and auth requirements.
-- **JSON-RPC 2.0** at `POST /` — canonical v1.0 methods (`SendMessage`, `SendStreamingMessage`, `GetTask`, `ListTasks`, `CancelTask`, `SubscribeToTask`, push-notification config CRUD) plus the pre-1.0 path-style aliases (`message/send`, …).
-- **SSE streaming** for `SendStreamingMessage`, with spec-correct JSON-RPC-enveloped frames.
-- **Push notifications** (webhooks) for long-running tasks, HMAC-SHA256 signed.
+The canonical v1.0 discovery path is:
 
-Inbound tasks are injected into a **live gateway session** — the same agent, memory, and tools that serve your other channels — and the final reply is returned to the caller as the task result. Conversations are keyed by the A2A `contextId`, so a peer can hold a multi-turn exchange.
+```text
+GET <A2A_BASE_URL>/.well-known/agent-card.json
+```
 
-Interoperability is verified against the official Python `a2a-sdk` (card resolution, `SendMessage`, streaming).
+Hermes also answers the legacy `/.well-known/agent.json` path. Select the
+`supportedInterfaces[]` entry whose `protocolBinding` is `JSONRPC`; its `url`
+is the endpoint for JSON-RPC requests. If a peer has no `supportedInterfaces`
+array, use its top-level `url` as a compatibility fallback.
+
+The card's `capabilities` reports whether streaming and push notifications are
+available. `skills` is a live view of the advertised toolsets. By default it is
+derived from the tool registry; `A2A_ADVERTISED_TOOLSETS` or
+`extra.advertised_toolsets` can restrict what is advertised.
+
+### Send a task
+
+The v1.0 method is `SendMessage`. The legacy `message/send` alias is also
+accepted. Both use a JSON-RPC 2.0 envelope:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "request-1",
+  "method": "SendMessage",
+  "params": {
+    "message": {
+      "role": "ROLE_USER",
+      "parts": [
+        {"text": "Summarize the supplied report.", "mediaType": "text/plain"}
+      ],
+      "messageId": "message-1",
+      "contextId": "context-1"
+    }
+  }
+}
+```
+
+`A2A-Version: 1.0` is the preferred request header. `messageId` and
+`contextId` are generated when omitted. To continue a conversation, repeat the
+same `contextId` inside each `params.message`. If the selected Agent Card
+interface advertises a `tenant`, echo it as `params.tenant`.
+
+Message parts are discriminated by member presence, not by a `kind` field:
+
+- Text parts contain `text` and `mediaType`.
+- File parts contain `url` or base64 `raw`, plus optional `filename` and
+  `mediaType`.
+- Data parts contain structured `data` and `mediaType`.
+
+Inbound file parts are rendered into the agent's text input with their filename
+and URL (or a base64 size note); data parts are rendered as JSON. Raw file bytes
+are not decoded by the plugin. Outbound replies are text-only. Older peers'
+text parts and the older nested file shape are tolerated.
+
+The JSON-RPC request `id` is echoed independently from the server-generated
+task id. For a v1.0 `SendMessage` request, `result` contains a `task` or
+`message` member:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "request-1",
+  "result": {
+    "task": {
+      "id": "task-<generated>",
+      "contextId": "context-1",
+      "status": {
+        "state": "TASK_STATE_COMPLETED",
+        "timestamp": "<utc-millisecond-timestamp>"
+      },
+      "artifacts": [
+        {"parts": [{"text": "The report is summarized here.", "mediaType": "text/plain"}]}
+      ]
+    }
+  }
+}
+```
+
+Legacy path aliases return the task or message without the v1.0 wrapper. A
+caller should check artifacts first, then `status.message`, and tolerate a bare
+message result from older peers. A v1.0 Task has a status timestamp; it does
+not include `createdAt` or `lastModified`. Push-configuration objects do include
+`createdAt`.
+
+### Task states
+
+| State | Meaning |
+|---|---|
+| `TASK_STATE_SUBMITTED` | Initial state, most visible at the start of a stream. |
+| `TASK_STATE_WORKING` | The agent is processing the task. |
+| `TASK_STATE_INPUT_REQUIRED` | The agent needs clarification; read `status.message` and answer with the same `contextId`. |
+| `TASK_STATE_COMPLETED` | The task completed; read its artifacts. |
+| `TASK_STATE_FAILED` | Processing failed or timed out; read `status.message` when present. |
+| `TASK_STATE_CANCELED` | The task was canceled. |
+| `TASK_STATE_REJECTED` | The request was rejected, for example by the anti-loop limit. |
+
+### Streaming and task queries
+
+The v1.0 streaming method is `SendStreamingMessage`; the legacy alias is
+`message/stream`. Reconnecting to an existing task uses `SubscribeToTask` or
+`tasks/subscribe`. Other v1.0 methods and their legacy path aliases are:
+
+| v1.0 method | Legacy alias | Purpose |
+|---|---|---|
+| `GetTask` | `tasks/get` | Fetch a task. |
+| `ListTasks` | `tasks/list` | List tasks with optional context/state filters and pagination. |
+| `CancelTask` | `tasks/cancel` | Soft-cancel a task and reset its context's anti-loop counter. |
+| `SubscribeToTask` | `tasks/subscribe` | Reconnect to a running task's stream. |
+| `CreateTaskPushNotificationConfig` | `tasks/pushNotificationConfig/create` | Register one callback for a task. |
+| `GetTaskPushNotificationConfig` | `tasks/pushNotificationConfig/get` | Fetch the task's callback configuration. |
+| `ListTaskPushNotificationConfigs` | `tasks/pushNotificationConfig/list` | List the task's callback configuration. |
+| `DeleteTaskPushNotificationConfig` | `tasks/pushNotificationConfig/delete` | Remove the task's callback configuration. |
+
+Streaming responses are SSE `data:` frames. Each v1.0 frame is a JSON-RPC
+response whose `result` is a `StreamResponse` containing a member such as
+`task`, `statusUpdate`, or `artifactUpdate`. There is no `final` field or named
+`done` data event: the stream closes to signal the terminal state. Keepalive
+comments and the final `: done` comment are not data frames.
+
+Completed tasks remain queryable in the in-memory task store, bounded to the
+most recent 500 terminal tasks. `CancelTask` cannot interrupt a live agent turn;
+it prevents the late reply from being returned to the canceled A2A task.
+
+### Push notifications
+
+Register a callback inline on `SendMessage` or with
+`CreateTaskPushNotificationConfig`:
+
+```json
+{
+  "configuration": {
+    "taskPushNotificationConfig": {
+      "url": "<callback-url>"
+    }
+  }
+}
+```
+
+The legacy create path is `tasks/pushNotificationConfig/create`; get, list, and
+delete paths are also supported. Hermes keeps at most one push configuration per
+task. A created configuration returns `configId` and `createdAt`.
+
+On a terminal transition, Hermes posts a `statusUpdate` StreamResponse. When a
+push secret is configured, the body is signed with HMAC-SHA256 in the
+`X-A2A-Signature` header. The signature covers the JSON body serialized with
+sorted keys; verify it before trusting the callback. The secret is
+`A2A_PUSH_SECRET`, falling back to the shared inbound bearer credential. If
+neither a dedicated push secret nor a shared bearer credential is configured,
+notifications are unsigned. In localhost-only mode, loopback callbacks are
+allowed for local testing; remote mode blocks obvious internal destinations.
+
+Callback URLs are limited to `http` and `https`. In remote mode, obvious
+loopback, link-local, private, reserved, and unspecified IP destinations are
+blocked. Localhost-only mode permits loopback callbacks for local testing but
+still blocks other private ranges.
 
 ## Security model
 
-Secure by default; every widening step is explicit:
+Hermes keeps the inbound surface local by default:
 
-- **No token ⇒ localhost only.** The server binds `127.0.0.1`. Remote exposure requires a bearer token **and** an explicit `A2A_HOST`.
-- **Per-peer tokens** — `A2A_PEER_TOKENS="alice:tok1,bob:tok2"` gives each peer its own credential; the authenticated name drives rate limiting, trust, and audit.
-- **Prompt-injection filtering** — inbound text is filtered and framed as untrusted peer input. Remote peers cannot invoke operator slash commands.
-- **Outbound redaction** — credential-shaped strings (API keys, JWTs, tokens) are scrubbed from replies.
-- **Audit log** — every exchange appends to `~/.hermes/a2a_audit.jsonl`.
-- **Anti-loop** — per-context turn caps stop two agents ping-ponging forever.
+- With neither `A2A_BEARER_TOKEN` nor `A2A_PEER_TOKENS`, the server binds to
+  `127.0.0.1` and the card does not require authentication.
+- A token alone does not widen the bind. Remote exposure requires a token and
+  an explicit non-loopback `A2A_HOST`.
+- `A2A_PEER_TOKENS` maps each presented bearer credential to a named peer. A
+  shared `A2A_BEARER_TOKEN` maps the authenticated identity to the caller IP.
+  Nothing in the request body can assert or replace that identity, and token
+  comparisons are constant-time.
+- `A2A_TRUSTED_PEERS` optionally restricts authenticated identities. Without an
+  allow-list, any authenticated peer is accepted; `A2A_ALLOW_ALL_USERS` can
+  explicitly override the allow-list for development.
+- Inbound text is filtered for common prompt-injection and role-boundary
+  markers, then framed as untrusted peer input. Remote peers cannot invoke
+  operator slash commands.
+- Outbound text is scrubbed for known credential-shaped patterns. Treat this as
+  a safety filter, not as a guarantee that arbitrary secrets are safe to send.
+- Exchanges are written best-effort to `<HERMES_HOME>/a2a_audit.jsonl`. Audit
+  records contain a bounded message summary, so protect the file as sensitive
+  local data; outbound redaction does not make audit storage a secret store.
+
+Conversations are persisted outside the context-compaction pipeline under
+`<HERMES_HOME>/a2a_conversations/`. The local `a2a_history` tool can recall
+them after compaction or restart. The default inbound route uses the live
+gateway session, including its memory and context; deployments that configure
+additional served-agent routes may forward a task to another local profile.
+
+Each context has an anti-loop limit controlled by
+`A2A_MAX_PINGPONG_TURNS` (default 5, hard maximum 20). Once the limit is
+exceeded, a task is rejected; canceling a task resets that context's counter.
 
 ## Configuration reference
 
-| Env var | Default | Meaning |
+These inbound settings are read by the A2A plugin:
+
+| Variable | Default | Meaning |
 |---|---|---|
-| `A2A_PEER_TOKENS` | _(unset)_ | Per-peer credentials `name:token,…` (preferred) |
-| `A2A_BEARER_TOKEN` | _(unset)_ | Shared token; identity falls back to caller IP |
-| `A2A_HOST` | `127.0.0.1` | Bind host — only widens when a token is set |
-| `A2A_PORT` | `9900` | Inbound port |
-| `A2A_AGENT_NAME` | hostname-derived | Name on the Agent Card |
-| `A2A_PUBLIC_URL` | _(unset)_ | Routable URL advertised on the card (reverse proxies / k8s) |
-| `A2A_TRUSTED_PEERS` | _(unset)_ | Allow-list of authenticated identities |
-| `A2A_ALLOW_ALL_USERS` | `false` | Allow any authenticated peer (dev only) |
-| `A2A_RATE_LIMIT` | `60` | Requests/minute per identity |
-| `A2A_MAX_PINGPONG_TURNS` | `5` | Anti-loop turn cap per context (max 20) |
-| `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply |
-| `A2A_PUSH_SECRET` | bearer token | HMAC secret for push-notification signing |
-| `A2A_ADVERTISED_TOOLSETS` | all registered | Restrict which skills appear on the Agent Card |
+| `A2A_PEER_TOKENS` | _(unset)_ | Per-peer credentials in `name:<token>,…` form. |
+| `A2A_BEARER_TOKEN` | _(unset)_ | Shared inbound credential; identity falls back to caller IP. |
+| `A2A_HOST` | `127.0.0.1` | Bind host; a non-loopback value is honored only when a token is set. |
+| `A2A_PORT` | `9900` | Inbound HTTP port. |
+| `A2A_AGENT_NAME` | hostname-derived | Name shown on the Agent Card. |
+| `A2A_PUBLIC_URL` | _(unset)_ | Public URL advertised on the card behind a proxy. Forwarded host/proto headers are used when this is unset. |
+| `A2A_TRUSTED_PEERS` | _(unset)_ | Comma-separated authenticated identities allowed to run tasks. |
+| `A2A_ALLOW_ALL_USERS` | `false` | Allow authenticated peers even when an allow-list is configured; development use only. |
+| `A2A_RATE_LIMIT` | `60` | Requests per minute per authenticated identity. |
+| `A2A_MAX_PINGPONG_TURNS` | `5` | Per-context anti-loop limit, capped at 20. |
+| `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for an agent reply. |
+| `A2A_PUSH_SECRET` | shared bearer credential | Dedicated HMAC secret for push signing. |
+| `A2A_ADVERTISED_TOOLSETS` | all registered | Restrict skills shown on the Agent Card. |
 
-Behind a reverse proxy or Kubernetes Service, set `A2A_PUBLIC_URL` (or rely on `X-Forwarded-Host`/`X-Forwarded-Proto`) so the Agent Card advertises a URL peers can actually call back.
+## Safe local check
 
-## Quick test
+The following shows the request shape without a live endpoint or credential:
 
 ```bash
-# From another machine / agent:
-curl http://your-host:9900/.well-known/agent-card.json
+BASE_URL="${A2A_BASE_URL}"  # set this only in your own environment
 
-curl -X POST http://your-host:9900/ \
+curl -s "${BASE_URL}/.well-known/agent-card.json"
+
+curl -s -X POST "${BASE_URL}/" \
   -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <token>' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"SendMessage",
-       "params":{"message":{"messageId":"m1","role":"ROLE_USER",
-                 "parts":[{"text":"What tools do you have?"}]}}}'
+  -H 'A2A-Version: 1.0' \
+  -d '{"jsonrpc":"2.0","id":"request-1","method":"SendMessage",
+       "params":{"message":{"role":"ROLE_USER",
+       "parts":[{"text":"What capabilities do you advertise?"}]}}}'
 ```
+
+If the card advertises a security scheme, add the bearer header through your
+secret manager or other private credential mechanism. Do not put a live
+credential in a shell history, document, issue, or repository.
 
 ## Troubleshooting
 
-- **Peers can't reach the card URL** — the card was advertising your bind address; set `A2A_PUBLIC_URL` to the externally routable URL.
-- **`401 Unauthorized`** — token mismatch; check `A2A_PEER_TOKENS`/`A2A_BEARER_TOKEN` on the server and the peer's `auth:` block.
-- **Server won't bind non-localhost** — by design: set a bearer token first, then `A2A_HOST=0.0.0.0`.
-- **Replies time out on long tasks** — raise `A2A_REPLY_TIMEOUT`, or have the caller register a push-notification config and poll `GetTask`.
+| Symptom | Likely cause and next step |
+|---|---|
+| The card URL is unreachable or advertises the wrong host | The server is stopped, the bind host is local-only, or a proxy is rewriting the public address. Set `A2A_PUBLIC_URL`, or configure the forwarded host/proto headers at the proxy. |
+| `401` or JSON-RPC `-32050` | The remote server requires a bearer credential and the request did not present the matching one. Use the peer's configured auth mechanism without exposing the value. |
+| `403` or JSON-RPC `-32052` | Authentication succeeded, but the identity is not in `A2A_TRUSTED_PEERS`. |
+| HTTP `429` or JSON-RPC `-32051` | The authenticated identity exceeded `A2A_RATE_LIMIT`; slow down or use a separate approved peer identity. |
+| `TASK_STATE_REJECTED` | The context reached the anti-loop limit. Start a new context or cancel the old task before continuing. |
+| `TASK_STATE_INPUT_REQUIRED` | This is a clarification request, not a failure. Read `status.message` and send the answer with the same `contextId`. |
+| A remote bind is forced back to localhost | A token is missing, or `A2A_HOST` is still a loopback value. Configure both deliberately before exposing the service. |
+| A long task times out | Raise `A2A_REPLY_TIMEOUT`, use streaming, or register a push callback and query the task later. Remember that canceling a task is soft. |
+| A reply does not contain text that was sent | Known credential-shaped content may have been removed by outbound redaction. Never use A2A as a secret transport. |
+| `/help`-style text has no operator effect | Remote input is intentionally framed and filtered; peers cannot invoke operator slash commands. |


### PR DESCRIPTION
## Summary

- reconcile two misplaced caller/runbook sources into the existing canonical A2A documentation
- correct v1 method, response, task-state, streaming, push, security, and troubleshooting guidance against current code and tests
- replace credential-like examples and ephemeral operations with inert placeholders
- retain exactly nine A2A-owned paths; no generated skill catalogs/sidebar pages

## Validation

- `scripts/run_tests.sh tests/plugins/test_a2a_plugin.py tests/plugins/test_a2a_phase23.py -q` — 151 passed
- `git diff --check`
- Ruff on changed A2A Python files
- `scripts/check-windows-footguns.py --all`
- `npm run lint:diagrams` — 402 files, 0 errors
- `npm run build:fast` — success; only pre-existing generated llms-link warnings
- filename/count-only destination scan — zero secret-shaped values and zero ephemeral-domain markers

No endpoint, credential, runtime configuration, release, publish, or deployment action was used.

Refs AGC-410
