### PR TITLE
fix(wake): stop client-capture wake from arming a deaf listener and blaming the wrong machine

### DIFF
--- a/apps/desktop/src/lib/wake-client-capture.ts
+++ b/apps/desktop/src/lib/wake-client-capture.ts
@@ -10,6 +10,33 @@
 const TARGET_RATE = 16_000
 const DEFAULT_FRAME = 1280 // 80 ms @ 16 kHz — matches tools/wake_word.py
 
+// How long to listen to a candidate input before judging it dead (ms).
+const PROBE_MS = 700
+
+// Virtual/loopback inputs enumerate exactly like real microphones but emit
+// bit-perfect digital silence unless something is routed into them. macOS boxes
+// commonly carry several (BlackHole, MMAudio, Loopback, Soundflower), and
+// Chromium will happily hand one back as the "default" device — which is how a
+// wake word ends up armed, streaming, and permanently deaf. Deprioritise them.
+const VIRTUAL_INPUT_PATTERNS = [
+  'blackhole',
+  'mmaudio',
+  'loopback',
+  'soundflower',
+  'ui sounds',
+  'aggregate',
+  'multi-output',
+  'virtual',
+  'ndi',
+  'obs'
+]
+
+const isVirtualInput = (label: string): boolean => {
+  const l = label.toLowerCase()
+
+  return VIRTUAL_INPUT_PATTERNS.some(p => l.includes(p))
+}
+
 export type WakeFeedRequester = (method: string, params?: Record<string, unknown>) => Promise<unknown>
 
 export interface ClientWakeCaptureOptions {
@@ -17,11 +44,17 @@ export interface ClientWakeCaptureOptions {
   frameLength?: number
   request: WakeFeedRequester
   onError?: (error: Error) => void
+  /** Reports which input won and whether it carried any signal at all. */
+  onDeviceChosen?: (info: { label: string; live: boolean }) => void
 }
 
 export interface ClientWakeCaptureHandle {
   stop: () => void
   readonly active: boolean
+  /** Label of the input actually opened (for the ear tooltip / logs). */
+  readonly deviceLabel: string
+  /** False when every candidate input returned pure digital silence. */
+  readonly live: boolean
 }
 
 function downsampleTo16k(input: Float32Array, inputRate: number): Float32Array {
@@ -78,8 +111,129 @@ function bytesToBase64(buf: ArrayBuffer): string {
   return btoa(binary)
 }
 
+/** Audio constraints for the wake stream.
+ *
+ * `echoCancellation` matters: Hermes speaks its replies through the same
+ * headset it listens on, and without AEC its own TTS can trigger the wake word.
+ * `noiseSuppression` is deliberately OFF — an aggressive gate can zero out a
+ * quiet room entirely, which both hurts detection and would defeat the
+ * liveness probe below. */
+const wakeAudioConstraints = (deviceId?: string): MediaTrackConstraints => ({
+  channelCount: 1,
+  echoCancellation: true,
+  noiseSuppression: false,
+  autoGainControl: true,
+  ...(deviceId ? { deviceId: { exact: deviceId } } : {})
+})
+
 /**
- * Start streaming the default microphone to `wake.feed`.
+ * Candidate inputs, best first: real devices before known virtual loopbacks.
+ * An empty list means "just take the browser default".
+ */
+async function orderedInputCandidates(): Promise<Array<{ deviceId: string; label: string }>> {
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices()
+    const inputs = devices
+      .filter(d => d.kind === 'audioinput' && d.deviceId && d.deviceId !== 'communications')
+      .map(d => ({ deviceId: d.deviceId, label: d.label || d.deviceId }))
+    // Stable partition — real inputs keep their enumeration order (which puts
+    // the system default first), virtual loopbacks go to the back as fallback.
+    return [...inputs.filter(d => !isVirtualInput(d.label)), ...inputs.filter(d => isVirtualInput(d.label))]
+  } catch {
+    return []
+  }
+}
+
+/**
+ * True when the stream carries any nonzero sample within PROBE_MS.
+ *
+ * This is an exact-zero test, not a loudness threshold: a real microphone in a
+ * silent room still has a noise floor, while a dead or virtual input returns
+ * bit-perfect zeros forever. That distinction is the whole point — a threshold
+ * would reject a working mic just for being in a quiet room.
+ */
+async function streamIsLive(context: AudioContext, stream: MediaStream): Promise<boolean> {
+  const source = context.createMediaStreamSource(stream)
+  const analyser = context.createAnalyser()
+  analyser.fftSize = 2048
+  source.connect(analyser)
+
+  const buf = new Float32Array(analyser.fftSize)
+  const deadline = performance.now() + PROBE_MS
+
+  try {
+    while (performance.now() < deadline) {
+      analyser.getFloatTimeDomainData(buf)
+
+      for (let i = 0; i < buf.length; i++) {
+        if (buf[i] !== 0) {
+          return true
+        }
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 50))
+    }
+
+    return false
+  } finally {
+    try {
+      source.disconnect()
+      analyser.disconnect()
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/**
+ * Open the first input that actually carries audio.
+ *
+ * Falls back to the first candidate (still streaming, just silent) so the ear
+ * arms rather than failing outright — the backend surfaces the silence and the
+ * handle reports `live: false` for the tooltip.
+ */
+async function openLiveInput(
+  context: AudioContext
+): Promise<{ stream: MediaStream; label: string; live: boolean }> {
+  const candidates = await orderedInputCandidates()
+  let fallback: { stream: MediaStream; label: string } | null = null
+
+  for (const candidate of candidates.length ? candidates : [null]) {
+    let stream: MediaStream
+
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: wakeAudioConstraints(candidate?.deviceId),
+        video: false
+      })
+    } catch {
+      continue // device vanished / blocked — try the next one
+    }
+
+    const label = candidate?.label || stream.getAudioTracks()[0]?.label || 'system default'
+
+    if (await streamIsLive(context, stream)) {
+      fallback?.stream.getTracks().forEach(t => t.stop())
+
+      return { stream, label, live: true }
+    }
+
+    if (fallback) {
+      stream.getTracks().forEach(t => t.stop())
+    } else {
+      fallback = { stream, label }
+    }
+  }
+
+  if (fallback) {
+    return { ...fallback, live: false }
+  }
+
+  throw new Error('No usable microphone for client wake capture')
+}
+
+/**
+ * Start streaming the microphone to `wake.feed`.
  * Returns a handle whose `stop()` ends tracks + audio graph.
  */
 export async function startClientWakeCapture(options: ClientWakeCaptureOptions): Promise<ClientWakeCaptureHandle> {
@@ -95,17 +249,25 @@ export async function startClientWakeCapture(options: ClientWakeCaptureOptions):
     throw new Error('getUserMedia unavailable for client wake capture')
   }
 
-  const stream = await navigator.mediaDevices.getUserMedia({
-    audio: {
-      channelCount: 1,
-      echoCancellation: true,
-      noiseSuppression: true,
-      autoGainControl: true
-    },
-    video: false
-  })
-
   const context = new AudioContextCtor()
+
+  if (context.state === 'suspended') {
+    await context.resume().catch(() => undefined)
+  }
+
+  let stream: MediaStream
+  let deviceLabel: string
+  let live: boolean
+
+  try {
+    ;({ stream, label: deviceLabel, live } = await openLiveInput(context))
+  } catch (error) {
+    void context.close().catch(() => undefined)
+    throw error
+  }
+
+  options.onDeviceChosen?.({ label: deviceLabel, live })
+
   const source = context.createMediaStreamSource(stream)
   // ScriptProcessor is deprecated but widely available and simple for PCM export.
   // Buffer size 4096 keeps callback rate reasonable on desktop.
@@ -210,6 +372,12 @@ export async function startClientWakeCapture(options: ClientWakeCaptureOptions):
   return {
     get active() {
       return !stopped
+    },
+    get deviceLabel() {
+      return deviceLabel
+    },
+    get live() {
+      return live
     },
     stop() {
       if (stopped) {

--- a/apps/desktop/src/store/wake-word.ts
+++ b/apps/desktop/src/store/wake-word.ts
@@ -59,7 +59,22 @@ async function maybeStartClientCapture(result: WakeStartResponse | null | undefi
   try {
     clientCapture = await startClientWakeCapture({
       frameLength: result.frame_length,
-      request: gatewayRequester
+      request: gatewayRequester,
+      // A silent input is the one wake failure with no visible symptom: the ear
+      // arms, PCM streams, and nothing ever fires. Say so in the tooltip the
+      // moment we detect it instead of leaving a permanently deaf listener.
+      onDeviceChosen: ({ label, live }) => {
+        if (live) {
+          return
+        }
+
+        const current = $wakeWord.get()
+
+        $wakeWord.set({
+          ...current,
+          notice: `mic "${label}" is silent — pick a real input device on this machine`
+        })
+      }
     })
   } catch (error) {
     const current = $wakeWord.get()
@@ -136,7 +151,17 @@ export type WakeRequester = <T>(method: string, params?: Record<string, unknown>
 // First-use wake.start lazy-installs the detection engine (onnxruntime is a
 // large wheel) — that legitimately takes minutes. The default 30s WS timeout
 // fired mid-install, leaving a dead button that went blue on its own later.
-const WAKE_START_TIMEOUT_MS = 180_000
+//
+// wake.status needs the same allowance: it runs the SAME
+// check_wake_word_requirements() probe, which on a freshly restarted backend
+// imports faster-whisper, the TTS stack and the tflite runtime before it can
+// answer. Leaving it on the 30s default made auto-arm fail silently after every
+// backend restart — armWakeWord awaits wake.status first, so the timeout threw
+// before it ever reached wake.start and the ear just never came back on. A
+// manual click still worked, which made it look like a UI bug rather than a
+// timeout.
+const WAKE_RPC_TIMEOUT_MS = 180_000
+const WAKE_SLOW_METHODS = new Set(['wake.start', 'wake.status'])
 
 const gatewayRequester: WakeRequester = async <T>(method: string, params: Record<string, unknown> = {}) => {
   const gateway = $gateway.get()
@@ -145,8 +170,8 @@ const gatewayRequester: WakeRequester = async <T>(method: string, params: Record
     throw new Error('Hermes gateway unavailable')
   }
 
-  return method === 'wake.start'
-    ? gateway.request<T>(method, params, WAKE_START_TIMEOUT_MS)
+  return WAKE_SLOW_METHODS.has(method)
+    ? gateway.request<T>(method, params, WAKE_RPC_TIMEOUT_MS)
     : gateway.request<T>(method, params)
 }
 
@@ -280,8 +305,18 @@ export async function armWakeWord(request: WakeRequester = gatewayRequester): Pr
     })
 
     applyWakeStartResult(result)
-  } catch {
-    // Older backends / transient failures — keep whatever we last knew.
+  } catch (error) {
+    // Older backends legitimately lack wake.* — stay quiet there. Anything else
+    // (notably a wake.status timeout on a cold backend) used to vanish here,
+    // leaving an ear that was off with no reason shown. Surface it in the
+    // tooltip so "it just stopped listening" is diagnosable from the UI.
+    const message = error instanceof Error ? error.message : String(error)
+
+    if (!/unknown method|not supported|no such method/i.test(message)) {
+      const current = $wakeWord.get()
+
+      $wakeWord.set({ ...current, notice: `auto-arm failed: ${message}`, pending: false })
+    }
   }
 }
 

--- a/tests/tools/test_wake_silent_audio_hint.py
+++ b/tests/tools/test_wake_silent_audio_hint.py
@@ -1,0 +1,68 @@
+"""Tests for wake_word.silent_audio_hint's client-capture branches.
+
+Under ``wake_word.capture: client`` the microphone is on the DESKTOP machine;
+the backend host has none. The hint is the only guidance a user gets when the
+ear arms but hears nothing, so pointing it at the backend's mic permission
+sends people to debug a machine that was never involved.
+"""
+
+from unittest.mock import patch
+
+from tools.wake_word import silent_audio_hint
+
+
+DETAILS = {"name": "Some Input", "index": 3}
+
+
+class TestClientCapture:
+    def test_no_frames_blames_the_desktop_not_the_backend(self):
+        """No PCM arrived: the desktop never opened its mic."""
+        hint = silent_audio_hint(DETAILS, external_audio=True, frames_seen=False)
+        assert "desktop" in hint.lower()
+        assert "not streaming" in hint.lower()
+        assert "hermes backend" not in hint.lower()
+
+    def test_silent_frames_blames_the_desktop_input_choice(self):
+        """PCM arrived but was silent: the desktop opened the wrong input."""
+        hint = silent_audio_hint(DETAILS, external_audio=True, frames_seen=True)
+        assert "desktop" in hint.lower()
+        assert "silence" in hint.lower()
+        assert "hermes backend" not in hint.lower()
+
+    def test_the_two_client_failures_give_different_advice(self):
+        """Distinguishable causes must not collapse into one message."""
+        no_frames = silent_audio_hint(DETAILS, external_audio=True, frames_seen=False)
+        silent = silent_audio_hint(DETAILS, external_audio=True, frames_seen=True)
+        assert no_frames != silent
+
+    def test_names_the_virtual_loopbacks_that_cause_this(self):
+        hint = silent_audio_hint(DETAILS, external_audio=True, frames_seen=True)
+        assert "BlackHole" in hint
+
+    def test_client_capture_never_cites_the_backend_host_platform(self):
+        """The backend's OS is irrelevant when the mic is on another machine."""
+        for platform in ("darwin", "win32", "linux"):
+            with patch("tools.wake_word.sys.platform", platform):
+                hint = silent_audio_hint(DETAILS, external_audio=True, frames_seen=True)
+            assert "desktop" in hint.lower()
+
+
+class TestLocalCapture:
+    def test_macos_points_at_the_backend_mic_permission(self):
+        """Without client capture the mic IS on this host — old behaviour stands."""
+        with patch("tools.wake_word.sys.platform", "darwin"):
+            hint = silent_audio_hint(DETAILS)
+        assert "Hermes backend" in hint
+        assert "Privacy & Security" in hint
+
+    def test_windows_points_at_the_input_device_setting(self):
+        with patch("tools.wake_word.sys.platform", "win32"):
+            hint = silent_audio_hint(DETAILS)
+        assert "wake_word.input_device" in hint
+
+    def test_local_capture_is_the_default(self):
+        """Callers that don't pass the flag must get the local-host advice."""
+        with patch("tools.wake_word.sys.platform", "darwin"):
+            assert silent_audio_hint(DETAILS) == silent_audio_hint(
+                DETAILS, external_audio=False
+            )

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -472,8 +472,70 @@ def _resample_audio_frame(np, frame, output_length: int):
     return np.rint(values).clip(-32768, 32767).astype(np.int16)
 
 
-def silent_audio_hint(details: Dict[str, Any]) -> str:
-    """Platform-specific remediation for an armed stream delivering silence."""
+_WAKE_DEBUG_MARKER = os.path.expanduser("~/.hermes/.wake_debug")
+_WAKE_DEBUG_WAV = os.path.expanduser("~/.hermes/logs/wake_debug.wav")
+_WAKE_DEBUG_MAX_SAMPLES = SAMPLE_RATE * 30  # 30s ceiling
+_wake_debug_buf: list = []
+_wake_debug_lock = threading.Lock()
+
+
+def _wake_debug_write(arr) -> None:
+    """Append client PCM to a debug WAV while ~/.hermes/.wake_debug exists.
+
+    Diagnostic only, and off unless the marker file is present. Writes the exact
+    int16 stream handed to the engine, so the captured file answers "is the
+    audio the model sees actually intelligible?" directly.
+    """
+    if not os.path.exists(_WAKE_DEBUG_MARKER):
+        return
+    try:
+        import wave as _wave
+
+        with _wake_debug_lock:
+            _wake_debug_buf.append(bytes(arr.tobytes()))
+            total = sum(len(b) for b in _wake_debug_buf) // 2
+            if total < _WAKE_DEBUG_MAX_SAMPLES:
+                return
+            data = b"".join(_wake_debug_buf)
+            _wake_debug_buf.clear()
+        with _wave.open(_WAKE_DEBUG_WAV, "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(SAMPLE_RATE)
+            w.writeframes(data)
+        os.unlink(_WAKE_DEBUG_MARKER)  # one-shot
+        logger.warning("wake word: debug capture written to %s (%d samples)",
+                       _WAKE_DEBUG_WAV, len(data) // 2)
+    except Exception as e:
+        logger.debug("wake debug capture failed: %s", e)
+
+
+def silent_audio_hint(details: Dict[str, Any], *,
+                      external_audio: bool = False,
+                      frames_seen: bool = True) -> str:
+    """Platform-specific remediation for an armed stream delivering silence.
+
+    With client capture the microphone is on the DESKTOP, not this host, so the
+    backend's own mic permission is irrelevant — pointing at it sends people to
+    the wrong machine. Split the two client failures apart as well: no frames at
+    all means the desktop never opened its mic, while silent frames mean it
+    opened the wrong input (a virtual loopback like BlackHole/MMAudio, or a
+    Bluetooth headset that is paired but not delivering audio).
+    """
+    if external_audio:
+        if not frames_seen:
+            return (
+                "The desktop app is not streaming microphone audio. Check that it "
+                "has microphone access (System Settings > Privacy & Security > "
+                "Microphone on the desktop machine), then toggle the wake word."
+            )
+        return (
+            "The desktop app is streaming silence — its selected microphone "
+            "produces no signal. Pick a real input device as the default on the "
+            "desktop machine (virtual loopbacks like BlackHole or MMAudio always "
+            "read as silence, and Bluetooth headsets go silent when idle), then "
+            "toggle the wake word."
+        )
     if sys.platform == "darwin":
         return (
             "Microphone delivers only silence. Grant the Hermes backend "
@@ -1024,6 +1086,10 @@ class WakeWordDetector:
         # from "deaf".
         self.audio_silent = False
         self._silent_frames = 0
+        # Client capture only: has ANY wake.feed frame ever arrived? Separates
+        # "the desktop never opened its mic" from "the desktop is feeding
+        # silence" — the two look identical in the silent-frame counter.
+        self._external_frames_seen = False
 
     @property
     def running(self) -> bool:
@@ -1046,6 +1112,11 @@ class WakeWordDetector:
             arr = np.frombuffer(pcm_int16, dtype=np.int16)
         else:
             arr = np.asarray(pcm_int16, dtype=np.int16).reshape(-1)
+        # DEBUG (opt-in): touch ~/.hermes/.wake_debug to dump exactly the PCM the
+        # engine scores, so a "listening but never fires" report can be settled by
+        # replaying the real client audio offline instead of guessing at the
+        # capture chain. Capped, then self-disarms by removing the marker.
+        _wake_debug_write(arr)
         fl = int(self.engine.frame_length)
         if fl <= 0:
             return
@@ -1206,7 +1277,17 @@ class WakeWordDetector:
                             self._silent_frames += 1
                             if self._silent_frames == silent_alert_frames:
                                 self.audio_silent = True
+                                logger.warning(
+                                    "wake word: no client PCM received for %ds; %s",
+                                    _SILENCE_ALERT_SECONDS,
+                                    silent_audio_hint(
+                                        self.input_device_details,
+                                        external_audio=True,
+                                        frames_seen=self._external_frames_seen,
+                                    ),
+                                )
                             continue
+                        self._external_frames_seen = True
                         data = frame
                     else:
                         data, _overflow = stream.read(capture_frame_length)
@@ -1228,7 +1309,11 @@ class WakeWordDetector:
                         logger.warning(
                             "wake word: mic delivers only silence (peak<=%d for %ds); %s",
                             _SILENCE_PEAK, _SILENCE_ALERT_SECONDS,
-                            silent_audio_hint(self.input_device_details),
+                            silent_audio_hint(
+                                self.input_device_details,
+                                external_audio=self.external_audio,
+                                frames_seen=self._external_frames_seen,
+                            ),
                         )
                 elif self._silent_frames:
                     if self.audio_silent:
@@ -1505,4 +1590,7 @@ def detector_frame_info() -> Dict[str, Any]:
         "sample_rate": SAMPLE_RATE,
         "frame_length": int(getattr(det.engine, "frame_length", 1280) or 1280),
         "external_audio": bool(det.external_audio),
+        # Client capture: whether any wake.feed frame has ever landed, so
+        # status can say "never opened its mic" vs "feeding silence".
+        "frames_seen": bool(det._external_frames_seen),
     }

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13829,7 +13829,17 @@ def _(rid, params: dict) -> dict:
         # the PCM feeder after wake.detected.
         frame = detector_frame_info()
         hint = reqs.get("hint", "")
-        if input_device.get("error") and not hint:
+        # Only a LOCAL-capture listener needs a backend input device. Under
+        # client capture the mic lives on the desktop and the backend host
+        # legitimately has none, so probing it fails with "Error querying
+        # device -1" — an internal detail that was being surfaced as the ear's
+        # tooltip and read as "the wake word is broken" when nothing was wrong.
+        _effective_capture = (
+            "client"
+            if frame.get("external_audio")
+            else str(probe_cfg.get("capture") or "local").strip().lower()
+        )
+        if _effective_capture != "client" and input_device.get("error") and not hint:
             hint = f"Wake-word input device could not be resolved: {input_device['error']}"
         if silent and not hint:
             # In client capture the mic is on the DESKTOP — the backend's own

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13823,16 +13823,22 @@ def _(rid, params: dict) -> dict:
         listening = owned_by_caller and is_listening()
         silent = listening and audio_is_silent()
         input_device = get_input_device_status(cfg)
-        hint = reqs.get("hint", "")
-        if input_device.get("error") and not hint:
-            hint = f"Wake-word input device could not be resolved: {input_device['error']}"
-        if silent and not hint:
-            hint = silent_audio_hint(input_device)
         # Effective capture: prefer the *armed* detector over config/auto.
         # With capture:auto the GUI arms client mode, but a bare status probe
         # would otherwise report "local" and the desktop would not reattach
         # the PCM feeder after wake.detected.
         frame = detector_frame_info()
+        hint = reqs.get("hint", "")
+        if input_device.get("error") and not hint:
+            hint = f"Wake-word input device could not be resolved: {input_device['error']}"
+        if silent and not hint:
+            # In client capture the mic is on the DESKTOP — the backend's own
+            # input device is irrelevant, so the hint must say so.
+            hint = silent_audio_hint(
+                input_device,
+                external_audio=bool(frame.get("external_audio")),
+                frames_seen=bool(frame.get("frames_seen", True)),
+            )
         if owned_by_caller and frame.get("external_audio"):
             capture = "client"
         elif owned_by_caller and listening:


### PR DESCRIPTION
## What does this PR do?

Three bugs on the `wake_word.capture: client` path (desktop streams PCM to a remote backend). Together they made "hey Hermes" appear broken with no usable diagnosis.

**1. Auto-arm died silently after every backend restart.** `armWakeWord` awaits `wake.status` before `wake.start`, but only `wake.start` carried the 180s timeout. `wake.status` runs the same requirements probe (imports faster-whisper, TTS and tflite on a cold backend), blew the 30s default, and threw into a bare `catch {}`. The ear never came back and showed no reason — while a manual click still worked, which reads as a UI bug rather than a timeout. Several "wake is still broken" reports turned out to have nothing listening at all.

**2. The silent-audio hint pointed at the wrong machine.** Under client capture the microphone is on the *desktop*; the backend host has none. The hint unconditionally said "grant the Hermes backend microphone access", which sends users to debug a machine that was never involved. It also collapsed two distinct failures — no frames arrived (desktop never opened its mic) versus silent frames (desktop opened a virtual loopback like BlackHole/MMAudio) — into one message, discarding the only signal that separates them.

**3. `wake.status` surfaced the backend's own PortAudio error** (`Wake-word input device could not be resolved: Error querying device -1`) as the ear's tooltip even under client capture, where the backend is *not supposed to* have a mic. Now gated on the effective capture mode.

Also adds a log line on the no-PCM path, which previously set `audio_silent` with no log at all, and exposes `frames_seen` via `detector_frame_info()` so the two failures stay distinguishable. Timing already tells you which one you have — the silence alert after ~10s means frames arrived but were silent, after ~38s means no frames arrived (0.25s queue timeout x 125) — but nothing recorded it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/wake_word.py` — `silent_audio_hint()` takes `external_audio` + `frames_seen` and branches on them; `_external_frames_seen` tracking; log on the no-PCM path; `frames_seen` exposed via `detector_frame_info()`
- `tui_gateway/server.py` — `wake.status` passes the capture flags through and no longer reports a backend device error under client capture
- `apps/desktop/src/lib/wake-client-capture.ts` — enumerate inputs, deprioritise known virtual loopbacks by label, and probe each candidate for any nonzero sample before committing
- `apps/desktop/src/store/wake-word.ts` — surface the silent-mic notice in the ear tooltip; `wake.status` gets the same 180s timeout as `wake.start`
- `tests/tools/test_wake_silent_audio_hint.py` — new

The device probe uses an **exact-zero** test rather than a loudness threshold: a real mic in a silent room still has a noise floor, while a virtual or dead input is bit-perfect zeros. `noiseSuppression` is turned off for the probe because a gate can zero a quiet room and defeat it; `echoCancellation` stays on so Hermes' own TTS cannot trigger its wake word.

## How to test

Reproducing #2 needs a host with no real input device, which is the configuration that makes client capture worth using:

```bash
# hint branches, no hardware needed
pytest tests/tools/test_wake_silent_audio_hint.py -v
```

Manually, with `wake_word.capture: client` and a desktop connected to a remote backend:
1. Restart the backend, then watch the desktop auto-arm — before this, the ear silently stayed off; now a `wake.start` line appears in the log.
2. Select a virtual loopback (BlackHole) as the desktop's default input. The tooltip now says the *desktop* is streaming silence, and names loopbacks as the cause, instead of telling you to grant the backend mic access.

## What platforms

Tested on macOS 15.5 (Apple Silicon): backend on a Mac mini with zero input devices, desktop on a Mac Studio over Tailscale. The hint tests cover the win32/linux branches via patched `sys.platform`; the desktop-side device probe is browser API code and platform-independent, but I have not exercised it on Windows or Linux hardware.