### PR TITLE
test: close coroutine warnings in regression fakes

### DIFF
--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1898,7 +1898,16 @@ class TestMultiTargetDeliveryContinuesOnFailure:
             fail_future.result.side_effect = ConnectionError("SMTP connection refused")
             ok_future = MagicMock()
             ok_future.result.return_value = {"success": True}
-            mock_pool.submit.side_effect = [fail_future, ok_future]
+            submitted = iter((fail_future, ok_future))
+
+            def submit_without_running(_runner, coro):
+                # The mocked executor never owns/runs the coroutine. Close it
+                # here, exactly as a rejected real submission must, so the
+                # regression test cannot hide an unawaited-coroutine warning.
+                coro.close()
+                return next(submitted)
+
+            mock_pool.submit.side_effect = submit_without_running
 
             result = _deliver_result(job, "Report content")
 
@@ -1927,7 +1936,11 @@ class TestMultiTargetDeliveryContinuesOnFailure:
 
             fail_future = MagicMock()
             fail_future.result.side_effect = ConnectionError("connection refused")
-            mock_pool.submit.return_value = fail_future
+            def submit_without_running(_runner, coro):
+                coro.close()
+                return fail_future
+
+            mock_pool.submit.side_effect = submit_without_running
 
             result = _deliver_result(job, "Report content")
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -147,6 +147,10 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
                 self.rows.append(m["content"])
             return list(range(1, len(messages) + 1))
 
+        def flush_token_counts(self):
+            """Match the SessionDB persist barrier used by production."""
+            return True
+
     db = _BarrierDB()
     agent._session_db = db
     agent._session_db_created = True


### PR DESCRIPTION
## Summary
- update the persistence-lock fake to implement the current SessionDB token-flush contract
- close coroutine objects that mocked executors intentionally do not run

## Verification
- targeted strict warning tests pass
- combined vision/run-agent/cron suite: 802 passed, 1 skipped
- local behavior guard: all required patches present