### PR TITLE
fix(desktop): relaunch into canonical /Applications/Hermes.app on macOS

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -236,6 +236,7 @@ import {
 } from './remote-liveness'
 import { missingRendererAssets } from './renderer-bundle'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
+import { runningAppBundle } from './running-app-bundle'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -3409,7 +3410,7 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
     const { branch: configuredBranch } = readDesktopUpdateConfig()
     const branch = await resolveHealedBranch(updateRoot, configuredBranch || DEFAULT_UPDATE_BRANCH)
     const updaterArgs = ['--update', '--branch', branch]
-    const targetApp = IS_MAC ? runningAppBundle() : null
+    const targetApp = IS_MAC ? runningAppBundle(app.getPath('exe')) : null
 
     if (targetApp) {
       updaterArgs.push('--target-app', targetApp)
@@ -3731,22 +3732,6 @@ async function handOffWindowsBootstrapRecovery(reason) {
   return true
 }
 
-// The running app's .app bundle (packaged macOS): execPath is
-// <App>.app/Contents/MacOS/<exe>; climb three levels to the bundle root.
-function runningAppBundle() {
-  if (!IS_MAC) {
-    return null
-  }
-
-  let dir = path.dirname(app.getPath('exe')) // .../Contents/MacOS
-
-  for (let i = 0; i < 2; i++) {
-    dir = path.dirname(dir)
-  } // -> .../X.app
-
-  return dir.endsWith('.app') ? dir : null
-}
-
 // ── Pre-flight state.db integrity guard (#68474) ─────────────────────
 // Take an emergency snapshot of state.db and verify the live copy is
 // intact before any update process mutates the install.  Runs in the
@@ -3886,7 +3871,7 @@ async function applyUpdatesPosixHandoff(opts: any) {
   // only a binary the rebuild replaced with a launchable sandbox helper —
   // replaying the original launch context (filtered args, cwd, sandbox
   // opt-out) so a deep-link or --no-sandbox launch survives the update.
-  const targetApp = IS_MAC ? runningAppBundle() : process.execPath
+  const targetApp = IS_MAC ? runningAppBundle(app.getPath('exe')) : process.execPath
 
   if (targetApp) {
     args.push('--relaunch-target', targetApp)

--- a/apps/desktop/electron/running-app-bundle.test.ts
+++ b/apps/desktop/electron/running-app-bundle.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { runningAppBundle } from './running-app-bundle'
+
+const missing = () => false
+const darwin = 'darwin' as const
+
+test('runningAppBundle: canonical install is used as-is', () => {
+  assert.equal(
+    runningAppBundle('/Applications/Hermes.app/Contents/MacOS/Hermes', () => true, darwin),
+    '/Applications/Hermes.app'
+  )
+})
+
+test('runningAppBundle: migration backup relaunches into an existing canonical install', () => {
+  const exists = (p: string) => p === '/Applications/Hermes.app'
+  assert.equal(
+    runningAppBundle(
+      '/Users/pool/.hermes.preclone-20260715-132112/hermes-agent/apps/desktop/release/mac-arm64/Hermes.app/Contents/MacOS/Hermes',
+      exists,
+      darwin
+    ),
+    '/Applications/Hermes.app'
+  )
+})
+
+test('runningAppBundle: mounted image relaunches into an existing canonical install', () => {
+  const exists = (p: string) => p === '/Applications/Hermes.app'
+  assert.equal(
+    runningAppBundle('/Volumes/Hermes/Hermes.app/Contents/MacOS/Hermes', exists, darwin),
+    '/Applications/Hermes.app'
+  )
+})
+
+test('runningAppBundle: arbitrary alternate install is not silently retargeted', () => {
+  const exists = (p: string) => p === '/Applications/Hermes.app'
+  assert.equal(
+    runningAppBundle('/Users/pool/Applications/Hermes.app/Contents/MacOS/Hermes', exists, darwin),
+    '/Users/pool/Applications/Hermes.app'
+  )
+})
+
+test('runningAppBundle: canonical name follows the running bundle name', () => {
+  const exists = (p: string) => p === '/Applications/Hermes Beta.app'
+  assert.equal(
+    runningAppBundle('/Volumes/Hermes Beta/Hermes Beta.app/Contents/MacOS/Hermes Beta', exists, darwin),
+    '/Applications/Hermes Beta.app'
+  )
+})
+
+test('runningAppBundle: transient location falls back when no canonical install exists', () => {
+  assert.equal(
+    runningAppBundle('/Volumes/Hermes/Hermes.app/Contents/MacOS/Hermes', missing, darwin),
+    '/Volumes/Hermes/Hermes.app'
+  )
+})
+
+test('runningAppBundle: non-mac returns null', () => {
+  assert.equal(runningAppBundle('/usr/bin/electron', missing, 'linux'), null)
+})

--- a/apps/desktop/electron/running-app-bundle.ts
+++ b/apps/desktop/electron/running-app-bundle.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+// The running app's .app bundle (packaged macOS): execPath is
+// <App>.app/Contents/MacOS/<exe>; climb three levels to the bundle root.
+//
+// Only clearly transient launch locations are redirected to /Applications.
+// An arbitrary alternate copy may be intentional (for example a beta or test
+// build) and must keep updating/relaunching itself even when another install
+// exists in /Applications.
+function isTransientMacBundle(bundlePath: string): boolean {
+  const normalized = path.normalize(bundlePath)
+  const parts = normalized.split(path.sep)
+
+  return normalized.startsWith(`/Volumes${path.sep}`) || parts.some((part) => part.startsWith('.hermes.preclone-'))
+}
+
+function canonicalMacBundle(bundlePath: string): string {
+  return path.join('/Applications', path.basename(bundlePath))
+}
+
+export function runningAppBundle(
+  execPath: string,
+  existsSync: (p: string) => boolean = fs.existsSync,
+  platform: NodeJS.Platform = process.platform
+): string | null {
+  if (platform !== 'darwin') {
+    return null
+  }
+
+  let dir = path.dirname(execPath) // .../Contents/MacOS
+
+  for (let i = 0; i < 2; i++) {
+    dir = path.dirname(dir)
+  } // -> .../X.app
+
+  const running = dir.endsWith('.app') ? dir : null
+
+  if (!running || running.startsWith(`/Applications${path.sep}`) || !isTransientMacBundle(running)) {
+    return running
+  }
+
+  const canonical = canonicalMacBundle(running)
+
+  return existsSync(canonical) ? canonical : running
+}


### PR DESCRIPTION
## Summary

When the packaged macOS Desktop app was launched from a clearly transient location, the updater used that stray bundle as both its update target and relaunch target. In the observed migration case, Hermes kept rebuilding and reopening a bundle under `.hermes.preclone-*` while the real `/Applications/Hermes.app` remained stale.

This change centralizes bundle resolution in a tested helper. It redirects only known transient locations (migration backups and mounted volumes) to the matching bundle name under `/Applications`, and only when that installed bundle exists. Arbitrary alternate installs keep targeting themselves, so beta/dev/test copies are not silently redirected.

## RED proof

The original PR head (`bf43ea2fae11`) failed the repository CI:

```text
running-app-bundle.test.ts:10: expected '/Applications/Hermes.app', received null
running-app-bundle.test.ts:20: expected '/Applications/Hermes.app', received null
running-app-bundle.test.ts:30: expected '/Volumes/Hermes/Hermes.app', received null
Test Files  1 failed | 86 passed | 1 skipped
Tests       3 failed | 1056 passed | 2 skipped
```

The tests had relied on the host platform instead of explicitly exercising `darwin`. The same head also failed lint:

```text
running-app-bundle.test.ts:2:1  error  Missed spacing between "node:assert/strict" and "vitest"
```

The review also exposed a behavioral regression: an arbitrary alternate bundle was redirected whenever `/Applications/Hermes.app` merely existed. The added `arbitrary alternate install is not silently retargeted` case fails under that broad policy and passes with the narrowed transient-location policy.

## Code path trace

1. **Symptom:** an update launched from a migration backup or mounted image rebuilds/reopens the transient copy while the installed app remains stale.
2. **Intermediate:** both `applyUpdates()` and `applyUpdatesPosixHandoff()` derive `--target-app` / `--relaunch-target` from `app.getPath('exe')`.
3. **Root cause:** bundle resolution previously had no distinction between an accidental transient launch location and an intentional alternate install; the first revision then overcorrected by redirecting every non-canonical bundle based only on path existence.

## Widening audit

- In-app updater `--target-app`: affected → uses the shared resolver.
- POSIX handoff `--relaunch-target`: affected → uses the same resolver.
- Migration backup (`.hermes.preclone-*`): affected → redirects to matching `/Applications/<bundle>` when present.
- Mounted image (`/Volumes/...`): affected → redirects to matching `/Applications/<bundle>` when present.
- Arbitrary alternate/beta/dev install: must remain independent → explicitly preserved.
- Product rename / alternate bundle name: canonical basename is derived from the running `.app`; no hardcoded `Hermes.app` constant.
- No installed matching bundle: falls back to the running bundle.
- Linux/Windows: unchanged; resolver returns `null` off macOS and existing call-site behavior is preserved.

## Verification

```text
npm run --prefix apps/desktop check:test:desktop:platforms
Test Files  99 passed | 1 skipped
Tests       1244 passed | 2 skipped

npm run --prefix apps/desktop test:desktop:platforms -- --run electron/running-app-bundle.test.ts
Test Files  1 passed
Tests       7 passed

npm run --prefix apps/desktop check:lint
0 errors (existing warnings only)

npm run --prefix apps/desktop check:test:desktop:all
Desktop build, package, and artifact validation passed
```

Rebased onto current `main` before verification. Net diff: 3 files, 111 insertions, 18 deletions.