### PR TITLE
fix(state): fall back to billing_provider in session_gateway_runtime

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6109,6 +6109,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return False
         return bool(raw.get("yolo_mode"))
 
+    # Billing-bucket classes that aren't a routable provider identity on
+    # their own — mirrors tui_gateway.server._BARE_BILLING_PROVIDERS. A
+    # session that persisted only one of these (never ran /model) must fall
+    # back to the ambient config default rather than restore a bare bucket.
+    _BARE_BILLING_PROVIDERS = ("auto", "custom")
+
     @staticmethod
     def session_gateway_runtime(session_meta: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         """Read the persisted runtime route off a session row dict.
@@ -6118,9 +6124,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ``gateway_runtime`` key (written by the gateway's
         ``_sync_session_model_from_agent`` and the CLI ``/model`` persist),
         falling back to the top-level ``provider``/``base_url``/``api_mode``
-        keys the TUI gateway's ``_runtime_model_config`` writes. Returns an
-        empty dict on any parse failure — resume falls back to ambient
-        config resolution.
+        keys the TUI gateway's ``_runtime_model_config`` writes, and finally
+        to the ``billing_provider`` column — set independently of ``/model``
+        on every session's first accounted API call — for a session that
+        never explicitly switched models. Returns an empty dict on any parse
+        failure — resume falls back to ambient config resolution.
         """
         raw = (session_meta or {}).get("model_config")
         if isinstance(raw, str):
@@ -6129,7 +6137,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             except Exception:
                 return {}
         if not isinstance(raw, dict):
-            return {}
+            raw = {}
         runtime = raw.get("gateway_runtime")
         if isinstance(runtime, dict) and runtime.get("provider"):
             return dict(runtime)
@@ -6140,7 +6148,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         }
         if top_level:
             return top_level
