### PR TITLE
fix(plugins): warn when transform_tool_result/terminal_output/llm_output skip a valid result

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -565,12 +565,23 @@ def finalize_turn(
                 model=agent.model,
                 platform=getattr(agent, "platform", None) or "",
             )
+            _skipped_valid = 0
             for _hook_result in _transform_results:
-                if isinstance(_hook_result, str) and _hook_result:
-                    _pre_transform_response = final_response
-                    final_response = _hook_result
-                    _response_transformed = True
-                    break  # First non-empty string wins
+                if not (isinstance(_hook_result, str) and _hook_result):
+                    continue
+                if _response_transformed:
+                    _skipped_valid += 1
+                    continue
+                _pre_transform_response = final_response
+                final_response = _hook_result
+                _response_transformed = True
+            if _response_transformed and _skipped_valid:
+                logger.warning(
+                    "transform_llm_output: skipped %d valid replacement(s) "
+                    "after the first result in registration order won "
+                    "(run-all-then-pick-first, #64714 skipped-transform rule)",
+                    _skipped_valid,
+                )
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -1552,10 +1552,23 @@ def handle_function_call(
                     error_type=error_type,
                     error_message=error_message,
                 )
+                _skipped_valid = 0
+                _winner_found = False
                 for hook_result in hook_results:
-                    if isinstance(hook_result, str):
-                        result = hook_result
-                        break
+                    if not isinstance(hook_result, str):
+                        continue
+                    if _winner_found:
+                        _skipped_valid += 1
+                        continue
+                    result = hook_result
+                    _winner_found = True
+                if _winner_found and _skipped_valid:
+                    logger.warning(
+                        "transform_tool_result: skipped %d valid replacement(s) "
+                        "after the first result in registration order won "
+                        "(run-all-then-pick-first, #64714 skipped-transform rule)",
+                        _skipped_valid,
+                    )
         except Exception as _hook_err:
             logger.debug("transform_tool_result hook error: %s", _hook_err)
 

--- a/tests/agent/test_turn_finalizer_transform_hook_skip_warning.py
+++ b/tests/agent/test_turn_finalizer_transform_hook_skip_warning.py
@@ -1,0 +1,61 @@
+"""transform_llm_output must log the #64714 skipped-transform warning.
+
+Mirrors the sibling ``transform_tool_result``/``transform_terminal_output``
+tests: a valid-but-losing replacement (a second registered plugin whose
+result would also have won, but the first-registered plugin already claimed
+the turn) must surface in logs instead of being silently shadowed — the
+gotcha issue #64714 was filed against for this exact hook.
+"""
+
+import logging
+
+from agent.turn_finalizer import finalize_turn
+from tests.agent.test_turn_finalizer_final_response_persistence import FakeAgent
+
+
+def _run_finalize(monkeypatch, invoke_hook):
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", invoke_hook)
+    agent = FakeAgent()
+    messages = [{"role": "user", "content": "hi"}]
+
+    return finalize_turn(
+        agent,
+        final_response="original",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="hi",
+        original_user_message="hi",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(final)",
+    )
+
+
+def test_skipped_valid_results_log_runtime_warning(monkeypatch, caplog):
+    with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+        result = _run_finalize(
+            monkeypatch,
+            invoke_hook=lambda name, **kw: (
+                [None, "first", "second"] if name == "transform_llm_output" else []
+            ),
+        )
+    assert result["final_response"] == "first"
+    warnings = [r.getMessage() for r in caplog.records if "skipped" in r.getMessage()]
+    assert len(warnings) == 1
+    assert "skipped 1 valid" in warnings[0]
+
+    # A lone winner is not a conflict: no warning.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+        result = _run_finalize(
+            monkeypatch,
+            invoke_hook=lambda name, **kw: (
+                ["only"] if name == "transform_llm_output" else []
+            ),
+        )
+    assert result["final_response"] == "only"
+    assert not [r for r in caplog.records if "skipped" in r.getMessage()]

--- a/tests/test_transform_tool_result_hook.py
+++ b/tests/test_transform_tool_result_hook.py
@@ -5,6 +5,7 @@ Mirrors the ``transform_terminal_output`` hook tests from Phase 1 but
 targets the generic tool-result seam that runs for every tool dispatch.
 """
 
+import logging
 import os
 from pathlib import Path
 
@@ -63,6 +64,31 @@ def test_first_valid_string_return_replaces_result(monkeypatch):
         invoke_hook=lambda hook_name, **kw: [None, {"x": 1}, "first", "second"],
     )
     assert out == "first"
+
+
+def test_skipped_valid_results_log_runtime_warning(monkeypatch, caplog):
+    # The #64714 skipped-transform rule: a valid-but-losing replacement must
+    # surface in logs, never be silently shadowed. Non-string results are
+    # not "skipped valid" and must not count.
+    with caplog.at_level(logging.WARNING, logger=model_tools.logger.name):
+        out = _run_handle_function_call(
+            monkeypatch,
+            invoke_hook=lambda hook_name, **kw: [None, "first", "second"],
+        )
+    assert out == "first"
+    warnings = [r.getMessage() for r in caplog.records if "skipped" in r.getMessage()]
+    assert len(warnings) == 1
+    assert "skipped 1 valid" in warnings[0]
+
+    # A lone winner is not a conflict: no warning.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger=model_tools.logger.name):
+        out = _run_handle_function_call(
+            monkeypatch,
+            invoke_hook=lambda hook_name, **kw: ["only"],
+        )
+    assert out == "only"
+    assert not [r for r in caplog.records if "skipped" in r.getMessage()]
 
 
 def test_hook_receives_expected_kwargs(monkeypatch):

--- a/tests/tools/test_terminal_output_transform_hook.py
+++ b/tests/tools/test_terminal_output_transform_hook.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -89,6 +90,34 @@ def test_terminal_output_transform_still_runs_strip_and_redact(monkeypatch, tmp_
     assert "OPENAI_API_KEY=" in result["output"]
     assert "sk-pro" in result["output"]  # prefix marker from _mask_token
     assert "abc123def456" not in result["output"]  # secret body is gone
+
+
+def test_skipped_valid_results_log_runtime_warning(monkeypatch, tmp_path, caplog):
+    # The #64714 skipped-transform rule: a valid-but-losing replacement must
+    # surface in logs, never be silently shadowed.
+    with caplog.at_level(logging.WARNING, logger=terminal_tool_module.logger.name):
+        result, _mock_env = _run_terminal(
+            monkeypatch,
+            tmp_path,
+            output="original",
+            invoke_hook=lambda hook_name, **kwargs: [None, "first", "second"],
+        )
+    assert result["output"] == "first"
+    warnings = [r.getMessage() for r in caplog.records if "skipped" in r.getMessage()]
+    assert len(warnings) == 1
+    assert "skipped 1 valid" in warnings[0]
+
+    # A lone winner is not a conflict: no warning.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger=terminal_tool_module.logger.name):
+        result, _mock_env = _run_terminal(
+            monkeypatch,
+            tmp_path,
+            output="original",
+            invoke_hook=lambda hook_name, **kwargs: ["only"],
+        )
+    assert result["output"] == "only"
+    assert not [r for r in caplog.records if "skipped" in r.getMessage()]
 
 
 def test_large_process_output_is_bounded_before_sudo_and_plugin_hooks(

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3353,10 +3353,24 @@ def terminal_tool(
                     task_id=effective_task_id or "",
                     env_type=env_type,
                 )
+                _skipped_valid = 0
+                _winner_found = False
                 for hook_result in hook_results:
-                    if isinstance(hook_result, str):
-                        output = hook_result
-                        break
+                    if not isinstance(hook_result, str):
+                        continue
+                    if _winner_found:
+                        _skipped_valid += 1
+                        continue
+                    output = hook_result
+                    _winner_found = True
+                if _winner_found and _skipped_valid:
+                    logger.warning(
+                        "transform_terminal_output: skipped %d valid "
+                        "replacement(s) after the first result in registration "
+                        "order won (run-all-then-pick-first, #64714 "
+                        "skipped-transform rule)",
+                        _skipped_valid,
+                    )
             except Exception:
                 pass
             


### PR DESCRIPTION
## Summary

Issue #64714 named **three** Hermes hooks with "first-wins" semantics — `transform_llm_output`, `transform_tool_result`, and `transform_terminal_output` — where a plugin's valid, non-empty return is silently shadowed once an earlier-registered plugin has already claimed the turn, with (the issue's own words) "no log, warning, or metric" when it happens. Its "medium term" suggestion was explicit: *"Log warning when handler is skipped due to first-wins."*

This window's `transform_api_error_classification` rename (`hermes_cli/plugins.py::get_plugin_error_classification`, `c7c687aa4b`) added exactly this warning — its docstring cites *"the #64714 skipped-transform rule"* — but that's a **fourth**, newer hook, not among the three #64714 was actually filed against. The three original hooks named in the issue never received the same treatment.

## Fix

Mirrors `get_plugin_error_classification`'s pattern at each of the three original sites: count valid-but-losing results (same `isinstance(hook_result, str)` check each site already uses to decide a winner) and log a runtime warning after the loop when a winner was found and at least one valid result was skipped.

- `model_tools.py` (`transform_tool_result`)
- `tools/terminal_tool.py` (`transform_terminal_output`)
- `agent/turn_finalizer.py` (`transform_llm_output`)

`turn_finalizer.py`'s loop also stopped early (`break`) on pre-fix code; this removes the `break` since `invoke_hook` already runs every registered callback before the loop starts (nothing is invoked twice), so iterating fully to count skips costs nothing extra — the same non-short-circuiting shape as the other two sites and the reference implementation.

## Verification

- Added a `test_skipped_valid_results_log_runtime_warning` test to each of the three relevant test files (mirroring `test_transform_api_error_classification_hook.py`'s existing test of the same name/shape): `tests/test_transform_tool_result_hook.py`, `tests/tools/test_terminal_output_transform_hook.py`, and a new `tests/agent/test_turn_finalizer_transform_hook_skip_warning.py` (reusing the established `FakeAgent` harness from `tests/agent/test_turn_finalizer_final_response_persistence.py`, per the cross-file-import convention already used by sibling `turn_finalizer` test files).
- Each test asserts the warning fires with the correct skip count when a second valid result loses, and does **not** fire for a lone winner.
- Mutation-verified: stashed all three production-file changes, confirmed all three new tests fail (no warning captured) against pre-fix code. Restored the fix, all three pass.
- Ran the broader neighbor suite (both changed test files + `test_transform_llm_output_hook.py` + all `test_turn_finalizer_*.py` files + `test_model_tools.py` + `test_transform_api_error_classification_hook.py`): 63/63 pass.
- `ruff check` clean on all changed files.

## Note on nearby PRs

Two open PRs touch adjacent code without conflicting: #71401 adds a *new*, separate `transform_terminal_output` call site in `tools/process_registry.py` for background-process output (doesn't modify the foreground dispatch loop this PR fixes); #44253 inserts new code immediately *after* the `transform_llm_output` block in `turn_finalizer.py` without touching the loop itself. Neither modifies the lines this PR changes.

## Test plan

- [x] New regression tests added to all three sites and pass
- [x] Mutation-verify: all three tests fail without the fix, pass with it
- [x] Broader neighbor test suites pass (63/63)
- [x] `ruff check` clean