### PR TITLE
fix(openviking): mirror native memory replace/remove with stable URIs

### DIFF
--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -106,17 +106,45 @@ work under every OpenViking auth mode and version; the `viking://~` alias only
 expands for USER/ADMIN roles, not the default dev mode.
 Explicit remembers do not depend on session commit extraction.
 
-Hermes built-in `memory` tool additions are mirrored to OpenViking after the
-local memory operation succeeds:
+Successful Hermes built-in `memory` mutations are mirrored to OpenViking in
+FIFO order. Hermes persists the exact OpenViking URI for each native memory
+entry in the active profile at
+`$HERMES_HOME/openviking/memory_mirror_registry.json`, so later mutations never
+need to guess a target by semantic similarity:
 
 | Hermes action | OpenViking operation |
 |---------------|----------------------|
-| `add` | `content/write` with `mode=create` under the configured peer memory namespace |
+| `add` | `content/write` with `mode=create`; store the exact returned URI in the mirror registry |
+| `replace` | resolve one registry entry from `target` + `old_text`, then replace the same URI and wait for semantic/vector refresh |
+| `remove` | resolve one registry entry from `target` + `old_text`, then delete that exact URI and wait for semantic cleanup |
 
-Built-in `replace` and `remove` operations are not mirrored because Hermes
-native memory entries do not yet carry stable OpenViking file URIs. Use
-`viking_forget` when the user explicitly asks to delete a specific OpenViking
-memory URI.
+URI construction uses the same server-asserted explicit user identity and client
+snapshot as the current OpenViking provider, so registry entries keep the canonical
+`viking://user/<user>/peers/...` identity used by current servers.
+
+The mirror registry owns only memories created through this built-in-memory
+bridge. Session-extracted memories and explicit `viking_remember` writes are not
+registered or modified by it. Existing OpenViking memories created before the
+registry was introduced also have no safe automatic mapping: a later built-in
+`replace` or `remove` for such an entry fails closed with a warning and leaves
+OpenViking unchanged rather than guessing which memory to mutate. Use
+`viking_forget` with an exact URI for manual cleanup of those entries.
+
+`replace` and `remove` resolve the same `old_text` supplied by the native memory
+tool against the registry's pre-mutation content. If that text no longer maps
+to exactly one registry entry, the OpenViking mutation fails closed rather than
+selecting a URI heuristically.
+
+The mirror is asynchronous and intentionally not a distributed transaction.
+The local Hermes memory mutation commits before the OpenViking request. If that
+remote request then fails (for example because of a transient network error),
+the failure is logged at WARNING and this PR does not durably replay the event;
+Hermes and OpenViking can therefore drift until the entry is repaired manually
+or later reconciliation/durable-outbox work handles it.
+
+Registry writes request file mode `0600` on POSIX systems. That mode is not an
+equivalent Windows ACL guarantee, so Windows deployments should rely on the
+normal account/filesystem access controls protecting `HERMES_HOME`.
 
 `viking_forget` is intentionally narrow. It only accepts concrete user memory
 file URIs, such as

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -4904,8 +4904,10 @@ class OpenVikingMemoryProvider(MemoryProvider):
         content: str,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Mirror successful built-in memory additions to OpenViking."""
-        if action != "add" or not content or not self._ensure_client():
+        """Mirror successful built-in memory mutations to OpenViking."""
+        if action not in {"add", "replace", "remove"} or not self._ensure_client():
+            return
+        if action in {"add", "replace"} and not content:
             return
 
         subdir = _MEMORY_WRITE_TARGET_SUBDIR_MAP.get(target, _DEFAULT_MEMORY_SUBDIR)
@@ -4917,32 +4919,19 @@ class OpenVikingMemoryProvider(MemoryProvider):
             logger.debug("OpenViking memory mirror client creation failed: %s", e)
             return
 
-        def _write():
-            try:
-                uri = self._build_memory_uri(
-                    subdir, client=client, timeout=_RECALL_MIN_TIMEOUT_SECONDS,
-                )
-                client.post("/api/v1/content/write", {
-                    "uri": uri,
-                    "content": content,
-                    "mode": "create",
-                })
-            except Exception as e:
-                logger.debug("OpenViking memory mirror failed: %s", e)
-            finally:
-                with self._memory_write_lock:
-                    self._memory_write_threads.discard(threading.current_thread())
+        from plugins.memory.openviking.native_memory_mirror import (
+            enqueue_native_memory_write,
+        )
 
-        t = threading.Thread(target=_write, daemon=True, name="openviking-memwrite")
-        with self._memory_write_lock:
-            if self._shutting_down:
-                return
-            self._memory_write_threads.add(t)
-            try:
-                t.start()
-            except Exception as e:
-                self._memory_write_threads.discard(t)
-                logger.debug("OpenViking memory mirror worker failed to start: %s", e)
+        enqueue_native_memory_write(
+            self,
+            action,
+            target,
+            content,
+            metadata=metadata,
+            subdir=subdir,
+            client=client,
+        )
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         return [
@@ -4979,6 +4968,11 @@ class OpenVikingMemoryProvider(MemoryProvider):
         # Stop deferred finalizers from issuing new commits against a
         # torn-down client, then drain everything still in flight.
         self._shutting_down = True
+        from plugins.memory.openviking.native_memory_mirror import (
+            shutdown_native_memory_mirror,
+        )
+
+        shutdown_native_memory_mirror(self, timeout=5.0)
         # Wait for every in-flight writer across all tracked sessions.
         with self._inflight_lock:
             all_workers = [

--- a/plugins/memory/openviking/native_memory_mirror.py
+++ b/plugins/memory/openviking/native_memory_mirror.py
@@ -1,0 +1,293 @@
+"""Stable mirroring for Hermes native MEMORY.md / USER.md entries.
+
+Hermes' built-in memory tool identifies entries by unique text substrings rather
+than durable IDs. OpenViking, by contrast, needs an exact ``viking://`` file URI
+to update or delete a memory safely. This module keeps the missing identity map
+in a small profile-scoped registry and serializes mirror operations through one
+FIFO worker.
+
+The registry is intentionally narrow: it tracks only memories created through
+the built-in-memory mirror. Session-extracted memories and explicit
+``viking_remember`` writes are outside its ownership and are never guessed at or
+deleted by similarity.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from utils import atomic_json_write
+
+logger = logging.getLogger("plugins.memory.openviking")
+
+_REGISTRY_VERSION = 1
+_REGISTRY_RELATIVE_PATH = Path("openviking") / "memory_mirror_registry.json"
+_SUPPORTED_ACTIONS = frozenset({"add", "replace", "remove"})
+_POLL_SECONDS = 0.05
+
+
+class _MappingError(RuntimeError):
+    """A destructive mirror operation could not resolve one exact URI."""
+
+
+class NativeMemoryMirror:
+    """FIFO, profile-scoped mirror of Hermes native memory into OpenViking."""
+
+    def __init__(self, provider: Any):
+        self._provider = provider
+        self._queue: queue.Queue[Dict[str, Any]] = queue.Queue()
+        self._state_lock = threading.Lock()
+        self._worker: Optional[threading.Thread] = None
+        self._shutting_down = False
+
+    def enqueue(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+        subdir: str,
+        client: Any,
+    ) -> None:
+        """Queue one committed built-in-memory mutation in call order."""
+        if action not in _SUPPORTED_ACTIONS:
+            return
+        if action in {"add", "replace"} and not content:
+            return
+
+        event = {
+            "action": action,
+            "target": str(target or "memory"),
+            "content": str(content or ""),
+            "metadata": dict(metadata or {}),
+            "subdir": str(subdir),
+            "client": client,
+        }
+
+        with self._state_lock:
+            if self._shutting_down:
+                logger.warning(
+                    "OpenViking memory mirror skipped %s during provider shutdown",
+                    action,
+                )
+                return
+            self._queue.put(event)
+            if self._worker is None or not self._worker.is_alive():
+                self._worker = threading.Thread(
+                    target=self._run,
+                    daemon=True,
+                    name="openviking-memory-mirror",
+                )
+                self._worker.start()
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        """Drain queued mirror operations, then stop the FIFO worker."""
+        with self._state_lock:
+            self._shutting_down = True
+            worker = self._worker
+
+        if worker is None:
+            return
+
+        deadline = time.monotonic() + max(0.0, timeout)
+        while self._queue.unfinished_tasks and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        remaining = max(0.0, deadline - time.monotonic())
+        if worker.is_alive() and remaining:
+            worker.join(timeout=remaining)
+        if worker.is_alive():
+            logger.warning("OpenViking memory mirror worker did not drain before shutdown")
+
+    def _run(self) -> None:
+        while True:
+            with self._state_lock:
+                stopping = self._shutting_down
+            if stopping and self._queue.empty():
+                return
+
+            try:
+                event = self._queue.get(timeout=_POLL_SECONDS)
+            except queue.Empty:
+                continue
+
+            try:
+                self._apply(event)
+            except _MappingError as exc:
+                logger.warning("OpenViking memory mirror skipped: %s", exc)
+            except Exception as exc:
+                logger.warning("OpenViking memory mirror failed: %s", exc)
+            finally:
+                self._queue.task_done()
+
+    def _registry_path(self) -> Path:
+        root = str(getattr(self._provider, "_hermes_home", "") or "").strip()
+        if not root:
+            from hermes_constants import get_hermes_home
+
+            root = str(get_hermes_home())
+        return Path(root) / _REGISTRY_RELATIVE_PATH
+
+    def _load_registry(self) -> Dict[str, Any]:
+        path = self._registry_path()
+        if not path.exists():
+            return {"version": _REGISTRY_VERSION, "entries": []}
+
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise RuntimeError(f"cannot read mirror registry {path}: {exc}") from exc
+
+        if not isinstance(payload, dict) or payload.get("version") != _REGISTRY_VERSION:
+            raise RuntimeError(f"unsupported or invalid mirror registry: {path}")
+        entries = payload.get("entries")
+        if not isinstance(entries, list):
+            raise RuntimeError(f"invalid mirror registry entries: {path}")
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise RuntimeError(f"invalid mirror registry entry: {path}")
+            if not all(isinstance(entry.get(key), str) for key in ("target", "uri", "content")):
+                raise RuntimeError(f"invalid mirror registry entry fields: {path}")
+        return payload
+
+    def _save_registry(self, registry: Dict[str, Any]) -> None:
+        path = self._registry_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_json_write(path, registry, mode=0o600)
+
+    @staticmethod
+    def _resolve_mapping(
+        registry: Dict[str, Any],
+        *,
+        target: str,
+        old_text: str,
+        action: str,
+    ) -> tuple[int, Dict[str, str]]:
+        old_text = str(old_text or "").strip()
+        if not old_text:
+            raise _MappingError(f"{action} requires old_text for stable URI resolution")
+
+        matches = [
+            (index, entry)
+            for index, entry in enumerate(registry["entries"])
+            if entry["target"] == target and old_text in entry["content"]
+        ]
+        if not matches:
+            raise _MappingError(
+                f"{action} has no stable OpenViking URI mapping for target={target!r}; "
+                "leaving OpenViking unchanged"
+            )
+        if len(matches) != 1:
+            raise _MappingError(
+                f"{action} matched {len(matches)} OpenViking URI mappings for "
+                f"target={target!r}; leaving OpenViking unchanged"
+            )
+        return matches[0]
+
+    def _apply(self, event: Dict[str, Any]) -> None:
+        action = event["action"]
+        target = event["target"]
+        content = event["content"]
+        metadata = event["metadata"]
+        registry = self._load_registry()
+        client = event["client"]
+
+        if action == "add":
+            # The native store treats exact duplicate adds as idempotent. Mirror
+            # the same way if a duplicate notification ever reaches us.
+            if any(
+                entry["target"] == target and entry["content"] == content
+                for entry in registry["entries"]
+            ):
+                return
+
+            requested_uri = self._provider._build_memory_uri(
+                event["subdir"], client=client, timeout=0.05
+            )
+            response = client.post(
+                "/api/v1/content/write",
+                {"uri": requested_uri, "content": content, "mode": "create"},
+            )
+            result = response.get("result", {}) if isinstance(response, dict) else {}
+            canonical_uri = (
+                str(result.get("uri") or "").strip()
+                if isinstance(result, dict)
+                else ""
+            ) or requested_uri
+            registry["entries"].append(
+                {"target": target, "uri": canonical_uri, "content": content}
+            )
+            self._save_registry(registry)
+            return
+
+        old_text = metadata.get("old_text")
+        index, mapping = self._resolve_mapping(
+            registry,
+            target=target,
+            old_text=str(old_text or ""),
+            action=action,
+        )
+        uri = mapping["uri"]
+
+        if action == "replace":
+            client.post(
+                "/api/v1/content/write",
+                {"uri": uri, "content": content, "mode": "replace", "wait": True},
+            )
+            registry["entries"][index] = {
+                "target": target,
+                "uri": uri,
+                "content": content,
+            }
+            self._save_registry(registry)
+            return
+
+        client.delete(
+            "/api/v1/fs",
+            params={"uri": uri, "recursive": False, "wait": True},
+        )
+        registry["entries"].pop(index)
+        self._save_registry(registry)
+
+
+_MIRROR_ATTR = "_native_memory_mirror"
+
+
+def enqueue_native_memory_write(
+    provider: Any,
+    action: str,
+    target: str,
+    content: str,
+    *,
+    metadata: Optional[Dict[str, Any]] = None,
+    subdir: str,
+    client: Any,
+) -> None:
+    """Lazily create the provider's FIFO mirror and enqueue one operation."""
+    mirror = getattr(provider, _MIRROR_ATTR, None)
+    if mirror is None:
+        mirror = NativeMemoryMirror(provider)
+        setattr(provider, _MIRROR_ATTR, mirror)
+    mirror.enqueue(
+        action,
+        target,
+        content,
+        metadata=metadata,
+        subdir=subdir,
+        client=client,
+    )
+
+
+def shutdown_native_memory_mirror(provider: Any, timeout: float = 5.0) -> None:
+    """Drain the provider's native-memory mirror if it was ever used."""
+    mirror = getattr(provider, _MIRROR_ATTR, None)
+    if mirror is not None:
+        mirror.shutdown(timeout=timeout)

--- a/tests/plugins/memory/test_openviking_memory_mirror.py
+++ b/tests/plugins/memory/test_openviking_memory_mirror.py
@@ -1,0 +1,257 @@
+# Regression coverage for hermes-agent#31000.
+
+import json
+import threading
+import time
+
+import pytest
+
+from plugins.memory.openviking import OpenVikingMemoryProvider
+
+
+class _FakeVikingClient:
+    def __init__(self, *, fail_post: bool = False):
+        self._lock = threading.Lock()
+        self.calls = []
+        self.fail_post = fail_post
+
+    def post(self, path, payload=None, **kwargs):
+        with self._lock:
+            self.calls.append(("post", path, dict(payload or {}), dict(kwargs)))
+        if self.fail_post:
+            raise RuntimeError("mirror write failed")
+        if path == "/api/v1/content/write":
+            return {
+                "status": "ok",
+                "result": {
+                    "uri": (payload or {}).get("uri", ""),
+                    "written_bytes": len((payload or {}).get("content", "")),
+                },
+            }
+        return {"status": "ok", "result": {}}
+
+    def get(self, path, params=None, **kwargs):
+        if path == "/api/v1/system/status":
+            return {"status": "ok", "result": {"user": "default"}}
+        return {"status": "ok", "result": {}}
+
+    def delete(self, path, **kwargs):
+        with self._lock:
+            self.calls.append(("delete", path, None, dict(kwargs)))
+        return {"status": "ok", "result": {"uri": kwargs.get("params", {}).get("uri", "")}}
+
+    def snapshot(self):
+        with self._lock:
+            return list(self.calls)
+
+
+def _provider(tmp_path, client):
+    provider = OpenVikingMemoryProvider()
+    provider._hermes_home = str(tmp_path)
+    provider._agent = "hermes"
+    provider._client = client
+    provider._ensure_client = lambda: client
+    provider._new_client = lambda: client
+    return provider
+
+
+def _wait_for(predicate, *, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    pytest.fail("timed out waiting for OpenViking mirror worker")
+
+
+def _registry_path(tmp_path):
+    return tmp_path / "openviking" / "memory_mirror_registry.json"
+
+
+def test_replace_updates_the_same_openviking_uri_and_registry(tmp_path):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+
+    provider.on_memory_write("add", "user", "Preferred provider is DeepInfra")
+    _wait_for(lambda: len(client.snapshot()) == 1)
+    create = client.snapshot()[0]
+    uri = create[2]["uri"]
+
+    provider.on_memory_write(
+        "replace",
+        "user",
+        "Preferred provider is OpenRouter",
+        metadata={"old_text": "DeepInfra"},
+    )
+    _wait_for(lambda: len(client.snapshot()) == 2)
+
+    replace = client.snapshot()[1]
+    assert replace[0:2] == ("post", "/api/v1/content/write")
+    assert replace[2]["uri"] == uri
+    assert replace[2]["content"] == "Preferred provider is OpenRouter"
+    assert replace[2]["mode"] == "replace"
+    assert replace[2]["wait"] is True
+
+    registry = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
+    assert registry == {
+        "version": 1,
+        "entries": [
+            {
+                "target": "user",
+                "uri": uri,
+                "content": "Preferred provider is OpenRouter",
+            }
+        ],
+    }
+    provider.shutdown()
+
+
+def test_remove_deletes_exact_mapped_uri_and_registry_entry(tmp_path):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+
+    provider.on_memory_write("add", "memory", "Project alpha is active")
+    _wait_for(lambda: len(client.snapshot()) == 1)
+    uri = client.snapshot()[0][2]["uri"]
+
+    provider.on_memory_write(
+        "remove",
+        "memory",
+        "",
+        metadata={"old_text": "alpha is active"},
+    )
+    _wait_for(lambda: len(client.snapshot()) == 2)
+
+    delete = client.snapshot()[1]
+    assert delete[0:2] == ("delete", "/api/v1/fs")
+    assert delete[3]["params"] == {"uri": uri, "recursive": False, "wait": True}
+
+    registry = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
+    assert registry == {"version": 1, "entries": []}
+    provider.shutdown()
+
+
+def test_mapping_survives_provider_restart_for_true_replace(tmp_path):
+    client = _FakeVikingClient()
+    first = _provider(tmp_path, client)
+
+    first.on_memory_write("add", "user", "Employment status is job seeking")
+    _wait_for(lambda: len(client.snapshot()) == 1)
+    uri = client.snapshot()[0][2]["uri"]
+    first.shutdown()
+
+    second = _provider(tmp_path, client)
+    second.on_memory_write(
+        "replace",
+        "user",
+        "Employment status is employed",
+        metadata={"old_text": "job seeking"},
+    )
+    _wait_for(lambda: len(client.snapshot()) == 2)
+
+    replace = client.snapshot()[1]
+    assert replace[2]["uri"] == uri
+    assert replace[2]["mode"] == "replace"
+    assert replace[2]["wait"] is True
+    assert replace[2]["content"] == "Employment status is employed"
+    second.shutdown()
+
+
+def test_rapid_add_replace_remove_is_processed_in_fifo_order(tmp_path):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+
+    provider.on_memory_write("add", "user", "Device owned: Tablet A")
+    provider.on_memory_write(
+        "replace",
+        "user",
+        "Device owned: Tablet B",
+        metadata={"old_text": "Tablet A"},
+    )
+    provider.on_memory_write(
+        "remove",
+        "user",
+        "",
+        metadata={"old_text": "Tablet B"},
+    )
+
+    _wait_for(lambda: len(client.snapshot()) == 3)
+    calls = client.snapshot()
+    uri = calls[0][2]["uri"]
+
+    assert [(call[0], call[1]) for call in calls] == [
+        ("post", "/api/v1/content/write"),
+        ("post", "/api/v1/content/write"),
+        ("delete", "/api/v1/fs"),
+    ]
+    assert calls[0][2]["mode"] == "create"
+    assert calls[1][2]["mode"] == "replace"
+    assert calls[1][2]["wait"] is True
+    assert calls[1][2]["uri"] == uri
+    assert calls[2][3]["params"] == {"uri": uri, "recursive": False, "wait": True}
+
+    registry = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
+    assert registry == {"version": 1, "entries": []}
+    provider.shutdown()
+
+
+def test_unmapped_replace_fails_closed_with_warning(tmp_path, caplog):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+
+    with caplog.at_level("WARNING", logger="plugins.memory.openviking"):
+        provider.on_memory_write(
+            "replace",
+            "user",
+            "Employment status is employed",
+            metadata={"old_text": "job seeking"},
+        )
+        provider.shutdown()
+
+    assert client.snapshot() == []
+    assert any(
+        "no stable OpenViking URI mapping" in record.message
+        for record in caplog.records
+    )
+
+
+def test_ambiguous_replace_fails_closed_without_guessing(tmp_path, caplog):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+
+    provider.on_memory_write("add", "user", "Device owned: Tablet A")
+    provider.on_memory_write("add", "user", "Device owned: Tablet B")
+    _wait_for(lambda: len(client.snapshot()) == 2)
+
+    with caplog.at_level("WARNING", logger="plugins.memory.openviking"):
+        provider.on_memory_write(
+            "replace",
+            "user",
+            "Device owned: Tablet C",
+            metadata={"old_text": "Tablet"},
+        )
+        provider.shutdown()
+
+    assert len(client.snapshot()) == 2
+    assert any(
+        "matched 2 OpenViking URI mappings" in record.message
+        for record in caplog.records
+    )
+
+
+def test_final_mirror_failure_is_visible_at_warning_level(tmp_path, caplog):
+    client = _FakeVikingClient(fail_post=True)
+    provider = _provider(tmp_path, client)
+
+    with caplog.at_level("WARNING", logger="plugins.memory.openviking"):
+        provider.on_memory_write("add", "user", "Visible failure")
+        _wait_for(lambda: len(client.snapshot()) == 1)
+        _wait_for(
+            lambda: any(
+                record.levelname == "WARNING" and "OpenViking memory mirror failed" in record.message
+                for record in caplog.records
+            )
+        )
+
+    assert not _registry_path(tmp_path).exists()
+    provider.shutdown()


### PR DESCRIPTION
## Summary

Addresses the OpenViking side of #31000 by giving Hermes native memory entries a stable OpenViking identity.

- persist a profile-scoped native-memory → OpenViking URI registry
- mirror successful `add` as create, `replace` on the same URI, and `remove` as an exact URI delete
- serialize mirror events through one FIFO worker
- wait for semantic/index refresh after replace/remove so stale retrieval does not survive the mutation ACK
- fail closed on missing or ambiguous mappings rather than guessing by semantic similarity
- surface mirror failures at WARNING
- document ownership/migration boundaries and add regression coverage

## Why

Hermes native memory uses substring-based `old_text` matching, while OpenViking requires an exact `viking://` URI for safe mutation. Earlier snapshot-style approaches could leave the old memory retrievable after replace/remove. The registry supplies the missing stable identity.

## Safety / compatibility

The mirror registry owns only memories created through this bridge. Session-extracted memories, explicit `viking_remember` memories, and memories mirrored before this registry existed are not guessed at or modified automatically.

For a pre-registry entry, built-in `replace`/`remove` fails closed with a warning; use `viking_forget` with the exact URI for manual cleanup.

`replace` and `remove` wait for OpenViking semantic/index cleanup before considering the remote mutation acknowledged, reducing the window where stale content can still be retrieved.

## Deliberate non-goals

This PR does not implement:

- durable outbox / crash replay
- reconciliation/backfill for pre-registry entries
- cross-process mirror serialization

Those are follow-up reliability work. In particular, this mirror is ordered within one provider process but is not a distributed transaction between `MEMORY.md`/`USER.md` and OpenViking.

## Validation

Test-driven validation:

- RED against current add-only behavior: 5 new regression tests failed while 2,673 existing tests in the same slice passed.
- GREEN focused OpenViking/memory suite: 103 passed.
- Index-freshness RED: 4 failed / 3 passed before `wait=true`.
- Index-freshness GREEN: 7 passed after replace/remove waited for semantic cleanup.
- Final clean commit: all 12 Python test slices passed, plus blocking ruff, ruff+ty diff, E2E, Windows footgun, macOS/Windows-specific, OSV, and supply-chain checks.

The fork-only contributor-attribution gate is not included in that claim: its reusable workflow compares against the fork's stale `origin/main` and flags unrelated upstream history. No contributor mapping is added for that false positive.

Addresses #31000