### PR TITLE
fix(desktop): start new chats in the active workspace

### DIFF
--- a/tests/tui_gateway/test_desktop_active_project_cwd.py
+++ b/tests/tui_gateway/test_desktop_active_project_cwd.py
@@ -1,0 +1,62 @@
+import contextlib
+from pathlib import Path
+
+from hermes_cli import projects_db
+from tui_gateway import server
+
+
+def _active_project(home: Path, primary: Path) -> None:
+    with contextlib.closing(projects_db.connect(home / "projects.db")) as conn:
+        project_id = projects_db.create_project(
+            conn,
+            name="Workspace",
+            primary_path=str(primary),
+        )
+        projects_db.set_active(conn, project_id)
+
+
+def test_desktop_session_falls_back_to_active_project(monkeypatch, tmp_path):
+    launch_dir = tmp_path / "hermes-agent"
+    workspace = tmp_path / "workspace"
+    launch_dir.mkdir()
+    workspace.mkdir()
+    _active_project(tmp_path, workspace)
+
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setattr(server, "_launch_configured_cwd", lambda: None)
+    monkeypatch.setenv("TERMINAL_CWD", str(launch_dir))
+    monkeypatch.chdir(launch_dir)
+
+    assert server._completion_cwd({"source": "desktop"}) == str(workspace)
+
+
+def test_explicit_and_configured_cwd_precede_active_project(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    configured = tmp_path / "configured"
+    explicit = tmp_path / "explicit"
+    for directory in (workspace, configured, explicit):
+        directory.mkdir()
+    _active_project(tmp_path, workspace)
+
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setattr(server, "_launch_configured_cwd", lambda: str(configured))
+
+    assert server._completion_cwd({"source": "desktop"}) == str(configured)
+    assert server._completion_cwd({"source": "desktop", "cwd": str(explicit)}) == str(explicit)
+
+
+def test_active_project_is_desktop_only_and_requires_existing_primary(monkeypatch, tmp_path):
+    launch_dir = tmp_path / "launch"
+    removed_workspace = tmp_path / "removed"
+    launch_dir.mkdir()
+    _active_project(tmp_path, removed_workspace)
+
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+    monkeypatch.setattr(server, "_launch_configured_cwd", lambda: None)
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    monkeypatch.chdir(launch_dir)
+
+    assert server._completion_cwd({"source": "desktop"}) == str(launch_dir)
+
+    removed_workspace.mkdir()
+    assert server._completion_cwd({"source": "cli"}) == str(launch_dir)

--- a/tests/tui_gateway/test_desktop_active_project_cwd.py
+++ b/tests/tui_gateway/test_desktop_active_project_cwd.py
@@ -60,3 +60,31 @@ def test_active_project_is_desktop_only_and_requires_existing_primary(monkeypatc
 
     removed_workspace.mkdir()
     assert server._completion_cwd({"source": "cli"}) == str(launch_dir)
+
+
+def test_named_profile_active_project_precedes_launch_profile_config(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    launch_configured = tmp_path / "launch-configured"
+    workspace.mkdir()
+    launch_configured.mkdir()
+
+    profile_home = tmp_path / "profiles" / "other"
+    profile_home.mkdir(parents=True)
+    _active_project(profile_home, workspace)
+
+    monkeypatch.setattr(server, "_profile_home", lambda profile: profile_home)
+    monkeypatch.setattr(server, "_profile_configured_cwd", lambda home: None)
+    monkeypatch.setattr(server, "_launch_configured_cwd", lambda: str(launch_configured))
+
+    assert server._completion_cwd({"source": "desktop", "profile": "other"}) == str(workspace)
+
+
+def test_active_project_cwd_is_persisted_for_desktop_session():
+    session = {
+        "source": "desktop",
+        "cwd": "/active/project",
+        "cwd_source": "active_project",
+        "explicit_cwd": False,
+    }
+
+    assert server._persisted_session_cwd(session) == "/active/project"

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -23,15 +23,15 @@ def _(rid, params: dict) -> dict:
     # sidebar can nest it under its parent. Mirrors the TUI /branch marker.
     parent_session_id = str(params.get("parent_session_id") or "").strip() or None
     # Did the client pick a workspace, or are we falling back to the gateway's
-    # launch directory? Only an explicit choice is persisted as the session's
-    # workspace (see _ensure_session_db_row); otherwise it lands in "No
-    # workspace" instead of whatever folder the desktop launched in.
+    # launch directory? Explicit choices and active-project fallbacks persist as
+    # session workspaces (see _persisted_session_cwd); a launch artifact lands
+    # in "No workspace" instead.
     raw_cwd = str(params.get("cwd") or "").strip()
     try:
         explicit_cwd = bool(raw_cwd) and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd)))
     except Exception:
         explicit_cwd = False
