### PR TITLE
fix(codex): surface phase-less interim progress

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -25,6 +25,22 @@ from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 logger = logging.getLogger(__name__)
 
 
+# Provider-executed Responses tools are reported as output items but do not
+# require a client-side function-call round trip.  Keep this list at module
+# scope so response normalization and the streaming event bridge share the
+# same classification.
+SERVER_SIDE_TOOL_CALL_TYPES = frozenset({
+    "web_search_call",
+    "web_extractor_call",
+    "file_search_call",
+    "code_interpreter_call",
+    "image_generation_call",
+    "computer_call",
+    "local_shell_call",
+    "mcp_call",
+})
+
+
 def _classify_responses_issuer(
     *,
     is_xai_responses: bool = False,
@@ -1347,17 +1363,27 @@ def _normalize_codex_response(
     # after 3 continuation attempts".  client-side function/custom tool
     # calls keep their own in_progress handling below (they are skipped,
     # not awaited).
-    _SERVER_SIDE_TOOL_CALL_TYPES = {
-        "web_search_call",
-        "file_search_call",
-        "code_interpreter_call",
-        "image_generation_call",
-        "computer_call",
-        "local_shell_call",
-        "mcp_call",
+    explicit_interim_ids = {
+        value
+        for value in (getattr(response, "interim_message_item_ids", None) or ())
+        if isinstance(value, str) and value
     }
+    explicit_interim_indexes = {
+        value
+        for value in (getattr(response, "interim_message_item_indexes", None) or ())
+        if isinstance(value, int) and not isinstance(value, bool)
+    }
+    last_server_tool_index = max(
+        (
+            index
+            for index, candidate in enumerate(output)
+            if getattr(candidate, "type", None) in SERVER_SIDE_TOOL_CALL_TYPES
+        ),
+        default=-1,
+    )
+    saw_inferred_interim = False
 
-    for item in output:
+    for item_index, item in enumerate(output):
         item_type = getattr(item, "type", None)
         item_status = getattr(item, "status", None)
         if isinstance(item_status, str):
@@ -1367,7 +1393,7 @@ def _normalize_codex_response(
 
         if (
             item_status in {"queued", "in_progress", "incomplete"}
-            and item_type not in _SERVER_SIDE_TOOL_CALL_TYPES
+            and item_type not in SERVER_SIDE_TOOL_CALL_TYPES
         ):
             has_incomplete_items = True
             saw_streaming_or_item_incomplete = True
@@ -1385,6 +1411,21 @@ def _normalize_codex_response(
                     saw_final_answer_phase = True
             message_text = _extract_responses_message_text(item)
             if message_text:
+                item_id = getattr(item, "id", None)
+                is_inferred_interim = (
+                    normalized_phase is None
+                    and (
+                        item_index in explicit_interim_indexes
+                        or (isinstance(item_id, str) and item_id in explicit_interim_ids)
+                        # Some OpenAI-compatible Responses providers omit the
+                        # ``phase`` field entirely.  A message followed by a
+                        # provider-side tool item is necessarily mid-turn
+                        # narration; only messages after the final such tool
+                        # can be the answer.
+                        or item_index < last_server_tool_index
+                    )
+                )
+                saw_inferred_interim = saw_inferred_interim or is_inferred_interim
                 # Responses ``commentary``/``analysis`` phase text is mid-turn
                 # preamble/progress narration, never the turn's final answer
                 # (Codex CLI excludes it from last-message extraction; issues
@@ -1395,7 +1436,7 @@ def _normalize_codex_response(
                 # item is still preserved below for replay/cache continuity.
                 if is_commentary_phase:
                     reasoning_parts.append(message_text)
-                else:
+                elif not is_inferred_interim:
                     content_parts.append(message_text)
                 raw_message_item: Dict[str, Any] = {
                     "type": "message",
@@ -1403,7 +1444,6 @@ def _normalize_codex_response(
                     "status": _normalize_responses_message_status(item_status),
                     "content": [{"type": "output_text", "text": message_text}],
                 }
-                item_id = getattr(item, "id", None)
                 if isinstance(item_id, str) and item_id:
                     raw_message_item["id"] = item_id
                 if normalized_phase:
@@ -1512,6 +1552,7 @@ def _normalize_codex_response(
         not final_text
         and hasattr(response, "output_text")
         and not (saw_commentary_phase and not saw_final_answer_phase)
+        and not saw_inferred_interim
     ):
         out_text = getattr(response, "output_text", "")
         if isinstance(out_text, str):

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -22,6 +22,7 @@ import time
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
+from agent.codex_responses_adapter import SERVER_SIDE_TOOL_CALL_TYPES
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 
 logger = logging.getLogger(__name__)
@@ -995,6 +996,148 @@ def _item_field(item: Any, name: str, default: Any = None) -> Any:
     return value if value is not None else default
 
 
+_RESPONSES_PROVIDER_TOOL_NAMES = {
+    "web_search_call": "web_search",
+    "web_extractor_call": "web_extractor",
+    "file_search_call": "file_search",
+    "code_interpreter_call": "code_interpreter",
+    "image_generation_call": "image_generation",
+    "computer_call": "computer",
+    "local_shell_call": "local_shell",
+    "mcp_call": "mcp",
+}
+
+
+def _responses_provider_tool_args(item: Any) -> dict[str, Any]:
+    """Return a small, display-safe argument preview for a server tool item."""
+    action = _item_field(item, "action")
+    if isinstance(action, dict):
+        return dict(action)
+    if action is not None and hasattr(action, "model_dump"):
+        try:
+            dumped = action.model_dump(exclude_none=True)
+            if isinstance(dumped, dict):
+                return dumped
+        except Exception:
+            pass
+
+    args: dict[str, Any] = {}
+    for key in ("query", "queries", "url", "urls", "name", "server_label"):
+        value = _item_field(item, key)
+        if value not in (None, "", [], {}):
+            args[key] = value
+    return args
+
+
+def make_codex_responses_event_bridge(agent) -> Callable[[Any], None]:
+    """Project provider-side Responses tools onto Hermes progress callbacks.
+
+    Responses-compatible providers execute tools such as ``web_search`` on
+    their own servers, so those calls never pass through Hermes' ordinary
+    function-tool dispatcher.  This bridge gives them the same start/complete
+    progress lifecycle without depending on any provider-specific model name.
+    Duplicate lifecycle frames are coalesced by output-item id.
+    """
+    known_items: dict[str, Any] = {}
+    started: dict[str, tuple[str, float]] = {}
+    completed: set[str] = set()
+
+    def _item_id(event: Any, item: Any = None) -> str:
+        value = _item_field(item, "id") if item is not None else None
+        if not value:
+            value = _event_field(event, "item_id")
+        return str(value or "")
+
+    def _tool_type_from_event(event_type: str, item: Any = None) -> str:
+        item_type = str(_item_field(item, "type", "") or "")
+        if item_type in SERVER_SIDE_TOOL_CALL_TYPES:
+            return item_type
+        for candidate in SERVER_SIDE_TOOL_CALL_TYPES:
+            if event_type.startswith(f"response.{candidate}."):
+                return candidate
+        return ""
+
+    def _start(call_key: str, tool_type: str, item: Any) -> None:
+        if call_key in started or call_key in completed:
+            return
+        name = _RESPONSES_PROVIDER_TOOL_NAMES.get(tool_type, tool_type.removesuffix("_call"))
+        started[call_key] = (name, time.monotonic())
+        cb = getattr(agent, "tool_progress_callback", None)
+        if cb is None:
+            return
+        args = _responses_provider_tool_args(item)
+        preview = json.dumps(args, ensure_ascii=False)[:500] if args else None
+        try:
+            cb("tool.started", name, preview, args)
+        except Exception:
+            logger.debug(
+                "tool_progress_callback raised on Responses tool.started for %s",
+                name,
+                exc_info=True,
+            )
+
+    def _complete(call_key: str, tool_type: str, item: Any) -> None:
+        if call_key in completed:
+            return
+        if call_key not in started:
+            _start(call_key, tool_type, item)
+        name, started_at = started.pop(
+            call_key,
+            (_RESPONSES_PROVIDER_TOOL_NAMES.get(tool_type, tool_type.removesuffix("_call")), time.monotonic()),
+        )
+        completed.add(call_key)
+        cb = getattr(agent, "tool_progress_callback", None)
+        if cb is None:
+            return
+        status = str(_item_field(item, "status", "") or "").lower()
+        is_error = status in {"failed", "cancelled", "incomplete"}
+        try:
+            cb(
+                "tool.completed",
+                name,
+                None,
+                None,
+                duration=max(0.0, time.monotonic() - started_at),
+                is_error=is_error,
+                result=None,
+            )
+        except Exception:
+            logger.debug(
+                "tool_progress_callback raised on Responses tool.completed for %s",
+                name,
+                exc_info=True,
+            )
+
+    def on_event(event: Any) -> None:
+        event_type = str(_event_field(event, "type", "") or "")
+        item = _event_field(event, "item")
+        tool_type = _tool_type_from_event(event_type, item)
+        if not tool_type:
+            return
+        call_key = _item_id(event, item)
+        if not call_key:
+            # Output indexes are stable within one response and provide a
+            # deterministic fallback for providers that omit item ids.
+            call_key = f"{tool_type}:{_event_field(event, 'output_index', 'unknown')}"
+        if item is not None:
+            known_items[call_key] = item
+        else:
+            item = known_items.get(call_key)
+
+        # Register output_item.added but wait for the provider's in-progress
+        # frame before displaying it. This lets the stream consumer first emit
+        # any immediately preceding unphased narration as commentary.
+        if event_type == "response.output_item.added":
+            return
+        if event_type == "response.output_item.done" or event_type.endswith(".completed"):
+            _complete(call_key, tool_type, item)
+            return
+        if event_type.endswith((".in_progress", ".searching", ".extracting")):
+            _start(call_key, tool_type, item)
+
+    return on_event
+
+
 def _raise_stream_error(event: Any) -> None:
     """Raise a ``_StreamErrorEvent`` from a ``type=error`` SSE frame.
 
@@ -1039,6 +1182,7 @@ def _consume_codex_event_stream(
     on_text_delta=None,
     on_reasoning_delta=None,
     on_commentary_message=None,
+    on_inferred_commentary_message=None,
     on_first_delta=None,
     on_event=None,
     interrupt_check=None,
@@ -1075,6 +1219,9 @@ def _consume_codex_event_stream(
       is supplied, commentary also uses this legacy fallback.
     * ``on_commentary_message(str)`` — fires once per completed
       ``phase=commentary`` message, before any following tool item executes.
+    * ``on_inferred_commentary_message(str)`` — optional separate sink for a
+      phase-less message inferred to be commentary from a following server
+      tool. Falls back to ``on_commentary_message`` when omitted.
     * ``on_first_delta()`` — one-shot, fires on the first text delta only.
     * ``on_event(event)`` — fires for every event before any other processing.
       Used for watchdog activity, debug logging, anything wire-shape-agnostic.
@@ -1086,6 +1233,9 @@ def _consume_codex_event_stream(
     first_delta_fired = False
     active_message_phase: str | None = None
     commentary_text_deltas: List[str] = []
+    pending_unphased_messages: list[tuple[int, Any]] = []
+    interim_message_item_ids: set[str] = set()
+    interim_message_item_indexes: set[int] = set()
     # Last reasoning summary_index seen. The Responses stream delimits summary
     # parts by this index and gives each part no separator of its own, so a
     # change of index is where the blank line belongs.
@@ -1131,6 +1281,38 @@ def _consume_codex_event_stream(
         if event_type == "response.output_item.added":
             item = _event_field(event, "item")
             item_type = _item_field(item, "type", "")
+            if item_type in SERVER_SIDE_TOOL_CALL_TYPES and pending_unphased_messages:
+                # A phase-less assistant message followed by a provider-side
+                # tool cannot be the final answer. Several compatible APIs
+                # (including Bailian) omit Codex's ``phase=commentary`` marker,
+                # so infer it from event ordering and emit it while the tool is
+                # still running. The exact raw item remains in output for
+                # replay/cache continuity.
+                for message_index, pending_item in pending_unphased_messages:
+                    interim_message_item_indexes.add(message_index)
+                    pending_id = _item_field(pending_item, "id")
+                    if isinstance(pending_id, str) and pending_id:
+                        interim_message_item_ids.add(pending_id)
+                    inferred_commentary_cb = (
+                        on_inferred_commentary_message or on_commentary_message
+                    )
+                    if inferred_commentary_cb is not None:
+                        content_parts = _item_field(pending_item, "content", [])
+                        if isinstance(content_parts, list):
+                            pending_text = "".join(
+                                str(_item_field(part, "text", "") or "")
+                                for part in content_parts
+                                if _item_field(part, "type", "") == "output_text"
+                            ).strip()
+                            if pending_text:
+                                try:
+                                    inferred_commentary_cb(pending_text)
+                                except Exception:
+                                    logger.debug(
+                                        "Codex stream inferred commentary callback raised",
+                                        exc_info=True,
+                                    )
+                pending_unphased_messages = []
             if item_type == "message":
                 phase = _item_field(item, "phase", None)
                 active_message_phase = phase.strip().lower() if isinstance(phase, str) else None
@@ -1206,6 +1388,10 @@ def _consume_codex_event_stream(
                 collected_output_items.append(done_item)
                 done_phase = _item_field(done_item, "phase", None)
                 done_phase = done_phase.strip().lower() if isinstance(done_phase, str) else None
+                if _item_field(done_item, "type", "") == "message" and done_phase is None:
+                    pending_unphased_messages.append(
+                        (len(collected_output_items) - 1, done_item)
+                    )
                 if done_phase == "commentary" and on_commentary_message is not None:
                     commentary_text = "".join(commentary_text_deltas).strip()
                     if not commentary_text:
@@ -1298,6 +1484,8 @@ def _consume_codex_event_stream(
         model=model,
         incomplete_details=terminal_incomplete_details,
         error=terminal_error,
+        interim_message_item_ids=tuple(sorted(interim_message_item_ids)),
+        interim_message_item_indexes=tuple(sorted(interim_message_item_indexes)),
     )
     return final
 
@@ -1331,10 +1519,27 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     def _on_commentary_message(text: str) -> None:
         agent._fire_streamed_codex_commentary(text)
 
+    def _on_inferred_commentary_message(text: str) -> None:
+        # Phase-less narration was already routed through the normal text
+        # delta channel before event ordering revealed that a provider tool
+        # follows it. Streaming surfaces should only close that segment;
+        # non-streaming surfaces still need the standalone interim message.
+        already_streamed = bool(
+            getattr(agent, "stream_delta_callback", None)
+            or getattr(agent, "_stream_callback", None)
+        )
+        agent._fire_streamed_codex_commentary(
+            text,
+            already_streamed=already_streamed,
+        )
+
+    responses_event_bridge = make_codex_responses_event_bridge(agent)
+
     def _on_event(event: Any) -> None:
         # TTFB watchdog and activity touch — runs once per SSE event.
         agent._codex_stream_last_event_ts = time.time()
         agent._touch_activity("receiving stream response")
+        responses_event_bridge(event)
 
     for attempt in range(max_stream_retries + 1):
         if agent._interrupt_requested:
@@ -1442,6 +1647,14 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     on_reasoning_delta=_on_reasoning_delta,
                     on_commentary_message=(
                         _on_commentary_message
+                        if (
+                            getattr(agent, "interim_assistant_callback", None) is not None
+                            and getattr(agent, "show_commentary", True)
+                        )
+                        else None
+                    ),
+                    on_inferred_commentary_message=(
+                        _on_inferred_commentary_message
                         if (
                             getattr(agent, "interim_assistant_callback", None) is not None
                             and getattr(agent, "show_commentary", True)
@@ -1566,4 +1779,5 @@ __all__ = [
     "run_codex_create_stream_fallback",
     "_consume_codex_event_stream",
     "make_codex_app_server_event_bridge",
+    "make_codex_responses_event_bridge",
 ]

--- a/cli.py
+++ b/cli.py
@@ -4421,6 +4421,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         
         # streaming: stream tokens to the terminal as they arrive (display.streaming in config.yaml)
         self.streaming_enabled = CLI_CONFIG["display"].get("streaming", False)
+        # Mid-turn natural-language narration is independent from token
+        # streaming and tool progress. The callback itself additionally gates
+        # on _interactive_turn so single-query stdout stays final-answer-only.
+        self.interim_assistant_messages_enabled = bool(
+            CLI_CONFIG["display"].get("interim_assistant_messages", True)
+        )
         # show_timestamps: prefix user and assistant labels with timestamps
         self.show_timestamps = CLI_CONFIG["display"].get("timestamps", False)
         self.timestamp_format = CLI_CONFIG["display"].get("timestamp_format", "%H:%M")
@@ -6832,6 +6838,49 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if deferred:
                 self._deferred_content = ""
                 self._emit_stream_text(deferred)
+
+    def _on_interim_assistant(
+        self,
+        text: str,
+        *,
+        already_streamed: bool = False,
+    ) -> None:
+        """Commit one mid-turn assistant message in the interactive CLI.
+
+        Responses providers can emit natural-language narration before a
+        server-side tool call.  The agent reports that completed segment here
+        independently from tool progress.  Non-interactive ``-q``/``-Q``
+        invocations intentionally keep their stdout final-answer-only, so this
+        callback is gated on the run loop's per-turn marker.
+
+        With token streaming enabled the same text is already in the open
+        response box; only close that segment before tool progress renders.
+        Otherwise feed the complete message through the normal stream renderer
+        so markdown stripping, terminal colours, and prompt-toolkit-safe output
+        stay identical to ordinary assistant text.
+        """
+        if not getattr(self, "_interactive_turn", False):
+            return
+
+        visible = str(text or "").strip()
+        if not visible:
+            return
+
+        self._flush_reasoning_preview(force=True)
+        if already_streamed:
+            self._flush_stream()
+            self._reset_stream_state()
+            self._invalidate()
+            return
+
+        # Start from a clean segment in case a provider switches from a
+        # reasoning surface to an unstreamed assistant status message.
+        self._flush_stream()
+        self._reset_stream_state()
+        self._stream_delta(visible)
+        self._flush_stream()
+        self._reset_stream_state()
+        self._invalidate()
 
     def _stream_delta(self, text) -> None:
         """Line-buffered streaming callback for real-time token rendering.

--- a/contributors/emails/me@jimifish.com
+++ b/contributors/emails/me@jimifish.com
@@ -1,0 +1,1 @@
+fishjimi

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -530,6 +530,11 @@ class CLIAgentSetupMixin:
                 tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
                 stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
+                interim_assistant_callback=(
+                    self._on_interim_assistant
+                    if getattr(self, "interim_assistant_messages_enabled", True)
+                    else None
+                ),
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
                 notice_callback=self._on_notice,
                 notice_clear_callback=self._on_notice_clear,

--- a/run_agent.py
+++ b/run_agent.py
@@ -6340,7 +6340,12 @@ class AIAgent:
                 self._delivered_interim_texts = delivered
             delivered.add(normalized)
 
-    def _fire_streamed_codex_commentary(self, text: str) -> None:
+    def _fire_streamed_codex_commentary(
+        self,
+        text: str,
+        *,
+        already_streamed: bool = False,
+    ) -> None:
         """Deliver a completed live Codex commentary message immediately."""
         cb = getattr(self, "interim_assistant_callback", None)
         if cb is None or not isinstance(text, str):
@@ -6351,7 +6356,7 @@ class AIAgent:
         if not visible or visible == "(empty)" or self._interim_text_was_delivered(visible):
             return
         try:
-            cb(visible, already_streamed=False)
+            cb(visible, already_streamed=already_streamed)
             self._record_delivered_interim_text(visible)
         except Exception:
             logger.debug("interim_assistant_callback error", exc_info=True)

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -227,6 +227,66 @@ def test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete():
     assert assistant_message.codex_reasoning_items is None
 
 
+def test_phase_less_messages_before_server_tools_are_not_joined_into_final_answer():
+    response = SimpleNamespace(
+        status="completed",
+        output_text="I will search now.Final answer.",
+        output=[
+            SimpleNamespace(
+                type="message",
+                id="msg_progress",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="I will search now.")],
+            ),
+            SimpleNamespace(
+                type="web_search_call",
+                id="search_1",
+                status="completed",
+            ),
+            SimpleNamespace(
+                type="message",
+                id="msg_final",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="Final answer.")],
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "stop"
+    assert assistant_message.content == "Final answer."
+    # Both exact message items remain available for Responses replay/cache
+    # continuity even though the progress narration is not final content.
+    assert [item["id"] for item in assistant_message.codex_message_items] == [
+        "msg_progress",
+        "msg_final",
+    ]
+
+
+def test_web_extractor_call_is_a_completed_provider_tool_not_incomplete_output():
+    response = SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="web_extractor_call",
+                id="extract_1",
+                status="in_progress",
+            ),
+            SimpleNamespace(
+                type="message",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="Extracted answer.")],
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "stop"
+    assert assistant_message.content == "Extracted answer."
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_interim_assistant_callback.py
+++ b/tests/cli/test_interim_assistant_callback.py
@@ -1,0 +1,77 @@
+"""Interactive CLI projection for mid-turn assistant narration."""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+import pytest
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+@pytest.fixture
+def cli_stub(monkeypatch):
+    import cli as cli_mod
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.show_reasoning = False
+    cli.final_response_markdown = "raw"
+    cli.show_timestamps = False
+    cli._interactive_turn = True
+    cli._spinner_text = ""
+    cli._invalidate = lambda *args, **kwargs: None
+    cli._reset_stream_state()
+
+    emitted: list[str] = []
+    monkeypatch.setattr(cli_mod, "_cprint", emitted.append)
+    monkeypatch.setattr(cli_mod, "_terminal_width_for_streaming", lambda: 74)
+    return cli, emitted
+
+
+def test_interactive_cli_renders_unstreamed_interim_message(cli_stub):
+    cli, emitted = cli_stub
+
+    cli._on_interim_assistant("Current action: search BRC-6804.")
+
+    plain = _strip_ansi("\n".join(emitted))
+    assert plain.count("Current action: search BRC-6804.") == 1
+    assert "Hermes" in plain
+    assert cli._stream_box_opened is False
+    assert cli._stream_buf == ""
+
+
+def test_interactive_cli_closes_already_streamed_segment_without_duplicate(cli_stub):
+    cli, emitted = cli_stub
+    cli._stream_delta("Current action: open the first result.")
+
+    cli._on_interim_assistant(
+        "Current action: open the first result.",
+        already_streamed=True,
+    )
+
+    plain = _strip_ansi("\n".join(emitted))
+    assert plain.count("Current action: open the first result.") == 1
+    assert cli._stream_box_opened is False
+    assert cli._stream_buf == ""
+
+
+def test_noninteractive_cli_keeps_interim_message_off_stdout(cli_stub):
+    cli, emitted = cli_stub
+    cli._interactive_turn = False
+
+    cli._on_interim_assistant("This must not precede the final answer.")
+
+    assert emitted == []
+
+
+def test_interactive_agent_setup_wires_interim_callback():
+    from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+    source = inspect.getsource(CLIAgentSetupMixin._init_agent)
+    assert "interim_assistant_callback=(" in source
+    assert "self._on_interim_assistant" in source
+    assert 'getattr(self, "interim_assistant_messages_enabled", True)' in source

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -662,6 +662,172 @@ def test_consume_codex_stream_separates_commentary_from_analysis(monkeypatch):
     assert response.output == [commentary_item]
 
 
+def test_consume_codex_stream_infers_phase_less_commentary_before_server_tool():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    progress_item = SimpleNamespace(
+        type="message",
+        id="msg_progress",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="I will search now.")],
+    )
+    search_item = SimpleNamespace(
+        type="web_search_call",
+        id="search_1",
+        status="completed",
+    )
+    final_item = SimpleNamespace(
+        type="message",
+        id="msg_final",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="Final answer.")],
+    )
+    commentary_messages = []
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="message", id="msg_progress"),
+            ),
+            SimpleNamespace(type="response.output_text.delta", delta="I will search now."),
+            SimpleNamespace(type="response.output_item.done", item=progress_item),
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="web_search_call", id="search_1"),
+            ),
+            SimpleNamespace(type="response.web_search_call.in_progress", item_id="search_1"),
+            SimpleNamespace(type="response.output_item.done", item=search_item),
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="message", id="msg_final"),
+            ),
+            SimpleNamespace(type="response.output_text.delta", delta="Final answer."),
+            SimpleNamespace(type="response.output_item.done", item=final_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            ),
+        ]),
+        model="research-model",
+        on_commentary_message=commentary_messages.append,
+    )
+
+    assert commentary_messages == ["I will search now."]
+    assert response.interim_message_item_ids == ("msg_progress",)
+    assert response.interim_message_item_indexes == (0,)
+    assert response.output == [progress_item, search_item, final_item]
+
+
+def test_responses_event_bridge_coalesces_provider_tool_lifecycle():
+    from agent.codex_runtime import make_codex_responses_event_bridge
+
+    observed = []
+    agent = SimpleNamespace(
+        tool_progress_callback=lambda event, name, preview, args, **kwargs: observed.append(
+            (event, name, args, kwargs.get("is_error"))
+        )
+    )
+    bridge = make_codex_responses_event_bridge(agent)
+    search_item = {
+        "type": "web_search_call",
+        "id": "search_1",
+        "status": "completed",
+        "action": {"type": "search", "query": "Hermes Agent"},
+    }
+
+    bridge({"type": "response.output_item.added", "item": search_item})
+    bridge({"type": "response.web_search_call.in_progress", "item_id": "search_1"})
+    bridge({"type": "response.web_search_call.searching", "item_id": "search_1"})
+    bridge({"type": "response.web_search_call.completed", "item_id": "search_1"})
+    bridge({"type": "response.output_item.done", "item": search_item})
+
+    assert observed == [
+        (
+            "tool.started",
+            "web_search",
+            {"type": "search", "query": "Hermes Agent"},
+            None,
+        ),
+        ("tool.completed", "web_search", None, False),
+    ]
+
+
+def test_inferred_commentary_marks_existing_stream_segment_instead_of_resending(
+    monkeypatch,
+):
+    agent = _build_agent(monkeypatch)
+    streamed = []
+    delivered = []
+    agent.stream_delta_callback = streamed.append
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: delivered.append(
+            (text, already_streamed)
+        )
+    )
+    progress_item = SimpleNamespace(
+        type="message",
+        id="msg_progress",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="I will search now.")],
+    )
+    search_item = SimpleNamespace(
+        type="web_search_call",
+        id="search_1",
+        status="completed",
+    )
+    final_item = SimpleNamespace(
+        type="message",
+        id="msg_final",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="Final answer.")],
+    )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            create=lambda **_kwargs: _FakeCreateStream([
+                SimpleNamespace(
+                    type="response.output_item.added",
+                    item=SimpleNamespace(type="message", id="msg_progress"),
+                ),
+                SimpleNamespace(
+                    type="response.output_text.delta",
+                    delta="I will search now.",
+                ),
+                SimpleNamespace(type="response.output_item.done", item=progress_item),
+                SimpleNamespace(
+                    type="response.output_item.added",
+                    item=SimpleNamespace(type="web_search_call", id="search_1"),
+                ),
+                SimpleNamespace(
+                    type="response.web_search_call.in_progress",
+                    item_id="search_1",
+                ),
+                SimpleNamespace(type="response.output_item.done", item=search_item),
+                SimpleNamespace(
+                    type="response.output_item.added",
+                    item=SimpleNamespace(type="message", id="msg_final"),
+                ),
+                SimpleNamespace(
+                    type="response.output_text.delta",
+                    delta="Final answer.",
+                ),
+                SimpleNamespace(type="response.output_item.done", item=final_item),
+                SimpleNamespace(
+                    type="response.completed",
+                    response=SimpleNamespace(status="completed"),
+                ),
+            ])
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert delivered == [("I will search now.", True)]
+    assert "".join(streamed) == "I will search now.Final answer."
+    assert response.interim_message_item_ids == ("msg_progress",)
+
+
 
 
 def test_run_codex_stream_delivers_redacted_commentary_once(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes Responses-compatible providers that omit Codex's `phase=commentary` marker. A phase-less assistant message followed by a provider-executed tool is classified as interim narration rather than the final answer, and provider-side tool items are projected onto Hermes progress callbacks.

Interactive CLI sessions receive completed interim segments while one-shot `-q` output remains final-answer-only.

## Related Issue

Related: #67580

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Share server-side Responses tool classification with normalization and streaming.
- Infer phase-less interim commentary from event ordering and exclude it from final-answer replay.
- Bridge provider-executed tool lifecycle events into Hermes progress callbacks.
- Display completed interim segments in interactive CLI sessions without changing one-shot output.
- Add normalization, streaming, progress, deduplication, and CLI regression coverage.

## How to Test

1. Use a Responses-compatible provider that emits a phase-less assistant message before a server-side tool item.
2. Verify narration is delivered before tool progress and is not repeated in the final answer.
3. Verify interactive CLI displays interim segments while `hermes -q` remains final-only.
4. Run `pytest tests/agent/test_codex_responses_adapter.py tests/cli/test_interim_assistant_callback.py tests/run_agent/test_run_agent_codex_responses.py -q`.

Targeted result on Windows 11: 72 passed. Ruff checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and merged PRs for duplicates
- [x] This PR contains only related changes
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted suite passed; full suite not run locally)
- [x] I've added regression tests
- [x] Tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation — N/A; no user-facing config changes
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas — N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted Ruff checks and all targeted tests passed.