### PR TITLE
fix(desktop): update composer actions test mock

### DIFF
--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -294,6 +294,7 @@ describe('useComposerActions native image drops', () => {
         scope: {
           add,
           remove: vi.fn(() => null),
+          update: vi.fn(() => false),
           target: 'test-composer'
         }
       })


### PR DESCRIPTION
## What does this PR do?

Adds the required `update` callback to the `ComposerActionsScope` test mock in `use-composer-actions.test.ts`.

`ComposerActionsScope` gained an `update` member, but this mock was not updated with the interface. As a result, the desktop workspace typecheck fails on current `main` with TS2741. The mock returns `false`, matching the no-op behavior needed by this test.

## Related Issue

Fixes #85814

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts` with the missing `update` mock.

## How to Test

1. Run `npm run typecheck --workspace apps/desktop`.
2. Run `npm exec --workspace apps/desktop -- vitest run --project ui src/app/chat/hooks/use-composer-actions.test.ts`.
3. Run `npm exec --workspace apps/desktop -- eslint src/app/chat/hooks/use-composer-actions.test.ts`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs and found no duplicate.
- [x] My PR contains only changes related to this fix.
- [x] Desktop-scoped validation passed; the Python `pytest tests/ -q` suite is not applicable to this TypeScript-only test mock change.
- [x] The existing test covers the affected mock and passes.
- [x] I've tested on Windows 11.

### Documentation & Housekeeping

- [x] Documentation update: N/A.
- [x] `cli-config.yaml.example` update: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A.
- [x] Cross-platform impact: N/A; this is a test-only TypeScript mock.
- [x] Tool descriptions/schemas update: N/A.

## Validation

- `npm run typecheck --workspace apps/desktop`
- `npm exec --workspace apps/desktop -- vitest run --project ui src/app/chat/hooks/use-composer-actions.test.ts` — 14 tests passed
- `npm exec --workspace apps/desktop -- eslint src/app/chat/hooks/use-composer-actions.test.ts`
- OSS preflight: PASS (`1` file, `+1/-0`, no deletions, no merge commits, current upstream base)

Prettier currently reports this existing file as non-conforming on the unchanged upstream version as well, so this PR intentionally avoids unrelated whole-file formatting churn.
