### PR TITLE
fix(gateway): prevent response history doubling

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7058,12 +7058,30 @@ class APIServerAdapter(BasePlatformAdapter):
         if not isinstance(agent_messages, list) or not agent_messages:
             return 0
 
+        def _without_persistence_metadata(message: Any) -> Any:
+            if not isinstance(message, dict):
+                return message
+            return {
+                key: value
+                for key, value in message.items()
+                if key not in {"_db_persisted", "_row_id"}
+            }
+
+        def _prefix_matches(expected: List[Dict[str, Any]]) -> bool:
+            if len(agent_messages) < len(expected):
+                return False
+            return all(
+                _without_persistence_metadata(actual)
+                == _without_persistence_metadata(wanted)
+                for actual, wanted in zip(agent_messages, expected)
+            )
+
         prior = list(conversation_history)
         current_user = {"role": "user", "content": user_message}
         expected_prefix = prior + [current_user]
-        if agent_messages[:len(expected_prefix)] == expected_prefix:
+        if _prefix_matches(expected_prefix):
             return len(expected_prefix)
-        if prior and agent_messages[:len(prior)] == prior:
+        if prior and _prefix_matches(prior):
             return len(prior)
         return 0
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -150,6 +150,7 @@ from gateway.platforms.base import (
 )
 # Re-exported here for existing imports and constructor monkeypatches.
 from gateway.platforms.api_server_run_idempotency import RunIdempotencyStore
+from agent.message_metadata import PERSISTENCE_ONLY_MESSAGE_FIELDS
 from agent.redact import redact_sensitive_text
 from agent.interrupt_compat import request_hard_interrupt
 from gateway.readiness import collect_runtime_readiness
@@ -7051,10 +7052,9 @@ class APIServerAdapter(BasePlatformAdapter):
     # side of the store round-trip. None of them change what a message *says*,
     # so none of them may decide whether a transcript already contains the
     # prior history -- see _messages_semantically_equal.
