### PR TITLE
feat(slack): add conversational Kanban intake

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,6 +161,11 @@
 # Get at: https://firecrawl.dev/
 # FIRECRAWL_API_KEY=
 
+# Slack → Hermes message shortcut authentication. This must match the
+# loopback dashboard process token and is a secret; configure the non-secret
+# endpoint as platforms.slack.hermes_intake_url in config.yaml.
+# HERMES_DASHBOARD_SESSION_TOKEN=
+
 
 # FAL.ai API Key - Image generation
 # Get at: https://fal.ai/

--- a/docs/assessments/slack-conversational-intake-review.md
+++ b/docs/assessments/slack-conversational-intake-review.md
@@ -1,0 +1,522 @@
+# Slack “Send to Hermes” conversational intake
+
+Status: **REVIEW REQUIRED — implementation is blocked on Jerry’s go/no-go**
+Assessment task: `t_7ce8f15c`
+Target repository/worktree inspected: `/Users/jj/.hermes/hermes-agent/.worktrees/t_3e6da870`
+Scope of this document: product and architecture decision; no production implementation
+
+## Decision summary
+
+**Recommendation: proceed with a private Slack DM-thread intake whose canonical promotion control is a persistent `Create card` button.** The selected Slack message must enter Hermes as the first ordinary user turn through the normal gateway prompt path. No Kanban card exists until an explicit promotion command passes completeness, authorization, privacy, and idempotency gates.
+
+The complete product direction permits two exact standalone language conveniences—`make the card` and `queue this`—that invoke the same promotion command. `go`, casual agreement, reactions, and inferred assent never mutate Kanban. For the first private dogfood slice, implement **button-only promotion**, text-only source capture, one authorized user/workspace/profile, a direct 1:1 DM, and a fixed **HRMS → Triage, unassigned** destination. Add the exact language conveniences only after the end-to-end route, restart recovery, and exactly-once card proof pass.
+
+This reconciles the desired conversational experience with the supported architecture:
+
+- Slack DM threads already provide the correct conversation surface and distinct Hermes routing identity.
+- Existing shortcut capture and privacy behavior are valuable and should be reused.
+- The existing immediate `victorylive` Kanban mutation is the wrong endpoint and should be replaced.
+- Generic CLI handoff orchestration is not a safe shortcut because its `chat_type="thread"` source does not match organic Slack DM replies (`chat_type="dm"`).
+- A small gateway-owned intake operation is required to create the thread, bind the organic-equivalent Hermes session, and submit one normal `MessageEvent`.
+- Exactly-once promotion requires a backend-enforced transactional uniqueness rule; an in-process lock plus preflight lookup is insufficient.
+
+## Go/no-go recommendation
+
+**Go**, provided Jerry approves these four product choices:
+
+1. Private dogfood writes only to **HRMS → Triage, unassigned**.
+2. The dogfood source is explicitly **text-only**; files, rich blocks, unfurls, and edited-source refresh are deferred.
+3. The first slice uses **button-only promotion**; the two exact standalone phrases are the approved near-term follow-up, not part of the initial proof.
+4. Re-invoking the shortcut deliberately creates a new intake, even for the same source message; Slack redelivery/retry of one invocation resumes the original intake.
+
+A no-go is appropriate if any of those choices is unacceptable without multi-board selection, rich-source canonical fetching, or broad natural-language promotion in the first release. Those additions materially enlarge the safety and recovery surface and should not be smuggled into the minimal slice.
+
+## Product contract
+
+### User-visible lifecycle
+
+1. **Invoke shortcut** — The user selects `More actions → Send to Hermes` on a Slack message. Slack is acknowledged immediately. Authorization happens before source text is rendered, cached, logged, or submitted.
+2. **Reserve intake** — Hermes mints or reloads a durable intake record for this shortcut invocation. This is not a Kanban card.
+3. **Start private thread** — Hermes opens the invoking user’s 1:1 DM in the correct Slack workspace and posts one thread seed. The thread is dedicated to this intake.
+4. **Bind Hermes session** — The gateway builds an organic-equivalent Slack DM `SessionSource`, resolves/creates the Hermes session, and durably binds intake, Slack source, DM thread, profile, session key, and session lineage.
+5. **Submit the source normally** — The captured source and optional context are submitted once as an ordinary human-originated `MessageEvent`. Hermes’s visible kickoff is the normal assistant response from that turn—not an outbound-only imitation.
+6. **Refine** — Hermes states its understanding, recommendation, assumptions, `No card exists yet`, and at most one material question. The user refines the brief in the same Slack thread. No Kanban mutation occurs.
+7. **Request promotion** — The current `Create card` button enters promotion evaluation. In the complete target behavior, exact standalone `make the card` and `queue this` do the same. Other plausible language only opens an explicit confirmation.
+8. **Complete or clarify** — If outcome, destination, privacy boundary, or execution posture is materially unresolved, Hermes previews the known draft and asks one blocking question. No card is created.
+9. **Create** — Controls move to `Creating card…`; promotion reauthorizes and submits one resolved brief under the intake’s immutable promotion key.
+10. **Confirm success** — The thread shows the card ID and `Open card`. Stale actions, retries, concurrent requests, and exact-phrase/button races return the same card.
+11. **Recover failure** — Definite failures preserve the intake and show `Retry creation`. Unknown outcomes reconcile by promotion key before any write is retried.
+
+### State model
+
+The durable state belongs to the intake record, not to one Slack message rendering or a process-local modal cache.
+
+| State | Required durable identity | Allowed transitions | Kanban write? |
+|---|---|---|---|
+| `reserved` | intake, source, owner, workspace/profile | `thread_bound`, `failed_retryable` | No |
+| `thread_bound` | plus DM channel/thread timestamp | `session_bound`, `failed_retryable`, `reconciling` | No |
+| `session_bound` | plus session key and logical session lineage | `dispatching`, `failed_retryable` | No |
+| `dispatching` | plus stable synthetic event ID | `active`, `failed_retryable`, `reconciling` | No |
+| `active` | accepted first turn; resolved brief revision | `active`, `clarifying`, `promotion_pending` | No |
+| `clarifying` | pending material question + draft revision | `active`, `clarifying`, `promotion_pending` | No |
+| `promotion_pending` | frozen candidate revision + promotion key | `creating`, `active`, `clarifying` | No |
+| `creating` | immutable promotion key and candidate hash/revision | `promoted`, `failed_retryable`, `reconciling` | At most one logical write |
+| `reconciling` | last operation and external identifiers | previous safe state or `promoted` | Lookup first; no blind write |
+| `failed_retryable` | safe failure code and last authoritative state | retry to the recorded step | Only if retrying the same promotion key |
+| `promoted` | board + card ID + promoted timestamp | remains `promoted` | Never again |
+| `closed` | close reason | optional explicit new intake, never implicit reopen | No |
+
+State writes use a monotonic revision or equivalent compare-and-swap. Readers must never observe `active` without a session binding or `promoted` without board and card ID. Slack UI messages are projections of this record and may be stale; every action resolves current durable state before acting.
+
+## Mutation-intent policy
+
+### Events allowed to reach promotion evaluation
+
+- Current `Create card` button scoped to the intake ID.
+- `Confirm create` after a material field was inferred or changed during promotion.
+- `Retry creation` / `Check & retry`, always with the existing promotion key.
+- After dogfood: exact normalized standalone `make the card` or `queue this`, allowing terminal punctuation only.
+
+### Events that can never directly write
+
+- `go`, `yes`, `yeah`, `do it`, `ship it`, `send it`, `create that`, `looks good`, `that makes sense`, `sounds right`.
+- Emoji, reactions, approval adjectives, or silence.
+- Text containing an allowed phrase as part of a larger utterance, quotation, question, or UI-label discussion.
+- Any stale Slack action whose intake owner, workspace, authorization, draft revision, or existing card state cannot be validated.
+
+Ambiguous language receives: `Do you want me to create the HRMS → Triage card now?` with `Create card` and `Keep refining`. That confirmation UI still performs zero writes until the button is pressed.
+
+### Completeness gate
+
+Promotion requires a resolved outcome, board, privacy-compatible source policy, and execution posture. Dogfood fixes board/status to HRMS → Triage, unassigned. If the user contradicts that default, promotion pauses rather than silently choosing. Hermes asks no more than one material question per turn and does not ask for values it can safely derive, such as title wording or acceptance-criteria prose.
+
+## Supported architecture
+
+### Required gateway-owned seam
+
+Add one supported operation, with the name illustrative rather than prescriptive:
+
+```python
+async def start_platform_intake(
+    request: PlatformIntakeRequest,
+) -> PlatformIntakeBinding:
+    ...
+```
+
+The operation owns the smallest atomic application boundary that can be made durable:
+
+1. Revalidate submitter, Slack workspace, served profile, and source authorization.
+2. Reserve or reload an intake by a stable invocation/delivery identity.
+3. Resolve the submitter’s 1:1 DM using the captured workspace’s Slack client.
+4. Post or reconcile exactly one thread seed and persist its timestamp.
+5. Build `SessionSource(platform=SLACK, chat_type="dm", scope_id=team_id, chat_id=dm_channel_id, thread_id=seed_ts, user_id=submitter_id, profile=resolved_profile)`.
+6. Resolve/create the session through `SessionStore.get_or_create_session()` and persist peer identity through the existing peer path.
+7. Persist the intake → route/session binding before dispatch.
+8. Submit one ordinary, non-internal `MessageEvent` through `BasePlatformAdapter.handle_message()` / the normal gateway runner path, with a stable synthetic event ID and the real user identity.
+9. Return a durable receipt containing intake ID, route/session identity, DM channel/thread, and accepted/retryable state.
+
+The boundary belongs in the gateway because profile routing, session storage, active-turn coordination, prompt ingress, and lifecycle hooks live there. Slack adapter code alone cannot safely return a session binding or reconcile asynchronous acceptance.
+
+### Paths explicitly prohibited
+
+- Direct transcript row insertion.
+- Direct `AIAgent.run_conversation()` invocation.
+- Posting a fabricated assistant kickoff before a corresponding accepted user turn.
+- Reusing generic CLI handoff’s `chat_type="thread"` for this Slack DM flow.
+- Letting Slack action values or `private_metadata` carry raw source text or mutation payloads.
+- Creating a Kanban card directly from modal submission.
+
+### Normal prompt path that must remain intact
+
+`Slack intake operation → organic-equivalent MessageEvent → BasePlatformAdapter.handle_message() → GatewayRunner._handle_message() → SessionStore/get_or-create + peer persistence → active-turn/lease/history/cache handling → agent.run_conversation() → normal transcript finalization → Slack delivery to the bound DM thread`
+
+This preserves authorization, profile routing, active-session serialization, prompt role alternation, cached-agent consistency, streaming/delivery behavior, and session lifecycle hooks.
+
+## Reuse versus replacement of the existing worktree
+
+### Reuse
+
+From `/Users/jj/.hermes/hermes-agent/.worktrees/t_3e6da870`:
+
+- Slack message shortcut manifest identity and Bolt callback registration.
+- Immediate acknowledgement before API work.
+- Authorization before source disclosure and repeated submit authorization.
+- Canonical Slack source identity `(team_id, channel_id, message_ts)`.
+- Source author, submitter, channel/workspace metadata capture.
+- Best-effort permalink lookup with honest unavailable state.
+- Opaque nonce in Slack metadata and server-side source custody.
+- Private modal/status rendering, bounded preview/context, and safe error copy.
+- Workspace-scoped DM resolution primitive.
+- Thread-seed posting primitive, but not generic handoff source construction.
+- Existing `MessageEvent`/gateway/session path.
+- Existing Kanban idempotency vocabulary as a starting point, after backend uniqueness is made structural.
+
+### Replace
+
+- `Create task` modal semantics and immediate modal-to-Kanban flow.
+- Fixed `victorylive` destination.
+- `build_task_payload()` raw source + freeform context mapping.
+- Loopback dashboard-token `HermesIntakeClient.create_task()` as shortcut submit’s terminal action.
+- Source-message-only idempotency.
+- Success trapped in a one-shot modal.
+- Process-local nonce/source map as the authoritative intake lifecycle.
+
+### Keep only at explicit promotion
+
+- Kanban creation API/tool path.
+- Private success/failure messaging.
+- Idempotent create behavior, upgraded to transactional uniqueness around the durable promotion key.
+
+## Durable lineage model
+
+Use an opaque immutable `intake_id` as the logical anchor. Suggested minimum record:
+
+- schema version, intake kind, intake ID, monotonic revision;
+- resolved profile;
+- Slack team/workspace ID, source channel ID, source message timestamp;
+- source permalink or explicit unavailable status, capture timestamp;
+- authorized submitter/owner ID;
+- Slack shortcut delivery/invocation identity used to collapse callback retries;
+- destination 1:1 DM channel ID and thread timestamp;
+- Hermes session key;
+- initial physical session ID and current/resolved session ID or compression-tip pointer;
+- stable first-turn synthetic event/message ID and dispatch status;
+- current lifecycle state and safe failure code;
+- current resolved-brief revision/hash, without duplicating raw transcript text;
+- immutable promotion key;
+- nullable card board and card ID;
+- created, updated, and promoted timestamps.
+
+### Bidirectional resolution requirements
+
+- From `intake_id`: source, DM thread, logical Hermes session, state, and card.
+- From card lineage: intake ID, source/permalink, DM thread, and Hermes session.
+- From session/peer binding: Slack DM/thread and intake after restart.
+- From Slack action value: opaque intake ID only, then server-side current-state lookup.
+
+### Session rotation/compression
+
+Treat `intake_id + session_key` as logical lineage; do not make one physical session ID the sole anchor. Store the initial session ID for provenance and resolve/update the current session through the repository’s compression/rotation tip policy. Promotion and `Open card` must follow logical lineage, not a stale physical ID.
+
+### Card lineage block
+
+The synthesized card contains identifiers and links, not the full Slack transcript:
+
+- Source Slack permalink when available, plus workspace/channel/message identity and capture time.
+- Intake ID.
+- Hermes logical session ID/key reference suitable for the supported UI.
+- Slack DM channel/thread timestamp or safe deep link.
+- Promotion key or stable lineage reference.
+- Resulting board/card identity is stored back on the intake record.
+
+## Authorization and privacy rules
+
+1. Acknowledge Slack quickly, then authorize before source text is rendered, persisted, logged, or sent elsewhere.
+2. Reauthorize at intake submit/prompt ingress, promotion, and `Open card`; authorization may change during a long intake.
+3. The invoking user must own the nonce/intake. Copied, stale, or cross-user controls fail closed.
+4. Slack team/workspace scopes user IDs, channel IDs, DM cache, clients/tokens, source identity, event dedupe, and session identity. No primary-client fallback may cross workspaces.
+5. Resolve profile before session creation. An unavailable explicit profile is an error, not a default-profile fallback.
+6. Intake occurs only in the invoking user’s 1:1 DM. Never fall back to the source channel or a shared home channel.
+7. Slack action metadata contains opaque IDs only. Raw source text stays in the authorized server-side source/transcript path.
+8. The lineage table stores identity/status, not a second raw-content copy.
+9. Permalink failure is represented honestly and does not broaden source access.
+10. `Private` describes refinement, not the resulting card. Copy must state that promotion sends the resolved brief and source attribution to the selected board.
+11. If source visibility and board visibility conflict materially, promotion blocks or requires a safe authorized destination.
+12. Card content is a synthesized brief; raw chat transcript is excluded.
+
+## Idempotency rules
+
+There are two identities with different semantics:
+
+1. **Invocation/delivery identity** collapses Slack redelivery or retry of one shortcut callback into one intake/thread/session.
+2. **Intake identity** is newly minted for each deliberate shortcut invocation, even when the selected source message is the same. This preserves the user’s ability to start a fresh interpretation intentionally.
+
+Use one immutable promotion key per intake, for example:
+
+`slack-intake:{profile}:{team_id}:{dm_channel_id}:{thread_ts}:{intake_id}`
+
+Required structural guarantees:
+
+- Unique invocation delivery key for active/replayed callback handling.
+- Unique intake ID.
+- Unique promotion key in the intake store.
+- Transactional backend uniqueness mapping `(board, promotion_key) → card_id` or an equivalent unique idempotency ledger.
+- Unique non-null lineage mapping from one intake to one resulting card.
+
+The current process lock and preflight `SELECT` are not sufficient. Two processes can both pass the lookup and insert. The implementation must prove concurrency against the real persistence boundary, not only a stateful fake.
+
+## Failure and retry behavior
+
+Slack and local persistence cannot form one transaction, so recovery states are product behavior, not an implementation detail.
+
+| Failure point | Authoritative result | Retry behavior |
+|---|---|---|
+| Authorization/profile resolution | Nothing disclosed or created | Fail closed; user may retry after access is restored |
+| DM open | Intake reserved; no thread/session | Retry same intake and workspace client |
+| Seed post definite failure | No thread/session | Retry same intake |
+| Seed posted, local write uncertain | Slack thread may exist | Reconcile by recorded request/response evidence before posting again |
+| Session bind failure | Thread exists | Reuse thread; resolve/create same organic-equivalent route |
+| Prompt dispatch rejected | Bound route exists; no accepted first turn | Retry same stable event ID and route |
+| Prompt accepted, model fails | Session/transcript is authoritative | Resume normal conversation; do not replay first turn blindly |
+| Assistant persisted, Slack delivery fails | Transcript is authoritative | Redeliver/recover output; do not rerun first turn |
+| Promotion definite failure before commit | Intake/draft remains active | Retry same promotion key |
+| Promotion commit, acknowledgment lost | Card may exist | Lookup/reconcile by promotion key before any retry |
+| Slack success update fails | Card is authoritative | Re-render `Already created` + `Open card` from intake state |
+| Gateway restart | Durable binding is authoritative | Reload state and continue exact recorded step |
+
+Errors shown to Slack remain private, safe, and machine-classified internally. Never erase an authoritative earlier step to simulate rollback. Retry controls are disabled while an operation is in flight and stale actions resolve the current state.
+
+## Safety invariants and test obligations
+
+A future implementation is not acceptable without executable proof of these invariants:
+
+1. Shortcut invocation creates zero Kanban cards.
+2. Unauthorized input never reveals or persists selected source text.
+3. The destination is the invoking user’s 1:1 DM in the correct workspace.
+4. Retry/restart creates at most one thread and one first user turn per intake.
+5. The synthetic intake source key exactly equals the next organic Slack DM-thread reply key, including profile, workspace, `chat_type="dm"`, DM channel, and thread timestamp.
+6. The first turn goes through normal gateway authorization, session, active-turn, lease, history, cache, and finalization paths.
+7. No direct transcript append, direct agent-loop call, or outbound-only kickoff occurs.
+8. The second organic reply sees exactly one intake user turn and one assistant turn.
+9. Casual agreement, reactions, and ambiguous phrases produce zero Kanban writes.
+10. Incomplete or privacy-conflicted promotion asks one question and preserves the draft.
+11. Button, stale button, retry, concurrent callers, restart, and unknown acknowledgment converge on one card ID.
+12. Transactional uniqueness is tested across two independent creators/process connections.
+13. Success replaces the action with `Open card`; inability to open never changes promoted state.
+14. The card has outcome, rationale, scope, non-goals, acceptance criteria, decisions, constraints, unresolved questions, source, session/thread, and intake lineage—but no raw transcript dump.
+15. Restart can resolve intake → source → DM thread → logical Hermes session → card in both directions.
+
+## Smallest end-to-end private-dogfood slice
+
+### Boundary
+
+Include only:
+
+- one explicitly authorized Jerry Slack identity;
+- one Slack workspace and one served Hermes profile;
+- text-only selected messages;
+- one deliberate invocation → one intake;
+- direct 1:1 DM and one dedicated thread;
+- durable intake/thread/session binding;
+- one source submission through the normal prompt path;
+- conversational refinement using ordinary Slack replies;
+- persistent **button-only** `Create card`;
+- fixed **HRMS → Triage, unassigned** destination;
+- a synthesized card with durable lineage;
+- backend-transactional exactly-once promotion;
+- `Open card`, safe retry, reconciliation, and restart recovery.
+
+Defer exact phrase promotion, attachments/rich blocks/unfurls, multi-board selection, multiple users/workspaces/profiles, source refresh/edit semantics, explicit `start over`, broad rollout controls, analytics, and polished deep-link fallbacks.
+
+### Setup
+
+1. Use an isolated local/dogfood gateway connected to the intended Slack app/workspace and a non-production HRMS board or clearly designated private dogfood lane.
+2. Restrict authorization to Jerry’s Slack identity.
+3. Install/update the shortcut and Block Kit action manifest for the dogfood app.
+4. Apply the durable intake storage and transactional promotion uniqueness migration with a documented rollback.
+5. Enable the feature behind a single config/feature flag defaulting off.
+6. Ensure logs expose correlation IDs only: intake ID, session key/ID, Slack team/channel/thread IDs, promotion key, card ID, state transition, and safe failure code—never raw private source text.
+7. Prepare one text-only source message whose expected resolved outcome is unambiguous and safe for HRMS Triage.
+
+### Primary live scenario
+
+1. Invoke `Send to Hermes` on the prepared message.
+2. Verify the private DM thread appears and no Kanban card exists.
+3. Verify Hermes’s first response contains understanding, recommendation, assumptions, a no-card notice, source attribution, and at most one material question.
+4. Reply naturally in the thread and confirm the same Hermes session continues.
+5. Send `yeah, that makes sense`; confirm no card appears.
+6. Click `Create card` once, then exercise a stale/double click or concurrent retry.
+7. Verify exactly one HRMS Triage card appears with the resolved brief and all lineage fields.
+8. Verify Slack shows the same card ID and `Open card`.
+9. Restart the gateway; click the stale action or retry path again and verify `Already created` returns the same ID.
+10. Open the card and follow lineage back to the intake/thread/session.
+
+### Failure injection scenario
+
+At minimum, inject:
+
+- restart after thread seed but before first-turn dispatch;
+- first-turn dispatch acceptance with Slack response delivery failure;
+- Kanban commit with acknowledgment/Slack update failure;
+- two concurrent promotion calls using separate backend connections.
+
+Each case must converge without a second thread, first turn, session route, or card.
+
+### Observability
+
+Capture a timestamped trace keyed by `intake_id` with:
+
+- each state transition and revision;
+- authorization decision category without private content;
+- Slack workspace, DM channel, and thread timestamp;
+- computed session key and resolved logical/physical session ID;
+- first-turn synthetic event ID and accepted/completed/delivered markers;
+- promotion key, create/reconcile operation, and resulting card ID;
+- retry count and safe failure code;
+- card lookup proving one result.
+
+Preserve the focused automated test output and a redacted live trace as review evidence. Record before/after card counts and query the promotion key directly after concurrency/failure tests.
+
+### Rollback
+
+- Disable the feature flag, removing the shortcut’s conversational submit path without deleting durable records.
+- Leave existing promoted cards and lineage intact; never “roll back” a committed card by allowing repromotion.
+- Revert the Slack manifest/action surface if needed.
+- Stop new intake creation while retaining read/reconcile support for in-flight/promoted records.
+- Roll back schema only if records are empty; otherwise retain the additive table/columns until a deliberate migration archives them.
+- The previous immediate-card flow may remain available on its branch for comparison, but do **not** automatically restore it in production because it violates the approved product contract.
+
+### Pass criteria
+
+All of the following must hold:
+
+- One invocation creates one private DM thread, one Hermes route/session, one accepted first turn, and zero cards before promotion.
+- The next organic reply continues the exact same session and sees correct history once.
+- Casual assent produces zero writes.
+- One explicit button promotion produces exactly one HRMS Triage card with correct content and bidirectional lineage.
+- Double click, concurrent promotion, unknown outcome, and restart return the same card ID.
+- No raw private text appears in action payloads, lineage rows, or logs.
+- Every failure injection has a deterministic, safe retry/reconcile result.
+- The feature flag rollback stops new intakes without corrupting existing lineage or cards.
+
+### Fail criteria
+
+Any duplicate thread, session route, first user turn, or card; any source disclosure before authorization; any source-shape mismatch with an organic reply; any direct transcript/agent bypass; any casual-language mutation; any unreconciled unknown outcome; any lineage break after restart/compression; or any raw content leak is a stop-ship failure.
+
+## Proposed implementation card — do not dispatch before approval
+
+### Title
+
+Implement the private Slack conversational-intake dogfood slice
+
+### Outcome
+
+An authorized user can invoke Slack `Send to Hermes`, refine the selected text in a dedicated private Hermes DM thread, and explicitly create exactly one context-rich HRMS Triage card through a persistent button, with durable source/session/thread/card lineage and restart-safe recovery.
+
+### Rationale
+
+The current shortcut safely captures source context but immediately mutates Kanban. The desired product is idea-to-execution intake: Hermes must reason with the user first, use Slack’s natural private thread surface, and promote only under unmistakable intent. The gateway already owns the ordinary prompt/session path; a supported intake seam and structural promotion idempotency are the missing pieces.
+
+### Scope
+
+- Reuse the existing shortcut registration, fast ack, authorization ordering, nonce/source capture, source attribution, permalink fallback, bounds, and private errors.
+- Add additive durable intake storage with revisioned lifecycle, invocation dedupe, logical session lineage, promotion key, and card binding.
+- Add the gateway-owned platform-intake start/reconcile operation.
+- Build an organic-equivalent Slack DM source and submit one ordinary `MessageEvent` with real user identity and stable event ID.
+- Render/update the dedicated DM-thread intake UI with `No card exists yet`, one-question refinement, persistent button states, and `Open card`.
+- Add button-only promotion to fixed HRMS → Triage, unassigned.
+- Synthesize the resolved card shape and lineage block; never dump the raw transcript.
+- Enforce transactional/unique backend promotion idempotency.
+- Implement private safe failure/reconcile/retry and feature-flag rollback.
+- Add focused unit, integration, concurrency, restart, and live-dogfood evidence.
+
+### Non-goals
+
+- Natural-language promotion, including the approved exact phrases.
+- `go` or broad intent classification.
+- Rich blocks, files, attachments, unfurls, or canonical source refetch.
+- Multi-board/status/assignee/workspace selection.
+- Multi-user, multi-workspace, or broad rollout.
+- Starting multiple versions from one intake; a new deliberate shortcut invocation creates a new intake.
+- Copying Slack transcripts into cards or lineage storage.
+- Reusing generic CLI handoff source shape.
+- Production rollout or migration of existing immediate-created cards.
+
+### Acceptance criteria
+
+1. Shortcut ack and authorization ordering are preserved; unauthorized source text never leaves the authorized capture path.
+2. Each deliberate invocation creates/resumes exactly one durable intake, private DM thread, organic-equivalent route, Hermes session binding, and first ordinary user turn; callback retries create none of those twice.
+3. The initial assistant response is normal model output in the bound thread and contains understanding, recommendation, assumptions, `No card exists yet`, source attribution, and at most one material question.
+4. The next organic Slack reply computes the same routing key and continues the same session with no duplicated history.
+5. No Kanban call occurs before the current `Create card` button is activated and completeness/privacy gates pass.
+6. Casual agreement and all text input produce zero writes in this slice.
+7. Promotion creates one synthesized HRMS Triage card, unassigned, containing outcome, why, scope, non-goals, acceptance criteria, decisions, constraints, unresolved questions, source permalink/identity, intake ID, Hermes session lineage, and Slack DM/thread lineage; raw transcript is absent.
+8. Backend uniqueness—not an in-process lock or preflight lookup—proves two independent concurrent promotions return one card ID.
+9. Definite failure, unknown commit acknowledgment, stale action, repeated click, and gateway restart reconcile using the same promotion key and return the same card.
+10. Success renders `Open card`; open failure leaves promoted state unchanged and exposes a copyable card ID.
+11. Feature flag off prevents new intakes while existing records remain readable/reconcilable.
+12. No raw source text appears in Slack action metadata, durable lineage rows, or logs.
+13. All safety invariants in this assessment have focused automated tests, and the private live scenario plus required failure injections pass with a redacted trace.
+
+### Dependencies
+
+- Jerry’s explicit approval of this assessment and the four dogfood decisions.
+- Access to the existing shortcut worktree as implementation input; its uncommitted changes must be preserved and reviewed rather than overwritten.
+- A dogfood Slack app/workspace and authorized Jerry identity.
+- An explicitly safe HRMS Triage dogfood destination.
+- A reviewable additive storage migration and supported Kanban uniqueness mechanism.
+
+### Testing
+
+Automated:
+
+- Existing shortcut/manifest suite remains green (`46 passed` was the audit baseline).
+- Source capture/authorization/privacy unit tests.
+- Routing key equality regression against a real organic Slack DM-thread event.
+- Full production-seam integration from intake start through real gateway handler/session store to assistant delivery spy.
+- Cached-session second-turn and restart rehydration tests.
+- Crash/failure tests at each durable transition.
+- Two-connection/process promotion uniqueness test against the real persistence implementation.
+- Card synthesis/lineage and raw-transcript exclusion assertions.
+- Feature-flag and rollback behavior tests.
+
+Live:
+
+- Execute the primary and failure-injection dogfood scenarios above.
+- Preserve redacted state-transition evidence, exact commands/results, before/after card counts, one resulting card ID, and proof that its promotion key resolves uniquely.
+
+### Review/delivery gate
+
+Use an isolated worktree and normal PR/review lane. Implementation is not complete at code/test success: an independent reviewer must verify the exact head, migration/idempotency behavior, ordinary-prompt-path proof, and redacted live dogfood evidence. Jerry retains go/no-go and rollout authority.
+
+### Follow-up hardening after the slice passes
+
+- Add exact standalone `make the card` / `queue this` promotion through the same command and tests; keep all other language confirmation-only.
+- Canonical rich-message/files/blocks ingestion with explicit privacy and size policy.
+- Multiple authorized users/workspaces/profiles and routing isolation matrix.
+- Board/status selection and visibility-aware destination policy.
+- Explicit `start over` / multiple-intake version UX.
+- Session compression/rotation stress testing and retention/deletion policy.
+- Action update/deep-link polish, analytics, rate limits, abuse controls, and operational dashboards.
+- Broad rollout, migration strategy, and user documentation.
+
+## Unresolved decisions for Jerry
+
+1. Approve or change the private dogfood destination: **HRMS → Triage, unassigned** is recommended; the existing branch’s fixed `victorylive` destination should not survive by accident.
+2. Confirm text-only source is acceptable for the first live proof.
+3. Confirm button-only dogfood, with exact standalone language promotion deferred until the base proof passes.
+4. Confirm deliberate re-invocation creates a distinct intake while callback redelivery resumes the original.
+5. Confirm whether the thread seed may be minimal system copy (`Starting a private Hermes intake…`) before model output, provided it contains no fabricated assistant analysis and the first substantive response remains normal Hermes output.
+6. Confirm retention/deletion expectations for private intake lineage and abandoned drafts before broad rollout; dogfood may retain them under existing Hermes local data controls.
+
+None of these should be silently selected by an implementation worker. Approval of this document should explicitly answer or accept the recommended defaults.
+
+## Risk register
+
+| Risk | Impact | Mitigation / gate |
+|---|---|---|
+| Generic handoff source mismatch | Next Slack reply opens a different session | Dedicated organic-equivalent DM source builder; key-equality regression test |
+| Process-local intake custody | Restart loses source/thread/card reconciliation | Additive durable intake state before dispatch |
+| Slack seed/local-write split brain | Duplicate or orphan thread | Reserve first; explicit reconciling state; stable Slack request evidence |
+| Async prompt acceptance ambiguity | Duplicate first turn or false success | Gateway receipt + stable event ID + durable accepted/completed markers |
+| Kanban preflight race | Duplicate cards under concurrent promotion | Transactional unique promotion mapping proven with independent connections |
+| Casual language misclassified | Unauthorized mutation | Button-only dogfood; later exact standalone allowlist; ambiguous confirmation |
+| Cross-workspace/profile fallback | Privacy breach or wrong session | Scope every identity/client/cache/key; fail closed on unavailable route |
+| Raw source copied into metadata/logs | Private-content leak | Opaque action IDs, identifiers-only lineage/logging, explicit leak tests |
+| Physical session ID becomes stale | Promotion/card loses conversation lineage | Logical intake/session key anchor + compression-tip resolution |
+| Existing worktree has uncommitted code | Accidental overwrite or misleading provenance | Implement in isolated follow-up worktree/branch after reviewing and preserving the existing diff |
+| Dogfood quietly expands to rich/multi-board | Safety surface grows before core proof | Enforce non-goals and require a new reviewed scope decision |
+| Rollback deletes authoritative lineage | Repromotion or broken card traceability | Feature flag stops new writes; retain records and committed cards |
+
+## Evidence used
+
+- Product recommendation from `t_11db995e`: `slack-conversational-intake-recommendation.md`.
+- Repository/seam audit from `t_7cfbdd42`: `slack-intake-seam-audit.md`.
+- Existing implementation worktree: `/Users/jj/.hermes/hermes-agent/.worktrees/t_3e6da870`.
+- Audit baseline: `uv run --with pytest --with pytest-asyncio pytest -q tests/gateway/test_slack_message_shortcut.py tests/hermes_cli/test_slack_cli.py` → **46 passed in 17.88s**.
+
+The earlier referenced `victorylive/assessments/12-slack-to-hermes-message-shortcut.md` and root card `t_3317bf28` were not available in the inspected worktree/visible board evidence. This assessment therefore does not claim to preserve decisions that exist only there. If recovered before approval, compare it for contradictory product constraints; do not delay review merely for duplicated implementation history.
+
+## Approval status
+
+**Blocked on Jerry’s review. No implementation card has been created or dispatched, and no production code was changed by this assessment task.**

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1964,6 +1964,7 @@ DEFAULT_CONFIG = {
     # Slack platform settings (gateway mode)
     "slack": {
         "require_mention": True,       # Require @mention to respond in channels
+        "conversational_intake_enabled": False,  # Private shortcut → DM-thread intake
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         # Channel IDs where @mention is ALWAYS required, even when

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3150,15 +3150,13 @@ def create_task(
             )
         skills_list = cleaned
 
-    # Idempotency check — return the existing task instead of creating a
-    # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
+    # Idempotency fast path. This lookup avoids taking a write lock for the
+    # common replay case. The authoritative lookup is repeated inside the
+    # BEGIN IMMEDIATE transaction below so independent connections cannot both
+    # pass preflight and insert the same logical task.
     if idempotency_key:
         row = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ? "
-            "AND status != 'archived' "
             "ORDER BY created_at DESC LIMIT 1",
             (idempotency_key,),
         ).fetchone()
@@ -3195,6 +3193,14 @@ def create_task(
             # compose create_task calls under one outer commit so the
             # dispatcher can never observe a partially constructed graph.
             with write_txn(conn, allow_nested=True):
+                if idempotency_key:
+                    row = conn.execute(
+                        "SELECT id FROM tasks WHERE idempotency_key = ? "
+                        "ORDER BY created_at DESC LIMIT 1",
+                        (idempotency_key,),
+                    ).fetchone()
+                    if row:
+                        return row["id"]
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -73,6 +73,14 @@ def _build_full_manifest(
             "display_name": bot_name[:80],
             "always_online": True,
         },
+        "shortcuts": [
+            {
+                "name": "Send to Hermes",
+                "callback_id": "hermes_send_message",
+                "description": "Refine this message privately with Hermes",
+                "type": "message",
+            }
+        ],
         "slash_commands": slashes,
     }
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -17,8 +17,10 @@ import os
 import re
 import time
 import unicodedata
+import uuid
 from dataclasses import dataclass, field
 from typing import Callable, ClassVar, Dict, Optional, Any, Tuple, List
+from urllib.parse import urlsplit
 
 import aiohttp
 
@@ -61,8 +63,26 @@ from gateway.platforms.base import (
 
 try:  # sibling module; support both package and flat plugin-dir import
     from .block_kit import render_blocks, sanitize_blocks
+    from .hermes_intake import (
+        HermesIntakeClient,
+        HermesIntakeError,
+        SlackIntakeStore,
+        build_intake_prompt,
+        build_intake_source,
+        build_promotion_payload,
+        parse_resolved_brief,
+    )
 except ImportError:  # pragma: no cover - plugin loaded outside package context
     from block_kit import render_blocks, sanitize_blocks  # type: ignore
+    from hermes_intake import (  # type: ignore
+        HermesIntakeClient,
+        HermesIntakeError,
+        SlackIntakeStore,
+        build_intake_prompt,
+        build_intake_source,
+        build_promotion_payload,
+        parse_resolved_brief,
+    )
 
 
 logger = logging.getLogger(__name__)
@@ -944,6 +964,10 @@ class SlackAdapter(BasePlatformAdapter):
         # user target (team_id:user_id) → opened DM conversation ID (D...)
         self._dm_conversation_cache: Dict[str, str] = {}
         self._DM_CONVERSATION_CACHE_MAX = 5000
+        # Message shortcut source payloads stay server-side. Slack modal
+        # private_metadata carries only the opaque nonce, never message text.
+        self._hermes_intake_client: Optional[HermesIntakeClient] = None
+        self._slack_intake_store = SlackIntakeStore()
         # Dedup cache: prevents duplicate bot responses when Socket Mode
         # reconnects redeliver events (#4777). The TTL must outlast Slack's
         # worst-case reconnect-redelivery gap, not just a few seconds — the
@@ -2082,6 +2106,11 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 await self._handle_slash_command(command)
 
+            self._register_send_to_hermes_handlers()
+            self._app.action("hermes_intake_create_card")(
+                self._handle_slack_intake_create_card
+            )
+
             # Register Block Kit action handlers for approval buttons
             for _action_id in (
                 "hermes_approve_once",
@@ -2354,7 +2383,413 @@ class SlackAdapter(BasePlatformAdapter):
         team_id = self._channel_team.get(chat_id)
         if team_id and team_id in self._team_clients:
             return self._team_clients[team_id]
-        return self._app.client  # fallback to primary
+        return self._app.client
+
+    def _send_to_hermes_client(self) -> Optional[HermesIntakeClient]:
+        if self._hermes_intake_client is not None:
+            return self._hermes_intake_client
+        base_url = str(
+            self.config.extra.get("hermes_intake_url")
+            or ""
+        ).strip()
+        parsed_url = urlsplit(base_url)
+        if parsed_url.scheme != "http" or parsed_url.hostname not in {
+            "127.0.0.1",
+            "::1",
+            "localhost",
+        }:
+            return None
+        try:
+            token = get_secret("HERMES_DASHBOARD_SESSION_TOKEN") or ""
+        except UnscopedSecretError:
+            token = ""
+        if not base_url or not token:
+            return None
+        self._hermes_intake_client = HermesIntakeClient(
+            base_url=base_url,
+            session_token=token,
+        )
+        return self._hermes_intake_client
+
+    def _register_send_to_hermes_handlers(self) -> None:
+        """Wire Slack's message shortcut and modal submission callbacks."""
+        # Test/minimal AsyncApp substitutes used by embedders may implement
+        # only event/command/action. Real slack_bolt AsyncApp exposes both.
+        if callable(getattr(self._app, "shortcut", None)):
+            @self._app.shortcut("hermes_send_message")
+            async def handle_send_to_hermes_shortcut(ack, body, client):
+                await self._handle_send_to_hermes_shortcut(ack, body, client)
+
+
+    @staticmethod
+    def _send_to_hermes_status_view(text: str) -> Dict[str, Any]:
+        return {
+            "type": "modal",
+            "title": {"type": "plain_text", "text": "Send to Hermes"},
+            "close": {"type": "plain_text", "text": "Close"},
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": text},
+                }
+            ],
+        }
+
+    async def _handle_send_to_hermes_shortcut(
+        self, ack: Any, body: Dict[str, Any], client: Any
+    ) -> None:
+        # Ack before authorization or API work so Slack does not retry while
+        # still keeping selected-message disclosure behind authorization.
+        await ack()
+        user = body.get("user") or {}
+        channel = body.get("channel") or {}
+        message = body.get("message") or {}
+        user_id = str(user.get("id") or "")
+        channel_id = str(channel.get("id") or "")
+        if self._is_sender_authorized(
+            user_id, chat_type="channel", chat_id=channel_id
+        ) is not True:
+            await client.views_open(
+                trigger_id=body.get("trigger_id"),
+                view=self._send_to_hermes_status_view(
+                    "You are not authorized to send messages to Hermes."
+                ),
+            )
+            return
+
+        if not bool(self.config.extra.get("conversational_intake_enabled", False)):
+            await client.views_open(
+                trigger_id=body.get("trigger_id"),
+                view=self._send_to_hermes_status_view(
+                    "Slack conversational intake is not enabled."
+                ),
+            )
+            return
+
+        team_id = str((body.get("team") or {}).get("id") or "")
+        message_ts = str(message.get("ts") or "")
+        permalink = ""
+        try:
+            result = await client.chat_getPermalink(
+                channel=channel_id, message_ts=message_ts
+            )
+            permalink = str(result.get("permalink") or "")
+        except Exception:
+            # The signed shortcut payload is still authorized source material;
+            # private-channel membership can independently deny permalink lookup.
+            pass
+
+        author_id = str(message.get("user") or "unknown")
+        author_name = await self._resolve_user_name(
+            author_id, chat_id=channel_id, team_id=team_id
+        )
+        source = {
+            "team_id": team_id,
+            "channel_id": channel_id,
+            "channel_name": str(channel.get("name") or ""),
+            "message_ts": message_ts,
+            "message_text": str(message.get("text") or ""),
+            "author_id": author_id,
+            "author_name": author_name,
+            "submitter_id": user_id,
+            "submitter_name": str(user.get("name") or user_id),
+            "permalink": permalink,
+        }
+        await self._start_slack_conversational_intake(
+            invocation_key=str(body.get("trigger_id") or ""),
+            source=source,
+            client=client,
+        )
+        return
+
+    async def _start_slack_conversational_intake(
+        self, *, invocation_key: str, source: Dict[str, str], client: Any
+    ) -> None:
+        """Reserve/reconcile a DM thread and submit one ordinary human turn."""
+        intake = self._slack_intake_store.reserve(invocation_key, "", source)
+        if intake.state == "active":
+            return
+
+        if not intake.dm_channel_id or not intake.thread_ts:
+            seed_owner = self._slack_intake_store.claim_stage(
+                intake.intake_id,
+                from_states=("reserved",),
+                claimed_state="seeding",
+            )
+            if not seed_owner:
+                return
+            try:
+                opened = await client.conversations_open(users=source["submitter_id"])
+                dm_channel_id = str(((opened or {}).get("channel") or {}).get("id") or "")
+                if not dm_channel_id:
+                    raise HermesIntakeError("Hermes could not open the private intake DM.")
+                seed = await client.chat_postMessage(
+                    channel=dm_channel_id,
+                    text="Starting a private Hermes intake… No card exists yet.",
+                    client_msg_id=intake.first_event_id,
+                )
+                thread_ts = str((seed or {}).get("ts") or "")
+                if not thread_ts:
+                    raise HermesIntakeError("Hermes could not start the private intake thread.")
+                intake = self._slack_intake_store.bind_thread(
+                    intake.intake_id, dm_channel_id, thread_ts,
+                    owner_token=seed_owner,
+                )
+                if intake.state != "thread_bound":
+                    return
+            except Exception:
+                self._slack_intake_store.complete_stage(
+                    intake.intake_id, owner_token=seed_owner, state="reserved"
+                )
+                raise
+
+        event_source = build_intake_source(
+            profile=intake.profile,
+            team_id=intake.team_id,
+            dm_channel_id=str(intake.dm_channel_id),
+            thread_ts=str(intake.thread_ts),
+            user_id=intake.submitter_id,
+            user_name=str(source.get("submitter_name") or intake.submitter_id),
+        )
+        profile = intake.profile or self._slack_intake_profile(event_source)
+        intake = self._slack_intake_store.bind_profile(intake.intake_id, profile)
+        event_source.profile = intake.profile
+
+        if not intake.session_key:
+            from gateway.session import build_session_key
+
+            session_key = build_session_key(
+                event_source,
+                group_sessions_per_user=self.config.extra.get(
+                    "group_sessions_per_user", True
+                ),
+                thread_sessions_per_user=self.config.extra.get(
+                    "thread_sessions_per_user", False
+                ),
+            )
+            session_id = "pending-normal-gateway-bind"
+            session_store = getattr(self, "_session_store", None)
+            if session_store is not None:
+                entry = session_store.get_or_create_session(event_source)
+                session_key, session_id = entry.session_key, entry.session_id
+            intake = self._slack_intake_store.bind_session(
+                intake.intake_id, session_key, session_id
+            )
+
+        dispatch_owner = self._slack_intake_store.claim_stage(
+            intake.intake_id,
+            from_states=("session_bound", "failed_retryable"),
+            claimed_state="dispatching",
+        )
+        if not dispatch_owner:
+            return
+
+        event = MessageEvent(
+            text=build_intake_prompt(source, intake_id=intake.intake_id),
+            message_type=MessageType.TEXT,
+            source=event_source,
+            raw_message={"intake_id": intake.intake_id},
+            message_id=intake.first_event_id,
+            user_id=intake.submitter_id,
+            user_name=str(source.get("submitter_name") or intake.submitter_id),
+            internal=False,
+            metadata={
+                "slack_team_id": intake.team_id,
+                "slack_channel_id": intake.dm_channel_id,
+                "slack_thread_ts": intake.thread_ts,
+                "slack_intake_id": intake.intake_id,
+                "slack_intake_owner": dispatch_owner,
+            },
+        )
+        await self.handle_message(event)
+        task = self._session_tasks.get(str(intake.session_key))
+        if task is not None:
+            await asyncio.shield(task)
+        intake = self._slack_intake_store.get(intake.intake_id)
+        if intake.state != "active":
+            return
+        await client.chat_postMessage(
+            channel=intake.dm_channel_id,
+            thread_ts=intake.thread_ts,
+            text="No card exists yet. Keep refining, then use Create card.",
+            blocks=[
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*No card exists yet.* Keep refining with Hermes, then promote explicitly.",
+                    },
+                },
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "action_id": "hermes_intake_create_card",
+                            "text": {"type": "plain_text", "text": "Create card"},
+                            "style": "primary",
+                            "value": intake.intake_id,
+                        }
+                    ],
+                },
+            ],
+        )
+
+    def _slack_intake_profile(self, source: Any = None) -> str:
+        """Use the gateway process profile, matching organic Slack messages."""
+        resolver = getattr(getattr(self, "gateway_runner", None), "_profile_name_for_source", None)
+        if source is not None and callable(resolver):
+            routed = resolver(source)
+            if routed:
+                return str(routed)
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name() or "default"
+
+    async def _handle_slack_intake_create_card(
+        self, ack: Any, body: Dict[str, Any], client: Any
+    ) -> None:
+        """Promote one authorized intake and reconcile retries to its card."""
+        await ack()
+        actions = body.get("actions") or []
+        intake_id = str((actions[0] if actions else {}).get("value") or "")
+        try:
+            intake = self._slack_intake_store.get(intake_id)
+        except KeyError:
+            return
+        user_id = str((body.get("user") or {}).get("id") or "")
+        channel_id = str((body.get("channel") or {}).get("id") or "")
+        team_id = str((body.get("team") or {}).get("id") or "")
+        action_message = body.get("message") or {}
+        action_thread_ts = str(
+            action_message.get("thread_ts") or action_message.get("ts") or ""
+        )
+        if (
+            user_id != intake.submitter_id
+            or team_id != intake.team_id
+            or channel_id != intake.dm_channel_id
+            or action_thread_ts != intake.thread_ts
+            or self._is_sender_authorized(
+                user_id, chat_type="dm", chat_id=channel_id
+            ) is not True
+        ):
+            return
+
+        if intake.card_id is None:
+            await client.chat_update(
+                channel=channel_id,
+                ts=(body.get("message") or {}).get("ts"),
+                text="Creating card…",
+                blocks=[
+                    {
+                        "type": "actions",
+                        "elements": [
+                            {
+                                "type": "button",
+                                "action_id": "hermes_intake_create_card",
+                                "text": {"type": "plain_text", "text": "Creating card…"},
+                                "value": intake.intake_id,
+                            }
+                        ],
+                    }
+                ],
+            )
+            self._slack_intake_store.set_state(intake_id, "creating")
+            source = self._slack_intake_store.source(intake_id)
+            session_store = getattr(self, "_session_store", None)
+            if session_store is None or not intake.session_id:
+                self._slack_intake_store.set_state(intake_id, "active")
+                return
+            try:
+                brief = parse_resolved_brief(
+                    session_store.load_transcript(str(intake.session_id))
+                )
+            except (TypeError, ValueError):
+                self._slack_intake_store.set_state(intake_id, "clarifying")
+                await client.chat_update(
+                    channel=channel_id,
+                    ts=(body.get("message") or {}).get("ts"),
+                    text="Keep refining before creating the card.",
+                    blocks=[
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": "The current brief is incomplete. Keep refining with Hermes; no card was created.",
+                            },
+                        },
+                        {
+                            "type": "actions",
+                            "elements": [
+                                {
+                                    "type": "button",
+                                    "action_id": "hermes_intake_create_card",
+                                    "text": {"type": "plain_text", "text": "Create card"},
+                                    "value": intake.intake_id,
+                                }
+                            ],
+                        },
+                    ],
+                )
+                return
+            payload = build_promotion_payload(
+                intake_id=intake_id,
+                promotion_key=intake.promotion_key,
+                source=source,
+                session_key=str(intake.session_key),
+                session_id=str(intake.session_id),
+                dm_channel_id=str(intake.dm_channel_id),
+                thread_ts=str(intake.thread_ts),
+                brief=brief,
+            )
+            creator = self._send_to_hermes_client()
+            if creator is None:
+                raise HermesIntakeError(
+                    "The Hermes intake integration is not configured."
+                )
+            try:
+                task = await creator.create_task(payload)
+            except Exception:
+                self._slack_intake_store.set_state(intake_id, "failed_retryable")
+                await client.chat_update(
+                    channel=channel_id,
+                    ts=(body.get("message") or {}).get("ts"),
+                    text="Card creation outcome is unknown. Check and retry safely.",
+                    blocks=[
+                        {
+                            "type": "actions",
+                            "elements": [
+                                {
+                                    "type": "button",
+                                    "action_id": "hermes_intake_create_card",
+                                    "text": {"type": "plain_text", "text": "Retry creation"},
+                                    "value": intake.intake_id,
+                                }
+                            ],
+                        }
+                    ],
+                )
+                return
+            intake = self._slack_intake_store.bind_card(
+                intake_id, "hrms", str(task["id"])
+            )
+
+        message = body.get("message") or {}
+        await client.chat_update(
+            channel=channel_id,
+            ts=message.get("ts"),
+            text=f"Already created as {intake.card_id}.",
+            blocks=[
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"Created HRMS Triage card `{intake.card_id}`.",
+                    },
+                }
+            ],
+        )
+
 
     async def _ensure_dm_conversation(
         self, chat_id: str, team_id: Optional[str] = None
@@ -3771,6 +4206,17 @@ class SlackAdapter(BasePlatformAdapter):
         self, event: MessageEvent, outcome: ProcessingOutcome
     ) -> None:
         """Swap the in-progress reaction for a final success/failure reaction."""
