### PR TITLE
feat(desktop): agent-to-agent messages render as attributed cards, not user bubbles

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/agent-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/agent-message.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { AGENT_MESSAGE_RE } from './user-message'
+
+// Agent-to-agent deliveries render as an attributed inter-agent card, not a
+// user bubble. This pins the detection contract: both the Bot Mode prefix
+// ("Message from 🤖 <sender>: …") and the legacy bracket form match, and
+// human prose that merely mentions the phrase does not.
+describe('agent message detection', () => {
+  it('matches the Bot Mode delivery prefix with sender and body', () => {
+    const m = AGENT_MESSAGE_RE.exec('Message from 🤖 Hermes: hello there')
+
+    expect(m?.[1]?.trim()).toBe('Hermes')
+    expect(m?.[3]).toBe('hello there')
+  })
+
+  it('matches without the robot emoji', () => {
+    const m = AGENT_MESSAGE_RE.exec('Message from Turquoise: ready to work')
+
+    expect(m?.[1]?.trim()).toBe('Turquoise')
+    expect(m?.[3]).toBe('ready to work')
+  })
+
+  it('matches the legacy bracket form', () => {
+    const m = AGENT_MESSAGE_RE.exec("[Message from agent 'turqoise'] ping")
+
+    expect(m?.[2]).toBe('turqoise')
+    expect(m?.[3]).toBe('ping')
+  })
+
+  it('spans multi-line bodies', () => {
+    const m = AGENT_MESSAGE_RE.exec('Message from 🤖 Dev: line one\nline two')
+
+    expect(m?.[3]).toBe('line one\nline two')
+  })
+
+  it('does not match prose that merely contains the phrase', () => {
+    expect(AGENT_MESSAGE_RE.test('I got a Message from 🤖 Hermes: earlier')).toBe(false)
+    expect(AGENT_MESSAGE_RE.test('can you explain what Message from means?')).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/agent-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/agent-message.test.tsx
@@ -2,36 +2,45 @@ import { describe, expect, it } from 'vitest'
 
 import { AGENT_MESSAGE_RE } from './user-message'
 
-// Agent-to-agent deliveries render as an attributed inter-agent card, not a
-// user bubble. This pins the detection contract: both the Bot Mode prefix
-// ("Message from 🤖 <sender>: …") and the legacy bracket form match, and
-// human prose that merely mentions the phrase does not.
+// Agent-to-agent deliveries render as a compact attributed timeline notice,
+// not a user bubble. This pins the detection contract: the Bot Mode prefix
+// ("Message from 🤖 <sender>: …"), the handle-carrying form
+// ("Message from 🤖 <sender> (@<handle>): …"), and the legacy bracket form
+// all match; human prose that merely mentions the phrase does not.
 describe('agent message detection', () => {
   it('matches the Bot Mode delivery prefix with sender and body', () => {
     const m = AGENT_MESSAGE_RE.exec('Message from 🤖 Hermes: hello there')
 
     expect(m?.[1]?.trim()).toBe('Hermes')
-    expect(m?.[3]).toBe('hello there')
+    expect(m?.[4]).toBe('hello there')
+  })
+
+  it('captures the @handle when present', () => {
+    const m = AGENT_MESSAGE_RE.exec('Message from 🤖 Eats Tests (@mr-tester): run them all')
+
+    expect(m?.[1]?.trim()).toBe('Eats Tests')
+    expect(m?.[2]).toBe('mr-tester')
+    expect(m?.[4]).toBe('run them all')
   })
 
   it('matches without the robot emoji', () => {
     const m = AGENT_MESSAGE_RE.exec('Message from Turquoise: ready to work')
 
     expect(m?.[1]?.trim()).toBe('Turquoise')
-    expect(m?.[3]).toBe('ready to work')
+    expect(m?.[4]).toBe('ready to work')
   })
 
   it('matches the legacy bracket form', () => {
     const m = AGENT_MESSAGE_RE.exec("[Message from agent 'turqoise'] ping")
 
-    expect(m?.[2]).toBe('turqoise')
-    expect(m?.[3]).toBe('ping')
+    expect(m?.[3]).toBe('turqoise')
+    expect(m?.[4]).toBe('ping')
   })
 
   it('spans multi-line bodies', () => {
     const m = AGENT_MESSAGE_RE.exec('Message from 🤖 Dev: line one\nline two')
 
-    expect(m?.[3]).toBe('line one\nline two')
+    expect(m?.[4]).toBe('line one\nline two')
   })
 
   it('does not match prose that merely contains the phrase', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -77,6 +77,37 @@ export const StopGlyph = <StopFilled aria-hidden className="size-3.5 -translate-
 // Shape: see tools/process_registry.py format_process_notification().
 const PROCESS_NOTIFICATION_RE = /^\[IMPORTANT: Background process [\s\S]*\]$/
 
+// Agent-to-agent deliveries ("Message from 🤖 <sender>: …", the Bot Mode /
+// multi-profile convention; legacy "[Message from agent '<sender>'] …" too).
+// They arrive on the user role because the recipient's turn runs on it, but
+// they are NOT the human speaking — render them as an attributed inter-agent
+// card instead of a user bubble.
+export const AGENT_MESSAGE_RE = /^(?:Message from (?:🤖\s*)?([^:\n]{1,64}):\s*|\[Message from agent '([^']{1,64})'\]\s*)([\s\S]*)$/u
+
+const AgentMessageNote: FC<{ text: string }> = ({ text }) => {
+  const match = AGENT_MESSAGE_RE.exec(text)
+  const sender = (match?.[1] || match?.[2] || 'agent').trim()
+  const body = (match?.[3] || '').trim()
+
+  return (
+    <div
+      className="flex w-full min-w-0 max-w-[min(92%,48rem)] flex-col gap-1 self-start rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-bg-secondary,rgba(255,255,255,0.03)) px-3 py-2"
+      data-slot="aui_agent-message-note"
+    >
+      <span className="flex items-center gap-1.5 text-[0.6875rem] font-medium uppercase tracking-wider text-(--ui-text-tertiary)">
+        <span aria-hidden className="text-[0.8125rem] leading-none">
+          🤖
+        </span>
+        <span className="wrap-anywhere normal-case">{sender}</span>
+        <span className="font-normal normal-case tracking-normal text-(--ui-text-quaternary)">· agent message</span>
+      </span>
+      <span className="wrap-anywhere text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground/90">
+        <UserMessageText text={body || text} />
+      </span>
+    </div>
+  )
+}
+
 const ProcessNotificationNote: FC<{ text: string }> = ({ text }) => {
   const body = text.replace(/^\[IMPORTANT:\s*/, '').replace(/\]$/, '')
   const newline = body.indexOf('\n')
@@ -225,6 +256,19 @@ export const UserMessage: FC<{
         data-slot="aui_user-message-root"
       >
         <ProcessNotificationNote text={messageText.trim()} />
+      </MessagePrimitive.Root>
+    )
+  }
+
+  // Agent-to-agent delivery, not a human prompt — attributed inter-agent card.
+  if (AGENT_MESSAGE_RE.test(messageText.trim())) {
+    return (
+      <MessagePrimitive.Root
+        className="flex w-full min-w-0 flex-col items-stretch pb-(--conversation-turn-gap)"
+        data-role="user"
+        data-slot="aui_user-message-root"
+      >
+        <AgentMessageNote text={messageText.trim()} />
       </MessagePrimitive.Root>
     )
   }

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -89,21 +89,32 @@ const AgentMessageNote: FC<{ text: string }> = ({ text }) => {
   const sender = (match?.[1] || match?.[2] || 'agent').trim()
   const body = (match?.[3] || '').trim()
 
+  // Grok-bots shape: an inter-agent delivery is a timeline EVENT, not a
+  // conversation bubble — a subtle centered notice ("Message from 🤖 X"),
+  // with the delivered text one click away instead of shouting in the
+  // transcript. The recipient's reply below it stays a normal assistant
+  // message, so the exchange still reads in order.
   return (
     <div
-      className="flex w-full min-w-0 max-w-[min(92%,48rem)] flex-col gap-1 self-start rounded-xl border border-(--ui-stroke-tertiary) bg-(--ui-bg-secondary,rgba(255,255,255,0.03)) px-3 py-2"
+      className="flex max-w-[min(86%,44rem)] flex-col gap-0.5 self-center px-2 py-0.5 text-[0.6875rem] leading-5 text-muted-foreground/60"
       data-slot="aui_agent-message-note"
     >
-      <span className="flex items-center gap-1.5 text-[0.6875rem] font-medium uppercase tracking-wider text-(--ui-text-tertiary)">
+      <span className="flex items-center justify-center gap-1.5">
         <span aria-hidden className="text-[0.8125rem] leading-none">
           🤖
         </span>
-        <span className="wrap-anywhere normal-case">{sender}</span>
-        <span className="font-normal normal-case tracking-normal text-(--ui-text-quaternary)">· agent message</span>
+        <span className="wrap-anywhere">Message from {sender}</span>
       </span>
-      <span className="wrap-anywhere text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground/90">
-        <UserMessageText text={body || text} />
-      </span>
+      {body && (
+        <details className="self-center">
+          <summary className="cursor-pointer select-none text-center text-muted-foreground/45 hover:text-muted-foreground/70">
+            show message
+          </summary>
+          <div className="mt-1 max-w-[36rem] rounded-lg border border-(--ui-stroke-tertiary) px-3 py-2 text-left text-[0.75rem] leading-5 text-foreground/85">
+            <UserMessageText text={body} />
+          </div>
+        </details>
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -2,7 +2,6 @@ import { ActionBarPrimitive, BranchPickerPrimitive, MessagePrimitive, useAuiStat
 import { type FC, type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
-import { $gateway } from '@/store/gateway'
 import { messageAttachmentRefs, messageContentText } from '@/components/assistant-ui/thread/content'
 import { ReactionBadge, ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
@@ -14,6 +13,7 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { StopFilled } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { $gateway } from '@/store/gateway'
 import { notifyThreadEditOpen } from '@/store/thread-scroll'
 import { isWatchWindow } from '@/store/windows'
 

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -1,7 +1,8 @@
 import { ActionBarPrimitive, BranchPickerPrimitive, MessagePrimitive, useAuiState } from '@assistant-ui/react'
-import { type FC, type ReactNode, useCallback, useRef, useState } from 'react'
+import { type FC, type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
+import { $gateway } from '@/store/gateway'
 import { messageAttachmentRefs, messageContentText } from '@/components/assistant-ui/thread/content'
 import { ReactionBadge, ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
@@ -78,16 +79,103 @@ export const StopGlyph = <StopFilled aria-hidden className="size-3.5 -translate-
 const PROCESS_NOTIFICATION_RE = /^\[IMPORTANT: Background process [\s\S]*\]$/
 
 // Agent-to-agent deliveries ("Message from 🤖 <sender>: …", the Bot Mode /
-// multi-profile convention; legacy "[Message from agent '<sender>'] …" too).
-// They arrive on the user role because the recipient's turn runs on it, but
-// they are NOT the human speaking — render them as an attributed inter-agent
-// card instead of a user bubble.
-export const AGENT_MESSAGE_RE = /^(?:Message from (?:🤖\s*)?([^:\n]{1,64}):\s*|\[Message from agent '([^']{1,64})'\]\s*)([\s\S]*)$/u
+// multi-profile convention; optional "(@<handle>)" carries the sender's
+// profile name for avatar resolution; legacy "[Message from agent
+// '<sender>'] …" too). They arrive on the user role because the recipient's
+// turn runs on it, but they are NOT the human speaking — render them as a
+// compact attributed timeline notice instead of a user bubble.
+export const AGENT_MESSAGE_RE =
+  /^(?:Message from (?:🤖\s*)?([^:\n(]{1,64}?)(?:\s*\(@([a-z0-9][a-z0-9_-]{0,63})\))?:\s*|\[Message from agent '([^']{1,64})'\]\s*)([\s\S]*)$/u
+
+// sender handle -> avatar data URL (null = known absent). Module-level so a
+// chat full of notices from one bot resolves once. Profiles change rarely;
+// stale entries only persist for the window's lifetime.
+const agentAvatarCache = new Map<string, null | string>()
+const agentAvatarInflight = new Map<string, Promise<null | string>>()
+
+async function resolveAgentAvatar(handle: string): Promise<null | string> {
+  const key = handle.trim().toLowerCase()
+
+  if (!key) {
+    return null
+  }
+
+  if (agentAvatarCache.has(key)) {
+    return agentAvatarCache.get(key) ?? null
+  }
+
+  const inflight = agentAvatarInflight.get(key)
+
+  if (inflight) {
+    return inflight
+  }
+
+  const run = (async (): Promise<null | string> => {
+    try {
+      const gateway = $gateway.get()
+
+      if (!gateway) {
+        return null
+      }
+
+      const res = await gateway.request<{ profiles?: Array<{ has_avatar?: boolean; name: string }> }>(
+        'profiles.list',
+        { include_sessions: false }
+      )
+      const profiles = res?.profiles ?? []
+      let profile = profiles.find(p => p.name.toLowerCase() === key)
+
+      // 'hermes' is the conventional alias for the primary profile.
+      if (!profile && key === 'hermes') {
+        profile = profiles.find(p => p.name === 'default')
+      }
+
+      if (!profile?.has_avatar) {
+        return null
+      }
+
+      const asset = await gateway.request<{ data?: string; found?: boolean }>('profiles.get_asset', {
+        asset: 'avatar',
+        name: profile.name
+      })
+
+      return asset?.found && asset.data ? asset.data : null
+    } catch {
+      // Older gateway (no profiles.* RPCs) or transient failure — the 🤖
+      // glyph fallback is always correct.
+      return null
+    } finally {
+      agentAvatarInflight.delete(key)
+    }
+  })()
+
+  agentAvatarInflight.set(key, run)
+  const out = await run
+  agentAvatarCache.set(key, out)
+
+  return out
+}
 
 const AgentMessageNote: FC<{ text: string }> = ({ text }) => {
   const match = AGENT_MESSAGE_RE.exec(text)
-  const sender = (match?.[1] || match?.[2] || 'agent').trim()
-  const body = (match?.[3] || '').trim()
+  const sender = (match?.[1] || match?.[3] || 'agent').trim()
+  const handle = (match?.[2] || match?.[3] || sender).trim()
+  const body = (match?.[4] || '').trim()
+  const [avatar, setAvatar] = useState<null | string>(() => agentAvatarCache.get(handle.toLowerCase()) ?? null)
+
+  useEffect(() => {
+    let live = true
+
+    void resolveAgentAvatar(handle).then(url => {
+      if (live && url) {
+        setAvatar(url)
+      }
+    })
+
+    return () => {
+      live = false
+    }
+  }, [handle])
 
   // Grok-bots shape: an inter-agent delivery is a timeline EVENT, not a
   // conversation bubble — a subtle centered notice ("Message from 🤖 X"),
@@ -100,9 +188,13 @@ const AgentMessageNote: FC<{ text: string }> = ({ text }) => {
       data-slot="aui_agent-message-note"
     >
       <span className="flex items-center justify-center gap-1.5">
-        <span aria-hidden className="text-[0.8125rem] leading-none">
-          🤖
-        </span>
+        {avatar ? (
+          <img alt="" aria-hidden className="size-4 shrink-0 rounded-full object-cover" src={avatar} />
+        ) : (
+          <span aria-hidden className="text-[0.8125rem] leading-none">
+            🤖
+          </span>
+        )}
         <span className="wrap-anywhere">Message from {sender}</span>
       </span>
       {body && (


### PR DESCRIPTION
Agent-to-agent messages (the Bot Mode plugin's bot-to-bot deliveries, `hermes -p <bot> chat -q "Message from 🤖 <sender>: …"`) necessarily arrive on the **user role** — the recipient's turn runs on it, and role alternation forbids anything else. But rendering them as user bubbles reads as "the human typed this," which is wrong and (user report, screenshot) genuinely confusing in multi-agent setups.

Follow the exact precedent of `PROCESS_NOTIFICATION_RE` / `ProcessNotificationNote` (background-process notifications, same file, same reason): detect the delivery prefix and render an **attributed inter-agent card** instead — left-aligned, 🤖 + sender name header with an "agent message" label, body through the same minimal markdown pipeline (`UserMessageText`). Detection is anchored (`^`), covers the current emoji form, the emoji-less form, and the legacy `[Message from agent '<name>']` bracket form, and cannot fire on prose that merely contains the phrase.

Purely presentational: message content, roles, persistence, and caching are untouched — the same text simply stops impersonating the human.

Validation: new `agent-message.test.tsx` pins the detection contract (modern/emoji-less/legacy forms, multi-line bodies, no mid-sentence matches) — 5/5.
