### PR TITLE
fix(cron): isolate root agent context

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -54,6 +54,7 @@ from hermes_cli.fallback_config import get_fallback_chain
 from hermes_time import now as _hermes_now
 from agent.interrupt_compat import request_hard_interrupt
 from agent.delegation_context import (
+    _DELEGATED_CHILD_CONTEXT,
     enter_non_dispatcher_owned_context,
     exit_non_dispatcher_owned_context,
 )
@@ -3867,6 +3868,7 @@ def run_job(
     _cron_session_var = _VAR_MAP["HERMES_CRON_SESSION"]
     _cron_session_token = None
     _non_dispatcher_token = None
+    _delegated_child_token = None
     try:
         if not _cwd_lock_acquired:
             # Fail closed (#79768): running without the lock would let a
@@ -3889,6 +3891,12 @@ def run_job(
         # which would suppress the legacy os.environ fallback used by standalone
         # cron entrypoints and tests.
         _cron_session_token = _cron_session_var.set("1")
+
+        # A scheduled cron run is a root agent execution even if the scheduler
+        # was invoked from a delegated child. Clear the task-local marker before
+        # constructing AIAgent so schema/tool availability uses cron identity;
+        # reset it in finally so the caller's child isolation is unchanged.
+        _delegated_child_token = _DELEGATED_CHILD_CONTEXT.set(False)
 
         # Mark this job as NOT the dispatcher-owned kanban worker.
         #
@@ -4705,6 +4713,8 @@ def run_job(
             _cron_session_var.reset(_cron_session_token)
         if _non_dispatcher_token is not None:
             exit_non_dispatcher_owned_context(_non_dispatcher_token)
+        if _delegated_child_token is not None:
+            _DELEGATED_CHILD_CONTEXT.reset(_delegated_child_token)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
         if _session_db:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4709,12 +4709,16 @@ def run_job(
         # clear_session_vars also clears _SESSION_CWD internally, so no
         # separate clear_session_cwd() call is needed.
         clear_session_vars(_ctx_tokens)
+        # Restore the caller's delegated-child identity first. A ContextVar
+        # reset can raise for a stale token, and this boundary must not leak
+        # cron's root identity back to the scheduler caller if another reset
+        # fails during cleanup.
+        if _delegated_child_token is not None:
+            _DELEGATED_CHILD_CONTEXT.reset(_delegated_child_token)
         if _cron_session_token is not None:
             _cron_session_var.reset(_cron_session_token)
         if _non_dispatcher_token is not None:
             exit_non_dispatcher_owned_context(_non_dispatcher_token)
-        if _delegated_child_token is not None:
-            _DELEGATED_CHILD_CONTEXT.reset(_delegated_child_token)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
         if _session_db:

--- a/tests/cron/test_scheduler_cron_session_isolation.py
+++ b/tests/cron/test_scheduler_cron_session_isolation.py
@@ -71,6 +71,61 @@ def _clear_approval_state(monkeypatch):
     reset_session_vars()
 
 
+def test_run_job_does_not_inherit_delegated_child_context(monkeypatch, tmp_path):
+    """Cron is a root session even when its caller is a delegated child."""
+    from agent.delegation_context import (
+        delegated_child_context,
+        is_delegated_child_context,
+    )
+
+    class _DelegationProbeAgent:
+        def __init__(self, *args, **kwargs):
+            assert is_delegated_child_context() is False
+            assert get_session_env("HERMES_CRON_SESSION") == "1"
+
+        def run_conversation(self, prompt):
+            assert is_delegated_child_context() is False
+            assert get_session_env("HERMES_CRON_SESSION") == "1"
+            return {
+                "completed": True,
+                "failed": False,
+                "final_response": "cron root context",
+                "turn_exit_reason": "",
+            }
+
+        def close(self):
+            pass
+
+    monkeypatch.setenv("HERMES_MODEL", "test-model")
+    monkeypatch.setattr("hermes_state.SessionDB", _DummySessionDB)
+    monkeypatch.setattr("run_agent.AIAgent", _DelegationProbeAgent)
+    monkeypatch.setattr(
+        "hermes_constants.resolve_reasoning_config", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "test-key", "base_url": None, "provider": "test-provider",
+            "api_mode": None, "command": None, "args": None,
+        },
+    )
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: [])
+    monkeypatch.setattr(cron_scheduler, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(cron_scheduler, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr(cron_scheduler, "_guard_job_credential_exfil", lambda _job: None)
+
+    with delegated_child_context():
+        success, _output, final_response, error = cron_scheduler.run_job({
+            "id": "delegated-cron", "name": "Delegated Cron", "prompt": "Run safely",
+            "schedule_display": "manual",
+        })
+        assert is_delegated_child_context() is True
+
+    assert success is True
+    assert error is None
+    assert final_response == "cron root context"
+
+
 def _register_gateway_auto_approve(session_key: str) -> None:
     def _notify(_approval_data):
         with approval_module._lock:

--- a/tests/cron/test_scheduler_cron_session_isolation.py
+++ b/tests/cron/test_scheduler_cron_session_isolation.py
@@ -126,6 +126,54 @@ def test_run_job_does_not_inherit_delegated_child_context(monkeypatch, tmp_path)
     assert final_response == "cron root context"
 
 
+def test_run_job_restores_delegated_context_when_cron_reset_raises(monkeypatch, tmp_path):
+    """A failing cron reset must not leak root identity back to the caller."""
+    from agent.delegation_context import (
+        delegated_child_context,
+        is_delegated_child_context,
+    )
+
+    class _RaisingResetVar:
+        def set(self, _value):
+            return object()
+
+        def reset(self, _token):
+            raise RuntimeError("cron reset failed")
+
+    monkeypatch.setenv("HERMES_MODEL", "test-model")
+    monkeypatch.setattr("hermes_state.SessionDB", _DummySessionDB)
+    monkeypatch.setattr("run_agent.AIAgent", _FakeCronAgent)
+    monkeypatch.setattr(
+        "hermes_constants.resolve_reasoning_config", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "***", "base_url": None, "provider": "test-provider",
+            "api_mode": None, "command": None, "args": None,
+        },
+    )
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: [])
+    monkeypatch.setattr(cron_scheduler, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(cron_scheduler, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr(cron_scheduler, "_guard_job_credential_exfil", lambda _job: None)
+    from gateway.session_context import _VAR_MAP
+
+    monkeypatch.setitem(_VAR_MAP, "HERMES_CRON_SESSION", _RaisingResetVar())
+
+    with delegated_child_context():
+        with pytest.raises(RuntimeError, match="cron reset failed"):
+            cron_scheduler.run_job(
+                {
+                    "id": "delegated-cron-reset-failure",
+                    "name": "Delegated Cron Reset Failure",
+                    "prompt": "Run safely",
+                    "schedule_display": "manual",
+                }
+            )
+        assert is_delegated_child_context() is True
+
+
 def _register_gateway_auto_approve(session_key: str) -> None:
     def _notify(_approval_data):
         with approval_module._lock:


### PR DESCRIPTION
## Summary

Fixes the delegated-child ContextVar leak at the cron scheduler boundary.

A cron run is a root agent session even when scheduler code is invoked while a `delegate_task` child context is active. Previously `contextvars.copy_context()` carried that marker into the thread running `agent.run_conversation`, which made the official Kanban CLI and tools fail closed.

## Changes

- clear only the delegated-child ContextVar for the full cron-run scope, before `AIAgent` construction and schema/tool resolution;
- reset that marker in `finally`, then preserve the corrected cron Context across the `run_conversation` thread handoff;
- add regression coverage that runs `run_job()` under `delegated_child_context()` and proves the cron agent sees a root context while the outer child context is restored.

## Safety

This does **not** relax Kanban permissions for real delegated children. It only prevents a top-level cron execution from inheriting the caller's task-local delegation identity.

## Validation

- `PYTHONPATH=. python3 -m pytest -q tests/cron/test_scheduler_cron_session_isolation.py -o 'addopts='` → 2 passed
- `PYTHONPATH=. python3 -m pytest -q tests/tools/test_delegate_kanban_isolation.py -o 'addopts='` → 6 passed
- `PYTHONPATH=. python3 -m pytest -q tests/cron/test_scheduler.py -o 'addopts='` → 72 passed
- `git diff --check`

Related: #81697
Complements #81767, which fixes explicit cron Kanban toolset selection; this change fixes the independent root-context inheritance path.
