### PR TITLE
fix(usage): normalize every provider cache/usage wire shape in normalize_usage (5-PR consolidation)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1312,6 +1312,15 @@ def normalize_usage(
             cache_read_tokens = _to_int(
                 getattr(response_usage, "prompt_cache_hit_tokens", 0)
             )
+        if not cache_read_tokens:
+            # Kimi/Moonshot's native API (api.moonshot.cn / .ai) reports
+            # context-cache hits as a top-level usage.cached_tokens, not the
+            # OpenAI nested prompt_tokens_details.cached_tokens shape. Without
+            # this, direct Kimi sessions always showed 0 cache-hit tokens and
+            # the hits were billed at the full input rate (#65722).
+            cache_read_tokens = _to_int(
+                getattr(response_usage, "cached_tokens", 0)
+            )
         cache_write_tokens = _to_int(
             getattr(details, "cache_write_tokens", 0) if details else 0
         )

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1030,6 +1030,19 @@ def _to_int(value: Any) -> int:
         return 0
 
 
+def _usage_get(obj: Any, name: str, default: Any = 0) -> Any:
+    """Read a field from a usage object that may be a dict or an attribute object.
+
+    The Responses API can return usage as either a typed SDK object (accessible
+    via ``getattr``) or a plain ``dict`` (from JSON deserialisation).  Using
+    ``getattr`` on a dict silently yields the default, zeroing out all token
+    counts.  This helper normalises access so both shapes work transparently.
+    """
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
 def resolve_billing_route(
     model_name: str,
     provider: Optional[str] = None,
@@ -1269,17 +1282,17 @@ def normalize_usage(
     mode = (api_mode or "").strip().lower()
 
     if mode == "anthropic_messages" or provider_name == "anthropic":
-        input_tokens = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
-        cache_write_tokens = _to_int(getattr(response_usage, "cache_creation_input_tokens", 0))
+        input_tokens = _to_int(_usage_get(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_get(response_usage, "output_tokens", 0))
+        cache_read_tokens = _to_int(_usage_get(response_usage, "cache_read_input_tokens", 0))
+        cache_write_tokens = _to_int(_usage_get(response_usage, "cache_creation_input_tokens", 0))
     elif mode == "codex_responses":
-        input_total = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        details = getattr(response_usage, "input_tokens_details", None)
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        input_total = _to_int(_usage_get(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_get(response_usage, "output_tokens", 0))
+        details = _usage_get(response_usage, "input_tokens_details", None)
+        cache_read_tokens = _to_int(_usage_get(details, "cached_tokens", 0) if details else 0)
         cache_write_tokens = _to_int(
-            getattr(details, "cache_creation_tokens", 0) if details else 0
+            _usage_get(details, "cache_creation_tokens", 0) if details else 0
         )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
@@ -1287,22 +1300,22 @@ def normalize_usage(
         # (input_tokens/output_tokens). Local OpenAI-compatible servers like
         # mlx_vlm.server emit the Anthropic names in chat_completions responses,
         # and the OpenAI Python client preserves them as extra attributes.
-        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0)) or _to_int(
-            getattr(response_usage, "input_tokens", 0)
+        prompt_total = _to_int(_usage_get(response_usage, "prompt_tokens", 0)) or _to_int(
+            _usage_get(response_usage, "input_tokens", 0)
         )
-        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0)) or _to_int(
-            getattr(response_usage, "output_tokens", 0)
+        output_tokens = _to_int(_usage_get(response_usage, "completion_tokens", 0)) or _to_int(
+            _usage_get(response_usage, "output_tokens", 0)
         )
-        details = getattr(response_usage, "prompt_tokens_details", None)
+        details = _usage_get(response_usage, "prompt_tokens_details", None)
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Vercel
         # AI Gateway, Cline) expose when routing Claude models — without this
         # fallback, cache writes are undercounted as 0 and cache reads can be
         # missed when the proxy only surfaces them at the top level.
         # Port of cline/cline#10266.
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        cache_read_tokens = _to_int(_usage_get(details, "cached_tokens", 0) if details else 0)
         if not cache_read_tokens:
-            cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
+            cache_read_tokens = _to_int(_usage_get(response_usage, "cache_read_input_tokens", 0))
         if not cache_read_tokens:
             # DeepSeek's native API (api.deepseek.com) reports context-cache
             # hits as top-level prompt_cache_hit_tokens (+ the complementary
@@ -1310,7 +1323,7 @@ def normalize_usage(
             # OpenAI nested shape. Without this, direct DeepSeek sessions
             # always showed 0 cache-hit tokens (#61871).
             cache_read_tokens = _to_int(
-                getattr(response_usage, "prompt_cache_hit_tokens", 0)
+                _usage_get(response_usage, "prompt_cache_hit_tokens", 0)
             )
         if not cache_read_tokens:
             # Kimi/Moonshot's native API (api.moonshot.cn / .ai) reports
@@ -1319,14 +1332,14 @@ def normalize_usage(
             # this, direct Kimi sessions always showed 0 cache-hit tokens and
             # the hits were billed at the full input rate (#65722).
             cache_read_tokens = _to_int(
-                getattr(response_usage, "cached_tokens", 0)
+                _usage_get(response_usage, "cached_tokens", 0)
             )
         cache_write_tokens = _to_int(
-            getattr(details, "cache_write_tokens", 0) if details else 0
+            _usage_get(details, "cache_write_tokens", 0) if details else 0
         )
         if not cache_write_tokens:
             cache_write_tokens = _to_int(
-                getattr(response_usage, "cache_creation_input_tokens", 0)
+                _usage_get(response_usage, "cache_creation_input_tokens", 0)
             )
         input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
 
@@ -1338,14 +1351,14 @@ def normalize_usage(
     # hidden thinking was invisible in session accounting even though it
     # dominates output spend on models like deepseek-v4-flash (measured:
     # single calls burning 21K reasoning tokens to emit 500 visible tokens).
-    output_details = getattr(response_usage, "output_tokens_details", None)
+    output_details = _usage_get(response_usage, "output_tokens_details", None)
     if output_details:
-        reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
+        reasoning_tokens = _to_int(_usage_get(output_details, "reasoning_tokens", 0))
     if not reasoning_tokens:
-        completion_details = getattr(response_usage, "completion_tokens_details", None)
+        completion_details = _usage_get(response_usage, "completion_tokens_details", None)
         if completion_details:
             reasoning_tokens = _to_int(
-                getattr(completion_details, "reasoning_tokens", 0)
+                _usage_get(completion_details, "reasoning_tokens", 0)
             )
 
     # Cache observability for MiniMax's Anthropic wire: on MiniMax-M3,

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1283,8 +1283,16 @@ def normalize_usage(
         )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
-        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0))
+        # OpenAI-style names first; fall back to Anthropic-style
+        # (input_tokens/output_tokens). Local OpenAI-compatible servers like
+        # mlx_vlm.server emit the Anthropic names in chat_completions responses,
+        # and the OpenAI Python client preserves them as extra attributes.
+        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0)) or _to_int(
+            getattr(response_usage, "input_tokens", 0)
+        )
+        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0)) or _to_int(
+            getattr(response_usage, "output_tokens", 0)
+        )
         details = getattr(response_usage, "prompt_tokens_details", None)
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Vercel

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1043,6 +1043,16 @@ def _usage_get(obj: Any, name: str, default: Any = 0) -> Any:
     return getattr(obj, name, default)
 
 
+def _usage_count(value: Any) -> int:
+    """Coerce a usage counter to a non-negative integer.
+
+    Providers occasionally emit malformed negative counters; clamp them to 0
+    so a bad field cannot corrupt session accounting (#85706).
+    """
+    return max(0, _to_int(value))
+
+
+
 def resolve_billing_route(
     model_name: str,
     provider: Optional[str] = None,
@@ -1282,30 +1292,42 @@ def normalize_usage(
     mode = (api_mode or "").strip().lower()
 
     if mode == "anthropic_messages" or provider_name == "anthropic":
-        input_tokens = _to_int(_usage_get(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(_usage_get(response_usage, "output_tokens", 0))
-        cache_read_tokens = _to_int(_usage_get(response_usage, "cache_read_input_tokens", 0))
-        cache_write_tokens = _to_int(_usage_get(response_usage, "cache_creation_input_tokens", 0))
-    elif mode == "codex_responses":
-        input_total = _to_int(_usage_get(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(_usage_get(response_usage, "output_tokens", 0))
-        details = _usage_get(response_usage, "input_tokens_details", None)
-        cache_read_tokens = _to_int(_usage_get(details, "cached_tokens", 0) if details else 0)
-        cache_write_tokens = _to_int(
-            _usage_get(details, "cache_creation_tokens", 0) if details else 0
+        input_tokens = _usage_count(_usage_get(response_usage, "input_tokens", 0))
+        output_tokens = _usage_count(_usage_get(response_usage, "output_tokens", 0))
+        cache_read_tokens = _usage_count(_usage_get(response_usage, "cache_read_input_tokens", 0))
+        cache_write_tokens = _usage_count(
+            _usage_get(response_usage, "cache_creation_input_tokens", 0)
         )
+    elif mode == "codex_responses":
+        input_total = _usage_count(_usage_get(response_usage, "input_tokens", 0))
+        output_tokens = _usage_count(_usage_get(response_usage, "output_tokens", 0))
+        details = _usage_get(response_usage, "input_tokens_details", None)
+        cache_read_tokens = _usage_count(
+            _usage_get(details, "cached_tokens", 0) if details else 0
+        )
+        # OpenAI's documented field for GPT-5.6+ explicit cache writes is
+        # `cache_write_tokens` (billed at 1.25x); `cache_creation_tokens` is
+        # kept as a fallback for older/alternate Responses-compatible
+        # endpoints (#70543).
+        cache_write_tokens = _usage_count(
+            _usage_get(details, "cache_write_tokens", 0) if details else 0
+        )
+        if not cache_write_tokens:
+            cache_write_tokens = _usage_count(
+                _usage_get(details, "cache_creation_tokens", 0) if details else 0
+            )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
         # OpenAI-style names first; fall back to Anthropic-style
         # (input_tokens/output_tokens). Local OpenAI-compatible servers like
         # mlx_vlm.server emit the Anthropic names in chat_completions responses,
         # and the OpenAI Python client preserves them as extra attributes.
-        prompt_total = _to_int(_usage_get(response_usage, "prompt_tokens", 0)) or _to_int(
-            _usage_get(response_usage, "input_tokens", 0)
-        )
-        output_tokens = _to_int(_usage_get(response_usage, "completion_tokens", 0)) or _to_int(
-            _usage_get(response_usage, "output_tokens", 0)
-        )
+        prompt_total = _usage_count(
+            _usage_get(response_usage, "prompt_tokens", 0)
+        ) or _usage_count(_usage_get(response_usage, "input_tokens", 0))
+        output_tokens = _usage_count(
+            _usage_get(response_usage, "completion_tokens", 0)
+        ) or _usage_count(_usage_get(response_usage, "output_tokens", 0))
         details = _usage_get(response_usage, "prompt_tokens_details", None)
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Vercel
@@ -1313,16 +1335,20 @@ def normalize_usage(
         # fallback, cache writes are undercounted as 0 and cache reads can be
         # missed when the proxy only surfaces them at the top level.
         # Port of cline/cline#10266.
-        cache_read_tokens = _to_int(_usage_get(details, "cached_tokens", 0) if details else 0)
+        cache_read_tokens = _usage_count(
+            _usage_get(details, "cached_tokens", 0) if details else 0
+        )
         if not cache_read_tokens:
-            cache_read_tokens = _to_int(_usage_get(response_usage, "cache_read_input_tokens", 0))
+            cache_read_tokens = _usage_count(
+                _usage_get(response_usage, "cache_read_input_tokens", 0)
+            )
         if not cache_read_tokens:
             # DeepSeek's native API (api.deepseek.com) reports context-cache
             # hits as top-level prompt_cache_hit_tokens (+ the complementary
             # prompt_cache_miss_tokens; prompt_tokens = hit + miss), not the
             # OpenAI nested shape. Without this, direct DeepSeek sessions
             # always showed 0 cache-hit tokens (#61871).
-            cache_read_tokens = _to_int(
+            cache_read_tokens = _usage_count(
                 _usage_get(response_usage, "prompt_cache_hit_tokens", 0)
             )
         if not cache_read_tokens:
@@ -1331,15 +1357,24 @@ def normalize_usage(
             # OpenAI nested prompt_tokens_details.cached_tokens shape. Without
             # this, direct Kimi sessions always showed 0 cache-hit tokens and
             # the hits were billed at the full input rate (#65722).
-            cache_read_tokens = _to_int(
+            cache_read_tokens = _usage_count(
                 _usage_get(response_usage, "cached_tokens", 0)
             )
-        cache_write_tokens = _to_int(
+        cache_write_tokens = _usage_count(
             _usage_get(details, "cache_write_tokens", 0) if details else 0
         )
         if not cache_write_tokens:
-            cache_write_tokens = _to_int(
+            cache_write_tokens = _usage_count(
+                _usage_get(details, "cache_creation_input_tokens", 0)
+                if details else 0
+            )
+        if not cache_write_tokens:
+            cache_write_tokens = _usage_count(
                 _usage_get(response_usage, "cache_creation_input_tokens", 0)
+            )
+        if not cache_write_tokens:
+            cache_write_tokens = _usage_count(
+                _usage_get(response_usage, "cache_write_tokens", 0)
             )
         input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
 
@@ -1353,11 +1388,11 @@ def normalize_usage(
     # single calls burning 21K reasoning tokens to emit 500 visible tokens).
     output_details = _usage_get(response_usage, "output_tokens_details", None)
     if output_details:
-        reasoning_tokens = _to_int(_usage_get(output_details, "reasoning_tokens", 0))
+        reasoning_tokens = _usage_count(_usage_get(output_details, "reasoning_tokens", 0))
     if not reasoning_tokens:
         completion_details = _usage_get(response_usage, "completion_tokens_details", None)
         if completion_details:
-            reasoning_tokens = _to_int(
+            reasoning_tokens = _usage_count(
                 _usage_get(completion_details, "reasoning_tokens", 0)
             )
 

--- a/contributors/emails/chengxizhou6@gmail.com
+++ b/contributors/emails/chengxizhou6@gmail.com
@@ -1,0 +1,1 @@
+silence-de

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -458,3 +458,63 @@ class TestSubscriptionIncludedNotes:
         assert result.amount_usd == Decimal("0")
         assert len(result.notes) > 0
         assert any("subscription" in note.lower() for note in result.notes)
+
+
+def test_normalize_usage_reads_kimi_top_level_cached_tokens():
+    """Kimi/Moonshot's native API reports context-cache hits as a top-level
+    usage.cached_tokens, not OpenAI's nested
+    prompt_tokens_details.cached_tokens and not DeepSeek's
+    prompt_cache_hit_tokens. Neither existing fallback matches that name, so
+    direct Kimi sessions normalized to cache_read_tokens=0 — the hits were
+    invisible in accounting and billed at the full input rate (#65722)."""
+    usage = SimpleNamespace(
+        prompt_tokens=3000,
+        completion_tokens=250,
+        cached_tokens=1800,
+    )
+
+    normalized = normalize_usage(usage, provider="kimi", api_mode="chat_completions")
+
+    assert normalized.cache_read_tokens == 1800
+    # prompt_tokens includes the cached prefix: 3000 - 1800 = fresh input
+    assert normalized.input_tokens == 1200
+    assert normalized.output_tokens == 250
+
+
+def test_kimi_fallback_does_not_override_the_nested_openai_shape():
+    """A provider that reports BOTH shapes must keep the nested value.
+
+    The new branch is last in the chain, so it only fills a genuine zero.
+    """
+    usage = SimpleNamespace(
+        prompt_tokens=1000,
+        completion_tokens=100,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=400),
+        cached_tokens=999,  # must be ignored
+    )
+
+    normalized = normalize_usage(usage, provider="kimi", api_mode="chat_completions")
+
+    assert normalized.cache_read_tokens == 400
+
+
+def test_kimi_fallback_does_not_override_deepseek_hit_tokens():
+    usage = SimpleNamespace(
+        prompt_tokens=2000,
+        completion_tokens=100,
+        prompt_cache_hit_tokens=1500,
+        cached_tokens=999,  # must be ignored
+    )
+
+    normalized = normalize_usage(usage, provider="deepseek", api_mode="chat_completions")
+
+    assert normalized.cache_read_tokens == 1500
+
+
+def test_usage_without_any_cache_fields_still_normalizes():
+    usage = SimpleNamespace(prompt_tokens=500, completion_tokens=50)
+
+    normalized = normalize_usage(usage, provider="kimi", api_mode="chat_completions")
+
+    assert normalized.cache_read_tokens == 0
+    assert normalized.input_tokens == 500

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -700,3 +700,69 @@ def test_normalize_usage_clamps_inconsistent_cache_total():
 
     assert normalized.input_tokens == 0
     assert normalized.prompt_tokens == 130
+
+
+def test_normalize_usage_codex_responses_reads_cache_write_tokens():
+    """GPT-5.6+ explicit prompt caching reports cache writes as
+    input_tokens_details.cache_write_tokens (billed at 1.25x), per OpenAI's
+    documented Responses API schema. Before this fix, the codex_responses
+    branch only read the undocumented `cache_creation_tokens` name and always
+    normalized cache writes to 0."""
+    usage = SimpleNamespace(
+        input_tokens=2006,
+        output_tokens=400,
+        input_tokens_details=SimpleNamespace(cached_tokens=1920, cache_write_tokens=50),
+    )
+
+    normalized = normalize_usage(usage, provider="openai", api_mode="codex_responses")
+
+    assert normalized.cache_read_tokens == 1920
+    assert normalized.cache_write_tokens == 50
+    assert normalized.input_tokens == 2006 - 1920 - 50
+
+
+def test_normalize_usage_codex_responses_falls_back_to_cache_creation_tokens():
+    """If cache_write_tokens is absent, fall back to the legacy
+    cache_creation_tokens name rather than reporting 0."""
+    usage = SimpleNamespace(
+        input_tokens=1000,
+        output_tokens=100,
+        input_tokens_details=SimpleNamespace(cached_tokens=200, cache_creation_tokens=80),
+    )
+
+    normalized = normalize_usage(usage, provider="openai", api_mode="codex_responses")
+
+    assert normalized.cache_write_tokens == 80
+
+
+def test_normalize_usage_reads_qwen_flat_cached_tokens():
+    """Some Alibaba/Qwen regional endpoints report cache reads as a flat
+    `usage.cached_tokens` field with no `prompt_tokens_details` wrapper at
+    all. Before this fix, those responses fell through every branch and
+    normalized to cache_read_tokens=0, undercounting cost."""
+    usage = SimpleNamespace(
+        prompt_tokens=2000,
+        completion_tokens=300,
+        cached_tokens=1200,
+    )
+
+    normalized = normalize_usage(usage, provider="qwen", api_mode="chat_completions")
+
+    assert normalized.cache_read_tokens == 1200
+    assert normalized.input_tokens == 800
+
+
+def test_normalize_usage_nested_details_win_over_qwen_flat_top_level():
+    """When both shapes are present, the nested OpenAI-style value wins and
+    the flat Qwen field is not double-read."""
+    usage = SimpleNamespace(
+        prompt_tokens=2000,
+        completion_tokens=100,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=900),
+        cached_tokens=1200,
+    )
+
+    normalized = normalize_usage(usage, provider="qwen", api_mode="chat_completions")
+
+    assert normalized.cache_read_tokens == 900
+    assert normalized.input_tokens == 1100

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -518,3 +518,55 @@ def test_usage_without_any_cache_fields_still_normalizes():
 
     assert normalized.cache_read_tokens == 0
     assert normalized.input_tokens == 500
+
+
+def test_normalize_usage_handles_dict_shaped_usage():
+    """Regression test for #74314: when the Responses API returns usage as a
+    plain dict (e.g. from a middleware/proxy that deserialises JSON to dict
+    instead of a typed SDK object), normalize_usage() must read the same
+    token counts as it would from an attribute-style object.
+
+    Before this fix, getattr() on a dict silently returned 0 for every field,
+    so token counts and cost appeared as zero for dict-shaped usage.
+    """
+    # Same payload as both a dict and a SimpleNamespace
+    payload = {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "input_tokens_details": {"cached_tokens": 60, "cache_creation_tokens": 10},
+    }
+    ns = SimpleNamespace(
+        input_tokens=100,
+        output_tokens=20,
+        input_tokens_details=SimpleNamespace(cached_tokens=60, cache_creation_tokens=10),
+    )
+
+    dict_result = normalize_usage(payload, api_mode="codex_responses")
+    ns_result = normalize_usage(ns, api_mode="codex_responses")
+
+    assert dict_result.input_tokens == ns_result.input_tokens, f"input_tokens: dict={dict_result.input_tokens} vs ns={ns_result.input_tokens}"
+    assert dict_result.output_tokens == ns_result.output_tokens, f"output_tokens: dict={dict_result.output_tokens} vs ns={ns_result.output_tokens}"
+    assert dict_result.cache_read_tokens == ns_result.cache_read_tokens, f"cache_read: dict={dict_result.cache_read_tokens} vs ns={ns_result.cache_read_tokens}"
+    assert dict_result.cache_write_tokens == ns_result.cache_write_tokens, f"cache_write: dict={dict_result.cache_write_tokens} vs ns={ns_result.cache_write_tokens}"
+    # Sanity: values must be non-zero (the whole point of the bug)
+    assert dict_result.input_tokens > 0
+    assert dict_result.cache_read_tokens > 0
+
+
+def test_normalize_usage_handles_dict_openai_chat_completions():
+    """Dict-shaped usage must also work in the default (OpenAI chat-completions)
+    branch, not just the codex_responses branch.
+    """
+    payload = {
+        "prompt_tokens": 500,
+        "completion_tokens": 100,
+        "prompt_tokens_details": {"cached_tokens": 200},
+        "completion_tokens_details": {"reasoning_tokens": 30},
+    }
+
+    result = normalize_usage(payload, api_mode="chat_completions")
+
+    assert result.output_tokens == 100
+    assert result.cache_read_tokens == 200
+    assert result.input_tokens == 500 - 200  # prompt_total - cache_read
+    assert result.reasoning_tokens == 30

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -570,3 +570,133 @@ def test_normalize_usage_handles_dict_openai_chat_completions():
     assert result.cache_read_tokens == 200
     assert result.input_tokens == 500 - 200  # prompt_total - cache_read
     assert result.reasoning_tokens == 30
+
+
+def test_normalize_usage_openai_reads_nested_cache_creation_tokens():
+    usage = SimpleNamespace(
+        prompt_tokens=1000,
+        completion_tokens=200,
+        prompt_tokens_details=SimpleNamespace(
+            cached_tokens=100,
+            cache_creation_input_tokens=300,
+        ),
+    )
+
+    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
+
+    assert normalized.cache_read_tokens == 100
+    assert normalized.cache_write_tokens == 300
+    assert normalized.input_tokens == 600
+
+
+def test_normalize_usage_openai_reads_mapping_cache_creation_tokens():
+    usage = {
+        "prompt_tokens": 1000,
+        "completion_tokens": 200,
+        "prompt_tokens_details": {"cache_creation_input_tokens": 300},
+    }
+
+    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
+
+    assert normalized.cache_write_tokens == 300
+    assert normalized.input_tokens == 700
+
+
+def test_normalize_usage_openai_prefers_nested_cache_write_tokens():
+    usage = SimpleNamespace(
+        prompt_tokens=1000,
+        prompt_tokens_details=SimpleNamespace(
+            cache_write_tokens=200,
+            cache_creation_input_tokens=300,
+        ),
+        cache_creation_input_tokens=400,
+        cache_write_tokens=500,
+    )
+
+    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
+
+    assert normalized.cache_write_tokens == 200
+
+
+def test_normalize_usage_mapping_preserves_reasoning_tokens():
+    usage = {
+        "prompt_tokens": 100,
+        "completion_tokens": 20,
+        "prompt_tokens_details": {"cached_tokens": 40},
+        "completion_tokens_details": {"reasoning_tokens": 12},
+    }
+
+    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
+
+    assert normalized.reasoning_tokens == 12
+
+
+def test_normalize_usage_mapping_anthropic_fields():
+    usage = {
+        "input_tokens": 80,
+        "output_tokens": 20,
+        "cache_read_input_tokens": 50,
+        "cache_creation_input_tokens": 10,
+        "output_tokens_details": {"reasoning_tokens": 7},
+    }
+
+    normalized = normalize_usage(usage, provider="anthropic", api_mode="anthropic_messages")
+
+    assert normalized.cache_read_tokens == 50
+    assert normalized.cache_write_tokens == 10
+    assert normalized.reasoning_tokens == 7
+
+
+def test_normalize_usage_mapping_codex_fields():
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "input_tokens_details": {
+            "cached_tokens": 60,
+            "cache_creation_tokens": 10,
+        },
+        "output_tokens_details": {"reasoning_tokens": 5},
+    }
+
+    normalized = normalize_usage(usage, provider="openai-codex", api_mode="codex_responses")
+
+    assert normalized.input_tokens == 30
+    assert normalized.cache_read_tokens == 60
+    assert normalized.cache_write_tokens == 10
+    assert normalized.reasoning_tokens == 5
+
+
+def test_normalize_usage_clamps_negative_counters():
+    usage = SimpleNamespace(
+        prompt_tokens=100,
+        completion_tokens=-5,
+        prompt_tokens_details=SimpleNamespace(
+            cached_tokens=-10,
+            cache_write_tokens=-20,
+        ),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=-3),
+    )
+
+    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
+
+    assert normalized.input_tokens == 100
+    assert normalized.output_tokens == 0
+    assert normalized.cache_read_tokens == 0
+    assert normalized.cache_write_tokens == 0
+    assert normalized.reasoning_tokens == 0
+
+
+def test_normalize_usage_clamps_inconsistent_cache_total():
+    usage = {
+        "prompt_tokens": 100,
+        "completion_tokens": 10,
+        "prompt_tokens_details": {
+            "cached_tokens": 80,
+            "cache_creation_input_tokens": 50,
+        },
+    }
+
+    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
+
+    assert normalized.input_tokens == 0
+    assert normalized.prompt_tokens == 130


### PR DESCRIPTION
## Summary

`normalize_usage()` now reads every known provider cache/usage wire shape — dict or SDK object — so cache writes, cache reads, and reasoning tokens are no longer silently normalized to 0 before session accounting and cost estimation.

Consolidated salvage of 5 overlapping PRs against the same function, authorship preserved per-commit:

- **#52571** @silence-de — Anthropic-style `input_tokens`/`output_tokens` name fallback in the chat_completions branch (mlx_vlm and other local OpenAI-compatible servers). Fixes #14686.
- **#66105** @mehmetkr-31 — flat top-level `usage.cached_tokens` fallback (Kimi/Moonshot native API; also covers Qwen regional endpoints). Fixes the accounting half of #65722.
- **#74591** @RelaxJonh — mapping-safe `_usage_get()` reads across all three branches (dict-shaped usage from decoded JSON no longer zeroes out). First submitter of the dict-shape fix. Fixes #74314, #82831.
- **#85702** @JoaoMarcos44 — cache-write field precedence (`details.cache_write_tokens` → `details.cache_creation_input_tokens` → `usage.cache_creation_input_tokens` → `usage.cache_write_tokens`), `_usage_count()` negative-counter clamping. Fixes #85706.
- **#70522** @JoaoMarcos44 — codex_responses branch reads `details.cache_write_tokens` (OpenAI's documented GPT-5.6+ name) with `cache_creation_tokens` fallback; Qwen/codex regression tests. Fixes #70543.

## Changes

- `agent/usage_pricing.py`: `_usage_get()` mapping-safe reader, `_usage_count()` non-negative clamp, applied to every read in all three wire branches; cache-write precedence chain; codex cache-write field; flat `cached_tokens` and Anthropic-name fallbacks.
- `tests/agent/test_usage_pricing.py`: +14 regression tests (mapping shapes for all three branches, cache-write precedence, negative clamping, inconsistent totals, Kimi/Qwen/mlx fallbacks, no-override guards for nested shapes).

## Validation

| | Before | After |
|---|---|---|
| tests/agent/test_usage_pricing.py | 12 fail on old normalize_usage (sabotage run) | 40/40 pass |
| tests/agent/transports/test_chat_completions.py | — | 46/46 pass |
| ruff | — | clean |

Fixes #74314. Fixes #82831. Fixes #85706. Fixes #70543. Fixes #14686.

## Infographic

![One normalizer, every usage wire](https://files.catbox.moe/2ya6c0.png)
