### PR TITLE
Fix/per profile remote ws routing

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -7990,7 +7990,7 @@ async function ensureBackend(profile) {
 
     // A shared backend still owes the caller its profile scope, so renderer-side
     // WebSocket, filesystem, and cache routing target the selected profile.
-    return route.descriptorProfile ? { ...connection, profile: route.descriptorProfile } : connection
+    return route.descriptorProfile ? { ...connection, profile: route.descriptorProfile, sharedPrimary: true } : connection
   }
 
   const existing = backendPool.get(key)

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -9,7 +9,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // the shared primary activates the primary socket instead of dialing.
 
 const gatewayMocks = vi.hoisted(() => ({
-  connect: vi.fn(async (_wsUrl: string) => undefined)
+  connect: vi.fn(async (_wsUrl: string): Promise<void> => {
+    throw new Error('dialed a socket for a shared-primary profile')
+  })
 }))
 
 vi.mock('@/hermes', () => ({
@@ -59,6 +61,7 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
 
     await ensureGatewayForProfile('venture')
 
+    expect(gatewayMocks.connect).not.toHaveBeenCalled()
     expect($gateway.get()).toBe(primary)
   })
 
@@ -77,6 +80,7 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
         wsUrl: remoteWsUrl
       }))
     })
+    gatewayMocks.connect.mockResolvedValueOnce(undefined)
 
     await ensureGatewayForProfile('worker')
 

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -8,12 +8,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // profile except the primary. These tests pin the fix: a profile routed to
 // the shared primary activates the primary socket instead of dialing.
 
+const gatewayMocks = vi.hoisted(() => ({
+  connect: vi.fn(async (_wsUrl: string) => undefined)
+}))
+
 vi.mock('@/hermes', () => ({
   HermesGateway: class {
     connectionState = 'closed'
-    connect = vi.fn(async () => {
-      throw new Error('dialed a socket for a shared-primary profile')
-    })
+    connect = gatewayMocks.connect
     onEvent = vi.fn(() => () => {})
     onState = vi.fn(() => () => {})
   }
@@ -60,19 +62,26 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
     expect($gateway.get()).toBe(primary)
   })
 
-  it('still pools a socket for profiles with their own descriptor (untagged)', async () => {
+  it('dials the exact WebSocket URL for a profile-owned remote descriptor', async () => {
     const primary = makePrimary()
+    const remoteWsUrl = 'wss://remote.invalid/api/ws?token=fake-test-token'
+
     setPrimaryGateway(primary as never, 'default')
     installDesktop({
-      // Own descriptor: no profile tag → normal pooled path (dial attempted).
-      getConnection: vi.fn(async () => ({ port: 5151, profile: 'worker', token: 't2' }))
+      getConnection: vi.fn(async () => ({
+        authMode: 'token',
+        baseUrl: 'https://remote.invalid',
+        mode: 'remote',
+        profile: 'worker',
+        token: 'fake-test-token',
+        wsUrl: remoteWsUrl
+      }))
     })
 
     await ensureGatewayForProfile('worker')
 
-    // The pooled path dialed (our stub throws, so the socket stays closed and
-    // reconnect is scheduled) — the important part is it did NOT silently
-    // reuse the primary.
+    expect(gatewayMocks.connect).toHaveBeenCalledOnce()
+    expect(gatewayMocks.connect).toHaveBeenCalledWith(remoteWsUrl)
     expect($gateway.get()).not.toBe(primary)
   })
 })

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -52,7 +52,7 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
     setPrimaryGateway(primary as never, 'default')
     installDesktop({
       // Shared descriptor: primary connection tagged with the profile.
-      getConnection: vi.fn(async () => ({ port: 4242, profile: 'venture', token: 't' }))
+      getConnection: vi.fn(async () => ({ port: 4242, profile: 'venture', sharedPrimary: true, token: 't' }))
     })
 
     await ensureGatewayForProfile('venture')
@@ -65,7 +65,7 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
     setPrimaryGateway(primary as never, 'default')
     installDesktop({
       // Own descriptor: no profile tag → normal pooled path (dial attempted).
-      getConnection: vi.fn(async () => ({ port: 5151, token: 't2' }))
+      getConnection: vi.fn(async () => ({ port: 5151, profile: 'worker', token: 't2' }))
     })
 
     await ensureGatewayForProfile('worker')

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -264,7 +264,7 @@ async function sharedPrimaryRoute(profile: string): Promise<boolean> {
   try {
     const conn = await desktop.getConnection(profile)
 
-    return Boolean(conn && typeof conn === 'object' && (conn as { profile?: string }).profile)
+    return Boolean(conn && typeof conn === 'object' && (conn as { sharedPrimary?: boolean }).sharedPrimary === true)
   } catch {
     return false
   }


### PR DESCRIPTION
# PR: fix(desktop): per-profile remote overrides attach chat WS to the local primary
## What
A Desktop profile configured with its own remote gateway override
(connection.json `profiles[name] = { mode: "remote", url, token }`)
silently runs its chat on the **local** primary backend:
- new sessions on the remote profile identify as the local host (e.g. macOS)
- resuming a remote-native session fails with "session not found"
- REST (session list, fs, git) correctly hits the remote via the override
Regression from #85665 (d16e2366d), merged 2026-08-13.
## Root cause
`sharedPrimaryRoute()` (apps/desktop/src/store/gateway.ts) decides a profile
is "served by the shared primary" when the descriptor has a `.profile` field:
```ts
return Boolean(conn && typeof conn === 'object' && (conn as { profile?: string }).profile)
```
But **two** routes produce a `.profile`-tagged descriptor:
1. Shared-primary (case 3, global remote): `ensureBackend` returns
   `{ ...connection, profile: route.descriptorProfile }` — the intended target
   of the check.
2. **Per-profile remote override (case 2): `spawnPoolBackend` returns
   `{ ...remote, profile, ... }` (electron/main.ts:8117) — the pool descriptor
   is tagged with the profile name too.**
The check cannot distinguish them, so a per-profile remote override is
misclassified as shared-primary → `ensureGatewayForProfile` activates the
PRIMARY (local) socket instead of dialing the profile's remote WS. The commit
message claims "per-profile remote overrides are untouched (pinned by test)" —
the test missed the `spawnPoolBackend` return path.
## Fix
Tag only the true shared-primary descriptor with a dedicated marker and check
for that, not `.profile`:
- `electron/main.ts` — primary route with `descriptorProfile`:
  `{ ...connection, profile: route.descriptorProfile, sharedPrimary: true }`
- `apps/desktop/src/store/gateway.ts` — `sharedPrimaryRoute` checks
  `conn.sharedPrimary === true`; pool descriptors never carry the marker.
Covers both callers (`openGatewayForProfile` pre-warm and
`ensureGatewayForProfile`) — the whole bug class, not just one path.
## Reproduction
1. Local primary profile; add a second profile with a remote gateway override.
2. Select the remote profile; open/resume a session.
3. Chat answers from the LOCAL host; remote sessions say "session not found",
   while the sidebar (REST) lists remote sessions.
## Test
- Unit: `sharedPrimaryRoute` — descriptor `{ profile: 'x' }` → false;
  `{ profile: 'x', sharedPrimary: true }` → true (covers both route shapes).
- E2E guidance: per-profile remote override + local primary must dial the
  override's WS URL (assert the chat socket target, not just REST).
## Related
- #85237 (same config shape, different symptom)
- #81198 (notes per-profile overrides worked pre-#85665)


Fixes #85777
