### PR TITLE
Expose sidebar sessions mode as data-attributes for custom skinning

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1368,6 +1368,20 @@ export function ChatSidebar({
   const showSessionSections =
     showSessionSkeletons || filtersActive || sortedSessions.length > 0 || projectModel.length > 0
 
+  // The sidebar's session-area mode — exposed as data-attributes so custom
+  // skins can target project mode (overview vs. entered), archived, or search
+  // without relying on internal class names. `data-sessions-project` carries
+  // the entered project's id for per-project targeting.
+  const sessionsMode: 'archived' | 'flat' | 'project' | 'projects' | 'search' = trimmedQuery
+    ? 'search'
+    : showArchived
+      ? 'archived'
+      : inProject
+        ? 'project'
+        : worktreeGroupingActive
+          ? 'projects'
+          : 'flat'
+
   // Each reorderable list reports its OWN new id order; persisting is a direct,
   // typed write — no id-prefix sniffing to figure out which level moved.
   const reorderSessions = (ids: string[]) => {
@@ -1514,7 +1528,11 @@ export function ChatSidebar({
         )}
 
         {showSessionSections && (
-          <div className={cn('flex min-h-0 flex-1 flex-col pb-1.75', SCROLL_Y, SCROLL_GUTTER)}>
+          <div
+            className={cn('flex min-h-0 flex-1 flex-col pb-1.75', SCROLL_Y, SCROLL_GUTTER)}
+            data-sessions-mode={sessionsMode}
+            data-sessions-project={inProject ? (enteredProjectId ?? undefined) : undefined}
+          >
             {trimmedQuery && (
               <SidebarSessionsSection
                 activeSessionId={activeSidebarSessionId}


### PR DESCRIPTION
## What

The sidebar sessions area wrapper now carries two data-attributes so custom skins can target project mode (and the other view modes) without relying on internal class names.

## Why

A user asked for a dedicated hook to identify project mode in the sessions area — so their custom UI can style it differently. The sidebar renders flat recents, the project overview, an entered project, archived sessions, and search results all inside the same wrapper `<div>`, and nothing on the DOM distinguished which mode was active.

## How

On the sessions wrapper `<div>` (the scroll container that holds Pinned / Sessions / Messaging / Cron):

| Attribute | Value | When |
|---|---|---|
| `data-sessions-mode` | `flat` | default recents list |
| | `projects` | grouped project overview |
| | `project` | entered/drilled into a specific project |
| | `archived` | archived view |
| | `search` | active search query |
| `data-sessions-project` | the entered project's id | only when `data-sessions-mode="project"` |

### Usage

```css
/* style the sessions area only in project mode */
[data-sessions-mode="project"] { /* … */ }

/* target a specific entered project */
[data-sessions-project="abc123"] { /* … */ }

/* the overview list of all projects */
[data-sessions-mode="projects"] { /* … */ }
```