### PR TITLE
[verified] Rotate OpenCode Go pool on RegionError

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4481,6 +4481,27 @@ def _pool_error_context(exc: Exception) -> Dict[str, Any]:
     return payload
 
 
+def _is_opencode_go_region_error(provider: str, exc: Exception) -> bool:
+    """Detect OpenCode Go workspace-region gates that should rotate keys.
+
+    OpenCode Go returns HTTP 403 ``RegionError`` when the selected workspace has
+    not opted into a model hosted only in China. The token is syntactically
+    valid, so treating this as refreshable auth leaves auxiliary tasks wedged
+    on the same fill-first pool entry. Another OpenCode Go pool entry may belong
+    to a workspace where the model is enabled, so rotate the credential.
+    """
+    if _normalize_aux_provider(provider) != "opencode-go":
+        return False
+    status = getattr(exc, "status_code", None)
+    if status != 403:
+        return False
+    err_lower = str(exc).lower()
+    return (
+        "regionerror" in err_lower
+        or ("hosted in china" in err_lower and "explicit opt in" in err_lower)
+    )
+
+
 def _recoverable_pool_provider(
     resolved_provider: str,
     client: Any,
@@ -4544,6 +4565,19 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
     status_code = getattr(exc, "status_code", None)
     error_context = _pool_error_context(exc)
     hint = failed_api_key or None
+
+    if _is_opencode_go_region_error(normalized, exc):
+        region_context = dict(error_context)
+        region_context.setdefault("reason", "region_error")
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=status_code if status_code is not None else 403,
+            error_context=region_context,
+            api_key_hint=hint,
+        )
+        if next_entry is not None:
+            _evict_cached_clients(normalized)
+            return True
+        return False
 
     if _is_auth_error(exc):
         refreshed = pool.try_refresh_current()

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -37,6 +37,7 @@ from agent.auxiliary_client import (
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
     _pool_runtime_base_url,
+    _recover_provider_pool,
 )
 
 
@@ -4612,3 +4613,68 @@ class TestFastModelTier:
             _FAST_MODEL_TASKS
         )
         assert not overlap
+
+
+class TestAuxiliaryOpenCodeGoRegionErrorPoolRecovery:
+    def test_opencode_go_regionerror_rotates_pool_entry_without_refresh(self, monkeypatch):
+        calls = []
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def try_refresh_current(self):
+                raise AssertionError("RegionError is workspace-gated, not refreshable auth")
+
+            def mark_exhausted_and_rotate(self, **kwargs):
+                calls.append(kwargs)
+                return SimpleNamespace(id="next-good-entry")
+
+        class _RegionError(Exception):
+            status_code = 403
+
+        exc = _RegionError(
+            "Error code: 403 - RegionError: The latest version of this model "
+            "is only available hosted in China and requires explicit opt in"
+        )
+
+        evicted = []
+        monkeypatch.setattr("agent.auxiliary_client.load_pool", lambda provider: _Pool())
+        monkeypatch.setattr("agent.auxiliary_client._evict_cached_clients", lambda provider: evicted.append(provider))
+
+        recovered = _recover_provider_pool("opencode-go", exc, failed_api_key="failed-key")
+
+        assert recovered is True
+        assert evicted == ["opencode-go"]
+        assert calls == [{
+            "status_code": 403,
+            "error_context": {
+                "message": str(exc),
+                "status_code": 403,
+                "reason": "region_error",
+            },
+            "api_key_hint": "failed-key",
+        }]
+
+    def test_non_opencode_go_regionerror_shape_does_not_rotate_generic_403(self, monkeypatch):
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def try_refresh_current(self):
+                return None
+
+            def mark_exhausted_and_rotate(self, **kwargs):
+                raise AssertionError("generic 403 must not be treated as OpenCode Go RegionError")
+
+        class _Forbidden(Exception):
+            status_code = 403
+
+        exc = _Forbidden(
+            "Error code: 403 - RegionError: The latest version of this model "
+            "is only available hosted in China and requires explicit opt in"
+        )
+
+        monkeypatch.setattr("agent.auxiliary_client.load_pool", lambda provider: _Pool())
+
+        assert _recover_provider_pool("openrouter", exc, failed_api_key="failed-key") is False


### PR DESCRIPTION
## Summary
- Detects OpenCode Go HTTP 403 RegionError workspace gates in auxiliary pool recovery
- Marks the selected pool credential exhausted with reason=region_error and rotates to the next entry
- Keeps generic non-OpenCode 403 behavior unchanged

## Test Plan
- RED before fix: `pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryOpenCodeGoRegionErrorPoolRecovery -q` failed because RegionError did not recover
- GREEN after fix: `pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryOpenCodeGoRegionErrorPoolRecovery -q` -> 2 passed
- `pytest tests/agent/test_auxiliary_client.py -q` -> 179 passed / 4 failed because this environment lacks pytest-asyncio support for existing async tests