### PR TITLE
fix(cli): reload cli module after prompt_toolkit stub in test_prompt_stash_cli

### DIFF
--- a/tests/cli/test_prompt_stash_cli.py
+++ b/tests/cli/test_prompt_stash_cli.py
@@ -50,16 +50,32 @@ def _make_cli(**kwargs):
         "prompt_toolkit.formatted_text": MagicMock(),
         "prompt_toolkit.auto_suggest": MagicMock(),
     }
-    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict(
-        "os.environ", clean_env, clear=False
-    ):
+    try:
+        with (
+            patch.dict(sys.modules, prompt_toolkit_stubs),
+            patch.dict("os.environ", clean_env, clear=False),
+        ):
+            import cli as _cli_mod
+
+            _cli_mod = importlib.reload(_cli_mod)
+            with (
+                patch.object(_cli_mod, "get_tool_definitions", return_value=[]),
+                patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}),
+            ):
+                return _cli_mod.HermesCLI(**kwargs)
+    finally:
+        # The reload above re-executed `cli.py`'s top-level
+        # `from prompt_toolkit import ... as _pt_print`-style imports against
+        # the MagicMock stubs. `patch.dict(sys.modules, ...)` restores the
+        # real `prompt_toolkit` on exit, but does nothing about the bindings
+        # `cli`'s module dict already captured — those stay MagicMocks and
+        # leak into every other test that does `from cli import ...`
+        # afterward (e.g. tests/cli/test_resume_quiet_stderr.py, whose
+        # stdout assertions then silently see nothing printed). Reload once
+        # more, now against the real modules, to restore genuine bindings.
         import cli as _cli_mod
 
-        _cli_mod = importlib.reload(_cli_mod)
-        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), patch.dict(
-            _cli_mod.__dict__, {"CLI_CONFIG": _clean_config}
-        ):
-            return _cli_mod.HermesCLI(**kwargs)
+        importlib.reload(_cli_mod)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary

- `tests/cli/test_prompt_stash_cli.py`'s `_make_cli()` helper stubs `prompt_toolkit` with `MagicMock`s and calls `importlib.reload(cli)` to construct a `HermesCLI` without a real TUI backend.
- That reload re-executes `cli.py`'s module-level `from prompt_toolkit import print_formatted_text as _pt_print` against the mocked `prompt_toolkit`, permanently rebinding `cli._pt_print` to a `MagicMock` in the shared `cli` module namespace.
- `patch.dict(sys.modules, ...)` restores the real `prompt_toolkit` module on exit, but never re-reloads `cli`, so the mocked binding leaks into every later test in the same pytest process that imports `cli`.
- `cli._cprint()` calls `_pt_print(...)` to write to stdout. With `_pt_print` mocked, `_cprint` silently prints nothing, so `tests/cli/test_resume_quiet_stderr.py::test_session_not_found_goes_to_stdout_in_full_mode` fails with an empty `capsys` capture — but only when it runs *after* `test_prompt_stash_cli.py` in the same process. In isolation it passes.
- `scripts/run_tests.sh` spawns one subprocess per test file for CI parity, so this order dependency never surfaces there — it only reproduces when running `pytest` directly across multiple files (e.g. `pytest tests/cli/`), which is likely how most contributors first sanity-check a change.

Fix: reload `cli` a second time in a `finally` block, after the `prompt_toolkit` stub context has exited, so the module's top-level bindings point back at the real objects.

## Test plan

```
python -m pytest tests/cli/test_prompt_stash_cli.py tests/cli/test_resume_quiet_stderr.py -q
python -m pytest tests/cli/ -q
ruff check tests/cli/test_prompt_stash_cli.py
ruff format --check tests/cli/test_prompt_stash_cli.py
python scripts/check-windows-footguns.py
```

- `966 passed, 9 skipped` on `tests/cli/` (previously `1 failed` in this same run).
- Tested on macOS 26.5.1 (arm64), Python 3.11.15.

## Duplicate check

Searched before opening:
```
gh search issues --repo NousResearch/hermes-agent "resume_quiet_stderr"
gh search issues --repo NousResearch/hermes-agent "flaky test"
gh search prs --repo NousResearch/hermes-agent --state open "resume_quiet_stderr"
gh search prs --repo NousResearch/hermes-agent --state closed "resume_quiet_stderr"
gh search prs --repo NousResearch/hermes-agent --state open "test pollution"
gh search prs --repo NousResearch/hermes-agent --state closed "test pollution"
```
No existing issue or PR (open or closed/merged) references this test or this specific `cli` module-reload leak.

Related issue: none filed — found directly while validating a fresh dev setup per CONTRIBUTING.md.