-    _TRANSCRIPT_BOOKKEEPING_FIELDS = frozenset({
+    _TRANSCRIPT_BOOKKEEPING_FIELDS = PERSISTENCE_ONLY_MESSAGE_FIELDS | frozenset({
         "_db_persisted",
         "_row_id",
-        "timestamp",
         "reasoning",
         "reasoning_content",
         "finish_reason",

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7047,8 +7047,51 @@ class APIServerAdapter(BasePlatformAdapter):
         full_history.append({"role": "assistant", "content": final_response})
         return full_history
 
-    @staticmethod
+    # Fields the agent stamps onto live messages, or that survive only on one
+    # side of the store round-trip. None of them change what a message *says*,
+    # so none of them may decide whether a transcript already contains the
+    # prior history -- see _messages_semantically_equal.
+    _TRANSCRIPT_BOOKKEEPING_FIELDS = frozenset({
+        "_db_persisted",
+        "_row_id",
+        "timestamp",
+        "reasoning",
+        "reasoning_content",
+        "finish_reason",
+    })
+
+    @classmethod
+    def _messages_semantically_equal(cls, left: Any, right: Any) -> bool:
+        """Compare two transcript messages ignoring bookkeeping-only differences."""
+        if not isinstance(left, dict) or not isinstance(right, dict):
+            return left == right
+
+        lhs = {k: v for k, v in left.items() if k not in cls._TRANSCRIPT_BOOKKEEPING_FIELDS}
+        rhs = {k: v for k, v in right.items() if k not in cls._TRANSCRIPT_BOOKKEEPING_FIELDS}
+
+        # ``name`` is present on live tool messages but is dropped on the store
+        # round-trip, so the same message can carry "terminal" on one side and
+        # nothing on the other. Compare it only when both sides still have it;
+        # ``tool_call_id`` already disambiguates tool results.
+        left_name = lhs.pop("name", None)
+        right_name = rhs.pop("name", None)
+        if left_name is not None and right_name is not None and left_name != right_name:
+            return False
+
+        return lhs == rhs
+
+    @classmethod
+    def _messages_prefix_matches(cls, messages: List[Any], prefix: List[Any]) -> bool:
+        if len(messages) < len(prefix):
+            return False
+        return all(
+            cls._messages_semantically_equal(message, expected)
+            for message, expected in zip(messages, prefix)
+        )
+
+    @classmethod
     def _response_messages_turn_start_index(
+        cls,
         conversation_history: List[Dict[str, Any]],
         user_message: Any,
         result: Dict[str, Any],
@@ -7058,30 +7101,12 @@ class APIServerAdapter(BasePlatformAdapter):
         if not isinstance(agent_messages, list) or not agent_messages:
             return 0
 
-        def _without_persistence_metadata(message: Any) -> Any:
-            if not isinstance(message, dict):
-                return message
-            return {
-                key: value
-                for key, value in message.items()
-                if key not in {"_db_persisted", "_row_id"}
-            }
-
-        def _prefix_matches(expected: List[Dict[str, Any]]) -> bool:
-            if len(agent_messages) < len(expected):
-                return False
-            return all(
-                _without_persistence_metadata(actual)
-                == _without_persistence_metadata(wanted)
-                for actual, wanted in zip(agent_messages, expected)
-            )
-
         prior = list(conversation_history)
         current_user = {"role": "user", "content": user_message}
         expected_prefix = prior + [current_user]
-        if _prefix_matches(expected_prefix):
+        if cls._messages_prefix_matches(agent_messages, expected_prefix):
             return len(expected_prefix)
-        if prior and _prefix_matches(prior):
+        if prior and cls._messages_prefix_matches(agent_messages, prior):
             return len(prior)
         return 0
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1336,6 +1336,54 @@ class TestDeriveChatSessionId:
 class TestResponsesEndpoint:
 
 
+    def test_response_history_matches_persisted_first_turn(self, adapter):
+        """Persistence markers must not make a full transcript look like a turn suffix."""
+        messages = [
+            {
+                "role": "user",
+                "content": "hello",
+                "_db_persisted": True,
+                "_row_id": 1,
+            },
+            {
+                "role": "assistant",
+                "content": "hi",
+                "_db_persisted": True,
+                "_row_id": 2,
+            },
+        ]
+        result = {"messages": messages, "final_response": "hi"}
+
+        assert adapter._response_messages_turn_start_index([], "hello", result) == 1
+        assert adapter._build_response_conversation_history([], "hello", result, "hi") == messages
+
+
+    def test_response_history_matches_persisted_chained_turn(self, adapter):
+        """Clean stored history must match the same transcript carrying persistence markers."""
+        prior = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        messages = [
+            {**message, "_db_persisted": True, "_row_id": index}
+            for index, message in enumerate(
+                [
+                    *prior,
+                    {"role": "user", "content": "again"},
+                    {"role": "assistant", "content": "hello again"},
+                ],
+                start=1,
+            )
+        ]
+        result = {"messages": messages, "final_response": "hello again"}
+
+        assert adapter._response_messages_turn_start_index(prior, "again", result) == 3
+        assert (
+            adapter._build_response_conversation_history(prior, "again", result, "hello again")
+            == messages
+        )
+
+
     @pytest.mark.asyncio
     async def test_successful_response_with_string_input(self, adapter):
         """String input is wrapped in a user message."""

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3133,3 +3133,101 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="s2", gateway_session_key="ch")
         assert captured[1]["model"] == "anthropic/claude-opus-4.6"
+
+
+class TestResponsesTranscriptPrefixDetection:
+    """Regression tests for stored /v1/responses history doubling.
+
+    ``_response_messages_turn_start_index`` used to compare whole message dicts.
+    The agent stamps live messages with bookkeeping fields (``_db_persisted``,
+    ``_row_id``, ``timestamp``, reasoning traces) that the API-layer history does
+    not carry, so the prefix check failed on every chained turn and
+    ``_build_response_conversation_history`` prepended history the transcript
+    already contained -- doubling the stored context each turn.
+    """
+
+    @staticmethod
+    def _turn_start(prior, user_message, agent_messages):
+        return APIServerAdapter._response_messages_turn_start_index(
+            prior, user_message, {"messages": agent_messages}
+        )
+
+    def test_bookkeeping_fields_do_not_break_prefix_detection(self):
+        prior = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        agent_messages = [
+            {"role": "user", "content": "hi", "_db_persisted": True, "_row_id": 41,
+             "timestamp": "2026-08-31T23:51:23"},
+            {"role": "assistant", "content": "hello", "_db_persisted": True, "_row_id": 42,
+             "timestamp": "2026-08-31T23:51:24", "reasoning": "...",
+             "reasoning_content": "...", "finish_reason": "stop"},
+            {"role": "user", "content": "and now?"},
+            {"role": "assistant", "content": "sure"},
+        ]
+        assert self._turn_start(prior, "and now?", agent_messages) == len(prior) + 1
+
+    def test_tool_name_dropped_on_round_trip_still_matches(self):
+        # Live tool messages carry ``name``; the stored copy loses it.
+        prior = [
+            {"role": "user", "content": "list them"},
+            {"role": "tool", "tool_call_id": "call_1", "content": '{"output": "a\\nb"}'},
+        ]
+        agent_messages = [
+            {"role": "user", "content": "list them", "_row_id": 7},
+            {"role": "tool", "tool_call_id": "call_1", "content": '{"output": "a\\nb"}',
+             "name": "terminal", "_row_id": 8},
+            {"role": "user", "content": "thanks"},
+        ]
+        assert self._turn_start(prior, "thanks", agent_messages) == len(prior) + 1
+
+    def test_conflicting_tool_names_are_not_treated_as_equal(self):
+        prior = [{"role": "tool", "tool_call_id": "call_1", "content": "x", "name": "terminal"}]
+        agent_messages = [
+            {"role": "tool", "tool_call_id": "call_1", "content": "x", "name": "read_file"},
+            {"role": "user", "content": "next"},
+        ]
+        assert self._turn_start(prior, "next", agent_messages) == 0
+
+    def test_differing_content_is_still_not_a_prefix(self):
+        prior = [{"role": "user", "content": "hi"}]
+        agent_messages = [
+            {"role": "user", "content": "something else", "_row_id": 1},
+            {"role": "assistant", "content": "hello"},
+        ]
+        assert self._turn_start(prior, "next", agent_messages) == 0
+
+    def test_stored_history_grows_linearly_across_chained_turns(self):
+        """Four chained turns must not double the stored transcript."""
+        history: list = []
+        row_id = 0
+        for turn in range(4):
+            user_message = f"question {turn}"
+            # The agent returns the authoritative full transcript, bookkeeping
+            # fields and all.
+            transcript = []
+            for message in history:
+                row_id += 1
+                transcript.append({**message, "_db_persisted": True, "_row_id": row_id,
+                                   "timestamp": f"t{row_id}"})
+            transcript.append({"role": "user", "content": user_message})
+            transcript.append({"role": "assistant", "content": f"answer {turn}"})
+
+            history = APIServerAdapter._build_response_conversation_history(
+                history, user_message, {"messages": transcript}, f"answer {turn}"
+            )
+            # Strip bookkeeping the way the store round-trip does.
+            history = [
+                {k: v for k, v in m.items()
+                 if k not in {"_db_persisted", "_row_id", "timestamp"}}
+                for m in history
+            ]
+
+        assert len(history) == 8, [m["content"] for m in history]
+        assert [m["content"] for m in history] == [
+            "question 0", "answer 0",
+            "question 1", "answer 1",
+            "question 2", "answer 2",
+            "question 3", "answer 3",
+        ]


### PR DESCRIPTION
## What does this PR do?

Prevents OpenAI Responses API conversation history from growing exponentially when Hermes returns an authoritative full transcript whose live message dictionaries differ from the stored prefix only in bookkeeping metadata.

`_response_messages_turn_start_index` previously compared whole dictionaries. The same logical message can differ across the live/store boundary through `_db_persisted`, `_row_id`, `timestamp`, reasoning sidecars, `finish_reason`, and a one-sided tool `name`. An exact-prefix miss made the adapter treat a full transcript as a turn-only suffix and prepend the old history again.

Prefix detection now compares logical message identity:

- persistence and response bookkeeping fields do not affect prefix identity;
- `name` is compared when both copies carry it, while tolerating the known tool-name loss on store round-trip;
- message content, roles, tool calls, and tool-call IDs remain strict;
- returned/stored messages are not normalized or mutated.

The persistence-field portion reuses `agent.message_metadata.PERSISTENCE_ONLY_MESSAGE_FIELDS` rather than maintaining a second timestamp policy.

## Provenance and related work

- @FrendoWu reproduced the broader field drift in production and contributed the semantic matcher plus multi-turn regressions in #99621. That authored commit is preserved in this branch.
- This is distinct from the post-compression history bug in #56895.
- #70695 covers a broader Responses turn-boundary/repair contract. This PR remains the narrow carrier for the confirmed persistence/store-round-trip reproduction unless maintainers select the broader carrier.

## Type of change

- [x] Bug fix
- [x] Regression tests

## Changes made

- Compare Responses transcript prefixes semantically while keeping message payloads unchanged.
- Cover persisted first-turn and chained-turn transcripts.
- Cover `timestamp`, reasoning fields, `finish_reason`, and one-sided tool `name`.
- Assert conflicting tool names and differing content still fail matching.
- Assert four chained turns grow linearly to eight messages.

## Validation

```text
Focused Responses regressions: 7 passed, 110 deselected
Production-shaped witness: turn_start=3, stored_length=4
Ruff (changed Python files): All checks passed
API-server file: 116 passed, 1 unrelated baseline failure
```

The remaining failure is `TestDisconnectedAgentReap::test_stop_run_reaps_owned_processes`; it reproduces unchanged on the exact `upstream/main` base and is outside this diff.

## Checklist

- [x] Read the contributing guide
- [x] Conventional commit messages
- [x] Focused diff only
- [x] Added behavior regressions
- [x] Cross-platform comparison logic
- [x] Documentation/config/tool schema changes: N/A
- [ ] Hosted CI on the rebased head