-    resolved_cwd = _completion_cwd(params)
+    resolved_cwd, cwd_source = _completion_cwd_resolution(params)
     source = _resolve_session_source(str(params.get("source") or "").strip() or None)
     _enable_gateway_prompts()
 
@@ -91,6 +91,7 @@ def _(rid, params: dict) -> dict:
             "history_version": 0,
             "image_counter": 0,
             "cwd": resolved_cwd,
+            "cwd_source": cwd_source,
             "inflight_turn": None,
             "last_active": now,
             "model_override": session_model_override,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1564,6 +1564,27 @@ def _launch_configured_cwd() -> str | None:
         return None
 
 
+def _active_project_cwd(profile_home: Path | None = None) -> str | None:
+    """Return the active project's existing primary folder for a profile."""
+    try:
+        from hermes_cli import projects_db
+
+        home = Path(profile_home) if profile_home is not None else Path(_hermes_home)
+        db_path = home / "projects.db"
+        if not db_path.is_file():
+            return None
+        with contextlib.closing(projects_db.connect(db_path)) as conn:
+            active_id = projects_db.get_active_id(conn)
+            project = projects_db.get_project(conn, active_id) if active_id else None
+        primary = str(project.primary_path or "").strip() if project else ""
+        if not primary:
+            return None
+        resolved = os.path.abspath(os.path.expanduser(primary))
+        return resolved if os.path.isdir(resolved) else None
+    except Exception:
+        return None
+
+
 def _default_session_cwd() -> str:
     """Fallback cwd for a session with no explicit / stored / profile cwd.
 
@@ -2412,17 +2433,23 @@ def _normalize_completion_path(path_part: str) -> str:
 
 def _completion_cwd(params: dict | None = None) -> str:
     params = params or {}
+    source = _resolve_session_source(str(params.get("source") or "").strip() or None)
+    profile_home = _profile_home(params.get("profile"))
     raw = (
         params.get("cwd")
         or _sessions.get(params.get("session_id") or "", {}).get("cwd")
         # A session bound to another profile resolves its workspace from THAT
         # profile's config before falling back to the launch profile's env var.
-        or _profile_configured_cwd(_profile_home(params.get("profile")))
+        or _profile_configured_cwd(profile_home)
         # The launch profile's dashboard /chat attaches to the dashboard's
         # in-memory gateway, which does NOT inherit the PTY child's bridged
         # TERMINAL_CWD. Read the launch profile's config.yaml directly so a
         # configured terminal.cwd wins over a stale process env / launch dir.
         or _launch_configured_cwd()
+        # A Desktop backend may launch from the packaged install/source clone.
+        # Its bridged TERMINAL_CWD can carry the same launch artifact, so the
+        # profile's active project must win before that process-global fallback.
+        or (_active_project_cwd(profile_home) if source == "desktop" else None)
         or os.environ.get("TERMINAL_CWD")
         or os.getcwd()
     )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2431,35 +2431,44 @@ def _normalize_completion_path(path_part: str) -> str:
     return expanded
 
 
-def _completion_cwd(params: dict | None = None) -> str:
+def _completion_cwd_resolution(params: dict | None = None) -> tuple[str, str]:
+    """Resolve a completion cwd and identify the winning precedence rung."""
     params = params or {}
     source = _resolve_session_source(str(params.get("source") or "").strip() or None)
     profile_home = _profile_home(params.get("profile"))
-    raw = (
-        params.get("cwd")
-        or _sessions.get(params.get("session_id") or "", {}).get("cwd")
+    candidates = (
+        (params.get("cwd"), "explicit"),
+        (_sessions.get(params.get("session_id") or "", {}).get("cwd"), "session"),
         # A session bound to another profile resolves its workspace from THAT
         # profile's config before falling back to the launch profile's env var.
-        or _profile_configured_cwd(profile_home)
+        (_profile_configured_cwd(profile_home), "profile_config"),
         # The launch profile's dashboard /chat attaches to the dashboard's
         # in-memory gateway, which does NOT inherit the PTY child's bridged
         # TERMINAL_CWD. Read the launch profile's config.yaml directly so a
         # configured terminal.cwd wins over a stale process env / launch dir.
-        or _launch_configured_cwd()
+        (_launch_configured_cwd() if profile_home is None else None, "launch_config"),
         # A Desktop backend may launch from the packaged install/source clone.
         # Its bridged TERMINAL_CWD can carry the same launch artifact, so the
         # profile's active project must win before that process-global fallback.
-        or (_active_project_cwd(profile_home) if source == "desktop" else None)
-        or os.environ.get("TERMINAL_CWD")
-        or os.getcwd()
+        (
+            _active_project_cwd(profile_home) if source == "desktop" else None,
+            "active_project",
+        ),
+        (os.environ.get("TERMINAL_CWD"), "process"),
+        (os.getcwd(), "process"),
     )
+    raw, cwd_source = next((value, origin) for value, origin in candidates if value)
     try:
         resolved = os.path.abspath(os.path.expanduser(str(raw)))
         if os.path.isdir(resolved):
-            return resolved
+            return resolved, cwd_source
     except Exception:
         pass
-    return os.getcwd()
+    return os.getcwd(), "process"
+
+
+def _completion_cwd(params: dict | None = None) -> str:
+    return _completion_cwd_resolution(params)[0]
 
 
 def _terminal_task_cwd(session: dict | None) -> str:
@@ -2560,7 +2569,13 @@ def _persisted_session_cwd(session: dict) -> str | None:
     if session.get("explicit_cwd"):
         return _session_cwd(session)
     if _session_source(session) in _LAUNCH_CWD_NOT_A_WORKSPACE:
-        return None
+        # An active project is an intentional profile workspace, not the
+        # launch artifact this Desktop-only guard exists to discard.
+        return (
+            _session_cwd(session)
+            if session.get("cwd_source") == "active_project"
+            else None
+        )
     # Only the session's OWN directory. `_session_cwd` falls back to the
     # gateway-wide completion cwd, which belongs to no session in particular —
     # stamping that would invent a workspace for a session that never had one.


### PR DESCRIPTION
## What does this PR do?

Fresh Desktop chats now start in the active project's primary workspace when the client does not provide a cwd and the profile has no concrete `terminal.cwd`. Previously, the backend fell through to its launch directory, so terminal execution and project context discovery could target the Hermes install/source clone and inject the wrong `AGENTS.md`.

### Symptom

A new Desktop chat reports the backend launch or Hermes clone directory as its cwd even though `hermes project show` identifies a different active project primary path.

### Impact

Desktop users can receive project instructions and tool execution rooted in the Hermes clone instead of their selected workspace. The session can also lose its intended project placement when persisted.

### Bug Cause

**Trigger:** `tui_gateway/server.py` / `_completion_cwd_resolution()` when a Desktop `session.create` request omits `cwd`.

**Causal chain:**
1. Desktop creates a session without an explicit cwd while the profile has an active project.
2. The gateway's cwd precedence ladder ignores the profile-scoped active project and falls through to `TERMINAL_CWD` or `os.getcwd()`.
3. The agent, terminal, and coding-context discovery use the backend launch directory instead of the active workspace.

**Why it is wrong:** Process launch state is not the user's selected project state, and named profiles must not inherit the launch profile's workspace configuration.

**Working sibling / contrast:** CLI `--in` and explicit Desktop cwd requests already supply a concrete cwd and continue to win the precedence ladder.

**Ruled out:** Context-file discovery is not independently choosing the clone. Real serve/WebSocket verification showed it follows the session cwd; correcting that cwd makes project facts and `AGENTS.md` discovery target the active workspace.

### Fix

Resolve Desktop session cwd from the active project's existing primary path after explicit and profile-configured paths but before process-global launch fallbacks. Track the winning resolution source so active-project workspaces are persisted, while launch artifacts remain detached. Named profiles read only their own config and `projects.db`, and missing or invalid project paths safely retain the existing fallback behavior.

## Related Issue

Closes #85668

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` - add profile-scoped active-project cwd resolution, precedence provenance, and persistence behavior.
- `tui_gateway/methods_session.py` - retain the cwd resolution source on newly created sessions.
- `tests/tui_gateway/test_desktop_active_project_cwd.py` - cover active-project fallback, precedence, profile isolation, invalid paths, and persistence.

## How to Test

1. Launch the headless Desktop backend from a directory different from the active project's primary workspace.
2. Create a Desktop session over `/api/ws` without `cwd`; verify the session, terminal cwd, and project facts use the active workspace.
3. Repeat with an explicit cwd and with a concrete profile `terminal.cwd`; verify each retains precedence.
4. Run the focused regression suite:

```bash
bash scripts/run_tests.sh tests/tui_gateway/test_desktop_active_project_cwd.py tests/tui_gateway/test_projects_rpc.py
```

Result: 28 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A because this restores the documented active-project behavior
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow contract changed
- [x] I've considered cross-platform impact; path validation uses existing `os.path` behavior
- [x] Tool description and schema updates are N/A because no model tool changed

## Screenshots / Logs

Real serve/WebSocket verification reproduced the base behavior selecting the launch directory. The fixed tip selected the active workspace, preserved explicit and configured cwd precedence, persisted the workspace, and resolved project facts from that workspace.