### PR TITLE
fix: harden Windows command path guidance

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1130,14 +1130,18 @@ def _windows_marketing_version() -> str:
 
 _WINDOWS_BASH_SHELL_HINT = (
     "Shell: on this Windows host your `terminal` tool runs commands through "
-    "bash (git-bash / MSYS), NOT PowerShell or cmd.exe. Use POSIX shell "
+    "bash (Git Bash / MSYS), NOT PowerShell or cmd.exe. Use POSIX shell "
     "syntax (`ls`, `$HOME`, `&&`, `|`, single-quoted strings) inside terminal "
-    "calls. MSYS-style paths like `/c/Users/<user>/...` work alongside "
-    "native `C:\\Users\\<user>\\...` paths. PowerShell builtins "
+    "calls. Prefer forward-slash Windows paths like `C:/Users/<user>/...` "
+    "for cross-tool references and scripts; use MSYS paths like "
+    "`/c/Users/<user>/...` only when a particular bash command requires them. "
+    "PowerShell builtins "
     "(`Get-ChildItem`, `$env:FOO`, `Select-String`) will NOT work — use their "
-    "POSIX equivalents (`ls`, `$FOO`, `grep`). Path arguments for NATIVE "
-    "Windows programs (git, rg, node, python, ...) are NOT translated: MSYS "
-    "path conversion is disabled here, so `git -C /c/Users/x` or "
+    "POSIX equivalents (`ls`, `$FOO`, `grep`). If PowerShell is specifically "
+    "required, invoke it explicitly from bash, for example "
+    "`powershell.exe -NoProfile -NonInteractive -Command 'Get-ChildItem'`. Path arguments for "
+    "NATIVE Windows programs (git, rg, node, python, ...) are NOT translated: "
+    "MSYS path conversion is disabled here, so `git -C /c/Users/x` or "
     "`node /tmp/a.js` fails with 'cannot change to'/'not found' even though "
     "`cd /c/Users/x` (a bash builtin) works. Pass `C:/Users/x`-style "
     "forward-slash native paths to native tools, and prefer "
@@ -1332,7 +1336,7 @@ def build_environment_hints() -> str:
             host_lines.append(
                 "Note: on Windows, the machine hostname (e.g. from `hostname` "
                 "or uname) is NOT the username. Use the 'User home directory' "
-                "above to construct paths under C:\\Users\\<user>\\, never the "
+                "above exactly when constructing paths; never substitute the "
                 "hostname."
             )
         hints.append("\n".join(host_lines))

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -744,6 +744,34 @@ class TestPromptBuilderConstants:
 
 class TestEnvironmentHints:
 
+    def test_windows_local_backend_describes_bash_and_uses_explicit_home(self, monkeypatch):
+        """Windows host identity and the terminal's shell are separate facts."""
+        import agent.prompt_builder as _pb
+        import os
+        import platform
+        import socket
+        import sys
+
+        explicit_home = "C:/Users/davep"
+        machine_hostname = "DAVE-HUB-01"
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(platform, "release", lambda: "11")
+        monkeypatch.setattr(os.path, "expanduser", lambda _path: explicit_home)
+        monkeypatch.setattr(socket, "gethostname", lambda: machine_hostname)
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_CWD", "C:/Users/davep/workspace")
+
+        result = _pb.build_environment_hints()
+
+        assert f"User home directory: {explicit_home}" in result
+        assert machine_hostname not in result
+        assert "bash (Git Bash / MSYS), NOT PowerShell or cmd.exe" in result
+        assert "C:/Users/<user>/..." in result
+        assert "/c/Users/<user>/..." in result
+        assert "Get-ChildItem" in result and "will NOT work" in result
+        assert "powershell.exe -NoProfile -NonInteractive -Command" in result
+
 
 
 
@@ -988,5 +1016,4 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -105,6 +105,23 @@ The dashboard's `/chat` tab embeds a real terminal via a POSIX PTY (`ptyprocess`
 
 Hermes's terminal tool runs commands through **Git Bash**, same strategy Claude Code uses. This sidesteps the POSIX-vs-Windows gap without rewriting every tool.
 
+Commands entered through Hermes's `terminal` tool therefore require **POSIX
+shell syntax**, even though Hermes itself is running on Windows. Use `ls`,
+`$HOME`, `grep`, `&&`, and pipes. PowerShell builtins such as `Get-ChildItem`,
+`$env:FOO`, and `Select-String` do not work in an ordinary terminal call.
+When a task genuinely requires PowerShell, invoke it explicitly from bash:
+
+```bash
+powershell.exe -NoProfile -NonInteractive -Command 'Get-ChildItem Env:'
+```
+
+For paths shared between Hermes tools, scripts, and Windows programs, prefer
+forward-slash Windows paths such as `C:/Users/alice/project`. Use the MSYS form
+`/c/Users/alice/project` only for a bash command that specifically requires it.
+Do not derive `C:/Users/<user>` from `hostname`: a machine name is not a Windows
+account name. Use the user home directory reported in Hermes's execution-
+environment context.
+
 Resolution order for `bash.exe`:
 
 1. `HERMES_GIT_BASH_PATH` environment variable if set.


### PR DESCRIPTION
## Summary
- clarify Windows local terminal prompt guidance for Git Bash/MSYS vs PowerShell
- prefer forward-slash Windows paths and explicit user home over hostname-derived paths
- add regression coverage for Windows local environment hints
- document the Windows terminal/path contract in native Windows docs

## Test Plan
- uv run --with pytest --with pytest-xdist --with pyyaml python -m pytest tests/agent/test_prompt_builder.py::TestEnvironmentHints -v --tb=short -n 0 --basetemp=C:/Users/davep/hermes-workspace/exports/tmp/pytest-windows-hardening

## Notes
- Dave workspace runbook also created outside this repo: C:/Users/davep/hermes-workspace/system/WINDOWS_COMMAND_PATH_HARDENING.md