### PR TITLE
Desktop: show MCP launch targets on the setup_mcp consent card (port of kimi-code#2843)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/mcp-setup-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/mcp-setup-tool.tsx
@@ -18,6 +18,7 @@ import {
   getMcpCatalog,
   getMcpOAuthFlow,
   installMcpCatalogEntry,
+  listMcpServers,
   type McpCatalogEntry,
   removeMcpServer,
   setMcpServerEnabled
@@ -28,6 +29,7 @@ import { AlertCircle, CheckCircle2, Loader2 } from '@/lib/icons'
 import { brandFor, brandGlyphStyle } from '@/lib/mcp-brands'
 import { completeMcpDesktopOAuth, McpOAuthCancelled } from '@/lib/mcp-dashboard-oauth'
 import { directoryEntry } from '@/lib/mcp-directory'
+import { formatMcpLaunchTarget, type McpLaunchTarget } from '@/lib/mcp-launch-target'
 import { prettyName } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { $gateway } from '@/store/gateway'
@@ -182,6 +184,10 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
   const [envDraft, setEnvDraft] = useState<Record<string, string>>({})
   const [entry, setEntry] = useState<McpCatalogEntry | null | undefined>(undefined)
   const [envOpen, setEnvOpen] = useState(false)
+  // What would actually execute (stdio command line) or be contacted (remote
+  // URL) — resolved BEFORE the user approves, so consent is informed
+  // (ported from MoonshotAI/kimi-code#2843).
+  const [launchTarget, setLaunchTarget] = useState<McpLaunchTarget | null>(null)
   // Set when the user cancels mid-flight (a stuck OAuth tab, a hung install).
   // The in-flight flow checks it at every poll boundary and aborts via the
   // CANCELLED sentinel; the declined respond has already been sent by then.
@@ -190,6 +196,55 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
   // Race: tool.start fires a tick before mcp.setup.request — hold the buttons
   // until the gateway request is wired (same spinner rule as clarify).
   const ready = Boolean(request?.requestId)
+
+  // Resolve the launch target for the pre-consent line. For installs this
+  // doubles as the catalog-entry prefetch approve() reuses; for enable /
+  // authorize the configured mcp_servers entry names the target. Best-effort:
+  // the card still works without the line when a lookup fails.
+  useEffect(() => {
+    if (!server) {
+      return
+    }
+
+    let stale = false
+
+    void (async () => {
+      try {
+        if (action === 'install') {
+          const catalog = await getMcpCatalog()
+          const resolved = catalog.entries.find(candidate => candidate.name === server) ?? null
+
+          if (stale) {
+            return
+          }
+
+          setEntry(resolved)
+
+          if (resolved) {
+            setLaunchTarget(formatMcpLaunchTarget(resolved))
+          } else {
+            const known = directoryEntry(server)
+            setLaunchTarget(known ? formatMcpLaunchTarget({ url: known.url }) : null)
+          }
+
+          return
+        }
+
+        const { servers } = await listMcpServers()
+        const configured = servers.find(candidate => candidate.name === server)
+
+        if (!stale) {
+          setLaunchTarget(configured ? formatMcpLaunchTarget(configured) : null)
+        }
+      } catch {
+        // Leave the target line off; approve() has its own error reporting.
+      }
+    })()
+
+    return () => {
+      stale = true
+    }
+  }, [action, server])
 
   const respond = useCallback(
     async (outcome: McpSetupOutcome) => {
@@ -399,12 +454,19 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
   const actionLabel =
     action === 'enable' ? copy.enableAction : action === 'authorize' ? copy.authorizeAction : copy.installAction
 
-  // What connecting actually means — the endpoint that will be contacted.
-  // VS Code's trust dialog links the config it's about to trust; same idea.
-  // Directory servers know their URL statically; catalog entries state their
-  // provenance (the reviewed manifest carries the transport).
+  // What connecting actually means — the endpoint that will be contacted or
+  // the command that will run. VS Code's trust dialog links the config it's
+  // about to trust; kimi-code's workspace-trust prompt lists launch targets
+  // (MoonshotAI/kimi-code#2843). The resolved target wins; installs without
+  // one fall back to the directory URL / catalog provenance line.
   const known = directoryEntry(server)
-  const sourceLine = action === 'install' ? (known?.url ?? copy.catalogSource) : null
+  const sourceLine = launchTarget
+    ? launchTarget.kind === 'stdio'
+      ? copy.launchCommand(launchTarget.target)
+      : copy.launchRemote(launchTarget.target)
+    : action === 'install'
+      ? (known?.url ?? copy.catalogSource)
+      : null
   const brand = brandFor(server)
 
   const trailingIcon = brand ? (

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2874,6 +2874,8 @@ export const en: Translations = {
       toolCount: count => (count === 1 ? '1 tool' : `${count} tools`),
       notInCatalog: server => `“${server}” is not in the MCP catalog`,
       catalogSource: 'From the Nous-approved catalog',
+      launchCommand: target => `Runs: ${target}`,
+      launchRemote: target => `Connects to: ${target}`,
       envRequired: 'Fill in the required credentials first',
       sendFailed: 'Could not send MCP setup response',
       reloadFailed: 'Server saved, but reloading MCP tools failed — they load next session',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2457,6 +2457,8 @@ export interface Translations {
       toolCount: (count: number) => string
       notInCatalog: (server: string) => string
       catalogSource: string
+      launchCommand: (target: string) => string
+      launchRemote: (target: string) => string
       envRequired: string
       sendFailed: string
       reloadFailed: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3046,6 +3046,8 @@ export const zh: Translations = {
       toolCount: count => `${count} 个工具`,
       notInCatalog: server => `“${server}”不在 MCP 目录中`,
       catalogSource: '来自 Nous 认证目录',
+      launchCommand: target => `将运行：${target}`,
+      launchRemote: target => `将连接：${target}`,
       envRequired: '请先填写所需凭据',
       sendFailed: '无法发送 MCP 设置响应',
       reloadFailed: '服务器已保存，但重新加载 MCP 工具失败 — 将在下个会话加载',

--- a/apps/desktop/src/lib/mcp-launch-target.test.ts
+++ b/apps/desktop/src/lib/mcp-launch-target.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatMcpLaunchTarget } from './mcp-launch-target'
+
+describe('formatMcpLaunchTarget', () => {
+  it('returns null when the source names no target', () => {
+    expect(formatMcpLaunchTarget({})).toBeNull()
+    expect(formatMcpLaunchTarget({ args: ['-y', 'pkg'] })).toBeNull()
+    expect(formatMcpLaunchTarget({ command: '   ' })).toBeNull()
+  })
+
+  it('prefers the remote URL over a stdio command', () => {
+    expect(
+      formatMcpLaunchTarget({ args: ['server'], command: 'node', url: 'https://mcp.example.com/sse' })
+    ).toEqual({ kind: 'remote', target: 'https://mcp.example.com/sse' })
+  })
+
+  it('joins command and args into one stdio line', () => {
+    expect(formatMcpLaunchTarget({ args: ['-y', '@scope/server', '--port', '80'], command: 'npx' })).toEqual({
+      kind: 'stdio',
+      target: 'npx -y @scope/server --port 80'
+    })
+  })
+
+  it('renders a bare command without args', () => {
+    expect(formatMcpLaunchTarget({ command: 'my-server' })).toEqual({ kind: 'stdio', target: 'my-server' })
+  })
+
+  it('strips terminal control characters from workspace-supplied text', () => {
+    const result = formatMcpLaunchTarget({
+      args: ['\u001B[2Jrun\u0007', '--flag\u009B31m'],
+      command: 'bash\u001B]0;pwned\u0007'
+    })
+
+    expect(result?.target).toBe('bash ]0;pwned [2Jrun --flag 31m')
+    expect(result?.target).not.toMatch(/[\u0000-\u001F\u007F-\u009F]/)
+  })
+
+  it('collapses newlines and repeated whitespace to a single line', () => {
+    expect(formatMcpLaunchTarget({ command: 'node', args: ['a\n\nb', '  c  '] })?.target).toBe('node a b c')
+  })
+
+  it('elides overlong targets with an ellipsis', () => {
+    const result = formatMcpLaunchTarget({ command: 'node', args: ['x'.repeat(400)] })
+
+    expect(result?.target.length).toBeLessThanOrEqual(160)
+    expect(result?.target.endsWith('…')).toBe(true)
+  })
+
+  it('sanitizes control characters inside URLs too', () => {
+    expect(formatMcpLaunchTarget({ url: 'https://evil.test/\u001B[1mpath' })?.target).toBe(
+      'https://evil.test/ [1mpath'
+    )
+  })
+})

--- a/apps/desktop/src/lib/mcp-launch-target.test.ts
+++ b/apps/desktop/src/lib/mcp-launch-target.test.ts
@@ -33,6 +33,7 @@ describe('formatMcpLaunchTarget', () => {
     })
 
     expect(result?.target).toBe('bash ]0;pwned [2Jrun --flag 31m')
+    // eslint-disable-next-line no-control-regex
     expect(result?.target).not.toMatch(/[\u0000-\u001F\u007F-\u009F]/)
   })
 

--- a/apps/desktop/src/lib/mcp-launch-target.ts
+++ b/apps/desktop/src/lib/mcp-launch-target.ts
@@ -1,0 +1,66 @@
+/**
+ * Launch-target formatting for the MCP consent card.
+ *
+ * Ported from MoonshotAI/kimi-code#2843: a pre-consent MCP prompt must show
+ * WHAT will actually execute (the stdio command line) or be contacted (the
+ * remote URL), not just the server's display name — otherwise the user
+ * approves a name without seeing the thing they are approving.
+ *
+ * Config-supplied text is untrusted (a planted config.yaml or a catalog
+ * mirror could carry terminal escape sequences), so every rendered target is
+ * stripped of control characters and bounded in length before it reaches the
+ * card.
+ */
+
+export interface McpLaunchSource {
+  url?: string | null
+  command?: string | null
+  args?: string[] | null
+}
+
+export interface McpLaunchTarget {
+  kind: 'remote' | 'stdio'
+  /** Sanitized, length-bounded display string (URL or command line). */
+  target: string
+}
+
+/** Longest target line the card will render before eliding. */
+const MAX_TARGET_LENGTH = 160
+
+// C0 controls (except nothing — the card renders a single line, so tab and
+// newline are just as unwelcome), DEL, and the C1 range. Covers raw ESC so a
+// crafted `args` entry cannot inject ANSI sequences into the pre-consent UI.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\u0000-\u001F\u007F-\u009F]/g
+
+function sanitize(text: string): string {
+  const clean = text.replace(CONTROL_CHARS, ' ').replace(/\s+/g, ' ').trim()
+
+  return clean.length > MAX_TARGET_LENGTH ? `${clean.slice(0, MAX_TARGET_LENGTH - 1)}…` : clean
+}
+
+/**
+ * Format a server config / catalog entry into the line the consent card
+ * shows. Remote URL wins when both are present (matches how the backend
+ * picks the transport); returns null when the source names no target.
+ */
+export function formatMcpLaunchTarget(source: McpLaunchSource): McpLaunchTarget | null {
+  const url = typeof source.url === 'string' ? sanitize(source.url) : ''
+
+  if (url) {
+    return { kind: 'remote', target: url }
+  }
+
+  const command = typeof source.command === 'string' ? sanitize(source.command) : ''
+
+  if (!command) {
+    return null
+  }
+
+  const args = (source.args ?? [])
+    .map(arg => sanitize(String(arg)))
+    .filter(Boolean)
+    .join(' ')
+
+  return { kind: 'stdio', target: sanitize(args ? `${command} ${args}` : command) }
+}


### PR DESCRIPTION
## Summary

The Desktop `setup_mcp` consent card now shows what will actually execute before the user approves — the stdio command line (`Runs: npx -y @scope/server ...`) or the remote endpoint (`Connects to: https://...`) — instead of asking for consent on a server display name alone.

Ported from [MoonshotAI/kimi-code#2843](https://github.com/MoonshotAI/kimi-code/pull/2843), which added launch targets to Kimi Code's workspace-trust prompt for exactly this reason: a user could approve trust without ever seeing the command that would run on their machine.

## Changes

- `apps/desktop/src/lib/mcp-launch-target.ts` (new): `formatMcpLaunchTarget()` — remote-URL-wins transport pick, terminal control-character stripping (config/catalog text is untrusted; a planted `config.yaml` cannot inject ANSI escapes into the pre-consent UI), whitespace collapse, 160-char bound with ellipsis.
- `apps/desktop/src/components/assistant-ui/mcp-setup-tool.tsx`: resolves the launch target pre-consent — catalog entry for installs (reusing the prefetch `approve()` needed anyway, so no extra request on approve), configured `mcp_servers` entry for enable/authorize — and renders it as the card's source line. Secrets never appear: `listMcpServers` already redacts `env` values server-side, and the formatter only reads `url`/`command`/`args`.
- i18n: `launchCommand` / `launchRemote` keys in `en` + `zh`; the other locales fall back through `defineLocale`.

## Validation

| Check | Result |
|---|---|
| `vitest run src/lib/mcp-launch-target.test.ts` | 8/8 passed |
| `vitest run src/i18n/languages.test.ts src/i18n/runtime.test.ts` | 11/11 passed |
| Control-char injection (`ESC]0;pwned BEL`, CSI, C1 range) | stripped, single-line output asserted |

## Infographic

![MCP consent card — launch targets](https://files.catbox.moe/ioiy2k.png)
