### PR TITLE
fix(install): name the failing stage in hermes update instead of always "Git update failed"

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6390,8 +6390,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
             sys.exit(1)
 
     except subprocess.CalledProcessError as e:
+        label, detail = _describe_update_failure(e)
+        mark = "⚠" if _m()._is_windows() else "✗"
+        print(f"{mark} {label}: {e}")
+        if detail:
+            print("  ↳ last output from the failed step:")
+            for line in detail.splitlines():
+                print(f"    {line}")
         if _m()._is_windows():
-            print(f"⚠ Git update failed: {e}")
             print("→ Falling back to ZIP download...")
             print()
             _update_via_zip(
@@ -6399,7 +6405,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 had_desktop_app_before_update=had_desktop_app_before_update,
             )
         else:
-            print(f"✗ Update failed: {e}")
             sys.exit(1)
 
 # --- Hoisted from the body of _cmd_update_impl (self-contained, no closure state) ---
@@ -6423,6 +6428,47 @@ def _restart_phase_failure_is_incomplete(surviving, pre_restart_pids) -> bool:
         return True
     # surviving == []: safe only if we know nothing was running beforehand.
     return pre_restart_pids is None or bool(pre_restart_pids)
+
+
+def _describe_update_failure(exc: subprocess.CalledProcessError) -> tuple[str, str]:
+    """Name the stage that actually failed, so a Python-deps failure is not
+    reported as a git failure.
+
+    The whole update runs under one ``try``. A failure in the Python-dependency
+    install (``uv/pip install -e .``) surfaced here as a bare
+    ``CalledProcessError`` and was printed as "Git update failed" — even though
+    the git pull had already succeeded — sending users to diagnose git when the
+    real cause was the deps step (e.g. the ``cryptography._rust.pyd`` self-lock
+    in #83569). Classify the failing command instead of assuming git, and
+    return any captured stderr/stdout tail to surface (#85840).
+
+    ``detail`` is best-effort: the streaming install path leaves ``stderr``
+    unset (uv writes its own progress to the console), so the tail is often
+    empty and callers fall back to the exit status alone.
+    """
+    cmd = exc.cmd
+    parts = cmd if isinstance(cmd, (list, tuple)) else [cmd]
+    tokens = [str(p) for p in parts]
+    lowered = [t.lower() for t in tokens]
+    exe = tokens[0].replace("\\", "/").rsplit("/", 1)[-1].lower() if tokens else ""
+
+    is_install = "install" in lowered and any(
+        ("pip" in t or "uv" in t) for t in lowered
+    )
+    if is_install:
+        label = "Python dependency install failed"
+    elif exe == "git" or exe == "git.exe":
+        label = "Git update failed"
+    else:
+        label = "Update step failed"
+
+    raw = exc.stderr or exc.output
+    detail = ""
+    if raw:
+        if isinstance(raw, (bytes, bytearray)):
+            raw = raw.decode("utf-8", "replace")
+        detail = "\n".join(str(raw).splitlines()[-12:]).strip()
+    return label, detail
 
 
 def _print_items(items, label, key, fallback_key=None):

