### PR TITLE
fix(agent): explain per-turn search caps without false retry claims

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7814,6 +7814,13 @@ class AIAgent:
 
     def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
         tool = decision.tool_name or "a tool"
+        if decision.code == "loop_web_search_cap":
+            return (
+                f"I stopped {tool} after {decision.count} web searches in this turn "
+                "because it reached the per-turn search limit "
+                f"({decision.code}). Continue with the results already collected or "
+                "change strategy."
+            )
         return (
             f"I stopped retrying {tool} because it hit the tool-call guardrail "
             f"({decision.code}) after {decision.count} repeated non-progressing "

--- a/run_agent.py
+++ b/run_agent.py
@@ -7821,6 +7821,13 @@ class AIAgent:
                 f"({decision.code}). Continue with the results already collected or "
                 "change strategy."
             )
+        if decision.code == "loop_subagent_cap":
+            return (
+                f"I stopped {tool} after spawning {decision.count} subagents in this turn "
+                "because it reached the per-turn subagent limit "
+                f"({decision.code}). Continue with the results already collected or "
+                "finish the work directly."
+            )
         return (
             f"I stopped retrying {tool} because it hit the tool-call guardrail "
             f"({decision.code}) after {decision.count} repeated non-progressing "

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -110,6 +110,25 @@ def test_web_search_cap_halt_response_reports_per_turn_limit_for_distinct_querie
     )
 
 
+def test_subagent_cap_halt_response_reports_per_turn_spawn_limit_for_distinct_tasks():
+    agent = _make_agent("delegate_task")
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_subagents=2))
+    )
+    for i in range(2):
+        decision = controller.before_call("delegate_task", {"goal": f"distinct {i}"})
+        assert decision.action == "allow"
+
+    decision = controller.before_call("delegate_task", {"goal": "distinct 2"})
+
+    assert decision.code == "loop_subagent_cap"
+    assert agent._toolguard_controlled_halt_response(decision) == (
+        "I stopped delegate_task after spawning 2 subagents in this turn because it "
+        "reached the per-turn subagent limit (loop_subagent_cap). Continue with the "
+        "results already collected or finish the work directly."
+    )
+
+
 def test_default_sequential_path_warns_repeated_exact_failure_without_blocking_execution():
     agent = _make_agent("web_search")
     args = {"query": "same"}

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -5,6 +5,11 @@ import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from agent.tool_guardrails import (
+    LoopCapConfig,
+    ToolCallGuardrailConfig,
+    ToolCallGuardrailController,
+)
 from run_agent import AIAgent
 
 
@@ -84,6 +89,25 @@ def _hard_stop_config(**overrides) -> dict:
     }
     cfg["tool_loop_guardrails"].update(overrides)
     return cfg
+
+
+def test_web_search_cap_halt_response_reports_per_turn_limit_for_distinct_queries():
+    agent = _make_agent("web_search")
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_web_searches=3))
+    )
+    for i in range(3):
+        decision = controller.before_call("web_search", {"query": f"distinct {i}"})
+        assert decision.action == "allow"
+
+    decision = controller.before_call("web_search", {"query": "distinct 3"})
+
+    assert decision.code == "loop_web_search_cap"
+    assert agent._toolguard_controlled_halt_response(decision) == (
+        "I stopped web_search after 3 web searches in this turn because it reached "
+        "the per-turn search limit (loop_web_search_cap). Continue with the results "
+        "already collected or change strategy."
+    )
 
 
 def test_default_sequential_path_warns_repeated_exact_failure_without_blocking_execution():


### PR DESCRIPTION
## What does this PR do?

When distinct web searches reach the per-turn cap, Hermes currently describes them as repeated non-progressing attempts. That diagnosis is inaccurate and can send users toward the wrong recovery action even though the searches were all different.

This change formats count-cap halt responses according to their decision codes. Web-search and subagent caps now report the per-turn limit they actually enforce, while repetition guardrails keep their existing retry-oriented explanation.

### Symptom

After 50 distinct `web_search` calls in one turn, the next call is blocked with `loop_web_search_cap`, but the final response says the agent made 50 repeated non-progressing attempts.

### Impact

Users who legitimately exhaust the search budget receive a false explanation of why execution stopped. The message incorrectly implies duplicated work instead of identifying the per-turn limit and advising the user to continue from collected results or change strategy.

### Bug Cause

**Trigger:** `run_agent.py` / `AIAgent._toolguard_controlled_halt_response()` formats a controlled halt after the guardrail controller returns a count-cap decision.

**Causal chain:**
1. Distinct `web_search` calls increment the unconditional per-turn search counter.
2. The next call returns `loop_web_search_cap` after the configured count is reached.
3. A generic halt formatter describes every decision as repeated non-progressing attempts, producing a false user-facing diagnosis.

**Why it is wrong:** Count caps measure total calls in a turn, not repeated arguments or lack of progress, so repetition wording does not describe the decision that stopped execution.

**Working sibling / contrast:** Exact-failure and idempotent no-progress guardrails do track repeated behavior, so their retry-oriented message remains unchanged. The sibling `loop_subagent_cap` count decision now receives the same code-aware treatment to prevent the same false diagnosis there.

**Ruled out:** The controller's counters and decision metadata are already correct. Controller-driven tests confirm that distinct inputs are allowed until the configured cap and then produce the expected count-cap code.

### Fix

Add decision-code-specific controlled halt messages for web-search and subagent per-turn caps, and cover both paths with controller-driven regression tests using distinct inputs.

## Related Issue

Closes #85746

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` - report web-search and subagent count caps as per-turn limits.
- `tests/run_agent/test_tool_call_guardrail_runtime.py` - verify code-aware halt messages after distinct searches and subagent tasks.

## How to Test

1. Configure small web-search and subagent loop caps.
2. Submit distinct inputs until each cap is reached.
3. Confirm the controlled halt names the applicable per-turn limit and does not call the inputs repeated non-progressing attempts.
4. Run the targeted guardrail tests:

```bash
scripts/run_tests.sh tests/agent/test_tool_guardrail_runtime.py tests/run_agent/test_tool_call_guardrail_runtime.py -k 'web_search_cap or subagent_cap'
```

Result: 3 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant guardrail tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing documentation contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no configuration changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - pure response formatting is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; tool execution and schemas are unchanged
