### PR TITLE
fix: relay flush_async (session reset) + title_generator retry cascade (400)

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -26,6 +26,36 @@ RUNTIME_INSTANCE_KEY = "hermes.relay.runtime_instance"
 _PROFILE_KEY_CACHE: dict[str, str] = {}
 
 
+def _consume_task_exception(task: asyncio.Future) -> None:
+    """Log and consume a flush task failure that escaped its own wrapper.
+
+    The scheduled ``flush_async`` wrapper already catches ``Exception``, so
+    this callback only fires for a ``BaseException`` (e.g. cancellation). It
+    exists so the event loop never reports "Task exception was never
+    retrieved" for the fire-and-forget barrier task.
+    """
+    try:
+        exc = task.exception()
+    except (asyncio.CancelledError, Exception):
+        return
+    if exc is not None:
+        logger.warning("Hermes Relay subscriber flush task failed: %s", exc)
+
+
+async def _flush_async_safely(relay: Any) -> None:
+    """Await the relay subscriber barrier, logging failures instead of raising.
+
+    ``close_session`` is synchronous, so when it runs inside a live asyncio
+    loop it can only schedule ``flush_async`` as a task. This wrapper keeps
+    that task from surfacing an unhandled exception while still recording the
+    failure in the log (the sync path records it on the failures list).
+    """
+    try:
+        await relay.subscribers.flush_async()
+    except Exception as exc:
+        logger.warning("Hermes Relay subscriber flush failed: %s", exc)
+
+
 @dataclass
 class RelaySession:
     """One isolated Relay scope stack owned by a Hermes session."""
@@ -327,7 +357,27 @@ class RelayRuntime:
                 except Exception as exc:
                     failures.append(f"session scope close failed: {exc}")
         try:
-            self.relay.subscribers.flush()
+            # subscribers.flush() is a blocking barrier that raises
+            # RuntimeError when an asyncio event loop is running on the
+            # current thread (nemo_relay/subscribers.py). close_session() is
+            # reached both from the gateway's asyncio event loop (session
+            # end / finalize / reset hooks) and from the sync shutdown() /
+            # atexit path. Detect the running loop and schedule flush_async()
+            # as a task instead of blocking the loop; the sync barrier stays
+            # for the shutdown path so captured output is complete before the
+            # process exits. Async failures are logged by the task wrapper
+            # (the sync path still records them on the failures list below).
+            try:
+                running_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                running_loop = None
+            if running_loop is not None:
+                task = running_loop.create_task(
+                    _flush_async_safely(self.relay)
+                )
+                task.add_done_callback(_consume_task_exception)
+            else:
+                self.relay.subscribers.flush()
         except Exception as exc:
             failures.append(f"subscriber flush failed: {exc}")
         with self._sessions_lock:

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -105,6 +105,17 @@ _TITLE_RESPONSE_FORMAT = {
     },
 }
 
+# Fallback cascade for relays that reject strict ``json_schema`` (see
+# ``_is_response_format_rejection``). ``json_object`` still constrains the
+# model to valid JSON — the prompt already demands it — while ``None`` drops
+# the constraint entirely and ``_extract_title_text``'s loose scan parses
+# whatever the model returns. Kept as a module constant so the retry loop
+# reads as a data-driven list rather than nested copy-paste.
+_TITLE_RESPONSE_FORMAT_FALLBACKS = (
+    {"type": "json_object"},
+    None,
+)
+
 # Control-tag wrappers that surround machine-authored content inside what is
 # nominally a "user" message. Titling from these is what produces a session
 # named after a slash command or an injected reminder rather than the user's
@@ -330,6 +341,40 @@ def _clean_title(text: str) -> Optional[str]:
     return title
 
 
+def _is_response_format_rejection(exc: Exception) -> bool:
+    """Return True when a 400 plausibly rejects our ``response_format``.
+
+    Strict ``json_schema`` support varies across OpenAI-compatible relays:
+    Nous/Novita-relayed models answer HTTP 400 "This request is not valid.
+    Check the model name and other parameters. Additional info: Provider
+    returned error" — the *parameter* is the problem, not the model or the
+    request body. Detecting that class lets ``generate_title`` retry with a
+    looser constraint instead of leaving the session with only a derived
+    title. Every other 400 class (model-not-found, max_tokens, …) is already
+    retried inside ``call_llm`` and reaches us only after it gave up, so it is
+    raised unchanged rather than masked by the cascade.
+    """
+    status = getattr(exc, "status_code", None)
+    if status is not None and status != 400:
+        return False
+    text = str(exc).lower()
+    markers = (
+        "response_format",
+        "json_schema",
+        "json schema",
+        "strict",
+        "additionalproperties",
+        "additional_properties",
+        "this request is not valid",
+        "not valid",
+        "unsupported parameter",
+        "unsupported_parameter",
+        "invalid request",
+        "request body",
+    )
+    return any(marker in text for marker in markers)
+
+
 def generate_title(
     user_message: str,
     timeout: Optional[float] = None,
@@ -391,31 +436,59 @@ def generate_title(
         {"role": "user", "content": user_snippet},
     ]
 
-    try:
-        response = call_llm(
-            task="title_generation",
-            messages=messages,
-            # A title is a handful of tokens. The old 500-token ceiling let a
-            # chatty model burn seconds generating prose we then threw away.
-            max_tokens=64,
-            temperature=0.3,
-            timeout=timeout,
-            main_runtime=main_runtime,
-            extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+    # Response-format cascade, strictest first. Most providers honor strict
+    # json_schema; relays that don't (Nous/Novita-relayed models) answer HTTP
+    # 400 — detect that class with _is_response_format_rejection and retry
+    # with a looser constraint instead of leaving the session with only a
+    # derived title. The prompt already demands JSON, so json_object is nearly
+    # as good, and the final tier drops the constraint entirely: the loose
+    # scan in _extract_title_text parses plain JSON or prose.
+    formats = (_TITLE_RESPONSE_FORMAT,) + _TITLE_RESPONSE_FORMAT_FALLBACKS
+    last_exc = None
+    for idx, response_format in enumerate(formats):
+        extra_body = (
+            {"response_format": response_format}
+            if response_format is not None
+            else {}
         )
-        content = response.choices[0].message.content or ""
-        return _clean_title(_extract_title_text(content))
-    except Exception as e:
-        # Log at WARNING so this shows up in agent.log without debug mode.
-        # Full detail at debug level for operators who need the stack.
-        logger.warning("Title generation failed: %s", e)
-        logger.debug("Title generation traceback", exc_info=True)
-        if failure_callback is not None:
-            try:
-                failure_callback("title generation", e)
-            except Exception:
-                logger.debug("Title generation failure_callback raised", exc_info=True)
-        return None
+        try:
+            response = call_llm(
+                task="title_generation",
+                messages=messages,
+                # A title is a handful of tokens. The old 500-token ceiling let a
+                # chatty model burn seconds generating prose we then threw away.
+                max_tokens=64,
+                temperature=0.3,
+                timeout=timeout,
+                main_runtime=main_runtime,
+                extra_body=extra_body,
+            )
+            content = response.choices[0].message.content or ""
+            return _clean_title(_extract_title_text(content))
+        except Exception as e:
+            last_exc = e
+            if not _is_response_format_rejection(e) or idx == len(formats) - 1:
+                # Not a response_format 400 (model-not-found, max_tokens, …),
+                # or every tier failed: report the original error unchanged.
+                break
+            logger.warning(
+                "Title generation response_format rejected (%s); "
+                "retrying with a looser constraint",
+                e,
+            )
+    e = last_exc
+    if e is None:  # pragma: no cover — formats is never empty
+        e = RuntimeError("title generation failed without an exception")
+    # Log at WARNING so this shows up in agent.log without debug mode.
+    # Full detail at debug level for operators who need the stack.
+    logger.warning("Title generation failed: %s", e)
+    logger.debug("Title generation traceback", exc_info=True)
+    if failure_callback is not None:
+        try:
+            failure_callback("title generation", e)
+        except Exception:
+            logger.debug("Title generation failure_callback raised", exc_info=True)
+    return None
 
 
 def _persist_session_title(session_db, session_id, title, *, source, dedupe=True):

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -560,3 +560,167 @@ class TestModelSwitchMarkerNotTitleable:
         assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
             "南京市秦淮区 小时级天气预报"
         )
+
+
+class _Fake400(Exception):
+    """Exception shaped like openai.BadRequestError (has .status_code)."""
+
+    status_code = 400
+
+
+class _Fake500(Exception):
+    """Exception shaped like an upstream 5xx (not a response_format issue)."""
+
+    status_code = 500
+
+
+class TestResponseFormatFallback:
+    """FIX-B: strict json_schema is rejected by Nous/Novita-relayed models with
+    HTTP 400; generate_title must retry with a looser constraint instead of
+    leaving the session with only a derived title.
+
+    Reproduction (live, 2026-08-11): json_schema strict -> 400, json_object
+    -> 200, no response_format -> 200.
+    """
+
+    def _nous_rejection(self):
+        return _Fake400(
+            "Error code: 400 - {'status': 400, 'message': 'This request is not "
+            "valid. Check the model name and other parameters. Additional info: "
+            "Provider returned error'}"
+        )
+
+    def test_retries_with_json_object_on_response_format_rejection(self):
+        """First tier (strict json_schema) 400s; the json_object tier succeeds."""
+        calls = []
+
+        def flaky_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise self._nous_rejection()
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Fix flaky auth test"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=flaky_call_llm):
+            title = generate_title("fix the flaky auth test in login")
+
+        assert title == "Fix flaky auth test"
+        assert len(calls) == 2
+        # First attempt sent strict json_schema; the retry sent json_object.
+        assert calls[0]["extra_body"]["response_format"]["type"] == "json_schema"
+        assert calls[1]["extra_body"]["response_format"] == {"type": "json_object"}
+
+    def test_drops_response_format_when_json_object_also_rejected(self):
+        """Both structured tiers 400; the unconstrained tier still titles."""
+        calls = []
+
+        def flaky_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) < 3:
+                raise self._nous_rejection()
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Fix flaky auth test"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=flaky_call_llm):
+            title = generate_title("fix the flaky auth test in login")
+
+        assert title == "Fix flaky auth test"
+        assert len(calls) == 3
+        assert calls[0]["extra_body"]["response_format"]["type"] == "json_schema"
+        assert calls[1]["extra_body"]["response_format"] == {"type": "json_object"}
+        # Last tier: no response_format at all — the loose parser handles prose.
+        assert "response_format" not in calls[2]["extra_body"]
+
+    def test_all_tiers_rejected_fires_callback_with_last_error(self):
+        """Every tier 400s: fall back to derived title and surface the failure."""
+        captured = []
+
+        def always_reject(**kwargs):
+            raise self._nous_rejection()
+
+        with patch("agent.title_generator.call_llm", side_effect=always_reject):
+            result = generate_title(
+                "question",
+                failure_callback=lambda task, exc: captured.append((task, exc)),
+            )
+
+        assert result is None
+        assert len(captured) == 1
+        assert captured[0][0] == "title generation"
+        assert captured[0][1].status_code == 400
+
+    def test_non_response_format_400_is_not_retried(self):
+        """A 400 that is not a response_format rejection (e.g. model-not-found)
+        must be reported unchanged, not masked by the cascade."""
+        calls = []
+        exc = _Fake400("Error code: 400 - model 'gpt-999' does not exist")
+        captured = []
+
+        def raise_exc(**kwargs):
+            calls.append(kwargs)
+            raise exc
+
+        with patch("agent.title_generator.call_llm", side_effect=raise_exc):
+            result = generate_title(
+                "question",
+                failure_callback=lambda task, e: captured.append((task, e)),
+            )
+
+        assert result is None
+        assert len(calls) == 1
+        assert captured == [("title generation", exc)]
+
+    def test_5xx_is_not_retried(self):
+        """Upstream 5xx (provider capacity) is already retried inside call_llm;
+        it must not trigger the response_format cascade."""
+        calls = []
+
+        def raise_exc(**kwargs):
+            calls.append(kwargs)
+            raise _Fake500("upstream capacity limits")
+
+        with patch("agent.title_generator.call_llm", side_effect=raise_exc):
+            result = generate_title("question")
+
+        assert result is None
+        assert len(calls) == 1
+
+
+class TestIsResponseFormatRejection:
+    """Detection predicate for the FIX-B cascade."""
+
+    def test_matches_nous_400_message(self):
+        from agent.title_generator import _is_response_format_rejection
+
+        exc = _Fake400(
+            "Error code: 400 - {'status': 400, 'message': 'This request is not "
+            "valid. Check the model name and other parameters. Additional info: "
+            "Provider returned error'}"
+        )
+        assert _is_response_format_rejection(exc) is True
+
+    def test_matches_explicit_response_format_markers(self):
+        from agent.title_generator import _is_response_format_rejection
+
+        assert _is_response_format_rejection(
+            _Fake400("unsupported parameter: response_format")
+        ) is True
+        assert _is_response_format_rejection(
+            _Fake400("json_schema is not supported by this model")
+        ) is True
+
+    def test_rejects_non_400_status(self):
+        from agent.title_generator import _is_response_format_rejection
+
+        exc = _Fake500("This request is not valid")
+        assert _is_response_format_rejection(exc) is False
+
+    def test_rejects_unrelated_400(self):
+        from agent.title_generator import _is_response_format_rejection
+
+        exc = _Fake400("Error code: 400 - model 'gpt-999' does not exist")
+        assert _is_response_format_rejection(exc) is False


