### PR TITLE
fix(delegation): keep switched custom-provider models on the correct route

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -737,6 +737,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 if base_url:
                     result = {
                         "name": entry.get("name", ep_name),
+                        "provider_key": str(ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
@@ -962,42 +963,31 @@ def canonical_custom_identity(
 
     Any code path that persists or restores a session's provider override
     must run the resolved provider through this helper so a bare ``"custom"``
-    is upgraded back to its durable ``custom:<name>`` menu key. Three
-    recovery sources, in priority order:
-
-    1. ``base_url`` — reverse-lookup the entry that owns the endpoint URL
-       (the one fact that always survives the persistence round-trip when a
-       URL was recorded).
-    2. ``model`` — reverse-lookup the entry that serves the session's model
-       (``model``/``default_model``/``models`` catalog). The session row
-       always stores the model name, so when no base_url survived (the
-       recurring Desktop/TUI regression vector) the model is the last
-       session-scoped fact that can recover the entry — and unlike the
-       config fallback below it stays correct after the user points their
-       global default at a different provider.
-    3. ``config_provider`` — the active ``config.model.provider`` (or its
-       ``provider``/``HERMES_INFERENCE_PROVIDER`` equivalent). When neither
-       a base_url nor a model recovered the entry, the configured provider
-       is the only durable identity left, so fall back to it when it names
-       a real entry.
+    is upgraded back to its durable ``custom:<name>`` menu key. URL, model,
+    and configured-provider evidence are reconciled rather than accepted in
+    isolation: a model or explicit named provider may disambiguate entries
+    that share one gateway URL, but may not override a different endpoint.
 
     Returns ``custom:<name>`` when a routable identity is recovered, else
     ``None`` (caller keeps whatever it had — bare ``"custom"`` only as a last
     resort, e.g. a genuine ad-hoc endpoint with no config entry).
     """
-    # 1. Reverse-lookup by endpoint URL.
-    if base_url:
-        identity = find_custom_provider_identity(base_url)
-        if identity:
-            return identity
-
-    # 2. Reverse-lookup by the session's model name.
+    url_identity = find_custom_provider_identity(base_url) if base_url else None
     if model:
-        identity = find_custom_provider_identity_by_model(model)
-        if identity:
-            return identity
+        model_identity = find_custom_provider_identity_by_model(model)
+        if model_identity:
+            if not base_url:
+                return model_identity
+            try:
+                model_entry = _get_named_custom_provider(model_identity)
+            except Exception:
+                model_entry = None
+            if model_entry and _normalize_base_url_for_match(
+                model_entry.get("base_url")
+            ) == _normalize_base_url_for_match(base_url):
+                return model_identity
 
-    # 3. Fall back to the configured provider when it names a real entry.
+    # A valid named provider beats URL order only when it owns this endpoint.
     candidate = str(config_provider or "").strip()
     if not candidate:
         try:
@@ -1008,31 +998,22 @@ def canonical_custom_identity(
         candidate = os.environ.get("HERMES_INFERENCE_PROVIDER", "").strip()
 
     candidate_norm = _normalize_custom_provider_name(candidate)
-    # A bare/non-routable candidate cannot heal a bare custom override.
-    if not candidate_norm or candidate_norm in {"custom", "auto", "openrouter"}:
-        return None
-    # Only return it when it actually resolves to a configured custom entry,
-    # so we never invent a `custom:<x>` that resolution can't honor.
-    try:
-        entry = _get_named_custom_provider(candidate)
-        if entry is not None:
-            # ``candidate`` matched, but it may be the entry's DISPLAY NAME —
-            # ``_get_named_custom_provider`` accepts either spelling. For a
-            # keyed ``providers:`` entry the display name is not the durable
-            # identity, so re-resolve through the endpoint the matched entry
-            # owns and return the same config-key slug every other path
-            # returns (7b5a18817). Without this, a display name that differs
-            # from its key heals to ``custom:<display-name>`` and stops
-            # matching the persisted identity.
-            identity = find_custom_provider_identity(str(entry.get("base_url") or ""))
-            if identity:
-                return identity
-            if candidate_norm.startswith("custom:"):
-                return candidate_norm
-            return f"custom:{candidate_norm}"
-    except Exception:
-        pass
-    return None
+    if candidate_norm and candidate_norm not in {"custom", "auto", "openrouter"}:
+        try:
+            entry = _get_named_custom_provider(candidate)
+        except Exception:
+            entry = None
+        if entry is not None and (
+            not base_url
+            or _normalize_base_url_for_match(entry.get("base_url"))
+            == _normalize_base_url_for_match(base_url)
+        ):
+            return custom_provider_slug(
+                str(entry.get("name") or candidate),
+                str(entry.get("provider_key") or ""),
+            )
+
+    return url_identity
 
 
 def _normalize_base_url_for_match(value) -> str:

--- a/tests/hermes_cli/test_canonical_custom_identity.py
+++ b/tests/hermes_cli/test_canonical_custom_identity.py
@@ -98,3 +98,45 @@ def test_legacy_unkeyed_entry_keeps_its_name_identity(monkeypatch):
     monkeypatch.setattr(rp, "_get_model_config", lambda: {})
 
     assert rp.canonical_custom_identity(config_provider="Legacy Endpoint") == "custom:legacy-endpoint"
+
+
+def test_model_disambiguates_named_providers_sharing_one_url(monkeypatch):
+    shared_url = "https://shared.invalid/v1"
+    config = {
+        "custom_providers": [
+            {
+                "name": "provider-a",
+                "base_url": shared_url,
+                "api_key": "provider-a-key",
+                "model": "model-a-default",
+                "models": {"model-a-default": {}},
+            },
+            {
+                "name": "provider-b",
+                "base_url": shared_url,
+                "api_key": "provider-b-key",
+                "model": "model-b-default",
+                "models": {
+                    "model-b-current": {},
+                    "model-b-default": {},
+                },
+            },
+        ]
+    }
+    monkeypatch.setattr(rp, "load_config", lambda *a, **k: config)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: config)
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "custom:provider-a"},
+    )
+
+    assert rp.find_custom_provider_identity(shared_url) == "custom:provider-a"
+    assert (
+        rp.canonical_custom_identity(
+            base_url=shared_url,
+            config_provider="custom:provider-a",
+            model="model-b-current",
+        )
+        == "custom:provider-b"
+    )

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -660,6 +660,48 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["api_mode"])
         self.assertIsNone(creds["model"])
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    @patch("hermes_cli.runtime_provider.canonical_custom_identity")
+    def test_no_override_resolves_switched_named_custom_runtime(
+        self, mock_canonical, mock_resolve
+    ):
+        mock_canonical.return_value = "custom:provider-b"
+        mock_resolve.return_value = {
+            "provider": "custom",
+            "model": "model-b-default",
+            "base_url": "https://shared.invalid/v1",
+            "api_key": "provider-b-key",
+            "api_mode": "chat_completions",
+            "request_overrides": {"extra_body": {"group": "provider-b"}},
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.model = "model-b-current"
+        parent.provider = "custom:provider-a"
+        parent.requested_provider = "custom:provider-a"
+        parent.base_url = "https://shared.invalid/v1"
+        parent.api_key = "provider-a-key"
+
+        creds = _resolve_delegation_credentials(
+            {"model": "", "provider": ""}, parent
+        )
+
+        self.assertEqual(creds["model"], "model-b-current")
+        self.assertEqual(creds["provider"], "custom:provider-b")
+        self.assertEqual(creds["api_key"], "provider-b-key")
+        self.assertNotEqual(creds["api_key"], parent.api_key)
+        self.assertEqual(
+            creds["request_overrides"],
+            {"extra_body": {"group": "provider-b"}},
+        )
+        mock_canonical.assert_called_once_with(
+            base_url="https://shared.invalid/v1",
+            config_provider="custom:provider-a",
+            model="model-b-current",
+        )
+        mock_resolve.assert_called_once_with(
+            requested="custom:provider-b", target_model="model-b-current"
+        )
+
     def test_direct_endpoint_uses_configured_base_url_and_api_key(self):
         parent = _make_mock_parent(depth=0)
         cfg = {

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4196,8 +4196,10 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     provider system — the same path used by CLI/gateway startup. This lets
     subagents run on a completely different provider:model pair.
 
-    If neither base_url nor provider is configured, returns None values so the
-    child inherits everything from the parent agent.
+    If neither base_url nor provider is configured, built-in providers inherit
+    directly. Named custom providers are first checked against the active model
+    catalog so a stale/generic parent identity cannot select the first entry at
+    an otherwise identical gateway URL.
 
     Raises ValueError with a user-friendly message on credential failure.
     """
@@ -4264,7 +4266,66 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         }
 
     if not configured_provider:
-        # No provider override — child inherits everything from parent
+        parent_model = str(getattr(parent_agent, "model", "") or "").strip()
+        parent_provider = str(getattr(parent_agent, "provider", "") or "").strip()
+        parent_requested_provider = str(
+            getattr(parent_agent, "requested_provider", "") or ""
+        ).strip()
+        parent_base_url = str(
+            getattr(parent_agent, "base_url", "") or ""
+        ).strip()
+        route_identity = parent_requested_provider or parent_provider
+        is_custom_parent = (
+            parent_provider.lower() == "custom"
+            or parent_provider.lower().startswith("custom:")
+            or route_identity.lower().startswith("custom:")
+        )
+        if is_custom_parent:
+            try:
+                from hermes_cli.runtime_provider import (
+                    canonical_custom_identity,
+                    resolve_runtime_provider,
+                )
+
+                custom_identity = canonical_custom_identity(
+                    base_url=parent_base_url,
+                    config_provider=route_identity,
+                    model=configured_model or parent_model,
+                )
+                if custom_identity and custom_identity.lower() != parent_provider.lower():
+                    target_model = configured_model or parent_model or None
+                    runtime = resolve_runtime_provider(
+                        requested=custom_identity,
+                        target_model=target_model,
+                    )
+                    api_key = runtime.get("api_key", "")
+                    if not api_key:
+                        raise ValueError(
+                            f"Inherited custom provider '{custom_identity}' resolved "
+                            "but has no API key."
+                        )
+                    return {
+                        "model": target_model or runtime.get("model") or None,
+                        "provider": custom_identity,
+                        "base_url": runtime.get("base_url"),
+                        "api_key": api_key,
+                        "api_mode": runtime.get("api_mode"),
+                        "request_overrides": dict(
+                            runtime.get("request_overrides") or {}
+                        ),
+                        "max_output_tokens": runtime.get("max_output_tokens"),
+                        "command": runtime.get("command"),
+                        "args": list(runtime.get("args") or []),
+                    }
+            except ValueError:
+                raise
+            except Exception as exc:
+                logger.debug(
+                    "Could not canonicalize inherited custom provider: %s", exc
+                )
+
+        # The parent identity is already complete, or this is a built-in/ad-hoc
+        # runtime. None overrides preserve its live credentials and pool.
         return {
             "model": configured_model,
             "provider": None,


### PR DESCRIPTION
## What does this PR do?

This PR keeps delegated workers on the active named custom provider after a model switch, even when multiple providers share one OpenAI-compatible URL. Without this fix, a child can combine the current model with another provider's credentials or routing group and fail every delegated request.

### Symptom

A parent session switched to a model served only by `custom:provider-b` works normally, but `delegate_task` sends its children through `provider-a` when both named providers use the same `base_url`. The children fail after retries with an HTTP 503 stating that the model has no available channel under the `provider-a` group.

### Impact

Users with same-URL custom providers and unset delegation overrides cannot delegate work after switching between those providers. The parent remains usable, but every affected child request is routed with the wrong provider identity and credentials.

### Bug Cause

**Trigger:** `tools/delegate_tool.py` / `_resolve_delegation_credentials()` when delegation overrides are empty and the parent model has switched between named custom providers sharing one URL.

**Causal chain:**
1. The parent switches to a model whose catalog belongs only to the second named custom provider.
2. Empty delegation overrides inherit parent fields, while custom-provider recovery and credential-pool selection use the shared URL and select the first matching entry.
3. The child sends the current model through the first provider's credentials or routing group and receives a provider-side 503.

**Why it is wrong:** A shared endpoint URL does not uniquely identify a named custom provider. The active model catalog and configured provider identity must participate in recovery before delegation resolves the complete credential bundle.

**Working sibling / contrast:** An explicit `delegation.provider` already resolves one complete runtime bundle, so it does not mix a model from one provider with another provider's credentials.

**Ruled out:** The failure is not caused by transport-mode detection or the provider API itself. Focused regressions reproduce the incorrect first-entry selection entirely inside provider identity and delegation credential resolution.

### Fix

Custom-provider identity recovery now reconciles the endpoint, active model catalog, and explicit named provider instead of accepting URL order alone. Delegation with no overrides canonicalizes an ambiguous custom parent against the active model and resolves the matching provider's complete runtime, including credentials, transport, request overrides, and output settings. Existing complete identities and built-in or ad-hoc runtimes retain the direct inheritance path.

## Related Issue

Closes #85847

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py` - disambiguate same-URL custom providers with model and named-provider evidence while preserving endpoint consistency.
- `tools/delegate_tool.py` - resolve the complete active custom-provider runtime before constructing delegated children.
- `tests/hermes_cli/test_canonical_custom_identity.py` - cover model-based identity recovery for disjoint catalogs on one URL.
- `tests/tools/test_delegate.py` - verify delegated children inherit the switched provider's model, credentials, and request overrides.

## How to Test

1. Configure two named custom providers with one `base_url`, disjoint model catalogs, and different credentials.
2. Switch the parent session to a model served only by the second provider and leave delegation overrides empty.
3. Confirm delegated credential resolution selects the second provider's identity and key rather than the first provider's key.
4. Run the focused automated suite (already run locally, 200 passed):

```bash
scripts/run_tests.sh tests/hermes_cli/test_canonical_custom_identity.py tests/tools/test_delegate.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - provider resolution is platform-independent and covered by in-process tests
- [x] Tool descriptions or schemas update: N/A - the `delegate_task` interface is unchanged

## Screenshots / Logs

N/A - the regression is covered by focused provider-resolution and delegation tests.
