### PR TITLE
feat(gemini): offer 3.7 Flash in direct provider setup

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -323,6 +323,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-2.5-pro",
     ],
     "gemini": [
+        "gemini-3.7-flash",
         "gemini-3.1-pro-preview",
         "gemini-3-pro-preview",
         "gemini-3.6-flash",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -91,6 +91,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "gemini-2.5-pro",
     ],
     "gemini": [
+        "gemini-3.7-flash",
         "gemini-3.1-pro-preview", "gemini-3-pro-preview",
         "gemini-3.6-flash", "gemini-3.1-flash-lite-preview",
     ],

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -107,6 +107,17 @@ class TestGeminiModelCatalog:
         assert "gemini" in _PROVIDER_MODELS
         assert len(_PROVIDER_MODELS["gemini"]) >= 1
 
+    def test_setup_fallback_matches_model_picker_catalog(self):
+        """The setup wizard and model picker must offer the same Gemini models.
+
+        This invariant catches the direct-provider drift that can otherwise
+        leave a newly supported model visible on one configuration surface
+        but absent from the other.
+        """
+        from hermes_cli.setup import _DEFAULT_PROVIDER_MODELS
+
+        assert _DEFAULT_PROVIDER_MODELS["gemini"] == _PROVIDER_MODELS["gemini"]
+
 
 # ── Model Normalization ──
 


### PR DESCRIPTION
## What does this PR do?

Adds `gemini-3.7-flash` to the **native Google AI Studio (`gemini`) provider** configuration surfaces.

PR #85526 added `google/gemini-3.7-flash` to the Nous and OpenRouter catalogs, but intentionally left the direct Gemini provider unchanged. As a result, users with `GEMINI_API_KEY` / `GOOGLE_API_KEY` could call the model when entered manually, but could not select it from the native Gemini model picker or setup wizard fallback list.

This keeps the existing `gemini-3.6-flash` auxiliary default unchanged and does not add guessed pricing. It only exposes the verified model through the direct-provider setup paths.

Live Google Gemini API verification (2026-08-14):

- official model ID: `gemini-3.7-flash`
- `generateContent`, `countTokens`, `createCachedContent`, and `batchGenerateContent` advertised
- 1,048,576 input-token limit and 65,536 output-token limit
- structured JSON generation succeeded
- native function calling succeeded
- Hermes native Gemini invocation succeeded

No credentials or live response payloads are included in this PR.

## Related Issue

Follow-up to #85526. No open issue found for the native Google AI Studio provider gap.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`: offer `gemini-3.7-flash` in the direct Gemini model picker.
- `hermes_cli/setup.py`: offer the same model in the setup wizard's offline/fallback catalog.
- `tests/hermes_cli/test_gemini_provider.py`: add a durable invariant requiring setup and picker catalogs to stay in lockstep, instead of freezing a specific model list in a snapshot test.

## How to Test

1. Run the direct Gemini provider tests:
   ```bash
   python3 -m pytest tests/hermes_cli/test_gemini_provider.py tests/plugins/model_providers/test_gemini_profile.py tests/hermes_cli/test_gemini_free_tier_setup_block.py -q
   ```
2. Run model/setup coverage:
   ```bash
   python3 -m pytest tests/hermes_cli/test_models.py tests/hermes_cli/test_model*.py tests/hermes_cli/test_setup*.py tests/hermes_cli/test_gemini*.py tests/plugins/model_providers/test_gemini_profile.py -q
   ```
3. Configure Google AI Studio and select `gemini-3.7-flash` from either `hermes model` or setup.

## Validation Results

- Direct Gemini suites: **23 passed**
- Model/setup suites: **308 passed**
- Catalog invariant/E2E import check: passed (`gemini-3.7-flash` first, setup/picker equal, no duplicates, auxiliary default still valid)
- Diff secret-pattern scan: clean
- `git diff --check`: clean
- Full `pytest tests/ -q`: attempted; the suite reached 35% before the 10-minute local timeout amid unrelated environment errors. The first isolated failure was the timing-sensitive Codex auxiliary timeout test (`test_enforces_total_timeout_while_stream_keeps_emitting_events`), which passed immediately when rerun alone (**1 passed**). No failure touched the three changed files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (attempted; see validation note above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.2, Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation update: N/A — no config key or user workflow changed; this extends existing provider model catalogs
- [x] `cli-config.yaml.example`: N/A — no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or workflow changes
- [x] Cross-platform impact considered — static catalog data plus Python invariant test only
- [x] Tool descriptions/schemas: N/A — no tool behavior changed

## Screenshots / Logs

Not applicable; this is a CLI catalog change. Test commands and results are included above.
