### PR TITLE
perf(tools): persist OSV malware-check verdict cache to disk

### DIFF
--- a/tests/tools/test_osv_check.py
+++ b/tests/tools/test_osv_check.py
@@ -66,14 +66,18 @@ class TestParsePackageFromArgs:
 
 class TestCheckPackageForMalware:
     @pytest.fixture(autouse=True)
-    def _fresh_cache(self):
+    def _fresh_cache(self, tmp_path, monkeypatch):
         from tools import osv_check
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         with osv_check._cache_lock:
             osv_check._cache.clear()
+            osv_check._disk_cache_loaded = False
+        (tmp_path / "cache" / "osv_check.json").unlink(missing_ok=True)
         yield
         with osv_check._cache_lock:
             osv_check._cache.clear()
-
+            osv_check._disk_cache_loaded = False
+        (tmp_path / "cache" / "osv_check.json").unlink(missing_ok=True)
     def test_clean_package(self):
         """Clean package returns None (allow)."""
         mock_response = MagicMock()
@@ -188,6 +192,56 @@ class TestCheckPackageForMalware:
                 osv_check._cache[key] = (0.0, result)
             check_package_for_malware("uvx", ["mcp-server-fetch"])
         assert mock_url.call_count == 2
+
+    def test_disk_cache_persists_and_reloads(self, tmp_path, monkeypatch):
+        """A warm disk cache is reused by a fresh in-process cache."""
+        from tools import osv_check
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"vulns": []}).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("tools.osv_check.urllib.request.urlopen", return_value=mock_response) as mock_url:
+            check_package_for_malware("uvx", ["mcp-server-persist"])
+
+        cache_file = tmp_path / "cache" / "osv_check.json"
+        assert cache_file.exists(), "disk cache should be written after a warm result"
+
+        with osv_check._cache_lock:
+            osv_check._cache.clear()
+            osv_check._disk_cache_loaded = False
+
+        with patch("tools.osv_check.urllib.request.urlopen", return_value=mock_response) as mock_url2:
+            check_package_for_malware("uvx", ["mcp-server-persist"])
+
+        assert mock_url2.call_count == 0, "disk cache must satisfy the second call"
+
+    def test_disk_cache_format_versioned(self, tmp_path, monkeypatch):
+        """Disk cache JSON has a version field and recoverable entries."""
+        from tools import osv_check
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"vulns": []}).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("tools.osv_check.urllib.request.urlopen", return_value=mock_response):
+            check_package_for_malware("uvx", ["mcp-server-format"])
+
+        cache_file = tmp_path / "cache" / "osv_check.json"
+        with open(cache_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        assert data["version"] == osv_check._DISK_CACHE_VERSION
+        assert "entries" in data
+        key = "PyPI|mcp-server-format|"
+        assert key in data["entries"]
+        assert "expiry" in data["entries"][key]
+        assert data["entries"][key]["result"] is None
 
 
 class TestLiveOsvQuery:

--- a/tests/tools/test_osv_check.py
+++ b/tests/tools/test_osv_check.py
@@ -1,6 +1,9 @@
 """Tests for OSV malware check on MCP extension packages."""
 
 import json
+import time
+from pathlib import Path
+
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -242,6 +245,44 @@ class TestCheckPackageForMalware:
         assert key in data["entries"]
         assert "expiry" in data["entries"][key]
         assert data["entries"][key]["result"] is None
+
+    def test_disk_cache_retries_after_transient_oserror(self, tmp_path, monkeypatch):
+        """A busy/unreadable cache file must not disable disk loads for the process."""
+        from tools import osv_check
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cache_file = tmp_path / "cache" / "osv_check.json"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text(
+            json.dumps({
+                "version": osv_check._DISK_CACHE_VERSION,
+                "entries": {
+                    "PyPI|mcp-server-retry|": {
+                        "expiry": time.time() + 3600,
+                        "result": None,
+                    }
+                },
+            }),
+            encoding="utf-8",
+        )
+
+        real_open = open
+        calls = {"n": 0}
+
+        def flaky_open(path, *args, **kwargs):
+            if Path(path) == cache_file:
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise OSError("resource temporarily unavailable")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", flaky_open)
+        with osv_check._cache_lock:
+            osv_check._load_disk_cache()
+            assert osv_check._disk_cache_loaded is False
+            osv_check._load_disk_cache()
+            assert osv_check._disk_cache_loaded is True
+            assert ("PyPI", "mcp-server-retry", None) in osv_check._cache
 
 
 class TestLiveOsvQuery:

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -80,18 +80,29 @@ def _load_disk_cache() -> None:
     global _disk_cache_loaded
     if _disk_cache_loaded:
         return
-    _disk_cache_loaded = True
 
     path = _disk_cache_path()
     if path is None:
+        _disk_cache_loaded = True
         return
 
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
+    except FileNotFoundError:
+        _disk_cache_loaded = True
+        return
+    except json.JSONDecodeError:
+        _disk_cache_loaded = True
+        return
+    except OSError:
+        # Transient I/O (file busy, brief permission flap). Retry next call.
+        return
     except Exception:
+        _disk_cache_loaded = True
         return
 
+    _disk_cache_loaded = True
     if not isinstance(data, dict) or data.get("version") != _DISK_CACHE_VERSION:
         return
 

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -9,44 +9,145 @@ Fail-open: network errors allow the package to proceed.
 
 Inspired by Block/goose's extension malware check.
 """
-
 import json
 import logging
 import os
 import re
+import tempfile
 import threading
 import time
 import urllib.request
+from pathlib import Path
 from typing import Optional, Tuple
-
 logger = logging.getLogger(__name__)
 
 _OSV_ENDPOINT = os.getenv("OSV_ENDPOINT", "https://api.osv.dev/v1/query")
 _TIMEOUT = 10  # seconds
 
-# Result cache: (ecosystem, package, version) -> (expiry_monotonic, result).
-# MCP reconnect ladders, stdio recycles, and parked-server self-probes re-run
-# the preflight for the SAME package on every spawn attempt. Without a cache,
-# a flapping server turns into a sustained OSV query/DNS stream — the #75485
-# incident logged 779K api.osv.dev DNS queries in 16h from revival loops.
-# Malware advisories don't appear or vanish on second-to-second timescales,
-# so a successful verdict (clean OR blocked) is reusable. Network failures
-# are NOT cached: fail-open already covers them, and caching a failure could
-# mask a real advisory once connectivity returns.
+# Result cache: (ecosystem, package, version) -> (expiry_timestamp, result).
+# MCP reconnect ladders, stdio recycles, parked-server self-probes, and
+# repeated `hermes mcp test` invocations re-run the preflight for the SAME
+# package on every spawn attempt. Without a cache, a flapping server turns
+# into a sustained OSV query/DNS stream — the #75485 incident logged 779K
+# api.osv.dev DNS queries in 16h from revival loops. Malware advisories don't
+# appear or vanish on second-to-second timescales, so a successful verdict
+# (clean OR blocked) is reusable. Network failures are NOT cached: fail-open
+# already covers them, and caching a failure could mask a real advisory once
+# connectivity returns.
+#
+# The cache is also persisted to disk inside the Hermes home so that separate
+# `hermes mcp test` processes (and gateway restarts) reuse a warm verdict
+# instead of re-querying OSV. Expiry is stored as absolute wall-clock time so
+# it survives process restarts and monotonic-clock skew.
 _CACHE_TTL_S = float(os.getenv("OSV_CHECK_CACHE_TTL", "3600"))
 _CACHE_MAX_ENTRIES = 256
 _cache: dict = {}
 _cache_lock = threading.Lock()
+_disk_cache_loaded = False
+_DISK_CACHE_VERSION = 1
+
+
+def _disk_cache_path() -> Optional[Path]:
+    """Return the path for the persistent OSV verdict cache.
+
+    Uses ``hermes_constants.get_hermes_home()`` so the cache follows the
+    active profile and is isolated across Hermes homes. The cache directory
+    is created on demand. Returns ``None`` when Hermes home cannot be
+    resolved, in which case only the in-process cache is used.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = get_hermes_home()
+    except Exception:
+        return None
+    try:
+        cache_dir = home / "cache"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return cache_dir / "osv_check.json"
+    except Exception:
+        return None
+
+
+def _load_disk_cache() -> None:
+    """Load persistent cache entries from disk into the in-process cache.
+
+    Called once under ``_cache_lock`` on first use. Skips expired or
+    malformed entries. Uses absolute wall-clock timestamps. Only adds
+    missing keys so an in-memory overwrite (e.g. a test forcing expiry)
+    is not silently reversed by the disk copy.
+    """
+    global _disk_cache_loaded
+    if _disk_cache_loaded:
+        return
+    _disk_cache_loaded = True
+
+    path = _disk_cache_path()
+    if path is None:
+        return
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return
+
+    if not isinstance(data, dict) or data.get("version") != _DISK_CACHE_VERSION:
+        return
+
+    now = time.time()
+    for key_str, entry in data.get("entries", {}).items():
+        if not isinstance(entry, dict):
+            continue
+        expiry = entry.get("expiry")
+        result = entry.get("result")
+        if expiry is None or expiry <= now:
+            continue
+        parts = key_str.split("|", 2)
+        if len(parts) != 3:
+            continue
+        key = (parts[0], parts[1], parts[2] or None)
+        if key not in _cache:
+            _cache[key] = (expiry, result)
+
+
+def _save_disk_cache() -> None:
+    """Persist the in-process cache to disk.
+
+    Caller must hold ``_cache_lock`` for consistency. Writes atomically to
+    a sibling file then renames into place.
+    """
+    path = _disk_cache_path()
+    if path is None:
+        return
+
+    entries: dict = {}
+    for key, (expiry, result) in _cache.items():
+        key_str = "|".join(str(k) if k is not None else "" for k in key)
+        entries[key_str] = {"expiry": expiry, "result": result}
+
+    data = {"version": _DISK_CACHE_VERSION, "entries": entries}
+
+    try:
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            dir=path.parent, prefix=path.name + ".tmp-"
+        )
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        os.replace(tmp_path, path)
+    except Exception as exc:
+        logger.debug("Failed to save OSV disk cache to %s: %s", path, exc)
 
 
 def _cache_get(key) -> Tuple[bool, Optional[str]]:
     """Return (hit, result) for a fresh cache entry."""
     with _cache_lock:
+        _load_disk_cache()
         entry = _cache.get(key)
         if entry is None:
             return False, None
         expiry, result = entry
-        if time.monotonic() >= expiry:
+        if time.time() >= expiry:
             del _cache[key]
             return False, None
         return True, result
@@ -54,13 +155,15 @@ def _cache_get(key) -> Tuple[bool, Optional[str]]:
 
 def _cache_put(key, result: Optional[str]) -> None:
     with _cache_lock:
+        _load_disk_cache()
         if len(_cache) >= _CACHE_MAX_ENTRIES:
-            now = time.monotonic()
+            now = time.time()
             for k in [k for k, (exp, _) in _cache.items() if exp <= now]:
                 del _cache[k]
             if len(_cache) >= _CACHE_MAX_ENTRIES:
                 _cache.clear()  # tiny working set in practice; safe reset
-        _cache[key] = (time.monotonic() + _CACHE_TTL_S, result)
+        _cache[key] = (time.time() + _CACHE_TTL_S, result)
+        _save_disk_cache()
 
 
 def check_package_for_malware(


### PR DESCRIPTION
## What does this PR do?

`hermes mcp test <stdio-server>` and other stdio MCP spawn paths were re-querying the OSV malware API on every process start, even for the same package. The existing cache was in-process only, so a new `hermes mcp test` invocation started with an empty cache and paid the full OSV network latency (up to 10s timeout) every time. This made the OSV preflight span show 5.91x variance (0.44-2.6s) on repeated runs and contributed heavily to the reported connection-time variance.

This PR persists the OSV malware-check verdict cache to disk inside the Hermes home (`<hermes_home>/cache/osv_check.json`), so separate `hermes mcp test` processes and gateway restarts reuse a warm verdict instead of re-querying the network.

Follow-up: `_load_disk_cache()` no longer marks the disk cache as loaded before the read. A transient `OSError` (file busy, brief permission flap) leaves the flag unset so the next call retries. Missing or permanently malformed files still mark the cache loaded so we do not spin on a bad file.

The change is intentionally narrow:
- It addresses the Hermes-owned OSV preflight variance component of #68416.
- Server-side `initialize` time is outside Hermes' control and still varies; the worklog documents this.

## Related Issue

Fixes #68416 (Hermes-owned OSV preflight variance component)

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)

## Changes Made

- `tools/osv_check.py`:
  - Persist the in-memory OSV verdict cache to `<hermes_home>/cache/osv_check.json`.
  - Cache expiry is stored as an absolute wall-clock timestamp so it survives process restarts and monotonic-clock skew.
  - Disk cache is loaded lazily on first `_cache_get` / `_cache_put`, only adds missing in-memory keys, and skips expired/malformed entries.
  - Disk writes are atomic (`tempfile.mkstemp` + `os.replace`) and happen under the existing cache lock.
  - Transient load failures no longer disable disk-cache loading for the process lifetime.
  - Switched cache timestamps from `time.monotonic()` to `time.time()` for persistence compatibility.
  - Kept `hermes_constants.get_hermes_home()` as a lazy import so `tools/osv_check.py` remains import-safe (stdlib + typing at module scope).

- `tests/tools/test_osv_check.py`:
  - Updated the autouse `_fresh_cache` fixture to set `HERMES_HOME` to `tmp_path` and clean the disk cache file, so tests are isolated.
  - Added `test_disk_cache_persists_and_reloads`: verifies a warm disk cache is reused by a fresh in-process cache without a network call.
  - Added `test_disk_cache_format_versioned`: verifies the JSON format includes `version` and recoverable per-key `expiry`/`result` fields.
  - Added `test_disk_cache_retries_after_transient_oserror`: a busy cache file must not disable later loads.

## How to Test

1. Run `pytest tests/tools/test_osv_check.py -q` — all 21 tests pass.
2. Run `pytest tests/tools/test_mcp_stability.py -q` — all 16 tests pass.
3. `ruff check tools/osv_check.py tests/tools/test_osv_check.py` — clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/tools/test_osv_check.py tests/tools/test_mcp_stability.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A