### PR TITLE
fix(gateway): preserve provider request overrides

### DIFF
--- a/contributors/emails/me@jimifish.com
+++ b/contributors/emails/me@jimifish.com
@@ -1,0 +1,1 @@
+fishjimi

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2666,6 +2666,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "request_overrides": dict(runtime.get("request_overrides") or {}),
         "max_tokens": max_tokens,
     }
 
@@ -2689,6 +2690,7 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "request_overrides": dict(runtime.get("request_overrides") or {}),
     }
 
 
@@ -2747,6 +2749,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
                     "credential_pool": runtime.get("credential_pool"),
+                    "request_overrides": dict(runtime.get("request_overrides") or {}),
                     "model": entry.get("model"),
                 }
             except Exception as fb_exc:
@@ -7579,16 +7582,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ),
         }
 
+        # Named custom providers can contribute request-only fields through
+        # ``runtime_kwargs["request_overrides"]`` (for example provider-side
+        # ``web_search`` tools in ``extra_body``).  Keep those fields separate
+        # from the AIAgent constructor kwargs, but never discard them while
+        # computing the per-turn fast-mode override.
+        request_overrides = dict(runtime_kwargs.get("request_overrides") or {})
+
         service_tier = getattr(self, "_service_tier", None)
         if not service_tier:
-            route["request_overrides"] = {}
+            route["request_overrides"] = request_overrides
             return route
 
         try:
             overrides = resolve_fast_mode_overrides(route["model"])
         except Exception:
             overrides = None
-        route["request_overrides"] = overrides or {}
+        # Fast mode and provider metadata are independent.  Merge nested maps
+        # such as ``extra_body``/``extra_headers`` instead of replacing the
+        # provider payload wholesale when both happen to use the same key.
+        for key, value in (overrides or {}).items():
+            current = request_overrides.get(key)
+            if isinstance(current, dict) and isinstance(value, dict):
+                request_overrides[key] = {**current, **value}
+            else:
+                request_overrides[key] = value
+        route["request_overrides"] = request_overrides
         return route
 
     def _sync_session_model_from_agent(self, session_id: str, agent: Any) -> None:

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -124,6 +124,61 @@ def test_turn_route_injects_priority_processing_without_changing_runtime():
     assert route["request_overrides"] == {"service_tier": "priority"}
 
 
+def test_turn_route_preserves_custom_provider_request_overrides():
+    runner = _make_runner()
+    provider_overrides = {
+        "extra_body": {
+            "enable_thinking": True,
+            "tools": [{"type": "web_search"}, {"type": "web_extractor"}],
+        }
+    }
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://example.invalid/v1",
+        "provider": "custom",
+        "requested_provider": "custom:research-provider",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "request_overrides": provider_overrides,
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner, "research this", "research-model", runtime_kwargs
+    )
+
+    assert route["request_overrides"] == provider_overrides
+    assert route["request_overrides"] is not provider_overrides
+
+
+def test_turn_route_merges_fast_mode_with_custom_provider_overrides():
+    runner = _make_runner()
+    runner._service_tier = "priority"
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://example.invalid/v1",
+        "provider": "custom",
+        "requested_provider": "custom:research-provider",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "request_overrides": {
+            "extra_body": {"tools": [{"type": "web_search"}]},
+        },
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner, "research this quickly", "gpt-5.4", runtime_kwargs
+    )
+
+    assert route["request_overrides"] == {
+        "extra_body": {"tools": [{"type": "web_search"}]},
+        "service_tier": "priority",
+    }
+
+
 @pytest.mark.asyncio
 async def test_handle_fast_command_global_flag_persists_config(monkeypatch, tmp_path):
     runner = _make_runner()

--- a/tests/gateway/test_runtime_request_overrides.py
+++ b/tests/gateway/test_runtime_request_overrides.py
@@ -1,0 +1,79 @@
+"""Regression tests for provider request metadata crossing Gateway routing."""
+
+from unittest.mock import patch
+
+import gateway.run as gateway_run
+
+
+_REQUEST_OVERRIDES = {
+    "extra_body": {
+        "enable_thinking": True,
+        "tools": [{"type": "web_search"}, {"type": "web_extractor"}],
+    }
+}
+
+
+def _resolved_runtime() -> dict:
+    return {
+        "api_key": "test-key",
+        "base_url": "https://example.invalid/v1",
+        "provider": "custom",
+        "requested_provider": "custom:research-provider",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "request_overrides": _REQUEST_OVERRIDES,
+    }
+
+
+def test_primary_runtime_preserves_provider_request_overrides():
+    with (
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=_resolved_runtime(),
+        ),
+        patch("hermes_cli.runtime_provider._get_model_config", return_value={}),
+    ):
+        result = gateway_run._resolve_runtime_agent_kwargs()
+
+    assert result["request_overrides"] == _REQUEST_OVERRIDES
+    assert result["request_overrides"] is not _REQUEST_OVERRIDES
+
+
+def test_channel_runtime_preserves_provider_request_overrides():
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value=_resolved_runtime(),
+    ) as resolve:
+        result = gateway_run._resolve_runtime_agent_kwargs_for_provider(
+            "custom:research-provider"
+        )
+
+    resolve.assert_called_once_with(requested="custom:research-provider")
+    assert result["request_overrides"] == _REQUEST_OVERRIDES
+    assert result["request_overrides"] is not _REQUEST_OVERRIDES
+
+
+def test_fallback_runtime_preserves_provider_request_overrides():
+    fallback = {
+        "provider": "custom:research-provider",
+        "model": "research-model",
+    }
+    with (
+        patch("gateway.run._load_gateway_runtime_config", return_value={}),
+        patch("gateway.run.get_fallback_chain", return_value=[fallback]),
+        patch(
+            "hermes_cli.fallback_config.resolve_entry_api_key",
+            return_value="test-key",
+        ),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=_resolved_runtime(),
+        ),
+    ):
+        result = gateway_run._try_resolve_fallback_provider()
+
+    assert result is not None
+    assert result["request_overrides"] == _REQUEST_OVERRIDES
+    assert result["request_overrides"] is not _REQUEST_OVERRIDES


### PR DESCRIPTION
## What does this PR do?

Preserves custom-provider `request_overrides` across Gateway runtime resolution. Primary, channel-specific, and fallback providers no longer lose request-only metadata such as `extra_body.tools`, and fast-mode service-tier overrides merge with provider metadata instead of replacing it.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Carry copied request overrides through primary, channel-specific, and fallback runtime resolution in `gateway/run.py`.
- Merge nested provider metadata safely with per-turn fast-mode overrides.
- Add regression coverage for primary, channel, fallback, and fast-mode routes.

## How to Test

1. Configure a named custom provider with `request_overrides.extra_body.tools`.
2. Resolve it as primary, channel override, and fallback; verify metadata reaches the turn route.
3. Enable fast mode and verify `service_tier` is added without dropping provider metadata.
4. Run `pytest tests/gateway/test_fast_command.py tests/gateway/test_runtime_request_overrides.py -q`.

Targeted result on Windows 11: 8 passed. Ruff checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and merged PRs for duplicates
- [x] This PR contains only related changes
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted suite passed; full suite not run locally)
- [x] I've added regression tests
- [x] Tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation — N/A; no new configuration schema
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas — N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted Ruff checks and all targeted tests passed.