### PR TITLE
feat(providers): add Inworld model provider

### DIFF
--- a/plugins/model-providers/inworld/__init__.py
+++ b/plugins/model-providers/inworld/__init__.py
@@ -1,0 +1,140 @@
+"""Inworld LLM router provider profile."""
+
+import json
+import logging
+import urllib.request
+from urllib.parse import urljoin
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.inworld.ai/v1"
+
+CATALOG_PATH = "/llm/v1alpha/models"
+
+# Selects a model server-side, so it works before any catalog fetch.
+ROUTER_MODEL = "auto"
+
+_CACHE: dict[str, list[str]] = {}
+
+
+def clear_cache() -> None:
+    """Drop cached catalogs so the next fetch hits the network."""
+    _CACHE.clear()
+
+
+def parse_catalog(payload: object) -> list[str]:
+    """Return tool-calling model ids from a catalog payload.
+
+    Ids join provider and model with a slash: the qualified form is what
+    distinguishes the same model served by several upstreams, and the short
+    form the API echoes back is rejected as a request id.
+
+    A model that does not advertise tool calling is dropped — Hermes drives
+    every turn through tool calls, so it could not run the agent.
+    """
+    if not isinstance(payload, dict):
+        return []
+    entries = payload.get("models")
+    if not isinstance(entries, list):
+        return []
+
+    ids: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("isSupported") is False:
+            continue
+        provider = entry.get("provider")
+        model = entry.get("model")
+        if not isinstance(provider, str) or not provider:
+            continue
+        if not isinstance(model, str) or not model:
+            continue
+        spec = entry.get("spec")
+        capabilities = spec.get("capabilities") if isinstance(spec, dict) else None
+        if not isinstance(capabilities, dict):
+            continue
+        if capabilities.get("functionCalling") is not True:
+            continue
+        ids.append(f"{provider}/{model}")
+    return ids
+
+
+class _InworldProfile(ProviderProfile):
+    """Inworld router profile — the catalog needs its own path, auth, and shape."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch the router catalog, or None to fall back to ``fallback_models``."""
+        url = urljoin(base_url or self.base_url or DEFAULT_BASE_URL, CATALOG_PATH)
+
+        cached = _CACHE.get(url)
+        if cached is not None:
+            return list(cached)
+
+        if not api_key:
+            logger.debug("fetch_models(inworld): no credential, skipping %s", url)
+            return None
+
+        if not url.startswith(("http://", "https://")):
+            logger.warning(
+                "Skipping Inworld catalog discovery: %r has no http:// or "
+                "https:// scheme. Set INWORLD_BASE_URL to e.g. %s.",
+                url, DEFAULT_BASE_URL,
+            )
+            return None
+
+        from hermes_cli.urllib_security import open_credentialed_url
+
+        req = urllib.request.Request(url)
+        # The catalog wants Basic; completions get Bearer from the OpenAI
+        # client. Inworld accepts both.
+        req.add_header("Authorization", f"Basic {api_key}")
+        req.add_header("Accept", "application/json")
+        for k, v in self.default_headers.items():
+            req.add_header(k, v)
+
+        try:
+            with open_credentialed_url(req, timeout=timeout) as resp:
+                payload = json.loads(resp.read().decode())
+        except Exception as exc:
+            logger.debug("fetch_models(inworld): %s", exc)
+            return None
+
+        discovered = parse_catalog(payload)
+        if not discovered:
+            logger.debug("Inworld catalog at %s returned no usable models", url)
+            return None
+
+        models = [ROUTER_MODEL, *discovered]
+        _CACHE[url] = list(models)
+        return models
+
+
+inworld = _InworldProfile(
+    name="inworld",
+    aliases=("inworld-ai", "inworld-router"),
+    display_name="Inworld",
+    description="Inworld — LLM router fronting first-party and upstream models",
+    signup_url="https://portal.inworld.ai/",
+    env_vars=("INWORLD_API_KEY", "INWORLD_BASE_URL"),
+    base_url=DEFAULT_BASE_URL,
+    auth_type="api_key",
+    # The catalog spans upstreams with different completion caps; each applies
+    # its own when we send none.
+    default_max_tokens=None,
+    default_aux_model="inworld/models/gemma-4-26b-a4b-it",
+    # Live discovery is the source of truth for everything else — a stale id
+    # here would route users to a model an upstream may have retired.
+    fallback_models=(ROUTER_MODEL,),
+)
+
+register_provider(inworld)

