### PR TITLE
fix(mcp): allow scripts to configure enabled server tools

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -964,7 +964,10 @@ def cmd_mcp_reauth(args):
 def cmd_mcp_configure(args):
     """Reconfigure which tools are enabled for an existing MCP server."""
     import sys as _sys
-    if not _sys.stdin.isatty():
+    requested_tools = getattr(args, "tools", None)
+    select_all = getattr(args, "all", False)
+    non_interactive = requested_tools is not None or select_all
+    if not non_interactive and not _sys.stdin.isatty():
         print("Error: 'hermes mcp configure' requires an interactive terminal.", file=_sys.stderr)
         _sys.exit(1)
     name = args.name
@@ -1032,20 +1035,34 @@ def cmd_mcp_configure(args):
     _info(f"Currently {currently}/{total} tools enabled for '{name}'.")
     print()
 
-    # Interactive checklist
-    from hermes_cli.curses_ui import curses_checklist
+    if requested_tools is not None:
+        requested_names = list(dict.fromkeys(
+            part.strip() for part in requested_tools.split(",") if part.strip()
+        ))
+        unknown = [tool for tool in requested_names if tool not in tool_names]
+        if unknown:
+            label = "tool" if len(unknown) == 1 else "tools"
+            print(
+                f"Error: Unknown {label} for '{name}': {', '.join(unknown)}",
+                file=_sys.stderr,
+            )
+            _sys.exit(1)
+        chosen = {tool_names.index(tool) for tool in requested_names}
+    elif select_all:
+        chosen = set(range(total))
+    else:
+        from hermes_cli.curses_ui import curses_checklist
 
-    labels = [f"{t[0]}  —  {t[1]}" for t in all_tools]
+        labels = [f"{t[0]}  —  {t[1]}" for t in all_tools]
+        chosen = curses_checklist(
+            f"Select tools for '{name}'",
+            labels,
+            pre_selected,
+        )
 
-    chosen = curses_checklist(
-        f"Select tools for '{name}'",
-        labels,
-        pre_selected,
-    )
-
-    if chosen == pre_selected:
-        _info("No changes made.")
-        return
+        if chosen == pre_selected:
+            _info("No changes made.")
+            return
 
     # Update config
     config = load_config()

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -1069,8 +1069,14 @@ def cmd_mcp_configure(args):
     server_entry = cfg_get(config, "mcp_servers", name, default={})
 
     if len(chosen) == total:
-        # All selected → remove include/exclude (register all)
-        server_entry.pop("tools", None)
+        # All selected → remove only selection filters (register all). Preserve
+        # independent utility-family toggles such as tools.prompts/resources.
+        tools_entry = server_entry.get("tools")
+        if isinstance(tools_entry, dict):
+            tools_entry.pop("include", None)
+            tools_entry.pop("exclude", None)
+            if not tools_entry:
+                server_entry.pop("tools", None)
     else:
         chosen_names = [tool_names[i] for i in sorted(chosen)]
         server_entry.setdefault("tools", {})

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -970,6 +970,17 @@ def cmd_mcp_configure(args):
     if not non_interactive and not _sys.stdin.isatty():
         print("Error: 'hermes mcp configure' requires an interactive terminal.", file=_sys.stderr)
         _sys.exit(1)
+    requested_names = None
+    if requested_tools is not None:
+        requested_names = list(dict.fromkeys(
+            part.strip() for part in requested_tools.split(",") if part.strip()
+        ))
+        if not requested_names:
+            print(
+                "Error: --tools requires at least one tool name.",
+                file=_sys.stderr,
+            )
+            _sys.exit(1)
     name = args.name
     servers = _get_mcp_servers()
 
@@ -1036,9 +1047,6 @@ def cmd_mcp_configure(args):
     print()
 
     if requested_tools is not None:
-        requested_names = list(dict.fromkeys(
-            part.strip() for part in requested_tools.split(",") if part.strip()
-        ))
         unknown = [tool for tool in requested_names if tool not in tool_names]
         if unknown:
             label = "tool" if len(unknown) == 1 else "tools"
@@ -1060,9 +1068,9 @@ def cmd_mcp_configure(args):
             pre_selected,
         )
 
-        if chosen == pre_selected:
-            _info("No changes made.")
-            return
+    if chosen == pre_selected:
+        _info("No changes made.")
+        return
 
     # Update config
     config = load_config()

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -84,6 +84,16 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         "configure", aliases=["config"], help="Toggle tool selection"
     )
     mcp_cfg_p.add_argument("name", help="Server name to configure")
