### PR TITLE
fix(gateway): reply-anchor clarify prompts so users get notified

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4219,9 +4219,15 @@ class BasePlatformAdapter(ABC):
             mark_awaiting_text(clarify_id)
         else:
             text = f"❓ {question}"
+        # Reply-anchor the prompt to the triggering message when the gateway
+        # supplied one — without it platforms that notify on replies (e.g.
+        # Slack, Discord's text path) deliver a bare message the user never
+        # gets pinged for. Mirrors WhatsApp's send_clarify override.
+        reply_to = (metadata or {}).get("reply_to_message_id") if metadata else None
         return await self.send(
             chat_id=chat_id,
             content=text,
+            reply_to=reply_to,
             metadata=metadata,
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5188,6 +5188,19 @@ class TurnRunner:
                 )
 
             send_ok = False
+            # Deliver the clarify prompt as a reply to the triggering message
+            # with notify semantics — final replies get this via
+            # _reply_anchor_for_event + _mark_notify_metadata; clarify must
+            # too, or the question lands as a bare channel message and the
+            # user gets no notification (Discord only pings the author of a
+            # message it replies to).
+            _clarify_metadata = (
+                dict(ctx._status_thread_metadata) if ctx._status_thread_metadata else {}
+            )
+            _anchor = getattr(ctx.source, "message_id", None)
+            if _anchor is not None:
+                _clarify_metadata["reply_to_message_id"] = str(_anchor)
+            _clarify_metadata["notify"] = True
             fut = safe_schedule_threadsafe(
                 ctx._status_adapter.send_clarify(
                     chat_id=ctx._status_chat_id,
@@ -5195,7 +5208,7 @@ class TurnRunner:
                     choices=list(choices) if choices else None,
                     clarify_id=clarify_id,
                     session_key=ctx.session_key or "",
-                    metadata=ctx._status_thread_metadata,
+                    metadata=_clarify_metadata,
                 ),
                 ctx._loop_for_step,
                 logger=logger,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7315,7 +7315,15 @@ class DiscordAdapter(BasePlatformAdapter):
                 "❓ **Hermes needs your input**", str(question or "").strip(),
                 tail=clarify_tail,
             )
-            msg = await channel.send(content=content, embed=embed, view=view) if view else await channel.send(content=content, embed=embed)
+            # Reply-reference the triggering message so the user actually gets
+            # a Discord notification — a bare channel message with no reply
+            # anchor does not ping the author (mirrors send()'s reply_to
+            # handling; honors reply_to_mode "off").
+            reference = None
+            reply_anchor = (metadata or {}).get("reply_to_message_id") if metadata else None
+            if reply_anchor:
+                reference = self._reply_reference_for_send(reply_anchor, channel)
+            msg = await channel.send(content=content, embed=embed, view=view, reference=reference) if view else await channel.send(content=content, embed=embed, reference=reference)
             if view:
                 view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))

--- a/tests/e2e/test_discord_clarify_reply_anchor.py
+++ b/tests/e2e/test_discord_clarify_reply_anchor.py
@@ -1,0 +1,130 @@
+"""Regression tests: Discord send_clarify reply-anchors the triggering message.
+
+The gateway now passes ``reply_to_message_id`` + ``notify`` in clarify
+metadata (see gateway/run.py). The Discord adapter must build a Discord
+MessageReference from that anchor so the user actually gets a notification —
+a bare channel message with no reply reference does not ping the author.
+
+These tests spy on ``_reply_reference_for_send`` (the same pre-existing
+helper ``send()`` uses) and assert ``send_clarify`` wires the anchor through
+to it, rather than asserting on ``discord.MessageReference`` internals (the
+test env mocks discord.py, whose mock discards kwargs).
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.e2e.conftest import (
+    make_fake_text_channel,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_client_with_channel(channel):
+    """Discord-like client whose get_channel returns the given channel."""
+    return SimpleNamespace(
+        user=SimpleNamespace(id=99999, name="HermesBot", display_name="HermesBot", bot=True),
+        get_channel=lambda _id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+
+def _patch_view_class(adapter_module):
+    """Replace ClarifyChoiceView with a plain dummy.
+
+    The test env mocks discord.py; constructing the real view class through
+    the mock's discord.ui.View machinery is flaky (exhausts a mock
+    side_effect on repeat construction). The view's internals are not what
+    this test covers.
+    """
+    return patch.object(adapter_module, "ClarifyChoiceView", SimpleNamespace)
+
+
+class TestDiscordSendClarifyReplyAnchor:
+    async def test_choice_clarify_reply_references_triggering_message(self, discord_adapter):
+        """metadata.reply_to_message_id → _reply_reference_for_send(anchor) result passed as reference=."""
+        import plugins.platforms.discord.adapter as da
+
+        channel = make_fake_text_channel()
+        channel.send = AsyncMock(return_value=SimpleNamespace(id=12345))
+        discord_adapter._client = _make_client_with_channel(channel)
+
+        sentinel = object()
+        with _patch_view_class(da), patch.object(
+            discord_adapter, "_reply_reference_for_send", return_value=sentinel
+        ) as spy:
+            result = await discord_adapter.send_clarify(
+                "22222", "Pick one", ["A", "B"], "clarify-1", "sk",
+                metadata={"reply_to_message_id": "70001", "notify": True},
+            )
+
+        assert result.success
+        spy.assert_called_once_with("70001", channel)
+        assert channel.send.await_args.kwargs["reference"] is sentinel
+
+    async def test_open_ended_clarify_reply_references_triggering_message(self, discord_adapter):
+        """No choices (open-ended) → still passes the reply reference."""
+        import plugins.platforms.discord.adapter as da
+
+        channel = make_fake_text_channel()
+        channel.send = AsyncMock(return_value=SimpleNamespace(id=12346))
+        discord_adapter._client = _make_client_with_channel(channel)
+
+        sentinel = object()
+        with patch.object(
+            discord_adapter, "_reply_reference_for_send", return_value=sentinel
+        ) as spy:
+            result = await discord_adapter.send_clarify(
+                "22222", "Tell me more", None, "clarify-2", "sk",
+                metadata={"reply_to_message_id": "70002", "notify": True},
+            )
+
+        assert result.success
+        spy.assert_called_once_with("70002", channel)
+        assert channel.send.await_args.kwargs["reference"] is sentinel
+
+    async def test_no_anchor_no_reference(self, discord_adapter):
+        """Without reply_to_message_id metadata → no reference (old behavior)."""
+        import plugins.platforms.discord.adapter as da
+
+        channel = make_fake_text_channel()
+        channel.send = AsyncMock(return_value=SimpleNamespace(id=12347))
+        discord_adapter._client = _make_client_with_channel(channel)
+
+        with _patch_view_class(da), patch.object(
+            discord_adapter, "_reply_reference_for_send", return_value=object()
+        ) as spy:
+            result = await discord_adapter.send_clarify(
+                "22222", "Pick one", ["A"], "clarify-3", "sk", metadata=None,
+            )
+
+        assert result.success
+        spy.assert_not_called()
+        assert channel.send.await_args.kwargs["reference"] is None
+
+    async def test_reply_to_mode_off_suppresses_reference(self, discord_adapter):
+        """reply_to_mode 'off' must suppress the anchor like send() does.
+
+        Uses the REAL _reply_reference_for_send (not a spy) — the off check
+        lives inside that method, so replacing it would bypass the behavior
+        under test.
+        """
+        import plugins.platforms.discord.adapter as da
+
+        channel = make_fake_text_channel()
+        channel.send = AsyncMock(return_value=SimpleNamespace(id=12348))
+        discord_adapter._client = _make_client_with_channel(channel)
+        discord_adapter._reply_to_mode = "off"
+
+        with _patch_view_class(da):
+            result = await discord_adapter.send_clarify(
+                "22222", "Pick one", ["A"], "clarify-4", "sk",
+                metadata={"reply_to_message_id": "70004", "notify": True},
+            )
+
+        assert result.success
+        assert channel.send.await_args.kwargs["reference"] is None

--- a/tests/gateway/test_clarify_active_session_bypass.py
+++ b/tests/gateway/test_clarify_active_session_bypass.py
@@ -87,3 +87,50 @@ async def test_active_session_routes_typed_choice_clarify_reply_to_runner_not_bu
     assert adapter._pending_messages == {}
 
 
+class _RecordingSendAdapter(BasePlatformAdapter):
+    """Base-adapter subclass that records the send() kwargs (base fallback)."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+        self.last_send_kwargs = None
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.last_send_kwargs = {
+            "chat_id": chat_id,
+            "content": content,
+            "reply_to": reply_to,
+            "metadata": metadata,
+        }
+        return SendResult(success=True, message_id="text")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "private"}
+
+
+@pytest.mark.asyncio
+async def test_base_send_clarify_forwards_reply_anchor_from_metadata():
+    """Open-ended base send_clarify passes reply_to when the gateway supplied an anchor."""
+    adapter = _RecordingSendAdapter()
+    result = await adapter.send_clarify(
+        "12345", "Pick one", None, "clarify-1", "sk",
+        metadata={"reply_to_message_id": "msg1", "notify": True},
+    )
+    assert result.success
+    assert adapter.last_send_kwargs["reply_to"] == "msg1"
+
+
+@pytest.mark.asyncio
+async def test_base_send_clarify_no_anchor_no_reply_to():
+    """Without reply_to_message_id metadata the base fallback sends reply_to=None."""
+    adapter = _RecordingSendAdapter()
+    await adapter.send_clarify("12345", "Pick one", None, "clarify-1", "sk", metadata=None)
+    assert adapter.last_send_kwargs["reply_to"] is None
+
+
+


### PR DESCRIPTION
## What does this PR do?

Users don't get a Discord notification when Hermes asks a clarify question.

Final replies are sent through `adapter.send()` with a reply anchor (`reply_to`) and `notify` metadata — Discord renders those as a reply and pings the user. Clarify prompts go through `send_clarify()`, which delivered a **bare channel message with no reply reference**, so the user was never notified that a question was waiting (Discord only pings the author of a message it replies to).

This PR makes clarify prompts behave like final replies: the gateway passes the triggering message id + `notify: true` in the clarify metadata, and the adapters build a reply reference from it.

## Related Issue

No issue filed — discovered while testing clarify on Discord locally.

## Related PRs

Two open upstream PRs address the same user-visible gap (no Discord notification when a blocking prompt waits): #47342 and its current-main successor #82982. Both use an **opt-in mention** approach — prepend `<@owner_id>` pings gated behind the `discord.approval_mentions` config (default off, requires numeric allowlist) — across the four blocking-prompt paths (exec approvals, slash confirms, clarify, update prompts).

This PR takes a different mechanism for the clarify path: build a native `discord.MessageReference` reply to the triggering message with `notify: true`, exactly mirroring how final replies are already delivered (`_reply_anchor_for_event` + `_mark_notify_metadata`). Reply-anchoring pings the specific user who asked, works with zero configuration, and needs no allowlist. The two are complementary: mention pings opt in to pinging all allowlisted owners; reply anchoring matches the user's own triggering message.

Not a duplicate: mechanism, scope, and default behavior differ, and upstream `send_clarify` (base fallback and Discord override) still sends a bare embed with no reference and no mention as of 2026-08-13.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — `_clarify_callback_sync` now builds clarify metadata with `reply_to_message_id` (from `ctx.source.message_id`) and `notify: true`, mirroring the final-reply path (`_reply_anchor_for_event` + `_mark_notify_metadata`).
- `gateway/platforms/base.py` — base `send_clarify` fallback forwards `reply_to_message_id` to `self.send()` as `reply_to`, mirroring WhatsApp's existing `send_clarify` override. Only affects adapters without their own override (Slack, generic text platforms).
- `plugins/platforms/discord/adapter.py` — Discord `send_clarify` builds a `discord.MessageReference` from `metadata["reply_to_message_id"]` and passes `reference=` to `channel.send`, honoring `reply_to_mode: "off"` via the existing `_reply_reference_for_send` helper (same path `send()` uses).
- Tests: `tests/gateway/test_clarify_active_session_bypass.py` (base fallback anchor forwarding), `tests/e2e/test_discord_clarify_reply_anchor.py` (Discord reference for choice + open-ended prompts, no-anchor, and `reply_to_mode: off`).

## How to Test

1. Ask Hermes something that triggers a clarify prompt on Discord (e.g. a tool call requiring a decision).
2. Before: the clarify message appears in the channel with no reply reference and no notification.
3. After: the clarify message appears as a **reply** to your triggering message and Discord pings you, exactly like a final response.
4. Regression: `scripts/run_tests.sh tests/e2e/test_discord_clarify_reply_anchor.py tests/gateway/test_clarify_active_session_bypass.py` — 7 tests pass (4 new Discord, 2 new base, 1 existing gateway clarify test).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux 6.17)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Behavioral change verified by the regression tests (7 targeted tests pass, including the 4 new Discord reply-anchor tests). Full suite: `scripts/run_tests.sh` — 2819 files, 30,360 tests passed, 344 skipped, 3 known-flaky files passed on retry. 33 files initially reported failed due to missing optional deps in the local venv (`acp`, `mcp`, lazy-install SDKs); after `uv sync --locked` to the exact CI extra set, all 33 re-ran with 551 tests passing, 0 failures.
