### PR TITLE
fix(honcho): surface backend failures from search_context/get_peer_card/get_session_context

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1557,7 +1557,13 @@ class HonchoMemoryProvider(MemoryProvider):
                     if result is None:
                         return tool_error("Failed to update peer card.")
                     return json.dumps({"result": f"Peer card updated ({len(result)} facts).", "card": result})
-                card = self._manager.get_peer_card(self._session_key, peer=peer)
+                # Explicit tool call: surface a backend failure as an error
+                # instead of collapsing it into the empty-card diagnostic
+                # hint, which actively guesses benign causes that would
+                # mislead when the real cause is a timeout/server error.
+                card = self._manager.get_peer_card(
+                    self._session_key, peer=peer, raise_errors=True,
+                )
                 if not card:
                     return json.dumps(self._empty_profile_hint(peer))
                 return json.dumps({"result": card})
@@ -1568,8 +1574,13 @@ class HonchoMemoryProvider(MemoryProvider):
                     return tool_error("Missing required parameter: query")
                 max_tokens = min(int(args.get("max_tokens", 800)), 2000)
                 peer = args.get("peer", "user")
+                # Explicit tool call: surface timeouts/server errors as
+                # errors instead of collapsing them into "no relevant
+                # context found", indistinguishable from a genuinely empty
+                # result (same #36098 issue 4 class dialectic_query fixes).
                 result = self._manager.search_context(
-                    self._session_key, query, max_tokens=max_tokens, peer=peer
+                    self._session_key, query, max_tokens=max_tokens, peer=peer,
+                    raise_errors=True,
                 )
                 if not result:
                     return json.dumps({"result": "No relevant context found."})
@@ -1612,7 +1623,12 @@ class HonchoMemoryProvider(MemoryProvider):
 
             elif tool_name == "honcho_context":
                 peer = args.get("peer", "user")
-                ctx = self._manager.get_session_context(self._session_key, peer=peer)
+                # Explicit tool call: surface backend failures as errors
+                # instead of collapsing them into "no context available
+                # yet", indistinguishable from a genuinely empty context.
+                ctx = self._manager.get_session_context(
+                    self._session_key, peer=peer, raise_errors=True,
+                )
                 if not ctx:
                     return json.dumps({"result": "No context available yet."})
                 parts = []

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1344,12 +1344,21 @@ class HonchoSessionManager:
 
         return {"representation": representation, "card": card}
 
-    def get_session_context(self, session_key: str, peer: str = "user") -> dict[str, Any]:
+    def get_session_context(
+        self, session_key: str, peer: str = "user", raise_errors: bool = False,
+    ) -> dict[str, Any]:
         """Fetch full session context from Honcho including summary.
 
         Uses the session-level context() API which returns summary,
         peer_representation, peer_card, and messages.
         Raises HonchoAuthError so callers can tell rejected credentials from no context.
+
+        Args:
+            raise_errors: Re-raise backend failures instead of returning {}.
+                Explicit tool calls pass True so a timeout or server error
+                surfaces as an error, not as "no context yet" — same
+                collapsing-failures-to-empty issue dialectic_query's
+                raise_errors fixes (#36098 issue 4).
         """
         session = self._cache.get(session_key)
         if not session:
@@ -1398,6 +1407,8 @@ class HonchoSessionManager:
             raise
         except Exception as e:
             logger.debug("Session context fetch failed: %s", e)
+            if raise_errors:
+                raise
             return {}
 
     def _resolve_peer_id(self, session: HonchoSession, peer: str | None) -> str:
@@ -1434,13 +1445,23 @@ class HonchoSessionManager:
 
         return target_peer_id, None
 
