### PR TITLE
fix(telegram): process inbound updates concurrently

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -685,6 +685,35 @@ class TelegramAdapter(BasePlatformAdapter):
     _TEXT_BATCH_SHORT_LEN = 1024
     _TEXT_BATCH_SHORT_DELAY_S = 0.24
 
+    # PTB processes one inbound update at a time unless configured otherwise.
+    # Hermes has per-session busy guards, so independent chats/forum topics can
+    # safely progress in parallel while messages in the same session remain
+    # serialized. Keep the default deliberately small: every slot can begin a
+    # tool-using agent turn.
+    _UPDATE_CONCURRENCY_DEFAULT = 4
+    _UPDATE_CONCURRENCY_MIN = 1
+    _UPDATE_CONCURRENCY_MAX = 16
+
+    def _update_concurrency(self) -> int:
+        """Return the bounded PTB inbound-update concurrency for this adapter."""
+        extra = getattr(self.config, "extra", {}) or {}
+        raw = extra.get("concurrent_updates", self._UPDATE_CONCURRENCY_DEFAULT)
+        try:
+            if isinstance(raw, bool):
+                raise ValueError("boolean is not a concurrency value")
+            value = int(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "[%s] Invalid telegram.extra.concurrent_updates=%r; using %d",
+                self.name,
+                raw,
+                self._UPDATE_CONCURRENCY_DEFAULT,
+            )
+            return self._UPDATE_CONCURRENCY_DEFAULT
+        return max(
+            self._UPDATE_CONCURRENCY_MIN, min(value, self._UPDATE_CONCURRENCY_MAX)
+        )
+
     @staticmethod
     def _env_float_clamped(
         name: str,
@@ -4018,6 +4047,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             # Build the application
             builder = Application.builder().token(self.config.token)
+            builder = builder.concurrent_updates(self._update_concurrency())
             custom_base_url = self.config.extra.get("base_url")
             if custom_base_url:
                 builder = builder.base_url(custom_base_url)

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -110,6 +110,7 @@ async def test_polling_conflict_retries_before_fatal(monkeypatch):
     )
     builder = MagicMock()
     builder.token.return_value = builder
+    builder.concurrent_updates.return_value = builder
     builder.request.return_value = builder
     builder.get_updates_request.return_value = builder
     builder.build.return_value = app
@@ -266,6 +267,7 @@ async def test_polling_conflict_becomes_fatal_after_retries(monkeypatch):
     )
     builder = MagicMock()
     builder.token.return_value = builder
+    builder.concurrent_updates.return_value = builder
     builder.request.return_value = builder
     builder.get_updates_request.return_value = builder
     builder.build.return_value = app
@@ -347,6 +349,7 @@ async def test_connect_clears_webhook_before_polling(monkeypatch):
     )
     builder = MagicMock()
     builder.token.return_value = builder
+    builder.concurrent_updates.return_value = builder
     builder.request.return_value = builder
     builder.get_updates_request.return_value = builder
     builder.build.return_value = app
@@ -415,6 +418,7 @@ async def test_connect_does_not_block_on_post_connect_housekeeping(monkeypatch):
     )
     builder = MagicMock()
     builder.token.return_value = builder
+    builder.concurrent_updates.return_value = builder
     builder.request.return_value = builder
     builder.get_updates_request.return_value = builder
     builder.build.return_value = app
@@ -491,6 +495,7 @@ async def test_polling_conflict_reschedule_uses_running_loop(monkeypatch):
     )
     builder = MagicMock()
     builder.token.return_value = builder
+    builder.concurrent_updates.return_value = builder
     builder.request.return_value = builder
     builder.get_updates_request.return_value = builder
     builder.build.return_value = app
@@ -553,6 +558,7 @@ def _build_polling_app(monkeypatch, adapter):
     )
     builder = MagicMock()
     builder.token.return_value = builder
+    builder.concurrent_updates.return_value = builder
     builder.request.return_value = builder
     builder.get_updates_request.return_value = builder
     builder.build.return_value = app
@@ -650,6 +656,7 @@ async def test_conflict_callback_disarms_before_scheduling(monkeypatch):
     )
     builder = MagicMock()
     builder.token.return_value = builder
+    builder.concurrent_updates.return_value = builder
     builder.request.return_value = builder
     builder.get_updates_request.return_value = builder
     builder.build.return_value = app

--- a/tests/gateway/test_telegram_polling_progress.py
+++ b/tests/gateway/test_telegram_polling_progress.py
@@ -65,6 +65,9 @@ class _LifecycleBuilder:
     def token(self, _token):
         return self
 
+    def concurrent_updates(self, _concurrency):
+        return self
+
     def request(self, _request):
         return self
 
