### PR TITLE
fix(gateway): honor explicit webhook disable in _apply_env_overrides

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2177,7 +2177,21 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if webhook_enabled:
         if Platform.WEBHOOK not in config.platforms:
             config.platforms[Platform.WEBHOOK] = PlatformConfig()
-        config.platforms[Platform.WEBHOOK].enabled = True
+        # Honor an explicit ``enabled: false`` in config.yaml (flagged by
+        # ``_enabled_explicit``). In multiplex mode a secondary profile's
+        # config.yaml pins ``platforms.webhook.enabled: false`` so it shares
+        # the default profile's listener instead of binding its own port. That
+        # profile still inherits the process-level env (including
+        # ``WEBHOOK_ENABLED`` via get_secret()'s fallback to the default
+        # profile's .env); without this guard the env var would force-enable
+        # the listener and trip the MultiplexConfigError check. Pop (don't
+        # read) the marker — the webhook branch is terminal (no later registry
+        # pass re-enables it), matching the api_server branch above.
+        webhook_explicit = config.platforms[Platform.WEBHOOK].extra.pop(
+            "_enabled_explicit", False
+        )
+        if not webhook_explicit or config.platforms[Platform.WEBHOOK].enabled:
+            config.platforms[Platform.WEBHOOK].enabled = True
         if webhook_port:
             try:
                 config.platforms[Platform.WEBHOOK].extra["port"] = int(webhook_port)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1184,3 +1184,50 @@ class TestApiServerEnvOverride:
         assert config.platforms[Platform.API_SERVER].enabled is False
         # The key is still wired through for the shared listener.
         assert config.platforms[Platform.API_SERVER].extra.get("key") == api_server_key
+
+
+class TestWebhookEnvOverride:
+    def test_env_key_does_not_reenable_explicitly_disabled_webhook(self):
+        """An explicit ``platforms.webhook.enabled: false`` must survive
+        _apply_env_overrides() even when WEBHOOK_ENABLED is truthy in the env.
+
+        Regression (#85637): _apply_env_overrides() force-set
+        webhook.enabled = True whenever WEBHOOK_ENABLED was truthy. In
+        multiplex mode a secondary profile pins ``webhook.enabled: false`` so
+        it shares the default profile's listener instead of binding its own
+        port, but it still inherits the process-level WEBHOOK_ENABLED
+        (get_secret() falls back to the default profile's .env when the
+        profile .env lacks WEBHOOK_* keys). The unconditional re-enable
+        flipped it back on and tripped the MultiplexConfigError check.
+
+        The fix honors the explicit disable, flagged by ``_enabled_explicit``
+        in the platform's extra (set when the config.yaml pins enabled).
+        """
+        config = GatewayConfig(
+            platforms={
+                Platform.WEBHOOK: PlatformConfig(
+                    enabled=False,
+                    extra={"_enabled_explicit": True},
+                ),
+            },
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "WEBHOOK_ENABLED": "true",
+                "WEBHOOK_PORT": "9999",
+                "WEBHOOK_SECRET": "shared-secret",
+            },
+            clear=True,
+        ):
+            _apply_env_overrides(config)
+
+        # Explicit disable wins over the env-var presence.
+        assert config.platforms[Platform.WEBHOOK].enabled is False
+        # Port/secret are still wired through for the shared listener.
+        assert config.platforms[Platform.WEBHOOK].extra.get("port") == 9999
+        assert (
+            config.platforms[Platform.WEBHOOK].extra.get("secret")
+            == "shared-secret"
+        )


### PR DESCRIPTION
## Summary
The webhook-specific env block in `_apply_env_overrides()` set `config.platforms[Platform.WEBHOOK].enabled = True` directly whenever `WEBHOOK_ENABLED` was truthy, ignoring the `_enabled_explicit` marker that the YAML merge sets for profiles that explicitly pin `platforms.webhook.enabled: false`.

## Root cause
In multiplex mode (`gateway.multiplex_profiles: true`), a secondary profile that pins `platforms.webhook.enabled: false` still inherits the process-level `WEBHOOK_ENABLED` — `get_secret()` falls back to the default profile'.env when the profile's `.env` lacks `WEBHOOK_*` keys. The unconditional `enabled = True` re-enabled the listener, tripping the `MultiplexConfigError` port-binding check and skipping the secondary profile:
`Skipping secondary profile ... enables port-binding platform(s) webhook ...`

## Change
`gateway/config.py`: in the webhook env block, pop the `_enabled_explicit` marker and only set `enabled = True` when the platform was not explicitly disabled — the same guard already used by the `api_server` env block (commit `c7fd3eb37`) and the generic `_enable_from_env` path. Port/secret env vars are still wired through so the profile can share the default listener.

## Verification
- New regression test `TestWebhookEnvOverride::test_env_key_does_not_reenable_explicitly_disabled_webhook` in `tests/gateway/test_config.py`: **fails on `main`** (`enabled` flips to `True`) and **passes with the fix**.
- `pytest tests/gateway/test_config.py tests/gateway/test_msgraph_webhook.py` → 67 passed
- `pytest tests/gateway/test_multiplex_phase0.py tests/gateway/test_multiplex_lifecycle.py tests/gateway/test_multiplex_profile_authz.py` → 18 passed

Closes #85637