### PR TITLE
fix(desktop): agent mentions insert as plain @name, not an @simple: chip

### DIFF
--- a/apps/desktop/src/app/chat/composer/directive-label.test.ts
+++ b/apps/desktop/src/app/chat/composer/directive-label.test.ts
@@ -88,6 +88,22 @@ describe('one label per reference, on every surface', () => {
     }
   })
 
+  it('an agent mention inserts as plain @name text, never an @simple: chip', () => {
+    // Rows exactly as complete.path emits profile mentions (colon-less text).
+    const item = backendRow('@mr-tester', '@mr-tester', 'agent profile')
+
+    expect(hermesDirectiveFormatter.serialize(item)).toBe('@mr-tester')
+
+    const { editor, result } = typed('@mr-')
+
+    act(() => result.current.replaceTriggerWithChip(item))
+
+    const plain = composerPlainText(editor)
+
+    expect(plain).toContain('@mr-tester')
+    expect(plain).not.toContain('@simple:')
+  })
+
   it('a folder pick reads as its path, not a bare basename', () => {
     // `src` and `desktop` repeat all over a repo — the row you picked said
     // where it was, and the chip has to keep saying it.

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -197,6 +197,15 @@ export const hermesDirectiveFormatter: Unstable_DirectiveFormatter = {
         return rawText
       }
 
+      // Colon-less completions (`@diff`, `@staged`, agent mentions like
+      // `@researcher`) are plain inline text, not typed references. classify()
+      // gives them `insertId = text`, and the typed-reference branch below
+      // would mint a bogus `@simple:` kind around them — the composer showed
+      // "@simple:`@mr-tester`" for a picked agent mention.
+      if (!rawText.includes(':')) {
+        return rawText
+      }
+
       // Typed references with a value — quote when needed.
       const kindMatch = rawText.match(/^@([^:]+):/)
       const kind = kindMatch?.[1] ?? item.type


### PR DESCRIPTION
Follow-up to #85799 (profile mentions in `complete.path`). Picking a mention row in the composer's @ drawer produced an `@simple:` chip wrapping the backtick-quoted name instead of plain `@mr-tester` — visually wrong (screenshot report from Bot Mode) and functionally wrong: the quoted form no longer parses as a bare mention, so plugin middleware that routes `@<profile>` handoffs never fires.

Root cause: `classify()` types colon-less entries as `'simple'` with `insertId = text`, which pushed them into `serialize()`'s typed-reference branch (`@<kind>:<quoted value>`). Colon-less rawText now inserts verbatim — the same behavior `@diff`/`@staged` already got via the empty-insertId path.

Validation: new directive-label test asserts mention rows serialize to plain `@name` and commit to the editor without an `@simple:` wrapper; suite 5/5 locally.
