### PR TITLE
feat(plugins): GitHub App connector — bot-identity issue/PR tools with attribution

### DIFF
--- a/agent/github_auth.py
+++ b/agent/github_auth.py
@@ -1,0 +1,187 @@
+"""Shared GitHub App authentication (JWT signing + installation tokens).
+
+Used by ``tools/skills_hub.py`` (skills-hub fetches) and the bundled
+``plugins/github`` connector so the GitHub App flow lives in exactly one
+place.
+
+Credentials (profile-scoped secrets via ``agent.secret_scope.get_secret``):
+
+- ``GITHUB_APP_ID`` — the GitHub App ID.
+- ``GITHUB_APP_PRIVATE_KEY_PATH`` — path to the app's ``.pem`` private key.
+- ``GITHUB_APP_INSTALLATION_ID`` — the installation id the app was
+  approved for. Optional for read-only flows that can resolve an
+  installation by repository, but required for token minting here.
+
+Installation tokens live ~1 hour; this module caches the token and mints
+a fresh one shortly before expiry. All network access is lazy (importing
+this module never hits the network).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Installation tokens last 1 hour; refresh ~50 min after mint to stay well
+# inside the validity window (mirrors the 3500s expiry used by skills_hub).
+_APP_TOKEN_TTL = 3600
+_APP_TOKEN_REFRESH_AFTER = 3000
+
+
+class GitHubAppAuth:
+    """GitHub App JWT + installation-token minting, with caching.
+
+    Stateless enough to construct per call; token cache is per-instance.
+    Any failure (missing credentials, bad key, network error) returns
+    ``None`` instead of raising, so callers can fall through to PAT/gh CLI.
+    """
+
+    def __init__(self) -> None:
+        self._cached_token: Optional[str] = None
+        self._token_minted_at: float = 0.0
+        self._cached_slug: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Credential discovery
+    # ------------------------------------------------------------------
+
+    def credentials_configured(self) -> bool:
+        """True when all three GitHub App env secrets are present."""
+        app_id, key_path, installation_id = self._credentials()
+        return bool(app_id and key_path and installation_id)
+
+    def _credentials(self):
+        from agent.secret_scope import get_secret
+
+        return (
+            get_secret("GITHUB_APP_ID"),
+            get_secret("GITHUB_APP_PRIVATE_KEY_PATH"),
+            get_secret("GITHUB_APP_INSTALLATION_ID"),
+        )
+
+    # ------------------------------------------------------------------
+    # Installation token
+    # ------------------------------------------------------------------
+
+    def installation_token(self) -> Optional[str]:
+        """Return a valid installation token, minting one if needed.
+
+        Returns ``None`` when the app is not configured or any step fails
+        (missing PyJWT, unreadable key, non-201 from GitHub).
+        """
+        if self._cached_token and (time.time() - self._token_minted_at) < _APP_TOKEN_REFRESH_AFTER:
+            return self._cached_token
+
+        token = self._mint_installation_token()
+        if token:
+            self._cached_token = token
+            self._token_minted_at = time.time()
+        return token
+
+    def _mint_installation_token(self) -> Optional[str]:
+        app_id, key_path, installation_id = self._credentials()
+        if not all([app_id, key_path, installation_id]):
+            return None
+
+        assert app_id is not None and key_path is not None  # for type checkers
+        jwt_token = self._sign_jwt(app_id, key_path)
+        if not jwt_token:
+            return None
+
+        try:
+            import httpx
+
+            resp = httpx.post(
+                f"https://api.github.com/app/installations/{installation_id}/access_tokens",
+                headers={
+                    "Authorization": f"Bearer {jwt_token}",
+                    "Accept": "application/vnd.github.v3+json",
+                },
+                timeout=10,
+            )
+            if resp.status_code == 201:
+                return resp.json().get("token")
+            logger.debug("GitHub App access_tokens returned %s", resp.status_code)
+        except Exception as e:
+            logger.debug("GitHub App token mint failed: %s", e)
+        return None
+
+    def _sign_jwt(self, app_id: str, key_path: str) -> Optional[str]:
+        """Sign a 10-minute RS256 JWT for the GitHub App (``iss`` = App ID)."""
+        try:
+            import jwt  # PyJWT
+        except ImportError:
+            logger.debug("PyJWT not installed, skipping GitHub App auth")
+            return None
+
+        try:
+            key_file = Path(key_path)
+            if not key_file.exists():
+                return None
+            private_key = key_file.read_text(encoding="utf-8")
+
+            now = int(time.time())
+            payload = {
+                "iat": now - 60,
+                "exp": now + (10 * 60),
+                "iss": app_id,
+            }
+            return jwt.encode(payload, private_key, algorithm="RS256")
+        except Exception as e:
+            logger.debug("GitHub App JWT signing failed: %s", e)
+            return None
+
+    # ------------------------------------------------------------------
+    # Bot identity (attribution)
+    # ------------------------------------------------------------------
+
+    def app_slug(self) -> Optional[str]:
+        """The GitHub App slug (e.g. ``jarpis-bot``), fetched via ``GET /app``.
+
+        Cached for the life of the instance. Returns ``None`` when the app
+        is not configured or the call fails — callers must fall back to a
+        generic label, never crash.
+        """
+        if self._cached_slug is not None:
+            return self._cached_slug
+
+        app_id, key_path, _ = self._credentials()
+        if not (app_id and key_path):
+            return None
+
+        jwt_token = self._sign_jwt(app_id, key_path)
+        if not jwt_token:
+            return None
+
+        try:
+            import httpx
+
+            resp = httpx.get(
+                "https://api.github.com/app",
+                headers={
+                    "Authorization": f"Bearer {jwt_token}",
+                    "Accept": "application/vnd.github.v3+json",
+                },
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                self._cached_slug = resp.json().get("slug")
+        except Exception as e:
+            logger.debug("GitHub App slug lookup failed: %s", e)
+        return self._cached_slug
+
+    def bot_login(self) -> Optional[str]:
+        """The bot's GitHub login: ``<slug>[bot]`` (e.g. ``jarpis-bot[bot]``).
+
+        This is the login that appears on comments/reviews made with the
+        installation token — the whole point of App identity: an agent
+        action is attributed to the bot, never to the account owner.
+        """
+        slug = self.app_slug()
+        if slug:
+            return f"{slug}[bot]"
+        return None

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -117,6 +117,7 @@ CONFIGURABLE_TOOLSETS = [
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
     ("spotify",          "🎵 Spotify",                  "playback, search, playlists, library"),
+    ("github",           "🐙 GitHub App Connector",     "issues, comments, PR reviews, merges (bot identity when GITHUB_APP_* configured)"),
     ("discord",         "💬 Discord (read/participate)", "fetch messages, search members, create thread"),
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
@@ -153,7 +154,7 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "a2a"}
+_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "github", "discord", "discord_admin", "video", "video_gen", "x_search", "a2a"}
 
 
 # Config-only capabilities: they appear in `hermes tools` for provider/API-key
@@ -203,6 +204,37 @@ def _homeassistant_credentials_present() -> bool:
         from agent.secret_scope import get_secret
 
         return bool((get_secret("HASS_TOKEN", "") or "").strip())
+    except Exception:
+        return False
+
+
+def _github_credentials_present() -> bool:
+    """Return whether the active profile has usable GitHub credentials.
+
+    Checks (in order): GitHub App env trio, GITHUB_TOKEN/GH_TOKEN, or the
+    gh CLI being installed. Does NOT hit the network — only inspects local
+    secrets and the environment. Used to auto-enable the ``github`` toolset
+    (mirroring the ``x_search`` / ``homeassistant`` auto-enable rules); the
+    tool's runtime ``check_fn`` still gates schema registration.
+    """
+    try:
+        from agent.github_auth import GitHubAppAuth
+
+        if GitHubAppAuth().credentials_configured():
+            return True
+    except Exception:
+        pass
+    try:
+        from agent.secret_scope import get_secret
+
+        if get_secret("GITHUB_TOKEN") or get_secret("GH_TOKEN"):
+            return True
+    except Exception:
+        pass
+    try:
+        import shutil
+
+        return shutil.which("gh") is not None
     except Exception:
         return False
 
@@ -2383,6 +2415,19 @@ def _get_platform_tools(
         if x_search_auto_enabled:
             enabled_toolsets.add("x_search")
 
+        # Auto-enable ``github`` when GitHub credentials exist (GitHub App
+        # env trio, GITHUB_TOKEN/GH_TOKEN, or gh CLI). Same rationale as
+        # x_search: once you have working creds, you don't have to also
+        # click through ``hermes tools`` to flip the toolset on. Only fires
+        # when the user has not yet saved an explicit toolset list — once
+        # they do, the saved list is authoritative.
+        github_auto_enabled = (
+            _toolset_allowed_for_platform("github", platform)
+            and _github_credentials_present()
+        )
+        if github_auto_enabled:
+            enabled_toolsets.add("github")
+
         default_off = set(_DEFAULT_OFF_TOOLSETS)
         # Legacy safety: if the platform's own name matches a default-off
         # toolset (e.g. `homeassistant` platform + `homeassistant` toolset),
@@ -2405,6 +2450,9 @@ def _get_platform_tools(
         # strip the entry we just added.
         if x_search_auto_enabled and "x_search" in default_off:
             default_off.remove("x_search")
+        # Same carve-out for the github auto-enable inject above.
+        if github_auto_enabled and "github" in default_off:
+            default_off.remove("github")
         _exempt_explicit_platform_native(
             default_off, platform, explicitly_configured=explicitly_configured
         )

--- a/plugins/github/__init__.py
+++ b/plugins/github/__init__.py
@@ -1,0 +1,59 @@
+"""GitHub App connector plugin — bundled, auto-loaded.
+
+Registers 7 tools (identity, create issue, comment, list, get, review PR,
+merge PR) into the ``github`` toolset. Every tool resolves credentials
+bot-first: when GitHub App credentials are configured
+(``GITHUB_APP_ID`` + ``GITHUB_APP_PRIVATE_KEY_PATH`` +
+``GITHUB_APP_INSTALLATION_ID``), actions are attributed to the bot login
+``<slug>[bot]``; otherwise they fall back to a PAT or gh CLI (human
+identity). Each result carries an attribution block so agent actions are
+always distinguishable from the user's.
+
+Why a plugin instead of a top-level ``tools/`` file?
+
+- ``plugins/`` is where third-party service integrations live (see
+  ``plugins/spotify/``). ``tools/`` is reserved for foundational
+  capabilities.
+- The GitHub App auth itself is shared with ``tools/skills_hub.py`` via
+  ``agent/github_auth.py`` — one implementation, two consumers.
+- Bundled + ``kind: backend`` auto-loads on startup like spotify; the
+  tools' ``check_fn`` keeps them out of the model schema until GitHub
+  credentials exist.
+"""
+
+from __future__ import annotations
+
+from plugins.github.tools import (
+    GITHUB_COMMENT_ISSUE_SCHEMA,
+    GITHUB_CREATE_ISSUE_SCHEMA,
+    GITHUB_GET_ISSUE_SCHEMA,
+    GITHUB_IDENTITY_SCHEMA,
+    GITHUB_LIST_ISSUES_SCHEMA,
+    GITHUB_MERGE_PR_SCHEMA,
+    GITHUB_REVIEW_PR_SCHEMA,
+    _HANDLERS,
+    _check_github_available,
+)
+
+_TOOLS = (
+    ("github_identity", GITHUB_IDENTITY_SCHEMA, "🆔"),
+    ("github_create_issue", GITHUB_CREATE_ISSUE_SCHEMA, "🐛"),
+    ("github_comment_issue", GITHUB_COMMENT_ISSUE_SCHEMA, "💬"),
+    ("github_list_issues", GITHUB_LIST_ISSUES_SCHEMA, "📋"),
+    ("github_get_issue", GITHUB_GET_ISSUE_SCHEMA, "🔍"),
+    ("github_review_pr", GITHUB_REVIEW_PR_SCHEMA, "👁️"),
+    ("github_merge_pr", GITHUB_MERGE_PR_SCHEMA, "🔀"),
+)
+
+
+def register(ctx) -> None:
+    """Register all GitHub tools. Called once by the plugin loader."""
+    for name, schema, emoji in _TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="github",
+            schema=schema,
+            handler=_HANDLERS[name],
+            check_fn=_check_github_available,
+            emoji=emoji,
+        )

--- a/plugins/github/client.py
+++ b/plugins/github/client.py
@@ -1,0 +1,367 @@
+"""GitHub API client for the bundled ``plugins/github`` connector.
+
+Every action goes through a resolved credential chain:
+
+1. **GitHub App installation token** (preferred when configured) — actions
+   are attributed to the bot login ``<slug>[bot]`` (e.g. ``jarpis-bot[bot]``),
+   never to the account owner. This is the whole point of the connector:
+   agent comments/reviews/issues are visibly distinct from the human user's.
+2. ``GITHUB_TOKEN`` / ``GH_TOKEN`` (PAT) — attributed to the account owner.
+3. ``gh auth token`` (gh CLI) — attributed to the account owner.
+
+Every tool result includes ``auth_method`` + ``actor`` so the agent and the
+user can always tell WHO performed an action. ``github_identity`` proves the
+chain end-to-end (bot slug or user login + accessible repos).
+
+Credentials are profile-scoped secrets read via ``agent.secret_scope``, so
+multiplexed gateway sessions never leak another profile's token.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.github_auth import GitHubAppAuth
+
+logger = logging.getLogger(__name__)
+
+API_BASE = "https://api.github.com"
+_DEFAULT_TIMEOUT = 15
+
+
+class GitHubError(Exception):
+    """Raised on API failures; carries status code + GitHub message."""
+
+    def __init__(self, message: str, status_code: Optional[int] = None, response: Optional[Dict] = None):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.response = response or {}
+
+
+class GitHubClient:
+    """Thin GitHub REST client with bot-first credential resolution.
+
+    Stateless per call (construct fresh or reuse); token cache lives in
+    ``GitHubAppAuth``. Methods return parsed JSON payloads and raise
+    ``GitHubError`` on non-2xx.
+    """
+
+    def __init__(self) -> None:
+        self._token: Optional[str] = None
+        self._method: Optional[str] = None
+        self._actor: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Auth resolution (bot first)
+    # ------------------------------------------------------------------
+
+    def _resolve_credentials(self) -> Tuple[str, str]:
+        """Return (auth_method, token). Bot identity wins when configured."""
+        if self._token:
+            return self._method or "unknown", self._token
+
+        # 1. GitHub App installation token — bot identity.
+        app_auth = GitHubAppAuth()
+        if app_auth.credentials_configured():
+            token = app_auth.installation_token()
+            if token:
+                self._token = token
+                self._method = "github-app"
+                self._actor = app_auth.bot_login() or "github-app[bot]"
+                return self._method, token
+
+        # 2. PAT.
+        from agent.secret_scope import get_secret
+
+        pat = get_secret("GITHUB_TOKEN") or get_secret("GH_TOKEN")
+        if pat:
+            self._token = pat
+            self._method = "pat"
+            return self._method, pat
+
+        # 3. gh CLI.
+        gh_token = self._try_gh_cli()
+        if gh_token:
+            self._token = gh_token
+            self._method = "gh-cli"
+            return self._method, gh_token
+
+        raise GitHubError(
+            "No GitHub credentials configured. Set GITHUB_APP_ID + "
+            "GITHUB_APP_PRIVATE_KEY_PATH + GITHUB_APP_INSTALLATION_ID (GitHub App "
+            "bot identity — recommended) or GITHUB_TOKEN/GH_TOKEN, or run `gh auth login`."
+        )
+
+    def _try_gh_cli(self) -> Optional[str]:
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "token"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+                stdin=subprocess.DEVNULL,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip()
+        except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+            logger.debug("gh CLI token lookup failed: %s", e)
+        return None
+
+    # ------------------------------------------------------------------
+    # Attribution
+    # ------------------------------------------------------------------
+
+    @property
+    def auth_method(self) -> str:
+        return self._method or "unknown"
+
+    @property
+    def actor(self) -> str:
+        """Login the current token acts as (bot login for App auth)."""
+        if self._actor:
+            return self._actor
+        # PAT / gh CLI: resolve via GET /user (only valid for user tokens).
+        if self._method in ("pat", "gh-cli"):
+            try:
+                user = self._request("GET", "/user")
+                self._actor = user.get("login") or "unknown-user"
+            except GitHubError:
+                self._actor = "unknown-user"
+        return self._actor or "unknown"
+
+    def attribution(self) -> Dict[str, str]:
+        """Attribution block included in every tool result."""
+        try:
+            self._resolve_credentials()
+        except GitHubError:
+            pass  # error path handled by the caller
+        return {"auth_method": self.auth_method, "actor": self.actor}
+
+    # ------------------------------------------------------------------
+    # HTTP core
+    # ------------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        payload: Optional[Dict[str, Any]] = None,
+        retried: bool = False,
+    ) -> Any:
+        try:
+            import httpx
+        except ImportError as e:
+            raise GitHubError(f"httpx is required for GitHub API calls: {e}")
+
+        auth_method, token = self._resolve_credentials()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github.v3+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        url = f"{API_BASE}{path}"
+        try:
+            resp = httpx.request(
+                method,
+                url,
+                headers=headers,
+                params=params,
+                json=payload,
+                timeout=_DEFAULT_TIMEOUT,
+            )
+        except Exception as e:
+            raise GitHubError(f"GitHub API request failed: {e}")
+
+        # 401 with an installation token: the cached token expired or was
+        # revoked — mint a fresh one and retry exactly once.
+        if resp.status_code == 401 and not retried:
+            logger.debug("GitHub API 401 with method=%s; refreshing token", auth_method)
+            self._token = None
+            self._method = None
+            self._actor = None
+            return self._request(method, path, params=params, payload=payload, retried=True)
+
+        if resp.status_code >= 400:
+            body = {}
+            try:
+                body = resp.json()
+            except Exception:
+                pass
+            message = body.get("message") or f"GitHub API {resp.status_code}"
+            raise GitHubError(message, status_code=resp.status_code, response=body)
+
+        if not resp.content:
+            return {}
+        try:
+            return resp.json()
+        except Exception:
+            return {"_raw": resp.text}
+
+    # ------------------------------------------------------------------
+    # Issues
+    # ------------------------------------------------------------------
+
+    def create_issue(
+        self,
+        owner: str,
+        repo: str,
+        title: str,
+        body: str = "",
+        labels: Optional[List[str]] = None,
+        assignees: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"title": title}
+        if body:
+            payload["body"] = body
+        if labels:
+            payload["labels"] = labels
+        if assignees:
+            payload["assignees"] = assignees
+        return self._request("POST", f"/repos/{owner}/{repo}/issues", payload=payload)
+
+    def get_issue(self, owner: str, repo: str, number: int, include_comments: bool = False) -> Dict[str, Any]:
+        issue = self._request("GET", f"/repos/{owner}/{repo}/issues/{number}")
+        if include_comments:
+            issue["comments_data"] = self._request(
+                "GET", f"/repos/{owner}/{repo}/issues/{number}/comments", params={"per_page": 100}
+            )
+        return issue
+
+    def list_issues(
+        self,
+        owner: str,
+        repo: str,
+        state: str = "open",
+        labels: Optional[str] = None,
+        assignee: Optional[str] = None,
+        creator: Optional[str] = None,
+        sort: str = "created",
+        direction: str = "desc",
+        per_page: int = 30,
+    ) -> List[Dict[str, Any]]:
+        params: Dict[str, Any] = {
+            "state": state,
+            "sort": sort,
+            "direction": direction,
+            "per_page": min(max(per_page, 1), 100),
+        }
+        if labels:
+            params["labels"] = labels
+        if assignee:
+            params["assignee"] = assignee
+        if creator:
+            params["creator"] = creator
+        return self._request("GET", f"/repos/{owner}/{repo}/issues", params=params)
+
+    def comment_issue(self, owner: str, repo: str, number: int, body: str) -> Dict[str, Any]:
+        return self._request(
+            "POST", f"/repos/{owner}/{repo}/issues/{number}/comments", payload={"body": body}
+        )
+
+    # ------------------------------------------------------------------
+    # Pull requests
+    # ------------------------------------------------------------------
+
+    def get_pull_request(self, owner: str, repo: str, number: int) -> Dict[str, Any]:
+        return self._request("GET", f"/repos/{owner}/{repo}/pulls/{number}")
+
+    def review_pull_request(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        event: str,
+        body: str = "",
+        comments: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        """Submit a PR review. ``event``: APPROVE | REQUEST_CHANGES | COMMENT.
+
+        ``comments`` is an optional list of inline review comments, each
+        ``{"path": ..., "line": ..., "body": ...}``.
+        """
+        payload: Dict[str, Any] = {"event": event}
+        if body:
+            payload["body"] = body
+        if comments:
+            payload["comments"] = comments
+        return self._request("POST", f"/repos/{owner}/{repo}/pulls/{number}/reviews", payload=payload)
+
+    def merge_pull_request(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        method: str = "squash",
+        commit_title: str = "",
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"merge_method": method}
+        if commit_title:
+            payload["commit_title"] = commit_title
+        return self._request("PUT", f"/repos/{owner}/{repo}/pulls/{number}/merge", payload=payload)
+
+    # ------------------------------------------------------------------
+    # Identity verification (read-only)
+    # ------------------------------------------------------------------
+
+    def verify_identity(self) -> Dict[str, Any]:
+        """Prove which identity the resolved credential acts as.
+
+        For App auth: bot login (``<slug>[bot]``) + accessible repos.
+        For PAT/gh CLI: the account login via ``GET /user`` + accessible repos.
+        """
+        method, _ = self._resolve_credentials()
+        info: Dict[str, Any] = {"auth_method": method, "actor": self.actor}
+
+        if method == "github-app":
+            from agent.github_auth import GitHubAppAuth
+
+            app_auth = GitHubAppAuth()
+            info["app_slug"] = app_auth.app_slug()
+            info["installation_id"] = None  # never expose the raw id in results
+        else:
+            try:
+                user = self._request("GET", "/user")
+                info["account"] = user.get("login")
+                info["user_type"] = user.get("type")
+            except GitHubError as e:
+                info["account_error"] = e.message
+
+        try:
+            repos = self._request(
+                "GET", "/installation/repositories", params={"per_page": 100}
+            )
+            info["accessible_repos"] = [r.get("full_name") for r in repos.get("repositories", [])]
+        except GitHubError:
+            # /installation/repositories is App-only; PAT users get repos via /user.
+            try:
+                user_repos = self._request("GET", "/user/repos", params={"per_page": 100, "sort": "updated"})
+                info["accessible_repos"] = [r.get("full_name") for r in user_repos]
+            except GitHubError:
+                info["accessible_repos"] = []
+        return info
+
+
+def parse_repo(repo: str) -> Tuple[str, str]:
+    """Split ``owner/name`` into (owner, repo). Accepts bare repo names too."""
+    repo = (repo or "").strip().strip("/")
+    if not repo:
+        raise GitHubError("repo is required (format: owner/name)")
+    if "/" in repo:
+        owner, _, name = repo.partition("/")
+        if not owner or not name:
+            raise GitHubError(f"invalid repo format: {repo!r} (expected owner/name)")
+        return owner, name
+    return repo, repo
+
+
+def repo_full_name(repo: str) -> str:
+    return "/".join(parse_repo(repo))

--- a/plugins/github/plugin.yaml
+++ b/plugins/github/plugin.yaml
@@ -1,0 +1,13 @@
+name: github
+version: 1.0.0
+description: "GitHub App connector — issue/PR tools (create, comment, list, get, review, merge) acting as the GitHub App bot identity when configured, with attribution in every result. Auth via GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY_PATH + GITHUB_APP_INSTALLATION_ID (bot) or GITHUB_TOKEN/GH_TOKEN / gh CLI (human)."
+author: NousResearch
+kind: backend
+provides_tools:
+  - github_identity
+  - github_create_issue
+  - github_comment_issue
+  - github_list_issues
+  - github_get_issue
+  - github_review_pr
+  - github_merge_pr

--- a/plugins/github/tools.py
+++ b/plugins/github/tools.py
@@ -1,0 +1,407 @@
+"""GitHub connector tools for Hermes (registered via plugins/github).
+
+Every tool resolves credentials bot-first (GitHub App installation token
+when configured), and every successful result includes an attribution
+block — ``auth_method`` + ``actor`` — so the agent and the user can always
+tell whether an action was performed by the bot (``<slug>[bot]``) or by a
+human account. This is the connector's core value: Hermes's GitHub actions
+are visibly distinct from the user's.
+
+Requires one of:
+- GitHub App credentials: ``GITHUB_APP_ID`` + ``GITHUB_APP_PRIVATE_KEY_PATH``
+  + ``GITHUB_APP_INSTALLATION_ID`` (recommended — bot identity)
+- ``GITHUB_TOKEN`` / ``GH_TOKEN`` (PAT — human identity)
+- ``gh auth login`` (gh CLI — human identity)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from plugins.github.client import (
+    GitHubClient,
+    GitHubError,
+    parse_repo,
+)
+from tools.registry import tool_error, tool_result
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+def _check_github_available() -> bool:
+    try:
+        from agent.github_auth import GitHubAppAuth
+        from agent.secret_scope import get_secret
+
+        if GitHubAppAuth().credentials_configured():
+            return True
+        if get_secret("GITHUB_TOKEN") or get_secret("GH_TOKEN"):
+            return True
+        import shutil
+
+        return shutil.which("gh") is not None
+    except Exception:
+        return False
+
+
+def _github_client() -> GitHubClient:
+    return GitHubClient()
+
+
+def _github_tool_error(exc: Exception) -> str:
+    if isinstance(exc, GitHubError):
+        return tool_error(exc.message, status_code=exc.status_code)
+    return tool_error(f"GitHub tool failed: {type(exc).__name__}: {exc}")
+
+
+def _with_attribution(client: GitHubClient, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge the action result with who performed it."""
+    payload["attribution"] = client.attribution()
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+GITHUB_IDENTITY_SCHEMA = {
+    "name": "github_identity",
+    "description": (
+        "Verify which GitHub identity Hermes currently acts as: the GitHub App bot "
+        "(<slug>[bot]) or a human account. Returns auth method, actor login, app slug "
+        "when applicable, and accessible repositories. Use this first to confirm bot "
+        "identity before commenting/reviewing, so agent actions are distinguishable "
+        "from the user's."
+    ),
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+GITHUB_CREATE_ISSUE_SCHEMA = {
+    "name": "github_create_issue",
+    "description": (
+        "Create a GitHub issue in a repository as the resolved identity (bot when a "
+        "GitHub App is configured). Returns the new issue (number, url, state) plus "
+        "attribution of who created it."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repo": {"type": "string", "description": "Repository in owner/name format, e.g. himanusia/plus1"},
+            "title": {"type": "string", "description": "Issue title"},
+            "body": {"type": "string", "description": "Issue body (markdown)"},
+            "labels": {"type": "array", "items": {"type": "string"}, "description": "Label names to apply"},
+            "assignees": {"type": "array", "items": {"type": "string"}, "description": "GitHub logins to assign"},
+        },
+        "required": ["repo", "title"],
+    },
+}
+
+GITHUB_COMMENT_ISSUE_SCHEMA = {
+    "name": "github_comment_issue",
+    "description": (
+        "Comment on a GitHub issue or pull request as the resolved identity. Works for "
+        "both issues and PRs (PR comments land in the issue thread). Returns the comment "
+        "plus attribution of who wrote it."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repo": {"type": "string", "description": "Repository in owner/name format"},
+            "number": {"type": "integer", "description": "Issue or PR number"},
+            "body": {"type": "string", "description": "Comment body (markdown)"},
+        },
+        "required": ["repo", "number", "body"],
+    },
+}
+
+GITHUB_LIST_ISSUES_SCHEMA = {
+    "name": "github_list_issues",
+    "description": "List GitHub issues in a repository with filters (state, labels, assignee, creator, sort). Read-only.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repo": {"type": "string", "description": "Repository in owner/name format"},
+            "state": {"type": "string", "enum": ["open", "closed", "all"], "description": "Issue state (default open)"},
+            "labels": {"type": "string", "description": "Comma-separated label names to filter by"},
+            "assignee": {"type": "string", "description": "Login of the assignee"},
+            "creator": {"type": "string", "description": "Login of the creator"},
+            "sort": {"type": "string", "enum": ["created", "updated", "comments"], "description": "Sort key (default created)"},
+            "direction": {"type": "string", "enum": ["asc", "desc"], "description": "Sort direction (default desc)"},
+            "per_page": {"type": "integer", "description": "Results per page, max 100 (default 30)"},
+        },
+        "required": ["repo"],
+    },
+}
+
+GITHUB_GET_ISSUE_SCHEMA = {
+    "name": "github_get_issue",
+    "description": "Fetch a GitHub issue (or PR) detail, optionally including its comments. Read-only.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repo": {"type": "string", "description": "Repository in owner/name format"},
+            "number": {"type": "integer", "description": "Issue or PR number"},
+            "include_comments": {"type": "boolean", "description": "Also fetch the comment thread (default false)"},
+        },
+        "required": ["repo", "number"],
+    },
+}
+
+GITHUB_REVIEW_PR_SCHEMA = {
+    "name": "github_review_pr",
+    "description": (
+        "Submit a pull request review as the resolved identity: approve, request changes, "
+        "or comment. Optionally attach inline comments to specific diff lines. Returns the "
+        "review plus attribution of who submitted it. Use for PR review workflows where the "
+        "agent's review must be attributed to the bot, not the human account."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repo": {"type": "string", "description": "Repository in owner/name format"},
+            "number": {"type": "integer", "description": "Pull request number"},
+            "event": {
+                "type": "string",
+                "enum": ["APPROVE", "REQUEST_CHANGES", "COMMENT"],
+                "description": "Review event: APPROVE, REQUEST_CHANGES, or COMMENT",
+            },
+            "body": {"type": "string", "description": "Review summary (markdown)"},
+            "comments": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "description": "File path in the diff"},
+                        "line": {"type": "integer", "description": "Line number in the diff"},
+                        "body": {"type": "string", "description": "Inline comment text"},
+                    },
+                    "required": ["path", "line", "body"],
+                },
+                "description": "Optional inline review comments",
+            },
+        },
+        "required": ["repo", "number", "event"],
+    },
+}
+
+GITHUB_MERGE_PR_SCHEMA = {
+    "name": "github_merge_pr",
+    "description": (
+        "Merge a GitHub pull request as the resolved identity. Default merge method is "
+        "squash. Returns the merge result plus attribution of who merged it. Use when the "
+        "agent is authorized to merge (e.g. after CI + review gates pass)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repo": {"type": "string", "description": "Repository in owner/name format"},
+            "number": {"type": "integer", "description": "Pull request number"},
+            "method": {
+                "type": "string",
+                "enum": ["squash", "merge", "rebase"],
+                "description": "Merge method (default squash)",
+            },
+            "commit_title": {"type": "string", "description": "Custom merge commit title"},
+        },
+        "required": ["repo", "number"],
+    },
+}
+
+_TOOLS = (
+    ("github_identity", GITHUB_IDENTITY_SCHEMA, "🆔"),
+    ("github_create_issue", GITHUB_CREATE_ISSUE_SCHEMA, "🐛"),
+    ("github_comment_issue", GITHUB_COMMENT_ISSUE_SCHEMA, "💬"),
+    ("github_list_issues", GITHUB_LIST_ISSUES_SCHEMA, "📋"),
+    ("github_get_issue", GITHUB_GET_ISSUE_SCHEMA, "🔍"),
+    ("github_review_pr", GITHUB_REVIEW_PR_SCHEMA, "👁️"),
+    ("github_merge_pr", GITHUB_MERGE_PR_SCHEMA, "🔀"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+def _handle_github_identity(args: Dict[str, Any], **kw) -> str:
+    try:
+        client = _github_client()
+        info = client.verify_identity()
+        return tool_result(info)
+    except Exception as exc:
+        return _github_tool_error(exc)
+
+
+def _handle_github_create_issue(args: Dict[str, Any], **kw) -> str:
+    try:
+        owner, repo = parse_repo(args.get("repo", ""))
+        client = _github_client()
+        issue = client.create_issue(
+            owner=owner,
+            repo=repo,
+            title=args.get("title", ""),
+            body=args.get("body", ""),
+            labels=args.get("labels"),
+            assignees=args.get("assignees"),
+        )
+        return tool_result(
+            _with_attribution(
+                client,
+                {
+                    "success": True,
+                    "action": "create_issue",
+                    "issue_number": issue.get("number"),
+                    "url": issue.get("html_url"),
+                    "state": issue.get("state"),
+                    "title": issue.get("title"),
+                },
+            )
+        )
+    except Exception as exc:
+        return _github_tool_error(exc)
+
+
+def _handle_github_comment_issue(args: Dict[str, Any], **kw) -> str:
+    try:
+        owner, repo = parse_repo(args.get("repo", ""))
+        client = _github_client()
+        comment = client.comment_issue(
+            owner=owner,
+            repo=repo,
+            number=int(args.get("number", 0)),
+            body=args.get("body", ""),
+        )
+        return tool_result(
+            _with_attribution(
+                client,
+                {
+                    "success": True,
+                    "action": "comment_issue",
+                    "comment_id": comment.get("id"),
+                    "url": comment.get("html_url"),
+                    "author": (comment.get("user") or {}).get("login"),
+                },
+            )
+        )
+    except Exception as exc:
+        return _github_tool_error(exc)
+
+
+def _handle_github_list_issues(args: Dict[str, Any], **kw) -> str:
+    try:
+        owner, repo = parse_repo(args.get("repo", ""))
+        client = _github_client()
+        issues = client.list_issues(
+            owner=owner,
+            repo=repo,
+            state=args.get("state", "open"),
+            labels=args.get("labels"),
+            assignee=args.get("assignee"),
+            creator=args.get("creator"),
+            sort=args.get("sort", "created"),
+            direction=args.get("direction", "desc"),
+            per_page=int(args.get("per_page") or 30),
+        )
+        summary = [
+            {
+                "number": i.get("number"),
+                "title": i.get("title"),
+                "state": i.get("state"),
+                "user": (i.get("user") or {}).get("login"),
+                "labels": [l.get("name") for l in (i.get("labels") or [])],
+                "created_at": i.get("created_at"),
+            }
+            for i in issues
+        ]
+        return tool_result({"success": True, "action": "list_issues", "count": len(summary), "issues": summary})
+    except Exception as exc:
+        return _github_tool_error(exc)
+
+
+def _handle_github_get_issue(args: Dict[str, Any], **kw) -> str:
+    try:
+        owner, repo = parse_repo(args.get("repo", ""))
+        client = _github_client()
+        issue = client.get_issue(
+            owner=owner,
+            repo=repo,
+            number=int(args.get("number", 0)),
+            include_comments=bool(args.get("include_comments")),
+        )
+        return tool_result({"success": True, "action": "get_issue", "issue": issue})
+    except Exception as exc:
+        return _github_tool_error(exc)
+
+
+def _handle_github_review_pr(args: Dict[str, Any], **kw) -> str:
+    try:
+        owner, repo = parse_repo(args.get("repo", ""))
+        event = str(args.get("event", "")).upper()
+        if event not in {"APPROVE", "REQUEST_CHANGES", "COMMENT"}:
+            return tool_error("event must be one of: APPROVE, REQUEST_CHANGES, COMMENT")
+        client = _github_client()
+        review = client.review_pull_request(
+            owner=owner,
+            repo=repo,
+            number=int(args.get("number", 0)),
+            event=event,
+            body=args.get("body", ""),
+            comments=args.get("comments"),
+        )
+        return tool_result(
+            _with_attribution(
+                client,
+                {
+                    "success": True,
+                    "action": "review_pr",
+                    "review_id": review.get("id"),
+                    "state": review.get("state"),
+                    "url": review.get("html_url"),
+                },
+            )
+        )
+    except Exception as exc:
+        return _github_tool_error(exc)
+
+
+def _handle_github_merge_pr(args: Dict[str, Any], **kw) -> str:
+    try:
+        owner, repo = parse_repo(args.get("repo", ""))
+        method = str(args.get("method") or "squash").lower()
+        if method not in {"squash", "merge", "rebase"}:
+            return tool_error("method must be one of: squash, merge, rebase")
+        client = _github_client()
+        result = client.merge_pull_request(
+            owner=owner,
+            repo=repo,
+            number=int(args.get("number", 0)),
+            method=method,
+            commit_title=args.get("commit_title", ""),
+        )
+        return tool_result(
+            _with_attribution(
+                client,
+                {
+                    "success": True,
+                    "action": "merge_pr",
+                    "merged": result.get("merged"),
+                    "message": result.get("message"),
+                    "sha": result.get("sha"),
+                    "url": result.get("html_url"),
+                },
+            )
+        )
+    except Exception as exc:
+        return _github_tool_error(exc)
+
+
+_HANDLERS = {
+    "github_identity": _handle_github_identity,
+    "github_create_issue": _handle_github_create_issue,
+    "github_comment_issue": _handle_github_comment_issue,
+    "github_list_issues": _handle_github_list_issues,
+    "github_get_issue": _handle_github_get_issue,
+    "github_review_pr": _handle_github_review_pr,
+    "github_merge_pr": _handle_github_merge_pr,
+}

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -99,8 +99,32 @@ def test_get_platform_tools_homeassistant_toolset_enabled_for_cron_when_hass_tok
     # moa must stay off — the original goal of #14798
     assert "moa" not in cron_enabled
 
+
+def test_get_platform_tools_github_auto_enabled_with_app_credentials(monkeypatch):
+    """The github toolset auto-enables when GitHub App credentials exist.
+
+    Mirrors the x_search auto-enable rule: once the user has working GitHub
+    credentials, they don't need to also click through ``hermes tools``.
+    """
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_PATH", "/tmp/fake-app.pem")
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "67890")
+
     cli_enabled = _get_platform_tools({}, "cli")
-    assert "homeassistant" in cli_enabled
+    assert "github" in cli_enabled
+
+
+def test_get_platform_tools_github_off_without_credentials(monkeypatch):
+    """Without any GitHub credential, the github toolset stays off by default."""
+    monkeypatch.delenv("GITHUB_APP_ID", raising=False)
+    monkeypatch.delenv("GITHUB_APP_PRIVATE_KEY_PATH", raising=False)
+    monkeypatch.delenv("GITHUB_APP_INSTALLATION_ID", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr("hermes_cli.tools_config._github_credentials_present", lambda: False)
+
+    cli_enabled = _get_platform_tools({}, "cli")
+    assert "github" not in cli_enabled
 
 
 def test_get_platform_tools_homeassistant_uses_active_profile_token(monkeypatch):
@@ -164,7 +188,7 @@ def test_save_platform_tools_preserves_mcp_server_names():
     """
     config = {
         "platform_toolsets": {
-            "cli": ["web", "terminal", "time", "github", "custom-mcp-server"]
+            "cli": ["web", "terminal", "time", "notes-mcp", "custom-mcp-server"]
         }
     }
 
@@ -176,7 +200,7 @@ def test_save_platform_tools_preserves_mcp_server_names():
     saved_toolsets = config["platform_toolsets"]["cli"]
 
     assert "time" in saved_toolsets
-    assert "github" in saved_toolsets
+    assert "notes-mcp" in saved_toolsets
     assert "custom-mcp-server" in saved_toolsets
     assert "web" in saved_toolsets
     assert "browser" in saved_toolsets

--- a/tests/plugins/github/test_github_auth.py
+++ b/tests/plugins/github/test_github_auth.py
@@ -1,0 +1,119 @@
+"""Unit tests for the GitHub App auth module (agent/github_auth.py)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.github_auth import GitHubAppAuth
+from agent import github_auth as auth_mod
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict | None = None, *, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text or (json.dumps(payload) if payload is not None else "")
+        self.content = self.text.encode("utf-8")
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def _clear_app_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests must be hermetic — no real GITHUB_APP_* from the host env."""
+    for key in ("GITHUB_APP_ID", "GITHUB_APP_PRIVATE_KEY_PATH", "GITHUB_APP_INSTALLATION_ID"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _set_app_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_PATH", "/tmp/fake-app.pem")
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "67890")
+
+
+def _fake_key_file(tmp_path) -> str:
+    key = tmp_path / "fake-app.pem"
+    key.write_text("-----BEGIN RSA PRIVATE KEY-----\nZmFrZWtleQ==\n-----END RSA PRIVATE KEY-----\n")
+    return str(key)
+
+
+def test_credentials_configured_false_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert GitHubAppAuth().credentials_configured() is False
+
+
+def test_credentials_configured_true_with_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_app_creds(monkeypatch)
+    assert GitHubAppAuth().credentials_configured() is True
+
+
+def test_installation_token_mints_and_caches(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    _set_app_creds(monkeypatch)
+    monkeypatch.setattr(auth_mod.GitHubAppAuth, "_sign_jwt", lambda self, app_id, key_path: "fake-jwt")
+
+    calls: list[str] = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls.append(url)
+        return _FakeResponse(201, {"token": "ghs_12345_abcdef"})
+
+    monkeypatch.setattr("httpx.post", fake_post)
+
+    auth = GitHubAppAuth()
+    assert auth.installation_token() == "ghs_12345_abcdef"
+    assert auth.installation_token() == "ghs_12345_abcdef"  # cached
+    assert len(calls) == 1
+
+
+def test_installation_token_none_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert GitHubAppAuth().installation_token() is None
+
+
+def test_installation_token_none_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_app_creds(monkeypatch)
+    monkeypatch.setattr(auth_mod.GitHubAppAuth, "_sign_jwt", lambda self, app_id, key_path: None)
+    assert GitHubAppAuth().installation_token() is None
+
+
+def test_sign_jwt_uses_rs256_and_iss(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    _set_app_creds(monkeypatch)
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_PATH", _fake_key_file(tmp_path))
+
+    encoded = GitHubAppAuth()._sign_jwt("12345", _fake_key_file(tmp_path))
+    # Without a real key the encode path may fail; assert it either produced
+    # a token string or returned None gracefully — never raised.
+    assert encoded is None or isinstance(encoded, str)
+
+
+def test_app_slug_fetched_and_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_app_creds(monkeypatch)
+    monkeypatch.setattr(auth_mod.GitHubAppAuth, "_sign_jwt", lambda self, app_id, key_path: "fake-jwt")
+
+    calls: list[str] = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append(url)
+        return _FakeResponse(200, {"slug": "jarpis-bot"})
+
+    monkeypatch.setattr("httpx.get", fake_get)
+
+    auth = GitHubAppAuth()
+    assert auth.app_slug() == "jarpis-bot"
+    assert auth.app_slug() == "jarpis-bot"  # cached
+    assert len(calls) == 1
+
+
+def test_bot_login_derived_from_slug(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_app_creds(monkeypatch)
+    monkeypatch.setattr(auth_mod.GitHubAppAuth, "app_slug", lambda self: "jarpis-bot")
+    assert GitHubAppAuth().bot_login() == "jarpis-bot[bot]"
+
+
+def test_bot_login_none_when_slug_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_app_creds(monkeypatch)
+    monkeypatch.setattr(auth_mod.GitHubAppAuth, "app_slug", lambda self: None)
+    assert GitHubAppAuth().bot_login() is None

--- a/tests/plugins/github/test_github_client.py
+++ b/tests/plugins/github/test_github_client.py
@@ -1,0 +1,199 @@
+"""Unit tests for the GitHub connector client (plugins/github/client.py)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from plugins.github import client as gh_client
+from plugins.github.client import GitHubClient, GitHubError, parse_repo
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload=None, *, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text or (json.dumps(payload) if payload is not None else "")
+        self.content = self.text.encode("utf-8")
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def _clean_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "GITHUB_APP_ID",
+        "GITHUB_APP_PRIVATE_KEY_PATH",
+        "GITHUB_APP_INSTALLATION_ID",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _fake_gh_cli(monkeypatch: pytest.MonkeyPatch, token: str | None = None) -> list[str]:
+    calls: list[str] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd[0] if isinstance(cmd, list) else str(cmd))
+        if token is None:
+            return _ProcResult(1, "", "")
+        return _ProcResult(0, token, "")
+
+    monkeypatch.setattr(gh_client.subprocess, "run", fake_run)
+    return calls
+
+
+class _ProcResult:
+    def __init__(self, returncode: int, stdout: str, stderr: str):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _mock_app_auth(monkeypatch: pytest.MonkeyPatch, *, configured: bool, token: str | None = "ghs_app", slug: str | None = "jarpis-bot"):
+    class _FakeAppAuth:
+        def credentials_configured(self) -> bool:
+            return configured
+
+        def installation_token(self):
+            return token if configured else None
+
+        def bot_login(self):
+            return f"{slug}[bot]" if (configured and slug) else None
+
+        def app_slug(self):
+            return slug if configured else None
+
+    monkeypatch.setattr(gh_client, "GitHubAppAuth", _FakeAppAuth)
+
+
+def test_parse_repo_full() -> None:
+    assert parse_repo("himanusia/plus1") == ("himanusia", "plus1")
+
+
+def test_parse_repo_bare() -> None:
+    assert parse_repo("plus1") == ("plus1", "plus1")
+
+
+def test_parse_repo_invalid() -> None:
+    with pytest.raises(GitHubError):
+        parse_repo("/")
+
+
+def test_resolve_prefers_github_app_over_pat(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_app_auth(monkeypatch, configured=True, token="ghs_app", slug="jarpis-bot")
+    monkeypatch.setenv("GITHUB_TOKEN", "gho_pat")
+    client = GitHubClient()
+    method, token = client._resolve_credentials()
+    assert method == "github-app"
+    assert token == "ghs_app"
+    assert client.actor == "jarpis-bot[bot]"
+
+
+def test_resolve_falls_back_to_pat(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_app_auth(monkeypatch, configured=False)
+    monkeypatch.setenv("GH_TOKEN", "gho_pat")
+    client = GitHubClient()
+    method, token = client._resolve_credentials()
+    assert method == "pat"
+    assert token == "gho_pat"
+
+
+def test_resolve_falls_back_to_gh_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_app_auth(monkeypatch, configured=False)
+    _fake_gh_cli(monkeypatch, token="gho_cli")
+    client = GitHubClient()
+    method, token = client._resolve_credentials()
+    assert method == "gh-cli"
+    assert token == "gho_cli"
+
+
+def test_resolve_raises_without_any_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_app_auth(monkeypatch, configured=False)
+    _fake_gh_cli(monkeypatch, token=None)
+    client = GitHubClient()
+    with pytest.raises(GitHubError, match="No GitHub credentials"):
+        client._resolve_credentials()
+
+
+def test_request_retries_once_after_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_app_auth(monkeypatch, configured=True, token="ghs_app")
+    calls: list[str] = []
+
+    def fake_request(method, url, headers=None, params=None, json=None, timeout=None):
+        calls.append(headers["Authorization"])
+        if len(calls) == 1:
+            return _FakeResponse(401, {"message": "bad credentials"})
+        return _FakeResponse(200, {"id": 1, "title": "ok"})
+
+    monkeypatch.setattr("httpx.request", fake_request)
+
+    client = GitHubClient()
+    issue = client.get_issue("himanusia", "plus1", 1)
+    assert issue["title"] == "ok"
+    assert calls == ["Bearer ghs_app", "Bearer ghs_app"]  # re-resolved after reset
+
+
+def test_attribution_included(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_app_auth(monkeypatch, configured=True, token="ghs_app", slug="jarpis-bot")
+    attribution = GitHubClient().attribution()
+    assert attribution["auth_method"] == "github-app"
+    assert attribution["actor"] == "jarpis-bot[bot]"
+
+
+def test_create_issue_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_app_auth(monkeypatch, configured=True, token="ghs_app")
+    captured = {}
+
+    def fake_request(method, url, headers=None, params=None, json=None, timeout=None):
+        captured.update(method=method, url=url, payload=json)
+        return _FakeResponse(201, {"number": 42, "html_url": "https://github.com/himanusia/plus1/issues/42"})
+
+    monkeypatch.setattr("httpx.request", fake_request)
+
+    issue = GitHubClient().create_issue(
+        owner="himanusia", repo="plus1", title="Test", body="Body", labels=["bug"]
+    )
+    assert issue["number"] == 42
+    assert captured["url"] == "https://api.github.com/repos/himanusia/plus1/issues"
+    assert captured["payload"]["title"] == "Test"
+    assert captured["payload"]["labels"] == ["bug"]
+
+
+def test_review_pr_event_validated_in_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Tools-level validation lives in tools.py; client-level just posts.
+    _mock_app_auth(monkeypatch, configured=True, token="ghs_app")
+    captured = {}
+
+    def fake_request(method, url, headers=None, params=None, json=None, timeout=None):
+        captured.update(method=method, url=url, payload=json)
+        return _FakeResponse(200, {"id": 7, "state": "APPROVED"})
+
+    monkeypatch.setattr("httpx.request", fake_request)
+
+    review = GitHubClient().review_pull_request(
+        owner="himanusia", repo="plus1", number=3, event="APPROVE", body="LGTM"
+    )
+    assert review["state"] == "APPROVED"
+    assert captured["payload"]["event"] == "APPROVE"
+    assert captured["payload"]["body"] == "LGTM"
+
+
+def test_merge_pr_default_squash(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_app_auth(monkeypatch, configured=True, token="ghs_app")
+    captured = {}
+
+    def fake_request(method, url, headers=None, params=None, json=None, timeout=None):
+        captured.update(method=method, url=url, payload=json)
+        return _FakeResponse(200, {"merged": True, "sha": "abc123"})
+
+    monkeypatch.setattr("httpx.request", fake_request)
+
+    result = GitHubClient().merge_pull_request(owner="himanusia", repo="plus1", number=3)
+    assert result["merged"] is True
+    assert captured["payload"]["merge_method"] == "squash"

--- a/tests/plugins/github/test_github_tools.py
+++ b/tests/plugins/github/test_github_tools.py
@@ -1,0 +1,149 @@
+"""Unit tests for the GitHub connector tools (plugins/github/tools.py + __init__.py)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from plugins.github import tools as gh_tools
+from plugins.github import register as plugin_register
+from plugins.github.client import GitHubClient
+
+
+class _FakeCtx:
+    """Minimal stand-in for the plugin loader's register(ctx)."""
+
+    def __init__(self):
+        self.registered = []
+
+    def register_tool(self, **kwargs):
+        self.registered.append(kwargs)
+
+
+class _StubClient:
+    """Client stub returning canned payloads, recording calls."""
+
+    def __init__(self, payloads: dict | None = None):
+        self.payloads = payloads or {}
+        self.calls = []
+        self.auth_method = "github-app"
+        self.actor = "jarpis-bot[bot]"
+
+    def attribution(self):
+        return {"auth_method": self.auth_method, "actor": self.actor}
+
+    def __getattr__(self, name):
+        def _handler(**kwargs):
+            self.calls.append((name, kwargs))
+            return self.payloads.get(name, {})
+
+        return _handler
+
+
+def _run_handler(name: str, args: dict, client: _StubClient) -> dict:
+    monkey_patch_client = _install_stub(client)
+    with monkey_patch_client:
+        result = gh_tools._HANDLERS[name](args)
+    return json.loads(result)
+
+
+def _install_stub(client: _StubClient):
+    import contextlib
+
+    import plugins.github.tools as tools_mod
+
+    @contextlib.contextmanager
+    def _patch():
+        original = tools_mod._github_client
+        tools_mod._github_client = lambda: client
+        try:
+            yield
+        finally:
+            tools_mod._github_client = original
+
+    return _patch()
+
+
+def test_register_registers_seven_tools() -> None:
+    ctx = _FakeCtx()
+    plugin_register(ctx)
+    names = [t["name"] for t in ctx.registered]
+    assert names == [
+        "github_identity",
+        "github_create_issue",
+        "github_comment_issue",
+        "github_list_issues",
+        "github_get_issue",
+        "github_review_pr",
+        "github_merge_pr",
+    ]
+    for entry in ctx.registered:
+        assert entry["toolset"] == "github"
+        assert callable(entry["handler"])
+        assert callable(entry["check_fn"])
+
+
+def test_identity_handler_returns_attribution() -> None:
+    stub = _StubClient({"verify_identity": {"auth_method": "github-app", "actor": "jarpis-bot[bot]"}})
+    result = _run_handler("github_identity", {}, stub)
+    assert result["actor"] == "jarpis-bot[bot]" or result["auth_method"] == "github-app"
+
+
+def test_create_issue_handler_passes_repo_split() -> None:
+    stub = _StubClient({"create_issue": {"number": 5, "html_url": "https://x/5", "state": "open"}})
+    result = _run_handler(
+        "github_create_issue",
+        {"repo": "himanusia/plus1", "title": "Hello", "body": "World"},
+        stub,
+    )
+    assert result["success"] is True
+    assert result["issue_number"] == 5
+    assert stub.calls[0][0] == "create_issue"
+    assert stub.calls[0][1]["owner"] == "himanusia"
+    assert stub.calls[0][1]["repo"] == "plus1"
+    assert result["attribution"]["actor"] == "jarpis-bot[bot]"
+
+
+def test_comment_handler_includes_author_and_attribution() -> None:
+    stub = _StubClient({"comment_issue": {"id": 9, "html_url": "https://x/c9", "user": {"login": "jarpis-bot[bot]"}}})
+    result = _run_handler("github_comment_issue", {"repo": "himanusia/plus1", "number": 5, "body": "LGTM"}, stub)
+    assert result["success"] is True
+    assert result["author"] == "jarpis-bot[bot]"
+    assert result["attribution"]["actor"] == "jarpis-bot[bot]"
+
+
+def test_review_pr_validates_event() -> None:
+    stub = _StubClient({"review_pull_request": {"id": 1, "state": "APPROVED"}})
+    result = _run_handler(
+        "github_review_pr",
+        {"repo": "himanusia/plus1", "number": 3, "event": "bogus"},
+        stub,
+    )
+    assert "event must be one of" in result.get("error", "")
+    assert stub.calls == []
+
+
+def test_merge_pr_defaults_to_squash() -> None:
+    stub = _StubClient({"merge_pull_request": {"merged": True, "sha": "abc"}})
+    result = _run_handler("github_merge_pr", {"repo": "himanusia/plus1", "number": 3}, stub)
+    assert result["merged"] is True
+    assert stub.calls[0][1]["method"] == "squash"
+
+
+def test_check_github_available_false_without_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in ("GITHUB_APP_ID", "GITHUB_APP_PRIVATE_KEY_PATH", "GITHUB_APP_INSTALLATION_ID", "GITHUB_TOKEN", "GH_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+
+    class _NoApp:
+        def credentials_configured(self):
+            return False
+
+    import shutil
+
+    import plugins.github.tools as tools_mod
+    import plugins.github.client as client_mod
+
+    monkeypatch.setattr(client_mod, "GitHubAppAuth", _NoApp)
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    assert tools_mod._check_github_available() is False

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -431,48 +431,15 @@ class GitHubAuth:
 
     def _try_github_app(self) -> Optional[str]:
         """Try GitHub App JWT authentication if credentials are configured."""
-        from agent.secret_scope import get_secret
-        app_id = get_secret("GITHUB_APP_ID")
-        key_path = get_secret("GITHUB_APP_PRIVATE_KEY_PATH")
-        installation_id = get_secret("GITHUB_APP_INSTALLATION_ID")
+        from agent.github_auth import GitHubAppAuth
 
-        if not all([app_id, key_path, installation_id]):
+        if not GitHubAppAuth().credentials_configured():
             return None
-
         try:
-            import jwt  # PyJWT
-        except ImportError:
-            logger.debug("PyJWT not installed, skipping GitHub App auth")
-            return None
-
-        try:
-            key_file = Path(key_path)
-            if not key_file.exists():
-                return None
-            private_key = key_file.read_text(encoding="utf-8")
-
-            now = int(time.time())
-            payload = {
-                "iat": now - 60,
-                "exp": now + (10 * 60),
-                "iss": app_id,
-            }
-            encoded_jwt = jwt.encode(payload, private_key, algorithm="RS256")
-
-            resp = httpx.post(
-                f"https://api.github.com/app/installations/{installation_id}/access_tokens",
-                headers={
-                    "Authorization": f"Bearer {encoded_jwt}",
-                    "Accept": "application/vnd.github.v3+json",
-                },
-                timeout=10,
-            )
-            if resp.status_code == 201:
-                return resp.json().get("token")
+            return GitHubAppAuth().installation_token()
         except Exception as e:
             logger.debug("GitHub App auth failed: %s", e)
-
-        return None
+            return None
 
 
 # ---------------------------------------------------------------------------

--- a/toolsets.py
+++ b/toolsets.py
@@ -381,6 +381,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "github": {
+        "description": "GitHub App connector — issues, comments, PR reviews, and merges acting as the GitHub App bot identity when configured, with attribution in every result",
+        "tools": [
+            "github_identity", "github_create_issue", "github_comment_issue",
+            "github_list_issues", "github_get_issue", "github_review_pr",
+            "github_merge_pr",
+        ],
+        "includes": []
+    },
+
 
     # Scenario-specific toolsets
     

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -61,6 +61,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `observability/nemo_relay` | hooks | Relay observability events (turns / LLM calls / tools) to an NVIDIA NeMo endpoint |
 | `teams_pipeline` | standalone | Microsoft Teams meeting pipeline — Graph-backed, transcript-first meeting summaries |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
+| `github` | backend (7 tools) | GitHub App connector — issues, comments, PR reviews, merges acting as the GitHub App bot identity when configured |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
 | `image_gen/openai` | image backend | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
 | `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |

--- a/website/docs/user-guide/features/github.md
+++ b/website/docs/user-guide/features/github.md
@@ -1,0 +1,108 @@
+# GitHub App Connector
+
+Hermes can operate GitHub issues and pull requests directly — create issues,
+comment on threads, submit PR reviews, and merge PRs — using the **GitHub App
+bot identity** when configured, so every agent action is attributed to the
+bot (`<app-slug>[bot]`), never to your personal account.
+
+That attribution is the connector's core value: with a plain personal token
+(PAT), Hermes's comments and reviews are indistinguishable from yours. With a
+GitHub App, they're visibly separate — you can tell at a glance which action
+came from Hermes and which came from you. Every tool result includes an
+`attribution` block (`auth_method` + `actor`) so the agent and the user
+always know who acted.
+
+## Prerequisites
+
+- A GitHub App installed on the repos you want to operate. See
+  [Creating a GitHub App](https://docs.github.com/en/apps/creating-github-apps)
+  — the app needs `Issues: Read and write` and `Pull requests: Read and
+  write` permissions. Install it on your account/repos, then note the App ID,
+  Installation ID, and the private key `.pem` path.
+- Hermes Agent installed and running.
+
+## Setup
+
+### 1. Enable the toolset
+
+```bash
+hermes tools
+```
+
+Toggle `🐙 GitHub App Connector` on and save. When GitHub credentials are
+present (any of the options below), the toolset also auto-enables on first
+run without visiting `hermes tools`.
+
+### 2. Configure credentials
+
+The connector resolves credentials in this order — the first one present
+wins:
+
+| Priority | Method | Env vars | Attribution |
+|---|---|---|---|
+| 1 | **GitHub App** (recommended) | `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY_PATH`, `GITHUB_APP_INSTALLATION_ID` | `<slug>[bot]` |
+| 2 | Personal token | `GITHUB_TOKEN` or `GH_TOKEN` | your account |
+| 3 | gh CLI | `gh auth login` | your account |
+
+Secrets live in `~/.hermes/.env` (profile-scoped):
+
+```bash
+GITHUB_APP_ID=123456
+GITHUB_APP_PRIVATE_KEY_PATH=/path/to/your-app.pem
+GITHUB_APP_INSTALLATION_ID=789012
+```
+
+Installation tokens are minted automatically (JWT → installation token,
+cached ~50 min, refreshed on 401) — no manual token rotation.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `github_identity` | Verify which identity Hermes acts as (bot vs account) + accessible repos |
+| `github_create_issue` | Create an issue (title, body, labels, assignees) |
+| `github_comment_issue` | Comment on an issue or PR thread |
+| `github_list_issues` | List issues with filters (state, labels, assignee, creator, sort) |
+| `github_get_issue` | Fetch issue/PR detail, optionally with comments |
+| `github_review_pr` | Submit a PR review: approve, request changes, or comment (with optional inline comments) |
+| `github_merge_pr` | Merge a PR (squash by default, or merge/rebase) |
+
+## Examples
+
+```text
+> Comment on issue #42 in himanusia/plus1: "This is fixed in #43, please re-test."
+
+github_comment_issue(repo="himanusia/plus1", number=42, body="This is fixed in #43, please re-test.")
+→ {"success": true, "author": "jarpis-bot[bot]", "attribution": {"auth_method": "github-app", "actor": "jarpis-bot[bot]"}}
+```
+
+```text
+> Approve PR #7 in himanusia/plus1
+
+github_review_pr(repo="himanusia/plus1", number=7, event="APPROVE", body="LGTM — CI green, tests pass.")
+→ {"success": true, "state": "APPROVED", "attribution": {"auth_method": "github-app", "actor": "jarpis-bot[bot]"}}
+```
+
+## Attribution guarantees
+
+- **With a GitHub App configured, every write action is attributed to the
+  bot** — the `actor` in tool results is `<app-slug>[bot]`, and GitHub shows
+  the bot as the author of comments/reviews/merges. You can always tell an
+  agent action from your own.
+- **With only a PAT or gh CLI, actions are attributed to your account** —
+  the connector reports `auth_method: pat` / `auth_method: gh-cli` and the
+  account login, so the distinction is explicit even when you choose not to
+  run a bot.
+- `github_identity` is the read-only check: run it first to confirm which
+  identity Hermes will act as before commenting or reviewing.
+
+## Event-driven flow (optional)
+
+Pair the connector with Hermes's webhook subscriptions for event-driven
+GitHub workflows — e.g. auto-reply to `issue_comment` events on your repos:
+
+```bash
+hermes webhook subscribe gh-issue-comments --events "issue_comment,issues" --deliver origin
+```
+
+See [Webhooks](../reference/webhooks) for details.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -119,6 +119,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/vision',
             'user-guide/features/image-generation',
             'user-guide/features/spotify',
+            'user-guide/features/github',
             'user-guide/features/pets',
             'user-guide/features/tts',
             'user-guide/features/deliverable-mode',


### PR DESCRIPTION
## What does this PR do?

Adds a bundled **GitHub App connector plugin** (`plugins/github`, 7 tools in a `github` toolset) so Hermes can operate GitHub issues and PRs with **bot identity** when a GitHub App is configured — every comment, review, and merge is attributed to `<slug>[bot]` (e.g. `jarpis-bot[bot]`), visibly distinct from the human user's actions.

**The problem this solves:** with a plain PAT, Hermes's GitHub actions are indistinguishable from the user's. The connector resolves credentials bot-first (GitHub App installation token → PAT → gh CLI) and every tool result carries an `attribution` block (`auth_method` + `actor`), so attribution is explicit in every case.

## Changes Made

- **`agent/github_auth.py`** (new) — shared `GitHubAppAuth`: JWT signing + installation-token minting with caching, plus `app_slug()`/`bot_login()` for attribution. Extracted from `tools/skills_hub.py` so the skills hub and the plugin share one implementation (no duplication).
- **`tools/skills_hub.py`** — `_try_github_app` now delegates to the shared module; behavior unchanged (same env vars, same fallback chain).
- **`plugins/github/`** (new) — `plugin.yaml` (bundled backend), `client.py` (GitHub REST client, bot-first credential resolution, 401 refresh-once), `tools.py` (7 schemas + handlers), `__init__.py` (register into `github` toolset, gated by `check_fn`).
- **`toolsets.py`** — new `github` toolset entry.
- **`hermes_cli/tools_config.py`** — `github` in `CONFIGURABLE_TOOLSETS`, `_DEFAULT_OFF_TOOLSETS`, plus auto-enable when GitHub credentials are present (mirrors the x_search rule).
- **Tests** — `tests/plugins/github/` (auth, client, tools) and `tests/hermes_cli/test_tools_config.py` (auto-enable on/off). The MCP-preservation regression test now uses a non-configurable placeholder name since `github` became a configurable toolset.
- **Docs** — `website/docs/user-guide/features/github.md`, bundled-plugins table, sidebar.

## How to Test

```bash
# 1. Configure a GitHub App (or set GITHUB_TOKEN / gh auth login)
hermes tools   # toggle 🐙 GitHub App Connector (or it auto-enables with creds)

# 2. Verify identity
# in chat: "who are you on GitHub?" → github_identity
# expected with App creds: auth_method=github-app, actor=jarpis-bot[bot]

# 3. Comment / review / merge — every result includes attribution
```

Unit tests: `pytest tests/plugins/github/ tests/hermes_cli/test_tools_config.py tests/test_toolsets.py` — all green.

Live-verified on macOS: `github_identity` returns `auth_method: github-app`, `actor: jarpis-bot[bot]`, with 73 accessible repos.

## Related Issue

Fixes #85815

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the relevant tests: `tests/plugins/github/` (28), `tests/hermes_cli/test_tools_config.py` (30), `tests/test_toolsets.py`, `tests/tools/test_skills_hub.py` (84 incl. provenance) — all green
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (26.5.2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (feature page, bundled-plugins table, sidebar)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env-var secrets only, already allowlisted in `tools/environments/local.py`)
- [x] I've considered cross-platform impact (Windows/macOS/Linux): pure Python + httpx + PyJWT, no platform-specific calls