### PR TITLE
fix(file-safety): whitelist kernel sinks (/dev/null etc.) in write-safe-root guard

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -129,8 +129,53 @@ def build_write_approval_paths(home: str) -> set[str]:
     }
 
 
+# Kernel character-device sinks that are ALWAYS safe to write to regardless
+# of ``HERMES_WRITE_SAFE_ROOT``. Writing here is a no-op at the OS level
+# (``/dev/null`` discards; ``/dev/stdout`` / ``/dev/stderr`` go to the
+# process's own streams; ``/dev/zero`` and ``/dev/tty`` are similarly
+# harmless as write targets), so gating them behind the safe-root check
+# only produces false-positive denials for legitimate shell redirection
+# patterns.
+#
+# The check is on the *user-supplied* path normalized to absolute form
+# (``os.path.normpath`` + ``os.path.abspath``) — NOT ``realpath`` —
+# specifically so a symlink like ``/opt/data/evil -> /dev/null`` cannot
+# ride this allowlist into bypassing the containment check for its own
+# absolute path. Membership is tested against the exact string set.
+_KERNEL_SINK_ALLOWLIST: frozenset[str] = frozenset({
+    "/dev/null",
+    "/dev/stdout",
+    "/dev/stderr",
+    "/dev/tty",
+    "/dev/zero",
+})
+
+
+def _is_kernel_sink(path: str) -> bool:
+    """True when ``path`` normalizes to one of the always-allowed kernel sinks.
+
+    Uses ``normpath`` + ``abspath`` (not ``realpath``) so a symlink whose
+    target happens to be ``/dev/null`` does NOT inherit the allowlist —
+    only the literal kernel-sink paths themselves short-circuit the guard.
+    """
+    try:
+        normalized = os.path.normpath(os.path.abspath(os.path.expanduser(str(path))))
+    except (OSError, ValueError):
+        return False
+    return normalized in _KERNEL_SINK_ALLOWLIST
+
+
 def _classify_write_denial(path: str) -> Optional[str]:
     """Return ``'credential'``, ``'safe_root'``, or ``None`` if writes are allowed."""
+    # Kernel character-device sinks (/dev/null etc.) are always writable —
+    # they're OS-level no-ops, and blocking them via HERMES_WRITE_SAFE_ROOT
+    # only breaks legitimate shell redirection. Short-circuit BEFORE any
+    # other check so the allowlist wins over safe-root containment; the
+    # rest of the guard (credential denylist, hermes-internal paths) is
+    # untouched below.
+    if _is_kernel_sink(path):
+        return None
+
     home = os.path.realpath(os.path.expanduser("~"))
     resolved = os.path.realpath(os.path.expanduser(str(path)))
 

--- a/tests/agent/test_file_safety.py
+++ b/tests/agent/test_file_safety.py
@@ -129,3 +129,109 @@ class TestCombinedGuards:
             error = get_read_block_error(str(cache))
             assert error is not None
             assert "internal Hermes cache" in error
+
+
+# ---------------------------------------------------------------------------
+# Kernel character-device sinks — always writable, even outside safe root
+# ---------------------------------------------------------------------------
+
+
+class TestKernelSinkAllowlist:
+    """Kernel character-device sinks (/dev/null etc.) must always be writable.
+
+    Writing to /dev/null and its siblings is an OS-level no-op used routinely
+    for shell redirection. Blocking them under HERMES_WRITE_SAFE_ROOT produces
+    false-positive denials for legitimate patterns. Regression guard for the
+    original report where writes to /dev/null failed with "outside
+    HERMES_WRITE_SAFE_ROOT".
+    """
+
+    ALLOWED_SINKS = [
+        "/dev/null",
+        "/dev/stdout",
+        "/dev/stderr",
+        "/dev/tty",
+        "/dev/zero",
+    ]
+
+    @pytest.mark.parametrize("sink", ALLOWED_SINKS)
+    def test_kernel_sink_allowed_under_mismatched_safe_root(self, sink, monkeypatch):
+        """Every allowlisted sink must return None (allowed) even when
+        HERMES_WRITE_SAFE_ROOT points somewhere else entirely."""
+        from agent.file_safety import _classify_write_denial
+
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", "/tmp/safe")
+        assert _classify_write_denial(sink) is None
+
+    def test_non_allowlisted_dev_path_still_rejected(self, monkeypatch):
+        """A /dev/... path NOT on the allowlist (e.g. /dev/random) still
+        goes through the normal safe-root check."""
+        from agent.file_safety import _classify_write_denial
+
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", "/tmp/safe")
+        # /dev/random is not on the allowlist and is not inside /tmp/safe
+        assert _classify_write_denial("/dev/random") == "safe_root"
+
+    def test_credential_path_still_rejected(self, monkeypatch, tmp_path):
+        """Adding the kernel-sink short-circuit must NOT weaken credential
+        denial for non-allowlisted paths."""
+        from agent.file_safety import _classify_write_denial
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(tmp_path))
+        ssh_key = tmp_path / ".ssh" / "id_ed25519"
+        ssh_key.parent.mkdir(parents=True)
+        ssh_key.write_text("")
+        assert _classify_write_denial(str(ssh_key)) == "credential"
+
+    def test_out_of_tree_path_still_rejected(self, monkeypatch, tmp_path):
+        """A genuinely out-of-safe-root path (not on the sink allowlist)
+        must still be rejected as safe_root."""
+        from agent.file_safety import _classify_write_denial
+
+        safe = tmp_path / "safe"
+        safe.mkdir()
+        elsewhere = tmp_path / "elsewhere" / "foo.txt"
+        elsewhere.parent.mkdir()
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe))
+        assert _classify_write_denial(str(elsewhere)) == "safe_root"
+
+    def test_symlink_to_dev_null_not_bypassed(self, monkeypatch, tmp_path):
+        """A symlink whose target is /dev/null must NOT ride the allowlist —
+        the check is on the user-supplied path's abspath, not its realpath,
+        precisely so this attack shape is blocked.
+
+        Skips gracefully on platforms without symlink support.
+        """
+        from agent.file_safety import _classify_write_denial
+
+        symlink = tmp_path / "evil"
+        try:
+            symlink.symlink_to("/dev/null")
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation not supported on this platform")
+
+        safe = tmp_path / "safe"
+        safe.mkdir()
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe))
+        # The symlink itself is NOT literally "/dev/null" — it's tmp_path/evil.
+        # Since it lives outside HERMES_WRITE_SAFE_ROOT, it must be rejected.
+        assert _classify_write_denial(str(symlink)) == "safe_root"
+
+    def test_is_kernel_sink_helper_recognizes_normalized_variants(self):
+        """The helper must recognize path variants that normalize to
+        an allowlisted sink (e.g. /dev/./null)."""
+        from agent.file_safety import _is_kernel_sink
+
+        assert _is_kernel_sink("/dev/null") is True
+        assert _is_kernel_sink("/dev/./null") is True
+        assert _is_kernel_sink("/dev/random") is False
+        assert _is_kernel_sink("/tmp/null") is False
+
+    def test_is_kernel_sink_handles_bad_input(self):
+        """The helper must return False (not raise) for empty or bogus paths."""
+        from agent.file_safety import _is_kernel_sink
+
+        assert _is_kernel_sink("") is False
+        # Non-existent parent components are fine — no filesystem is touched
+        assert _is_kernel_sink("/nonexistent/random/thing") is False


### PR DESCRIPTION
## Summary

Fixes a false-positive denial in the `HERMES_WRITE_SAFE_ROOT` guard: writes to kernel character-device sinks like `/dev/null` were being rejected as "outside HERMES_WRITE_SAFE_ROOT" even though those paths are OS-level no-ops used routinely for legitimate shell redirection.

**Reproducer** (on `main` before this change, in any container with `HERMES_WRITE_SAFE_ROOT=/opt/data`):

```
$ hermes chat -q 'run: echo x > /dev/null'
Write denied: '/dev/null' is outside HERMES_WRITE_SAFE_ROOT (/opt/data). ...
```

`/dev/null` and its siblings cannot be made to persist state, so gating them behind the safe-root check only breaks legitimate patterns (silencing chatter, discarding stderr, ...) with no safety benefit.

## Fix

Additive-only, 45 lines in `agent/file_safety.py`:

- A five-entry `_KERNEL_SINK_ALLOWLIST` frozenset: `/dev/null`, `/dev/stdout`, `/dev/stderr`, `/dev/tty`, `/dev/zero`.
- A helper `_is_kernel_sink()` that normalizes with `os.path.normpath` + `os.path.abspath` (deliberately **not** `realpath`) and membership-tests against the set.
- `_classify_write_denial()` gains one short-circuit at the top: `if _is_kernel_sink(path): return None`.

Everything else in the guard (credential denylist, hermes-internal path checks, safe-root containment) is untouched.

### Why `abspath` and not `realpath`

If we resolved symlinks, a symlink at e.g. `/opt/data/evil -> /dev/null` would inherit the allowlist and let an arbitrary out-of-tree name bypass the safe-root check. Using `abspath` on the user-supplied string means **only literal** `/dev/null` etc. short-circuit; a symlink pointing at one still gets rejected on its own absolute path. There is an explicit test for this attack shape (`test_symlink_to_dev_null_not_bypassed`).

## Tests

11 new cases appended to `tests/agent/test_file_safety.py` under a new `TestKernelSinkAllowlist` class:

- Parametrized sweep — every one of the five sinks is allowed under a mismatched `HERMES_WRITE_SAFE_ROOT=/tmp/safe`
- `/dev/random` (not on allowlist) still returns `'safe_root'`
- `/etc/passwd`-style credential paths still return `'credential'`
- Genuinely out-of-tree paths still return `'safe_root'`
- Symlink-bypass regression — `/tmp/evil -> /dev/null` gets rejected on its own abspath
- Helper recognizes normalized variants like `/dev/./null`
- Helper handles empty/bogus input without raising

## Invariants preserved

- Public API unchanged (no signature or return-type changes on `_classify_write_denial`)
- Error message shape for genuine rejections unchanged (still `outside HERMES_WRITE_SAFE_ROOT (...)`)
- No new config keys, env vars, or user-facing surface
- No changes to credential denylist, hermes-internal path checks, or safe-root containment logic
- Behavior is defined by the frozenset — no user-configurable extra entries (explicitly out of scope per the original request)

## Out of scope

- User-configurable extra allowlist entries
- Any redesign of the `HERMES_WRITE_SAFE_ROOT` mechanism itself
