### PR TITLE
fix: voice dictation broken in profiles created via profiles.create (missing stt/tts config)

### DIFF
--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -250,11 +250,22 @@ def _(rid, params: dict) -> dict:
         freshly created profile has only a ``model`` section, so voice fell
         back to defaults (local whisper, often not installed) and dictation
         "didn't work in bot mode" while working on the primary profile.
+
+        Reads/writes go through the canonical loaders scoped to the target
+        profile via the context-local HERMES_HOME override — the same
+        mechanism as ``_write_profile_model`` (config-read-guard: no raw
+        yaml on config.yaml).
         """
         try:
-            import yaml as _yaml
-
-            from hermes_cli.config import load_config_readonly
+            from hermes_cli.config import (
+                load_config_readonly,
+                read_user_config_raw,
+                save_config,
+            )
+            from hermes_constants import (
+                reset_hermes_home_override,
+                set_hermes_home_override,
+            )
 
             src_cfg = load_config_readonly() or {}
             sections = {
@@ -263,22 +274,22 @@ def _(rid, params: dict) -> dict:
             if not sections:
                 return False
 
-            cfg_path = path / "config.yaml"
-            dst_cfg = {}
-            if cfg_path.exists():
-                dst_cfg = _yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
-            changed = False
-            for key, value in sections.items():
-                if key not in dst_cfg:
-                    dst_cfg[key] = value
-                    changed = True
-            if changed:
-                tmp = cfg_path.with_suffix(".yaml.tmp")
-                tmp.write_text(
-                    _yaml.safe_dump(dst_cfg, sort_keys=False, allow_unicode=True),
-                    encoding="utf-8",
-                )
-                tmp.replace(cfg_path)
+            token = set_hermes_home_override(str(path))
+            try:
+                # Write-back round-trip on the raw file: load_config() would
+                # merge DEFAULT_CONFIG, making every section look present and
+                # the mirror a no-op (and save_config would then persist the
+                # entire default tree into the fresh profile).
+                dst_cfg = read_user_config_raw() or {}
+                changed = False
+                for key, value in sections.items():
+                    if key not in dst_cfg:
+                        dst_cfg[key] = value
+                        changed = True
+                if changed:
+                    save_config(dst_cfg)
+            finally:
+                reset_hermes_home_override(token)
             return changed
         except Exception:
             return False

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -206,7 +206,7 @@ def _(rid, params: dict) -> dict:
     # .env (only over the seeded comment-only stub — never clobber real
     # secrets a clone brought along) and auth.json (only when absent), then
     # inherit model.provider/model.default unless the caller pinned a model.
-    mirrored = {"env": False, "auth": False, "model_inherited": False}
+    mirrored = {"env": False, "auth": False, "model_inherited": False, "voice": False}
     if is_truthy_value(params.get("mirror_credentials", True)):
         import shutil
 
@@ -241,6 +241,51 @@ def _(rid, params: dict) -> dict:
     model = str(params.get("model") or "").strip()
     provider = str(params.get("provider") or "").strip()
     model_set = False
+
+    def _mirror_voice_sections() -> bool:
+        """Copy voice config (stt/tts/voice) from the launch profile.
+
+        Desktop dictation and TTS are profile-scoped: /api/audio/transcribe
+        resolves the ``stt`` section inside the TARGET profile's home. A
+        freshly created profile has only a ``model`` section, so voice fell
+        back to defaults (local whisper, often not installed) and dictation
+        "didn't work in bot mode" while working on the primary profile.
+        """
+        try:
+            import yaml as _yaml
+
+            from hermes_cli.config import load_config_readonly
+
+            src_cfg = load_config_readonly() or {}
+            sections = {
+                k: src_cfg[k] for k in ("stt", "tts", "voice") if src_cfg.get(k)
+            }
+            if not sections:
+                return False
+
+            cfg_path = path / "config.yaml"
+            dst_cfg = {}
+            if cfg_path.exists():
+                dst_cfg = _yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+            changed = False
+            for key, value in sections.items():
+                if key not in dst_cfg:
+                    dst_cfg[key] = value
+                    changed = True
+            if changed:
+                tmp = cfg_path.with_suffix(".yaml.tmp")
+                tmp.write_text(
+                    _yaml.safe_dump(dst_cfg, sort_keys=False, allow_unicode=True),
+                    encoding="utf-8",
+                )
+                tmp.replace(cfg_path)
+            return changed
+        except Exception:
+            return False
+
+    if is_truthy_value(params.get("mirror_credentials", True)):
+        mirrored["voice"] = _mirror_voice_sections()
+
     if model and provider:
         try:
             from hermes_cli.web_routers.profiles import _write_profile_model


### PR DESCRIPTION
Desktop dictation is profile-scoped: `/api/audio/transcribe` runs `transcribe_recording` under `_config_profile_scope(profile)`, resolving the `stt` section from the TARGET profile's config.yaml. Profiles created via `profiles.create` (#85093) get only a `model` section — so STT falls back to defaults and dictation breaks in every created-profile chat while working fine on the primary ('voice dictation doesn't work in bot mode but is fine in regular mode' — Bot Mode user report).

Fix: mirror the launch profile's `stt`/`tts`/`voice` config sections into the new profile, key-wise (sections a clone already carries are never overwritten), gated on the same `mirror_credentials` flag as .env/auth mirroring, reported as `mirrored.voice`.

Verified live: profiles.create → new profile's config.yaml carries stt+tts+model → cleanup. Same pattern as the #85111 credential mirroring.