### PR TITLE
fix(agent): contain hung sequential tool execution

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -20,6 +20,7 @@ preserved.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import re
 import sys
@@ -1690,6 +1691,38 @@ def init_agent(
         _agent_cfg = _load_agent_config()
     except Exception:
         _agent_cfg = {}
+
+    _agent_section = (
+        _agent_cfg.get("agent", {}) if isinstance(_agent_cfg, dict) else {}
+    )
+    if not isinstance(_agent_section, dict):
+        _agent_section = {}
+    try:
+        _sequential_timeout = float(
+            _agent_section.get("sequential_tool_timeout", 420)
+        )
+    except (TypeError, ValueError):
+        _sequential_timeout = 420.0
+    if not math.isfinite(_sequential_timeout):
+        _sequential_timeout = 420.0
+    agent.sequential_tool_timeout_s = (
+        _sequential_timeout if _sequential_timeout > 0 else None
+    )
+    try:
+        _abandoned_worker_cap = int(
+            _agent_section.get("max_abandoned_tool_workers", 2)
+        )
+    except (TypeError, ValueError, OverflowError):
+        _abandoned_worker_cap = 2
+    agent.max_abandoned_tool_workers = max(1, min(_abandoned_worker_cap, 16))
+    # Event -> may-have-side-effect. Effectful abandoned workers quarantine
+    # later mutations across model rounds until they actually exit.
+    # ``None`` marks an atomically reserved slot for an in-flight supervised
+    # call; a bool marks a timed-out worker and whether it may have side effects.
+    agent._abandoned_tool_workers: dict[threading.Event, bool | None] = {}
+    agent._abandoned_tool_workers_lock = threading.Lock()
+    agent._detached_post_hook_events: set[threading.Event] = set()
+    agent._detached_post_hook_events_lock = threading.Lock()
 
     # Codex commentary visibility (display.show_commentary, default true).
     # When true, completed Codex phase=commentary messages are delivered as

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -109,6 +109,9 @@ _START_ORDER_GATE_TIMEOUT_S = 120.0
 # answering an approval prompt, which self-terminates at approvals.timeout —
 # so a holder that overstays it is wedged and must not starve the batch.
 _AUTHORIZATION_GATE_LOCK_TIMEOUT_S = 360.0
+_SEQUENTIAL_WAIT_POLL_S = 0.05
+_SYNTHETIC_POST_HOOK_GRACE_S = 0.25
+_HUMAN_RESPONSE_TOOLS = frozenset({"clarify", "setup_mcp"})
 
 
 def _authorization_gate_lock_timeout() -> float:
@@ -136,6 +139,32 @@ class _BatchAbandoned(BaseException):
     Derives from BaseException so intermediate ``except Exception`` handlers in
     the middleware chain cannot swallow it and dispatch the tool anyway.
     """
+
+
+class _SequentialCallAbandoned(BaseException):
+    """Stop a worker that reaches dispatch after its owner has moved on."""
+
+
+class _SequentialTerminalResult(str):
+    """Synthetic terminal result plus the metadata needed by the owner."""
+
+    def __new__(
+        cls,
+        value: str,
+        *,
+        status: str,
+        error_type: str,
+        effect_disposition: str,
+        dispatched: bool,
+        duration_s: float,
+    ):
+        instance = super().__new__(cls, value)
+        instance.status = status
+        instance.error_type = error_type
+        instance.effect_disposition = effect_disposition
+        instance.dispatched = dispatched
+        instance.duration_s = duration_s
+        return instance
 
 
 def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
@@ -289,6 +318,66 @@ def _emit_terminal_post_tool_call(
         )
     except Exception:
         pass
+
+
+def _run_bounded_post_tool_hook(agent, callback, *, function_name: str) -> None:
+    """Run one observer with bounded waiting and bounded detached threads."""
+    lock = getattr(agent, "_detached_post_hook_events_lock", None)
+    events = getattr(agent, "_detached_post_hook_events", None)
+    if lock is None or events is None:
+        lock = threading.Lock()
+        events = set()
+        agent._detached_post_hook_events_lock = lock
+        agent._detached_post_hook_events = events
+
+    done = threading.Event()
+    with lock:
+        events.difference_update(event for event in events if event.is_set())
+        if events:
+            logger.warning(
+                "Skipping post_tool_call for %s: prior hook is still running",
+                function_name,
+            )
+            return
+        events.add(done)
+
+    def _run() -> None:
+        try:
+            callback()
+        except Exception as exc:
+            logger.debug("post_tool_call hook error: %s", exc)
+        finally:
+            done.set()
+            with lock:
+                events.discard(done)
+
+    worker = threading.Thread(
+        target=propagate_context_to_thread(_run),
+        name="hermes-post-tool-hook",
+        daemon=True,
+    )
+    worker.start()
+    if not done.wait(_SYNTHETIC_POST_HOOK_GRACE_S):
+        logger.warning(
+            "Detached a slow post_tool_call hook for %s",
+            function_name,
+        )
+
+
+def _emit_bounded_post_tool_call(agent, **kwargs) -> None:
+    """Emit an owner-generated terminal hook without re-wedging the turn."""
+    try:
+        from hermes_cli.lifecycle import has_hook
+
+        if not has_hook("post_tool_call"):
+            return
+    except Exception:
+        return
+    _run_bounded_post_tool_hook(
+        agent,
+        lambda: _emit_terminal_post_tool_call(agent, **kwargs),
+        function_name=kwargs.get("function_name", "unknown"),
+    )
 
 
 def _cancelled_tool_result(reason: str = "user interrupt") -> str:
@@ -480,6 +569,331 @@ def _managed_values(
     )
 
 
+def _has_abandoned_effect_worker(agent) -> bool:
+    """Prune completed workers and report a still-live unknown effect."""
+    lock = getattr(agent, "_abandoned_tool_workers_lock", None)
+    workers = getattr(agent, "_abandoned_tool_workers", None)
+    if lock is None or workers is None:
+        return False
+    with lock:
+        if isinstance(workers, set):
+            workers = {event: True for event in workers}
+            agent._abandoned_tool_workers = workers
+        for event in [event for event in workers if event.is_set()]:
+            workers.pop(event, None)
+        return any(workers.values())
+
+
+class _SequentialToolSupervisor:
+    """Own one sequential call without letting it own the conversation thread.
+
+    Python cannot safely kill a running thread. Containment therefore has three
+    layers: a pre-dispatch fence, cooperative interrupt fan-out after dispatch,
+    and a per-agent budget for workers that still do not return. Human approval
+    time is measured at its source and excluded from the deadline, matching the
+    concurrent executor's contract.
+    """
+
+    def __init__(
+        self,
+        agent,
+        *,
+        function_name: str,
+        authorization_gate: _ConcurrentToolAuthorizationGate,
+        suspend_deadline_after_dispatch: bool = False,
+    ) -> None:
+        self.agent = agent
+        self.function_name = function_name
+        self.authorization_gate = authorization_gate
+        self.suspend_deadline_after_dispatch = suspend_deadline_after_dispatch
+        self.timeout_s = getattr(agent, "sequential_tool_timeout_s", 420.0)
+        self._state_lock = threading.Lock()
+        self._abandoned = False
+        self._dispatched = False
+        self._execution_terminal = False
+        self._human_wait_started: float | None = None
+        self._human_excluded_s = 0.0
+        self._observer_wait_started: float | None = None
+        self._observer_excluded_s = 0.0
+        self._worker_tid: int | None = None
+        self._done = threading.Event()
+        self._reservation_error_type = "abandoned_worker_capacity"
+
+    def begin_execution(self, callback=None) -> None:
+        """Atomically fence dispatch once the owner synthesized a result."""
+        with self._state_lock:
+            if self._abandoned:
+                raise _SequentialCallAbandoned(self.function_name)
+            self._dispatched = True
+            if self.suspend_deadline_after_dispatch:
+                self._human_wait_started = time.monotonic()
+        if callback is not None:
+            callback()
+
+    def mark_execution_terminal(self) -> None:
+        """Resume a human tool's deadline once its handler has returned."""
+        with self._state_lock:
+            if self._execution_terminal:
+                return
+            self._execution_terminal = True
+            if self._human_wait_started is not None:
+                self._human_excluded_s += max(
+                    0.0, time.monotonic() - self._human_wait_started
+                )
+                self._human_wait_started = None
+
+    def dispatch_post_hook(self, callback) -> None:
+        """Preserve fast-hook ordering but detach a hook that could wedge."""
+        started = time.monotonic()
+        with self._state_lock:
+            if self._abandoned:
+                return
+            if not self._execution_terminal:
+                self._execution_terminal = True
+                if self._human_wait_started is not None:
+                    self._human_excluded_s += max(
+                        0.0, started - self._human_wait_started
+                    )
+                    self._human_wait_started = None
+            self._observer_wait_started = started
+        try:
+            _run_bounded_post_tool_hook(
+                self.agent,
+                callback,
+                function_name=self.function_name,
+            )
+        finally:
+            finished = time.monotonic()
+            with self._state_lock:
+                if self._observer_wait_started is not None:
+                    self._observer_excluded_s += max(
+                        0.0, finished - self._observer_wait_started
+                    )
+                    self._observer_wait_started = None
+
+    def _worker(self, callback):
+        worker_tid = threading.current_thread().ident
+        with self._state_lock:
+            self._worker_tid = worker_tid
+            abandoned = self._abandoned
+        with self.agent._tool_worker_threads_lock:
+            self.agent._tool_worker_threads.add(worker_tid)
+        if abandoned or self.agent._interrupt_requested:
+            try:
+                _ra()._set_interrupt(True, worker_tid)
+            except Exception:
+                pass
+        try:
+            return callback()
+        finally:
+            self._done.set()
+            with self.agent._tool_worker_threads_lock:
+                self.agent._tool_worker_threads.discard(worker_tid)
+            try:
+                _ra()._set_interrupt(False, worker_tid)
+            except Exception:
+                pass
+
+    def _try_reserve_worker(self) -> bool:
+        from agent.tool_result_classification import tool_may_have_side_effect
+
+        lock = getattr(self.agent, "_abandoned_tool_workers_lock", None)
+        workers = getattr(self.agent, "_abandoned_tool_workers", None)
+        if lock is None or workers is None:
+            self.agent._abandoned_tool_workers_lock = threading.Lock()
+            self.agent._abandoned_tool_workers = {}
+            lock = self.agent._abandoned_tool_workers_lock
+            workers = self.agent._abandoned_tool_workers
+        with lock:
+            if isinstance(workers, set):
+                # Compatibility for test doubles and in-process agents created
+                # before this field became effect-aware.
+                workers = {event: True for event in workers}
+                self.agent._abandoned_tool_workers = workers
+            for event in [event for event in workers if event.is_set()]:
+                workers.pop(event, None)
+            if tool_may_have_side_effect(self.function_name) and any(workers.values()):
+                self._reservation_error_type = "abandoned_effect_quarantine"
+                return False
+            cap = max(1, int(getattr(self.agent, "max_abandoned_tool_workers", 2)))
+            if len(workers) >= cap:
+                self._reservation_error_type = "abandoned_worker_capacity"
+                return False
+            # Reserve before submission while holding the same lock used by
+            # competing owners. ``None`` is active but not quarantined; on a
+            # timeout it is atomically promoted to an abandoned-worker record.
+            workers[self._done] = None
+            return True
+
+    def _release_worker_reservation(self) -> None:
+        lock = getattr(self.agent, "_abandoned_tool_workers_lock", None)
+        workers = getattr(self.agent, "_abandoned_tool_workers", None)
+        if lock is None or workers is None:
+            return
+        with lock:
+            workers.pop(self._done, None)
+
+    def _remember_abandoned_worker(self) -> None:
+        from agent.tool_result_classification import tool_may_have_side_effect
+
+        with self.agent._abandoned_tool_workers_lock:
+            if self._done.is_set():
+                self.agent._abandoned_tool_workers.pop(self._done, None)
+                return
+            self.agent._abandoned_tool_workers[self._done] = tool_may_have_side_effect(
+                self.function_name
+            )
+
+    def _synthetic(
+        self,
+        message: str,
+        *,
+        status: str,
+        error_type: str,
+        started_at: float,
+    ) -> _ManagedToolResult:
+        with self._state_lock:
+            dispatched = self._dispatched
+        result = _SequentialTerminalResult(
+            message,
+            status=status,
+            error_type=error_type,
+            effect_disposition="unknown" if dispatched else "none",
+            dispatched=dispatched,
+            duration_s=max(0.0, time.monotonic() - started_at),
+        )
+        return _ManagedToolResult(
+            result=result,
+            args={},
+            middleware_trace=[],
+            blocked=False,
+            dispatched=dispatched,
+        )
+
+    def run(self, callback) -> _ManagedToolResult:
+        if self.timeout_s is None:
+            return callback()
+        if not self._try_reserve_worker():
+            detail = (
+                "an earlier effectful tool is still running after timeout; "
+                "tool was not started"
+                if self._reservation_error_type == "abandoned_effect_quarantine"
+                else "abandoned worker capacity reached; tool was not started"
+            )
+            return self._synthetic(
+                f"Error executing tool '{self.function_name}': {detail}",
+                status="error",
+                error_type=self._reservation_error_type,
+                started_at=time.monotonic(),
+            )
+
+        from tools.daemon_pool import DaemonThreadPoolExecutor
+
+        started_at = time.monotonic()
+        deadline = started_at + float(self.timeout_s)
+        executor = DaemonThreadPoolExecutor(max_workers=1)
+        from model_tools import (
+            _reset_post_tool_call_dispatcher,
+            _reset_tool_handler_terminal_callback,
+            _set_post_tool_call_dispatcher,
+            _set_tool_handler_terminal_callback,
+        )
+
+        dispatcher_token = _set_post_tool_call_dispatcher(self.dispatch_post_hook)
+        terminal_token = _set_tool_handler_terminal_callback(
+            self.mark_execution_terminal
+        )
+        try:
+            worker = propagate_context_to_thread(self._worker)
+        finally:
+            _reset_tool_handler_terminal_callback(terminal_token)
+            _reset_post_tool_call_dispatcher(dispatcher_token)
+        try:
+            future = executor.submit(worker, callback)
+        except BaseException:
+            self._release_worker_reservation()
+            executor.shutdown(wait=False, cancel_futures=True)
+            raise
+        abandon = False
+        try:
+            while True:
+                with self._state_lock:
+                    waiting_for_human = (
+                        self.suspend_deadline_after_dispatch
+                        and self._dispatched
+                        and not self._execution_terminal
+                    )
+                    human_excluded = self._human_excluded_s
+                    if self._human_wait_started is not None:
+                        human_excluded += max(
+                            0.0, time.monotonic() - self._human_wait_started
+                        )
+                    observer_excluded = self._observer_excluded_s
+                    if self._observer_wait_started is not None:
+                        observer_excluded += max(
+                            0.0, time.monotonic() - self._observer_wait_started
+                        )
+                if waiting_for_human:
+                    remaining = _SEQUENTIAL_WAIT_POLL_S
+                else:
+                    effective_deadline = (
+                        deadline
+                        + self.authorization_gate.excluded_seconds()
+                        + human_excluded
+                        + observer_excluded
+                    )
+                    remaining = effective_deadline - time.monotonic()
+                    if remaining <= 0:
+                        if future.done():
+                            return future.result()
+                        with self._state_lock:
+                            self._abandoned = True
+                        abandon = True
+                        reason = "timeout"
+                        break
+                try:
+                    return future.result(
+                        timeout=min(_SEQUENTIAL_WAIT_POLL_S, remaining)
+                    )
+                except concurrent.futures.TimeoutError:
+                    if self.agent._interrupt_requested:
+                        with self._state_lock:
+                            self._abandoned = True
+                        abandon = True
+                        reason = "interrupt"
+                        break
+        finally:
+            if not abandon:
+                self._release_worker_reservation()
+                executor.shutdown(wait=True, cancel_futures=False)
+
+        with self._state_lock:
+            self._abandoned = True
+            worker_tid = self._worker_tid
+        future.cancel()
+        if worker_tid is not None:
+            try:
+                _ra()._set_interrupt(True, worker_tid)
+            except Exception:
+                pass
+        self._remember_abandoned_worker()
+        executor.shutdown(wait=False, cancel_futures=True)
+
+        if reason == "interrupt":
+            return self._synthetic(
+                f"[Tool execution cancelled — {self.function_name} was interrupted by the user]",
+                status="cancelled",
+                error_type="user_interrupt",
+                started_at=started_at,
+            )
+        return self._synthetic(
+            f"Error executing tool '{self.function_name}': timed out after {float(self.timeout_s):.1f}s",
+            status="timeout",
+            error_type="tool_timeout",
+            started_at=started_at,
+        )
+
+
 def _run_agent_tool_execution_middleware(
     agent,
     *,
@@ -492,6 +906,7 @@ def _run_agent_tool_execution_middleware(
     display_index: int | None = None,
     middleware_trace: list[dict[str, Any]] | None = None,
     begin_execution=None,
+    execution_completed=None,
     authorization_gate: _ConcurrentToolAuthorizationGate | None = None,
 ) -> _ManagedToolResult:
     """Run Relay rewrites before Hermes policy and dispatch exactly once."""
@@ -608,7 +1023,11 @@ def _run_agent_tool_execution_middleware(
             agent._iters_since_skill = 0
 
         _advance_start_order(_begin)
-        return execute(final_args)
+        try:
+            return execute(final_args)
+        finally:
+            if execution_completed is not None:
+                execution_completed()
 
     def _hermes_pipeline(relay_args: dict[str, Any]) -> Any:
         request_result = apply_tool_request_middleware(
@@ -661,6 +1080,33 @@ def _run_agent_tool_execution_middleware(
         blocked=bool(state["blocked"]),
         dispatched=bool(state["dispatched"]),
     )
+
+
+def _run_sequential_tool_execution_middleware(
+    agent,
+    **kwargs,
+) -> _ManagedToolResult:
+    """Apply one deadline to the complete sequential middleware/dispatch path."""
+    function_name = kwargs["function_name"]
+    authorization_gate = _ConcurrentToolAuthorizationGate(
+        session_key=getattr(agent, "session_id", None)
+    )
+    supervisor = _SequentialToolSupervisor(
+        agent,
+        function_name=function_name,
+        authorization_gate=authorization_gate,
+        suspend_deadline_after_dispatch=function_name in _HUMAN_RESPONSE_TOOLS,
+    )
+    kwargs["begin_execution"] = supervisor.begin_execution
+    kwargs["authorization_gate"] = authorization_gate
+    kwargs["execution_completed"] = supervisor.mark_execution_terminal
+    outcome = supervisor.run(
+        lambda: _run_agent_tool_execution_middleware(agent, **kwargs)
+    )
+    if isinstance(outcome.result, _SequentialTerminalResult):
+        outcome.args = kwargs["function_args"]
+        outcome.middleware_trace = list(kwargs.get("middleware_trace") or [])
+    return outcome
 
 
 def _begin_tool_execution(
@@ -1610,6 +2056,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     """
     # Resolve the context-scaled tool-output budget once per turn.
     _tool_budget = _budget_for_agent(agent)
+    batch_abandoned = False
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         if getattr(agent, "_incremental_persistence_failed", False):
             return
@@ -1632,7 +2079,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     skipped_tc.id,
                     effect_disposition="none",
                 ))
-                _emit_terminal_post_tool_call(
+                _emit_bounded_post_tool_call(
                     agent,
                     function_name=skipped_name,
                     function_args={},
@@ -1657,7 +2104,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_call.function.arguments
         )
         if malformed_args_result is not None:
-            _emit_terminal_post_tool_call(
+            _emit_bounded_post_tool_call(
                 agent,
                 function_name=function_name,
                 function_args=function_args,
@@ -1734,7 +2181,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     merge=next_args.get("merge", False),
                     store=agent._todo_store,
                 )
-            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_sequential_tool_execution_middleware(
                 agent,
                 function_name=function_name,
                 function_args=function_args,
@@ -1765,7 +2212,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     db=session_db,
                     current_session_id=agent.session_id,
                 )
-            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_sequential_tool_execution_middleware(
                 agent,
                 function_name=function_name,
                 function_args=function_args,
@@ -1804,7 +2251,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         ),
                     )
                 return result
-            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_sequential_tool_execution_middleware(
                 agent,
                 function_name=function_name,
                 function_args=function_args,
@@ -1826,7 +2273,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     multi_select=next_args.get("multi_select", False),
                     callback=agent.clarify_callback,
                 )
-            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_sequential_tool_execution_middleware(
                 agent,
                 function_name=function_name,
                 function_args=function_args,
@@ -1847,7 +2294,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     count=next_args.get("count"),
                     callback=getattr(agent, "read_terminal_callback", None),
                 )
-            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_sequential_tool_execution_middleware(
                 agent,
                 function_name=function_name,
                 function_args=function_args,
@@ -1868,7 +2315,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     count=next_args.get("count"),
                     callback=getattr(agent, "read_preview_callback", None),
                 )
-            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_sequential_tool_execution_middleware(
                 agent,
                 function_name=function_name,
                 function_args=function_args,
@@ -1887,7 +2334,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 return _read_window_below_tool(
                     callback=getattr(agent, "read_window_below_callback", None),
                 )
-            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_sequential_tool_execution_middleware(
                 agent,
                 function_name=function_name,
                 function_args=function_args,
@@ -1909,7 +2356,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     reason=next_args.get("reason", ""),
                     callback=getattr(agent, "setup_mcp_callback", None),
                 )
-            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_sequential_tool_execution_middleware(
                 agent,
                 function_name=function_name,
                 function_args=function_args,
@@ -1946,7 +2393,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             try:
                 def _execute(next_args: dict) -> Any:
                     return agent._dispatch_delegate_task(next_args)
-                function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+                function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_sequential_tool_execution_middleware(
                     agent,
                     function_name=function_name,
                     function_args=function_args,
@@ -1979,7 +2426,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             try:
                 def _execute(next_args: dict) -> Any:
                     return agent.context_compressor.handle_tool_call(function_name, next_args, messages=messages)
-                function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+                function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_sequential_tool_execution_middleware(
                     agent,
                     function_name=function_name,
                     function_args=function_args,
@@ -2015,7 +2462,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             try:
                 def _execute(next_args: dict) -> Any:
                     return agent._memory_manager.handle_tool_call(function_name, next_args)
-                function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+                function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_sequential_tool_execution_middleware(
                     agent,
                     function_name=function_name,
                     function_args=function_args,
@@ -2077,7 +2524,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     _execution_blocked,
                     _execution_dispatched,
                 ) = _managed_values(
-                    _run_agent_tool_execution_middleware(
+                    _run_sequential_tool_execution_middleware(
                         agent,
                         function_name=function_name,
                         function_args=function_args,
@@ -2156,7 +2603,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     _execution_blocked,
                     _execution_dispatched,
                 ) = _managed_values(
-                    _run_agent_tool_execution_middleware(
+                    _run_sequential_tool_execution_middleware(
                         agent,
                         function_name=function_name,
                         function_args=function_args,
@@ -2208,22 +2655,18 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Log tool errors to the persistent error log so [error] tags
         # in the UI always have a corresponding detailed entry on disk.
         _is_error_result, _ = _detect_tool_failure(function_name, function_result)
-        # The agent-runtime tools above (todo, session_search, memory,
-        # context-engine, memory-manager, clarify, delegate_task) are
-        # dispatched inline — they never reach handle_function_call, so the
-        # executor is the one that has to fire post_tool_call. For
-        # registry-dispatched tools the else-branch above invoked
-        # handle_function_call, which already fires the hook.
-        from agent.agent_runtime_helpers import agent_runtime_owns_post_tool_hook
-        _executor_must_emit_post_hook = (
-            not _execution_blocked
-            and (
-                not _execution_dispatched
-                or agent_runtime_owns_post_tool_hook(agent, function_name)
-            )
+        _synthetic_terminal = isinstance(
+            function_result, _SequentialTerminalResult
         )
-        if _executor_must_emit_post_hook:
-            _emit_terminal_post_tool_call(
+        _synthetic_effect_disposition = (
+            function_result.effect_disposition if _synthetic_terminal else None
+        )
+        _synthetic_dispatched = (
+            function_result.dispatched if _synthetic_terminal else False
+        )
+        if _synthetic_terminal:
+            tool_duration = function_result.duration_s
+            _emit_bounded_post_tool_call(
                 agent,
                 function_name=function_name,
                 function_args=function_args,
@@ -2231,9 +2674,33 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 effective_task_id=effective_task_id,
                 tool_call_id=getattr(tool_call, "id", "") or "",
                 duration_ms=int(tool_duration * 1000),
+                status=function_result.status,
+                error_type=function_result.error_type,
+                error_message=str(function_result),
                 middleware_trace=list(middleware_trace),
             )
-        if not _execution_blocked:
+        else:
+            from agent.agent_runtime_helpers import agent_runtime_owns_post_tool_hook
+
+            _executor_must_emit_post_hook = (
+                not _execution_blocked
+                and (
+                    not _execution_dispatched
+                    or agent_runtime_owns_post_tool_hook(agent, function_name)
+                )
+            )
+            if _executor_must_emit_post_hook:
+                _emit_bounded_post_tool_call(
+                    agent,
+                    function_name=function_name,
+                    function_args=function_args,
+                    result=function_result,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    duration_ms=int(tool_duration * 1000),
+                    middleware_trace=list(middleware_trace),
+                )
+        if not _execution_blocked and not _synthetic_terminal:
             function_result = agent._append_guardrail_observation(
                 function_name,
                 function_args,
@@ -2252,7 +2719,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # the concurrent path for the rationale; both paths must feed
         # the same state so the footer reflects every tool call in the
         # turn, not just the parallel ones.
-        if not _execution_blocked:
+        if not _execution_blocked and not _synthetic_terminal:
             try:
                 agent._record_file_mutation_result(
                     function_name, function_args, function_result, _is_error_result,
@@ -2289,7 +2756,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
-        tool_message = make_tool_result_message(function_name, _tool_content, tool_call.id)
+        tool_message = make_tool_result_message(
+            function_name,
+            _tool_content,
+            tool_call.id,
+            effect_disposition=_synthetic_effect_disposition,
+        )
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
         if not _flush_session_db_after_tool_progress(
@@ -2352,17 +2824,52 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 response_preview = _fr_str[:agent.log_prefix_chars] + "..." if len(_fr_str) > agent.log_prefix_chars else _fr_str
                 print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s - {response_preview}")
 
-        if agent._interrupt_requested and i < len(assistant_message.tool_calls):
+        if _synthetic_terminal and _synthetic_dispatched:
+            # The worker may still apply an effect. Preserve the sequential
+            # ordering contract by refusing to start later calls in this batch.
+            batch_abandoned = True
+
+        if (
+            (agent._interrupt_requested or batch_abandoned)
+            and i < len(assistant_message.tool_calls)
+        ):
             remaining = len(assistant_message.tool_calls) - i
-            agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {remaining} remaining tool call(s)", force=True)
+            reason = (
+                "an earlier tool timed out with an unknown effect"
+                if batch_abandoned
+                else "user interrupt"
+            )
+            agent._vprint(
+                f"{agent.log_prefix}⚡ Skipping {remaining} remaining tool call(s): {reason}",
+                force=True,
+            )
             for skipped_tc in assistant_message.tool_calls[i:]:
                 skipped_name = skipped_tc.function.name
+                skipped_result = (
+                    f"[Tool execution skipped — {skipped_name} was not started "
+                    f"due to {reason}]"
+                )
                 messages.append(make_tool_result_message(
                     skipped_name,
-                    f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",
+                    skipped_result,
                     skipped_tc.id,
                     effect_disposition="none",
                 ))
+                _emit_bounded_post_tool_call(
+                    agent,
+                    function_name=skipped_name,
+                    function_args={},
+                    result=skipped_result,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(skipped_tc, "id", "") or "",
+                    status="cancelled",
+                    error_type=(
+                        "prior_tool_unknown_effect"
+                        if batch_abandoned
+                        else "user_interrupt"
+                    ),
+                    error_message=reason,
+                )
                 if not _flush_session_db_after_tool_progress(
                     agent,
                     messages,
@@ -2384,6 +2891,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     # applied to sequential execution as well.
     if finalize and num_tools_seq > 0:
         agent._apply_pending_steer_to_tool_results(messages, num_tools_seq)
+    return batch_abandoned
 
 
 
@@ -2418,7 +2926,13 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
         _exec_cwd = Path(_active_env.cwd) if _active_env is not None and _active_env.cwd else None
         segments = _plan_tool_batch_segments(assistant_message.tool_calls, execution_cwd=_exec_cwd)
 
-    for kind, calls in segments:
+    # A detached effectful worker can finish in a later model round. Route the
+    # whole batch through the sequential supervisor while that quarantine is
+    # active so even tools that are normally parallel-safe cannot bypass it.
+    if _has_abandoned_effect_worker(agent):
+        segments = [("sequential", list(assistant_message.tool_calls))]
+
+    for segment_index, (kind, calls) in enumerate(segments):
         if getattr(agent, "_incremental_persistence_failed", False):
             return
         segment_message = SimpleNamespace(tool_calls=list(calls))
@@ -2428,10 +2942,47 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
                 finalize=False,
             )
         else:
-            execute_tool_calls_sequential(
+            batch_abandoned = execute_tool_calls_sequential(
                 agent, segment_message, messages, effective_task_id, api_call_count,
                 finalize=False,
             )
+            if batch_abandoned:
+                future_calls = [
+                    call
+                    for _future_kind, future_segment in segments[segment_index + 1:]
+                    for call in future_segment
+                ]
+                _append_cancelled_tool_results(
+                    messages,
+                    future_calls,
+                    reason="an earlier tool timed out with an unknown effect",
+                )
+                for skipped_tc in future_calls:
+                    skipped_name = skipped_tc.function.name
+                    _emit_bounded_post_tool_call(
+                        agent,
+                        function_name=skipped_name,
+                        function_args={},
+                        result=(
+                            f"[Tool execution cancelled — {skipped_name} was "
+                            "skipped due to an earlier tool timed out with an "
+                            "unknown effect]"
+                        ),
+                        effective_task_id=effective_task_id,
+                        tool_call_id=getattr(skipped_tc, "id", "") or "",
+                        status="cancelled",
+                        error_type="prior_tool_unknown_effect",
+                        error_message=(
+                            "An earlier tool timed out with an unknown effect"
+                        ),
+                    )
+                if future_calls:
+                    _flush_session_db_after_tool_progress(
+                        agent,
+                        messages,
+                        stage="skipped post-timeout tool results",
+                    )
+                break
 
         if getattr(agent, "_incremental_persistence_failed", False):
             return

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -102,6 +102,16 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        # Wall-clock budget for one non-interactive tool on the sequential
+        # executor. A single tool call otherwise owns the conversation thread
+        # forever when its transport or plugin never returns (#84719).
+        # Human-response tools (clarify/setup_mcp) keep their own lifecycle
+        # timeouts and are not charged to this budget. 0 = unlimited.
+        "sequential_tool_timeout": 420,
+        # A timed-out Python thread cannot be killed safely. Bound the number
+        # of detached sequential workers per agent so repeated hangs cannot
+        # grow threads without limit; completed workers are pruned lazily.
+        "max_abandoned_tool_workers": 2,
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.

--- a/model_tools.py
+++ b/model_tools.py
@@ -24,6 +24,7 @@ import os
 import json
 import re
 import asyncio
+import contextvars
 import logging
 import threading
 import time
@@ -39,6 +40,32 @@ from tools.registry import (
 from toolsets import resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
+
+_POST_TOOL_CALL_DISPATCHER: contextvars.ContextVar = contextvars.ContextVar(
+    "post_tool_call_dispatcher",
+    default=None,
+)
+_TOOL_HANDLER_TERMINAL_CALLBACK: contextvars.ContextVar = contextvars.ContextVar(
+    "tool_handler_terminal_callback",
+    default=None,
+)
+
+
+def _set_post_tool_call_dispatcher(dispatcher):
+    """Bind a supervisor-owned observer dispatcher into this context."""
+    return _POST_TOOL_CALL_DISPATCHER.set(dispatcher)
+
+
+def _reset_post_tool_call_dispatcher(token) -> None:
+    _POST_TOOL_CALL_DISPATCHER.reset(token)
+
+
+def _set_tool_handler_terminal_callback(callback):
+    return _TOOL_HANDLER_TERMINAL_CALLBACK.set(callback)
+
+
+def _reset_tool_handler_terminal_callback(token) -> None:
+    _TOOL_HANDLER_TERMINAL_CALLBACK.reset(token)
 
 # Tracks platform-bundle names already flagged in disabled_toolsets so the
 # advisory (#33924) is logged once per name, not on every tool recompute.
@@ -1131,39 +1158,56 @@ def _emit_post_tool_call_hook(
 ) -> None:
     """Emit the ``post_tool_call`` observer hook.
 
-    No-ops cheaply when no plugin has registered for ``post_tool_call`` —
-    the ``has_hook`` gate skips both the result-field derivation and the
-    payload dispatch so the no-listener path costs one dict lookup.  When
-    ``status`` is not supplied, the ok/error fields are derived from the
-    result *after* the gate (parsing the result is only worth it when a
-    listener will actually consume it).
+    No-ops cheaply when no plugin has registered for ``post_tool_call``.
+    Sequential supervision may provide a bounded dispatcher so a stuck
+    observer cannot own the conversation thread. When ``status`` is omitted,
+    fields are derived only after the listener check.
     """
+    terminal_callback = _TOOL_HANDLER_TERMINAL_CALLBACK.get()
+
+    def _mark_terminal() -> None:
+        if terminal_callback is not None:
+            try:
+                terminal_callback()
+            except Exception:
+                pass
+
     try:
         from hermes_cli.lifecycle import has_hook, invoke_hook
         if not has_hook("post_tool_call"):
+            _mark_terminal()
             return
         if status is None:
             status, error_type, error_message = _tool_result_observer_fields(
                 function_name,
                 result,
             )
-        invoke_hook(
-            "post_tool_call",
-            tool_name=function_name,
-            args=function_args,
-            result=result,
-            task_id=task_id or "",
-            session_id=session_id or "",
-            tool_call_id=tool_call_id or "",
-            turn_id=turn_id or "",
-            api_request_id=api_request_id or "",
-            duration_ms=duration_ms,
-            status=status,
-            error_type=error_type,
-            error_message=error_message,
-            middleware_trace=list(middleware_trace or []),
-        )
+        def _invoke() -> None:
+            invoke_hook(
+                "post_tool_call",
+                tool_name=function_name,
+                args=function_args,
+                result=result,
+                task_id=task_id or "",
+                session_id=session_id or "",
+                tool_call_id=tool_call_id or "",
+                turn_id=turn_id or "",
+                api_request_id=api_request_id or "",
+                duration_ms=duration_ms,
+                status=status,
+                error_type=error_type,
+                error_message=error_message,
+                middleware_trace=list(middleware_trace or []),
+            )
+
+        dispatcher = _POST_TOOL_CALL_DISPATCHER.get()
+        if dispatcher is None:
+            _mark_terminal()
+            _invoke()
+        else:
+            dispatcher(_invoke)
     except Exception as _hook_err:
+        _mark_terminal()
         logger.debug("post_tool_call hook error: %s", _hook_err)
 
 
@@ -1213,6 +1257,7 @@ def handle_function_call(
     if not isinstance(function_args, dict):
         function_args = {}
     _tool_middleware_trace = list(tool_request_middleware_trace or [])
+
 
     # ── Tool Search bridge dispatch ──────────────────────────────────
     # tool_search and tool_describe are pure catalog reads — handle them

--- a/run_agent.py
+++ b/run_agent.py
@@ -7866,6 +7866,21 @@ class AIAgent:
                     assistant_message, messages, effective_task_id, api_call_count
                 )
 
+            from agent.tool_executor import (
+                _has_abandoned_effect_worker,
+                execute_tool_calls_segmented,
+            )
+
+            if _has_abandoned_effect_worker(self):
+                return execute_tool_calls_segmented(
+                    self,
+                    assistant_message,
+                    messages,
+                    effective_task_id,
+                    api_call_count,
+                    segments=[("sequential", list(tool_calls))],
+                )
+
             from agent.tool_dispatch_helpers import _plan_tool_batch_segments
             _active_env = get_active_env(effective_task_id)
             _exec_cwd = Path(_active_env.cwd) if _active_env is not None and _active_env.cwd else None
@@ -7881,7 +7896,6 @@ class AIAgent:
                     assistant_message, messages, effective_task_id, api_call_count
                 )
 
-            from agent.tool_executor import execute_tool_calls_segmented
             return execute_tool_calls_segmented(
                 self, assistant_message, messages, effective_task_id, api_call_count,
                 segments=segments,

--- a/tests/run_agent/test_sequential_tool_deadline.py
+++ b/tests/run_agent/test_sequential_tool_deadline.py
@@ -1,0 +1,712 @@
+"""Behavior contracts for supervised sequential tool execution (#84719)."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import run_agent
+from run_agent import AIAgent
+
+
+def _tool_call(name: str, arguments: dict | None = None, call_id: str = "call-1"):
+    return SimpleNamespace(
+        id=call_id,
+        function=SimpleNamespace(
+            name=name,
+            arguments=json.dumps(arguments or {}),
+        ),
+    )
+
+
+@pytest.fixture()
+def agent():
+    tool_defs = [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "test tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    with (
+        patch("run_agent.get_tool_definitions", return_value=tool_defs),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        instance = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    instance.client = MagicMock()
+    instance._flush_messages_to_session_db = MagicMock(return_value=True)
+    instance.sequential_tool_timeout_s = 0.5
+    instance.max_abandoned_tool_workers = 2
+    return instance
+
+
+@pytest.mark.parametrize("configured", ["nan", "inf", "-inf"])
+def test_non_finite_sequential_timeout_falls_back_to_finite_default(configured):
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={"agent": {"sequential_tool_timeout": configured}},
+    ):
+        instance = AIAgent(api_key="test", base_url="https://example.test/v1")
+
+    assert instance.sequential_tool_timeout_s == 420.0
+
+
+def test_native_infinite_abandoned_worker_cap_falls_back_to_default():
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={"agent": {"max_abandoned_tool_workers": float("inf")}},
+    ):
+        instance = AIAgent(api_key="test", base_url="https://example.test/v1")
+
+    assert instance.max_abandoned_tool_workers == 2
+
+
+def _run_in_daemon(agent: AIAgent, tool_call, messages: list[dict]):
+    assistant_message = SimpleNamespace(tool_calls=[tool_call])
+    failure: list[BaseException] = []
+
+    def _target():
+        try:
+            agent._execute_tool_calls_sequential(
+                assistant_message,
+                messages,
+                "task-deadline",
+            )
+        except BaseException as exc:  # pragma: no cover - asserted by caller
+            failure.append(exc)
+
+    thread = threading.Thread(target=_target, daemon=True)
+    thread.start()
+    return thread, failure
+
+
+def test_hung_single_tool_returns_timeout_and_preserves_tool_pairing(agent):
+    release = threading.Event()
+    started = threading.Event()
+    messages: list[dict] = []
+    agent._subdirectory_hints.check_tool_call = MagicMock(
+        return_value="\n<context-hint>preserved</context-hint>"
+    )
+
+    def _hung(*args, **kwargs):
+        started.set()
+        release.wait()
+        return "late result"
+
+    with patch("run_agent.handle_function_call", side_effect=_hung):
+        thread, failure = _run_in_daemon(agent, _tool_call("web_search"), messages)
+        assert started.wait(timeout=1)
+        thread.join(timeout=1.5)
+
+    release.set()
+    assert not thread.is_alive(), "a single hung tool must not wedge the turn"
+    assert failure == []
+    assert len(messages) == 1
+    assert messages[0]["role"] == "tool"
+    assert messages[0]["tool_call_id"] == "call-1"
+    assert messages[0]["effect_disposition"] == "unknown"
+    assert "timed out" in messages[0]["content"]
+    assert "<context-hint>preserved</context-hint>" in messages[0]["content"].lower()
+
+
+def test_stop_interrupts_sequential_waiter_without_waiting_for_deadline(agent):
+    agent.sequential_tool_timeout_s = 30.0
+    release = threading.Event()
+    started = threading.Event()
+    messages: list[dict] = []
+
+    def _hung(*args, **kwargs):
+        started.set()
+        release.wait()
+        return "late result"
+
+    with patch("run_agent.handle_function_call", side_effect=_hung):
+        thread, failure = _run_in_daemon(agent, _tool_call("web_search"), messages)
+        assert started.wait(timeout=1)
+        before = time.monotonic()
+        agent.interrupt("user requested stop")
+        thread.join(timeout=1)
+        elapsed = time.monotonic() - before
+
+    release.set()
+    assert not thread.is_alive()
+    assert elapsed < 1
+    assert failure == []
+    assert "cancelled" in messages[0]["content"].lower()
+    assert messages[0]["effect_disposition"] == "unknown"
+
+
+def test_setup_mcp_human_wait_is_not_charged_to_tool_deadline(agent):
+    release = threading.Event()
+    started = threading.Event()
+    messages: list[dict] = []
+
+    def _wait_for_user(*args, **kwargs):
+        started.set()
+        release.wait(timeout=2)
+        return json.dumps({"status": "installed", "server": "linear"})
+
+    agent.setup_mcp_callback = _wait_for_user
+    thread, failure = _run_in_daemon(
+        agent,
+        _tool_call("setup_mcp", {"server": "linear"}),
+        messages,
+    )
+    assert started.wait(timeout=1)
+    time.sleep(0.1)
+    assert thread.is_alive(), "human consent must use its own lifecycle timeout"
+
+    release.set()
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert failure == []
+    assert "installed" in messages[0]["content"]
+    assert "effect_disposition" not in messages[0]
+
+
+def test_setup_mcp_human_wait_is_not_charged_retroactively(agent):
+    agent.sequential_tool_timeout_s = 0.15
+    started = threading.Event()
+    messages: list[dict] = []
+
+    def _wait_for_user(*args, **kwargs):
+        started.set()
+        time.sleep(0.35)
+        return json.dumps({"status": "installed", "server": "linear"})
+
+    agent.setup_mcp_callback = _wait_for_user
+    thread, failure = _run_in_daemon(
+        agent,
+        _tool_call("setup_mcp", {"server": "linear"}),
+        messages,
+    )
+    assert started.wait(timeout=1)
+    thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    assert failure == []
+    assert "installed" in messages[0]["content"]
+    assert "timed out" not in messages[0]["content"]
+
+
+def test_human_wait_extends_deadline_for_post_handler_processing(agent):
+    from agent.tool_executor import (
+        _ConcurrentToolAuthorizationGate,
+        _SequentialToolSupervisor,
+    )
+
+    agent.sequential_tool_timeout_s = 0.15
+    supervisor = _SequentialToolSupervisor(
+        agent,
+        function_name="clarify",
+        authorization_gate=_ConcurrentToolAuthorizationGate(),
+        suspend_deadline_after_dispatch=True,
+    )
+
+    def _callback():
+        supervisor.begin_execution()
+        time.sleep(0.3)
+        supervisor.mark_execution_terminal()
+        time.sleep(0.05)
+        return "answered"
+
+    assert supervisor.run(_callback) == "answered"
+
+
+def test_timeout_before_dispatch_fences_late_middleware_callback(agent, monkeypatch):
+    from hermes_cli import middleware
+
+    release = threading.Event()
+    middleware_entered = threading.Event()
+    dispatched = threading.Event()
+    messages: list[dict] = []
+
+    def _late_middleware(
+        function_name,
+        function_args,
+        callback,
+        **kwargs,
+    ):
+        middleware_entered.set()
+        release.wait(timeout=2)
+        return callback(function_args)
+
+    monkeypatch.setattr(middleware, "run_tool_execution_middleware", _late_middleware)
+
+    def _dispatch(*args, **kwargs):
+        dispatched.set()
+        return "must not run"
+
+    with patch("run_agent.handle_function_call", side_effect=_dispatch):
+        thread, failure = _run_in_daemon(agent, _tool_call("web_search"), messages)
+        assert middleware_entered.wait(timeout=1)
+        thread.join(timeout=1.5)
+        assert not thread.is_alive()
+        release.set()
+        time.sleep(0.1)
+
+    assert failure == []
+    assert not dispatched.is_set(), "an abandoned pre-dispatch worker must stay fenced"
+    assert messages[0]["effect_disposition"] == "none"
+
+
+def test_abandoned_worker_budget_prevents_unbounded_thread_growth(agent):
+    agent.max_abandoned_tool_workers = 1
+    first_release = threading.Event()
+    first_started = threading.Event()
+    calls = 0
+
+    def _dispatch(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_started.set()
+            first_release.wait()
+        return "ok"
+
+    first_messages: list[dict] = []
+    second_messages: list[dict] = []
+    with patch("run_agent.handle_function_call", side_effect=_dispatch):
+        first, first_failure = _run_in_daemon(
+            agent,
+            _tool_call("web_search", call_id="first"),
+            first_messages,
+        )
+        assert first_started.wait(timeout=1)
+        first.join(timeout=1.5)
+        assert not first.is_alive()
+
+        second, second_failure = _run_in_daemon(
+            agent,
+            _tool_call("web_search", call_id="second"),
+            second_messages,
+        )
+        second.join(timeout=1.5)
+
+    first_release.set()
+    assert first_failure == []
+    assert second_failure == []
+    assert not second.is_alive()
+    assert calls == 1
+    assert "worker capacity" in second_messages[0]["content"].lower()
+    assert second_messages[0]["effect_disposition"] == "none"
+
+
+def test_abandoned_worker_budget_is_reserved_atomically(agent):
+    from agent.tool_executor import (
+        _ConcurrentToolAuthorizationGate,
+        _SequentialToolSupervisor,
+    )
+
+    agent.max_abandoned_tool_workers = 1
+    agent.sequential_tool_timeout_s = 0.15
+    owners_ready = threading.Barrier(3)
+    callback_release = threading.Event()
+    callback_count = 0
+    callback_lock = threading.Lock()
+    outcomes = []
+
+    def _callback():
+        nonlocal callback_count
+        with callback_lock:
+            callback_count += 1
+        callback_release.wait(timeout=2)
+        return "late"
+
+    def _owner():
+        supervisor = _SequentialToolSupervisor(
+            agent,
+            function_name="web_search",
+            authorization_gate=_ConcurrentToolAuthorizationGate(),
+        )
+        owners_ready.wait(timeout=1)
+        outcomes.append(supervisor.run(_callback))
+
+    owners = [threading.Thread(target=_owner, daemon=True) for _ in range(2)]
+    for owner in owners:
+        owner.start()
+    owners_ready.wait(timeout=1)
+    for owner in owners:
+        owner.join(timeout=1)
+
+    callback_release.set()
+    assert all(not owner.is_alive() for owner in owners)
+    assert callback_count == 1
+    assert sorted(outcome.result.error_type for outcome in outcomes) == [
+        "abandoned_worker_capacity",
+        "tool_timeout",
+    ]
+
+
+def test_timeout_emits_one_terminal_hook_even_if_worker_returns_late(agent, monkeypatch):
+    from hermes_cli import lifecycle
+
+    release = threading.Event()
+    started = threading.Event()
+    post_events: list[dict] = []
+    messages: list[dict] = []
+
+    monkeypatch.setattr(lifecycle, "has_hook", lambda name: name == "post_tool_call")
+
+    def _capture(name, **kwargs):
+        if name == "post_tool_call":
+            post_events.append(kwargs)
+        return []
+
+    monkeypatch.setattr(lifecycle, "invoke_hook", _capture)
+
+    def _late(*args, **kwargs):
+        started.set()
+        release.wait(timeout=2)
+        from model_tools import _emit_post_tool_call_hook
+
+        _emit_post_tool_call_hook(
+            function_name="web_search",
+            function_args={},
+            result="late success",
+            task_id="task-deadline",
+            tool_call_id=kwargs.get("tool_call_id", ""),
+        )
+        return "late success"
+
+    with patch("run_agent.handle_function_call", side_effect=_late):
+        thread, failure = _run_in_daemon(agent, _tool_call("web_search"), messages)
+        assert started.wait(timeout=1)
+        thread.join(timeout=1.5)
+        release.set()
+        time.sleep(0.15)
+
+    assert failure == []
+    assert len(post_events) == 1
+    assert post_events[0]["status"] == "timeout"
+    assert post_events[0]["tool_call_id"] == "call-1"
+
+
+def test_stuck_synthetic_post_hook_cannot_rewedge_owner(agent, monkeypatch):
+    from hermes_cli import lifecycle
+
+    tool_release = threading.Event()
+    hook_release = threading.Event()
+    hook_started = threading.Event()
+    messages: list[dict] = []
+
+    monkeypatch.setattr(lifecycle, "has_hook", lambda name: name == "post_tool_call")
+
+    def _hook(name, **payload):
+        if name == "post_tool_call" and payload.get("status") == "timeout":
+            hook_started.set()
+            hook_release.wait(timeout=5)
+
+    monkeypatch.setattr(lifecycle, "invoke_hook", _hook)
+
+    with patch(
+        "run_agent.handle_function_call",
+        side_effect=lambda *a, **kw: (tool_release.wait(timeout=5) or "late"),
+    ):
+        thread, failure = _run_in_daemon(agent, _tool_call("web_search"), messages)
+        assert hook_started.wait(timeout=2)
+        thread.join(timeout=1.5)
+
+    assert not thread.is_alive()
+    assert failure == []
+    assert messages[0]["effect_disposition"] == "unknown"
+    assert "timed out" in messages[0]["content"]
+    hook_release.set()
+    tool_release.set()
+
+
+def test_human_tool_resumes_deadline_and_detaches_slow_success_hook(agent, monkeypatch):
+    from hermes_cli import lifecycle
+
+    agent.sequential_tool_timeout_s = 1.0
+    callback_called = threading.Event()
+
+    def _clarify_callback(*args, **kwargs):
+        callback_called.set()
+        return "answered"
+
+    agent.clarify_callback = _clarify_callback
+    hook_release = threading.Event()
+    hook_started = threading.Event()
+    events: list[str] = []
+    messages: list[dict] = []
+
+    monkeypatch.setattr(lifecycle, "has_hook", lambda name: name == "post_tool_call")
+
+    def _hook(name, **payload):
+        if name != "post_tool_call":
+            return
+        hook_started.set()
+        hook_release.wait(timeout=5)
+        events.append(payload["status"])
+
+    monkeypatch.setattr(lifecycle, "invoke_hook", _hook)
+
+    call = SimpleNamespace(
+        id="call-1",
+        function=SimpleNamespace(
+            name="clarify",
+            arguments=json.dumps({"question": "Continue?"}),
+        ),
+    )
+    thread, failure = _run_in_daemon(agent, call, messages)
+    assert callback_called.wait(timeout=1)
+    assert hook_started.wait(timeout=1)
+    thread.join(timeout=1.5)
+
+    assert not thread.is_alive()
+    assert failure == []
+    assert json.loads(messages[0]["content"])["user_response"] == "answered"
+    assert "timed out" not in messages[0]["content"]
+    hook_release.set()
+    deadline = time.monotonic() + 1
+    while events != ["ok"] and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert events == ["ok"]
+
+
+def test_unknown_late_effect_skips_remaining_calls_in_same_batch(agent):
+    release = threading.Event()
+    first_started = threading.Event()
+    dispatched: list[str] = []
+    messages: list[dict] = []
+    assistant_message = SimpleNamespace(
+        tool_calls=[
+            _tool_call("web_search", call_id="first"),
+            _tool_call("web_search", call_id="second"),
+        ]
+    )
+
+    def _dispatch(*args, **kwargs):
+        call_id = kwargs.get("tool_call_id", "")
+        dispatched.append(call_id)
+        if call_id == "first":
+            first_started.set()
+            release.wait(timeout=2)
+        return "ok"
+
+    failure: list[BaseException] = []
+
+    def _target():
+        try:
+            agent._execute_tool_calls_sequential(
+                assistant_message,
+                messages,
+                "task-deadline",
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failure.append(exc)
+
+    with patch("run_agent.handle_function_call", side_effect=_dispatch):
+        thread = threading.Thread(target=_target, daemon=True)
+        thread.start()
+        assert first_started.wait(timeout=1)
+        thread.join(timeout=1.5)
+
+    release.set()
+    assert not thread.is_alive()
+    assert failure == []
+    assert dispatched == ["first"]
+    assert [message["tool_call_id"] for message in messages] == ["first", "second"]
+    assert messages[0]["effect_disposition"] == "unknown"
+    assert messages[1]["effect_disposition"] == "none"
+    assert "was not started" in messages[1]["content"]
+
+
+def test_normal_registry_call_keeps_inner_post_hook_ownership(agent, monkeypatch):
+    from hermes_cli import lifecycle
+    from model_tools import _emit_post_tool_call_hook
+
+    post_events: list[dict] = []
+    messages: list[dict] = []
+    monkeypatch.setattr(lifecycle, "has_hook", lambda name: name == "post_tool_call")
+    def _capture(name, **kwargs):
+        if name == "post_tool_call":
+            post_events.append(kwargs)
+        return []
+
+    monkeypatch.setattr(lifecycle, "invoke_hook", _capture)
+
+    def _dispatch(*args, **kwargs):
+        _emit_post_tool_call_hook(
+            function_name="web_search",
+            function_args={},
+            result="raw result",
+            task_id="task-deadline",
+            tool_call_id=kwargs.get("tool_call_id", ""),
+        )
+        return "raw result"
+
+    with patch("run_agent.handle_function_call", side_effect=_dispatch):
+        thread, failure = _run_in_daemon(agent, _tool_call("web_search"), messages)
+        thread.join(timeout=1.5)
+
+    assert failure == []
+    assert not thread.is_alive()
+    assert len(post_events) == 1
+    assert post_events[0]["result"] == "raw result"
+    assert messages[0]["content"] == "raw result"
+
+
+def test_human_approval_wait_is_excluded_from_deadline(agent, monkeypatch):
+    from tools import approval
+
+    agent.sequential_tool_timeout_s = 0.3
+    wait_started: list[float] = []
+    messages: list[dict] = []
+
+    def _human_wait_seconds(session_key=None):
+        if not wait_started:
+            return 0.0
+        return time.monotonic() - wait_started[0]
+
+    monkeypatch.setattr(approval, "human_wait_seconds", _human_wait_seconds)
+
+    def _approved_after_wait(*args, **kwargs):
+        wait_started.append(time.monotonic())
+        time.sleep(0.6)
+        return "approved result"
+
+    with patch("run_agent.handle_function_call", side_effect=_approved_after_wait):
+        thread, failure = _run_in_daemon(agent, _tool_call("web_search"), messages)
+        thread.join(timeout=1.5)
+
+    assert not thread.is_alive()
+    assert failure == []
+    assert messages[0]["content"] == "approved result"
+    assert "effect_disposition" not in messages[0]
+
+
+def test_unknown_effect_cancels_later_segment_without_dispatch(agent, monkeypatch):
+    release = threading.Event()
+    started = threading.Event()
+    dispatched: list[str] = []
+    messages: list[dict] = []
+
+    def _call(name: str, arguments: dict, call_id: str):
+        return SimpleNamespace(
+            id=call_id,
+            function=SimpleNamespace(
+                name=name,
+                arguments=json.dumps(arguments),
+            ),
+        )
+
+    assistant_message = SimpleNamespace(
+        tool_calls=[
+            _call("web_search", {"query": "first"}, "first"),
+            _call("web_search", {"query": "later one"}, "later-1"),
+            _call("web_search", {"query": "later two"}, "later-2"),
+        ]
+    )
+    monkeypatch.setattr(
+        "agent.tool_executor._plan_tool_batch_segments",
+        lambda tool_calls, **kwargs: [
+            ("sequential", [tool_calls[0]]),
+            ("parallel", list(tool_calls[1:])),
+        ],
+    )
+
+    def _dispatch(*args, **kwargs):
+        call_id = kwargs.get("tool_call_id", "")
+        dispatched.append(call_id)
+        if call_id == "first":
+            started.set()
+            release.wait(timeout=2)
+        return "ok"
+
+    failure: list[BaseException] = []
+
+    def _target():
+        try:
+            from agent.tool_executor import execute_tool_calls_segmented
+
+            execute_tool_calls_segmented(
+                agent,
+                assistant_message,
+                messages,
+                "task-deadline",
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failure.append(exc)
+
+    with patch("run_agent.handle_function_call", side_effect=_dispatch):
+        thread = threading.Thread(target=_target, daemon=True)
+        thread.start()
+        assert started.wait(timeout=1)
+        thread.join(timeout=1.5)
+
+    release.set()
+    assert failure == []
+    assert not thread.is_alive()
+    assert dispatched == ["first"]
+    assert [message["tool_call_id"] for message in messages] == [
+        "first",
+        "later-1",
+        "later-2",
+    ]
+    assert messages[0]["effect_disposition"] == "unknown"
+    assert all(message["effect_disposition"] == "none" for message in messages[1:])
+
+
+def test_effectful_abandoned_worker_quarantines_later_mutations(agent):
+    agent.max_abandoned_tool_workers = 2
+    release = threading.Event()
+    started = threading.Event()
+    dispatched: list[str] = []
+
+    def _call(name: str, arguments: dict, call_id: str):
+        return SimpleNamespace(
+            id=call_id,
+            function=SimpleNamespace(name=name, arguments=json.dumps(arguments)),
+        )
+
+    calls = [
+        _call("terminal", {"command": "pwd"}, "hung-effect"),
+        _call("web_search", {"query": "diagnose"}, "safe-read"),
+        _call("write_file", {"path": "later.txt", "content": "x"}, "mutation"),
+    ]
+    results: list[list[dict]] = [[], []]
+
+    def _dispatch(*args, **kwargs):
+        call_id = kwargs.get("tool_call_id", "")
+        dispatched.append(call_id)
+        if call_id == "hung-effect":
+            started.set()
+            release.wait(timeout=3)
+        return "ok"
+
+    with patch("run_agent.handle_function_call", side_effect=_dispatch):
+        first, first_failure = _run_in_daemon(agent, calls[0], results[0])
+        assert started.wait(timeout=1)
+        first.join(timeout=1.5)
+        assert not first.is_alive()
+
+        agent._execute_tool_calls(
+            SimpleNamespace(tool_calls=calls[1:]),
+            results[1],
+            "task-deadline",
+        )
+
+    release.set()
+    assert first_failure == []
+    assert dispatched == ["hung-effect", "safe-read"]
+    assert results[0][0]["effect_disposition"] == "unknown"
+    assert results[1][0]["content"] == "ok"
+    assert results[1][1]["effect_disposition"] == "none"
+    assert "still running after timeout" in results[1][1]["content"]

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1008,11 +1008,32 @@ Instead, when the budget is actually exhausted (500/500), Hermes injects one mes
 agent:
   max_turns: 500               # Max iterations per conversation turn (default: 500)
   api_max_retries: 3           # Retries per provider before fallback engages (default: 3)
+  sequential_tool_timeout: 420 # Max seconds for one non-interactive sequential tool (0 = unlimited)
+  max_abandoned_tool_workers: 2 # Per-agent cap for timed-out workers that have not exited
 ```
 
 When the iteration budget is fully exhausted, the CLI shows a notification to the user: `⚠ Iteration budget reached (500/500) — response may be incomplete`.
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
+
+`agent.sequential_tool_timeout` prevents one stalled tool handler, transport, or
+plugin middleware from owning the conversation thread indefinitely. The default
+is 420 seconds. Approval time is excluded from this budget, and tools that wait
+for a direct human response (`clarify` and the Desktop `setup_mcp` card) retain
+their own lifecycle timeouts. When a dispatched call exceeds the deadline,
+Hermes records an `unknown` effect disposition and skips later calls from the
+same model batch so a late side effect cannot be reordered behind them.
+
+Python cannot forcibly terminate an arbitrary running thread safely. Hermes
+signals timed-out workers cooperatively and detaches those that do not stop;
+`agent.max_abandoned_tool_workers` bounds those detached workers per agent
+(default `2`, clamped to `1`–`16`). Once the cap is reached, subsequent
+non-interactive sequential calls fail without starting until an abandoned
+worker exits. When the abandoned tool may have side effects, later effectful
+tools are quarantined even below the cap; read-only diagnostics remain
+available. This prevents cross-round mutation reordering and protects
+long-running gateway processes from unbounded thread growth while preserving
+the conversation's ability to return a result.
 
 ## Verify-on-Stop (coding verification)
 


### PR DESCRIPTION
## Summary

Fixes #84719.

A lone tool call currently enters `execute_tool_calls_sequential()` without an external deadline. If its handler, transport, middleware, or observer never returns, the conversation thread remains blocked until the Hermes process is restarted.

This change adds a per-call sequential supervisor that recovers the turn while preserving existing middleware, approval, persistence, and hook contracts. It is an independent, more defensive alternative to #84795: it also contains late side effects, `/stop`, human waits, stuck observers, worker growth, and cross-round ordering rather than continuing blindly after abandoning a thread.

This is a reliability/availability correction with side-effect containment. It is not presented as a security vulnerability.

## Type of change

- [x] Bug fix (non-breaking reliability correction)
- [x] Tests
- [x] Documentation

## Root cause

- Single-call batches are routed to the sequential executor.
- The concurrent executor has an external deadline; the sequential executor called the middleware/handler directly on the conversation thread.
- Internal tool timeouts are insufficient when a transport, plugin, or handler stops returning entirely.
- Python cannot safely kill an arbitrary running thread, so simply timing out a future can leave late mutations and hooks behind.

## Why this is separate from #84795

#84795 correctly adds a bounded waiter and suppresses late success events, but it deliberately continues later calls after a timed-out worker whose effect is unknown and exempts `clarify` from the deadline after dispatch. This implementation takes a stricter containment approach:

- later calls are cancelled when an abandoned worker may still produce an unknown effect;
- effectful workers quarantine later mutations across model rounds until they exit;
- human-response time is measured and excluded, while post-response processing remains supervised;
- observer hooks and abandoned-worker growth are independently bounded;
- timeout and capacity controls are user-facing `config.yaml` settings with validation and documentation.

The additional surface is intentional: recovery should not let a late worker contradict the canonical result, reorder side effects, or replace one indefinite wait with unbounded detached threads.

## Implementation

- Run the complete sequential middleware/dispatch path in a daemon worker under a configurable wall-clock deadline.
- Keep human approval time out of the deadline using the existing source-tracked approval gate.
- Suspend `clarify` / `setup_mcp` only while their actual handler is waiting, measure that interval explicitly, and extend the effective deadline so it cannot be charged retroactively during post-handler processing.
- Make `/stop` wake the owner immediately and propagate cooperative interruption to the worker.
- Fence dispatch if timeout wins before execution starts.
- Persist a paired synthetic `tool` result with `error_type=tool_timeout` and `effect_disposition=unknown` after a dispatched timeout.
- Skip later calls in the same batch after an unknown late effect.
- Quarantine later effectful calls across model rounds while an effectful abandoned worker remains alive; read-only diagnostics can continue.
- Atomically reserve abandoned-worker capacity before submission, release it on ordinary completion or submit failure, and retain it only while a timed-out worker remains alive. This makes the per-agent cap effective under concurrent entry.
- Bound `post_tool_call` observer execution and allow only one detached observer per agent, so a stuck hook cannot re-wedge the owner or leak an unbounded number of threads.
- Use ContextVars to preserve normal fast-hook ordering while ensuring a late success observer cannot defeat the canonical timeout result.
- Preserve synthetic metadata before persistence/subdirectory-hint transformations.
- Reject non-finite timeout and worker-cap configuration values, including YAML-native `.inf`.

## Configuration

```yaml
agent:
  sequential_tool_timeout: 420
  max_abandoned_tool_workers: 2
```

`sequential_tool_timeout: 0` retains the legacy unlimited behavior. Both settings are documented in the configuration guide.

## Regression coverage

The new behavior tests cover:

- hung single-call recovery and tool-call pairing;
- `/stop` responsiveness;
- `clarify` and `setup_mcp` human waits;
- approval-wait exclusion;
- pre-dispatch abandonment fencing;
- one canonical terminal hook with late worker completion;
- stuck synthetic and success hooks;
- subdirectory hints preserving timeout metadata;
- same-batch and segmented-batch cancellation;
- abandoned-worker capacity;
- atomic worker-cap admission under concurrent owners;
- cross-round effect quarantine, including homogeneous parallel batches;
- ContextVar propagation;
- non-finite timeout and worker-cap configuration fallback;
- post-handler work after a long human response does not incur the response time retroactively.

Verified locally on Windows:

- `scripts/run_tests.sh tests/run_agent/test_sequential_tool_deadline.py tests/test_model_tools.py tests/run_agent/test_tool_call_incremental_persistence.py` — 57 passed
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py` — 244 passed
- `scripts/run_tests.sh tests/run_agent/test_interrupt_propagation.py tests/run_agent/test_concurrent_interrupt.py` — 12 passed
- Three additional no-retry stability runs of `test_sequential_tool_deadline.py` — 20/20 passed each run
- Ruff on every changed Python file — passed
- `git diff --check` — passed

An independent final read-only review of the complete 7-file diff returned **PASS with no concrete P0/P1/P2 findings**. It separately exercised human-deadline accounting, atomic worker admission/release, ContextVar reset, hook ownership, and non-finite configuration handling (38 focused tests plus in-memory probes).

Two unrelated host-dependent tests remain locally red and reproduce on `origin/main`: a Windows symlink privilege test (`WinError 1314`) and a POSIX-path assertion in the guardrail test. They are not changed or masked here.

## Performance

The supervisor deliberately uses per-call daemon workers so one abandoned call cannot starve a shared pool. A local 100-call micro-probe measured approximately 5 ms of supervisory overhead per sequential call. No observer thread is created when no `post_tool_call` hook is registered.

## Files changed

- `agent/tool_executor.py` — sequential supervision, effect containment, bounded observer dispatch, atomic worker admission.
- `agent/agent_init.py` — validated timeout/cap configuration and per-agent supervisor state.
- `model_tools.py` — context-local terminal-hook ownership and handler-completion signaling.
- `run_agent.py` — route sequential execution through the supervised path and preserve timeout metadata.
- `hermes_cli/config_defaults.py` — user-facing defaults.
- `website/docs/user-guide/configuration.md` — configuration semantics and operational caveats.
- `tests/run_agent/test_sequential_tool_deadline.py` — end-to-end and deterministic concurrency regressions.

## Checklist

- [x] Read the contributing guide.
- [x] Conventional commit message.
- [x] Searched open and closed issues/PRs; the overlap and stricter scope relative to #84795 are documented above.
- [x] Diff is limited to the reported root cause and its containment/configuration contracts.
- [x] Added regression coverage and ran the repository's canonical test wrapper on the affected suites.
- [x] Tested on Windows 11.
- [x] Updated user-facing configuration documentation.
- [x] Considered cross-platform behavior; the implementation uses portable `threading`, `contextvars`, and `concurrent.futures` primitives.
- [x] Tool schemas are unchanged (N/A).

## Infographic :

<img width="1024" height="1024" alt="hung_execution_fix_85784" src="https://github.com/user-attachments/assets/2e4409d7-3d88-4eff-aabd-b90b0932fe20" />
