### PR TITLE
fix(desktop): keep non-ASCII MEDIA filenames intact in mediaName()

### DIFF
--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -11,9 +11,32 @@ import {
   isInlineMediaSrc,
   isRemoteGateway,
   mediaExternalUrl,
+  mediaName,
   resolveMediaDisplaySrc,
   resolveMediaPlaybackSrc
 } from './media'
+
+describe('mediaName', () => {
+  it('returns the decoded basename for a Windows path with non-ASCII characters', () => {
+    expect(
+      mediaName(
+        String.raw`C:\Users\user\Documents\張耀祖論文_送印前稽核報告.md`
+      )
+    ).toBe('張耀祖論文_送印前稽核報告.md')
+  })
+
+  it('decodes a percent-encoded non-ASCII basename from a file URL', () => {
+    expect(
+      mediaName(
+        'file:///C:/Users/user/Documents/%E5%BC%B5%E8%80%80%E7%A5%96%E8%AB%96%E6%96%87_%E9%80%81%E5%8D%B0%E5%89%8D%E7%A8%BD%E6%A0%B8%E5%A0%B1%E5%91%8A.md'
+      )
+    ).toBe('張耀祖論文_送印前稽核報告.md')
+  })
+
+  it('preserves a basename containing a malformed percent escape', () => {
+    expect(mediaName('file:///C:/Users/user/Documents/report%ZZ.md')).toBe('report%ZZ.md')
+  })
+})
 
 describe('isRemoteGateway', () => {
   afterEach(() => {

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -36,6 +36,50 @@ describe('mediaName', () => {
   it('preserves a basename containing a malformed percent escape', () => {
     expect(mediaName('file:///C:/Users/user/Documents/report%ZZ.md')).toBe('report%ZZ.md')
   })
+
+  it('keeps non-ASCII characters in Windows drive-letter paths with forward slashes', () => {
+    expect(mediaName('D:/pb/Hermes_Agency/码上编码对照统计/候选总部推荐_v2.xlsx')).toBe(
+      '候选总部推荐_v2.xlsx'
+    )
+  })
+
+  it('handles Windows paths with spaces without URL-parsing them', () => {
+    expect(mediaName(String.raw`C:\Users\qxp\My Documents\报告 2026.xlsx`)).toBe('报告 2026.xlsx')
+  })
+
+  it('keeps non-ASCII characters in UNC paths', () => {
+    expect(mediaName(String.raw`\\tsclient\F\workspace\数据分析.xlsx`)).toBe('数据分析.xlsx')
+  })
+
+  it('keeps non-ASCII characters in home-relative paths', () => {
+    expect(mediaName('~/Documents/报告.md')).toBe('报告.md')
+  })
+
+  it('keeps non-ASCII characters in POSIX absolute paths', () => {
+    expect(mediaName('/home/user/报告.md')).toBe('报告.md')
+  })
+
+  it('decodes a percent-encoded basename from an https URL', () => {
+    expect(mediaName('https://example.com/files/%E6%8A%A5%E5%91%8A.xlsx')).toBe('报告.xlsx')
+  })
+
+  it('does not decode literal percent sequences in real on-disk filenames', () => {
+    // `a%20b.txt` is the genuine filename on disk — decoding would corrupt it.
+    expect(mediaName(String.raw`D:\dir\a%20b.txt`)).toBe('a%20b.txt')
+    expect(mediaName('a%20b.txt')).toBe('a%20b.txt')
+  })
+
+  it('returns the basename for a plain URL', () => {
+    expect(mediaName('https://example.com/foo/bar.txt')).toBe('bar.txt')
+  })
+
+  it('returns the basename for a relative path', () => {
+    expect(mediaName('foo/bar.txt')).toBe('bar.txt')
+  })
+
+  it('returns the input unchanged for a URL without path segments', () => {
+    expect(mediaName('https://example.com')).toBe('https://example.com')
+  })
 })
 
 describe('isRemoteGateway', () => {

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -44,14 +44,26 @@ export function mediaMime(path: string): string {
   return mediaInfo(path)?.mime ?? 'application/octet-stream'
 }
 
+function decodeMediaName(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
 export function mediaName(path: string): string {
+  let name: string | undefined
+
   try {
     const url = new URL(path)
 
-    return url.pathname.split('/').filter(Boolean).pop() || path
+    name = url.pathname.split(/[\\/]/).filter(Boolean).pop()
   } catch {
-    return path.split(/[\\/]/).filter(Boolean).pop() || path
+    name = path.split(/[\\/]/).filter(Boolean).pop()
   }
+
+  return decodeMediaName(name || path)
 }
 
 export function mediaMarkdownHref(path: string): string {

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -52,18 +52,30 @@ function decodeMediaName(value: string): string {
   }
 }
 
+// Filesystem paths are NOT URLs. A Windows drive letter like `D:` parses as a
+// URL *scheme* under WHATWG rules, so `new URL()` never throws for them and
+// the catch branch is dead code for exactly the paths Desktop produces most
+// (MEDIA: artifact deliveries). Routing a real filename through the URL parser
+// also percent-encodes non-ASCII characters, and decoding such a path would
+// corrupt genuine on-disk names containing literal '%' sequences (e.g.
+// `a%20b.txt`). Split filesystem paths directly instead.
+const FILESYSTEM_PATH_RE = /^(?:[a-zA-Z]:[\\/]|\\\\|~(?=$|[\\/])|\/)/
+
 export function mediaName(path: string): string {
-  let name: string | undefined
+  if (FILESYSTEM_PATH_RE.test(path)) {
+    return path.split(/[\\/]/).filter(Boolean).pop() || path
+  }
 
   try {
     const url = new URL(path)
+    // Non-special-scheme URLs (incl. drive-letter-shaped strings) keep
+    // backslashes in the pathname, so split on both separators.
+    const name = url.pathname.split(/[\\/]/).filter(Boolean).pop()
 
-    name = url.pathname.split(/[\\/]/).filter(Boolean).pop()
+    return decodeMediaName(name || path)
   } catch {
-    name = path.split(/[\\/]/).filter(Boolean).pop()
+    return path.split(/[\\/]/).filter(Boolean).pop() || path
   }
-
-  return decodeMediaName(name || path)
 }
 
 export function mediaMarkdownHref(path: string): string {


### PR DESCRIPTION
Fixes #84588, fixes #85257.

> Built on top of #68788 by @mhtsai888 (applied via `git am`, authorship preserved) — this adds the filesystem-path bypass and closes the literal-`%` regression. See "Relation to existing PRs" below.

## Problem

In the Desktop app, a `MEDIA:` attachment whose path contains non-ASCII characters renders a percent-encoded label — e.g. `File: %E6%9C%AA%E5%85%B3%E8%81%94...xlsx` instead of `File: 未关联门店...xlsx`.

Root cause in `mediaName()` (`apps/desktop/src/lib/media.ts`): every path is routed through `new URL()`. A Windows drive letter (`D:`) parses as a URL **scheme** under WHATWG rules, so:

1. The `catch` string-split branch is dead code for exactly the paths Desktop produces most (`MEDIA:` artifact deliveries);
2. The URL parser percent-encodes non-ASCII characters in `pathname`;
3. For non-special schemes, backslashes are not path separators, so `split('/')` returns the entire percent-encoded remainder as a single segment.

Repro (Windows, local mode): have the agent emit

```
MEDIA:D:\dir\码上编码对照统计\报告.xlsx
```

→ the chat label renders `File: \dir\%E7%A0%81%E4%B8%8A...%E6%8A%A5%E5%91%8A.xlsx`.

## Fix

Two commits:

1. **From #68788 (@mhtsai888)** — dual-separator split (`split(/[\\/]/)`) + defensive `decodeURIComponent` wrapper.
2. **Added in this PR** — filesystem paths (`D:\…`/`D:/…`, `\\unc\…`, `~/…`, `/…`) bypass `new URL()` entirely, and decoding applies **only to URL-parser output**, so genuine on-disk filenames containing literal `%` sequences (`a%20b.txt`) are no longer corrupted into `a b.txt`.

## Relation to existing PRs

- **#84631** — handles drive letters but never decodes the URL branch (https/file URLs with CJK names stay encoded), has no tests, and bundles an unrelated `agent/model_metadata.py` pricing change.
- **#84635** — close to correct, but `decodeURIComponent` is unguarded: a URL like `https://example.com/100%.txt` throws `URIError` while rendering the label. No `file://` coverage.
- **#68788** (base of this PR) — has the guarded decode and dual-separator split, but applies decode uniformly, so real on-disk names with literal `%` (`D:\dir\a%20b.txt`) get wrongly decoded to `a b.txt`; it also relies on opaque-path quirks of non-special URL schemes to survive drive letters rather than bypassing URL parsing for filesystem paths.

Happy to rebase/close if the maintainers prefer to land one of the others first.

## Tests

13 `mediaName` cases added/covered in `media.remote.test.ts`: Windows backslash & forward-slash CJK paths, paths with spaces, UNC, `~`, POSIX absolute, `file://` percent-encoded CJK, malformed `%` escapes, https URL decode, literal-`%` preservation (absolute + relative), plain-URL / relative-path / no-path-segment regressions.

Verified on Windows 10:

- `vitest run src/lib/media.remote.test.ts src/lib/chat-messages.test.ts` — **85/85 ✅**
- `vitest run src/lib` — **685/685 ✅** (72 files)
- `npm run typecheck` — **✅** (all three tsconfigs)