--- a/plugins/model-providers/inworld/__init__.py
+++ b/plugins/model-providers/inworld/__init__.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import time
 import urllib.request
 from urllib.parse import urljoin
 
@@ -17,12 +18,29 @@ CATALOG_PATH = "/llm/v1alpha/models"
 # Selects a model server-side, so it works before any catalog fetch.
 ROUTER_MODEL = "auto"
 
-_CACHE: dict[str, list[str]] = {}
+# Matches _PROVIDER_MODELS_CACHE_TTL in hermes_cli/models.py, so a long-lived
+# gateway picks up catalog changes without a restart.
+_CACHE_TTL_SECONDS = 3600
+
+# url -> (monotonic timestamp, model ids)
+_CACHE: dict[str, tuple[float, list[str]]] = {}
 
 
 def clear_cache() -> None:
     """Drop cached catalogs so the next fetch hits the network."""
     _CACHE.clear()
+
+
+def _cached_models(url: str) -> list[str] | None:
+    """Return the cached catalog for *url* while it is still fresh."""
+    entry = _CACHE.get(url)
+    if entry is None:
+        return None
+    fetched_at, models = entry
+    if time.monotonic() - fetched_at >= _CACHE_TTL_SECONDS:
+        _CACHE.pop(url, None)
+        return None
+    return list(models)
 
 
 def parse_catalog(payload: object) -> list[str]:
@@ -66,6 +84,33 @@ def parse_catalog(payload: object) -> list[str]:
 class _InworldProfile(ProviderProfile):
     """Inworld router profile — the catalog needs its own path, auth, and shape."""
 
