### PR TITLE
fix(gateway): exclude service-managed PIDs from orphan reaping

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1556,6 +1556,11 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     if extra_exclude:
         own |= extra_exclude
     try:
+        # launchd/systemd-supervised gateways are not orphans — never reap them.
+        own |= _get_service_pids()
+    except Exception:
+        pass
+    try:
         # find_gateway_pids() includes no-supervisor `gateway restart` runtimes
         # for the current profile when no systemd supervisor is present.
         orphans = [p for p in find_gateway_pids(exclude_pids=own) if p and p > 0]


### PR DESCRIPTION
## Summary

`_reap_unsupervised_gateway_orphans()` kills every gateway PID found by `find_gateway_pids()` on hosts without systemd (macOS launchd, Windows Scheduled Task). This includes **service-managed gateways that are NOT orphans** — they are supervised by launchd/systemd and should never be killed during a stale-process sweep.

The function's own docstring says `exclude_pids` is for "service-managed PIDs that should not be killed during a stale-process sweep", but it only excludes its own PID — not service-managed ones.

## Root Cause

`_reap_unsupervised_gateway_orphans()` calls `find_gateway_pids(exclude_pids=own)` where `own` only contains `{os.getpid()}` plus `extra_exclude`. `find_gateway_pids()` includes `_get_service_pids()` in its results (line 634), but those service-managed PIDs are NOT in the exclusion set — so they get reaped.

## Fix

Add `own |= _get_service_pids()` to the exclusion set before scanning, wrapped in try/except for robustness. This preserves the #77276 orphan protection while excluding launchd/systemd-supervised gateways.

True orphans (reparented leftovers not present in `launchctl list` / `systemctl`) are still found and reaped.

## Changes

- `hermes_cli/gateway.py`: Add 5 lines in `_reap_unsupervised_gateway_orphans()` to exclude `_get_service_pids()` from the reap target set.

## Test Plan

- [x] Syntax check passes
- [x] Module imports correctly
- [ ] On macOS with launchd gateway: verify desktop serve startup no longer kills the gateway
- [ ] On Windows with Scheduled Task gateway: verify desktop serve startup no longer kills the gateway
- [ ] Verify true orphans (no service supervisor) are still reaped

Fixes #85344
Fixes #85044
Fixes #84855
Fixes #85368