@@ -284,6 +287,9 @@ async def test_general_request_success_cannot_record_polling_progress(monkeypatc
             self.polling_request = None
 
         def token(self, _token):
+            return self
+
+        def concurrent_updates(self, _concurrency):
             return self
 
         def request(self, request):

--- a/tests/gateway/test_telegram_update_concurrency.py
+++ b/tests/gateway/test_telegram_update_concurrency.py
@@ -1,0 +1,85 @@
+"""Regression coverage for Telegram inbound update concurrency.
+
+Telegram forum topics map to distinct Hermes sessions.  The PTB application must
+therefore dispatch a bounded number of inbound updates concurrently so a
+long-running command in one topic cannot stop another topic from reaching its
+own session guard.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram import adapter as tg_adapter
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+class _StopAfterBuild(Exception):
+    """Abort connect after the application builder has been fully configured."""
+
+
+def _build_adapter(*, extra=None) -> TelegramAdapter:
+    return TelegramAdapter(
+        PlatformConfig(enabled=True, token="test-token", extra=extra or {})
+    )
+
+
+def _record_builder_concurrency(monkeypatch, *, extra=None) -> MagicMock:
+    """Run connect up to build(), recording the PTB builder configuration."""
+    builder = MagicMock()
+    for method in (
+        "token",
+        "concurrent_updates",
+        "base_url",
+        "base_file_url",
+        "local_mode",
+        "request",
+        "get_updates_request",
+    ):
+        getattr(builder, method).return_value = builder
+    builder.build.side_effect = _StopAfterBuild
+
+    application = MagicMock()
+    application.builder.return_value = builder
+    monkeypatch.setattr(tg_adapter, "Application", application)
+    monkeypatch.setattr(tg_adapter, "HTTPXRequest", MagicMock())
+
+    async def _no_fallback_ips():
+        return []
+
+    monkeypatch.setattr(tg_adapter, "discover_fallback_ips", _no_fallback_ips)
+    monkeypatch.setattr(tg_adapter, "resolve_proxy_url", lambda *_args, **_kwargs: None)
+
+    adapter = _build_adapter(extra=extra)
+    monkeypatch.setattr(adapter, "_acquire_platform_lock", lambda *_args: True)
+    monkeypatch.setattr(adapter, "_fallback_ips", lambda: [])
+
+    # connect() turns a builder error into a failed connection.  That is fine:
+    # this test only exercises the real adapter's configuration path before
+    # any network or PTB startup work begins.
+    assert asyncio.run(adapter.connect()) is False
+    return builder
+
+
+def test_telegram_connect_uses_four_concurrent_updates_by_default(monkeypatch):
+    """Separate topic updates have a safe, useful default concurrency."""
+    builder = _record_builder_concurrency(monkeypatch)
+
+    builder.concurrent_updates.assert_called_once_with(4)
+
+
+def test_telegram_connect_honors_bounded_concurrent_updates_setting(monkeypatch):
+    """Operators can narrow or widen Telegram dispatch without source patches."""
+    builder = _record_builder_concurrency(monkeypatch, extra={"concurrent_updates": 7})
+
+    builder.concurrent_updates.assert_called_once_with(7)
+
+
+def test_telegram_connect_clamps_invalid_concurrent_updates_setting(monkeypatch):
+    """Malformed or excessive settings cannot create an unbounded update fan-out."""
+    for configured, expected in ((0, 1), (99, 16), ("fast", 4)):
+        builder = _record_builder_concurrency(
+            monkeypatch, extra={"concurrent_updates": configured}
+        )
+
+        builder.concurrent_updates.assert_called_once_with(expected)

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -104,6 +104,24 @@ platforms:
 
 Telegram allows up to 100 BotCommands, but large command payloads can fail. Hermes defaults to 60 for reliability and clamps configured values to `1..100`; use `/commands` for the full command list.
 
+### Concurrent inbound updates (Optional)
+
+Telegram forum topics and chats have separate Hermes sessions. By default, Hermes
+therefore processes up to **4** inbound Telegram updates at once: one slow agent
+turn in a topic cannot prevent another topic from reaching its own session.
+Messages in the *same* topic remain serialized by the gateway's session guard.
+
+To choose a different bound, set `concurrent_updates` under Telegram's `extra`
+configuration. Hermes clamps it to `1..16`; use `1` only when you specifically
+need all inbound Telegram updates to be globally ordered.
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      concurrent_updates: 4
+```
+
 ## Step 3: Privacy Mode (Critical for Groups)
 
 Telegram bots have a **privacy mode** that is **enabled by default**. This is the single most common source of confusion when using bots in groups.


### PR DESCRIPTION
## What does this PR do?

Fixes Telegram forum topics and independent chats appearing to run serially. Hermes already gives each topic its own session lane, but python-telegram-bot defaults to one inbound update at a time. This configures a bounded update processor so separate sessions can begin concurrently while Hermes' existing session guard retains same-topic ordering.

## Related Issue

No existing issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Configure PTB `concurrent_updates` with a default of 4.
- Add `platforms.telegram.extra.concurrent_updates`, clamped to `1..16`; `1` preserves globally serial processing.
- Document the setting and add regression coverage for defaults, overrides, and invalid values.
- Update existing Telegram builder test doubles.

## How to Test

1. Set `platforms.telegram.extra.concurrent_updates: 4` (or leave it unset for the default).
2. Send work to two separate forum topics; both should enter their independent session lanes without waiting for the other.
3. Send consecutive messages in one topic; the existing session guard retains ordering.

## Verification

- `scripts/run_tests.sh tests/gateway/test_telegram*.py -q` — 525 passed
- `ruff check` on changed Python files — passed
- Verified against PTB 22.8: `Application.builder().concurrent_updates(4)` creates `SimpleUpdateProcessor(max_concurrent_updates=4)`.

## Checklist

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and closed issues/PRs for this topic; no duplicate found.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` (targeted Telegram suite run instead; see Verification).
- [x] I've added tests for my changes.
- [x] I've updated relevant documentation.
- [x] I've considered cross-platform impact: pure Python/PTB builder configuration, no platform-specific behavior.
