### PR TITLE
fix(cli): disambiguate custom provider identity by model before URL

### DIFF
--- a/hermes_cli/runtime_provider_custom.py
+++ b/hermes_cli/runtime_provider_custom.py
@@ -281,23 +281,20 @@ def canonical_custom_identity(*, base_url: Optional[str] = None, config_provider
     if not candidate:
         candidate = os.environ.get("HERMES_INFERENCE_PROVIDER", "").strip()
     candidate_norm = _normalize_custom_provider_name(candidate)
-    # A bare/non-routable candidate cannot heal a bare custom override.
-    if not candidate_norm or candidate_norm in {"custom", "auto", "openrouter"}:
-        # 3. URL-only recovery is a last resort because several named custom providers can
-        #    legitimately share the same gateway URL.
-        return url_identity
-    # Only when it resolves to a configured entry — never invent a ``custom:<x>`` resolution
-    # can't honor. ``candidate`` may be the entry's DISPLAY NAME, not the durable identity of a
-    # keyed ``providers:`` entry — return the durable config-key identity instead of deriving it
-    # from the ambiguous base_url.
-    try:
-        entry = rp._get_named_custom_provider(candidate)
-    except Exception:
-        entry = None
-    if entry is not None:
-        provider_key = _clean(entry.get("provider_key", ""))
-        entry_name = _clean(entry.get("name", "")) or candidate
-        return custom_provider_slug(entry_name, provider_key)
+    if candidate_norm and candidate_norm not in {"custom", "auto", "openrouter"}:
+        # Only return it when it actually resolves to a configured custom entry, so we never
+        # invent a ``custom:<x>`` that resolution can't honor. ``candidate`` may be the entry's
+        # DISPLAY NAME — ``_get_named_custom_provider`` accepts either spelling. Return the
+        # durable config-key identity instead of deriving it from the ambiguous base_url.
+        try:
+            entry = rp._get_named_custom_provider(candidate)
+        except Exception:
+            entry = None
+        if entry is not None:
+            provider_key = _clean(entry.get("provider_key", ""))
+            entry_name = _clean(entry.get("name", "")) or candidate
+            return custom_provider_slug(entry_name, provider_key)
+
     # 3. URL-only recovery is a last resort because several named custom providers can
     #    legitimately share the same gateway URL.
     return url_identity

--- a/hermes_cli/runtime_provider_custom.py
+++ b/hermes_cli/runtime_provider_custom.py
@@ -252,23 +252,26 @@ def find_custom_provider_identity_by_model(model: str) -> Optional[str]:
 
 def canonical_custom_identity(*, base_url: Optional[str] = None, config_provider: Optional[str] = None,
                               model: Optional[str] = None) -> Optional[str]:
-    """Recover the durable menu identity for a bare custom provider. Match a configured
-    endpoint first, then the ownership-checked managed server, then a configured model or
-    provider. Every session persistence/restore path shares this lookup."""
+    """Recover the durable menu identity for a bare custom provider. Named providers use the
+    model catalog first, then the configured provider, then URL ownership as a last resort for
+    shared gateways. An unconfigured, ownership-checked managed endpoint keeps its llama.cpp
+    identity ahead of model or config recovery. Every persistence/restore path shares this lookup."""
     rp = _rp()
-    if base_url:
-        identity = find_custom_provider_identity(base_url)
-        if identity:
-            return identity
+    url_identity = find_custom_provider_identity(base_url) if base_url else None
+    if base_url and not url_identity:
         # The managed server has no custom-provider config entry. Recover its menu key
         # from the ownership-checked endpoint, never from a model name or a fixed port.
         from hermes_cli.local_runtime.endpoint import _state_endpoint
         endpoint = _state_endpoint()
         if endpoint and _normalize_base_url_for_match(base_url) == _normalize_base_url_for_match(endpoint["base_url"]):
             return "llamacpp"
-    identity = find_custom_provider_identity_by_model(model) if model else None
-    if identity:
-        return identity
+    # 1. Prefer the session's model over the first configured owner of a shared gateway URL,
+    #    which can silently pair a model with the wrong key.
+    if model:
+        identity = find_custom_provider_identity_by_model(model)
+        if identity:
+            return identity
+    # 2. Fall back to the configured provider when it names a real entry.
     candidate = str(config_provider or "").strip()
     if not candidate:
         try:
@@ -280,22 +283,24 @@ def canonical_custom_identity(*, base_url: Optional[str] = None, config_provider
     candidate_norm = _normalize_custom_provider_name(candidate)
     # A bare/non-routable candidate cannot heal a bare custom override.
     if not candidate_norm or candidate_norm in {"custom", "auto", "openrouter"}:
-        return None
+        # 3. URL-only recovery is a last resort because several named custom providers can
+        #    legitimately share the same gateway URL.
+        return url_identity
     # Only when it resolves to a configured entry — never invent a ``custom:<x>`` resolution
     # can't honor. ``candidate`` may be the entry's DISPLAY NAME, not the durable identity of a
-    # keyed ``providers:`` entry — re-resolve via its endpoint so every path returns the same
-    # config-key slug.
+    # keyed ``providers:`` entry — return the durable config-key identity instead of deriving it
+    # from the ambiguous base_url.
     try:
         entry = rp._get_named_custom_provider(candidate)
     except Exception:
-        return None
-    if entry is None:
-        return None
-    try:
-        identity = find_custom_provider_identity(str(entry.get("base_url") or ""))
-    except Exception:
-        return None
-    return identity or custom_provider_slug(candidate_norm)
+        entry = None
+    if entry is not None:
+        provider_key = _clean(entry.get("provider_key", ""))
+        entry_name = _clean(entry.get("name", "")) or candidate
+        return custom_provider_slug(entry_name, provider_key)
+    # 3. URL-only recovery is a last resort because several named custom providers can
+    #    legitimately share the same gateway URL.
+    return url_identity
 
 
 def is_routable_provider(provider: Optional[str]) -> bool:

--- a/tests/hermes_cli/test_canonical_custom_identity.py
+++ b/tests/hermes_cli/test_canonical_custom_identity.py
@@ -204,3 +204,38 @@ def test_model_beats_ambiguous_shared_base_url(monkeypatch):
         )
         == "custom:newapi"
     )
