### PR TITLE
fix(photon): default iMessage replies to plain text

### DIFF
--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -124,7 +124,7 @@ All env vars are documented in `plugin.yaml`. The most important:
 | `PHOTON_REQUIRE_MENTION`  | false                      | Gate group chats on a wake word      |
 | `PHOTON_MAX_INLINE_ATTACHMENT_BYTES` | 20 MB           | Max inbound attachment size the sidecar reads & inlines |
 | `PHOTON_TELEMETRY`        | false                      | Spectrum SDK telemetry — toggle with `hermes photon telemetry on\|off` (restart the gateway to apply) |
-| `PHOTON_MARKDOWN`         | true                       | Send agent replies as markdown (iMessage renders natively). `false` strips formatting to plain text |
+| `PHOTON_MARKDOWN`         | false                      | Strip formatting to clean plain text. Set `true` only after verifying native rendering end to end for the message shapes you use |
 | `PHOTON_REACTIONS`        | false                      | Tapback 👀/👍/👎 as processing status; tapbacks on bot messages reach the agent as `reaction:added:<emoji>` |
 
 ## Attachments & limitations
@@ -150,12 +150,11 @@ All env vars are documented in `plugin.yaml`. The most important:
   documents are sent via `space.send(attachment(...))` /
   `space.send(voice(...))` through the sidecar's `/send-attachment`
   endpoint; a caption is delivered as a separate text bubble after the media.
-- **Markdown is rendered.** Replies go out via spectrum-ts' `markdown()`
-  builder; iMessage renders bold/italics/lists/code natively and other
-  Spectrum platforms degrade to readable plain text. URL-only replies go out
-  via spectrum-ts' `richlink()` builder so iMessage can render a native link
-  preview card. `PHOTON_MARKDOWN=false` reverts to stripped plain text and
-  disables rich-link routing.
+- **Plain text is the default.** Replies have Markdown syntax stripped before
+  they reach spectrum-ts, including messages that contain raw URLs. Set
+  `PHOTON_MARKDOWN=true` only after verifying native rendering end to end for
+  the message shapes you use. Markdown mode also enables URL-only rich-link
+  routing.
 - **Reactions (tapbacks) are supported** behind `PHOTON_REACTIONS` (default
   off): the adapter tapbacks 👀 while processing and swaps it for 👍/👎 on
   completion, and a user tapback on a bot-sent message is routed to the agent

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -586,12 +586,12 @@ def _env_enablement() -> Optional[dict]:
 def _markdown_enabled() -> bool:
     """Send agent replies as markdown (spectrum-ts ``markdown()`` builder).
 
-    iMessage renders it natively; other Spectrum platforms degrade to
-    readable plain text. On-device rendering can't be unit-tested, so
-    ``PHOTON_MARKDOWN=false`` is the kill-switch back to stripped plain
-    text without a release.
+    Native rich-text rendering varies by message shape and cannot be proven
+    end to end in unit tests, so clean conversational plain text is the safe
+    default. ``PHOTON_MARKDOWN=true`` explicitly opts into the spectrum-ts
+    markdown builder.
     """
-    return os.getenv("PHOTON_MARKDOWN", "true").strip().lower() not in {
+    return os.getenv("PHOTON_MARKDOWN", "false").strip().lower() not in {
         "false", "0", "no",
     }
 
@@ -2848,9 +2848,12 @@ async def _standalone_send(
                     else:
                         rich_url = None
                 if not rich_url:
+                    outbound_text = (
+                        message if _markdown_enabled() else strip_markdown(message)
+                    )
                     send_body: Dict[str, Any] = {
                         "spaceId": chat_id,
-                        "text": message[:_MAX_MESSAGE_LENGTH],
+                        "text": outbound_text[:_MAX_MESSAGE_LENGTH],
                     }
                     if _markdown_enabled() and not _richlink_candidate(message):
                         send_body["format"] = "markdown"

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -596,6 +596,12 @@ def _markdown_enabled() -> bool:
     }
 
 
+def _plain_text(content: str) -> str:
+    """Normalize Markdown-shaped replies for conversational iMessage text."""
+    stripped = strip_markdown(content)
+    return re.sub(r"(?m)^\s*(?:[-*+] |\d+[.)] )", "", stripped)
+
+
 def _url_only_candidate(text: str) -> Optional[str]:
     candidate = (text or "").strip()
     if not re.fullmatch(r"https?://\S+", candidate, flags=re.IGNORECASE):
@@ -2384,7 +2390,7 @@ class PhotonAdapter(BasePlatformAdapter):
         # as the PHOTON_MARKDOWN=false kill-switch.
         if _markdown_enabled():
             return content
-        return strip_markdown(content)
+        return _plain_text(content)
 
     @staticmethod
     def _is_retryable_error(error: Optional[str]) -> bool:
@@ -2849,7 +2855,7 @@ async def _standalone_send(
                         rich_url = None
                 if not rich_url:
                     outbound_text = (
-                        message if _markdown_enabled() else strip_markdown(message)
+                        message if _markdown_enabled() else _plain_text(message)
                     )
                     send_body: Dict[str, Any] = {
                         "spaceId": chat_id,

--- a/plugins/platforms/photon/plugin.yaml
+++ b/plugins/platforms/photon/plugin.yaml
@@ -79,7 +79,7 @@ optional_env:
     prompt: "Enable Spectrum telemetry? (true/false)"
     password: false
   - name: PHOTON_MARKDOWN
-    description: "Send agent replies as markdown — iMessage renders it natively, other Spectrum platforms degrade to plain text (true/false, default true)"
+    description: "Send agent replies as markdown (true/false, default false; opt in only after verifying native rendering end to end)"
     prompt: "Render replies as markdown? (true/false)"
     password: false
   - name: PHOTON_REACTIONS

--- a/tests/plugins/platforms/photon/test_markdown.py
+++ b/tests/plugins/platforms/photon/test_markdown.py
@@ -138,7 +138,7 @@ async def test_markdown_plus_raw_url_delivers_plain_builder_payload(
     assert path == "/send"
     assert body == {
         "spaceId": "+15551234567",
-        "text": "Update\n\n- Read the docs: https://example.com/docs",
+        "text": "Update\nRead the docs: https://example.com/docs",
     }
-    for marker in ("##", "- **", "**", "[the docs]("):
+    for marker in ("##", "\n- ", "- **", "**", "[the docs]("):
         assert marker not in body["text"]

--- a/tests/plugins/platforms/photon/test_markdown.py
+++ b/tests/plugins/platforms/photon/test_markdown.py
@@ -1,8 +1,7 @@
 """Markdown handling tests for PhotonAdapter.
 
-Markdown is on by default (the sidecar sends it via spectrum-ts'
-``markdown()`` builder and iMessage renders it); ``PHOTON_MARKDOWN=false``
-reverts to the stripped-plain-text path.
+Plain text is the safe default. ``PHOTON_MARKDOWN=true`` explicitly opts into
+the spectrum-ts ``markdown()`` builder.
 """
 from __future__ import annotations
 
@@ -35,23 +34,23 @@ def _capture_sidecar(adapter: PhotonAdapter) -> List[Tuple[str, Dict[str, Any]]]
     return calls
 
 
-def test_format_message_passthrough_by_default(
+def test_format_message_strips_markdown_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
     adapter = _make_adapter(monkeypatch)
-    assert adapter.format_message(_MD) == _MD
+    assert adapter.format_message(_MD) == "bold and code"
 
 
 def test_supports_code_blocks_mirrors_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
-    assert _make_adapter(monkeypatch).supports_code_blocks is True
-    monkeypatch.setenv("PHOTON_MARKDOWN", "false")
     assert _make_adapter(monkeypatch).supports_code_blocks is False
+    monkeypatch.setenv("PHOTON_MARKDOWN", "true")
+    assert _make_adapter(monkeypatch).supports_code_blocks is True
 
 
 @pytest.mark.asyncio
-async def test_sidecar_send_includes_markdown_format(
+async def test_sidecar_send_defaults_to_stripped_plain_text(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
@@ -62,12 +61,28 @@ async def test_sidecar_send_includes_markdown_format(
 
     path, body = calls[0]
     assert path == "/send"
-    assert body["format"] == "markdown"
-    assert body["text"] == _MD  # passed through unstripped
+    assert "format" not in body
+    assert body["text"] == "bold and code"
 
 
 @pytest.mark.asyncio
-async def test_standalone_send_includes_markdown_format(
+async def test_sidecar_send_can_explicitly_opt_in_to_markdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHOTON_MARKDOWN", "true")
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    await adapter.send("+15551234567", _MD)
+
+    path, body = calls[0]
+    assert path == "/send"
+    assert body["format"] == "markdown"
+    assert body["text"] == _MD
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_defaults_to_stripped_plain_text(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
@@ -102,4 +117,28 @@ async def test_standalone_send_includes_markdown_format(
     result = await photon_adapter._standalone_send(cfg, "+15551234567", _MD)
 
     assert result.get("success") is True
-    assert posted[0][1]["format"] == "markdown"
+    assert "format" not in posted[0][1]
+    assert posted[0][1]["text"] == "bold and code"
+
+
+@pytest.mark.asyncio
+async def test_markdown_plus_raw_url_delivers_plain_builder_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    await adapter.send(
+        "+15551234567",
+        "## Update\n\n- **Read the docs:** https://example.com/docs",
+    )
+
+    path, body = calls[0]
+    assert path == "/send"
+    assert body == {
+        "spaceId": "+15551234567",
+        "text": "Update\n\n- Read the docs: https://example.com/docs",
+    }
+    for marker in ("##", "- **", "**", "[the docs]("):
+        assert marker not in body["text"]

--- a/tests/plugins/platforms/photon/test_rich_links.py
+++ b/tests/plugins/platforms/photon/test_rich_links.py
@@ -23,6 +23,8 @@ _URL = "https://example.com/article"
 def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
     monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
     monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    # Rich-link routing is part of the explicitly opted-in Markdown mode.
+    monkeypatch.setenv("PHOTON_MARKDOWN", "true")
     cfg = PlatformConfig(enabled=True, token="", extra={})
     return PhotonAdapter(cfg)
 
@@ -152,7 +154,7 @@ async def test_direct_url_only_send_falls_back_to_plain_send(
 async def test_standalone_url_only_send_routes_to_richlink_endpoint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("PHOTON_MARKDOWN", raising=False)
+    monkeypatch.setenv("PHOTON_MARKDOWN", "true")
     monkeypatch.setenv("PHOTON_SIDECAR_TOKEN", "tok")
     posted: List[Tuple[str, Dict[str, Any]]] = []
 
@@ -235,5 +237,4 @@ def _preview_attachment_by_id(
     payload["id"] = attachment_id
     payload["name"] = None
     return payload
-
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -684,7 +684,7 @@ Connect Hermes to [Photon](https://photon.codes/) / Spectrum (iMessage and other
 | `PHOTON_MENTION_PATTERNS` | Mention wake-word regexes for group chats (JSON list or comma/newline-separated; defaults to Hermes wake words). |
 | `PHOTON_HOME_CHANNEL` | Default Photon target for cron / notification delivery: Spectrum space id, DM GUID, or bare E.164 phone number. |
 | `PHOTON_HOME_CHANNEL_NAME` | Human label for the home channel. |
-| `PHOTON_MARKDOWN` | Send agent replies as markdown — iMessage renders it natively, other Spectrum platforms degrade to plain text (`true`/`false`, default `true`). |
+| `PHOTON_MARKDOWN` | Send agent replies as markdown (`true`/`false`, default `false`). Opt in only after verifying native rendering end to end; the default strips formatting to clean plain text. |
 | `PHOTON_REACTIONS` | Tapback 👀/👍/👎 on messages as processing status and route tapbacks on bot messages to the agent (`true`/`false`, default `false`). |
 | `PHOTON_TELEMETRY` | Enable Spectrum SDK telemetry in the sidecar (`true`/`false`, default `false`; toggle with `hermes photon telemetry on|off`). |
 | `PHOTON_SIDECAR_PORT` | Loopback port for the Node sidecar control + inbound channel (default `8789`). |


### PR DESCRIPTION
## Summary

- default Photon replies to stripped plain text; Markdown remains an explicit opt-in
- normalize standalone sends through the same plain-text path
- add a regression for Markdown plus a raw URL and assert the delivered `/send` builder payload retains the URL without visible Markdown syntax
- update plugin and environment-variable documentation

## Why

In the live Julia+iMessage pilot, `PHOTON_MARKDOWN=true` preserved raw Markdown in the adapter. When a response contained a URL, `chooseSendFormat()` changed only the spectrum-ts builder from Markdown to text to avoid the data-detection failure. The payload remained raw Markdown, so iMessage displayed headings, asterisks, list syntax, and bracketed links.

Plain text is the stable transport default. Native rich rendering remains available via `PHOTON_MARKDOWN=true` after end-to-end validation for the message shapes in use.

## Verification

`pytest tests/plugins/platforms/photon`: 130 passed, 1 skipped.

## Review follow-up

Plain-text normalization now also removes line-leading unordered and ordered list markers. The regression rejects `\n- ` explicitly and expects `Update\nRead the docs: https://example.com/docs`. Exact head `937d67603898b50407347e16387f49c7b74cc0bf`; full Photon package: 130 passed, 1 skipped.
