### PR TITLE
docs(desktop): document HUD mode

### DIFF
--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -127,6 +127,15 @@ Quick Entry is a small always-available composer summoned by a **global hotkey f
 
 Talk to Hermes and hear it back, the same [voice mode](./features/voice-mode.md) available elsewhere. On macOS the OS will prompt once for microphone access.
 
+### HUD mode
+
+**⌘/Ctrl+Shift+H** (or the titlebar button) detaches the chat into a chrome-free, always-on-top floating bar that sits over whatever you are working in. The app window steps aside; the HUD keeps your live conversation and a composer. Where you park it is context — the bar's position tells Hermes which app and screen you're asking about, so "this", "here", and "that page" resolve to what's underneath it.
+
+- **Moving the bar** — **press and hold** anywhere on the composer for a beat, then drag. A quick press still types; a held press grabs the window. This is the only way to move the HUD — there is no titlebar to drag.
+- **Resizing** — drag the bottom-right corner of the bar.
+- **Snap to pointer** — **⌘/Ctrl+Shift+G** (a global hotkey, works from any app) jumps the HUD to wherever your cursor is.
+- **Exiting** — click the exit button on the bar, or press **⌘/Ctrl+Shift+H** again. The app window comes back with your session intact.
+
 ### Settings & onboarding
 
 Manage providers, models, tools, and credentials from a real UI instead of editing YAML. First-run onboarding gets you to your first message in seconds. The settings panes cover providers/keys, model selection, toolset configuration, MCP servers, the gateway, and session management.


### PR DESCRIPTION
The desktop docs page had no HUD mode section at all — the feature was entirely undocumented.

Adds a **HUD mode** section to `desktop.md` covering:

- **Long-press to move** — press and hold anywhere on the composer, then drag. This is the only way to move the bar (no titlebar). Sourced from `composer-drag.ts` (`LONG_PRESS_MS = 140`).
- **Resize** — drag the bottom-right corner (`resize-handle.ts`).
- **Snap to pointer** — ⌘/Ctrl+Shift+G global hotkey (`hud.snapToPointer`).
- **Exit** — exit button or ⌘/Ctrl+Shift+H toggle (`view.toggleHud`).

Also updated the personal `hud-mode` skill with a "How the bar moves" section so the agent knows the long-press interaction and why the subject can shift between turns without the user mentioning it.