### PR TITLE
feat(providers): support Inworld OpenAI-compatible endpoint

### DIFF
--- a/plugins/model-providers/inworld/__init__.py
+++ b/plugins/model-providers/inworld/__init__.py
@@ -1,0 +1,36 @@
+"""Inworld Router provider profile.
+
+Inworld exposes an OpenAI-compatible LLM router at ``https://api.inworld.ai/v1``
+(tool calling, streaming, prompt caching, and per-model reasoning effort).
+Alongside proxied upstreams it serves first-party hosted models, all of which
+support tool calling — the property that makes them usable for agent work.
+
+The router accepts standard OpenAI Chat Completions requests; the API key is
+passed through the OpenAI SDK's ``api_key`` slot (the Inworld docs demonstrate
+exactly that usage). No adapter or extra_body quirks are needed, so this is a
+plain declarative ``ProviderProfile``.
+
+Model IDs on the router are ``<provider>/<model>`` slugs (e.g.
+``openai/gpt-5.5``, ``anthropic/claude-sonnet-4-6``) or user-defined router
+names (``inworld/<router-name>``). Because the catalog is dynamic and depends
+on the user's workspace, no static fallback list is pinned here — the live
+``/models`` fetch (when available) or an explicit ``--model`` id is used.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+inworld = ProviderProfile(
+    name="inworld",
+    aliases=("inworld-router",),
+    env_vars=("INWORLD_API_KEY",),
+    display_name="Inworld",
+    description="Inworld Router — OpenAI-compatible LLM router",
+    signup_url="https://platform.inworld.ai/",
+    base_url="https://api.inworld.ai/v1",
+    auth_type="api_key",
+    default_aux_model="",
+    fallback_models=(),
+)
+
+register_provider(inworld)

--- a/plugins/model-providers/inworld/plugin.yaml
+++ b/plugins/model-providers/inworld/plugin.yaml
@@ -1,0 +1,5 @@
+name: inworld-provider
+kind: model-provider
+version: 1.0.0
+description: Inworld Router — OpenAI-compatible LLM router
+author: Nous Research

--- a/tests/plugins/model_providers/test_inworld_profile.py
+++ b/tests/plugins/model_providers/test_inworld_profile.py
@@ -1,0 +1,104 @@
+"""Unit tests for the Inworld Router provider profile.
+
+Inworld exposes an OpenAI-compatible LLM router at ``https://api.inworld.ai/v1``.
+The provider is registered as a declarative ``ProviderProfile`` plugin (no
+adapter needed — standard Chat Completions wire format). These tests verify:
+
+  1. The profile registers with the expected identity, auth, and endpoint.
+  2. The default hooks don't emit request-side quirks (plain chat completions).
+  3. The generic custom-provider path also covers the endpoint, including the
+     ``extra_headers`` escape hatch for Inworld's Basic-auth scheme on its
+     non-chat APIs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def inworld_profile():
+    """Resolve the registered Inworld profile via the provider registry.
+
+    Importing ``model_tools`` triggers plugin discovery, which registers the
+    Inworld profile. Going through ``get_provider_profile`` keeps the test
+    honest: if the registered class is ever swapped for a plain
+    ``ProviderProfile`` the assertions below collapse.
+    """
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("inworld")
+    assert profile is not None, "inworld provider profile must be registered"
+    return profile
+
+
+class TestInworldProfile:
+    def test_registered_identity(self, inworld_profile):
+        assert inworld_profile.name == "inworld"
+        assert "inworld-router" in inworld_profile.aliases
+
+    def test_openai_compatible_endpoint(self, inworld_profile):
+        # Doc: https://docs.inworld.ai/router/openai-compatibility
+        assert inworld_profile.api_mode == "chat_completions"
+        assert inworld_profile.base_url == "https://api.inworld.ai/v1"
+        assert inworld_profile.auth_type == "api_key"
+
+    def test_env_vars(self, inworld_profile):
+        assert inworld_profile.env_vars == ("INWORLD_API_KEY",)
+
+    def test_plain_chat_completions_no_request_quirks(self, inworld_profile):
+        """No extra_body / top-level kwargs unless something is configured.
+
+        Inworld is a plain OpenAI-compatible router: no thinking flags, no
+        provider-routing knobs should be emitted by the default hooks.
+        """
+        extra_body, top_level = inworld_profile.build_api_kwargs_extras(
+            reasoning_config=None
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_hostname_derived_from_base_url(self, inworld_profile):
+        assert inworld_profile.get_hostname() == "api.inworld.ai"
+
+
+class TestInworldGenericCustomProviderPath:
+    """The generic custom-provider mechanism already covers api.inworld.ai.
+
+    A user can point a named custom provider at the Inworld endpoint without
+    any code change — and, for Inworld's Basic-auth surfaces, the existing
+    ``extra_headers`` mechanism provides the escape hatch.
+    """
+
+    def test_custom_provider_extra_headers_match_inworld_base_url(self):
+        from hermes_cli.config import get_custom_provider_extra_headers
+
+        providers = [
+            {
+                "name": "inworld",
+                "base_url": "https://api.inworld.ai/v1",
+                "extra_headers": {"Authorization": "Basic <base64-key>"},
+            }
+        ]
+        headers = get_custom_provider_extra_headers(
+            "https://api.inworld.ai/v1",
+            custom_providers=providers,
+        )
+        assert headers == {"Authorization": "Basic <base64-key>"}
+
+    def test_custom_provider_extra_headers_no_match_for_other_host(self):
+        from hermes_cli.config import get_custom_provider_extra_headers
+
+        providers = [
+            {
+                "name": "inworld",
+                "base_url": "https://api.inworld.ai/v1",
+                "extra_headers": {"Authorization": "Basic <base64-key>"},
+            }
+        ]
+        # Prefix look-alike host must not match (no substring bypass).
+        assert get_custom_provider_extra_headers(
+            "https://api.inworld.ai.attacker.test/v1",
+            custom_providers=providers,
+        ) == {}

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -92,6 +92,7 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `STEPFUN_BASE_URL` | Override StepFun base URL (default: `https://api.stepfun.com/v1`) |
 | `OLLAMA_API_KEY` | Ollama Cloud API key — managed Ollama catalog without local GPU ([ollama.com/settings/keys](https://ollama.com/settings/keys)) |
 | `OLLAMA_BASE_URL` | Override Ollama Cloud base URL (default: `https://ollama.com/v1`) |
+| `INWORLD_API_KEY` | Inworld Router API key — OpenAI-compatible LLM router ([platform.inworld.ai](https://platform.inworld.ai/)) |
 | `XAI_API_KEY` | xAI (Grok) API key for chat + TTS + web search ([console.x.ai](https://console.x.ai/)) |
 | `XAI_BASE_URL` | Override xAI base URL (default: `https://api.x.ai/v1`) |
 | `MISTRAL_API_KEY` | Mistral API key for Voxtral TTS and Voxtral STT ([console.mistral.ai](https://console.mistral.ai)) |


### PR DESCRIPTION
## Summary

Adds **Inworld** as a model provider for Hermes Agent, resolving #85666.

Inworld exposes an OpenAI-compatible LLM router at `https://api.inworld.ai/v1` with tool calling, streaming, prompt caching, and per-model reasoning effort. Alongside proxied upstreams it serves first-party hosted models that are cheap and fast enough for everyday agent use; all router models support tool calling.

## Approach — plugin fast path, not core surface

Investigation showed Hermes already has a documented fast path for simple API-key providers: a declarative **model-provider plugin** (`plugins/model-providers/<name>/`) that auto-wires credential resolution, `api_mode=chat_completions`, `base_url`, `--provider` CLI flag, `/model` menu, and `provider:model` aliases with zero core changes (see `website/docs/developer-guide/adding-providers.md` → "Fast path: Simple API-key providers").

Since Inworld is a plain OpenAI-compatible chat-completions endpoint, no adapter, `run_agent.py` branch, or `api_mode` is required. The generic custom-provider path (`custom_providers` in `config.yaml`) also already covers this endpoint — including the `extra_headers` escape hatch for Inworld's Basic-auth surfaces — which is now pinned by a regression test.

## Change

- `plugins/model-providers/inworld/__init__.py` — `ProviderProfile`: `INWORLD_API_KEY` env var, `base_url=https://api.inworld.ai/v1`, `auth_type=api_key`, alias `inworld-router`
- `plugins/model-providers/inworld/plugin.yaml` — plugin manifest
- `tests/plugins/model_providers/test_inworld_profile.py` — profile identity/endpoint/hook invariants + generic custom-provider path tests for `api.inworld.ai`
- `website/docs/reference/environment-variables.md` — `INWORLD_API_KEY` entry

## Verification

- `pytest tests/plugins/model_providers/test_inworld_profile.py tests/providers/test_plugin_discovery.py tests/hermes_cli/test_custom_provider_extra_headers.py` → 23 passed
- `pytest tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_runtime_provider_resolution.py` → 157 passed
- Registry smoke test: `get_provider_profile("inworld")` resolves with correct base_url/api_mode/auth

Note: no live API call is included — testing against api.inworld.ai requires real credentials, which are not used in CI.

## Closes

Closes #85666