### PR TITLE
fix(agent): add reasoning stale-timeout floors for kimi-k3 and raise qwen3

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -87,7 +87,8 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     # ``qwen3-.*-thinking``) breaks the moment NVIDIA or Alibaba
     # ships a slightly different naming shape.
     ("qwq-32b", 300),
-    ("qwen3", 180),
+    ("qwen3", 600),
+    ("kimi-k3", 600),
     # OpenAI o-series — known multi-minute TTFB.  Each variant
     # enumerated explicitly so bare ``o1`` doesn't over-match
     # ``olmo-1`` or hypothetical future community derivatives.
@@ -206,7 +207,9 @@ def get_reasoning_stale_timeout_floor(model: object) -> Optional[float]:
     >>> get_reasoning_stale_timeout_floor("deepseek/deepseek-v4-pro")
     600.0
     >>> get_reasoning_stale_timeout_floor("qwen/qwen3-235b-a22b-thinking")
-    180.0
+    600.0
+    >>> get_reasoning_stale_timeout_floor("moonshotai/kimi-k3")
+    600.0
     >>> get_reasoning_stale_timeout_floor("x-ai/grok-4-fast-reasoning")
     300.0
     >>> get_reasoning_stale_timeout_floor("anthropic/claude-opus-4-6")


### PR DESCRIPTION
## Problem

OpenRouter-served reasoning models can buffer their thinking phase for minutes. Hermes' stream stale detector (`HERMES_STREAM_STALE_TIMEOUT`, default **180s**, scaled 240/300s for >50K/100K contexts — `_derive_stream_stale_timeout` in `agent/chat_completion_helpers.py`) kills the request when no bytes arrive.

Observed with `moonshotai/kimi-k3` on a long adversarial review dispatch (2026-08-13): each API call was stale-killed after ~150-180s (`error_type=TimeoutError`), retries returned "Empty response (no content or reasoning)", and the subagent ended `status=completed` with a "Reasoning-only response (no visible content)" — no deliverable, despite 15 minutes of work.

The floor table in `agent/reasoning_timeouts.py` is the mitigation for exactly this class of model, but:

- **kimi-k3 has no entry** → falls through to the 180s base.
- **qwen3's entry is 180s** — equal to the default base, so it is a no-op for `qwen/qwen3.8-max` and other qwen3 thinking variants.

## Fix

```python
-    ("qwen3", 180),
+    ("qwen3", 600),
+    ("kimi-k3", 600),
```

Floors are applied as `max(default, floor)` and never override explicit `providers.<id>.*.stale_timeout_seconds` user config, so this only raises patience for these slugs.

## Verification

- `python -m doctest agent/reasoning_timeouts.py` — all pass (updated the qwen3 example, added a kimi-k3 case)
- `python -m py_compile` clean
- Probe: `get_reasoning_stale_timeout_floor("moonshotai/kimi-k3")` → `600.0`; `("qwen/qwen3.8-max")` → `600.0`; unrelated slugs (e.g. `gpt-4o`) still `None`

Related: the module's own reference (#52217) documents this failure class for other reasoning models.