+        intake_id = str((event.metadata or {}).get("slack_intake_id") or "")
+        if intake_id:
+            self._slack_intake_store.complete_stage(
+                intake_id,
+                owner_token=str((event.metadata or {}).get("slack_intake_owner") or ""),
+                state=(
+                    "active"
+                    if outcome == ProcessingOutcome.SUCCESS
+                    else "failed_retryable"
+                ),
+            )
         if not self._reactions_enabled():
             return
         ts = getattr(event, "message_id", None)

--- a/plugins/platforms/slack/hermes_intake.py
+++ b/plugins/platforms/slack/hermes_intake.py
@@ -1,0 +1,655 @@
+"""Slack message → Hermes Kanban intake mapping and HTTP client."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sqlite3
+import time
+import uuid
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+import aiohttp
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+from hermes_constants import get_hermes_home
+
+BOARD = "hrms"
+MAX_CONTEXT_LENGTH = 2_000
+MAX_TITLE_LENGTH = 80
+
+Transport = Callable[
+    [str, dict[str, str], dict[str, Any]],
+    Awaitable[dict[str, Any]],
+]
+
+
+@dataclass(frozen=True)
+class SlackIntakeRecord:
+    intake_id: str
+    revision: int
+    state: str
+    profile: str
+    team_id: str
+    source_channel_id: str
+    source_message_ts: str
+    source_permalink: str
+    submitter_id: str
+    invocation_key: str
+    dm_channel_id: str | None
+    thread_ts: str | None
+    session_key: str | None
+    session_id: str | None
+    first_event_id: str
+    promotion_key: str
+    card_board: str | None
+    card_id: str | None
+
+
+class SlackIntakeStore:
+    """Restart-safe Slack intake lineage with transactional state changes."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path or (get_hermes_home() / "slack_intakes.db"))
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.path), timeout=30)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=30000")
+        for artifact in (self.path, self.path.with_name(self.path.name + "-wal"),
+                         self.path.with_name(self.path.name + "-shm")):
+            if artifact.exists():
+                os.chmod(artifact, 0o600)
+        return conn
+
+    def _init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS slack_intakes (
+                    intake_id TEXT PRIMARY KEY,
+                    schema_version INTEGER NOT NULL DEFAULT 1,
+                    revision INTEGER NOT NULL DEFAULT 0,
+                    state TEXT NOT NULL,
+                    claim_owner TEXT,
+                    claim_pid INTEGER,
+                    profile TEXT NOT NULL,
+                    team_id TEXT NOT NULL,
+                    source_channel_id TEXT NOT NULL,
+                    source_message_ts TEXT NOT NULL,
+                    source_permalink TEXT NOT NULL DEFAULT '',
+                    submitter_id TEXT NOT NULL,
+                    invocation_key TEXT NOT NULL UNIQUE,
+                    dm_channel_id TEXT,
+                    thread_ts TEXT,
+                    session_key TEXT,
+                    session_id TEXT,
+                    first_event_id TEXT NOT NULL UNIQUE,
+                    promotion_key TEXT NOT NULL UNIQUE,
+                    card_board TEXT,
+                    card_id TEXT UNIQUE,
+                    created_at INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL,
+                    promoted_at INTEGER
+                );
+                CREATE TABLE IF NOT EXISTS slack_intake_sources (
+                    intake_id TEXT PRIMARY KEY REFERENCES slack_intakes(intake_id),
+                    source_json TEXT NOT NULL
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_slack_intake_thread
+                    ON slack_intakes(team_id, dm_channel_id, thread_ts)
+                    WHERE dm_channel_id IS NOT NULL AND thread_ts IS NOT NULL;
+                """
+            )
+            columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(slack_intakes)")
+            }
+            if "claim_owner" not in columns:
+                conn.execute("ALTER TABLE slack_intakes ADD COLUMN claim_owner TEXT")
+            if "claim_pid" not in columns:
+                conn.execute("ALTER TABLE slack_intakes ADD COLUMN claim_pid INTEGER")
+        os.chmod(self.path, 0o600)
+
+    @staticmethod
+    def _record(row: sqlite3.Row) -> SlackIntakeRecord:
+        fields = SlackIntakeRecord.__dataclass_fields__
+        return SlackIntakeRecord(**{name: row[name] for name in fields})
+
+    def reserve(
+        self, invocation_key: str, profile: str, source: Mapping[str, Any]
+    ) -> SlackIntakeRecord:
+        now = int(time.time())
+        intake_id = f"i_{uuid.uuid4().hex}"
+        first_event_id = f"slack-intake:{intake_id}:first-turn"
+        promotion_key = f"slack-intake:{profile}:{source['team_id']}:{intake_id}"
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            existing = conn.execute(
+                "SELECT * FROM slack_intakes WHERE invocation_key = ?",
+                (invocation_key,),
+            ).fetchone()
+            if existing is not None:
+                conn.commit()
+                return self._record(existing)
+            conn.execute(
+                """
+                INSERT INTO slack_intakes (
+                    intake_id, state, profile, team_id, source_channel_id,
+                    source_message_ts, source_permalink, submitter_id,
+                    invocation_key, first_event_id, promotion_key,
+                    created_at, updated_at
+                ) VALUES (?, 'reserved', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    intake_id, profile, str(source["team_id"]),
+                    str(source["channel_id"]), str(source["message_ts"]),
+                    str(source.get("permalink") or ""),
+                    str(source["submitter_id"]), invocation_key,
+                    first_event_id, promotion_key, now, now,
+                ),
+            )
+            conn.execute(
+                "INSERT INTO slack_intake_sources (intake_id, source_json) VALUES (?, ?)",
+                (intake_id, json.dumps(dict(source), sort_keys=True)),
+            )
+            row = conn.execute(
+                "SELECT * FROM slack_intakes WHERE intake_id = ?", (intake_id,)
+            ).fetchone()
+            conn.commit()
+        return self._record(row)
+
+    def get(self, intake_id: str) -> SlackIntakeRecord:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM slack_intakes WHERE intake_id = ?", (intake_id,)
+            ).fetchone()
+        if row is None:
+            raise KeyError(intake_id)
+        return self._record(row)
+
+    def source(self, intake_id: str) -> dict[str, Any]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT source_json FROM slack_intake_sources WHERE intake_id = ?",
+                (intake_id,),
+            ).fetchone()
+        if row is None:
+            raise KeyError(intake_id)
+        return json.loads(row["source_json"])
+
+    def _bind(
+        self, intake_id: str, assignments: Mapping[str, Any], state: str
+    ) -> SlackIntakeRecord:
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            current = conn.execute(
+                "SELECT * FROM slack_intakes WHERE intake_id = ?", (intake_id,)
+            ).fetchone()
+            if current is None:
+                raise KeyError(intake_id)
+            columns = "".join(f"{name} = ?, " for name in assignments)
+            conn.execute(
+                f"UPDATE slack_intakes SET {columns}state = ?, "
+                "revision = revision + 1, updated_at = ? WHERE intake_id = ?",
+                (*assignments.values(), state, int(time.time()), intake_id),
+            )
+            row = conn.execute(
+                "SELECT * FROM slack_intakes WHERE intake_id = ?", (intake_id,)
+            ).fetchone()
+            conn.commit()
+        return self._record(row)
+
+    def bind_thread(
+        self, intake_id: str, dm_channel_id: str, thread_ts: str,
+        *, owner_token: str | None = None,
+    ) -> SlackIntakeRecord:
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            current = conn.execute(
+                "SELECT * FROM slack_intakes WHERE intake_id = ?", (intake_id,)
+            ).fetchone()
+            if current is None:
+                raise KeyError(intake_id)
+            if not current["dm_channel_id"] or not current["thread_ts"]:
+                owner_clause = " AND claim_owner = ?" if owner_token else ""
+                conn.execute(
+                    "UPDATE slack_intakes SET dm_channel_id = ?, thread_ts = ?, "
+                    "state = 'thread_bound', claim_owner = NULL, claim_pid = NULL, "
+                    "revision = revision + 1, updated_at = ? "
+                    "WHERE intake_id = ? AND dm_channel_id IS NULL AND thread_ts IS NULL"
+                    + owner_clause,
+                    (
+                        dm_channel_id, thread_ts, int(time.time()), intake_id,
+                        *((owner_token,) if owner_token else ()),
+                    ),
+                )
+            row = conn.execute(
+                "SELECT * FROM slack_intakes WHERE intake_id = ?", (intake_id,)
+            ).fetchone()
+            conn.commit()
+        return self._record(row)
+
+    def bind_session(
+        self, intake_id: str, session_key: str, session_id: str
+    ) -> SlackIntakeRecord:
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            current = conn.execute(
+                "SELECT * FROM slack_intakes WHERE intake_id = ?", (intake_id,)
+            ).fetchone()
+            if current is None:
+                raise KeyError(intake_id)
+            if not current["session_key"] or not current["session_id"]:
+                conn.execute(
+                    "UPDATE slack_intakes SET session_key = ?, session_id = ?, "
+                    "state = 'session_bound', revision = revision + 1, updated_at = ? "
+                    "WHERE intake_id = ? AND session_key IS NULL AND session_id IS NULL",
+                    (session_key, session_id, int(time.time()), intake_id),
+                )
+            row = conn.execute(
+                "SELECT * FROM slack_intakes WHERE intake_id = ?", (intake_id,)
+            ).fetchone()
+            conn.commit()
+        return self._record(row)
+
+    def set_state(self, intake_id: str, state: str) -> SlackIntakeRecord:
+        """Advance lifecycle state without weakening the lineage invariants."""
+        return self._bind(intake_id, {}, state)
+
+    def claim_stage(
+        self,
+        intake_id: str,
+        *,
+        from_states: tuple[str, ...],
+        claimed_state: str,
+        stale_after: int = 60,
+    ) -> str | None:
+        """Durably claim one side-effecting stage, with crash-lease recovery."""
+        now = int(time.time())
+        owner_token = uuid.uuid4().hex
+        placeholders = ",".join("?" for _ in from_states)
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            current = conn.execute(
+                "SELECT state, updated_at, claim_pid FROM slack_intakes WHERE intake_id = ?",
+                (intake_id,),
+            ).fetchone()
+            if current is None:
+                raise KeyError(intake_id)
+            stale_owner_dead = (
+                current["state"] == claimed_state
+                and int(current["updated_at"]) <= now - stale_after
+                and not self._pid_is_alive(current["claim_pid"])
+            )
+            allowed = current["state"] in from_states or stale_owner_dead
+            if not allowed:
+                conn.commit()
+                return None
+            cur = conn.execute(
+                f"UPDATE slack_intakes SET state = ?, claim_owner = ?, claim_pid = ?, "
+                "revision = revision + 1, "
+                f"updated_at = ? WHERE intake_id = ? AND (state IN ({placeholders}) "
+                "OR (state = ? AND updated_at <= ? AND claim_pid = ?))",
+                (
+                    claimed_state, owner_token, os.getpid(), now, intake_id, *from_states,
+                    claimed_state, now - stale_after, current["claim_pid"],
+                ),
+            )
+            conn.commit()
+        return owner_token if cur.rowcount == 1 else None
+
+    def complete_stage(
+        self, intake_id: str, *, owner_token: str, state: str
+    ) -> bool:
+        """Complete a claimed stage only while this worker still owns its lease."""
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            cur = conn.execute(
+                "UPDATE slack_intakes SET state = ?, claim_owner = NULL, claim_pid = NULL, "
+                "revision = revision + 1, updated_at = ? "
+                "WHERE intake_id = ? AND claim_owner = ?",
+                (state, int(time.time()), intake_id, owner_token),
+            )
+            conn.commit()
+        return cur.rowcount == 1
+
+    @staticmethod
+    def _pid_is_alive(pid: Any) -> bool:
+        try:
+            value = int(pid)
+            if value <= 0:
+                return False
+            os.kill(value, 0)
+            return True
+        except (TypeError, ValueError, ProcessLookupError):
+            return False
+        except PermissionError:
+            return True
+
+    def bind_profile(self, intake_id: str, profile: str) -> SlackIntakeRecord:
+        """Persist the profile selected by the gateway's normal route resolver."""
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                "UPDATE slack_intakes SET profile = ?, "
+                "promotion_key = 'slack-intake:' || ? || ':' || team_id || ':' || intake_id, "
+                "revision = revision + 1, "
+                "updated_at = ? WHERE intake_id = ? AND profile = ''",
+                (profile, profile, int(time.time()), intake_id),
+            )
+            row = conn.execute(
+                "SELECT * FROM slack_intakes WHERE intake_id = ?", (intake_id,)
+            ).fetchone()
+            conn.commit()
+        if row is None:
+            raise KeyError(intake_id)
+        return self._record(row)
+
+    def bind_card(self, intake_id: str, board: str, card_id: str) -> SlackIntakeRecord:
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            current = conn.execute(
+                "SELECT * FROM slack_intakes WHERE intake_id = ?", (intake_id,)
+            ).fetchone()
+            if current is None:
+                raise KeyError(intake_id)
+            if current["card_id"] is None:
+                now = int(time.time())
+                conn.execute(
+                    "UPDATE slack_intakes SET card_board = ?, card_id = ?, "
+                    "state = 'promoted', promoted_at = ?, updated_at = ?, "
+                    "revision = revision + 1 WHERE intake_id = ? AND card_id IS NULL",
+                    (board, card_id, now, now, intake_id),
+                )
+            row = conn.execute(
+                "SELECT * FROM slack_intakes WHERE intake_id = ?", (intake_id,)
+            ).fetchone()
+            conn.commit()
+        return self._record(row)
+
+    def lineage(self, intake_id: str) -> dict[str, Any]:
+        return asdict(self.get(intake_id))
+
+
+def build_intake_source(
+    *, profile: str, team_id: str, dm_channel_id: str, thread_ts: str,
+    user_id: str, user_name: str,
+) -> SessionSource:
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id=dm_channel_id,
+        chat_type="dm",
+        user_id=user_id,
+        user_name=user_name,
+        thread_id=thread_ts,
+        scope_id=team_id,
+        profile=profile,
+    )
+
+
+def build_intake_prompt(source: Mapping[str, Any], *, intake_id: str) -> str:
+    permalink = str(source.get("permalink") or "unavailable")
+    return (
+        "You are beginning a private conversational intake from an authorized "
+        "Slack message. Treat the following as an ordinary user-provided source, "
+        "help refine it into an execution-ready brief, ask at most one material "
+        "question, and do not create a Kanban card from text. End every response "
+        "with the current brief using these exact Markdown headings: ## Outcome, "
+        "## Why, ## Scope, ## Non-goals, ## Acceptance criteria, ## Decisions, "
+        "## Constraints, and ## Unresolved questions. No card exists yet; only "
+        "the persistent Create card button can promote this intake.\n\n"
+        f"Intake ID: {intake_id}\nSource: {permalink}\n\n"
+        f"Selected message:\n{source.get('message_text') or '(no text)'}"
+    )
+
+
+_BRIEF_HEADINGS = {
+    "Outcome": "outcome",
+    "Why": "why",
+    "Scope": "scope",
+    "Non-goals": "non_goals",
+    "Acceptance criteria": "acceptance_criteria",
+    "Decisions": "decisions",
+    "Constraints": "constraints",
+    "Unresolved questions": "unresolved_questions",
+}
+
+
+def parse_resolved_brief(messages: list[Mapping[str, Any]]) -> dict[str, Any]:
+    """Parse the latest assistant's explicit current-draft projection."""
+    content = next(
+        (
+            str(message.get("content") or "")
+            for message in reversed(messages)
+            if message.get("role") == "assistant" and message.get("content")
+        ),
+        "",
+    )
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in content.splitlines():
+        heading = line.removeprefix("## ").strip() if line.startswith("## ") else ""
+        if heading in _BRIEF_HEADINGS:
+            current = _BRIEF_HEADINGS[heading]
+            sections[current] = []
+        elif current is not None and line.strip():
+            sections[current].append(line.strip())
+    if not sections.get("outcome"):
+        raise ValueError("resolved intake brief is incomplete")
+    result: dict[str, Any] = {}
+    for key in _BRIEF_HEADINGS.values():
+        values = sections.get(key, [])
+        if key in {"outcome", "why"}:
+            result[key] = " ".join(value.lstrip("- ") for value in values)
+        else:
+            result[key] = [
+                value.lstrip("- ") for value in values
+                if value.lstrip("- ").lower() not in {"none", "not specified"}
+            ]
+    return result
+
+
+def _brief_section(title: str, value: Any) -> str:
+    if isinstance(value, (list, tuple)):
+        rendered = "\n".join(f"- {item}" for item in value) or "- None"
+    else:
+        rendered = str(value or "Not specified")
+    return f"## {title}\n\n{rendered}"
+
+
+def build_promotion_payload(
+    *, intake_id: str, promotion_key: str, source: Mapping[str, Any],
+    session_key: str, session_id: str, dm_channel_id: str, thread_ts: str,
+    brief: Mapping[str, Any], raw_transcript: str | None = None,
+) -> dict[str, Any]:
+    del raw_transcript
+    outcome = str(brief.get("outcome") or "").strip()
+    if not outcome:
+        raise ValueError("outcome is required before promotion")
+    sections = [
+        _brief_section("Outcome", outcome),
+        _brief_section("Why", brief.get("why")),
+        _brief_section("Scope", brief.get("scope")),
+        _brief_section("Non-goals", brief.get("non_goals")),
+        _brief_section("Acceptance criteria", brief.get("acceptance_criteria")),
+        _brief_section("Decisions", brief.get("decisions")),
+        _brief_section("Constraints", brief.get("constraints")),
+        _brief_section("Unresolved questions", brief.get("unresolved_questions")),
+        "## Lineage\n\n"
+        f"- Slack source: {source.get('permalink') or 'unavailable'} "
+        f"(`{source.get('team_id')}` / `{source.get('channel_id')}` / `{source.get('message_ts')}`)\n"
+        f"- Intake ID: `{intake_id}`\n"
+        f"- Hermes session: `{session_key}` / `{session_id}`\n"
+        f"- Slack DM thread: `{dm_channel_id}` / `{thread_ts}`\n"
+        f"- Promotion key: `{promotion_key}`",
+    ]
+    return {
+        "title": _bounded_title(outcome, str(source.get("author_name") or "")),
+        "body": "\n\n".join(sections),
+        "triage": True,
+        "idempotency_key": promotion_key,
+    }
+
+
+def _clean_label(value: Any, fallback: str) -> str:
+    text = " ".join(str(value or "").split())
+    return text or fallback
+
+
+def _bounded_title(message_text: str, author_name: str) -> str:
+    first_line = next(
+        (" ".join(line.split()) for line in str(message_text).splitlines() if line.strip()),
+        "",
+    )
+    title = first_line or f"Slack follow-up from {_clean_label(author_name, 'unknown author')}"
+    if len(title) <= MAX_TITLE_LENGTH:
+        return title
+    return title[: MAX_TITLE_LENGTH - 1].rstrip() + "…"
+
+
+def build_task_payload(source: Mapping[str, Any], context: str) -> dict[str, Any]:
+    """Build the bounded Kanban request for one authorized Slack message."""
+    team_id = str(source.get("team_id") or "").strip()
+    channel_id = str(source.get("channel_id") or "").strip()
+    message_ts = str(source.get("message_ts") or "").strip()
+    message_text = str(source.get("message_text") or "")
+    author_id = str(source.get("author_id") or "unknown")
+    submitter_id = str(source.get("submitter_id") or "unknown")
+    author_name = _clean_label(source.get("author_name"), author_id)
+    submitter_name = _clean_label(source.get("submitter_name"), submitter_id)
+    channel_name = _clean_label(source.get("channel_name"), "private channel")
+    permalink = str(source.get("permalink") or "").strip()
+    bounded_context = str(context or "")[:MAX_CONTEXT_LENGTH].strip()
+
+    if not team_id or not channel_id or not message_ts:
+        raise ValueError("Slack source identity is incomplete")
+
+    body = "\n".join(
+        [
+            "## Context from the submitter",
+            "",
+            bounded_context or "No additional context supplied.",
+            "",
+            "## Source Slack message",
+            "",
+            message_text or "(No text content supplied by Slack.)",
+            "",
+            "## Source metadata",
+            "",
+            f"- Author: {author_name} (`{author_id}`)",
+            f"- Submitted by: {submitter_name} (`{submitter_id}`)",
+            f"- Channel: {channel_name} (`{channel_id}`)",
+            f"- Message timestamp: `{message_ts}`",
+            f"- Permalink: {permalink or 'unavailable to the integration'}",
+            f"- Slack workspace: `{team_id}`",
+        ]
+    )
+    return {
+        "title": _bounded_title(message_text, author_name),
+        "body": body,
+        "triage": True,
+        "idempotency_key": f"slack-message:{team_id}:{channel_id}:{message_ts}",
+    }
+
+
+class HermesIntakeError(RuntimeError):
+    """A safe, user-displayable Hermes intake failure."""
+
+
+class HermesIntakeClient:
+    """Create HRMS Triage tasks with per-promotion serialization."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        session_token: str,
+        transport: Transport | None = None,
+    ) -> None:
+        self._base_url = str(base_url).rstrip("/")
+        self._session_token = str(session_token)
+        self._transport = transport or self._post
+        self._locks: dict[str, tuple[asyncio.Lock, int]] = {}
+        self._locks_guard = asyncio.Lock()
+
+    async def _source_lock(self, key: str) -> asyncio.Lock:
+        async with self._locks_guard:
+            lock, users = self._locks.get(key, (asyncio.Lock(), 0))
+            self._locks[key] = (lock, users + 1)
+            return lock
+
+    async def _release_source_lock(self, key: str, lock: asyncio.Lock) -> None:
+        async with self._locks_guard:
+            current, users = self._locks.get(key, (lock, 1))
+            if current is not lock:
+                return
+            if users <= 1:
+                self._locks.pop(key, None)
+            else:
+                self._locks[key] = (lock, users - 1)
+
+    async def create_task(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        key = str(payload.get("idempotency_key") or "")
+        if not key:
+            raise ValueError("idempotency_key is required")
+        lock = await self._source_lock(key)
+        try:
+            async with lock:
+                response = await self._transport(
+                    f"{self._base_url}/api/plugins/kanban/tasks?{urlencode({'board': BOARD})}",
+                    {"X-Hermes-Session-Token": self._session_token},
+                    dict(payload),
+                )
+        finally:
+            await self._release_source_lock(key, lock)
+
+        task = response.get("task") if isinstance(response, dict) else None
+        if not isinstance(task, dict) or not task.get("id"):
+            raise HermesIntakeError("Hermes returned an invalid task response.")
+        return task
+
+    async def _post(
+        self,
+        url: str,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        timeout = aiohttp.ClientTimeout(total=15)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(url, headers=headers, json=payload) as response:
+                    if response.status != 200:
+                        if response.status in {401, 403}:
+                            raise HermesIntakeError(
+                                "Hermes rejected the integration credentials."
+                            )
+                        if response.status == 404:
+                            raise HermesIntakeError(
+                                "The HRMS Kanban board is unavailable."
+                            )
+                        if response.status == 429 or response.status >= 500:
+                            raise HermesIntakeError(
+                                "Hermes is temporarily unavailable; please retry."
+                            )
+                        raise HermesIntakeError(
+                            "Hermes rejected this task; review the source and retry."
+                        )
+                    data = await response.json(content_type=None)
+        except HermesIntakeError:
+            raise
+        except (aiohttp.ClientError, asyncio.TimeoutError):
+            raise HermesIntakeError(
+                "Hermes is temporarily unavailable; please retry."
+            ) from None
+        except (TypeError, ValueError):
+            raise HermesIntakeError("Hermes returned an invalid task response.") from None
+        return data

--- a/tests/gateway/test_slack_conversational_intake.py
+++ b/tests/gateway/test_slack_conversational_intake.py
@@ -1,0 +1,631 @@
+"""Behavior contracts for private Slack conversational intake."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import asyncio
+import json
+import stat
+
+import pytest
+
+from gateway.config import Platform
+from gateway.config import PlatformConfig
+from gateway.session import build_session_key
+from plugins.platforms.slack.adapter import SlackAdapter
+from plugins.platforms.slack.hermes_intake import (
+    SlackIntakeStore,
+    build_intake_prompt,
+    build_intake_source,
+    build_promotion_payload,
+    parse_resolved_brief,
+)
+
+
+def _source(**overrides):
+    value = {
+        "team_id": "T123",
+        "channel_id": "C456",
+        "channel_name": "private-source",
+        "message_ts": "123.456",
+        "message_text": "Private source text",
+        "author_id": "UAUTHOR",
+        "author_name": "A. User",
+        "submitter_id": "UJERRY",
+        "submitter_name": "Jerry",
+        "permalink": "https://example.slack.com/archives/C456/p123456",
+    }
+    value.update(overrides)
+    return value
+
+
+async def _record_async(target, value):
+    target.append(value)
+
+
+def test_store_dedupes_callback_delivery_but_new_invocation_gets_new_intake(tmp_path):
+    store = SlackIntakeStore(tmp_path / "intakes.db")
+
+    first = store.reserve("delivery-1", "coding", _source())
+    retry = store.reserve("delivery-1", "coding", _source())
+    deliberate = store.reserve("delivery-2", "coding", _source())
+
+    assert retry.intake_id == first.intake_id
+    assert deliberate.intake_id != first.intake_id
+    assert store.get(first.intake_id).state == "reserved"
+
+
+def test_private_source_database_is_owner_only(tmp_path):
+    path = tmp_path / "intakes.db"
+
+    SlackIntakeStore(path)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    for suffix in ("-wal", "-shm"):
+        artifact = path.with_name(path.name + suffix)
+        if artifact.exists():
+            assert stat.S_IMODE(artifact.stat().st_mode) == 0o600
+
+
+def test_lineage_rows_do_not_duplicate_raw_source_text(tmp_path):
+    store = SlackIntakeStore(tmp_path / "intakes.db")
+    record = store.reserve("delivery-1", "coding", _source())
+    store.bind_thread(record.intake_id, "D123", "200.001")
+    store.bind_session(record.intake_id, "slack:T123:D123:200.001", "session-1")
+
+    lineage = store.lineage(record.intake_id)
+    assert "Private source text" not in json.dumps(lineage)
+    assert lineage["dm_channel_id"] == "D123"
+    assert lineage["thread_ts"] == "200.001"
+
+
+def test_synthetic_source_matches_organic_dm_thread_identity():
+    synthetic = build_intake_source(
+        profile="coding",
+        team_id="T123",
+        dm_channel_id="D123",
+        thread_ts="200.001",
+        user_id="UJERRY",
+        user_name="Jerry",
+    )
+
+    assert synthetic.platform is Platform.SLACK
+    assert synthetic.chat_type == "dm"
+    assert synthetic.scope_id == "T123"
+    assert synthetic.chat_id == "D123"
+    assert synthetic.thread_id == "200.001"
+    assert synthetic.profile == "coding"
+
+    adapter = _adapter_for_source_identity()
+    organic = adapter.build_source(
+        chat_id="D123",
+        chat_type="dm",
+        user_id="UJERRY",
+        user_name="Jerry",
+        thread_id="200.001",
+        scope_id="T123",
+    )
+    assert build_session_key(synthetic) == build_session_key(organic)
+
+
+def _adapter_for_source_identity():
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="fake"))
+
+    class Runner:
+        @staticmethod
+        def _profile_name_for_source(source):
+            return "coding"
+
+    adapter.gateway_runner = Runner()  # type: ignore[assignment]
+    return adapter
+
+
+def test_initial_prompt_is_human_originated_and_states_no_card_exists():
+    prompt = build_intake_prompt(_source(), intake_id="i_123")
+
+    assert "Private source text" in prompt
+    assert "No card exists yet" in prompt
+    assert "Create card" in prompt
+    assert "i_123" in prompt
+    assert "## Outcome" in prompt
+
+
+def test_resolved_brief_is_parsed_from_latest_assistant_draft():
+    brief = parse_resolved_brief(
+        [{"role": "user", "content": "raw private source"}, {
+            "role": "assistant",
+            "content": (
+                "## Outcome\nInvestigate checkout failures\n"
+                "## Why\nCustomers cannot pay\n"
+                "## Scope\n- Checkout API\n"
+                "## Non-goals\n- Checkout redesign\n"
+                "## Acceptance criteria\n- Root cause documented\n"
+                "## Decisions\n- Triage first\n"
+                "## Constraints\n- No customer data\n"
+                "## Unresolved questions\n- Which deploy?"
+            ),
+        }]
+    )
+
+    assert brief["outcome"] == "Investigate checkout failures"
+    assert brief["scope"] == ["Checkout API"]
+    assert brief["unresolved_questions"] == ["Which deploy?"]
+
+
+def test_promotion_payload_is_synthesized_lineage_not_raw_transcript():
+    payload = build_promotion_payload(
+        intake_id="i_123",
+        promotion_key="slack-intake:promotion-1",
+        source=_source(),
+        session_key="slack:T123:D123:200.001",
+        session_id="session-1",
+        dm_channel_id="D123",
+        thread_ts="200.001",
+        brief={
+            "outcome": "Investigate checkout failures",
+            "why": "Customers cannot pay",
+            "scope": ["Checkout API"],
+            "non_goals": ["Redesign checkout"],
+            "acceptance_criteria": ["Root cause is documented"],
+            "decisions": ["Triage first"],
+            "constraints": ["Do not expose customer data"],
+            "unresolved_questions": ["Which deploy introduced it?"],
+        },
+        raw_transcript="SECRET TRANSCRIPT MUST NOT LEAK",
+    )
+
+    assert payload["triage"] is True
+    assert "assignee" not in payload
+    assert payload["idempotency_key"] == "slack-intake:promotion-1"
+    assert "SECRET TRANSCRIPT MUST NOT LEAK" not in payload["body"]
+    for heading in (
+        "Outcome", "Why", "Scope", "Non-goals", "Acceptance criteria",
+        "Decisions", "Constraints", "Unresolved questions", "Lineage",
+    ):
+        assert heading in payload["body"]
+
+
+def test_concurrent_promotion_binding_converges_on_one_card(tmp_path):
+    path = tmp_path / "intakes.db"
+    initial = SlackIntakeStore(path)
+    intake = initial.reserve("delivery-1", "coding", _source())
+
+    def bind(card_id: str) -> str:
+        return SlackIntakeStore(path).bind_card(intake.intake_id, "hrms", card_id).card_id
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(bind, ["t_first", "t_second"]))
+
+    assert len(set(results)) == 1
+    assert initial.get(intake.intake_id).card_id == results[0]
+
+
+def test_concurrent_thread_binding_preserves_first_seed(tmp_path):
+    path = tmp_path / "intakes.db"
+    initial = SlackIntakeStore(path)
+    intake = initial.reserve("delivery-1", "coding", _source())
+
+    def bind(thread_ts: str) -> str | None:
+        return SlackIntakeStore(path).bind_thread(
+            intake.intake_id, "D123", thread_ts
+        ).thread_ts
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(bind, ["200.001", "200.002"]))
+
+    assert len(set(results)) == 1
+    assert initial.get(intake.intake_id).thread_ts == results[0]
+
+
+def test_concurrent_session_binding_preserves_first_session(tmp_path):
+    path = tmp_path / "intakes.db"
+    initial = SlackIntakeStore(path)
+    intake = initial.reserve("delivery-1", "coding", _source())
+
+    def bind(session_id: str) -> str | None:
+        return SlackIntakeStore(path).bind_session(
+            intake.intake_id, f"key:{session_id}", session_id
+        ).session_id
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(bind, ["session-1", "session-2"]))
+
+    assert len(set(results)) == 1
+    assert initial.get(intake.intake_id).session_id == results[0]
+
+
+def test_stale_stage_claim_is_recoverable_after_crash_lease(tmp_path):
+    store = SlackIntakeStore(tmp_path / "intakes.db")
+    intake = store.reserve("delivery-1", "coding", _source())
+    first_owner = store.claim_stage(
+        intake.intake_id, from_states=("reserved",), claimed_state="seeding"
+    )
+    assert first_owner
+    assert not store.claim_stage(
+        intake.intake_id, from_states=("reserved",), claimed_state="seeding"
+    )
+    with store._connect() as conn:
+        conn.execute(
+            "UPDATE slack_intakes SET updated_at = updated_at - 120, "
+            "claim_pid = 2147483647 WHERE intake_id = ?",
+            (intake.intake_id,),
+        )
+
+    second_owner = store.claim_stage(
+        intake.intake_id, from_states=("reserved",), claimed_state="seeding"
+    )
+    assert second_owner and second_owner != first_owner
+    assert not store.complete_stage(
+        intake.intake_id, owner_token=first_owner, state="thread_bound"
+    )
+    assert store.complete_stage(
+        intake.intake_id, owner_token=second_owner, state="thread_bound"
+    )
+
+
+def test_stale_stage_claim_does_not_overtake_live_owner(tmp_path):
+    store = SlackIntakeStore(tmp_path / "intakes.db")
+    intake = store.reserve("delivery-1", "coding", _source())
+    owner = store.claim_stage(
+        intake.intake_id, from_states=("reserved",), claimed_state="dispatching"
+    )
+    assert owner
+    with store._connect() as conn:
+        conn.execute(
+            "UPDATE slack_intakes SET updated_at = updated_at - 120 WHERE intake_id = ?",
+            (intake.intake_id,),
+        )
+
+    assert not store.claim_stage(
+        intake.intake_id, from_states=("reserved",), claimed_state="dispatching"
+    )
+
+
+def _adapter(tmp_path, *, enabled=True):
+    adapter = SlackAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="fake",
+            extra={"conversational_intake_enabled": enabled},
+        )
+    )
+    adapter._slack_intake_store = SlackIntakeStore(tmp_path / "intakes.db")
+    adapter.set_authorization_check(
+        lambda user_id, chat_type=None, chat_id=None: user_id == "UJERRY"
+    )
+    return adapter
+
+
+class _TranscriptStore:
+    @staticmethod
+    def load_transcript(session_id):
+        assert session_id == "session-1"
+        return [{
+            "role": "assistant",
+            "content": (
+                "## Outcome\nInvestigate checkout failures\n"
+                "## Why\nCustomers cannot pay\n"
+                "## Scope\n- Checkout API\n"
+                "## Non-goals\n- Checkout redesign\n"
+                "## Acceptance criteria\n- Root cause documented\n"
+                "## Decisions\n- Triage first\n"
+                "## Constraints\n- No customer data\n"
+                "## Unresolved questions\n- None"
+            ),
+        }]
+
+
+@pytest.mark.asyncio
+async def test_shortcut_starts_one_normal_dm_thread_turn_and_zero_cards(tmp_path):
+    adapter = _adapter(tmp_path)
+    seen = []
+    async def handle(event):
+        seen.append(event)
+        return "Hermes response"
+
+    adapter.set_message_handler(handle)
+
+    class Client:
+        async def chat_getPermalink(self, **kwargs):
+            return {"permalink": "https://example.slack.com/source"}
+
+        async def conversations_open(self, **kwargs):
+            return {"channel": {"id": "D123"}}
+
+        async def chat_postMessage(self, **kwargs):
+            return {"ts": "200.001"}
+
+    body = {
+        "trigger_id": "delivery-1",
+        "team": {"id": "T123"},
+        "user": {"id": "UJERRY", "name": "Jerry"},
+        "channel": {"id": "C456", "name": "private-source"},
+        "message": {"ts": "123.456", "user": "UAUTHOR", "text": "Private source"},
+    }
+    acked = []
+    await adapter._handle_send_to_hermes_shortcut(
+        lambda **kwargs: _record_async(acked, kwargs), body, Client()
+    )
+    if adapter._background_tasks:
+        await asyncio.gather(*tuple(adapter._background_tasks))
+
+    assert acked == [{}]
+    assert len(seen) == 1
+    assert seen[0].internal is False
+    assert seen[0].message_id.startswith("slack-intake:")
+    assert seen[0].source.chat_type == "dm"
+    assert seen[0].source.chat_id == "D123"
+    assert seen[0].source.thread_id == "200.001"
+    with adapter._slack_intake_store._connect() as conn:
+        row = conn.execute("SELECT * FROM slack_intakes").fetchone()
+    assert row["card_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_retry_after_thread_binding_dispatches_without_second_seed(tmp_path):
+    adapter = _adapter(tmp_path)
+    source = _source(message_text="Private source")
+    intake = adapter._slack_intake_store.reserve("delivery-1", "", source)
+    adapter._slack_intake_store.bind_thread(intake.intake_id, "D123", "200.001")
+    seen = []
+    adapter.set_message_handler(lambda event: _record_async(seen, event))
+
+    class Client:
+        async def conversations_open(self, **kwargs):
+            raise AssertionError("retry must reuse the bound DM")
+
+        async def chat_postMessage(self, **kwargs):
+            if "thread_ts" not in kwargs:
+                raise AssertionError("retry must not post a second seed")
+            return {"ts": "200.002"}
+
+    await adapter._start_slack_conversational_intake(
+        invocation_key="delivery-1", source=source, client=Client()
+    )
+    if adapter._background_tasks:
+        await asyncio.gather(*tuple(adapter._background_tasks))
+
+    assert len(seen) == 1
+    assert adapter._slack_intake_store.get(intake.intake_id).state == "active"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_shortcut_retries_share_one_seed_and_first_turn(tmp_path):
+    adapter = _adapter(tmp_path)
+    second = _adapter(tmp_path)
+    source = _source(message_text="Private source")
+    seed_calls = []
+    seen = []
+
+    async def handler(event):
+        seen.append(event.message_id)
+        await asyncio.sleep(0)
+        return None
+
+    adapter.set_message_handler(handler)
+    second.set_message_handler(handler)
+
+    class Client:
+        async def conversations_open(self, **kwargs):
+            return {"channel": {"id": "D123"}}
+
+        async def chat_postMessage(self, **kwargs):
+            if "thread_ts" not in kwargs:
+                seed_calls.append(kwargs["client_msg_id"])
+                await asyncio.sleep(0)
+                return {"ts": "200.001"}
+            return {"ts": "controls"}
+
+    await asyncio.gather(
+        adapter._start_slack_conversational_intake(
+            invocation_key="concurrent-1", source=source, client=Client()
+        ),
+        second._start_slack_conversational_intake(
+            invocation_key="concurrent-1", source=source, client=Client()
+        ),
+    )
+
+    assert len(seed_calls) == 1
+    assert len(seen) == 1
+
+
+def test_intake_source_uses_active_gateway_profile(tmp_path, monkeypatch):
+    adapter = _adapter(tmp_path)
+    monkeypatch.setattr("hermes_cli.profiles.get_active_profile_name", lambda: "coding")
+
+    assert adapter._slack_intake_profile() == "coding"
+
+
+def test_intake_source_prefers_gateway_profile_route(tmp_path):
+    adapter = _adapter(tmp_path)
+
+    class Runner:
+        @staticmethod
+        def _profile_name_for_source(source):
+            assert source.chat_id == "D123"
+            return "victory-live"
+
+    adapter.gateway_runner = Runner()  # type: ignore[assignment]
+
+    assert adapter._slack_intake_profile(
+        build_intake_source(
+            profile="",
+            team_id="T123",
+            dm_channel_id="D123",
+            thread_ts="200.001",
+            user_id="UJERRY",
+            user_name="Jerry",
+        )
+    ) == "victory-live"
+
+
+@pytest.mark.asyncio
+async def test_failed_first_turn_stays_retryable_with_stable_event_id(tmp_path):
+    adapter = _adapter(tmp_path)
+    source = _source(message_text="Private source")
+    seen = []
+
+    async def fail(event):
+        seen.append(event.message_id)
+        raise RuntimeError("delivery failed")
+
+    adapter.set_message_handler(fail)
+
+    class Client:
+        async def conversations_open(self, **kwargs):
+            return {"channel": {"id": "D123"}}
+
+        async def chat_postMessage(self, **kwargs):
+            return {"ts": "200.001"}
+
+    await adapter._start_slack_conversational_intake(
+        invocation_key="delivery-1", source=source, client=Client()
+    )
+
+    intake = adapter._slack_intake_store.reserve("delivery-1", "", source)
+    assert intake.state == "failed_retryable"
+    assert seen == [intake.first_event_id]
+
+
+@pytest.mark.asyncio
+async def test_feature_flag_off_blocks_new_intake_without_persisting_source(tmp_path):
+    adapter = _adapter(tmp_path, enabled=False)
+    opened = []
+
+    class Client:
+        async def views_open(self, **kwargs):
+            opened.append(kwargs)
+
+    await adapter._handle_send_to_hermes_shortcut(
+        lambda **kwargs: _record_async([], kwargs),
+        {
+            "trigger_id": "delivery-off",
+            "team": {"id": "T123"},
+            "user": {"id": "UJERRY"},
+            "channel": {"id": "C456"},
+            "message": {"ts": "123.456", "text": "must not persist"},
+        },
+        Client(),
+    )
+
+    assert "not enabled" in json.dumps(opened).lower()
+    with adapter._slack_intake_store._connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM slack_intakes").fetchone()[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_create_card_action_reauthorizes_and_reuses_promoted_card(tmp_path):
+    adapter = _adapter(tmp_path)
+    source = _source(submitter_id="UJERRY", message_text="Investigate checkout failures")
+    intake = adapter._slack_intake_store.reserve("delivery-1", "coding", source)
+    adapter._slack_intake_store.bind_thread(intake.intake_id, "D123", "200.001")
+    adapter._slack_intake_store.bind_session(
+        intake.intake_id, "slack:T123:D123:200.001", "session-1"
+    )
+    adapter._session_store = _TranscriptStore()
+    created = []
+
+    class IntakeClient:
+        async def create_task(self, payload):
+            created.append(payload)
+            return {"id": "t_only_one", "status": "triage"}
+
+    adapter._hermes_intake_client = IntakeClient()
+    acked = []
+    updates = []
+
+    class Client:
+        async def chat_update(self, **kwargs):
+            updates.append(kwargs)
+
+    body = {
+        "user": {"id": "UJERRY"},
+        "team": {"id": "T123"},
+        "channel": {"id": "D123"},
+        "message": {"ts": "200.002", "thread_ts": "200.001"},
+        "actions": [{"value": intake.intake_id}],
+    }
+    ack = lambda **kwargs: _record_async(acked, kwargs)
+
+    await adapter._handle_slack_intake_create_card(ack, body, Client())
+    await adapter._handle_slack_intake_create_card(ack, body, Client())
+
+    assert len(created) == 1
+    assert created[0]["triage"] is True
+    assert "assignee" not in created[0]
+    assert adapter._slack_intake_store.get(intake.intake_id).card_id == "t_only_one"
+    assert "Creating card" in json.dumps(updates[0])
+    assert all("t_only_one" in json.dumps(update) for update in updates[1:])
+    assert all("hermes_intake_open_card" not in json.dumps(update) for update in updates)
+
+
+@pytest.mark.asyncio
+async def test_create_card_action_rejects_same_dm_wrong_thread(tmp_path):
+    adapter = _adapter(tmp_path)
+    intake = adapter._slack_intake_store.reserve("delivery-1", "coding", _source())
+    adapter._slack_intake_store.bind_thread(intake.intake_id, "D123", "200.001")
+    adapter._slack_intake_store.bind_session(
+        intake.intake_id, "slack:T123:D123:200.001", "session-1"
+    )
+    created = []
+
+    class IntakeClient:
+        async def create_task(self, payload):
+            created.append(payload)
+            return {"id": "must-not-exist"}
+
+    adapter._hermes_intake_client = IntakeClient()
+    await adapter._handle_slack_intake_create_card(
+        lambda **kwargs: _record_async([], kwargs),
+        {
+            "user": {"id": "UJERRY"},
+            "team": {"id": "T123"},
+            "channel": {"id": "D123"},
+            "message": {"ts": "999.001", "thread_ts": "999.001"},
+            "actions": [{"value": intake.intake_id}],
+        },
+        object(),
+    )
+
+    assert created == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_promotion_outcome_keeps_same_key_and_renders_retry(tmp_path):
+    adapter = _adapter(tmp_path)
+    source = _source(submitter_id="UJERRY", message_text="Investigate checkout failures")
+    intake = adapter._slack_intake_store.reserve("delivery-1", "coding", source)
+    adapter._slack_intake_store.bind_thread(intake.intake_id, "D123", "200.001")
+    adapter._slack_intake_store.bind_session(
+        intake.intake_id, "slack:T123:D123:200.001", "session-1"
+    )
+    adapter._session_store = _TranscriptStore()
+    keys = []
+
+    class IntakeClient:
+        async def create_task(self, payload):
+            keys.append(payload["idempotency_key"])
+            raise RuntimeError("acknowledgment lost")
+
+    adapter._hermes_intake_client = IntakeClient()  # type: ignore[assignment]
+    updates = []
+
+    class Client:
+        async def chat_update(self, **kwargs):
+            updates.append(kwargs)
+
+    body = {
+        "user": {"id": "UJERRY"},
+        "team": {"id": "T123"},
+        "channel": {"id": "D123"},
+        "message": {"ts": "200.002", "thread_ts": "200.001"},
+        "actions": [{"value": intake.intake_id}],
+    }
+
+    await adapter._handle_slack_intake_create_card(
+        lambda **kwargs: _record_async([], kwargs), body, Client()
+    )
+
+    assert keys == [intake.promotion_key]
+    assert adapter._slack_intake_store.get(intake.intake_id).state == "failed_retryable"
+    assert "Retry creation" in json.dumps(updates)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -39,6 +39,41 @@ def _init_git_repo(repo: Path) -> None:
     subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, capture_output=True, text=True)
 
 
