### PR TITLE
fix(tui): scope config writes to session profile

### DIFF
--- a/tests/tui_gateway/test_config_set_profile_scope.py
+++ b/tests/tui_gateway/test_config_set_profile_scope.py
@@ -1,0 +1,172 @@
+"""Profile-scoped config writes for the desktop/TUI gateway."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+import tui_gateway.server as server
+
+
+def _reset_cfg_cache() -> None:
+    server._cfg_cache = None
+    server._cfg_mtime = None
+    server._cfg_path = None
+
+
+@pytest.fixture
+def profile_config_home(tmp_path, monkeypatch):
+    launch = tmp_path
+    worker = launch / "profiles" / "worker"
+    worker.mkdir(parents=True)
+    workdir = launch / "worker-cwd"
+    workdir.mkdir()
+
+    (launch / "config.yaml").write_text(
+        "\n".join(
+            [
+                "display:",
+                "  busy_input_mode: interrupt",
+                "  tool_progress: all",
+                "terminal:",
+                "  cwd: /tmp/default",
+                "approvals:",
+                "  mode: manual",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (worker / "config.yaml").write_text(
+        "\n".join(
+            [
+                "display:",
+                "  busy_input_mode: queue",
+                "  tool_progress: new",
+                "terminal:",
+                "  cwd: /tmp/worker",
+                "approvals:",
+                "  mode: smart",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(launch))
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    monkeypatch.setattr(server, "_hermes_home", launch)
+    _reset_cfg_cache()
+    yield launch, worker, workdir
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    _reset_cfg_cache()
+
+
+def _read_config(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _set(params: dict) -> dict:
+    return server._methods["config.set"]("rid-1", params)
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "section", "field", "expected"),
+    [
+        ("busy", "steer", "display", "busy_input_mode", "steer"),
+        ("verbose", "off", "display", "tool_progress", "off"),
+        ("approval_mode", "off", "approvals", "mode", "off"),
+    ],
+)
+def test_config_set_writes_session_profile_config(
+    profile_config_home, key, value, section, field, expected
+) -> None:
+    launch, worker, _workdir = profile_config_home
+    session = {
+        "agent": None,
+        "profile_home": str(worker),
+        "session_key": "worker-session",
+        "tool_progress_mode": "new",
+    }
+
+    with patch.dict(server._sessions, {"s-worker": session}, clear=False):
+        resp = _set({"session_id": "s-worker", "key": key, "value": value})
+
+    assert resp["result"]["value"] == expected
+    launch_cfg = _read_config(launch / "config.yaml")
+    worker_cfg = _read_config(worker / "config.yaml")
+    assert worker_cfg[section][field] == expected
+    assert launch_cfg[section][field] != expected
+
+
+def test_config_set_cwd_writes_session_profile_config(
+    profile_config_home, monkeypatch
+) -> None:
+    launch, worker, workdir = profile_config_home
+    monkeypatch.setenv("TERMINAL_CWD", "/tmp/default")
+    session = {
+        "agent": None,
+        "profile_home": str(worker),
+        "session_key": "worker-session",
+    }
+
+    with patch.dict(server._sessions, {"s-worker": session}, clear=False):
+        resp = _set(
+            {"session_id": "s-worker", "key": "cwd", "value": str(workdir)}
+        )
+
+    assert resp["result"]["cwd"] == str(workdir)
+    launch_cfg = _read_config(launch / "config.yaml")
+    worker_cfg = _read_config(worker / "config.yaml")
+    assert worker_cfg["terminal"]["cwd"] == str(workdir)
+    assert launch_cfg["terminal"]["cwd"] == "/tmp/default"
+    assert server.os.environ["TERMINAL_CWD"] == "/tmp/default"
+
+
+def test_config_set_without_session_still_writes_launch_config(
+    profile_config_home,
+) -> None:
+    launch, worker, _workdir = profile_config_home
+
+    resp = _set({"key": "busy", "value": "steer"})
+
+    assert resp["result"]["value"] == "steer"
+    launch_cfg = _read_config(launch / "config.yaml")
+    worker_cfg = _read_config(worker / "config.yaml")
+    assert launch_cfg["display"]["busy_input_mode"] == "steer"
+    assert worker_cfg["display"]["busy_input_mode"] == "queue"
+
+
+def test_config_set_without_session_cwd_still_updates_launch_env(
+    profile_config_home, monkeypatch
+) -> None:
+    launch, worker, workdir = profile_config_home
+    monkeypatch.setenv("TERMINAL_CWD", "/tmp/default")
+
+    resp = _set({"key": "cwd", "value": str(workdir)})
+
+    assert resp["result"]["cwd"] == str(workdir)
+    launch_cfg = _read_config(launch / "config.yaml")
+    worker_cfg = _read_config(worker / "config.yaml")
+    assert launch_cfg["terminal"]["cwd"] == str(workdir)
+    assert worker_cfg["terminal"]["cwd"] == "/tmp/worker"
+    assert server.os.environ["TERMINAL_CWD"] == str(workdir)
+
+
+def test_raw_config_save_honors_profile_home_override(profile_config_home) -> None:
+    launch, worker, _workdir = profile_config_home
+    token = server.set_hermes_home_override(str(worker))
+    try:
+        cfg = server._load_cfg_raw()
+        cfg.setdefault("display", {})["busy_input_mode"] = "steer"
+        server._save_cfg(cfg)
+    finally:
+        server.reset_hermes_home_override(token)
+
+    launch_cfg = _read_config(launch / "config.yaml")
+    worker_cfg = _read_config(worker / "config.yaml")
+    assert worker_cfg["display"]["busy_input_mode"] == "steer"
+    assert launch_cfg["display"]["busy_input_mode"] == "interrupt"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1493,6 +1493,22 @@ def _profile_scoped(handler):
     return wrapper
 
 
+@contextlib.contextmanager
+def _session_config_scope(session: dict | None):
+    """Bind config read/write helpers to the session's profile home."""
+    profile_home = (
+        session.get("profile_home") if isinstance(session, dict) else None
+    )
+    if not profile_home:
+        yield
+        return
+    token = set_hermes_home_override(profile_home)
+    try:
+        yield
+    finally:
+        reset_hermes_home_override(token)
+
+
 # Placeholder ``terminal.cwd`` values that don't name a real directory — the
 # gateway resolves these to the home dir at runtime, so they must NOT be treated
 # as an explicit workspace (mirrors gateway/run.py's config bridge).
@@ -3181,7 +3197,9 @@ def _save_cfg(cfg: dict):
 
     from utils import atomic_roundtrip_yaml_save
 
-    path = _hermes_home / "config.yaml"
+    override = get_hermes_home_override()
+    home = Path(override) if isinstance(override, str) and override else _hermes_home
+    path = home / "config.yaml"
     # Comment-, ordering-, and Unicode-preserving full-state write.
     # Replaces the previous `yaml.safe_dump(cfg, f)` (and later
     # `atomic_config_write`, which is not comment-preserving) which clobbered
@@ -10900,8 +10918,13 @@ def _respond(rid, params, key, *, allow_expired=False):
 # in a follow-up once that PR lands.
 @method("config.set")
 def _(rid, params: dict) -> dict:
-    key, value = params.get("key", ""), params.get("value", "")
     session = _sessions.get(params.get("session_id", ""))
+    with _session_config_scope(session):
+        return _config_set(rid, params, session)
+
+
+def _config_set(rid, params: dict, session: dict | None = None) -> dict:
+    key, value = params.get("key", ""), params.get("value", "")
 
     if key == "model":
         try:
@@ -11545,7 +11568,11 @@ def _(rid, params: dict) -> dict:
         if not os.path.isdir(cwd):
             return _err(rid, 4002, f"working directory does not exist: {raw}")
         _write_config_key("terminal.cwd", cwd)
-        os.environ["TERMINAL_CWD"] = cwd
+        # In app-global desktop mode, TERMINAL_CWD belongs to the launch
+        # process. Profile-bound sessions persist their cwd through that
+        # profile's config.yaml and must not leak it into other profiles.
+        if not (isinstance(session, dict) and session.get("profile_home")):
+            os.environ["TERMINAL_CWD"] = cwd
         return _ok(
             rid,
             {"key": "terminal.cwd", "value": cwd, "cwd": cwd, "branch": _git_branch_for_cwd(cwd)},


### PR DESCRIPTION
Fixes #85669

Desktop/app-global sessions already carry profile_home when they are created for a non-launch profile, but config.set persisted through the launch process config path. That let focused-profile changes such as busy mode, verbose mode, approval mode, and cwd mutate the launch/default config.yaml while the selected profile config stayed unchanged.

This patch binds config.set read/write helpers to the session profile home when session_id resolves to a session with profile_home. Calls without a profile-bound session keep the existing launch-profile behavior.

It also makes profile-bound cwd writes avoid updating the process-global TERMINAL_CWD, since that env var belongs to the launch backend process and can leak a worker profile cwd into other profiles.

Regression coverage verifies:

- worker-profile config.set busy writes profiles/worker/config.yaml, not launch config.yaml
- verbose writes follow the same scoped path
- approval_mode writes follow the same scoped path
- cwd writes update the worker profile config without leaking TERMINAL_CWD
- no-session/global config.set still writes the launch profile as before
- _save_cfg honors the active HERMES_HOME override

Validation:

uv run --extra dev pytest tests/tui_gateway/test_config_set_profile_scope.py -q
7 passed

uv run --extra dev pytest tests/tui_gateway/test_config_set_profile_scope.py tests/tui_gateway/test_fast_session_scope.py tests/tui_gateway/test_reasoning_session_scope.py tests/tui_gateway/test_personality_clobbers_system_prompt.py -q
23 passed