### PR TITLE
fix(desktop): retain HUD composer focus

### DIFF
--- a/apps/desktop/src/app/hud/click-through.test.ts
+++ b/apps/desktop/src/app/hud/click-through.test.ts
@@ -14,6 +14,7 @@ function hud() {
   shell.setAttribute('data-hud-shell', '')
 
   const bar = document.createElement('input')
+  bar.setAttribute('data-slot', 'composer-rich-input')
 
   const overlay = document.createElement('div')
   overlay.setAttribute('role', 'dialog')
@@ -45,10 +46,23 @@ describe('hudIgnoresMouse', () => {
     expect(hudIgnoresMouse(shell, overlay, null, true)).toBe(false)
   })
 
-  it('does not pin the window just because the composer holds the caret', () => {
+  it('keeps the native HUD window solid while the composer holds the caret', () => {
     const { bar, mount, shell } = hud()
 
-    expect(hudIgnoresMouse(shell, mount, bar, true)).toBe(true)
+    // On Windows, making the native window click-through while its editor owns
+    // focus can immediately hand the mouse activation back to the app below.
+    // The caret then flashes, focus leaves, and the transcript collapses before
+    // the user can read it.
+    expect(hudIgnoresMouse(shell, mount, bar, true)).toBe(false)
+  })
+
+  it('keeps the native HUD window solid while focus is inside the composer editor', () => {
+    const { bar, mount, shell } = hud()
+    const editable = document.createElement('span')
+    editable.contentEditable = 'true'
+    bar.append(editable)
+
+    expect(hudIgnoresMouse(shell, mount, editable, true)).toBe(false)
   })
 
   it('pins the window while a portalled overlay holds focus, so an outside click can dismiss it', () => {

--- a/apps/desktop/src/app/hud/click-through.ts
+++ b/apps/desktop/src/app/hud/click-through.ts
@@ -15,10 +15,10 @@ import { type RefObject, useEffect } from 'react'
  * - Focus BESIDE the shell is a portalled dialog, popover or menu, and it owns
  *   the next click — including the one outside itself that dismisses it, which
  *   the hit test cannot see coming. That pins the window solid.
- * - Focus INSIDE the shell does not. The composer holding the caret is the
- *   HUD's resting state rather than a claim on the whole rectangle, and reading
- *   it as one is what made an engaged HUD eat every click in its own empty
- *   space — on a fresh thread, the entire window.
+ * - Focus INSIDE the shell is normally the HUD's resting state — except for
+ *   the composer caret. On Windows the native window must stay solid while the
+ *   editor owns focus: making it click-through can immediately reactivate the
+ *   application underneath, steal the caret, and collapse the transcript.
  */
 export function hudIgnoresMouse(
   root: Element,
@@ -34,11 +34,16 @@ export function hudIgnoresMouse(
   }
 
   const overSomething = hit !== null && !hit.contains(root)
-  // `windowFocused` is what stops a stale `active` — the composer keeps focus
-  // after you click away to another app — pinning the HUD solid forever.
+
+  const composerFocused =
+    windowFocused &&
+    active !== null &&
+    root.contains(active) &&
+    active.closest('[data-slot="composer-rich-input"]') !== null
+
   const overlayFocused = windowFocused && active !== null && !root.contains(active) && !active.contains(root)
 
-  return !overSomething && !overlayFocused
+  return !composerFocused && !overSomething && !overlayFocused
 }
 
 /**


### PR DESCRIPTION
## Summary
- keep the native HUD window mouse-solid while focus is inside the rich composer
- retain normal click-through once composer focus leaves
- cover both direct composer focus and focus on an editor descendant

## Problem
On Windows, HUD may make its native window click-through immediately after the composer receives focus. The underlying app can then reactivate and steal the caret, causing the transcript to collapse before the user can read or type.

## Test plan
- [x] Added focused regression coverage for direct and nested composer focus
- [x] `npx vitest run src/app/hud/click-through.test.ts`
- [x] `npx eslint src/app/hud/click-through.ts src/app/hud/click-through.test.ts`
- [x] `npx prettier --check src/app/hud/click-through.ts src/app/hud/click-through.test.ts`

Related to #81893 (HUD focus reliability), but addresses the Windows click-through activation path specifically.
