### PR TITLE
fix(weixin): bound content fallback deduplication

### DIFF
--- a/contributors/emails/me@jimifish.com
+++ b/contributors/emails/me@jimifish.com
@@ -1,0 +1,1 @@
+fishjimi

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -113,6 +113,11 @@ BACKOFF_DELAY_SECONDS = 30
 SESSION_EXPIRED_ERRCODE = -14
 RATE_LIMIT_ERRCODE = -2  # iLink frequency limit — backoff and retry
 MESSAGE_DEDUP_TTL_SECONDS = 300
+# iLink can occasionally redeliver identical content under a fresh message ID.
+# Keep that fallback window short: unlike a platform message ID, text is not a
+# stable event identity and users legitimately resend the same prompt after a
+# stop, retry, or correction.
+CONTENT_DEDUP_TTL_SECONDS = 5
 
 
 def _is_stale_session_ret(
@@ -1192,6 +1197,9 @@ class WeixinAdapter(BasePlatformAdapter):
         self._send_session: Optional[aiohttp.ClientSession] = None
         self._poll_task: Optional[asyncio.Task] = None
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
+        self._content_dedup = MessageDeduplicator(
+            ttl_seconds=CONTENT_DEDUP_TTL_SECONDS
+        )
 
         self._account_id = str(extra.get("account_id") or _wx_secret("WEIXIN_ACCOUNT_ID", "")).strip()
         self._token = str(config.token or extra.get("token") or _wx_secret("WEIXIN_TOKEN", "")).strip()
@@ -1451,8 +1459,13 @@ class WeixinAdapter(BasePlatformAdapter):
         text = _extract_text(item_list)
         if text:
             content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
-            if self._dedup.is_duplicate(content_key):
-                logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)
+            if self._content_dedup.is_duplicate(content_key):
+                logger.info(
+                    "[%s] Content-dedup: skipping near-simultaneous duplicate "
+                    "message from %s",
+                    self.name,
+                    _safe_id(sender_id),
+                )
                 return
 
         chat_type, effective_chat_id = _guess_chat_type(message, self._account_id)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -545,6 +545,43 @@ class TestWeixinContentDedup:
         event = adapter.handle_message.await_args[0][0]
         assert event.text == "hello world"
 
+    def test_same_content_can_be_resent_after_short_fallback_window(self):
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+        adapter._text_batch_delay_seconds = 0.01
+        adapter._text_batch_split_delay_seconds = 0.01
+
+        text = "run the same search again"
+        base_msg = {
+            "from_user_id": "wxid_user1",
+            "item_list": [{"type": 1, "text_item": {"text": text}}],
+        }
+
+        async def _drive():
+            with patch("gateway.platforms.helpers.time.time", return_value=100.0):
+                await adapter._process_message(
+                    {**base_msg, "message_id": "msg-1"}
+                )
+            await asyncio.sleep(0.05)
+
+            after_window = 101.0 + weixin.CONTENT_DEDUP_TTL_SECONDS
+            with patch(
+                "gateway.platforms.helpers.time.time",
+                return_value=after_window,
+            ):
+                await adapter._process_message(
+                    {**base_msg, "message_id": "msg-2"}
+                )
+            await asyncio.sleep(0.05)
+
+        asyncio.run(_drive())
+
+        assert adapter.handle_message.await_count == 2
+        assert [
+            call.args[0].text for call in adapter.handle_message.await_args_list
+        ] == [text, text]
+
 
 class TestWeixinTextDebounce:
     """Text-debounce batching for rapid multi-message bursts (issue #35301).


### PR DESCRIPTION
## What does this PR do?

Separates Weixin's stable message-ID deduplication from its content fallback. Identical text under a fresh message ID is suppressed only for a short five-second redelivery window, allowing users to intentionally resend the same task after a stop, retry, or correction.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Retain the five-minute message-ID cache and add a separate five-second content cache.
- Sanitize the sender identifier in duplicate logs.
- Add regression coverage proving repeated content under a fresh message ID is accepted after the fallback window.

## How to Test

1. Send a Weixin task and stop or complete it.
2. After more than five seconds, resend the exact same text under a new message ID.
3. Verify both messages reach the agent while near-simultaneous platform redelivery remains suppressed.
4. Run `pytest tests/gateway/test_weixin.py -q -k TestWeixinContentDedup`.

Targeted result on Windows 11: 2 passed. The full file produced 30 passes and one unrelated environment failure because the local sealed venv lacks optional `aiohttp` for an existing QR-login mock. Ruff checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and merged PRs for duplicates
- [x] This PR contains only related changes
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted tests passed; full suite not run locally)
- [x] I've added regression tests
- [x] Tested on Windows 11 with Weixin

### Documentation & Housekeeping

- [x] Documentation — N/A; no user-facing config changes
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas — N/A

## For New Skills

N/A

## Screenshots / Logs

The new content-dedup regression test passes.