### PR TITLE
fix(matrix): read Bitwarden profile aliases at startup

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -947,11 +947,35 @@ def _startup_env_secret(name: str) -> str:
     secret scope verdict (scoped miss ⇒ empty, no borrowing the process
     env); only an UNSCOPED read under multiplex (default-profile startup
     loop) falls back to ``os.environ``, which is that profile's own value.
+
+    External secret sources add one more single-profile edge case: startup can
+    report that a Bitwarden profile alias was applied, while a later Matrix
+    credential read still sees an empty ``os.environ`` value during adapter
+    construction.  In non-multiplex gateways, use the per-HERMES_HOME external
+    secret snapshot as a safe fallback before declaring the credential absent.
+    Multiplex gateways remain fail-closed: a scoped miss must not borrow from a
+    process/global snapshot that might belong to another profile.
     """
     try:
-        return (get_secret(name) or "").strip()
+        val = (get_secret(name) or "").strip()
     except UnscopedSecretError:
         return os.getenv(name, "").strip()
+    if val:
+        return val
+
+    try:
+        from agent.secret_scope import is_multiplex_active
+
+        if not is_multiplex_active():
+            from hermes_cli.config import get_hermes_home
+            from hermes_cli.env_loader import get_secret_source_values
+
+            val = (get_secret_source_values(get_hermes_home()).get(name) or "").strip()
+            if val:
+                return val
+    except Exception:
+        pass
+    return ""
 
 
 def matrix_deps_present() -> bool:

--- a/tests/gateway/test_matrix_recovery_key_scope.py
+++ b/tests/gateway/test_matrix_recovery_key_scope.py
@@ -11,7 +11,7 @@ established Slack app-token pattern (#59739).
 import pytest
 
 from agent import secret_scope as ss
-from plugins.platforms.matrix.adapter import _scoped_recovery_key
+from plugins.platforms.matrix.adapter import _scoped_recovery_key, _startup_env_secret
 
 
 @pytest.fixture(autouse=True)
@@ -77,3 +77,59 @@ class TestScopedRecoveryKey:
     def test_unset_returns_empty(self, monkeypatch):
         monkeypatch.delenv("MATRIX_RECOVERY_KEY", raising=False)
         assert _scoped_recovery_key() == ""
+
+
+class TestMatrixStartupEnvSecret:
+    def test_single_profile_uses_external_secret_snapshot_when_env_empty(
+        self, monkeypatch, tmp_path
+    ):
+        """Bitwarden profile aliases must reach Matrix startup credential reads.
+
+        A single-profile gateway can log that the external source applied
+        ``MATRIX_ACCESS_TOKEN_ASHER as MATRIX_ACCESS_TOKEN``. If a later Matrix
+        startup check sees only an empty env value, it must still consult the
+        per-HERMES_HOME external-secret snapshot before failing credentials.
+        """
+        home = tmp_path / ".hermes" / "profiles" / "asher"
+        home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "")
+        ss.set_multiplex_active(False)
+
+        from hermes_cli import config as hermes_config
+        from hermes_cli import env_loader
+
+        monkeypatch.setattr(hermes_config, "get_hermes_home", lambda: home)
+        monkeypatch.setitem(
+            env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+            str(home.resolve()),
+            {"MATRIX_ACCESS_TOKEN": "token-from-bitwarden-alias"},
+        )
+
+        assert _startup_env_secret("MATRIX_ACCESS_TOKEN") == "token-from-bitwarden-alias"
+
+    def test_multiplex_scoped_miss_does_not_use_external_snapshot(
+        self, monkeypatch, tmp_path
+    ):
+        """Multiplex mode remains fail-closed on scoped misses."""
+        home = tmp_path / ".hermes" / "profiles" / "asher"
+        home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "default-profile-token")
+        ss.set_multiplex_active(True)
+
+        from hermes_cli import config as hermes_config
+        from hermes_cli import env_loader
+
+        monkeypatch.setattr(hermes_config, "get_hermes_home", lambda: home)
+        monkeypatch.setitem(
+            env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+            str(home.resolve()),
+            {"MATRIX_ACCESS_TOKEN": "token-from-bitwarden-alias"},
+        )
+
+        token = ss.set_secret_scope({})
+        try:
+            assert _startup_env_secret("MATRIX_ACCESS_TOKEN") == ""
+        finally:
+            ss.reset_secret_scope(token)


### PR DESCRIPTION
## Summary

- Let Matrix startup credential reads use the per-`HERMES_HOME` external secret snapshot when `get_secret()` returns empty in single-profile gateways.
- Preserve multiplex fail-closed behavior so a scoped miss cannot borrow another profile's secret.
- Add regression coverage for Bitwarden/profile-alias startup reads.

Fixes #85805.

## Test plan

```bash
pytest tests/gateway/test_matrix_recovery_key_scope.py tests/secret_sources/test_profile_secrets.py -q
```

Result: `14 passed`.
