### PR TITLE
fix(agent): anchor ZAI/Kimi base_url host matching to avoid substring false positives

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1283,7 +1283,7 @@ def _to_openai_base_url(base_url: str) -> str:
         # ZAI uses /api/anthropic for the Coding Plan's Anthropic wire.  The
         # matching OpenAI-wire endpoint is /api/coding/paas/v4; /api/paas/v4
         # is the independently billed general API.
-        if "open.bigmodel.cn" in url or "bigmodel" in url or "api.z.ai" in url:
+        if base_url_host_matches(url, "open.bigmodel.cn") or base_url_host_matches(url, "api.z.ai"):
             rewritten = url[: -len("/anthropic")] + "/coding/paas/v4"
             logger.debug("Auxiliary client: rewrote ZAI base URL %s → %s", url, rewritten)
             return rewritten
@@ -1297,7 +1297,7 @@ def _to_openai_base_url(base_url: str) -> str:
             url,
         )
         return url
-    if "api.kimi.com" in url and url.endswith("/coding"):
+    if base_url_host_matches(url, "api.kimi.com") and url.endswith("/coding"):
         # Kimi Code uses /coding/v1/messages for Anthropic SDK (appends /v1/messages)
         # but /coding/v1/chat/completions for OpenAI SDK (appends /chat/completions)
         # Without /v1 here, OpenAI SDK hits /coding/chat/completions — a 404.

--- a/tests/agent/test_minimax_auxiliary_url.py
+++ b/tests/agent/test_minimax_auxiliary_url.py
@@ -51,5 +51,24 @@ class TestToOpenaiBaseUrl:
             == "https://open.bigmodel.cn/api/coding/paas/v4"
         )
 
+    def test_bigmodel_marker_in_path_does_not_false_positive(self):
+        """Host-anchored matching: 'bigmodel' in the path must not trigger rewrite."""
+        url = "https://gateway.example.com/proxy/bigmodel-fallback/anthropic"
+        assert _to_openai_base_url(url) == url
+
+    def test_zai_marker_in_path_does_not_false_positive(self):
+        url = "https://gateway.example.com/api.z.ai-mirror/anthropic"
+        assert _to_openai_base_url(url) == url
+
+    def test_kimi_coding_host_rewritten(self):
+        assert (
+            _to_openai_base_url("https://api.kimi.com/coding")
+            == "https://api.kimi.com/coding/v1"
+        )
+
+    def test_kimi_marker_in_path_does_not_false_positive(self):
+        url = "https://gateway.example.com/some/api.kimi.com-proxy/coding"
+        assert _to_openai_base_url(url) == url
+
     def test_none(self):
         assert _to_openai_base_url(None) == ""


### PR DESCRIPTION
## Summary

`_to_openai_base_url()` in `agent/auxiliary_client.py` matches ZAI (`open.bigmodel.cn`, `api.z.ai`, bare `"bigmodel"`) and Kimi (`api.kimi.com`) hosts via raw `substring in url` checks. Any custom Anthropic-compatible gateway whose `base_url` happens to contain one of those strings as a path segment (e.g. a reverse-proxy prefix like `/proxy/bigmodel-fallback/anthropic`, or a mirror named `api.z.ai-mirror`) is silently misrouted to the wrong OpenAI-wire endpoint shape instead of being left untouched.

This is the exact same false-positive class `6f33f510e8` (merged earlier the same day as this PR's base) fixed for the MiniMax branch in the same function, by switching from substring matching to `base_url_host_matches()` (hostname-anchored, via `urlparse`). That commit added `_is_dual_surface_anthropic_host()` plus regression tests (`test_marker_in_path_does_not_false_positive`, `test_lookalike_host_suffix_not_matched`) — but only touched the MiniMax branch. The adjacent ZAI and Kimi branches, a few lines above/below in the same function, kept the pre-fix substring pattern.

## Fix

- ZAI branch: `base_url_host_matches(url, "open.bigmodel.cn") or base_url_host_matches(url, "api.z.ai")`, dropping the bare `"bigmodel"` substring check — `open.bigmodel.cn` is the only canonical bigmodel-family host referenced anywhere else in the codebase (`agent/model_metadata.py`'s provider-detection dict, `hermes_cli/auth.py`'s provider base-URL table).
- Kimi branch: `base_url_host_matches(url, "api.kimi.com")`, matching the pattern already used elsewhere in this same file for Kimi host checks (e.g. lines 2663, 2703, 4504, 6002, 6394, 6666).

Out of scope: two unrelated `"bigmodel" in base_url` checks elsewhere in the file (error-string heuristics gated on a specific error code, not endpoint routing) are a different, much lower-risk bug class and were intentionally left untouched to keep this fix narrowly scoped.

## Verification

- Reproduced the false positive live against `HEAD~1` (pre-fix): a gateway URL containing `bigmodel-fallback`, `api.z.ai-mirror`, or `api.kimi.com-proxy` as a path segment got rewritten to the ZAI/Kimi-specific endpoint shape instead of being left alone.
- Added 4 regression tests to `tests/agent/test_minimax_auxiliary_url.py`, mirroring the MiniMax marker-in-path tests added by `6f33f510e8`.
- Mutation-verified: stashed the fix, confirmed all 3 new false-positive tests fail against pre-fix code with the exact wrong-rewrite output; restored the fix, all pass.
- Ran the full existing `test_minimax_auxiliary_url.py` suite (13/13 pass) plus the direct neighbor suites (`test_auxiliary_client.py`, `test_minimax_provider.py`, `test_set_runtime_main_custom_provider.py`, `test_auxiliary_explicit_base_anthropic.py`, `test_fallback_api_mode_preservation.py`, `test_minimax_profile.py` — 245/246 pass). The one pre-existing failure (`test_named_custom_anthropic_messages_keeps_full_name_and_url`) reproduces identically with the fix stashed out — it's an unrelated, pre-existing environment gap (`anthropic` SDK not installed in this sandbox), not a regression from this change.
- `ruff check` clean on both changed files.

## Test plan

- [x] New regression tests added and pass
- [x] Mutation-verify: tests fail without the fix, pass with it
- [x] Direct neighbor test suites pass (excluding one pre-existing, fix-independent environment failure)
- [x] `ruff check` clean