### PR TITLE
fix(desktop): keep vendor casing in model display names

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -137,7 +137,7 @@ describe('ModelMenuPanel current selection', () => {
     const { content } = renderPanel()
 
     const currentRow = (await content.findByText(/Gemini 3\.1 Pro/i)).closest('[role="menuitem"]')
-    const staleRow = content.getByText('Deepseek Chat').closest('[role="menuitem"]')
+    const staleRow = content.getByText('DeepSeek Chat').closest('[role="menuitem"]')
 
     expect(currentRow?.querySelector('.codicon-check')).not.toBeNull()
     expect(staleRow?.querySelector('.codicon-check')).toBeNull()
@@ -159,7 +159,7 @@ describe('ModelMenuPanel search', () => {
     $currentModel.set('deepseek-v4-pro')
     const { content } = renderPanel()
 
-    await content.findByText(/Deepseek V4 Pro/i)
+    await content.findByText(/DeepSeek V4 Pro/i)
 
     const input = screen.getByRole('textbox', { name: 'Search models' })
     fireEvent.change(input, { target: { value: 'gemini' } })
@@ -167,7 +167,7 @@ describe('ModelMenuPanel search', () => {
     await vi.waitFor(() => {
       expect(rowWithText(content, /Gemini 3\.1 Pro/i)).not.toBeNull()
     })
-    expect(rowWithText(content, /Deepseek V4 Pro/i)).toBeNull()
+    expect(rowWithText(content, /DeepSeek V4 Pro/i)).toBeNull()
   })
 
   it('Enter in the search field commits the first match', async () => {
@@ -271,8 +271,8 @@ describe('ModelMenuPanel provider collapse', () => {
     const { content } = renderPanel()
 
     await content.findByText('DeepSeek')
-    expect(content.queryByText('Deepseek V4 Pro')).not.toBeNull()
-    expect(content.queryByText('Deepseek Chat')).not.toBeNull()
+    expect(content.queryByText('DeepSeek V4 Pro')).not.toBeNull()
+    expect(content.queryByText('DeepSeek Chat')).not.toBeNull()
   })
 
   it('collapses provider models when header is clicked', async () => {
@@ -282,7 +282,7 @@ describe('ModelMenuPanel provider collapse', () => {
     fireEvent.click(header)
 
     // Models should disappear but header stays
-    expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+    expect(content.queryByText('DeepSeek V4 Pro')).toBeNull()
     expect(content.queryByText('DeepSeek')).not.toBeNull()
   })
 
@@ -292,11 +292,11 @@ describe('ModelMenuPanel provider collapse', () => {
     const header = await content.findByText('DeepSeek')
     // Collapse
     fireEvent.click(header)
-    expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+    expect(content.queryByText('DeepSeek V4 Pro')).toBeNull()
     // Expand
     fireEvent.click(header)
     await vi.waitFor(() => {
-      expect(content.queryByText('Deepseek V4 Pro')).not.toBeNull()
+      expect(content.queryByText('DeepSeek V4 Pro')).not.toBeNull()
     })
   })
 
@@ -311,7 +311,7 @@ describe('ModelMenuPanel provider collapse', () => {
     // The current provider is collapsible like any other — clicking its header
     // hides its models rather than forcing them to stay open.
     await vi.waitFor(() => {
-      expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+      expect(content.queryByText('DeepSeek V4 Pro')).toBeNull()
     })
   })
 
@@ -320,7 +320,7 @@ describe('ModelMenuPanel provider collapse', () => {
 
     const header = await content.findByText('DeepSeek')
     fireEvent.click(header)
-    expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+    expect(content.queryByText('DeepSeek V4 Pro')).toBeNull()
 
     // Type in the search bar (auto-focused by DropdownMenuSearch)
     const input = screen.getByRole('textbox', { name: 'Search models' })
@@ -333,7 +333,7 @@ describe('ModelMenuPanel provider collapse', () => {
     await vi.waitFor(() => {
       expect(
         content.queryByText(
-          (_, element) => element?.tagName === 'SPAN' && (element.textContent ?? '').startsWith('Deepseek V4 Pro')
+          (_, element) => element?.tagName === 'SPAN' && (element.textContent ?? '').startsWith('DeepSeek V4 Pro')
         )
       ).not.toBeNull()
     })
@@ -346,7 +346,7 @@ describe('ModelMenuPanel provider collapse', () => {
     // Radix DropdownMenuItem fires onSelect on Enter from the onKeyDown handler
     fireEvent.keyDown(header.closest('[role="menuitem"]') ?? header, { key: 'Enter' })
 
-    expect(content.queryByText('Deepseek V4 Pro')).toBeNull()
+    expect(content.queryByText('DeepSeek V4 Pro')).toBeNull()
   })
 
   // The collapsed-providers set is a global presentation preference

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -7,7 +7,7 @@ describe('model-status-label', () => {
   it('formats display names consistently', () => {
     expect(displayModelName('anthropic/claude-opus-4.8-fast')).toBe('Opus 4.8')
     expect(displayModelName('openai/gpt-5.5-fast')).toBe('GPT-5.5')
-    expect(displayModelName('deepseek/deepseek-v4-pro-thinking')).toBe('Deepseek V4 Pro')
+    expect(displayModelName('deepseek/deepseek-v4-pro-thinking')).toBe('DeepSeek V4 Pro')
     expect(displayModelName('openai/gpt-5.5')).toBe('GPT-5.5')
   })
 
@@ -44,6 +44,28 @@ describe('model-status-label', () => {
 
   it('returns just the placeholder name when there is no model', () => {
     expect(formatModelStatusLabel('')).toBe('No model')
+  })
+
+  it('keeps vendor casing that the model id does not carry', () => {
+    expect(displayModelName('glm-5.2')).toBe('GLM 5.2')
+    expect(displayModelName('zai-org/glm-5.1')).toBe('GLM 5.1')
+    expect(displayModelName('deepseek-v4-flash')).toBe('DeepSeek V4 Flash')
+    expect(displayModelName('minimax/minimax-01')).toBe('MiniMax 01')
+    expect(displayModelName('xiaomi/mimo-v2.5')).toBe('MiMo V2.5')
+    expect(displayModelName('ernie-5.1')).toBe('ERNIE 5.1')
+    expect(displayModelName('baai/bge-m3')).toBe('BGE M3')
+  })
+
+  it('capitalises parameter counts the way vendors write them', () => {
+    expect(displayModelName('qwen3-32b')).toBe('Qwen3 32B')
+    expect(displayModelName('qwen/qwen3.5-35b-a3b')).toBe('Qwen3.5 35B A3B')
+    expect(displayModelName('meta/llama-3.1-8b-instruct-fp8')).toBe('Llama 3.1 8B Instruct FP8')
+  })
+
+  it('title-cases gemini names like every other branch', () => {
+    expect(displayModelName('gemini-2.5-pro')).toBe('Gemini 2.5 Pro')
+    expect(displayModelName('gemini-2.0-flash')).toBe('Gemini 2.0 Flash')
+    expect(displayModelName('google/gemini-2.5-flash-lite')).toBe('Gemini 2.5 Flash Lite')
   })
 
   describe('currentPickerSelection', () => {

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -53,20 +53,57 @@ const VARIANT_TAGS: ReadonlyArray<readonly [RegExp, string]> = [
 
 const titleCase = (text: string): string => text.replace(/\b\w/g, char => char.toUpperCase()).trim()
 
+// Vendors write their own names in casing a model id does not carry, and
+// title-casing the id overrides it: `glm-5.2` reads as "Glm 5.2" rather than
+// "GLM 5.2". Restore the vendor's casing after title-casing rather than before,
+// so the rule is one pass over a normalized string.
+const VENDOR_CASING: ReadonlyArray<readonly [RegExp, string]> = [
+  [/\bDeepseek\b/g, 'DeepSeek'],
+  [/\bGlm\b/g, 'GLM'],
+  [/\bMinimax\b/g, 'MiniMax'],
+  [/\bOpenai\b/g, 'OpenAI'],
+  [/\bErnie\b/g, 'ERNIE'],
+  [/\bMimo\b/g, 'MiMo'],
+  [/\bBge\b/g, 'BGE'],
+  [/\bVl\b/g, 'VL'],
+  [/\bIt\b/g, 'IT'],
+  [/\bFp8\b/g, 'FP8'],
+  [/\bAi\b/g, 'AI']
+]
+
+// Parameter counts and active-parameter counts: vendors write 8B, 235B, A22B,
+// never 8b. Matched after title-casing, so the token looks like "8b" or "A3b".
+const PARAMETER_COUNT = /\b(a?)(\d+(?:\.\d+)?)b\b/gi
+
+const applyVendorCasing = (text: string): string => {
+  let cased = text.replace(
+    PARAMETER_COUNT,
+    (_match, prefix: string, size: string) => `${prefix.toUpperCase()}${size}B`
+  )
+
+  for (const [pattern, replacement] of VENDOR_CASING) {
+    cased = cased.replace(pattern, replacement)
+  }
+
+  return cased
+}
+
 function prettifyBase(base: string): string {
   if (/^claude-/i.test(base)) {
-    return titleCase(base.replace(/^claude-/i, '').replace(/-/g, ' '))
+    return applyVendorCasing(titleCase(base.replace(/^claude-/i, '').replace(/-/g, ' ')))
   }
 
   if (/^gpt-/i.test(base)) {
     return base.replace(/^gpt-/i, 'GPT-')
   }
 
+  // Title-case this branch too. Without it `gemini-2.5-pro` renders as
+  // "Gemini 2.5 pro", the only branch that left its words lowercase.
   if (/^gemini-/i.test(base)) {
-    return base.replace(/^gemini-/i, 'Gemini ').replace(/-/g, ' ')
+    return applyVendorCasing(titleCase(base.replace(/^gemini-/i, 'Gemini ').replace(/-/g, ' ')))
   }
 
-  return titleCase(base.replace(/-/g, ' '))
+  return applyVendorCasing(titleCase(base.replace(/-/g, ' ')))
 }
 
 /** Split a model id into a clean display name plus an optional grayed variant


### PR DESCRIPTION
## What does this PR do?

`prettifyBase()` in `apps/desktop/src/lib/model-status-label.ts` builds picker labels by title-casing the model id, which overrides the casing vendors use for their own names. `glm-5.2` renders as "Glm 5.2" and `deepseek-v4-flash` as "Deepseek V4 Flash". Separately, the `gemini-` branch returns before any capitalisation happens, so `gemini-2.5-pro` renders as "Gemini 2.5 pro", the only branch whose words stay lowercase.

The picker only ever receives model ids (`ModelFamily` in `apps/desktop/src/store/model-visibility.ts` is `{ id, fastId }`, with no catalogue name available in the renderer), so this keeps the id-based approach and corrects the casing afterwards:

1. `VENDOR_CASING`, a whole-word table applied after `titleCase` (GLM, DeepSeek, MiniMax, OpenAI, ERNIE, MiMo, BGE, and the acronyms VL, IT, FP8, AI).
2. `PARAMETER_COUNT`, so `8b` becomes `8B` and `a3b` becomes `A3B`. Vendors always capitalise a parameter count.
3. The `gemini-` branch now runs through `titleCase` like the Claude branch does.

Version tokens are deliberately untouched. Vendors disagree there (DeepSeek writes "V4", NVIDIA writes "v2" in the same catalogue), so there is no single correct answer and normalising would trade one wrong label for another.

### Prior art

@jbbottoms opened #78680 on the same bug (brand casing plus GPT variant tokens) and self-closed it unmerged on 7 Aug with no review on it. This PR is narrower: it leaves the GPT branch alone, and like #78680 it leaves dash-separated version normalisation to #78663, which is still open. Happy to close this in favour of either if you would rather take those.

## Related Issue

Fixes #85849

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/model-status-label.ts`: add `VENDOR_CASING`, `PARAMETER_COUNT` and `applyVendorCasing()`, apply it in the Claude, Gemini and fallback branches of `prettifyBase()`, and title-case the Gemini branch.
- `apps/desktop/src/lib/model-status-label.test.ts`: three new cases (vendor casing, parameter counts, Gemini names). One existing expectation pinned the bug, `'Deepseek V4 Pro'`, and is updated to `'DeepSeek V4 Pro'`.
- `apps/desktop/src/app/shell/model-menu-panel.test.tsx`: the menu tests assert on rendered labels, so they carried the mis-cased form too. Worth noting that the provider fixture at the top of that same file already spells the provider `'DeepSeek'`, so the labels now agree with it. Model ids in the fixtures are untouched and stay lowercase. The Gemini assertions there already used case-insensitive regexes, so they needed no change.

## How to Test

The helper is exported, so the behaviour is checkable directly:

```js
displayModelName('glm-5.2')                  // was "Glm 5.2",           now "GLM 5.2"
displayModelName('deepseek-v4-flash')        // was "Deepseek V4 Flash", now "DeepSeek V4 Flash"
displayModelName('gemini-2.5-pro')           // was "Gemini 2.5 pro",    now "Gemini 2.5 Pro"
displayModelName('qwen/qwen3.5-35b-a3b')     // was "Qwen3.5 35b A3b",   now "Qwen3.5 35B A3B"
displayModelName('gpt-5.5')                  // "GPT-5.5" (unchanged)
displayModelName('claude-opus-4.8-fast')     // "Opus 4.8" (unchanged)
```

1. `cd apps/desktop && npx vitest run --project ui src/lib/model-status-label.test.ts`
2. Or open the desktop model picker with a GLM, DeepSeek or Gemini model configured and read the labels.

To check it does not make anything worse, I ran both the old and the new logic over every model in the models.dev catalogue Hermes already caches (`~/.hermes/models_dev_cache.json`, 3154 entries carrying both an id and a vendor name) and compared each rendered label against the vendor name:

- **288** labels that did not match the vendor name now do.
- **19** now differ from the catalogue name, and in every one of those the catalogue name is itself the mangled form. For example `zai-org/glm-5.2` is named "GLM 5.2" while Cloudflare's mirror of the same model, `@cf/zai-org/glm-5.2`, is named "Glm 5.2"; others include "Llama 3.1 8b Instruct" and "Hermes 3 Llama 3.1 405b". None of them is a case where a correct label became wrong.
- Before this change, 1093 of the 3154 differed from the vendor name by letter case alone.

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (found #78680, self-closed unmerged, and #78663, open and scoped to dash versions; both are addressed above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is TypeScript in the desktop app and touches no Python. The vitest command above is the equivalent, and CI runs the desktop suite.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A. N/A, the change is internal to one helper and is documented by comments next to the two tables.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A. N/A, no config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A. N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A. Pure string handling in the renderer, no platform-specific behaviour.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A. N/A.

## Screenshots / Logs

| Model id | Before | After |
|---|---|---|
| `glm-5.2` | Glm 5.2 | GLM 5.2 |
| `deepseek-v4-flash` | Deepseek V4 Flash | DeepSeek V4 Flash |
| `minimax-01` | Minimax 01 | MiniMax 01 |
| `gemini-2.5-pro` | Gemini 2.5 pro | Gemini 2.5 Pro |
| `qwen3.5-35b-a3b` | Qwen3.5 35b A3b | Qwen3.5 35B A3B |
| `llama-3.1-8b-instruct-fp8` | Llama 3.1 8b Instruct Fp8 | Llama 3.1 8B Instruct FP8 |
| `gpt-5.5` | GPT-5.5 | GPT-5.5 |

---

🤖 Generated with Claude Code (Claude Opus 5)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee
