### PR TITLE
fix(mcp): add non-interactive tool selection

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -961,20 +961,73 @@ def cmd_mcp_reauth(args):
 
 # ─── hermes mcp configure ────────────────────────────────────────────────────
 
+def _clear_mcp_tool_name_filters(server_entry):
+    """Enable every server tool while preserving capability settings."""
+    tools_config = server_entry.get("tools")
+    if not isinstance(tools_config, dict):
+        changed = "tools" in server_entry
+        server_entry.pop("tools", None)
+        return changed
+
+    changed = "include" in tools_config or "exclude" in tools_config
+    tools_config.pop("include", None)
+    tools_config.pop("exclude", None)
+    if not tools_config:
+        server_entry.pop("tools", None)
+    return changed
+
+
 def cmd_mcp_configure(args):
     """Reconfigure which tools are enabled for an existing MCP server."""
     import sys as _sys
-    if not _sys.stdin.isatty():
+
+    requested_tools = getattr(args, "tools", None)
+    select_all = bool(getattr(args, "all", False))
+    flag_selection = requested_tools is not None or select_all
+
+    if requested_tools is not None and select_all:
+        print("Error: --tools and --all cannot be used together.", file=_sys.stderr)
+        _sys.exit(2)
+
+    requested_names = []
+    if requested_tools is not None:
+        requested_names = list(dict.fromkeys(
+            part.strip() for part in requested_tools.split(",") if part.strip()
+        ))
+        if not requested_names:
+            print("Error: --tools requires at least one tool name.", file=_sys.stderr)
+            _sys.exit(2)
+
+    if not flag_selection and not _sys.stdin.isatty():
         print("Error: 'hermes mcp configure' requires an interactive terminal.", file=_sys.stderr)
         _sys.exit(1)
     name = args.name
     servers = _get_mcp_servers()
 
     if name not in servers:
-        _error(f"Server '{name}' not found in config.")
+        message = f"Server '{name}' not found in config."
+        if flag_selection:
+            print(f"Error: {message}", file=_sys.stderr)
+        else:
+            _error(message)
         available = list(servers.keys())
         if available:
             _info(f"Available: {', '.join(available)}")
+        if flag_selection:
+            _sys.exit(1)
+        return
+
+    if select_all:
+        config = load_config()
+        server_entry = cfg_get(config, "mcp_servers", name, default={})
+        if not _clear_mcp_tool_name_filters(server_entry):
+            _info("No changes made.")
+            return
+
+        config.setdefault("mcp_servers", {})[name] = server_entry
+        save_config(config)
+        _success("Updated config: all tools enabled")
+        _info("Start a new session for changes to take effect.")
         return
 
     cfg = servers[name]
@@ -986,10 +1039,17 @@ def cmd_mcp_configure(args):
     try:
         all_tools = _probe_single_server(name, cfg)
     except Exception as exc:
-        _error(f"Failed to connect: {exc}")
+        message = f"Failed to connect: {exc}"
+        if flag_selection:
+            print(f"Error: {message}", file=_sys.stderr)
+            _sys.exit(1)
+        _error(message)
         return
 
     if not all_tools:
+        if flag_selection:
+            print("Error: Server reports no tools.", file=_sys.stderr)
+            _sys.exit(1)
         _warning("Server reports no tools.")
         return
 
@@ -1032,16 +1092,34 @@ def cmd_mcp_configure(args):
     _info(f"Currently {currently}/{total} tools enabled for '{name}'.")
     print()
 
-    # Interactive checklist
-    from hermes_cli.curses_ui import curses_checklist
+    if requested_tools is not None:
+        available_names = set(tool_names)
+        unknown = [
+            tool_name for tool_name in requested_names
+            if tool_name not in available_names
+        ]
+        if unknown:
+            print(
+                f"Error: Unknown tool(s) for '{name}': {', '.join(unknown)}",
+                file=_sys.stderr,
+            )
+            print(f"Available tools: {', '.join(tool_names)}", file=_sys.stderr)
+            _sys.exit(1)
+        requested_name_set = set(requested_names)
+        chosen = {
+            i for i, tool_name in enumerate(tool_names)
+            if tool_name in requested_name_set
+        }
+    else:
+        # Keep the existing checklist for the interactive, no-flag path.
+        from hermes_cli.curses_ui import curses_checklist
 
-    labels = [f"{t[0]}  —  {t[1]}" for t in all_tools]
-
-    chosen = curses_checklist(
-        f"Select tools for '{name}'",
-        labels,
-        pre_selected,
-    )
+        labels = [f"{t[0]}  —  {t[1]}" for t in all_tools]
+        chosen = curses_checklist(
+            f"Select tools for '{name}'",
+            labels,
+            pre_selected,
+        )
 
     if chosen == pre_selected:
         _info("No changes made.")
@@ -1052,8 +1130,8 @@ def cmd_mcp_configure(args):
     server_entry = cfg_get(config, "mcp_servers", name, default={})
 
     if len(chosen) == total:
-        # All selected → remove include/exclude (register all)
-        server_entry.pop("tools", None)
+        # All selected → remove name filters (register all).
+        _clear_mcp_tool_name_filters(server_entry)
     else:
         chosen_names = [tool_names[i] for i in sorted(chosen)]
         server_entry.setdefault("tools", {})

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -84,6 +84,17 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         "configure", aliases=["config"], help="Toggle tool selection"
     )
     mcp_cfg_p.add_argument("name", help="Server name to configure")
+    mcp_cfg_selection = mcp_cfg_p.add_mutually_exclusive_group()
+    mcp_cfg_selection.add_argument(
+        "--tools",
+        metavar="NAME[,NAME...]",
+        help="Enable a comma-separated list of tools without opening the picker",
+    )
+    mcp_cfg_selection.add_argument(
+        "--all",
+        action="store_true",
+        help="Enable every tool without opening the picker",
+    )
 
     mcp_login_p = mcp_sub.add_parser(
         "login",

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -52,6 +52,8 @@ def _make_args(**kwargs):
         "auth": None,
         "preset": None,
         "env": None,
+        "tools": None,
+        "all": False,
         "mcp_action": None,
     }
     defaults.update(kwargs)
@@ -339,6 +341,151 @@ class TestMcpTest:
         assert captured["inner_timeout"] == 300.0
         assert captured["outer_timeout"] == 310.0
         assert captured["shutdown"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: cmd_mcp_configure
+# ---------------------------------------------------------------------------
+
+class TestMcpConfigure:
+    @staticmethod
+    def _non_tty(monkeypatch):
+        import sys
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: False))
+
+    @staticmethod
+    def _tools(monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda _name, _cfg: [
+                ("search", "Search documents"),
+                ("read", "Read a document"),
+                ("write", "Write a document"),
+            ],
+        )
+
+    def test_tools_flag_updates_config_without_tty(self, tmp_path, monkeypatch):
+        _seed_config(tmp_path, {
+            "docs": {
+                "url": "https://example.com/mcp",
+                "tools": {"exclude": ["write"]},
+            },
+        })
+        self._non_tty(monkeypatch)
+        self._tools(monkeypatch)
+
+        from hermes_cli.config import load_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="docs", tools=" write,search,write "))
+
+        server = load_config()["mcp_servers"]["docs"]
+        assert server["tools"] == {"include": ["search", "write"]}
+
+    def test_all_flag_removes_tool_filters_without_tty(self, tmp_path, monkeypatch):
+        _seed_config(tmp_path, {
+            "docs": {
+                "url": "https://example.com/mcp",
+                "tools": {"include": ["read"], "prompts": False},
+            },
+        })
+        self._non_tty(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda *_args, **_kwargs: pytest.fail("--all must not probe the server"),
+        )
+
+        from hermes_cli.config import load_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        cmd_mcp_configure(_make_args(name="docs", all=True))
+
+        assert load_config()["mcp_servers"]["docs"]["tools"] == {
+            "prompts": False,
+        }
+
+    def test_tools_flag_probe_failure_is_nonzero_and_atomic(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        original = {
+            "docs": {
+                "url": "https://example.com/mcp",
+                "tools": {"include": ["read"]},
+            },
+        }
+        _seed_config(tmp_path, original)
+        self._non_tty(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("offline")),
+        )
+
+        from hermes_cli.config import load_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_mcp_configure(_make_args(name="docs", tools="search"))
+
+        assert exc.value.code == 1
+        assert "Failed to connect: offline" in capsys.readouterr().err
+        assert load_config()["mcp_servers"] == original
+
+    def test_empty_tools_flag_is_rejected_without_writing(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        original = {"docs": {"url": "https://example.com/mcp"}}
+        _seed_config(tmp_path, original)
+        self._non_tty(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda *_args, **_kwargs: pytest.fail("empty --tools must not probe"),
+        )
+
+        from hermes_cli.config import load_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_mcp_configure(_make_args(name="docs", tools=" , "))
+
+        assert exc.value.code == 2
+        assert "requires at least one tool name" in capsys.readouterr().err
+        assert load_config()["mcp_servers"] == original
+
+    def test_unknown_tool_is_a_nonzero_error(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "docs": {"url": "https://example.com/mcp"},
+        })
+        self._non_tty(monkeypatch)
+        self._tools(monkeypatch)
+
+        from hermes_cli.config import load_config
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_mcp_configure(_make_args(name="docs", tools="search,missing"))
+
+        assert exc.value.code == 1
+        assert "Unknown tool(s) for 'docs': missing" in capsys.readouterr().err
+        assert "tools" not in load_config()["mcp_servers"]["docs"]
+
+    def test_no_flags_still_requires_tty(self, tmp_path, monkeypatch):
+        _seed_config(tmp_path, {
+            "docs": {"url": "https://example.com/mcp"},
+        })
+        self._non_tty(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda *_args, **_kwargs: pytest.fail("must not probe without a selection"),
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_configure
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_mcp_configure(_make_args(name="docs"))
+
+        assert exc.value.code == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -64,3 +64,22 @@ def test_mcp_and_acp_accept_hooks_flag():
     # acp takes --accept-hooks at top level
     ns = parser.parse_args(["acp", "--accept-hooks"])
     assert ns.accept_hooks is True
+
+
+def test_mcp_configure_accepts_noninteractive_tool_selection_flags():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_mcp_parser(sub, cmd_mcp=_h("mcp"))
+
+    selected = parser.parse_args(["mcp", "configure", "docs", "--tools", "search,read"])
+    assert selected.tools == "search,read"
+    assert selected.all is False
+
+    all_tools = parser.parse_args(["mcp", "configure", "docs", "--all"])
+    assert all_tools.tools is None
+    assert all_tools.all is True
+
+    with pytest.raises(SystemExit):
+        parser.parse_args([
+            "mcp", "configure", "docs", "--tools", "search", "--all"
+        ])


### PR DESCRIPTION
## What does this PR do?

`hermes mcp configure` previously required an interactive terminal and offered only a curses picker. That made tool selection unusable from provisioning scripts, containers, and CI.

This adds two explicit non-interactive paths while leaving the existing no-flag picker unchanged:

- `hermes mcp configure <name> --tools search,read`
- `hermes mcp configure <name> --all`

`--tools` discovers the live tool list and validates every requested name before writing config. Empty selections, unknown names, unavailable servers, and discovery failures return a nonzero exit without changing the file. `--all` clears only include/exclude filters without contacting the server, so it also works offline and preserves capability settings such as `tools.prompts` and `tools.resources`.

## Related Issue

Fixes #85670

## Concurrent PR Note

#85686 appeared during the final publication check. This version additionally:

- Makes `--all` a fully offline operation instead of requiring successful tool discovery.
- Rejects an empty `--tools` value before connecting or writing config.
- Returns nonzero for a missing server, discovery failure, or server with no tools in flag-based mode.
- Verifies failed operations leave the existing configuration unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added mutually exclusive `--tools` and `--all` arguments to the MCP configure parser.
- Routed flag-based selection around the TTY gate while retaining the interactive picker for the no-flag command.
- Made invalid non-interactive selections fail atomically with useful errors.
- Made `--all` an offline config-only operation that preserves unrelated MCP capability settings.
- Added parser, persistence, validation, failure, non-TTY, and offline regression coverage.

## How to Test

1. Configure an MCP server with an existing `tools.include` or `tools.exclude` filter.
2. Run `hermes mcp configure <name> --tools tool_a,tool_b < /dev/null`, then run `hermes mcp configure <name> --all < /dev/null`.
3. Run `scripts/run_tests.sh tests/hermes_cli/test_mcp*.py tests/hermes_cli/test_subcommands_followup.py -q`.

Focused result: 107 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; the CLI help is generated from the parser arguments
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Not applicable; this is a CLI/configuration change covered by automated tests.
