### PR TITLE
fix: preserve regex backslashes in search_files patterns on Windows

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1144,6 +1144,18 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _escape_shell_pattern(self, arg: str) -> str:
+        """Single-quote a regex/glob argument WITHOUT Windows path rewriting.
+
+        ``_escape_shell_arg`` runs ``_bash_safe_path`` which, on Windows,
+        rewrites drive-letter paths and turns backslashes into forward
+        slashes.  That is correct for filesystem paths embedded in a Git Bash
+        script, but it corrupts regex escapes and glob metacharacters in the
+        ``pattern`` / ``file_glob`` arguments.  Patterns must only be
+        single-quote-escaped so the shell does not expand them.
+        """
+        return "'" + arg.replace("'", "'\"'\"'") + "'"
+
     def _escape_native_tool_arg(self, arg: str) -> str:
         """Escape a path argument destined for a NATIVE Windows binary.
 
@@ -2727,10 +2739,10 @@ class ShellFileOperations(FileOperations):
         """
         if not self._has_command('rg'):
             return None
-        glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
+        glob_expr = f" --glob {self._escape_shell_pattern(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_shell_pattern(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2752,7 +2764,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_shell_pattern(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2772,7 +2784,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+                f"{self._escape_shell_pattern(pattern)} {self._escape_native_tool_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -2893,7 +2905,7 @@ class ShellFileOperations(FileOperations):
         fetch_limit = limit + offset
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
-            f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
+            f"rg --files --sortr=modified -g {self._escape_shell_pattern(glob_pattern)} "
             f"{self._escape_native_tool_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
@@ -2904,7 +2916,7 @@ class ShellFileOperations(FileOperations):
         if not all_files and not limit_reason:
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
-                f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
+                f"rg --files -g {self._escape_shell_pattern(glob_pattern)} "
                 f"{self._escape_native_tool_arg(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
@@ -2979,7 +2991,7 @@ class ShellFileOperations(FileOperations):
         
         # Add file glob filter (must be quoted to prevent shell expansion)
         if file_glob:
-            cmd_parts.extend(["--glob", self._escape_shell_arg(file_glob)])
+            cmd_parts.extend(["--glob", self._escape_shell_pattern(file_glob)])
         
         # Output mode handling
         if output_mode == "files_only":
@@ -2988,7 +3000,7 @@ class ShellFileOperations(FileOperations):
             cmd_parts.append("-c")  # Count per file
         
         # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        cmd_parts.append(self._escape_shell_pattern(pattern))
         # rg is a native Windows binary when installed via winget/cargo/choco:
         # it needs the C:/... path form, not the MSYS /c/... form (which
         # nothing converts back — Hermes sets MSYS_NO_PATHCONV for its bash).
@@ -3118,7 +3130,7 @@ class ShellFileOperations(FileOperations):
         
         # Add file pattern filter (must be quoted to prevent shell expansion)
         if file_glob:
-            cmd_parts.extend(["--include", self._escape_shell_arg(file_glob)])
+            cmd_parts.extend(["--include", self._escape_shell_pattern(file_glob)])
         
         # Output mode handling
         if output_mode == "files_only":
@@ -3131,7 +3143,7 @@ class ShellFileOperations(FileOperations):
         # ``.*`` to exclude the entire search. Anchor relative paths at the
         # shell's live cwd; quoting $PWD separately keeps user paths escaped
         # while working across local, container, and remote backends.
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        cmd_parts.append(self._escape_shell_pattern(pattern))
         is_absolute = path.startswith(("/", "\\\\")) or bool(
             re.match(r"^[A-Za-z]:[\\/]", path)
         )


### PR DESCRIPTION
## Problem
On Windows, `search_files` corrupts regex escapes in its `pattern` argument.
A pattern like `COMP\w+` reaches ripgrep as `COMP/w+`, so:

- `\w` -> `/w`  (silently matches the wrong text / returns 0 results)
- `\(` -> `/(`  (rg fails with `regex parse error: unclosed group`)
- `\d`, `\.`, `\s` etc. all broken the same way

## Root cause
`_search_with_rg` escapes the pattern with `_escape_shell_arg`, which runs
`_bash_safe_path` on Windows. `_bash_safe_path` normalizes filesystem paths
for Git Bash (collapses backslashes to forward slashes, rewrites `C:/x` to
`/c/x`). Applied to a regex/glob argument, that normalization mangles the
escapes.

This is separate from the MSYS `/d/...` path issue fixed in #84378 (that is
the `path` argument, now via `_escape_native_tool_arg`); this is `pattern` /
`file_glob` still going through `_escape_shell_arg`.

## Fix
Add `_escape_shell_pattern` (same single-quote escaping, no `_bash_safe_path`)
and route every regex/glob argument through it; path arguments untouched:

| Call site | Arguments switched |
|---|---|
| `_search_with_rg` | `pattern`, `file_glob` |
| `_search_files_rg` | `glob_pattern` (sortr + plain) |
| `_search_with_grep` | `pattern`, `file_glob` |
| `_zero_match_probe` | `pattern` (x3), `file_glob` |

## Verification
Windows + git-bash + native ripgrep 15.1 (16 checks, all pass):

- `_escape_shell_pattern` preserves backslashes (unit-tested)
- `_escape_shell_arg` still mangles them (documents the old bug)
- content search `COMP\w+` -> 3 matches incl. `COMPort.cs`
- content search `def search\(` -> no parse error, 2 matches
- regression: MSYS `/d/...` path (files + content) still works
- zero-match backslash pattern -> no error
