### PR TITLE
feat(gateway): guard daily session reset against live turns and kanban work

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1578,6 +1578,7 @@ def run_conversation(
     _should_review_memory = _ctx.should_review_memory
     _plugin_user_context = _ctx.plugin_user_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
+    _recent_links_block = _ctx.recent_links_block
 
     # Commentary deduplication spans all provider continuations and tool calls
     # within one user turn, but must not suppress the same phrase next turn.
@@ -1883,10 +1884,10 @@ def run_conversation(
 
             # Inject ephemeral context into the current turn's user message.
             # Sources: memory manager prefetch + plugin pre_llm_call hooks
-            # with target="user_message" (the default).  Both are
-            # API-call-time only — the original message in `messages` is
-            # never mutated beyond the api_content stamp, so nothing leaks
-            # into the clean transcript content.
+            # with target="user_message" (the default) + the recent
+            # shared-links block.  All are API-call-time only — the original
+            # message in `messages` is never mutated beyond the api_content
+            # stamp, so nothing leaks into the clean transcript content.
             if idx == current_turn_user_idx and msg.get("role") == "user":
                 if isinstance(_api_content, str) and _api_content:
                     # Stamped by the prologue from the same composition —
@@ -1901,6 +1902,7 @@ def run_conversation(
                         api_msg.get("content", ""),
                         _ext_prefetch_cache,
                         _plugin_user_context,
+                        _recent_links_block,
                     )
                     if _composed is not None:
                         api_msg["content"] = _composed

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -516,6 +516,30 @@ def _billing_block_dict(provider, base_url, model, message="") -> Optional[dict]
         return None
 
 
+def _critical_both_failed_message(provider: str, model: str, summary: str) -> str:
+    """Distinct, higher-severity message for the double-failure case.
+
+    Fires only when the PRIMARY provider failed for a billing/credit reason
+    (HTTP 402 / ``FailoverReason.billing``) in this same turn AND the
+    fallback provider activated in response to that also failed (auth or
+    billing) before the turn could complete. An ordinary single-provider
+    auth/billing hiccup (primary fails, fallback succeeds; or only a
+    fallback is ever tried and it fails alone) keeps the existing generic
+    copy -- see ``TurnRetryState.primary_failed_billing_or_credit`` for the
+    exact gating. (kanban t_7b1728c5 / t_069d2d08)
+    """
+    provider_label = (provider or "").strip() or "unknown provider"
+    model_label = (model or "").strip() or "unknown model"
+    return (
+        "🔴 CRITICAL: both primary and fallback inference failed this turn. "
+        "The primary provider failed for a billing/credit reason (e.g. HTTP "
+        f"402), and the fallback provider ({provider_label} / {model_label}) "
+        f"also failed before completing this request: {summary}\n\n"
+        "Nothing will succeed until at least one of the two is fixed -- check "
+        "credentials/credits for BOTH the primary and fallback providers."
+    )
+
+
 def _print_billing_or_entitlement_guidance(
     agent,
     *,
@@ -4849,7 +4873,21 @@ def run_conversation(
                             )
                         else:
                             agent._buffer_status("⚠️ Rate limited — switching to fallback provider...")
+                        # Record "primary died on billing/credits" ONLY when
+                        # this activation is still leaving the primary
+                        # (fallback_index was 0 before this call, i.e. we're
+                        # about to move to fallback_index 1). If we're
+                        # already deeper in an existing fallback chain, the
+                        # primary wasn't the source of this failure, so this
+                        # is ordinary fallback-chain churn, not the
+                        # "both-dead" case. See t_7b1728c5.
+                        _primary_billing_failure = (
+                            classified.reason == FailoverReason.billing
+                            and agent._fallback_index == 0
+                        )
                         if agent._try_activate_fallback(reason=classified.reason):
+                            if _primary_billing_failure:
+                                _retry.primary_failed_billing_or_credit = True
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
                             retry_count = 0
@@ -5661,6 +5699,23 @@ def run_conversation(
                     # the result with the same structured recovery descriptor as
                     # the max-retries path so every surface (CLI, TUI, desktop)
                     # renders one consistent billing signal.
+                    #
+                    # Distinct CRITICAL case: the primary already died on a
+                    # billing/credit reason this turn and the fallback we
+                    # switched to has now ALSO failed (billing or auth) before
+                    # completing — both legs of the failover are dead in the
+                    # same turn. That is a materially different, higher-
+                    # severity situation than an ordinary single-provider
+                    # billing/auth hiccup, so it gets its own message instead
+                    # of silently reusing the generic copy. (t_7b1728c5)
+                    _both_failed = (
+                        _retry.primary_failed_billing_or_credit
+                        and classified.reason in {
+                            FailoverReason.billing,
+                            FailoverReason.auth,
+                            FailoverReason.auth_permanent,
+                        }
+                    )
                     if classified.reason == FailoverReason.billing:
                         _ce_guidance = _billing_or_entitlement_message(
                             capability="model access",
@@ -5668,7 +5723,12 @@ def run_conversation(
                             base_url=str(_base),
                             model=_model,
                         )
-                        _ce_final = f"Billing or credits exhausted: {_nonretryable_summary}"
+                        if _both_failed:
+                            _ce_final = _critical_both_failed_message(
+                                _provider, _model, _nonretryable_summary,
+                            )
+                        else:
+                            _ce_final = f"Billing or credits exhausted: {_nonretryable_summary}"
                         if _ce_guidance:
                             _ce_final += f"\n\n{_ce_guidance}"
                         _ce_block = _billing_block_dict(_provider, _base, _model, _ce_guidance)
@@ -5679,8 +5739,24 @@ def run_conversation(
                             "completed": False,
                             "failed": True,
                             "error": _nonretryable_summary,
-                            "failure_reason": classified.reason.value,
+                            "failure_reason": (
+                                "critical_both_primary_and_fallback_failed"
+                                if _both_failed else classified.reason.value
+                            ),
                             "billing_block": _ce_block,
+                        }
+                    if _both_failed:
+                        _critical_final = _critical_both_failed_message(
+                            _provider, _model, _nonretryable_summary,
+                        )
+                        return {
+                            "final_response": _critical_final,
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "failed": True,
+                            "error": _nonretryable_summary,
+                            "failure_reason": "critical_both_primary_and_fallback_failed",
                         }
                     return {
                         "final_response": _nonretryable_summary,
@@ -5843,13 +5919,30 @@ def run_conversation(
                         )
                     agent._persist_session(messages, conversation_history)
                     _billing_block = None
+                    _both_failed_mr = (
+                        _retry.primary_failed_billing_or_credit
+                        and classified.reason in {
+                            FailoverReason.billing,
+                            FailoverReason.auth,
+                            FailoverReason.auth_permanent,
+                        }
+                    )
                     if classified.reason == FailoverReason.billing:
-                        _final_response = f"Billing or credits exhausted: {_final_summary}"
+                        if _both_failed_mr:
+                            _final_response = _critical_both_failed_message(
+                                _provider, _model, _final_summary,
+                            )
+                        else:
+                            _final_response = f"Billing or credits exhausted: {_final_summary}"
                         if _billing_guidance:
                             _final_response += f"\n\n{_billing_guidance}"
                         # Structured recovery descriptor so every surface renders
                         # the same link + label from one signal (see helper).
                         _billing_block = _billing_block_dict(_provider, _base, _model, _billing_guidance)
+                    elif _both_failed_mr:
+                        _final_response = _critical_both_failed_message(
+                            _provider, _model, _final_summary,
+                        )
                     else:
                         _final_response = f"API call failed after {max_retries} retries: {_final_summary}"
                     if _is_thinking_timeout:
@@ -5888,7 +5981,10 @@ def run_conversation(
                         # transient throttle from a real failure and choose a
                         # different exit code. ``rate_limit`` / ``billing`` here
                         # mean "quota wall, not a task error".
-                        "failure_reason": classified.reason.value,
+                        "failure_reason": (
+                            "critical_both_primary_and_fallback_failed"
+                            if _both_failed_mr else classified.reason.value
+                        ),
                         # Present only for billing walls: structured recovery
                         # descriptor (provider, billing_url, is_nous, message).
                         "billing_block": _billing_block,

--- a/agent/shared_media_tracker.py
+++ b/agent/shared_media_tracker.py
@@ -1,0 +1,166 @@
+"""Recent-shared-links tracking for the per-turn user-message sidecar.
+
+A URL pasted in message *text* (as opposed to a file/image attachment) gets
+no structured extraction anywhere in the pipeline, so it survives only as
+prose inside one historical user turn. Several turns later the model has no
+durable "the user cares about this" marker to look at, the user re-sends the
+link, and FTS5 session search can't recover it from a vague description
+("that video you sent") because the query never matches the URL text.
+
+This module keeps a small, bounded index of those URLs: it scans persisted
+user-message rows, renders each distinct URL as a short host+path label with
+a recency marker, and hands the caller a fenced block to inject.
+
+Both functions are pure — the caller fetches the rows (see
+``SessionDB.get_recent_user_messages``) and passes them in. Reading from the
+PERSISTED rows rather than the live ``conversation_history`` is deliberate:
+idle/preflight compaction rewrites the in-memory list into a summary, so a
+link shared before a compaction boundary would vanish from the in-memory
+view while still sitting in the durable transcript.
+
+The rendered block rides the per-turn ``api_content`` sidecar (see
+``agent.turn_context.compose_user_api_content``), never the system prompt —
+its contents change every turn, and the system prompt must stay byte-stable
+turn-to-turn for the provider prompt cache.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Sequence
+
+from agent.message_content import flatten_message_text
+
+# http/https only: those are the links a user can actually be asked about
+# again. Stops at whitespace and at the bracket/quote characters that
+# routinely *surround* a pasted URL rather than belong to it.
+_URL_RE = re.compile(r'https?://[^\s<>"\'`\]\)\}]+', re.IGNORECASE)
+
+# Trailing punctuation that reads as sentence punctuation, not URL content
+# ("see https://example.com/x." → the period is the sentence's).
+_TRAILING_PUNCT = ".,;:!?'\"`"
+
+# Label budget. The point of the label is to be *recognisable*, not
+# resolvable — the full URL still lives in the transcript, so paying ~40
+# extra tokens per entry to repeat it every turn buys nothing.
+_MAX_LABEL_CHARS = 48
+_ELLIPSIS = "..."
+
+
+def _row_text(row: Dict[str, Any]) -> str:
+    """Return the scannable text of a persisted message row.
+
+    Session rows store ``content``; some callers (and older row shapes)
+    carry ``text`` instead. Multimodal rows decode to a list of parts, so
+    the shared flattener is used rather than a str() that would stringify
+    the whole part list including base64 image payloads.
+    """
+    if not isinstance(row, dict):
+        return ""
+    content = row.get("content")
+    if content is None:
+        content = row.get("text")
+    return flatten_message_text(content)
+
+
+def _normalize_url(raw: str) -> str:
+    """Strip trailing sentence punctuation from a regex-matched URL."""
+    return raw.rstrip(_TRAILING_PUNCT)
+
+
+def link_label(url: str) -> str:
+    """Render ``url`` as a short host+path label for the context block.
+
+    Drops the scheme and a leading ``www.`` (pure noise at this size) and
+    truncates the whole thing to ``_MAX_LABEL_CHARS`` with an ellipsis, so
+    a 300-character tracking URL costs the same as a short one.
+    """
+    label = re.sub(r"^https?://", "", url, flags=re.IGNORECASE)
+    label = re.sub(r"^www\.", "", label, flags=re.IGNORECASE)
+    label = label.rstrip("/") or label
+    if len(label) > _MAX_LABEL_CHARS:
+        label = label[: _MAX_LABEL_CHARS - len(_ELLIPSIS)] + _ELLIPSIS
+    return label
+
+
+def extract_recent_shared_links(
+    rows: Sequence[Dict[str, Any]], limit: int = 8
+) -> List[Dict[str, Any]]:
+    """Extract the most recent distinct URLs shared in ``rows``.
+
+    ``rows`` are persisted user-message rows in chronological order (oldest
+    first) — the shape ``SessionDB.get_recent_user_messages`` returns. Rows
+    that carry a ``role`` other than ``user`` are skipped, so a caller that
+    hands over a mixed slice of the transcript still only mines what the
+    *user* actually shared.
+
+    Returns at most ``limit`` entries, newest first, each a dict of:
+
+    * ``url`` — the full URL, for callers that need to resolve it,
+    * ``label`` — the truncated host+path rendering (see :func:`link_label`),
+    * ``turns_ago`` — distance in user turns, counting the newest supplied
+      row as 1. At the prologue call site the current turn's row has not
+      been persisted yet, so the newest row is genuinely the previous turn.
+
+    Deduped by URL keeping the most recent mention: a link re-sent this turn
+    should read as fresh, not as however old its first appearance was.
+    """
+    if limit <= 0:
+        return []
+
+    user_rows = [
+        row
+        for row in rows or []
+        if isinstance(row, dict) and row.get("role", "user") == "user"
+    ]
+
+    found: List[Dict[str, Any]] = []
+    seen: set = set()
+    # Newest first so the first sighting of a URL is also its most recent.
+    for offset, row in enumerate(reversed(user_rows)):
+        text = _row_text(row)
+        if not text or "http" not in text:
+            continue
+        for match in _URL_RE.finditer(text):
+            url = _normalize_url(match.group(0))
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            found.append(
+                {
+                    "url": url,
+                    "label": link_label(url),
+                    "turns_ago": offset + 1,
+                }
+            )
+            if len(found) >= limit:
+                return found
+    return found
+
+
+def build_recent_links_context_block(
+    rows: Sequence[Dict[str, Any]], limit: int = 8
+) -> str:
+    """Render recent shared links as a fenced block, or ``""`` when none.
+
+    Empty-input convention mirrors
+    :func:`agent.memory_manager.build_memory_context_block`: an empty string
+    (not ``None``), so ``compose_user_api_content`` can treat every
+    injection source with the same falsy check.
+    """
+    links = extract_recent_shared_links(rows, limit=limit)
+    if not links:
+        return ""
+    lines = [
+        "- {label} ({turns} turn{plural} ago)".format(
+            label=link["label"],
+            turns=link["turns_ago"],
+            plural="" if link["turns_ago"] == 1 else "s",
+        )
+        for link in links
+    ]
+    return (
+        "<recent-shared-links>\n"
+        + "\n".join(lines)
+        + "\n</recent-shared-links>"
+    )

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -46,6 +46,7 @@ from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
 )
+from agent.shared_media_tracker import build_recent_links_context_block
 
 logger = logging.getLogger(__name__)
 
@@ -54,12 +55,14 @@ def compose_user_api_content(
     content: Any,
     ext_prefetch_cache: str,
     plugin_user_context: str,
+    recent_links_block: str = "",
 ) -> Optional[str]:
     """Compose the API-bound content of the current turn's user message.
 
     Sources: memory-manager prefetch + ``pre_llm_call`` plugin context with
-    target="user_message" (the default). Both are appended to the *API copy*
-    of the user message only — the stored content stays clean.
+    target="user_message" (the default) + the recent-shared-links block
+    (``agent.shared_media_tracker``). All are appended to the *API copy* of
+    the user message only — the stored content stays clean.
 
     This is the single source of that composition. The prologue stamps the
     result onto the live message as ``api_content`` (persisted alongside the
@@ -80,6 +83,8 @@ def compose_user_api_content(
             injections.append(fenced)
     if plugin_user_context:
         injections.append(plugin_user_context)
+    if recent_links_block:
+        injections.append(recent_links_block)
     if not injections:
         return None
     return content + "\n\n" + "\n\n".join(injections)
@@ -423,6 +428,8 @@ class TurnContext:
     plugin_user_context: str = ""
     # External-memory prefetch result, reused across loop iterations.
     ext_prefetch_cache: str = ""
+    # Fenced recent-shared-links block (appended to the user message).
+    recent_links_block: str = ""
     # Turn-start preflight already proved an immediate retry ineffective.
     preflight_compression_blocked: bool = False
 
@@ -1266,6 +1273,23 @@ def build_turn_context(
         except Exception:
             pass
 
+    # Recent shared links: a bounded scan of what the user pasted earlier in
+    # THIS session, rendered as a short label list. Read from the persisted
+    # rows rather than ``messages`` so a link shared before an idle/preflight
+    # compaction boundary survives — the in-memory list has been rewritten
+    # into a summary by then, the durable transcript has not. One indexed
+    # SELECT of at most 50 user rows, and never fatal: a failed read costs
+    # the block, not the turn.
+    recent_links_block = ""
+    _links_db = getattr(agent, "_session_db", None)
+    if _links_db is not None and agent.session_id:
+        try:
+            recent_links_block = build_recent_links_context_block(
+                _links_db.get_recent_user_messages(agent.session_id, limit=50)
+            )
+        except Exception:
+            logger.debug("recent-shared-links scan skipped", exc_info=True)
+
     # ── api_content sidecar: persist what you send ──
     # The prefetch/plugin context above is injected into the API copy of this
     # turn's user message, never into the stored content — so on the next
@@ -1291,7 +1315,10 @@ def build_turn_context(
     ):
         _turn_user_msg = messages[current_turn_user_idx]
         _api_content = compose_user_api_content(
-            _turn_user_msg.get("content", ""), ext_prefetch_cache, plugin_user_context
+            _turn_user_msg.get("content", ""),
+            ext_prefetch_cache,
+            plugin_user_context,
+            recent_links_block,
         )
         if _api_content is not None and _api_content != _turn_user_msg.get("content"):
             _turn_user_msg["api_content"] = _api_content
@@ -1374,5 +1401,6 @@ def build_turn_context(
         should_review_memory=should_review_memory,
         plugin_user_context=plugin_user_context,
         ext_prefetch_cache=ext_prefetch_cache,
+        recent_links_block=recent_links_block,
         preflight_compression_blocked=_preflight_compression_blocked,
     )

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -74,6 +74,17 @@ class TurnRetryState:
     # don't loop on the same auth failover within one attempt.
     auth_failover_attempted: bool = False
 
+    # Set once, within this same api-call attempt cycle, when the PRIMARY
+    # provider (fallback_index was 0) failed for a billing/credit reason
+    # (HTTP 402 / FailoverReason.billing) and we successfully activated the
+    # next entry in the fallback chain. If the fallback subsequently ALSO
+    # fails (auth or billing) before this cycle ends, the terminal-error
+    # branches use this flag to distinguish the "both primary AND fallback
+    # are dead" case — which needs a distinct, higher-severity alert — from
+    # an ordinary single-provider auth/billing hiccup. See the
+    # "both-primary-and-fallback-failed" fix (kanban t_7b1728c5 / t_069d2d08).
+    primary_failed_billing_or_credit: bool = False
+
     # ── Restart signals (read by the outer loop after the attempt) ───────
     restart_with_compressed_messages: bool = False
     restart_with_length_continuation: bool = False

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -143,6 +143,30 @@ function Meta({ children, icon }: { children: ReactNode; icon: string }) {
   )
 }
 
+/** A decomposed root parked in todo/ready looks exactly like a card nobody has
+ *  started — but it is tracking live child work. Say so, in the "scheduled"
+ *  (waiting) tone the board already uses for cards that are deliberately idle. */
+function WaitingOnChildren({ done, total }: { done: number; total: number }) {
+  const k = useKanban()
+  const tone = columnMeta('scheduled').tone
+
+  return (
+    <Tip label={k.waitingOnChildrenTip(done, total)}>
+      <span
+        className="inline-flex shrink-0 cursor-help items-center gap-1 rounded-full border px-1.5 py-px text-[0.5625rem] font-medium uppercase tracking-wide"
+        style={{
+          backgroundColor: `color-mix(in srgb, ${tone} 14%, transparent)`,
+          borderColor: `color-mix(in srgb, ${tone} 45%, transparent)`,
+          color: tone
+        }}
+      >
+        <Codicon name="type-hierarchy-sub" size="0.7rem" />
+        {k.waitingOnChildren(done, total)}
+      </span>
+    </Tip>
+  )
+}
+
 function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
   const k = useKanban()
   const created = ago(task.created_at)
@@ -160,8 +184,13 @@ function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
 
   const meta = columnMeta(task.status)
 
+  // Decomposed root still tracking children: this is the card's status signal,
+  // so it leads the footer.
+  const waiting = task.is_decomposed_parent && task.progress && task.progress.total > 0 ? task.progress : null
+
   return (
     <div className="flex items-center gap-2 whitespace-nowrap text-[0.625rem] text-(--ui-text-tertiary)">
+      {waiting && <WaitingOnChildren done={waiting.done} total={waiting.total} />}
       {arc === 'queued' && attached ? (
         // WHO is coming for the card. The arc only animates once the agent is
         // actually working; while queued, the named chip carries "attached".
@@ -214,7 +243,8 @@ function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
             {task.priority}
           </span>
         )}
-        {task.progress && task.progress.total > 0 && (
+        {/* The waiting badge already carries N/M — don't print it twice. */}
+        {!waiting && task.progress && task.progress.total > 0 && (
           <Meta icon="checklist">
             {task.progress.done}/{task.progress.total}
           </Meta>

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -40,6 +40,8 @@ type KanbanMessages = {
   wontRun: string
   wontRunTip: string
   noHeartbeat: string
+  waitingOnChildren: (done: number, total: number) => string
+  waitingOnChildrenTip: (done: number, total: number) => string
   expand: (label: string) => string
   collapse: (label: string) => string
   newTaskIn: (label: string) => string
@@ -229,6 +231,9 @@ const en: KanbanMessages = {
   wontRunTip:
     'Ready cards only run once a profile is assigned. Open the card and set an assignee, or configure a default assignee in orchestration settings.',
   noHeartbeat: 'no heartbeat',
+  waitingOnChildren: (done, total) => `waiting on children (${done}/${total} done)`,
+  waitingOnChildrenTip: (done, total) =>
+    `This card was decomposed into ${total} child tasks and is waiting on them — ${done} done so far. It wakes up on its own when every child completes; it is not an unstarted card.`,
   expand: label => `Expand ${label}`,
   collapse: label => `Collapse ${label}`,
   newTaskIn: label => `New task in ${label}`,
@@ -421,6 +426,9 @@ const ja: KanbanMessages = {
   wontRunTip:
     'Ready のカードはプロフィールが割り当てられて初めて実行されます。カードを開いて担当を設定するか、オーケストレーション設定でデフォルトの担当を設定してください。',
   noHeartbeat: 'ハートビートなし',
+  waitingOnChildren: (done, total) => `子タスク待ち (${done}/${total} 完了)`,
+  waitingOnChildrenTip: (done, total) =>
+    `このカードは ${total} 件の子タスクに分解され、その完了を待っています（現在 ${done} 件完了）。すべての子タスクが完了すると自動的に再開します — 未着手のカードではありません。`,
   expand: label => `${label} を展開`,
   collapse: label => `${label} を折りたたむ`,
   newTaskIn: label => `${label} に新しいタスク`,
@@ -611,6 +619,9 @@ const zh: KanbanMessages = {
   wontRun: '不会运行',
   wontRunTip: '就绪卡片只有在分配了配置档后才会运行。打开卡片设置负责人，或在编排设置中配置默认负责人。',
   noHeartbeat: '无心跳',
+  waitingOnChildren: (done, total) => `等待子任务 (${done}/${total} 已完成)`,
+  waitingOnChildrenTip: (done, total) =>
+    `此卡片已拆分为 ${total} 个子任务并正在等待它们完成（已完成 ${done} 个）。所有子任务完成后它会自动恢复 — 这不是一张未开始的卡片。`,
   expand: label => `展开 ${label}`,
   collapse: label => `折叠 ${label}`,
   newTaskIn: label => `在 ${label} 新建任务`,
@@ -799,6 +810,9 @@ const zhHant: KanbanMessages = {
   wontRun: '不會執行',
   wontRunTip: '就緒卡片只有在指派了設定檔後才會執行。開啟卡片設定負責人，或在編排設定中設定預設負責人。',
   noHeartbeat: '無心跳',
+  waitingOnChildren: (done, total) => `等待子任務 (${done}/${total} 已完成)`,
+  waitingOnChildrenTip: (done, total) =>
+    `此卡片已拆分為 ${total} 個子任務並正在等待它們完成（已完成 ${done} 個）。所有子任務完成後它會自動恢復 — 這不是一張未開始的卡片。`,
   expand: label => `展開 ${label}`,
   collapse: label => `摺疊 ${label}`,
   newTaskIn: label => `在 ${label} 新增任務`,

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -17,6 +17,9 @@ export interface KanbanTask {
   link_counts?: { parents: number; children: number }
   /** N-of-M child completion, or null when the task has no children. */
   progress?: null | { done: number; total: number }
+  /** True when the task was decomposed into children and is still open —
+   *  a 'todo'/'ready' parent tracking real child work, not an idle card. */
+  is_decomposed_parent?: boolean
   /** Compact diagnostics rollup — present only when a card has warnings. */
   warnings?: null | { count: number; highest_severity?: null | string }
   /** Worker liveness (present on running cards) — drives the arc + run clock. */

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1366,7 +1366,8 @@ display:
   # acks or heartbeats), but interim_assistant_messages and
   # long_running_notifications STAY ON so the user has real signal between
   # turn start and final answer (mid-turn assistant commentary + a single
-  # edit-in-place "⏳ Working — N min" heartbeat). Override under
+  # edit-in-place "⏳ Still working — about N minutes in." heartbeat).
+  # Override under
   # display.platforms.telegram.
 
   # Auto-cleanup of temporary progress bubbles after the final response lands.
@@ -1396,7 +1397,7 @@ display:
   interim_assistant_messages: true
 
   # Gateway-only long-running status heartbeats.
-  # When false, the platform does not receive periodic "⏳ Working — N min"
+  # When false, the platform does not receive periodic "⏳ Still working"
   # notifications even if agent.gateway_notify_interval is non-zero. The
   # heartbeat edits a single message in place (where the adapter supports
   # editing) instead of posting a new bubble each interval.
@@ -1406,9 +1407,10 @@ display:
 
   # Include detailed iteration/tool/status context in busy acknowledgments
   # and long-running heartbeats. When true, busy acks show "iteration 21/60,
-  # terminal, 10 min" and the heartbeat shows "⏳ Working — 12 min,
-  # iteration 21/60, terminal". When false (Telegram default), both stay
-  # terse: "Interrupting current task" and "⏳ Working — 12 min, terminal".
+  # terminal, 10 min" and the heartbeat shows "⏳ Still working — about 12
+  # minutes in. / Latest update: iteration 21/60, terminal". When false
+  # (Telegram default), both stay terse: "Interrupting current task" and
+  # "⏳ Still working — about 12 minutes in. / Latest update: terminal".
   busy_ack_detail: true
 
   # What Enter does when Hermes is already busy (CLI and gateway platforms).

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1652,10 +1652,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     if wrap_response:
         task_name = job.get("name", job["id"])
         job_id = job.get("id", "")
+        local_time = datetime.now().astimezone().strftime("%H:%M")
         delivery_content = (
-            f"Cronjob Response: {task_name}\n"
-            f"(job_id: {job_id})\n"
-            f"-------------\n\n"
+            f"[{task_name} \u00b7 job:{job_id} \u00b7 {local_time}]\n"
             f"{content}\n\n"
             f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
         )

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -497,6 +497,11 @@ class SessionResetPolicy:
     via the `session_reset` section in config.yaml (or gateway.json
     overrides). Changed July 2026 from "both" (24h idle + daily 4am), which
     surprised users who expected their conversations to persist.
+
+    The "daily" boundary additionally refuses to expire a session that has a
+    turn in flight or live kanban work (running/blocked tasks) attached to it
+    — it fires on wall-clock time, so without those guards it could cut a
+    conversation mid-work. See ``SessionStore._is_session_expired``.
     """
     mode: str = "none"  # "daily", "idle", "both", or "none"
     at_hour: int = 4  # Hour for daily reset (0-23, local time)

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -52,7 +52,7 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # Disable when the platform should steer silently (the text still lands in
     # the active run; only the confirmation echo is suppressed).
     "busy_steer_ack_enabled": True,
-    # When true, delete tool-progress / "⏳ Working — N min" / status bubbles
+    # When true, delete tool-progress / "⏳ Still working" / status bubbles
     # after the final response lands on platforms that support message
     # deletion (e.g. Telegram). Off by default — progress is still shown
     # live, just cleaned up after success so the chat doesn't fill up with

--- a/gateway/heartbeat_text.py
+++ b/gateway/heartbeat_text.py
@@ -1,0 +1,71 @@
+"""Shared rendering for "still working" progress heartbeats.
+
+Two independent code paths tell a user that something is still running:
+
+- ``gateway/run.py``'s ``_notify_long_running`` — the periodic ping for a
+  long CoS conversational turn.
+- ``gateway/kanban_watchers.py``'s ``progress`` event branch — the periodic
+  ping for a dispatched kanban task.
+
+They used to render in two different dialects ("⏳ Working — 4 min —
+iteration 4/40, delegate_task" vs "⏳ Still working on X (running as Y) —
+about 7 minutes in."), so the same user got two vocabularies for the same
+idea. This module owns the one canonical shape; both call sites format
+through it so wording changes happen in exactly one place.
+
+The kanban phrasing is the canonical template — it is the richer of the two
+and its exact substrings are asserted by
+``tests/gateway/test_kanban_progress_heartbeat.py``. Fields the caller does
+not have (title, assignee) are omitted gracefully rather than faked.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+__all__ = ["format_progress_heartbeat"]
+
+# Keep parity with the kanban payload truncation that predated this helper.
+_TITLE_LIMIT = 120
+_NOTE_LIMIT = 200
+
+
+def _elapsed_phrase(elapsed_minutes: Any) -> str:
+    """Plain-English elapsed wording, or "still going" when unknown."""
+    try:
+        minutes = int(elapsed_minutes)
+    except (TypeError, ValueError):
+        return "still going"
+    if minutes < 1:
+        return "less than a minute in"
+    if minutes == 1:
+        return "about 1 minute in"
+    return f"about {minutes} minutes in"
+
+
+def format_progress_heartbeat(
+    title: Optional[Any] = None,
+    who: Optional[Any] = None,
+    elapsed_minutes: Optional[Any] = None,
+    note: Optional[Any] = None,
+    board_tag: str = "",
+) -> str:
+    """Render one progress heartbeat in the canonical two-line shape.
+
+    ``⏳ <board_tag>Still working[ on <title>][ (running as <who>)] — <elapsed>.``
+    ``Latest update: <note>`` (or ``No status update yet.``)
+
+    Every field is optional: a caller with no task title (the CoS turn path)
+    simply gets "Still working — about 7 minutes in." with no dangling "on".
+    """
+    on_what = f" on {str(title)[:_TITLE_LIMIT]}" if title else ""
+    as_who = f" (running as {who})" if who else ""
+    update = (
+        f"Latest update: {str(note)[:_NOTE_LIMIT]}"
+        if note else "No status update yet."
+    )
+    return (
+        f"⏳ {board_tag}Still working"
+        f"{on_what}{as_who} — {_elapsed_phrase(elapsed_minutes)}."
+        f"\n{update}"
+    )

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from agent.i18n import t
+from gateway.heartbeat_text import format_progress_heartbeat
 
 # Match the logger run.py uses (logging.getLogger(__name__) where __name__ ==
 # "gateway.run") so extracted log records keep their original logger name.
@@ -504,38 +505,15 @@ class GatewayKanbanWatchersMixin:
                                 # advances past the event.
                                 continue
                             payload = ev.payload or {}
-                            progress_title = str(
-                                payload.get("title") or title
-                            )[:120]
-                            who_progress = (
-                                payload.get("assignee")
-                                or (task.assignee if task else "")
-                            )
-                            as_who = (
-                                f" (running as {who_progress})"
-                                if who_progress else ""
-                            )
-                            try:
-                                minutes = int(payload["elapsed_minutes"])
-                            except (KeyError, TypeError, ValueError):
-                                minutes = None
-                            if minutes is None:
-                                elapsed_phrase = "still going"
-                            elif minutes < 1:
-                                elapsed_phrase = "less than a minute in"
-                            elif minutes == 1:
-                                elapsed_phrase = "about 1 minute in"
-                            else:
-                                elapsed_phrase = f"about {minutes} minutes in"
-                            note = payload.get("note")
-                            update = (
-                                f"Latest update: {str(note)[:200]}"
-                                if note else "No status update yet."
-                            )
-                            msg = (
-                                f"⏳ {board_tag}Still working on "
-                                f"{progress_title}{as_who} — {elapsed_phrase}."
-                                f"\n{update}"
+                            msg = format_progress_heartbeat(
+                                title=payload.get("title") or title,
+                                who=(
+                                    payload.get("assignee")
+                                    or (task.assignee if task else "")
+                                ),
+                                elapsed_minutes=payload.get("elapsed_minutes"),
+                                note=payload.get("note"),
+                                board_tag=board_tag,
                             )
                         elif kind == "block_loop_detected":
                             # A task re-blocked for the same cause past the

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -184,6 +184,16 @@ class GatewayKanbanWatchersMixin:
         # task is genuinely done lets the cursor (advanced atomically by
         # claim_unseen_events_for_sub) handle dedup, and any retry-loop
         # event reaches the user.
+        #
+        # `progress` ("still working on it" pings from the dispatcher, see
+        # kanban_db.emit_progress_events) is claimed and delivered alongside
+        # the terminal kinds, but deliberately does NOT live in
+        # TERMINAL_KINDS: that tuple names the events that mean something
+        # happened to the task, and is the natural place a future change
+        # would hang unsubscribe/final-state logic off. A progress ping is the
+        # opposite — proof the task is still alive — and must never end a
+        # subscription or wake the creating agent.
+        NOTIFY_KINDS = TERMINAL_KINDS + ("progress",)
         # Per-subscription send-failure counter. Adapter.send raising
         # means the chat is dead (deleted, bot kicked, etc.) — after N
         # consecutive send failures the sub is dropped so we don't spin
@@ -341,7 +351,7 @@ class GatewayKanbanWatchersMixin:
                                         platform=sub["platform"],
                                         chat_id=sub["chat_id"],
                                         thread_id=sub.get("thread_id") or "",
-                                        kinds=TERMINAL_KINDS,
+                                        kinds=NOTIFY_KINDS,
                                     )
                                     if not events:
                                         continue
@@ -479,6 +489,54 @@ class GatewayKanbanWatchersMixin:
                             if ev.payload and ev.payload.get("status"):
                                 new_status = str(ev.payload["status"])
                             msg = f"🔄 {board_tag}{tag}Kanban {sub['task_id']} → {new_status}"
+                        elif kind == "progress":
+                            # "Still working on it" ping while the task runs.
+                            # Plain English on purpose: this one goes out
+                            # repeatedly to a human who just wants to know the
+                            # thing didn't die, so no IDs, no status codes.
+                            if task is not None and task.status != "running":
+                                # The task finished between the dispatcher
+                                # emitting this ping and us delivering it. Its
+                                # completion message is already out (or right
+                                # behind this event in the same claim), so a
+                                # "still working" line here would contradict
+                                # it. Drop the message; the cursor still
+                                # advances past the event.
+                                continue
+                            payload = ev.payload or {}
+                            progress_title = str(
+                                payload.get("title") or title
+                            )[:120]
+                            who_progress = (
+                                payload.get("assignee")
+                                or (task.assignee if task else "")
+                            )
+                            as_who = (
+                                f" (running as {who_progress})"
+                                if who_progress else ""
+                            )
+                            try:
+                                minutes = int(payload["elapsed_minutes"])
+                            except (KeyError, TypeError, ValueError):
+                                minutes = None
+                            if minutes is None:
+                                elapsed_phrase = "still going"
+                            elif minutes < 1:
+                                elapsed_phrase = "less than a minute in"
+                            elif minutes == 1:
+                                elapsed_phrase = "about 1 minute in"
+                            else:
+                                elapsed_phrase = f"about {minutes} minutes in"
+                            note = payload.get("note")
+                            update = (
+                                f"Latest update: {str(note)[:200]}"
+                                if note else "No status update yet."
+                            )
+                            msg = (
+                                f"⏳ {board_tag}Still working on "
+                                f"{progress_title}{as_who} — {elapsed_phrase}."
+                                f"\n{update}"
+                            )
                         elif kind == "block_loop_detected":
                             # A task re-blocked for the same cause past the
                             # recurrence limit and was routed to `triage` for a
@@ -1111,6 +1169,29 @@ class GatewayKanbanWatchersMixin:
             )
             stale_timeout_seconds = 0
 
+        # Read progress_notify_interval_seconds — how often a still-running
+        # task pings its subscribers with a "still working on it" message.
+        # 0 (or an unparseable value) disables progress pings entirely; the
+        # check is then skipped outright, so an install that doesn't want
+        # them pays nothing for the feature.
+        raw_progress = kanban_cfg.get("progress_notify_interval_seconds", 0)
+        try:
+            progress_interval_seconds = int(raw_progress or 0)
+        except (TypeError, ValueError):
+            logger.warning(
+                "kanban dispatcher: invalid kanban.progress_notify_interval_seconds=%r; "
+                "disabling progress pings",
+                raw_progress,
+            )
+            progress_interval_seconds = 0
+        if progress_interval_seconds < 0:
+            logger.warning(
+                "kanban dispatcher: kanban.progress_notify_interval_seconds=%r is "
+                "negative; disabling progress pings",
+                raw_progress,
+            )
+            progress_interval_seconds = 0
+
         # kanban.reconcile_orphans (config.yaml, default true): each tick,
         # requeue 'running' cards whose claim bookkeeping is broken (no
         # valid claim, dead/gone worker) — the zombie-card reconciliation
@@ -1244,7 +1325,7 @@ class GatewayKanbanWatchersMixin:
                 # re-ran the migration on a second connection, racing
                 # the first. See the matching comment in
                 # `_kanban_notifier_watcher` and issue #21378.
-                return _kb.dispatch_once(
+                result = _kb.dispatch_once(
                     conn,
                     board=slug,
                     max_spawn=max_spawn,
@@ -1255,6 +1336,29 @@ class GatewayKanbanWatchersMixin:
                     max_in_progress_per_profile=max_in_progress_per_profile,
                     reconcile_orphans=reconcile_orphans,
                 )
+                # Progress pings ride the same tick and the same connection
+                # as dispatch: the running set was just reconciled, so this
+                # sees the freshest possible view of what's actually alive.
+                # Isolated in its own try — a cosmetic "still working"
+                # notification must never take down real dispatch work.
+                if progress_interval_seconds > 0:
+                    try:
+                        pinged = _kb.emit_progress_events(
+                            conn, progress_interval_seconds, board=slug,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "kanban dispatcher: progress ping failed on board %s",
+                            slug,
+                        )
+                    else:
+                        if pinged:
+                            logger.info(
+                                "kanban dispatcher [%s]: progress ping for %d "
+                                "running task(s): %s",
+                                slug, len(pinged), pinged,
+                            )
+                return result
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):
                     disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -4739,22 +4739,24 @@ class MessageSender:
 
     @staticmethod
     def strip_cron_wrapper(content: str) -> str:
-        """Strip scheduler cron header/footer wrapper for cleaner Yuanbao output."""
-        if not content.startswith("Cronjob Response: "):
+        """Strip scheduler cron header/footer wrapper for cleaner Yuanbao output.
+
+        Matches the single-line header format from cron.scheduler._deliver_result:
+        "[{task_name} \u00b7 job:{job_id} \u00b7 {HH:MM}]\\n{content}\\n\\n{footer}".
+        """
+        if not content.startswith("[") or " \u00b7 job:" not in content.split("\n", 1)[0]:
             return content
 
-        divider = "\n-------------\n\n"
+        header_end = content.find("]\n")
+        if header_end < 0:
+            return content
+
         footer_prefix = '\n\nTo stop or manage this job, send me a new message (e.g. "stop reminder '
-        divider_pos = content.find(divider)
         footer_pos = content.rfind(footer_prefix)
-        if divider_pos < 0 or footer_pos < 0 or footer_pos <= divider_pos:
+        if footer_pos < 0 or footer_pos <= header_end:
             return content
 
-        header = content[:divider_pos]
-        if "\n(job_id: " not in header:
-            return content
-
-        body_start = divider_pos + len(divider)
+        body_start = header_end + len("]\n")
         body = content[body_start:footer_pos].strip()
         return body or content
 

--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -23,6 +23,27 @@ LIVE_GATEWAY_SILENT_MARKERS = frozenset({
     "NO REPLY",
 })
 
+# U+2014 EM DASH.  Named rather than inlined so the literal never has to be
+# eyeballed in a diff against the visually near-identical en dash (U+2013),
+# which is deliberately NOT rewritten.
+EM_DASH = "—"
+
+
+def sanitize_em_dashes(text: Any) -> Any:
+    """Replace em dashes (U+2014) with a plain hyphen for outbound delivery.
+
+    Applied at the delivery boundary only: the conversation history, the
+    transcript, and the logs keep the model's original characters.  This is a
+    presentation-layer rewrite, so it must never run over text that is merely
+    being stored or compared against stored text.
+
+    Non-string input is returned untouched so this can sit inline in a
+    sanitizing chain without having to guard every call site.
+    """
+    if not isinstance(text, str) or EM_DASH not in text:
+        return text
+    return text.replace(EM_DASH, "-")
+
 
 def _canonical_silence_candidate(text: str) -> str:
     return " ".join(text.strip().upper().split())

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5952,6 +5952,60 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         state = self._peek_session_state(session_key)
         return state is not None and state.turn.agent is not None
 
+    def _profile_for_session_key(self, session_key: str) -> str:
+        """Return the profile a session key belongs to.
+
+        Keys are ``agent:<ns>:<platform>:...`` where ``<ns>`` is ``main`` for
+        the default/non-multiplexed namespace (see
+        ``gateway.session._session_key_namespace``) and the profile id
+        otherwise. ``main`` resolves to whichever profile this process is
+        actually serving.
+        """
+        parts = (session_key or "").split(":")
+        ns = parts[1] if len(parts) > 2 and parts[0] == "agent" else ""
+        if not ns or ns == "main":
+            return self._active_profile_name()
+        return ns
+
+    def _has_active_kanban_for_session(self, session_key: str) -> bool:
+        """True when the session's profile has running/blocked kanban tasks.
+
+        A coarse "is this profile mid-work" probe used to hold the daily
+        session-reset boundary open (see ``SessionStore._is_session_expired``).
+        Deliberately best-effort: a missing, locked, or schema-less board means
+        we cannot see any live work, so we return False and let the reset
+        proceed. Only genuine ``running``/``blocked`` rows block it.
+        """
+        try:
+            import sqlite3
+
+            from hermes_cli.kanban_db import kanban_db_path
+            from hermes_cli.profiles import normalize_profile_name
+
+            db_path = kanban_db_path()
+            if not db_path.exists():
+                return False
+            assignee = normalize_profile_name(
+                self._profile_for_session_key(session_key)
+            )
+            # Read-only + short timeout: the dispatcher writes to this DB
+            # constantly and a reset guard must never queue behind it.
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=2.0)
+            try:
+                row = conn.execute(
+                    "SELECT COUNT(*) FROM tasks "
+                    "WHERE status IN ('running', 'blocked') AND assignee = ?",
+                    (assignee,),
+                ).fetchone()
+            finally:
+                conn.close()
+            return bool(row and row[0])
+        except Exception as exc:
+            logger.debug(
+                "Kanban reset guard lookup failed for %s: %s", session_key, exc
+            )
+            return False
+
     def _running_agent_items(self) -> List[tuple]:
         """(session_key, agent) pairs for sessions with a running turn
         (including pending sentinels), matching the old ``_running_agents``
@@ -6024,11 +6078,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _bg_max_age_seconds = (
             _bg_max_age_hours * 3600 if _bg_max_age_hours and _bg_max_age_hours > 0 else None
         )
+        # Two further guards, daily-boundary only: the daily reset fires on
+        # wall-clock time rather than on activity, so it must not cut a turn
+        # that is mid-flight or a profile that is actively working a kanban
+        # board. Both are best-effort probes; see _is_session_expired.
         self.session_store = SessionStore(
             self.config.sessions_dir, self.config,
             has_active_processes_fn=lambda key: process_registry.has_active_for_session(
                 key, max_active_age=_bg_max_age_seconds,
             ),
+            is_session_running_fn=lambda key: self._is_session_running(key),
+            has_active_kanban_fn=lambda key: self._has_active_kanban_for_session(key),
         )
         # One enforced loop-side boundary for the synchronous SessionStore.
         # Sync helpers keep using ``session_store`` directly; async gateway

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25745,9 +25745,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Periodic "still working" notifications for long-running tasks.
         # Fires every N seconds so the user knows the agent hasn't died.
         # Config: agent.gateway_notify_interval in config.yaml, or
-        # HERMES_AGENT_NOTIFY_INTERVAL env var.  Default 180s (3 min).
+        # HERMES_AGENT_NOTIFY_INTERVAL env var.  Default 300s (5 min),
+        # matching the kanban dispatcher's own progress-heartbeat cadence
+        # (kanban.progress_notify_interval_seconds) for one consistent
+        # rhythm across CoS turns and dispatched kanban tasks.
         # 0 = disable notifications.
-        _NOTIFY_INTERVAL_RAW = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 180)
+        _NOTIFY_INTERVAL_RAW = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 300)
         _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
         _long_running_mode = _display_surface_mode(
             "long_running_notifications",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -63,6 +63,7 @@ from agent.interrupt_compat import request_hard_interrupt
 from agent.turn_context import (
     compression_made_progress,
 )
+from gateway.response_filters import sanitize_em_dashes
 from hermes_cli.config import _is_ssh_remote_tilde_cwd, cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -737,8 +738,13 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
     if _looks_like_gateway_provider_error(redacted):
-        return _gateway_provider_error_reply(redacted)
-    return redacted
+        return sanitize_em_dashes(_gateway_provider_error_reply(redacted))
+
+    # House style: no em dashes on chat surfaces. Rewritten here, at the
+    # delivery boundary, rather than in the agent loop so the stored
+    # transcript keeps what the model actually produced and every platform
+    # inherits the rule without an adapter-side patch.
+    return sanitize_em_dashes(redacted)
 
 
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2433,6 +2433,7 @@ from gateway.session_state import (
     legacy_lease_token_property,
 )
 from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.heartbeat_text import format_progress_heartbeat
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.turn_context import TurnContext
@@ -25278,7 +25279,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Auto-cleanup of temporary progress bubbles (Telegram + any adapter
         # that implements ``delete_message``). When enabled via
         # ``display.platforms.<platform>.cleanup_progress: true``, message IDs
-        # from the tool-progress / "⏳ Working — N min" / status-callback bubbles
+        # from the tool-progress / "⏳ Still working" / status-callback bubbles
         # are collected here and deleted after the final response lands.
         # Failed runs skip cleanup so the bubbles remain as breadcrumbs.
         _cleanup_progress = bool(
@@ -25816,13 +25817,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if _action:
                             _parts.append(str(_action))
                         if _parts:
-                            _status_detail = " — " + ", ".join(_parts)
+                            _status_detail = ", ".join(_parts)
                     except Exception:
                         pass
+                # Same wording as the kanban task heartbeat (shared renderer)
+                # so one user sees one style of "still working" ping whether
+                # the work is a CoS turn or a dispatched kanban task. This
+                # path has no task title or assignee, so those clauses are
+                # omitted; the activity detail plays the "latest update" role.
                 _heartbeat_text = (
                     _generic_status_phrase("status")
                     if _long_running_mode == "generic"
-                    else f"⏳ Working — {_elapsed_mins} min{_status_detail}"
+                    else format_progress_heartbeat(
+                        elapsed_minutes=_elapsed_mins,
+                        note=_status_detail or None,
+                    )
                 )
                 try:
                     _notify_res = None

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1241,7 +1241,9 @@ class SessionStore:
     """
     
     def __init__(self, sessions_dir: Path, config: GatewayConfig,
-                 has_active_processes_fn=None):
+                 has_active_processes_fn=None,
+                 is_session_running_fn=None,
+                 has_active_kanban_fn=None):
         self.sessions_dir = sessions_dir
         self.config = config
         self._entries: Dict[str, SessionEntry] = {}
@@ -1275,6 +1277,11 @@ class SessionStore:
         self._transcript_append_failures: Dict[str, int] = {}
         self._fts_rebuild_attempted = False
         self._has_active_processes_fn = has_active_processes_fn
+        # Live-work guards for the *daily* boundary (see _is_session_expired).
+        # Both are optional callables wired in by the gateway runner; when
+        # unset (tests, embedded stores) they simply don't guard anything.
+        self._is_session_running_fn = is_session_running_fn
+        self._has_active_kanban_fn = has_active_kanban_fn
         # Whether to keep writing the legacy sessions.json mirror alongside
         # the primary gateway_routing table in state.db. Default True for
         # backward compatibility; disable via gateway.write_sessions_json.
@@ -1312,7 +1319,45 @@ class SessionStore:
                 exc,
             )
             return True
-    
+
+    def _is_session_running_safe(self, session_key: str) -> bool:
+        """Return whether a session holds an in-flight turn, failing closed.
+
+        Mirrors :meth:`_has_active_processes_safe`: a raising callable means we
+        cannot tell, so we assume the session IS running and keep it alive
+        rather than resetting a conversation mid-turn.
+        """
+        if self._is_session_running_fn is None:
+            return False
+        try:
+            return bool(self._is_session_running_fn(session_key))
+        except Exception as exc:
+            logger.warning(
+                "is_session_running_fn raised for %s; keeping session alive: %s",
+                session_key,
+                exc,
+            )
+            return True
+
+    def _has_active_kanban_safe(self, session_key: str) -> bool:
+        """Return whether live kanban work is attached to a session, failing closed.
+
+        Same contract as :meth:`_is_session_running_safe`. The callable itself
+        swallows benign lookup failures (missing/locked board) and returns
+        False; anything that escapes it is treated as "assume busy".
+        """
+        if self._has_active_kanban_fn is None:
+            return False
+        try:
+            return bool(self._has_active_kanban_fn(session_key))
+        except Exception as exc:
+            logger.warning(
+                "has_active_kanban_fn raised for %s; keeping session alive: %s",
+                session_key,
+                exc,
+            )
+            return True
+
     def _ensure_loaded(self) -> None:
         """Load sessions index from disk if not already loaded."""
         with self._lock:
@@ -2250,6 +2295,23 @@ class SessionStore:
             if now.hour < policy.at_hour:
                 today_reset -= timedelta(days=1)
             if entry.updated_at < today_reset:
+                # The daily boundary fires on wall-clock time, not on user
+                # activity, so it can land squarely on top of live work: a
+                # long-running turn, or a kanban task the session is driving.
+                # ``updated_at`` doesn't move during a turn, so neither guard
+                # is implied by the staleness check above. Both fail closed.
+                if self._is_session_running_safe(entry.session_key):
+                    logger.debug(
+                        "Session %s not expired — turn in flight",
+                        entry.session_key,
+                    )
+                    return False
+                if self._has_active_kanban_safe(entry.session_key):
+                    logger.debug(
+                        "Session %s not expired — active kanban work",
+                        entry.session_key,
+                    )
+                    return False
                 return True
 
         return False

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -35,6 +35,7 @@ from gateway.config import (
 from gateway.response_filters import (
     is_intentional_silence_response as _is_intentional_silence_response,
     is_partial_silence_marker as _is_partial_silence_marker,
+    sanitize_em_dashes,
 )
 
 logger = logging.getLogger("gateway.stream_consumer")
@@ -1235,8 +1236,17 @@ class GatewayStreamConsumer:
         delivered separately via ``_deliver_media_from_response()`` after the
         stream finishes — we just need to hide the raw directives from the
         user.
+
+        Em dashes are rewritten here too so the streaming path obeys the same
+        house style as the non-streaming boundary
+        (``_sanitize_gateway_final_response``).  Every delivered-text
+        comparison below (``delivered_final_matches``, ``has_delivered_text``)
+        normalizes both sides through this method, so the dedup verdicts stay
+        symmetric.
         """
-        return _BasePlatformAdapter.strip_media_directives_for_display(text)
+        return sanitize_em_dashes(
+            _BasePlatformAdapter.strip_media_directives_for_display(text)
+        )
 
     async def _send_new_chunk(
         self,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2394,6 +2394,17 @@ DEFAULT_CONFIG = {
         # worker process (if still running host-locally) is terminated
         # before the reclaim.  0 disables stale detection entirely.
         "dispatch_stale_timeout_seconds": 14400,
+        # Progress pings: while a task is 'running', the dispatcher emits a
+        # ``progress`` task event roughly every this many seconds, which the
+        # notifier delivers to that task's subscribers as a plain-English
+        # "still working on it" message (task title, minutes elapsed, and the
+        # latest ``kanban_heartbeat`` note if the worker left one). Timing is
+        # deliberately approximate — the check only runs once per
+        # ``dispatch_interval_seconds`` tick, so the real gap is this value
+        # rounded up to the next tick. Nothing is emitted when no task is
+        # running, and pings stop as soon as the task leaves 'running'.
+        # 0 disables progress pings entirely.
+        "progress_notify_interval_seconds": 300,
         # Orphaned-card reconciliation: each dispatcher tick, requeue
         # 'running' cards whose claim bookkeeping is broken (claim_lock or
         # claim_expires NULL with a dead/gone worker) — zombies invisible

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -204,10 +204,11 @@ DEFAULT_CONFIG = {
         # Sends a status message every N seconds so the user knows the
         # agent hasn't died during long tasks.  0 = disable notifications.
         # Lower values mean faster feedback on slow tasks but more chat
-        # noise; 180s is a compromise that catches spinning weak-model runs
-        # (60+ tool iterations with tiny output) before users assume the
-        # bot is dead and /restart.
-        "gateway_notify_interval": 180,
+        # noise; 300s (5min) matches the standard heartbeat cadence used
+        # elsewhere (kanban.progress_notify_interval_seconds) so the user
+        # gets one consistent "still working" rhythm across CoS turns and
+        # dispatched kanban tasks.
+        "gateway_notify_interval": 300,
         # Session stall watchdog (seconds). Scope (#76354): this is a
         # RECOVERY notifier for an in-process AIAgent that has an
         # adapter-queued follow-up (pending inbound / queued event) while its

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2324,6 +2324,24 @@ DEFAULT_CONFIG = {
         # behaviour — e.g. for a profile that prefers explicit
         # ``kanban_notify-subscribe`` calls per task.
         "auto_subscribe_on_create": True,
+        # Session-independent fallback subscription. ``auto_subscribe_on_create``
+        # only fires when a task is created from inside a live gateway/TUI
+        # session; CLI (`hermes kanban create`), cron, and dispatcher-spawned
+        # workers have no session context, so those tasks used to complete
+        # silently. When this is true, every task created through
+        # ``kanban_db.create_task`` also subscribes the active profile's
+        # configured home channel (``platforms.<platform>.home_channel``), so
+        # completion / block events always reach the user's own chat regardless
+        # of where the task was created. Set to false to restore the
+        # session-only behaviour.
+        "default_notify_home_channel": True,
+        # Only subscribe the home channel for tasks at or above this priority.
+        # 0 (the default task priority) means "every task".
+        "default_notify_min_priority": 0,
+        # Platform whose home channel receives the fallback subscription.
+        # Empty = auto-detect: the first enabled platform in ``platforms:``
+        # that has a ``home_channel.chat_id``.
+        "default_notify_platform": "",
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3271,6 +3271,9 @@ def create_task(
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
+            # Outside the write txn: add_notify_sub opens its own
+            # BEGIN IMMEDIATE and write_txn is not reentrant.
+            _maybe_subscribe_home_channel(conn, task_id, priority=priority)
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -3332,6 +3335,155 @@ def _inherit_notify_subs(
             *parent_ids,
         ),
     )
+
+
+def _resolve_home_channel_target() -> Optional[dict[str, Any]]:
+    """Resolve the active profile's home channel for fallback notifications.
+
+    Returns ``None`` when the feature is disabled, no platform is enabled with
+    a ``home_channel.chat_id``, or config can't be read. The caller treats any
+    failure as "don't subscribe" — this is bookkeeping, never a hard error.
+    """
+    from hermes_cli.config import load_config_readonly, cfg_get
+
+    cfg = load_config_readonly()
+    if not cfg_get(cfg, "kanban", "default_notify_home_channel", default=True):
+        return None
+
+    platforms = cfg_get(cfg, "platforms", default=None)
+    if not isinstance(platforms, Mapping):
+        return None
+
+    configured = str(
+        cfg_get(cfg, "kanban", "default_notify_platform", default="") or ""
+    ).strip().lower()
+    # Explicit platform wins; otherwise take the first enabled platform that
+    # actually has a home channel (config order, so a single-platform install
+    # needs no extra config at all).
+    candidates = [configured] if configured else list(platforms.keys())
+    for name in candidates:
+        plat_cfg = platforms.get(name)
+        if not isinstance(plat_cfg, Mapping) or not plat_cfg.get("enabled"):
+            continue
+        home = plat_cfg.get("home_channel")
+        if not isinstance(home, Mapping):
+            continue
+        chat_id = str(home.get("chat_id") or "").strip()
+        if not chat_id:
+            continue
+        platform = str(name).strip().lower()
+        chat_type = str(home.get("chat_type") or "").strip() or None
+        if not chat_type and platform == "slack" and chat_id.startswith("D"):
+            # Slack DM ids are D-prefixed; the notifier keys wake-sessions off
+            # chat_type and would otherwise fall back to "group".
+            chat_type = "dm"
+        return {
+            "platform": platform,
+            "chat_id": chat_id,
+            "chat_type": chat_type,
+            "thread_id": str(home.get("thread_id") or "").strip() or None,
+            "user_id": str(home.get("user_id") or "").strip() or None,
+        }
+    return None
+
+
+def _maybe_subscribe_home_channel(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    priority: int = 0,
+) -> bool:
+    """Subscribe the active profile's home channel to a new task's events.
+
+    ``tools/kanban_tools.py::_maybe_auto_subscribe`` only fires when the
+    creating call has live session context (a gateway chat or a TUI session
+    key). Tasks created by `hermes kanban create`, cron, or a dispatcher-spawned
+    worker have none, so their completion / block events reached nobody. This
+    hook lives in the DB-layer ``create_task`` — the single chokepoint every
+    surface goes through — so the user's home channel is subscribed regardless
+    of where the task came from.
+
+    Gated by ``kanban.default_notify_home_channel`` (default True) and
+    ``kanban.default_notify_min_priority`` (default 0 = all tasks). Returns
+    True only when a row was written.
+
+    Duplicate suppression: skipped when any subscription for this task already
+    targets the same platform+chat (e.g. inherited from a parent), and when the
+    calling session IS the home channel — there the richer session-based
+    subscription (thread anchor, delivery metadata) is written by the tool
+    layer right after this and would otherwise double-notify on a sibling
+    thread_id.
+
+    Best-effort by design: every failure is logged at WARNING and swallowed so
+    notification bookkeeping can never fail a task creation.
+    """
+    try:
+        target = _resolve_home_channel_target()
+        if not target:
+            return False
+
+        from hermes_cli.config import load_config_readonly, cfg_get
+        cfg = load_config_readonly()
+        try:
+            min_priority = int(
+                cfg_get(cfg, "kanban", "default_notify_min_priority", default=0) or 0
+            )
+        except (TypeError, ValueError):
+            min_priority = 0
+        if int(priority or 0) < min_priority:
+            return False
+
+        platform = target["platform"]
+        chat_id = target["chat_id"]
+
+        # The session-based auto-subscribe covers this exact chat with better
+        # routing metadata; let it win instead of writing a second row.
+        if cfg_get(cfg, "kanban", "auto_subscribe_on_create", default=True):
+            try:
+                from gateway.session_context import get_session_env
+                if (
+                    get_session_env("HERMES_SESSION_PLATFORM", "").lower() == platform
+                    and get_session_env("HERMES_SESSION_CHAT_ID", "") == chat_id
+                ):
+                    return False
+            except Exception:
+                pass
+
+        existing = conn.execute(
+            "SELECT 1 FROM kanban_notify_subs "
+            "WHERE task_id = ? AND platform = ? AND chat_id = ? LIMIT 1",
+            (task_id, platform, chat_id),
+        ).fetchone()
+        if existing:
+            return False
+
+        # Stamp the profile whose config supplied the home channel: the chat id
+        # is that profile's own bot conversation, so only a gateway hosting that
+        # profile's adapter can deliver to it.
+        notifier_profile = os.environ.get("HERMES_PROFILE") or ""
+        if not notifier_profile:
+            try:
+                from hermes_cli.profiles import get_active_profile_name
+                notifier_profile = get_active_profile_name() or "default"
+            except Exception:
+                notifier_profile = "default"
+
+        add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform=platform,
+            chat_id=chat_id,
+            chat_type=target["chat_type"],
+            thread_id=target["thread_id"],
+            user_id=target["user_id"],
+            notifier_profile=notifier_profile,
+        )
+        return True
+    except Exception as exc:
+        _log.warning(
+            "_maybe_subscribe_home_channel failed for %s: %r", task_id, exc
+        )
+        return False
 
 
 def get_task(conn: sqlite3.Connection, task_id: str) -> Optional[Task]:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3270,6 +3270,24 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                # A task parked in ``blocked`` at creation needs a real
+                # ``blocked`` event too, not just status='blocked' on the
+                # row — that event is the only signal _has_sticky_block()
+                # reads, so without it recompute_ready() would happily
+                # promote a deliberately-parked task back to ready. No
+                # run_id: nothing has run yet, this is creation rather
+                # than a transition out of a run.
+                if task_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": "created blocked (parked at creation)",
+                            "kind": None,
+                            "recurrences": 0,
+                        },
+                    )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             # Outside the write txn: add_notify_sub opens its own
             # BEGIN IMMEDIATE and write_txn is not reentrant.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7340,6 +7340,129 @@ def heartbeat_worker(
     return True
 
 
+def emit_progress_events(
+    conn: sqlite3.Connection,
+    interval_seconds: int,
+    *,
+    board: Optional[str] = None,
+) -> list[str]:
+    """Emit a ``progress`` event for every long-running task.
+
+    This is the "still working on it" signal a user gets in chat while a
+    task is in flight, so a slow task doesn't look like a dead one. It is
+    dispatcher-side and purely additive: the notifier picks the events up
+    and renders them, nothing else in the lifecycle reads them.
+
+    Deliberately NOT the ``heartbeat`` kind. A ``heartbeat`` event is the
+    worker telling the dispatcher it is alive (feeding stale detection in
+    :func:`detect_stale_running`); ``progress`` is the dispatcher telling
+    the human how it's going. The two have different writers, different
+    cadences, and different consumers — overloading one kind for both
+    would make a missing worker heartbeat indistinguishable from a
+    delivered user ping.
+
+    A task is due for a ping when ``interval_seconds`` have passed since
+    its most recent ``progress`` event, or — for a task that has never had
+    one — since the current run started. Only ``status='running'`` tasks
+    are considered, so nothing is emitted on an idle board and pings stop
+    on their own the moment a task completes, blocks, or is reclaimed.
+
+    The payload carries everything the notifier needs to write a message
+    without re-querying: ``task_id``, ``title``, ``assignee``, ``board``,
+    ``elapsed_minutes`` (total time in the current run, not time since the
+    last ping) and ``note`` — the most recent ``kanban_heartbeat`` note
+    left within the window just measured, or ``None`` when the worker
+    hasn't said anything since the last ping.
+
+    Timing is approximate by design: the caller only checks once per
+    dispatcher tick, so the real gap is ``interval_seconds`` rounded up to
+    the next tick. ``interval_seconds <= 0`` disables the check entirely.
+
+    Returns the list of task IDs that got a new ``progress`` event.
+    """
+    if interval_seconds <= 0:
+        return []
+
+    now = int(time.time())
+    emitted: list[str] = []
+
+    rows = conn.execute(
+        "SELECT t.id, t.title, t.assignee, t.current_run_id, "
+        "       COALESCE(r.started_at, t.started_at) AS active_started_at "
+        "FROM tasks t "
+        "LEFT JOIN task_runs r ON r.id = t.current_run_id "
+        "WHERE t.status = 'running'"
+    ).fetchall()
+
+    for row in rows:
+        tid = row["id"]
+        # A running task with no start timestamp shouldn't happen, but a
+        # legacy/hand-edited row must not crash the dispatcher tick.
+        if row["active_started_at"] is None:
+            continue
+        started_at = int(row["active_started_at"])
+
+        last_progress = conn.execute(
+            "SELECT created_at FROM task_events "
+            "WHERE task_id = ? AND kind = 'progress' "
+            "ORDER BY created_at DESC, id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()
+        window_start = (
+            int(last_progress["created_at"])
+            if last_progress is not None
+            else started_at
+        )
+        if now - window_start < interval_seconds:
+            continue
+
+        # Most recent thing the worker actually said since the last ping.
+        # Older notes are intentionally not repeated — the user already saw
+        # them on the previous ping.
+        note = None
+        hb_row = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'heartbeat' AND created_at >= ? "
+            "ORDER BY created_at DESC, id DESC LIMIT 1",
+            (tid, window_start),
+        ).fetchone()
+        if hb_row is not None and hb_row["payload"]:
+            try:
+                hb_payload = json.loads(hb_row["payload"])
+            except (ValueError, TypeError):
+                hb_payload = None
+            if isinstance(hb_payload, dict) and hb_payload.get("note"):
+                note = str(hb_payload["note"])
+
+        payload = {
+            "task_id": tid,
+            "title": row["title"],
+            "assignee": row["assignee"],
+            "board": board or get_current_board(),
+            "elapsed_minutes": int(max(0, now - started_at) // 60),
+            "note": note,
+        }
+
+        with write_txn(conn):
+            # Re-check under the write lock: the task may have completed
+            # between the SELECT above and here, and a "still working"
+            # ping racing its own completion message is exactly the
+            # confusing double-notification this guard exists to avoid.
+            still_running = conn.execute(
+                "SELECT status FROM tasks WHERE id = ?", (tid,),
+            ).fetchone()
+            if still_running is None or still_running["status"] != "running":
+                continue
+            run_id = row["current_run_id"]
+            _append_event(
+                conn, tid, "progress", payload,
+                run_id=int(run_id) if run_id else None,
+            )
+        emitted.append(tid)
+
+    return emitted
+
+
 def enforce_max_runtime(
     conn: sqlite3.Connection,
     *,

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -452,7 +452,7 @@ TIPS = [
 
     # --- Gateway Behavior Env Vars ---
     'HERMES_GATEWAY_BUSY_ACK_ENABLED=false silences the ⚡/⏳/⏩ ack messages when a user messages a busy agent.',
-    'HERMES_AGENT_NOTIFY_INTERVAL (default 180s) sets how often the gateway pings with progress on long turns.',
+    'HERMES_AGENT_NOTIFY_INTERVAL (default 300s) sets how often the gateway pings with progress on long turns.',
     'HERMES_RESTART_DRAIN_TIMEOUT (default 900s) caps how long /restart waits for in-flight runs before forcing.',
     'HERMES_CHECKPOINT_TIMEOUT (default 30s) caps filesystem checkpoint creation — raise it on huge monorepos.',
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8216,6 +8216,42 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             result.append(msg)
         return result
 
+    def get_recent_user_messages(
+        self, session_id: str, limit: int = 50
+    ) -> List[Dict[str, Any]]:
+        """Load the newest ``limit`` active user rows, oldest-first.
+
+        A narrow read for per-turn scans of what the user actually said
+        (see ``agent.shared_media_tracker``): it runs on EVERY turn, so it
+        selects only the three columns such a scan needs, filters ``role``
+        in SQL instead of dragging a tool-heavy transcript into Python, and
+        rides the ``idx_messages_session_id`` index — ``get_messages`` would
+        return the whole session (or a tail dominated by tool rows).
+
+        Ordered by AUTOINCREMENT id like :meth:`get_messages` (true insertion
+        order; see c03acca50 for the WSL2 clock-regression rationale), taken
+        from the newest end and reversed back into chronological order.
+        """
+        if limit <= 0:
+            return []
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                "SELECT id, content, timestamp FROM messages "
+                "WHERE session_id = ? AND role = 'user' AND active = 1 "
+                "ORDER BY id DESC LIMIT ?",
+                (session_id, limit),
+            ).fetchall()
+        rows.reverse()
+        return [
+            {
+                "id": row["id"],
+                "role": "user",
+                "content": self._decode_content(row["content"]),
+                "timestamp": row["timestamp"],
+            }
+            for row in rows
+        ]
+
     def find_pr_url_messages(self, session_ids: List[str]) -> List[Dict[str, Any]]:
         """Tool results in these sessions that mention a GitHub PR url.
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -427,17 +427,44 @@ def get_board(
         }
 
         # Progress rollup: for each parent, how many children are done / total.
-        # One pass over task_links joined with child status — cheaper than
-        # N per-task queries and the plugin uses it to render "N/M".
+        # One pass over task_links joined with both endpoints' status —
+        # cheaper than N per-task queries and the plugin uses it to render
+        # "N/M".
+        #
+        # ``waiting_progress`` is the same count in the other direction (how
+        # many of a task's *dependencies* are done). Decomposition links the
+        # root as a child of every task it spawned — the root wakes when they
+        # all finish — so a decomposed root never appears in ``progress``;
+        # its real child progress only shows up here.
         progress: dict[str, dict[str, int]] = {}
+        waiting_progress: dict[str, dict[str, int]] = {}
         for row in conn.execute(
-            "SELECT l.parent_id AS pid, t.status AS cstatus "
-            "FROM task_links l JOIN tasks t ON t.id = l.child_id"
+            "SELECT l.parent_id AS pid, l.child_id AS cid, "
+            "p.status AS pstatus, c.status AS cstatus "
+            "FROM task_links l "
+            "JOIN tasks p ON p.id = l.parent_id "
+            "JOIN tasks c ON c.id = l.child_id"
         ).fetchall():
             p = progress.setdefault(row["pid"], {"done": 0, "total": 0})
             p["total"] += 1
             if row["cstatus"] == "done":
                 p["done"] += 1
+            w = waiting_progress.setdefault(row["cid"], {"done": 0, "total": 0})
+            w["total"] += 1
+            if row["pstatus"] == "done":
+                w["done"] += 1
+
+        # Tasks that were fanned out by the decomposer. A decomposed root
+        # sits in 'todo' while its children run, which is visually identical
+        # to a never-started card — the board uses this flag to say
+        # "waiting on children" instead. One aggregate query, same shape as
+        # the counts above.
+        decomposed_ids: set[str] = {
+            r["task_id"]
+            for r in conn.execute(
+                "SELECT DISTINCT task_id FROM task_events WHERE kind = 'decomposed'"
+            )
+        }
 
         # Diagnostics rollup for this board — see kanban_diagnostics.
         # We get the full structured list per task AND a compact
@@ -468,6 +495,16 @@ def get_board(
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
             d["comment_count"] = comment_counts.get(t.id, 0)
             d["progress"] = progress.get(t.id)  # None when the task has no children
+            # Only meaningful while the root itself is still open — once it
+            # reaches a terminal status it is not waiting on anything.
+            is_decomposed_parent = (
+                t.id in decomposed_ids and t.status not in ("done", "archived")
+            )
+            d["is_decomposed_parent"] = is_decomposed_parent
+            if is_decomposed_parent and d["progress"] is None:
+                # The tasks a decomposed root is waiting on ARE its children;
+                # surface them as its progress so the card can show N/M.
+                d["progress"] = waiting_progress.get(t.id)
             diags = diagnostics_per_task.get(t.id)
             if diags:
                 # Full list goes into the payload so the drawer can render

--- a/run_agent.py
+++ b/run_agent.py
@@ -1078,7 +1078,7 @@ class AIAgent:
         - TUI / Desktop: the same callback is bridged to the ``thinking.delta``
           event, which both render as the live spinner/status line.
         - Gateway: ``_touch_activity`` stores the text as the activity
-          description, which the "⏳ Working — N min" heartbeat includes.
+          description, which the "⏳ Still working" heartbeat includes.
 
         Never raises — a wait notice must not break the API-call wait loop.
         """

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -30,6 +30,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent.memory_manager import build_memory_context_block
+from agent.shared_media_tracker import build_recent_links_context_block
 from agent.turn_context import build_turn_context, compose_user_api_content
 from hermes_state import SessionDB
 
@@ -47,6 +48,29 @@ class TestComposeUserApiContent:
         out = compose_user_api_content("hello", "likes tea", "PLUGIN-CTX")
         fenced = build_memory_context_block("likes tea")
         assert out == "hello" + "\n\n" + fenced + "\n\n" + "PLUGIN-CTX"
+
+    def test_recent_links_block_is_the_third_injection(self):
+        links = build_recent_links_context_block(
+            [{"role": "user", "content": "https://example.com/a"}]
+        )
+        assert links  # test precondition
+        out = compose_user_api_content("hello", "likes tea", "PLUGIN-CTX", links)
+        fenced = build_memory_context_block("likes tea")
+        assert out == (
+            "hello" + "\n\n" + fenced + "\n\n" + "PLUGIN-CTX" + "\n\n" + links
+        )
+
+    def test_recent_links_block_alone(self):
+        out = compose_user_api_content("hello", "", "", "<recent-shared-links>\nx\n</recent-shared-links>")
+        assert out == "hello\n\n<recent-shared-links>\nx\n</recent-shared-links>"
+
+    def test_empty_recent_links_block_changes_nothing(self):
+        """Regression safety for the two pre-existing injection sources: an
+        empty third source must compose byte-identically to the 3-arg call."""
+        assert compose_user_api_content("hello", "", "", "") is None
+        assert compose_user_api_content(
+            "hello", "likes tea", "PLUGIN-CTX", ""
+        ) == compose_user_api_content("hello", "likes tea", "PLUGIN-CTX")
 
 
 
@@ -268,6 +292,64 @@ class TestPrologueStamping:
             ctx = _build(agent)
         assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
         assert agent.api_content_at_persist is None
+
+    def test_recent_shared_links_ride_the_sidecar(self, tmp_path):
+        """A URL pasted several turns ago is read back from the PERSISTED
+        rows and appended to the API copy only — the clean content and the
+        system prompt are untouched."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session("sess-1", source="cli")
+            db.append_message(
+                "sess-1", "user", content="watch https://youtube.com/watch?v=abc123"
+            )
+            db.append_message("sess-1", "assistant", content="ok")
+            for i in range(3):
+                db.append_message("sess-1", "user", content=f"follow-up {i}")
+
+            agent = _FakeAgent()
+            agent._session_db = db
+            with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+                ctx = _build(agent)
+
+            msg = ctx.messages[ctx.current_turn_user_idx]
+            assert msg["content"] == "hello"  # clean content untouched
+            assert msg["api_content"] == (
+                "hello\n\n<recent-shared-links>\n"
+                "- youtube.com/watch?v=abc123 (4 turns ago)\n"
+                "</recent-shared-links>"
+            )
+            assert ctx.recent_links_block in msg["api_content"]
+            # The system prompt is not an injection target.
+            assert ctx.active_system_prompt == "SYSTEM"
+        finally:
+            db.close()
+
+    def test_no_recent_links_block_without_urls(self):
+        """No URLs in the session ⇒ no third injection, no stamp at all."""
+        agent = _FakeAgent()
+        agent._session_db = MagicMock()
+        agent._session_db.get_recent_user_messages.return_value = [
+            {"role": "user", "content": "no links here"}
+        ]
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            ctx = _build(agent)
+        assert ctx.recent_links_block == ""
+        assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
+
+    def test_failed_link_read_never_breaks_the_turn(self):
+        agent = _FakeAgent()
+        agent._session_db = MagicMock()
+        agent._session_db.get_recent_user_messages.side_effect = RuntimeError("db down")
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[{"context": "PLUGIN-CTX"}],
+        ):
+            ctx = _build(agent)
+        assert ctx.recent_links_block == ""
+        assert ctx.messages[ctx.current_turn_user_idx]["api_content"] == (
+            "hello\n\nPLUGIN-CTX"
+        )
 
     def test_no_stamp_for_codex_app_server(self):
         """codex_app_server turns bypass the api_messages build, so the

--- a/tests/agent/test_shared_media_tracker.py
+++ b/tests/agent/test_shared_media_tracker.py
@@ -1,0 +1,297 @@
+"""Tests for recent-shared-links tracking (``agent.shared_media_tracker``).
+
+A URL pasted in message text has no structured extraction anywhere else in
+the pipeline, so it survives only as prose in one historical user turn and
+the model loses track of it a few turns later. These cover the extraction
+(dedup, limit, recency), the fenced block format, and the durability
+property that motivates reading persisted rows: a link shared several turns
+back must still reach the block.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.shared_media_tracker import (
+    build_recent_links_context_block,
+    extract_recent_shared_links,
+    link_label,
+)
+from hermes_state import SessionDB
+
+
+def _rows(*texts: str) -> list:
+    """Persisted user rows, oldest first (the DB read's order)."""
+    return [
+        {"id": i, "role": "user", "content": t, "timestamp": 1000.0 + i}
+        for i, t in enumerate(texts)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# extract_recent_shared_links
+# ---------------------------------------------------------------------------
+
+class TestExtractRecentSharedLinks:
+    def test_no_urls_is_empty(self):
+        assert extract_recent_shared_links(_rows("hello", "how are you")) == []
+
+    def test_empty_input_is_empty(self):
+        assert extract_recent_shared_links([]) == []
+        assert extract_recent_shared_links(None) == []
+
+    def test_single_url(self):
+        links = extract_recent_shared_links(_rows("look at https://example.com/a"))
+        assert links == [
+            {
+                "url": "https://example.com/a",
+                "label": "example.com/a",
+                "turns_ago": 1,
+            }
+        ]
+
+    def test_multiple_urls_newest_first(self):
+        links = extract_recent_shared_links(
+            _rows(
+                "first https://a.com/1",
+                "no link here",
+                "second https://b.com/2",
+            )
+        )
+        assert [link["url"] for link in links] == [
+            "https://b.com/2",
+            "https://a.com/1",
+        ]
+        # Newest supplied row is 1 turn ago; the first row is 3 rows back.
+        assert [link["turns_ago"] for link in links] == [1, 3]
+
+    def test_two_urls_in_one_message(self):
+        links = extract_recent_shared_links(
+            _rows("compare https://a.com/1 and https://b.com/2")
+        )
+        assert [link["url"] for link in links] == [
+            "https://a.com/1",
+            "https://b.com/2",
+        ]
+        assert all(link["turns_ago"] == 1 for link in links)
+
+    def test_dedup_keeps_most_recent_mention(self):
+        links = extract_recent_shared_links(
+            _rows(
+                "https://example.com/x",
+                "unrelated",
+                "again https://example.com/x",
+            )
+        )
+        assert len(links) == 1
+        assert links[0]["turns_ago"] == 1  # the recent mention, not the old one
+
+    def test_limit_keeps_most_recent_n(self):
+        links = extract_recent_shared_links(
+            _rows(*[f"link https://site{i}.com/p" for i in range(12)]), limit=3
+        )
+        assert [link["url"] for link in links] == [
+            "https://site11.com/p",
+            "https://site10.com/p",
+            "https://site9.com/p",
+        ]
+
+    def test_default_limit_is_eight(self):
+        links = extract_recent_shared_links(
+            _rows(*[f"https://site{i}.com/p" for i in range(20)])
+        )
+        assert len(links) == 8
+
+    def test_non_positive_limit_is_empty(self):
+        assert extract_recent_shared_links(_rows("https://a.com/1"), limit=0) == []
+
+    def test_non_user_rows_are_skipped(self):
+        rows = [
+            {"role": "assistant", "content": "see https://assistant.com/x"},
+            {"role": "user", "content": "mine https://user.com/y"},
+        ]
+        assert [link["url"] for link in extract_recent_shared_links(rows)] == [
+            "https://user.com/y"
+        ]
+
+    def test_text_field_fallback(self):
+        rows = [{"role": "user", "text": "https://example.com/from-text"}]
+        assert extract_recent_shared_links(rows)[0]["url"] == (
+            "https://example.com/from-text"
+        )
+
+    def test_multimodal_content_parts_are_scanned(self):
+        rows = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "check https://example.com/img-note"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                ],
+            }
+        ]
+        assert extract_recent_shared_links(rows)[0]["url"] == (
+            "https://example.com/img-note"
+        )
+
+    def test_http_and_https_both_matched(self):
+        links = extract_recent_shared_links(
+            _rows("http://plain.example.com/a https://secure.example.com/b")
+        )
+        assert {link["url"] for link in links} == {
+            "http://plain.example.com/a",
+            "https://secure.example.com/b",
+        }
+
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("see https://example.com/a.", "https://example.com/a"),
+            ("see https://example.com/a, then", "https://example.com/a"),
+            ("(https://example.com/a)", "https://example.com/a"),
+            ("<https://example.com/a>", "https://example.com/a"),
+            ("[link](https://example.com/a)", "https://example.com/a"),
+        ],
+    )
+    def test_surrounding_punctuation_is_not_part_of_the_url(self, text, expected):
+        assert extract_recent_shared_links(_rows(text))[0]["url"] == expected
+
+    def test_non_dict_rows_are_ignored(self):
+        rows = ["junk", None, {"role": "user", "content": "https://a.com/1"}]
+        assert len(extract_recent_shared_links(rows)) == 1
+
+
+# ---------------------------------------------------------------------------
+# link_label — host + truncated path, not the full URL (token budget)
+# ---------------------------------------------------------------------------
+
+class TestLinkLabel:
+    def test_drops_scheme_and_www(self):
+        assert link_label("https://www.example.com/a") == "example.com/a"
+        assert link_label("http://example.com/a") == "example.com/a"
+
+    def test_keeps_query_string(self):
+        assert link_label("https://youtube.com/watch?v=abc123") == (
+            "youtube.com/watch?v=abc123"
+        )
+
+    def test_truncates_long_urls(self):
+        label = link_label("https://example.com/" + "x" * 500)
+        assert len(label) == 48
+        assert label.endswith("...")
+        assert label.startswith("example.com/xxx")
+
+    def test_trailing_slash_dropped(self):
+        assert link_label("https://example.com/") == "example.com"
+
+
+# ---------------------------------------------------------------------------
+# build_recent_links_context_block
+# ---------------------------------------------------------------------------
+
+class TestBuildRecentLinksContextBlock:
+    def test_empty_when_no_links(self):
+        assert build_recent_links_context_block(_rows("hello")) == ""
+        assert build_recent_links_context_block([]) == ""
+
+    def test_fenced_block_format(self):
+        block = build_recent_links_context_block(
+            _rows(
+                "pr is https://github.com/org/repo/pull/42",
+                "t1",
+                "t2",
+                "t3",
+                "watch https://youtube.com/watch?v=abc123",
+                "t5",
+                "t6",
+            )
+        )
+        assert block == (
+            "<recent-shared-links>\n"
+            "- youtube.com/watch?v=abc123 (3 turns ago)\n"
+            "- github.com/org/repo/pull/42 (7 turns ago)\n"
+            "</recent-shared-links>"
+        )
+
+    def test_singular_turn_wording(self):
+        block = build_recent_links_context_block(_rows("https://a.com/1"))
+        assert "(1 turn ago)" in block
+        assert "1 turns ago" not in block
+
+    def test_limit_is_forwarded(self):
+        block = build_recent_links_context_block(
+            _rows(*[f"https://site{i}.com/p" for i in range(5)]), limit=2
+        )
+        assert sum(line.startswith("- ") for line in block.splitlines()) == 2
+
+    def test_url_survives_several_intervening_turns(self):
+        """The original failure case, at unit level: a URL shared early is
+        still labelled in the block many user turns later."""
+        rows = _rows(
+            "here is the video https://youtube.com/watch?v=abc123",
+            *[f"unrelated question {i}" for i in range(9)],
+        )
+        block = build_recent_links_context_block(rows)
+        assert "youtube.com/watch?v=abc123" in block
+        assert "(10 turns ago)" in block
+
+
+# ---------------------------------------------------------------------------
+# The persisted-row read the prologue feeds the tracker
+# ---------------------------------------------------------------------------
+
+class TestGetRecentUserMessages:
+    def _open(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("s1", source="cli")
+        return db
+
+    def test_returns_only_user_rows_oldest_first(self, tmp_path):
+        db = self._open(tmp_path)
+        try:
+            db.append_message("s1", "user", content="q1")
+            db.append_message("s1", "assistant", content="a1")
+            db.append_message("s1", "tool", content="t1")
+            db.append_message("s1", "user", content="q2")
+            rows = db.get_recent_user_messages("s1")
+            assert [r["content"] for r in rows] == ["q1", "q2"]
+            assert all(r["role"] == "user" for r in rows)
+        finally:
+            db.close()
+
+    def test_limit_takes_the_newest(self, tmp_path):
+        db = self._open(tmp_path)
+        try:
+            for i in range(5):
+                db.append_message("s1", "user", content=f"q{i}")
+            rows = db.get_recent_user_messages("s1", limit=2)
+            assert [r["content"] for r in rows] == ["q3", "q4"]
+        finally:
+            db.close()
+
+    def test_non_positive_limit_is_empty(self, tmp_path):
+        db = self._open(tmp_path)
+        try:
+            db.append_message("s1", "user", content="q1")
+            assert db.get_recent_user_messages("s1", limit=0) == []
+        finally:
+            db.close()
+
+    def test_feeds_the_tracker_end_to_end(self, tmp_path):
+        """Persist a URL turn, several turns pass, the block still labels it."""
+        db = self._open(tmp_path)
+        try:
+            db.append_message("s1", "user", content="see https://github.com/org/repo/pull/42")
+            for i in range(4):
+                db.append_message("s1", "assistant", content=f"a{i}")
+                db.append_message("s1", "user", content=f"follow-up {i}")
+            block = build_recent_links_context_block(
+                db.get_recent_user_messages("s1", limit=50)
+            )
+            assert block == (
+                "<recent-shared-links>\n"
+                "- github.com/org/repo/pull/42 (5 turns ago)\n"
+                "</recent-shared-links>"
+            )
+        finally:
+            db.close()

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -31,6 +31,7 @@ EXPECTED_FIELDS = {
     "primary_recovery_attempted",
     "has_retried_429",
     "auth_failover_attempted",
+    "primary_failed_billing_or_credit",
     "restart_with_compressed_messages",
     "restart_with_length_continuation",
     "restart_with_rebuilt_messages",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -279,11 +279,14 @@ class TestDeliverResultWrapping:
 
         send_mock.assert_called_once()
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
-        assert "Cronjob Response: daily-report" in sent_content
-        assert "(job_id: test-job)" in sent_content
-        assert "-------------" in sent_content
+        assert "[daily-report \u00b7 job:test-job \u00b7 " in sent_content
         assert "Here is today's summary." in sent_content
         assert "To stop or manage this job" in sent_content
+        # Single-line header: everything up to the first newline should be
+        # the compact bracketed header, not the old 4-line block.
+        header_line = sent_content.split("\n", 1)[0]
+        assert header_line.startswith("[daily-report \u00b7 job:test-job \u00b7 ")
+        assert header_line.endswith("]")
 
 
     def test_relay_fronted_home_uses_relay_config_and_live_adapter(self, monkeypatch, tmp_path):

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -148,7 +148,8 @@ class TestPlatformDefaults:
         # Real model voice — keep on. Without this, Telegram users see
         # "typing..." for the entire turn duration with no feedback.
         assert resolve_display_setting({}, "telegram", "interim_assistant_messages") is True
-        # Periodic "Working — N min" heartbeat — keep on. Otherwise long
+        # Periodic "Still working — about N minutes in." heartbeat — keep
+        # on. Otherwise long
         # turns appear completely silent.
         assert resolve_display_setting({}, "telegram", "long_running_notifications") is True
         # Verbose iteration counter in busy-ack and heartbeat — off by

--- a/tests/gateway/test_em_dash_filter.py
+++ b/tests/gateway/test_em_dash_filter.py
@@ -1,0 +1,83 @@
+"""Em dashes never reach a chat surface.
+
+House style bans U+2014 in delivered agent text. The rewrite lives at the
+gateway delivery boundary (``gateway.response_filters.sanitize_em_dashes``)
+rather than in any adapter, so every platform inherits it, and rather than in
+the agent loop, so the stored transcript keeps what the model actually wrote.
+"""
+
+from gateway.response_filters import EM_DASH, sanitize_em_dashes
+
+EM = "—"
+EN = "–"
+
+
+class TestSanitizeEmDashes:
+    def test_constant_is_u2014(self):
+        assert EM_DASH == EM
+
+    def test_single_em_dash_becomes_hyphen(self):
+        assert sanitize_em_dashes(f"yes{EM}but") == "yes-but"
+
+    def test_every_occurrence_replaced(self):
+        text = f"a{EM}b{EM}c{EM}d"
+        assert sanitize_em_dashes(text) == "a-b-c-d"
+        assert EM not in sanitize_em_dashes(text)
+
+    def test_spaced_em_dash_keeps_its_spaces(self):
+        # Only the character is rewritten; surrounding whitespace is the
+        # model's business.
+        assert sanitize_em_dashes(f"done {EM} shipping now") == "done - shipping now"
+
+    def test_en_dash_is_left_alone(self):
+        """U+2013 is a different character with a different job (ranges)."""
+        assert sanitize_em_dashes(f"pages 3{EN}7") == f"pages 3{EN}7"
+
+    def test_existing_hyphens_untouched(self):
+        assert sanitize_em_dashes("well-known re-entrant") == "well-known re-entrant"
+
+    def test_clean_text_returned_unchanged(self):
+        text = "Nothing to do here."
+        assert sanitize_em_dashes(text) is text
+
+    def test_empty_string(self):
+        assert sanitize_em_dashes("") == ""
+
+    def test_non_string_passes_through(self):
+        """Callers chain this inline; None/int must not explode."""
+        assert sanitize_em_dashes(None) is None
+        assert sanitize_em_dashes(42) == 42
+
+
+class TestGatewaySendPathAppliesIt:
+    """The filter is wired into the real delivery boundary, not just exported."""
+
+    def test_final_response_sanitizer_strips_em_dashes(self):
+        from gateway.run import _sanitize_gateway_final_response
+
+        cleaned = _sanitize_gateway_final_response(
+            "telegram", f"Deploy finished{EM}no rollback needed"
+        )
+        assert EM not in cleaned
+        assert cleaned == "Deploy finished-no rollback needed"
+
+    def test_applies_across_platforms(self):
+        """Wired once at the boundary, so no adapter needs its own copy."""
+        from gateway.run import _sanitize_gateway_final_response
+
+        for platform in ("telegram", "discord", "slack", "signal", "whatsapp"):
+            assert EM not in _sanitize_gateway_final_response(platform, f"a{EM}b")
+
+    def test_raw_text_surfaces_keep_the_em_dash(self):
+        """`local`/API/webhook are programmatic, not chat. Rule doesn't apply."""
+        from gateway.run import _sanitize_gateway_final_response
+
+        raw = f"Deploy finished{EM}no rollback needed"
+        assert _sanitize_gateway_final_response("local", raw) == raw
+        assert _sanitize_gateway_final_response("api_server", raw) == raw
+
+    def test_streaming_display_path_strips_em_dashes(self):
+        """The streaming consumer shares the same rule as the final send."""
+        from gateway.stream_consumer import GatewayStreamConsumer
+
+        assert GatewayStreamConsumer._clean_for_display(f"a{EM}b") == "a-b"

--- a/tests/gateway/test_kanban_progress_heartbeat.py
+++ b/tests/gateway/test_kanban_progress_heartbeat.py
@@ -1,0 +1,462 @@
+"""Progress heartbeat: dispatcher-side "still working on it" pings.
+
+Covers the two halves of the feature together, because the interesting
+failure modes live at the seam:
+
+* ``kanban_db.emit_progress_events`` — emit a ``progress`` event for a
+  running task once the interval has elapsed, and for nothing else.
+* the gateway notifier — claim and render those events in plain English
+  without ever unsubscribing the subscriber.
+"""
+
+import asyncio
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+
+
+class RecordingAdapter:
+    def __init__(self):
+        self.sent = []
+        self.handled = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+
+
+def _make_runner(adapter):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    return runner
+
+
+async def _run_one_notifier_tick(monkeypatch, runner):
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await runner._kanban_notifier_watcher(interval=1)
+
+
+def _board(tmp_path, monkeypatch, name):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / name))
+    kb.init_db()
+
+
+def _running_task(conn, *, title="build the thing", assignee="worker"):
+    """Create a task and take it to 'running' the way a worker would."""
+    tid = kb.create_task(conn, title=title, assignee=assignee)
+    assert kb.claim_task(conn, tid) is not None
+    return tid
+
+
+def _age_run(conn, tid, seconds):
+    """Backdate the task/run start so it looks like it's been running a while."""
+    conn.execute(
+        "UPDATE tasks SET started_at = started_at - ? WHERE id = ?",
+        (seconds, tid),
+    )
+    conn.execute(
+        "UPDATE task_runs SET started_at = started_at - ? WHERE task_id = ?",
+        (seconds, tid),
+    )
+    conn.commit()
+
+
+def _progress_events(conn, tid):
+    return conn.execute(
+        "SELECT payload, created_at FROM task_events "
+        "WHERE task_id = ? AND kind = 'progress' ORDER BY id",
+        (tid,),
+    ).fetchall()
+
+
+# ---------------------------------------------------------------------------
+# (a) emitted only once the interval has elapsed
+# ---------------------------------------------------------------------------
+
+def test_progress_event_waits_for_the_interval(tmp_path, monkeypatch):
+    _board(tmp_path, monkeypatch, "interval.db")
+    conn = kb.connect()
+    try:
+        tid = _running_task(conn)
+
+        # Just started — far too early to claim we've been at it a while.
+        assert kb.emit_progress_events(conn, 300) == []
+        assert _progress_events(conn, tid) == []
+
+        _age_run(conn, tid, 400)
+        assert kb.emit_progress_events(conn, 300) == [tid]
+        rows = _progress_events(conn, tid)
+        assert len(rows) == 1
+
+        import json
+        payload = json.loads(rows[0]["payload"])
+        assert payload["task_id"] == tid
+        assert payload["title"] == "build the thing"
+        assert payload["assignee"] == "worker"
+        assert payload["elapsed_minutes"] == 6  # 400s
+        assert payload["note"] is None
+        assert payload["board"]
+
+        # Second tick right after: the interval restarts from the ping we
+        # just wrote, so the user is not spammed every dispatcher tick.
+        assert kb.emit_progress_events(conn, 300) == []
+        assert len(_progress_events(conn, tid)) == 1
+
+        # ...but once another interval passes, another ping goes out.
+        conn.execute(
+            "UPDATE task_events SET created_at = created_at - 400 "
+            "WHERE task_id = ? AND kind = 'progress'",
+            (tid,),
+        )
+        conn.commit()
+        assert kb.emit_progress_events(conn, 300) == [tid]
+        assert len(_progress_events(conn, tid)) == 2
+    finally:
+        conn.close()
+
+
+def test_progress_event_carries_latest_heartbeat_note(tmp_path, monkeypatch):
+    """The note the worker left is what makes the ping worth reading."""
+    _board(tmp_path, monkeypatch, "note.db")
+    conn = kb.connect()
+    try:
+        tid = _running_task(conn)
+        assert kb.heartbeat_worker(conn, tid, note="ran the migration")
+        assert kb.heartbeat_worker(conn, tid, note="now backfilling rows")
+        _age_run(conn, tid, 900)
+
+        assert kb.emit_progress_events(conn, 300) == [tid]
+        import json
+        payload = json.loads(_progress_events(conn, tid)[0]["payload"])
+        assert payload["note"] == "now backfilling rows"
+
+        # A note from BEFORE the last ping is not repeated: the user has
+        # already seen it, and re-sending it reads as "no progress". Push
+        # both events into the past, keeping the notes older than the ping.
+        conn.execute(
+            "UPDATE task_events SET created_at = created_at - 400 "
+            "WHERE task_id = ? AND kind = 'progress'",
+            (tid,),
+        )
+        conn.execute(
+            "UPDATE task_events SET created_at = created_at - 800 "
+            "WHERE task_id = ? AND kind = 'heartbeat'",
+            (tid,),
+        )
+        conn.commit()
+        assert kb.emit_progress_events(conn, 300) == [tid]
+        payload = json.loads(_progress_events(conn, tid)[1]["payload"])
+        assert payload["note"] is None
+    finally:
+        conn.close()
+
+
+def test_progress_ping_disabled_by_zero_interval(tmp_path, monkeypatch):
+    _board(tmp_path, monkeypatch, "disabled.db")
+    conn = kb.connect()
+    try:
+        tid = _running_task(conn)
+        _age_run(conn, tid, 3600)
+        assert kb.emit_progress_events(conn, 0) == []
+        assert _progress_events(conn, tid) == []
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# (b) never emitted for a task that isn't running
+# ---------------------------------------------------------------------------
+
+def test_no_progress_event_for_non_running_tasks(tmp_path, monkeypatch):
+    _board(tmp_path, monkeypatch, "not-running.db")
+    conn = kb.connect()
+    try:
+        # ready (never claimed)
+        ready_id = kb.create_task(conn, title="waiting to start", assignee="worker")
+        conn.execute(
+            "UPDATE tasks SET started_at = strftime('%s','now') - 3600 WHERE id = ?",
+            (ready_id,),
+        )
+        # blocked
+        blocked_id = _running_task(conn, title="stuck task")
+        _age_run(conn, blocked_id, 3600)
+        kb.block_task(conn, blocked_id, reason="needs credentials")
+        conn.commit()
+
+        assert kb.emit_progress_events(conn, 300) == []
+        assert _progress_events(conn, ready_id) == []
+        assert _progress_events(conn, blocked_id) == []
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# (d) a completed task neither emits nor notifies
+# ---------------------------------------------------------------------------
+
+def test_completed_task_emits_no_progress_event(tmp_path, monkeypatch):
+    _board(tmp_path, monkeypatch, "completed.db")
+    conn = kb.connect()
+    try:
+        tid = _running_task(conn, title="already finished")
+        _age_run(conn, tid, 3600)
+        kb.complete_task(conn, tid, summary="all done")
+
+        assert kb.emit_progress_events(conn, 300) == []
+        assert _progress_events(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_notifier_skips_progress_ping_for_a_finished_task(tmp_path, monkeypatch):
+    """A ping that lost the race with completion must not be delivered.
+
+    The dispatcher can emit a progress event moments before the worker
+    calls ``kanban_complete``. Sending "still working on it" next to (or
+    after) the completion message is the exact confusing double-ping this
+    feature must avoid, so the notifier drops it — while still advancing
+    the cursor past it.
+    """
+    _board(tmp_path, monkeypatch, "raced.db")
+    conn = kb.connect()
+    try:
+        tid = _running_task(conn, title="finished mid-ping")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        _age_run(conn, tid, 900)
+        assert kb.emit_progress_events(conn, 300) == [tid]
+        kb.complete_task(conn, tid, summary="wrapped up")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    texts = [s["text"] for s in adapter.sent]
+    assert not any("Still working on" in t for t in texts), texts
+    assert any("done" in t for t in texts), texts
+
+    conn = kb.connect()
+    try:
+        _, remaining = kb.unseen_events_for_sub(
+            conn, task_id=tid, platform="telegram", chat_id="chat-1",
+            kinds=["progress", "completed"],
+        )
+    finally:
+        conn.close()
+    assert remaining == [], "cursor must advance past the dropped progress event"
+
+
+# ---------------------------------------------------------------------------
+# (c) the notifier claims + formats progress, and keeps the subscription
+# ---------------------------------------------------------------------------
+
+def test_notifier_delivers_progress_ping_and_keeps_subscription(tmp_path, monkeypatch):
+    _board(tmp_path, monkeypatch, "notify-progress.db")
+    conn = kb.connect()
+    try:
+        tid = _running_task(conn, title="reindex the archive", assignee="scribe")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        assert kb.heartbeat_worker(conn, tid, note="halfway through the backlog")
+        _age_run(conn, tid, 7 * 60)
+        assert kb.emit_progress_events(conn, 300) == [tid]
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1, adapter.sent
+    text = adapter.sent[0]["text"]
+    assert "Still working on reindex the archive" in text
+    assert "running as scribe" in text
+    assert "about 7 minutes in" in text
+    assert "Latest update: halfway through the backlog" in text
+
+    conn = kb.connect()
+    try:
+        # Subscription survives: progress is proof of life, not a terminal
+        # event, so the user must still get the completion ping later.
+        subs = kb.list_notify_subs(conn)
+        assert [s["task_id"] for s in subs] == [tid]
+        # Cursor advanced — the same ping is not re-delivered next tick.
+        _, remaining = kb.unseen_events_for_sub(
+            conn, task_id=tid, platform="telegram", chat_id="chat-1",
+            kinds=["progress"],
+        )
+    finally:
+        conn.close()
+    assert remaining == []
+
+    # Second tick with no new event: silence, and still subscribed.
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert len(adapter.sent) == 1
+
+
+def test_notifier_progress_ping_without_a_note(tmp_path, monkeypatch):
+    _board(tmp_path, monkeypatch, "notify-no-note.db")
+    conn = kb.connect()
+    try:
+        tid = _running_task(conn, title="quiet worker", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        _age_run(conn, tid, 305)
+        assert kb.emit_progress_events(conn, 300) == [tid]
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1, adapter.sent
+    text = adapter.sent[0]["text"]
+    assert "Still working on quiet worker" in text
+    assert "No status update yet." in text
+
+
+# ---------------------------------------------------------------------------
+# dispatcher wiring
+# ---------------------------------------------------------------------------
+
+def test_dispatcher_tick_emits_progress_pings(tmp_path, monkeypatch):
+    """The dispatcher tick is what actually drives the pings in production."""
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path / "home"))
+    _board(tmp_path, monkeypatch, "dispatch-tick.db")
+    conn = kb.connect()
+    try:
+        tid = _running_task(conn, title="long job")
+        _age_run(conn, tid, 600)
+    finally:
+        conn.close()
+
+    import hermes_cli.config as _cfg_mod
+    monkeypatch.setattr(
+        _cfg_mod, "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
+                "progress_notify_interval_seconds": 300,
+            }
+        },
+    )
+    # Real dispatch would reclaim/respawn this hand-made running task; the
+    # ping path is what's under test here.
+    monkeypatch.setattr(kb, "dispatch_once", lambda conn, **kwargs: None)
+    monkeypatch.setattr(kb, "reap_worker_zombies", lambda: [])
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+
+    calls = {"n": 0}
+
+    async def _to_thread(fn, *args, **kwargs):
+        calls["n"] += 1
+        result = fn(*args, **kwargs)
+        if calls["n"] >= 3:  # reaper + _tick_once + _ready_nonempty
+            runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr(asyncio, "to_thread", _to_thread)
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+    asyncio.run(
+        asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=5.0)
+    )
+
+    conn = kb.connect()
+    try:
+        assert len(_progress_events(conn, tid)) == 1
+    finally:
+        conn.close()
+
+
+def test_dispatcher_tick_skips_progress_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path / "home"))
+    _board(tmp_path, monkeypatch, "dispatch-tick-off.db")
+    conn = kb.connect()
+    try:
+        tid = _running_task(conn, title="long job")
+        _age_run(conn, tid, 600)
+    finally:
+        conn.close()
+
+    import hermes_cli.config as _cfg_mod
+    monkeypatch.setattr(
+        _cfg_mod, "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
+                "progress_notify_interval_seconds": 0,
+            }
+        },
+    )
+    monkeypatch.setattr(kb, "dispatch_once", lambda conn, **kwargs: None)
+    monkeypatch.setattr(kb, "reap_worker_zombies", lambda: [])
+
+    def _boom(*args, **kwargs):  # pragma: no cover - must never run
+        raise AssertionError("progress ping must not run when disabled")
+
+    monkeypatch.setattr(kb, "emit_progress_events", _boom)
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+
+    calls = {"n": 0}
+
+    async def _to_thread(fn, *args, **kwargs):
+        calls["n"] += 1
+        result = fn(*args, **kwargs)
+        if calls["n"] >= 3:
+            runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr(asyncio, "to_thread", _to_thread)
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+    asyncio.run(
+        asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=5.0)
+    )
+
+    conn = kb.connect()
+    try:
+        assert _progress_events(conn, tid) == []
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# config default
+# ---------------------------------------------------------------------------
+
+def test_progress_notify_interval_default():
+    from hermes_cli.config import DEFAULT_CONFIG
+    kanban = DEFAULT_CONFIG.get("kanban", {})
+    interval = kanban.get("progress_notify_interval_seconds")
+    assert isinstance(interval, int) and interval == 300, (
+        "kanban.progress_notify_interval_seconds should default to 300 "
+        f"(5 minutes); got {interval!r}"
+    )

--- a/tests/gateway/test_kanban_reset_guard_probe.py
+++ b/tests/gateway/test_kanban_reset_guard_probe.py
@@ -1,0 +1,152 @@
+"""The kanban probe behind the daily session-reset guard.
+
+``GatewayRunner._has_active_kanban_for_session`` is the callable wired into
+``SessionStore(has_active_kanban_fn=...)``. It answers "is this session's
+profile mid-work on the board?" and its answer holds the daily reset open.
+
+Two contracts matter here and both are exercised against a REAL kanban schema
+(``init_db``), not a hand-rolled table — the query names real columns and would
+silently degrade to "not busy" if either drifted:
+
+1. Only ``running``/``blocked`` rows for *this profile's* assignee count.
+2. Every lookup failure — missing board, unreadable file — resolves to False.
+   A reset guard that fails closed on a missing DB would pin every session
+   open forever on installs that never use kanban.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+class _Runner:
+    """Minimal stand-in — the probe only needs the profile resolver."""
+
+    def __init__(self, profile: str = "default"):
+        self._profile = profile
+
+    def _active_profile_name(self) -> str:
+        return self._profile
+
+    _profile_for_session_key = GatewayRunner._profile_for_session_key
+    _has_active_kanban_for_session = GatewayRunner._has_active_kanban_for_session
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    """A real kanban.db, pinned via HERMES_KANBAN_DB, with an insert helper."""
+    from hermes_cli.kanban_db import init_db
+
+    db_path = tmp_path / "kanban.db"
+    init_db(db_path)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+
+    def add(task_id: str, status: str, assignee: str | None) -> None:
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO tasks (id, title, status, assignee, created_at, "
+                "workspace_kind) VALUES (?, ?, ?, ?, ?, 'scratch')",
+                (task_id, f"task {task_id}", status, assignee, int(time.time())),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    return add
+
+
+_KEY = "agent:main:telegram:dm:123"
+
+
+# ---------------------------------------------------------------------------
+# Profile resolution from the session key
+# ---------------------------------------------------------------------------
+
+class TestProfileForSessionKey:
+
+    def test_main_namespace_resolves_to_the_active_profile(self):
+        assert _Runner("coder")._profile_for_session_key(_KEY) == "coder"
+
+    def test_named_namespace_wins_over_the_active_profile(self):
+        runner = _Runner("coder")
+        key = "agent:research:telegram:dm:123"
+        assert runner._profile_for_session_key(key) == "research"
+
+    def test_malformed_key_falls_back_to_the_active_profile(self):
+        runner = _Runner("coder")
+        assert runner._profile_for_session_key("") == "coder"
+        assert runner._profile_for_session_key("garbage") == "coder"
+
+
+# ---------------------------------------------------------------------------
+# What counts as live kanban work
+# ---------------------------------------------------------------------------
+
+class TestActiveKanbanProbe:
+
+    @pytest.mark.parametrize("status", ["running", "blocked"])
+    def test_live_task_for_this_profile_is_busy(self, board, status):
+        board("t1", status, "default")
+        assert _Runner()._has_active_kanban_for_session(_KEY) is True
+
+    @pytest.mark.parametrize("status", ["todo", "ready", "review", "done", "archived"])
+    def test_other_statuses_are_not_busy(self, board, status):
+        board("t1", status, "default")
+        assert _Runner()._has_active_kanban_for_session(_KEY) is False
+
+    def test_empty_board_is_not_busy(self, board):
+        assert _Runner()._has_active_kanban_for_session(_KEY) is False
+
+    def test_another_profiles_running_task_does_not_block(self, board):
+        board("t1", "running", "research")
+        assert _Runner("default")._has_active_kanban_for_session(_KEY) is False
+        assert _Runner("research")._has_active_kanban_for_session(_KEY) is True
+
+    def test_assignee_matching_is_case_insensitive(self, board):
+        """Rows are stored canonicalised; the probe normalises to match."""
+        board("t1", "running", "research")
+        runner = _Runner("Research")
+        assert runner._has_active_kanban_for_session(_KEY) is True
+
+    def test_session_key_namespace_selects_the_profile(self, board):
+        board("t1", "running", "research")
+        runner = _Runner("default")
+        key = "agent:research:telegram:dm:123"
+        assert runner._has_active_kanban_for_session(key) is True
+
+
+# ---------------------------------------------------------------------------
+# Failure modes must never block the reset
+# ---------------------------------------------------------------------------
+
+class TestProbeFailsOpen:
+
+    def test_missing_board_is_not_busy(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "nope.db"))
+        assert _Runner()._has_active_kanban_for_session(_KEY) is False
+
+    def test_unreadable_board_is_not_busy(self, tmp_path, monkeypatch):
+        garbage = tmp_path / "kanban.db"
+        garbage.write_bytes(b"not a sqlite file at all")
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(garbage))
+        assert _Runner()._has_active_kanban_for_session(_KEY) is False
+
+    def test_schemaless_board_is_not_busy(self, tmp_path, monkeypatch):
+        empty = tmp_path / "kanban.db"
+        sqlite3.connect(empty).close()  # valid sqlite, no tasks table
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(empty))
+        assert _Runner()._has_active_kanban_for_session(_KEY) is False
+
+    def test_profile_resolution_error_is_not_busy(self, board):
+        class _Broken(_Runner):
+            def _active_profile_name(self):
+                raise RuntimeError("profiles unavailable")
+
+        board("t1", "running", "default")
+        assert _Broken()._has_active_kanban_for_session(_KEY) is False

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -2,7 +2,7 @@
 
 When ``display.platforms.<plat>.cleanup_progress: true`` is set for a
 platform whose adapter supports message deletion (e.g. Telegram), the
-tool-progress bubble, "⏳ Working — N min" heartbeats, and status-callback
+tool-progress bubble, "⏳ Still working" heartbeats, and status-callback
 messages sent during a run are deleted after the final response is
 delivered.
 

--- a/tests/gateway/test_session_daily_reset_live_work_guards.py
+++ b/tests/gateway/test_session_daily_reset_live_work_guards.py
@@ -1,0 +1,192 @@
+"""Daily session reset must not cut live work.
+
+The daily boundary fires on wall-clock time rather than on user activity, so
+unlike the idle boundary it can land on top of a session that is mid-turn or
+whose profile is actively working a kanban board. ``updated_at`` does not move
+while a turn runs, so the staleness check alone cannot see either condition.
+
+``SessionStore._is_session_expired`` therefore consults two optional callables
+before letting the *daily* branch expire a session — and both fail closed, so a
+probe that raises keeps the conversation alive rather than resetting it on a
+guess. The idle branch is deliberately unguarded: idle expiry already implies
+``idle_minutes`` of no activity.
+"""
+
+from datetime import datetime, timedelta
+
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.session import SessionEntry, SessionStore
+
+
+def _make_store(
+    tmp_path,
+    policy=None,
+    is_session_running_fn=None,
+    has_active_kanban_fn=None,
+):
+    config = GatewayConfig()
+    if policy:
+        config.default_reset_policy = policy
+    return SessionStore(
+        sessions_dir=tmp_path,
+        config=config,
+        is_session_running_fn=is_session_running_fn,
+        has_active_kanban_fn=has_active_kanban_fn,
+    )
+
+
+def _stale_entry(days: int = 3) -> SessionEntry:
+    """An entry whose updated_at is unambiguously before today's reset hour."""
+    now = datetime.now()
+    return SessionEntry(
+        session_key="agent:main:telegram:dm:123",
+        session_id="s1",
+        created_at=now - timedelta(days=days + 1),
+        updated_at=now - timedelta(days=days),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+
+
+def _raise(_session_key):
+    raise RuntimeError("probe unavailable")
+
+
+DAILY = SessionResetPolicy(mode="daily", at_hour=4)
+
+
+# ---------------------------------------------------------------------------
+# Base case — the guards must not break ordinary daily expiry
+# ---------------------------------------------------------------------------
+
+class TestDailyExpiryStillWorks:
+
+    def test_stale_session_expires_with_no_guards_wired(self, tmp_path):
+        store = _make_store(tmp_path, DAILY)
+        assert store._is_session_expired(_stale_entry()) is True
+
+    def test_stale_session_expires_when_both_guards_say_idle(self, tmp_path):
+        store = _make_store(
+            tmp_path, DAILY,
+            is_session_running_fn=lambda key: False,
+            has_active_kanban_fn=lambda key: False,
+        )
+        assert store._is_session_expired(_stale_entry()) is True
+
+    def test_fresh_session_does_not_expire(self, tmp_path):
+        store = _make_store(
+            tmp_path, DAILY,
+            is_session_running_fn=lambda key: False,
+            has_active_kanban_fn=lambda key: False,
+        )
+        entry = _stale_entry()
+        entry.updated_at = datetime.now()
+        assert store._is_session_expired(entry) is False
+
+
+# ---------------------------------------------------------------------------
+# Guard: a turn is in flight
+# ---------------------------------------------------------------------------
+
+class TestRunningTurnGuard:
+
+    def test_running_session_not_expired(self, tmp_path):
+        store = _make_store(
+            tmp_path, DAILY,
+            is_session_running_fn=lambda key: True,
+        )
+        assert store._is_session_expired(_stale_entry()) is False
+
+    def test_guard_receives_the_session_key(self, tmp_path):
+        seen = []
+
+        store = _make_store(
+            tmp_path, DAILY,
+            is_session_running_fn=lambda key: seen.append(key) or False,
+        )
+        store._is_session_expired(_stale_entry())
+        assert seen == ["agent:main:telegram:dm:123"]
+
+    def test_probe_error_fails_closed(self, tmp_path):
+        store = _make_store(tmp_path, DAILY, is_session_running_fn=_raise)
+        assert store._is_session_expired(_stale_entry()) is False
+
+    def test_both_mode_also_guarded(self, tmp_path):
+        """``both`` reaches the daily branch once idle_minutes is generous."""
+        store = _make_store(
+            tmp_path,
+            SessionResetPolicy(mode="both", at_hour=4, idle_minutes=60 * 24 * 30),
+            is_session_running_fn=lambda key: True,
+        )
+        assert store._is_session_expired(_stale_entry()) is False
+
+
+# ---------------------------------------------------------------------------
+# Guard: live kanban work
+# ---------------------------------------------------------------------------
+
+class TestKanbanGuard:
+
+    def test_active_kanban_not_expired(self, tmp_path):
+        store = _make_store(
+            tmp_path, DAILY,
+            has_active_kanban_fn=lambda key: True,
+        )
+        assert store._is_session_expired(_stale_entry()) is False
+
+    def test_probe_error_fails_closed(self, tmp_path):
+        store = _make_store(tmp_path, DAILY, has_active_kanban_fn=_raise)
+        assert store._is_session_expired(_stale_entry()) is False
+
+    def test_not_consulted_when_a_turn_is_already_running(self, tmp_path):
+        """The running-turn guard short-circuits — no need for the DB hit."""
+        calls = []
+
+        store = _make_store(
+            tmp_path, DAILY,
+            is_session_running_fn=lambda key: True,
+            has_active_kanban_fn=lambda key: calls.append(key) or True,
+        )
+        assert store._is_session_expired(_stale_entry()) is False
+        assert calls == []
+
+    def test_both_mode_also_guarded(self, tmp_path):
+        store = _make_store(
+            tmp_path,
+            SessionResetPolicy(mode="both", at_hour=4, idle_minutes=60 * 24 * 30),
+            has_active_kanban_fn=lambda key: True,
+        )
+        assert store._is_session_expired(_stale_entry()) is False
+
+
+# ---------------------------------------------------------------------------
+# The idle branch is intentionally NOT guarded
+# ---------------------------------------------------------------------------
+
+class TestIdleBranchUnguarded:
+
+    def test_idle_expiry_ignores_the_daily_guards(self, tmp_path):
+        store = _make_store(
+            tmp_path,
+            SessionResetPolicy(mode="idle", idle_minutes=30),
+            is_session_running_fn=lambda key: True,
+            has_active_kanban_fn=lambda key: True,
+        )
+        entry = _stale_entry()
+        entry.updated_at = datetime.now() - timedelta(hours=1)
+        assert store._is_session_expired(entry) is True
+
+    def test_both_mode_idle_trigger_ignores_the_daily_guards(self, tmp_path):
+        store = _make_store(
+            tmp_path,
+            SessionResetPolicy(mode="both", at_hour=4, idle_minutes=30),
+            is_session_running_fn=lambda key: True,
+            has_active_kanban_fn=lambda key: True,
+        )
+        entry = _stale_entry()
+        entry.updated_at = datetime.now() - timedelta(hours=1)
+        assert store._is_session_expired(entry) is True
+
+    def test_mode_none_never_expires(self, tmp_path):
+        store = _make_store(tmp_path, SessionResetPolicy(mode="none"))
+        assert store._is_session_expired(_stale_entry()) is False

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -134,7 +134,14 @@ def test_programmatic_surfaces_keep_raw_status():
         )
 
 
-@pytest.mark.parametrize("message", ["still on it", "⏳ Working — 3 min"])
+@pytest.mark.parametrize(
+    "message",
+    [
+        "still on it",
+        # The real CoS heartbeat shape (gateway.heartbeat_text).
+        "⏳ Still working — about 3 minutes in.\nLatest update: iteration 4/40, delegate_task",
+    ],
+)
 def test_telegram_status_keeps_legitimate_heartbeat_messages(message):
     """The compression filter must not swallow user-facing work heartbeats."""
     assert _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", message) == message

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -78,6 +78,39 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
 
 
 
+def test_created_blocked_task_is_sticky(kanban_home: Path) -> None:
+    """A task created with ``initial_status='blocked'`` is just as
+    deliberate a park as an explicit ``kanban_block`` and must be sticky.
+
+    It has no parents, so the parent-gate in ``recompute_ready`` passes
+    vacuously — the *only* thing standing between it and an auto-promote
+    is the sticky-block guard, and that guard reads ``task_events``, not
+    ``tasks.status``.  Before the fix, ``create_task`` wrote a ``created``
+    event but no ``blocked`` event, so ``_has_sticky_block`` returned
+    False and the very next tick promoted the task to ``ready``.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="parked at creation", initial_status="blocked",
+        )
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        # A real event row, not just a status column value.
+        kinds = [
+            r["kind"] for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id",
+                (tid,),
+            ).fetchall()
+        ]
+        assert "blocked" in kinds, f"no blocked event recorded, got {kinds}"
+        assert kb._has_sticky_block(conn, tid)
+
+        for _ in range(5):
+            promoted = kb.recompute_ready(conn)
+            assert promoted == 0, "created-blocked task must not auto-promote"
+            assert kb.get_task(conn, tid).status == "blocked"
+
+
 # ---------------------------------------------------------------------------
 # Circuit-breaker blocks still auto-recover (preserve #40c1decb3 intent)
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1583,3 +1583,175 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# create_task(): home-channel fallback notification subscription
+#
+# The session-based auto-subscribe in tools/kanban_tools.py only fires when the
+# caller has live gateway/TUI session context. CLI, cron, and dispatcher-spawned
+# worker creations have none, so those tasks completed silently. create_task()
+# now also subscribes the active profile's configured home channel, gated by
+# kanban.default_notify_home_channel.
+# ---------------------------------------------------------------------------
+
+_SLACK_HOME_CONFIG = (
+    "platforms:\n"
+    "  slack:\n"
+    "    enabled: true\n"
+    "    home_channel:\n"
+    "      platform: slack\n"
+    "      chat_id: D0HOMECHAN\n"
+    "      name: D0HOMECHAN\n"
+    "      user_id: U0USER\n"
+)
+
+
+def _subs_for(task_id):
+    conn = kb.connect()
+    try:
+        return list(kb.list_notify_subs(conn, task_id))
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def slack_home(kanban_home):
+    """kanban_home plus a slack home channel in config.yaml."""
+    (kanban_home / "config.yaml").write_text(_SLACK_HOME_CONFIG, encoding="utf-8")
+    return kanban_home
+
+
+def test_create_task_subscribes_home_channel_by_default(slack_home):
+    """A CLI-style create (no session context) still gets a notify sub."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="home channel default", assignee="peer")
+    finally:
+        conn.close()
+
+    subs = _subs_for(tid)
+    assert len(subs) == 1, subs
+    assert subs[0]["platform"] == "slack"
+    assert subs[0]["chat_id"] == "D0HOMECHAN"
+    assert subs[0]["chat_type"] == "dm"  # D-prefixed slack id -> DM
+    assert subs[0]["user_id"] == "U0USER"
+    assert subs[0]["notifier_profile"]  # stamped with the owning profile
+
+
+def test_create_task_home_channel_gate_disabled(slack_home):
+    """kanban.default_notify_home_channel: false restores session-only behaviour."""
+    (slack_home / "config.yaml").write_text(
+        _SLACK_HOME_CONFIG + "kanban:\n  default_notify_home_channel: false\n",
+        encoding="utf-8",
+    )
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="gated off", assignee="peer")
+    finally:
+        conn.close()
+
+    assert _subs_for(tid) == []
+
+
+def test_create_task_home_channel_respects_min_priority(slack_home):
+    """Below default_notify_min_priority nothing is subscribed; at/above it is."""
+    (slack_home / "config.yaml").write_text(
+        _SLACK_HOME_CONFIG + "kanban:\n  default_notify_min_priority: 5\n",
+        encoding="utf-8",
+    )
+    conn = kb.connect()
+    try:
+        low = kb.create_task(conn, title="low prio", assignee="peer", priority=1)
+        high = kb.create_task(conn, title="high prio", assignee="peer", priority=5)
+    finally:
+        conn.close()
+
+    assert _subs_for(low) == []
+    assert len(_subs_for(high)) == 1
+
+
+def test_create_task_no_home_channel_configured_is_noop(kanban_home):
+    """No platforms/home_channel in config -> no subscription, no error."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="no home channel", assignee="peer")
+    finally:
+        conn.close()
+
+    assert _subs_for(tid) == []
+
+
+def test_create_task_home_channel_skipped_for_originating_session(
+    slack_home, monkeypatch
+):
+    """When the calling session IS the home channel, the richer session-based
+    subscription written by tools/kanban_tools.py::_maybe_auto_subscribe must be
+    the only row — otherwise a thread_id mismatch double-notifies."""
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "slack")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "D0HOMECHAN")
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="session owns it", assignee="peer")
+        assert _subs_for(tid) == []
+        # The tool layer then writes its own session-scoped subscription.
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="slack",
+            chat_id="D0HOMECHAN",
+            thread_id="1699999.0001",
+            notifier_profile="default",
+        )
+    finally:
+        conn.close()
+
+    subs = _subs_for(tid)
+    assert len(subs) == 1, subs
+    assert subs[0]["thread_id"] == "1699999.0001"
+
+
+def test_create_task_home_channel_not_duplicated_when_sub_exists(slack_home):
+    """A pre-existing sub for the same chat suppresses the fallback row even
+    when its thread_id differs (no unique-constraint overlap to rely on)."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="dupe guard", assignee="peer")
+        assert len(_subs_for(tid)) == 1
+        # A second pass (e.g. a re-entrant caller) must not add another row for
+        # the same (task, platform, chat).
+        assert kb._maybe_subscribe_home_channel(conn, tid) is False
+
+        other = kb.create_task(conn, title="dupe guard 2", assignee="peer")
+        kb.add_notify_sub(
+            conn,
+            task_id=other,
+            platform="slack",
+            chat_id="D0HOMECHAN",
+            thread_id="some-thread",
+        )
+        assert kb._maybe_subscribe_home_channel(conn, other) is False
+    finally:
+        conn.close()
+
+    assert len(_subs_for(tid)) == 1
+    assert len(_subs_for(other)) == 2  # fallback row + the explicit threaded one
+
+
+def test_create_task_home_channel_failure_never_breaks_create(
+    slack_home, monkeypatch
+):
+    """add_notify_sub blowing up must not fail the task creation."""
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated DB failure")
+
+    monkeypatch.setattr(kb, "add_notify_sub", _boom)
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="best effort", assignee="peer")
+    finally:
+        conn.close()
+
+    assert tid
+    assert _subs_for(tid) == []

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -283,6 +283,84 @@ def test_delete_task(client):
 
 
 # ---------------------------------------------------------------------------
+# Decomposed parents on /board
+# ---------------------------------------------------------------------------
+
+
+def _find_card(board: dict, task_id: str) -> dict:
+    for col in board["columns"]:
+        for card in col["tasks"]:
+            if card["id"] == task_id:
+                return card
+    raise AssertionError(f"{task_id} not on board")
+
+
+def test_board_flags_decomposed_parent_waiting_on_children(client):
+    """A decomposed root sits in 'todo' looking exactly like an unstarted card.
+
+    The board needs ``is_decomposed_parent`` to tell the two apart; a plain
+    todo with no decomposed event must stay False.
+    """
+    conn = kb.connect()
+    try:
+        root = kb.create_task(conn, title="ship the thing", triage=True)
+        children = kb.decompose_triage_task(
+            conn,
+            root,
+            root_assignee="orchestrator",
+            children=[{"title": "part one"}, {"title": "part two"}],
+        )
+        assert children and len(children) == 2
+        plain = kb.create_task(conn, title="never started", initial_status="running")
+        conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (plain,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    board = client.get("/api/plugins/kanban/board").json()
+
+    parent_card = _find_card(board, root)
+    assert parent_card["is_decomposed_parent"] is True
+    assert parent_card["progress"] == {"done": 0, "total": 2}
+
+    plain_card = _find_card(board, plain)
+    assert plain_card["is_decomposed_parent"] is False
+    assert plain_card["progress"] is None
+
+    # A child is an ordinary card — it was not decomposed itself.
+    assert _find_card(board, children[0])["is_decomposed_parent"] is False
+
+
+def test_decomposed_parent_flag_clears_once_the_root_is_done(client):
+    """Terminal roots aren't waiting on anything, so the badge must go away."""
+    conn = kb.connect()
+    try:
+        root = kb.create_task(conn, title="ship the thing", triage=True)
+        assert kb.decompose_triage_task(
+            conn,
+            root,
+            root_assignee="orchestrator",
+            children=[{"title": "only child"}],
+        )
+    finally:
+        conn.close()
+
+    assert _find_card(
+        client.get("/api/plugins/kanban/board").json(), root
+    )["is_decomposed_parent"] is True
+
+    conn = kb.connect()
+    try:
+        conn.execute("UPDATE tasks SET status='done' WHERE id=?", (root,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    done_card = _find_card(client.get("/api/plugins/kanban/board").json(), root)
+    assert done_card["is_decomposed_parent"] is False
+
+
+# ---------------------------------------------------------------------------
 # Comments + Links
 # ---------------------------------------------------------------------------
 

--- a/tests/run_agent/test_both_primary_and_fallback_failed.py
+++ b/tests/run_agent/test_both_primary_and_fallback_failed.py
@@ -1,0 +1,122 @@
+"""CRITICAL alert for the double-failure case: primary died on billing/
+credit exhaustion (HTTP 402) in this turn AND the fallback provider that
+was activated in response also failed (auth or billing) before completing.
+
+Before this fix, that sequence surfaced through the same generic
+"Provider authentication failed" / "Billing or credits exhausted" copy
+used for any ordinary single-provider hiccup, giving the user no signal
+that BOTH legs of the failover chain were dead in the same turn (real
+incident: 2026-08-09 20:59, Nous 402 -> Anthropic fallback 401 -> turn
+aborted with the generic message; see kanban t_069d2d08 / t_7b1728c5).
+
+These tests pin the exact gating logic added to
+``agent/conversation_loop.py`` (mirrored here rather than driving the full
+7000-line retry loop, matching the existing project convention in
+``tests/run_agent/test_auth_provider_failover.py``) and the message
+builder in isolation.
+"""
+
+from agent.error_classifier import FailoverReason
+from agent.turn_retry_state import TurnRetryState
+from agent.conversation_loop import _critical_both_failed_message
+
+
+def _should_flag_both_failed(retry: TurnRetryState, reason: FailoverReason) -> bool:
+    """Mirror the exact `_both_failed` / `_both_failed_mr` gating condition
+    added to conversation_loop.py's non-retryable and max-retries-exhausted
+    terminal branches."""
+    return retry.primary_failed_billing_or_credit and reason in {
+        FailoverReason.billing,
+        FailoverReason.auth,
+        FailoverReason.auth_permanent,
+    }
+
+
+class TestGuardFlagDefaults:
+    def test_flag_defaults_false(self):
+        assert TurnRetryState().primary_failed_billing_or_credit is False
+
+
+class TestDoubleFailureGating:
+    """The actual failure-mode from the incident: primary 402, fallback 401."""
+
+    def test_primary_billing_then_fallback_auth_flags_critical(self):
+        retry = TurnRetryState()
+        retry.primary_failed_billing_or_credit = True  # set when primary 402'd and fallback activated
+        assert _should_flag_both_failed(retry, FailoverReason.auth) is True
+        assert _should_flag_both_failed(retry, FailoverReason.auth_permanent) is True
+
+    def test_primary_billing_then_fallback_billing_flags_critical(self):
+        """Both providers billing-exhausted in the same turn is also CRITICAL."""
+        retry = TurnRetryState()
+        retry.primary_failed_billing_or_credit = True
+        assert _should_flag_both_failed(retry, FailoverReason.billing) is True
+
+    def test_primary_billing_then_fallback_succeeds_never_sets_flag(self):
+        """If the fallback call succeeds, the loop never reaches the terminal
+        error branches at all this turn -- nothing to assert on the flag's
+        effect here beyond: a fresh TurnRetryState per api_call_count means
+        a later, unrelated failure doesn't inherit a stale True from an
+        earlier successful turn."""
+        retry = TurnRetryState()
+        assert retry.primary_failed_billing_or_credit is False
+
+
+class TestOrdinarySingleProviderFailureNotFlagged:
+    """The generic message must be preserved for every non-double-failure shape."""
+
+    def test_fallback_only_auth_failure_without_primary_billing_not_critical(self):
+        """Fallback auth failure alone (primary never hit billing this turn,
+        e.g. primary_index already > 0 from a prior turn, or this is a
+        fresh transport-error escalation) must NOT be flagged."""
+        retry = TurnRetryState()  # flag never set -- primary did not fail on billing
+        assert _should_flag_both_failed(retry, FailoverReason.auth) is False
+
+    def test_primary_auth_failure_not_billing_not_critical(self):
+        """Primary failing on a plain auth error (not billing/credits) and
+        then the fallback also failing is NOT the specific case this fix
+        targets -- the flag is only set on FailoverReason.billing at the
+        primary, so it stays False here."""
+        retry = TurnRetryState()
+        # Primary failed on auth (not billing) -> the eager-fallback billing
+        # branch never runs, so primary_failed_billing_or_credit stays False.
+        assert retry.primary_failed_billing_or_credit is False
+        assert _should_flag_both_failed(retry, FailoverReason.auth) is False
+
+    def test_primary_billing_then_fallback_rate_limited_not_critical(self):
+        """Fallback merely rate-limited (not auth/billing dead) is transient,
+        not the 'nothing will work' case -- excluded from the critical set."""
+        retry = TurnRetryState()
+        retry.primary_failed_billing_or_credit = True
+        assert _should_flag_both_failed(retry, FailoverReason.rate_limit) is False
+
+    def test_only_fallback_ever_tried_and_it_fails_alone(self):
+        """No fallback chain / fallback never actually needed primary-billing
+        escalation this turn (e.g. channel-level provider override configured
+        directly, not a failover) -- flag never set, stays generic."""
+        retry = TurnRetryState()
+        assert _should_flag_both_failed(retry, FailoverReason.auth) is False
+        assert _should_flag_both_failed(retry, FailoverReason.billing) is False
+
+
+class TestCriticalMessageContent:
+    """The message itself must be visibly distinct from the generic copy."""
+
+    def test_message_contains_critical_marker_and_details(self):
+        msg = _critical_both_failed_message("anthropic", "claude-sonnet-5", "401 invalid x-api-key")
+        assert "CRITICAL" in msg
+        assert "both primary and fallback" in msg.lower()
+        assert "anthropic" in msg
+        assert "claude-sonnet-5" in msg
+        assert "401 invalid x-api-key" in msg
+
+    def test_message_distinct_from_generic_billing_copy(self):
+        msg = _critical_both_failed_message("openrouter", "gpt-4o", "boom")
+        generic = "Billing or credits exhausted: boom"
+        assert msg != generic
+        assert "CRITICAL" not in generic  # sanity: generic copy has no such marker
+
+    def test_message_handles_missing_provider_model(self):
+        msg = _critical_both_failed_message("", "", "some error")
+        assert "unknown provider" in msg
+        assert "unknown model" in msg

--- a/tests/run_agent/test_wait_state_visibility.py
+++ b/tests/run_agent/test_wait_state_visibility.py
@@ -5,7 +5,7 @@ thinking for minutes) used to leave CLI/TUI/Desktop users staring at a generic
 "cogitating..." spinner with no explanation. ``AIAgent._emit_wait_notice``
 rewrites the live spinner/status line (via ``thinking_callback``, bridged to
 ``thinking.delta`` for TUI/Desktop) and updates the activity tracker (which the
-gateway's "⏳ Working — N min" heartbeat includes).
+gateway's "⏳ Still working" heartbeat includes as its "Latest update").
 """
 
 from __future__ import annotations

--- a/tests/tools/test_clarify_choices_validation.py
+++ b/tests/tools/test_clarify_choices_validation.py
@@ -1,0 +1,166 @@
+"""`choices` holds button labels, never prose.
+
+Models routinely hand ``clarify`` a full sentence per choice because the array
+reads like a list of answers. It isn't: every surface renders these as buttons
+or numbered rows, and the selected string comes back verbatim as
+``user_response``. The guard is reject-and-retry rather than truncation -- a
+shortened sentence is still the wrong label and has silently lost the words
+that made it meaningful, so the model must move the prose into ``question``
+and re-issue.
+"""
+
+import json
+
+import pytest
+
+from tools.clarify_tool import (
+    CLARIFY_SCHEMA,
+    MAX_CHOICE_WORDS,
+    _prose_choice_reason,
+    clarify_tool,
+)
+
+
+class _RecordingCallback:
+    """Callback that fails the test if a rejected call ever reaches the UI."""
+
+    def __init__(self, answer="Approve"):
+        self.calls = []
+        self._answer = answer
+
+    def __call__(self, question, choices, multi_select=False):
+        self.calls.append((question, choices, multi_select))
+        return self._answer
+
+
+def _error_of(result):
+    """Return the ``tool_error`` message, or None if this isn't an error.
+
+    ``tools.registry.tool_error`` returns ``{"error": "<message>"}`` as a JSON
+    string, so a rejected call is distinguishable from a successful one (which
+    carries ``question``/``choices_offered``/``user_response``) by that key.
+    """
+    payload = json.loads(result)
+    return payload.get("error")
+
+
+class TestProseChoicesRejected:
+    def test_full_sentence_choice_is_rejected(self):
+        cb = _RecordingCallback()
+
+        result = clarify_tool(
+            "What should I do?",
+            choices=["Approve this urgent change to the shared config file"],
+            callback=cb,
+        )
+
+        assert _error_of(result) is not None
+        # Reject-and-retry: the user was never prompted.
+        assert cb.calls == []
+
+    def test_rejection_names_the_offending_choice_and_the_fix(self):
+        result = clarify_tool(
+            "What should I do?",
+            choices=["Approve this urgent change to the shared config file"],
+            callback=_RecordingCallback(),
+        )
+
+        message = _error_of(result)
+        assert "Approve this urgent change to the shared config file" in message
+        # The model needs to be told where the prose goes and that a retry works.
+        assert "question" in message
+        assert "clarify again" in message
+
+    def test_one_bad_choice_rejects_the_whole_call(self):
+        cb = _RecordingCallback()
+
+        result = clarify_tool(
+            "Ship it?",
+            choices=["Approve", "Hold off until the migration lands next week"],
+            callback=cb,
+        )
+
+        assert _error_of(result) is not None
+        assert cb.calls == []
+
+    def test_colon_explanation_is_rejected(self):
+        result = clarify_tool(
+            "Which one?",
+            choices=["Approve: it only touches the staging config"],
+            callback=_RecordingCallback(),
+        )
+        assert _error_of(result) is not None
+
+    @pytest.mark.parametrize("label", ["Approve.", "Approve!", "Approve?"])
+    def test_sentence_terminal_punctuation_is_rejected(self, label):
+        result = clarify_tool(
+            "Which one?", choices=[label], callback=_RecordingCallback()
+        )
+        assert _error_of(result) is not None
+
+    def test_word_count_boundary(self):
+        """The limit is inclusive: >MAX_CHOICE_WORDS is prose, == is fine."""
+        at_limit = " ".join(["word"] * MAX_CHOICE_WORDS)
+        over_limit = " ".join(["word"] * (MAX_CHOICE_WORDS + 1))
+
+        assert _prose_choice_reason(at_limit) is None
+        assert _prose_choice_reason(over_limit) is not None
+
+    def test_prose_in_a_dict_shaped_choice_is_caught_after_flattening(self):
+        """The check runs on the display string, so dict choices can't smuggle."""
+        cb = _RecordingCallback()
+
+        result = clarify_tool(
+            "Which layout?",
+            choices=[{"description": "Tight layout that covers all three points."}],
+            callback=cb,
+        )
+
+        assert _error_of(result) is not None
+        assert cb.calls == []
+
+
+class TestValidChoicesStillWork:
+    def test_bare_labels_reach_the_callback(self):
+        cb = _RecordingCallback()
+
+        result = json.loads(
+            clarify_tool("Ship it?", choices=["Approve", "Hold off"], callback=cb)
+        )
+
+        assert _error_of(json.dumps(result)) is None
+        assert result["choices_offered"] == ["Approve", "Hold off"]
+        assert result["user_response"] == "Approve"
+        assert len(cb.calls) == 1
+
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "Approve",
+            "Hold off",
+            "Rebase onto main",
+            "3:1",          # bare colon, no explanation after it
+            "12:30",
+            "v1.2 rollout",  # internal period, not terminal
+            "Other (type your answer)",
+        ],
+    )
+    def test_realistic_labels_are_accepted(self, label):
+        assert _prose_choice_reason(label) is None
+
+    def test_open_ended_question_unaffected(self):
+        cb = _RecordingCallback(answer="whatever")
+
+        result = json.loads(clarify_tool("How did that go?", callback=cb))
+
+        assert result["choices_offered"] is None
+        assert len(cb.calls) == 1
+
+
+class TestSchemaDocumentsTheRule:
+    def test_choices_description_states_the_constraint(self):
+        description = CLARIFY_SCHEMA["parameters"]["properties"]["choices"][
+            "description"
+        ]
+        assert str(MAX_CHOICE_WORDS) in description
+        assert "REJECTED" in description

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -15,12 +15,26 @@ a thin dispatcher that delegates to a platform-provided callback.
 """
 
 import json
+import re
 from typing import List, Optional, Callable
 
 
 # Maximum number of predefined choices the agent can offer.
 # A 5th "Other (type your answer)" option is always appended by the UI.
 MAX_CHOICES = 4
+
+# Longest a bare button label is allowed to be, in whitespace-separated words.
+# "Approve", "Hold off", "Rebase onto main" all fit; a sentence does not.
+MAX_CHOICE_WORDS = 5
+
+# A colon followed by whitespace and more text is the "Label: explanation"
+# shape we want out of `choices` and into `question`. The whitespace
+# requirement keeps legitimate colon-bearing labels ("3:1", "12:30") valid.
+_CHOICE_EXPLANATORY_COLON_RE = re.compile(r":\s+\S")
+
+# Sentence-terminal punctuation. A button label is a noun phrase or an
+# imperative, never a terminated sentence.
+_CHOICE_SENTENCE_ENDINGS = (".", "!", "?")
 
 
 def _flatten_choice(c) -> str:
@@ -54,6 +68,31 @@ def _flatten_choice(c) -> str:
     if isinstance(c, (list, tuple)):
         return " ".join(_flatten_choice(x) for x in c).strip()
     return str(c).strip()
+
+
+def _prose_choice_reason(label: str) -> Optional[str]:
+    """Return why ``label`` reads as prose rather than a button label, else None.
+
+    Models routinely hand `choices` a full sentence ("Approve this urgent
+    change to the shared config file") because the array reads like a list of
+    answers.  It isn't — every surface renders these as buttons or numbered
+    rows, so a sentence is truncated by Discord's 80-char button cap, wraps
+    into unreadable rows in Telegram, and comes back as the literal
+    ``user_response`` the agent then has to parse.  The description belongs in
+    ``question``; the array holds the labels.
+
+    Detection is deliberately mechanical (word count / colon / terminal
+    punctuation) so the verdict is predictable and a retry with short labels
+    reliably succeeds.
+    """
+    if _CHOICE_EXPLANATORY_COLON_RE.search(label):
+        return "contains a colon followed by explanatory text"
+    if label.endswith(_CHOICE_SENTENCE_ENDINGS):
+        return "ends in sentence-terminal punctuation"
+    word_count = len(label.split())
+    if word_count > MAX_CHOICE_WORDS:
+        return f"is {word_count} words long (limit is {MAX_CHOICE_WORDS})"
+    return None
 
 
 def _invoke_callback(callback, question, choices, multi_select):
@@ -151,6 +190,21 @@ def clarify_tool(
         # so the CLI panel, Discord buttons, and Telegram list all render clean
         # text and the resolved answer is never a raw Python dict repr.
         choices = [s for s in (_flatten_choice(c) for c in choices) if s]
+        # Reject-and-retry, never silent truncation: a shortened sentence is
+        # still the wrong label AND has quietly lost the words that made it
+        # meaningful. Failing the call lets the model move the prose into
+        # `question` and re-issue with real labels.
+        for choice in choices:
+            reason = _prose_choice_reason(choice)
+            if reason:
+                return tool_error(
+                    f"Choice {choice!r} {reason}, so it reads as a description "
+                    "rather than a button label. Every entry in `choices` must "
+                    "be a bare short label the user can click (e.g. 'Approve', "
+                    "'Hold off', 'Rebase onto main'). Move the explanation into "
+                    "the `question` parameter and call clarify again with short "
+                    "labels."
+                )
         if len(choices) > MAX_CHOICES:
             choices = choices[:MAX_CHOICES]
         if not choices:
@@ -231,7 +285,13 @@ CLARIFY_SCHEMA = {
                     "each distinct option is its own array element (up to 4). "
                     "The UI renders these as pickable rows and auto-appends an "
                     "'Other (type your answer)' option. Omit this parameter "
-                    "entirely ONLY for a genuinely open-ended free-text question."
+                    "entirely ONLY for a genuinely open-ended free-text question.\n"
+                    "Each element must be a BARE BUTTON LABEL, not a sentence: "
+                    f"at most {MAX_CHOICE_WORDS} words, no trailing '.'/'!'/'?', "
+                    "and no 'Label: explanation' form. Right: ['Approve', "
+                    "'Hold off']. Wrong: ['Approve this urgent change to the "
+                    "shared config file.']. A prose choice is REJECTED with an "
+                    "error - put the explanation in `question` and retry."
                 ),
             },
             "multi_select": {

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -226,7 +226,25 @@ up on the next tick (60s by default).
 kanban:
   dispatch_in_gateway: true        # default
   dispatch_interval_seconds: 60    # default
+  progress_notify_interval_seconds: 300   # default; 0 disables
 ```
+
+`progress_notify_interval_seconds` controls the "still working on it"
+pings. While a task is `running`, the dispatcher emits a `progress` event
+roughly every 5 minutes, and anyone subscribed to that task gets a short
+plain-English message in chat — task title, how long it's been going, and
+the most recent `kanban_heartbeat` note if the worker left one:
+
+```
+⏳ Still working on reindex the archive (running as scribe) — about 7 minutes in.
+Latest update: halfway through the backlog
+```
+
+Timing is approximate: the check only runs once per dispatcher tick, so
+the real gap is this value rounded up to the next tick. Nothing is sent
+while no task is running, and the pings stop as soon as the task leaves
+`running` — a ping that loses the race with completion is dropped rather
+than delivered next to the completion message.
 
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`
 for debugging. Standard gateway supervision applies: run `hermes gateway
@@ -1022,6 +1040,7 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 |---|---|---|
 | `spawned` | `{pid}` | Dispatcher successfully started a worker process. |
 | `heartbeat` | `{note?}` | Worker called `hermes kanban heartbeat $TASK` to signal liveness during long operations. |
+| `progress` | `{task_id, title, assignee, board, elapsed_minutes, note}` | Dispatcher-side "still working on it" ping for a task that has been `running` for `kanban.progress_notify_interval_seconds` (default 5 min) since the last ping. Delivered to the task's notification subscribers as a plain-English message; `note` carries the most recent `kanban_heartbeat` note left since the previous ping, or `null`. Purely informational — it never changes task state, never ends a subscription, and is not emitted once the task stops running. |
 | `reclaimed` | `{stale_lock}` | Claim TTL expired without a completion; task goes back to `ready`. |
 | `crashed` | `{pid, claimer}` | Worker PID no longer alive but TTL hadn't expired yet. |
 | `timed_out` | `{pid, elapsed_seconds, limit_seconds, sigkill}` | `max_runtime_seconds` exceeded; dispatcher SIGTERM'd (then SIGKILL'd after 5 s grace) and re-queued. |

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -584,6 +584,9 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
+| `default_notify_home_channel` | `true` | Session-independent fallback: every task created through `kanban_db.create_task` — CLI (`hermes kanban create`), cron, dispatcher-spawned workers, the `kanban_create` tool — also subscribes the active profile's `platforms.<platform>.home_channel`. Without it, tasks created outside a live chat session complete silently, because `auto_subscribe_on_create` has no session context to subscribe. Skipped when the creating session already *is* the home channel (the session-scoped row wins) or when a subscription for that chat already exists. |
+| `default_notify_min_priority` | `0` | Only fall back to the home channel for tasks at or above this priority. `0` (the default task priority) means every task. |
+| `default_notify_platform` | `""` | Platform whose home channel receives the fallback subscription. Empty = the first enabled platform in `platforms:` that has a `home_channel.chat_id`. |
 
 And the two auxiliary LLM slots:
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -738,7 +738,7 @@ Telegram is usually a mobile inbox, so the defaults are tuned for that surface:
 - **`tool_progress`** defaults to **`off`** — no per-tool breadcrumb stream filling up the chat.
 - **`busy_ack_detail`** defaults to **`off`** — busy-state acknowledgments and long-running heartbeats stay terse (no `iteration 21/60` debug detail).
 - **`interim_assistant_messages`** stays **on** — real mid-turn assistant commentary (the model literally telling you what it's about to do) is signal, not noise.
-- **`long_running_notifications`** stays **on** — a single edit-in-place "⏳ Working — N min" bubble updates every few minutes so you have a heartbeat instead of staring at `typing…` for half an hour.
+- **`long_running_notifications`** stays **on** — a single edit-in-place "⏳ Still working — about N minutes in." bubble updates every few minutes so you have a heartbeat instead of staring at `typing…` for half an hour.
 
 Opt out of either of the kept-on defaults or opt back into verbose progress per platform:
 


### PR DESCRIPTION
The daily reset boundary fires on wall-clock time rather than on user activity, so unlike idle expiry it can land on top of live work. An entry's `updated_at` does not move while a turn runs, so the staleness check alone cannot see it.

`SessionStore._is_session_expired` now consults two optional callables before letting the daily/both branch expire a session:

- `is_session_running_fn` - the session holds an in-flight turn. Wired to `GatewayRunner._is_session_running`.
- `has_active_kanban_fn` - the session's profile has running/blocked kanban tasks. Wired to a new `GatewayRunner._has_active_kanban_for_session`, which resolves the profile from the session key's namespace slot and does a read-only COUNT against the active board's kanban.db. This is a coarse per-profile proxy: there is no session<->task tagging today.

Both guards fail closed in `SessionStore` (a raising callable means "assume busy, keep the session alive"), matching the existing `has_active_processes_fn` contract. The kanban probe itself fails open on lookup errors - a missing, corrupt, or schema-less board must not pin every session open forever on installs that never use kanban; only real running/blocked rows block a reset.

The idle branch is intentionally left unguarded: idle expiry already implies `idle_minutes` of no activity, so the same wall-clock race does not apply.

## Tests

32 new cases across two files:
- `tests/gateway/test_session_daily_reset_live_work_guards.py` (14) - base daily expiry still fires, each guard individually, both modes daily and both, exception fail-closed per guard, key passthrough, idle branch and mode=none unaffected.
- `tests/gateway/test_kanban_reset_guard_probe.py` (18) - profile resolution from the session key, status/assignee matching against a real `init_db` schema, and every failure mode resolving to "not busy".

Verified: `scripts/run_tests.sh` over `test_session.py`, `test_session_store_expiry_finalized.py`, `test_session_store_runtime_stale_guard.py`, `test_session_boundary_hooks.py` and both new files - 107 passed, 0 failed. Full `tests/gateway/` - 5154 passed, 2 failed; both failures (`test_systemd_notify.py`, `test_shutdown_forensics.py`) reproduce unchanged on a clean tree and are macOS-environment failures unrelated to this change.

Config default is untouched: `session_reset.mode` still ships as `"none"`.