### PR TITLE
fix(auth): preserve auth store ownership on replace

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1345,11 +1345,6 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
         except FileNotFoundError:
             owner_stat = os.stat(auth_file.parent)
         owner = (owner_stat.st_uid, owner_stat.st_gid)
-        # The replacement inode is already created as this process. Avoid an
-        # unnecessary fchown (which some network filesystems reject) when the
-        # intended owner is exactly the current process identity.
-        if owner == (os.getuid(), os.getgid()):
-            owner = None
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
     payload = json.dumps(auth_store, indent=2) + "\n"
@@ -1366,7 +1361,13 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
         )
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(payload)
-            if owner is not None:
+            # Compare the temp inode itself, not process uid/gid: the latter
+            # are unavailable on Windows and need not describe a filesystem's
+            # ownership mapping.  Avoid a needless fchown on filesystems that
+            # reject it when the replacement inode already has the owner we
+            # must preserve.
+            temp_stat = os.fstat(handle.fileno())
+            if owner is not None and (temp_stat.st_uid, temp_stat.st_gid) != owner:
                 os.fchown(handle.fileno(), *owner)
             handle.flush()
             os.fsync(handle.fileno())

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1331,6 +1331,20 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     # No-op on Windows (POSIX mode bits not enforced); ignore failures.
     # secure_parent_dir refuses to chmod / or top-level dirs (#25821).
     secure_parent_dir(auth_file)
+    # ``os.replace`` swaps in the temp inode, including its UID/GID.  That is
+    # normally invisible when the CLI and gateway run as the same user, but a
+    # privileged ``hermes auth`` invocation would otherwise replace a
+    # service-owned 0600 store with a root-owned one and lock the gateway out.
+    # Preserve the existing store owner; on first creation inherit the
+    # HERMES_HOME directory owner.  Do this before creating/replacing the
+    # destination so a wrong-owner credential inode is never published.
+    owner: Optional[tuple[int, int]] = None
+    if hasattr(os, "fchown"):
+        try:
+            owner_stat = os.stat(auth_file)
+        except FileNotFoundError:
+            owner_stat = os.stat(auth_file.parent)
+        owner = (owner_stat.st_uid, owner_stat.st_gid)
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
     payload = json.dumps(auth_store, indent=2) + "\n"
@@ -1347,6 +1361,8 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
         )
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(payload)
+            if owner is not None:
+                os.fchown(handle.fileno(), *owner)
             handle.flush()
             os.fsync(handle.fileno())
         atomic_replace(tmp_path, auth_file)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1345,6 +1345,11 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
         except FileNotFoundError:
             owner_stat = os.stat(auth_file.parent)
         owner = (owner_stat.st_uid, owner_stat.st_gid)
+        # The replacement inode is already created as this process. Avoid an
+        # unnecessary fchown (which some network filesystems reject) when the
+        # intended owner is exactly the current process identity.
+        if owner == (os.getuid(), os.getgid()):
+            owner = None
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
     payload = json.dumps(auth_store, indent=2) + "\n"

--- a/tests/hermes_cli/test_auth_toctou_file_modes.py
+++ b/tests/hermes_cli/test_auth_toctou_file_modes.py
@@ -33,6 +33,18 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+class _StatWithOwner:
+    """Keep the real stat payload while overriding only ownership fields."""
+
+    def __init__(self, result, uid, gid):
+        self._result = result
+        self.st_uid = uid
+        self.st_gid = gid
+
+    def __getattr__(self, name):
+        return getattr(self._result, name)
+
+
 # ---------------------------------------------------------------------------
 # _save_auth_store  (~/.hermes/auth.json — every native OAuth provider)
 # ---------------------------------------------------------------------------
@@ -67,6 +79,87 @@ def test_save_auth_store_writes_0o600_with_0o700_parent(tmp_path, monkeypatch):
     # Content survived the rewrite
     data = json.loads(auth_path.read_text())
     assert data["providers"]["openai-codex"]["tokens"]["access_token"] == "secret-x"
