### PR TITLE
Fix suggestion pills coming back dead after one click

### DIFF
--- a/apps/desktop/src/app/chat/composer/suggestion-pills.test.tsx
+++ b/apps/desktop/src/app/chat/composer/suggestion-pills.test.tsx
@@ -1,0 +1,183 @@
+import { act, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $composerSuggestionsBySession, type ComposerSuggestion, offerSuggestions } from '@/store/composer-suggestions'
+
+import { SuggestionPills } from './suggestion-pills'
+
+/**
+ * The pill strip owns phase; the bus owns existence. These cover the seam
+ * between them — what has to happen to a pill's phase and its in-flight work
+ * when the bus withdraws it, which is the normal way a suggestion ends.
+ */
+
+interface Flow {
+  resolve: () => void
+  reject: (error: unknown) => void
+  /** Latest value of the invoke context's `cancelled()` poll. */
+  cancelled: () => boolean
+}
+
+function pill(id: string, provider = 'mcp'): { suggestion: ComposerSuggestion; flow: Flow } {
+  const flow: Partial<Flow> = {}
+
+  const suggestion: ComposerSuggestion = {
+    doneLabel: `Added ${id}`,
+    doneTip: 'done',
+    id,
+    invoke: context =>
+      new Promise<void>((resolve, reject) => {
+        flow.resolve = resolve
+        flow.reject = reject
+        flow.cancelled = context.cancelled
+      }),
+    label: `Add ${id}`,
+    provider,
+    tip: 'because',
+    workingLabel: `Connecting ${id}…`,
+    workingTip: 'cancel'
+  }
+
+  return { flow: flow as Flow, suggestion }
+}
+
+const labels = (container: HTMLElement) => [...container.querySelectorAll('button')].map(button => button.textContent)
+
+const click = async (container: HTMLElement) => {
+  await act(async () => {
+    container.querySelector('button')!.click()
+  })
+}
+
+afterEach(() => {
+  $composerSuggestionsBySession.set({})
+})
+
+describe('SuggestionPills', () => {
+  it('narrates idle → working → done through one invoke', async () => {
+    const { flow, suggestion } = pill('github')
+    const { container } = render(<SuggestionPills sessionId="s1" />)
+
+    act(() => offerSuggestions('s1', 'mcp', [suggestion]))
+    expect(labels(container)).toEqual(['Add github'])
+
+    await click(container)
+    expect(labels(container)).toEqual(['Connecting github…'])
+
+    await act(async () => flow.resolve())
+    expect(labels(container)).toEqual(['Added github'])
+  })
+
+  it('re-offering a withdrawn key starts from idle, not a stale done', async () => {
+    const first = pill('github')
+    const { container } = render(<SuggestionPills sessionId="s1" />)
+
+    act(() => offerSuggestions('s1', 'mcp', [first.suggestion]))
+    await click(container)
+    await act(async () => first.flow.resolve())
+    expect(labels(container)).toEqual(['Added github'])
+
+    // The provider withdraws (draft lost the trigger) and offers again later.
+    act(() => offerSuggestions('s1', 'mcp', []))
+    act(() => offerSuggestions('s1', 'mcp', [pill('github').suggestion]))
+
+    expect(labels(container)).toEqual(['Add github'])
+  })
+
+  it('a fresh offer is clickable again after an earlier one completed', async () => {
+    const first = pill('github')
+    const second = pill('github')
+    const { container } = render(<SuggestionPills sessionId="s1" />)
+
+    act(() => offerSuggestions('s1', 'mcp', [first.suggestion]))
+    await click(container)
+    await act(async () => first.flow.resolve())
+
+    act(() => offerSuggestions('s1', 'mcp', []))
+    act(() => offerSuggestions('s1', 'mcp', [second.suggestion]))
+    await click(container)
+
+    // A stale `done` swallows the click (only idle invokes) — this is the
+    // user-visible half of the phase leak.
+    expect(labels(container)).toEqual(['Connecting github…'])
+  })
+
+  it('cancels the in-flight action when the pill is withdrawn mid-flight', async () => {
+    const { flow, suggestion } = pill('github')
+    const { container } = render(<SuggestionPills sessionId="s1" />)
+
+    act(() => offerSuggestions('s1', 'mcp', [suggestion]))
+    await click(container)
+    expect(flow.cancelled()).toBe(false)
+
+    // The pill is the only cancel affordance; losing it must abort the work.
+    act(() => offerSuggestions('s1', 'mcp', []))
+
+    expect(labels(container)).toEqual([])
+    expect(flow.cancelled()).toBe(true)
+  })
+
+  it('cancels in-flight work when the strip unmounts', async () => {
+    const { flow, suggestion } = pill('github')
+    const { container, unmount } = render(<SuggestionPills sessionId="s1" />)
+
+    act(() => offerSuggestions('s1', 'mcp', [suggestion]))
+    await click(container)
+
+    unmount()
+
+    expect(flow.cancelled()).toBe(true)
+  })
+
+  it('does not carry phase across a session switch on one mounted composer', async () => {
+    const { flow, suggestion } = pill('github')
+    const { container, rerender } = render(<SuggestionPills sessionId="s1" />)
+
+    act(() => offerSuggestions('s1', 'mcp', [suggestion]))
+    await click(container)
+    await act(async () => flow.resolve())
+    expect(labels(container)).toEqual(['Added github'])
+
+    act(() => offerSuggestions('s2', 'mcp', [pill('github').suggestion]))
+    rerender(<SuggestionPills sessionId="s2" />)
+
+    expect(labels(container)).toEqual(['Add github'])
+  })
+
+  it('returns to idle when the provider rejects, so it can be retried', async () => {
+    const { flow, suggestion } = pill('github')
+    const { container } = render(<SuggestionPills sessionId="s1" />)
+
+    act(() => offerSuggestions('s1', 'mcp', [suggestion]))
+    await click(container)
+
+    await act(async () => flow.reject(new Error('nope')))
+
+    expect(labels(container)).toEqual(['Add github'])
+  })
+
+  it('a second click on a working pill requests cancel', async () => {
+    const { flow, suggestion } = pill('github')
+    const { container } = render(<SuggestionPills sessionId="s1" />)
+
+    act(() => offerSuggestions('s1', 'mcp', [suggestion]))
+    await click(container)
+    await click(container)
+
+    expect(flow.cancelled()).toBe(true)
+    expect(labels(container)).toEqual(['Connecting github…'])
+  })
+
+  it('invokes each pill independently when two are offered', async () => {
+    const a = pill('github')
+    const b = pill('linear')
+    const invoke = vi.spyOn(b.suggestion, 'invoke')
+    const { container } = render(<SuggestionPills sessionId="s1" />)
+
+    act(() => offerSuggestions('s1', 'mcp', [a.suggestion, b.suggestion]))
+    await click(container)
+
+    expect(labels(container)).toEqual(['Connecting github…', 'Add linear'])
+    expect(invoke).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/suggestion-pills.tsx
+++ b/apps/desktop/src/app/chat/composer/suggestion-pills.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { composerFloatingPill } from '@/components/chat/composer-dock'
 import { Codicon } from '@/components/ui/codicon'
@@ -32,13 +32,70 @@ import { $composerSuggestionsBySession, markSuggestionInvoked, suggestionKey } f
 
 type PillPhase = 'done' | 'idle' | 'working'
 
+/**
+ * Phase belongs to the pill the user is looking at, so it lives and dies with
+ * that pill — the bus owns whether a suggestion exists, this owns only how far
+ * along it is. Remounting per session enforces the half of that the strip
+ * can't see: one composer stays mounted across a session switch, and phase
+ * keys are `provider:id`, so without this "Added GitHub" in one chat renders
+ * the next chat's genuine offer as already-done and inert.
+ */
 export function SuggestionPills({ sessionId }: { sessionId: null | string }) {
+  return <SessionSuggestionPills key={sessionId ?? ''} sessionId={sessionId} />
+}
+
+function SessionSuggestionPills({ sessionId }: { sessionId: null | string }) {
   const suggestions = useSessionSlice($composerSuggestionsBySession, sessionId)
   const [phases, setPhases] = useState<Record<string, PillPhase>>({})
   // Cancel flags outlive renders but never trigger them (poll-boundary abort).
   const [cancels] = useState(() => new Map<string, boolean>())
 
   const setPhase = (key: string, phase: PillPhase) => setPhases(current => ({ ...current, [key]: phase }))
+
+  // A pill that leaves the strip takes its phase with it, and cancels whatever
+  // it had in flight. Both halves matter:
+  //
+  //  - Phase, because keys repeat. A provider withdraws and re-offers the same
+  //    `provider:id` constantly (the draft loses and regains the trigger word,
+  //    a connect fails and the word is still typed), and a `done` left on file
+  //    paints the fresh offer as "Added GitHub" — a pill that says it already
+  //    worked and ignores clicks, since only `idle` invokes.
+  //  - Cancellation, because a withdrawn pill is the user's ONLY cancel
+  //    affordance. Clicking a working pill sets this flag; once the pill is
+  //    gone nothing can, so an OAuth flow the user walked away from would poll
+  //    forever, hold the server's in-progress slot against a retry, and either
+  //    land a server they never confirmed or roll one back with no UI to say
+  //    so. Withdrawal aborts it at the next poll boundary and lets the
+  //    provider roll back.
+  //
+  // `suggestions` is reference-stable while the offered set is unchanged (the
+  // bus preserves identity on no-op writes), so this runs on real churn only.
+  useEffect(() => {
+    const live = new Set(suggestions.map(suggestionKey))
+
+    for (const key of cancels.keys()) {
+      if (!live.has(key)) {
+        cancels.set(key, true)
+      }
+    }
+
+    setPhases(current => {
+      const kept = Object.entries(current).filter(([key]) => live.has(key))
+
+      return kept.length === Object.keys(current).length ? current : Object.fromEntries(kept)
+    })
+  }, [cancels, suggestions])
+
+  // Unmount withdraws everything at once (composer closing, session switch
+  // remounting this subtree) — same rule, same reason.
+  useEffect(
+    () => () => {
+      for (const key of cancels.keys()) {
+        cancels.set(key, true)
+      }
+    },
+    [cancels]
+  )
 
   return suggestions.map(suggestion => {
     const key = suggestionKey(suggestion)
@@ -66,6 +123,8 @@ export function SuggestionPills({ sessionId }: { sessionId: null | string }) {
         // Provider owns error surfacing (and swallows its own cancels);
         // the pill just returns to idle so it can be tried again.
         setPhase(key, 'idle')
+      } finally {
+        cancels.delete(key)
       }
     }
 

--- a/apps/desktop/src/store/composer-suggestions.test.ts
+++ b/apps/desktop/src/store/composer-suggestions.test.ts
@@ -80,4 +80,47 @@ describe('composer suggestion bus', () => {
 
     offerSuggestions('s6', 'test', [])
   })
+
+  it('replaces an offer whose rendered copy changed under the same key', () => {
+    offerSuggestions('s7', 'test', [{ ...suggestion('linear'), tip: 'because you mentioned “linear”' }])
+    offerSuggestions('s7', 'test', [{ ...suggestion('linear'), tip: 'because you pasted linear.app' }])
+
+    // Same key, new trigger — the strip must paint the new reason, not the
+    // first one it ever saw.
+    expect(($composerSuggestionsBySession.get().s7 ?? []).map(s => s.tip)).toEqual(['because you pasted linear.app'])
+
+    offerSuggestions('s7', 'test', [])
+  })
+
+  it('re-offering the same key swaps in the fresh invoke closure', async () => {
+    const calls: string[] = []
+
+    const offer = (tag: string) =>
+      offerSuggestions('s8', 'test', [
+        { ...suggestion('linear'), invoke: async () => void calls.push(tag), label: `Add linear ${tag}` }
+      ])
+
+    offer('first')
+    offer('second')
+
+    await ($composerSuggestionsBySession.get().s8 ?? [])[0]!.invoke({ cancelled: () => false, sessionId: 's8' })
+
+    // A pinned first object means the pill runs work built for a draft the
+    // user has since changed.
+    expect(calls).toEqual(['second'])
+
+    offerSuggestions('s8', 'test', [])
+  })
+
+  it('keeps the array reference when nothing the pill paints changed', () => {
+    offerSuggestions('s9', 'test', [suggestion('linear')])
+
+    const first = $composerSuggestionsBySession.get().s9
+
+    offerSuggestions('s9', 'test', [suggestion('linear')])
+
+    expect($composerSuggestionsBySession.get().s9).toBe(first)
+
+    offerSuggestions('s9', 'test', [])
+  })
 })

--- a/apps/desktop/src/store/composer-suggestions.ts
+++ b/apps/desktop/src/store/composer-suggestions.ts
@@ -67,8 +67,31 @@ export const $composerSuggestionsBySession = atom<Record<string, ComposerSuggest
 
 const keyFor = (sessionId: string | null | undefined): string => sessionId ?? ''
 
+// Everything the pill actually paints. Compared field-by-field rather than by
+// key alone: a provider rebuilds its suggestion objects on every sample, so
+// key equality is true constantly, and treating that as "no change" pins the
+// FIRST object forever — the strip then paints a stale tip and, worse, calls a
+// stale `invoke` closure. Comparing the rendered copy keeps the cheap bail-out
+// for the common case (same draft, same match) while letting a genuinely
+// changed offer through.
+const RENDERED: readonly (keyof ComposerSuggestion)[] = [
+  'brand',
+  'doneLabel',
+  'doneTip',
+  'icon',
+  'label',
+  'tip',
+  'workingLabel',
+  'workingTip'
+]
+
 const sameSuggestions = (a: readonly ComposerSuggestion[], b: readonly ComposerSuggestion[]) =>
-  a.length === b.length && a.every((x, i) => suggestionKey(x) === suggestionKey(b[i]!))
+  a.length === b.length &&
+  a.every((x, i) => {
+    const y = b[i]!
+
+    return suggestionKey(x) === suggestionKey(y) && RENDERED.every(field => x[field] === y[field])
+  })
 
 function write(sessionId: string | null | undefined, suggestions: ComposerSuggestion[]): void {
   const key = keyFor(sessionId)

--- a/apps/desktop/src/store/suggestion-providers/mcp.ts
+++ b/apps/desktop/src/store/suggestion-providers/mcp.ts
@@ -172,7 +172,9 @@ function toSuggestion(match: McpMatch, sessionId: string | null): ComposerSugges
     doneLabel: copy('added', name),
     doneTip: copy('addedTip'),
     id: match.server,
-    invoke: context => connect(match.server, sessionId, context.cancelled),
+    // The pill's session wins over the one captured at sample time: the reload
+    // has to reach the session the user is actually looking at.
+    invoke: context => connect(match.server, context.sessionId ?? sessionId, context.cancelled),
     label: copy('label', name),
     provider: 'mcp',
     tip: copy('tip', match.keyword),

--- a/apps/desktop/src/store/suggestion-providers/repair.ts
+++ b/apps/desktop/src/store/suggestion-providers/repair.ts
@@ -73,7 +73,7 @@ function toSuggestion(server: string, sessionId: string | null): ComposerSuggest
     doneTip: copy('doneTip'),
     icon: 'plug',
     id: server,
-    invoke: context => reconnect(server, sessionId, context.cancelled),
+    invoke: context => reconnect(server, context.sessionId ?? sessionId, context.cancelled),
     label: copy('label', name),
     provider: 'repair',
     tip: copy('tip', name),


### PR DESCRIPTION
A suggestion pill that had already been clicked once could come back as a dead
button: it rendered "Added GitHub" with a check, ignored clicks, and then
vanished when the draft changed — the "empty space where the connect button
was" people have been hitting. Three independent defects in the pills shipped
by #85036 / #85070 / #85091 produced it, and all three are fixed here.

## Phase outlived the pill

Pill phase (idle → working → done) lived in a `Record<key, phase>` that only
ever grew, keyed `provider:id`. Those keys repeat constantly by design — a
provider withdraws and re-offers the same suggestion every time the draft
loses and regains its trigger word — so a leftover `done` painted the *next*
genuine offer as already-connected. Only `idle` invokes, so the pill also
swallowed the click.

The same map outlived a session switch. One composer stays mounted across it,
so connecting GitHub in one chat left the next chat's real offer inert.

Phase now lives and dies with the pill it describes: withdrawn keys drop
their phase, and the strip remounts per session.

## Withdrawal stranded in-flight work

The pill is the only cancel affordance — clicking a working pill sets the flag
the provider polls at each OAuth poll boundary. Once the pill left the strip
nothing could set it, so a flow the user walked away from kept polling, held
the server's per-server in-progress slot against a retry, and resolved into a
config write with no UI left to narrate it or roll it back.

Withdrawal (and unmount) now trips that flag, so the provider aborts and rolls
back on its own existing path.

## The bus pinned the first offer it ever saw

`sameSuggestions` compared offers by key alone. Providers rebuild their
suggestion objects on every draft sample, so key equality held constantly and
the write bailed out permanently — freezing the first object for the life of
the offer. The pill kept painting a stale reason ("you mentioned linear" after
you pasted a linear.app link) and kept calling a stale `invoke` closure built
for a draft that no longer existed.

It now compares the fields the pill actually renders. The reference-identity
bail-out that keeps typing from re-rendering the strip is preserved for the
real no-op case.

## Wrong session on connect

Both connect providers captured `sessionId` at sample time and ignored the one
`invoke` receives, so `reload.mcp` fired at the session the draft was sampled
in. An offer that outlived a switch reloaded tools into the wrong chat — the
one you clicked from resumed without the tools the pill just promised.

## Worked example

Type "check the linear board", let the pill appear, click it, cancel the OAuth
tab. Before: the pill returns as "Added Linear" with a check, does nothing when
clicked, and disappears on the next keystroke while the abandoned flow keeps
polling and blocks a retry with a 409. After: it returns as "Add Linear",
connects on click, and the cancelled flow is released server-side.

## Test plan

- [x] `suggestion-pills.test.tsx` — 9 cases over the phase/withdrawal seam: the
      idle→working→done narration, re-offer after done starting from idle and
      being clickable, cancellation on withdrawal and on unmount, no phase
      carried across a session switch, reject returning to idle, second-click
      cancel, and two pills invoking independently. 5 of them fail on `main`
      with exactly the reported symptom (`expected [ 'Added github' ] to deeply
      equal [ 'Add github' ]`).
- [x] `composer-suggestions.test.ts` — changed copy replaces a same-key offer,
      a re-offer swaps in the fresh `invoke`, and an unchanged set still keeps
      its array reference. First two fail on `main`.
- [x] Reproduced the stale-object and dead-click behaviour against a running
      desktop app over CDP before fixing, and confirmed the pill's DOM,
      geometry, brand glyph, and computed colours are otherwise correct.
- [x] Full `src/app/chat/composer/` + `src/store/` UI suite: 1072 passed.
- [x] `tsc -p . --noEmit` and `eslint` clean on the touched files.
