### PR TITLE
feat(teams): allow plugins to handle Adaptive Card Action.Execute

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2927,6 +2927,64 @@ class PluginContext:
         )
         return handle
 
+    # -- teams card action handler registration -----------------------------
+
+    def register_teams_card_action_handler(
+        self,
+        hermes_action: str,
+        callback: Callable,
+    ) -> PluginRegistration:
+        """Register a Teams Adaptive Card ``Action.Execute`` handler.
+
+        Hermes' Teams adapter dispatches card invokes whose
+        ``data.hermes_action`` matches ``hermes_action`` to the callback
+        (after the built-in approval actions). Use this for firm-specific
+        workflows (e.g. claim a referral) without patching the adapter.
+
+        Callback signature::
+
+            async def handler(*, ctx, data, adapter) -> Any:
+                # ctx: ActivityContext for the card invoke
+                # data: action.data dict from the Adaptive Card
+                # adapter: TeamsAdapter instance
+                # Return a short status string, an AdaptiveCard / card dict,
+                # an InvokeResponse, or None to decline the match.
+
+        Args:
+            hermes_action: Exact ``data.hermes_action`` string to match.
+            callback: Async callable receiving ``ctx``, ``data``, ``adapter``.
+
+        Raises:
+            ValueError: if ``callback`` is not callable, or ``hermes_action``
+                is empty.
+        """
+        if not callable(callback):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register a Teams "
+                f"card action handler with a non-callable callback."
+            )
+        if not isinstance(hermes_action, str) or not hermes_action.strip():
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register a Teams "
+                f"card action handler with an empty hermes_action."
+            )
+        key = hermes_action.strip()
+        entry = (key, callback, self.manifest.name)
+        self._manager._teams_card_action_handlers.append(entry)
+        handle = self._track(
+            "teams_card_action_handler",
+            key,
+            lambda: self._manager._remove_identity(
+                self._manager._teams_card_action_handlers, entry
+            ),
+        )
+        logger.debug(
+            "Plugin %s registered Teams card action handler: %s",
+            self.manifest.name,
+            key,
+        )
+        return handle
+
     # -- hook registration --------------------------------------------------
 
     # -- auxiliary task registration ---------------------------------------
@@ -3437,6 +3495,11 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        # Teams Adaptive Card Action.Execute handlers registered by plugins.
+        # Each entry is (hermes_action, callback, plugin_name). The Teams
+        # adapter dispatches on ``data.hermes_action`` at card-invoke time.
+        # Callback: ``async def handler(*, ctx, data, adapter) -> Any``.
+        self._teams_card_action_handlers: List[tuple] = []
         # Registration handles are kept both per plugin (ownership lookup) and
         # globally (reverse-order teardown for overrides spanning plugins).
         #
@@ -3717,6 +3780,7 @@ class PluginManager:
             self._system_prompt_sections.clear()
             self._approval_transports.clear()
             self._slack_action_handlers.clear()
+            self._teams_card_action_handlers.clear()
             self._context_engine = None
             self._discovered = False
         else:
@@ -5289,6 +5353,17 @@ class PluginManager:
         :meth:`PluginContext.register_slack_action_handler`.
         """
         return list(self._slack_action_handlers)
+
+    def get_teams_card_action_handlers(self) -> List[tuple]:
+        """Return plugin-registered Teams Adaptive Card action handlers.
+
+        Each entry is a ``(hermes_action, callback, plugin_name)`` tuple.
+        Consumed by the Teams adapter on ``Action.Execute`` invokes.
+
+        Plugins register handlers via
+        :meth:`PluginContext.register_teams_card_action_handler`.
+        """
+        return list(self._teams_card_action_handlers)
 
     # -----------------------------------------------------------------------
     # Introspection

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2938,8 +2938,14 @@ class PluginContext:
 
         Hermes' Teams adapter dispatches card invokes whose
         ``data.hermes_action`` matches ``hermes_action`` to the callback
-        (after the built-in approval actions). Use this for firm-specific
-        workflows (e.g. claim a referral) without patching the adapter.
+        **before** the built-in approval actions (so custom actions do not
+        need a ``session_key``). Use this for plugin workflows (e.g. claim
+        a referral) without patching the adapter.
+
+        When several plugins register the same ``hermes_action``, handlers
+        run in registration order; the first non-``None`` return wins. A
+        handler that raises soft-fails immediately (error status to Teams)
+        and does not fall through to later handlers.
 
         Callback signature::
 
@@ -2947,11 +2953,16 @@ class PluginContext:
                 # ctx: ActivityContext for the card invoke
                 # data: action.data dict from the Adaptive Card
                 # adapter: TeamsAdapter instance
-                # Return a short status string, an AdaptiveCard / card dict,
-                # an InvokeResponse, or None to decline the match.
+                # Return a short status string, an AdaptiveCard SDK object
+                # (full card replace), a raw AdaptiveCard dict (status text
+                # from the first TextBlock only), an InvokeResponse, or
+                # None to decline the match and try the next handler.
 
         Args:
             hermes_action: Exact ``data.hermes_action`` string to match.
+                Avoid colliding with built-in approval ids
+                (``approve_once``, ``approve_session``, ``approve_always``,
+                ``deny``) — a matching plugin handler shadows them.
             callback: Async callable receiving ``ctx``, ``data``, ``adapter``.
 
         Raises:
@@ -5357,8 +5368,9 @@ class PluginManager:
     def get_teams_card_action_handlers(self) -> List[tuple]:
         """Return plugin-registered Teams Adaptive Card action handlers.
 
-        Each entry is a ``(hermes_action, callback, plugin_name)`` tuple.
-        Consumed by the Teams adapter on ``Action.Execute`` invokes.
+        Each entry is a ``(hermes_action, callback, plugin_name)`` tuple in
+        registration order (first registered first). Consumed by the Teams
+        adapter on ``Action.Execute`` invokes; first non-``None`` result wins.
 
         Plugins register handlers via
         :meth:`PluginContext.register_teams_card_action_handler`.

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1071,13 +1071,19 @@ class TeamsAdapter(BasePlatformAdapter):
         hermes_action = data.get("hermes_action", "")
         session_key = data.get("session_key", "")
 
-        if not hermes_action or not session_key:
+        if not hermes_action:
             return InvokeResponse(
                 status=200,
                 body=AdaptiveCardActionMessageResponse(value="Unknown action."),
             )
 
-        # Only authorized users may click approval buttons.
+        # Cache conversation ref so proactive follow-ups (claim results, etc.)
+        # can land back in the same channel/thread.
+        conv_id = getattr(getattr(ctx.activity, "conversation", None), "id", None)
+        if conv_id:
+            self._conv_refs[conv_id] = ctx.conversation_ref
+
+        # Only authorized users may click approval / custom card buttons.
         # Default-deny: require either TEAMS_ALLOWED_USERS or an explicit
         # TEAMS_ALLOW_ALL_USERS=true opt-in. Without one of these set, the
         # bot silently treated every clicker as authorized — meaning any
@@ -1107,6 +1113,15 @@ class TeamsAdapter(BasePlatformAdapter):
                     body=AdaptiveCardActionMessageResponse(value="⛔ Not authorized."),
                 )
 
+        # Plugin-registered Action.Execute handlers (firm workflows, etc.).
+        # Checked before built-in approvals so custom actions don't need a
+        # session_key. First matching non-None result wins.
+        plugin_response = await self._dispatch_plugin_card_action(
+            hermes_action, ctx=ctx, data=data
+        )
+        if plugin_response is not None:
+            return plugin_response
+
         choice_map = {
             "approve_once": "once",
             "approve_session": "session",
@@ -1115,6 +1130,12 @@ class TeamsAdapter(BasePlatformAdapter):
         }
         choice = choice_map.get(hermes_action)
         if not choice:
+            return InvokeResponse(
+                status=200,
+                body=AdaptiveCardActionMessageResponse(value="Unknown action."),
+            )
+
+        if not session_key:
             return InvokeResponse(
                 status=200,
                 body=AdaptiveCardActionMessageResponse(value="Unknown action."),
@@ -1153,6 +1174,87 @@ class TeamsAdapter(BasePlatformAdapter):
             body=AdaptiveCardActionCardResponse(
                 value=AdaptiveCard().with_version("1.4").with_body(body)
             ),
+        )
+
+    async def _dispatch_plugin_card_action(
+        self,
+        hermes_action: str,
+        *,
+        ctx: "ActivityContext[AdaptiveCardInvokeActivity]",
+        data: Dict[str, Any],
+    ) -> "Optional[InvokeResponse]":
+        """Dispatch a card invoke to plugin-registered Teams handlers."""
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+
+            handlers = get_plugin_manager().get_teams_card_action_handlers()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("[teams] Could not load plugin card action handlers: %s", exc)
+            return None
+
+        for action_id, callback, plugin_name in handlers:
+            if action_id != hermes_action:
+                continue
+            try:
+                result = await callback(ctx=ctx, data=data, adapter=self)
+            except Exception as exc:
+                logger.error(
+                    "[teams] Plugin '%s' card action '%s' raised: %s",
+                    plugin_name,
+                    hermes_action,
+                    exc,
+                    exc_info=True,
+                )
+                return InvokeResponse(
+                    status=200,
+                    body=AdaptiveCardActionMessageResponse(
+                        value=f"⚠️ Action failed ({plugin_name}). Check gateway logs."
+                    ),
+                )
+            if result is None:
+                continue
+            return self._coerce_card_action_response(result)
+
+        return None
+
+    def _coerce_card_action_response(self, result: Any) -> "InvokeResponse":
+        """Normalize plugin handler return values into an InvokeResponse."""
+        if isinstance(result, InvokeResponse):
+            return result
+        if isinstance(result, str):
+            return InvokeResponse(
+                status=200,
+                body=AdaptiveCardActionMessageResponse(value=result),
+            )
+        # AdaptiveCard SDK object
+        if AdaptiveCard is not None and isinstance(result, AdaptiveCard):
+            return InvokeResponse(
+                status=200,
+                body=AdaptiveCardActionCardResponse(value=result),
+            )
+        # Raw Adaptive Card dict → rebuild via SDK when possible
+        if isinstance(result, dict) and result.get("type") == "AdaptiveCard":
+            try:
+                card = AdaptiveCard().with_version(str(result.get("version") or "1.4"))
+                # Prefer message response with a short status if body is complex;
+                # plugins that need a full replace should return AdaptiveCard.
+                title = "Done."
+                for block in result.get("body") or []:
+                    if isinstance(block, dict) and block.get("type") == "TextBlock":
+                        title = str(block.get("text") or title)
+                        break
+                return InvokeResponse(
+                    status=200,
+                    body=AdaptiveCardActionMessageResponse(value=title),
+                )
+            except Exception:
+                return InvokeResponse(
+                    status=200,
+                    body=AdaptiveCardActionMessageResponse(value="Done."),
+                )
+        return InvokeResponse(
+            status=200,
+            body=AdaptiveCardActionMessageResponse(value=str(result)),
         )
 
     async def send_exec_approval(

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1077,8 +1077,8 @@ class TeamsAdapter(BasePlatformAdapter):
                 body=AdaptiveCardActionMessageResponse(value="Unknown action."),
             )
 
-        # Cache conversation ref so proactive follow-ups (claim results, etc.)
-        # can land back in the same channel/thread.
+        # Cache conversation ref so proactive follow-ups can land back in the
+        # same channel/thread (same pattern as _on_message).
         conv_id = getattr(getattr(ctx.activity, "conversation", None), "id", None)
         if conv_id:
             self._conv_refs[conv_id] = ctx.conversation_ref
@@ -1113,9 +1113,9 @@ class TeamsAdapter(BasePlatformAdapter):
                     body=AdaptiveCardActionMessageResponse(value="⛔ Not authorized."),
                 )
 
-        # Plugin-registered Action.Execute handlers (firm workflows, etc.).
-        # Checked before built-in approvals so custom actions don't need a
-        # session_key. First matching non-None result wins.
+        # Plugin-registered Action.Execute handlers run before built-in
+        # approvals so custom actions don't need a session_key. Registration
+        # order; first non-None result wins (see register_teams_card_action_handler).
         plugin_response = await self._dispatch_plugin_card_action(
             hermes_action, ctx=ctx, data=data
         )
@@ -1183,7 +1183,12 @@ class TeamsAdapter(BasePlatformAdapter):
         ctx: "ActivityContext[AdaptiveCardInvokeActivity]",
         data: Dict[str, Any],
     ) -> "Optional[InvokeResponse]":
-        """Dispatch a card invoke to plugin-registered Teams handlers."""
+        """Dispatch a card invoke to plugin-registered Teams handlers.
+
+        Walks handlers in registration order. The first non-``None`` return
+        wins. A raised exception soft-fails (error message to Teams) and does
+        not continue to later handlers for the same action.
+        """
         try:
             from hermes_cli.plugins import get_plugin_manager
 
@@ -1218,7 +1223,16 @@ class TeamsAdapter(BasePlatformAdapter):
         return None
 
     def _coerce_card_action_response(self, result: Any) -> "InvokeResponse":
-        """Normalize plugin handler return values into an InvokeResponse."""
+        """Normalize plugin handler return values into an InvokeResponse.
+
+        Supported returns:
+        - ``InvokeResponse`` — passed through
+        - ``str`` — status message
+        - ``AdaptiveCard`` SDK object — full card replace
+        - raw AdaptiveCard ``dict`` — **status message only** (first TextBlock
+          text); return an ``AdaptiveCard`` instance for a full card replace
+        - anything else — ``str(result)`` as a status message
+        """
         if isinstance(result, InvokeResponse):
             return result
         if isinstance(result, str):
@@ -1226,32 +1240,26 @@ class TeamsAdapter(BasePlatformAdapter):
                 status=200,
                 body=AdaptiveCardActionMessageResponse(value=result),
             )
-        # AdaptiveCard SDK object
+        # AdaptiveCard SDK object — full card replace
         if AdaptiveCard is not None and isinstance(result, AdaptiveCard):
             return InvokeResponse(
                 status=200,
                 body=AdaptiveCardActionCardResponse(value=result),
             )
-        # Raw Adaptive Card dict → rebuild via SDK when possible
+        # Raw Adaptive Card dict → status text only (not a full card rebuild)
         if isinstance(result, dict) and result.get("type") == "AdaptiveCard":
+            title = "Done."
             try:
-                card = AdaptiveCard().with_version(str(result.get("version") or "1.4"))
-                # Prefer message response with a short status if body is complex;
-                # plugins that need a full replace should return AdaptiveCard.
-                title = "Done."
                 for block in result.get("body") or []:
                     if isinstance(block, dict) and block.get("type") == "TextBlock":
                         title = str(block.get("text") or title)
                         break
-                return InvokeResponse(
-                    status=200,
-                    body=AdaptiveCardActionMessageResponse(value=title),
-                )
             except Exception:
-                return InvokeResponse(
-                    status=200,
-                    body=AdaptiveCardActionMessageResponse(value="Done."),
-                )
+                title = "Done."
+            return InvokeResponse(
+                status=200,
+                body=AdaptiveCardActionMessageResponse(value=title),
+            )
         return InvokeResponse(
             status=200,
             body=AdaptiveCardActionMessageResponse(value=str(result)),

--- a/tests/gateway/test_teams_plugin_card_action_handlers.py
+++ b/tests/gateway/test_teams_plugin_card_action_handlers.py
@@ -1,0 +1,262 @@
+"""Tests for plugin-registered Teams Adaptive Card Action.Execute handlers."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_teams_mock() -> None:
+    if "microsoft_teams" in sys.modules and hasattr(sys.modules["microsoft_teams"], "__file__"):
+        return
+
+    microsoft_teams = types.ModuleType("microsoft_teams")
+    microsoft_teams_apps = types.ModuleType("microsoft_teams.apps")
+    microsoft_teams_api = types.ModuleType("microsoft_teams.api")
+    microsoft_teams_api_activities = types.ModuleType("microsoft_teams.api.activities")
+    microsoft_teams_api_activities_typing = types.ModuleType(
+        "microsoft_teams.api.activities.typing"
+    )
+    microsoft_teams_api_activities_invoke = types.ModuleType(
+        "microsoft_teams.api.activities.invoke"
+    )
+    microsoft_teams_api_activities_invoke_adaptive_card = types.ModuleType(
+        "microsoft_teams.api.activities.invoke.adaptive_card"
+    )
+    microsoft_teams_common = types.ModuleType("microsoft_teams.common")
+    microsoft_teams_common_http = types.ModuleType("microsoft_teams.common.http")
+    microsoft_teams_common_http_client = types.ModuleType(
+        "microsoft_teams.common.http.client"
+    )
+    microsoft_teams_api_models = types.ModuleType("microsoft_teams.api.models")
+    microsoft_teams_api_models_adaptive_card = types.ModuleType(
+        "microsoft_teams.api.models.adaptive_card"
+    )
+    microsoft_teams_api_models_invoke_response = types.ModuleType(
+        "microsoft_teams.api.models.invoke_response"
+    )
+    microsoft_teams_cards = types.ModuleType("microsoft_teams.cards")
+    microsoft_teams_apps_http = types.ModuleType("microsoft_teams.apps.http")
+    microsoft_teams_apps_http_adapter = types.ModuleType(
+        "microsoft_teams.apps.http.adapter"
+    )
+
+    class MockApp:
+        def __init__(self, **kwargs):
+            self._client_id = kwargs.get("client_id")
+
+        @property
+        def id(self):
+            return self._client_id
+
+        def on_message(self, func):
+            return func
+
+        def on_card_action(self, func):
+            return func
+
+        async def initialize(self):
+            pass
+
+        async def send(self, conversation_id, activity):
+            result = MagicMock()
+            result.id = "sent-activity-id"
+            return result
+
+    class MockAdaptiveCard:
+        def with_version(self, *_a, **_k):
+            return self
+
+        def with_body(self, *_a, **_k):
+            return self
+
+        def with_actions(self, *_a, **_k):
+            return self
+
+    class MockInvokeResponse:
+        def __init__(self, status=200, body=None):
+            self.status = status
+            self.body = body
+
+    class MockMessageResponse:
+        def __init__(self, value=""):
+            self.value = value
+
+    class MockCardResponse:
+        def __init__(self, value=None):
+            self.value = value
+
+    microsoft_teams_apps.App = MockApp
+    microsoft_teams_apps.ActivityContext = object
+    microsoft_teams_common_http_client.ClientOptions = MagicMock
+    microsoft_teams_api.MessageActivity = object
+    microsoft_teams_api.ConversationReference = object
+    microsoft_teams_api_activities_typing.TypingActivityInput = MagicMock
+    microsoft_teams_api_activities_invoke_adaptive_card.AdaptiveCardInvokeActivity = object
+    microsoft_teams_api_models_adaptive_card.AdaptiveCardActionCardResponse = MockCardResponse
+    microsoft_teams_api_models_adaptive_card.AdaptiveCardActionMessageResponse = (
+        MockMessageResponse
+    )
+    microsoft_teams_api_models_invoke_response.InvokeResponse = MockInvokeResponse
+    microsoft_teams_api_models_invoke_response.AdaptiveCardInvokeResponse = object
+    microsoft_teams_apps_http_adapter.HttpMethod = object
+    microsoft_teams_apps_http_adapter.HttpRequest = object
+    microsoft_teams_apps_http_adapter.HttpResponse = object
+    microsoft_teams_apps_http_adapter.HttpRouteHandler = object
+    microsoft_teams_cards.AdaptiveCard = MockAdaptiveCard
+    microsoft_teams_cards.ExecuteAction = MagicMock
+    microsoft_teams_cards.TextBlock = MagicMock
+
+    for name, mod in [
+        ("microsoft_teams", microsoft_teams),
+        ("microsoft_teams.apps", microsoft_teams_apps),
+        ("microsoft_teams.api", microsoft_teams_api),
+        ("microsoft_teams.api.activities", microsoft_teams_api_activities),
+        ("microsoft_teams.api.activities.typing", microsoft_teams_api_activities_typing),
+        ("microsoft_teams.api.activities.invoke", microsoft_teams_api_activities_invoke),
+        (
+            "microsoft_teams.api.activities.invoke.adaptive_card",
+            microsoft_teams_api_activities_invoke_adaptive_card,
+        ),
+        ("microsoft_teams.common", microsoft_teams_common),
+        ("microsoft_teams.common.http", microsoft_teams_common_http),
+        ("microsoft_teams.common.http.client", microsoft_teams_common_http_client),
+        ("microsoft_teams.api.models", microsoft_teams_api_models),
+        (
+            "microsoft_teams.api.models.adaptive_card",
+            microsoft_teams_api_models_adaptive_card,
+        ),
+        (
+            "microsoft_teams.api.models.invoke_response",
+            microsoft_teams_api_models_invoke_response,
+        ),
+        ("microsoft_teams.cards", microsoft_teams_cards),
+        ("microsoft_teams.apps.http", microsoft_teams_apps_http),
+        ("microsoft_teams.apps.http.adapter", microsoft_teams_apps_http_adapter),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+    sys.modules.setdefault("aiohttp", MagicMock())
+    sys.modules.setdefault("aiohttp.web", MagicMock())
+
+
+_ensure_teams_mock()
+
+from gateway.config import PlatformConfig  # noqa: E402
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest  # noqa: E402
+from plugins.platforms.teams import adapter as teams_mod  # noqa: E402
+
+teams_mod.TEAMS_SDK_AVAILABLE = True
+teams_mod.AIOHTTP_AVAILABLE = True
+teams_mod.App = sys.modules["microsoft_teams.apps"].App
+teams_mod.InvokeResponse = sys.modules[
+    "microsoft_teams.api.models.invoke_response"
+].InvokeResponse
+teams_mod.AdaptiveCardActionMessageResponse = sys.modules[
+    "microsoft_teams.api.models.adaptive_card"
+].AdaptiveCardActionMessageResponse
+teams_mod.AdaptiveCardActionCardResponse = sys.modules[
+    "microsoft_teams.api.models.adaptive_card"
+].AdaptiveCardActionCardResponse
+teams_mod.AdaptiveCard = sys.modules["microsoft_teams.cards"].AdaptiveCard
+teams_mod.TextBlock = sys.modules["microsoft_teams.cards"].TextBlock
+teams_mod.ExecuteAction = sys.modules["microsoft_teams.cards"].ExecuteAction
+
+
+def _make_ctx(name: str = "test_plugin") -> tuple[PluginManager, PluginContext]:
+    mgr = PluginManager()
+    manifest = PluginManifest(name=name, version="0.1.0", description="test")
+    return mgr, PluginContext(manifest=manifest, manager=mgr)
+
+
+class TestRegisterTeamsCardActionHandlerAPI:
+    def test_string_action_is_queued(self):
+        mgr, ctx = _make_ctx()
+
+        async def cb(*, ctx, data, adapter):  # pragma: no cover
+            return "ok"
+
+        ctx.register_teams_card_action_handler("claim_referral", cb)
+        handlers = mgr.get_teams_card_action_handlers()
+        assert len(handlers) == 1
+        assert handlers[0][0] == "claim_referral"
+        assert handlers[0][2] == "test_plugin"
+
+    def test_empty_action_rejected(self):
+        _, ctx = _make_ctx()
+
+        async def cb(*, ctx, data, adapter):  # pragma: no cover
+            return None
+
+        with pytest.raises(ValueError, match="empty hermes_action"):
+            ctx.register_teams_card_action_handler("  ", cb)
+
+
+@pytest.mark.asyncio
+async def test_card_action_dispatches_plugin_handler(monkeypatch):
+    monkeypatch.setenv("TEAMS_ALLOW_ALL_USERS", "true")
+    mgr, pctx = _make_ctx("laborde")
+    seen = {}
+
+    async def cb(*, ctx, data, adapter):
+        seen["pnc"] = data.get("pnc_id")
+        return f"claimed {data.get('pnc_id')}"
+
+    pctx.register_teams_card_action_handler("claim_referral", cb)
+
+    adapter = teams_mod.TeamsAdapter(
+        PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y", "tenant_id": "z"})
+    )
+    adapter._conv_refs = {}
+
+    activity = SimpleNamespace(
+        value=SimpleNamespace(
+            action=SimpleNamespace(
+                data={"hermes_action": "claim_referral", "pnc_id": "PNC-1"}
+            )
+        ),
+        conversation=SimpleNamespace(id="19:channel@thread.tacv2"),
+        from_=SimpleNamespace(aad_object_id="user-1", id="user-1"),
+    )
+    ctx = SimpleNamespace(activity=activity, conversation_ref="ref-1")
+
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=mgr):
+        resp = await adapter._on_card_action(ctx)
+
+    assert seen["pnc"] == "PNC-1"
+    assert resp.body.value == "claimed PNC-1"
+    assert adapter._conv_refs["19:channel@thread.tacv2"] == "ref-1"
+
+
+@pytest.mark.asyncio
+async def test_card_action_plugin_exception_is_soft(monkeypatch):
+    monkeypatch.setenv("TEAMS_ALLOW_ALL_USERS", "true")
+    mgr, pctx = _make_ctx("boom")
+
+    async def cb(*, ctx, data, adapter):
+        raise RuntimeError("nope")
+
+    pctx.register_teams_card_action_handler("claim_referral", cb)
+    adapter = teams_mod.TeamsAdapter(
+        PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y", "tenant_id": "z"})
+    )
+    activity = SimpleNamespace(
+        value=SimpleNamespace(
+            action=SimpleNamespace(data={"hermes_action": "claim_referral", "pnc_id": "PNC-1"})
+        ),
+        conversation=SimpleNamespace(id="c1"),
+        from_=SimpleNamespace(aad_object_id="u", id="u"),
+    )
+    ctx = SimpleNamespace(activity=activity, conversation_ref="r")
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=mgr):
+        resp = await adapter._on_card_action(ctx)
+    assert "Action failed" in resp.body.value

--- a/tests/gateway/test_teams_plugin_card_action_handlers.py
+++ b/tests/gateway/test_teams_plugin_card_action_handlers.py
@@ -185,10 +185,10 @@ class TestRegisterTeamsCardActionHandlerAPI:
         async def cb(*, ctx, data, adapter):  # pragma: no cover
             return "ok"
 
-        ctx.register_teams_card_action_handler("claim_referral", cb)
+        ctx.register_teams_card_action_handler("claim_item", cb)
         handlers = mgr.get_teams_card_action_handlers()
         assert len(handlers) == 1
-        assert handlers[0][0] == "claim_referral"
+        assert handlers[0][0] == "claim_item"
         assert handlers[0][2] == "test_plugin"
 
     def test_empty_action_rejected(self):
@@ -204,14 +204,14 @@ class TestRegisterTeamsCardActionHandlerAPI:
 @pytest.mark.asyncio
 async def test_card_action_dispatches_plugin_handler(monkeypatch):
     monkeypatch.setenv("TEAMS_ALLOW_ALL_USERS", "true")
-    mgr, pctx = _make_ctx("laborde")
+    mgr, pctx = _make_ctx("demo_plugin")
     seen = {}
 
     async def cb(*, ctx, data, adapter):
-        seen["pnc"] = data.get("pnc_id")
-        return f"claimed {data.get('pnc_id')}"
+        seen["item_id"] = data.get("item_id")
+        return f"claimed {data.get('item_id')}"
 
-    pctx.register_teams_card_action_handler("claim_referral", cb)
+    pctx.register_teams_card_action_handler("claim_item", cb)
 
     adapter = teams_mod.TeamsAdapter(
         PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y", "tenant_id": "z"})
@@ -221,7 +221,7 @@ async def test_card_action_dispatches_plugin_handler(monkeypatch):
     activity = SimpleNamespace(
         value=SimpleNamespace(
             action=SimpleNamespace(
-                data={"hermes_action": "claim_referral", "pnc_id": "PNC-1"}
+                data={"hermes_action": "claim_item", "item_id": "ITEM-1"}
             )
         ),
         conversation=SimpleNamespace(id="19:channel@thread.tacv2"),
@@ -232,8 +232,8 @@ async def test_card_action_dispatches_plugin_handler(monkeypatch):
     with patch("hermes_cli.plugins.get_plugin_manager", return_value=mgr):
         resp = await adapter._on_card_action(ctx)
 
-    assert seen["pnc"] == "PNC-1"
-    assert resp.body.value == "claimed PNC-1"
+    assert seen["item_id"] == "ITEM-1"
+    assert resp.body.value == "claimed ITEM-1"
     assert adapter._conv_refs["19:channel@thread.tacv2"] == "ref-1"
 
 
@@ -245,13 +245,13 @@ async def test_card_action_plugin_exception_is_soft(monkeypatch):
     async def cb(*, ctx, data, adapter):
         raise RuntimeError("nope")
 
-    pctx.register_teams_card_action_handler("claim_referral", cb)
+    pctx.register_teams_card_action_handler("claim_item", cb)
     adapter = teams_mod.TeamsAdapter(
         PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y", "tenant_id": "z"})
     )
     activity = SimpleNamespace(
         value=SimpleNamespace(
-            action=SimpleNamespace(data={"hermes_action": "claim_referral", "pnc_id": "PNC-1"})
+            action=SimpleNamespace(data={"hermes_action": "claim_item", "item_id": "ITEM-1"})
         ),
         conversation=SimpleNamespace(id="c1"),
         from_=SimpleNamespace(aad_object_id="u", id="u"),
@@ -260,3 +260,34 @@ async def test_card_action_plugin_exception_is_soft(monkeypatch):
     with patch("hermes_cli.plugins.get_plugin_manager", return_value=mgr):
         resp = await adapter._on_card_action(ctx)
     assert "Action failed" in resp.body.value
+
+
+@pytest.mark.asyncio
+async def test_card_action_unauthorized_skips_plugin_handler(monkeypatch):
+    """Plugin handlers must not run when the clicker fails the auth gate."""
+    monkeypatch.delenv("TEAMS_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.setenv("TEAMS_ALLOWED_USERS", "allowed-user")
+    mgr, pctx = _make_ctx("demo_plugin")
+    called = {"n": 0}
+
+    async def cb(*, ctx, data, adapter):
+        called["n"] += 1
+        return "should not run"
+
+    pctx.register_teams_card_action_handler("claim_item", cb)
+    adapter = teams_mod.TeamsAdapter(
+        PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y", "tenant_id": "z"})
+    )
+    activity = SimpleNamespace(
+        value=SimpleNamespace(
+            action=SimpleNamespace(data={"hermes_action": "claim_item", "item_id": "ITEM-1"})
+        ),
+        conversation=SimpleNamespace(id="c1"),
+        from_=SimpleNamespace(aad_object_id="other-user", id="other-user"),
+    )
+    ctx = SimpleNamespace(activity=activity, conversation_ref="r")
+    with patch("hermes_cli.plugins.get_plugin_manager", return_value=mgr):
+        resp = await adapter._on_card_action(ctx)
+
+    assert called["n"] == 0
+    assert "Not authorized" in resp.body.value


### PR DESCRIPTION
## Summary
- Adds `PluginContext.register_teams_card_action_handler` (mirrors Slack’s Block Kit action registration) so plugins can bind Teams Adaptive Card `Action.Execute` callbacks by `hermes_action`.
- Teams adapter dispatches plugin handlers **before** built-in approval actions, caches conversation refs for channel replies (same pattern as `_on_message`), and soft-fails plugin errors so the gateway stays up.
- Includes unit tests for registration, dispatch, soft-fail, and the auth gate.

## Review follow-ups
- Docstring now matches code (before approvals, not after) and documents first-wins registration order + raise short-circuit.
- Raw AdaptiveCard `dict` returns are documented as status-text only (first TextBlock); return an `AdaptiveCard` SDK object for a full card replace.
- `_conv_refs` write on card invoke mirrors the existing unbounded message-path cache — no new LRU in this PR.
- Added `test_card_action_unauthorized_skips_plugin_handler`.

## Test plan
- [x] `tests/gateway/test_teams_plugin_card_action_handlers.py` (register + dispatch + soft-fail + unauthorized)
- [ ] Gateway with a plugin registering a custom `hermes_action` — click `Action.Execute` in a Teams channel card and confirm invoke + channel reply
- [ ] Existing Teams approval cards still approve/deny as before