### PR TITLE
fix(desktop): distinguish pooled profile backends

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -7990,7 +7990,9 @@ async function ensureBackend(profile) {
 
     // A shared backend still owes the caller its profile scope, so renderer-side
     // WebSocket, filesystem, and cache routing target the selected profile.
-    return route.descriptorProfile ? { ...connection, profile: route.descriptorProfile } : connection
+    return route.descriptorProfile
+      ? { ...connection, profile: route.descriptorProfile, sharedPrimary: true }
+      : connection
   }
 
   const existing = backendPool.get(key)

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -534,6 +534,10 @@ export interface HermesConnection {
   // Set for pool (non-primary) backends so the renderer knows which profile a
   // connection belongs to.
   profile?: string
+  // True only when `profile` is a request scope on the shared primary backend.
+  // A pooled backend also carries `profile`, so presence alone cannot identify
+  // the shared-primary routing case.
+  sharedPrimary?: boolean
   windowButtonPosition: { x: number; y: number } | null
 }
 

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // The global-remote share (backend routing case 3): every profile is served
-// by the PRIMARY backend over one host, and getConnection() tags the shared
-// descriptor with `profile`. Dialing a second WebSocket at that descriptor
+// by the PRIMARY backend over one host, and getConnection() explicitly tags
+// the descriptor with `sharedPrimary`. Dialing a second WebSocket at it
 // used to fail over SSH (per-backend tunnel/ticket) and poison the active
 // gateway with a closed socket — "Hermes gateway is not connected" for every
 // profile except the primary. These tests pin the fix: a profile routed to
@@ -47,12 +47,11 @@ afterEach(() => {
 })
 
 describe('ensureGatewayForProfile under a shared global remote', () => {
-  it('activates the primary socket for a profile tagged onto the shared descriptor', async () => {
+  it('activates the primary socket for an explicitly shared-primary descriptor', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')
     installDesktop({
-      // Shared descriptor: primary connection tagged with the profile.
-      getConnection: vi.fn(async () => ({ port: 4242, profile: 'venture', token: 't' }))
+      getConnection: vi.fn(async () => ({ port: 4242, profile: 'venture', sharedPrimary: true, token: 't' }))
     })
 
     await ensureGatewayForProfile('venture')
@@ -60,12 +59,13 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
     expect($gateway.get()).toBe(primary)
   })
 
-  it('still pools a socket for profiles with their own descriptor (untagged)', async () => {
+  it('still pools a socket for a local profile descriptor that also carries profile', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')
     installDesktop({
-      // Own descriptor: no profile tag → normal pooled path (dial attempted).
-      getConnection: vi.fn(async () => ({ port: 5151, token: 't2' }))
+      // Pool descriptors need `profile` for fresh WS URL minting, but they are
+      // not shared-primary routes and must still dial their own socket.
+      getConnection: vi.fn(async () => ({ port: 5151, profile: 'worker', token: 't2' }))
     })
 
     await ensureGatewayForProfile('worker')

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -248,12 +248,10 @@ function createSecondary(profile: string): Secondary {
 }
 
 // True when `profile`'s backend route resolves to the SHARED primary backend
-// (global-remote case 3 in resolveProfileBackendRoute): the descriptor comes
-// back as the primary connection tagged with `profile`. Own-remote-override
-// and local pooled descriptors are never tagged. Dialing a second socket at
-// that descriptor is wrong — over SSH the second dial fails (tunnel/token are
-// per-backend) and the closed socket poisons the active gateway with
-// "not connected" even though the primary is open right next to it.
+// (global-remote case 3 in resolveProfileBackendRoute). Both shared-primary and
+// pooled descriptors carry `profile` so WebSocket URL minting targets the right
+// profile. `sharedPrimary` is the explicit discriminator; treating every tagged
+// descriptor as shared strands local pooled profiles on the default socket.
 async function sharedPrimaryRoute(profile: string): Promise<boolean> {
   const desktop = window.hermesDesktop
 
@@ -264,7 +262,7 @@ async function sharedPrimaryRoute(profile: string): Promise<boolean> {
   try {
     const conn = await desktop.getConnection(profile)
 
-    return Boolean(conn && typeof conn === 'object' && (conn as { profile?: string }).profile)
+    return Boolean(conn && typeof conn === 'object' && (conn as { sharedPrimary?: boolean }).sharedPrimary === true)
   } catch {
     return false
   }


### PR DESCRIPTION
## What does this PR do?

Fixes local Desktop profile switching after pooled connection descriptors began carrying `profile` for WebSocket URL minting.

`sharedPrimaryRoute()` inferred that any descriptor with `profile` was served by the shared primary backend. Local pooled descriptors also carry `profile`, so a named local profile was misclassified and Desktop reused the default socket instead of opening the profile's persistent WebSocket.

This change gives the shared-primary route an explicit `sharedPrimary` marker and checks that marker instead of overloading `profile` with two meanings.

## Related Issue

Fixes #85777

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/main.ts`: marks only profile-scoped primary descriptors as `sharedPrimary`.
- `apps/desktop/src/global.d.ts`: types the explicit route discriminator.
- `apps/desktop/src/store/gateway.ts`: distinguishes shared-primary descriptors from profile-owned pooled descriptors.
- `apps/desktop/src/store/gateway-shared-remote.test.ts`: covers both sides of the routing invariant, including a pooled descriptor that carries `profile`.

## How to Test

1. Configure Desktop with local `default` and local named profiles.
2. Launch Desktop on `default` and select a named profile from the profile rail.
3. Confirm the named backend receives a persistent WebSocket and the sidebar/agent context switches to it.
4. Switch back to `default` and confirm the primary socket is restored.

Automated checks:

```bash
cd apps/desktop
npm test -- --run src/store/gateway-shared-remote.test.ts src/store/profile.test.ts
# 2 files passed, 13 tests passed

npm run lint
# 0 errors (88 pre-existing warnings)
```

`npm run typecheck` passed on the checkout used to build and validate the installed fix. After rebasing onto current `origin/main` (`edb33be51`), it is presently blocked by an unrelated baseline error in `src/app/chat/hooks/use-composer-actions.test.ts:294`: the new `ComposerActionsScope.update` field is missing from that test fixture. This PR does not modify that code.

The rebuilt macOS package was installed locally and the reporter confirmed profile switching works after restart.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: Desktop TypeScript-only change; focused Vitest coverage ran instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.1, Apple silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; internal routing bug
- [x] I've updated `cli-config.yaml.example` — N/A; no config change
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A; no workflow change
- [x] I've considered cross-platform impact — the explicit descriptor marker is platform-independent
- [x] I've updated tool descriptions/schemas — N/A; no tool change

## Screenshots / Logs

Before the fix, the named backend started and its one-shot startup probe connected, but no persistent WebSocket followed:

```text
Starting Hermes backend for profile "fiction-writer"
HERMES_BACKEND_READY port=64271
Hermes backend listening on 127.0.0.1:64271
...
tui_gateway.ws: ws accepted ...
tui_gateway.ws: ws closed ... messages=0
```

After rebuilding with this change and restarting Desktop, switching between `default` and the local named profile works normally.
