### PR TITLE
fix(tools): TERMINAL_TIMEOUT<=0 falls back to the documented 180s default

### DIFF
--- a/tests/test_terminal_timeout_shared_helper_85811.py
+++ b/tests/test_terminal_timeout_shared_helper_85811.py
@@ -1,0 +1,88 @@
+"""Tests for the shared TERMINAL_TIMEOUT resolution helper.
+
+Regression for issue #85809 / review of #85811: TERMINAL_TIMEOUT was read
+independently by tools/terminal_tool.py::_get_env_config AND
+tools/process_registry.py's wait() path -- fixing only the first still
+left the second producing a misleading "timed out after 0s" for
+TERMINAL_TIMEOUT<=0. resolve_terminal_timeout_default() is the single
+shared helper both now call, so the guard covers the whole class, not one
+call site.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from utils import TERMINAL_TIMEOUT_DEFAULT_SECONDS, resolve_terminal_timeout_default
+
+
+def test_default_is_180_seconds():
+    assert TERMINAL_TIMEOUT_DEFAULT_SECONDS == 180
+
+
+def test_zero_falls_back_to_default():
+    with patch.dict("os.environ", {"TERMINAL_TIMEOUT": "0"}, clear=True):
+        assert resolve_terminal_timeout_default() == 180
+
+
+def test_negative_falls_back_to_default():
+    with patch.dict("os.environ", {"TERMINAL_TIMEOUT": "-30"}, clear=True):
+        assert resolve_terminal_timeout_default() == 180
+
+
+def test_unparseable_string_falls_back_to_default():
+    with patch.dict("os.environ", {"TERMINAL_TIMEOUT": "5m"}, clear=True):
+        assert resolve_terminal_timeout_default() == 180
+
+
+def test_positive_value_passes_through_unchanged():
+    with patch.dict("os.environ", {"TERMINAL_TIMEOUT": "600"}, clear=True):
+        assert resolve_terminal_timeout_default() == 600
+
+
+def test_unset_uses_default():
+    with patch.dict("os.environ", {}, clear=True):
+        assert resolve_terminal_timeout_default() == 180
+
+
+def test_process_registry_wait_actually_uses_the_shared_helpers_return_value():
+    """Regression: process_registry.py's wait() must genuinely call
+    resolve_terminal_timeout_default() and use its return value as the
+    effective timeout -- a reversion to a standalone
+    `int(os.getenv("TERMINAL_TIMEOUT", "180"))` would silently
+    reintroduce the unguarded-second-reader bug (issue #85809 / review
+    of #85811).
+
+    Verified behaviorally: patches the shared helper to return a small,
+    distinct value (2s) and confirms wait() on a session that never
+    finishes gives up in roughly that time, not the real 180s default
+    and not near-instantly (which is what TERMINAL_TIMEOUT=0 produced
+    before this fix, on this exact call site)."""
+    import time as _time
+    from unittest.mock import patch as _patch
+
+    import tools.process_registry as pr_mod
+
+    registry = pr_mod.ProcessRegistry()
+    session = pr_mod.ProcessSession(
+        id="proc_shared_timeout_test",
+        command="sleep 999",
+        task_id="t1",
+        started_at=_time.time(),
+        exited=False,
+        exit_code=None,
+        output_buffer="",
+    )
+    registry._running[session.id] = session
+
+    with _patch("utils.resolve_terminal_timeout_default", return_value=2):
+        start = _time.monotonic()
+        result = registry.wait(session.id, timeout=None)
+        elapsed = _time.monotonic() - start
+
+    assert result["status"] == "timeout", result
+    assert 1.5 <= elapsed <= 4.0, (
+        f"wait() took {elapsed:.2f}s -- expected ~2s (the patched shared "
+        f"helper's return value), not near-instant (the TERMINAL_TIMEOUT=0 "
+        f"bug this guards against) or the real 180s unpatched default"
+    )

--- a/tests/tools/test_parse_env_var.py
+++ b/tests/tools/test_parse_env_var.py
@@ -31,6 +31,52 @@ class TestParseEnvVar:
             assert config["docker_forward_env"] == ["GITHUB_TOKEN", "NPM_TOKEN"]
 
 
+    # -- TERMINAL_TIMEOUT=0 is a "0 = infinite" misunderstanding, not a
+    #    request for an instant timeout (issue #85809) --
+
+    def test_zero_timeout_falls_back_to_default_180(self, caplog):
+        """TERMINAL_TIMEOUT=0 parses as a valid int, but 0 means "time out
+        instantly" for the underlying subprocess/asyncio timeout -- not
+        "no timeout" as a user might reasonably assume. Every command
+        must not silently fail with "timed out after 0s"."""
+        with patch.dict("os.environ", {"TERMINAL_TIMEOUT": "0"}, clear=False):
+            config = _tt_mod._get_env_config()
+            assert config["timeout"] == 180, (
+                f"TERMINAL_TIMEOUT=0 must fall back to the 180s default, "
+                f"got {config['timeout']}"
+            )
+        assert any(
+            "TERMINAL_TIMEOUT" in r.message and "0" in r.message
+            for r in caplog.records
+        ), "a warning must be logged so the misconfiguration is diagnosable"
+
+    def test_negative_timeout_falls_back_to_default_180(self):
+        """Same guard must catch a negative value, not just exactly 0."""
+        with patch.dict("os.environ", {"TERMINAL_TIMEOUT": "-5"}, clear=False):
+            config = _tt_mod._get_env_config()
+            assert config["timeout"] == 180
+
+    def test_positive_timeout_is_used_unchanged(self):
+        """Sanity: a genuinely positive, intentional timeout override must
+        pass through untouched -- the guard is a floor at 0, not a
+        rewrite of every configured value."""
+        with patch.dict("os.environ", {"TERMINAL_TIMEOUT": "86400"}, clear=False):
+            config = _tt_mod._get_env_config()
+            assert config["timeout"] == 86400
+
+    def test_unset_timeout_uses_default_180(self):
+        """Sanity: the ordinary unset case still resolves to the
+        documented 180s default, unaffected by the new guard."""
+        with patch.dict("os.environ", {}, clear=False):
+            os_environ_backup = _tt_mod.os.environ.pop("TERMINAL_TIMEOUT", None)
+            try:
+                config = _tt_mod._get_env_config()
+                assert config["timeout"] == 180
+            finally:
+                if os_environ_backup is not None:
+                    _tt_mod.os.environ["TERMINAL_TIMEOUT"] = os_environ_backup
+
+
     # -- invalid int raises ValueError with env var name --
 
 

--- a/tests/tools/test_parse_env_var.py
+++ b/tests/tools/test_parse_env_var.py
@@ -67,14 +67,9 @@ class TestParseEnvVar:
     def test_unset_timeout_uses_default_180(self):
         """Sanity: the ordinary unset case still resolves to the
         documented 180s default, unaffected by the new guard."""
-        with patch.dict("os.environ", {}, clear=False):
-            os_environ_backup = _tt_mod.os.environ.pop("TERMINAL_TIMEOUT", None)
-            try:
-                config = _tt_mod._get_env_config()
-                assert config["timeout"] == 180
-            finally:
-                if os_environ_backup is not None:
-                    _tt_mod.os.environ["TERMINAL_TIMEOUT"] = os_environ_backup
+        with patch.dict("os.environ", {}, clear=True):
+            config = _tt_mod._get_env_config()
+            assert config["timeout"] == 180
 
 
     # -- invalid int raises ValueError with env var name --

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1903,11 +1903,16 @@ class ProcessRegistry:
         """
         from tools.ansi_strip import strip_ansi
         from tools.interrupt import is_interrupted as _is_interrupted
+        from utils import resolve_terminal_timeout_default
 
-        try:
-            default_timeout = int(os.getenv("TERMINAL_TIMEOUT", "180"))
-        except (ValueError, TypeError):
-            default_timeout = 180
+        # TERMINAL_TIMEOUT<=0 is a "0 means no timeout" misunderstanding,
+        # not a request for an instant timeout -- see the shared helper's
+        # own docstring and issue #85809. This reader used to parse the
+        # env var independently of terminal_tool.py's guard, so a
+        # misconfigured value still produced an immediate, misleading
+        # "timed out after 0s" on this wait() path specifically (review
+        # of #85811).
+        default_timeout = resolve_terminal_timeout_default()
         max_timeout = default_timeout
         requested_timeout = timeout
         timeout_note = None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1643,6 +1643,22 @@ def _get_env_config() -> Dict[str, Any]:
                         cwd, env_type, default_cwd)
             cwd = default_cwd
 
+    # TERMINAL_TIMEOUT=0 parses as a valid int, but 0 means "time out
+    # instantly" for the underlying subprocess/asyncio timeout -- not
+    # "no timeout" as a user might reasonably (but incorrectly) assume.
+    # Left unguarded, this silently breaks every terminal command with a
+    # misleading "timed out after 0s" error that looks like an IPC/hang
+    # bug rather than a config mistake (issue #85809).
+    _configured_timeout = _parse_env_var("TERMINAL_TIMEOUT", "180")
+    if _configured_timeout <= 0:
+        logger.warning(
+            "TERMINAL_TIMEOUT=%s is invalid (must be > 0); falling back to "
+            "180s. 0 does NOT mean \"no timeout\" -- it means instant "
+            "timeout. Check ~/.hermes/.env.",
+            _configured_timeout,
+        )
+        _configured_timeout = 180
+
     return {
         "env_type": env_type,
         "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
@@ -1655,7 +1671,7 @@ def _get_env_config() -> Dict[str, Any]:
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
-        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
+        "timeout": _configured_timeout,
         "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
         # SSH-specific config
         "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -49,7 +49,7 @@ import subprocess
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
-from utils import env_var_enabled
+from utils import TERMINAL_TIMEOUT_DEFAULT_SECONDS, env_var_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -1649,15 +1649,18 @@ def _get_env_config() -> Dict[str, Any]:
     # Left unguarded, this silently breaks every terminal command with a
     # misleading "timed out after 0s" error that looks like an IPC/hang
     # bug rather than a config mistake (issue #85809).
-    _configured_timeout = _parse_env_var("TERMINAL_TIMEOUT", "180")
+    _configured_timeout = _parse_env_var(
+        "TERMINAL_TIMEOUT", str(TERMINAL_TIMEOUT_DEFAULT_SECONDS)
+    )
     if _configured_timeout <= 0:
         logger.warning(
             "TERMINAL_TIMEOUT=%s is invalid (must be > 0); falling back to "
-            "180s. 0 does NOT mean \"no timeout\" -- it means instant "
+            "%ss. 0 does NOT mean \"no timeout\" -- it means instant "
             "timeout. Check ~/.hermes/.env.",
             _configured_timeout,
+            TERMINAL_TIMEOUT_DEFAULT_SECONDS,
         )
-        _configured_timeout = 180
+        _configured_timeout = TERMINAL_TIMEOUT_DEFAULT_SECONDS
 
     return {
         "env_type": env_type,

--- a/utils.py
+++ b/utils.py
@@ -36,6 +36,34 @@ def env_var_enabled(name: str, default: str = "") -> bool:
     return is_truthy_value(os.getenv(name, default), default=False)
 
 
+# The one canonical fallback for TERMINAL_TIMEOUT. Referenced by both
+# tools/terminal_tool.py::_get_env_config and tools/process_registry.py's
+# wait() path (issue #85809 / review of #85811) so the two independent
+# readers of this env var can't drift out of sync on the hardcoded value.
+TERMINAL_TIMEOUT_DEFAULT_SECONDS = 180
+
+
+def resolve_terminal_timeout_default() -> int:
+    """Parse TERMINAL_TIMEOUT with a floor at >0, falling back to the one
+    canonical default (TERMINAL_TIMEOUT_DEFAULT_SECONDS) for any
+    unparseable OR non-positive value.
+
+    TERMINAL_TIMEOUT=0 (or a negative value) is a "0 means no timeout"
+    misunderstanding, not a real request for an instant timeout -- 0
+    actually means the underlying subprocess/asyncio timeout fires
+    immediately. Left unguarded at any READER of this env var, every
+    terminal command silently fails with a misleading "timed out after
+    0s" that looks like a hang/IPC bug rather than a config mistake
+    (issue #85809). Shared by every reader of TERMINAL_TIMEOUT so the
+    guard covers the whole class, not one call site at a time.
+    """
+    try:
+        value = int(os.getenv("TERMINAL_TIMEOUT", str(TERMINAL_TIMEOUT_DEFAULT_SECONDS)))
+    except (ValueError, TypeError):
+        return TERMINAL_TIMEOUT_DEFAULT_SECONDS
+    return value if value > 0 else TERMINAL_TIMEOUT_DEFAULT_SECONDS
+
+
 def _preserve_file_mode(path: Path) -> "int | None":
     """Capture the permission bits of *path* if it exists, else ``None``."""
     try:


### PR DESCRIPTION
Fixes #85809.

## Problem

`TERMINAL_TIMEOUT=0` parsed as a valid int (no error from `_parse_env_var`), but 0 means "time out instantly" for the underlying subprocess/asyncio timeout -- not "no timeout" as a user might reasonably assume. Every terminal command then failed with the misleading "Command timed out after 0s" error. Reported as 205 failures in 3 months on one deployment, concentrated in cron jobs.

## Fix

Pre-computed the timeout value with a minimum-value guard: when the configured value is `<= 0`, log a warning naming the exact misunderstanding and fall back to the documented 180s default.

This is distinct from #15686 (already open): that PR guards against unparseable strings (e.g. `TERMINAL_TIMEOUT=5m`); this fixes a value that parses successfully but is semantically invalid for a timeout. Independent, non-conflicting fixes.

## Verification

Added 4 regression tests extending the existing test file. Verified as a genuine regression by reverting the fix and confirming the zero/negative tests fail with the exact reported behavior.

9/9 pass in the extended test file; 74/74 across three more related test files (no regression).