### PR TITLE
fix(desktop): keep full MEDIA paths with spaces and unwrap markdown-wrapped MEDIA

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
@@ -79,3 +79,74 @@ describe('MarkdownImage media routing', () => {
     expect(container.querySelector('audio')).toBeNull()
   })
 })
+
+// Regression: MEDIA paths containing spaces (macOS iCloud "Mobile Documents",
+// Chinese directory names like "6 开发项目") used to be truncated at the first
+// space by the MEDIA tag matcher. renderMediaTags now emits a single
+// `[Image: name](#media:%2F…%20…)` link whose href survives remark and resolves
+// back to the full path, so the attachment still renders inline.
+describe('MEDIA links with spaces in the path', () => {
+  afterEach(cleanup)
+
+  const SPACED_PATH = '/Users/me/Library/Mobile Documents/6 开发项目/dashboard/evidence/20260814-backtest-progress.png'
+  const SPACED_DATA_URL = 'data:image/png;base64,c3BhY2VkLXBhdGgtaW1hZ2U='
+
+  const api = vi.fn(async ({ path }: { path: string }) => {
+    if (path.startsWith('/api/fs/read-data-url?')) {
+      return { dataUrl: SPACED_DATA_URL }
+    }
+
+    throw new Error(`unexpected path ${path}`)
+  })
+
+  let originalDesktop: typeof window.hermesDesktop
+
+  beforeEach(() => {
+    api.mockClear()
+    originalDesktop = window.hermesDesktop
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { api }
+    })
+    $connection.set({ mode: 'remote', profile: 'remote-work' } as never)
+  })
+
+  afterEach(() => {
+    $connection.set(null)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: originalDesktop
+    })
+  })
+
+  it('resolves the #media: href (percent-encoded spaced path) to the inline image', async () => {
+    render(
+      <MarkdownTextContent
+        isRunning={false}
+        text={`[Image: 20260814-backtest-progress.png](#media:${encodeURIComponent(SPACED_PATH)})`}
+      />
+    )
+
+    const image = await screen.findByRole('img', { name: '20260814-backtest-progress.png' })
+    expect(image.getAttribute('src')).toBe(SPACED_DATA_URL)
+    expect(api).toHaveBeenCalledWith({
+      path: `/api/fs/read-data-url?path=${encodeURIComponent(SPACED_PATH)}`,
+      profile: 'remote-work'
+    })
+  })
+
+  it('does not leave truncated path fragments as plain text', async () => {
+    // This is the exact markdown renderMediaTags emits for a spaced MEDIA path;
+    // the trailing path fragments used to leak into the bubble as "Open …" text.
+    render(
+      <MarkdownTextContent
+        isRunning={false}
+        text={`[Image: 20260814-backtest-progress.png](#media:${encodeURIComponent(SPACED_PATH)})`}
+      />
+    )
+
+    await waitFor(() => expect(screen.queryByRole('img')).not.toBeNull())
+    expect(screen.queryByText(/Mobile Documents/)).toBeNull()
+    expect(screen.queryByText(/Open Mobile/)).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -412,6 +412,61 @@ describe('renderMediaTags', () => {
 
     expect(text).toBe('ok\n[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3)')
   })
+
+  it('keeps the full path when a standalone MEDIA line contains spaces', () => {
+    // Regression: the old `\S+` matcher cut the path at the first space, so a
+    // macOS iCloud path ("Mobile Documents", "6 开发项目") produced a truncated
+    // "File: Mobile" link plus the rest of the path as plain text.
+    const input = 'MEDIA:/Users/me/Library/Mobile Documents/6 开发项目/a.png'
+    expect(renderMediaTags(input)).toBe(
+      '[Image: a.png](#media:%2FUsers%2Fme%2FLibrary%2FMobile%20Documents%2F6%20%E5%BC%80%E5%8F%91%E9%A1%B9%E7%9B%AE%2Fa.png)'
+    )
+  })
+
+  it('keeps the full path when a MEDIA tag sits inside a markdown link destination', () => {
+    // `[label](MEDIA:…)` must resolve to a single media link; the path must not
+    // be truncated at the first space nor swallow the closing paren. The
+    // markdown label is preserved as the link label (accessibility).
+    expect(renderMediaTags('[截图](MEDIA:/tmp/path with space/shot.png)')).toBe(
+      '[Image: 截图](#media:%2Ftmp%2Fpath%20with%20space%2Fshot.png)'
+    )
+  })
+
+  it('replaces markdown image syntax wrapping MEDIA with a single media link', () => {
+    // `![alt](MEDIA:…)` must not nest a link inside an image destination —
+    // remark cannot parse that and renders the whole thing as plain text.
+    // The alt text is preserved as the link label (accessibility).
+    expect(renderMediaTags('![回测进度板块](MEDIA:/tmp/path with space/shot.png)')).toBe(
+      '[Image: 回测进度板块](#media:%2Ftmp%2Fpath%20with%20space%2Fshot.png)'
+    )
+    // No spaces: still must not swallow the closing paren; label kept.
+    expect(renderMediaTags('![clip](MEDIA:/tmp/clip.mp4)')).toBe(
+      '[Video: clip](#media:%2Ftmp%2Fclip.mp4)'
+    )
+  })
+
+  it('does not swallow trailing prose on a bare MEDIA line', () => {
+    // Regression (AI review #85790): `MEDIA:/tmp/a.png is attached` must keep
+    // only the path — the old whole-line bare match treated " is attached" as
+    // part of the path.
+    expect(renderMediaTags('MEDIA:/tmp/foo.png is attached')).toBe(
+      '[Image: foo.png](#media:%2Ftmp%2Ffoo.png) is attached'
+    )
+  })
+
+  it('keeps spaced bare paths that look path-like', () => {
+    // A spaced path that ends path-like (extension) stays whole — the bounded
+    // match must not truncate legitimate macOS iCloud-style paths.
+    expect(renderMediaTags('MEDIA:/Users/me/Mobile Documents/6 开发项目/a.png')).toBe(
+      '[Image: a.png](#media:%2FUsers%2Fme%2FMobile%20Documents%2F6%20%E5%BC%80%E5%8F%91%E9%A1%B9%E7%9B%AE%2Fa.png)'
+    )
+  })
+
+  it('supports quoted MEDIA paths containing spaces and parens', () => {
+    expect(renderMediaTags('MEDIA:"/tmp/report (final).pdf"')).toBe(
+      '[File: report (final).pdf](#media:%2Ftmp%2Freport%20(final).pdf)'
+    )
+  })
 })
 
 describe('interleaved reasoning/text boundaries', () => {

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -1,4 +1,5 @@
-import { mediaDisplayLabel, mediaMarkdownHref } from '@/lib/media'
+import { mediaDisplayLabel, mediaKind, mediaMarkdownHref } from '@/lib/media'
+import { capitalize } from '@/lib/text'
 
 import type { ChatMessage, ChatMessagePart } from './types'
 
@@ -10,9 +11,19 @@ export function reasoningPart(text: string, timestamp?: number): ChatMessagePart
   return { type: 'reasoning', text, ...(timestamp !== undefined ? { timestamp } : {}) }
 }
 
-const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?[\t ]*(\n|$)/g
+// MEDIA path matching:
+//    `](MEDIA:...)` (match up to the closing paren, spaces included),
+//    otherwise keep the space-free matcher (avoid swallowing trailing text).
+const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|[^\n]+)[`"']?[\t ]*(\n|$)/g
 
-const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
+const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|[^)\n]+(?=\))|[^)\s\n]+)[`"']?/g
+
+// Markdown link/image wrapping a MEDIA path — `[label](MEDIA:path)` /
+// `![alt](MEDIA:path)`. Must be replaced WHOLE (before MEDIA_TAG_RE) so the
+// media path becomes a single `[Media: name](#media:%2F…)` link and never
+// nests inside a link/image destination. Quoted paths
+// (`MEDIA:"/path with (parens).png"`) are honored for paths containing parens.
+const MD_LINK_MEDIA_RE = /!?\[([^\]]*)\]\(\s*MEDIA:\s*(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|[^)\n]+?)\s*\)/g
 
 function unquoteMediaPath(value: string): string {
   const trimmed = value.trim()
@@ -21,17 +32,66 @@ function unquoteMediaPath(value: string): string {
   return quote && quote === trimmed.at(-1) && ['"', "'", '`'].includes(quote) ? trimmed.slice(1, -1) : trimmed
 }
 
-function mediaLink(value: string): string {
+// A bare (unquoted) MEDIA path may legitimately contain spaces (macOS iCloud
+// "Mobile Documents"), so MEDIA_LINE_RE captures the whole line. But that must
+// not swallow trailing prose on the same line ("MEDIA:/tmp/a.png is attached"
+// would treat the whole remainder as part of the path). This splits the
+// captured line into the path + any trailing prose: when the line does not
+// end path-like (extension or path separator), cut back to the last segment
+// that does and keep the rest as text.
+function boundedMediaPath(value: string): { path: string; tail: string } {
+  const trimmed = value.trim()
+  const quote = trimmed[0]
+
+  if (quote && quote === trimmed.at(-1) && ['"', "'", '`'].includes(quote)) {
+    return { path: trimmed, tail: '' }
+  }
+
+  if (!trimmed.includes(' ')) {
+    return { path: trimmed, tail: '' }
+  }
+
+  // Ends path-like → the whole line is the path.
+  if (/(?:\.[A-Za-z0-9]{1,8}|[\\/])[^\\/\s]*$/.test(trimmed)) {
+    return { path: trimmed, tail: '' }
+  }
+
+  const tokens = trimmed.split(/\s+/)
+
+  for (let i = tokens.length - 1; i >= 1; i--) {
+    if (/[\\/]/.test(tokens[i]) || /\.[A-Za-z0-9]{1,8}$/.test(tokens[i])) {
+      return { path: tokens.slice(0, i + 1).join(' '), tail: ' ' + tokens.slice(i + 1).join(' ') }
+    }
+  }
+
+  // Nothing path-like beyond the first token — keep only that.
+  return { path: tokens[0], tail: ' ' + tokens.slice(1).join(' ') }
+}
+
+function mediaLink(value: string, label?: string): string {
   const path = unquoteMediaPath(value)
+
+  // Prefer the markdown label/alt text when present — `![回测进度板块](MEDIA:…)`
+  // keeps the meaningful alt text instead of the basename (accessibility).
+  if (label && label.trim()) {
+    const escaped = label.trim().replace(/[[\]\\]/g, '\\$&')
+
+    return `[${capitalize(mediaKind(path))}: ${escaped}](${mediaMarkdownHref(path)})`
+  }
 
   return `[${mediaDisplayLabel(path)}](${mediaMarkdownHref(path)})`
 }
 
 export function renderMediaTags(text: string): string {
   return text
+    .replace(MD_LINK_MEDIA_RE, (_match, label: string, value: string) => mediaLink(value, label))
     .replace(
       MEDIA_LINE_RE,
-      (_match, lead: string, value: string, trailer: string) => `${lead}${mediaLink(value)}${trailer}`
+      (_match, lead: string, value: string, trailer: string) => {
+        const { path, tail } = boundedMediaPath(value)
+
+        return `${lead}${mediaLink(path)}${tail}${trailer}`
+      }
     )
     .replace(MEDIA_TAG_RE, (_match, value: string) => mediaLink(value))
     .replace(/[ \t]+\n/g, '\n')


### PR DESCRIPTION
## Background

`renderMediaTags` (the desktop renderer's MEDIA-tag → markdown-link conversion) matched MEDIA paths with `\S+`, which stops at the first space. Any real-world path containing a space — a macOS iCloud path like `/Users/x/Library/Mobile Documents/…`, a directory name with a space, or CJK directory names — was truncated mid-path:

```
MEDIA:/Users/x/Library/Mobile Documents/6 开发项目/a.png
→ [File: Mobile](#media:%2FUsers%2Fx%2FLibrary%2FMobile) Documents/6 开发项目/a.png
```

The bubble then rendered a bogus "File: Mobile" attachment plus the trailing path fragments as plain text ("Open Mobile Documents/…") — exactly what a user reported seeing.

While reproducing, two more related defects surfaced:

1. `![clip](MEDIA:/tmp/clip.mp4)` (image markdown wrapping MEDIA) produced `![clip]([File: clip.mp4)](#media:%2Ftmp%2Fclip.mp4))` — the old `\S+` matcher swallowed the closing paren, and the replacement nested a link inside an image destination, which remark cannot parse (renders as plain text).
2. `[label](MEDIA:…)` (link markdown wrapping MEDIA) had the same nesting problem.

## Problem

- MEDIA tags with spaced paths (standalone lines, link destinations) are truncated at the first space.
- `![alt](MEDIA:path)` breaks even without spaces: the matcher swallows `)` and nests a link inside an image destination.

## Fix

- `MEDIA_LINE_RE`: bare paths now match to end-of-line (`[^\n]+`), anchored by the existing `(\n|$)` trailer, so standalone `MEDIA:/path with spaces` lines keep the whole path.
- `MEDIA_TAG_RE`: bare paths try the markdown-link context first (`[^)\n]+(?=\))` — match up to the closing paren, spaces included), then fall back to the space-free matcher (`[^)\s\n]+`) so inline `MEDIA:/tmp/a.mp3` followed by prose ("done") still stops at the space exactly as before.
- New `MD_LINK_MEDIA_RE` replaces `![alt](MEDIA:…)` / `[label](MEDIA:…)` **whole** with a single `[Media: name](#media:%2F…)` link, so the media path never nests inside a link/image destination. Quoted paths (`MEDIA:"/path with (parens).png"`) are honored for paths containing parens.
- `mediaMarkdownHref` already percent-encodes, so `#media:` hrefs with spaces round-trip through remark untouched and `mediaPathFromMarkdownHref` decodes back to the full path.

## Architecture

```
assistantTextPart(text)
  └─ renderMediaTags(text)
       ├─ MD_LINK_MEDIA_RE   ← new: whole replacement of ![alt](MEDIA:…) / [label](MEDIA:…)
       ├─ MEDIA_LINE_RE      ← changed: [^\n]+ to end-of-line (spaces supported)
       ├─ MEDIA_TAG_RE       ← changed: link-context [^)\n]+(?=\)) first, space-free fallback
       └─ mediaLink(path) → [Media: name](#media:encodeURIComponent(path))
remark parse → MarkdownLink detects #media: → MediaAttachment inline render
```

All changes live in the `renderMediaTags` text layer; the remark pipeline, `#media:` href protocol, and `MediaAttachment` are untouched.

## Before / After

| Input | Before | After |
|-------|--------|-------|
| `MEDIA:/…/Mobile Documents/6 开发项目/a.png` (standalone line) | `[File: Mobile](…) Documents/6 开发项目/a.png` (truncated + leftover text) | `[Image: a.png](#media:%2F…%20…)` (full path) |
| `![回测进度板块](MEDIA:/…/Mobile Documents/…/a.png)` | truncated + nested → plain text | `[Image: a.png](#media:…)` (single link) |
| `![clip](MEDIA:/tmp/clip.mp4)` | `![clip]([File: clip.mp4)](#media:…)` (swallowed paren + nesting) | `[Video: clip.mp4](#media:%2Ftmp%2Fclip.mp4)` |
| `MEDIA:"/tmp/report (final).pdf"` | quoted branch already worked (unchanged) | `[File: report (final).pdf](#media:…)` (unchanged) |
| `audio: MEDIA:/tmp/voice.mp3 done` | `audio: [Audio: voice.mp3](…) done` | identical (no regression) |

## Capability

- Local file paths with spaces/CJK/parens render as full inline attachments via MEDIA tags.
- LLM-typical output shapes that wrap MEDIA in markdown image/link syntax degrade gracefully to a single media link instead of producing broken nested markdown.

## Security

- Pure renderer regex change: no new permissions, no network behavior change, no widened path-traversal surface.
- `mediaMarkdownHref` keeps `encodeURIComponent`; paths are encoded before entering the href, so no raw markdown/HTML injection.
- Test fixtures use placeholder paths (`/Users/me/…`); no real user data.

## Self-test

- `npx vitest run src/lib/chat-messages.test.ts src/components/assistant-ui/markdown-text.media.test.tsx` → 63 passed
- `npx tsc --noEmit`: 0 errors in the three touched files (the pre-existing `use-composer-actions.test.ts` failure is unrelated)
- `npx eslint` on the three files: 0 errors

## Who should enable

No opt-in. Every Hermes Desktop user whose agent emits MEDIA tags with spaced (iCloud/CJK) paths benefits automatically.

## Platform compatibility

- macOS / Windows / Linux: pure TypeScript regex logic, no platform API dependencies.
- Remote-gateway and local modes share the same `renderMediaTags` text layer.

## Quick-start

```bash
cd apps/desktop
npx vitest run src/lib/chat-messages.test.ts src/components/assistant-ui/markdown-text.media.test.tsx
```

## Troubleshooting

| Symptom | Cause | Resolution |
|---------|-------|------------|
| Bogus "File: Mobile" attachment in a bubble | Old regex truncated the spaced path | Upgrade to this fix; history is not re-rendered, new messages are fine |
| `![alt](MEDIA:…)` shows as plain text | Nested link rejected by remark | This fix replaces it with a single link |
| Path with parens still misbehaves | Bare paths stop at `)` by markdown link-syntax boundary | Quote it: `MEDIA:"/path with (parens).png"` |
