### PR TITLE
feat(skills): autocomplete plugin skill commands

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -574,6 +574,66 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     return scan_skill_commands()
 
 
+def get_plugin_skill_commands() -> Dict[str, Dict[str, Any]]:
+    """Return qualified plugin skills as interactive slash commands.
+
+    Plugin skills stay namespaced (``/plugin:skill``) so they cannot collide
+    with flat filesystem skills. They are intentionally kept out of
+    :func:`get_skill_commands`, which also feeds native messaging-platform
+    command menus where ``:`` is not a portable command character.
+    """
+    commands: Dict[str, Dict[str, Any]] = {}
+    try:
+        from agent.skill_utils import get_disabled_skill_names, parse_frontmatter
+        from hermes_cli.plugins import discover_plugins, get_plugin_manager
+        from tools.skills_tool import skill_matches_environment, skill_matches_platform
+
+        discover_plugins()
+        manager = get_plugin_manager()
+        disabled = get_disabled_skill_names()
+        for metadata in manager.list_plugin_skill_metadata():
+            qualified = str(metadata.get("name") or "").strip()
+            if not qualified or ":" not in qualified or qualified in disabled:
+                continue
+            skill_md = manager.find_plugin_skill(qualified)
+            if skill_md is None or not skill_md.is_file():
+                continue
+            frontmatter = metadata.get("frontmatter") or {}
+            description = str(metadata.get("description") or "").strip()
+            if not frontmatter or not description:
+                try:
+                    parsed, _ = parse_frontmatter(
+                        skill_md.read_text(encoding="utf-8-sig", errors="replace")
+                    )
+                except Exception:
+                    parsed = {}
+                if not frontmatter:
+                    frontmatter = parsed
+                if not description:
+                    description = str(parsed.get("description") or "").strip()
+            if not skill_matches_platform(frontmatter):
+                continue
+            if not skill_matches_environment(frontmatter):
+                continue
+            commands[f"/{qualified.lower()}"] = {
+                "name": qualified,
+                "description": description
+                or f"Invoke the {qualified} plugin skill",
+                "skill_identifier": qualified,
+                "skill_md_path": str(skill_md),
+                "skill_dir": str(skill_md.parent),
+                "source": "plugin",
+            }
+    except Exception:
+        logger.debug("Plugin skill slash-command discovery failed", exc_info=True)
+    return commands
+
+
+def get_interactive_skill_commands() -> Dict[str, Dict[str, Any]]:
+    """Return filesystem and qualified plugin skills for CLI/TUI surfaces."""
+    return {**get_skill_commands(), **get_plugin_skill_commands()}
+
+
 def reload_skills() -> Dict[str, Any]:
     """Re-scan the skills directory and return a diff of what changed.
 
@@ -639,7 +699,9 @@ def reload_skills() -> Dict[str, Any]:
     }
 
 
-def resolve_skill_command_key(command: str) -> Optional[str]:
+def resolve_skill_command_key(
+    command: str, *, interactive: bool = True
+) -> Optional[str]:
     """Resolve a user-typed /command to its canonical skill_cmds key.
 
     Skills are always stored with hyphens — ``scan_skill_commands`` normalizes
@@ -649,13 +711,27 @@ def resolve_skill_command_key(command: str) -> Optional[str]:
     (which disallow hyphens, so ``/claude-code`` is registered as
     ``/claude_code`` and comes back in the underscored form).
 
-    Returns the matching ``/slug`` key from ``get_skill_commands()`` or
-    ``None`` if no match.
+    ``interactive`` selects which registry to resolve against. Interactive
+    callers (CLI/TUI) resolve against the union that also holds namespaced
+    plugin skills. Messaging-platform gateways must pass ``interactive=False``:
+    they index ``get_skill_commands()`` with the returned key, so a
+    plugin-qualified key that is absent from that filesystem-only mapping
+    would raise ``KeyError`` — and ``:`` is not a portable character in a
+    native platform command anyway.
+
+    Returns the matching ``/slug`` key from the selected mapping, or ``None``
+    if no match.
     """
     if not command:
         return None
-    cmd_key = f"/{command.replace('_', '-')}"
-    return cmd_key if cmd_key in get_skill_commands() else None
+    commands = (
+        get_interactive_skill_commands() if interactive else get_skill_commands()
+    )
+    exact_key = f"/{command.lower()}"
+    if exact_key in commands:
+        return exact_key
+    normalized_key = f"/{command.replace('_', '-').lower()}"
+    return normalized_key if normalized_key in commands else None
 
 
 def build_skill_invocation_message(
@@ -673,12 +749,15 @@ def build_skill_invocation_message(
     Returns:
         The formatted message string, or None if the skill wasn't found.
     """
-    commands = get_skill_commands()
+    commands = get_interactive_skill_commands()
     skill_info = commands.get(cmd_key)
     if not skill_info:
         return None
 
-    loaded = _load_skill_payload(skill_info["skill_dir"], task_id=task_id)
+    loaded = _load_skill_payload(
+        skill_info.get("skill_identifier") or skill_info["skill_dir"],
+        task_id=task_id,
+    )
     if not loaded:
         return None
 
@@ -769,7 +848,7 @@ def build_stacked_skill_invocation_message(
         ``(message, loaded_skill_names, missing_skill_names)`` or ``None``
         when no skill could be loaded at all.
     """
-    commands = get_skill_commands()
+    commands = get_interactive_skill_commands()
 
     loaded_names: list[str] = []
     missing: list[str] = []
@@ -786,7 +865,10 @@ def build_stacked_skill_invocation_message(
             missing.append(cmd_key.lstrip("/"))
             continue
 
-        loaded = _load_skill_payload(skill_info["skill_dir"], task_id=task_id)
+        loaded = _load_skill_payload(
+            skill_info.get("skill_identifier") or skill_info["skill_dir"],
+            task_id=task_id,
+        )
         if not loaded:
             missing.append(cmd_key.lstrip("/"))
             continue

--- a/cli.py
+++ b/cli.py
@@ -4786,9 +4786,9 @@ _skill_bundles = None
 def _ensure_skill_commands() -> dict:
     global _skill_commands
     if _skill_commands is None:
-        from agent.skill_commands import scan_skill_commands
+        from agent.skill_commands import get_interactive_skill_commands
 
-        _skill_commands = scan_skill_commands()
+        _skill_commands = get_interactive_skill_commands()
     return _skill_commands
 
 
@@ -14085,7 +14085,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         prompt caching intact.
         """
         try:
-            from agent.skill_commands import reload_skills, get_skill_commands
+            from agent.skill_commands import get_interactive_skill_commands, reload_skills
 
             if not self._command_running:
                 print("🔄 Reloading skills...")
@@ -14096,7 +14096,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # (help display, command dispatch, Tab-completion lambda) see the
             # updated dict without needing to restart the session.
             global _skill_commands
-            _skill_commands = get_skill_commands()
+            _skill_commands = get_interactive_skill_commands()
             added = result.get("added", [])      # [{"name", "description"}, ...]
             removed = result.get("removed", [])  # [{"name", "description"}, ...]
             total = result.get("total", 0)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17831,7 +17831,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     resolve_skill_command_key,
                 )
                 skill_cmds = get_skill_commands()
-                cmd_key = resolve_skill_command_key(command)
+                # interactive=False keeps resolution inside skill_cmds. The
+                # interactive registry also holds namespaced plugin skills, and
+                # MessageEvent.get_command() permits ':', so an interactive
+                # resolve here could hand back a "/plugin:skill" key that is
+                # absent from skill_cmds and raise KeyError just below.
+                cmd_key = resolve_skill_command_key(command, interactive=False)
                 if cmd_key is not None:
                     # Check per-platform disabled status before executing.
                     # get_skill_commands() only applies the *global* disabled

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1560,18 +1560,22 @@ class SlashCommandCompleter(Completer):
 
     # -- stacked slash-skill completion helpers ---------------------------
 
-    @staticmethod
-    def _normalize_skill_token(token: str) -> str:
+    def _resolve_skill_token(self, token: str) -> str:
         """Canonicalize a typed skill token to its hyphenated /slug form.
 
         Mirrors resolve_skill_command_key() in agent/skill_commands.py:
-        underscores (Telegram bot-command form) are interchangeable with
-        hyphens.
+        exact qualified plugin names win, while underscores in filesystem
+        skill commands remain interchangeable with hyphens for messaging
+        platform compatibility.
         """
-        return "/" + token.lstrip("/").replace("_", "-").lower()
+        commands = self._iter_skill_commands()
+        exact = "/" + token.lstrip("/").lower()
+        if exact in commands:
+            return exact
+        return exact.replace("_", "-")
 
     def _is_skill_command(self, token: str) -> bool:
-        return self._normalize_skill_token(token) in self._iter_skill_commands()
+        return self._resolve_skill_token(token) in self._iter_skill_commands()
 
     def _stacked_skill_completions(self, text: str):
         """Offer skill-command completions for stacked invocations.
@@ -1600,7 +1604,7 @@ class SlashCommandCompleter(Completer):
         # skill command, and there's room left under the cap.
         seen: set[str] = set()
         for token in completed:
-            key = self._normalize_skill_token(token)
+            key = self._resolve_skill_token(token)
             if key not in self._iter_skill_commands() or key in seen:
                 return
             seen.add(key)
@@ -1612,7 +1616,7 @@ class SlashCommandCompleter(Completer):
         if not current_word.startswith("/"):
             return
 
-        word_key = self._normalize_skill_token(current_word)
+        word_key = self._resolve_skill_token(current_word)
         for cmd, info in self._iter_skill_commands().items():
             if cmd in seen or not cmd.startswith(word_key):
                 continue

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -104,6 +104,185 @@ class TestPluginSkillRegistry:
         pm.remove_plugin_skill("p:x")
 
 
+class TestPluginSkillSlashCommands:
+    @pytest.fixture(autouse=True)
+    def _registered_plugin_skill(self, tmp_path, monkeypatch):
+        from agent import skill_commands
+        from hermes_cli import plugins as plugins_mod
+        from hermes_cli.plugins import PluginManager
+
+        self.pm = PluginManager()
+        self.pm._discovered = True
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", self.pm)
+
+        empty = tmp_path / "empty-skills"
+        empty.mkdir()
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", empty)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        skill_dir = tmp_path / "plugins" / "superpowers" / "skills" / "writing-plans"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(
+            "---\nname: writing-plans\ndescription: Write a grounded plan.\n---\n"
+            "\n# Writing plans\n\nPlan carefully.\n"
+        )
+        self.pm._plugin_skills["superpowers:writing-plans"] = {
+            "path": skill_md,
+            "plugin": "superpowers",
+            "bare_name": "writing-plans",
+            "description": "Write a grounded plan.",
+            "frontmatter": {},
+        }
+
+        skill_commands._skill_commands = {}
+        skill_commands._skill_commands_platform = None
+        yield
+        skill_commands._skill_commands = {}
+        skill_commands._skill_commands_platform = None
+
+    def test_interactive_registry_exposes_qualified_plugin_skill(self):
+        from agent.skill_commands import get_interactive_skill_commands
+
+        commands = get_interactive_skill_commands()
+
+        assert commands["/superpowers:writing-plans"]["name"] == (
+            "superpowers:writing-plans"
+        )
+        assert commands["/superpowers:writing-plans"]["source"] == "plugin"
+
+    def test_interactive_registry_reads_description_from_skill_frontmatter(self):
+        self.pm._plugin_skills["superpowers:writing-plans"]["description"] = ""
+        self.pm._plugin_skills["superpowers:writing-plans"]["frontmatter"] = {}
+
+        from agent.skill_commands import get_interactive_skill_commands
+
+        commands = get_interactive_skill_commands()
+
+        assert commands["/superpowers:writing-plans"]["description"] == (
+            "Write a grounded plan."
+        )
+
+    def test_qualified_plugin_skill_builds_invocation_message(self):
+        from agent.skill_commands import build_skill_invocation_message
+
+        message = build_skill_invocation_message(
+            "/superpowers:writing-plans", "draft the protocol"
+        )
+
+        assert message is not None
+        assert '"superpowers:writing-plans" skill' in message
+        assert "Plan carefully." in message
+        assert "draft the protocol" in message
+        assert "plugins/superpowers/skills/writing-plans" in message
+
+    def test_qualified_plugin_skill_respects_disabled_config(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.skill_utils.get_disabled_skill_names",
+            lambda: {"superpowers:writing-plans"},
+        )
+
+        from agent.skill_commands import get_interactive_skill_commands
+
+        assert "/superpowers:writing-plans" not in get_interactive_skill_commands()
+
+    def test_qualified_plugin_skill_preserves_valid_underscores(self):
+        from agent.skill_commands import resolve_skill_command_key
+
+        original = self.pm._plugin_skills.pop("superpowers:writing-plans")
+        self.pm._plugin_skills["super_powers:writing_plans"] = {
+            **original,
+            "plugin": "super_powers",
+            "bare_name": "writing_plans",
+        }
+
+        assert resolve_skill_command_key("super_powers:writing_plans") == (
+            "/super_powers:writing_plans"
+        )
+
+    def test_tui_completes_and_dispatches_qualified_plugin_skill(self):
+        from tui_gateway import server
+
+        completed = server.handle_request(
+            {
+                "id": "complete",
+                "method": "complete.slash",
+                "params": {"text": "/superpowers:"},
+            }
+        )
+        rows = completed["result"]["items"]
+        row = next(item for item in rows if item["text"] == "superpowers:writing-plans")
+        assert row["kind"] == "skill"
+
+        dispatched = server.handle_request(
+            {
+                "id": "dispatch",
+                "method": "command.dispatch",
+                "params": {
+                    "name": "superpowers:writing-plans",
+                    "arg": "draft the protocol",
+                },
+            }
+        )
+        result = dispatched["result"]
+        assert result["type"] == "skill"
+        assert result["name"] == "superpowers:writing-plans"
+        assert result["display"] == (
+            "/superpowers:writing-plans draft the protocol"
+        )
+
+    def test_dispatch_is_case_insensitive(self):
+        """Mixed-case names from the UI must still dispatch.
+
+        Registry keys are lowercased, so an unfolded ``f"/{name}"`` lookup fell
+        through to generic command handling instead of the skill.
+        """
+        from tui_gateway import server
+
+        dispatched = server.handle_request(
+            {
+                "id": "dispatch-mixed-case",
+                "method": "command.dispatch",
+                "params": {
+                    "name": "SuperPowers:Writing-Plans",
+                    "arg": "draft the protocol",
+                },
+            }
+        )
+        result = dispatched["result"]
+        assert result["type"] == "skill"
+        assert result["name"] == "superpowers:writing-plans"
+
+    def test_gateway_scoped_resolution_refuses_plugin_keys(self):
+        """``interactive=False`` must not return a plugin-qualified key.
+
+        Messaging gateways index ``get_skill_commands()`` with whatever this
+        returns. That mapping is filesystem-only, so a ``/plugin:skill`` key
+        leaking through raises KeyError — and ``:`` is not a portable
+        character in a native platform command anyway.
+        """
+        from agent.skill_commands import (
+            get_skill_commands,
+            resolve_skill_command_key,
+        )
+
+        assert (
+            resolve_skill_command_key(
+                "superpowers:writing-plans", interactive=False
+            )
+            is None
+        )
+        # The interactive path still resolves it.
+        assert resolve_skill_command_key("superpowers:writing-plans") == (
+            "/superpowers:writing-plans"
+        )
+        # And the gateway's own indexing stays safe for everything it accepts.
+        skill_cmds = get_skill_commands()
+        for command in ("superpowers:writing-plans", "does-not-exist"):
+            key = resolve_skill_command_key(command, interactive=False)
+            assert key is None or key in skill_cmds
+
+
 class TestPluginContextRegisterSkill:
     @pytest.fixture
     def ctx(self, tmp_path, monkeypatch):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1045,6 +1045,8 @@ def _serve_plugin_skill(
             "description": description,
             "linked_files": _plugin_skill_linked_files(skill_md.parent),
             "readiness_status": SkillReadinessStatus.AVAILABLE.value,
+            "skill_dir": str(skill_md.parent),
+            "_source_path": str(skill_md),
         },
         ensure_ascii=False,
     )

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -338,11 +338,12 @@ def _(rid, params: dict) -> dict:
         from prompt_toolkit.document import Document
         from prompt_toolkit.formatted_text import to_plain_text
 
-        from agent.skill_commands import get_skill_commands
+        from agent.skill_commands import get_interactive_skill_commands
         from agent.skill_bundles import get_skill_bundles
 
+        interactive_skill_commands = get_interactive_skill_commands()
         completer = SlashCommandCompleter(
-            skill_commands_provider=lambda: get_skill_commands(),
+            skill_commands_provider=lambda: interactive_skill_commands,
             skill_bundles_provider=lambda: get_skill_bundles(),
         )
         doc = Document(text, len(text))
@@ -352,7 +353,7 @@ def _(rid, params: dict) -> dict:
         # uses — no sniffing the ⚡/▣ meta glyphs, which are display text.
         skill_names = {
             key.lstrip("/").lower()
-            for key in (*get_skill_commands(), *get_skill_bundles())
+            for key in (*interactive_skill_commands, *get_skill_bundles())
         }
         items = [
             {

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -543,12 +543,16 @@ def _(rid, params: dict) -> dict:
 
     try:
         from agent.skill_commands import (
-            scan_skill_commands,
             build_skill_invocation_message,
+            get_interactive_skill_commands,
         )
 
-        cmds = scan_skill_commands()
-        key = f"/{name}"
+        cmds = get_interactive_skill_commands()
+        # Keys are stored lowercased, so a mixed-case name from the UI has to
+        # be folded before lookup or it falls through to generic command
+        # handling instead of dispatching the skill. Mirrors
+        # parseSlashCommand()'s name.lower() on the TUI side.
+        key = f"/{name}".lower()
         if key in cmds:
             msg = build_skill_invocation_message(
                 key, arg, task_id=session.get("session_key", "") if session else ""
@@ -1192,10 +1196,10 @@ def _(rid, params: dict) -> dict:
         pass
 
     try:
-        from agent.skill_commands import get_skill_commands
+        from agent.skill_commands import get_interactive_skill_commands
         from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
-        # Re-bind HERMES_HOME to the session's profile so get_skill_commands()
+        # Re-bind HERMES_HOME to the session's profile so get_interactive_skill_commands()
         # sees that profile's skills.external_dirs rather than whatever the
         # process-level env happens to carry (#88023): dispatch() runs this
         # handler on the pool with a copied context, and nothing upstream of
@@ -1206,7 +1210,7 @@ def _(rid, params: dict) -> dict:
         )
         try:
             _cmd_key = f"/{_cmd_base}"
-            if _cmd_key in get_skill_commands():
+            if _cmd_key in get_interactive_skill_commands():
                 return _err(
                     rid, 4018, f"skill command: use command.dispatch for {_cmd_key}"
                 )

--- a/ui-tui/src/__tests__/inlineSlashSkill.test.ts
+++ b/ui-tui/src/__tests__/inlineSlashSkill.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { inlineSlashTrigger } from '../domain/slash.js'
+import { inlineSlashTrigger, splitSlashSkillRefs } from '../domain/slash.js'
 import { completionRequestForInput } from '../hooks/useCompletion.js'
 
 describe('inlineSlashTrigger', () => {
@@ -16,6 +16,13 @@ describe('inlineSlashTrigger', () => {
 
   it('fires after a newline, not just a space', () => {
     expect(inlineSlashTrigger('text\n/skill')).toEqual({ query: 'skill', start: 5 })
+  })
+
+  it('accepts a qualified plugin skill token', () => {
+    expect(inlineSlashTrigger('please use /konsta-research:manu')).toEqual({
+      query: 'konsta-research:manu',
+      start: 11
+    })
   })
 
   it('does not fire at position 0 — that is a command invocation', () => {
@@ -89,5 +96,53 @@ describe('completionRequestForInput — inline skill references', () => {
   it('routes a real mid-message path to path completion, not skills', () => {
     expect(completionRequestForInput('open src/foo/ba')).toMatchObject({ method: 'complete.path' })
     expect(completionRequestForInput('open /usr/lo')).toMatchObject({ method: 'complete.path' })
+  })
+})
+
+describe('splitSlashSkillRefs', () => {
+  it('marks a skill referenced mid-prose', () => {
+    expect(splitSlashSkillRefs('clean this up with /clean')).toEqual([
+      { ref: false, text: 'clean this up with ' },
+      { ref: true, text: '/clean' }
+    ])
+  })
+
+  it('marks a qualified plugin skill referenced mid-prose', () => {
+    expect(splitSlashSkillRefs('review with /konsta-research:manuscript')).toEqual([
+      { ref: false, text: 'review with ' },
+      { ref: true, text: '/konsta-research:manuscript' }
+    ])
+  })
+
+  it('keeps the prose on both sides of the reference', () => {
+    expect(splitSlashSkillRefs('run /clean then ship')).toEqual([
+      { ref: false, text: 'run ' },
+      { ref: true, text: '/clean' },
+      { ref: false, text: ' then ship' }
+    ])
+  })
+
+  it('does not mark paths', () => {
+    for (const text of ['look at /usr/local/bin', 'check src/foo/bar', 'a 3 /4 b']) {
+      expect(splitSlashSkillRefs(text)).toEqual([{ ref: false, text }])
+    }
+  })
+
+  it('does not mark a leading slash — that is a command, not a reference', () => {
+    expect(splitSlashSkillRefs('/clean')).toEqual([{ ref: false, text: '/clean' }])
+  })
+
+  it('round-trips the input exactly', () => {
+    for (const text of ['run /clean then /work ok', 'plain text', '', 'look at /usr/local/bin']) {
+      expect(
+        splitSlashSkillRefs(text)
+          .map(s => s.text)
+          .join('')
+      ).toBe(text)
+    }
+  })
+
+  it('always returns at least one segment', () => {
+    expect(splitSlashSkillRefs('')).toEqual([{ ref: false, text: '' }])
   })
 })

--- a/ui-tui/src/domain/slash.ts
+++ b/ui-tui/src/domain/slash.ts
@@ -28,7 +28,7 @@ export const looksLikeSlashCommand = (text: string) => /^\/[^\s/]*(?:\s|$)/.test
 // `look at /usr/local/bin` and `check src/foo/bar` never match. A bare `/us` is
 // genuinely ambiguous with an absolute path, and resolves as a skill reference
 // — typing the next `/` flips it straight back to path completion.
-const INLINE_SLASH_RE = /\s\/([a-zA-Z][\w-]*)?$/
+const INLINE_SLASH_RE = /\s\/([a-zA-Z][\w-]*(?::[\w-]*)?)?$/
 
 /**
  * Locate an inline `/skill` reference at the end of `text`, or null when the
@@ -51,6 +51,44 @@ export const parseSlashCommand = (cmd: string) => {
   const [name = '', ...rest] = cmd.slice(1).split(/\s+/)
 
   return { arg: rest.join(' '), cmd, name: name.toLowerCase() }
+}
+
+// A skill referenced mid-prose in a message that's already been sent
+// ("clean this up with /clean"). The composer offers it as a completion, so
+// the transcript marks it as one rather than flattening it into the body text.
+//
+// Unlike the caret-anchored trigger above this scans finished text, so it has
+// to reject a token that continues into a path: `/usr/local/bin` would
+// otherwise mark `/usr`. `(?![\w-]*\/)` requires the token to end at something
+// other than another slash. A leading `/` is excluded too — that's a command
+// invocation, which never reaches the transcript as a user message.
+const SLASH_SKILL_REF_RE = /(?<=\s)\/[a-zA-Z][\w-]*(?::[\w-]+)?(?![\w:-]*\/)/g
+
+/**
+ * Split `text` into alternating plain and `/skill` reference runs. Always
+ * returns at least one segment, and concatenating every `text` reproduces the
+ * input exactly — the transcript styles the reference without rewriting it.
+ */
+export const splitSlashSkillRefs = (text: string): { ref: boolean; text: string }[] => {
+  const out: { ref: boolean; text: string }[] = []
+  let last = 0
+
+  for (const match of text.matchAll(SLASH_SKILL_REF_RE)) {
+    const start = match.index ?? 0
+
+    if (start > last) {
+      out.push({ ref: false, text: text.slice(last, start) })
+    }
+
+    out.push({ ref: true, text: match[0] })
+    last = start + match[0].length
+  }
+
+  if (last < text.length || !out.length) {
+    out.push({ ref: false, text: text.slice(last) })
+  }
+
+  return out
 }
 
 /**


### PR DESCRIPTION
## Summary
- expose plugin-provided skills as qualified interactive slash commands such as `/konsta-research:manuscript`
- make TUI and classic CLI completion suggestions dispatchable, including stacked invocations and inline prompt references
- preserve native messaging-platform command constraints and plugin skill disable/platform guards

## Verification
- 73 focused Python tests passed
- 13 TUI gateway completion/dispatch tests passed
- complete TUI suite: 1549 passed, 1 skipped
- TUI typecheck passed
- TUI production build passed
- real terminal smoke: typing `/konsta-research:` displayed plugin skill descriptions; selecting `/konsta-research:standards` loaded the plugin and completed a sentinel agent turn

## Notes
- Canonical full Python runner reached 78.9% before the 10-minute foreground limit; failures observed before timeout were in unrelated pre-existing LSP/coding-context/MCP tests. The changed plugin-skill file passed 34/34 in that isolated runner.