+    mcp_cfg_selection = mcp_cfg_p.add_mutually_exclusive_group()
+    mcp_cfg_selection.add_argument(
+        "--tools",
+        help="Comma-separated tool names to enable (non-interactive)",
+    )
+    mcp_cfg_selection.add_argument(
+        "--all",
+        action="store_true",
+        help="Enable every discovered tool (non-interactive)",
+    )
 
     mcp_login_p = mcp_sub.add_parser(
         "login",

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -52,6 +52,8 @@ def _make_args(**kwargs):
         "auth": None,
         "preset": None,
         "env": None,
+        "tools": None,
+        "all": False,
         "mcp_action": None,
     }
     defaults.update(kwargs)
@@ -339,6 +341,106 @@ class TestMcpTest:
         assert captured["inner_timeout"] == 300.0
         assert captured["outer_timeout"] == 310.0
         assert captured["shutdown"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: cmd_mcp_configure
+# ---------------------------------------------------------------------------
+
+class TestMcpConfigure:
+    @staticmethod
+    def _seed_server(tmp_path):
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.ml.ink/mcp",
+                "tools": {"include": ["create_service"]},
+            },
+        })
+
+    @staticmethod
+    def _mock_tools(monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config: [
+                ("create_service", "Deploy"),
+                ("list_services", "List all"),
+                ("delete_service", "Delete"),
+            ],
+        )
+
+    def test_tools_selects_named_tools_without_tty(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        self._seed_server(tmp_path)
+        self._mock_tools(monkeypatch)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(
+            _make_args(name="ink", tools="list_services, delete_service")
+        )
+
+        assert read_raw_config()["mcp_servers"]["ink"]["tools"] == {
+            "include": ["list_services", "delete_service"]
+        }
+        assert "Updated config: 2/3 tools enabled" in capsys.readouterr().out
+
+    def test_all_enables_every_tool_without_tty(
+        self, tmp_path, monkeypatch
+    ):
+        self._seed_server(tmp_path)
+        self._mock_tools(monkeypatch)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="ink", all=True))
+
+        assert "tools" not in read_raw_config()["mcp_servers"]["ink"]
+
+    def test_unknown_tools_fail_without_changing_config(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        self._seed_server(tmp_path)
+        self._mock_tools(monkeypatch)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_configure(_make_args(name="ink", tools="missing_tool"))
+
+        assert exc_info.value.code == 1
+        assert "Unknown tool for 'ink': missing_tool" in capsys.readouterr().err
+        assert read_raw_config()["mcp_servers"]["ink"]["tools"] == {
+            "include": ["create_service"]
+        }
+
+    def test_flagless_non_tty_still_fails_before_discovery(
+        self, tmp_path, monkeypatch
+    ):
+        self._seed_server(tmp_path)
+        probe_called = False
+
+        def probe(name, config):
+            nonlocal probe_called
+            probe_called = True
+            return []
+
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", probe)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_configure(_make_args(name="ink"))
+
+        assert exc_info.value.code == 1
+        assert probe_called is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -401,6 +401,32 @@ class TestMcpConfigure:
 
         assert "tools" not in read_raw_config()["mcp_servers"]["ink"]
 
+    def test_all_preserves_utility_tool_settings(
+        self, tmp_path, monkeypatch
+    ):
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.ml.ink/mcp",
+                "tools": {
+                    "include": ["create_service"],
+                    "prompts": False,
+                    "resources": False,
+                },
+            },
+        })
+        self._mock_tools(monkeypatch)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="ink", all=True))
+
+        assert read_raw_config()["mcp_servers"]["ink"]["tools"] == {
+            "prompts": False,
+            "resources": False,
+        }
+
     def test_unknown_tools_fail_without_changing_config(
         self, tmp_path, capsys, monkeypatch
     ):

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -446,6 +446,41 @@ class TestMcpConfigure:
             "include": ["create_service"]
         }
 
+    @pytest.mark.parametrize("tools", ["", ",", " , "])
+    def test_empty_tools_fail_without_changing_config(
+        self, tools, tmp_path, capsys, monkeypatch
+    ):
+        self._seed_server(tmp_path)
+        self._mock_tools(monkeypatch)
+
+        from hermes_cli.config import read_raw_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_configure(_make_args(name="ink", tools=tools))
+
+        assert exc_info.value.code == 1
+        assert "--tools requires at least one tool name" in capsys.readouterr().err
+        assert read_raw_config()["mcp_servers"]["ink"]["tools"] == {
+            "include": ["create_service"]
+        }
+
+    def test_unchanged_explicit_selection_does_not_write_config(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        self._seed_server(tmp_path)
+        self._mock_tools(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config.save_config",
+            lambda config: pytest.fail("unchanged selection must not write config"),
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="ink", tools="create_service"))
+
+        assert "No changes made." in capsys.readouterr().out
+
     def test_flagless_non_tty_still_fails_before_discovery(
         self, tmp_path, monkeypatch
     ):

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -64,3 +64,33 @@ def test_mcp_and_acp_accept_hooks_flag():
     # acp takes --accept-hooks at top level
     ns = parser.parse_args(["acp", "--accept-hooks"])
     assert ns.accept_hooks is True
