### PR TITLE
feat(tools): expire persisted tool results after 7 days via file mtime (port opencode#40987)

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -12,12 +12,16 @@ from tools.tool_result_storage import (
     HEREDOC_MARKER,
     PERSISTED_OUTPUT_TAG,
     PERSISTED_OUTPUT_CLOSING_TAG,
+    RETENTION_DAYS,
     STORAGE_DIR,
     _build_persisted_message,
     _heredoc_marker,
+    _last_cleanup_at,
     _resolve_storage_dir,
     _safe_result_filename,
+    _should_run_cleanup,
     _write_to_sandbox,
+    cleanup_stale_results,
     enforce_turn_budget,
     generate_preview,
     maybe_persist_tool_result,
@@ -169,6 +173,11 @@ class TestBuildPersistedMessage:
 # ── maybe_persist_tool_result ─────────────────────────────────────────
 
 class TestMaybePersistToolResult:
+    def setup_method(self):
+        # Deterministic cleanup-throttle state: the first persist in each
+        # test triggers the retention sweep.
+        _last_cleanup_at.clear()
+
     def test_below_threshold_returns_unchanged(self):
         content = "small result"
         result = maybe_persist_tool_result(
@@ -194,7 +203,9 @@ class TestMaybePersistToolResult:
         assert PERSISTED_OUTPUT_TAG in result
         assert "tc_456.txt" in result
         assert len(result) < len(content)
-        env.execute.assert_called_once()
+        # Call 1 writes the result; call 2 is the retention sweep.
+        assert env.execute.call_count == 2
+        assert "cat >" in env.execute.call_args_list[0][0][0]
 
     def test_persists_full_content_as_is(self):
         """Content is persisted verbatim — no JSON extraction."""
@@ -213,7 +224,8 @@ class TestMaybePersistToolResult:
         assert PERSISTED_OUTPUT_TAG in result
         # Content is delivered through stdin (no longer embedded in the
         # command string — see test_large_content_via_stdin for why).
-        assert env.execute.call_args[1]["stdin_data"] == content
+        write_call = env.execute.call_args_list[0]
+        assert write_call[1]["stdin_data"] == content
 
 
     def test_tool_use_id_cannot_escape_storage_dir(self):
@@ -228,7 +240,7 @@ class TestMaybePersistToolResult:
             env=env,
             threshold=30_000,
         )
-        cmd = env.execute.call_args[0][0]
+        cmd = env.execute.call_args_list[0][0][0]
         target = cmd.split("cat > ", 1)[1].split(" <<", 1)[0]
 
         assert "Full output saved to: /tmp/hermes-results/outside_whoami_x_" in result
@@ -287,6 +299,72 @@ class TestEnforceTurnBudget:
     def test_empty_messages(self):
         result = enforce_turn_budget([], env=None, config=BudgetConfig(turn_budget=200_000))
         assert result == []
+
+
+# ── cleanup_stale_results ─────────────────────────────────────────────
+
+class TestCleanupStaleResults:
+    def setup_method(self):
+        _last_cleanup_at.clear()
+
+    def test_none_env_is_noop(self):
+        cleanup_stale_results(None)  # must not raise
+
+    def test_runs_find_with_mtime_and_retention(self):
+        env = MagicMock()
+        env.get_temp_dir = None  # fall back to STORAGE_DIR
+        env.execute.return_value = {"output": "", "returncode": 0}
+        cleanup_stale_results(env, STORAGE_DIR)
+        env.execute.assert_called_once()
+        cmd = env.execute.call_args[0][0]
+        assert "find" in cmd
+        assert STORAGE_DIR in cmd
+        assert f"-mtime +{RETENTION_DAYS - 1}" in cmd
+        assert "-delete" in cmd
+        assert "-maxdepth 1" in cmd
+        assert "'*.txt'" in cmd
+
+    def test_throttled_within_interval(self):
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        cleanup_stale_results(env, STORAGE_DIR)
+        cleanup_stale_results(env, STORAGE_DIR)
+        assert env.execute.call_count == 1
+
+    def test_separate_dirs_each_swept(self):
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        cleanup_stale_results(env, "/tmp/hermes-results")
+        cleanup_stale_results(env, "/other/hermes-results")
+        assert env.execute.call_count == 2
+
+    def test_execute_failure_swallowed(self):
+        env = MagicMock()
+        env.execute.side_effect = RuntimeError("backend gone")
+        cleanup_stale_results(env, STORAGE_DIR)  # must not raise
+
+    def test_should_run_cleanup_gate(self):
+        assert _should_run_cleanup("/tmp/x", now=1000.0) is True
+        assert _should_run_cleanup("/tmp/x", now=1000.0 + 60) is False
+        assert _should_run_cleanup("/tmp/x", now=1000.0 + 7 * 60 * 60) is True
+
+    def test_persist_triggers_cleanup(self):
+        env = MagicMock()
+        env.get_temp_dir = MagicMock(return_value="/tmp")
+        env.execute.return_value = {"output": "", "returncode": 0}
+        content = "x" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_cleanup",
+            env=env,
+            threshold=30_000,
+        )
+        assert PERSISTED_OUTPUT_TAG in result
+        # First call writes the result; second call is the cleanup sweep.
+        cmds = [c[0][0] for c in env.execute.call_args_list]
+        assert any("cat >" in c for c in cmds)
+        assert any("find" in c and "-delete" in c for c in cmds)
 
 
 # ── Per-tool threshold integration ────────────────────────────────────

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -27,6 +27,7 @@ import logging
 import os
 import re
 import shlex
+import threading
 import uuid
 
 from tools.budget_config import (
@@ -43,6 +44,17 @@ HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
 _UNSAFE_RESULT_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9_.-]+")
 _MAX_RESULT_FILENAME_STEM = 120
+
+# Retention for persisted results (port of anomalyco/opencode#40987's
+# truncation-cleanup design, adapted to Hermes' env.execute() model).
+# Persisted results are session artifacts the model reads back within the
+# same conversation; anything older than the retention window is dead weight
+# that otherwise accumulates until a reboot clears /tmp (and on Termux or
+# Docker volumes, never clears at all).
+RETENTION_DAYS = 7
+_CLEANUP_MIN_INTERVAL_SECONDS = 6 * 60 * 60  # at most one sweep per 6h per process
+_cleanup_lock = threading.Lock()
+_last_cleanup_at: dict[str, float] = {}
 
 
 def _resolve_storage_dir(env) -> str:
@@ -116,6 +128,53 @@ def _write_to_sandbox(content: str, remote_path: str, env) -> bool:
     return result.get("returncode", 1) == 0
 
 
+def _should_run_cleanup(storage_dir: str, *, now: float | None = None) -> bool:
+    """Throttle gate: at most one cleanup sweep per storage dir per interval.
+
+    Keeps the sweep off the hot path — persistence fires on large tool
+    results, so without a throttle every oversized result would pay for a
+    ``find`` in the sandbox.
+    """
+    import time
+
+    now = time.monotonic() if now is None else now
+    with _cleanup_lock:
+        last = _last_cleanup_at.get(storage_dir)
+        if last is not None and (now - last) < _CLEANUP_MIN_INTERVAL_SECONDS:
+            return False
+        _last_cleanup_at[storage_dir] = now
+        return True
+
+
+def cleanup_stale_results(env, storage_dir: str | None = None) -> None:
+    """Delete persisted results older than ``RETENTION_DAYS`` (best-effort).
+
+    Uses file mtime — not any timestamp encoded in the filename — as the age
+    signal, matching opencode#40987's fix (ID-embedded timestamps wrap/drift;
+    the filesystem's own clock is authoritative). Runs through env.execute()
+    so it works on every backend (local, Docker, SSH, Modal); failures are
+    swallowed — retention is hygiene, never a reason to fail a tool result.
+
+    ``find -mtime +N`` matches files whose age strictly exceeds N*24h, so
+    ``+{RETENTION_DAYS - 1}`` deletes anything older than RETENTION_DAYS days
+    in whole-day granularity while never touching same-week files.
+    """
+    if env is None:
+        return
+    target = storage_dir or _resolve_storage_dir(env)
+    if not _should_run_cleanup(target):
+        return
+    cmd = (
+        f"[ -d {shlex.quote(target)} ] && "
+        f"find {shlex.quote(target)} -maxdepth 1 -type f -name '*.txt' "
+        f"-mtime +{RETENTION_DAYS - 1} -delete || true"
+    )
+    try:
+        env.execute(cmd, timeout=15)
+    except Exception as exc:
+        logger.debug("Stale persisted-result cleanup failed for %s: %s", target, exc)
+
+
 def _build_persisted_message(
     preview: str,
     has_more: bool,
@@ -185,6 +244,7 @@ def maybe_persist_tool_result(
                     "Persisted large tool result: %s (%s, %d chars -> %s)",
                     tool_name, tool_use_id, len(content), remote_path,
                 )
+                cleanup_stale_results(env, storage_dir)
                 return _build_persisted_message(preview, has_more, len(content), remote_path)
         except Exception as exc:
             logger.warning("Sandbox write failed for %s: %s", tool_use_id, exc)


### PR DESCRIPTION
## Summary
Persisted oversized tool results now expire after 7 days — `/tmp/hermes-results` (and the backend temp dir on Termux/Docker/Modal) no longer grows forever.

Port from [anomalyco/opencode#40987](https://github.com/anomalyco/opencode/pull/40987) ("use file times for truncation cleanup"), opened by the OpenCode PR scout cron.

## What was ported and how it was adapted

OpenCode's truncation-output store had the same shape as Hermes' tool-result persistence layer: large outputs spilled to disk, never deleted. Their fix keys cleanup on **file mtime** (not any timestamp encoded in the filename/ID, which wraps and drifts) with a retention window. Adapted to Hermes' architecture:

- `cleanup_stale_results(env, storage_dir)` in `tools/tool_result_storage.py`: a best-effort mtime sweep (`find … -mtime +6 -type f -name '*.txt'`) run through `env.execute()`, so it works identically on local, Docker, SSH, Modal, and Termux backends — same routing as the write path.
- Triggered opportunistically after a successful persist, **throttled to one sweep per storage dir per 6h per process** — zero added hot-path cost, no new background thread, no new config surface.
- Fail-open: any cleanup error is swallowed and logged at debug. Retention is hygiene; it can never fail a tool result.
- Scoped tightly: `-maxdepth 1`, `*.txt` only — nothing else in the temp dir is ever touched.

Architectural difference vs source: OpenCode runs cleanup in an Effect service layer at store startup; Hermes has no equivalent daemon hook for sandbox temp dirs, so the sweep piggybacks on the persist path (the only moment we know the backend's storage dir is live and reachable).

## Validation
| Check | Result |
|---|---|
| `tests/tools/test_tool_result_storage.py` (incl. 7 new tests) | 33/33 pass |
| Sibling test files (`test_malformed_tool_arguments`, `test_tool_call_incremental_persistence`, `test_focus_view`) | 54/54 pass |
| E2E (real subprocess env, real `utimes`-aged files) | 10-day-old `.txt` deleted, 3-day-old kept, non-`.txt` untouched, fresh persist survives its own sweep, throttle suppresses repeat sweeps |
| Sabotage run (cleanup wiring disabled) | E2E fails as expected — test actually exercises the fix |

## Infographic

![tool-result-retention](https://files.catbox.moe/dwgh5p.png)
