### PR TITLE
fix(gateway): skip home prompt for unsupported plugins

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1840,6 +1840,13 @@ def _home_target_env_var(platform_name: str) -> str:
     return f"{platform_name.upper()}_HOME_CHANNEL"
 
 
+def _platform_supports_home_channel(platform_name: str) -> bool:
+    """Return whether a platform declares cron/home-channel delivery support."""
+    from cron.scheduler import _resolve_home_env_var
+
+    return bool(_resolve_home_env_var(platform_name))
+
+
 def _home_thread_env_var(platform_name: str) -> str:
     """Return the optional thread/topic env var for a platform home target."""
     return f"{_home_target_env_var(platform_name)}_THREAD_ID"
@@ -18818,7 +18825,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # One-time prompt if no home channel is set for this platform
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
-        if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
+        if (
+            not history
+            and source.platform
+            and source.platform != Platform.LOCAL
+            and source.platform != Platform.WEBHOOK
+            and _platform_supports_home_channel(source.platform.value)
+        ):
             platform_name = source.platform.value
             env_key = _home_target_env_var(platform_name)
             # Multiplex: home channel may live only in the profile secret

--- a/tests/gateway/test_home_target_env_var.py
+++ b/tests/gateway/test_home_target_env_var.py
@@ -8,11 +8,25 @@ to env vars nothing read on startup — the home channel appeared to set
 successfully but was lost on every new gateway session.
 """
 
-from gateway.run import _home_target_env_var, _home_thread_env_var
+from gateway.run import (
+    _home_target_env_var,
+    _home_thread_env_var,
+    _platform_supports_home_channel,
+)
 
 
 def test_matrix_home_target_env_var_uses_home_room():
     assert _home_target_env_var("matrix") == "MATRIX_HOME_ROOM"
+
+
+def test_builtin_home_channel_platform_is_supported():
+    assert _platform_supports_home_channel("telegram") is True
+
+
+def test_plugin_without_cron_delivery_skips_home_channel_onboarding(monkeypatch):
+    monkeypatch.setattr("cron.scheduler._resolve_home_env_var", lambda _name: "")
+
+    assert _platform_supports_home_channel("vintru_whatsapp") is False
 
 
 def test_email_home_target_env_var_uses_home_address():


### PR DESCRIPTION
## Summary
- only show first-message home-channel onboarding when the platform declares home/cron delivery support
- preserve existing behavior for all built-in home-channel platforms
- prevent customer-facing standalone plugins without `cron_deliver_env_var` from leaking an internal `/sethome` notice

## Real-world symptom
A public customer-service WhatsApp plugin correctly persisted and authorized an inbound message, but Hermes sent the internal "No home channel is set" onboarding notice to the customer. The plugin intentionally does not declare home-channel delivery support.

## Validation
- 13 focused gateway tests pass
- Ruff passes
- `git diff --check` passes
