### PR TITLE
docs(website): add Japanese locale

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -24,7 +24,7 @@ const config: Config = {
 
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'zh-Hans'],
+    locales: ['en', 'zh-Hans', 'ja-JP'],
     localeConfigs: {
       en: {
         label: 'English',
@@ -32,6 +32,10 @@ const config: Config = {
       'zh-Hans': {
         label: '简体中文',
         htmlLang: 'zh-Hans',
+      },
+      'ja-JP': {
+        label: '日本語',
+        htmlLang: 'ja-JP',
       },
     },
   },

--- a/website/i18n/ja-JP/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/ja-JP/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,254 @@
+{
+  "version.label": {
+    "message": "Next",
+    "description": "The label for version current"
+  },
+  "sidebar.docs.category.Getting Started": {
+    "message": "はじめに",
+    "description": "The label for category 'Getting Started' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Using Hermes": {
+    "message": "Hermes の使い方",
+    "description": "The label for category 'Using Hermes' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Secrets": {
+    "message": "シークレット",
+    "description": "The label for category 'Secrets' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Egress proxy": {
+    "message": "Egress プロキシ",
+    "description": "The label for category 'Egress proxy' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Features": {
+    "message": "機能",
+    "description": "The label for category 'Features' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Core": {
+    "message": "コア",
+    "description": "The label for category 'Core' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Automation": {
+    "message": "自動化",
+    "description": "The label for category 'Automation' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Media & Web": {
+    "message": "メディアとWeb",
+    "description": "The label for category 'Media & Web' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Management": {
+    "message": "管理",
+    "description": "The label for category 'Management' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Skills": {
+    "message": "スキル",
+    "description": "The label for category 'Skills' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Bundled": {
+    "message": "同梱",
+    "description": "The label for category 'Bundled' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-apple": {
+    "message": "Apple",
+    "description": "The label for category 'apple' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-autonomous-ai-agents": {
+    "message": "自律型AIエージェント",
+    "description": "The label for category 'autonomous-ai-agents' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-creative": {
+    "message": "クリエイティブ",
+    "description": "The label for category 'creative' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-email": {
+    "message": "メール",
+    "description": "The label for category 'email' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-github": {
+    "message": "GitHub",
+    "description": "The label for category 'github' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-media": {
+    "message": "メディア",
+    "description": "The label for category 'media' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-mlops": {
+    "message": "MLOps",
+    "description": "The label for category 'mlops' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-note-taking": {
+    "message": "ノート作成",
+    "description": "The label for category 'note-taking' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-productivity": {
+    "message": "生産性",
+    "description": "The label for category 'productivity' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-research": {
+    "message": "リサーチ",
+    "description": "The label for category 'research' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-smart-home": {
+    "message": "スマートホーム",
+    "description": "The label for category 'smart-home' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-social-media": {
+    "message": "ソーシャルメディア",
+    "description": "The label for category 'social-media' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-bundled-software-development": {
+    "message": "ソフトウェア開発",
+    "description": "The label for category 'software-development' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Optional": {
+    "message": "オプション",
+    "description": "The label for category 'Optional' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-autonomous-ai-agents": {
+    "message": "自律型AIエージェント",
+    "description": "The label for category 'autonomous-ai-agents' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-blockchain": {
+    "message": "ブロックチェーン",
+    "description": "The label for category 'blockchain' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-communication": {
+    "message": "コミュニケーション",
+    "description": "The label for category 'communication' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-creative": {
+    "message": "クリエイティブ",
+    "description": "The label for category 'creative' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-data-science": {
+    "message": "データサイエンス",
+    "description": "The label for category 'data-science' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-devops": {
+    "message": "DevOps",
+    "description": "The label for category 'devops' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-dogfood": {
+    "message": "ドッグフーディング",
+    "description": "The label for category 'dogfood' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-email": {
+    "message": "メール",
+    "description": "The label for category 'email' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-finance": {
+    "message": "ファイナンス",
+    "description": "The label for category 'finance' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-gaming": {
+    "message": "ゲーム",
+    "description": "The label for category 'gaming' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-health": {
+    "message": "ヘルスケア",
+    "description": "The label for category 'health' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-mcp": {
+    "message": "MCP",
+    "description": "The label for category 'mcp' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-migration": {
+    "message": "移行",
+    "description": "The label for category 'migration' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-mlops": {
+    "message": "MLOps",
+    "description": "The label for category 'mlops' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-payments": {
+    "message": "決済",
+    "description": "The label for category 'payments' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-productivity": {
+    "message": "生産性",
+    "description": "The label for category 'productivity' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-research": {
+    "message": "リサーチ",
+    "description": "The label for category 'research' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-security": {
+    "message": "セキュリティ",
+    "description": "The label for category 'security' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-software-development": {
+    "message": "ソフトウェア開発",
+    "description": "The label for category 'software-development' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-web-development": {
+    "message": "Web開発",
+    "description": "The label for category 'web-development' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.skills-optional-yuanbao": {
+    "message": "元宝",
+    "description": "The label for category 'yuanbao' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Messaging Platforms": {
+    "message": "メッセージングプラットフォーム",
+    "description": "The label for category 'Messaging Platforms' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Popular": {
+    "message": "人気",
+    "description": "The label for category 'Popular' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Microsoft 365": {
+    "message": "Microsoft 365",
+    "description": "The label for category 'Microsoft 365' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Chinese platforms": {
+    "message": "中国のプラットフォーム",
+    "description": "The label for category 'Chinese platforms' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Other": {
+    "message": "その他",
+    "description": "The label for category 'Other' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Integrations": {
+    "message": "統合",
+    "description": "The label for category 'Integrations' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Guides & Tutorials": {
+    "message": "ガイドとチュートリアル",
+    "description": "The label for category 'Guides & Tutorials' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Developer Guide": {
+    "message": "開発者ガイド",
+    "description": "The label for category 'Developer Guide' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Architecture": {
+    "message": "アーキテクチャ",
+    "description": "The label for category 'Architecture' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Extending": {
+    "message": "拡張",
+    "description": "The label for category 'Extending' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Plugins": {
+    "message": "プラグイン",
+    "description": "The label for category 'Plugins' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Internals": {
+    "message": "内部構造",
+    "description": "The label for category 'Internals' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Reference": {
+    "message": "リファレンス",
+    "description": "The label for category 'Reference' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Command Reference": {
+    "message": "コマンドリファレンス",
+    "description": "The label for category 'Command Reference' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Configuration Reference": {
+    "message": "設定リファレンス",
+    "description": "The label for category 'Configuration Reference' in sidebar 'docs'"
+  },
+  "sidebar.docs.category.Tools & Skills Reference": {
+    "message": "ツール & スキルリファレンス",
+    "description": "The label for category 'Tools & Skills Reference' in sidebar 'docs'"
+  }
+}

--- a/website/i18n/ja-JP/docusaurus-theme-classic/footer.json
+++ b/website/i18n/ja-JP/docusaurus-theme-classic/footer.json
@@ -1,0 +1,58 @@
+{
+  "link.title.Docs": {
+    "message": "ドキュメント",
+    "description": "The title of the footer links column with title=Docs in the footer"
+  },
+  "link.title.Community": {
+    "message": "コミュニティ",
+    "description": "The title of the footer links column with title=Community in the footer"
+  },
+  "link.title.More": {
+    "message": "その他",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Getting Started": {
+    "message": "はじめに",
+    "description": "The label of footer link with label=Getting Started linking to /getting-started/quickstart"
+  },
+  "link.item.label.User Guide": {
+    "message": "ユーザーガイド",
+    "description": "The label of footer link with label=User Guide linking to /user-guide/cli"
+  },
+  "link.item.label.Developer Guide": {
+    "message": "開発者ガイド",
+    "description": "The label of footer link with label=Developer Guide linking to /developer-guide/architecture"
+  },
+  "link.item.label.Reference": {
+    "message": "リファレンス",
+    "description": "The label of footer link with label=Reference linking to /reference/cli-commands"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.gg/NousResearch"
+  },
+  "link.item.label.GitHub Issues": {
+    "message": "GitHub Issues",
+    "description": "The label of footer link with label=GitHub Issues linking to https://github.com/NousResearch/hermes-agent/issues"
+  },
+  "link.item.label.Skills Hub": {
+    "message": "Skills Hub",
+    "description": "The label of footer link with label=Skills Hub linking to https://agentskills.io"
+  },
+  "link.item.label.Desktop Download": {
+    "message": "デスクトップ版のダウンロード",
+    "description": "The label of footer link with label=Desktop Download linking to https://hermes-agent.nousresearch.com/"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/NousResearch/hermes-agent"
+  },
+  "link.item.label.Nous Research": {
+    "message": "Nous Research",
+    "description": "The label of footer link with label=Nous Research linking to https://nousresearch.com"
+  },
+  "copyright": {
+    "message": "Built by <a href=\"https://nousresearch.com\">Nous Research</a> · MIT License · 2026",
+    "description": "The footer copyright"
+  }
+}

--- a/website/i18n/ja-JP/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/ja-JP/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,34 @@
+{
+  "title": {
+    "message": "Hermes Agent",
+    "description": "The title in the navbar"
+  },
+  "logo.alt": {
+    "message": "Hermes Agent",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Docs": {
+    "message": "ドキュメント",
+    "description": "Navbar item with label Docs"
+  },
+  "item.label.Skills": {
+    "message": "スキル",
+    "description": "Navbar item with label Skills"
+  },
+  "item.label.Download": {
+    "message": "ダウンロード",
+    "description": "Navbar item with label Download"
+  },
+  "item.label.Home": {
+    "message": "ホーム",
+    "description": "Navbar item with label Home"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  },
+  "item.label.Discord": {
+    "message": "Discord",
+    "description": "Navbar item with label Discord"
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds the `ja-JP` Docusaurus locale to the documentation site. The existing locale dropdown now offers `日本語`, and the site can publish the current documentation at `/docs/ja-JP/` while untranslated pages safely fall back to the default English content.

## Related Issue

N/A

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- Add `ja-JP` to `website/docusaurus.config.ts`.
- Define the Japanese dropdown label and BCP 47 HTML language tag.
- Keep the change intentionally configuration-only: no copied docs, placeholder translations, dependency changes, or generated output.

## How to Test

1. Run `cd website && npm ci`.
2. Run `npm run build`.
3. Confirm `build/ja-JP/index.html` exists, uses `lang="ja-JP"`, and renders `日本語` in the locale dropdown.

## Validation

- [x] `npm run build -- --locale ja-JP`
- [x] `npm run build` for `en`, `zh-Hans`, and `ja-JP`
- [x] Verified each generated locale landing page has the expected HTML language tag.
- [x] Verified `build/ja-JP/getting-started/quickstart/index.html` is generated.
- [x] Diff is limited to `website/docusaurus.config.ts` and has no secrets.

## Notes

- The existing `npm run typecheck` is blocked on official main by TypeScript 6 deprecation handling and unrelated JSX/generated-data errors; this PR does not change TypeScript code or configuration.
- The existing production `npm audit --omit=dev` reports two high findings from the upstream dependency tree; this PR intentionally makes no dependency change.
