### PR TITLE
fix(cron): clear tool-definition availability caches after dotenv reload

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2175,9 +2175,18 @@ def _reload_dotenv_and_publish_delivery_target(job: dict) -> None:
     # (only the placeholder reloads -> 401s).
     from hermes_cli.env_loader import load_hermes_dotenv, reset_secret_source_cache
     from gateway.session_context import _VAR_MAP
+    from model_tools import _clear_tool_defs_cache
 
     reset_secret_source_cache()
     load_hermes_dotenv(hermes_home=_get_hermes_home())
+    # .env may have changed TAVILY_API_KEY, web backend selection, or other
+    # check_fn-gated env vars. get_tool_definitions() memoizes quiet_mode=True
+    # results with a key that does not include env state, so a stale pre-.env
+    # cache would permanently hide tools that the freshly-loaded env now makes
+    # available (e.g. web_search in a cron job with
+    # enabled_toolsets=["web","file"]). Clear the cache every time cron
+    # re-reads the environment (#82912).
+    _clear_tool_defs_cache()
 
     delivery_target = _resolve_delivery_target(job)
     if delivery_target:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2176,20 +2176,16 @@ def _reload_dotenv_and_publish_delivery_target(job: dict) -> None:
     from hermes_cli.env_loader import load_hermes_dotenv, reset_secret_source_cache
     from gateway.session_context import _VAR_MAP
     from model_tools import _clear_tool_defs_cache
+    from tools.registry import invalidate_check_fn_cache
 
     reset_secret_source_cache()
     load_hermes_dotenv(hermes_home=_get_hermes_home())
     # Dotenv reload and tool-schema invalidation form one cache-coherence
-    # boundary. The schema cache is process-global and its key deliberately
-    # excludes env state, so keep this invalidation adjacent to the reload
-    # instead of treating it as a per-job detail that can drift away.
-    # .env may have changed TAVILY_API_KEY, web backend selection, or other
-    # check_fn-gated env vars. get_tool_definitions() memoizes quiet_mode=True
-    # results with a key that does not include env state, so a stale pre-.env
-    # cache would permanently hide tools that the freshly-loaded env now makes
-    # available (e.g. web_search in a cron job with
-    # enabled_toolsets=["web","file"]). Clear the cache every time cron
-    # re-reads the environment (#82912).
+    # boundary. The schema cache and the lower-level availability cache are
+    # separate, and both keys deliberately exclude env state. Clear both after
+    # every reload so newly available tools are visible while preserving the
+    # registry's transient-failure semantics elsewhere (#82912).
+    invalidate_check_fn_cache()
     _clear_tool_defs_cache()
 
     delivery_target = _resolve_delivery_target(job)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2179,6 +2179,10 @@ def _reload_dotenv_and_publish_delivery_target(job: dict) -> None:
 
     reset_secret_source_cache()
     load_hermes_dotenv(hermes_home=_get_hermes_home())
+    # Dotenv reload and tool-schema invalidation form one cache-coherence
+    # boundary. The schema cache is process-global and its key deliberately
+    # excludes env state, so keep this invalidation adjacent to the reload
+    # instead of treating it as a per-job detail that can drift away.
     # .env may have changed TAVILY_API_KEY, web backend selection, or other
     # check_fn-gated env vars. get_tool_definitions() memoizes quiet_mode=True
     # results with a key that does not include env state, so a stale pre-.env

--- a/model_tools.py
+++ b/model_tools.py
@@ -18,7 +18,7 @@ import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
 
-from tools.registry import CHECK_FN_CACHE_BYPASS, check_fn_cache_scope, discover_builtin_tools, invalidate_check_fn_cache, registry, tool_error
+from tools.registry import CHECK_FN_CACHE_BYPASS, check_fn_cache_scope, discover_builtin_tools, registry, tool_error
 from tools.registry import _MAX_TOOL_ERROR_CHARS as _TOOL_ERROR_MAX_LEN
 from toolsets import resolve_toolset, validate_toolset
 from tools.arg_coercion import coerce_tool_args
@@ -209,15 +209,9 @@ _TOOL_DEFS_CACHE_MAX = 8
 def _clear_tool_defs_cache() -> None:
     """Drop memoized results when a dynamic-schema dependency changes (discord caps, sandbox mode).
 
-    Also called by cron after every dotenv reload: this cache is process-global
-    rather than per-session, so invalidating a concurrent interactive or gateway
-    lookup is intentional — the next lookup recomputes both the availability
-    probes and the schema snapshot through their synchronized cache paths.
+    Callers that also changed environment-backed availability probes must
+    invalidate the registry's separate check-function cache explicitly.
     """
-    # Invalidate the underlying availability probes first, so any lookup that
-    # starts after this boundary re-probes dependencies before rebuilding its
-    # schema snapshot.
-    invalidate_check_fn_cache()
     with _tool_defs_cache_lock:
         _tool_defs_cache.clear()
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -18,7 +18,7 @@ import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
 
