### PR TITLE
fix(kanban): inherit durable parent session for dispatcher-spawned child cards

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1171,7 +1171,8 @@ def test_create_in_worker_inherits_parent_session_id(worker_env, monkeypatch):
     ephemeral_worker_session = "worker-ephemeral-session-123"
 
     from hermes_cli import kanban_db as kb
-    conn = kb.connect()
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
     try:
         conn.execute(
             "UPDATE tasks SET session_id = ? WHERE id = ?",
@@ -1196,7 +1197,7 @@ def test_create_in_worker_inherits_parent_session_id(worker_env, monkeypatch):
     d = json.loads(out)
     assert d["ok"] is True, out
 
-    conn = kb.connect()
+    conn = kbc.connect()
     try:
         child = kb.get_task(conn, d["task_id"])
         assert child.session_id == durable_parent_session, (
@@ -1213,7 +1214,8 @@ def test_create_in_worker_prefers_explicit_session_id(worker_env, monkeypatch):
     explicit_session = "explicit-override-789"
 
     from hermes_cli import kanban_db as kb
-    conn = kb.connect()
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
     try:
         conn.execute(
             "UPDATE tasks SET session_id = ? WHERE id = ?",
@@ -1233,7 +1235,7 @@ def test_create_in_worker_prefers_explicit_session_id(worker_env, monkeypatch):
     d = json.loads(out)
     assert d["ok"] is True, out
 
-    conn = kb.connect()
+    conn = kbc.connect()
     try:
         child = kb.get_task(conn, d["task_id"])
         assert child.session_id == explicit_session, (
@@ -1250,7 +1252,8 @@ def test_create_in_worker_falls_back_to_hermes_session_id(worker_env, monkeypatc
     monkeypatch.setenv("HERMES_SESSION_ID", ephemeral_worker_session)
 
     from hermes_cli import kanban_db as kb
-    conn = kb.connect()
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
     try:
         conn.execute(
             "UPDATE tasks SET session_id = NULL WHERE id = ?",
@@ -1267,7 +1270,7 @@ def test_create_in_worker_falls_back_to_hermes_session_id(worker_env, monkeypatc
     d = json.loads(out)
     assert d["ok"] is True, out
 
-    conn = kb.connect()
+    conn = kbc.connect()
     try:
         child = kb.get_task(conn, d["task_id"])
         assert child.session_id == ephemeral_worker_session, (

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1161,3 +1161,111 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:
         conn.close()
+
+
+def test_create_in_worker_inherits_parent_session_id(worker_env, monkeypatch):
+    """A dispatcher-spawned worker must not stamp child cards with its own
+    ephemeral HERMES_SESSION_ID; they should inherit the durable parent session
+    from the worker's task row (#85575)."""
+    durable_parent_session = "parent-durable-session-456"
+    ephemeral_worker_session = "worker-ephemeral-session-123"
+
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        conn.execute(
+            "UPDATE tasks SET session_id = ? WHERE id = ?",
+            (durable_parent_session, worker_env),
+        )
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_SESSION_ID", ephemeral_worker_session)
+
+    from tools import kanban_tools as kt
+    out = kt._handle_create({
+        "title": "child task",
+        "assignee": "peer",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True, out
+
+    conn = kb.connect()
+    try:
+        child = kb.get_task(conn, d["task_id"])
+        assert child.session_id == durable_parent_session, (
+            f"expected {durable_parent_session!r}, got {child.session_id!r}"
+        )
+    finally:
+        conn.close()
+
+
+def test_create_in_worker_prefers_explicit_session_id(worker_env, monkeypatch):
+    """An explicit session_id argument wins over the worker task row fallback
+    so callers can still override the wake target (#85575)."""
+    durable_parent_session = "parent-durable-session-456"
+    explicit_session = "explicit-override-789"
+
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        conn.execute(
+            "UPDATE tasks SET session_id = ? WHERE id = ?",
+            (durable_parent_session, worker_env),
+        )
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_SESSION_ID", "worker-ephemeral-session-123")
+
+    from tools import kanban_tools as kt
+    out = kt._handle_create({
+        "title": "child task",
+        "assignee": "peer",
+        "session_id": explicit_session,
+    })
+    d = json.loads(out)
+    assert d["ok"] is True, out
+
+    conn = kb.connect()
+    try:
+        child = kb.get_task(conn, d["task_id"])
+        assert child.session_id == explicit_session, (
+            f"expected {explicit_session!r}, got {child.session_id!r}"
+        )
+    finally:
+        conn.close()
+
+
+def test_create_in_worker_falls_back_to_hermes_session_id(worker_env, monkeypatch):
+    """When the worker task row has no session_id, the legacy HERMES_SESSION_ID
+    fallback is preserved for non-dispatcher callers (#85575)."""
+    ephemeral_worker_session = "worker-ephemeral-session-123"
+    monkeypatch.setenv("HERMES_SESSION_ID", ephemeral_worker_session)
+
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        conn.execute(
+            "UPDATE tasks SET session_id = NULL WHERE id = ?",
+            (worker_env,),
+        )
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_create({
+        "title": "child task",
+        "assignee": "peer",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True, out
+
+    conn = kb.connect()
+    try:
+        child = kb.get_task(conn, d["task_id"])
+        assert child.session_id == ephemeral_worker_session, (
+            f"expected {ephemeral_worker_session!r}, got {child.session_id!r}"
+        )
+    finally:
+        conn.close()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1181,6 +1181,12 @@ def test_create_in_worker_inherits_parent_session_id(worker_env, monkeypatch):
         conn.close()
 
     monkeypatch.setenv("HERMES_SESSION_ID", ephemeral_worker_session)
+    from tools import async_delegation
+    monkeypatch.setattr(
+        async_delegation,
+        "_current_origin_session_id",
+        lambda: "api-origin-session-999",
+    )
 
     from tools import kanban_tools as kt
     out = kt._handle_create({

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -808,12 +808,6 @@ def _handle_create(args: dict, **kw) -> str:
     assignee = args.get("assignee")
     _check(assignee, "assignee is required — name the profile that should execute this "
                      "task (the dispatcher will only spawn tasks with an assignee)")
-    # Prefer the request-scoped api_server origin binding over HERMES_SESSION_ID: the env
-    # var is clobbered with a subagent's internal id whenever a child agent is constructed
-    # in-process, which would stamp — and later wake — the wrong session.
-    from tools.async_delegation import _current_origin_session_id
-    session_id = (args.get("session_id") or _current_origin_session_id()
-                  or os.environ.get("HERMES_SESSION_ID"))
     # Workspace sharing is always explicit: omitted fields mean a fresh scratch workspace
     # even for a dispatcher-spawned creator (reusing the parent's path would let a child
     # mutate review evidence or race its checkout). Project identity is the one safe thing
@@ -829,9 +823,22 @@ def _handle_create(args: dict, **kw) -> str:
     _check(model_override or not provider_override, "'provider' requires 'model' to be set as well")
     parents = _coerce_str_list(args.get("parents") or [], "parents", "task ids")
     with _board(args.get("board")) as (kb, conn):
+        # Resolve the session to wake on completion. Prefer the request-scoped
+        # api_server origin binding over HERMES_SESSION_ID: the env var is
+        # clobbered with a subagent's internal id whenever a child agent is
+        # constructed in-process, which would stamp — and later wake — the
+        # wrong session. In a dispatcher-spawned worker HERMES_SESSION_ID is
+        # the worker's own ephemeral session; child cards must wake the
+        # durable parent session stored on the worker's task row (#85575).
+        from tools.async_delegation import _current_origin_session_id
+        session_id: Optional[str] = args.get("session_id") or _current_origin_session_id()
+        self_tid = os.environ.get("HERMES_KANBAN_TASK")
+        self_task = kb.get_task(conn, self_tid) if self_tid else None
+        if not session_id and self_task is not None and self_task.session_id:
+            session_id = self_task.session_id
+        if not session_id:
+            session_id = os.environ.get("HERMES_SESSION_ID")
         if project_id is None and workspace_kind is None and workspace_path is None:
-            self_tid = os.environ.get("HERMES_KANBAN_TASK")
-            self_task = kb.get_task(conn, self_tid) if self_tid else None
             if self_task is not None and self_task.project_id:
                 project_id, project_source_task_id = self_task.project_id, self_task.id
         new_tid = kb.create_task(

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 KANBAN_LIST_DEFAULT_LIMIT = 50
 KANBAN_LIST_MAX_LIMIT = 200
+KANBAN_TASK_ENV = "HERMES_KANBAN_TASK"
 
 
 # --- Gating ---
@@ -66,7 +67,7 @@ def _visible(*, to_env_worker: bool) -> bool:
     (HERMES_KANBAN_TASK) per flag; else the profile toolset decides."""
     if _is_delegated_child_context():
         return False
-    if os.environ.get("HERMES_KANBAN_TASK") and _is_dispatcher_owned_worker():
+    if os.environ.get(KANBAN_TASK_ENV) and _is_dispatcher_owned_worker():
         return to_env_worker
     return _profile_has_kanban_toolset()
 
@@ -132,7 +133,7 @@ def _default_task_id(arg: Optional[str]) -> Optional[str]:
         return arg
     if _is_delegated_child_context() or not _is_dispatcher_owned_worker():
         return None
-    return os.environ.get("HERMES_KANBAN_TASK") or None
+    return os.environ.get(KANBAN_TASK_ENV) or None
 
 
 def _require_task_id(args: dict) -> str:
@@ -143,7 +144,7 @@ def _require_task_id(args: dict) -> str:
 
 def _own_task_env(task_id: str, var: str) -> Optional[str]:
     """``$var`` only when this worker is scoped to ``task_id``; else None."""
-    return os.environ.get(var) if os.environ.get("HERMES_KANBAN_TASK") == task_id else None
+    return os.environ.get(var) if os.environ.get(KANBAN_TASK_ENV) == task_id else None
 
 
 def _worker_run_id(task_id: str) -> Optional[int]:
@@ -170,7 +171,7 @@ def _enforce_worker_task_ownership(tid: str) -> None:
     a buggy or prompt-injected worker that passed an explicit ``task_id`` for some other task could corrupt
     sibling or cross-tenant runs (see #19534).
     """
-    env_tid = os.environ.get("HERMES_KANBAN_TASK")
+    env_tid = os.environ.get(KANBAN_TASK_ENV)
     if env_tid and tid != env_tid:
         raise _Reject(
             f"worker is scoped to task {env_tid}; refusing to mutate {tid}. Use kanban_comment "
@@ -189,7 +190,7 @@ def _worker_guard(tool_name: str, args: dict) -> str:
 def _require_orchestrator_tool(tool_name: str) -> None:
     """The check_fn already hides orchestrator tools from workers; this catches
     a stale registration or test harness routing a worker here anyway."""
-    if os.environ.get("HERMES_KANBAN_TASK"):
+    if os.environ.get(KANBAN_TASK_ENV):
         raise _Reject(
             f"{tool_name} is orchestrator-only; dispatcher-spawned workers must use "
             "kanban_complete, kanban_block, kanban_heartbeat, or kanban_comment for their "
@@ -420,7 +421,7 @@ def heartbeat_current_worker_from_env() -> bool:
     attempted. ``HERMES_KANBAN_RUN_ID`` pins the run row so a reclaimed stale run is not
     heartbeated; ``HERMES_KANBAN_CLAIM_LOCK`` absent -> default claimer (local workers)."""
     global _auto_heartbeat_last_attempt
-    tid = os.environ.get("HERMES_KANBAN_TASK")
+    tid = os.environ.get(KANBAN_TASK_ENV)
     now = time.monotonic()
     if not tid or (now - _auto_heartbeat_last_attempt) < _AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS:
         return False
@@ -454,7 +455,7 @@ def inject_new_comments_from_env(agent: Any) -> bool:
     """Steer new operator comments on the worker's task into ``agent``; True iff a
     steer was injected; never raises. Own comments (``HERMES_PROFILE``) are skipped."""
     global _comment_poll_last_attempt
-    tid = os.environ.get("HERMES_KANBAN_TASK")
+    tid = os.environ.get(KANBAN_TASK_ENV)
     now = time.monotonic()
     if (not tid or agent is None or not hasattr(agent, "steer")
             or (now - _comment_poll_last_attempt) < _COMMENT_POLL_MIN_INTERVAL_SECONDS):
@@ -823,19 +824,20 @@ def _handle_create(args: dict, **kw) -> str:
     _check(model_override or not provider_override, "'provider' requires 'model' to be set as well")
     parents = _coerce_str_list(args.get("parents") or [], "parents", "task ids")
     with _board(args.get("board")) as (kb, conn):
-        # Resolve the session to wake on completion. Prefer the request-scoped
-        # api_server origin binding over HERMES_SESSION_ID: the env var is
-        # clobbered with a subagent's internal id whenever a child agent is
-        # constructed in-process, which would stamp — and later wake — the
-        # wrong session. In a dispatcher-spawned worker HERMES_SESSION_ID is
-        # the worker's own ephemeral session; child cards must wake the
-        # durable parent session stored on the worker's task row (#85575).
+        # Resolve the session to wake on completion. Explicit tool args win.
+        # For dispatcher workers, the durable parent session on the worker
+        # task wins over request-origin and process-global session bindings
+        # — HERMES_SESSION_ID is the worker's own ephemeral session, which
+        # no longer exists after the worker exits (#85575). Orchestrator/API
+        # callers then use the request origin before the legacy env fallback.
         from tools.async_delegation import _current_origin_session_id
-        session_id: Optional[str] = args.get("session_id") or _current_origin_session_id()
-        self_tid = os.environ.get("HERMES_KANBAN_TASK")
+        self_tid = os.environ.get(KANBAN_TASK_ENV)
         self_task = kb.get_task(conn, self_tid) if self_tid else None
-        if not session_id and self_task is not None and self_task.session_id:
+        session_id: Optional[str] = args.get("session_id")
+        if not session_id and self_task is not None:
             session_id = self_task.session_id
+        if not session_id:
+            session_id = _current_origin_session_id()
         if not session_id:
             session_id = os.environ.get("HERMES_SESSION_ID")
         if project_id is None and workspace_kind is None and workspace_path is None:


### PR DESCRIPTION
## What does this PR do?

When the kanban dispatcher spawns child cards, they previously inherited the origin session (which might be transient) instead of the durable parent session that actually spawned the task. This caused child cards to lose context when the origin session ended.

This PR:
1. Inherits the durable parent session (`self_task.session_id`) for dispatcher-spawned child cards.
2. Reprioritizes session_id resolution: `args.get("session_id")` → `self_task.session_id` → `_current_origin_session_id()` → `HERMES_SESSION_ID`.
3. Introduces `KANBAN_TASK_ENV` constant replacing string literals.

## Related Issue

Fixes #85575

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/kanban_tools.py`: Session inheritance and reprioritization; `KANBAN_TASK_ENV` constant.
- `tests/tools/test_kanban_tools.py`: Tests for session inheritance.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_kanban_tools.py` — kanban tools tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing