### PR TITLE
fix(desktop): pass active profile in gateway WebSocket URL

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -413,6 +413,29 @@ test('buildGatewayWsUrl url-encodes the token', () => {
   assert.equal(buildGatewayWsUrl('https://host', 'a/b c+d'), 'wss://host/api/ws?token=a%2Fb%20c%2Bd')
 })
 
+test('buildGatewayWsUrl appends profile param when provided', () => {
+  assert.equal(buildGatewayWsUrl('https://gw.example.com', 'tok123', 'sheepyr'), 'wss://gw.example.com/api/ws?token=tok123&profile=sheepyr')
+})
+
+test('buildGatewayWsUrl omits profile param when null', () => {
+  assert.equal(buildGatewayWsUrl('https://gw.example.com', 'tok123', null), 'wss://gw.example.com/api/ws?token=tok123')
+})
+
+test('buildGatewayWsUrl url-encodes the profile', () => {
+  assert.equal(buildGatewayWsUrl('https://gw.example.com', 'tok123', 'my profile'), 'wss://gw.example.com/api/ws?token=tok123&profile=my%20profile')
+})
+
+test('buildGatewayWsUrlWithTicket appends profile param when provided', () => {
+  const url = buildGatewayWsUrlWithTicket('https://gw.example.com/hermes', 'tkt-9', 'sheepyr')
+  assert.equal(url, 'wss://gw.example.com/hermes/api/ws?ticket=tkt-9&profile=sheepyr')
+  assert.ok(!url.includes('token='))
+})
+
+test('buildGatewayWsUrlWithTicket omits profile param when null', () => {
+  const url = buildGatewayWsUrlWithTicket('https://gw.example.com/hermes', 'tkt-9', null)
+  assert.equal(url, 'wss://gw.example.com/hermes/api/ws?ticket=tkt-9')
+})
+
 // --- buildGatewayWsUrlWithTicket (oauth) ---
 
 test('buildGatewayWsUrlWithTicket uses ?ticket= not ?token=', () => {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -99,20 +99,20 @@ function normalizeRemoteBaseUrl(rawUrl) {
   return parsed.toString().replace(/\/+$/, '')
 }
 
-function buildGatewayWsUrl(baseUrl, token) {
+function buildGatewayWsUrl(baseUrl, token, profile?: string | null) {
   const parsed = new URL(baseUrl)
   const wsScheme = parsed.protocol === 'https:' ? 'wss' : 'ws'
   const prefix = parsed.pathname.replace(/\/+$/, '')
 
-  return `${wsScheme}://${parsed.host}${prefix}/api/ws?token=${encodeURIComponent(token)}`
+  return `${wsScheme}://${parsed.host}${prefix}/api/ws?token=${encodeURIComponent(token)}${profile ? `&profile=${encodeURIComponent(profile)}` : ""}`
 }
 
-function buildGatewayWsUrlWithTicket(baseUrl, ticket) {
+function buildGatewayWsUrlWithTicket(baseUrl, ticket, profile?: string | null) {
   const parsed = new URL(baseUrl)
   const wsScheme = parsed.protocol === 'https:' ? 'wss' : 'ws'
   const prefix = parsed.pathname.replace(/\/+$/, '')
 
-  return `${wsScheme}://${parsed.host}${prefix}/api/ws?ticket=${encodeURIComponent(ticket)}`
+  return `${wsScheme}://${parsed.host}${prefix}/api/ws?ticket=${encodeURIComponent(ticket)}${profile ? `&profile=${encodeURIComponent(profile)}` : ""}`
 }
 
 /** True only when a gateway explicitly rejected the current OAuth session. */

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8730,7 +8730,10 @@ async function resolveRemoteBackend(profile) {
     authMode,
     token,
     'settings',
-    undefined, undefined, profile
+    undefined,
+    config.mode === 'cloud' ? 'cloud' : 'url',
+    undefined,
+    profile
   )
 }
 
@@ -9307,7 +9310,9 @@ async function connectRegistryBackend(source, profile, key, poolEntry) {
     token,
     `registry:${source.id}`,
     undefined,
-    source.kind === 'cloud' ? 'cloud' : 'url'
+    source.kind === 'cloud' ? 'cloud' : 'url',
+    undefined,
+    profileKey
   )
 
   await waitForHermes(connection.baseUrl, connection.token, undefined, connection.authMode)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -7129,7 +7129,7 @@ async function freshGatewayWsUrl(profile) {
   if (connection.authMode === 'oauth') {
     const ticket = await mintGatewayWsTicket(connection.baseUrl)
 
-    return buildGatewayWsUrlWithTicket(connection.baseUrl, ticket)
+    return buildGatewayWsUrlWithTicket(connection.baseUrl, ticket, profile)
   }
 
   // Local/token: the cached wsUrl already carries the (long-lived) token.
@@ -8280,7 +8280,7 @@ async function buildRemoteConnection(
   source,
   remoteHost?,
   remoteKind = 'url',
-  remoteIdentity?
+  remoteIdentity?, profile?
 ) {
   const baseUrl = normalizeRemoteBaseUrl(rawUrl)
   // For token/oauth remotes the meaningful host is the real backend URL; for
@@ -8339,7 +8339,7 @@ async function buildRemoteConnection(
       remoteKind,
       // No static token in OAuth mode; REST is cookie-authed via the partition.
       token: null,
-      wsUrl: buildGatewayWsUrlWithTicket(baseUrl, ticket)
+      wsUrl: buildGatewayWsUrlWithTicket(baseUrl, ticket, profile)
     }
   }
 
@@ -8359,7 +8359,7 @@ async function buildRemoteConnection(
     remoteIdentity,
     remoteKind,
     token,
-    wsUrl: buildGatewayWsUrl(baseUrl, token)
+    wsUrl: buildGatewayWsUrl(baseUrl, token, profile)
   }
 }
 
@@ -8611,7 +8611,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     source,
     hostLabel,
     'ssh',
-    result.ownershipId
+    result.ownershipId, profile
   )
 
   return { ...connection, remoteHermesVersion: result.hermesVersion || '' }
@@ -8684,8 +8684,9 @@ async function resolveRemoteBackend(profile) {
       token,
       'profile',
       undefined,
-      config.profiles?.[connectionScopeKey(profile)]?.mode === 'cloud' ? 'cloud' : 'url'
-    )
+      config.profiles?.[connectionScopeKey(profile)]?.mode === 'cloud' ? 'cloud' : 'url',
+    undefined, profile
+  )
   }
 
   // 2. Env override (global, token-auth only).
@@ -8700,7 +8701,7 @@ async function resolveRemoteBackend(profile) {
       )
     }
 
-    return buildRemoteConnection(rawEnvUrl, 'token', rawEnvToken, 'env')
+    return buildRemoteConnection(rawEnvUrl, 'token', rawEnvToken, 'env', undefined, undefined, undefined, profile)
   }
 
   // 3. Global remote.
@@ -8729,8 +8730,7 @@ async function resolveRemoteBackend(profile) {
     authMode,
     token,
     'settings',
-    undefined,
-    config.mode === 'cloud' ? 'cloud' : 'url'
+    undefined, undefined, profile
   )
 }
 


### PR DESCRIPTION
## What does this PR do?

When Hermes Desktop connects to a remote dashboard with multiple profiles, the active profile was stored in localStorage but never appended to the WebSocket `/api/ws` URL as `?profile=<name>`. The dashboard backend scopes sessions by `ws.query_params.get("profile")` (see `hermes_cli/web_server.py`), so the session landed on the dashboard's boot profile instead of the profile selected in the Desktop UI.

### Fix

- `buildGatewayWsUrl` and `buildGatewayWsUrlWithTicket` in `apps/desktop/electron/connection-config.ts` now accept an optional `profile` argument and append `&profile=<encoded>` when present.
- Remote-connection call sites in `apps/desktop/electron/main.ts` pass the active `profile` as the last `buildRemoteConnection` argument (after `remoteKind` / `remoteIdentity`). The global Settings remote path previously bound `profile` to `remoteIdentity`; the registry remote/cloud path omitted it.

## Related Issue

Fixes #71527

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/connection-config.ts`: add `profile?: string | null` to `buildGatewayWsUrl` and `buildGatewayWsUrlWithTicket`; append `&profile=...` when truthy.
- `apps/desktop/electron/main.ts`: propagate `profile` through `buildRemoteConnection` and the gateway WS URL builders, including the global Settings path and the registry remote/cloud path.
- `apps/desktop/electron/connection-config.test.ts`: add 5 regression tests covering token/ticket URLs with profile, with null/undefined, and with URL-encoded profile names.

## How to Test

1. `cd apps/desktop && bun test electron/connection-config.test.ts` — URL builder tests pass.
2. Confirm `resolveRemoteBackend` Settings call is `buildRemoteConnection(..., undefined, cloud|url, undefined, profile)` and the registry call passes `profileKey` last.
3. `scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/71527` — blocking gates green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A