### PR TITLE
fix(hermes): attribute background-review usage to the parent session

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1049,18 +1049,23 @@ def _run_review_in_thread(
                 # next live turn. Runs on both the success and exception
                 # path (this whole block is inside the try/finally above).
                 _unregister_review_agent(review_agent)
-
-            # Attribute the review fork's usage to the PARENT session. The
-            # fork runs with ``_session_db=None`` (persistence isolation — see
-            # the PERSISTENCE ISOLATION comment above), so its API calls are
-            # billed by the provider but never written to
-            # ``session_model_usage``. The fork still accumulates the same
-            # in-memory counters the main loop does (session_*_tokens), so
-            # snapshot them BEFORE close() and record them against the parent
-            # session via the aux-accounting chokepoint, which writes only
-            # session_model_usage (never the transcript, never the sessions
-            # summary row).
-            _record_review_usage_to_parent(agent, review_agent)
+                # Attribute the review fork's usage to the PARENT session. The
+                # fork runs with ``_session_db=None`` (persistence isolation — see
+                # the PERSISTENCE ISOLATION comment above), so its API calls are
+                # billed by the provider but never written to
+                # ``session_model_usage``. The fork still accumulates the same
+                # in-memory counters the main loop does (session_*_tokens), so
+                # snapshot them BEFORE close() and record them against the parent
+                # session via the aux-accounting chokepoint, which writes only
+                # session_model_usage (never the transcript, never the sessions
+                # summary row). Placed in this finally (not after the
+                # try/finally) so a fork that consumed tokens and THEN raised
+                # is still attributed — otherwise its billed calls would miss
+                # session_model_usage, the same gap this accounting exists to
+                # close. Best-effort: the recording never raises into the
+                # review thread (its own try/except), and a fork that made no
+                # successful calls no-ops on all-zero counters.
+                _record_review_usage_to_parent(agent, review_agent)
 
             # Snapshot review actions before teardown. close() is allowed to
             # clean per-session state, but the user-visible self-improvement

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -651,6 +651,66 @@ def build_memory_write_metadata(
     return {k: v for k, v in metadata.items() if v not in {None, ""}}
 
 
+def _record_review_usage_to_parent(parent_agent: Any, review_agent: Any) -> None:
+    """Record a background-review fork's usage against the parent session.
+
+    Background-review forks run with ``_session_db = None`` for persistence
+    isolation (see the PERSISTENCE ISOLATION comment in
+    :func:`_run_review_in_thread`): the fork must never write its harness turn
+    into the user's real session. A side effect of that isolation is that the
+    fork's API calls — which the provider bills — were never recorded in
+    ``session_model_usage``, because the accounting path in
+    ``conversation_loop`` is gated on the DB handle. This hides the
+    background-review volume from billing analytics.
+
+    The fork still accumulates the same in-memory counters the main loop does
+    (``session_input_tokens`` etc., incremented regardless of ``_session_db``)
+    and shares the parent's ``session_id``, so its usage can be attributed to
+    the parent session through the aux-accounting chokepoint, which writes
+    only ``session_model_usage`` — never the transcript or the ``sessions``
+    summary row.
+
+    Best-effort by contract: accounting must never fail the review.
+    """
+    try:
+        session_db = getattr(parent_agent, "_session_db", None)
+        session_id = getattr(parent_agent, "session_id", None)
+        if session_db is None or not session_id:
+            return
+        model = getattr(review_agent, "model", None)
+        provider = getattr(review_agent, "provider", None)
+        base_url = getattr(review_agent, "base_url", None)
+        input_tokens = int(getattr(review_agent, "session_input_tokens", 0) or 0)
+        output_tokens = int(getattr(review_agent, "session_output_tokens", 0) or 0)
+        cache_read = int(getattr(review_agent, "session_cache_read_tokens", 0) or 0)
+        cache_write = int(getattr(review_agent, "session_cache_write_tokens", 0) or 0)
+        reasoning = int(getattr(review_agent, "session_reasoning_tokens", 0) or 0)
+        api_calls = int(getattr(review_agent, "session_api_calls", 0) or 0)
+        est_cost = getattr(review_agent, "session_estimated_cost_usd", None)
+        if not (input_tokens or output_tokens or cache_read or cache_write
+                or reasoning or api_calls):
+            return  # fork made no successful API calls (e.g. failed at spawn)
+        session_db.record_auxiliary_usage(
+            session_id,
+            task="background_review",
+            model=model,
+            billing_provider=provider,
+            billing_base_url=base_url,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read,
+            cache_write_tokens=cache_write,
+            reasoning_tokens=reasoning,
+            estimated_cost_usd=est_cost,
+        )
+    except Exception as e:
+        # Same contract as record_auxiliary_usage itself: accounting loss is
+        # logged, never raised into the review thread.
+        logger.debug(
+            "Background review usage recording failed (non-fatal): %s", e
+        )
+
+
 def _run_review_in_thread(
     agent: Any,
     messages_snapshot: List[Dict],
@@ -989,6 +1049,18 @@ def _run_review_in_thread(
                 # next live turn. Runs on both the success and exception
                 # path (this whole block is inside the try/finally above).
                 _unregister_review_agent(review_agent)
+
+            # Attribute the review fork's usage to the PARENT session. The
+            # fork runs with ``_session_db=None`` (persistence isolation — see
+            # the PERSISTENCE ISOLATION comment above), so its API calls are
+            # billed by the provider but never written to
+            # ``session_model_usage``. The fork still accumulates the same
+            # in-memory counters the main loop does (session_*_tokens), so
+            # snapshot them BEFORE close() and record them against the parent
+            # session via the aux-accounting chokepoint, which writes only
+            # session_model_usage (never the transcript, never the sessions
+            # summary row).
+            _record_review_usage_to_parent(agent, review_agent)
 
             # Snapshot review actions before teardown. close() is allowed to
             # clean per-session state, but the user-visible self-improvement

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -702,6 +702,7 @@ def _record_review_usage_to_parent(parent_agent: Any, review_agent: Any) -> None
             cache_write_tokens=cache_write,
             reasoning_tokens=reasoning,
             estimated_cost_usd=est_cost,
+            api_call_count=api_calls,
         )
     except Exception as e:
         # Same contract as record_auxiliary_usage itself: accounting loss is
@@ -1043,13 +1044,9 @@ def _run_review_in_thread(
                 )
             finally:
                 clear_thread_tool_whitelist()
-                # Unregister as soon as run_conversation() itself has
-                # returned — that's the only phase making outbound API
-                # calls, i.e. the only phase that can race the parent's
-                # next live turn. Runs on both the success and exception
-                # path (this whole block is inside the try/finally above).
-                _unregister_review_agent(review_agent)
-                # Attribute the review fork's usage to the PARENT session. The
+                # Attribute the review fork's usage to the PARENT session. Runs
+                # BEFORE ``_unregister_review_agent`` below so a teardown failure
+                # there cannot skip the recording. The
                 # fork runs with ``_session_db=None`` (persistence isolation — see
                 # the PERSISTENCE ISOLATION comment above), so its API calls are
                 # billed by the provider but never written to
@@ -1066,6 +1063,12 @@ def _run_review_in_thread(
                 # review thread (its own try/except), and a fork that made no
                 # successful calls no-ops on all-zero counters.
                 _record_review_usage_to_parent(agent, review_agent)
+                # Unregister as soon as run_conversation() itself has
+                # returned — that's the only phase making outbound API
+                # calls, i.e. the only phase that can race the parent's
+                # next live turn. Runs on both the success and exception
+                # path (this whole block is inside the try/finally above).
+                _unregister_review_agent(review_agent)
 
             # Snapshot review actions before teardown. close() is allowed to
             # clean per-session state, but the user-visible self-improvement

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6730,6 +6730,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         cache_write_tokens: int = 0,
         reasoning_tokens: int = 0,
         estimated_cost_usd: Optional[float] = None,
+        api_call_count: int = 1,
     ) -> None:
         """Record an auxiliary LLM call's usage against *session_id* (issue #23270).
 
@@ -6770,7 +6771,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 actual_cost_usd=None,
                 cost_status=None,
                 cost_source=None,
-                api_call_count=1,
+                api_call_count=api_call_count or 1,
                 task=task,
             )
         self._execute_write(_do)

--- a/tests/agent/test_background_review_usage.py
+++ b/tests/agent/test_background_review_usage.py
@@ -125,3 +125,112 @@ def test_survives_accounting_failure():
     # Must swallow the failure, never raise into the review thread.
     background_review._record_review_usage_to_parent(_FakeParent(_BoomDB()), _review_agent())
     assert True
+
+
+# ---------------------------------------------------------------------------
+# Wiring tests: the recording call must run even when the fork's
+# run_conversation raises after consuming tokens. Regression for the PR #85714
+# triage finding — the call originally sat AFTER the try/finally wrapping
+# run_conversation, so the exception path (outer except in _run_review_in_thread)
+# skipped attribution entirely.
+# ---------------------------------------------------------------------------
+
+
+def _make_review_parent(db):
+    """Minimal parent stand-in carrying the attributes _run_review_in_thread reads."""
+    parent = _FakeParent(db)
+    for _name, _val in {
+        "model": "test-model",
+        "provider": "test-provider",
+        "platform": "test",
+        "_memory_store": None,
+        "_memory_enabled": False,
+        "_user_profile_enabled": False,
+        "_cached_system_prompt": None,
+        "session_start": "2026-08-14T00:00:00",
+        "background_review_callback": None,
+        "memory_notifications": "off",
+        "_background_review_agent": None,
+        "_background_review_lock": None,
+        "_active_children": [],
+        "_active_children_lock": None,
+        "_safe_print": lambda *a, **k: None,
+        "_emit_auxiliary_failure": lambda *a, **k: None,
+    }.items():
+        setattr(parent, _name, _val)
+    return parent
+
+
+class _FakeFork(_FakeReview):
+    """Fork stand-in whose run_conversation can raise after consuming tokens."""
+
+    def __init__(self, calls=3, cache=50000, raise_on_call=True):
+        # Same counters conversation_loop populates on a real fork; the
+        # session_* names matter (_FakeReview only stores whatever keys it
+        # is handed).
+        super().__init__(**vars(_review_agent(calls=calls, cache=cache)))
+        self._session_messages = []
+        self.raise_on_call = raise_on_call
+        self.close_called = False
+        self.shutdown_called = False
+
+    def run_conversation(self, **kwargs):
+        if self.raise_on_call:
+            # Simulates a fork that landed API calls (counters populated by
+            # conversation_loop) and then failed mid-review.
+            raise RuntimeError("simulated mid-review failure after API calls")
+
+    def shutdown_memory_provider(self):
+        self.shutdown_called = True
+
+    def close(self):
+        self.close_called = True
+
+
+def _run_review_with_fake_fork(db, monkeypatch, fork):
+    db.create_session("sess-parent", source="cli")
+    parent = _make_review_parent(db)
+    monkeypatch.setattr("run_agent.AIAgent", lambda **kwargs: fork)
+    monkeypatch.setattr(
+        background_review,
+        "_resolve_review_runtime",
+        lambda agent: {"routed": False},
+    )
+
+    background_review._run_review_in_thread(parent, [], "review prompt")
+    return parent
+
+
+def test_records_usage_when_fork_raises_after_calls(db, monkeypatch):
+    """A fork that consumed tokens and THEN raised is still attributed.
+
+    Before the fix the recording call sat after the try/finally wrapping
+    run_conversation, so the exception jumped to the outer except and the
+    fork's billed calls were never written to session_model_usage.
+    """
+    fork = _FakeFork(calls=3, cache=50000, raise_on_call=True)
+    _run_review_with_fake_fork(db, monkeypatch, fork)
+
+    assert fork.close_called  # exception path still tears the fork down
+    rows = _usage_rows(db, "sess-parent")
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["task"] == "background_review"
+    assert r["model"] == "test-model"
+    assert r["input_tokens"] == 12000
+    assert r["output_tokens"] == 2400
+    assert r["cache_read_tokens"] == 50000
+    assert r.get("estimated_cost_usd") == 0.05
+
+
+def test_records_usage_once_when_fork_completes(db, monkeypatch):
+    """Normal completion still records exactly once (finally placement must
+    not double-record on the success path)."""
+    fork = _FakeFork(calls=3, cache=50000, raise_on_call=False)
+    _run_review_with_fake_fork(db, monkeypatch, fork)
+
+    assert fork.close_called  # success path tears the fork down at close()
+    rows = _usage_rows(db, "sess-parent")
+    assert len(rows) == 1
+    assert rows[0]["input_tokens"] == 12000
+    assert rows[0]["cache_read_tokens"] == 50000

--- a/tests/agent/test_background_review_usage.py
+++ b/tests/agent/test_background_review_usage.py
@@ -1,0 +1,127 @@
+"""Background-review usage attribution.
+
+Background-review forks run with ``_session_db = None`` (persistence
+isolation), so their provider-billed API calls were never recorded in
+``session_model_usage``. ``_record_review_usage_to_parent`` closes that gap
+by snapshotting the fork's in-memory counters and recording them against the
+parent session via the aux-accounting chokepoint, which writes only
+``session_model_usage`` (never the transcript or the ``sessions`` summary
+row).
+
+Tests run against the real ``SessionDB`` (tmp file) wherever the wrapper's
+guard logic permits, mirroring ``tests/hermes_state/test_aux_usage_accounting.py``.
+"""
+
+import pytest
+
+from agent import background_review
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _usage_rows(db, session_id):
+    with db._lock:
+        rows = db._conn.execute(
+            "SELECT * FROM session_model_usage WHERE session_id = ? ORDER BY task",
+            (session_id,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+class _FakeParent:
+    def __init__(self, session_db, session_id="sess-parent"):
+        self._session_db = session_db
+        self.session_id = session_id
+
+
+class _FakeReview:
+    """Minimal fork stand-in carrying the counters conversation_loop sets."""
+
+    def __init__(self, **counters):
+        for k, v in counters.items():
+            setattr(self, k, v)
+
+
+def _review_agent(calls=5, cache=190000, model="test-model"):
+    return _FakeReview(
+        model=model,
+        provider="test-provider",
+        base_url="https://example.invalid/v1",
+        session_input_tokens=12000,
+        session_output_tokens=2400,
+        session_cache_read_tokens=cache,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=0,
+        session_api_calls=calls,
+        session_estimated_cost_usd=0.05,
+    )
+
+
+def test_records_fork_usage_against_parent_session(db):
+    db.create_session("sess-parent", source="cli")
+
+    background_review._record_review_usage_to_parent(_FakeParent(db), _review_agent())
+
+    rows = _usage_rows(db, "sess-parent")
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["task"] == "background_review"
+    assert r["model"] == "test-model"
+    assert r["billing_provider"] == "test-provider"
+    assert r["input_tokens"] == 12000
+    assert r["output_tokens"] == 2400
+    assert r["cache_read_tokens"] == 190000
+    assert r.get("estimated_cost_usd") == 0.05
+
+
+def test_accumulates_repeated_forks_same_model(db):
+    """Same task+model upserts into ONE row with summed counters."""
+    db.create_session("sess-parent", source="cli")
+    parent = _FakeParent(db)
+
+    background_review._record_review_usage_to_parent(parent, _review_agent(calls=5))
+    background_review._record_review_usage_to_parent(parent, _review_agent(calls=7))
+
+    rows = _usage_rows(db, "sess-parent")
+    assert len(rows) == 1
+    assert rows[0]["input_tokens"] == 24000
+
+
+def test_noop_when_fork_made_no_calls(db):
+    db.create_session("sess-parent", source="cli")
+
+    background_review._record_review_usage_to_parent(
+        _FakeParent(db), _FakeReview(model="m")  # no counters set -> zero usage
+    )
+
+    assert _usage_rows(db, "sess-parent") == []
+
+
+def test_noop_when_parent_has_no_session_db():
+    # No DB to write to — must not raise (best-effort by contract).
+    background_review._record_review_usage_to_parent(_FakeParent(None), _review_agent())
+    assert True
+
+
+def test_noop_when_parent_has_no_session_id(db):
+    db.create_session("sess-parent", source="cli")
+
+    background_review._record_review_usage_to_parent(
+        _FakeParent(db, session_id=""), _review_agent()
+    )
+
+    assert _usage_rows(db, "sess-parent") == []
+
+
+def test_survives_accounting_failure():
+    class _BoomDB:
+        def record_auxiliary_usage(self, *args, **kwargs):
+            raise RuntimeError("simulated accounting failure")
+
+    # Must swallow the failure, never raise into the review thread.
+    background_review._record_review_usage_to_parent(_FakeParent(_BoomDB()), _review_agent())
+    assert True


### PR DESCRIPTION
## What does this PR do?

Background memory/skill review (`agent/background_review.py`) forks a second agent after a turn and lets it call the memory/skill-management tools. That fork is deliberately isolated from the parent session's persistence:

```python
review_agent._persist_disabled = True
review_agent._session_db = None
review_agent._session_json_enabled = False
```

The isolation is correct — without it the fork's harness turn would land in the user's real transcript — but `_session_db = None` has an accounting side effect: every API call the fork makes is **billed by the provider** yet never recorded in `session_model_usage`, because the main-loop accounting path is gated on the DB handle (`if agent._session_db and agent.session_id`). Billing analytics silently miss the entire background-review volume, so cost reporting under-counts what a session actually cost.

This PR attributes the review fork's usage to the **parent session** through the existing aux-accounting chokepoint, which writes only `session_model_usage` — never the transcript and never the `sessions` summary row:

- `_record_review_usage_to_parent()` snapshots the fork's in-memory counters (`session_*_tokens`, `session_api_calls`, `session_estimated_cost_usd`) **before** `close()` and records them under `task="background_review"` with the fork's real model/provider route.
- Best-effort by contract: any accounting failure is logged at `debug` and never raised into the review thread.

## Related Issue

Discovered during local dashboard buildout. Raising as work on visualization of usage data is also ongoing — related to [NousResearch/hermes-agent#77263](https://github.com/NousResearch/hermes-agent/pull/77263).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/background_review.py`: add `_record_review_usage_to_parent()`; call it inside the `finally` wrapping `run_conversation()` (before `close()`) in `_run_review_in_thread`, so a fork that consumed tokens and then raised is still attributed to the parent session (exception-path gap from triage comment 5288308895, fixed in follow-up commit `1fb6650`).
- `tests/agent/test_background_review_usage.py`: new — 8 tests against the real `SessionDB` (tmp-file fixture, matching `tests/hermes_state/test_aux_usage_accounting.py`): parent-session attribution, repeated-fork upsert accumulation, no-call noop, no-DB noop, no-session-id noop, failure-swallow, plus 2 wiring tests that run `_run_review_in_thread` with a fake fork — success path records exactly once, and a fork that raises after landing API calls is still attributed.

## How to Test

1. `pytest tests/agent/test_background_review_usage.py tests/hermes_state/test_aux_usage_accounting.py -q` — **17 passed** (8 new + upstream's 9).
2. Repro before fix: run a session that triggers background review (self-improvement review) → the fork's API calls appear in provider billing but are absent from `session_model_usage`.
3. After fix: the parent session's `session_model_usage` gains one `task='background_review'` row with the fork's tokens/cost; the transcript and `sessions` summary row are unchanged.

Full `pytest tests/ -q` was attempted locally but could not complete in this environment: two relay tests fail collection (missing `pytest_asyncio` in the local venv) and unrelated heavyweight tests (desktop `npm run build`, network-bound) hang. The targeted suite above — which covers the changed code and the upstream aux-accounting chokepoint — passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — **targeted suite only** (17/17; full suite blocked by env gaps, see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — **N/A**
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — **N/A**
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — **N/A**
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — **N/A** (pure accounting-path change, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — **N/A**

## Screenshots / Logs

```
$ pytest tests/agent/test_background_review_usage.py tests/hermes_state/test_aux_usage_accounting.py -q
.................                                                          [100%]
17 passed in 1.72s
```
