### PR TITLE
test(desktop): complete composer action scope mock

### DIFF
--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -294,6 +294,7 @@ describe('useComposerActions native image drops', () => {
         scope: {
           add,
           remove: vi.fn(() => null),
+          update: vi.fn(() => false),
           target: 'test-composer'
         }
       })


### PR DESCRIPTION
## Summary

- complete the `ComposerActionsScope` mock with its required `update` action
- restore the Desktop TypeScript contract check after the scope interface evolved

Current `main` fails `apps/desktop` typechecking because the native-image-drop test constructs a stale scope shape without `update`. The production scope already implements the member; this keeps the test fixture aligned with that public contract.

## Validation

- `cd apps/desktop && npm run typecheck`
- `cd apps/desktop && npx vitest run src/app/chat/hooks/use-composer-actions.test.ts` (14 passed)
- `git diff --check origin/main..HEAD`

No runtime behavior changes; this is a one-line test-fixture repair.
