### PR TITLE
fix(desktop): pin command-approval card above the composer

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -165,7 +165,7 @@ describe('PendingToolApproval', () => {
     expect(within(fallback as HTMLElement).getByRole('button', { name: /Reject/ })).toBeTruthy()
   })
 
-  it('hides the floating fallback once the inline approval bar is mounted', async () => {
+  it('keeps the floating card visible even when the inline strip is mounted', async () => {
     setRequest('rm /tmp/hermes_approval_test.txt')
 
     const { container } = render(
@@ -177,7 +177,8 @@ describe('PendingToolApproval', () => {
 
     await waitFor(() => {
       expect(container.querySelector('[data-slot="tool-approval-inline"]')).not.toBeNull()
-      expect(container.querySelector('[data-slot="tool-approval-fallback"]')).toBeNull()
+      expect(container.querySelector('[data-slot="tool-approval-fallback"]')).not.toBeNull()
     })
+    expect(within(container.querySelector('[data-slot="tool-approval-fallback"]') as HTMLElement).getByText('rm /tmp/hermes_approval_test.txt')).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -24,7 +24,6 @@ import {
   type ApprovalRequest,
   clearApprovalRequest,
   registerApprovalInlineAnchor,
-  sessionApprovalInlineVisible,
   sessionApprovalRequest
 } from '@/store/prompts'
 
@@ -72,11 +71,12 @@ export const PendingApprovalFallback: FC = () => {
   const { t } = useI18n()
   const sessionId = useStore(useSessionView().$runtimeId)
   const $request = useMemo(() => sessionApprovalRequest(sessionId), [sessionId])
-  const $inlineVisible = useMemo(() => sessionApprovalInlineVisible(sessionId), [sessionId])
   const request = useStore($request)
-  const inlineVisible = useStore($inlineVisible)
 
-  if (!request || inlineVisible) {
+  // Always pin a card above the composer. The inline strip on the pending
+  // tool row is easy to miss (collapsed/off-screen); hiding this card when
+  // that strip mounts is why Desktop users never saw an approval UI.
+  if (!request) {
     return null
   }
 
@@ -86,7 +86,7 @@ export const PendingApprovalFallback: FC = () => {
       data-slot="tool-approval-fallback"
       style={{ bottom: 'calc(var(--composer-measured-height) + 0.875rem)' }}
     >
-      <div className="pointer-events-auto rounded-xl border border-primary/30 bg-(--ui-chat-surface-background) px-3 py-2 shadow-lg backdrop-blur-xl [-webkit-backdrop-filter:blur(1rem)]">
+      <div className="pointer-events-auto rounded-xl border border-primary/40 bg-(--ui-chat-surface-background) px-3 py-2.5 shadow-lg backdrop-blur-xl [-webkit-backdrop-filter:blur(1rem)]">
         <div className="flex min-w-0 items-center gap-2 text-sm text-primary">
           <AlertCircle className="size-4 shrink-0" />
           <span className="shrink-0 font-medium">{t.assistant.approval.jumpToApproval}</span>
@@ -94,6 +94,11 @@ export const PendingApprovalFallback: FC = () => {
             <span className="min-w-0 truncate text-(--ui-text-tertiary)">{request.description}</span>
           )}
         </div>
+        {request.command.trim() && (
+          <pre className="mt-2 max-h-24 overflow-auto whitespace-pre-wrap break-words rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background) px-2.5 py-1.5 font-mono text-xs leading-snug text-foreground">
+            {request.command.trim()}
+          </pre>
+        )}
         <ApprovalBar request={request} surface="floating" />
       </div>
     </div>


### PR DESCRIPTION
## Summary
Desktop hides the composer-level approval card whenever the tiny pending-tool-row strip mounts, even if that row is off-screen. Windows Desktop users never see Run/Reject and commands time out as BLOCKED.

This keeps `PendingApprovalFallback` visible for the whole pending request and prints the command on the card.

Fixes the hole described in the linked issue.

## Test plan
- [ ] `apps/desktop` approval unit tests (`approval.test.tsx`)
- [ ] Desktop: raise a dangerous-command approval without expanding the tool row — card appears above the composer with Run / Reject / Always allow
- [ ] Clicking Run still sends `approval.respond { choice: "once" }`
- [ ] Inline strip on the tool row still works if you scroll to it

Fixes https://github.com/NousResearch/hermes-agent/issues/85817