### PR TITLE
fix(telegram): rebind TypeHandler after lazy install

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -415,7 +415,7 @@ def check_telegram_requirements() -> bool:
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
-    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler, TypeHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -435,7 +435,7 @@ def check_telegram_requirements() -> bool:
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
             MessageHandler as _MH,
-            ContextTypes as _CT, filters as _filters,
+            ContextTypes as _CT, TypeHandler as _TH, filters as _filters,
         )
         from telegram.constants import ParseMode as _PM, ChatType as _CtT
         from telegram.request import HTTPXRequest as _HR
@@ -451,6 +451,7 @@ def check_telegram_requirements() -> bool:
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
     TelegramMessageHandler = _MH
+    TypeHandler = _TH
     ContextTypes = _CT
     filters = _filters
     ParseMode = _PM

--- a/tests/gateway/test_telegram_connect.py
+++ b/tests/gateway/test_telegram_connect.py
@@ -54,3 +54,17 @@ class TestTelegramUnconfiguredNonRetryable:
         assert adapter.fatal_error_retryable is False
         assert adapter.fatal_error_code == "missing_dependency"
 
+
+def test_lazy_install_rebinds_type_handler(monkeypatch):
+    """A transient missing SDK import must not leave TypeHandler as typing.Any."""
+    import typing
+
+    import tools.lazy_deps
+    from telegram.ext import TypeHandler
+
+    monkeypatch.setattr(telegram_mod, "TELEGRAM_AVAILABLE", False)
+    monkeypatch.setattr(telegram_mod, "TypeHandler", typing.Any)
+    monkeypatch.setattr(tools.lazy_deps, "ensure", lambda *_args, **_kwargs: None)
+
+    assert telegram_mod.check_telegram_requirements() is True
+    assert telegram_mod.TypeHandler is TypeHandler


### PR DESCRIPTION
## Summary

Fixes the deferred Telegram SDK import path: after `check_telegram_requirements()` installs and reloads python-telegram-bot, `TypeHandler` was the only module alias not rebound. It therefore remained `typing.Any`, and gateway startup failed with `TypeError: Any cannot be instantiated` when registering the handler.

This patch restores `TypeHandler` alongside its sibling aliases and adds a regression test for the deferred/lazy-install path.

## Production impact

Observed during an OCI Hermes auto-update: Telegram failed to reconnect until the gateway process was fully restarted. A rollback restored polling immediately.

## Validation

- 551 Telegram tests passed
- ruff passed

## Related work

This independently reproduces and extends #85421 with a targeted regression test for the exact deferred-import failure mode.
