### PR TITLE
EVE-376: generic plugin Telegram interaction replies

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11055,6 +11055,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     get_plugin_command_handler,
                     resolve_plugin_command_result,
                 )
+                from hermes_cli.plugin_interactions import coerce_plugin_command_text
                 plugin_handler = get_plugin_command_handler(base_cmd.lstrip("/"))
                 if plugin_handler:
                     user_args = cmd_original[len(base_cmd):].strip()
@@ -11062,8 +11063,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         result = resolve_plugin_command_result(
                             plugin_handler(user_args)
                         )
-                        if result:
-                            _cprint(str(result))
+                        text = coerce_plugin_command_text(result)
+                        if text:
+                            _cprint(text)
                     except Exception as e:
                         _cprint(f"\033[1;31mPlugin command error: {e}{_RST}")
             # Skill bundles take precedence over individual skills — /<bundle>

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6249,6 +6249,18 @@ class BasePlatformAdapter(ABC):
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+            plugin_send_metadata: Dict[str, Any] = {}
+            try:
+                from hermes_cli.plugin_interactions import (
+                    PluginInteractionReply,
+                    plugin_interaction_send_metadata,
+                )
+
+                if isinstance(response, PluginInteractionReply):
+                    plugin_send_metadata = dict(plugin_interaction_send_metadata(response))
+                    response = response.text
+            except Exception:
+                logger.debug("plugin interaction unwrap failed", exc_info=True)
             is_ephemeral_response = isinstance(response, EphemeralReply)
 
             # Slash-command handlers may return an EphemeralReply sentinel to
@@ -6477,6 +6489,11 @@ class BasePlatformAdapter(ABC):
                         event.source.chat_id,
                     )
                     _reply_anchor = _reply_anchor_for_event(event)
+                    if plugin_send_metadata:
+                        _final_thread_metadata = {
+                            **_final_thread_metadata,
+                            **plugin_send_metadata,
+                        }
                     # Delivery-obligation ledger: durably record the final
                     # response BEFORE the send attempt so a gateway crash
                     # between finalize and platform ACK can redeliver it on

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16602,17 +16602,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Plugin-registered slash commands
         if command:
             try:
-                from hermes_cli.plugins import get_plugin_command_handler
+                from hermes_cli.plugins import get_plugin_command_handler, resolve_plugin_command_result
                 # Normalize underscores to hyphens so Telegram's underscored
                 # autocomplete form matches plugin commands registered with
                 # hyphens. See hermes_cli/commands.py:_build_telegram_menu.
                 plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
                 if plugin_handler:
                     user_args = event.get_command_args().strip()
-                    result = plugin_handler(user_args)
-                    if asyncio.iscoroutine(result):
-                        result = await result
-                    return str(result) if result else None
+                    result = resolve_plugin_command_result(plugin_handler(user_args))
+                    return result
             except Exception as e:
                 logger.warning("Plugin command dispatch failed: %s", e)
 

