### PR TITLE
feat(delegate): add judge-based Best-of-N selection to batch delegation (#479)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7918,6 +7918,7 @@ class AIAgent:
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            judge=function_args.get("judge"),
             action=function_args.get("action"),
             subagent_id=function_args.get("subagent_id"),
             message=function_args.get("message"),

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -22,6 +22,9 @@ from tools.delegate_tool import (
     DELEGATE_TASK_SCHEMA,
     DelegateEvent,
     _get_max_concurrent_children,
+    _judge_best_of_n,
+    _normalize_best_of_n_judge,
+    _parse_best_of_n_judge_response,
     _load_config,
     delegate_task,
     _build_child_agent,
@@ -64,6 +67,7 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("goal", props)
         self.assertIn("tasks", props)
         self.assertIn("context", props)
+        self.assertEqual(props["judge"]["type"], "string")
         # toolsets is intentionally NOT exposed to the model — subagents always
         # inherit the parent's toolsets. Letting the model name toolsets was a
         # capability-selection surface the model should not control.
@@ -263,6 +267,289 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("depth limit", result["error"].lower())
 
 
+class TestBestOfNJudge(unittest.TestCase):
+    _GOAL = "Implement a robust cache invalidation strategy"
+
+    @staticmethod
+    def _response(payload):
+        response = MagicMock()
+        response.choices[0].message.content = (
+            payload if isinstance(payload, str) else json.dumps(payload)
+        )
+        return response
+
+    @staticmethod
+    def _result(task_index, summary, *, status="completed", **metadata):
+        return {
+            "task_index": task_index,
+            "status": status,
+            "summary": summary,
+            **metadata,
+        }
+
+    def test_normalizes_default_and_custom_criteria(self):
+        default, error = _normalize_best_of_n_judge(True)
+        self.assertIsNone(error)
+        self.assertIn("correctness", default.lower())
+        custom, error = _normalize_best_of_n_judge(" Prefer simpler code ")
+        self.assertIsNone(error)
+        self.assertEqual(custom, "Prefer simpler code")
+
+    def test_success_calls_judge_once_with_blind_stable_candidates(self):
+        results = [
+            self._result(2, "third answer", model="secret-model-c", provider="secret-c"),
+            self._result(0, "first answer", model="secret-model-a", provider="secret-a"),
+            self._result(1, "second answer", model="secret-model-b", provider="secret-b"),
+        ]
+        tasks = [{"goal": self._GOAL} for _ in results]
+        verdict = {
+            "winner_index": 1,
+            "scores": [
+                {"candidate": "A", "score": 70},
+                {"candidate": "B", "score": 95},
+                {"candidate": "C", "score": 80},
+            ],
+            "reasoning": "Candidate B is the most robust.",
+        }
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=self._response(verdict),
+        ) as call:
+            evaluation, winner = _judge_best_of_n(
+                results, tasks, "Prefer robust and maintainable code"
+            )
+
+        call.assert_called_once()
+        self.assertEqual(evaluation["status"], "completed")
+        self.assertEqual(evaluation["winner_index"], 1)
+        self.assertEqual(winner, {"task_index": 1, "candidate": "B"})
+        self.assertEqual(
+            [score["candidate"] for score in evaluation["scores"]],
+            ["A", "B", "C"],
+        )
+        request = call.call_args.kwargs
+        self.assertEqual(request["task"], "delegate_judge")
+        prompt = request["messages"][1]["content"]
+        self.assertIn(self._GOAL, prompt)
+        self.assertIn("Prefer robust and maintainable code", prompt)
+        self.assertLess(prompt.index("Candidate A"), prompt.index("Candidate B"))
+        self.assertLess(prompt.index("Candidate B"), prompt.index("Candidate C"))
+        self.assertNotIn("secret-model", prompt)
+        self.assertNotIn("secret-a", prompt)
+        self.assertNotIn("secret-b", prompt)
+        self.assertNotIn("secret-c", prompt)
+
+    def test_malformed_empty_and_out_of_range_verdicts_fail_safely(self):
+        results = [self._result(0, "A"), self._result(1, "B")]
+        tasks = [{"goal": self._GOAL}, {"goal": self._GOAL}]
+        responses = (
+            "not json",
+            "",
+            {
+                "winner_index": 7,
+                "scores": [
+                    {"candidate": "A", "score": 50},
+                    {"candidate": "B", "score": 60},
+                ],
+                "reasoning": "invalid winner",
+            },
+        )
+        original = json.loads(json.dumps(results))
+        for response in responses:
+            with self.subTest(response=response):
+                with patch(
+                    "agent.auxiliary_client.call_llm",
+                    return_value=self._response(response),
+                ):
+                    evaluation, winner = _judge_best_of_n(
+                        results, tasks, "Select the best answer"
+                    )
+                self.assertEqual(evaluation["status"], "failed")
+                self.assertIsNone(winner)
+                self.assertEqual(results, original)
+
+    def test_provider_error_preserves_results(self):
+        results = [self._result(0, "A"), self._result(1, "B")]
+        tasks = [{"goal": self._GOAL}, {"goal": self._GOAL}]
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            side_effect=TimeoutError("judge timeout"),
+        ):
+            evaluation, winner = _judge_best_of_n(
+                results, tasks, "Select the best answer"
+            )
+        self.assertEqual(evaluation["status"], "failed")
+        self.assertIn("TimeoutError", evaluation["error"])
+        self.assertIsNone(winner)
+        self.assertEqual([entry["summary"] for entry in results], ["A", "B"])
+
+    def test_failed_candidate_is_excluded_without_renumbering(self):
+        results = [
+            self._result(0, None, status="failed", model="failed-model"),
+            self._result(1, "second answer"),
+            self._result(2, "third answer"),
+        ]
+        tasks = [{"goal": self._GOAL} for _ in results]
+        verdict = {
+            "winner_index": 2,
+            "scores": [
+                {"candidate": "B", "score": 80},
+                {"candidate": "C", "score": 90},
+            ],
+            "reasoning": "Candidate C is stronger.",
+        }
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=self._response(verdict),
+        ) as call:
+            evaluation, winner = _judge_best_of_n(
+                results, tasks, "Select the best answer"
+            )
+        prompt = call.call_args.kwargs["messages"][1]["content"]
+        self.assertNotIn("Candidate A", prompt)
+        self.assertIn("Candidate B", prompt)
+        self.assertIn("Candidate C", prompt)
+        self.assertEqual(evaluation["winner_index"], 2)
+        self.assertEqual(winner["candidate"], "C")
+
+    def test_all_failed_skips_judge(self):
+        results = [
+            self._result(0, None, status="failed"),
+            self._result(1, None, status="error"),
+        ]
+        tasks = [{"goal": self._GOAL}, {"goal": self._GOAL}]
+        with patch("agent.auxiliary_client.call_llm") as call:
+            evaluation, winner = _judge_best_of_n(
+                results, tasks, "Select the best answer"
+            )
+        call.assert_not_called()
+        self.assertEqual(evaluation["status"], "skipped")
+        self.assertIsNone(winner)
+
+    def test_single_success_is_selected_without_judge_call(self):
+        results = [
+            self._result(0, None, status="failed"),
+            self._result(1, "only successful answer"),
+        ]
+        tasks = [{"goal": self._GOAL}, {"goal": self._GOAL}]
+        with patch("agent.auxiliary_client.call_llm") as call:
+            evaluation, winner = _judge_best_of_n(
+                results, tasks, "Select the best answer"
+            )
+        call.assert_not_called()
+        self.assertEqual(evaluation["status"], "skipped")
+        self.assertEqual(winner, {"task_index": 1, "candidate": "B"})
+
+    def test_parser_rejects_incomplete_or_inconsistent_scores(self):
+        candidates = [
+            {"candidate": "A", "task_index": 0, "summary": "A"},
+            {"candidate": "B", "task_index": 1, "summary": "B"},
+        ]
+        payloads = (
+            {
+                "winner_index": 1,
+                "scores": [{"candidate": "B", "score": 90}],
+                "reasoning": "missing A",
+            },
+            {
+                "winner_index": 0,
+                "scores": [
+                    {"candidate": "A", "score": 10},
+                    {"candidate": "B", "score": 90},
+                ],
+                "reasoning": "winner is not highest",
+            },
+        )
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                verdict, error = _parse_best_of_n_judge_response(
+                    json.dumps(payload), candidates
+                )
+                self.assertIsNone(verdict)
+                self.assertTrue(error)
+
+    def test_no_judge_keeps_legacy_result_shape(self):
+        parent = _make_mock_parent(depth=0)
+        result_entries = [
+            self._result(0, "first answer"),
+            self._result(1, "second answer"),
+        ]
+        with (
+            patch("tools.delegate_tool._run_single_child", side_effect=result_entries),
+            patch("tools.delegate_tool._judge_best_of_n") as judge_call,
+        ):
+            result = json.loads(
+                delegate_task(
+                    tasks=[{"goal": self._GOAL}, {"goal": self._GOAL}],
+                    parent_agent=parent,
+                )
+            )
+        judge_call.assert_not_called()
+        self.assertNotIn("evaluation", result)
+        self.assertNotIn("winner", result)
+
+    def test_background_batch_completion_contains_evaluation(self):
+        parent = _make_mock_parent(depth=0)
+        parent.session_id = "parent-session"
+        captured = {}
+
+        def fake_dispatch(**kwargs):
+            captured["completion"] = kwargs["runner"]()
+            return {"status": "dispatched", "delegation_id": "judge-batch"}
+
+        result_entries = [
+            self._result(0, "first answer"),
+            self._result(1, "second answer"),
+        ]
+        evaluation = {
+            "status": "completed",
+            "criteria": "Select the best answer",
+            "winner_index": 1,
+        }
+        with (
+            patch("tools.delegate_tool._run_single_child", side_effect=result_entries),
+            patch(
+                "tools.delegate_tool._judge_best_of_n",
+                return_value=(evaluation, {"task_index": 1, "candidate": "B"}),
+            ) as judge_call,
+            patch(
+                "tools.async_delegation.dispatch_async_delegation_batch",
+                side_effect=fake_dispatch,
+            ),
+            patch("gateway.session_context.async_delivery_supported", return_value=True),
+        ):
+            dispatch_result = json.loads(
+                delegate_task(
+                    tasks=[{"goal": self._GOAL}, {"goal": self._GOAL}],
+                    judge="Select the best answer",
+                    background=True,
+                    parent_agent=parent,
+                )
+            )
+
+        self.assertEqual(dispatch_result["status"], "dispatched")
+        judge_call.assert_called_once()
+        self.assertEqual(captured["completion"]["evaluation"], evaluation)
+        self.assertEqual(captured["completion"]["winner"]["task_index"], 1)
+
+    def test_judge_rejects_unrelated_batch_goals_before_spawn(self):
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as agent:
+            result = json.loads(
+                delegate_task(
+                    tasks=[
+                        {"goal": "Implement a robust cache invalidation strategy"},
+                        {"goal": "Write comprehensive database migration tests"},
+                    ],
+                    judge="Select the best answer",
+                    parent_agent=parent,
+                )
+            )
+        agent.assert_not_called()
+        self.assertIn("same goal", result["error"])
+
+
+class TestDelegateTaskRuntimeCredentials(unittest.TestCase):
     def test_child_inherits_runtime_credentials(self):
         parent = _make_mock_parent(depth=0)
         parent.base_url = "https://chatgpt.com/backend-api/codex"
@@ -1257,6 +1544,59 @@ class TestDispatchDelegateTask(unittest.TestCase):
         self.assertEqual(captured["goal"], "test")
         self.assertNotIn("acp_command", captured["tasks"][0])
         self.assertNotIn("acp_args", captured["tasks"][0])
+
+    def test_judge_is_forwarded_from_model_dispatch(self):
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {
+                    "tasks": [
+                        {"goal": "Implement a robust cache invalidation strategy"},
+                        {"goal": "Implement a robust cache invalidation strategy"},
+                    ],
+                    "judge": "Prefer correctness and maintainability",
+                },
+            )
+
+        self.assertEqual(
+            captured["judge"], "Prefer correctness and maintainability"
+        )
+
+    def test_judge_is_forwarded_from_registry_fallback(self):
+        from tools.registry import registry
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        entry = registry.get_entry("delegate_task")
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            entry.handler(
+                {
+                    "tasks": [
+                        {"goal": "Implement a robust cache invalidation strategy"},
+                        {"goal": "Implement a robust cache invalidation strategy"},
+                    ],
+                    "judge": "Prefer correctness and maintainability",
+                },
+                parent_agent=parent,
+            )
+
+        self.assertEqual(
+            captured["judge"], "Prefer correctness and maintainability"
+        )
 
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -68,6 +68,7 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertEqual(props["judge"]["type"], "string")
+        self.assertEqual(props["judge"]["maxLength"], 500)
         # toolsets is intentionally NOT exposed to the model — subagents always
         # inherit the parent's toolsets. Letting the model name toolsets was a
         # capability-selection surface the model should not control.
@@ -295,6 +296,10 @@ class TestBestOfNJudge(unittest.TestCase):
         self.assertIsNone(error)
         self.assertEqual(custom, "Prefer simpler code")
 
+        too_long, error = _normalize_best_of_n_judge("x" * 501)
+        self.assertIsNone(too_long)
+        self.assertIn("at most 500 characters", error)
+
     def test_success_calls_judge_once_with_blind_stable_candidates(self):
         results = [
             self._result(2, "third answer", model="secret-model-c", provider="secret-c"),
@@ -339,7 +344,7 @@ class TestBestOfNJudge(unittest.TestCase):
         self.assertNotIn("secret-b", prompt)
         self.assertNotIn("secret-c", prompt)
 
-    def test_malformed_empty_and_out_of_range_verdicts_fail_safely(self):
+    def test_malformed_empty_and_out_of_range_verdicts_use_stable_fallback(self):
         results = [self._result(0, "A"), self._result(1, "B")]
         tasks = [{"goal": self._GOAL}, {"goal": self._GOAL}]
         responses = (
@@ -365,7 +370,9 @@ class TestBestOfNJudge(unittest.TestCase):
                         results, tasks, "Select the best answer"
                     )
                 self.assertEqual(evaluation["status"], "failed")
-                self.assertIsNone(winner)
+                self.assertEqual(evaluation["fallback"], "first_completed_candidate")
+                self.assertEqual(evaluation["winner_index"], 0)
+                self.assertEqual(winner, {"task_index": 0, "candidate": "A"})
                 self.assertEqual(results, original)
 
     def test_provider_error_preserves_results(self):
@@ -380,7 +387,8 @@ class TestBestOfNJudge(unittest.TestCase):
             )
         self.assertEqual(evaluation["status"], "failed")
         self.assertIn("TimeoutError", evaluation["error"])
-        self.assertIsNone(winner)
+        self.assertEqual(evaluation["fallback"], "first_completed_candidate")
+        self.assertEqual(winner, {"task_index": 0, "candidate": "A"})
         self.assertEqual([entry["summary"] for entry in results], ["A", "B"])
 
     def test_failed_candidate_is_excluded_without_renumbering(self):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -296,6 +296,10 @@ class TestBestOfNJudge(unittest.TestCase):
         self.assertIsNone(error)
         self.assertEqual(custom, "Prefer simpler code")
 
+        max_length, error = _normalize_best_of_n_judge("x" * 500)
+        self.assertIsNone(error)
+        self.assertEqual(len(max_length), 500)
+
         too_long, error = _normalize_best_of_n_judge("x" * 501)
         self.assertIsNone(too_long)
         self.assertIn("at most 500 characters", error)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -31,7 +31,7 @@ import weakref
 from concurrent.futures import (
     TimeoutError as FuturesTimeoutError,
 )
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlsplit, urlunsplit
 
 from toolsets import TOOLSETS
@@ -3305,6 +3305,238 @@ def _recover_tasks_from_json_string(
     return parsed, None
 
 
+_DEFAULT_BEST_OF_N_CRITERIA = (
+    "Evaluate correctness, completeness, robustness, and maintainability."
+)
+_BEST_OF_N_JUDGE_SYSTEM_PROMPT = """You are an independent evaluator comparing
+anonymous candidate answers to the same task. Judge only the answer content.
+Return exactly one JSON object with this shape:
+{
+  "winner_index": 0,
+  "scores": [
+    {"candidate": "A", "score": 0}
+  ],
+  "reasoning": "brief explanation"
+}
+
+winner_index is the zero-based task index shown with each candidate. Include
+exactly one integer score from 0 to 100 for every candidate. The winner must
+have a highest score. Do not add markdown fences or any other text."""
+
+
+def _normalize_best_of_n_judge(
+    judge: Any,
+) -> tuple[Optional[str], Optional[str]]:
+    """Return normalized criteria or an actionable validation error.
+
+    The model-facing schema intentionally exposes a string to avoid provider
+    incompatibilities around boolean-or-string unions. Direct Python callers
+    may still use ``True`` for the default rubric and ``False`` to disable it.
+    """
+    if judge is None or judge is False:
+        return None, None
+    if judge is True:
+        return _DEFAULT_BEST_OF_N_CRITERIA, None
+    if not isinstance(judge, str):
+        return None, "judge must be a criteria string, true, false, or null."
+    criteria = judge.strip()
+    if not criteria:
+        return None, None
+    if criteria.lower() in {"default", "true"}:
+        return _DEFAULT_BEST_OF_N_CRITERIA, None
+    return criteria, None
+
+
+def _best_of_n_candidate_label(index: int) -> str:
+    """Map a zero-based task index to a stable spreadsheet-style label."""
+    label = ""
+    value = index + 1
+    while value > 0:
+        value, remainder = divmod(value - 1, 26)
+        label = chr(ord("A") + remainder) + label
+    return label
+
+
+def _parse_best_of_n_judge_response(
+    raw: str,
+    candidates: List[Dict[str, Any]],
+) -> tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Validate and normalize the judge's structured verdict."""
+    if not isinstance(raw, str) or not raw.strip():
+        return None, "Judge returned an empty response."
+
+    from tools.delegation_output_schema import extract_json_candidate
+
+    try:
+        payload = json.loads(extract_json_candidate(raw))
+    except (TypeError, ValueError) as exc:
+        return None, f"Judge returned malformed JSON: {exc}"
+    if not isinstance(payload, dict):
+        return None, "Judge response must be a JSON object."
+
+    eligible_by_index = {candidate["task_index"]: candidate for candidate in candidates}
+    winner_index = payload.get("winner_index")
+    if type(winner_index) is not int or winner_index not in eligible_by_index:
+        return None, "Judge returned an invalid or ineligible winner_index."
+
+    scores = payload.get("scores")
+    if not isinstance(scores, list):
+        return None, "Judge response is missing a scores array."
+
+    expected_labels = {candidate["candidate"] for candidate in candidates}
+    scores_by_label: Dict[str, int] = {}
+    for item in scores:
+        if not isinstance(item, dict):
+            return None, "Each judge score must be an object."
+        label = item.get("candidate")
+        score = item.get("score")
+        if label not in expected_labels or label in scores_by_label:
+            return None, "Judge scores contain an unknown or duplicate candidate."
+        if type(score) is not int or not 0 <= score <= 100:
+            return None, "Judge scores must be integers from 0 to 100."
+        scores_by_label[label] = score
+    if set(scores_by_label) != expected_labels:
+        return None, "Judge scores must include every eligible candidate exactly once."
+
+    winner = eligible_by_index[winner_index]
+    winner_score = scores_by_label[winner["candidate"]]
+    if winner_score != max(scores_by_label.values()):
+        return None, "Judge winner_index does not identify a highest-scoring candidate."
+
+    reasoning = payload.get("reasoning")
+    if not isinstance(reasoning, str) or not reasoning.strip():
+        return None, "Judge response is missing non-empty reasoning."
+
+    normalized_scores = [
+        {
+            "candidate": candidate["candidate"],
+            "task_index": candidate["task_index"],
+            "score": scores_by_label[candidate["candidate"]],
+        }
+        for candidate in candidates
+    ]
+    return (
+        {
+            "winner_index": winner_index,
+            "winner_candidate": winner["candidate"],
+            "scores": normalized_scores,
+            "reasoning": reasoning.strip(),
+        },
+        None,
+    )
+
+
+def _judge_best_of_n(
+    results: List[Dict[str, Any]],
+    task_list: List[Dict[str, Any]],
+    criteria: str,
+) -> tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Compare successful anonymous candidates without risking their results."""
+    candidates: List[Dict[str, Any]] = []
+    for entry in results:
+        task_index = entry.get("task_index")
+        summary = entry.get("summary")
+        if (
+            type(task_index) is int
+            and entry.get("status") == "completed"
+            and isinstance(summary, str)
+            and summary.strip()
+        ):
+            candidates.append(
+                {
+                    "candidate": _best_of_n_candidate_label(task_index),
+                    "task_index": task_index,
+                    "summary": summary.strip(),
+                }
+            )
+    candidates.sort(key=lambda candidate: candidate["task_index"])
+
+    evaluation_base: Dict[str, Any] = {"criteria": criteria}
+    if not candidates:
+        return (
+            {
+                **evaluation_base,
+                "status": "skipped",
+                "reasoning": "No successful candidates were available to judge.",
+            },
+            None,
+        )
+    if len(candidates) == 1:
+        candidate = candidates[0]
+        winner = {
+            "task_index": candidate["task_index"],
+            "candidate": candidate["candidate"],
+        }
+        return (
+            {
+                **evaluation_base,
+                "status": "skipped",
+                "winner_index": candidate["task_index"],
+                "winner_candidate": candidate["candidate"],
+                "reasoning": (
+                    "Only one successful candidate was available; no comparative "
+                    "judge call was needed."
+                ),
+            },
+            winner,
+        )
+
+    original_task = str(task_list[0].get("goal", "")).strip()
+    candidate_blocks = []
+    for candidate in candidates:
+        candidate_blocks.append(
+            f"Candidate {candidate['candidate']} "
+            f"(task_index={candidate['task_index']}):\n{candidate['summary']}"
+        )
+    user_prompt = (
+        f"ORIGINAL TASK:\n{original_task}\n\n"
+        f"EVALUATION CRITERIA:\n{criteria}\n\n"
+        "ANONYMOUS CANDIDATES:\n\n"
+        + "\n\n".join(candidate_blocks)
+    )
+
+    try:
+        from agent.auxiliary_client import call_llm
+
+        response = call_llm(
+            task="delegate_judge",
+            messages=[
+                {"role": "system", "content": _BEST_OF_N_JUDGE_SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=0,
+            max_tokens=2048,
+        )
+        raw = response.choices[0].message.content or ""
+    except Exception as exc:
+        logger.info("delegate_task Best-of-N judge call failed: %s", exc)
+        return (
+            {
+                **evaluation_base,
+                "status": "failed",
+                "error": f"Judge call failed: {type(exc).__name__}",
+            },
+            None,
+        )
+
+    verdict, parse_error = _parse_best_of_n_judge_response(raw, candidates)
+    if verdict is None:
+        return (
+            {
+                **evaluation_base,
+                "status": "failed",
+                "error": parse_error or "Judge returned an invalid response.",
+            },
+            None,
+        )
+
+    winner = {
+        "task_index": verdict["winner_index"],
+        "candidate": verdict["winner_candidate"],
+    }
+    return {**evaluation_base, "status": "completed", **verdict}, winner
+
+
 # Placeholder shapes for batch goal validation: bare 'TODO', bare 'task N'
 # labels, or goals still carrying unexpanded template markers.
 #
@@ -3377,6 +3609,7 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
+    judge: Optional[Union[bool, str]] = None,
     action: Optional[str] = None,
     subagent_id: Optional[str] = None,
     message: Optional[str] = None,
@@ -3418,6 +3651,10 @@ def delegate_task(
         return tool_error(
             f"Unknown action '{action}'. Use spawn (default), list, steer, or stop."
         )
+
+    judge_criteria, judge_error = _normalize_best_of_n_judge(judge)
+    if judge_error:
+        return tool_error(judge_error)
 
     # Operator-controlled kill switch — lets the TUI freeze new fan-out
     # when a runaway tree is detected, without interrupting already-running
@@ -3533,6 +3770,15 @@ def delegate_task(
         batch_error = _validate_batch_tasks(task_list)
         if batch_error:
             return tool_error(batch_error)
+        if judge_criteria:
+            normalized_goals = {
+                " ".join(str(task.get("goal", "")).split()) for task in task_list
+            }
+            if len(normalized_goals) != 1:
+                return tool_error(
+                    "Best-of-N judge requires every batch candidate to use the "
+                    "same goal. Omit judge when delegating unrelated tasks."
+                )
 
     # T1-24: coerce/validate optional per-task output_schema up front so a
     # malformed schema fails the whole call loudly instead of spawning
@@ -3813,6 +4059,13 @@ def delegate_task(
         # Covers both the single-task and batch paths. See PR #9126.
         _finalize_child_results(results, task_list, children, parent_agent)
 
+        evaluation = None
+        winner = None
+        if judge_criteria:
+            evaluation, winner = _judge_best_of_n(
+                results, task_list, judge_criteria
+            )
+
         total_duration = round(time.monotonic() - overall_start, 2)
 
         # Close out the live transcripts: terminal marker per task + manifest
@@ -3841,6 +4094,10 @@ def delegate_task(
         }
         if live_paths:
             combined["live_transcripts"] = list(live_paths)
+        if evaluation is not None:
+            combined["evaluation"] = evaluation
+            if winner is not None:
+                combined["winner"] = winner
         return combined
 
     # ----- Background dispatch: run the WHOLE batch as one async unit -----
@@ -4562,6 +4819,17 @@ DELEGATE_TASK_SCHEMA = {
                     "(same semantics as tasks[].output_schema)."
                 ),
             },
+            "judge": {
+                "type": "string",
+                "description": (
+                    "Optional Best-of-N evaluation criteria for batch tasks "
+                    "that share the same goal. Use 'default' for correctness, "
+                    "completeness, robustness, and maintainability. The judge "
+                    "compares anonymous Candidate A/B/C outputs, returns "
+                    "structured scores and a winner, and never discards "
+                    "successful child results if evaluation fails."
+                ),
+            },
             "background": {
                 "type": "boolean",
                 "description": (
@@ -4667,6 +4935,7 @@ registry.register(
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
         output_schema=args.get("output_schema"),
+        judge=args.get("judge"),
         action=args.get("action"),
         subagent_id=args.get("subagent_id"),
         message=args.get("message"),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3308,6 +3308,7 @@ def _recover_tasks_from_json_string(
 _DEFAULT_BEST_OF_N_CRITERIA = (
     "Evaluate correctness, completeness, robustness, and maintainability."
 )
+_MAX_BEST_OF_N_CRITERIA_LENGTH = 500
 _BEST_OF_N_JUDGE_SYSTEM_PROMPT = """You are an independent evaluator comparing
 anonymous candidate answers to the same task. Judge only the answer content.
 Return exactly one JSON object with this shape:
@@ -3344,6 +3345,11 @@ def _normalize_best_of_n_judge(
         return None, None
     if criteria.lower() in {"default", "true"}:
         return _DEFAULT_BEST_OF_N_CRITERIA, None
+    if len(criteria) > _MAX_BEST_OF_N_CRITERIA_LENGTH:
+        return None, (
+            "judge criteria must be at most "
+            f"{_MAX_BEST_OF_N_CRITERIA_LENGTH} characters."
+        )
     return criteria, None
 
 
@@ -3481,6 +3487,12 @@ def _judge_best_of_n(
             winner,
         )
 
+    fallback_candidate = candidates[0]
+    fallback_winner = {
+        "task_index": fallback_candidate["task_index"],
+        "candidate": fallback_candidate["candidate"],
+    }
+
     original_task = str(task_list[0].get("goal", "")).strip()
     candidate_blocks = []
     for candidate in candidates:
@@ -3509,25 +3521,42 @@ def _judge_best_of_n(
         )
         raw = response.choices[0].message.content or ""
     except Exception as exc:
-        logger.info("delegate_task Best-of-N judge call failed: %s", exc)
+        logger.warning(
+            "delegate_task Best-of-N judge call failed; selecting the first "
+            "completed candidate (%s) as fallback: %s",
+            fallback_candidate["candidate"],
+            exc,
+        )
         return (
             {
                 **evaluation_base,
                 "status": "failed",
                 "error": f"Judge call failed: {type(exc).__name__}",
+                "fallback": "first_completed_candidate",
+                "winner_index": fallback_candidate["task_index"],
+                "winner_candidate": fallback_candidate["candidate"],
             },
-            None,
+            fallback_winner,
         )
 
     verdict, parse_error = _parse_best_of_n_judge_response(raw, candidates)
     if verdict is None:
+        logger.warning(
+            "delegate_task Best-of-N judge response was invalid; selecting "
+            "the first completed candidate (%s) as fallback: %s",
+            fallback_candidate["candidate"],
+            parse_error or "unknown parse error",
+        )
         return (
             {
                 **evaluation_base,
                 "status": "failed",
                 "error": parse_error or "Judge returned an invalid response.",
+                "fallback": "first_completed_candidate",
+                "winner_index": fallback_candidate["task_index"],
+                "winner_candidate": fallback_candidate["candidate"],
             },
-            None,
+            fallback_winner,
         )
 
     winner = {
@@ -4821,6 +4850,7 @@ DELEGATE_TASK_SCHEMA = {
             },
             "judge": {
                 "type": "string",
+                "maxLength": _MAX_BEST_OF_N_CRITERIA_LENGTH,
                 "description": (
                     "Optional Best-of-N evaluation criteria for batch tasks "
                     "that share the same goal. Use 'default' for correctness, "


### PR DESCRIPTION
## Summary

Adds optional judge-based Best-of-N selection to the existing `delegate_task` batch path.

This implements only Phase 1 of #479.

- keeps the legacy result shape unchanged when `judge` is omitted
- supports default criteria through `judge="default"` and custom criteria strings
- accepts `judge=True` for direct Python callers without exposing a provider-hostile boolean/string union in the model-facing schema
- evaluates successful candidates anonymously as stable Candidate A/B/C labels
- returns structured scores, evaluation status, reasoning, and a compact winner pointer
- preserves every child result when the judge fails, times out, returns empty or malformed JSON, or selects an invalid winner, and deterministically falls back to the first successful task
- skips the auxiliary judge when every candidate failed; a sole successful candidate is selected deterministically
- wires `judge` through both the live `run_agent.py` dispatch and the registry fallback
- runs evaluation inside the current consolidated batch completion closure, including background delegation

## Root cause

Batch delegation already fans out independent child agents and restores results to input order, but it returns all candidate outputs without a shared rubric or structured winner. The parent must compare them manually, consuming context and producing an ad-hoc verdict.

## API

```python
delegate_task(
    tasks=[
        {"goal": "Implement the requested change"},
        {"goal": "Implement the requested change"},
        {"goal": "Implement the requested change"},
    ],
    judge="Evaluate correctness, completeness, robustness, and maintainability.",
)
```

The model-facing tool schema uses a criteria string. `judge="default"` selects the built-in rubric. Direct Python callers may also use `judge=True`.

Best-of-N evaluation requires the batch entries to share the same goal; unrelated batch tasks retain the existing non-judge behavior.

## Result shape

```json
{
  "results": ["...existing per-task results..."],
  "evaluation": {
    "status": "completed",
    "criteria": "...",
    "winner_index": 1,
    "winner_candidate": "B",
    "scores": [
      {"candidate": "A", "task_index": 0, "score": 78},
      {"candidate": "B", "task_index": 1, "score": 91}
    ],
    "reasoning": "..."
  },
  "winner": {
    "task_index": 1,
    "candidate": "B"
  }
}
```

If evaluation fails, `results` remains intact, `evaluation.status` is `failed`, and `winner` deterministically points to the successful candidate with the lowest task index. Custom judge criteria are capped at 500 characters. If no successful candidates exist, the judge is not called and the status is `skipped`.

## Blind evaluation

The judge prompt contains only:

- the shared original task
- optional evaluation criteria
- successful candidate summaries
- stable anonymous labels and original task indices

Execution metadata such as model and provider identity is not included.

## Validation

- `pytest -q tests/tools/test_delegate.py`
  - 76 passed, 5 subtests passed
- `ruff check .`
  - passed
- `ty check` on changed files
  - no diagnostics on added/modified lines
  - the existing files still contain pre-existing non-blocking type diagnostics
- Full non-integration suite was attempted, but this checkout could not install all dev/optional extras because the current lock resolution rejects `defusedxml==0.7.1` for missing publish-time metadata. The fallback environment then produced unrelated collection failures for missing `acp`, `pytest-asyncio`, and `anthropic`. No changed-scope test failed.

## Prior work

PR #18115 explored the same Phase 1 direction. This implementation is rebuilt on current `main`, credits that work, and addresses its unresolved review feedback by:

- forwarding the argument through both model dispatch boundaries
- integrating with the current async consolidated batch closure
- adding model-dispatch and background-completion regression tests
- excluding the unrelated acceptance-criteria helper

## Out of scope

This PR does not include:

- cross-CLI coding agents
- per-task model or provider routing
- historical ranking or Elo
- long-term reputation systems
- Desktop or TUI changes
- MoA synthesis
- unrelated refactors

Part of #479.