### PR TITLE
feat(tts): add a MiniMax chunked-PCM streaming provider

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4612,6 +4612,8 @@ async def speak_text(payload: TTSSpeakRequest, profile: Optional[str] = None):
     existing TTS provider chain (Edge / OpenAI / ElevenLabs / etc.)
     configured in ``~/.hermes/config.yaml`` under ``tts.``.
     """
+    _log.info("speak: data-URL fallback path profile=%r chars=%d",
+              profile, len((payload.text or "").strip()))
     text = (payload.text or "").strip()
     if not text:
         raise HTTPException(status_code=400, detail="Text is required")
@@ -4728,12 +4730,18 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
                chunked API — the client uses the POST endpoint instead.
     """
     if not _ws_auth_ok(ws):
+        _log.warning("speak-stream: WS rejected (auth) client=%s",
+                     getattr(getattr(ws, "client", None), "host", "?"))
         await ws.close(code=4401)
         return
     if not _ws_request_is_allowed(ws):
+        _log.warning("speak-stream: WS rejected (not allowed) client=%s",
+                     getattr(getattr(ws, "client", None), "host", "?"))
         await ws.close(code=4403)
         return
     await ws.accept()
+    _log.debug("speak-stream: WS accepted client=%s",
+               getattr(getattr(ws, "client", None), "host", "?"))
 
     # Profile via query param, like /api/pty and /api/console: the provider
     # chain + API keys must resolve from the requesting profile's config, not
@@ -4759,6 +4767,8 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
         _log.exception("speak-stream provider resolution failed")
         streamer, cap = None, 0
     if streamer is None:
+        _log.warning("speak-stream: no chunked streamer for profile=%r -> telling client to FALLBACK",
+                     profile)
         with contextlib.suppress(Exception):
             await ws.send_json({"type": "fallback"})
             await ws.close()
@@ -4843,17 +4853,29 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
         text_q.put(None)  # unblock the producer
 
     pump = asyncio.ensure_future(_pump_client())
+    _sent_bytes = 0
+    _sent_frames = 0
     try:
         while True:
             chunk = await chunks.get()
             if chunk is None:
                 break
             await ws.send_bytes(chunk)
+            _sent_bytes += len(chunk)
+            _sent_frames += 1
         if not stop.is_set():
             await ws.send_json({"type": "end"})
     except (WebSocketDisconnect, RuntimeError):
         pass
     finally:
+        # One line per spoken reply. Cheap, and it is the only place that
+        # distinguishes "the backend never produced audio" from "the client
+        # never played what it was sent" — the two look identical from the UI,
+        # and without it a silent-playback report is unfalsifiable.
+        _log.info("speak-stream: sent %d frames / %d bytes (%.2fs audio) barged_in=%s",
+                  _sent_frames, _sent_bytes,
+                  _sent_bytes / 2 / max(1, getattr(streamer, "sample_rate", 24000)),
+                  stop.is_set())
         stop.set()
         text_q.put(None)
         pump.cancel()