+    def resolve_aux_model(self, *, vision: bool = False) -> str:
+        """Fall back to the router when the pinned aux model leaves the catalog.
+
+        ``default_aux_model`` is a hardcoded id, so it rots the day Inworld
+        retires that model and every auxiliary call 404s. Consults only an
+        already-cached catalog — this runs on client-resolution paths and has
+        no credential to fetch with — and returns "" when it has no basis for
+        an opinion, which sends the caller to ``default_aux_model`` as before.
+        """
+        try:
+            catalogs = [
+                models
+                for models in (_cached_models(url) for url in list(_CACHE))
+                if models
+            ]
+            if not catalogs:
+                return ""
+            if any(self.default_aux_model in models for models in catalogs):
+                return ""
+            logger.debug(
+                "Inworld aux model %s is absent from the catalog; using %s",
+                self.default_aux_model, ROUTER_MODEL,
+            )
+            return ROUTER_MODEL
+        except Exception:
+            return ""
+
     def fetch_models(
         self,
         *,
@@ -76,12 +121,21 @@ class _InworldProfile(ProviderProfile):
         """Fetch the router catalog, or None to fall back to ``fallback_models``."""
         url = urljoin(base_url or self.base_url or DEFAULT_BASE_URL, CATALOG_PATH)
 
-        cached = _CACHE.get(url)
+        cached = _cached_models(url)
         if cached is not None:
-            return list(cached)
+            return cached
 
-        if not api_key:
+        key = (api_key or "").strip()
+        if not key:
             logger.debug("fetch_models(inworld): no credential, skipping %s", url)
+            return None
+
+        if not key.isascii() or any(c.isspace() for c in key):
+            logger.warning(
+                "Skipping Inworld catalog discovery: INWORLD_API_KEY contains "
+                "characters that cannot appear in an Authorization header. "
+                "Expected the base64 key string shown in the Inworld portal."
+            )
             return None
 
         if not url.startswith(("http://", "https://")):
@@ -95,9 +149,7 @@ class _InworldProfile(ProviderProfile):
         from hermes_cli.urllib_security import open_credentialed_url
 
         req = urllib.request.Request(url)
-        # The catalog wants Basic; completions get Bearer from the OpenAI
-        # client. Inworld accepts both.
-        req.add_header("Authorization", f"Basic {api_key}")
+        req.add_header("Authorization", f"Basic {key}")
         req.add_header("Accept", "application/json")
         for k, v in self.default_headers.items():
             req.add_header(k, v)
@@ -111,11 +163,17 @@ class _InworldProfile(ProviderProfile):
 
         discovered = parse_catalog(payload)
         if not discovered:
-            logger.debug("Inworld catalog at %s returned no usable models", url)
+            # Reached and understood the catalog, and it offered nothing usable
+            # — an account/region problem an operator can act on, unlike the
+            # transient transport failures logged at debug above.
+            logger.warning(
+                "Inworld catalog at %s returned no tool-calling models; "
+                "only %r will be offered.", url, ROUTER_MODEL,
+            )
             return None
 
         models = [ROUTER_MODEL, *discovered]
-        _CACHE[url] = list(models)
+        _CACHE[url] = (time.monotonic(), list(models))
         return models
 
 

--- a/plugins/model-providers/inworld/plugin.yaml
+++ b/plugins/model-providers/inworld/plugin.yaml
@@ -1,0 +1,5 @@
+name: inworld-provider
+kind: model-provider
+version: 1.0.0
+description: Inworld — LLM router fronting first-party and upstream models
+author: Anastasia Smolskaya

--- a/tests/providers/test_inworld_profile.py
+++ b/tests/providers/test_inworld_profile.py
@@ -1,0 +1,188 @@
+"""Tests for the Inworld LLM router provider profile."""
+
+import json
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from providers import get_provider_profile
+
+
+@pytest.fixture
+def profile():
+    """The registered Inworld profile (discovery runs on first lookup)."""
+    return get_provider_profile("inworld")
+
+
+@pytest.fixture
+def inworld(profile):
+    """The plugin module, reached through the profile the registry loaded."""
+    module = sys.modules[type(profile).__module__]
+    module.clear_cache()
+    yield module
+    module.clear_cache()
+
+
+def _entry(provider="openai", model="gpt-5.2", **spec):
+    """Build a catalog entry with an overridable ``spec``."""
+    base = {
+        "contextLength": 272000,
+        "maxCompletionTokens": 128000,
+        "inputModalities": ["text", "image"],
+        "outputModalities": ["text"],
+        "capabilities": {"functionCalling": True, "reasoning": True},
+    }
+    base.update(spec)
+    return {"model": model, "provider": provider, "isSupported": True, "spec": base}
+
+
+class _FakeResponse:
+    """Minimal context manager returning a fixed JSON body."""
+
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def read(self):
+        return self._body
+
+
+class TestRegistration:
+    def test_profile_is_registered(self, profile):
+        assert profile is not None
+        assert profile.name == "inworld"
+
+    def test_aliases_resolve(self, profile):
+        assert get_provider_profile("inworld-ai") is profile
+        assert get_provider_profile("inworld-router") is profile
+
+    def test_openai_compatible_endpoint(self, profile):
+        assert profile.base_url == "https://api.inworld.ai/v1"
+        assert profile.api_mode == "chat_completions"
+        assert profile.get_hostname() == "api.inworld.ai"
+
+    def test_router_model_is_the_offline_fallback(self, profile, inworld):
+        """The picker stays usable when the catalog is unreachable."""
+        assert profile.fallback_models == (inworld.ROUTER_MODEL,)
+
+    def test_aux_model_is_a_qualified_catalog_id(self, profile):
+        """Aux resolution is synchronous, so this id is sent as-is."""
+        assert profile.default_aux_model == "inworld/models/gemma-4-26b-a4b-it"
+
+
+class TestParseCatalog:
+    def test_ids_join_provider_and_model(self, inworld):
+        catalog = inworld.parse_catalog(
+            {
+                "models": [
+                    _entry(provider="deepinfra", model="deepseek-ai/DeepSeek-V3.2"),
+                    _entry(provider="inworld", model="models/gemma-4-31b-it"),
+                ]
+            }
+        )
+
+        assert catalog == [
+            "deepinfra/deepseek-ai/DeepSeek-V3.2",
+            "inworld/models/gemma-4-31b-it",
+        ]
+
+    def test_unsupported_entries_are_skipped(self, inworld):
+        entry = _entry()
+        entry["isSupported"] = False
+
+        assert inworld.parse_catalog({"models": [entry]}) == []
+
+    def test_models_without_tool_calling_are_skipped(self, inworld):
+        """A model that cannot call tools cannot drive the agent."""
+        catalog = inworld.parse_catalog(
+            {"models": [_entry(capabilities={"functionCalling": False})]}
+        )
+
+        assert catalog == []
+
+    def test_unstated_tool_calling_is_not_guessed(self, inworld):
+        catalog = inworld.parse_catalog({"models": [_entry(capabilities={})]})
+
+        assert catalog == []
+
+    @pytest.mark.parametrize(
+        "payload",
+        [None, {}, {"models": None}, {"models": [None]}, {"models": [{}]}],
+    )
+    def test_malformed_payloads_yield_no_models(self, inworld, payload):
+        assert inworld.parse_catalog(payload) == []
+
+
+class TestFetchModels:
+    def _fetch(self, profile, payload, **kwargs):
+        """Run ``fetch_models`` against a stubbed catalog, returning the request."""
+        captured = {}
+
+        def _open(request, *, timeout):
+            captured["request"] = request
+            return _FakeResponse(payload)
+
+        with patch("hermes_cli.urllib_security.open_credentialed_url", _open):
+            models = profile.fetch_models(api_key="k", **kwargs)
+        return models, captured.get("request")
+
+    def test_catalog_path_replaces_the_v1_prefix(self, profile, inworld):
+        """The catalog sits outside ``/v1``, so its path replaces base_url's."""
+        _, request = self._fetch(profile, {"models": [_entry()]})
+
+        assert request.full_url == "https://api.inworld.ai/llm/v1alpha/models"
+
+    def test_custom_base_url_follows_its_own_host(self, profile, inworld):
+        _, request = self._fetch(
+            profile, {"models": [_entry()]}, base_url="https://staging.example.com/v1"
+        )
+
+        assert request.full_url == "https://staging.example.com/llm/v1alpha/models"
+
+    def test_catalog_uses_basic_auth(self, profile, inworld):
+        """Bearer is built by the OpenAI client on the completions path only."""
+        _, request = self._fetch(profile, {"models": [_entry()]})
+
+        assert request.get_header("Authorization") == "Basic k"
+
+    def test_router_model_leads_the_list(self, profile, inworld):
+        models, _ = self._fetch(profile, {"models": [_entry()]})
+
+        assert models == [inworld.ROUTER_MODEL, "openai/gpt-5.2"]
+
+    def test_missing_credential_skips_the_fetch(self, profile, inworld):
+        """The catalog requires auth; an anonymous probe would only 401."""
+        with patch(
+            "hermes_cli.urllib_security.open_credentialed_url",
+            side_effect=AssertionError("network touched"),
+        ):
+            assert profile.fetch_models(api_key=None) is None
+
+    def test_transport_failure_degrades_to_fallback(self, profile, inworld):
+        with patch(
+            "hermes_cli.urllib_security.open_credentialed_url",
+            side_effect=OSError("unreachable"),
+        ):
+            assert profile.fetch_models(api_key="k") is None
+
+    def test_empty_catalog_degrades_to_fallback(self, profile, inworld):
+        models, _ = self._fetch(profile, {"models": []})
+
+        assert models is None
+
+    def test_result_is_cached_per_url(self, profile, inworld):
+        first, _ = self._fetch(profile, {"models": [_entry()]})
+
+        with patch(
+            "hermes_cli.urllib_security.open_credentialed_url",
+            side_effect=AssertionError("refetched"),
+        ):
+            second = profile.fetch_models(api_key="k")
+
+        assert second == first

--- a/tests/providers/test_inworld_profile.py
+++ b/tests/providers/test_inworld_profile.py
@@ -186,3 +186,71 @@ class TestFetchModels:
             second = profile.fetch_models(api_key="k")
 
         assert second == first
+
+    def test_cache_expires_so_new_models_appear_without_a_restart(
+        self, profile, inworld, monkeypatch
+    ):
+        clock = [1000.0]
+        monkeypatch.setattr(inworld.time, "monotonic", lambda: clock[0])
+
+        self._fetch(profile, {"models": [_entry()]})
+        clock[0] += inworld._CACHE_TTL_SECONDS + 1
+        refreshed, _ = self._fetch(
+            profile, {"models": [_entry(model="gpt-6")]}
+        )
+
+        assert refreshed == [inworld.ROUTER_MODEL, "openai/gpt-6"]
+
+    @pytest.mark.parametrize("key", ["abc\r\nX-Injected: 1", "abc def", "ké"])
+    def test_keys_that_cannot_form_a_header_are_rejected(
+        self, profile, inworld, key
+    ):
+        """A malformed key is named, not sent as an opaque failed request."""
+        with patch(
+            "hermes_cli.urllib_security.open_credentialed_url",
+            side_effect=AssertionError("network touched"),
+        ):
+            assert profile.fetch_models(api_key=key) is None
+
+    def test_empty_catalog_warns_while_transport_failure_does_not(
+        self, profile, inworld, caplog
+    ):
+        """An operator can tell 'no usable models' from 'network down'."""
+        with caplog.at_level("WARNING"):
+            self._fetch(profile, {"models": []})
+        assert any("no tool-calling models" in r.message for r in caplog.records)
+
+        caplog.clear()
+        with caplog.at_level("WARNING"), patch(
+            "hermes_cli.urllib_security.open_credentialed_url",
+            side_effect=OSError("unreachable"),
+        ):
+            profile.fetch_models(api_key="k")
+        assert not caplog.records
+
+
+class TestResolveAuxModel:
+    def _fetch(self, profile, payload):
+        def _open(request, *, timeout):
+            return _FakeResponse(payload)
+
+        with patch("hermes_cli.urllib_security.open_credentialed_url", _open):
+            profile.fetch_models(api_key="k")
+
+    def test_no_opinion_without_a_cached_catalog(self, profile, inworld):
+        """Falls through to default_aux_model rather than guessing."""
+        assert profile.resolve_aux_model() == ""
+
+    def test_no_opinion_while_the_pinned_model_is_live(self, profile, inworld):
+        self._fetch(
+            profile,
+            {"models": [_entry(provider="inworld", model="models/gemma-4-26b-a4b-it")]},
+        )
+
+        assert profile.resolve_aux_model() == ""
+
+    def test_retired_aux_model_falls_back_to_the_router(self, profile, inworld):
+        """Aux calls survive Inworld retiring the pinned model."""
+        self._fetch(profile, {"models": [_entry()]})
+
+        assert profile.resolve_aux_model() == inworld.ROUTER_MODEL

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -296,6 +296,10 @@ hermes chat --provider meta-ai --model muse-spark-1.2
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 # Requires: GMI_API_KEY in ~/.hermes/.env
+
+# Inworld LLM router
+hermes chat --provider inworld --model auto
+# Requires: INWORLD_API_KEY in ~/.hermes/.env
 ```
 
 Fireworks uses its native slash-form catalog IDs, such as `accounts/fireworks/models/kimi-k2p6`. Run `hermes model`, choose **Fireworks AI**, and select from the live catalog or enter another Fireworks model ID. The default endpoint is `https://api.fireworks.ai/inference/v1`; configure a different endpoint through `model.base_url` in `config.yaml`, not `.env`.
@@ -307,10 +311,16 @@ model:
   default: "zai-org/GLM-5.1-FP8"
 ```
 
-Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `META_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `INWORLD_BASE_URL`, `META_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
 
 :::note Meta contributor tier
 `muse-spark-1.2-contributor` is Meta's discounted tier — Meta may train on your prompts and completions, so [interactive model selection asks for confirmation](../user-guide/configuring-models.md) before using it. Use `muse-spark-1.2` (standard pricing, no training) for confidential work.
+:::
+
+:::note Inworld Model IDs
+Inworld is a router: one endpoint fronting its own models alongside upstream providers. Model IDs are qualified with the upstream that serves them — `inworld/models/deepseek-v4-flash`, `openai/gpt-5.2`, `deepinfra/zai-org/GLM-5.2` — because the same model may be available from several. The default `auto` lets the router choose for you, and is the one model that works before the catalog has been fetched.
+
+`hermes model` lists the live catalog from `https://api.inworld.ai/llm/v1alpha/models`, filtered to models that advertise tool calling. If the catalog is unreachable or `INWORLD_API_KEY` is unset, the picker offers `auto` alone.
 :::
 
 :::note Z.AI Endpoint Auto-Detection

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -45,6 +45,8 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `ARCEE_BASE_URL` | Override Arcee base URL (default: `https://api.arcee.ai/api/v1`) |
 | `GMI_API_KEY` | GMI Cloud API key ([gmicloud.ai](https://www.gmicloud.ai/)) |
 | `GMI_BASE_URL` | Override GMI Cloud base URL (default: `https://api.gmi-serving.com/v1`) |
+| `INWORLD_API_KEY` | Inworld LLM router API key ([portal.inworld.ai](https://portal.inworld.ai/)) |
+| `INWORLD_BASE_URL` | Override Inworld base URL (default: `https://api.inworld.ai/v1`) |
 | `ACTUAL_API_KEY` | Actual Computer inference key (`ac_...`, [actual.inc/user/keys](https://actual.inc/user/keys)). Not needed for the local daemon. |
 | `ACTUAL_BASE_URL` | Override Actual Computer base URL (default: `https://api.actual.inc/v1`). Set to `http://127.0.0.1:8080` for the local offline daemon — loopback hosts need no API key. |
 | `MINIMAX_API_KEY` | MiniMax API key — global endpoint ([minimax.io](https://www.minimax.io)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |


### PR DESCRIPTION
## What does this PR do?

Adds **Inworld** as a first-class model provider.

Inworld exposes an OpenAI-compatible completions endpoint at `https://api.inworld.ai/v1` that fronts its own models (`inworld/models/…`) alongside several upstream providers (`openai/`, `anthropic/`, `deepinfra/`, …). Chat needs no adapter and no new `api_mode`, so this follows the documented plugin fast path — **zero core edits**.

The one part that needs real code is the model catalog, which differs from the OpenAI convention in three independent ways that `ProviderProfile.fetch_models` cannot absorb through configuration:

| | Base `fetch_models` | Inworld |
|---|---|---|
| URL | `{base_url}/models` → `/v1/models` | `/llm/v1alpha/models` — host-absolute, outside the `/v1` prefix |
| Auth | `Bearer` | `Basic` (completions still take `Bearer`, which the OpenAI client builds itself — Inworld accepts both) |
| Shape | `{"data": [{"id": …}]}` | `{"models": [{provider, model, spec}]}` |

`fetch_models` is overridden for those, and filters to models advertising `functionCalling` — Hermes drives every turn through tool calls, so a model without them cannot run the agent. A model that declines to state the capability is treated as lacking it rather than guessed into the picker.

Discovery is best-effort and cached per catalog URL. Any failure — no credential, unreachable host, empty catalog — degrades to the router's `auto` model, which selects server-side and so works with no catalog at all. That is why `auto` is the sole `fallback_models` entry: pinning stale ids there would route users to models an upstream may have retired.

## Related Issue

Closes #85666

Relationship to #85716, which also implements this issue: that PR is a plain declarative profile with `fallback_models=()`, `default_aux_model=""`, and no catalog override, so it relies on the base `fetch_models` hitting `/v1/models` with `Bearer`. If that endpoint does not serve the router catalog, the `/model` picker is left empty and users must type a full model id by hand. This PR adds the catalog path/auth/shape handling, the `auto` fallback, an aux model, and `INWORLD_BASE_URL`. Happy to fold this into that PR instead if maintainers prefer it there — the goal is a working integration, not authorship.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/model-providers/inworld/__init__.py` — `ProviderProfile` with `fetch_models` override for the router catalog
- `plugins/model-providers/inworld/plugin.yaml` — manifest
- `tests/providers/test_inworld_profile.py` — 22 tests: registration/aliases, catalog parsing, and fetch behaviour
- `website/docs/integrations/providers.md` — CLI example, base-URL override, model-ID note
- `website/docs/reference/environment-variables.md` — `INWORLD_API_KEY`, `INWORLD_BASE_URL`

Everything else wires up from the registry: credential resolution, `--provider inworld`, the `hermes model` menu, `hermes setup`, `provider:model` aliases, runtime resolution, and the doctor health check.

## How to Test

1. Put `INWORLD_API_KEY` in `~/.hermes/.env` (get one at https://portal.inworld.ai/)
2. `hermes model` → **Inworld** → the live catalog lists tool-calling models, with `auto` first
3. `hermes chat --provider inworld --model auto -q "Say hello"`
4. Unset the key and re-run step 2 — the picker still offers `auto` rather than failing

Verify the registry wiring directly:

```python
from hermes_cli.runtime_provider import resolve_runtime_provider
resolve_runtime_provider(requested="inworld")
# {'provider': 'inworld', 'api_mode': 'chat_completions',
#  'base_url': 'https://api.inworld.ai/v1', 'source': 'env:INWORLD_API_KEY'}
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the note on #85716 above
- [x] My PR contains **only** changes related to this feature
- [x] I've run the tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/`)
- [x] N/A — no new config keys, so `cli-config.yaml.example` is unchanged
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: pure-Python, no file I/O, no process or terminal handling
- [x] N/A — no tool behaviour changed

## Test Results

Run per-file, matching `scripts/run_tests.sh` and CI:

```
tests/providers/                          78 passed
tests/hermes_cli/test_provider_parity.py       2 passed
tests/hermes_cli/test_provider_precedence.py   5 passed
tests/hermes_cli/test_model_validation.py     29 passed
tests/hermes_cli/test_runtime_provider_resolution.py  55 passed
tests/hermes_cli/test_doctor.py               52 passed
tests/hermes_cli/test_setup_model_provider.py  3 passed
ruff check                                All checks passed
```

I also ran all 74 `tests/hermes_cli` files that fail under a single-process `pytest tests/hermes_cli` run — every one passes in its own subprocess, so those failures are pre-existing cross-file pollution, not regressions from this change.

## Live verification

Run against `api.inworld.ai` with a real key (the automated tests themselves use stubbed payloads — no network in CI):

| Check | Result |
|---|---|
| `GET /llm/v1alpha/models` with `Basic` | `200`, body matches the parser's expected shape |
| `GET /v1/models` with `Basic` | `404` — confirms the catalog is not on the OpenAI-conventional path |
| `fetch_models()` through this profile | 91 models, `auto` first, every other id provider-qualified |
| `default_aux_model` present in catalog | yes — `inworld/models/gemma-4-26b-a4b-it` |
| Completion with `auto` | `OK` (router selected `deepinfra/MiniMaxAI/MiniMax-M2.5`) |
| Completion with the aux model | `OK` |
| Tool call with `auto` | `get_weather{"city": "Paris"}` |

One note for anyone testing by hand: `auto` may route to a reasoning model, so a small `max_tokens` can return empty content with `finish_reason=stop` — the above needed 69 completion tokens for a one-word answer. Not specific to this PR, but easy to misread as a broken integration.

## Known gaps (deliberate, not oversights)

- **Context lengths.** `agent/model_metadata.py` probes for snake_case keys at `{base_url}/models`; Inworld publishes `spec.contextLength` in camelCase at a different path, so models fall back to `DEFAULT_FALLBACK_CONTEXT` and compaction thresholds will be off. Fixing it properly needs a `ProviderProfile.model_context_length(model)` hook, which would help OpenRouter and DeepInfra equally — worth its own issue rather than a provider-specific workaround here.
- **`supports_vision` left `False`.** The flag is provider-wide; Inworld fronts both vision-capable and text-only models, so asserting it for all of them would be wrong. Falls through to the existing model-catalog lookup.
- **Per-model reasoning effort.** The catalog publishes `EFFORT_*` levels per model; this PR does not clamp configured effort to them the way the Kimi and OpenRouter profiles do. Additive follow-up.
