### PR TITLE
fix(cron): reuse secret cache and clarify home delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1647,6 +1647,19 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+def _delivery_intentionally_targets_home_root(job: dict, platform_name: str) -> bool:
+    """True when a threadless target is an explicit home/root routing choice.
+
+    Bare platform tokens (``telegram``, ``discord``...) and ``all`` resolve to
+    configured home channels by contract; they must not inherit an unrelated
+    origin topic. ``origin`` and explicit ``platform:chat[:thread]`` targets do
+    not use this exemption.
+    """
+    deliver = _normalize_deliver_value(job.get("deliver", "local"))
+    parts = {part.strip().lower() for part in deliver.split(",") if part.strip()}
+    return "all" in parts or str(platform_name).lower() in parts
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -1742,9 +1755,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # Diagnostic: log thread_id for topic-aware delivery debugging
         origin = _resolve_origin(job) or {}
         origin_thread = origin.get("thread_id")
-        if origin_thread and not thread_id:
+        if (
+            origin_thread
+            and not thread_id
+            and not _delivery_intentionally_targets_home_root(job, platform_name)
+        ):
             logger.warning(
-                "Job '%s': origin has thread_id=%s but delivery target lost it "
+                "Job '%s': origin has thread_id=%s but origin-targeted delivery lost it "
                 "(deliver=%s, target=%s)",
                 job["id"], origin_thread, job.get("deliver", "local"), target,
             )
@@ -3712,23 +3729,17 @@ def run_job(
             os.environ["TERMINAL_CWD"] = _job_workdir
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
 
-        # Re-read .env and config.yaml fresh every run so provider/key
-        # changes take effect without a gateway restart. Route through
-        # load_hermes_dotenv (not a bare load_dotenv) and reset the secret-
-        # source cache first: startup already applied external secrets and
-        # recorded this HERMES_HOME in _APPLIED_HOMES, so a naive reload would
-        # re-apply only the .env placeholder and never re-resolve a Bitwarden/
-        # BSM-backed secret — leaving cron jobs 401'ing on the placeholder
-        # (#33465). Clearing the cache forces the re-pull; the resolved secret
-        # overrides the placeholder only when secrets.bitwarden.override_existing
-        # is set (mirrors startup), and the Bitwarden value-cache keeps the
-        # forced re-pull off the network. load_hermes_dotenv also handles the
-        # utf-8/latin-1 encoding fallback internally.
-        from hermes_cli.env_loader import (
-            load_hermes_dotenv,
-            reset_secret_source_cache,
-        )
-        reset_secret_source_cache()
+        # Re-read local .env and config.yaml every run so provider/key changes
+        # take effect without a gateway restart. Do NOT clear the external
+        # secret-source cache here: doing so forces every cron fire to refetch
+        # all configured backends (1Password/Bitwarden), and a slow source can
+        # delay unrelated jobs by its full timeout. ``load_hermes_dotenv`` still
+        # reloads local files; its once-per-HERMES_HOME guard reuses the external
+        # source snapshot already established at gateway startup. Explicit
+        # secret/config reload paths may call reset_secret_source_cache when a
+        # user actually requests a Vault refresh.
+        from hermes_cli.env_loader import load_hermes_dotenv
+
         load_hermes_dotenv(hermes_home=_get_hermes_home())
 
         delivery_target = _resolve_delivery_target(job)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets, _delivery_intentionally_targets_home_root
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -142,6 +142,28 @@ class TestResolveDeliveryTarget:
             "chat_id": "home-parent",
             "thread_id": None,
         }
+
+    def test_home_platform_delivery_is_not_thread_loss(self):
+        job = {
+            "deliver": "telegram",
+            "origin": {
+                "platform": "telegram",
+                "chat_id": "7054850204",
+                "thread_id": "2451",
+            },
+        }
+        assert _delivery_intentionally_targets_home_root(job, "telegram") is True
+
+    def test_origin_delivery_still_requires_origin_thread(self):
+        job = {
+            "deliver": "origin",
+            "origin": {
+                "platform": "telegram",
+                "chat_id": "7054850204",
+                "thread_id": "2451",
+            },
+        }
+        assert _delivery_intentionally_targets_home_root(job, "telegram") is False
 
     def test_telegram_cron_thread_id_overrides_home_thread_id(self, monkeypatch):
         """TELEGRAM_CRON_THREAD_ID wins over TELEGRAM_HOME_CHANNEL_THREAD_ID for cron (#24409)."""
@@ -442,6 +464,42 @@ class TestDeliverResultErrorReturns:
 
 
 class TestRunJobSessionPersistence:
+    def test_run_job_reuses_cached_external_secrets(self, tmp_path):
+        """Every cron fire must not force-refresh slow external secret sources."""
+        job = {"id": "cached-secrets-job", "name": "cached secrets", "prompt": "hello"}
+        fake_db = MagicMock()
+        reset_cache = MagicMock()
+        load_dotenv = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv", load_dotenv), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache", reset_cache), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert any(
+            call.kwargs.get("hermes_home") == tmp_path
+            for call in load_dotenv.call_args_list
+        )
+        reset_cache.assert_not_called()
+
     def test_run_job_passes_session_db_and_cron_platform(self, tmp_path):
         job = {
             "id": "test-job",


### PR DESCRIPTION
## Summary

- reuse the process-cached external secret-source snapshot for cron runs instead of force-refreshing every configured backend on each fire
- continue reloading local `.env` values on every cron run
- suppress the misleading "delivery target lost thread" warning when a bare platform target intentionally routes to its configured Home root
- preserve strict thread diagnostics for `deliver="origin"`

## Root cause

`run_job()` called `reset_secret_source_cache()` immediately before `load_hermes_dotenv()`. That defeated the once-per-`HERMES_HOME` cache and forced unrelated cron jobs to wait for the full 1Password/Bitwarden timeout. In the observed incident, a local `OPENAI_API_KEY` was already present in `.env`, but the generic cron reload still waited on 1Password.

The delivery warning also treated the documented `deliver="telegram"` Home-root behavior as thread loss, even though the explicit bare-platform route is intentionally independent from the origin topic.

## Verification

- `uv run --extra dev pytest tests/cron/test_scheduler.py tests/cron/test_scheduler_mcp_init.py -q`
  - 72 passed
  - 1 pre-existing un-awaited coroutine warning
- `uv run --extra dev ruff check cron/scheduler.py tests/cron/test_scheduler.py`
  - passed
- `git diff --check`
  - passed

No live Twilio call or paid OpenAI TTS request was made while verifying this change.