+
+
+@pytest.mark.skipif(not hasattr(os, "fchown"), reason="fchown is unavailable on Windows")
+def test_save_auth_store_preserves_existing_owner_before_atomic_replace(tmp_path, monkeypatch):
+    """The replacement inode must retain the existing store's service owner.
+
+    This models an administrator rewriting a 0600 store owned by the gateway
+    account: ownership must be applied to the temporary inode *before*
+    ``atomic_replace`` exposes it.
+    """
+    from hermes_cli import auth as auth_mod
+
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text('{"version": 1, "providers": {}}\n')
+    owner = (1234, 5678)
+
+    real_stat = os.stat
+
+    def stat_with_service_owner(path, *args, **kwargs):
+        result = real_stat(path, *args, **kwargs)
+        if os.fspath(path) == os.fspath(auth_path):
+            return _StatWithOwner(result, *owner)
+        return result
+
+    captured = []
+    monkeypatch.setattr(auth_mod.os, "stat", stat_with_service_owner)
+    monkeypatch.setattr(auth_mod.os, "fchown", lambda fd, uid, gid: captured.append((uid, gid)))
+
+    auth_mod._save_auth_store({"providers": {}}, target_path=auth_path)
+
+    assert captured == [owner]
+
+
+@pytest.mark.skipif(not hasattr(os, "fchown"), reason="fchown is unavailable on Windows")
+def test_save_auth_store_first_write_inherits_parent_owner(tmp_path, monkeypatch):
+    """A first store write belongs to the HERMES_HOME owner, not the CLI."""
+    from hermes_cli import auth as auth_mod
+
+    auth_path = tmp_path / "auth.json"
+    owner = (2345, 6789)
+    real_stat = os.stat
+
+    def stat_with_service_owner(path, *args, **kwargs):
+        result = real_stat(path, *args, **kwargs)
+        if os.fspath(path) == os.fspath(auth_path.parent):
+            return _StatWithOwner(result, *owner)
+        return result
+
+    captured = []
+    monkeypatch.setattr(auth_mod.os, "stat", stat_with_service_owner)
+    monkeypatch.setattr(auth_mod.os, "fchown", lambda fd, uid, gid: captured.append((uid, gid)))
+
+    auth_mod._save_auth_store({"providers": {}}, target_path=auth_path)
+
+    assert captured == [owner]
+
+
+@pytest.mark.skipif(not hasattr(os, "fchown"), reason="fchown is unavailable on Windows")
+def test_save_auth_store_does_not_replace_when_owner_transfer_fails(tmp_path, monkeypatch):
+    """A failed fchown must leave the old credential store untouched."""
+    from hermes_cli import auth as auth_mod
+
+    auth_path = tmp_path / "auth.json"
+    original = '{"version": 1, "providers": {"old": {}}}\n'
+    auth_path.write_text(original)
+    real_stat = os.stat
+
+    def stat_with_service_owner(path, *args, **kwargs):
+        result = real_stat(path, *args, **kwargs)
+        if os.fspath(path) == os.fspath(auth_path):
+            return _StatWithOwner(result, 1234, 5678)
+        return result
+
+    monkeypatch.setattr(auth_mod.os, "stat", stat_with_service_owner)
+    monkeypatch.setattr(auth_mod.os, "fchown", lambda *_args: (_ for _ in ()).throw(PermissionError("denied")))
+
+    with pytest.raises(PermissionError, match="denied"):
+        auth_mod._save_auth_store({"providers": {"new": {}}}, target_path=auth_path)
+
+    assert auth_path.read_text() == original
+    assert not list(tmp_path.glob("auth.json.tmp.*"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_auth_toctou_file_modes.py
+++ b/tests/hermes_cli/test_auth_toctou_file_modes.py
@@ -137,6 +137,18 @@ def test_save_auth_store_first_write_inherits_parent_owner(tmp_path, monkeypatch
 
 
 @pytest.mark.skipif(not hasattr(os, "fchown"), reason="fchown is unavailable on Windows")
+def test_save_auth_store_skips_fchown_for_current_owner(tmp_path, monkeypatch):
+    """A same-user rewrite must not depend on a needless ownership syscall."""
+    from hermes_cli import auth as auth_mod
+
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text('{"providers": {}}\n')
+    monkeypatch.setattr(auth_mod.os, "fchown", lambda *_args: pytest.fail("unexpected fchown"))
+
+    auth_mod._save_auth_store({"providers": {}}, target_path=auth_path)
+
+
+@pytest.mark.skipif(not hasattr(os, "fchown"), reason="fchown is unavailable on Windows")
 def test_save_auth_store_does_not_replace_when_owner_transfer_fails(tmp_path, monkeypatch):
     """A failed fchown must leave the old credential store untouched."""
     from hermes_cli import auth as auth_mod


### PR DESCRIPTION
Fixes #85281.

Atomic replacement now preserves the existing `auth.json` UID/GID. When the store does not yet exist, the replacement inode inherits the resolved `HERMES_HOME` directory owner. Ownership is applied to the temporary inode before `os.replace`; if it fails, the old store remains untouched and the temporary file is cleaned up.

Platforms without `os.fchown` retain existing behavior.

Validation:
- 35 auth-store related tests passed
- `ruff check hermes_cli/auth.py tests/hermes_cli/test_auth_toctou_file_modes.py`
- `git diff --check`