+def test_concurrent_idempotent_creators_return_one_task(kanban_home):
+    """Independent DB connections must not create duplicate idempotency rows."""
+    db_path = kanban_home / "kanban.db"
+
+    def create() -> str:
+        with kb.connect(db_path) as conn:
+            return kb.create_task(
+                conn,
+                title="promoted Slack intake",
+                triage=True,
+                idempotency_key="slack-intake:promotion-1",
+            )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        task_ids = list(pool.map(lambda _index: create(), range(2)))
+
+    assert len(set(task_ids)) == 1
+    with kb.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ?",
+            ("slack-intake:promotion-1",),
+        ).fetchall()
+    assert [row["id"] for row in rows] == [task_ids[0]]
+
+
+def test_archived_task_still_satisfies_idempotency_key(kanban_home):
+    db_path = kanban_home / "kanban.db"
+    with kb.connect(db_path) as conn:
+        first = kb.create_task(conn, title="first", idempotency_key="promotion:one")
+        assert kb.archive_task(conn, first)
+        replay = kb.create_task(conn, title="replay", idempotency_key="promotion:one")
+
+    assert replay == first
+
+
 # ---------------------------------------------------------------------------
 # Schema / init
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_slack_cli.py
+++ b/tests/hermes_cli/test_slack_cli.py
@@ -116,6 +116,20 @@ class TestSlackManifestArgparse:
 class TestSlackFullManifest:
     """Generated full Slack app manifest used by `hermes slack manifest`."""
 
