### PR TITLE
feat(wecom): add turn-scoped native streaming

### DIFF
--- a/contributors/emails/me@jimifish.com
+++ b/contributors/emails/me@jimifish.com
@@ -1,0 +1,1 @@
+fishjimi

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2949,6 +2949,13 @@ class BasePlatformAdapter(ABC):
     # set this to False to stay correct-by-default.
     supports_async_delivery: bool = True
 
+    # Most platform typing indicators are ephemeral status signals and can
+    # safely start as soon as background dispatch begins.  A platform whose
+    # indicator creates a persistent user-visible message can opt into the
+    # later agent boundary instead, so auth, pairing, commands, and other
+    # pre-agent short-circuits never leave behind a fake model turn.
+    typing_starts_at_agent_boundary: bool = False
+
     # Whether this adapter's ``send()`` splits long content into multiple
     # messages via ``truncate_message()``.  When True, the delivery router
     # (gateway/delivery.py) skips gateway-level truncation and lets the
@@ -5332,6 +5339,13 @@ class BasePlatformAdapter(ABC):
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Hook called when background processing begins."""
 
+    async def on_agent_turn_start(
+        self,
+        event: MessageEvent,
+        session_key: str,
+    ) -> None:
+        """Hook called after pre-agent gates and immediately before Agent work."""
+
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Hook called when background processing completes.
 
@@ -6230,7 +6244,10 @@ class BasePlatformAdapter(ABC):
             _thread_metadata = dict(_thread_metadata or {})
             _thread_metadata["wecom_session_key"] = session_key
         typing_task: Optional[asyncio.Task] = None
-        if getattr(self.config, "typing_indicator", True):
+        if (
+            getattr(self.config, "typing_indicator", True)
+            and not getattr(self, "typing_starts_at_agent_boundary", False)
+        ):
             _keep_typing_kwargs: Dict[str, Any] = {"metadata": _thread_metadata}
             try:
                 _keep_typing_sig = inspect.signature(self._keep_typing)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -102,19 +102,24 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     synthetic/resumed sends that have no reply anchor fall back to Telegram's
     ``direct_messages_topic_id`` when the Bot API supports it.
     """
+    platform_name = _platform_name(getattr(source, "platform", None))
     thread_id = getattr(source, "thread_id", None)
     metadata = {"thread_id": thread_id} if thread_id is not None else {}
+    if platform_name == "wecom":
+        anchor = reply_to_message_id or getattr(source, "message_id", None)
+        if anchor is not None:
+            metadata["wecom_reply_to_message_id"] = str(anchor)
     # Slack workspace identity is durable routing state, not ephemeral event
     # metadata. Carry it on every outbound path (including unthreaded sends)
     # so a multi-workspace Socket Mode gateway never falls back to its primary
     # WebClient after an async, stream, or recovery boundary.
-    if _platform_name(getattr(source, "platform", None)) == "slack":
+    if platform_name == "slack":
         scope_id = getattr(source, "scope_id", None)
         if scope_id:
             metadata["slack_team_id"] = str(scope_id)
     if not metadata:
         return None
-    if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
+    if platform_name == "telegram" and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)
         if tid and tid not in {"", "1"}:
@@ -6221,6 +6226,9 @@ class BasePlatformAdapter(ABC):
         # never spawned, so no "typing…" / "is thinking…" status is shown.
         # typing_task stays None; _stop_typing_refresh already no-ops on None.
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+        if _platform_name(event.source.platform) == "wecom":
+            _thread_metadata = dict(_thread_metadata or {})
+            _thread_metadata["wecom_session_key"] = session_key
         typing_task: Optional[asyncio.Task] = None
         if getattr(self.config, "typing_indicator", True):
             _keep_typing_kwargs: Dict[str, Any] = {"metadata": _thread_metadata}
@@ -6795,7 +6803,7 @@ class BasePlatformAdapter(ABC):
                         f"{error_detail}\n"
                         "Try again or use /reset to start a fresh session."
                     ),
-                    metadata=_thread_metadata,
+                    metadata=_mark_notify_metadata(_thread_metadata),
                 )
             except Exception as notify_err:
                 logger.error(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5034,11 +5034,15 @@ class TurnRunner:
                 return
             if already_streamed or not ctx._status_adapter or not str(display_text or "").strip():
                 return
+            interim_metadata = ctx._status_thread_metadata
+            if ctx.source.platform == Platform.WECOM:
+                interim_metadata = dict(interim_metadata or {})
+                interim_metadata["wecom_interim_assistant"] = True
             safe_schedule_threadsafe(
                 ctx._status_adapter.send(
                     ctx._status_chat_id,
                     display_text,
-                    metadata=ctx._status_thread_metadata,
+                    metadata=interim_metadata,
                 ),
                 ctx._loop_for_step,
                 logger=logger,
@@ -9711,6 +9715,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
         is_redirect_mode = effective_mode == "interrupt" and redirected
+
+        # WeCom's native stream is a one-turn placeholder, not the steering
+        # acknowledgment itself. If steering succeeds before the first agent
+        # text, finish that placeholder in place so the ack and every later
+        # assistant message are delivered as ordinary, chronologically stable
+        # messages. Adapter hooks are optional and failures must not block steer.
+        if is_steer_mode and event.source.platform == Platform.WECOM:
+            finish_pending_stream = getattr(
+                adapter,
+                "finish_pending_stream_for_busy_input",
+                None,
+            )
+            if callable(finish_pending_stream):
+                try:
+                    await finish_pending_stream(session_key)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to finish busy-turn placeholder for session %s: %s",
+                        session_key,
+                        exc,
+                    )
 
         # If not in queue/steer mode, interrupt the running agent immediately.
         # This aborts in-flight tool calls and causes the agent loop to exit
@@ -22276,9 +22303,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter: Optional[Any] = None,
     ) -> Optional[Dict[str, Any]]:
         """Build thread metadata for synthetic sends that only have routing state."""