+
+
+def test_keyed_model_beats_shared_base_url_and_keeps_provider_key(monkeypatch):
+    """Keyed providers retain their config key when model and URL disagree."""
+    shared = "https://shared.invalid/v1"
+    config = {
+        "providers": {
+            "provider-a": {
+                "name": "Provider A",
+                "api": shared,
+                "api_key": "sk-a",
+                "default_model": "model-a",
+                "models": ["model-a"],
+            },
+            "provider-b": {
+                "name": "Provider B",
+                "api": shared,
+                "api_key": "sk-b",
+                "default_model": "model-b",
+                "models": ["model-b"],
+            },
+        }
+    }
+    monkeypatch.setattr(rp, "load_config", lambda *a, **k: config)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: config)
+
+    assert rp.find_custom_provider_identity(shared) == "custom:provider-a"
+    assert (
+        rp.canonical_custom_identity(
+            base_url=shared,
+            config_provider="custom:provider-a",
+            model="model-b",
+        )
+        == "custom:provider-b"
+    )

--- a/tests/hermes_cli/test_canonical_custom_identity.py
+++ b/tests/hermes_cli/test_canonical_custom_identity.py
@@ -15,6 +15,9 @@ asserting any particular spelling is rejected.
 
 from __future__ import annotations
 
+import json
+import os
+
 import pytest
 
 from hermes_cli import runtime_provider as rp
@@ -100,6 +103,26 @@ def test_legacy_unkeyed_entry_keeps_its_name_identity(monkeypatch):
     assert rp.canonical_custom_identity(config_provider="Legacy Endpoint") == "custom:legacy-endpoint"
 
 
+@pytest.mark.parametrize("owned,expected", [(True, "llamacpp"), (False, CANONICAL)])
+def test_managed_endpoint_identity_respects_ownership(
+    keyed_provider_config, tmp_path, monkeypatch, owned, expected
+):
+    """Only a live owned endpoint outranks an unrelated configured model."""
+    managed_url = "http://127.0.0.1:18434/v1"
+    state_file = tmp_path / "server.json"
+    state_file.write_text(
+        json.dumps({"base_url": managed_url, "pid": os.getpid() if owned else 0}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.local_runtime.supervisor.state_path", lambda: state_file
+    )
+
+    assert rp.canonical_custom_identity(
+        base_url=managed_url + "/", config_provider=PROVIDER_KEY, model=MODEL
+    ) == expected
+
+
 class TestIsRoutableProvider:
     """``is_routable_provider`` gates session-resume fallback: a persisted
     provider name that no longer resolves (renamed/removed) must be detected
@@ -146,3 +169,38 @@ class TestIsRoutableProvider:
         assert rp.is_routable_provider("legacy-endpoint") is True
         assert rp.is_routable_provider("custom:legacy-endpoint") is True
         assert rp.is_routable_provider("Legacy Endpoint") is True
+
+
+def test_model_beats_ambiguous_shared_base_url(monkeypatch):
+    """Disjoint model catalogs disambiguate providers sharing one gateway."""
+    shared = "https://shared.invalid/v1"
+    config = {
+        "custom_providers": [
+            {
+                "name": "ark",
+                "base_url": shared,
+                "api_key": "sk-ark",
+                "model": "model-a-default",
+                "models": {"model-a-default": {}},
+            },
+            {
+                "name": "newapi",
+                "base_url": shared,
+                "api_key": "sk-newapi",
+                "model": "model-b-default",
+                "models": {"model-b-current": {}, "model-b-default": {}},
+            },
+        ]
+    }
+    monkeypatch.setattr(rp, "load_config", lambda *a, **k: config)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: config)
+
+    assert rp.find_custom_provider_identity(shared) == "custom:ark"
+    assert (
+        rp.canonical_custom_identity(
+            base_url=shared,
+            config_provider="custom:ark",
+            model="model-b-current",
+        )
+        == "custom:newapi"
+    )

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -413,8 +413,8 @@ class TestDelegateTask(unittest.TestCase):
                 child_db = kwargs["session_db"]
                 self.assertIsInstance(child_db, SessionDB)
                 self.assertIsNot(child_db, parent_db)
-                self.assertEqual(
-                    str(child_db.db_path), str(parent_db.db_path)
+                self.assertTrue(
+                    Path(child_db.db_path).samefile(parent_db.db_path)
                 )
             finally:
                 if child_db is not None:

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1142,6 +1142,25 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         )
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    @patch("hermes_cli.runtime_provider.canonical_custom_identity")
+    def test_builtin_parent_keeps_ordinary_inheritance_path(
+        self, mock_canonical, mock_resolve
+    ):
+        """A built-in parent must not be remapped by a matching custom URL."""
+        parent = _make_mock_parent(depth=0)
+        parent.base_url = "https://shared.invalid/v1"
+
+        creds = _resolve_delegation_credentials(
+            {"model": "", "provider": ""}, parent
+        )
+
+        self.assertIsNone(creds["provider"])
+        self.assertIsNone(creds["base_url"])
+        self.assertIsNone(creds["api_key"])
+        mock_canonical.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolves_but_no_api_key_raises(self, mock_resolve):
         """When provider resolves but has no API key, ValueError is raised."""
         mock_resolve.return_value = {

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1107,6 +1107,41 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIn("Cannot resolve", str(ctx.exception))
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    @patch("hermes_cli.runtime_provider.canonical_custom_identity")
+    def test_no_override_disambiguates_shared_custom_url_by_parent_model(
+        self, mock_canonical, mock_resolve
+    ):
+        """A switched custom model must not inherit the previous provider key."""
+        mock_canonical.return_value = "custom:provider-b"
+        mock_resolve.return_value = {
+            "provider": "custom",
+            "model": "model-b-default",
+            "base_url": "https://shared.invalid/v1",
+            "api_key": "provider-b-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.model = "model-b-current"
+        parent.provider = "custom:provider-a"
+        parent.base_url = "https://shared.invalid/v1"
+
+        creds = _resolve_delegation_credentials(
+            {"model": "", "provider": ""}, parent
+        )
+
+        self.assertEqual(creds["model"], "model-b-current")
+        self.assertEqual(creds["provider"], "custom:provider-b")
+        self.assertEqual(creds["api_key"], "provider-b-key")
+        mock_canonical.assert_called_once_with(
+            base_url="https://shared.invalid/v1",
+            config_provider="custom:provider-a",
+            model="model-b-current",
+        )
+        mock_resolve.assert_called_once_with(
+            requested="custom:provider-b", target_model="model-b-current"
+        )
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolves_but_no_api_key_raises(self, mock_resolve):
         """When provider resolves but has no API key, ValueError is raised."""
         mock_resolve.return_value = {

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -386,36 +386,37 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         parent_model = str(getattr(parent_agent, "model", "") or "").strip()
         parent_provider = str(getattr(parent_agent, "provider", "") or "").strip()
         parent_base_url = str(getattr(parent_agent, "base_url", "") or "").strip()
-        try:
-            from hermes_cli.runtime_provider import (
-                canonical_custom_identity,
-                resolve_runtime_provider,
-            )
+        if parent_provider.lower().startswith("custom"):
+            try:
+                from hermes_cli.runtime_provider import (
+                    canonical_custom_identity,
+                    resolve_runtime_provider,
+                )
 
-            custom_identity = canonical_custom_identity(
-                base_url=parent_base_url,
-                config_provider=parent_provider,
-                model=values["model"] or parent_model,
-            )
-            if custom_identity:
-                runtime = resolve_runtime_provider(
-                    requested=custom_identity,
-                    target_model=values["model"] or parent_model or None,
+                custom_identity = canonical_custom_identity(
+                    base_url=parent_base_url,
+                    config_provider=parent_provider,
+                    model=values["model"] or parent_model,
                 )
-                return _credential_bundle(
-                    values["model"] or parent_model or runtime.get("model") or None,
-                    custom_identity,
-                    runtime.get("base_url"),
-                    runtime.get("api_key") or None,
-                    runtime.get("api_mode"),
-                    _merge_request_overrides(
-                        runtime.get("request_overrides"), explicit_request_overrides
-                    ) or {},
-                    command=runtime.get("command"),
-                    args=list(runtime.get("args") or []),
-                )
-        except Exception as exc:
-            logger.debug("Could not canonicalize inherited custom provider: %s", exc)
+                if custom_identity:
+                    runtime = resolve_runtime_provider(
+                        requested=custom_identity,
+                        target_model=values["model"] or parent_model or None,
+                    )
+                    return _credential_bundle(
+                        values["model"] or parent_model or runtime.get("model") or None,
+                        custom_identity,
+                        runtime.get("base_url"),
+                        runtime.get("api_key") or None,
+                        runtime.get("api_mode"),
+                        _merge_request_overrides(
+                            runtime.get("request_overrides"), explicit_request_overrides
+                        ) or {},
+                        command=runtime.get("command"),
+                        args=list(runtime.get("args") or []),
+                    )
+            except Exception as exc:
+                logger.debug("Could not canonicalize inherited custom provider: %s", exc)
 
         # Built-ins and genuine ad-hoc endpoints keep the ordinary inheritance path; None
         # overrides are resolved from the parent in _build_child_agent.

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -376,7 +376,49 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     if values["base_url"] and not is_native_sdk_provider:
         return _direct_endpoint_credentials(values, explicit_request_overrides)
     if not values["provider"]:
-        # Pure inherit; explicit request_overrides still merge OVER the parent's.
+        # No explicit delegation override: normally inherit the parent. Named custom providers
+        # need one extra identity check, however. The live agent stores the resolved billing
+        # class as bare ``custom`` and two named providers may share the same base_url. In that
+        # case blindly inheriting the parent's provider/key can pair a switched model with the
+        # previous custom provider (e.g. model-b-current + provider-a credentials). Recover the
+        # named identity from the model catalog first and resolve its complete credential bundle
+        # for the child.
+        parent_model = str(getattr(parent_agent, "model", "") or "").strip()
+        parent_provider = str(getattr(parent_agent, "provider", "") or "").strip()
+        parent_base_url = str(getattr(parent_agent, "base_url", "") or "").strip()
+        try:
+            from hermes_cli.runtime_provider import (
+                canonical_custom_identity,
+                resolve_runtime_provider,
+            )
+
+            custom_identity = canonical_custom_identity(
+                base_url=parent_base_url,
+                config_provider=parent_provider,
+                model=values["model"] or parent_model,
+            )
+            if custom_identity:
+                runtime = resolve_runtime_provider(
+                    requested=custom_identity,
+                    target_model=values["model"] or parent_model or None,
+                )
+                return _credential_bundle(
+                    values["model"] or parent_model or runtime.get("model") or None,
+                    custom_identity,
+                    runtime.get("base_url"),
+                    runtime.get("api_key") or None,
+                    runtime.get("api_mode"),
+                    _merge_request_overrides(
+                        runtime.get("request_overrides"), explicit_request_overrides
+                    ) or {},
+                    command=runtime.get("command"),
+                    args=list(runtime.get("args") or []),
+                )
+        except Exception as exc:
+            logger.debug("Could not canonicalize inherited custom provider: %s", exc)
+
+        # Built-ins and genuine ad-hoc endpoints keep the ordinary inheritance path; None
+        # overrides are resolved from the parent in _build_child_agent.
         return _credential_bundle(
             values["model"], None, None, None, None,
             _merge_request_overrides(getattr(parent_agent, "request_overrides", None), explicit_request_overrides),


### PR DESCRIPTION
## What does this PR do?

When named custom providers share one OpenAI-compatible URL but expose different model catalogs, URL-first recovery can pair a switched model with another provider's credentials. Recover named-provider identity from the model catalog, then the configured provider, with URL ownership as the last resort.

The ownership-checked managed llama.cpp endpoint keeps its local identity even when an unrelated configured provider lists the same model. Built-in parents keep ordinary delegation inheritance.

## Related Issue

Fixes #85847

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_cli/runtime_provider_custom.py`: Prefer the matching model catalog, preserve durable config-key identities and retain managed-endpoint recovery.
- `tools/delegate_tool_config.py`: Resolve the complete credential bundle for inherited custom parents using the current upstream bundle signature.
- `tests/hermes_cli/test_canonical_custom_identity.py`: Cover legacy and keyed providers sharing a URL, plus live-owned and stale managed-endpoint state.
- `tests/tools/test_delegate.py`: Cover custom-parent credential resolution and unchanged built-in inheritance; compare the actual parent/child database file across path aliases.

## Related PRs

The issue also links #85876, #91252 and #91267. This updates the existing focused identity-recovery PR. The same-model ambiguity between two named custom providers remains outside this disjoint-catalog fix.

## How to Test

Run `scripts/run_tests.sh tests/hermes_cli/test_canonical_custom_identity.py tests/tools/test_delegate.py tests/hermes_cli/test_runtime_provider_resolution.py tests/tools/test_delegate_toolset_scope.py`.

Local verification on macOS with Python 3.11 passes all 168 selected tests. The paired run executes 98 cases per side with identical test bytes: exactly the three shared-URL regressions fail on BASE and all cases pass on HEAD. The managed-endpoint cases use real state files and process-ownership checks without launching a model server.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing
