### PR TITLE
fix(desktop): stop offering unsupported GitHub MCP OAuth

### DIFF
--- a/apps/desktop/src/lib/mcp-directory.ts
+++ b/apps/desktop/src/lib/mcp-directory.ts
@@ -75,15 +75,10 @@ export const MCP_DIRECTORY: McpDirectoryEntry[] = [
     name: 'datadog',
     url: 'https://mcp.datadoghq.com/api/unstable/mcp-server/mcp'
   },
-  {
-    description: 'Repos, issues, and pull requests via GitHub’s hosted MCP.',
-    docs: 'https://docs.github.com/en/copilot/customizing-copilot/using-model-context-protocol/using-the-github-mcp-server',
-    // No hosts on purpose: github.com links are everywhere in a coding chat
-    // (commits, PRs under review, pasted diffs) and would fire constantly.
-    keywords: ['github'],
-    name: 'github',
-    url: 'https://api.githubcopilot.com/mcp/'
-  },
+  // GitHub's hosted MCP is intentionally absent. Directory entries are wired
+  // through generic Dynamic Client Registration, but GitHub requires each MCP
+  // host to provide its own OAuth app (or use a PAT). Advertising it here makes
+  // both the composer pill and setup_mcp fail at /register with HTTP 404.
   {
     description: 'Pages and databases from your Notion workspace.',
     docs: 'https://developers.notion.com/docs/mcp',

--- a/apps/desktop/src/store/suggestion-providers/mcp.test.ts
+++ b/apps/desktop/src/store/suggestion-providers/mcp.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import { MCP_DIRECTORY } from '@/lib/mcp-directory'
+
 import { matchSuggestions } from './mcp'
 
 const INDEX = [
@@ -91,5 +93,11 @@ describe('matchSuggestions', () => {
     expect(matchSuggestions('look at https://linear.app/team/issue/ABC-1', index)).toEqual([
       { keyword: 'linear.app', server: 'linear' }
     ])
+  })
+
+  it('does not offer GitHub through the generic OAuth registration path', () => {
+    const index = MCP_DIRECTORY.map(entry => ({ hosts: entry.hosts, keywords: entry.keywords, server: entry.name }))
+
+    expect(matchSuggestions('connect github', index)).toEqual([])
   })
 })


### PR DESCRIPTION
## What does this PR do?

Stops Hermes Desktop from advertising GitHub's hosted MCP server through the generic one-click OAuth path.

The Desktop MCP directory assumes every hosted remote supports OAuth Dynamic Client Registration. GitHub requires each MCP host to provide its own GitHub OAuth app, or authenticate with a PAT. Clicking `Add GitHub` therefore saved `https://api.githubcopilot.com/mcp/`, attempted registration, received `Registration failed: 404 404 page not found`, and rolled the entry back.

This removes GitHub from the DCR-backed directory until Desktop has a GitHub-specific OAuth or PAT setup flow. It also prevents the agent-driven `setup_mcp` card from reaching the same broken directory fallback. Manual PAT configuration under Capabilities > MCP remains available.

## Related Issue

No GitHub issue. Reproduced from a Discord support report against the newly shipped Desktop suggestion.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Removed the GitHub hosted endpoint from `apps/desktop/src/lib/mcp-directory.ts`, the directory shared by composer suggestions and the `setup_mcp` fallback.
- Documented why GitHub cannot use the directory's generic DCR contract.
- Added a regression proving the shipped directory does not offer GitHub through that path.

## How to Test

1. Run `npm --workspace apps/desktop run test:ui -- src/store/suggestion-providers/mcp.test.ts`.
2. In Desktop, type `connect github` in the composer.
3. Confirm Desktop no longer offers the broken `Add GitHub` OAuth pill. Existing manually configured GitHub MCP servers remain unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A: JS-only Desktop change; no Python tests run)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, focused Vitest plus Desktop typecheck and targeted ESLint

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the source comment records the provider constraint
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only directory data
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused validation:

- `mcp.test.ts`: 12 tests passed
- Desktop TypeScript typecheck: passed
- Targeted ESLint: passed
- Prettier and `git diff --check`: passed