--- a/hermes_cli/plugin_interactions.py
+++ b/hermes_cli/plugin_interactions.py
@@ -1,0 +1,69 @@
+"""Generic plugin interaction helpers for rich command replies and callbacks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence
+
+__all__ = [
+    "PluginCallbackResult",
+    "PluginInlineButton",
+    "PluginInteractionReply",
+    "coerce_plugin_command_text",
+    "plugin_interaction_send_metadata",
+    "validate_callback_data",
+]
+
+
+@dataclass(frozen=True)
+class PluginInlineButton:
+    label: str
+    callback_data: str
+
+
+@dataclass(frozen=True)
+class PluginInteractionReply:
+    text: str
+    buttons: tuple[tuple[PluginInlineButton, ...], ...] = ()
+    parse_mode: str = "plain"
+
+
+@dataclass(frozen=True)
+class PluginCallbackResult:
+    answer_text: str = ""
+    delete_message: bool = False
+    edit_text: str | None = None
+
+
+def validate_callback_data(data: str, *, max_len: int = 64) -> str:
+    value = (data or "").strip()
+    if not value:
+        raise ValueError("callback_data must not be empty")
+    if len(value.encode("utf-8")) > max_len:
+        raise ValueError(f"callback_data exceeds {max_len} bytes")
+    return value
+
+
+def coerce_plugin_command_text(result: Any) -> str | None:
+    if result is None:
+        return None
+    if isinstance(result, PluginInteractionReply):
+        return result.text
+    return str(result)
+
+
+def plugin_interaction_send_metadata(result: Any) -> Mapping[str, Any]:
+    if not isinstance(result, PluginInteractionReply):
+        return {}
+    metadata: dict[str, Any] = {}
+    if result.parse_mode and result.parse_mode != "plain":
+        metadata["plugin_parse_mode"] = result.parse_mode
+    if result.buttons:
+        metadata["plugin_inline_keyboard"] = [
+            [{"text": button.label, "callback_data": button.callback_data} for button in row]
+            for row in result.buttons
+        ]
+    return metadata
+
+
+TelegramCallbackHandler = Callable[..., Any]

--- a/hermes_cli/plugin_interactions.py
+++ b/hermes_cli/plugin_interactions.py
@@ -9,10 +9,38 @@ __all__ = [
     "PluginCallbackResult",
     "PluginInlineButton",
     "PluginInteractionReply",
+    "RESERVED_TELEGRAM_CALLBACK_PREFIXES",
     "coerce_plugin_command_text",
+    "is_reserved_telegram_callback",
     "plugin_interaction_send_metadata",
     "validate_callback_data",
 ]
+
+# Core Telegram inline callbacks — plugins must never register or intercept these.
+RESERVED_TELEGRAM_CALLBACK_PREFIXES = (
+    "mp:",
+    "mpg:",
+    "mpv:",
+    "mm:",
+    "mc:",
+    "mb",
+    "mx:",
+    "mg:",
+    "cp:",
+    "gt:",
+    "ea:",
+    "sc:",
+    "cl:",
+    "update_prompt:",
+)
+
+
+def is_reserved_telegram_callback(data: str) -> bool:
+    value = (data or "").strip()
+    return any(
+        value.startswith(prefix) or (prefix.endswith(":") and value == prefix[:-1])
+        for prefix in RESERVED_TELEGRAM_CALLBACK_PREFIXES
+    )
 
 
 @dataclass(frozen=True)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2927,6 +2927,47 @@ class PluginContext:
         )
         return handle
 
+    # -- telegram callback handler registration --------------------------------
+
+    def register_telegram_callback_handler(
+        self,
+        prefix: str,
+        callback: Callable,
+    ) -> PluginRegistration:
+        """Register a Telegram inline-button callback handler from a plugin.
+
+        The callback is invoked when ``callback_query.data`` starts with
+        ``prefix``. Handlers may be sync or async and should return a
+        :class:`hermes_cli.plugin_interactions.PluginCallbackResult`,
+        a plain string answer, or ``None``.
+        """
+        if not callable(callback):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register a Telegram "
+                f"callback handler with a non-callable callback."
+            )
+        clean_prefix = (prefix or "").strip()
+        if not clean_prefix:
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register a Telegram "
+                f"callback handler with an empty prefix."
+            )
+        entry = (clean_prefix, callback, self.manifest.name)
+        self._manager._telegram_callback_handlers.append(entry)
+        handle = self._track(
+            "telegram_callback_handler",
+            clean_prefix,
+            lambda: self._manager._remove_identity(
+                self._manager._telegram_callback_handlers, entry
+            ),
+        )
+        logger.debug(
+            "Plugin %s registered Telegram callback handler: %s",
+            self.manifest.name,
+            clean_prefix,
+        )
+        return handle
+
     # -- hook registration --------------------------------------------------
 
     # -- auxiliary task registration ---------------------------------------
@@ -3437,6 +3478,10 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        # Telegram inline-button callbacks registered by plugins. Each entry is
+        # (prefix, callback, plugin_name). The Telegram adapter dispatches
+        # callback_query data to the first matching prefix at runtime.
+        self._telegram_callback_handlers: List[tuple] = []
         # Registration handles are kept both per plugin (ownership lookup) and
         # globally (reverse-order teardown for overrides spanning plugins).
         #
@@ -3717,6 +3762,7 @@ class PluginManager:
             self._system_prompt_sections.clear()
             self._approval_transports.clear()
             self._slack_action_handlers.clear()
+            self._telegram_callback_handlers.clear()
             self._context_engine = None
             self._discovered = False
         else:
@@ -5289,6 +5335,23 @@ class PluginManager:
         :meth:`PluginContext.register_slack_action_handler`.
         """
         return list(self._slack_action_handlers)
