### PR TITLE
fix(grounded-citations): fold typographic Unicode so honest verbatim quotes match

### DIFF
--- a/skills/research/grounded-citations/scripts/sources.py
+++ b/skills/research/grounded-citations/scripts/sources.py
@@ -244,16 +244,48 @@ _MD_LINK_RE = re.compile(r"\[([^\]]*)\]\((?:[^()\s]|\([^()]*\))*\)")
 _MD_NOISE_RE = re.compile(r"[*_`~]|\\(?=[^\w\s])")
 
 
+def _normalize_unicode(text: str) -> str:
+    """Fold typographic/Unicode variants so honest quotes of curly-quote or
+    ASCII-typed sources match.
+
+    Covers the class that failed the x-monitor digest-1 gate (2026-08-12):
+    raw pages typed with U+2011 non-breaking hyphens, curly quotes, ≥/−, and
+    ellipses were ASCII-folded by the worker and so failed naive verbatim
+    matching even though every figure was exact. Apply NFKC (which already
+    folds many of these) then a small explicit fold table for the residual
+    separators/ellipsis forms NFKC does not unify.
+    """
+    import unicodedata
+
+    s = unicodedata.normalize("NFKC", text or "")
+    # Explicit folds for the NFKC residuals most common in prose: hyphen family,
+    # apostrophe/quote family, ellipsis family, and the min/greater-equal signs.
+    table = {
+        "\u2010\u2011\u2012\u2013\u2014": "-",  # hyphen, non-breaking, en, em
+        "\u2018\u2019\u02bb\u201b": "'",  # left/right single quote, ʻ, reversed
+        "\u201c\u201d\u2033": '"',  # left/right double quote, double prime
+        "\u2026": "...",  # ellipsis (multi-char fold via single-char replace)
+        "\u2265": ">=",  # greater-than-or-equal
+        "\u2264": "<=",  # less-than-or-equal
+        "\u2212": "-",  # minus sign
+    }
+    for chars, repl in table.items():
+        for ch in chars:
+            s = s.replace(ch, repl)
+    return s
+
+
 def _match_key(text: str) -> str:
     """Canonicalize text for verbatim comparison.
 
-    Whitespace-, case-, and markdown-insensitive: inline links collapse to
-    their label, emphasis/code markers and backslash escapes are dropped.  The
-    stored quote keeps whatever the caller passed, so the rendered evidence
-    block shows clean prose rather than extractor artifacts.
+    Whitespace-, case-, markdown-, and Unicode-insensitive: inline links
+    collapse to their label, emphasis/code markers and backslash escapes are
+    dropped, and typographic variants fold to ASCII. The stored quote keeps
+    whatever the caller passed, so the rendered evidence block shows clean
+    prose rather than extractor artifacts.
     """
     collapsed = _MD_LINK_RE.sub(r"\1", text or "")
-    return _normalize_ws(_MD_NOISE_RE.sub("", collapsed)).casefold()
+    return _normalize_ws(_normalize_unicode(_MD_NOISE_RE.sub("", collapsed))).casefold()
 
 
 def quote_in_evidence(quote: str, evidence: str) -> bool:

--- a/tests/skills/test_grounded_citations_skill.py
+++ b/tests/skills/test_grounded_citations_skill.py
@@ -522,6 +522,59 @@ def test_markup_tolerance_does_not_admit_paraphrase(sources_mod, ledger: Path) -
 
 
 # ---------------------------------------------------------------------------
+# Unicode / typographic tolerance in the verbatim check
+#
+# x-monitor digest-1 DEFECT (2026-08-12): raw pages typed with U+2011 non-breaking
+# hyphens, curly quotes, ≥/−, and ellipses were ASCII-folded by the worker and so
+# failed naive verbatim matching even though every figure was exact.  This test
+# pins the fix so it cannot silently regress (or be lost on an upstream update).
+# Genuine truncations/paraphrases must still fail — the fabrication line stays.
+# ---------------------------------------------------------------------------
+
+# Same sentence twice: once with the raw typographic characters a real page
+# carries, once as the ASCII-typed honest quote a worker would produce.
+_PAGE_TYPOGRAPHIC = (
+    "Tetra’s 5–year run saw ≥12% of revenue from its flagship product,\n"
+    "and margins held at −4.2% “all-in” through the close…\n"
+    "A second, cleanly-typed line for the paraphrase guard.\n"
+)
+
+
+def test_quote_matches_through_typographic_unicode(sources_mod, ledger: Path) -> None:
+    """Honest ASCII quote of a typographically-typed page must still match.
+
+    Reproduces x-monitor digest-1: the worker ASCII-folds its rendering while the
+    source page carries U+2011 NB-hyphen, curly quotes, ≥/−, and ellipsis.  Every
+    figure is exact, so the match must survive.
+    """
+    sources_mod.add_sources(ledger, ["https://x.example"])
+    entry = sources_mod.attach_quote(
+        ledger,
+        1,
+        "Tetra's 5-year run saw >=12% of revenue from its flagship product, "
+        "and margins held at -4.2% \"all-in\" through the close...",
+        _PAGE_TYPOGRAPHIC,
+    )
+    assert len(entry["quotes"]) == 1
+    # The stored quote keeps the caller's clean ASCII prose.
+    assert entry["quotes"][0]["text"] == (
+        'Tetra\'s 5-year run saw >=12% of revenue from its flagship product, '
+        'and margins held at -4.2% "all-in" through the close...'
+    )
+
+
+def test_typographic_tolerance_does_not_admit_paraphrase(sources_mod, ledger: Path) -> None:
+    """Unicode folding must not admit a genuinely different sentence."""
+    sources_mod.add_sources(ledger, ["https://x.example"])
+    with pytest.raises(SystemExit) as exc:
+        sources_mod.attach_quote(
+            ledger, 1, "A quarter of sales came from the firm's top offering in five years.",
+            _PAGE_TYPOGRAPHIC,
+        )
+    assert "not found verbatim" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
 # render --replace-in
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`_match_key` in `skills/research/grounded-citations/scripts/sources.py` performs verbatim quote matching for the evidence gate, but only whitespace/case/markdown-normalizes. Source pages are frequently typed with typographic characters — U+2011 non-breaking hyphens, curly quotes, `≥`/`≤`, `−`, and ellipses (`…`) — while the agent quoting them renders ASCII forms. The result: **exact figures fail verbatim matching** purely from presentation-only differences, pushing the skill toward weaker evidence fragments or false "not found verbatim" rejections.

## Change

Add `_normalize_unicode()` and call it inside `_match_key`:
- `unicodedata.normalize("NFKC", ...)` folds many variants.
- An explicit fold table handles NFKC residuals common in prose: hyphen family (`\u2010\u2011\u2012\u2013\u2014` → `-`), apostrophe/quote family, ellipsis (`…` → `...`), `≥`/`≤`, and `−`.

**The fabrication line is preserved**: genuine truncations and paraphrases still fail the check — this only folds *presentation* variants, not meaning.

## Tests

Two regression tests added to `tests/skills/test_grounded_citations_skill.py`:
1. `test_quote_matches_through_typographic_unicode` — an honest ASCII quote of a typographically-typed page matches.
2. `test_typographic_tolerance_does_not_admit_paraphrase` — a genuinely different sentence still fails.

`pytest tests/skills/test_grounded_citations_skill.py` → **49 passed**.

## Notes

- Draft PR — happy to adjust scope, add more fold cases, or move the fold to a shared normalization helper if the maintainers prefer.