### PR TITLE
fix(cli): --in accepts Git Bash / MSYS-style paths on Windows

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2538,7 +2538,15 @@ def cmd_chat(args):
     # recorded cwd (so the restore step below is skipped).
     in_dir = getattr(args, "in_dir", None)
     if in_dir:
-        _target_dir = os.path.abspath(os.path.expanduser(in_dir))
+        # Git Bash / MSYS hands the CLI POSIX-style paths (`--in ~` expands to
+        # `/c/Users/x` before Python ever sees it; MSYS2's path conversion is
+        # disabled for native executables). Translate the MSYS/Cygwin/WSL
+        # drive-root spellings to native Windows form first — no-op elsewhere.
+        from tools.environments.local import _msys_to_windows_path
+
+        _target_dir = os.path.abspath(
+            os.path.expanduser(_msys_to_windows_path(in_dir))
+        )
         if not os.path.isdir(_target_dir):
             print(f"Error: --in directory not found: {in_dir}")
             sys.exit(1)

--- a/tests/hermes_cli/test_in_dir_msys_paths.py
+++ b/tests/hermes_cli/test_in_dir_msys_paths.py
@@ -13,26 +13,23 @@ coverage in tests/tools/test_local_env_windows_msys.py; this pins the
 ``--in`` call site actually applying it.
 """
 
-import os
 from unittest import mock
 
 from tools.environments.local import _msys_to_windows_path
 
 
-def _resolve_in_dir(raw: str) -> str:
-    """The exact resolution expression used by hermes_cli.main for --in."""
-    return os.path.abspath(os.path.expanduser(_msys_to_windows_path(raw)))
-
-
 class TestInDirMsysResolution:
-    def test_git_bash_tilde_expansion_resolves_on_windows(self):
-        with (
-            mock.patch("tools.environments.local._IS_WINDOWS", True),
-            mock.patch.dict(os.environ, {"USERPROFILE": r"C:\Users\alice"}),
-        ):
-            resolved = _resolve_in_dir("/c/Users/alice")
-            assert resolved.lower().startswith("c:"), resolved
-            assert "/c/" not in resolved
+    def test_git_bash_tilde_expansion_translates_on_windows(self):
+        # Assert the translation itself — abspath/expanduser are platform
+        # functions, and this test also runs on Linux CI where posix abspath
+        # would treat 'C:\\...' as relative and prepend the runner's cwd.
+        with mock.patch("tools.environments.local._IS_WINDOWS", True):
+            translated = _msys_to_windows_path("/c/Users/alice")
+            assert translated == "C:" + chr(92) + "Users" + chr(92) + "alice"
+            # ntpath (what the resolver uses on Windows) sees it as absolute.
+            import ntpath
+
+            assert ntpath.isabs(translated)
 
     def test_native_and_posix_forms_untouched(self):
         with mock.patch("tools.environments.local._IS_WINDOWS", True):

--- a/tests/hermes_cli/test_in_dir_msys_paths.py
+++ b/tests/hermes_cli/test_in_dir_msys_paths.py
@@ -1,0 +1,62 @@
+"""``--in`` accepts Git Bash / MSYS-style paths on Windows.
+
+Under Git Bash, ``hermes chat --in ~`` reaches the native CLI as
+``/c/Users/<user>`` — the shell expands ``~`` to an MSYS POSIX path and
+MSYS2's automatic argument conversion is disabled for native executables.
+The resolver must translate the MSYS/Cygwin/WSL drive-root spellings to
+native form before the isdir check, or every Git Bash invocation dies with
+"--in directory not found" (hit live by the Bot Mode agent-messaging flow,
+whose SOUL protocol tells agents to deliver with ``--in ~``).
+
+The translation itself (``_msys_to_windows_path``) has exhaustive unit
+coverage in tests/tools/test_local_env_windows_msys.py; this pins the
+``--in`` call site actually applying it.
+"""
+
+import os
+from unittest import mock
+
+from tools.environments.local import _msys_to_windows_path
+
+
+def _resolve_in_dir(raw: str) -> str:
+    """The exact resolution expression used by hermes_cli.main for --in."""
+    return os.path.abspath(os.path.expanduser(_msys_to_windows_path(raw)))
+
+
+class TestInDirMsysResolution:
+    def test_git_bash_tilde_expansion_resolves_on_windows(self):
+        with (
+            mock.patch("tools.environments.local._IS_WINDOWS", True),
+            mock.patch.dict(os.environ, {"USERPROFILE": r"C:\Users\alice"}),
+        ):
+            resolved = _resolve_in_dir("/c/Users/alice")
+            assert resolved.lower().startswith("c:"), resolved
+            assert "/c/" not in resolved
+
+    def test_native_and_posix_forms_untouched(self):
+        with mock.patch("tools.environments.local._IS_WINDOWS", True):
+            assert _msys_to_windows_path("C:/Users/alice") == "C:/Users/alice"
+            assert _msys_to_windows_path("~/projects") == "~/projects"
+
+    def test_non_windows_never_translates(self):
+        with mock.patch("tools.environments.local._IS_WINDOWS", False):
+            assert _msys_to_windows_path("/c/Users/alice") == "/c/Users/alice"
+
+    def test_main_call_site_uses_translation(self):
+        """Guard: the --in resolution in hermes_cli.main must route through
+        _msys_to_windows_path (a plain expanduser/abspath does not survive
+        Git Bash). Source-level check keeps this honest without spawning
+        the full CLI."""
+        import inspect
+
+        import hermes_cli.main as main_mod
+
+        src = inspect.getsource(main_mod)
+        idx = src.find('in_dir = getattr(args, "in_dir", None)')
+        assert idx != -1, "--in resolution block moved; update this test"
+        block = src[idx : idx + 800]
+        assert "_msys_to_windows_path" in block, (
+            "--in no longer translates MSYS paths; Git Bash `--in ~` will "
+            "fail with '--in directory not found: /c/Users/...'"
+        )


### PR DESCRIPTION
Under Git Bash, `hermes chat --in ~` reaches the native CLI as `/c/Users/<user>` — the shell expands `~` to an MSYS POSIX path, and MSYS2's automatic argument conversion is disabled for native executables. The `--in` resolver did a plain `expanduser`/`abspath`, so every such invocation died with `--in directory not found: /c/Users/...`.

Hit live tonight: the Bot Mode plugin's agent-messaging protocol tells agents to deliver with `--in ~ -c "Bot Chat"`, so every bot-to-bot send from a Git Bash-driven agent failed on Windows until the sender improvised.

Fix: route the value through the existing, exhaustively-tested `_msys_to_windows_path` translator (accepts `/c/…`, `/cygdrive/c/…`, `/mnt/c/…`; strict no-op on non-Windows hosts and non-MSYS forms) before `expanduser`/`abspath` — same pattern the terminal tool already uses for cwd handling.

Validation: new test pins the Git Bash tilde case, native/POSIX no-ops, non-Windows no-op, and (source-level) that the `--in` call site routes through the translator. 4/4 locally; translation edge cases already covered by tests/tools/test_local_env_windows_msys.py.