### PR TITLE
fix(discord): preserve thread routing for progress edits

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -482,6 +482,35 @@ def _non_conversational_metadata(
     return merged
 
 
+async def _edit_message_with_optional_metadata(
+    adapter: Any,
+    *,
+    chat_id: str,
+    message_id: str,
+    content: str,
+    finalize: bool = False,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """Edit while preserving legacy adapters that do not accept metadata."""
+    kwargs: Dict[str, Any] = {
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "content": content,
+        "finalize": finalize,
+    }
+    if metadata:
+        try:
+            params = inspect.signature(adapter.edit_message).parameters
+            if "metadata" in params or any(
+                param.kind is inspect.Parameter.VAR_KEYWORD
+                for param in params.values()
+            ):
+                kwargs["metadata"] = metadata
+        except (TypeError, ValueError):
+            pass
+    return await adapter.edit_message(**kwargs)
+
+
 def _seed_hygiene_system_prompt(
     agent: Any,
     session_row: Optional[Dict[str, Any]],
@@ -26936,10 +26965,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _notify_res = None
                     if _heartbeat_msg_id:
                         try:
-                            _notify_res = await _notify_adapter.edit_message(
-                                source.chat_id,
-                                _heartbeat_msg_id,
-                                _heartbeat_text,
+                            _notify_res = await _edit_message_with_optional_metadata(
+                                _notify_adapter,
+                                chat_id=source.chat_id,
+                                message_id=_heartbeat_msg_id,
+                                content=_heartbeat_text,
+                                metadata=_non_conversational_metadata(
+                                    _status_thread_metadata,
+                                    platform=source.platform,
+                                ),
                             )
                         except Exception as _ee:
                             logger.debug("Heartbeat edit failed: %s", _ee)
@@ -27837,11 +27871,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 elif _sc_msg_id and _sc_msg_id != "__no_edit__" and _sc_adapter is not None:
                     try:
-                        _reconcile_res = await _sc_adapter.edit_message(
+                        _reconcile_res = await _edit_message_with_optional_metadata(
+                            _sc_adapter,
                             chat_id=source.chat_id,
                             message_id=_sc_msg_id,
                             content=_final,
                             finalize=True,
+                            metadata=_status_thread_metadata,
                         )
                         if getattr(_reconcile_res, "success", True):
                             response["already_sent"] = True
@@ -27871,11 +27907,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _sc_msg_id = _sc.message_id
                 if _sc_msg_id:
                     try:
-                        await _sc.adapter.edit_message(
+                        await _edit_message_with_optional_metadata(
+                            _sc.adapter,
                             chat_id=source.chat_id,
                             message_id=_sc_msg_id,
                             content=response["final_response"],
                             finalize=True,
+                            metadata=_status_thread_metadata,
                         )
                         response["already_sent"] = True
                         logger.info(

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3717,9 +3717,14 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
         try:
-            channel = self._client.get_channel(int(chat_id))
+            # Match send() routing: edits for messages delivered into a thread
+            # must resolve that thread, not the parent chat. Discord message
+            # snowflakes are channel-scoped for edit endpoints; using the parent
+            # yields 10008 Unknown Message even while the message exists.
+            target_id = str((metadata or {}).get("thread_id") or chat_id)
+            channel = self._client.get_channel(int(target_id))
             if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
+                channel = await self._client.fetch_channel(int(target_id))
             msg = channel.get_partial_message(int(message_id))
             formatted = self.format_message(content)
 

--- a/tests/gateway/test_discord_edit_message_overflow.py
+++ b/tests/gateway/test_discord_edit_message_overflow.py
@@ -16,6 +16,7 @@ The fix mirrors the proven Telegram contract (and its #48648 lesson):
   in ``message_id`` plus every continuation in ``continuation_message_ids``.
 """
 
+import asyncio
 import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -87,6 +88,38 @@ def _wire_channel(adapter, *, original_msg, send_side_effect=None):
 
 
 class TestEditMessageHappyPath:
+    def test_edit_uses_metadata_thread_target_instead_of_parent_chat(self):
+        adapter = _make_adapter()
+        parent_message = SimpleNamespace(id=42, edit=AsyncMock())
+        thread_message = SimpleNamespace(id=42, edit=AsyncMock())
+        parent = SimpleNamespace(
+            id=555,
+            get_partial_message=MagicMock(return_value=parent_message),
+        )
+        thread = SimpleNamespace(
+            id=777,
+            get_partial_message=MagicMock(return_value=thread_message),
+        )
+        adapter._client = SimpleNamespace(
+            get_channel=lambda cid: {555: parent, 777: thread}.get(cid),
+            fetch_channel=AsyncMock(return_value=None),
+        )
+
+        result = asyncio.run(
+            adapter.edit_message(
+                "555",
+                "42",
+                "thread progress update",
+                metadata={"thread_id": "777"},
+            )
+        )
+
+        assert result.success is True
+        thread.get_partial_message.assert_called_once_with(42)
+        thread_message.edit.assert_awaited_once_with(content="thread progress update")
+        parent.get_partial_message.assert_not_called()
+        parent_message.edit.assert_not_awaited()
+
     @pytest.mark.asyncio
     async def test_short_edit_in_place(self):
         adapter = _make_adapter()

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -70,8 +70,17 @@ class CleanupCaptureAdapter(BasePlatformAdapter):
         )
         return SendResult(success=True, message_id=mid)
 
-    async def edit_message(self, chat_id, message_id, content) -> SendResult:
-        self.edits.append({"chat_id": chat_id, "message_id": message_id, "content": content})
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
+    ) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "metadata": metadata,
+            }
+        )
         return SendResult(success=True, message_id=message_id)
 
     async def delete_message(self, chat_id, message_id) -> bool:
@@ -118,6 +127,15 @@ class ProgressAgent:
             time.sleep(0.2)
             cb("tool.started", "terminal", "ls", {})
             time.sleep(0.2)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class SlowHeartbeatAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        time.sleep(0.35)
         return {"final_response": "done", "messages": [], "api_calls": 1}
 
 
@@ -204,6 +222,56 @@ def _install_fakes(
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discord_heartbeat_edit_keeps_thread_metadata(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0.02")
+    adapter = CleanupCaptureAdapter(platform=Platform.DISCORD)
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(
+        monkeypatch,
+        SlowHeartbeatAgent,
+        cleanup_on=False,
+        cleanup_platform=Platform.DISCORD,
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    _original_float_env = gateway_run._float_env
+    monkeypatch.setattr(
+        gateway_run,
+        "_float_env",
+        lambda name, default: 0.02
+        if name == "HERMES_AGENT_NOTIFY_INTERVAL"
+        else _original_float_env(name, default),
+    )
+    monkeypatch.setattr(
+        runner, "_should_emit_long_running_notification", lambda *args: True
+    )
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="parent-1",
+        chat_type="thread",
+        thread_id="thread-9",
+    )
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-heartbeat-thread",
+        session_key="agent:main:discord:thread:parent-1:thread-9",
+    )
+
+    assert result["final_response"] == "done"
+    heartbeat_sends = [s for s in adapter.sent if "Working" in s["content"]]
+    heartbeat_edits = [e for e in adapter.edits if "Working" in e["content"]]
+    assert heartbeat_sends
+    assert heartbeat_edits
+    assert all(
+        (e.get("metadata") or {}).get("thread_id") == "thread-9"
+        for e in heartbeat_edits
+    ), heartbeat_edits
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -15,6 +15,80 @@ from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageTyp
 from gateway.session import SessionSource
 
 
+@pytest.mark.asyncio
+async def test_edit_with_optional_metadata_preserves_legacy_adapter_contract():
+    from gateway.run import _edit_message_with_optional_metadata
+
+    class LegacyAdapter:
+        def __init__(self):
+            self.calls = []
+
+        async def edit_message(
+            self, chat_id, message_id, content, *, finalize=False
+        ):
+            self.calls.append(
+                {
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "content": content,
+                    "finalize": finalize,
+                }
+            )
+            return SendResult(success=True, message_id=message_id)
+
+    class MetadataAdapter(LegacyAdapter):
+        async def edit_message(
+            self,
+            chat_id,
+            message_id,
+            content,
+            *,
+            finalize=False,
+            metadata=None,
+        ):
+            self.calls.append(
+                {
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "content": content,
+                    "finalize": finalize,
+                    "metadata": metadata,
+                }
+            )
+            return SendResult(success=True, message_id=message_id)
+
+    metadata = {"thread_id": "thread-1"}
+    legacy = LegacyAdapter()
+    modern = MetadataAdapter()
+
+    await _edit_message_with_optional_metadata(
+        legacy,
+        chat_id="parent-1",
+        message_id="message-1",
+        content="updated",
+        finalize=True,
+        metadata=metadata,
+    )
+    await _edit_message_with_optional_metadata(
+        modern,
+        chat_id="parent-1",
+        message_id="message-1",
+        content="updated",
+        finalize=True,
+        metadata=metadata,
+    )
+
+    assert legacy.calls == [
+        {
+            "chat_id": "parent-1",
+            "message_id": "message-1",
+            "content": "updated",
+            "finalize": True,
+        }
+    ]
+    assert modern.calls[0]["metadata"] == metadata
+
+
 class ProgressCaptureAdapter(BasePlatformAdapter):
     def __init__(self, platform=Platform.TELEGRAM):
         super().__init__(PlatformConfig(enabled=True, token="***"), platform)
@@ -1237,6 +1311,14 @@ async def test_transformed_response_edits_streamed_message_in_place(monkeypatch,
     assert any("[plugin appended this]" in text for text in edited_texts), (
         f"expected transformed text in adapter.edits, got: {edited_texts!r}"
     )
+    transformed_edits = [
+        e for e in adapter.edits if "[plugin appended this]" in e["content"]
+    ]
+    assert transformed_edits
+    assert all(
+        (e.get("metadata") or {}).get("thread_id") == "$thread"
+        for e in transformed_edits
+    ), transformed_edits
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_stale_finalize_suppression.py
+++ b/tests/gateway/test_stale_finalize_suppression.py
@@ -71,6 +71,7 @@ class FinalizeCaptureAdapter(BasePlatformAdapter):
                 "message_id": message_id,
                 "content": content,
                 "finalize": finalize,
+                "metadata": metadata,
             }
         )
         return SendResult(success=True, message_id=message_id)
@@ -158,7 +159,10 @@ def _make_runner(adapter):
     return runner
 
 
-async def _run_streaming_turn(monkeypatch, tmp_path, agent_cls, session_id):
+async def _run_streaming_turn(
+    monkeypatch, tmp_path, agent_cls, session_id, *, platform=Platform.TELEGRAM,
+    chat_id="-1001", chat_type="group", thread_id=None,
+):
     import yaml
 
     (tmp_path / "config.yaml").write_text(
@@ -183,7 +187,7 @@ async def _run_streaming_turn(monkeypatch, tmp_path, agent_cls, session_id):
     fake_run_agent.AIAgent = agent_cls
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
-    adapter = FinalizeCaptureAdapter()
+    adapter = FinalizeCaptureAdapter(platform=platform)
     runner = _make_runner(adapter)
     gateway_run = importlib.import_module("gateway.run")
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
@@ -192,17 +196,21 @@ async def _run_streaming_turn(monkeypatch, tmp_path, agent_cls, session_id):
     )
 
     source = SessionSource(
-        platform=Platform.TELEGRAM,
-        chat_id="-1001",
-        chat_type="group",
+        platform=platform,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        thread_id=thread_id,
     )
+    session_key = f"agent:main:{platform.value}:{chat_type}:{chat_id}"
+    if thread_id:
+        session_key = f"{session_key}:{thread_id}"
     result = await runner._run_agent(
         message="describe this photo",
         context_prompt="",
         history=[],
         source=source,
         session_id=session_id,
-        session_key="agent:main:telegram:group:-1001",
+        session_key=session_key,
     )
     return adapter, result
 
@@ -238,6 +246,33 @@ async def test_stale_finalize_does_not_suppress_complete_response(
         assert any(
             e["content"] == FULL_RESPONSE and e["finalize"] for e in adapter.edits
         ), "already_sent=True but no edit carried the complete response"
+
+
+@pytest.mark.asyncio
+async def test_stale_finalize_reconciliation_keeps_discord_thread_metadata(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_streaming_turn(
+        monkeypatch,
+        tmp_path,
+        StalePrefixAgent,
+        "sess-71643-discord-thread",
+        platform=Platform.DISCORD,
+        chat_id="parent-1",
+        chat_type="thread",
+        thread_id="thread-9",
+    )
+
+    assert result.get("already_sent") is True
+    reconciliation_edits = [
+        e for e in adapter.edits
+        if e["content"] == FULL_RESPONSE and e["finalize"]
+    ]
+    assert reconciliation_edits
+    assert all(
+        (e.get("metadata") or {}).get("thread_id") == "thread-9"
+        for e in reconciliation_edits
+    ), reconciliation_edits
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix Discord progress-message edits that target the parent channel even when the message was originally sent inside a thread.

- Resolve Discord edit targets from `metadata.thread_id`, falling back to `chat_id` when thread metadata is absent.
- Preserve thread routing for long-running heartbeat edits, stale streamed-finalize reconciliation, and plugin-transformed final edits.
- Keep legacy platform adapters compatible by passing metadata only when their `edit_message()` signature supports it.

## Root cause

Discord progress sends honor `metadata.thread_id`, but `DiscordAdapter.edit_message()` previously fetched the message from the parent `chat_id`. Discord therefore returned `10008 Unknown Message` / HTTP 404 for a message that existed in the thread.

## Tests

- Reproduced RED for adapter, heartbeat, stale-finalize, and transformed-response paths.
- Focused routing tests: 5/5 normal and 5/5 optimized.
- Discord edit/overflow tests: 9/9 normal and 9/9 optimized.
- Kanban notifier tests: 9/9 normal and 9/9 optimized.
- `py_compile`: 6/6.
- `git diff --check`: PASS.
- Independent pre-commit review: PASS (B0/M0/m0).

## Scope

Six files changed. No schema, database, daemon, retry-policy, or credential changes.