-        if thread_id is None:
+        metadata: Dict[str, Any] = {}
+        if thread_id is not None:
+            metadata["thread_id"] = thread_id
+        if platform == Platform.WECOM and reply_to_message_id is not None:
+            metadata["wecom_reply_to_message_id"] = str(reply_to_message_id)
+        if not metadata:
             return None
-        metadata: Dict[str, Any] = {"thread_id": thread_id}
         if self._is_telegram_dm_topic_target(
             platform,
             chat_id,
@@ -26523,12 +26554,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 chat_type=getattr(source, "chat_type", None),
                 reply_to_message_id=event_message_id,
             )
-        ) if _progress_thread_id else None
+        ) if (_progress_thread_id or source.platform == Platform.WECOM) else None
         if _progress_metadata is None and _relay_prospective_thread_id:
             # No real thread yet, but the connector will auto-thread on the
             # reply anchor; carry it so progress joins that thread.
             _progress_metadata = {"reply_to_message_id": event_message_id}
         _progress_metadata = _non_conversational_metadata(_progress_metadata, platform=source.platform)
+        if source.platform == Platform.WECOM:
+            _progress_metadata = dict(_progress_metadata or {})
+            _progress_metadata["wecom_session_key"] = session_key
         if _native_slack_task_cards:
             # chat.startStream in channels requires the recipient team/user
             # pair; harmless extras elsewhere, so stamp them whenever known.
@@ -26665,7 +26699,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     chat_type=getattr(source, "chat_type", None),
                     reply_to_message_id=event_message_id,
                 )
-            ) if _progress_thread_id else None
+            ) if (_progress_thread_id or source.platform == Platform.WECOM) else None
             if _status_thread_metadata is None and _relay_prospective_thread_id:
                 # Relay Discord auto-thread lane (see _progress_metadata above):
                 # carry the reply anchor so status/interim bubbles route into
@@ -26673,6 +26707,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _status_thread_metadata = {
                     "reply_to_message_id": event_message_id
                 }
+        if source.platform == Platform.WECOM:
+            _status_thread_metadata = dict(_status_thread_metadata or {})
+            _status_thread_metadata["wecom_session_key"] = session_key
 
         # Bridge extracted to TurnRunner._status_callback_sync; publish the
         # status wiring computed above onto the shared TurnContext at the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18985,6 +18985,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
 
         try:
+            # Persistent, user-visible working indicators must begin only once
+            # this message has survived auth, pairing, command, and preprocessing
+            # gates. Ephemeral platform typing continues to start in the base
+            # adapter at dispatch time; adapters opt into this later boundary.
+            _agent_adapter = self._adapter_for_source(source)
+            _agent_hook_runner = getattr(
+                _agent_adapter,
+                "_run_processing_hook",
+                None,
+            )
+            if (
+                _agent_adapter is not None
+                and getattr(
+                    _agent_adapter,
+                    "typing_starts_at_agent_boundary",
+                    False,
+                )
+                and callable(_agent_hook_runner)
+            ):
+                await _agent_hook_runner(
+                    "on_agent_turn_start",
+                    event,
+                    session_key,
+                )
+
             # Emit agent:start hook
             hook_ctx = {
                 "platform": source.platform.value if source.platform else "",

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -7,6 +7,7 @@ The adapter focuses on the core gateway path:
 - authenticate via ``aibot_subscribe``
 - receive inbound ``aibot_msg_callback`` events
 - send outbound markdown messages via ``aibot_send_msg``
+- stream per-turn thinking, interim, and final text via ``aibot_respond_msg``
 - upload outbound media via ``aibot_upload_media_*`` and send native attachments
 - best-effort download of inbound image/file attachments for agent context
 
@@ -39,6 +40,7 @@ import os
 import re
 import time
 import uuid
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -64,6 +66,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     SendResult,
     cache_document_from_bytes,
     cache_image_from_bytes,
@@ -113,6 +116,8 @@ CALLBACK_COMMANDS = {APP_CMD_CALLBACK, APP_CMD_LEGACY_CALLBACK}
 NON_RESPONSE_COMMANDS = CALLBACK_COMMANDS | {APP_CMD_EVENT_CALLBACK}
 
 MAX_MESSAGE_LENGTH = 4000
+STREAM_MAX_BYTES = 20 * 1024
+STREAM_THINKING_CONTENT = "正在思考中…"
 CONNECT_TIMEOUT_SECONDS = 20.0
 REQUEST_TIMEOUT_SECONDS = 15.0
 HEARTBEAT_INTERVAL_SECONDS = 30.0
@@ -164,10 +169,30 @@ def _entry_matches(entries: List[str], target: str) -> bool:
     return False
 
 
+@dataclass
+class _NativeStreamState:
+    """One WeCom native stream bound to one triggering inbound message."""
+
+    chat_id: str
+    message_id: str
+    reply_req_id: str
+    stream_id: str
+    session_key: Optional[str] = None
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    content: str = ""
+    started: bool = False
+    finished: bool = False
+    failed: bool = False
+    start_task: Optional[asyncio.Task] = field(default=None, repr=False)
+
+
 class WeComAdapter(BasePlatformAdapter):
     """WeCom AI Bot adapter backed by a persistent WebSocket connection."""
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+    # WeCom streams can only update the reply bound to one inbound req_id;
+    # they are not arbitrary message edits and must not enter the generic
+    # edit-based GatewayStreamConsumer path.
     SUPPORTS_MESSAGE_EDITING = False
     # Threshold for detecting WeCom client-side message splits.
     # When a chunk is near the 4000-char limit, a continuation is almost certain.
@@ -208,6 +233,8 @@ class WeComAdapter(BasePlatformAdapter):
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._dedup = MessageDeduplicator(max_size=DEDUP_MAX_SIZE)
         self._reply_req_ids: Dict[str, str] = {}
+        self._native_streams: Dict[str, _NativeStreamState] = {}
+        self._native_streams_by_session: Dict[str, str] = {}
 
         # Text batching: merge rapid successive messages (Telegram-style).
         # WeCom clients split long messages around 4000 chars.
@@ -297,6 +324,8 @@ class WeComAdapter(BasePlatformAdapter):
             self._http_client = None
 
         self._dedup.clear()
+        self._native_streams.clear()
+        self._native_streams_by_session.clear()
         logger.info("[%s] Disconnected", self.name)
 
     async def _cleanup_ws(self) -> None:
@@ -575,6 +604,7 @@ class WeComAdapter(BasePlatformAdapter):
             chat_type="group" if is_group else "dm",
             user_id=sender_id or None,
             user_name=sender_id or None,
+            message_id=msg_id,
         )
 
         event = MessageEvent(
@@ -977,6 +1007,125 @@ class WeComAdapter(BasePlatformAdapter):
         if not normalized or normalized.startswith("quote:"):
             return None
         return self._reply_req_ids.get(normalized)
+
+    @staticmethod
+    def _stream_anchor(
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        """Resolve the inbound message that owns a native reply stream."""
+        candidates = []
+        if isinstance(metadata, dict):
+            candidates.append(metadata.get("wecom_reply_to_message_id"))
+        candidates.append(reply_to)
+        for candidate in candidates:
+            normalized = str(candidate or "").strip()
+            if normalized and not normalized.startswith("quote:"):
+                return normalized
+        return None
+
+    def _native_stream_state(
+        self,
+        chat_id: str,
+        message_id: Optional[str],
+        *,
+        create: bool,
+        session_key: Optional[str] = None,
+    ) -> Optional[_NativeStreamState]:
+        normalized_message_id = str(message_id or "").strip()
+        normalized_session_key = str(session_key or "").strip() or None
+        if not normalized_message_id:
+            return None
+
+        existing = self._native_streams.get(normalized_message_id)
+        if existing is not None:
+            if normalized_session_key and not existing.session_key:
+                existing.session_key = normalized_session_key
+                self._native_streams_by_session[normalized_session_key] = normalized_message_id
+            return existing
+        if not create:
+            return None
+
+        reply_req_id = self._reply_req_id_for_message(normalized_message_id)
+        if not reply_req_id:
+            return None
+
+        state = _NativeStreamState(
+            chat_id=str(chat_id),
+            message_id=normalized_message_id,
+            reply_req_id=reply_req_id,
+            stream_id=uuid.uuid4().hex,
+            session_key=normalized_session_key,
+        )
+        self._native_streams[normalized_message_id] = state
+        if normalized_session_key:
+            self._native_streams_by_session[normalized_session_key] = normalized_message_id
+        while len(self._native_streams) > DEDUP_MAX_SIZE:
+            evicted_message_id = next(iter(self._native_streams))
+            evicted = self._native_streams.pop(evicted_message_id)
+            if (
+                evicted.session_key
+                and self._native_streams_by_session.get(evicted.session_key) == evicted_message_id
+            ):
+                self._native_streams_by_session.pop(evicted.session_key, None)
+        return state
+
+    @staticmethod
+    def _stream_session_key(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        if not isinstance(metadata, dict):
+            return None
+        return str(metadata.get("wecom_session_key") or "").strip() or None
+
+    def _release_native_stream_session(self, state: _NativeStreamState) -> None:
+        session_key = state.session_key
+        if (
+            session_key
+            and self._native_streams_by_session.get(session_key) == state.message_id
+        ):
+            self._native_streams_by_session.pop(session_key, None)
+
+    @staticmethod
+    def _stream_content(content: str) -> str:
+        """Fit stream content to WeCom's 20 KiB UTF-8 payload limit."""
+        normalized = str(content or "")
+        encoded = normalized.encode("utf-8")
+        if len(encoded) <= STREAM_MAX_BYTES:
+            return normalized
+        return encoded[:STREAM_MAX_BYTES].decode("utf-8", errors="ignore")
+
+    async def _send_native_stream_frame(
+        self,
+        state: _NativeStreamState,
+        content: str,
+        *,
+        finish: bool,
+    ) -> Dict[str, Any]:
+        """Send one serialized full-content update for a native WeCom stream."""
+        async with state.lock:
+            if state.finished:
+                return {"hermes_stream_finished": True}
+            if state.failed:
+                raise RuntimeError("WeCom native stream is disabled for this turn")
+
+            stream_content = self._stream_content(content)
+            if state.started and not finish and state.content == stream_content:
+                return {"hermes_stream_unchanged": True}
+            response = await self._send_reply_request(
+                state.reply_req_id,
+                {
+                    "msgtype": "stream",
+                    "stream": {
+                        "id": state.stream_id,
+                        "finish": finish,
+                        "content": stream_content,
+                    },
+                },
+            )
+            self._raise_for_wecom_error(response, "send native stream")
+            state.content = stream_content
+            state.started = True
+            state.finished = finish
+            return response
 
     # ------------------------------------------------------------------
     # Outbound messaging
@@ -1426,14 +1575,61 @@ class WeComAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send markdown to a WeCom chat via proactive ``aibot_send_msg``."""
-        del metadata
+        """Send a native turn stream or a regular WeCom markdown message."""
 
         if not chat_id:
             return SendResult(success=False, error="chat_id is required")
 
+        stream_anchor = self._stream_anchor(reply_to, metadata)
+        first_agent_content = bool(
+            isinstance(metadata, dict)
+            and metadata.get("wecom_reply_to_message_id")
+            and stream_anchor
+            and (
+                metadata.get("wecom_interim_assistant")
+                or metadata.get("notify")
+            )
+        )
+        if first_agent_content:
+            state = self._native_stream_state(
+                chat_id,
+                stream_anchor,
+                create=False,
+                session_key=self._stream_session_key(metadata),
+            )
+            if state is not None and not state.failed and not state.finished:
+                try:
+                    response = await self._send_native_stream_frame(
+                        state,
+                        content,
+                        finish=True,
+                    )
+                    # Another assistant send may have won the per-stream lock
+                    # and finished the placeholder while this coroutine was
+                    # waiting. That later message must remain visible as an
+                    # ordinary message rather than being silently swallowed.
+                    if not response.get("hermes_stream_finished"):
+                        return SendResult(
+                            success=True,
+                            message_id=state.stream_id,
+                            raw_response=response,
+                        )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    state.failed = True
+                    logger.warning(
+                        "[%s] Native stream send failed for %s; falling back to markdown: %s",
+                        self.name,
+                        stream_anchor,
+                        exc,
+                    )
+
         try:
             reply_req_id = self._reply_req_id_for_message(reply_to)
+
+            if not reply_req_id and stream_anchor:
+                reply_req_id = self._reply_req_id_for_message(stream_anchor)
 
             if not reply_req_id and chat_id in self._last_chat_req_ids:
                 reply_req_id = self._last_chat_req_ids[chat_id]
@@ -1555,8 +1751,115 @@ class WeComAdapter(BasePlatformAdapter):
         )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
-        """WeCom does not expose typing indicators in this adapter."""
-        del chat_id, metadata
+        """Open one native stream placeholder for the current inbound turn."""
+        stream_anchor = self._stream_anchor(None, metadata)
+        state = self._native_stream_state(
+            chat_id,
+            stream_anchor,
+            create=True,
+            session_key=self._stream_session_key(metadata),
+        )
+        if state is None or state.started or state.finished or state.failed:
+            return
+        if state.start_task is None or state.start_task.done():
+            async def _start_stream() -> None:
+                try:
+                    await self._send_native_stream_frame(
+                        state,
+                        STREAM_THINKING_CONTENT,
+                        finish=False,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    state.failed = True
+                    logger.warning(
+                        "[%s] Failed to start native stream for %s: %s",
+                        self.name,
+                        stream_anchor,
+                        exc,
+                    )
+                finally:
+                    if state.start_task is asyncio.current_task():
+                        state.start_task = None
+
+            state.start_task = asyncio.create_task(_start_stream())
+
+        # BasePlatformAdapter bounds typing calls to 1.5s. Shield the actual
+        # request so a slow ACK cannot leave a late response racing a retry
+        # that reuses the same inbound req_id.
+        await asyncio.shield(state.start_task)
+
+    async def finish_pending_stream_for_busy_input(self, session_key: str) -> None:
+        """Finish this turn's placeholder before acknowledging a successful steer."""
+        normalized_session_key = str(session_key or "").strip()
+        message_id = self._native_streams_by_session.get(normalized_session_key)
+        state = self._native_streams.get(message_id or "")
+        if state is None or state.finished or state.failed:
+            return
+        if not state.started and state.start_task is None:
+            return
+
+        try:
+            await self._send_native_stream_frame(
+                state,
+                state.content or STREAM_THINKING_CONTENT,
+                finish=True,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            state.failed = True
+            logger.warning(
+                "[%s] Failed to finish native stream before steer for %s: %s",
+                self.name,
+                normalized_session_key,
+                exc,
+            )
+
+    async def on_processing_complete(
+        self,
+        event: MessageEvent,
+        outcome: ProcessingOutcome,
+    ) -> None:
+        """Close a native stream left open by an empty or interrupted turn."""
+        state = self._native_stream_state(
+            event.source.chat_id,
+            event.message_id,
+            create=False,
+        )
+        if state is None:
+            return
+        try:
+            if (
+                not state.started
+                or state.finished
+                or state.failed
+                or outcome == ProcessingOutcome.FAILURE
+            ):
+                return
+
+            content = state.content
+            if content == STREAM_THINKING_CONTENT:
+                content = (
+                    "已停止当前任务。"
+                    if outcome == ProcessingOutcome.CANCELLED
+                    else "处理已结束。"
+                )
+            try:
+                await self._send_native_stream_frame(state, content, finish=True)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                state.failed = True
+                logger.warning(
+                    "[%s] Failed to finalize native stream for %s: %s",
+                    self.name,
+                    event.message_id,
+                    exc,
+                )
+        finally:
+            self._release_native_stream_session(state)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return minimal chat info."""

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -189,6 +189,11 @@ class _NativeStreamState:
 class WeComAdapter(BasePlatformAdapter):
     """WeCom AI Bot adapter backed by a persistent WebSocket connection."""
 
+    # Native stream frames are persistent chat cards, not an ephemeral typing
+    # signal. Start them only at the real Agent boundary so pairing and other
+    # Hermes-owned short-circuit replies do not create a false thinking card.
+    typing_starts_at_agent_boundary = True
+
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
     # WeCom streams can only update the reply bound to one inbound req_id;
     # they are not arbitrary message edits and must not enter the generic
@@ -1789,6 +1794,36 @@ class WeComAdapter(BasePlatformAdapter):
         # request so a slow ACK cannot leave a late response racing a retry
         # that reuses the same inbound req_id.
         await asyncio.shield(state.start_task)
+
+    async def on_agent_turn_start(
+        self,
+        event: MessageEvent,
+        session_key: str,
+    ) -> None:
+        """Open the native placeholder only after dispatch reaches the Agent."""
+        if not getattr(self.config, "typing_indicator", True):
+            return
+
+        source = event.source
+        message_id = getattr(event, "message_id", None) or getattr(
+            source,
+            "message_id",
+            None,
+        )
+        metadata = {
+            "wecom_reply_to_message_id": str(message_id or ""),
+            "wecom_session_key": str(session_key or ""),
+        }
+        try:
+            # Match the base refresh loop's bounded typing call. send_typing
+            # shields the underlying request, so a slow WeCom ACK can finish
+            # in the background without delaying the model invocation.
+            await asyncio.wait_for(
+                self.send_typing(source.chat_id, metadata=metadata),
+                timeout=1.5,
+            )
+        except asyncio.TimeoutError:
+            pass
 
     async def finish_pending_stream_for_busy_input(self, session_key: str) -> None:
         """Finish this turn's placeholder before acknowledging a successful steer."""

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -226,6 +226,32 @@ class TestBusySessionAck:
         assert "Interrupting" not in content
 
     @pytest.mark.asyncio
+    async def test_wecom_steer_finishes_turn_placeholder_before_ack(self, monkeypatch):
+        """A successful WeCom steer closes only the active turn's placeholder."""
+        import gateway.run as _gr
+
+        monkeypatch.delenv("HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED", raising=False)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter(platform_val="wecom")
+        adapter.finish_pending_stream_for_busy_input = AsyncMock()
+
+        event = _make_event(text="继续查", platform_val="wecom")
+        event.source.platform = Platform.WECOM
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        adapter.finish_pending_stream_for_busy_input.assert_awaited_once_with(sk)
+        adapter._send_with_retry.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_steer_mode_transcribes_voice_before_injection(self, monkeypatch):
         """A busy voice follow-up is transcribed and steered, never queued."""
         import gateway.run as _gr

--- a/tests/gateway/test_gateway_silence_tokens.py
+++ b/tests/gateway/test_gateway_silence_tokens.py
@@ -166,6 +166,42 @@ async def test_prose_mentioning_silence_token_is_delivered(monkeypatch, tmp_path
 
 
 @pytest.mark.asyncio
+async def test_agent_turn_lifecycle_hook_runs_at_agent_boundary(monkeypatch, tmp_path):
+    runner = _runner(monkeypatch, tmp_path)
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter._run_processing_hook = AsyncMock()
+    adapter.typing_starts_at_agent_boundary = True
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._run_agent = AsyncMock(return_value={
+        "final_response": "done",
+        "messages": [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "done"},
+        ],
+        "tools": [],
+        "history_offset": 0,
+        "last_prompt_tokens": 0,
+        "api_calls": 1,
+        "failed": False,
+    })
+    event = _event()
+
+    await runner._handle_message_with_agent(
+        event,
+        _source(),
+        "agent:main:telegram:group:-1001:12345",
+        1,
+    )
+
+    adapter._run_processing_hook.assert_awaited_once_with(
+        "on_agent_turn_start",
+        event,
+        "agent:main:telegram:group:-1001:12345",
+    )
+
+
+@pytest.mark.asyncio
 async def test_agent_end_hook_includes_model_and_provider(monkeypatch, tmp_path):
     """Gateway hooks receive the actual model/provider for post-turn routing."""
     runner = _runner(monkeypatch, tmp_path)

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1003,6 +1003,7 @@ async def _run_with_agent(
     chat_id="-1001",
     chat_type="group",
     thread_id="17585",
+    event_message_id=None,
     adapter_cls=ProgressCaptureAdapter,
     user_id=None,
     scope_id=None,
@@ -1032,6 +1033,7 @@ async def _run_with_agent(
         chat_id=chat_id,
         chat_type=chat_type,
         thread_id=thread_id,
+        message_id=event_message_id,
         user_id=user_id,
         scope_id=scope_id,
     )
@@ -1053,6 +1055,7 @@ async def _run_with_agent(
         source=source,
         session_id=session_id,
         session_key=session_key,
+        event_message_id=event_message_id,
     )
     return adapter, result
 
@@ -1181,6 +1184,44 @@ async def test_display_streaming_does_not_enable_gateway_streaming(monkeypatch, 
     assert result.get("already_sent") is not True
     assert adapter.edits == []
     assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
+
+
+@pytest.mark.asyncio
+async def test_unthreaded_wecom_interim_keeps_inbound_reply_anchor(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-wecom-interim-anchor",
+        config_data={
+            "display": {
+                "tool_progress": "off",
+                "interim_assistant_messages": True,
+            },
+            "streaming": {"enabled": False},
+        },
+        platform=Platform.WECOM,
+        chat_id="wecom-chat-1",
+        chat_type="dm",
+        thread_id=None,
+        event_message_id="wecom-msg-1",
+        adapter_cls=NonEditingProgressCaptureAdapter,
+    )
+
+    assert result.get("already_sent") is not True
+    assert adapter.edits == []
+    assert adapter.sent == [
+        {
+            "chat_id": "wecom-chat-1",
+            "content": "I'll inspect the repo first.",
+            "reply_to": None,
+            "metadata": {
+                "wecom_reply_to_message_id": "wecom-msg-1",
+                "wecom_session_key": "agent:main:wecom:dm:wecom-chat-1",
+                "wecom_interim_assistant": True,
+            },
+        }
+    ]
 
 
 class TransformedStreamAgent:

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gateway.config import PlatformConfig
-from gateway.platforms.base import SendResult
+from gateway.platforms.base import MessageEvent, ProcessingOutcome, SendResult
 
 
 class TestWeComRequirements:
@@ -137,6 +137,291 @@ class TestWeComReplyMode:
         args = adapter._send_reply_request.await_args.args
         assert args[0] == "req-1"
         assert args[1] == {"msgtype": "image", "image": {"media_id": "media-1"}}
+
+
+class TestWeComNativeStream:
+    @staticmethod
+    def _adapter():
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._send_reply_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0}
+        )
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_first_agent_text_finishes_stream_and_later_text_is_separate(self):
+        adapter = self._adapter()
+        metadata = {
+            "wecom_reply_to_message_id": "msg-1",
+            "wecom_session_key": "session-1",
+        }
+
+        await adapter.send_typing("chat-1", metadata=metadata)
+        await adapter.send_typing("chat-1", metadata=metadata)
+        first_interim = await adapter.send(
+            "chat-1",
+            "先查一下资料。",
+            metadata={**metadata, "wecom_interim_assistant": True},
+        )
+        second_interim = await adapter.send(
+            "chat-1",
+            "再交叉验证。",
+            metadata={**metadata, "wecom_interim_assistant": True},
+        )
+        final = await adapter.send(
+            "chat-1",
+            "查询完成。",
+            reply_to="msg-1",
+            metadata={**metadata, "notify": True},
+        )
+
+        assert first_interim.success is True
+        assert second_interim.success is True
+        assert final.success is True
+        assert adapter._send_reply_request.await_count == 4
+
+        calls = adapter._send_reply_request.await_args_list
+        bodies = [call.args[1] for call in calls]
+        assert [body["msgtype"] for body in bodies] == [
+            "stream",
+            "stream",
+            "markdown",
+            "markdown",
+        ]
+        assert [body["stream"]["finish"] for body in bodies[:2]] == [False, True]
+        assert [body["stream"]["content"] for body in bodies[:2]] == [
+            "正在思考中…",
+            "先查一下资料。",
+        ]
+        assert len({body["stream"]["id"] for body in bodies[:2]}) == 1
+        assert bodies[2]["markdown"]["content"] == "再交叉验证。"
+        assert bodies[3]["markdown"]["content"] == "查询完成。"
+
+    @pytest.mark.asyncio
+    async def test_native_stream_frames_are_serialized_for_shared_req_id(self):
+        adapter = self._adapter()
+        metadata = {"wecom_reply_to_message_id": "msg-1"}
+        in_flight = 0
+        max_in_flight = 0
+
+        async def slow_reply(_req_id, _body):
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0)
+            in_flight -= 1
+            return {"headers": {"req_id": "req-1"}, "errcode": 0}
+
+        adapter._send_reply_request = AsyncMock(side_effect=slow_reply)
+        await adapter.send_typing("chat-1", metadata=metadata)
+
+        interim_task = asyncio.create_task(
+            adapter.send(
+                "chat-1",
+                "中间状态",
+                metadata={**metadata, "wecom_interim_assistant": True},
+            )
+        )
+        await asyncio.sleep(0)
+        final_task = asyncio.create_task(
+            adapter.send(
+                "chat-1",
+                "最终结果",
+                metadata={**metadata, "notify": True},
+            )
+        )
+        await asyncio.gather(interim_task, final_task)
+
+        assert max_in_flight == 1
+        bodies = [call.args[1] for call in adapter._send_reply_request.await_args_list]
+        assert [body["msgtype"] for body in bodies].count("stream") == 2
+        assert [body["msgtype"] for body in bodies].count("markdown") == 1
+
+    @pytest.mark.asyncio
+    async def test_typing_timeout_does_not_cancel_or_duplicate_stream_start(self):
+        adapter = self._adapter()
+        metadata = {"wecom_reply_to_message_id": "msg-1"}
+        release = asyncio.Event()
+
+        async def slow_reply(_req_id, _body):
+            await release.wait()
+            return {"headers": {"req_id": "req-1"}, "errcode": 0}
+
+        adapter._send_reply_request = AsyncMock(side_effect=slow_reply)
+        first = asyncio.create_task(adapter.send_typing("chat-1", metadata=metadata))
+        await asyncio.sleep(0)
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+        second = asyncio.create_task(adapter.send_typing("chat-1", metadata=metadata))
+        await asyncio.sleep(0)
+        release.set()
+        await second
+
+        assert adapter._send_reply_request.await_count == 1
+        assert adapter._native_streams["msg-1"].started is True
+
+    @pytest.mark.asyncio
+    async def test_native_stream_failure_falls_back_to_markdown(self):
+        adapter = self._adapter()
+        adapter._send_reply_request = AsyncMock(
+            side_effect=[
+                {"headers": {"req_id": "req-1"}, "errcode": 0},
+                RuntimeError("stream unavailable"),
+                {"headers": {"req_id": "req-1"}, "errcode": 0},
+            ]
+        )
+        metadata = {"wecom_reply_to_message_id": "msg-1"}
+        await adapter.send_typing("chat-1", metadata=metadata)
+
+        result = await adapter.send(
+            "chat-1",
+            "最终结果",
+            reply_to="msg-1",
+            metadata={**metadata, "notify": True},
+        )
+
+        assert result.success is True
+        assert adapter._send_reply_request.await_count == 3
+        failed_body = adapter._send_reply_request.await_args_list[1].args[1]
+        fallback_body = adapter._send_reply_request.await_args_list[2].args[1]
+        assert failed_body["msgtype"] == "stream"
+        assert failed_body["stream"]["finish"] is True
+        assert fallback_body == {
+            "msgtype": "markdown",
+            "markdown": {"content": "最终结果"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_non_agent_message_does_not_consume_placeholder(self):
+        adapter = self._adapter()
+        metadata = {"wecom_reply_to_message_id": "msg-1"}
+        await adapter.send_typing("chat-1", metadata=metadata)
+
+        await adapter.send("chat-1", "工具状态", metadata=metadata)
+        await adapter.send(
+            "chat-1",
+            "第一条 Agent 文本",
+            metadata={**metadata, "wecom_interim_assistant": True},
+        )
+
+        bodies = [call.args[1] for call in adapter._send_reply_request.await_args_list]
+        assert [body["msgtype"] for body in bodies] == ["stream", "markdown", "stream"]
+        assert bodies[-1]["stream"]["finish"] is True
+        assert bodies[-1]["stream"]["content"] == "第一条 Agent 文本"
+
+    @pytest.mark.asyncio
+    async def test_steer_finishes_placeholder_and_next_turn_opens_a_new_one(self):
+        adapter = self._adapter()
+        first_metadata = {
+            "wecom_reply_to_message_id": "msg-1",
+            "wecom_session_key": "session-1",
+        }
+        await adapter.send_typing("chat-1", metadata=first_metadata)
+
+        await adapter.finish_pending_stream_for_busy_input("session-1")
+        await adapter.send(
+            "chat-1",
+            "steer 后的中间话术",
+            metadata={**first_metadata, "wecom_interim_assistant": True},
+        )
+
+        first_bodies = [call.args[1] for call in adapter._send_reply_request.await_args_list]
+        assert [body["msgtype"] for body in first_bodies] == [
+            "stream",
+            "stream",
+            "markdown",
+        ]
+        assert first_bodies[1]["stream"]["finish"] is True
+
+        first_event = MessageEvent(
+            text="第一轮",
+            message_id="msg-1",
+            source=adapter.build_source(
+                chat_id="chat-1",
+                user_id="user-1",
+                message_id="msg-1",
+            ),
+        )
+        await adapter.on_processing_complete(first_event, ProcessingOutcome.SUCCESS)
+        assert "session-1" not in adapter._native_streams_by_session
+
+        adapter._reply_req_ids["msg-2"] = "req-2"
+        second_metadata = {
+            "wecom_reply_to_message_id": "msg-2",
+            "wecom_session_key": "session-1",
+        }
+        await adapter.send_typing("chat-1", metadata=second_metadata)
+
+        second_start = adapter._send_reply_request.await_args_list[-1].args[1]
+        assert second_start["msgtype"] == "stream"
+        assert second_start["stream"]["finish"] is False
+        assert second_start["stream"]["content"] == "正在思考中…"
+        assert second_start["stream"]["id"] != first_bodies[0]["stream"]["id"]
+
+    @pytest.mark.asyncio
+    async def test_final_without_typing_placeholder_is_regular_markdown(self):
+        adapter = self._adapter()
+
+        result = await adapter.send(
+            "chat-1",
+            "直接结论",
+            reply_to="msg-1",
+            metadata={"wecom_reply_to_message_id": "msg-1", "notify": True},
+        )
+
+        assert result.success is True
+        body = adapter._send_reply_request.await_args.args[1]
+        assert body == {
+            "msgtype": "markdown",
+            "markdown": {"content": "直接结论"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_processing_complete_closes_an_unfinished_placeholder(self):
+        adapter = self._adapter()
+        metadata = {"wecom_reply_to_message_id": "msg-1"}
+        await adapter.send_typing("chat-1", metadata=metadata)
+        event = MessageEvent(
+            text="停止",
+            message_id="msg-1",
+            source=adapter.build_source(
+                chat_id="chat-1",
+                user_id="user-1",
+                message_id="msg-1",
+            ),
+        )
+
+        await adapter.on_processing_complete(event, ProcessingOutcome.CANCELLED)
+
+        final_body = adapter._send_reply_request.await_args_list[-1].args[1]
+        assert final_body["stream"]["finish"] is True
+        assert final_body["stream"]["content"] == "已停止当前任务。"
+
+    def test_unthreaded_wecom_metadata_keeps_exact_reply_anchor(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import _thread_metadata_for_source
+        from gateway.run import GatewayRunner
+
+        adapter = self._adapter()
+        source = adapter.build_source(
+            chat_id="chat-1",
+            user_id="user-1",
+            message_id="msg-1",
+        )
+
+        assert source.platform == Platform.WECOM
+        assert _thread_metadata_for_source(source) == {
+            "wecom_reply_to_message_id": "msg-1"
+        }
+        runner = object.__new__(GatewayRunner)
+        assert runner._thread_metadata_for_source(source) == {
+            "wecom_reply_to_message_id": "msg-1"
+        }
 
 
 class TestExtractText:
@@ -348,6 +633,7 @@ class TestInboundMessages:
         assert event.text == "hello"
         assert event.source.chat_id == "group-1"
         assert event.source.user_id == "user-1"
+        assert event.source.message_id == "msg-1"
         assert event.media_urls == ["/tmp/test.png"]
         assert event.media_types == ["image/png"]
 

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -201,6 +201,59 @@ class TestWeComNativeStream:
         assert bodies[3]["markdown"]["content"] == "查询完成。"
 
     @pytest.mark.asyncio
+    async def test_pairing_reply_does_not_open_a_native_stream(self):
+        adapter = self._adapter()
+        adapter._last_chat_req_ids["chat-1"] = "req-1"
+        event = MessageEvent(
+            text="1",
+            message_id="msg-1",
+            source=adapter.build_source(
+                chat_id="chat-1",
+                user_id="unpaired-user",
+                message_id="msg-1",
+            ),
+        )
+
+        async def pairing_handler(_event):
+            await adapter.send("chat-1", "Here's your pairing code: `ABC12345`")
+            return None
+
+        adapter._message_handler = pairing_handler
+        adapter._active_sessions["session-1"] = asyncio.Event()
+
+        await adapter._process_message_background(event, "session-1")
+
+        bodies = [call.args[1] for call in adapter._send_reply_request.await_args_list]
+        assert bodies == [
+            {
+                "msgtype": "markdown",
+                "markdown": {"content": "Here's your pairing code: `ABC12345`"},
+            }
+        ]
+        assert adapter._native_streams == {}
+
+    @pytest.mark.asyncio
+    async def test_agent_turn_start_opens_native_stream(self):
+        adapter = self._adapter()
+        event = MessageEvent(
+            text="开始调查",
+            message_id="msg-1",
+            source=adapter.build_source(
+                chat_id="chat-1",
+                user_id="paired-user",
+                message_id="msg-1",
+            ),
+        )
+
+        await adapter.on_agent_turn_start(event, "session-1")
+
+        body = adapter._send_reply_request.await_args.args[1]
+        assert body["msgtype"] == "stream"
+        assert body["stream"]["finish"] is False
+        assert body["stream"]["content"] == "正在思考中…"
+        assert adapter._native_streams["msg-1"].session_key == "session-1"
+
+    @pytest.mark.asyncio
     async def test_native_stream_frames_are_serialized_for_shared_req_id(self):
         adapter = self._adapter()
         metadata = {"wecom_reply_to_message_id": "msg-1"}


### PR DESCRIPTION
## What does this PR do?

Adds turn-scoped native progressive replies for WeCom AI Bot. The stream begins only at the real agent boundary, completes with the first user-visible assistant message, and keeps later interim/final replies independent. Pairing and other short-circuit responses no longer create false thinking cards.

## Related Issue

Fixes #38641
Related: #70634

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Add serialized per-turn native stream lifecycle in `plugins/platforms/wecom/adapter.py`.
- Add an opt-in agent-boundary lifecycle hook in `gateway/platforms/base.py` and `gateway/run.py`.
- Add pairing, steer/cancel, routing, concurrency, and next-turn regression coverage.

## How to Test

1. Send a normal WeCom task and verify a thinking card starts only when agent work begins.
2. Verify the first assistant message completes it and later messages arrive independently.
3. Verify pairing creates no thinking card and steer/cancel does not leak state into the next turn.
4. Run the targeted gateway tests listed in the test files changed by this PR.

Targeted result on Windows 11: 76 passed. Ruff checks passed. Two unrelated pre-existing Windows file-URI assertions were excluded.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and merged PRs for duplicates
- [x] This PR contains only related changes
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted suites passed; full suite not run locally)
- [x] I've added regression tests
- [x] Tested on Windows 11 with a WeCom AI Bot channel

### Documentation & Housekeeping

- [x] Documentation — N/A; no user-facing config changes
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas — N/A

## For New Skills

N/A

## Screenshots / Logs

Manual coverage included completion, interim messages, stop, steer, pairing, and subsequent turns.