### PR TITLE
fix(tools): route browser snapshot storage through the symlink-safe writer

### DIFF
--- a/tests/tools/test_browser_hardening.py
+++ b/tests/tools/test_browser_hardening.py
@@ -229,6 +229,39 @@ class TestTruncateSnapshot:
         content = Path(stored).read_text(encoding="utf-8")
         assert "STOREDSNAPSHOTSECRET" not in content
 
+    def test_stored_snapshot_refuses_planted_symlink(self, tmp_path, monkeypatch):
+        """A pre-planted symlink at the content-hash path must not be
+        followed to its target — only the link itself may be replaced.
+
+        Mirrors web_tools._store_full_text's use of write_text_exclusive
+        (overwrite=True) for the same cache/web directory and naming
+        scheme: a legitimate re-snapshot of the same page state safely
+        replaces a same-path symlink with a real file, never writing
+        through it onto whatever the link points at.
+        """
+        import hashlib
+        from pathlib import Path
+        from tools.browser_tool import _store_full_snapshot
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        snapshot = "\n".join(f"- line {i}" for i in range(50))
+        # No secret-like content, so redact_sensitive_text leaves it
+        # unchanged and the digest is predictable from the raw text.
+        digest = hashlib.sha256(snapshot.encode("utf-8")).hexdigest()[:10]
+
+        cache_dir = tmp_path / "cache" / "web"
+        cache_dir.mkdir(parents=True)
+        victim = tmp_path / "victim.txt"
+        victim.write_text("original", encoding="utf-8")
+        planted = cache_dir / f"browser-snapshot-{digest}.txt"
+        planted.symlink_to(victim)
+
+        stored = _store_full_snapshot(snapshot)
+        assert stored is not None
+        assert victim.read_text(encoding="utf-8") == "original"  # link target untouched
+        assert not planted.is_symlink()  # link replaced by a real file
+        assert Path(stored).read_text(encoding="utf-8") == snapshot
+
     def test_extract_relevant_content_appends_stored_pointer(self):
         """LLM-summarized snapshots also point at the stored full text."""
         from unittest.mock import MagicMock

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3040,11 +3040,18 @@ def _store_full_snapshot(snapshot_text: str) -> Optional[str]:
                 + f"\n\n[... stored copy truncated at {MAX_STORED_SNAPSHOT_CHARS:,} chars "
                 f"of {len(content):,} ...]"
             )
+        from tools.spill_safety import ensure_spill_dir, write_text_exclusive
+
         cache_dir = get_hermes_dir("cache/web", "web_cache")
-        cache_dir.mkdir(parents=True, exist_ok=True)
+        ensure_spill_dir(cache_dir, private=False)
         digest = hashlib.sha256(content.encode("utf-8")).hexdigest()[:10]
         path = cache_dir / f"browser-snapshot-{digest}.txt"
-        path.write_text(content, encoding="utf-8")
+        # Deterministic filename in a well-known dir: refuse symlinks via
+        # lstat-unlink + exclusive create. Re-snapshotting the same page
+        # state legitimately overwrites (same content-hash name). Not
+        # private: cache/web is bind-mounted into remote backends whose
+        # container UID must be able to read it.
+        write_text_exclusive(path, content, private=False, overwrite=True)
         return str(path)
     except Exception as exc:  # noqa: BLE001
         logger.debug("Failed to store full browser snapshot: %s", exc)


### PR DESCRIPTION
## Summary

Today's `tools/spill_safety.py` hardening ("symlink-safe exclusive creation for all spill/cache writers") migrated `tools/web_tools.py::_store_full_text()` — which writes the full extracted page text to `cache/web`, keyed on a content hash — to `write_text_exclusive()`/`ensure_spill_dir()` (`O_CREAT|O_EXCL|O_NOFOLLOW`, refusing to follow a pre-planted symlink). Its near-identical sibling, `tools/browser_tool.py::_store_full_snapshot()`, writes to the *same* `cache/web` directory with the *same* content-hash filename pattern (`browser-snapshot-<digest>.txt` vs. `<slug>-<digest>.md`) but was left on the pre-fix plain `cache_dir.mkdir(...)` + `path.write_text(...)` pattern.

## Reproduction

With a symlink planted at the exact `cache/web/browser-snapshot-<digest>.txt` path (predictable from the snapshot content hash), the pre-fix write follows the link and overwrites its target with the snapshot content. Confirmed via mutation-verify (see below) — the pre-fix code wrote the (secret-redacted, but otherwise page/user-controlled) snapshot text directly into the symlink's target file.

## Fix

Mirrors `_store_full_text`'s exact usage:
- `ensure_spill_dir(cache_dir, private=False)` — not private, since `cache/web` is bind-mounted read-only into remote backends (`credential_files._CACHE_DIRS`) whose container UID must be able to read it.
- `write_text_exclusive(path, content, private=False, overwrite=True)` — `overwrite=True` because re-snapshotting the same page state legitimately reuses the same content-hash name; the overwrite path `lstat`-unlinks the *link itself* (never follows it to write through), then creates exclusively.

## Verification

- Added `test_stored_snapshot_refuses_planted_symlink` to `tests/tools/test_browser_hardening.py`: plants a symlink at the exact digest path pointing at a "victim" file, calls `_store_full_snapshot`, and asserts the victim's content is untouched and the link itself was safely replaced by a real file containing the actual snapshot content.
- Mutation-verified: stashed the fix, confirmed the new test fails — the pre-fix write follows the symlink and overwrites the victim file's content with the snapshot text, reproducing the vulnerability exactly. Restored the fix, test passes.
- Ran `tests/tools/test_browser_hardening.py` + `tests/tools/test_spill_safety.py` + `tests/tools/test_web_tools_truncate.py` + `tests/tools/test_web_extract_robustness.py`: 42/42 pass.
- `ruff check` clean on both changed files.

## Test plan

- [x] New regression test added and passes
- [x] Mutation-verify: test fails without the fix (reproduces the symlink-follow), passes with it
- [x] Broader neighbor test suites pass (42/42)
- [x] `ruff check` clean