### PR TITLE
fix: preserve multiline shell tokenization for cron lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -153,11 +153,11 @@ _ReadRemoteScriptFn = Callable[[str], Optional[str]]
 
 def _iter_command_segments(command: str) -> Iterator[list[str]]:
     """Yield shell-tokenized command segments, honoring quotes and comments."""
-    normalized = command.replace("\\\n", "")
-    for line in normalized.splitlines() or [normalized]:
+
+    def _tokenize(command_text: str) -> Iterator[list[str]]:
         try:
             lexer = shlex.shlex(
-                line,
+                command_text,
                 posix=True,
                 punctuation_chars=";&|()",
             )
@@ -165,7 +165,7 @@ def _iter_command_segments(command: str) -> Iterator[list[str]]:
             lexer.commenters = "#"
             tokens = list(lexer)
         except ValueError:
-            continue
+            return
 
         segment: list[str] = []
         for token in tokens:
@@ -177,6 +177,27 @@ def _iter_command_segments(command: str) -> Iterator[list[str]]:
             segment.append(token)
         if segment:
             yield segment
+
+    # Normalize line continuations.
+    normalized = _SHELL_LINE_CONTINUATION.sub(" ", command)
+    # Drop shebang metadata lines before command-separator normalization.
+    normalized = re.sub(r"(?m)^\s*#!.*(?:\r?\n|$)", "", normalized)
+
+    # Normalize remaining newlines as shell command separators while preserving quoted
+    # multi-line arguments (shlex treats punctuation chars as separators only when
+    # not quoted).
+    normalized = normalized.replace("\r\n", "\n").replace("\n", ";")
+
+    parsed = False
+    for segment in _tokenize(normalized):
+        parsed = True
+        yield segment
+    if parsed:
+        return
+
+    for line in normalized.split(";") if normalized else [normalized]:
+        yield from _tokenize(line)
+
 
 
 def _command_token_index(segment: list[str]) -> Optional[int]:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,25 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_multiline_python_c_command_does_not_false_positive(self):
+        """#85557: a multi-line python -c payload with a db path should not be
+        re-tokenized as a shell script reference and should return False."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        command = (
+            "ls /opt/data/*.db; python3 -c \"\n"
+            "import sqlite3\n"
+            "c = sqlite3.connect('/opt/data/state.db')\n"
+            "print(1)\n"
+            "\""
+        )
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(command)
+            is False
+        )
+
     def test_nul_byte_in_path_token_does_not_crash_guard(self):
         """Residual #76762 class: when a NUL byte survives into the *path
         token itself* (tokenized binary-adjacent command text), ``os.open``


### PR DESCRIPTION
## Summary
- Updated `cron/lifecycle_guard.py` command tokenization to preserve multiline shell arguments while keeping command boundaries, fixing false positives for multiline `python3 -c` payloads and existing launchctl/script-reference detection.
- Added regression test for issue-like multiline `python3 -c` payload containing a db path.
- Kept shell-script scanning behavior for launchctl and referenced scripts intact.

## Test Plan
- [x] `python3 -m py_compile cron/lifecycle_guard.py tests/hermes_cli/test_gateway_restart_loop.py`
- [x] `python3 -m pytest tests/hermes_cli/test_gateway_restart_loop.py`
- [x] `python3 -m pytest tests/hermes_cli/test_gateway_restart_loop.py -k "multiline_python_c_command_does_not_false_positive or launchctl_submit_raises or shell_script_reference_walk_still_works" -q`

Closes #85557