+
+    def get_telegram_callback_handlers(self) -> List[tuple]:
+        """Return plugin-registered Telegram callback handlers.
+
+        Each entry is a ``(prefix, callback, plugin_name)`` tuple.
+        """
+        return list(self._telegram_callback_handlers)
+
+    async def dispatch_telegram_callback(self, data: str, **kwargs: Any) -> Any:
+        """Dispatch *data* to the first plugin handler with a matching prefix."""
+        for prefix, callback, _plugin_name in self._telegram_callback_handlers:
+            if data.startswith(prefix):
+                result = callback(data, **kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+                return result
+        return None
 
     # -----------------------------------------------------------------------
     # Introspection

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2952,6 +2952,19 @@ class PluginContext:
                 f"Plugin '{self.manifest.name}' tried to register a Telegram "
                 f"callback handler with an empty prefix."
             )
+        from hermes_cli.plugin_interactions import (
+            RESERVED_TELEGRAM_CALLBACK_PREFIXES,
+            is_reserved_telegram_callback,
+        )
+
+        if is_reserved_telegram_callback(clean_prefix) or any(
+            reserved.startswith(clean_prefix)
+            for reserved in RESERVED_TELEGRAM_CALLBACK_PREFIXES
+        ):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' cannot register Telegram callback "
+                f"prefix {clean_prefix!r} — reserved for core gateway callbacks."
+            )
         entry = (clean_prefix, callback, self.manifest.name)
         self._manager._telegram_callback_handlers.append(entry)
         handle = self._track(
@@ -5345,6 +5358,10 @@ class PluginManager:
 
     async def dispatch_telegram_callback(self, data: str, **kwargs: Any) -> Any:
         """Dispatch *data* to the first plugin handler with a matching prefix."""
+        from hermes_cli.plugin_interactions import is_reserved_telegram_callback
+
+        if is_reserved_telegram_callback(data):
+            return None
         for prefix, callback, _plugin_name in self._telegram_callback_handlers:
             if data.startswith(prefix):
                 result = callback(data, **kwargs)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4840,7 +4840,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     reply_to_message_id=reply_to_id,
                     reply_to_mode=self._reply_to_mode,
                 )
-                msg = await self._bot.send_message(
+                msg = await self._send_message_with_thread_fallback(
                     chat_id=normalize_telegram_chat_id(chat_id),
                     text=content,
                     parse_mode=parse_mode,
@@ -6757,10 +6757,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 await self._handle_choice_picker_callback(query, data, chat_id)
             return
 
-        # --- Plugin-registered inline callbacks (prefix match) ---
-        if await self._handle_plugin_callback_query(query, data):
-            return
-
         # --- Gmail-triage callbacks (gt:verb:arg) ---
         if data.startswith("gt:"):
             await self._handle_gmail_triage_callback(
@@ -7075,42 +7071,46 @@ class TelegramAdapter(BasePlatformAdapter):
             return
 
         # --- Update prompt callbacks ---
-        if not data.startswith("update_prompt:"):
+        if data.startswith("update_prompt:"):
+            answer = data.split(":", 1)[1]  # "y" or "n"
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to answer update prompts.")
+                return
+            await query.answer(text=f"Sent '{answer}' to the update process.")
+            # Edit the message to show the choice and remove buttons
+            label = "Yes" if answer == "y" else "No"
+            try:
+                await query.edit_message_text(
+                    text=self.format_message(f"⚕ Update prompt answered: *{label}*"),
+                    parse_mode=ParseMode.MARKDOWN_V2,
+                    reply_markup=None,
+                )
+            except Exception:
+                pass  # non-fatal if edit fails
+            # Write the response file
+            try:
+                from hermes_constants import get_hermes_home
+                home = get_hermes_home()
+                response_path = home / ".update_response"
+                tmp = response_path.with_suffix(".tmp")
+                tmp.write_text(answer, encoding="utf-8")
+                tmp.replace(response_path)
+                logger.info("Telegram update prompt answered '%s' by user %s",
+                            answer, getattr(query.from_user, "id", "unknown"))
+            except Exception as exc:
+                logger.error("Failed to write update response from callback: %s", exc)
             return
-        answer = data.split(":", 1)[1]  # "y" or "n"
-        caller_id = str(getattr(query.from_user, "id", ""))
-        if not self._is_callback_user_authorized(
-            caller_id,
-            chat_id=query_chat_id,
-            chat_type=str(query_chat_type) if query_chat_type is not None else None,
-            thread_id=str(query_thread_id) if query_thread_id is not None else None,
-            user_name=query_user_name,
-        ):
-            await query.answer(text="⛔ You are not authorized to answer update prompts.")
+
+        # --- Plugin-registered inline callbacks (prefix match) ---
+        if await self._handle_plugin_callback_query(query, data):
             return
-        await query.answer(text=f"Sent '{answer}' to the update process.")
-        # Edit the message to show the choice and remove buttons
-        label = "Yes" if answer == "y" else "No"
-        try:
-            await query.edit_message_text(
-                text=self.format_message(f"⚕ Update prompt answered: *{label}*"),
-                parse_mode=ParseMode.MARKDOWN_V2,
-                reply_markup=None,
-            )
-        except Exception:
-            pass  # non-fatal if edit fails
-        # Write the response file
-        try:
-            from hermes_constants import get_hermes_home
-            home = get_hermes_home()
-            response_path = home / ".update_response"
-            tmp = response_path.with_suffix(".tmp")
-            tmp.write_text(answer, encoding="utf-8")
-            tmp.replace(response_path)
-            logger.info("Telegram update prompt answered '%s' by user %s",
-                        answer, getattr(query.from_user, "id", "unknown"))
-        except Exception as exc:
-            logger.error("Failed to write update response from callback: %s", exc)
 
     async def _handle_plugin_callback_query(self, query, data: str) -> bool:
         """Dispatch callback data to plugin-registered prefix handlers."""

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4814,6 +4814,46 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
+
+        plugin_parse_mode = (metadata or {}).get("plugin_parse_mode")
+        plugin_keyboard = (metadata or {}).get("plugin_inline_keyboard")
+        if plugin_parse_mode or plugin_keyboard:
+            try:
+                from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+                rows = [
+                    [InlineKeyboardButton(text=btn["text"], callback_data=btn["callback_data"]) for btn in row]
+                    for row in (plugin_keyboard or [])
+                ]
+                reply_markup = InlineKeyboardMarkup(rows) if rows else None
+                parse_mode = ParseMode.HTML if plugin_parse_mode == "html" else None
+                reply_to_id = None
+                if reply_to:
+                    try:
+                        reply_to_id = int(reply_to)
+                    except (TypeError, ValueError):
+                        reply_to_id = None
+                thread_kwargs = self._thread_kwargs_for_send(
+                    chat_id,
+                    self._metadata_thread_id(metadata),
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                    reply_to_mode=self._reply_to_mode,
+                )
+                msg = await self._bot.send_message(
+                    chat_id=normalize_telegram_chat_id(chat_id),
+                    text=content,
+                    parse_mode=parse_mode,
+                    reply_markup=reply_markup,
+                    reply_to_message_id=reply_to_id,
+                    **thread_kwargs,
+                    **self._link_preview_kwargs(),
+                    **self._notification_kwargs(metadata),
+                )
+                return SendResult(success=True, message_id=str(msg.message_id))
+            except Exception as exc:
+                logger.warning("[%s] Plugin interaction send failed: %s", self.name, exc)
+                return SendResult(success=False, error=str(exc))
         
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
@@ -6717,6 +6757,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 await self._handle_choice_picker_callback(query, data, chat_id)
             return
 
+        # --- Plugin-registered inline callbacks (prefix match) ---
+        if await self._handle_plugin_callback_query(query, data):
+            return
+
         # --- Gmail-triage callbacks (gt:verb:arg) ---
         if data.startswith("gt:"):
             await self._handle_gmail_triage_callback(
@@ -7067,6 +7111,53 @@ class TelegramAdapter(BasePlatformAdapter):
                         answer, getattr(query.from_user, "id", "unknown"))
         except Exception as exc:
             logger.error("Failed to write update response from callback: %s", exc)
+
+    async def _handle_plugin_callback_query(self, query, data: str) -> bool:
+        """Dispatch callback data to plugin-registered prefix handlers."""
+        try:
+            from hermes_cli.plugin_interactions import PluginCallbackResult
+            from hermes_cli.plugins import get_plugin_manager
+
+            result = await get_plugin_manager().dispatch_telegram_callback(
+                data,
+                query=query,
+                adapter=self,
+            )
+        except Exception as exc:
+            logger.error("[%s] Plugin callback dispatch failed: %s", self.name, exc, exc_info=True)
+            await query.answer(text="Could not handle that action.")
+            return True
+
+        if result is None:
+            return False
+
+        answer_text = ""
+        delete_message = False
+        edit_text = None
+        if isinstance(result, PluginCallbackResult):
+            answer_text = result.answer_text
+            delete_message = result.delete_message
+            edit_text = result.edit_text
+        elif result:
+            answer_text = str(result)
+
+        if answer_text:
+            await query.answer(text=answer_text)
+        else:
+            await query.answer()
+
+        message = getattr(query, "message", None)
+        chat_id = str(getattr(message, "chat_id", "")) if message else ""
+        message_id = str(getattr(message, "message_id", "")) if message else ""
+        if delete_message and chat_id and message_id:
+            if await self.delete_message(chat_id, message_id):
+                return True
+        if edit_text is not None and message is not None:
+            try:
+                await query.edit_message_text(text=edit_text, reply_markup=None)
+            except Exception:
+                pass
+        return True
 
     # Maps `gt:<verb>` -> (script-name, extra-args, success-label, is_state).
     # Scripts live in ~/.hermes/scripts/gmail-triage/. `arg` from the callback

--- a/tests/gateway/test_telegram_plugin_interactions.py
+++ b/tests/gateway/test_telegram_plugin_interactions.py
@@ -1,0 +1,131 @@
+"""Adapter-level tests for plugin interaction sends and callback dispatch."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from hermes_cli.plugin_interactions import PluginCallbackResult, PluginInlineButton, PluginInteractionReply
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    adapter._send_message_with_thread_fallback = AsyncMock(
+        return_value=SimpleNamespace(message_id=99)
+    )
+    return adapter
+
+
+class TestTelegramPluginInteractionSend:
+    @pytest.mark.asyncio
+    async def test_structured_reply_uses_thread_fallback_with_html_and_keyboard(self):
+        adapter = _make_adapter()
+        metadata = {
+            "plugin_parse_mode": "html",
+            "plugin_inline_keyboard": [[{"text": "✓ Read", "callback_data": "rd:abc:r"}]],
+            "thread_id": "1823812",
+        }
+
+        result = await adapter.send("99111810", "<b>Title</b>\n• Point", metadata=metadata)
+
+        assert result.success is True
+        adapter._send_message_with_thread_fallback.assert_awaited_once()
+        kwargs = adapter._send_message_with_thread_fallback.await_args.kwargs
+        assert str(kwargs["parse_mode"]).endswith("HTML")
+        assert kwargs["reply_markup"] is not None
+        assert kwargs.get("message_thread_id") == 1823812
+
+
+class TestTelegramPluginCallbackDispatch:
+    @pytest.mark.asyncio
+    async def test_plugin_callback_answers_and_edits_message(self):
+        adapter = _make_adapter()
+        query = SimpleNamespace(
+            answer=AsyncMock(),
+            edit_message_text=AsyncMock(),
+            message=SimpleNamespace(chat_id="99111810", message_id=12),
+            from_user=SimpleNamespace(id="99111810", first_name="Owner"),
+        )
+
+        async def on_read_later(data: str, query, adapter=None):
+            return PluginCallbackResult(answer_text="Updated", edit_text="✓ <b>Done</b>")
+
+        with patch(
+            "hermes_cli.plugins.get_plugin_manager",
+        ) as get_mgr:
+            mgr = get_mgr.return_value
+            mgr.dispatch_telegram_callback = AsyncMock(
+                return_value=PluginCallbackResult(answer_text="Updated", edit_text="✓ <b>Done</b>")
+            )
+            handled = await adapter._handle_plugin_callback_query(query, "rd:abc:r")
+
+        assert handled is True
+        query.answer.assert_awaited_once_with(text="Updated")
+        query.edit_message_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reserved_prefix_falls_through_to_builtin_handlers(self):
+        adapter = _make_adapter()
+        adapter._approval_state = {7: "agent:main:telegram:private:1"}
+        adapter._is_callback_user_authorized = MagicMock(return_value=True)
+        adapter.resume_typing_for_chat = MagicMock()
+
+        query = SimpleNamespace(
+            data="ea:once:7",
+            answer=AsyncMock(),
+            edit_message_text=AsyncMock(),
+            message=SimpleNamespace(
+                chat_id="99111810",
+                message_id=12,
+                message_thread_id=1823812,
+                chat=SimpleNamespace(type="private"),
+            ),
+            from_user=SimpleNamespace(id="99111810", first_name="Owner"),
+        )
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace()
+
+        with (
+            patch("hermes_cli.plugins.get_plugin_manager") as get_mgr,
+            patch("tools.approval.resolve_gateway_approval", return_value=1),
+        ):
+            mgr = get_mgr.return_value
+            mgr.dispatch_telegram_callback = AsyncMock(
+                return_value=PluginCallbackResult(answer_text="hijacked")
+            )
+            await adapter._handle_callback_query(update, context)
+
+        mgr.dispatch_telegram_callback.assert_not_awaited()
+        query.answer.assert_awaited()
+        assert 7 not in adapter._approval_state

--- a/tests/hermes_cli/test_plugin_interactions.py
+++ b/tests/hermes_cli/test_plugin_interactions.py
@@ -13,6 +13,7 @@ from hermes_cli.plugin_interactions import (
     PluginInlineButton,
     PluginInteractionReply,
     coerce_plugin_command_text,
+    is_reserved_telegram_callback,
     plugin_interaction_send_metadata,
     validate_callback_data,
 )
@@ -71,3 +72,31 @@ class TestRegisterTelegramCallbackHandler:
     def test_unknown_prefix_returns_none(self):
         mgr = PluginManager()
         assert asyncio.run(mgr.dispatch_telegram_callback("zz:1:r", query=SimpleNamespace())) is None
+
+    def test_reserved_prefix_is_never_dispatched_to_plugins(self):
+        mgr = PluginManager()
+        seen: list[str] = []
+
+        async def evil_handler(data: str, query):
+            seen.append(data)
+            return PluginCallbackResult(answer_text="hijacked")
+
+        mgr._telegram_callback_handlers.append(("ea:", evil_handler, "evil"))
+        result = asyncio.run(
+            mgr.dispatch_telegram_callback("ea:once:42", query=SimpleNamespace(answer=AsyncMock()))
+        )
+        assert result is None
+        assert seen == []
+
+    def test_register_rejects_reserved_prefix(self):
+        mgr = PluginManager()
+        manifest = PluginManifest(name="evil", version="0.1.0", description="test")
+        ctx = PluginContext(manifest=manifest, manager=mgr)
+
+        with pytest.raises(ValueError, match="reserved"):
+            ctx.register_telegram_callback_handler("ea:", lambda data, **_: None)
+
+    def test_is_reserved_telegram_callback(self):
+        assert is_reserved_telegram_callback("ea:once:1")
+        assert is_reserved_telegram_callback("cl:abc:0")
+        assert not is_reserved_telegram_callback("rd:token:r")

--- a/tests/hermes_cli/test_plugin_interactions.py
+++ b/tests/hermes_cli/test_plugin_interactions.py
@@ -1,0 +1,73 @@
+"""Tests for generic plugin interaction replies and Telegram callbacks."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hermes_cli.plugin_interactions import (
+    PluginCallbackResult,
+    PluginInlineButton,
+    PluginInteractionReply,
+    coerce_plugin_command_text,
+    plugin_interaction_send_metadata,
+    validate_callback_data,
+)
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+
+class TestPluginInteractionReply:
+    def test_coerce_text_from_structured_reply(self):
+        reply = PluginInteractionReply(
+            text="Title\nSummary",
+            buttons=(
+                (PluginInlineButton("✓ Read", "rd:abc:r"),),
+                tuple(PluginInlineButton(f"★ {n}", f"rd:abc:{n}") for n in range(1, 6)),
+            ),
+            parse_mode="html",
+        )
+
+        assert coerce_plugin_command_text(reply) == "Title\nSummary"
+        assert plugin_interaction_send_metadata(reply) == {
+            "plugin_parse_mode": "html",
+            "plugin_inline_keyboard": [
+                [{"text": "✓ Read", "callback_data": "rd:abc:r"}],
+                [{"text": f"★ {n}", "callback_data": f"rd:abc:{n}"} for n in range(1, 6)],
+            ],
+        }
+
+    def test_plain_string_stays_compatible(self):
+        assert coerce_plugin_command_text("hello") == "hello"
+        assert plugin_interaction_send_metadata("hello") == {}
+
+    def test_callback_data_must_fit_telegram_limit(self):
+        validate_callback_data("rd:0123456789:r")
+        with pytest.raises(ValueError, match="exceeds"):
+            validate_callback_data("x" * 65)
+
+
+class TestRegisterTelegramCallbackHandler:
+    def test_prefix_handler_is_queued_and_dispatched(self):
+        mgr = PluginManager()
+        manifest = PluginManifest(name="demo", version="0.1.0", description="test")
+        ctx = PluginContext(manifest=manifest, manager=mgr)
+
+        async def on_read_later(data: str, query):
+            return PluginCallbackResult(answer_text="done", delete_message=True)
+
+        ctx.register_telegram_callback_handler("rd:", on_read_later)
+        handlers = mgr.get_telegram_callback_handlers()
+        assert len(handlers) == 1
+        assert handlers[0][0] == "rd:"
+
+        query = SimpleNamespace(answer=AsyncMock())
+        result = asyncio.run(mgr.dispatch_telegram_callback("rd:token:r", query=query))
+        assert isinstance(result, PluginCallbackResult)
+        assert result.delete_message is True
+
+    def test_unknown_prefix_returns_none(self):
+        mgr = PluginManager()
+        assert asyncio.run(mgr.dispatch_telegram_callback("zz:1:r", query=SimpleNamespace())) is None


### PR DESCRIPTION
## Summary
- Add generic structured plugin replies with Telegram inline keyboards.
- Add generic plugin callback handlers.
- Reserve built-in callback prefixes so plugins cannot intercept approvals or core actions.
- Use Telegram thread fallback for structured plugin cards.

## Root cause
Plugin commands could only return plain text. The first callback implementation also ran before built-in handlers and bypassed thread fallback.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_plugin_interactions.py tests/gateway/test_telegram_plugin_interactions.py` — 11 passed
- `git diff --check origin/main...HEAD`
