### PR TITLE
fix(gateway): keep operator-facing notices out of group chats

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -150,6 +150,20 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
+# Status notices addressed to the deployment OPERATOR, not chat participants.
+# The anchor is the embedded `hermes config set …` opt-out command: a status
+# that tells the reader to run the Hermes CLI is by construction directed at
+# whoever operates the install (e.g. the one-time Codex auto-compaction raise
+# notice from agent/agent_init.py). In a multi-user chat every member would
+# see it — and in a group-bot deployment the FIRST activation is usually a
+# public group, so internal provider/model/config details leaked to third
+# parties. Suppressed only on group scopes; DMs and operator surfaces
+# (CLI/TUI/local) keep the notice.
+_GATEWAY_OPERATOR_STATUS_NOTICE_RE = re.compile(
+    r"\bhermes\s+config\s+set\b",
+    re.IGNORECASE,
+)
+
 
 _HYGIENE_COOLDOWN_LADDER_MULTIPLIERS = (1, 3, 9)
 # Absolute ceiling on an escalated hygiene cooldown, mirroring
@@ -387,6 +401,35 @@ _GATEWAY_RAW_TEXT_PLATFORMS = frozenset(
 def _gateway_surface_passes_raw_text(platform: Any) -> bool:
     """True only for programmatic/local surfaces that must keep raw text."""
     return _gateway_platform_value(platform) in _GATEWAY_RAW_TEXT_PLATFORMS
+
+
+def _source_is_group_scope(source: Any) -> bool:
+    """True when the source chat is a multi-user scope (group/channel/thread).
+
+    Reuses the DM-vs-group mapping from ``gateway.slash_access`` so both
+    gates classify a chat identically. Anything that is not an explicit DM
+    counts as group — for operator-facing deliveries an unknown chat type
+    must fail closed (suppress) rather than post to a possibly-public chat.
+    """
+    from gateway.slash_access import _scope_for_chat_type
+
+    return _scope_for_chat_type(getattr(source, "chat_type", None)) == "group"
+
+
+def _adapter_sends_truly_private_notice(adapter: Any) -> bool:
+    """True when the adapter overrides ``send_private_notice`` for real.
+
+    The ``BasePlatformAdapter`` default falls back to a normal ``send`` so
+    single-recipient platforms can share one call path — but in a group chat
+    that fallback posts the notice publicly, which is exactly the leak the
+    group gate exists to prevent, so the default must not count as private.
+    Only a genuine override (e.g. Slack ephemerals) qualifies.
+    """
+    impl = getattr(type(adapter), "send_private_notice", None)
+    if impl is None:
+        # Instance-level implementations (plugin adapters, test doubles).
+        return callable(getattr(adapter, "send_private_notice", None))
+    return impl is not BasePlatformAdapter.send_private_notice
 
 
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
@@ -816,11 +859,22 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     return redacted
 
 
-def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
+def _prepare_gateway_status_message(
+    platform: Any,
+    event_type: str,
+    message: str,
+    *,
+    group_scope: bool = False,
+) -> Optional[str]:
     """Filter/sanitize agent status callbacks before platform delivery.
 
     Local/CLI sessions keep the raw diagnostic stream. Messaging gateway
     surfaces should not receive transient auxiliary/compression chatter.
+
+    ``group_scope`` marks multi-user chats (groups/channels/threads):
+    operator-directed config notices are additionally suppressed there,
+    because every member of the chat would see them. DM delivery is
+    unchanged.
     """
     text = str(message or "").strip()
     if not text:
@@ -829,6 +883,11 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         return text
 
     text = _redact_gateway_user_facing_secrets(text)
+    if group_scope and _GATEWAY_OPERATOR_STATUS_NOTICE_RE.search(text):
+        # Operator-facing config notice (embeds a `hermes config set`
+        # opt-out) in a multi-user chat: keep it out of the group and let
+        # the operator see it in logs / their own DM instead.
+        return None
     if _TELEGRAM_NOISY_STATUS_RE.search(text):
         # Opt-in #52995: `compression.progress_notices: true` lets ROUTINE
         # compression progress statuses through to chat platforms. The
@@ -5043,6 +5102,7 @@ class TurnRunner:
             ctx.source.platform,
             event_type,
             message,
+            group_scope=_source_is_group_scope(ctx.source),
         )
         if prepared_message is None:
             logger.debug(
@@ -15451,7 +15511,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
     async def _deliver_platform_notice(self, source, content: str) -> None:
-        """Deliver a setup/operational notice using platform-specific privacy rules."""
+        """Deliver a setup/operational notice using platform-specific privacy rules.
+
+        Everything on this rail is operator-facing (home-channel setup
+        prompt, credit-band notices), so a multi-user chat never gets the
+        public path: in a group/channel the notice goes out only through a
+        genuinely private adapter route (Slack ephemerals) and is otherwise
+        logged and dropped. In a group-bot deployment the first activation
+        is usually a public group — delivering there exposed internal setup
+        details (/sethome, provider/model, billing) to every member and
+        invited any of them to claim the home channel. DM delivery keeps
+        its public fallback unchanged: the "public" chat IS the operator.
+        """
         adapter = self._adapter_for_source(source)
         if not adapter:
             return
@@ -15472,23 +15543,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if config and hasattr(config, "get_notice_delivery"):
             notice_delivery = config.get_notice_delivery(source.platform)
 
+        group_scope = _source_is_group_scope(source)
         metadata = self._thread_metadata_for_source(source)
         if notice_delivery == "private" and getattr(source, "user_id", None):
-            try:
-                result = await adapter.send_private_notice(
-                    source.chat_id,
-                    source.user_id,
-                    content,
-                    metadata=metadata,
-                )
-                if getattr(result, "success", False):
-                    return
-            except Exception:
-                logger.debug(
-                    "[%s] send_private_notice failed, falling back to public",
-                    getattr(source, "platform", "?"),
-                    exc_info=True,
-                )
+            # In a group, the BasePlatformAdapter send_private_notice
+            # default falls back to a normal public send — that fallback IS
+            # the leak, so only a real private override counts there.
+            if not group_scope or _adapter_sends_truly_private_notice(adapter):
+                try:
+                    result = await adapter.send_private_notice(
+                        source.chat_id,
+                        source.user_id,
+                        content,
+                        metadata=metadata,
+                    )
+                    if getattr(result, "success", False):
+                        return
+                except Exception:
+                    logger.debug(
+                        "[%s] send_private_notice failed%s",
+                        getattr(source, "platform", "?"),
+                        "" if group_scope else ", falling back to public",
+                        exc_info=True,
+                    )
+
+        if group_scope:
+            logger.info(
+                "Suppressing operator notice in group chat %s:%s (operator-"
+                "facing; would be visible to all members): %s",
+                getattr(getattr(source, "platform", None), "value", "?"),
+                getattr(source, "chat_id", "?"),
+                str(content or "").splitlines()[0][:120] if content else "",
+            )
+            return
 
         await adapter.send(source.chat_id, content, metadata=metadata)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -159,6 +159,17 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
 # public group, so internal provider/model/config details leaked to third
 # parties. Suppressed only on group scopes; DMs and operator surfaces
 # (CLI/TUI/local) keep the notice.
+#
+# Why this is a text rule while _deliver_platform_notice gates on scope
+# alone: an AgentNotice is operator-directed by construction, so that path
+# can suppress the whole class in a group. The status stream is mixed — the
+# same callback carries progress and errors chat participants legitimately
+# see — so it needs a rule that separates the operator-directed subset out of
+# it. The two gates are not redundant and the scope gate is the stronger of
+# the two; a status that stops embedding the CLI opt-out would fall out of
+# this one, which is why the tests build the notice from the emit-site helper
+# (agent_init._build_codex_gpt5_autoraise_notice) instead of a literal, so a
+# rewording fails a test rather than silently reopening the leak.
 _GATEWAY_OPERATOR_STATUS_NOTICE_RE = re.compile(
     r"\bhermes\s+config\s+set\b",
     re.IGNORECASE,
@@ -408,12 +419,11 @@ def _source_is_group_scope(source: Any) -> bool:
 
     Reuses the DM-vs-group mapping from ``gateway.slash_access`` so both
     gates classify a chat identically. Anything that is not an explicit DM
-    counts as group — for operator-facing deliveries an unknown chat type
-    must fail closed (suppress) rather than post to a possibly-public chat.
+    counts as group — for operator-facing deliveries an unknown or empty
+    chat type must fail closed (suppress) rather than post to a
+    possibly-public chat.
     """
-    from gateway.slash_access import _scope_for_chat_type
-
-    return _scope_for_chat_type(getattr(source, "chat_type", None)) == "group"
+    return scope_for_chat_type(getattr(source, "chat_type", None)) == "group"
 
 
 def _adapter_sends_truly_private_notice(adapter: Any) -> bool:
@@ -424,6 +434,15 @@ def _adapter_sends_truly_private_notice(adapter: Any) -> bool:
     that fallback posts the notice publicly, which is exactly the leak the
     group gate exists to prevent, so the default must not count as private.
     Only a genuine override (e.g. Slack ephemerals) qualifies.
+
+    The contract the identity check assumes: ``send_private_notice`` is a
+    plain method on the class, so "is the base function" means "no override".
+    A subclass that binds a real private implementation as an *instance*
+    attribute is not seen here (the class lookup still finds the base) and a
+    property/descriptor on the base compares equal for non-overriders — both
+    drifts resolve to "not private", which suppresses. A mistake here costs a
+    notice nobody receives, never a group leak, but anything that changes how
+    the base declares this method has to revisit this function.
     """
     impl = getattr(type(adapter), "send_private_notice", None)
     if impl is None:
@@ -2590,6 +2609,7 @@ from gateway.session_state import (
 )
 from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
+from gateway.slash_access import scope_for_chat_type
 from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.turn_context import TurnContext
 from gateway.platforms.base import (

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -88,7 +88,11 @@ class SlashAccessPolicy:
         return canonical_cmd in self.user_allowed_commands
 
 
-_DM_CHAT_TYPES = frozenset({"dm", "direct", "private", ""})
+# EXPLICIT DM chat types only. An unset/unknown chat type is deliberately not
+# a member: callers that fail closed on the group side (slash gating, the
+# operator-notice group gate in gateway/run.py) must not have an empty string
+# resolve to "dm" and hand a multi-user chat the DM policy.
+_DM_CHAT_TYPES = frozenset({"dm", "direct", "private"})
 
 
 def _coerce_id_list(raw: Any) -> FrozenSet[str]:
@@ -137,7 +141,14 @@ def _coerce_command_list(raw: Any) -> FrozenSet[str]:
     return frozenset(out)
 
 
-def _scope_for_chat_type(chat_type: Optional[str]) -> str:
+def scope_for_chat_type(chat_type: Optional[str]) -> str:
+    """Map a platform chat type onto the ``dm`` / ``group`` policy scope.
+
+    Public because more than one gate depends on both classifying a chat the
+    same way — slash access here, operator-notice delivery in
+    ``gateway/run.py``. Anything that is not an explicit DM value (including
+    ``None`` and ``""``) resolves to ``group``, the fail-closed side.
+    """
     if chat_type and chat_type.lower() in _DM_CHAT_TYPES:
         return "dm"
     return "group"
@@ -218,7 +229,7 @@ def policy_for_source(gateway_config: Any, source: Any) -> SlashAccessPolicy:
         except Exception:
             platform_config = None
     extra = _platform_extra(platform_config)
-    scope = _scope_for_chat_type(getattr(source, "chat_type", None))
+    scope = scope_for_chat_type(getattr(source, "chat_type", None))
     return policy_from_extra(extra, scope)
 
 
@@ -226,4 +237,5 @@ __all__ = [
     "SlashAccessPolicy",
     "policy_from_extra",
     "policy_for_source",
+    "scope_for_chat_type",
 ]

--- a/tests/gateway/test_notice_delivery.py
+++ b/tests/gateway/test_notice_delivery.py
@@ -95,6 +95,36 @@ async def test_whatsapp_group_public_notice_is_suppressed():
     adapter.send_private_notice.assert_not_awaited()
 
 
+@pytest.mark.parametrize("chat_type", ["", None, "channel", "thread", "supergroup"])
+def test_unknown_or_empty_chat_type_is_group_scope(chat_type):
+    """Only an explicit DM value may take the DM path — everything else
+    fails closed, including an adapter that never set a chat type."""
+    from gateway.run import _source_is_group_scope
+
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type=chat_type,
+        user_id="U123",
+    )
+
+    assert _source_is_group_scope(source) is True
+
+
+@pytest.mark.asyncio
+async def test_unknown_chat_type_notice_is_suppressed():
+    """The fail-closed classification reaches delivery, not just the helper."""
+    runner, adapter = _make_runner()
+    source = SessionSource(
+        platform=Platform.SLACK, chat_id="C123", chat_type="", user_id="U123"
+    )
+
+    await runner._deliver_platform_notice(source, "📬 No home channel is set…")
+
+    adapter.send.assert_not_awaited()
+    adapter.send_private_notice.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_dm_public_notice_still_delivered():
     """DM delivery is unchanged — the 'public' chat IS the operator."""

--- a/tests/gateway/test_notice_delivery.py
+++ b/tests/gateway/test_notice_delivery.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import SendResult
+from gateway.platforms.base import BasePlatformAdapter, SendResult
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
 
@@ -18,17 +18,35 @@ def _make_source() -> SessionSource:
     )
 
 
-def _make_runner(extra=None):
+def _make_dm_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id="D123",
+        chat_type="dm",
+        user_id="U123",
+    )
+
+
+def _make_whatsapp_group_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="1234567890-1600000000@g.us",
+        chat_type="group",
+        user_id="9720000000001@c.us",
+    )
+
+
+def _make_runner(extra=None, platform=Platform.SLACK):
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
         platforms={
-            Platform.SLACK: PlatformConfig(enabled=True, token="***", extra=extra or {})
+            platform: PlatformConfig(enabled=True, token="***", extra=extra or {})
         }
     )
     adapter = MagicMock()
     adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="public-1"))
     adapter.send_private_notice = AsyncMock(return_value=SendResult(success=True, message_id="private-1"))
-    runner.adapters = {Platform.SLACK: adapter}
+    runner.adapters = {platform: adapter}
     return runner, adapter
 
 
@@ -44,6 +62,100 @@ async def test_deliver_platform_notice_uses_private_delivery_when_configured():
         "hello",
         metadata={"thread_id": "111.222"},
     )
+    adapter.send.assert_not_awaited()
+
+
+# ── Group-scope suppression: operator notices must never post publicly in a
+# multi-user chat. In a group-bot deployment the first activation is usually
+# a public group, so the home-channel /sethome prompt and credit notices
+# leaked internal setup details to every member.
+
+
+@pytest.mark.asyncio
+async def test_group_public_notice_is_suppressed():
+    """Default (public) delivery in a group scope stays in the logs."""
+    runner, adapter = _make_runner()
+
+    await runner._deliver_platform_notice(_make_source(), "📬 No home channel is set…")
+
+    adapter.send.assert_not_awaited()
+    adapter.send_private_notice.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_group_public_notice_is_suppressed():
+    """The live leak shape: a WhatsApp group session's first activation."""
+    runner, adapter = _make_runner(platform=Platform.WHATSAPP)
+
+    await runner._deliver_platform_notice(
+        _make_whatsapp_group_source(), "📬 No home channel is set…"
+    )
+
+    adapter.send.assert_not_awaited()
+    adapter.send_private_notice.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dm_public_notice_still_delivered():
+    """DM delivery is unchanged — the 'public' chat IS the operator."""
+    runner, adapter = _make_runner()
+
+    await runner._deliver_platform_notice(_make_dm_source(), "hello")
+
+    adapter.send.assert_awaited_once()
+    assert adapter.send.call_args.args[0] == "D123"
+
+
+@pytest.mark.asyncio
+async def test_group_private_failure_does_not_fall_back_to_public():
+    """A failed private send in a group must not degrade to a public post."""
+    runner, adapter = _make_runner(extra={"notice_delivery": "private"})
+    adapter.send_private_notice = AsyncMock(
+        return_value=SendResult(success=False, error="no ephemeral")
+    )
+
+    await runner._deliver_platform_notice(_make_source(), "hello")
+
+    adapter.send_private_notice.assert_awaited_once()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dm_private_failure_still_falls_back_to_public():
+    """The pre-existing DM fallback (private → public) is preserved."""
+    runner, adapter = _make_runner(extra={"notice_delivery": "private"})
+    adapter.send_private_notice = AsyncMock(
+        return_value=SendResult(success=False, error="nope")
+    )
+
+    await runner._deliver_platform_notice(_make_dm_source(), "hello")
+
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_group_private_base_default_does_not_count_as_private():
+    """The BasePlatformAdapter send_private_notice default falls back to a
+    normal public send — in a group that fallback IS the leak, so it must
+    not be treated as a private path."""
+
+    class _NoPrivatePathAdapter:
+        # Deliberately the Base default, not an override.
+        send_private_notice = BasePlatformAdapter.send_private_notice
+
+        def __init__(self):
+            self.send = AsyncMock(
+                return_value=SendResult(success=True, message_id="public-1")
+            )
+
+    runner, _ = _make_runner(
+        extra={"notice_delivery": "private"}, platform=Platform.WHATSAPP
+    )
+    adapter = _NoPrivatePathAdapter()
+    runner.adapters = {Platform.WHATSAPP: adapter}
+
+    await runner._deliver_platform_notice(_make_whatsapp_group_source(), "hello")
+
     adapter.send.assert_not_awaited()
 
 

--- a/tests/gateway/test_notice_rendering.py
+++ b/tests/gateway/test_notice_rendering.py
@@ -101,6 +101,10 @@ def _make_source(platform_value="telegram", chat_id="555", user_id="u1"):
     # auto-attribute would read as a truthy "stamped profile" and trip the
     # fail-closed path in _adapter_for_source (see AGENTS.md pitfall #17).
     src.profile = None
+    # Real SessionSource.chat_type defaults to "dm"; a MagicMock auto-attribute
+    # would read as an unknown chat type and trip the fail-closed group-scope
+    # suppression in _deliver_platform_notice.
+    src.chat_type = "dm"
     return src
 
 

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -140,6 +140,73 @@ def test_telegram_status_keeps_legitimate_heartbeat_messages(message):
     assert _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", message) == message
 
 
+# ── Operator-directed config notices in group scope ─────────────────────────
+# Statuses that embed a `hermes config set …` opt-out are addressed to the
+# deployment operator, not chat participants. In a group-bot deployment the
+# first activation is usually a public group, so the one-time Codex
+# auto-compaction raise notice leaked provider/model/config details to every
+# member. Group scope suppresses them; DM delivery is unchanged.
+
+
+def _codex_autoraise_notice() -> str:
+    # Built from the SAME helper the emit site uses (agent/agent_init.py →
+    # agent._compression_warning → status_callback("lifecycle", …)), so a
+    # rewording that drops the CLI opt-out anchor fails here instead of
+    # silently reopening the group leak.
+    from agent.agent_init import _build_codex_gpt5_autoraise_notice
+
+    return _build_codex_gpt5_autoraise_notice(
+        {"model": "gpt-5.6-sol", "from": 0.5, "to": 0.85}, context_length=272_000
+    )
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS + ["whatsapp"])
+def test_operator_config_notice_suppressed_in_group_scope(platform):
+    notice = _codex_autoraise_notice()
+    assert "hermes config set" in notice  # the anchor the gate keys on
+    assert (
+        _prepare_gateway_status_message(
+            platform, "lifecycle", notice, group_scope=True
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS + ["whatsapp"])
+def test_operator_config_notice_still_delivered_in_dm_scope(platform):
+    """DMs reach exactly one person — the operator discovery path stays."""
+    notice = _codex_autoraise_notice()
+    assert (
+        _prepare_gateway_status_message(
+            platform, "lifecycle", notice, group_scope=False
+        )
+        == notice
+    )
+
+
+@pytest.mark.parametrize("message", ["still on it", "⏳ Working — 3 min"])
+def test_group_scope_keeps_ordinary_status_messages(message):
+    """The group gate only targets operator config notices, not heartbeats."""
+    assert (
+        _prepare_gateway_status_message(
+            Platform.TELEGRAM, "lifecycle", message, group_scope=True
+        )
+        == message
+    )
+
+
+def test_programmatic_surfaces_keep_operator_notice_regardless_of_scope():
+    """Raw surfaces (local/api/webhook) never lose the diagnostic stream."""
+    notice = _codex_autoraise_notice()
+    for platform in ("local", "api_server", "webhook", "msgraph_webhook"):
+        assert (
+            _prepare_gateway_status_message(
+                platform, "lifecycle", notice, group_scope=True
+            )
+            == notice
+        )
+
+
 @pytest.mark.parametrize("platform", CHAT_PLATFORMS)
 @pytest.mark.parametrize("message", NOISY_STATUS_MESSAGES)
 def test_all_chat_gateways_suppress_noise(platform, message):


### PR DESCRIPTION
## Summary

- Keep operator-only setup and model-configuration notices out of multi-user chats.
- Preserve direct-message delivery, including the existing private-to-public fallback where the public chat is still the operator's DM.
- Allow a group notice only through a genuinely private adapter route; never degrade a failed or default private send into a public group post.

## Problem

The first activation of a group bot is often a public group. Today two one-time operator notices can be delivered there:

1. the home-channel setup prompt, including the `/sethome` instruction;
2. the Codex context auto-raise notice, including a local `hermes config set ...` command.

These messages describe deployment configuration and are intended for the operator, not group participants. The home-channel prompt can also advertise an actionable command in a scope where the operator may not have configured group-admin gating yet.

## Fix

The change gates the notice class at the two common delivery seams:

- `_deliver_platform_notice`: multi-user scopes never receive the normal public path. `notice_delivery: private` is allowed only when the adapter overrides `send_private_notice` with a real private route. A failure does not fall back to the group. DM behavior remains unchanged.
- `_prepare_gateway_status_message`: statuses that embed the operator-facing model configuration command are suppressed for group scope while remaining available in DMs and non-chat surfaces.

Suppressed notices remain visible in server logs with a bounded preview, and the operator can still receive them in a direct conversation.

## Tests

- Slack channel and WhatsApp group public delivery is suppressed.
- Group `private` delivery has no public fallback.
- The base adapter's public fallback is not misclassified as private.
- DM public delivery and DM private-to-public fallback are preserved.
- Model-configuration lifecycle notices are filtered only in multi-user scope.

Validation on current `main`:

```text
155 passed
ruff: clean
git diff --check: clean
```

## Out of scope

This PR does not change slash-command policy. It prevents operator guidance from being published to a group; command authorization remains a separate concern.
