### PR TITLE
fix(config): recognize agent.reasoning_effort as a known key

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -282,6 +282,11 @@ DEFAULT_CONFIG = {
         "image_input_mode": "auto",
         "disabled_toolsets": [],
 
+        # Global reasoning effort: none|minimal|low|medium|high|xhigh|max|ultra
+        # (empty = provider default). Read by the CLI/gateway at session start
+        # (cli.py _parse_reasoning_config). Sits alongside reasoning_overrides,
+        # which takes precedence when the current model matches a key in it.
+        "reasoning_effort": "",
         # Per-model reasoning effort overrides (spelling-tolerant).
         # Dict mapping model names (any reasonable spelling) to effort levels.
         # Takes precedence over agent.reasoning_effort when the current model

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -111,6 +111,13 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "script_timeout_seconds: 600" in _read_config(_isolated_hermes_home)
 
+    def test_agent_reasoning_effort_is_recognized(self, _isolated_hermes_home, capsys):
+        """The global agent.reasoning_effort scalar must not trip the unknown-key warning."""
+        set_config_value("agent.reasoning_effort", "high")
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+        assert "reasoning_effort: high" in _read_config(_isolated_hermes_home)
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)


### PR DESCRIPTION
Fixes #85741

`hermes config set agent.reasoning_effort high` saved the value but emitted a false
"not a recognized config key" warning suggesting `agent.reasoning_overrides`.

## Root cause
`hermes_cli/config.py` `_validate_config_key()` walks `DEFAULT_CONFIG` to decide whether
a dotted key is recognized. The `agent` section declared `reasoning_overrides` (the
per-model mapping) but not the global scalar `agent.reasoning_effort`, even though that
scalar is read at runtime at session start (`cli.py` → `_parse_reasoning_config(...)`
→ `CLI_CONFIG["agent"].get("reasoning_effort", "")`). The key is honored at runtime but
was misreported as unknown by the CLI, complete with a misleading "did you mean"
hint pointing at the per-model mapping.

## Fix
Add the documented `agent.reasoning_effort` default (`""`) to `DEFAULT_CONFIG["agent"]`,
alongside `reasoning_overrides`. The recognizer now accepts the scalar key without a
warning; the value remains written to and read from `config.yaml` exactly as before.

## Validation
- New regression test `test_agent_reasoning_effort_is_recognized` reproduces the bug
  (pre-fix it fails with the exact warning text) and passes post-fix.
- Full `tests/hermes_cli/test_set_config_value.py`: 84 passed.
- `ruff check` on `hermes_cli/config_defaults.py` and the test file: clean.