### PR TITLE
fix(desktop): expand HUD transcript when resized

### DIFF
--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -18,6 +18,7 @@ import { titlebarButtonClass } from '../shell/titlebar'
 import { useHudClickThrough } from './click-through'
 import { useHudGlass } from './glass'
 import { useHudGoto, useReportHudSession } from './handoff'
+import { hudTranscriptHeight } from './layout'
 import { useHudResizeHandle } from './resize-handle'
 import { useHudThreadFocus } from './thread-focus'
 
@@ -47,15 +48,6 @@ const HUD_COLLAPSE_MS = Math.round(HUD_FADE_MS * 0.66)
  *  somewhere to land. Folded into the measured height rather than added in CSS,
  *  so an empty transcript measures a true zero instead of a 12px strip. */
 const HUD_SHEET_OVERHANG_PX = 12
-
-/** Ceiling on the transcript band, which still auto-sizes up from 0. It reads
- *  over another app, so it is a glance rather than a panel: whichever of these
- *  is smaller wins, so a tall HUD doesn't turn the band into a second window
- *  and a short one doesn't get swallowed by it. */
-const HUD_BAND_MAX_PX = 152
-const HUD_BAND_MAX_FRACTION = 0.42
-
-const hudBandMaxPx = () => Math.min(window.innerHeight * HUD_BAND_MAX_FRACTION, HUD_BAND_MAX_PX)
 
 /** Composer on top, transcript always hanging below it — Spotlight's shape,
  *  rather than flipping to follow the screen edge the HUD is parked against. */
@@ -302,7 +294,14 @@ export function HudShell() {
 
       const contentSpan = text < 1 ? 0 : text + HUD_SHEET_OVERHANG_PX
 
-      const visible = Math.min(hudBandMaxPx(), Math.max(0, Math.round(contentSpan)))
+      // Once the HUD has a transcript, a resize must buy readable scrollback.
+      // The old glance-band ceiling froze this at 152px and turned every extra
+      // pixel of native window height into empty transparent chrome.
+      const visible = hudTranscriptHeight({
+        barHeight: root.querySelector<HTMLElement>('[data-slot="composer-dock"]')?.getBoundingClientRect().height ?? 0,
+        contentHeight: contentSpan,
+        viewportHeight: window.innerHeight
+      })
 
       root.style.setProperty('--hud-band-height', `${visible}px`)
 
@@ -323,12 +322,16 @@ export function HudShell() {
     }
 
     // The viewport mounts async (lazy chat surface); poll briefly until it
-    // exists, then let the ResizeObserver own it.
+    // exists, then let the ResizeObserver own it. Window resize is separate:
+    // the transcript's rows may not change size, but the available scrollback
+    // must, so observing the rows alone cannot update the band.
     measure()
     const probe = setInterval(measure, 500)
+    window.addEventListener('resize', measure)
 
     return () => {
       clearInterval(probe)
+      window.removeEventListener('resize', measure)
       ro.disconnect()
     }
   }, [])

--- a/apps/desktop/src/app/hud/layout.test.ts
+++ b/apps/desktop/src/app/hud/layout.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { hudTranscriptHeight } from './layout'
+
+describe('hudTranscriptHeight', () => {
+  it('uses the resized window space for a non-empty transcript', () => {
+    // The transcript is intentionally not constrained to its content height:
+    // resizing HUD must reveal more scrollback instead of growing an empty
+    // transparent window below a fixed-height chat band.
+    expect(
+      hudTranscriptHeight({
+        barHeight: 58,
+        contentHeight: 72,
+        viewportHeight: 640
+      })
+    ).toBe(582)
+  })
+
+  it('keeps an empty HUD collapsed', () => {
+    expect(hudTranscriptHeight({ barHeight: 58, contentHeight: 0, viewportHeight: 640 })).toBe(0)
+  })
+})

--- a/apps/desktop/src/app/hud/layout.ts
+++ b/apps/desktop/src/app/hud/layout.ts
@@ -1,0 +1,22 @@
+export interface HudTranscriptHeightInput {
+  /** Measured message rows, including the HUD sheet overhang. */
+  contentHeight: number
+  /** The composer's measured height. */
+  barHeight: number
+  /** The HUD window's current inner height. */
+  viewportHeight: number
+}
+
+/**
+ * The HUD transcript owns all available space after the composer once there is
+ * something to show. A resizable HUD must expose more scrollback as it grows;
+ * sizing the band to its message rows instead leaves a larger empty native
+ * window around the same fixed-height transcript.
+ */
+export function hudTranscriptHeight({ barHeight, contentHeight, viewportHeight }: HudTranscriptHeightInput): number {
+  if (contentHeight < 1) {
+    return 0
+  }
+
+  return Math.max(0, Math.round(viewportHeight - barHeight))
+}


### PR DESCRIPTION
## Summary
- make a non-empty HUD transcript use the space available above/below the composer
- recompute that viewport when the native HUD window is resized
- preserve the compact, rolled-up shape for an empty HUD

## Problem
HUD exposes a bottom-right resize handle, but its transcript band is capped at 152px. Enlarging the native window therefore creates unused transparent space instead of revealing more conversation content.

## Test plan
- [x] Added focused unit coverage for an expanded non-empty viewport and the empty-HUD state
- [x] `npx vitest run --project ui src/app/hud/layout.test.ts src/app/hud/click-through.test.ts`
- [x] `npx eslint src/app/hud/hud-shell.tsx src/app/hud/layout.ts src/app/hud/layout.test.ts`
- [x] `npx prettier --check src/app/hud/hud-shell.tsx src/app/hud/layout.ts src/app/hud/layout.test.ts`
- [x] Manually exercised the packaged Windows HUD at compact and expanded sizes
