### PR TITLE
fix(feishu): use real card message ID for synthetic card-action events

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3069,6 +3069,12 @@ class FeishuAdapter(BasePlatformAdapter):
 
         context = getattr(event, "context", None)
         chat_id = str(getattr(context, "open_chat_id", "") or "")
+        # The card callback token is a short-lived card-update credential,
+        # NOT an IM message ID. Use the original card message's real ID
+        # (present in the callback context) so processing-status reactions
+        # and reply anchoring work; fall back to the token only when the
+        # payload omits it.
+        card_message_id = str(getattr(context, "open_message_id", "") or "")
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
         if not chat_id or not open_id:
@@ -3103,7 +3109,7 @@ class FeishuAdapter(BasePlatformAdapter):
             message_type=MessageType.COMMAND,
             source=source,
             raw_message=data,
-            message_id=token or str(uuid.uuid4()),
+            message_id=card_message_id or token or str(uuid.uuid4()),
             channel_prompt=self._resolve_channel_prompt(chat_id),
             timestamp=datetime.now(),
         )

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3104,6 +3104,12 @@ class FeishuAdapter(BasePlatformAdapter):
             thread_id=None,
             user_id_alt=sender_profile["user_id_alt"],
         )
+        # If the payload omitted open_message_id, the event is routed with the
+        # callback token — log it so future 99992354 reports are diagnosable.
+        if not card_message_id and token:
+            logger.debug(
+                "[Feishu] Card action callback omitted open_message_id; falling back to callback token as message_id"
+            )
         synthetic_event = MessageEvent(
             text=synthetic_text,
             message_type=MessageType.COMMAND,

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -304,6 +304,31 @@ class TestNonApprovalCardAction:
         event = mock_handle.call_args[0][0]
         assert event.message_id == "om_original_card_msg"
 
+    @pytest.mark.asyncio
+    async def test_synthetic_event_falls_back_to_token_without_open_message_id(self):
+        """Fall back to the token when the payload omits open_message_id."""
+        adapter = _make_adapter()
+
+        data = _make_card_action_data(
+            action_value={"custom_action": "something_else"},
+            token="tok_fallback_123",
+            open_message_id="",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Dave", "user_id_alt": None},
+            ),
+            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        mock_handle.assert_called_once()
+        event = mock_handle.call_args[0][0]
+        assert event.message_id == "tok_fallback_123"
+
 
 # ===========================================================================
 # _on_card_action_trigger — inline card response for approval actions

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -59,12 +59,16 @@ def _make_card_action_data(
     chat_id: str = "oc_12345",
     open_id: str = "ou_user1",
     token: str = "tok_abc",
+    open_message_id: str = "om_card_message_001",
 ) -> SimpleNamespace:
     """Create a mock Feishu card action callback data object."""
     return SimpleNamespace(
         event=SimpleNamespace(
             token=token,
-            context=SimpleNamespace(open_chat_id=chat_id),
+            context=SimpleNamespace(
+                open_chat_id=chat_id,
+                open_message_id=open_message_id,
+            ),
             operator=SimpleNamespace(open_id=open_id),
             action=SimpleNamespace(
                 tag="button",
@@ -266,6 +270,39 @@ class TestNonApprovalCardAction:
         mock_handle.assert_called_once()
         event = mock_handle.call_args[0][0]
         assert "/card button" in event.text
+
+    @pytest.mark.asyncio
+    async def test_synthetic_event_uses_open_message_id(self):
+        """Synthetic card-action events must carry the original card message ID.
+
+        The card callback token is a short-lived card-update credential, not
+        an IM message ID. Using the token as ``event.message_id`` makes the
+        processing-status reaction (``on_processing_start`` → ``_add_reaction``)
+        and the reply anchor (``_reply_anchor_for_event``) fail with Feishu
+        error 99992354. The callback payload provides the real card message ID
+        in ``event.context.open_message_id`` — use it. (Issue #7200)
+        """
+        adapter = _make_adapter()
+
+        data = _make_card_action_data(
+            action_value={"custom_action": "something_else"},
+            token="c-card-update-credential",
+            open_message_id="om_original_card_msg",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Dave", "user_id_alt": None},
+            ),
+            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        mock_handle.assert_called_once()
+        event = mock_handle.call_args[0][0]
+        assert event.message_id == "om_original_card_msg"
 
 
 # ===========================================================================

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -38,6 +38,7 @@ def _ensure_feishu_mocks():
 _ensure_feishu_mocks()
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import _reply_anchor_for_event
 import plugins.platforms.feishu.adapter as feishu_module
 from plugins.platforms.feishu.adapter import FeishuAdapter
 
@@ -304,6 +305,14 @@ class TestNonApprovalCardAction:
         event = mock_handle.call_args[0][0]
         assert event.message_id == "om_original_card_msg"
 
+        # Downstream lock (issue #7200 symptom): the reply anchor and the
+        # processing-status reaction must both resolve from the real card
+        # message ID, not the callback token.
+        assert _reply_anchor_for_event(event) == "om_original_card_msg"
+        with patch.object(adapter, "_add_reaction", new_callable=AsyncMock, return_value="reaction_1") as mock_add_reaction:
+            await adapter.on_processing_start(event)
+        mock_add_reaction.assert_awaited_once_with("om_original_card_msg", feishu_module._FEISHU_REACTION_IN_PROGRESS)
+
     @pytest.mark.asyncio
     async def test_synthetic_event_falls_back_to_token_without_open_message_id(self):
         """Fall back to the token when the payload omits open_message_id."""
@@ -328,6 +337,7 @@ class TestNonApprovalCardAction:
         mock_handle.assert_called_once()
         event = mock_handle.call_args[0][0]
         assert event.message_id == "tok_fallback_123"
+        assert _reply_anchor_for_event(event) == "tok_fallback_123"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Fixes #7200 — Feishu card button clicks show no reaction feedback.

When a user clicks an interactive card button, `_handle_card_action_event` builds a synthetic `COMMAND` event. It used the card **callback token** (a short-lived card-update credential, not an IM message ID) as `event.message_id`. Downstream that breaks two things:

1. **Processing-status reactions never appear** — `on_processing_start` → `_add_reaction(event.message_id, "Typing")` calls Feishu `CreateMessageReaction` with the token, which is not a valid message ID, so the API rejects it and the user sees no feedback (the issue's reported symptom).
2. **Agent responses are dropped** — `_reply_anchor_for_event` returns `event.message_id` for Feishu, so responses are sent with `reply_to=<token>` and Feishu rejects them with error `99992354` (invalid open_message_id).

The card callback payload already carries the original card message's real ID in `event.context.open_message_id` (the adapter already reads `open_chat_id` from the same `CallBackContext`). This PR uses it, falling back to the previous token/UUID behavior only when the payload omits it.

## What this PR does

- `plugins/platforms/feishu/adapter.py`: read `context.open_message_id` in `_handle_card_action_event` and use it as the synthetic event's `message_id` (`card_message_id or token or str(uuid.uuid4())`).
- `tests/gateway/test_feishu_approval_buttons.py`: fixture now carries `open_message_id`; new test asserts the synthetic event uses it (RED before fix, GREEN after) and that the reply anchor and the processing-status reaction resolve from it; new test asserts token fallback when the field is absent.

## Design decisions

- **Narrow scope:** only the `message_id` assignment changes. The `MessageType.COMMAND` type and `/card {tag}` synthetic text are untouched — the issue is about the reaction ID, and #43609 verified live that COMMAND-type synthetic events do reach the agent.
- **Fallback preserved:** when a payload omits `open_message_id`, behavior is identical to today (token, then UUID), so malformed callbacks don't regress. A debug log on that path (added per review) keeps future 99992354 reports diagnosable.
- **Per-message reaction dedup:** card actions on the same card share `open_message_id`, so the existing in-flight skip in `on_processing_start` (`message_id in _pending_processing_reactions`) now dedups duplicate Typing badges on the same card message as intended; `on_processing_complete` removes the badge and cache entry by message ID.

## Notes

- **Competing PRs:** #6422 (same `open_message_id` direction) targets the pre-migration `gateway/platforms/feishu.py` path and bundles text/type changes — it needs a migration-aware rebase; #43609 and #43048 set `message_id=None`, which prevents the reaction feedback that #7200 asks for. This PR is the narrow fix on the current plugin path.
- **Open question:** whether the bot may react to its own card message in Feishu. The API accepts any message in the bot's chats; live validation from #6422's testers confirms reactions fail only on the invalid token ID, not on a valid card message ID. Happy to adjust if maintainers know of a restriction.

## Verification

- New test failed before the fix (`AssertionError: 'c-card-update-credential' == 'om_original_card_msg'`), passes after.
- Mutation check: reverting the fix line (`message_id=card_message_id or ...` → `message_id=token or ...`) fails the new test with `'c-card-update-credential' == 'om_original_card_msg'`; restored → `test_feishu_approval_buttons.py` 15 passed.
- Full Feishu suite: `tests/gateway/test_feishu.py test_feishu_approval_buttons.py test_feishu_meeting_invite.py test_text_batching.py` → **85 passed, 18 skipped**.
- `git diff origin/main...HEAD --stat`: 2 files, +86/−2.