-    def get_peer_card(self, session_key: str, peer: str = "user") -> list[str]:
+    def get_peer_card(
+        self, session_key: str, peer: str = "user", raise_errors: bool = False,
+    ) -> list[str]:
         """
         Fetch a peer card — a curated list of key facts.
 
         Fast, no LLM reasoning. Returns raw structured facts Honcho has
         inferred about the target peer (name, role, preferences, patterns).
         Empty list if unavailable; raises HonchoAuthError on rejected credentials.
+
+        Args:
+            raise_errors: Re-raise backend failures instead of returning [].
+                Explicit tool calls pass True so a timeout or server error
+                surfaces as an error instead of the empty-card diagnostic
+                hint, which actively guesses benign causes ("observation
+                disabled", "not enough turns yet") that would mislead when
+                the real cause is a backend failure.
         """
         session = self._cache.get(session_key)
         if not session:
@@ -1460,6 +1481,8 @@ class HonchoSessionManager:
             raise
         except Exception as e:
             logger.debug("Failed to fetch peer card from Honcho: %s", e)
+            if raise_errors:
+                raise
             return []
 
     def search_context(
@@ -1468,6 +1491,7 @@ class HonchoSessionManager:
         query: str,
         max_tokens: int = 800,
         peer: str = "user",
+        raise_errors: bool = False,
     ) -> str:
         """
         Search raw messages across every session visible from the target
@@ -1480,6 +1504,10 @@ class HonchoSessionManager:
             max_tokens: Approximate budget for returned content. Snippets are
                 accumulated until this budget (≈4 chars/token) is exhausted.
             peer: Peer alias or explicit peer ID whose sessions to search.
+            raise_errors: Re-raise a backend failure (after the peer-search
+                fallback also fails) instead of returning "". Explicit tool
+                calls pass True so a timeout or server error surfaces as an
+                error, not as "no relevant context found".
 
         Returns:
             Ranked message excerpts as a formatted string, or empty string
@@ -1530,6 +1558,8 @@ class HonchoSessionManager:
                 raise
             except Exception as e2:
                 logger.debug("Honcho peer search fallback also failed: %s", e2)
+                if raise_errors:
+                    raise
                 return ""
 
         if not messages:

--- a/tests/honcho_plugin/test_auth_recovery.py
+++ b/tests/honcho_plugin/test_auth_recovery.py
@@ -815,7 +815,7 @@ class TestToolAuthVisibility:
 
     def test_context_tool_reports_auth_failure(self):
         class _Mgr:
-            def get_session_context(self, key, peer="user"):
+            def get_session_context(self, key, peer="user", raise_errors=False):
                 raise HonchoAuthError("Honcho rejected our credentials")
 
         out = self._provider(_Mgr()).handle_tool_call("honcho_context", {})
@@ -824,7 +824,7 @@ class TestToolAuthVisibility:
 
     def test_search_tool_reports_auth_failure(self):
         class _Mgr:
-            def search_context(self, key, query, max_tokens=800, peer="user"):
+            def search_context(self, key, query, max_tokens=800, peer="user", raise_errors=False):
                 raise HonchoAuthError("Honcho rejected our credentials")
 
         out = self._provider(_Mgr()).handle_tool_call("honcho_search", {"query": "schema"})
@@ -833,7 +833,7 @@ class TestToolAuthVisibility:
 
     def test_profile_tool_reports_auth_failure_not_empty_profile(self):
         class _Mgr:
-            def get_peer_card(self, key, peer="user"):
+            def get_peer_card(self, key, peer="user", raise_errors=False):
                 raise HonchoAuthError("Honcho rejected our credentials")
 
         out = self._provider(_Mgr()).handle_tool_call("honcho_profile", {})

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -199,6 +199,89 @@ class TestPeerLookupHelpers:
         }])
 
 
+class TestReadMethodRaiseErrors:
+    """search_context / get_peer_card / get_session_context must offer the
+    same raise_errors escape hatch dialectic_query has: an explicit tool
+    call needs to tell a genuine backend failure apart from a legitimately
+    empty result (#36098 issue 4 class), instead of collapsing both to a
+    falsy return value.
+    """
+
+    def _make_cached_manager(self):
+        mgr = HonchoSessionManager()
+        session = HonchoSession(
+            key="telegram:123",
+            user_peer_id="robert",
+            assistant_peer_id="hermes",
+            honcho_session_id="telegram-123",
+        )
+        mgr._cache[session.key] = session
+        mgr._sessions_cache[session.honcho_session_id] = MagicMock()
+        return mgr, session
+
+    def test_search_context_default_swallows_error(self):
+        mgr, session = self._make_cached_manager()
+        mgr._authed_call = MagicMock(side_effect=RuntimeError("backend down"))
+        mgr._get_or_create_peer = MagicMock(
+            return_value=MagicMock(search=MagicMock(side_effect=RuntimeError("backend down")))
+        )
+        assert mgr.search_context(session.key, "neuralancer") == ""
+
+    def test_search_context_raise_errors_propagates_after_fallback_fails(self):
+        mgr, session = self._make_cached_manager()
+        mgr._authed_call = MagicMock(side_effect=RuntimeError("backend down"))
+        try:
+            mgr.search_context(session.key, "neuralancer", raise_errors=True)
+        except RuntimeError as e:
+            assert "backend down" in str(e)
+        else:
+            raise AssertionError("expected RuntimeError to propagate")
+
+    def test_get_peer_card_default_swallows_error(self):
+        mgr, session = self._make_cached_manager()
+        mgr._fetch_peer_card = MagicMock(side_effect=RuntimeError("backend down"))
+        assert mgr.get_peer_card(session.key) == []
+
+    def test_get_peer_card_raise_errors_propagates(self):
+        mgr, session = self._make_cached_manager()
+        mgr._fetch_peer_card = MagicMock(side_effect=RuntimeError("backend down"))
+        try:
+            mgr.get_peer_card(session.key, raise_errors=True)
+        except RuntimeError as e:
+            assert "backend down" in str(e)
+        else:
+            raise AssertionError("expected RuntimeError to propagate")
+
+    def test_get_session_context_default_swallows_error(self):
+        mgr, session = self._make_cached_manager()
+        mgr._authed_call = MagicMock(side_effect=RuntimeError("backend down"))
+        assert mgr.get_session_context(session.key) == {}
+
+    def test_get_session_context_raise_errors_propagates(self):
+        mgr, session = self._make_cached_manager()
+        mgr._authed_call = MagicMock(side_effect=RuntimeError("backend down"))
+        try:
+            mgr.get_session_context(session.key, raise_errors=True)
+        except RuntimeError as e:
+            assert "backend down" in str(e)
+        else:
+            raise AssertionError("expected RuntimeError to propagate")
+
+    def test_raise_errors_never_masks_auth_error(self):
+        """HonchoAuthError must always propagate, raise_errors or not — it's
+        never collapsed into an empty result at any raise_errors setting."""
+        from plugins.memory.honcho.session import HonchoAuthError
+
+        mgr, session = self._make_cached_manager()
+        mgr._fetch_peer_card = MagicMock(side_effect=HonchoAuthError("nope"))
+        try:
+            mgr.get_peer_card(session.key)  # raise_errors=False (default)
+        except HonchoAuthError:
+            pass
+        else:
+            raise AssertionError("expected HonchoAuthError to propagate even with raise_errors=False")
+
+
 class TestConcludeToolDispatch:
     def test_conclude_schema_has_no_anyof(self):
         """anyOf/oneOf/allOf breaks Anthropic and Fireworks APIs — schema must be plain object."""

--- a/tests/test_honcho_startup_fail_open.py
+++ b/tests/test_honcho_startup_fail_open.py
@@ -306,7 +306,7 @@ def test_honcho_tools_lazy_hooks_do_not_prestart_background_init(monkeypatch):
     assert provider._session_initialized is False
 
     class ToolManager:
-        def get_peer_card(self, session_key, peer="user"):
+        def get_peer_card(self, session_key, peer="user", raise_errors=False):
             return ["ready"]
 
     init_calls = []


### PR DESCRIPTION
## Summary

`dialectic_query()` got a `raise_errors=True` opt-in this window (`c28c434706`) so `honcho_reasoning`'s explicit tool call surfaces a genuine backend failure (timeout, 500) instead of collapsing it into `""` — indistinguishable from a legitimately empty answer, the exact confusion issue #36098's item 4 describes ("operators... sent down rabbit holes when the real cause was a 30s timeout").

Three sibling read methods in `plugins/memory/honcho/session.py` have the identical catch-`Exception`-return-falsy pattern and were not given the same treatment:

- `search_context()` → `""` → `honcho_search` renders `"No relevant context found."`
- `get_peer_card()` → `[]` → `honcho_profile` renders `_empty_profile_hint()`, which **actively guesses benign causes** ("observation disabled", "not enough turns yet", "self-hosted backend < 3.x") — actively misleading when the real cause is a backend error.
- `get_session_context()` → `{}` → `honcho_context` renders `"No context available yet."`

None of the three tool-call branches in `handle_tool_call` wrapped these calls in their own try/except either, so a raised exception is caught entirely inside the `session.py` method before the outer dispatch's generic `except Exception` handler (which already correctly renders `"Honcho {tool_name} failed: {e}"`) ever sees it.

## Fix

Adds the same `raise_errors: bool = False` parameter to all three methods (default preserves existing prefetch/auto-injection callers' silent-failure behavior — verified each has exactly one production call site, the explicit tool-call handler), and wires the three explicit tool-call sites in `__init__.py` to pass `raise_errors=True`, letting the exception propagate to the existing outer handler rather than duplicating `honcho_reasoning`'s own inner try/except (there's no `honcho_search`/`profile`/`context`-specific guidance to add beyond the generic message the outer handler already produces).

For `search_context()`'s two-stage fallback (primary `peer_perspective` search, falling back to plain peer search if the filter is unsupported by the running Honcho version), only the *final* failure (both attempts failed) respects `raise_errors` — the first stage's exception is a legitimate "try the fallback" transition, not a genuine failure yet.

`HonchoAuthError` continues to propagate unconditionally in all three, regardless of `raise_errors` — unchanged from the existing behavior.

## Verification

- Added `TestReadMethodRaiseErrors` (7 tests) to `tests/honcho_plugin/test_session.py`: default (`raise_errors=False`) still swallows a generic backend error for all three methods; `raise_errors=True` propagates it (including after `search_context`'s fallback also fails); `HonchoAuthError` always propagates regardless of the flag.
- Mutation-verified: stashed the fix, confirmed the 3 `raise_errors=True` propagation tests fail (`TypeError: unexpected keyword argument`) against pre-fix code; the 4 default-swallow/auth-error tests were unaffected. Restored the fix, all 7 pass.
- Updated 4 pre-existing test fakes whose stub method signatures didn't accept the new kwarg: 3 in `tests/honcho_plugin/test_auth_recovery.py::TestToolAuthVisibility` (which specifically test these three tools' auth-error visibility — the exact bug class this PR closes for generic errors too) and 1 in `tests/test_honcho_startup_fail_open.py`.
- Ran the full `tests/honcho_plugin/` + related honcho test files: 351 passed, 16 skipped (pre-existing, environment-dependent).
- `ruff check` clean on all changed files.

## Note on a nearby PR

Open PR #29403 also touches `get_peer_card`/`search_context` in the same file (adding output token-budget truncation), but its diff is against a stale, pre-refactor version of `search_context` (missing the current two-stage `peer_perspective` → peer-search fallback structure already on `main`) — textual proximity in the same functions, no line-level or semantic overlap with this change.

## Test plan

- [x] New regression tests added and pass (7/7)
- [x] Mutation-verify: raise_errors propagation tests fail without the fix, pass with it
- [x] Pre-existing test fakes updated for the new parameter; full honcho test suite passes
- [x] `ruff check` clean