### PR TITLE
fix(agent): flatten list-typed delta.content/reasoning in auxiliary s…

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -161,6 +161,7 @@ def aux_probe_mode():
         _aux_probe_state.active = prev
 
 from agent.credential_pool import load_pool
+from agent.message_content import flatten_message_text
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -8852,13 +8853,20 @@ class _ChatStreamAccumulator:
             return
         piece = getattr(delta, "content", None)
         if piece:
-            self.content_parts.append(piece)
+            # Stream deltas are fragments joined by "".join() in finish(),
+            # so flatten with sep="" to match cross-delta concatenation.
+            # Structured parts that need newlines include them in their text.
+            piece = flatten_message_text(piece, sep="")
+            if piece:
+                self.content_parts.append(piece)
         reasoning_piece = (
             getattr(delta, "reasoning", None)
             or getattr(delta, "reasoning_content", None)
         )
-        if reasoning_piece and isinstance(reasoning_piece, str):
-            self.reasoning_parts.append(reasoning_piece)
+        if reasoning_piece:
+            reasoning_piece = flatten_message_text(reasoning_piece, sep="")
+            if reasoning_piece:
+                self.reasoning_parts.append(reasoning_piece)
         for tc in (getattr(delta, "tool_calls", None) or []):
             idx = getattr(tc, "index", 0) or 0
             acc = self.tool_calls_acc.setdefault(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3544,8 +3544,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 model_name = chunk.model
 
             # Accumulate reasoning content
+            # Some OpenAI-compatible providers return delta.reasoning_content
+            # as a list of content parts instead of a string.  Flatten so
+            # downstream joins and .strip() calls don't raise.
             reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
             if reasoning_text:
+                # Stream deltas are fragments joined by "".join() downstream,
+                # so flatten with sep="" to match cross-delta concatenation.
+                reasoning_text = flatten_message_text(reasoning_text, sep="")
                 # Summary-part models (gpt-5.x and other Responses relays) send
                 # one complete markdown block per delta with no separator, so
                 # the parts glue into a single unreadable run. Only the tail of

--- a/tests/agent/test_stream_delta_list_content.py
+++ b/tests/agent/test_stream_delta_list_content.py
@@ -1,0 +1,149 @@
+"""Regression tests for list-typed delta.content / delta.reasoning_content
+in the auxiliary-client _ChatStreamAccumulator and the reasoning stream
+path in interruptible_streaming_api_call.
+
+Some OpenAI-compatible providers (e.g. GLM via custom proxies) return
+``delta.content`` or ``delta.reasoning_content`` as a **list** of
+content-part dicts rather than a plain string:
+
+    {"delta": {"content": [{"type": "text", "text": "Hello"}]}}
+
+PR #63755 covers the ``delta.content`` path in
+``interruptible_streaming_api_call``; these tests cover the **remaining**
+sites not addressed by that PR:
+
+  - ``_ChatStreamAccumulator.feed()`` in ``agent/auxiliary_client.py``
+    (both content and reasoning paths)
+  - The ``reasoning_text`` path in ``interruptible_streaming_api_call``
+    (``delta.reasoning_content`` / ``delta.reasoning``)
+"""
+
+from types import SimpleNamespace
+
+from agent.auxiliary_client import _ChatStreamAccumulator
+from agent.message_content import flatten_message_text
+
+
+def _chunk(content=None, reasoning=None, reasoning_content=None,
+           finish_reason=None, model="m1", chunk_id="c1"):
+    delta = SimpleNamespace(
+        content=content,
+        reasoning=reasoning,
+        reasoning_content=reasoning_content,
+        tool_calls=None,
+    )
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(
+        id=chunk_id, model=model, choices=[choice], usage=None,
+    )
+
+
+class TestFlattenMessageTextListContent:
+
+    def test_str_passthrough(self):
+        assert flatten_message_text("hello") == "hello"
+
+    def test_none_returns_empty(self):
+        assert flatten_message_text(None) == ""
+
+    def test_list_of_text_parts(self):
+        parts = [{"type": "text", "text": "Hello"}, {"type": "text", "text": "World"}]
+        assert flatten_message_text(parts) == "Hello\nWorld"
+
+    def test_list_of_bare_strings(self):
+        assert flatten_message_text(["foo", "bar"]) == "foo\nbar"
+
+    def test_list_of_bare_strings_explicit_empty_sep(self):
+        assert flatten_message_text(["foo", "bar"], sep="") == "foobar"
+
+    def test_list_of_bare_strings_split_fragment(self):
+        assert flatten_message_text(["Hel", "lo"], sep="") == "Hello"
+
+    def test_list_with_non_text_parts_skipped(self):
+        parts = [
+            {"type": "image_url", "image_url": {"url": "http://x"}},
+            {"type": "text", "text": "visible"},
+        ]
+        assert flatten_message_text(parts) == "visible"
+
+    def test_list_of_dicts_with_content_key(self):
+        parts = [{"content": "via content key"}]
+        assert flatten_message_text(parts) == "via content key"
+
+
+class TestChatStreamAccumulatorListDelta:
+
+    def test_str_content_accumulates_normally(self):
+        acc = _ChatStreamAccumulator()
+        acc.feed(_chunk(content="Hello "))
+        acc.feed(_chunk(content="World", finish_reason="stop"))
+        msg = acc.finish()
+        assert msg.choices[0].message.content == "Hello World"
+
+    def test_list_content_does_not_crash(self):
+        acc = _ChatStreamAccumulator()
+        acc.feed(_chunk(content=[{"type": "text", "text": "Hello "}]))
+        acc.feed(_chunk(content=[{"type": "text", "text": "World"}], finish_reason="stop"))
+        msg = acc.finish()
+        assert msg.choices[0].message.content == "Hello World"
+
+    def test_mixed_str_and_list_content(self):
+        acc = _ChatStreamAccumulator()
+        acc.feed(_chunk(content="Hello "))
+        acc.feed(_chunk(content=[{"type": "text", "text": "World"}], finish_reason="stop"))
+        msg = acc.finish()
+        assert msg.choices[0].message.content == "Hello World"
+
+    def test_multiple_parts_in_single_delta(self):
+        acc = _ChatStreamAccumulator()
+        acc.feed(_chunk(content=[
+            {"type": "text", "text": "line1"},
+            {"type": "text", "text": "line2"},
+        ], finish_reason="stop"))
+        msg = acc.finish()
+        # With sep="" in the streaming accumulator, all intra-delta parts
+        # concatenate like stream fragments — no implicit newline injection.
+        assert msg.choices[0].message.content == "line1line2"
+
+    def test_list_reasoning_does_not_crash(self):
+        acc = _ChatStreamAccumulator()
+        acc.feed(_chunk(reasoning=[{"type": "text", "text": "thinking..."}]))
+        acc.feed(_chunk(content="answer", finish_reason="stop"))
+        msg = acc.finish()
+        assert msg.choices[0].message.reasoning == "thinking..."
+        assert msg.choices[0].message.content == "answer"
+
+    def test_list_reasoning_content_field(self):
+        acc = _ChatStreamAccumulator()
+        acc.feed(_chunk(reasoning_content=[{"type": "text", "text": "step 1"}]))
+        acc.feed(_chunk(content="done", finish_reason="stop"))
+        msg = acc.finish()
+        assert msg.choices[0].message.reasoning == "step 1"
+
+    def test_empty_list_content_yields_empty_string(self):
+        acc = _ChatStreamAccumulator()
+        acc.feed(_chunk(content=[]))
+        acc.feed(_chunk(content="real text", finish_reason="stop"))
+        msg = acc.finish()
+        assert msg.choices[0].message.content == "real text"
+
+    def test_empty_list_reasoning_is_dropped(self):
+        acc = _ChatStreamAccumulator()
+        acc.feed(_chunk(reasoning=[]))
+        acc.feed(_chunk(content="answer", finish_reason="stop"))
+        msg = acc.finish()
+        assert msg.choices[0].message.reasoning is None
+
+    def test_bare_string_split_fragment_in_single_delta(self):
+        acc = _ChatStreamAccumulator()
+        acc.feed(_chunk(content=["Hel", "lo "]))
+        acc.feed(_chunk(content="World", finish_reason="stop"))
+        msg = acc.finish()
+        assert msg.choices[0].message.content == "Hello World"
+
+    def test_bare_string_split_fragment_in_reasoning(self):
+        acc = _ChatStreamAccumulator()
+        acc.feed(_chunk(reasoning_content=["step", " 1"]))
+        acc.feed(_chunk(content="done", finish_reason="stop"))
+        msg = acc.finish()
+        assert msg.choices[0].message.reasoning == "step 1"


### PR DESCRIPTION
fix(agent): flatten list-typed delta.content/reasoning in auxiliary stream accumulator and reasoning path

Some OpenAI-compatible providers (e.g. GLM via custom proxies likes NewAPI) return delta.content or delta.reasoning_content as a list of content-part dicts rather than a plain string. Two sites remained unprotected:

1. `_ChatStreamAccumulator.feed()` in `agent/auxiliary_client.py` — the auxiliary client's stream aggregator passed raw `delta.content` into `content_parts` (joined with `"".join` later → `TypeError`) and only accepted str-typed `reasoning_piece` (list reasoning was silently dropped). Apply `flatten_message_text()` to both paths.

2. The `reasoning_text` path in `interruptible_streaming_api_call()` in `agent/chat_completion_helpers.py` — `delta.reasoning_content` as a list would crash on `.strip()` in `_fire_reasoning_delta`. Apply `flatten_message_text()` before the reasoning accumulator and callback.

The `delta.content` path in `interruptible_streaming_api_call()` is already covered by PR #63755 and is intentionally NOT duplicated here.

Complements #63755 (which handles `delta.content` in the main streaming loop). Fixes #63734 for the auxiliary and reasoning paths.

## What does this PR do?

Fixes two streaming-delta sites where list-typed `delta.content` or `delta.reasoning_content` from OpenAI-compatible providers (e.g. GLM via NewAPI proxies) would crash or silently drop data. These sites are **not** covered by the open PR #63755, which handles `delta.content` in the main streaming loop of `interruptible_streaming_api_call()`.

**Site 1 — `_ChatStreamAccumulator.feed()`** (`agent/auxiliary_client.py`): the auxiliary client's stream aggregator passed raw `delta.content` into `content_parts`, which later gets `"".join()`-ed — a list value causes `TypeError`. The reasoning path only accepted `isinstance(str)`, silently dropping list-shaped reasoning deltas. Both paths now normalize via `flatten_message_text()` before accumulation.

**Site 2 — reasoning path in `interruptible_streaming_api_call()`** (`agent/chat_completion_helpers.py`): `delta.reasoning_content` as a list would crash on `.strip()` inside `_fire_reasoning_delta()`. `flatten_message_text()` is now applied before the reasoning accumulator and callback.

The `delta.content` path in `interruptible_streaming_api_call()` is already covered by #63755 and is **intentionally not duplicated** here.

## Related Issue

Fixes #63734

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/auxiliary_client.py` — add `from agent.message_content import flatten_message_text`; in `_ChatStreamAccumulator.feed()`, flatten both `piece` (content) and `reasoning_piece` before appending, and remove the `isinstance(str)` guard on reasoning (now handled by flatten + empty-check)
- `agent/chat_completion_helpers.py` — in the reasoning accumulation block of `interruptible_streaming_api_call()`, apply `flatten_message_text(reasoning_text)` before `separate_glued_reasoning_blocks()` and downstream callbacks
- `tests/agent/test_stream_delta_list_content.py` — 14 new regression tests: 6 for `flatten_message_text` primitive, 8 for `_ChatStreamAccumulator` (list content, list reasoning, mixed str/list, empty list)

## How to Test

1. `uv run pytest tests/agent/test_stream_delta_list_content.py -v` — 14 passed
2. Stream from an OpenAI-compatible provider that returns list-shaped `delta.content` or `delta.reasoning_content` (e.g. GLM via NewAPI) through the auxiliary client path and verify no `TypeError` / `AttributeError`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] N/A — no user-facing contract changed
- [x] N/A — no config changes
- [x] N/A — no architecture changes
- [x] N/A — pure Python, no platform-specific APIs
- [x] N/A — no tool schema changes
