### PR TITLE
fix(prompt): tolerate inaccessible git roots (#85758)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -85,10 +85,21 @@ def _find_git_root(start: Path) -> Optional[Path]:
     Returns the directory containing ``.git``, or ``None`` if we hit the
     filesystem root without finding one.
     """
-    current = start.resolve()
+    try:
+        current = start.resolve()
+    except OSError:
+        # A configured cwd may be inaccessible to the gateway user.  Context
+        # discovery is best-effort and must not prevent prompt construction.
+        return None
+
     for parent in [current, *current.parents]:
-        if (parent / ".git").exists():
-            return parent
+        try:
+            if (parent / ".git").exists():
+                return parent
+        except OSError:
+            # PermissionError (and other filesystem errors) mean this
+            # directory cannot be inspected; continue checking its parents.
+            continue
     return None
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -637,6 +637,12 @@ class TestFindGitRoot:
         sub.mkdir(parents=True)
         assert _find_git_root(sub) == tmp_path
 
+    def test_ignores_inaccessible_git_markers(self, tmp_path):
+        from unittest.mock import patch
+
+        with patch("pathlib.Path.exists", side_effect=PermissionError):
+            assert _find_git_root(tmp_path) is None
+
     def test_returns_none_without_git(self, tmp_path):
         # Create an isolated dir tree with no .git anywhere in it.
         # tmp_path itself might be under a git repo, so we test with


### PR DESCRIPTION
## Summary
- make git-root discovery tolerate inaccessible configured working directories
- keep prompt construction running when `.git` checks raise filesystem permission errors
- add regression coverage for inaccessible git markers

Closes #85758

## Tests
- `pytest -q tests/agent/test_prompt_builder.py` (62 passed)
