### PR TITLE
fix(desktop): add missing update mock to ComposerActionsScope test double (main CI red)

### DIFF
--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -294,7 +294,8 @@ describe('useComposerActions native image drops', () => {
         scope: {
           add,
           remove: vi.fn(() => null),
-          target: 'test-composer'
+          target: 'test-composer',
+          update: vi.fn(() => true)
         }
       })
     )


### PR DESCRIPTION
## Summary

Fixes the desktop `check:lint` job that is currently red on `main`: the `ComposerActionsScope` test double in `use-composer-actions.test.ts` is missing the `update` member the interface now requires.

Root cause: 071d27d1c3 ("paste a PR review comment as structured composer context") added a required `update: (attachment) => boolean` member to `ComposerActionsScope`, but this test's scope mock was never extended — `tsc -p .` fails with TS2741, which fails `check:lint` for every PR.

## Changes

- `apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts`: add `update: vi.fn(() => true)` to the scope double.

## Validation

| | Before | After |
|---|---|---|
| `tsc -p . --noEmit` | TS2741 at line 294 | clean |
| `vitest run use-composer-actions.test.ts` | (blocked by tsc in CI) | 14/14 pass |

## Infographic

![CI green again — test double fix](https://files.catbox.moe/vhnp1l.png)