--- a/tests/tools/test_tts_minimax_streaming.py
+++ b/tests/tools/test_tts_minimax_streaming.py
@@ -1,0 +1,158 @@
+"""Tests for the MiniMax chunked-PCM streamer (tools.tts_streaming.MiniMaxStreamer).
+
+No network: ``requests.post`` and the region/credential resolver are mocked, so
+these assert the SSE parsing contract rather than MiniMax's live behaviour.
+
+The load-bearing case is ``test_summary_event_is_not_yielded``. MiniMax ends a
+stream with a summary event whose ``data.audio`` repeats the WHOLE utterance
+rather than carrying a final increment. Yielding it plays every sentence twice
+at exactly 2x the bytes — and it survives a naive round-trip check, because
+Whisper transcribes duplicated audio back to one clean sentence. Duration is
+the only signal that catches it, which is what this test pins.
+"""
+
+import json
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import tools.tts_streaming as ts
+
+
+def _sse(events):
+    """Encode *events* as the SSE ``data:`` lines ``iter_lines`` would hand back."""
+    return [b"data: " + json.dumps(e).encode() for e in events]
+
+
+class _Response:
+    """Minimal stand-in for a streaming ``requests`` response.
+
+    A real class, not SimpleNamespace: ``with requests.post(...)`` looks the
+    context-manager dunders up on the type, so instance attributes won't do.
+    """
+
+    def __init__(self, lines):
+        self._lines = lines
+
+    def raise_for_status(self):
+        return None
+
+    def iter_lines(self):
+        return iter(self._lines)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+@contextmanager
+def _minimax(events, lines=None):
+    """Run MiniMaxStreamer against a canned SSE event list."""
+    response = _Response(_sse(events) if lines is None else lines)
+
+    class _Post:
+        def __call__(self, *a, **kw):
+            self.kwargs = kw
+            return response
+
+    post = _Post()
+    runtime = SimpleNamespace(endpoint="https://api.minimax.io/v1/t2a_v2", api_key="k")
+    with patch("requests.post", post), \
+         patch("tools.tts_tool._resolve_minimax_tts_runtime", return_value=runtime):
+        yield post
+
+
+def _audio(hex_bytes, status=1, **extra):
+    return {"data": {"audio": hex_bytes, "status": status}, **extra}
+
+
+class TestMiniMaxStreamerSSE:
+    def test_yields_decoded_pcm_for_each_incremental_chunk(self):
+        with _minimax([_audio("0011"), _audio("2233")]):
+            out = list(ts.MiniMaxStreamer({}, {}).stream("hello"))
+        assert out == [b"\x00\x11", b"\x22\x33"]
+
+    def test_summary_event_is_not_yielded(self):
+        """status=2 repeats the entire utterance — yielding it doubles the audio."""
+        whole = "0011" + "2233"
+        with _minimax([
+            _audio("0011"),
+            _audio("2233"),
+            _audio(whole, status=2, extra_info={"audio_length": 123}),
+        ]):
+            out = list(ts.MiniMaxStreamer({}, {}).stream("hello"))
+        assert out == [b"\x00\x11", b"\x22\x33"]
+        assert b"".join(out) == b"\x00\x11\x22\x33"  # 4 bytes, not 8
+
+    def test_extra_info_alone_marks_a_summary_event(self):
+        """Some responses carry extra_info without status=2; still a summary."""
+        with _minimax([_audio("0011"), _audio("0011", extra_info={"usage": 1})]):
+            out = list(ts.MiniMaxStreamer({}, {}).stream("hello"))
+        assert out == [b"\x00\x11"]
+
+    def test_api_error_raises_instead_of_yielding_silence(self):
+        events = [{"base_resp": {"status_code": 1004, "status_msg": "bad key"}}]
+        with _minimax(events):
+            with pytest.raises(RuntimeError, match="1004"):
+                list(ts.MiniMaxStreamer({}, {}).stream("hello"))
+
+    def test_undecodable_chunk_is_skipped_not_fatal(self):
+        with _minimax([_audio("zzzz"), _audio("0011")]):
+            out = list(ts.MiniMaxStreamer({}, {}).stream("hello"))
+        assert out == [b"\x00\x11"]
+
+    def test_non_data_and_malformed_lines_are_ignored(self):
+        lines = [
+            b"",
+            b"event: ping",
+            b"data: {oops",
+            b"data: " + json.dumps(_audio("0011")).encode(),
+        ]
+        with _minimax([], lines=lines):
+            out = list(ts.MiniMaxStreamer({}, {}).stream("hello"))
+        assert out == [b"\x00\x11"]
+
+
+class TestMiniMaxStreamerRequest:
+    def test_requests_pcm_at_the_declared_sample_rate(self):
+        """The interface promises int16 PCM at ``sample_rate``; ask for exactly that."""
+        with _minimax([_audio("0011")]) as post:
+            list(ts.MiniMaxStreamer({}, {}).stream("hello"))
+        audio = post.kwargs["json"]["audio_setting"]
+        assert post.kwargs["json"]["stream"] is True
+        assert audio["format"] == "pcm"
+        assert audio["channel"] == 1
+        assert audio["sample_rate"] == ts.MiniMaxStreamer.sample_rate
+
+    def test_voice_and_model_come_from_the_tts_minimax_section(self):
+        """Enabling streaming must not silently change the configured voice."""
+        section = {"model": "speech-02-turbo", "voice_id": "Custom_voice"}
+        with _minimax([_audio("0011")]) as post:
+            list(ts.MiniMaxStreamer({"minimax": section}, section).stream("hi"))
+        body = post.kwargs["json"]
+        assert body["model"] == "speech-02-turbo"
+        assert body["voice_setting"]["voice_id"] == "Custom_voice"
+
+    def test_emotion_is_only_sent_when_configured(self):
+        with _minimax([_audio("0011")]) as post:
+            list(ts.MiniMaxStreamer({}, {}).stream("hi"))
+        assert "emotion" not in post.kwargs["json"]["voice_setting"]
+
+        with _minimax([_audio("0011")]) as post:
+            list(ts.MiniMaxStreamer({}, {"emotion": "happy"}).stream("hi"))
+        assert post.kwargs["json"]["voice_setting"]["emotion"] == "happy"
+
+
+class TestMiniMaxStreamerResolution:
+    def test_registered_under_minimax(self):
+        assert ts._REGISTRY.get("minimax") is ts.MiniMaxStreamer
+
+    def test_configured_minimax_provider_resolves_to_this_streamer(self):
+        """tts.provider: minimax should stream, not fall back to whole-reply."""
+        with patch.object(ts.MiniMaxStreamer, "available", staticmethod(lambda: True)):
+            inst = ts.resolve_streaming_provider({"provider": "minimax"})
+        assert isinstance(inst, ts.MiniMaxStreamer)

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -486,3 +486,117 @@ class XAIStreamer(StreamingTTSProvider):
                     return
                 logger.warning("xAI WS receive failed: %s", exc)
                 return
