### PR TITLE
fix(model_metadata): guard the openrouter-provider branch against MiniMax 32K underreport too

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3024,10 +3024,11 @@ def get_model_context_length(
         entry = metadata.get(model)
         if entry:
             or_ctx = entry.get("context_length")
-            # Guard against the known OpenRouter Kimi-family 32k underreport
-            # (same class the hardcoded overrides exist to mitigate).
+            # Guard against the known OpenRouter Kimi/MiniMax-family 32k
+            # underreport (same class the hardcoded overrides exist to
+            # mitigate) — mirrors the step-6 fallback's guard below.
             if isinstance(or_ctx, int) and or_ctx > 0 and not (
-                or_ctx == 32768 and _model_name_suggests_kimi(model)
+                or_ctx == 32768 and _model_name_suggests_stale_32k_underreport(model)
             ):
                 return or_ctx
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -767,6 +767,23 @@ class TestGetModelContextLength:
         result = get_model_context_length("MiniMax-M2.7")
         assert result == 204800
 
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_openrouter_provider_32k_underreport_for_minimax_falls_through_to_default(
+        self, mock_fetch, mock_models_dev
+    ):
+        """The effective_provider=='openrouter' branch must reject stale 32K for
+        MiniMax too, not just Kimi — same guard as the unknown-provider fallback."""
+        mock_fetch.return_value = {
+            "minimaxai/minimax-m2": {"context_length": 32768}
+        }
+        result = get_model_context_length(
+            "minimaxai/minimax-m2",
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert result == 204800
+
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
     def test_non_minimax_32k_cache_is_still_respected(self, mock_models_dev, mock_fetch, tmp_path):


### PR DESCRIPTION
## Summary

`get_model_context_length()` has three call sites guarding against the known OpenRouter 32K-underreport bug for Kimi/MiniMax models:

1. `_resolve_nous_context_length` (persisted-cache guard) — uses the shared `_model_name_suggests_stale_32k_underreport()` helper (covers Kimi **and** MiniMax).
2. The `effective_provider == "openrouter"` branch (step "5f", added this window so OpenRouter's authoritative live catalog wins over models.dev/hardcoded defaults for OpenRouter-routed models) — used only `_model_name_suggests_kimi()`.
3. The unknown-provider fallback (step 6) — uses the shared helper.

Sites 1 and 3 were generalized to cover MiniMax by an earlier commit in this window; site 2 kept the older, narrower Kimi-only check and was never updated.

## Reproduction

```python
get_model_context_length(
    "minimaxai/minimax-m2",
    provider="openrouter",
    base_url="https://openrouter.ai/api/v1",
)
```
against a stale OpenRouter catalog entry (`{"context_length": 32768}`) returns `32768` instead of falling through to the hardcoded `204800` default — the exact bug the other two guards exist to prevent, reachable via a common, realistic configuration (any user with `provider: openrouter` + a MiniMax model on OpenRouter's live catalog).

## Fix

Swap `_model_name_suggests_kimi(model)` for `_model_name_suggests_stale_32k_underreport(model)` at the `effective_provider == "openrouter"` branch, matching the other two guards. No new helper needed — the shared one already exists and is already used by its two siblings.

## Verification

- Added `test_openrouter_provider_32k_underreport_for_minimax_falls_through_to_default` to `tests/agent/test_model_metadata.py`, exercising this specific branch — the existing MiniMax 32K regression test only covers the unknown-provider fallback (site 3), not this one.
- Mutation-verified: stashed the fix, confirmed the new test fails against pre-fix code (`32768 == 204800` assertion error, reproducing the bug exactly); restored the fix, test passes.
- Ran the full `test_model_metadata.py`, `test_models_dev.py`, and `test_minimax_provider.py` suites: 171/171 pass.
- `ruff check` clean on both changed files.

## Test plan

- [x] New regression test added and passes
- [x] Mutation-verify: test fails without the fix, passes with it
- [x] `test_model_metadata.py` + `test_models_dev.py` + `test_minimax_provider.py` all pass (171/171)
- [x] `ruff check` clean