### PR TITLE
fix(kanban): fire on_kanban_task_updated from edit_completed_task_result

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6110,18 +6110,22 @@ def edit_completed_task_result(
                 )
         _ev_lines = (handoff_summary or "").strip().splitlines()
         ev_summary = _ev_lines[0][:400] if _ev_lines else ""
+        changed_fields = ["result", "summary"] + (
+            ["metadata"] if metadata is not None else []
+        )
         _append_event(
             conn, task_id, "edited",
             {
-                "fields": (
-                    ["result", "summary"]
-                    + (["metadata"] if metadata is not None else [])
-                ),
+                "fields": changed_fields,
                 "result_len": len(result) if result else 0,
                 "summary": ev_summary or None,
             },
             run_id=run_id,
         )
+    # Task-mutation observer (RFC #58548), fired AFTER the edit txn has
+    # committed — result/summary are user-facing task fields, same class as
+    # assign_task/set_model_override/set_reasoning_effort.
+    notify_task_updated(conn, task_id, changed_fields)
     return True
 
 

--- a/tests/hermes_cli/test_kanban_task_updated_hook.py
+++ b/tests/hermes_cli/test_kanban_task_updated_hook.py
@@ -115,3 +115,57 @@ def test_no_subscriber_short_circuits_task_updated(kanban_home, monkeypatch):
     finally:
         conn.close()
     assert "on_kanban_task_updated" not in invoked
+
+
+def test_edit_completed_task_result_fires_updated_with_changed_fields(
+    kanban_home, captured_updates
+):
+    """edit_completed_task_result (the CLI --result backfill path) mutates a
+    user-facing task field outside the claim/complete/block lifecycle — same
+    class as assign_task/set_model_override/set_reasoning_effort — and must
+    fire the observer post-commit."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t", assignee="alice")
+        assert kb.complete_task(conn, tid, result="original") is True
+        captured_updates.clear()  # completion-time bookkeeping is not under test
+        assert kb.edit_completed_task_result(
+            conn, tid, result="backfilled result", summary="backfilled summary"
+        ) is True
+    finally:
+        conn.close()
+
+    assert len(captured_updates) == 1
+    kw = captured_updates[0]
+    assert kw["task_id"] == tid
+    assert kw["changed_fields"] == ["result", "summary"]
+
+
+def test_edit_completed_task_result_with_metadata_includes_field(
+    kanban_home, captured_updates
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t", assignee="alice")
+        assert kb.complete_task(conn, tid, result="original") is True
+        captured_updates.clear()
+        assert kb.edit_completed_task_result(
+            conn, tid, result="r2", metadata={"note": "x"}
+        ) is True
+    finally:
+        conn.close()
+
+    assert captured_updates[0]["changed_fields"] == ["result", "summary", "metadata"]
+
+
+def test_edit_completed_task_result_refused_edit_never_fires(
+    kanban_home, captured_updates
+):
+    """A task that isn't 'done' yet must not fire the observer (refused edit)."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t", assignee="alice")
+        assert kb.edit_completed_task_result(conn, tid, result="r") is False
+    finally:
+        conn.close()
+    assert captured_updates == []


### PR DESCRIPTION
## Summary

RFC #58548's task-mutation observer (`notify_task_updated` → `on_kanban_task_updated`) was wired into every user-facing task-FIELD editor: `assign_task`, `set_model_override`, `set_reasoning_effort`, and the dashboard plugin API's direct-SQL priority/title/body editors (single and bulk). The introducing commit's own message explicitly enumerates what's deliberately excluded from this observer: status transitions (belong to the lifecycle hook family), dispatcher bookkeeping columns, link/comment/attachment tables, and the dispatcher's default-assignee auto-assign.

`edit_completed_task_result()` — the `hermes kanban edit <id> --result` CLI backfill path for an already-completed task's user-visible result — fits none of those exclusions. It mutates `tasks.result` (and the closing run's `summary`/`metadata`) via direct SQL outside the claim/complete/block lifecycle, exactly the surface `notify_task_updated`'s own docstring says must call it ("a surface that mutates a task row outside the claim/complete/block lifecycle calls this AFTER its write txn has committed"). It never did.

No existing test exercised `edit_completed_task_result` at all before this change — it wasn't covered by either of the task-mutation-observer test files added alongside the RFC #58548 work.

## Fix

Fires `notify_task_updated(conn, task_id, changed_fields)` after the write transaction commits, reusing the same `changed_fields` list (`["result", "summary"]`, plus `"metadata"` when provided) already computed for the function's own `"edited"` event — matching the established pattern in `assign_task`/`set_model_override`/`set_reasoning_effort`.

## Verification

- Added 3 regression tests to `tests/hermes_cli/test_kanban_task_updated_hook.py`, following the file's existing `captured_updates` fixture pattern: the hook fires with the correct `changed_fields` on a plain result/summary edit, includes `"metadata"` when a metadata dict is passed, and does **not** fire when the edit is refused (task not `done` yet).
- Mutation-verified: stashed the fix, confirmed the 2 positive tests fail (no hook call captured) against pre-fix code; the refused-edit negative test still passed (no false positive). Restored the fix, all 6 tests in the file pass.
- Ran the broader neighbor suite (`test_kanban_task_updated_hook.py`, `test_kanban_db.py`, `test_kanban_review_surfaces.py`, `test_kanban_dashboard_task_updated_hook.py`): 46 passed, 1 skipped.
- `ruff check` clean on both changed files.

## Test plan

- [x] New regression tests added and pass
- [x] Mutation-verify: positive tests fail without the fix, pass with it; negative test unaffected
- [x] Broader kanban test suites pass
- [x] `ruff check` clean