### PR DESCRIPTION
## Summary
Two INTERNAL fixes from the 5ac crash-audit (06-13/08), previously written + REVIEWED + APPROVED (REVIEW-A t_66290d19, REVIEW-B t_c5fe5484) but lost when the live checkout was `reset to origin/main` (HEAD b088535c, 08/12). This branch cherry-picks the two exact approved commits so they can be merged and deployed under CEO review.

**FIX-A — relay_runtime.close_session flush_async** (`900ffbda`)
`agent/relay_runtime.py:330` called blocking `self.relay.subscribers.flush()` inside the gateway asyncio event loop → `nemo_relay/subscribers.py` raises `RuntimeError` → session closed "with errors", flush never ran → session ended in state.db but stayed live in sessions.json → gateway recovery reset the session (#54878), 18×/week. Detect the running loop and schedule `flush_async()` as a task (via `_flush_async_safely` + `_consume_task_exception`); keep sync `flush()` for the shutdown path.

**FIX-B — title_generator response_format retry cascade** (`795542e2`)
`agent/title_generator.py:404` always sent `response_format: json_schema strict`, which Nous/Novita-relayed models reject with HTTP 400 → title generation failed 12×/week. Cascade strict json_schema → json_object → no constraint, gated by `_is_response_format_rejection`; the loose `_extract_title_text` parser handles all tiers so parsing never breaks.

## Verification
- Both approved commits cherry-picked clean onto b088535c (the two files are byte-identical vs the old base 6a7cf193)
- `python -c "import agent.relay_runtime, agent.title_generator"` → OK
- pytest relay (25 passed) + title_generator (42 passed)
- Live probe: json_schema strict=400, json_object=200, none=200 (inference-api.nousresearch.com)

Note: patch needs re-apply after each upstream `hermes update` until this merges. 5ac will deploy to production only after CEO approval.