--- a/tests/hermes_cli/test_update_failure_stage_label.py
+++ b/tests/hermes_cli/test_update_failure_stage_label.py
@@ -1,0 +1,79 @@
+"""Regression tests for update-failure stage attribution (issue #85840).
+
+The whole ``hermes update`` runs under one ``try``: a failure in the
+Python-dependency install (``uv/pip install -e .``) reached the handler as a
+bare ``CalledProcessError`` and was printed as "Git update failed" even though
+the git pull had already succeeded — sending users to diagnose git when the
+real cause was the deps step (e.g. the ``cryptography._rust.pyd`` self-lock of
+#83569). ``_describe_update_failure`` classifies the failing command instead of
+assuming git, and surfaces any captured stderr/stdout tail.
+"""
+
+import subprocess
+
+from hermes_cli.update_cmd import _describe_update_failure
+
+
+def _err(cmd, *, stderr=None, output=None, code=2):
+    return subprocess.CalledProcessError(code, cmd, output=output, stderr=stderr)
+
+
+def test_uv_pip_install_is_python_deps_not_git():
+    label, _ = _describe_update_failure(
+        _err(["C:\\hermes\\bin\\uv.exe", "pip", "install", "-e", "."])
+    )
+    assert label == "Python dependency install failed"
+
+
+def test_venv_pip_module_install_is_python_deps():
+    label, _ = _describe_update_failure(
+        _err(["/venv/bin/python", "-m", "pip", "install", "-e", ".[all]"])
+    )
+    assert label == "Python dependency install failed"
+
+
+def test_git_command_is_git_update():
+    label, _ = _describe_update_failure(_err(["git", "pull", "--ff-only"]))
+    assert label == "Git update failed"
+
+
+def test_git_exe_basename_is_git_update():
+    label, _ = _describe_update_failure(
+        _err(["C:\\Program Files\\Git\\cmd\\git.exe", "reset", "--hard"])
+    )
+    assert label == "Git update failed"
+
+
+def test_unknown_command_is_generic_step():
+    label, _ = _describe_update_failure(_err(["node", "build.js"]))
+    assert label == "Update step failed"
+
+
+def test_stderr_tail_is_surfaced():
+    tail = "\n".join(f"line {i}" for i in range(1, 20))
+    _, detail = _describe_update_failure(
+        _err(["uv", "pip", "install", "-e", "."], stderr=tail)
+    )
+    # Only the last 12 lines are kept, and the earliest surviving one is line 8.
+    assert "line 19" in detail
+    assert "line 8" in detail
+    assert "line 7" not in detail
+
+
+def test_bytes_stderr_is_decoded():
+    _, detail = _describe_update_failure(
+        _err(["uv", "pip", "install", "-e", "."], stderr=b"os error 5: Access is denied")
+    )
+    assert "Access is denied" in detail
+
+
+def test_output_used_when_stderr_absent():
+    _, detail = _describe_update_failure(
+        _err(["uv", "pip", "install", "-e", "."], output="fallback stdout tail")
+    )
+    assert detail == "fallback stdout tail"
+
+
+def test_no_captured_output_yields_empty_detail():
+    _, detail = _describe_update_failure(_err(["uv", "pip", "install", "-e", "."]))
+    assert detail == ""


### PR DESCRIPTION
## What

`hermes update` runs the git pull and the Python-dependency install under a single `try`, so when the deps step failed the handler printed:

```
⚠ Git update failed: Command '['...\uv.exe', 'pip', 'install', '-e', '.']' returned non-zero exit status 2.
→ Falling back to ZIP download...
```

…even though the **git pull had already succeeded** (fast-forward applied, `.update_check` recorded `behind: 0`). The message pointed at git while the real failure was the Python-deps stage — the exact mis-attribution reported in #85840, which hid the deps cause (the `cryptography._rust.pyd` self-lock tracked in #83569).

## Change

- Add `_describe_update_failure(exc)` — classifies the failing `CalledProcessError` by its command:
  - `uv/pip … install …` → **"Python dependency install failed"**
  - `git …` → **"Git update failed"**
  - anything else → **"Update step failed"**
- The update handler now prints the classified stage on every platform (Windows keeps the ZIP fallback), and surfaces the last ~12 lines of any captured stderr/stdout next to the exit status.

## Scope note (ask #1 — surfacing raw uv/pip stderr)

The issue also asks to surface the failing subprocess's stderr in `update.log`. The dependency install streams through `_run_install_with_heartbeat`, which runs `subprocess.run(check=True)` **without** capturing output — on purpose, so uv's own progress (which uv writes to stderr) streams live during the multi-minute Rust/C compile the heartbeat exists for. Capturing that stderr to replay it on failure would hide uv's live progress, a UX regression on exactly that slow path. So `_describe_update_failure` surfaces stderr **opportunistically** (when a failing call did capture it) and I've left the capture-vs-stream change for the deps path as a separate, maintainer-directed follow-up. This PR fully fixes the misleading stage attribution (ask #2), which is what sent the reporter down the wrong diagnostic path.

## Tests

`tests/hermes_cli/test_update_failure_stage_label.py` — covers uv-install / venv-pip-install → deps, `git` / `git.exe` → git, unknown → generic, stderr-tail truncation (last 12 lines), bytes decoding, `output` fallback, and empty-detail when nothing was captured.

Fixes #85840