-        return dict(runtime) if isinstance(runtime, dict) else {}
+        if isinstance(runtime, dict) and runtime:
+            return dict(runtime)
+        billing_provider = str((session_meta or {}).get("billing_provider") or "").strip()
+        if billing_provider and billing_provider.lower() not in SessionDB._BARE_BILLING_PROVIDERS:
+            return {"provider": billing_provider}
+        return {}
 
     def update_session_billing_route(
         self,

--- a/tests/cli/test_resume_model_restore.py
+++ b/tests/cli/test_resume_model_restore.py
@@ -30,10 +30,11 @@ def _make_stub(**overrides):
     return stub
 
 
-def _row(model="glm-4.7", model_config=None):
+def _row(model="glm-4.7", model_config=None, billing_provider=None):
     return {
         "model": model,
         "model_config": json.dumps(model_config) if model_config else None,
+        "billing_provider": billing_provider,
     }
 
 
@@ -62,6 +63,33 @@ def test_session_gateway_runtime_tolerates_garbage():
     assert SessionDB.session_gateway_runtime({}) == {}
     assert SessionDB.session_gateway_runtime({"model_config": "{not json"}) == {}
     assert SessionDB.session_gateway_runtime({"model_config": json.dumps([1, 2])}) == {}
+
+
+def test_session_gateway_runtime_falls_back_to_billing_provider():
+    """A plain session that never ran /model has no gateway_runtime or
+    top-level provider keys in model_config — only billing_provider, set
+    independently on the session's first accounted API call."""
+    meta = _row(model_config={"max_iterations": 60}, billing_provider="minimax")
+    runtime = SessionDB.session_gateway_runtime(meta)
+    assert runtime == {"provider": "minimax"}
+
+
+def test_session_gateway_runtime_billing_provider_bare_bucket_ignored():
+    """A bare billing bucket ('custom'/'auto') isn't a routable identity —
+    must fall back to the ambient default, not restore the bucket verbatim."""
+    meta = _row(model_config=None, billing_provider="custom")
+    assert SessionDB.session_gateway_runtime(meta) == {}
+    meta = _row(model_config=None, billing_provider="auto")
+    assert SessionDB.session_gateway_runtime(meta) == {}
+
+
+def test_session_gateway_runtime_explicit_provider_wins_over_billing_provider():
+    meta = _row(
+        model_config={"provider": "nous"},
+        billing_provider="openrouter",
+    )
+    runtime = SessionDB.session_gateway_runtime(meta)
+    assert runtime == {"provider": "nous"}
 
 
 # ── _restore_session_model ──────────────────────────────────────────
@@ -93,6 +121,21 @@ def test_restore_session_model_no_stored_model_is_noop():
     stub = _make_stub()
     stub._restore_session_model(_row(model=None))
     assert stub.model == "ambient-model"
+
+
+def test_restore_session_model_restores_billing_provider_fallback():
+    """A session that never ran /model still recorded billing_provider on its
+    first accounted API call — resume must route to that provider, not the
+    ambient default the user may have changed since."""
+    stub = _make_stub()
+    stub._restore_session_model(_row(
+        model="glm-4.7",
+        model_config={"max_iterations": 60},
+        billing_provider="minimax",
+    ))
+    assert stub.model == "glm-4.7"
+    assert stub.provider == "minimax"
+    assert stub.requested_provider == "minimax"
 
 
 def test_restore_session_model_matching_state_is_silent_noop():


### PR DESCRIPTION
## Summary

`SessionDB.session_gateway_runtime()` — added this week as "the canonical tolerant row-level route reader" for CLI resume, and consumed by its only production caller, `cli.py::_restore_session_model` — reads the persisted provider from `model_config.gateway_runtime.provider` (nested) or the top-level `model_config.provider`/`base_url`/`api_mode` keys. It never falls back to the `sessions.billing_provider` column.

`billing_provider` is an independent, durable source of truth for "what provider actually served this session": it's written via `COALESCE(billing_provider, ?)` in `update_token_counts()` on every session's first accounted API call, completely independent of whether the user ever ran `/model`.

A plain `hermes` CLI session that never explicitly switched models never gets a `gateway_runtime` or top-level provider written into `model_config` — `create_session()`'s two CLI call sites (`cli.py`'s normal launch/`/new` path, and `hermes_cli/cli_commands_mixin.py`'s `/branch` path) only ever pass `max_iterations`/`reasoning_config` (plus `_branched_from` for branches). For such a session, `billing_provider` is the *only* durable record of the provider it actually used.

## Effect

`hermes --resume <session>` (or mid-chat `/resume`) on a session that never ran `/model`, after the ambient config-default provider has changed since that session was last used, silently keeps the new ambient provider instead of restoring the one the session actually used — routing the old model to the wrong provider/endpoint (auth errors, or a same-named model resolving on the wrong provider).

## Fix

`session_gateway_runtime()`'s sibling reader for TUI/desktop resume — `tui_gateway/server.py::_stored_session_runtime_overrides` — already falls back to `billing_provider`, filtering out non-routable bare billing buckets (`"auto"`/`"custom"`, via `_BARE_BILLING_PROVIDERS`). This PR mirrors that same fallback and filter in `session_gateway_runtime()`. Bare `"custom"` is intentionally excluded from the fallback — it needs URL-based identity recovery (`canonical_custom_identity`), which `_restore_session_model`'s existing healing logic already provides when reachable via the `gateway_runtime`-sourced path.

## Verification

- Traced the write path (`create_session`'s two CLI call sites, `update_token_counts`) and the read path (`session_gateway_runtime`, `_restore_session_model`) directly in the live code, not from commit messages.
- Added 5 regression tests to `tests/cli/test_resume_model_restore.py`: `session_gateway_runtime` falling back to `billing_provider`, ignoring bare buckets, explicit provider still winning over `billing_provider`, and an end-to-end `_restore_session_model` test confirming `stub.provider` is actually restored.
- Mutation-verified: stashed the fix, confirmed the new fallback tests fail against pre-fix code (`_restore_session_model` kept the stub on the ambient `"openrouter"` instead of restoring `"minimax"`); the two negative-fallback tests still passed (no false positive introduced). Restored the fix, all pass.
- Ran the full `tests/cli/` directory + `tests/test_hermes_state.py` (1198 passed, 9 skipped). Two unrelated failures reproduce identically with the fix stashed out: one is a pre-existing `FTS5Search` context-enrichment-count assertion failure, the other (`test_session_not_found_goes_to_stdout_in_full_mode`) passes in isolation both with and without the fix — test-order pollution from the full suite, not caused by this change.
- `ruff check` clean on both changed files.

## Test plan

- [x] New regression tests added and pass
- [x] Mutation-verify: fallback tests fail without the fix, pass with it; negative tests unaffected
- [x] `tests/cli/` + `tests/test_hermes_state.py` pass (excluding two pre-existing, fix-independent failures)
- [x] `ruff check` clean