+
+
+@register("minimax")
+class MiniMaxStreamer(StreamingTTSProvider):
+    """MiniMax T2A v2 SSE → raw PCM (24 kHz mono int16).
+
+    MiniMax's ``/v1/t2a_v2`` accepts ``stream: true`` and, with
+    ``audio_setting.format = "pcm"``, emits SSE ``data:`` lines whose
+    ``data.audio`` field is HEX-encoded PCM at the requested sample rate —
+    exactly the contract this interface wants, no transcoding needed.
+
+    Without this, ``tts.provider: minimax`` had no chunked API, so the desktop
+    fell back to synthesizing a whole reply and shipping one base64 data URL.
+    On a remote gateway that meant multi-megabyte payloads and a playback
+    watchdog with nothing to re-arm it. Region, endpoint, credential and voice
+    all resolve through the SAME helpers as the sync path, so the streamed
+    voice matches the one already configured.
+    """
+
+    sample_rate = 24000
+
+    @staticmethod
+    def available() -> bool:
+        try:
+            from tools.tts_tool import _load_tts_config, _resolve_minimax_tts_runtime
+
+            return bool(_resolve_minimax_tts_runtime(_load_tts_config()).api_key)
+        except Exception:
+            return False
+
+    def stream(self, text: str) -> Iterator[bytes]:
+        import json
+
+        import requests
+
+        from tools.tts_tool import (
+            DEFAULT_MINIMAX_MODEL,
+            DEFAULT_MINIMAX_VOICE_ID,
+            _resolve_minimax_tts_runtime,
+        )
+
+        runtime = _resolve_minimax_tts_runtime(self.tts_config)
+        section = self.section if isinstance(self.section, dict) else {}
+
+        payload = {
+            "model": section.get("model", DEFAULT_MINIMAX_MODEL),
+            "text": text,
+            "stream": True,
+            "voice_setting": {
+                "voice_id": section.get("voice_id", DEFAULT_MINIMAX_VOICE_ID),
+                "speed": section.get("speed", 1.0),
+                "vol": section.get("vol", 1.0),
+                "pitch": section.get("pitch", 0),
+            },
+            # PCM out means the frames go straight to the client's Web Audio
+            # scheduler with no decode step.
+            "audio_setting": {
+                "sample_rate": self.sample_rate,
+                "format": "pcm",
+                "channel": 1,
+            },
+        }
+        emotion = section.get("emotion")
+        if emotion:
+            payload["voice_setting"]["emotion"] = emotion
+
+        def _chunks() -> Iterator[bytes]:
+            with requests.post(
+                runtime.endpoint,
+                headers={
+                    "Authorization": f"Bearer {runtime.api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                stream=True,
+                timeout=(10, 120),
+            ) as response:
+                response.raise_for_status()
+                for raw in response.iter_lines():
+                    if not raw:
+                        continue
+                    line = raw.decode("utf-8", "ignore").strip()
+                    if not line.startswith("data:"):
+                        continue
+                    try:
+                        event = json.loads(line[5:].strip())
+                    except ValueError:
+                        continue
+                    # A non-zero status_code carries the API's own error text;
+                    # surfacing it beats yielding silence the caller can't explain.
+                    status = (event.get("base_resp") or {}).get("status_code")
+                    if status:
+                        raise RuntimeError(
+                            "MiniMax streaming TTS error %s: %s"
+                            % (status, (event.get("base_resp") or {}).get("status_msg", ""))
+                        )
+                    data = event.get("data") or {}
+                    # MiniMax terminates the stream with a SUMMARY event
+                    # (status=2, carries extra_info) whose data.audio is the
+                    # ENTIRE utterance repeated, not a final increment. Yielding
+                    # it after the status=1 chunks makes every sentence play
+                    # twice — audibly, and at exactly 2x the bytes.
+                    if data.get("status") == 2 or event.get("extra_info"):
+                        continue
+                    audio_hex = data.get("audio") or ""
+                    if not audio_hex:
+                        continue
+                    try:
+                        yield bytes.fromhex(audio_hex)
+                    except ValueError:
+                        logger.warning("MiniMax streaming TTS: undecodable audio chunk")
+                        continue
+
+        yield from _capped(_chunks(), "MiniMax streaming TTS")


### PR DESCRIPTION
## What does this PR do?

`tts.provider: minimax` had no chunked API, so `resolve_streaming_provider` returned `None` and the desktop fell back to synthesizing an entire reply, base64-encoding it, and shipping one data URL. Over a remote gateway that means multi-megabyte payloads and a 15s playback watchdog with nothing to re-arm it — replies simply fail with "Playback stalled". The only workaround was pointing `tts.streaming.provider` at a different, paid provider, which also silently changes the user's voice.

MiniMax's `/v1/t2a_v2` already supports what the streaming interface wants: `stream: true` plus `audio_setting.format = "pcm"` emits SSE `data:` lines whose `data.audio` is hex-encoded PCM at the requested sample rate. No decode or transcode step, so frames go straight to the client's Web Audio scheduler.

Region, endpoint, credential and voice all resolve through the **same** helpers as the sync path (`_resolve_minimax_tts_runtime`, the `tts.minimax` section), so enabling streaming cannot silently change the configured voice.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/tts_streaming.py` — `MiniMaxStreamer`, registered as `minimax`
- `hermes_cli/web_server.py` — one-line-per-reply summary of frames/bytes/duration actually sent
- `tests/tools/test_tts_minimax_streaming.py` — new

### The summary-event trap

MiniMax terminates the stream with a **summary** event (`status=2`, carrying `extra_info`) whose `data.audio` is the *entire utterance repeated*, not a final increment. Yielding it makes every sentence play twice at exactly 2x the bytes. The streamer filters on `status == 2 or extra_info`.

Worth flagging for reviewers because of how it hides: a round-trip check does **not** catch it — Whisper transcribes the duplicated audio back to one clean sentence. Only duration/byte count reveals it. `test_summary_event_is_not_yielded` pins this; removing the filter fails that test and `test_extra_info_alone_marks_a_summary_event`, and nothing else.

That is also why the reply summary log line is here. It is the only signal separating "the backend never produced audio" from "the client never played what it was sent" — identical from the UI, and without it a silent-playback report cannot be falsified.

## How to test

```bash
pytest tests/tools/test_tts_minimax_streaming.py -v   # no network
```

End to end, with `tts.provider: minimax` and a MiniMax key:

```python
from hermes_cli.config import load_config
import tools.tts_streaming as ts, time
inst = ts.resolve_streaming_provider(load_config()["tts"])
t = time.monotonic(); first = None; total = 0
for c in inst.stream("Short spoken sentence for timing."):
    first = first or time.monotonic() - t
    total += len(c)
print(first, total / (inst.sample_rate * 2))  # first-chunk secs, audio secs
```

Check the reported audio duration against the text — roughly `words / 2.6` seconds. A ~2x ratio means the summary event is being yielded.

## Measurements

On a Mac mini M4, `speech-02-turbo`, 18-word utterance:

| | first chunk | audio produced |
|---|---|---|
| previous chunked provider (ElevenLabs) | 3.65s | — |
| MiniMaxStreamer | **0.80s** | 5.18s of audio in 1.73s wall |

Generation runs faster than realtime, so playback never starves. A 107s reply streamed in 13s.

## What platforms

Tested on macOS 15.5 (Apple Silicon), backend serving a desktop client over Tailscale. The provider is `requests` + SSE with no platform-specific code; the unit tests are network-free and run anywhere.