### PR TITLE
fix(feishu): fall back from stale topics

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -161,6 +161,8 @@ def _get_scoped_secret(name, default=None):
 
 logger = logging.getLogger(__name__)
 
+_FEISHU_THREAD_FALLBACK_CODES = frozenset({99992402})
+
 # ---------------------------------------------------------------------------
 # Regex patterns
 # ---------------------------------------------------------------------------
@@ -4846,22 +4848,34 @@ class FeishuAdapter(BasePlatformAdapter):
                 uuid_value=str(uuid.uuid4()),
             )
             request = self._build_create_message_request("thread_id", body)
-        else:
-            receive_id = chat_id
-            receive_id_type = "chat_id"
-            if chat_id.startswith("feishu_user_id:"):
-                receive_id = chat_id.split(":", 1)[1]
-                receive_id_type = "user_id"
-            elif chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
-
-            body = self._build_create_message_body(
-                receive_id=receive_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
+            response = await self._run_blocking(self._client.im.v1.message.create, request)
+            if (
+                self._response_succeeded(response)
+                or getattr(response, "code", None) not in _FEISHU_THREAD_FALLBACK_CODES
+            ):
+                return response
+            logger.warning(
+                "[Feishu] Thread %s is unavailable (code=%s); retrying in parent chat %s",
+                _thread_id,
+                getattr(response, "code", None),
+                chat_id,
             )
-            request = self._build_create_message_request(receive_id_type, body)
+
+        receive_id = chat_id
+        receive_id_type = "chat_id"
+        if chat_id.startswith("feishu_user_id:"):
+            receive_id = chat_id.split(":", 1)[1]
+            receive_id_type = "user_id"
+        elif chat_id.startswith("ou_"):
+            receive_id_type = "open_id"
+
+        body = self._build_create_message_body(
+            receive_id=receive_id,
+            msg_type=msg_type,
+            content=payload,
+            uuid_value=str(uuid.uuid4()),
+        )
+        request = self._build_create_message_request(receive_id_type, body)
         return await self._run_blocking(self._client.im.v1.message.create, request)
 
     @staticmethod

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1248,6 +1248,56 @@ class TestAdapterBehavior(unittest.TestCase):
 
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_raw_message_falls_back_to_parent_chat_when_thread_is_invalid(self):
+        """A stale Feishu topic must not make a normal outbound message disappear."""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = []
+
+        class _MessageAPI:
+            def create(self, request):
+                captured.append(request)
+                if len(captured) == 1:
+                    return SimpleNamespace(success=lambda: False, code=99992402)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    code=0,
+                    data=SimpleNamespace(message_id="om_parent_fallback"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            response = asyncio.run(
+                adapter._send_raw_message(
+                    chat_id="oc_parent",
+                    msg_type="text",
+                    payload=json.dumps({"text": "hello"}),
+                    reply_to=None,
+                    metadata={"thread_id": "omt_stale"},
+                )
+            )
+
+        self.assertTrue(response.success())
+        self.assertEqual(len(captured), 2)
+        self.assertEqual(captured[0].receive_id_type, "thread_id")
+        self.assertEqual(captured[0].request_body.receive_id, "omt_stale")
+        self.assertEqual(captured[1].receive_id_type, "chat_id")
+        self.assertEqual(captured[1].request_body.receive_id, "oc_parent")
+
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_post_for_every_chunk_of_multi_chunk_markdown(self):
         """Regression for #26841: when a long Markdown message is split
         across multiple chunks, every chunk must go out as
@@ -2465,5 +2515,4 @@ class TestChatLockEviction(unittest.TestCase):
 
         adapter = self._make_adapter()
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
-
 


### PR DESCRIPTION
## Summary
- retry a generic Feishu outbound create in the parent chat when a stale thread returns code `99992402`
- preserve the existing `chat_id`, `user_id`, and `open_id` routing semantics for the fallback
- add a behavior-level regression test through `_send_raw_message`

## Why
The audio path already handles this Feishu error, but normal text/post sends can disappear when a saved topic is invalid or expired. This keeps other failure codes unchanged and only falls back for the known stale-thread response.

## Verification
- focused regression test passes on current `main`
- Ruff passes for both changed files
- stable v2026.8.13 Feishu suite: 76 passed; one environment-specific pre-existing SSRF/proxy test failure is unrelated to this patch