### PR TITLE
fix(aux): stop probe stubs poisoning the client cache

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7682,6 +7682,14 @@ def _get_cached_client(
         is_vision=is_vision,
         task=task,
     )
+    if isinstance(client, _AuxProbeClientStub):
+        # Probe stubs must never enter the cache here. _store_cached_client()
+        # already refuses them, but this function writes to _client_cache
+        # directly and so bypasses that guard. check_fns (tool gating) resolve
+        # through this path inside aux_probe_mode(), and the cache key does not
+        # distinguish probe from runtime -- so a stored stub is handed to the
+        # next real caller sharing the key, which dies on attribute access.
+        return client, model or default_model
     if client is not None:
         # For async clients, remember which loop they were created on so we
         # can detect stale entries later.

--- a/tests/tools/test_startup_latency_regressions.py
+++ b/tests/tools/test_startup_latency_regressions.py
@@ -34,6 +34,41 @@ class TestAuxProbeMode:
         with aux._client_cache_lock:
             assert key not in aux._client_cache
 
+    def test_probe_stub_never_cached_via_get_cached_client(self):
+        """The inline store in _get_cached_client must honour the same guard.
+
+        test_probe_stub_never_cached above covers _store_cached_client(), but
+        _get_cached_client() assigns to _client_cache directly instead of
+        calling it. That is the path check_fns actually take inside
+        aux_probe_mode(), so without a guard there the probe poisons the entry
+        and the next runtime caller with the same key gets a dead client.
+        """
+        import agent.auxiliary_client as aux
+
+        stub = aux._AuxProbeClientStub()
+        try:
+            with patch.object(
+                aux, "resolve_provider_client", lambda *a, **k: (stub, "m")
+            ):
+                with aux.aux_probe_mode():
+                    client, _model = aux._get_cached_client("probe-guard-test", "m")
+            assert client is stub
+            with aux._client_cache_lock:
+                poisoned = [
+                    key
+                    for key, entry in aux._client_cache.items()
+                    if isinstance(entry[0], aux._AuxProbeClientStub)
+                ]
+            assert poisoned == [], f"probe stub reached the cache: {poisoned}"
+        finally:
+            with aux._client_cache_lock:
+                for key in [
+                    k
+                    for k, e in aux._client_cache.items()
+                    if isinstance(e[0], aux._AuxProbeClientStub)
+                ]:
+                    del aux._client_cache[key]
+
     def test_probe_stub_raises_on_runtime_use(self):
         import agent.auxiliary_client as aux
 


### PR DESCRIPTION
## Summary

`_store_cached_client()` refuses to cache an `_AuxProbeClientStub`. `_get_cached_client()` assigns to `_client_cache` directly and never reaches that guard — so the one function that *is* protected is not the function the availability probes actually go through.

The result: a tool-gating `check_fn` caches a non-functional stub, and the next runtime caller with the same cache key gets it back and dies.

```
RuntimeError: _AuxProbeClientStub used as a real client (attribute 'chat');
aux_probe_mode is for availability checks only
```

## How it happens

1. Tool-schema assembly calls `check_browser_vision_requirements()` → `check_vision_requirements()`.
2. That resolves inside `aux_probe_mode()`, which is correct — it only wants to know whether a client is *resolvable*, and building a real SDK client for that answer costs an `openai` import plus httpx/SSL setup on the cold-start path.
3. Resolution runs through `_get_cached_client()`, which stores the returned stub in `_client_cache`. The cache key has no probe/runtime field, so nothing marks the entry as poisoned.
4. The next real vision call hits that key, receives the stub, and raises on attribute access.

## Why it stayed hidden

The cache key's second field is `async_mode`. The probe caches the **sync** variant:

```
('<provider>', False, '', '', '', (), True, '', '', '<model>') -> _AuxProbeClientStub
```

So the two consumers diverge:

- `analyze_image` resolves **async**, misses the poisoned key, builds a real client, and works.
- `browser_vision` resolves **sync**, hits the poisoned key, and fails on every call.

A setup that only ever attaches images directly never sees this. It surfaces the moment a sync vision consumer runs after tool gating — for us, as soon as `browser_vision` became reachable.

Reproduced deterministically against a local OpenAI-compatible vision endpoint:

```
[after probe] cache entries: 1
    (..., False, ..., True, '<model>') -> _AuxProbeClientStub  <-- STUB
real resolve -> <provider> _AuxProbeClientStub <model>
BOOM: _AuxProbeClientStub used as a real client (attribute 'chat')
```

With the patch, the probe leaves the cache empty and the real resolve builds and caches a genuine client.

## The fix

Guard the inline store in `_get_cached_client()` the same way `_store_cached_client()` already guards its own, and return the stub to the probe caller without caching it. Two lines of behavior, no change to resolution policy, no change to the probe's fast path.

## Why the existing test did not catch it

`test_probe_stub_never_cached` asserts the invariant by calling `_store_cached_client()` — the door that was already locked. The new test drives `_get_cached_client()` under `aux_probe_mode()` and asserts no stub reaches `_client_cache`. It fails on `main` and passes with the fix:

```
AssertionError: probe stub reached the cache: [('probe-guard-test', False, ...)]
```

## Tests

```
tests/tools/test_startup_latency_regressions.py  17 passed
tests/agent/test_vision_routing_31179.py          8 passed
tests/tools/test_browser_use_cli.py              79 passed
```

Run with a Python 3.10+ interpreter (the codebase uses `X | Y` unions):

```sh
~/.hermes/hermes-agent/venv/bin/python -m pip install --target /tmp/prlibs pytest
cd ~/hermes-agent
PYTHONPATH=/tmp/prlibs ~/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/tools/test_startup_latency_regressions.py -q
```

### Unrelated pre-existing failure, noted for the reviewer

Running `tests/agent/test_vision_routing_31179.py` and `tests/tools/test_browser_use_cli.py` **in the same pytest process** produces 10 failures in the latter. This reproduces on pristine `main` without this patch, and both files pass when run separately. It is cross-file state leakage in the existing suite, not a regression from this change, and is left alone here.