+
+
+def test_mcp_configure_accepts_noninteractive_tool_selection():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_mcp_parser(sub, cmd_mcp=_h("mcp"))
+
+    selected = parser.parse_args(
+        ["mcp", "configure", "ink", "--tools", "create_service,list_services"]
+    )
+    assert selected.tools == "create_service,list_services"
+    assert selected.all is False
+
+    all_tools = parser.parse_args(["mcp", "configure", "ink", "--all"])
+    assert all_tools.all is True
+    assert all_tools.tools is None
+
+
+def test_mcp_configure_rejects_conflicting_tool_selection(capsys):
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_mcp_parser(sub, cmd_mcp=_h("mcp"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(
+            ["mcp", "configure", "ink", "--tools", "search", "--all"]
+        )
+
+    assert exc_info.value.code == 2
+    assert "not allowed with argument" in capsys.readouterr().err


### PR DESCRIPTION
## What does this PR do?

`hermes mcp configure <name>` currently rejects non-interactive stdin before tool discovery, so scripts and configuration-management jobs cannot change an existing server's enabled tools. This change adds explicit `--tools` and `--all` selection modes that bypass only the interactive picker while preserving the existing non-TTY error for flagless use.

### Symptom

Running `hermes mcp configure <name>` with redirected stdin fails with `requires an interactive terminal`, and the command previously exposed no supported flag for selecting tools.

### Impact

Operators cannot automate enabled-tool configuration for existing MCP servers. They must use a terminal picker or edit configuration state outside the supported command path.

### Bug Cause

**Trigger:** `hermes_cli/mcp_config.py:cmd_mcp_configure` checks `stdin.isatty()` before loading the server or discovering tools.

**Causal chain:**
1. A script invokes `hermes mcp configure <name>` with redirected stdin.
2. The unconditional TTY guard exits before configuration or discovery, while the parser provides no explicit selection arguments.
3. The command cannot update tool selection in unattended environments.

**Why it is wrong:** The command coupled every configure operation to the curses picker even when the requested selection can be represented explicitly.

**Working sibling / contrast:** Flagless interactive use continues through the existing curses checklist. Explicit selection now takes a separate deterministic path after normal server validation and tool discovery.

**Ruled out:** Removing only the TTY guard is insufficient because a cancelled checklist under non-interactive stdin can equal the prior selection and report a successful no-op. The fix therefore requires explicit selection flags and name validation.

### Fix

- Add mutually exclusive `--tools <comma-separated names>` and `--all` arguments.
- Validate explicit names against discovered server tools and fail before writing configuration when any name is unknown.
- Keep the existing TTY requirement for flagless picker use.
- Clear only include/exclude selection filters for `--all`, preserving independent MCP utility-family settings.

## Related Issue

Refs #85670

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/subcommands/mcp.py` - expose mutually exclusive unattended selection flags.
- `hermes_cli/mcp_config.py` - apply and validate explicit selections while preserving interactive behavior and independent utility settings.
- `tests/hermes_cli/test_mcp_config.py` - cover non-TTY selection, unknown and empty input, aliases, persistence, and utility-setting preservation.
- `tests/hermes_cli/test_subcommands_followup.py` - cover parser acceptance and mutual exclusion.

## How to Test

1. Configure an existing server with `hermes mcp configure <name> --tools tool_a,tool_b` while stdin is redirected and confirm only those discovered tools are enabled.
2. Run `hermes mcp configure <name> --all` and confirm selection filters are removed without changing utility-family settings.
3. Run the focused automated suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_subcommands_followup.py
```

Result: 55 passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the focused tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A, command help is generated from argparse
- [x] `cli-config.yaml.example` update: N/A, no config key was added or changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A, no architecture or workflow changed
- [x] Cross-platform impact considered: the explicit path does not depend on terminal implementation
- [x] Tool descriptions/schemas update: N/A, no model tool schema changed

## Screenshots / Logs

Focused test result: 55 passed, 0 failed.
