### PR TITLE
fix(streaming): treat OpenCode Go cost-only terminal chunk as finish_reason stop

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3898,6 +3898,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         role = "assistant"
         reasoning_parts: list = []
         usage_obj = None
+        # OpenCode Go terminates some successful streams with a final
+        # choices=[] chunk carrying only provider metadata (currently cost),
+        # without emitting the OpenAI-standard finish_reason or [DONE] event.
+        # Keep this scoped to that provider so a genuinely truncated stream
+        # from other OpenAI-compatible endpoints still enters the retry path.
+        opencode_go_cost_terminal = False
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
         _writer_token = {"value": None}
@@ -4122,9 +4128,33 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         ),
                         raw_text=f"{_err_type}: {_err_msg}",
                     )
+                if agent.provider == "opencode-go":
+                    # OpenCode Go terminates some successful streams with a
+                    # final choices=[] chunk carrying only provider metadata
+                    # (currently cost) and no OpenAI-standard finish_reason
+                    # or [DONE].  The SDK may expose ``cost`` through
+                    # ``model_extra`` instead of a direct attribute,
+                    # depending on its version.
+                    extra = getattr(chunk, "model_extra", None)
+                    if (
+                        getattr(chunk, "cost", None) is not None
+                        or (isinstance(extra, dict) and "cost" in extra)
+                    ):
+                        opencode_go_cost_terminal = True
                 continue
 
             delta = chunk.choices[0].delta
+            # A cost-only chunk followed by real stream content was an
+            # incremental metadata update, not a terminator — re-arm the
+            # flag so a subsequent genuine truncation still enters the
+            # retry path instead of being masked as a clean stop.
+            if opencode_go_cost_terminal and (
+                getattr(delta, "content", None)
+                or getattr(delta, "reasoning_content", None)
+                or getattr(delta, "reasoning", None)
+                or getattr(delta, "tool_calls", None)
+            ):
+                opencode_go_cost_terminal = False
             if hasattr(chunk, "model") and chunk.model:
                 model_name = chunk.model
 
@@ -4269,6 +4299,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 usage_obj = chunk.usage
 
         _close_managed_stream()
+
+        if opencode_go_cost_terminal and finish_reason is None:
+            finish_reason = "stop"
 
         if _stream_attempt_was_cancelled(stream_attempt_id):
             raise _httpx.RemoteProtocolError(

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -48,9 +48,9 @@ def _make_tool_call_delta(index=0, tc_id=None, name=None, arguments=None, extra_
     return delta
 
 
-def _make_empty_chunk(model=None, usage=None):
+def _make_empty_chunk(model=None, usage=None, cost=None):
     """Build a chunk with no choices (usage-only final chunk)."""
-    return SimpleNamespace(choices=[], model=model, usage=usage)
+    return SimpleNamespace(choices=[], model=model, usage=usage, cost=cost)
 
 
 # ── Test: Streaming Accumulator ──────────────────────────────────────────
@@ -183,6 +183,89 @@ class TestStreamingAccumulator:
         assert tool_call.function.name == ""
         assert tool_call.function.arguments == '{"city":"Paris"}'
         assert response.choices[0].finish_reason == "tool_calls"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_opencode_go_cost_terminal_chunk_completes_text_without_finish_reason(
+        self, mock_close, mock_create,
+    ):
+        """OpenCode Go ends text streams with a cost-only chunk, not stop."""
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(content="STREAM_OK", model="gpt-5.6-luna"),
+            _make_empty_chunk(
+                usage=SimpleNamespace(prompt_tokens=10, completion_tokens=1),
+            ),
+            _make_empty_chunk(cost=0),
+        ]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://opencode.ai/zen/go/v1",
+            provider="opencode-go",
+            model="gpt-5.6-luna",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.choices[0].message.content == "STREAM_OK"
+        assert response.choices[0].finish_reason == "stop"
+        assert mock_client.chat.completions.create.call_count == 1
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_opencode_go_midstream_cost_update_then_truncation_still_retries(
+        self, mock_close, mock_create,
+    ):
+        """A cost chunk followed by real content is an incremental update.
+
+        The terminal-chunk heuristic must re-arm after any subsequent
+        content/tool/reasoning delta. Otherwise a genuine truncation after a
+        mid-stream cost update would be stamped finish_reason="stop" here,
+        bypassing the upstream mid-stream-drop guards (#32086) that turn a
+        no-finish_reason tail into an honest partial-stream stub.
+        """
+        from run_agent import AIAgent
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+
+        chunks = [
+            _make_stream_chunk(content="partial", model="gpt-5.6-luna"),
+            _make_empty_chunk(cost=0),
+            _make_stream_chunk(
+                content=" more text then truncates", model="gpt-5.6-luna"
+            ),
+        ]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://opencode.ai/zen/go/v1",
+            provider="opencode-go",
+            model="gpt-5.6-luna",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        # The truncated tail must reach the mid-stream-drop guards (partial
+        # stub), not be masked as a clean "stop" by the stale cost flag.
+        assert getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
+        assert mock_client.chat.completions.create.call_count == 1
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")


### PR DESCRIPTION
## Problem

OpenCode Go terminates some successful streams with a final `choices=[]` chunk carrying only provider metadata (currently `cost`), without emitting the OpenAI-standard `finish_reason` or `[DONE]` event. `interruptible_streaming_api_call` treats a missing `finish_reason` as a truncated stream and enters the retry path — causing spurious retries / errors on otherwise healthy completions.

## Fix

Detect the OpenCode Go cost-only terminal chunk (via direct `cost` attribute or `model_extra`) and map it to `finish_reason="stop"`. The detection is scoped to the `opencode-go` provider so genuinely truncated streams from other OpenAI-compatible endpoints still enter the retry path.

A cost chunk followed by further content/reasoning/tool deltas is an **incremental metadata update, not a terminator**: the flag re-arms so a subsequent genuine truncation still reaches the upstream mid-stream-drop guards instead of being masked as a clean stop.

## Tests

- Cost-only terminal chunk completes the stream as `stop` (happy path).
- Mid-stream cost update followed by truncation yields an honest partial-stream stub (`PARTIAL_STREAM_STUB_ID`), not a masked stop — sabotage-verified against the re-arm logic.

Verified locally against opencode-go + deepseek-v4-flash (Hermes v0.20.0): sessions complete with a normal stop instead of a retry loop.

## Related

Companion to the title-generation work on #83390 (same provider family, different failure point).