### PR TITLE
fix(tools): insert -- end-of-options separator before search_files patterns

### DIFF
--- a/tests/tools/test_search_leading_dash_pattern_85795.py
+++ b/tests/tools/test_search_leading_dash_pattern_85795.py
@@ -1,0 +1,177 @@
+"""Regression for #85795 — search_files fails on any pattern starting with
+"-": missing "--" end-of-options separator before the pattern argument,
+in both the rg and grep search paths.
+
+`_escape_shell_arg` correctly single-quotes the pattern (a shell
+word-splitting concern), but that does nothing to stop `rg`/`grep`
+themselves from parsing a leading "-" as an option flag -- only a `--`
+separator immediately before the pattern does that.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import ShellFileOperations
+
+
+@pytest.fixture
+def markdown_checklist_tree(tmp_path):
+    """A note vault containing the exact reported repro content."""
+    notes = tmp_path / "notes"
+    notes.mkdir()
+    (notes / "Project.md").write_text("- [ ] pending task\n")
+    (notes / "Diff.md").write_text("-foo removed line\n")
+    return tmp_path
+
+
+def _grep_ops(root, monkeypatch):
+    ops = ShellFileOperations(LocalEnvironment(cwd=str(root)), cwd=str(root))
+    monkeypatch.setattr(ops, "_has_command", lambda command: command == "grep")
+    return ops
+
+
+def _rg_ops(root, monkeypatch):
+    ops = ShellFileOperations(LocalEnvironment(cwd=str(root)), cwd=str(root))
+    monkeypatch.setattr(ops, "_has_command", lambda command: command == "rg")
+    return ops
+
+
+class TestGrepSearchLeadingDashPattern:
+    """The real grep fallback must not treat a leading-"-" pattern as a
+    flag -- exercised end-to-end (real grep subprocess, no mocking)."""
+
+    def test_leading_dash_pattern_does_not_error(
+        self, markdown_checklist_tree, monkeypatch
+    ):
+        result = _grep_ops(markdown_checklist_tree, monkeypatch).search(
+            "-foo", path=".", target="content"
+        )
+        assert result.error is None, (
+            f"a pattern starting with '-' must not be parsed as a grep "
+            f"flag: {result.error!r}"
+        )
+        assert result.total_count == 1
+        assert any("Diff.md" in match.path for match in result.matches)
+
+    def test_leading_dash_pattern_no_longer_reports_invalid_option(
+        self, markdown_checklist_tree, monkeypatch
+    ):
+        """The exact reported symptom: grep's own 'invalid option' error
+        text must not appear -- confirms the parsing failure itself is
+        gone, independent of whether every character in a given pattern
+        happens to match under grep's regex semantics."""
+        result = _grep_ops(markdown_checklist_tree, monkeypatch).search(
+            "- [ ]", path=".", target="content"
+        )
+        assert result.error is None
+        assert "invalid option" not in str(result.error)
+
+
+class TestRgCommandIncludesEndOfOptionsSeparator:
+    """rg isn't installed in this sandbox, so verify the constructed
+    command string directly rather than running rg -- the `--` must sit
+    immediately before the (quoted) pattern argument."""
+
+    def test_rg_command_includes_separator_before_pattern(
+        self, markdown_checklist_tree, monkeypatch
+    ):
+        ops = _rg_ops(markdown_checklist_tree, monkeypatch)
+        captured = {}
+
+        class _FakeResult:
+            exit_code = 1  # rg's "no matches" code -- a clean, error-free run
+            stdout = ""
+
+        def _fake_exec(command, cwd=None, timeout=None, **kwargs):
+            captured["command"] = command
+            return _FakeResult()
+
+        monkeypatch.setattr(ops, "_exec", _fake_exec)
+
+        ops.search("-foo", path=".", target="content")
+
+        assert "command" in captured, "rg path was not exercised"
+        assert " -- '-foo'" in captured["command"], (
+            f"the -- separator must appear immediately before the quoted "
+            f"pattern: {captured['command']!r}"
+        )
+        # And it must come strictly before the pattern, not after it or
+        # before the path only.
+        sep_idx = captured["command"].index(" -- ")
+        pattern_idx = captured["command"].index("'-foo'")
+        assert sep_idx < pattern_idx
+
+
+class TestGrepCommandIncludesEndOfOptionsSeparator:
+    """Same direct command-construction check for the grep path, so the
+    separator's presence is verified independent of grep's own regex
+    interpretation of any particular pattern."""
+
+    def test_grep_command_includes_separator_before_pattern(
+        self, markdown_checklist_tree, monkeypatch
+    ):
+        ops = _grep_ops(markdown_checklist_tree, monkeypatch)
+        captured = {}
+
+        class _FakeResult:
+            exit_code = 1
+            stdout = ""
+
+        def _fake_exec(command, cwd=None, timeout=None, **kwargs):
+            captured["command"] = command
+            return _FakeResult()
+
+        monkeypatch.setattr(ops, "_exec", _fake_exec)
+
+        ops.search("-foo", path=".", target="content")
+
+        assert "command" in captured, "grep path was not exercised"
+        assert " -- '-foo'" in captured["command"], (
+            f"the -- separator must appear immediately before the quoted "
+            f"pattern: {captured['command']!r}"
+        )
+
+
+class TestZeroMatchProbeIncludesEndOfOptionsSeparator:
+    """_zero_match_probe() runs up to three of its own separate rg
+    invocations (case-insensitive retry, hidden/gitignored retry, fixed-
+    string retry) as a "why did this return zero matches" hint when the
+    main search finds nothing. These were NOT cited in the original issue
+    report but share the exact same missing-separator bug -- each builds
+    its own "rg ... {pattern} {path}" command string independently of
+    _search_with_rg."""
+
+    def test_all_three_probe_invocations_include_separator(
+        self, markdown_checklist_tree, monkeypatch
+    ):
+        ops = _rg_ops(markdown_checklist_tree, monkeypatch)
+        captured_commands = []
+
+        class _FakeResult:
+            exit_code = 1
+            stdout = ""
+
+        def _fake_exec(command, cwd=None, timeout=None, **kwargs):
+            captured_commands.append(command)
+            return _FakeResult()
+
+        monkeypatch.setattr(ops, "_exec", _fake_exec)
+
+        # A pattern with a regex metacharacter (".") so all three probe
+        # branches run: case-insensitive, hidden/gitignored, AND the
+        # fixed-string retry (gated on re.search(r"[.\[\](){}?*+^$\\|]",
+        # pattern)).
+        ops._zero_match_probe("-fo.o", path=".", file_glob=None)
+
+        rg_commands = [c for c in captured_commands if c.startswith("rg ")]
+        assert len(rg_commands) == 3, (
+            f"expected all three probe branches to run, got "
+            f"{len(rg_commands)}: {rg_commands}"
+        )
+        for cmd in rg_commands:
+            assert " -- '-fo.o'" in cmd, (
+                f"probe invocation missing the -- separator before the "
+                f"pattern: {cmd!r}"
+            )

--- a/tests/tools/test_search_leading_dash_pattern_85795.py
+++ b/tests/tools/test_search_leading_dash_pattern_85795.py
@@ -132,6 +132,12 @@ class TestGrepCommandIncludesEndOfOptionsSeparator:
             f"the -- separator must appear immediately before the quoted "
             f"pattern: {captured['command']!r}"
         )
+        # Positional check (review of #85798, point 3), robust to any
+        # future change in _escape_shell_arg's exact quoting format --
+        # not just this specific quoted-string shape.
+        sep_idx = captured["command"].index(" -- ")
+        pattern_idx = captured["command"].index("'-foo'")
+        assert sep_idx < pattern_idx
 
 
 class TestZeroMatchProbeIncludesEndOfOptionsSeparator:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2729,7 +2729,7 @@ class ShellFileOperations(FileOperations):
             return None
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
-            f"rg -i --count-matches{glob_expr} "
+            f"rg -i --count-matches{glob_expr} -- "
             f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
@@ -2751,7 +2751,7 @@ class ShellFileOperations(FileOperations):
         # returning a bare zero (bench case: match in .hidden/ silently
         # missing from results).
         hidden = self._exec(
-            f"rg --hidden --no-ignore --count-matches{glob_expr} "
+            f"rg --hidden --no-ignore --count-matches{glob_expr} -- "
             f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
@@ -2771,7 +2771,7 @@ class ShellFileOperations(FileOperations):
             )
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
-                f"rg -F --count-matches{glob_expr} "
+                f"rg -F --count-matches{glob_expr} -- "
                 f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
@@ -2987,7 +2987,11 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")  # Count per file
         
-        # Add pattern and path
+        # Add pattern and path. `--` stops option parsing so a pattern that
+        # starts with "-" (e.g. the Markdown checkbox "- [ ]") is not read
+        # as a flag by rg itself -- _escape_shell_arg's quoting only
+        # protects against shell word-splitting, not rg's own argv parsing.
+        cmd_parts.append("--")
         cmd_parts.append(self._escape_shell_arg(pattern))
         # rg is a native Windows binary when installed via winget/cargo/choco:
         # it needs the C:/... path form, not the MSYS /c/... form (which
@@ -3131,6 +3135,11 @@ class ShellFileOperations(FileOperations):
         # ``.*`` to exclude the entire search. Anchor relative paths at the
         # shell's live cwd; quoting $PWD separately keeps user paths escaped
         # while working across local, container, and remote backends.
+        # `--` stops option parsing so a pattern that starts with "-" (e.g.
+        # the Markdown checkbox "- [ ]") is not read as a flag by grep
+        # itself -- _escape_shell_arg's quoting only protects against shell
+        # word-splitting, not grep's own argv parsing.
+        cmd_parts.append("--")
         cmd_parts.append(self._escape_shell_arg(pattern))
         is_absolute = path.startswith(("/", "\\\\")) or bool(
             re.match(r"^[A-Za-z]:[\\/]", path)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1144,6 +1144,32 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _pattern_arg(self, pattern: str) -> str:
+        """Escape *pattern* and prefix it with the ``--`` end-of-options
+        separator, as a single string ready to drop into a search
+        command's argv.
+
+        Single choke point for the rg/grep argv fix in issue #85795: a
+        pattern starting with ``-`` (the Markdown checkbox ``- [ ]``,
+        diff-style ``-foo`` lines, etc.) is parsed as a flag by rg/grep
+        themselves unless preceded by ``--``; ``_escape_shell_arg``'s
+        quoting only protects against shell word-splitting, not the
+        target program's own argv parsing. ``--`` is a de-facto
+        convention rather than POSIX-mandated, but is accepted by every
+        variant this project actually shells out to (GNU grep, BSD grep,
+        ripgrep, BusyBox grep).
+
+        Every rg/grep command this class builds -- including the
+        ``_zero_match_probe`` diagnostic sub-searches -- must go through
+        this helper rather than inlining ``-- {escaped pattern}``
+        separately, so a future call site can't reintroduce the missing-
+        separator bug (review of #85798, point 2: the probe's own
+        duplication is exactly how the original issue slipped past the
+        main search path).
+        """
+        return f"-- {self._escape_shell_arg(pattern)}"
+
+
     def _escape_native_tool_arg(self, arg: str) -> str:
         """Escape a path argument destined for a NATIVE Windows binary.
 
@@ -2729,8 +2755,8 @@ class ShellFileOperations(FileOperations):
             return None
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
-            f"rg -i --count-matches{glob_expr} -- "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"rg -i --count-matches{glob_expr} "
+            f"{self._pattern_arg(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2751,8 +2777,8 @@ class ShellFileOperations(FileOperations):
         # returning a bare zero (bench case: match in .hidden/ silently
         # missing from results).
         hidden = self._exec(
-            f"rg --hidden --no-ignore --count-matches{glob_expr} -- "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"rg --hidden --no-ignore --count-matches{glob_expr} "
+            f"{self._pattern_arg(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2771,8 +2797,8 @@ class ShellFileOperations(FileOperations):
             )
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
-                f"rg -F --count-matches{glob_expr} -- "
-                f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+                f"rg -F --count-matches{glob_expr} "
+                f"{self._pattern_arg(pattern)} {self._escape_native_tool_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -2989,10 +3015,9 @@ class ShellFileOperations(FileOperations):
         
         # Add pattern and path. `--` stops option parsing so a pattern that
         # starts with "-" (e.g. the Markdown checkbox "- [ ]") is not read
-        # as a flag by rg itself -- _escape_shell_arg's quoting only
-        # protects against shell word-splitting, not rg's own argv parsing.
-        cmd_parts.append("--")
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        # as a flag by rg itself -- see _pattern_arg()'s docstring for the
+        # full rationale.
+        cmd_parts.append(self._pattern_arg(pattern))
         # rg is a native Windows binary when installed via winget/cargo/choco:
         # it needs the C:/... path form, not the MSYS /c/... form (which
         # nothing converts back — Hermes sets MSYS_NO_PATHCONV for its bash).
@@ -3137,10 +3162,8 @@ class ShellFileOperations(FileOperations):
         # while working across local, container, and remote backends.
         # `--` stops option parsing so a pattern that starts with "-" (e.g.
         # the Markdown checkbox "- [ ]") is not read as a flag by grep
-        # itself -- _escape_shell_arg's quoting only protects against shell
-        # word-splitting, not grep's own argv parsing.
-        cmd_parts.append("--")
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        # itself -- see _pattern_arg()'s docstring for the full rationale.
+        cmd_parts.append(self._pattern_arg(pattern))
         is_absolute = path.startswith(("/", "\\\\")) or bool(
             re.match(r"^[A-Za-z]:[\\/]", path)
         )


### PR DESCRIPTION
Fixes #85795.

## Problem

`_search_with_rg` and `_search_with_grep` built their shell commands without the `--` end-of-options separator before the pattern argument. `_escape_shell_arg` correctly single-quotes the pattern (a shell word-splitting concern), but that does nothing to stop `rg`/`grep` themselves from parsing a leading `-` as an option flag. Any pattern starting with `-` (the extremely common Markdown checkbox `- [ ]`, diff-style lines like `-foo`, etc.) failed silently -- `total_count: 0` with an error string a cron job never surfaces.

## Fix

Inserted `--` immediately before the pattern in both functions, matching the exact fix verified against real rg/grep in the issue report.

While fixing this, found **three more call sites** with the identical bug, not cited in the original report: `_zero_match_probe()`'s own three separate rg invocations (a "why did this return zero matches" hint). Fixed all three identically.

Verified the two `rg --files` (file-listing) call sites are NOT affected -- their pattern-shaped argument is the direct value of `-g`, unambiguous regardless of what it starts with. Left unchanged.

## Verification

Verified end-to-end against real grep in this sandbox (rg isn't installed here): reproduced the exact reported error on unmodified code, confirmed it's gone after the fix.

Added 5 regression tests. Verified as genuine regressions by stashing the entire fix and confirming all 5 fail against unmodified main.

91 pass / 4 skip (pre-existing) across the new test file plus four related search test files. One pre-existing, unrelated failure (multiline search requiring `rg` specifically, not installed in this sandbox) confirmed present identically on unmodified main.