### PR TITLE
fix(config): stop runtime CWD values from triggering dotenv warnings

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2105,24 +2105,13 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
     messaging_cwd = str(env_map.get("MESSAGING_CWD") or "").strip()
     terminal_cwd_env = str(env_map.get("TERMINAL_CWD") or "").strip()
 
-    if config is None:
-        try:
-            config = load_config()
-        except Exception:
-            return
-
-    terminal_cfg = config.get("terminal", {})
-    config_cwd = terminal_cfg.get("cwd", ".") if isinstance(terminal_cfg, dict) else "."
-    # Only warn if config.yaml doesn't have an explicit path
-    config_has_explicit_cwd = config_cwd not in {".", "auto", "cwd", ""}
-
     lines: list[str] = []
     if messaging_cwd:
         lines.append(
             f"  \033[33m⚠\033[0m MESSAGING_CWD={messaging_cwd} found in .env — "
             f"this is deprecated."
         )
-    if terminal_cwd_env and not config_has_explicit_cwd:
+    if terminal_cwd_env:
         lines.append(
             f"  \033[33m⚠\033[0m TERMINAL_CWD={terminal_cwd_env} found in .env — "
             f"this is deprecated."

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2093,10 +2093,17 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
     """Warn if MESSAGING_CWD or TERMINAL_CWD is set in .env instead of config.yaml.
 
     These env vars are deprecated — the canonical setting is terminal.cwd
-    in config.yaml.  Prints a migration hint to stderr.
+    in config.yaml.  Read the file rather than ``os.environ`` because runtime
+    config bridges and session restoration legitimately set ``TERMINAL_CWD``.
+    Prints a migration hint to stderr.
     """
-    messaging_cwd = os.environ.get("MESSAGING_CWD")
-    terminal_cwd_env = os.environ.get("TERMINAL_CWD")
+    try:
+        env_map = load_env()
+    except Exception:
+        return
+
+    messaging_cwd = str(env_map.get("MESSAGING_CWD") or "").strip()
+    terminal_cwd_env = str(env_map.get("TERMINAL_CWD") or "").strip()
 
     if config is None:
         try:
@@ -2116,7 +2123,6 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
             f"this is deprecated."
         )
     if terminal_cwd_env and not config_has_explicit_cwd:
-        # TERMINAL_CWD in env but not from config bridge — likely from .env
         lines.append(
             f"  \033[33m⚠\033[0m TERMINAL_CWD={terminal_cwd_env} found in .env — "
             f"this is deprecated."

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2089,7 +2089,7 @@ def print_config_warnings(config: Optional[Dict[str, Any]] = None) -> None:
     sys.stderr.write("\n".join(lines) + "\n\n")
 
 
-def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> None:
+def warn_deprecated_cwd_env_vars() -> None:
     """Warn if MESSAGING_CWD or TERMINAL_CWD is set in .env instead of config.yaml.
 
     These env vars are deprecated — the canonical setting is terminal.cwd

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -46,6 +46,17 @@ class TestDeprecatedCwdWarning:
         assert "deprecated" in captured.err.lower()
         assert "config.yaml" in captured.err
 
+    def test_dotenv_terminal_cwd_warns_with_explicit_config(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        _write_env(monkeypatch, tmp_path, "TERMINAL_CWD=/legacy/path\n")
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+
+        warn_deprecated_cwd_env_vars(config={"terminal": {"cwd": "/current/path"}})
+
+        assert "TERMINAL_CWD=/legacy/path" in capsys.readouterr().err
+
     def test_commented_and_empty_dotenv_values_do_not_warn(
         self, monkeypatch, tmp_path, capsys
     ):

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -1,29 +1,63 @@
 """Tests for warn_deprecated_cwd_env_vars() migration warning."""
 
 
+def _write_env(monkeypatch, tmp_path, content):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text(content, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
 class TestDeprecatedCwdWarning:
     """Warn when MESSAGING_CWD or TERMINAL_CWD is set in .env."""
 
-    def test_messaging_cwd_triggers_warning(self, monkeypatch, capsys):
-        monkeypatch.setenv("MESSAGING_CWD", "/some/path")
+    def test_process_environment_does_not_trigger_warning(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        _write_env(monkeypatch, tmp_path, "# TERMINAL_CWD=.\n")
+        monkeypatch.setenv("MESSAGING_CWD", "/process/message-path")
+        monkeypatch.setenv("TERMINAL_CWD", "/process/terminal-path")
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+
+        warn_deprecated_cwd_env_vars(config={})
+
+        assert capsys.readouterr().err == ""
+
+    def test_both_deprecated_vars_in_dotenv_warn(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        _write_env(
+            monkeypatch,
+            tmp_path,
+            "MESSAGING_CWD=/msg/path\nTERMINAL_CWD=/term/path\n",
+        )
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
         monkeypatch.delenv("TERMINAL_CWD", raising=False)
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
-        warn_deprecated_cwd_env_vars(config={})
 
-        captured = capsys.readouterr()
-        assert "MESSAGING_CWD" in captured.err
-        assert "deprecated" in captured.err.lower()
-        assert "config.yaml" in captured.err
-
-
-    def test_both_deprecated_vars_warn(self, monkeypatch, capsys):
-        monkeypatch.setenv("MESSAGING_CWD", "/msg/path")
-        monkeypatch.setenv("TERMINAL_CWD", "/term/path")
-
-        from hermes_cli.config import warn_deprecated_cwd_env_vars
         warn_deprecated_cwd_env_vars(config={})
 
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
         assert "TERMINAL_CWD" in captured.err
+        assert "deprecated" in captured.err.lower()
+        assert "config.yaml" in captured.err
+
+    def test_commented_and_empty_dotenv_values_do_not_warn(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        _write_env(
+            monkeypatch,
+            tmp_path,
+            "# MESSAGING_CWD=/commented\nTERMINAL_CWD=\n",
+        )
+        monkeypatch.setenv("TERMINAL_CWD", "/process/bridge")
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+
+        warn_deprecated_cwd_env_vars(config={})
+
+        assert capsys.readouterr().err == ""

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -21,7 +21,7 @@ class TestDeprecatedCwdWarning:
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
 
-        warn_deprecated_cwd_env_vars(config={})
+        warn_deprecated_cwd_env_vars()
 
         assert capsys.readouterr().err == ""
 
@@ -38,7 +38,7 @@ class TestDeprecatedCwdWarning:
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
 
-        warn_deprecated_cwd_env_vars(config={})
+        warn_deprecated_cwd_env_vars()
 
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
@@ -49,11 +49,16 @@ class TestDeprecatedCwdWarning:
     def test_dotenv_terminal_cwd_warns_with_explicit_config(
         self, monkeypatch, tmp_path, capsys
     ):
-        _write_env(monkeypatch, tmp_path, "TERMINAL_CWD=/legacy/path\n")
+        hermes_home = _write_env(
+            monkeypatch, tmp_path, "TERMINAL_CWD=/legacy/path\n"
+        )
+        (hermes_home / "config.yaml").write_text(
+            "terminal:\n  cwd: /current/path\n", encoding="utf-8"
+        )
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
 
-        warn_deprecated_cwd_env_vars(config={"terminal": {"cwd": "/current/path"}})
+        warn_deprecated_cwd_env_vars()
 
         assert "TERMINAL_CWD=/legacy/path" in capsys.readouterr().err
 
@@ -69,7 +74,7 @@ class TestDeprecatedCwdWarning:
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
 
-        warn_deprecated_cwd_env_vars(config={})
+        warn_deprecated_cwd_env_vars()
 
         assert capsys.readouterr().err == ""
 
@@ -81,6 +86,6 @@ class TestDeprecatedCwdWarning:
 
         monkeypatch.setattr(config_module, "load_env", raise_read_error)
 
-        config_module.warn_deprecated_cwd_env_vars(config={})
+        config_module.warn_deprecated_cwd_env_vars()
 
         assert capsys.readouterr().err == ""

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -72,3 +72,15 @@ class TestDeprecatedCwdWarning:
         warn_deprecated_cwd_env_vars(config={})
 
         assert capsys.readouterr().err == ""
+
+    def test_dotenv_read_failure_is_silent(self, monkeypatch, capsys):
+        import hermes_cli.config as config_module
+
+        def raise_read_error():
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(config_module, "load_env", raise_read_error)
+
+        config_module.warn_deprecated_cwd_env_vars(config={})
+
+        assert capsys.readouterr().err == ""


### PR DESCRIPTION
## What does this PR do?

Stops Hermes from reporting `TERMINAL_CWD` or `MESSAGING_CWD` as deprecated `.env` settings when those values exist only in the process environment. Gateway starts and resumed sessions no longer show a false migration warning, while real deprecated entries on disk continue to produce the warning.

### Symptom

Starting the gateway with a runtime-populated `TERMINAL_CWD` prints a warning claiming that the value was found in `.env`, even when `.env` contains no active entry.

### Impact

Affected users see an incorrect deprecation warning on every gateway start and are instructed to remove a setting that is not present in their `.env` file. This obscures legitimate migration warnings and makes normal config bridges or session restoration appear misconfigured.

### Bug Cause

**Trigger:** `hermes_cli/config.py` / `warn_deprecated_cwd_env_vars()` reading `os.environ`

**Causal chain:**
1. Runtime config bridging or session restoration places `TERMINAL_CWD` in the process environment.
2. `warn_deprecated_cwd_env_vars()` reads the merged process environment instead of the `.env` file it claims to diagnose.
3. Hermes reports the runtime-only value as a deprecated `.env` entry.

**Why it is wrong:** Process environment provenance cannot distinguish a user-authored `.env` entry from legitimate runtime state, so the warning attributes values to the wrong source.

**Working sibling / contrast:** The doctor diagnostic already checks parsed `.env` contents rather than process environment values, which avoids this false positive.

**Ruled out:** A commented `# TERMINAL_CWD=.` line is not parsed as an active setting; regression coverage confirms commented and empty values remain silent.

### Fix

Read deprecated CWD settings through the existing `.env` parser, trim empty values, and warn for every real deprecated disk entry regardless of the current `terminal.cwd` config. Regression tests cover process-only values, both deprecated disk entries, explicit config combined with a legacy disk entry, and commented or empty values.

## Related Issue

Fixes #85695

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` - inspect parsed `.env` values instead of `os.environ` when emitting CWD migration warnings.
- `tests/hermes_cli/test_deprecated_cwd_warning.py` - add provenance and legacy-entry behavior coverage.

## How to Test

1. Put only a commented `# TERMINAL_CWD=.` entry in `.env`, set `TERMINAL_CWD` in the process environment, and confirm no deprecation warning is emitted.
2. Add an active `TERMINAL_CWD=/legacy/path` entry to `.env` and confirm the migration warning is emitted, including when `terminal.cwd` is explicitly configured.
3. Automated (already run locally, 56 passed):

```bash
scripts/run_tests.sh tests/hermes_cli/test_deprecated_cwd_warning.py tests/hermes_cli/test_doctor.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - no user-facing configuration contract changed
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - `.env` parsing is shared across supported platforms
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed

## Screenshots / Logs

Targeted test suite: 56 passed.
