### PR TITLE
fix(models): refresh xAI picker via models.dev at call time; pin grok-4.6

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -720,7 +720,7 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
         DEFAULT_XAI_OAUTH_BASE_URL,
         PROVIDER_REGISTRY,
     )
-    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.models import provider_model_ids
 
     status = get_xai_oauth_auth_status()
     if status.get("logged_in"):
@@ -780,8 +780,8 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
     except Exception:
         pass
 
-    models = list(_PROVIDER_MODELS.get("xai-oauth") or _PROVIDER_MODELS.get("xai") or [])
-    selected = _prompt_model_selection(models, current_model=current_model or (models[0] if models else "grok-build-0.1"))
+    models = provider_model_ids("xai-oauth")
+    selected = _prompt_model_selection(models, current_model=current_model or (models[0] if models else "grok-4.6"))
     if selected:
         _save_model_choice(selected)
         _update_config_for_provider("xai-oauth", base_url)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -154,8 +154,8 @@ def _codex_curated_models() -> list[str]:
 # (grok-4, grok-4-0709, grok-4-fast{,-reasoning,-non-reasoning},
 #  grok-4-1-fast{,-reasoning,-non-reasoning}, grok-code-fast-1 → grok-4.3).
 _XAI_STATIC_FALLBACK: list[str] = [
-    "grok-build-0.1",
     "grok-4.6",
+    "grok-build-0.1",
     "grok-4.5",
     "grok-4.3",
     "grok-4.20-0309-reasoning",
@@ -171,7 +171,7 @@ _XAI_CURATED_EXTRAS: list[str] = [
 ]
 
 
-_XAI_TOP_MODEL = "grok-build-0.1"
+_XAI_TOP_MODEL = "grok-4.6"
 
 
 def _xai_promote_top(ids: list[str]) -> list[str]:
@@ -193,16 +193,15 @@ def _xai_merge_curated_extras(ids: list[str]) -> list[str]:
     return out
 
 
+def _xai_finalize_catalog(ids: list[str]) -> list[str]:
+    return _xai_promote_top(_xai_merge_curated_extras(ids))
+
+
 def _xai_curated_models() -> list[str]:
-    """Derive the xAI-direct curated list from models.dev disk cache.
+    """Offline curated floor for xAI / xAI OAuth pickers.
 
-    Reads $HERMES_HOME/models_dev_cache.json directly (no network) so this
-    runs at import time without blocking. Falls back to ``_XAI_STATIC_FALLBACK``
-    when the cache is empty or unreadable. Hermes refreshes the cache from
-    https://models.dev/api.json on normal use, so this list self-heals as
-    xAI renames models.
-
-    Mirrors ``_codex_curated_models()``'s role for openai-codex.
+    Reads $HERMES_HOME/models_dev_cache.json directly (no network). Falls
+    back to ``_XAI_STATIC_FALLBACK`` when the cache is empty or unreadable.
     """
     try:
         from agent.models_dev import _load_disk_cache
@@ -212,12 +211,12 @@ def _xai_curated_models() -> list[str]:
         if isinstance(models, dict) and models:
             ids = [mid for mid in models.keys() if isinstance(mid, str)]
             if ids:
-                return _xai_merge_curated_extras(_xai_promote_top(sorted(ids)))
+                return _xai_finalize_catalog(sorted(ids))
     except Exception:
         # Any failure (missing file, malformed JSON, import error)
         # falls through to the static list.
         pass
-    return _xai_merge_curated_extras(list(_XAI_STATIC_FALLBACK))
+    return _xai_finalize_catalog(list(_XAI_STATIC_FALLBACK))
 
 
 _PROVIDER_MODELS: dict[str, list[str]] = {
@@ -3005,6 +3004,8 @@ _MODELS_DEV_PREFERRED: frozenset[str] = frozenset({
     "zai",
     "gemini",
     "google",
+    "xai",
+    "xai-oauth",
 })
 
 
@@ -3116,8 +3117,6 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         except Exception:
             access_token = None
         return get_codex_model_ids(access_token=access_token)
-    if normalized == "xai-oauth":
-        return list(_PROVIDER_MODELS.get("xai-oauth", _PROVIDER_MODELS.get("xai", [])))
     if normalized in {"copilot", "copilot-acp"}:
         try:
             live = _fetch_github_models(_resolve_copilot_catalog_api_key())
@@ -3335,7 +3334,10 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
 
     curated_static = list(_PROVIDER_MODELS.get(normalized, []))
     if normalized in _MODELS_DEV_PREFERRED:
-        return _merge_with_models_dev(normalized, curated_static)
+        merged = _merge_with_models_dev(normalized, curated_static)
+        if normalized in {"xai", "xai-oauth"}:
+            return _xai_finalize_catalog(merged)
+        return merged
     return curated_static
 
 

--- a/tests/hermes_cli/test_xai_curated_models.py
+++ b/tests/hermes_cli/test_xai_curated_models.py
@@ -1,14 +1,56 @@
-"""Regression tests for xAI curated model list (OAuth picker)."""
+"""Regression tests for xAI curated + models.dev picker-time merge."""
 
-from hermes_cli.models import _PROVIDER_MODELS, provider_model_ids
+from unittest.mock import patch
+
+from hermes_cli.models import (
+    _MODELS_DEV_PREFERRED,
+    _PROVIDER_MODELS,
+    provider_model_ids,
+)
 
 
-def test_xai_oauth_includes_grok_composer_2_5_fast():
-    models = provider_model_ids("xai-oauth")
-    assert "grok-composer-2.5-fast" in models
-
-
-def test_grok_composer_slots_after_grok_build():
+def test_grok_4_6_is_default_pin():
     models = _PROVIDER_MODELS["xai-oauth"]
-    assert models[0] == "grok-build-0.1"
-    assert models[1] == "grok-composer-2.5-fast"
+    assert models[0] == "grok-4.6"
+
+
+def test_xai_providers_are_models_dev_preferred():
+    assert "xai" in _MODELS_DEV_PREFERRED
+    assert "xai-oauth" in _MODELS_DEV_PREFERRED
+
+
+def test_xai_oauth_picker_merges_models_dev_at_call_time():
+    """xai-oauth must not return the import-frozen list; merge at picker time."""
+    mdev = ["grok-build-0.1", "grok-new-from-models-dev", "grok-4.6"]
+    with patch("agent.models_dev.list_agentic_models", return_value=mdev) as mocked:
+        models = provider_model_ids("xai-oauth")
+
+    mocked.assert_called()
+    assert models[0] == "grok-4.6"
+    assert "grok-new-from-models-dev" in models
+
+
+def test_xai_api_key_picker_merges_models_dev_when_live_unavailable():
+    """Without a live /v1/models hit, xai uses the models.dev preferred path."""
+    mdev = ["grok-build-0.1", "grok-new-from-models-dev", "grok-4.6"]
+    with (
+        patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            side_effect=Exception("no key"),
+        ),
+        patch("agent.models_dev.list_agentic_models", return_value=mdev) as mocked,
+    ):
+        models = provider_model_ids("xai")
+
+    mocked.assert_called()
+    assert "grok-new-from-models-dev" in models
+    assert models[0] == "grok-4.6"
+
+
+def test_xai_pin_survives_when_top_model_only_in_extras():
+    """If models.dev omits grok-4.6, curated extras + finalize still pin it."""
+    mdev = ["grok-build-0.1", "grok-new-from-models-dev"]
+    with patch("agent.models_dev.list_agentic_models", return_value=mdev):
+        models = provider_model_ids("xai-oauth")
+
+    assert models[0] == "grok-4.6"

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -22,7 +22,7 @@ The same OAuth bearer token is also reused by every direct-to-xAI surface in Her
 | Display name | xAI Grok OAuth (SuperGrok / X Premium+) |
 | Auth type | Browser OAuth 2.0 device code |
 | Transport | xAI Responses API (`codex_responses`) |
-| Default model | `grok-build-0.1` |
+| Default model | `grok-4.6` |
 | Endpoint | `https://api.x.ai/v1` |
 | Auth server | `https://accounts.x.ai` |
 | Requires env var | No (`XAI_API_KEY` is **not** used for this provider) |
@@ -47,7 +47,7 @@ hermes model
 # → Select "xAI Grok OAuth (SuperGrok / X Premium+)" from the provider list
 # → Hermes opens or prints an accounts.x.ai verification URL
 # → Enter the displayed code if prompted, then approve access in the browser
-# → Pick a model (grok-build-0.1 is at the top)
+# → Pick a model (grok-4.6 is at the top)
 # → Start chatting
 
 hermes
@@ -94,13 +94,13 @@ The `◆ Auth Providers` section will show the current state of every provider, 
 ```bash
 hermes model
 # → Select "xAI Grok OAuth (SuperGrok / X Premium+)"
-# → Pick from the model list (grok-build-0.1 is pinned to the top)
+# → Pick from the model list (grok-4.6 is pinned to the top)
 ```
 
 Or set the model directly:
 
 ```bash
-hermes config set model.default grok-build-0.1
+hermes config set model.default grok-4.6
 hermes config set model.provider xai-oauth
 ```
 
@@ -110,7 +110,7 @@ After login, `~/.hermes/config.yaml` will contain:
 
 ```yaml
 model:
-  default: grok-build-0.1
+  default: grok-4.6
   provider: xai-oauth
   base_url: https://api.x.ai/v1
 ```
@@ -154,8 +154,9 @@ The `x_search` toolset auto-enables whenever xAI credentials (a SuperGrok / X Pr
 
 | Tool | Model | Notes |
 |------|-------|-------|
-| Chat | `grok-build-0.1` | Default; auto-selected when you log in via OAuth |
-| Chat | `grok-4.3` | Previous default |
+| Chat | `grok-4.6` | Default; pinned to the top of the OAuth picker |
+| Chat | `grok-build-0.1` | Coding-oriented Grok Build model |
+| Chat | `grok-4.3` | Previous generation |
 | Chat | `grok-4.20-0309-reasoning` | Reasoning variant |
 | Chat | `grok-4.20-0309-non-reasoning` | Non-reasoning variant |
 | Chat | `grok-4.20-multi-agent-0309` | Multi-agent variant |
@@ -165,7 +166,7 @@ The `x_search` toolset auto-enables whenever xAI credentials (a SuperGrok / X Pr
 | Video | `grok-imagine-video-1.5-preview` | Image-to-video; dated alias `grok-imagine-video-1.5-2026-05-30` |
 | TTS | (default voice) | xAI `/v1/tts` endpoint |
 
-The chat catalog is derived live from the on-disk `models.dev` cache; new xAI releases appear automatically once that cache refreshes. `grok-build-0.1` is always pinned to the top of the list.
+The chat catalog is derived live from the on-disk `models.dev` cache; new xAI releases appear automatically once that cache refreshes. `grok-4.6` is always pinned to the top of the list.
 
 ## Environment Variables
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/xai-grok-oauth.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/xai-grok-oauth.md
@@ -22,7 +22,7 @@ Hermes Agent 通过基于浏览器的 OAuth 登录流程支持 xAI Grok，认证
 | 显示名称 | xAI Grok OAuth (SuperGrok / X Premium+) |
 | 认证类型 | 浏览器 OAuth 2.0 设备代码 |
 | 传输层 | xAI Responses API（`codex_responses`） |
-| 默认模型 | `grok-build-0.1` |
+| 默认模型 | `grok-4.6` |
 | 端点 | `https://api.x.ai/v1` |
 | 认证服务器 | `https://accounts.x.ai` |
 | 需要环境变量 | 否（此 provider 不使用 `XAI_API_KEY`） |
@@ -47,7 +47,7 @@ hermes model
 # → 从 provider 列表中选择 "xAI Grok OAuth (SuperGrok / X Premium+)"
 # → Hermes 打开或打印 accounts.x.ai 验证 URL
 # → 如有提示，输入显示的代码，然后在浏览器中批准访问
-# → 选择模型（grok-build-0.1 在列表顶部）
+# → 选择模型（grok-4.6 在列表顶部）
 # → 开始对话
 
 hermes
@@ -94,13 +94,13 @@ hermes doctor
 ```bash
 hermes model
 # → 选择 "xAI Grok OAuth (SuperGrok / X Premium+)"
-# → 从模型列表中选择（grok-build-0.1 固定在顶部）
+# → 从模型列表中选择（grok-4.6 固定在顶部）
 ```
 
 或直接设置模型：
 
 ```bash
-hermes config set model.default grok-build-0.1
+hermes config set model.default grok-4.6
 hermes config set model.provider xai-oauth
 ```
 
@@ -110,7 +110,7 @@ hermes config set model.provider xai-oauth
 
 ```yaml
 model:
-  default: grok-build-0.1
+  default: grok-4.6
   provider: xai-oauth
   base_url: https://api.x.ai/v1
 ```
@@ -154,7 +154,8 @@ hermes tools
 
 | 工具 | 模型 | 说明 |
 |------|-------|-------|
-| 对话 | `grok-build-0.1` | 默认；通过 OAuth 登录时自动选择 |
+| 对话 | `grok-4.6` | 默认；固定在 OAuth 选择器顶部 |
+| 对话 | `grok-build-0.1` | 面向编程的 Grok Build 模型 |
 | 对话 | `grok-4.3` | 之前的默认 |
 | 对话 | `grok-4.20-0309-reasoning` | 推理变体 |
 | 对话 | `grok-4.20-0309-non-reasoning` | 非推理变体 |
@@ -165,7 +166,7 @@ hermes tools
 | 视频 | `grok-imagine-video-1.5-preview` | 图像转视频；日期别名 `grok-imagine-video-1.5-2026-05-30` |
 | TTS | （默认音色） | xAI `/v1/tts` 端点 |
 
-对话模型目录从磁盘上的 `models.dev` 缓存实时获取；缓存刷新后，新的 xAI 模型会自动出现。`grok-build-0.1` 始终固定在列表顶部。
+对话模型目录从磁盘上的 `models.dev` 缓存实时获取；缓存刷新后，新的 xAI 模型会自动出现。`grok-4.6` 始终固定在列表顶部。
 
 ## 环境变量
 


### PR DESCRIPTION
## Summary
The xAI / xAI-OAuth model pickers now merge the models.dev catalog at picker time instead of serving a list frozen at import, and `grok-4.6` becomes the pinned default. New Grok releases appear in `/model` and the OAuth setup flow as soon as the models.dev disk cache refreshes — no Hermes restart.

Salvages #85683 by @Jaaneek onto current main with authorship preserved.

## Changes
- `hermes_cli/models.py`: add `xai`/`xai-oauth` to `_MODELS_DEV_PREFERRED`; drop the import-frozen `xai-oauth` early return in `provider_model_ids()`; re-apply pin + curated extras via `_xai_finalize_catalog()` after the merge; `_XAI_TOP_MODEL` → `grok-4.6`
- `hermes_cli/model_setup_flows.py`: OAuth setup picks models via `provider_model_ids("xai-oauth")` — same path as `/model`
- `tests/hermes_cli/test_xai_curated_models.py`: call-time merge, preferred membership, and pin-survival regressions
- `website/docs/guides/xai-grok-oauth.md` (+ zh-Hans): `grok-4.6` documented as default/pin

## Validation
| | Before | After |
|---|---|---|
| Cache refresh mid-session | picker list frozen until restart | new IDs appear on next picker open (E2E-verified against temp HERMES_HOME) |
| Picker top entry | grok-build-0.1 | grok-4.6 (survives even when models.dev omits it) |
| Targeted tests | — | 8/8 passing (`test_xai_curated_models.py`, `test_xai_model_flow.py`) |

## Infographic

![xAI picker live refresh](https://files.catbox.moe/hsqh83.png)