-from tools.registry import CHECK_FN_CACHE_BYPASS, check_fn_cache_scope, discover_builtin_tools, registry, tool_error
+from tools.registry import CHECK_FN_CACHE_BYPASS, check_fn_cache_scope, discover_builtin_tools, invalidate_check_fn_cache, registry, tool_error
 from tools.registry import _MAX_TOOL_ERROR_CHARS as _TOOL_ERROR_MAX_LEN
 from toolsets import resolve_toolset, validate_toolset
 from tools.arg_coercion import coerce_tool_args
@@ -191,7 +191,10 @@ _LEGACY_TOOLSET_MAP = {
 # non-quiet path prints). Hot callers (gateway runner, AIAgent.__init__) hit it
 # every turn; a miss costs ~7 ms of registry walk + check_fn probing. The key
 # includes registry._generation (bumped on register/deregister/alias) so
-# invalidation is transparent; check_fn drift is handled by registry.py's 30 s TTL.
+# invalidation is transparent; check_fn drift is handled by registry.py's 30 s
+# TTL. The key intentionally does not include environment state: callers that
+# reload environment files in a long-lived process, such as cron, must
+# explicitly call _clear_tool_defs_cache() after the reload.
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
 _tool_defs_cache_lock = threading.Lock()
 # FIFO cap: 8 covers a long-lived gateway's warm set of platform/toolset combos.
@@ -204,7 +207,17 @@ _TOOL_DEFS_CACHE_MAX = 8
 
 
 def _clear_tool_defs_cache() -> None:
-    """Drop memoized results when a dynamic-schema dependency changes (discord caps, sandbox mode)."""
+    """Drop memoized results when a dynamic-schema dependency changes (discord caps, sandbox mode).
+
+    Also called by cron after every dotenv reload: this cache is process-global
+    rather than per-session, so invalidating a concurrent interactive or gateway
+    lookup is intentional — the next lookup recomputes both the availability
+    probes and the schema snapshot through their synchronized cache paths.
+    """
+    # Invalidate the underlying availability probes first, so any lookup that
+    # starts after this boundary re-probes dependencies before rebuilding its
+    # schema snapshot.
+    invalidate_check_fn_cache()
     with _tool_defs_cache_lock:
         _tool_defs_cache.clear()
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -8,6 +8,7 @@ import os
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
+import model_tools
 
 from cron.scheduler import (
     SILENT_MARKER,
@@ -1157,6 +1158,43 @@ class TestRunJobConfigEnvVarExpansion:
         assert kwargs["model"] == "gpt-4o-mini-cron-test", (
             f"Expected model='gpt-4o-mini-cron-test', got {kwargs['model']!r}. "
             "config.yaml ${VAR} was not expanded in the cron execution path."
+        )
+
+    def test_tool_definitions_cache_is_cleared_after_dotenv_reload(self, tmp_path):
+        """Loading .env before a cron job must invalidate the tool-defs cache.
+
+        get_tool_definitions(quiet_mode=True) memoizes results with a key
+        that does not include env state. A previous call made before
+        TAVILY_API_KEY was available can cache a web/file-only result that
+        excludes web_search/web_extract. When cron re-reads .env each tick
+        it must drop that stale cache so the freshly loaded env is reflected
+        in the agent's tool list (#82912).
+        """
+        model_tools._clear_tool_defs_cache()
+        model_tools._tool_defs_cache[("stale-key",)] = [
+            {"type": "function", "function": {"name": "stale_tool"}}
+        ]
+
+        job = {"id": "cache-clear-job", "name": "cache test", "prompt": "hi"}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert not model_tools._tool_defs_cache, (
+            "run_job must clear model_tools._tool_defs_cache after reloading .env"
         )
 
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1160,42 +1160,85 @@ class TestRunJobConfigEnvVarExpansion:
             "config.yaml ${VAR} was not expanded in the cron execution path."
         )
 
-    def test_tool_definitions_cache_is_cleared_after_dotenv_reload(self, tmp_path):
-        """Loading .env before a cron job must invalidate the tool-defs cache.
+    def test_tool_definitions_cache_is_cleared_after_dotenv_reload(
+        self, tmp_path, monkeypatch
+    ):
+        """A cron dotenv reload must expose newly available tools (#82912).
 
-        get_tool_definitions(quiet_mode=True) memoizes results with a key
-        that does not include env state. A previous call made before
-        TAVILY_API_KEY was available can cache a web/file-only result that
-        excludes web_search/web_extract. When cron re-reads .env each tick
-        it must drop that stale cache so the freshly loaded env is reflected
-        in the agent's tool list (#82912).
+        Seed the real quiet-mode cache before ``TAVILY_API_KEY`` exists, then
+        run a cron job whose real tool-definition lookup happens after the
+        reload. This verifies the user-visible agent toolset rather than only
+        inspecting the private cache dictionary.
         """
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  default: gpt-4o-mini-cron-test\n"
+            "web:\n  backend: tavily\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+        from tools import web_tools
+
+        # Keep the test independent of packages or credentials installed on
+        # the developer machine. Tavily remains the only availability signal.
+        def tavily_only_backend_available(backend):
+            return backend == "tavily" and bool(os.environ.get("TAVILY_API_KEY"))
+
         model_tools._clear_tool_defs_cache()
-        model_tools._tool_defs_cache[("stale-key",)] = [
-            {"type": "function", "function": {"name": "stale_tool"}}
-        ]
+        with patch.object(
+            web_tools,
+            "_is_backend_available",
+            side_effect=tavily_only_backend_available,
+        ), patch(
+            "agent.web_search_registry.get_active_search_provider",
+            return_value=None,
+        ), patch(
+            "agent.web_search_registry.get_active_extract_provider",
+            return_value=None,
+        ):
+            stale_tools = model_tools.get_tool_definitions(
+                enabled_toolsets=["web", "file"], quiet_mode=True
+            )
+            stale_names = {tool["function"]["name"] for tool in stale_tools}
+            assert "web_search" not in stale_names
+            (tmp_path / ".env").write_text("TAVILY_API_KEY=cron-test-key\n")
 
-        job = {"id": "cache-clear-job", "name": "cache test", "prompt": "hi"}
-        fake_db = MagicMock()
+            created_agents = []
 
-        with patch("cron.scheduler._hermes_home", tmp_path), \
-             patch("cron.scheduler._resolve_origin", return_value=None), \
-             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
-             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
-             patch("hermes_state.SessionDB", return_value=fake_db), \
-             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
-                   return_value=self._RUNTIME), \
-             patch("run_agent.AIAgent") as mock_agent_cls:
-            mock_agent = MagicMock()
-            mock_agent.run_conversation.return_value = {"final_response": "ok"}
-            mock_agent_cls.return_value = mock_agent
-            success, _, _, error = run_job(job)
+            def build_agent(**kwargs):
+                agent = MagicMock()
+                agent.tools = model_tools.get_tool_definitions(
+                    enabled_toolsets=kwargs["enabled_toolsets"],
+                    disabled_toolsets=kwargs["disabled_toolsets"],
+                    quiet_mode=kwargs["quiet_mode"],
+                )
+                agent.run_conversation.return_value = {"final_response": "ok"}
+                created_agents.append(agent)
+                return agent
+
+            job = {
+                "id": "cache-clear-job",
+                "name": "cache test",
+                "prompt": "hi",
+                "enabled_toolsets": ["web", "file"],
+            }
+            fake_db = MagicMock()
+
+            with patch("cron.scheduler._hermes_home", tmp_path), \
+                 patch("cron.scheduler._resolve_origin", return_value=None), \
+                 patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+                 patch("hermes_state.SessionDB", return_value=fake_db), \
+                 patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                       return_value=self._RUNTIME), \
+                 patch("run_agent.AIAgent", side_effect=build_agent) as mock_agent_cls:
+                success, _, _, error = run_job(job)
 
         assert success is True
         assert error is None
-        assert not model_tools._tool_defs_cache, (
-            "run_job must clear model_tools._tool_defs_cache after reloading .env"
-        )
+        mock_agent_cls.assert_called_once()
+        assert len(created_agents) == 1
+        tool_names = {tool["function"]["name"] for tool in created_agents[0].tools}
+        assert {"web_search", "web_extract"} <= tool_names
 
 
     def test_transient_dns_fallback_switches_provider_and_model_together(self, tmp_path):
@@ -2900,8 +2943,6 @@ class TestSetCronSessionTitle:
         out = _set_cron_session_title(db, "sess-1", "Nightly Synthesis")
         assert out == "Nightly Synthesis #2"
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
-
-
 
 
 class TestFailureStreakNudge:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1225,7 +1225,7 @@ class TestRunJobConfigEnvVarExpansion:
             fake_db = MagicMock()
 
             with patch("cron.scheduler._hermes_home", tmp_path), \
-                 patch("cron.scheduler._resolve_origin", return_value=None), \
+                 patch("cron.scheduler._resolve_delivery_target", return_value=None), \
                  patch("hermes_cli.env_loader.reset_secret_source_cache"), \
                  patch("hermes_state.SessionDB", return_value=fake_db), \
                  patch("hermes_cli.runtime_provider.resolve_runtime_provider",


### PR DESCRIPTION
## What does this PR do?

When cron reloads `.env`, tool-definition caches (like `check_fn` TTL caches) become stale because new env vars may enable/disable tools. This PR clears both the tool-schema cache and the availability cache after dotenv reload, so newly available tools are visible.

## Related Issue

Fixes #82912

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `cron/scheduler.py`: `_reload_dotenv_and_publish_delivery_target()` calls `invalidate_check_fn_cache()` and `_clear_tool_defs_cache()` after dotenv reload.
- `model_tools.py`: Updated `_clear_tool_defs_cache()` docstring.
- `tests/cron/test_scheduler.py`: Updated test to patch `_resolve_delivery_target`.

## How to Test

1. `scripts/run_tests.sh tests/cron/test_scheduler.py` — scheduler tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing