### PR TITLE
fix(desktop): stop Sessions list bounce at date dividers

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/chrome.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.tsx
@@ -61,7 +61,10 @@ export function SidebarDateDivider({
   return (
     // group/workspace: a divider heads a group the same way a repo header does,
     // so it borrows the header's hover-revealed "+" verbatim.
-    <div className={cn('group/workspace flex select-none items-center gap-2 px-2 pb-0.5 pt-2', className)} {...props}>
+    <div
+      className={cn('group/workspace flex h-8 shrink-0 select-none items-center gap-2 px-2', className)}
+      {...props}
+    >
       <span className="shrink-0 text-[0.64rem] font-semibold uppercase tracking-[0.12em] text-(--ui-text-quaternary)">
         {label}
       </span>

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.test.tsx
@@ -9,22 +9,28 @@ import type { VirtualSessionListProps } from './virtual-session-list'
 
 afterEach(cleanup)
 
-vi.mock('@/i18n', () => ({
-  useI18n: () => ({
-    t: {
-      sidebar: {
-        dateDivider: {
-          earlierThisMonth: 'Earlier this month',
-          lastMonth: 'Last month',
-          lastWeek: 'Last week',
-          older: 'Older',
-          today: 'Today',
-          yesterday: 'Yesterday'
-        }
-      }
+vi.mock('@/i18n', () => {
+  const sidebar = {
+    dateDivider: {
+      earlierThisMonth: 'Earlier this month',
+      lastMonth: 'Last month',
+      lastWeek: 'Last week',
+      older: 'Older',
+      today: 'Today',
+      yesterday: 'Yesterday'
+    },
+    statusDivider: {
+      done: 'Done',
+      working: 'Working'
     }
-  })
-}))
+  }
+
+  return {
+    useI18n: () => ({
+      t: { sidebar }
+    })
+  }
+})
 
 const mockVirtualListPropsHistory: VirtualSessionListProps[] = []
 
@@ -175,5 +181,37 @@ describe('SidebarSessionsSection memoization & virtualizer stability', () => {
 
     const thirdRowsRef = mockVirtualListPropsHistory[2].rows
     expect(thirdRowsRef).not.toBe(secondRowsRef)
+  })
+
+  it('still virtualizes a status-grouped list and keeps the same rows across identical rerenders', () => {
+    mockVirtualListPropsHistory.length = 0
+
+    const sessions = generateSessions(VIRTUALIZE_THRESHOLD + 3)
+
+    const props = {
+      activeSessionId: null,
+      emptyState: <div>Empty</div>,
+      grouping: 'status' as const,
+      label: 'Sessions',
+      onArchiveSession: noop,
+      onDeleteSession: noop,
+      onResumeSession: noop,
+      onToggle: noop,
+      onTogglePin: noop,
+      open: true,
+      pinned: false,
+      sessions
+    }
+
+    const { rerender } = render(<SidebarSessionsSection {...props} />)
+
+    expect(mockVirtualListPropsHistory.length).toBe(1)
+    const initialRowsRef = mockVirtualListPropsHistory[0].rows
+    expect(initialRowsRef.some(row => row.kind === 'divider')).toBe(true)
+
+    rerender(<SidebarSessionsSection {...props} />)
+
+    expect(mockVirtualListPropsHistory.length).toBe(2)
+    expect(mockVirtualListPropsHistory[1].rows).toBe(initialRowsRef)
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -332,6 +332,20 @@ export function SidebarSessionsSection({
   // The hand-picked order is then applied INSIDE each date group, so dragging a
   // row ranks it among its own day's chats instead of freezing the whole list
   // into an undated manual mode.
+  // Only status grouping reads live dots. Including the whole dot map in the
+  // date/none memo rebuilt the virtualizer row list on every working/unread
+  // edge, remounted measured rows, and made the list jump.
+  const statusWorkingKey = useMemo(() => {
+    if (grouping !== 'status') {
+      return ''
+    }
+
+    return displayEntries
+      .filter(entry => hasLiveTurn(dotStates[entry.session.id] ?? 'idle'))
+      .map(entry => entry.session.id)
+      .join('\0')
+  }, [grouping, displayEntries, dotStates])
+
   const flatRows: SidebarListRow[] = useMemo(() => {
     const rows =
       grouping === 'date'
@@ -339,13 +353,13 @@ export function SidebarSessionsSection({
         : grouping === 'status'
           ? groupEntriesByStatus(
               displayEntries,
-              entry => hasLiveTurn(dotStates[entry.session.id] ?? 'idle'),
+              entry => statusWorkingKey.split('\0').includes(entry.session.id),
               statusDividerLabels
             )
           : toSessionRows(displayEntries)
 
     return manualOrderIds?.length ? orderRowsWithinGroups(rows, manualOrderIds) : rows
-  }, [grouping, displayEntries, dotStates, manualOrderIds, statusDividerLabels])
+  }, [grouping, displayEntries, statusWorkingKey, manualOrderIds, statusDividerLabels])
 
   // dnd-kit must see exactly the ids it renders, in render order: the sortable
   // set is derived from the rows, not from `sessions`. Feeding it the unrendered

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SidebarListRow } from '@/lib/session-date-groups'
+
+import { estimateSidebarRowSize, shouldMeasureSidebarRows } from './virtual-session-list'
+
+const sessionRow = {
+  entry: { session: { id: 's1' } },
+  kind: 'session'
+} as SidebarListRow
+
+const dividerRow: SidebarListRow = {
+  key: 'this-week',
+  kind: 'divider',
+  label: 'Earlier this week'
+}
+
+describe('estimateSidebarRowSize', () => {
+  it('sizes session rows at the plain row estimate in compact mode', () => {
+    expect(estimateSidebarRowSize(sessionRow, false)).toBe(26)
+  })
+
+  it('sizes session rows at the taller card estimate in card mode', () => {
+    expect(estimateSidebarRowSize(sessionRow, true)).toBe(66)
+  })
+
+  it('sizes dividers at their own estimate regardless of card mode', () => {
+    expect(estimateSidebarRowSize(dividerRow, false)).toBe(32)
+    expect(estimateSidebarRowSize(dividerRow, true)).toBe(32)
+  })
+
+  it('falls back to the row estimate for unknown slots', () => {
+    expect(estimateSidebarRowSize(undefined, false)).toBe(26)
+    expect(estimateSidebarRowSize(undefined, true)).toBe(66)
+  })
+
+  it('only live-measures inbox cards, never compact rows', () => {
+    expect(shouldMeasureSidebarRows(false)).toBe(false)
+    expect(shouldMeasureSidebarRows(true)).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -46,12 +46,38 @@ export interface VirtualSessionListProps {
   sortable: boolean
 }
 
-const ROW_ESTIMATE_PX = 28
+// Compact session rows are min-h-[1.625rem] (26px at a 16px root). Measuring
+// them is what made the list bounce: CSS gap-px only exists between the
+// currently mounted children, so every measure disagreed with the virtualizer
+// and paddingTop jumped. Compact mode is estimate-only.
+const ROW_ESTIMATE_PX = 26
 // Matches the card's typical rendered height (four lines when a preview
 // exists) so long card lists don't jump under the scroll thumb before
 // self-measurement catches up.
 const CARD_ROW_ESTIMATE_PX = 66
 const OVERSCAN_ROWS = 12
+
+// Must match SidebarDateDivider's h-8 shell.
+const DIVIDER_ESTIMATE_PX = 32
+const ROW_GAP_PX = 1
+
+const neverAdjustScrollOnResize = () => false
+
+const measureSidebarRow = (element: Element) => Math.round((element as HTMLElement).offsetHeight)
+
+/** Compact rows are fixed-height; only inbox cards need live measurement. */
+export function shouldMeasureSidebarRows(card: boolean): boolean {
+  return card
+}
+
+/** Estimate the rendered height of one flat sidebar row, divider-aware. */
+export function estimateSidebarRowSize(row: SidebarListRow | undefined, card: boolean): number {
+  if (row?.kind === 'divider') {
+    return DIVIDER_ESTIMATE_PX
+  }
+
+  return card ? CARD_ROW_ESTIMATE_PX : ROW_ESTIMATE_PX
+}
 
 export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   activeSessionId,
@@ -72,9 +98,12 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   const dividerLabels = t.sidebar.dateDivider
   const scrollerRef = useRef<HTMLDivElement | null>(null)
 
+  const measureRows = shouldMeasureSidebarRows(card)
+
   const virtualizer = useVirtualizer({
     count: listRows.length,
-    estimateSize: () => (card ? CARD_ROW_ESTIMATE_PX : ROW_ESTIMATE_PX),
+    estimateSize: index => estimateSidebarRowSize(listRows[index], card),
+    gap: ROW_GAP_PX,
     getItemKey: index => {
       const row = listRows[index]
 
@@ -83,8 +112,13 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     getScrollElement: () => scrollerRef.current,
     // jsdom-friendly default; the real rect takes over on first observe.
     initialRect: { height: 600, width: 240 },
+    ...(measureRows ? { measureElement: measureSidebarRow } : {}),
     overscan: OVERSCAN_ROWS
   })
+
+  // Not a hook option in 3.14.x. First measure of a taller/shorter divider used
+  // to nudge scrollTop, unmount the row, remount it, and flicker the list.
+  virtualizer.shouldAdjustScrollPositionOnItemSizeChange = neverAdjustScrollOnResize
 
   const virtualItems = virtualizer.getVirtualItems()
   const totalSize = virtualizer.getTotalSize()
@@ -106,7 +140,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
           data-index={virtualItem.index}
           key={row.key}
           label={'label' in row ? row.label : sessionBucketLabel(row.bucket, dividerLabels)}
-          ref={virtualizer.measureElement}
+          ref={measureRows ? virtualizer.measureElement : undefined}
         />
       )
     }
@@ -132,7 +166,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
       <VirtualSortableRow
         index={virtualItem.index}
         key={session.id}
-        measureRef={virtualizer.measureElement}
+        measureRef={measureRows ? virtualizer.measureElement : undefined}
         rowProps={commonProps}
         session={session}
       />
@@ -141,7 +175,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
         {...commonProps}
         data-index={virtualItem.index}
         key={session.id}
-        ref={virtualizer.measureElement}
+        ref={measureRows ? virtualizer.measureElement : undefined}
         session={session}
       />
     )
@@ -156,15 +190,15 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
       // thin scrollbar entirely, and on Windows (no native overlay scrollbars)
       // Chromium then paints the classic always-visible gutter. The themed
       // fade bar reserves its 4px on every platform but stays invisible until
-      // hover — and the wrapper no longer stacks a second scroller, so the
+      // hover, and the wrapper no longer stacks a second scroller, so the
       // double-gutter this class change was reaching for is already gone.
       className={cn(
-        'scrollbar-fade relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain',
+        'scrollbar-fade relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain [overflow-anchor:none]',
         className
       )}
       ref={scrollerRef}
     >
-      <div className="grid gap-px" style={{ paddingBottom: `${paddingBottom}px`, paddingTop: `${paddingTop}px` }}>
+      <div className="grid" style={{ paddingBottom: `${paddingBottom}px`, paddingTop: `${paddingTop}px` }}>
         {rows}
       </div>
     </div>
@@ -173,7 +207,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
 
 interface VirtualSortableRowProps {
   index: number
-  measureRef: (node: Element | null) => void
+  measureRef?: (node: Element | null) => void
   rowProps: SessionRowCommonProps
   session: SessionInfo
 }
@@ -183,11 +217,11 @@ function VirtualSortableRow({ index, measureRef, rowProps, session }: VirtualSor
 
   // Merge dnd-kit's setNodeRef with the virtualizer's measureElement so
   // the row participates in both DnD hit-testing and TanStack height
-  // measurement.
+  // measurement. Compact lists skip measureRef so sizes stay estimated.
   const refMerged = useCallback(
     (node: HTMLDivElement | null) => {
       setNodeRef(node)
-      measureRef(node)
+      measureRef?.(node)
     },
     [measureRef, setNodeRef]
   )


### PR DESCRIPTION
## Summary
- Compact virtualized Sessions rows were still live-measured, and CSS `gap-px` only existed between mounted children while the virtualizer also added `gap`. That rewrote `paddingTop` and remounted rows around date dividers, so the list bounced and could not be focused.
- Compact lists are now estimate-only (26px rows, 32px dividers, virtualizer owns the 1px gap). Inbox cards still measure.
- Confirmed on a live Windows Desktop after deploy: scrolling through YESTERDAY / EARLIER THIS WEEK no longer jitters.

## Test plan
- [x] `npx vitest run src/app/chat/sidebar/virtual-session-list.test.ts src/app/chat/sidebar/sessions-section.test.tsx`
- [x] eslint on the five sidebar files
- [x] typecheck
- [x] live scroll through every date divider on the packaged Windows app