### PR TITLE
fix(accounting): record OpenRouter reported costs

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2770,6 +2770,7 @@ def init_agent(
     agent.session_cache_write_tokens = 0
     agent.session_reasoning_tokens = 0
     agent.session_estimated_cost_usd = 0.0
+    agent.session_actual_cost_usd = 0.0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
     

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2771,6 +2771,7 @@ def init_agent(
     agent.session_reasoning_tokens = 0
     agent.session_estimated_cost_usd = 0.0
     agent.session_actual_cost_usd = 0.0
+    agent.session_actual_cost_api_calls = 0
     agent.session_cost_status = "unknown"
     agent.session_cost_source = "none"
     

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -90,7 +90,7 @@ from agent.trajectory import has_incomplete_scratchpad
 # Bind before the turn starts so a source-tree swap cannot load a skewed
 # finalizer at turn end.
 from agent.turn_finalizer import finalize_turn
-from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.usage_pricing import estimate_usage_cost, normalize_usage, reported_usage_cost
 from hermes_constants import PARTIAL_STREAM_STUB_ID
 from hermes_logging import set_session_context
 from tools.skill_provenance import set_current_write_origin
@@ -3761,8 +3761,11 @@ def run_conversation(
                         base_url=_agg_cost_base_url,
                         api_key=getattr(agent, "api_key", ""),
                     )
+                    actual_cost_result = reported_usage_cost(aggregator_usage)
                     if cost_result.amount_usd is not None:
                         agent.session_estimated_cost_usd += float(cost_result.amount_usd)
+                    if actual_cost_result is not None and actual_cost_result.amount_usd is not None:
+                        agent.session_actual_cost_usd += float(actual_cost_result.amount_usd)
                     # Add MoA advisor cost (already priced per-advisor at each
                     # advisor's own model rate) on top of the aggregator cost.
                     if _moa_ref_cost is not None:
@@ -3770,8 +3773,9 @@ def run_conversation(
                             agent.session_estimated_cost_usd += float(_moa_ref_cost)
                         except (TypeError, ValueError):  # pragma: no cover - defensive
                             pass
-                    agent.session_cost_status = cost_result.status
-                    agent.session_cost_source = cost_result.source
+                    effective_cost_result = actual_cost_result or cost_result
+                    agent.session_cost_status = effective_cost_result.status
+                    agent.session_cost_source = effective_cost_result.source
 
                     # Persist token counts to session DB for /insights.
                     # Do this for every platform with a session_id so non-CLI
@@ -3797,6 +3801,12 @@ def run_conversation(
                             _cost_delta = None
                             if cost_result.amount_usd is not None:
                                 _cost_delta = float(cost_result.amount_usd)
+                            _actual_cost_delta = (
+                                float(actual_cost_result.amount_usd)
+                                if actual_cost_result is not None
+                                and actual_cost_result.amount_usd is not None
+                                else None
+                            )
                             if _moa_ref_cost is not None:
                                 try:
                                     _cost_delta = (_cost_delta or 0.0) + float(_moa_ref_cost)
@@ -3815,8 +3825,9 @@ def run_conversation(
                                 cache_write_tokens=canonical_usage.cache_write_tokens,
                                 reasoning_tokens=canonical_usage.reasoning_tokens,
                                 estimated_cost_usd=_cost_delta,
-                                cost_status=cost_result.status,
-                                cost_source=cost_result.source,
+                                actual_cost_usd=_actual_cost_delta,
+                                cost_status=effective_cost_result.status,
+                                cost_source=effective_cost_result.source,
                                 billing_provider=agent.provider,
                                 billing_base_url=agent.base_url,
                                 billing_mode="subscription_included"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3761,11 +3761,17 @@ def run_conversation(
                         base_url=_agg_cost_base_url,
                         api_key=getattr(agent, "api_key", ""),
                     )
-                    actual_cost_result = reported_usage_cost(aggregator_usage)
+                    # Use the fully folded usage here, not just the aggregator:
+                    # CanonicalUsage only preserves actual_cost_usd across an
+                    # addition when both sides reported it. A MoA turn therefore
+                    # becomes actual only when every advisor and the aggregator
+                    # supplied provider costs.
+                    actual_cost_result = reported_usage_cost(canonical_usage)
                     if cost_result.amount_usd is not None:
                         agent.session_estimated_cost_usd += float(cost_result.amount_usd)
                     if actual_cost_result is not None and actual_cost_result.amount_usd is not None:
                         agent.session_actual_cost_usd += float(actual_cost_result.amount_usd)
+                        agent.session_actual_cost_api_calls += 1
                     # Add MoA advisor cost (already priced per-advisor at each
                     # advisor's own model rate) on top of the aggregator cost.
                     if _moa_ref_cost is not None:
@@ -3773,7 +3779,11 @@ def run_conversation(
                             agent.session_estimated_cost_usd += float(_moa_ref_cost)
                         except (TypeError, ValueError):  # pragma: no cover - defensive
                             pass
-                    effective_cost_result = actual_cost_result or cost_result
+                    actual_cost_complete = (
+                        actual_cost_result is not None
+                        and agent.session_actual_cost_api_calls == agent.session_api_calls
+                    )
+                    effective_cost_result = actual_cost_result if actual_cost_complete else cost_result
                     agent.session_cost_status = effective_cost_result.status
                     agent.session_cost_source = effective_cost_result.source
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -679,7 +679,13 @@ def finalize_turn(
         "total_tokens": agent.session_total_tokens,
         "last_prompt_tokens": getattr(agent.context_compressor, "last_prompt_tokens", 0) or 0,
         "estimated_cost_usd": agent.session_estimated_cost_usd,
-        "actual_cost_usd": getattr(agent, "session_actual_cost_usd", 0.0),
+        "actual_cost_usd": (
+            getattr(agent, "session_actual_cost_usd", 0.0)
+            if getattr(agent, "session_actual_cost_api_calls", 0)
+            == getattr(agent, "session_api_calls", 0)
+            and getattr(agent, "session_api_calls", 0) > 0
+            else None
+        ),
         "cost_status": agent.session_cost_status,
         "cost_source": agent.session_cost_source,
         # Requested service tier (from request_overrides.extra_body), for

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -679,6 +679,7 @@ def finalize_turn(
         "total_tokens": agent.session_total_tokens,
         "last_prompt_tokens": getattr(agent.context_compressor, "last_prompt_tokens", 0) or 0,
         "estimated_cost_usd": agent.session_estimated_cost_usd,
+        "actual_cost_usd": getattr(agent, "session_actual_cost_usd", 0.0),
         "cost_status": agent.session_cost_status,
         "cost_source": agent.session_cost_source,
         # Requested service tier (from request_overrides.extra_body), for

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -78,6 +78,7 @@ class CanonicalUsage:
     cache_write_tokens: int = 0
     reasoning_tokens: int = 0
     request_count: int = 1
+    actual_cost_usd: Optional[Decimal] = None
     raw_usage: Optional[dict[str, Any]] = None
 
     @property
@@ -104,6 +105,12 @@ class CanonicalUsage:
             cache_write_tokens=self.cache_write_tokens + other.cache_write_tokens,
             reasoning_tokens=self.reasoning_tokens + other.reasoning_tokens,
             request_count=self.request_count + other.request_count,
+            actual_cost_usd=(
+                self.actual_cost_usd + other.actual_cost_usd
+                if self.actual_cost_usd is not None
+                and other.actual_cost_usd is not None
+                else None
+            ),
             raw_usage=None,
         )
 
@@ -1349,12 +1356,41 @@ def normalize_usage(
             cache_read_tokens, cache_write_tokens,
         )
 
+    actual_cost_usd = None
+    if provider_name == "openrouter":
+        reported_cost = _to_decimal(getattr(response_usage, "cost", None))
+        if reported_cost is not None and reported_cost.is_finite() and reported_cost >= _ZERO:
+            actual_cost_usd = reported_cost
+
     return CanonicalUsage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         cache_read_tokens=cache_read_tokens,
         cache_write_tokens=cache_write_tokens,
         reasoning_tokens=reasoning_tokens,
+        actual_cost_usd=actual_cost_usd,
+    )
+
+
+def reported_usage_cost(usage: CanonicalUsage) -> Optional[CostResult]:
+    """Return the provider-reported charge carried by a usage response.
+
+    ``normalize_usage`` only accepts this field from providers whose response
+    contract defines it as the account charge.  OpenRouter currently supplies
+    ``usage.cost`` on every completed response, including the final streaming
+    event.  Callers should persist this result as actual cost while retaining
+    ``estimate_usage_cost`` as an independent fallback/comparison value.
+    """
+    if usage.actual_cost_usd is None:
+        return None
+    label = format_cost_label(usage.actual_cost_usd)
+    if label.startswith("~"):
+        label = label[1:]
+    return CostResult(
+        amount_usd=usage.actual_cost_usd,
+        status="actual",
+        source="provider_cost_api",
+        label=label,
     )
 
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -137,6 +137,7 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
 
         report = {
             "estimated_cost_usd": result.get("estimated_cost_usd"),
+            "actual_cost_usd": result.get("actual_cost_usd"),
             "cost_status": result.get("cost_status"),
             "cost_source": result.get("cost_source"),
             "input_tokens": result.get("input_tokens"),

--- a/run_agent.py
+++ b/run_agent.py
@@ -781,6 +781,7 @@ class AIAgent:
         self.session_api_calls = 0
         self.session_estimated_cost_usd = 0.0
         self.session_actual_cost_usd = 0.0
+        self.session_actual_cost_api_calls = 0
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"
         

--- a/run_agent.py
+++ b/run_agent.py
@@ -780,6 +780,7 @@ class AIAgent:
         self.session_reasoning_tokens = 0
         self.session_api_calls = 0
         self.session_estimated_cost_usd = 0.0
+        self.session_actual_cost_usd = 0.0
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"
         
@@ -2688,6 +2689,8 @@ class AIAgent:
         cu = normalize_usage(raw_usage, provider=self.provider, api_mode=self.api_mode)
         summary = asdict(cu)
         summary.pop("raw_usage", None)
+        if summary.get("actual_cost_usd") is not None:
+            summary["actual_cost_usd"] = float(summary["actual_cost_usd"])
         summary["prompt_tokens"] = cu.prompt_tokens
         summary["total_tokens"] = cu.total_tokens
         return summary

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -6,6 +6,7 @@ from agent.usage_pricing import (
     estimate_usage_cost,
     get_pricing_entry,
     normalize_usage,
+    reported_usage_cost,
     resolve_billing_route,
 )
 from decimal import Decimal
@@ -458,3 +459,38 @@ class TestSubscriptionIncludedNotes:
         assert result.amount_usd == Decimal("0")
         assert len(result.notes) > 0
         assert any("subscription" in note.lower() for note in result.notes)
+
+
+def test_openrouter_usage_cost_is_preserved_as_provider_reported_actual():
+    usage = SimpleNamespace(
+        prompt_tokens=100,
+        completion_tokens=20,
+        cost="0.012345",
+    )
+
+    normalized = normalize_usage(
+        usage,
+        provider="openrouter",
+        api_mode="chat_completions",
+    )
+    actual = reported_usage_cost(normalized)
+
+    assert normalized.actual_cost_usd == Decimal("0.012345")
+    assert actual is not None
+    assert actual.amount_usd == Decimal("0.012345")
+    assert actual.status == "actual"
+    assert actual.source == "provider_cost_api"
+    assert actual.label == "$0.01"
+
+
+def test_usage_cost_is_not_trusted_for_openai_compatible_providers_generically():
+    usage = SimpleNamespace(prompt_tokens=100, completion_tokens=20, cost="0.012345")
+
+    normalized = normalize_usage(
+        usage,
+        provider="custom",
+        api_mode="chat_completions",
+    )
+
+    assert normalized.actual_cost_usd is None
+    assert reported_usage_cost(normalized) is None

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -494,3 +494,19 @@ def test_usage_cost_is_not_trusted_for_openai_compatible_providers_generically()
 
     assert normalized.actual_cost_usd is None
     assert reported_usage_cost(normalized) is None
+
+
+def test_combined_usage_only_preserves_actual_cost_when_every_call_reports_it():
+    complete = CanonicalUsage(
+        input_tokens=10,
+        actual_cost_usd=Decimal("0.01"),
+    ) + CanonicalUsage(
+        output_tokens=5,
+        actual_cost_usd=Decimal("0.02"),
+    )
+    incomplete = complete + CanonicalUsage(output_tokens=1)
+
+    assert complete.actual_cost_usd == Decimal("0.03")
+    assert complete.request_count == 2
+    assert incomplete.actual_cost_usd is None
+    assert incomplete.request_count == 3

--- a/tests/hermes_cli/test_oneshot_usage_file.py
+++ b/tests/hermes_cli/test_oneshot_usage_file.py
@@ -8,6 +8,7 @@ from hermes_cli.oneshot import _write_usage_file
 def _result(**overrides):
     base = {
         "estimated_cost_usd": 0.1234,
+        "actual_cost_usd": 0.12,
         "cost_status": "estimated",
         "cost_source": "pricing-table",
         "input_tokens": 1000,
@@ -33,6 +34,7 @@ class TestWriteUsageFile:
         _write_usage_file(str(path), _result())
         report = json.loads(path.read_text())
         assert report["estimated_cost_usd"] == 0.1234
+        assert report["actual_cost_usd"] == 0.12
         assert report["input_tokens"] == 1000
         assert report["output_tokens"] == 200
         assert report["model"] == "openai/gpt-5.5"
@@ -53,5 +55,4 @@ class TestWriteUsageFile:
         assert report["failure"] == "boom"
         # Missing result fields serialize as null, not KeyError.
         assert report["estimated_cost_usd"] is None
-
-
+        assert report["actual_cost_usd"] is None

--- a/tests/run_agent/test_token_persistence_non_cli.py
+++ b/tests/run_agent/test_token_persistence_non_cli.py
@@ -25,6 +25,7 @@ def _make_agent(session_db, *, platform: str):
         agent = AIAgent(
             api_key="test-key",
             base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -54,6 +55,29 @@ def test_run_conversation_persists_tokens_for_telegram_sessions():
     # (queue_token_counts) rather than written inline on the turn thread.
     session_db.queue_token_counts.assert_called_once()
     assert session_db.queue_token_counts.call_args.args[0] == "telegram-session"
+
+
+def test_run_conversation_persists_openrouter_reported_cost_as_actual():
+    session_db = MagicMock()
+    agent = _make_agent(session_db, platform="telegram")
+    agent.client.chat.completions.create.return_value = _mock_response(
+        usage={
+            "prompt_tokens": 11,
+            "completion_tokens": 7,
+            "total_tokens": 18,
+            "cost": 0.012345,
+        }
+    )
+
+    result = agent.run_conversation("hello")
+
+    assert result["actual_cost_usd"] == 0.012345
+    assert result["cost_status"] == "actual"
+    assert result["cost_source"] == "provider_cost_api"
+    persisted = session_db.queue_token_counts.call_args.kwargs
+    assert persisted["actual_cost_usd"] == 0.012345
+    assert persisted["cost_status"] == "actual"
+    assert persisted["cost_source"] == "provider_cost_api"
 
 
 


### PR DESCRIPTION
## Summary
- record OpenRouter's response-reported `usage.cost` as actual provider spend
- preserve the existing models-catalog estimate independently for fallback and comparison
- persist actual cost through session storage and expose it in one-shot usage reports
- trust the provider-specific field only for OpenRouter rather than all OpenAI-compatible endpoints

## Test plan
- [x] Run `scripts/run_tests.sh tests/agent/test_usage_pricing.py tests/run_agent/test_token_persistence_non_cli.py tests/hermes_cli/test_oneshot_usage_file.py tests/run_agent/test_run_agent.py -q`
- [x] Run Ruff against all modified Python files
- [x] Validate that the pinned OpenAI SDK preserves OpenRouter's extra `usage.cost` field
