### PR TITLE
fix(desktop-update): drive the Windows hand-off through the venv python, not the hermes.exe shim

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -672,23 +672,55 @@ try {
     # is unlocked; the venv-python holder guard (orphan reap included) stays
     # active. Our marker claim is adopted by the child via update_lock.py's
     # process-ancestry rule.
-    $hermesExe = Join-Path $InstallRoot "venv\Scripts\hermes.exe"
-    if (-not (Test-Path -LiteralPath $hermesExe)) {
+    #
+    # DRIVE THE UPDATE THROUGH venv\Scripts\python.exe, NOT venv\Scripts\hermes.exe.
+    # `uv pip install -e .` has to replace the console-script shims, so
+    # _quarantine_running_hermes_exe must first rename the running hermes.exe
+    # out of the way. On Windows that rename fails whenever ANY child process
+    # spawned from that hermes.exe is still alive: a child inherits a handle on
+    # the parent image, and the resulting sharing violation is indistinguishable
+    # from a user leaving a second Hermes window open. It is the inherited
+    # handle, not the trampoline itself, that pins the file -- killing the child
+    # makes the same rename succeed immediately, and the shim flavour (uv
+    # trampoline vs distlib launcher) makes no difference.
+    #
+    # The updater reliably spawns such children itself (npx cache warm, memory
+    # provider refresh -- hindsight-api runs as a daemon with --idle-timeout
+    # 300 and outlives the step that started it), so this is a race, not a
+    # deterministic failure: the same hand-off succeeds on one run and dies on
+    # the next. Step 2's preflight cannot catch it, because the shim genuinely
+    # IS unlocked at that moment.
+    #
+    # When the rename loses that race, _schedule_replace_on_reboot is the last
+    # resort -- and it writes to HKLM\...\PendingFileRenameOperations, which
+    # requires elevation. A Desktop-driven update runs non-elevated, so it
+    # returns ERROR_ACCESS_DENIED and `uv pip install -e .` exits 2. The ZIP
+    # fallback repeats the identical sequence, so the desktop build stage is
+    # never reached and apps/desktop/release is left missing -- an install whose
+    # Start Menu shortcut points at a Hermes.exe that no longer exists.
+    #
+    # Running the same code as `python.exe -m hermes_cli.main update` puts the
+    # inherited handles on python.exe, which uv never has to replace.
+    #
+    # posix.sh is deliberately left alone: unlinking a running executable is
+    # legal there, so the equivalent call is harmless.
+    $pythonExe = Join-Path $InstallRoot "venv\Scripts\python.exe"
+    if (-not (Test-Path -LiteralPath $pythonExe)) {
         $finalCode = 3
-        $finalMsg = "Update aborted: $hermesExe is missing. The install needs repair (run the Hermes installer or `hermes doctor`)."
+        $finalMsg = "Update aborted: $pythonExe is missing. The install needs repair (run the Hermes installer or `hermes doctor`)."
         Write-HandoffLog $finalMsg
         exit $finalCode
     }
-    $updateArgs = @("update", "--yes", "--gateway", "--force", "--branch", $Branch)
-    Write-HandoffLog ("running: hermes " + ($updateArgs -join " "))
-    $res = Invoke-HermesStep $hermesExe $updateArgs "update"
+    $updateArgs = @("-m", "hermes_cli.main", "update", "--yes", "--gateway", "--force", "--branch", $Branch)
+    Write-HandoffLog ("running: python " + ($updateArgs -join " "))
+    $res = Invoke-HermesStep $pythonExe $updateArgs "update"
     Write-HandoffLog "hermes update exit code: $($res.Code)"
 
     if ($res.Code -ne 0 -and $res.Code -ne 2) {
         # One retry for the update-boundary class (fresh code on disk, stale
         # code in memory). Exit 2 ("close all Hermes windows") is not retryable.
         Write-HandoffLog "first attempt failed; retrying once (freshly pulled fix loads on the second run)"
-        $res = Invoke-HermesStep $hermesExe $updateArgs "update"
+        $res = Invoke-HermesStep $pythonExe $updateArgs "update"
         Write-HandoffLog "retry exit code: $($res.Code)"
     }
 
@@ -700,7 +732,7 @@ try {
     $desktopBuildFailed = $false
     if ($res.Code -eq 0 -and $res.Output -match "Desktop build failed") {
         Write-HandoffLog "hermes update reported a desktop build failure (non-fatal there, fatal here); retrying build"
-        $rebuild = Invoke-HermesStep $hermesExe @("desktop", "--force-build", "--build-only") "rebuild"
+        $rebuild = Invoke-HermesStep $pythonExe @("-m", "hermes_cli.main", "desktop", "--force-build", "--build-only") "rebuild"
         Write-HandoffLog "desktop rebuild exit code: $($rebuild.Code)"
         if ($rebuild.Code -ne 0) { $desktopBuildFailed = $true }
     }


### PR DESCRIPTION
## Problem

`scripts/desktop-update/windows.ps1` runs the update as
`venv\Scripts\hermes.exe update --yes --gateway --force`. `uv pip install -e .`
then has to replace the console-script shims, so `_quarantine_running_hermes_exe`
must rename the running `hermes.exe` out of the way first.

That rename fails whenever **any child process spawned from that `hermes.exe` is
still alive** — on Windows a child inherits a handle on the parent image. It is
the inherited handle, not the trampoline, that pins the file.

When the rename fails, `_schedule_replace_on_reboot` is the last resort, but
`MOVEFILE_DELAY_UNTIL_REBOOT` writes to
`HKLM\System\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations`
and therefore requires elevation. A Desktop-driven update is not elevated, so it
returns `ERROR_ACCESS_DENIED`, `uv pip install -e .` exits 2, and the ZIP
fallback repeats the identical sequence.

The consequence is not a skipped update. The desktop build stage is never
reached while the pre-build clean has already removed `apps/desktop/release`, so
the install is left with a Start Menu shortcut pointing at a `Hermes.exe` that no
longer exists. That is how one install here lost its Desktop app entirely on
2026-08-13; the CLI and gateway kept running, which made it look like an app bug
rather than a failed update.

## Measurements

Windows 11 26200, non-elevated session, hermes-agent 0.20.1, uv 0.12.1.

Renaming `venv\Scripts\hermes.exe` while a process runs from it:

| Situation | `Rename-Item` |
| --- | --- |
| `hermes.exe serve` running, its child `python.exe` alive | blocked (sharing violation) |
| same parent, child killed first | **succeeds** |
| nothing running from the shim | succeeds |

Shim flavour is irrelevant — a uv trampoline (46080 B) and a distlib launcher
(108436 B, `hindsight-api.exe`) are pinned identically.

Reboot fallback, non-elevated:

```powershell
[P.K32]::MoveFileExW($src, $dst, 0x1 -bor 0x4)  # REPLACE_EXISTING | DELAY_UNTIL_REBOOT
# -> False, GetLastError = 5 (ERROR_ACCESS_DENIED)
```

The account is in the local Administrators group; the session carries the
filtered UAC token (`EnableLUA=1`, `ConsentPromptBehaviorAdmin=5`).

## Why it reads as flaky

`logs/desktop-update-handoff.log`, one machine, one code path:

```
2026-08-11T20:11:30  running: hermes update --yes --gateway --force --branch main
2026-08-11T20:15:00  hermes update exit code: 0
2026-08-13T20:18:52  running: hermes update --yes --gateway --force --branch main
2026-08-13T20:22:33  hermes update exit code: 0
2026-08-13T20:37:18  running: hermes update --yes --gateway --force --branch main
2026-08-13T20:39:05  hermes update exit code: 1
2026-08-13T20:40:50  retry exit code: 1
```

Eighteen minutes apart: success, then hard failure. The only variable is whether a
long-lived child is alive when the quarantine runs. The reliable producers are the
updater's own steps — the npx cache warm and the memory-provider refresh
(`hindsight-api` runs as a daemon with `--idle-timeout 300`, so it outlives the
step that started it). Installs whose `memory.provider` spawns no daemon rarely
hit this, which likely explains the low report rate.

Step 2's preflight (`File.Open(shim, 'Open', 'ReadWrite', 'None')`) cannot catch
it: the shim genuinely is unlocked at that moment. The pinning child appears
later, during the update.

## Fix

Invoke the same code through the venv interpreter, so the inherited handles land
on `python.exe` — which uv never has to replace. Three call sites: the update,
its retry, and the `desktop --force-build --build-only` rebuild.

`scripts/desktop-update/posix.sh` is deliberately untouched: unlinking a running
executable is legal there, so the equivalent call is harmless.

## Verification

The manual equivalent (`venv\Scripts\python.exe -m hermes_cli.main update --yes`)
completed with exit 0 on the first attempt after three consecutive shim-driven
failures on the same install, and the subsequent
`python.exe -m hermes_cli.main desktop --force-build --build-only` rebuilt
`release/win-unpacked/Hermes.exe` cleanly.

No test changes: `apps/desktop/electron/updater-process.test.ts` asserts the
hand-off script's *path*, not its contents, and CI's PowerShell job covers
`scripts/install.ps1` only.

## Possibly worth a follow-up

1. `_quarantine_running_hermes_exe` could reap or wait for its own descendants
   before renaming, rather than depending on the reboot fallback.
2. The reboot fallback's elevation requirement is undocumented at the call site.
   When it returns `False` the warning tells the user to close Hermes Desktop,
   exit other REPLs or stop the gateway — misleading when the actual holder is a
   grandchild of the updater itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