+    def test_manifest_registers_send_to_hermes_message_shortcut(self):
+        manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
+
+        assert manifest["features"]["shortcuts"] == [
+            {
+                "name": "Send to Hermes",
+                "callback_id": "hermes_send_message",
+                "description": "Refine this message privately with Hermes",
+                "type": "message",
+            }
+        ]
+        assert manifest["settings"]["interactivity"]["is_enabled"] is True
+        assert "commands" in manifest["oauth_config"]["scopes"]["bot"]
+
 
 
 

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -281,6 +281,44 @@ identify a Messages-tab DM and receive the user's active Slack context with a
 turn. Hermes only supplies that context as a label; it does not read the viewed
 channel's history.
 
+### Private conversational intake from a Slack message
+
+Hermes's generated manifest includes **Send to Hermes** (`hermes_send_message`).
+When `platforms.slack.conversational_intake_enabled` is `true`, an authorized
+user can invoke it from a text message's **More actions** menu. Hermes opens a
+dedicated thread in that user's 1:1 DM, submits the selected text through the
+normal gateway conversation path, and states **No card exists yet**.
+
+Continue refining in the DM thread. Text replies, including casual assent, do
+not create Kanban cards. The persistent **Create card** button is the only
+promotion control. It creates one unassigned card in **HRMS → Triage** with a
+synthesized brief and source/session/thread lineage; raw transcript content is
+not copied into the card. Retries and stale clicks reconcile to the same card.
+
+Enable the private dogfood slice with:
+
+```bash
+hermes config set platforms.slack.conversational_intake_enabled true
+hermes config set platforms.slack.hermes_intake_url http://127.0.0.1:9119 --force
+```
+
+The local Kanban API session token remains a secret in the normal secret store.
+The loopback URL and feature flag are non-secret `config.yaml` settings. The
+feature defaults off. Disabling it stops new intakes while preserving existing
+lineage for retry/reconciliation.
+
+Regenerate and apply the Slack manifest after upgrading:
+
+```bash
+hermes slack manifest --agent-view --write
+```
+
+Verify one invocation yields one private DM thread and zero cards, a natural
+reply continues the same session, casual assent still yields zero cards, and a
+double click on **Create card** yields exactly one HRMS Triage card plus an
+**Open card** control. For rollback, set the feature flag to `false`; do not
+delete the local intake database or already-promoted cards.
+
 ### Refreshing slash commands after updates
 
 When Hermes adds new commands (e.g. after `hermes update`), regenerate


### PR DESCRIPTION
## Summary

- replace Slack’s immediate-card message shortcut with an opt-in private DM-thread conversational intake
- persist intake lineage and private source data with restart-safe, owner-fenced stage claims
- promote only from an explicit persistent button into one unassigned HRMS Triage card
- harden Kanban idempotency across concurrent requests and archived-card retries
- document configuration, recovery behavior, privacy boundaries, and operator setup

## Verification

- `scripts/run_tests.sh tests/gateway/test_slack_*.py tests/hermes_cli/test_slack_cli.py tests/hermes_cli/test_kanban_db.py` — 214 passed, 1 Windows-only skip
- `python -m compileall -q plugins/platforms/slack/hermes_intake.py plugins/platforms/slack/adapter.py hermes_cli/kanban_db.py`
- `git diff --check`
- independent exact-staged-diff review: APPROVE; verified live-owner non-takeover, dead-process recovery, fencing, exact-thread authorization, route-selected profile identity, DB/WAL/SHM permissions, and archived idempotency

## Live dogfood

Not run from the implementation profile: its conversational-intake config, loopback Kanban URL/session secret, Slack allowlist, and gateway were not active. The separate default-profile gateway was intentionally left untouched. This remains the explicit experiential acceptance gate before merge.

## Security and privacy

- raw selected-message text is stored only in the owner-only intake source database and normal Hermes session transcript
- lineage, action metadata, and promoted cards contain identifiers/permalink plus the synthesized brief, not a copied raw transcript
- promotion reauthorizes user, workspace, DM, and exact intake thread
- stale work can be recovered only after lease expiry and owner-process death
