### PR TITLE
fix(compression): require todo revalidation after compaction

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -63,6 +63,10 @@ def _build_plan_update_from_todo_result(result: Any) -> AgentPlanUpdate | None:
         "pending": "pending",
         "in_progress": "in_progress",
         "completed": "completed",
+        # ACP has no paused/reconfirmation state. Keep the task non-terminal
+        # but label it explicitly so clients do not present stale work as an
+        # ordinary actionable pending item.
+        "needs_reconfirmation": "pending",
         # ACP plans only support pending/in_progress/completed. Preserve
         # cancelled tasks as terminal entries instead of dropping them and
         # making the client's full-list replacement lose visible context.
@@ -75,10 +79,16 @@ def _build_plan_update_from_todo_result(result: Any) -> AgentPlanUpdate | None:
         content = str(item.get("content") or item.get("id") or "").strip()
         if not content:
             continue
-        raw_status = str(item.get("status") or "pending").strip()
+        raw_status = (
+            "needs_reconfirmation"
+            if item.get("needs_reconfirmation") is True
+            else str(item.get("status") or "pending").strip()
+        )
         status = status_map.get(raw_status, "pending")
         if raw_status == "cancelled":
             content = f"[cancelled] {content}"
+        elif raw_status == "needs_reconfirmation":
+            content = f"[needs reconfirmation] {content}"
         entries.append(PlanEntry(content=content, priority="medium", status=status))
 
     return AgentPlanUpdate(session_update="plan", entries=entries)

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -431,8 +431,6 @@ class SessionManager:
             session_meta["base_url"] = base_url.strip()
         if isinstance(api_mode, str) and api_mode.strip():
             session_meta["api_mode"] = api_mode.strip()
-        cwd_json = json.dumps(session_meta)
-
         try:
             # Ensure the session record exists.
             existing = db.get_session(state.session_id)
@@ -444,9 +442,14 @@ class SessionManager:
                     model_config={"cwd": state.cwd},
                 )
             else:
-                # Update model_config (contains cwd) if changed.
+                # Merge ACP-owned keys rather than replacing model_config: it
+                # also carries private lineage/runtime state such as durable
+                # post-compaction todos. The patch helper merges inside its
+                # write transaction, avoiding a read/modify/write lost update.
                 try:
-                    db.update_session_meta(state.session_id, cwd_json, model_str)
+                    db.patch_session_model_config(state.session_id, session_meta)
+                    if model_str:
+                        db.update_session_model(state.session_id, model_str)
                 except Exception:
                     logger.debug("Failed to update ACP session metadata", exc_info=True)
 

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1680,9 +1680,27 @@ def init_agent(
     except Exception:
         pass
     
-    # In-memory todo list for task planning (one per agent/session)
-    from tools.todo_tool import TodoStore
-    agent._todo_store = TodoStore()
+    # In-memory todo list for task planning (one per agent/session). Mirror
+    # every authoritative write into the session's trusted model_config so a
+    # fresh gateway agent cannot resurrect an older pre-compaction tool result.
+    from tools.todo_tool import TODO_STATE_MODEL_CONFIG_KEY, TodoStore
+
+    def _persist_todo_state(items):
+        state = [dict(item) for item in items]
+        agent._session_init_model_config[TODO_STATE_MODEL_CONFIG_KEY] = state
+        if getattr(agent, "_persist_disabled", False):
+            return
+        session_db = getattr(agent, "_session_db", None)
+        session_id = getattr(agent, "session_id", None)
+        patch_config = getattr(session_db, "patch_session_model_config", None)
+        if not session_id or not callable(patch_config):
+            return
+        try:
+            patch_config(session_id, {TODO_STATE_MODEL_CONFIG_KEY: state})
+        except Exception:
+            logger.debug("Could not persist todo state", exc_info=True)
+
+    agent._todo_store = TodoStore(on_change=_persist_todo_state)
     
     # Load config once for memory, skills, and compression sections
     try:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -52,6 +52,21 @@ logger = logging.getLogger(__name__)
 # spins forever and never reaches ``_try_activate_fallback``. See #26080.
 _MAX_AUTH_REFRESH_ATTEMPTS = 2
 
+# Tools that can gather evidence or update the plan without carrying out the
+# preserved plan itself. Everything else stays behind the compaction barrier.
+_TODO_RECONFIRMATION_SAFE_TOOLS = frozenset({
+    "clarify",
+    "read_file",
+    "search_files",
+    "session_search",
+    "skill_view",
+    "skills_list",
+    "todo",
+    "vision_analyze",
+    "web_extract",
+    "web_search",
+})
+
 
 _REASONING_TAG_NAMES = ("think", "thinking", "reasoning", "REASONING_SCRATCHPAD", "thought")
 _TOOL_CALL_TAG_NAMES = ("tool_call", "tool_calls", "tool_result", "function_call", "function_calls")
@@ -2945,12 +2960,37 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     except Exception as _mw_err:
         logger.debug("tool_request middleware error: %s", _mw_err)
 
-    # Check plugin hooks for a block or approval directive before executing.
+    # A post-compaction plan is a hard execution barrier, not advisory prose.
+    # The todo call and read-only evidence tools remain available so the model
+    # can revalidate/cancel every preserved item before any action-capable tool
+    # runs.
     block_message: Optional[str] = None
+    block_error_type = "plugin_block"
+    if function_name not in _TODO_RECONFIRMATION_SAFE_TOOLS:
+        todo_store = getattr(agent, "_todo_store", None)
+        requires_reconfirmation = getattr(
+            todo_store,
+            "requires_reconfirmation",
+            None,
+        )
+        if (
+            callable(requires_reconfirmation)
+            and requires_reconfirmation() is True
+        ):
+            block_error_type = "todo_reconfirmation"
+            block_message = (
+                "Action-capable tool execution is blocked until the preserved "
+                "todo plan is revalidated after context compression. Use only "
+                "evidence-gathering tools, then call todo and "
+                "explicitly restore each valid item to pending/in_progress "
+                "or cancel it."
+            )
+
+    # Check plugin hooks for a block or approval directive before executing.
     if not pre_tool_block_checked:
         try:
             from hermes_cli.plugins import resolve_pre_tool_block
-            block_message = resolve_pre_tool_block(
+            plugin_block = resolve_pre_tool_block(
                 function_name,
                 function_args,
                 task_id=effective_task_id or "",
@@ -2960,8 +3000,11 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                 middleware_trace=list(_tool_middleware_trace),
             )
+            if block_message is None:
+                block_message = plugin_block
+                block_error_type = "plugin_block"
         except Exception:
-            block_message = None
+            pass
     if block_message is not None:
         result = json.dumps({"error": block_message}, ensure_ascii=False)
         try:
@@ -2976,7 +3019,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                 status="blocked",
-                error_type="plugin_block",
+                error_type=block_error_type,
                 error_message=block_message,
                 middleware_trace=list(_tool_middleware_trace),
             )

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3168,7 +3168,25 @@ def compress_context(
                         "check auxiliary.compression.model in config.yaml."
                     )
 
-        todo_snapshot = agent._todo_store.format_for_injection()
+        # A compression boundary is also a provenance boundary: context that
+        # justified an active plan may be summarized or pruned.  Preserve the
+        # plan for continuity, but make it explicitly non-actionable until the
+        # model revalidates it in the post-compaction context.
+        from tools.todo_tool import TODO_STATE_MODEL_CONFIG_KEY, TodoStore
+
+        # Do not invoke the ordinary persistence callback before the transcript
+        # commit. The state rides the same atomic DB operation below; publishing
+        # it early could make a failed compaction invalidate an uncompressed plan.
+        _todo_state_before_compression = agent._todo_store.read()
+        _todo_snapshot_store = TodoStore()
+        _todo_snapshot_store.write(
+            _todo_state_before_compression,
+            merge=False,
+            notify=False,
+        )
+        _todo_snapshot_store.mark_active_for_reconfirmation(notify=False)
+        _todo_state_after_compression = _todo_snapshot_store.read()
+        todo_snapshot = _todo_snapshot_store.format_for_injection()
         if todo_snapshot:
             # Fold the snapshot into a trailing REAL user message so
             # compression never introduces a synthetic user/user pair. Any
@@ -3257,6 +3275,17 @@ def compress_context(
             new_system_prompt = agent._build_system_prompt(system_message)
             agent._cached_system_prompt = new_system_prompt
 
+        # All summary/prompt transforms succeeded. Publish the tentative state
+        # in memory immediately before its durable commit; the DB exception path
+        # below restores the old state if publication never happens.
+        agent._todo_store.write(
+            _todo_state_after_compression,
+            merge=False,
+            notify=False,
+        )
+        _todo_state_committed = not bool(agent._session_db)
+        if _todo_state_committed:
+            agent._todo_store.persist()
         _session_commit_succeeded = False
         split_status = "not_applicable"
         if agent._session_db:
@@ -3296,8 +3325,10 @@ def compress_context(
                         compressed,
                         model_config_patch={
                             PROACTIVE_PRUNE_REARM_MODEL_CONFIG_KEY: None,
+                            TODO_STATE_MODEL_CONFIG_KEY: _todo_state_after_compression,
                         },
                     )
+                    _todo_state_committed = True
                     split_status = "in_place_committed"
                     # Reset the flush identity set so the next turn's appends are
                     # diffed against the COMPACTED transcript: the compacted dicts
@@ -3360,13 +3391,17 @@ def compress_context(
                         f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_"
                         f"{uuid.uuid4().hex[:6]}"
                     )
+                    _child_model_config = dict(agent._session_init_model_config)
+                    _child_model_config[TODO_STATE_MODEL_CONFIG_KEY] = (
+                        _todo_state_after_compression
+                    )
                     agent._session_db.publish_compression_child(
                         parent_session_id=old_session_id,
                         child_session_id=new_session_id,
                         source=agent.platform
                         or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                         model=agent.model,
-                        model_config=agent._session_init_model_config,
+                        model_config=_child_model_config,
                         system_prompt=new_system_prompt,
                         messages=compressed,
                         cwd=getattr(agent, "working_directory", None),
@@ -3374,6 +3409,7 @@ def compress_context(
                         compression_lock_holder=_lock_holder,
                         require_compression_lease=_lock_holder is not None,
                     )
+                    _todo_state_committed = True
                     agent.session_id = new_session_id
                     try:
                         from gateway.session_context import set_current_session_id
@@ -3467,7 +3503,19 @@ def compress_context(
                         if isinstance(message, dict)
                     }
                 _session_commit_succeeded = True
+                # Keep future rotation config in sync without rewriting the
+                # potentially large todo payload: the atomic DB operation above
+                # already committed this exact state.
+                agent._session_init_model_config[TODO_STATE_MODEL_CONFIG_KEY] = (
+                    _todo_state_after_compression
+                )
             except Exception as e:
+                if not _todo_state_committed:
+                    agent._todo_store.write(
+                        _todo_state_before_compression,
+                        merge=False,
+                        notify=False,
+                    )
                 if (
                     not in_place
                     and locals().get("old_session_id")

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -629,9 +629,11 @@ def build_turn_context(
         if isinstance(pending_cli_message, dict):
             agent._pending_cli_user_message = None
 
-    # Hydrate todo store from conversation history.
-    if conversation_history and not agent._todo_store.has_items():
-        agent._hydrate_todo_store(conversation_history)
+    # Hydrate from trusted session state first, falling back to paired tool
+    # results in history. A resumed gateway turn can have durable todo state
+    # even when its caller supplies no transcript rows.
+    if not agent._todo_store.has_items():
+        agent._hydrate_todo_store(conversation_history or [])
 
     # Hydrate per-session nudge counters from persisted history (issue #22357).
     if conversation_history and agent._user_turn_count == 0:

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -19,7 +19,8 @@ const toolLabel = (name: string) => name.split('_').filter(Boolean).map(capitali
 // the in-progress item.
 const TODO_GLYPHS: Record<Exclude<TodoStatus, 'in_progress' | 'pending'>, { icon: string; tone: string }> = {
   cancelled: { icon: 'circle-slash', tone: 'text-muted-foreground/45' },
-  completed: { icon: 'pass-filled', tone: 'text-emerald-500/80' }
+  completed: { icon: 'pass-filled', tone: 'text-emerald-500/80' },
+  needs_reconfirmation: { icon: 'question', tone: 'text-amber-500/80' }
 }
 
 // Left slot: braille spinner while running, otherwise a small status dot

--- a/apps/desktop/src/lib/todos.test.ts
+++ b/apps/desktop/src/lib/todos.test.ts
@@ -8,13 +8,23 @@ describe('parseTodos', () => {
       parseTodos([
         { content: 'Gather ingredients', id: 'prep', status: 'completed' },
         { content: 'Boil water', id: 'boil', status: 'in_progress' },
+        { content: 'Check request', id: 'check', status: 'needs_reconfirmation' },
         { content: 'Serve', id: 'serve', status: 'pending' }
       ])
     ).toEqual([
       { content: 'Gather ingredients', id: 'prep', status: 'completed' },
       { content: 'Boil water', id: 'boil', status: 'in_progress' },
+      { content: 'Check request', id: 'check', status: 'needs_reconfirmation' },
       { content: 'Serve', id: 'serve', status: 'pending' }
     ])
+  })
+
+  it('promotes the backward-compatible reconfirmation wire flag', () => {
+    expect(
+      parseTodos([
+        { content: 'Recheck evidence', id: 'a', needs_reconfirmation: true, status: 'pending' }
+      ])
+    ).toEqual([{ content: 'Recheck evidence', id: 'a', status: 'needs_reconfirmation' }])
   })
 
   it('parses nested todo payloads from wrapped objects and JSON strings', () => {

--- a/apps/desktop/src/lib/todos.ts
+++ b/apps/desktop/src/lib/todos.ts
@@ -1,4 +1,4 @@
-export type TodoStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled'
+export type TodoStatus = 'pending' | 'in_progress' | 'needs_reconfirmation' | 'completed' | 'cancelled'
 
 export interface TodoItem {
   content: string
@@ -6,7 +6,13 @@ export interface TodoItem {
   status: TodoStatus
 }
 
-const STATUSES: readonly TodoStatus[] = ['pending', 'in_progress', 'completed', 'cancelled']
+const STATUSES: readonly TodoStatus[] = [
+  'pending',
+  'in_progress',
+  'needs_reconfirmation',
+  'completed',
+  'cancelled'
+]
 
 const isRecord = (v: unknown): v is Record<string, unknown> => Boolean(v && typeof v === 'object' && !Array.isArray(v))
 const isStatus = (v: unknown): v is TodoStatus => (STATUSES as readonly string[]).includes(v as string)
@@ -19,8 +25,9 @@ function parseArray(value: unknown[]): TodoItem[] {
 
     const id = String(item.id ?? '').trim()
     const content = String(item.content ?? '').trim()
+    const status = item.needs_reconfirmation === true ? 'needs_reconfirmation' : item.status
 
-    return id && content ? [{ content, id, status: item.status }] : []
+    return id && content ? [{ content, id, status }] : []
   })
 }
 

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -32,7 +32,7 @@ export interface ComposerStatusItem {
   sessionId?: string
   state: StatusItemState
   title: string
-  /** todo: the full four-state status driving the row's checkmark glyph. */
+  /** todo: the full status driving the row's checkmark/reconfirmation glyph. */
   todoStatus?: TodoStatus
   type: StatusItemType
 }

--- a/apps/desktop/src/store/todos.test.ts
+++ b/apps/desktop/src/store/todos.test.ts
@@ -30,6 +30,14 @@ describe('setSessionTodos finished-list auto-clear', () => {
     expect($todosBySession.get().s1).toHaveLength(2)
   })
 
+  it('keeps a list that is waiting for reconfirmation visible', () => {
+    setSessionTodos('s1', [todo('a', 'needs_reconfirmation')])
+
+    vi.advanceTimersByTime(60_000)
+
+    expect($todosBySession.get().s1).toHaveLength(1)
+  })
+
   it('drops the list shortly after every item completes', () => {
     setSessionTodos('s1', [todo('a', 'completed'), todo('b', 'cancelled')])
 
@@ -91,6 +99,7 @@ describe('todosForHydration (stale-active guard on restore)', () => {
   it('does not restore an active list (stale after a completed turn)', () => {
     expect(todosForHydration([todo('a', 'completed'), todo('b', 'in_progress')])).toBeNull()
     expect(todosForHydration([todo('a', 'pending')])).toBeNull()
+    expect(todosForHydration([todo('a', 'needs_reconfirmation')])).toBeNull()
   })
 
   it('restores a finished list so its linger shows the final checkmarks', () => {

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -18,7 +18,7 @@ import { $sessionStates } from './session-states'
 export const $todosBySession = atom<Record<string, TodoItem[]>>({})
 
 export const todoListActive = (todos: readonly TodoItem[]) =>
-  todos.some(t => t.status === 'pending' || t.status === 'in_progress')
+  todos.some(t => t.status === 'pending' || t.status === 'in_progress' || t.status === 'needs_reconfirmation')
 
 let todoProgress: Readonly<Record<string, string>> = {}
 
@@ -52,8 +52,8 @@ export const $todoProgressBySession = computed(
 )
 
 // Decide which todo list to restore when rehydrating a session from stored
-// history. Rehydration runs *after* a turn completes, so an active list (last
-// item still pending/in_progress) is stale — the turn ended without a final
+// history. Rehydration runs *after* a turn completes, so an unresolved list
+// (pending/in_progress/reconfirmation) is stale — the turn ended without a final
 // `todo` update — and must NOT be re-pinned (that would undo the turn-end
 // clear and, because it's read back from history, resurrect on restart). Only
 // a finished list is restored, so its short linger shows the last checkmark.
@@ -109,7 +109,7 @@ export function clearSessionTodos(sid: string) {
   $todosBySession.set(rest)
 }
 
-// Drop a still-active todo list (any pending/in_progress item) — used at turn
+// Drop a still-active todo list (pending/in_progress/reconfirmation) — used at turn
 // end, when an unfinished list means the turn stopped without a final `todo`
 // update, so the "Tasks N/M" panel would otherwise stay pinned above the
 // composer forever. A finished list is left untouched so its short linger

--- a/cli.py
+++ b/cli.py
@@ -8843,8 +8843,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 self.agent._last_flushed_db_idx = 0
             if hasattr(self.agent, "_todo_store"):
                 try:
-                    from tools.todo_tool import TodoStore
-                    self.agent._todo_store = TodoStore()
+                    # Keep the store's persistence callback attached. The new
+                    # session has no state to persist yet.
+                    self.agent._todo_store.write([], merge=False, notify=False)
                 except Exception:
                     pass
             if hasattr(self.agent, "_invalidate_system_prompt"):

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1086,8 +1086,9 @@ class CLICommandsMixin:
                 self.agent._last_flushed_db_idx = len(self.conversation_history)
             if hasattr(self.agent, "_todo_store"):
                 try:
-                    from tools.todo_tool import TodoStore
-                    self.agent._todo_store = TodoStore()
+                    # Preserve the persistence callback; the target session's
+                    # durable state is hydrated on its next turn.
+                    self.agent._todo_store.write([], merge=False, notify=False)
                 except Exception:
                     pass
             if hasattr(self.agent, "_invalidate_system_prompt"):
@@ -1307,8 +1308,9 @@ class CLICommandsMixin:
                 self.agent._last_flushed_db_idx = len(self.conversation_history)
             if hasattr(self.agent, "_todo_store"):
                 try:
-                    from tools.todo_tool import TodoStore
-                    self.agent._todo_store = TodoStore()
+                    # Preserve the persistence callback; the target session's
+                    # durable state is hydrated on its next turn.
+                    self.agent._todo_store.write([], merge=False, notify=False)
                 except Exception:
                     pass
             if hasattr(self.agent, "_invalidate_system_prompt"):

--- a/run_agent.py
+++ b/run_agent.py
@@ -4458,7 +4458,37 @@ class AIAgent:
         seed the store without a matching canonical tool call
         (GHSA-5g4g-6jrg-mw3g).
         """
-        from tools.todo_tool import MAX_TODO_RESULT_CHARS
+        from tools.todo_tool import (
+            MAX_TODO_RESULT_CHARS,
+            TODO_STATE_MODEL_CONFIG_KEY,
+        )
+
+        # Session metadata is written by every authoritative TodoStore update
+        # and atomically at compaction. It therefore wins over older tool
+        # results that may survive in the protected compression tail.
+        session_db = getattr(self, "_session_db", None)
+        get_config = getattr(session_db, "get_session_model_config_value", None)
+        if self.session_id and callable(get_config):
+            missing = object()
+            persisted = get_config(
+                self.session_id,
+                TODO_STATE_MODEL_CONFIG_KEY,
+                missing,
+            )
+            if persisted is not missing and isinstance(persisted, list):
+                # Already durable; avoid rewriting model_config on every fresh
+                # gateway agent hydration.
+                self._todo_store.write(persisted, merge=False, notify=False)
+                self._session_init_model_config[TODO_STATE_MODEL_CONFIG_KEY] = (
+                    self._todo_store.read()
+                )
+                if not self.quiet_mode:
+                    self._vprint(
+                        f"{self.log_prefix}📋 Restored {len(persisted)} "
+                        "todo item(s) from session state"
+                    )
+                _set_interrupt(False)
+                return
 
         # Walk history backwards to find the most recent todo tool response
         last_todo_response = None
@@ -4492,8 +4522,15 @@ class AIAgent:
                 continue
 
         if last_todo_response:
-            # Replay the items into the store (replace mode)
-            self._todo_store.write(last_todo_response, merge=False)
+            # Legacy history is caller-supplied on API surfaces. It is useful
+            # for this turn, but must not be promoted into trusted durable
+            # session metadata. Fresh post-compaction sessions already carry
+            # an authoritative model_config snapshot.
+            self._todo_store.write(
+                last_todo_response,
+                merge=False,
+                notify=False,
+            )
             if not self.quiet_mode:
                 self._vprint(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
         _set_interrupt(False)

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -180,8 +180,10 @@ class TestStepCallback:
             '{"todos":['
             '{"id":"inspect","content":"Inspect ACP","status":"completed"},'
             '{"id":"patch","content":"Patch renderer","status":"in_progress"},'
+            '{"id":"verify","content":"Recheck assumptions","status":"pending",'
+            '"needs_reconfirmation":true},'
             '{"id":"old","content":"Drop stale task","status":"cancelled"}'
-            '],"summary":{"total":3}}'
+            '],"summary":{"total":4}}'
         )
 
         with patch("acp_adapter.events._send_update") as mock_send:
@@ -197,10 +199,21 @@ class TestStepCallback:
         assert [entry.content for entry in plan.entries] == [
             "Inspect ACP",
             "Patch renderer",
+            "[needs reconfirmation] Recheck assumptions",
             "[cancelled] Drop stale task",
         ]
-        assert [entry.status for entry in plan.entries] == ["completed", "in_progress", "completed"]
-        assert [entry.priority for entry in plan.entries] == ["medium", "medium", "medium"]
+        assert [entry.status for entry in plan.entries] == [
+            "completed",
+            "in_progress",
+            "pending",
+            "completed",
+        ]
+        assert [entry.priority for entry in plan.entries] == [
+            "medium",
+            "medium",
+            "medium",
+            "medium",
+        ]
 
 
 

--- a/tests/acp/test_session_db_private_access.py
+++ b/tests/acp/test_session_db_private_access.py
@@ -3,8 +3,8 @@
 Verifies that:
 1. SessionDB.update_session_meta() exists and works correctly via the
    public _execute_write path (not db._lock / db._conn directly).
-2. session.py _persist() no longer touches db._lock or db._conn.
-3. update_session_meta updates the correct columns atomically.
+2. session.py _persist() uses only public SessionDB mutators.
+3. metadata updates preserve unrelated private model_config state.
 """
 
 import ast
@@ -102,31 +102,8 @@ class TestNoPrviateDBAccess:
         assert violations == [], (
             "session.py accesses private SessionDB internals: "
             + ", ".join(violations)
-            + " — use db.update_session_meta() instead"
+            + " — use a public SessionDB mutator instead"
         )
-
-    def test_persist_calls_update_session_meta(self):
-        """AST check: _persist must call db.update_session_meta()."""
-        with open("acp_adapter/session.py", encoding="utf-8") as f:
-            tree = ast.parse(f.read())
-
-        found = False
-        for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef) and node.name == "_persist":
-                for child in ast.walk(node):
-                    if isinstance(child, ast.Call):
-                        func = child.func
-                        if isinstance(func, ast.Attribute):
-                            if func.attr == "update_session_meta":
-                                found = True
-                                break
-                break
-
-        assert found, (
-            "_persist() must call db.update_session_meta() "
-            "instead of db._conn.execute() directly"
-        )
-
 
 # ---------------------------------------------------------------------------
 # Integration: _persist round-trip via SessionManager
@@ -160,6 +137,30 @@ class TestPersistRoundTrip:
 
         row = db.get_session(state.session_id)
         assert row["model"] == "new-model-xyz"
+
+    def test_save_preserves_existing_private_model_config(self, tmp_path):
+        db = _tmp_db(tmp_path)
+        manager = SessionManager(agent_factory=_mock_agent, db=db)
+        state = manager.create_session(cwd="/original")
+        durable_todos = [
+            {
+                "id": "review",
+                "content": "Revalidate plan",
+                "status": "needs_reconfirmation",
+            }
+        ]
+        db.patch_session_model_config(
+            state.session_id,
+            {"_todo_state": durable_todos},
+        )
+
+        state.cwd = "/updated"
+        manager.save_session(state.session_id)
+
+        row = db.get_session(state.session_id)
+        config = json.loads(row["model_config"])
+        assert config["cwd"] == "/updated"
+        assert config["_todo_state"] == durable_todos
 
     def test_existing_model_not_cleared_on_save(self, tmp_path):
         """If state.model is empty, the DB model column must not be overwritten."""

--- a/tests/agent/test_compression_attempt_telemetry.py
+++ b/tests/agent/test_compression_attempt_telemetry.py
@@ -8,6 +8,18 @@ from agent.context_compressor import ContextCompressor
 
 
 class _TodoStore:
+    def read(self):
+        return []
+
+    def write(self, todos, merge=False, *, notify=True):
+        return todos
+
+    def mark_active_for_reconfirmation(self, *, notify=True):
+        return 0
+
+    def persist(self):
+        pass
+
     def format_for_injection(self):
         return ""
 

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -125,6 +125,9 @@ class TestOrphanRollbackOnCreateFailure:
         parent = "PARENT_ORPHAN_ROT"
         db.create_session(parent, source="cli")
         agent = _build_agent_with_db(db, parent)
+        agent._todo_store.write(
+            [{"id": "keep", "content": "Keep plan", "status": "pending"}]
+        )
 
         # Atomic publication failure must leave the live parent and caller's
         # original list untouched even when a plugin compressor mutates in place.
@@ -155,6 +158,7 @@ class TestOrphanRollbackOnCreateFailure:
         assert parent_row is not None
         assert parent_row["ended_at"] is None
         assert db.find_live_compression_child(parent) is None
+        assert agent._todo_store.read()[0]["status"] == "pending"
 
 
 class TestWorkspaceMetadataFollowsRotation:
@@ -522,12 +526,9 @@ class TestTodoSnapshotMergedNotDuplicated:
             {"role": "assistant", "content": "acknowledged"},
             {"role": "user", "content": "tail"},
         ]
-        agent._todo_store._todos = [
+        agent._todo_store.write([
             {"id": "t1", "content": "task A", "status": "pending"}
-        ]
-        agent._todo_store.format_for_injection = (
-            lambda: "## Current Tasks\n- [ ] task A"
-        )
+        ])
 
         compressed, _ = agent._compress_context(
             _msgs(), "sys", approx_tokens=120_000
@@ -565,12 +566,9 @@ class TestTodoSnapshotMergedNotDuplicated:
             {"role": "assistant", "content": "ok"},
             {"role": "user", "content": list(original_parts)},
         ]
-        agent._todo_store._todos = [
+        agent._todo_store.write([
             {"id": "t1", "content": "inspect image", "status": "in_progress"}
-        ]
-        agent._todo_store.format_for_injection = (
-            lambda: "## Current Tasks\n- [ ] inspect image"
-        )
+        ])
 
         compressed, _ = agent._compress_context(
             _msgs(), "sys", approx_tokens=120_000
@@ -648,6 +646,15 @@ class TestTodoSnapshotScaffoldingTails:
         assert tail["role"] == "user"
         assert "please fix the login bug" in tail["content"]
         assert "task A" in tail["content"]
+        assert "needs_reconfirmation" in tail["content"]
+        assert agent._todo_store.read()[0]["status"] == "needs_reconfirmation"
+        from tools.todo_tool import TODO_STATE_MODEL_CONFIG_KEY
+
+        durable_todos = db.get_session_model_config_value(
+            agent.session_id,
+            TODO_STATE_MODEL_CONFIG_KEY,
+        )
+        assert durable_todos[0]["status"] == "needs_reconfirmation"
         assert "old finished task" not in tail["content"]
         assert tail["content"].count(TODO_INJECTION_HEADER) == 1
         assert not any(

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -153,6 +153,7 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
     cli = _prepare_cli_with_active_session(tmp_path)
     old_session_id = cli.session_id
     old_session_start = cli.session_start
+    original_todo_store = cli.agent._todo_store
 
     cli.process_command("/new")
 
@@ -169,6 +170,7 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
 
     assert cli.agent.session_id == cli.session_id
     assert cli.agent._last_flushed_db_idx == 0
+    assert cli.agent._todo_store is original_todo_store
     assert cli.agent._todo_store.read() == []
     assert cli.session_start > old_session_start
     assert cli.agent.session_start == cli.session_start

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -873,6 +873,88 @@ class TestHydrateTodoStore:
             agent._hydrate_todo_store(history)
         assert not agent._todo_store.has_items()
 
+    def test_session_state_wins_over_stale_pre_compaction_tool_result(self, agent):
+        persisted = [
+            {
+                "id": "dangerous",
+                "content": "Deploy the old build",
+                "status": "needs_reconfirmation",
+            }
+        ]
+        agent.session_id = "child"
+        agent._session_db = SimpleNamespace(
+            get_session_model_config_value=lambda *_args: persisted,
+        )
+        history = [
+            self._assistant_todo_call(),
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": json.dumps(
+                    {
+                        "todos": [
+                            {
+                                "id": "dangerous",
+                                "content": "Deploy the old build",
+                                "status": "in_progress",
+                            }
+                        ]
+                    }
+                ),
+            },
+        ]
+
+        with patch("run_agent._set_interrupt"):
+            agent._hydrate_todo_store(history)
+
+        assert agent._todo_store.read() == persisted
+
+    def test_authoritative_empty_session_state_does_not_resurrect_history(self, agent):
+        agent._todo_store.write(
+            [{"id": "old", "content": "Old task", "status": "pending"}],
+            notify=False,
+        )
+        agent.session_id = "child"
+        agent._session_db = SimpleNamespace(
+            get_session_model_config_value=lambda *_args: [],
+        )
+
+        with patch("run_agent._set_interrupt"):
+            agent._hydrate_todo_store([])
+
+        assert agent._todo_store.read() == []
+
+    def test_caller_history_is_not_promoted_to_durable_session_state(self, agent):
+        from tools.todo_tool import TodoStore
+
+        observed = []
+        agent._todo_store = TodoStore(on_change=observed.append)
+        history = [
+            self._assistant_todo_call(),
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": json.dumps(
+                    {
+                        "todos": [
+                            {
+                                "id": "review",
+                                "content": "Recheck evidence",
+                                "status": "pending",
+                                "needs_reconfirmation": True,
+                            }
+                        ]
+                    }
+                ),
+            },
+        ]
+
+        with patch("run_agent._set_interrupt"):
+            agent._hydrate_todo_store(history)
+
+        assert observed == []
+        assert agent._todo_store.read()[0]["status"] == "needs_reconfirmation"
+
 
 
 
@@ -1946,6 +2028,76 @@ class TestConcurrentToolExecution:
                 tool_request_middleware_trace=[],
             )
             assert result == "result"
+
+    def test_invoke_tool_blocks_actions_until_todos_are_revalidated(self, agent):
+        agent._todo_store.write(
+            [
+                {
+                    "id": "stale",
+                    "content": "Deploy old build",
+                    "status": "needs_reconfirmation",
+                }
+            ],
+            notify=False,
+        )
+
+        with patch("run_agent.handle_function_call") as mock_dispatch:
+            result = json.loads(
+                agent._invoke_tool("terminal", {"command": "deploy"}, "task-1")
+            )
+
+        assert "blocked" in result["error"].lower()
+        mock_dispatch.assert_not_called()
+
+    def test_reconfirmation_gate_allows_evidence_gathering(self, agent):
+        agent._todo_store.write(
+            [
+                {
+                    "id": "stale",
+                    "content": "Check current implementation",
+                    "status": "needs_reconfirmation",
+                }
+            ],
+            notify=False,
+        )
+
+        with patch("run_agent.handle_function_call", return_value="evidence") as dispatch:
+            result = agent._invoke_tool("read_file", {"path": "README.md"}, "task-1")
+
+        assert result == "evidence"
+        dispatch.assert_called_once()
+
+    def test_todo_revalidation_unlocks_other_tools(self, agent):
+        agent._todo_store.write(
+            [
+                {
+                    "id": "reviewed",
+                    "content": "Run verified tests",
+                    "status": "needs_reconfirmation",
+                }
+            ],
+            notify=False,
+        )
+
+        agent._invoke_tool(
+            "todo",
+            {
+                "todos": [
+                    {
+                        "id": "reviewed",
+                        "content": "Run verified tests",
+                        "status": "pending",
+                    }
+                ]
+            },
+            "task-1",
+        )
+
+        with patch("run_agent.handle_function_call", return_value="ran") as mock_dispatch:
+            result = agent._invoke_tool("terminal", {"command": "test"}, "task-1")
+
+        assert result == "ran"
+        mock_dispatch.assert_called_once()
 
     def test_sequential_tool_callbacks_fire_in_order(self, agent):
         tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")

--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -65,6 +65,53 @@ class TestFormatForInjection:
         assert "Working" in text
         assert "context compression" in text.lower()
 
+    def test_compaction_downgrades_active_items_until_revalidated(self):
+        store = TodoStore()
+        store.write([
+            {"id": "keep", "content": "Review evidence", "status": "pending"},
+            {"id": "work", "content": "Apply change", "status": "in_progress"},
+            {"id": "done", "content": "Finished", "status": "completed"},
+        ])
+
+        assert store.mark_active_for_reconfirmation() == 2
+        items = store.read()
+        assert [item["status"] for item in items] == [
+            "needs_reconfirmation",
+            "needs_reconfirmation",
+            "completed",
+        ]
+
+        text = store.format_for_injection()
+        assert text.count("(needs_reconfirmation)") == 2
+        assert "not actionable" in text
+        assert "Apply change" in text
+
+        store.write(
+            [{"id": "work", "status": "in_progress"}],
+            merge=True,
+        )
+        assert store.read()[1]["status"] == "in_progress"
+
+    def test_reconfirmation_is_idempotent(self):
+        store = TodoStore()
+        store.write([{"id": "1", "content": "Task", "status": "pending"}])
+
+        assert store.mark_active_for_reconfirmation() == 1
+        assert store.mark_active_for_reconfirmation() == 0
+
+    def test_reconfirmation_guidance_is_emitted_once_for_large_plans(self):
+        store = TodoStore()
+        store.write([
+            {"id": str(i), "content": f"Task {i}", "status": "pending"}
+            for i in range(256)
+        ])
+
+        store.mark_active_for_reconfirmation()
+        text = store.format_for_injection()
+
+        assert text.count("are not actionable") == 1
+        assert len(text) < 20_000
+
 
 class TestMergeMode:
     def test_update_existing_by_id(self):
@@ -104,6 +151,49 @@ class TestTodoToolFunction:
     def test_no_store_returns_error(self):
         result = json.loads(todo_tool())
         assert "error" in result
+
+    def test_reconfirmation_status_is_server_managed(self):
+        from tools.todo_tool import TODO_SCHEMA
+
+        writable_statuses = TODO_SCHEMA["parameters"]["properties"]["todos"][
+            "items"
+        ]["properties"]["status"]["enum"]
+
+        assert "needs_reconfirmation" not in writable_statuses
+
+    def test_reconfirmation_uses_backward_compatible_wire_status(self):
+        store = TodoStore()
+        store.write([{"id": "1", "content": "Task", "status": "pending"}])
+        store.mark_active_for_reconfirmation()
+
+        result = json.loads(todo_tool(store=store))
+
+        assert result["todos"] == [
+            {
+                "id": "1",
+                "content": "Task",
+                "status": "pending",
+                "needs_reconfirmation": True,
+            }
+        ]
+        assert result["summary"]["needs_reconfirmation"] == 1
+        assert store.read()[0]["status"] == "needs_reconfirmation"
+
+    def test_wire_flag_rehydrates_internal_reconfirmation_state(self):
+        store = TodoStore()
+
+        store.write(
+            [
+                {
+                    "id": "1",
+                    "content": "Task",
+                    "status": "pending",
+                    "needs_reconfirmation": True,
+                }
+            ]
+        )
+
+        assert store.read()[0]["status"] == "needs_reconfirmation"
 
 
 class TestTodoStoreBounds:
@@ -154,3 +244,32 @@ class TestTodoStoreBounds:
         items = store.read()
         assert [i["content"] for i in items] == ["write the report", "review PR"]
         assert "[truncated]" not in items[0]["content"]
+
+
+class TestTodoPersistenceCallback:
+    def test_write_and_state_transition_notify_with_copies(self):
+        observed = []
+        store = TodoStore(on_change=observed.append)
+
+        store.write([{"id": "a", "content": "A", "status": "pending"}])
+        store.mark_active_for_reconfirmation()
+
+        assert [states[0]["status"] for states in observed] == [
+            "pending",
+            "needs_reconfirmation",
+        ]
+        observed[0][0]["status"] = "completed"
+        assert store.read()[0]["status"] == "needs_reconfirmation"
+
+    def test_notify_can_be_deferred_until_atomic_commit(self):
+        observed = []
+        store = TodoStore(on_change=observed.append)
+        store.write(
+            [{"id": "a", "content": "A", "status": "pending"}],
+            notify=False,
+        )
+        store.mark_active_for_reconfirmation(notify=False)
+
+        assert observed == []
+        store.persist()
+        assert observed[0][0]["status"] == "needs_reconfirmation"

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -15,11 +15,19 @@ Design:
 """
 
 import json
-from typing import Dict, Any, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 
 # Valid status values for todo items
-VALID_STATUSES = {"pending", "in_progress", "completed", "cancelled"}
+VALID_STATUSES = {
+    "pending",
+    "in_progress",
+    "needs_reconfirmation",
+    "completed",
+    "cancelled",
+}
+ACTIONABLE_STATUSES = {"pending", "in_progress"}
+TODO_STATE_MODEL_CONFIG_KEY = "_todo_state"
 
 # Bounds on persisted todo state. The todo list is a planning aid the model
 # re-reads after every context-compression event (see format_for_injection),
@@ -50,13 +58,31 @@ class TodoStore:
     Items are ordered -- list position is priority. Each item has:
       - id: unique string identifier (agent-chosen)
       - content: task description
-      - status: pending | in_progress | completed | cancelled
+      - status: pending | in_progress | needs_reconfirmation | completed | cancelled
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        on_change: Optional[Callable[[List[Dict[str, str]]], None]] = None,
+    ):
         self._items: List[Dict[str, str]] = []
+        self._on_change = on_change
 
-    def write(self, todos: List[Dict[str, Any]], merge: bool = False) -> List[Dict[str, str]]:
+    def _notify_change(self) -> None:
+        if self._on_change is not None:
+            self._on_change(self.read())
+
+    def persist(self) -> None:
+        """Persist the current state through the owning agent callback."""
+        self._notify_change()
+
+    def write(
+        self,
+        todos: List[Dict[str, Any]],
+        merge: bool = False,
+        *,
+        notify: bool = True,
+    ) -> List[Dict[str, str]]:
         """
         Write todos. Returns the full current list after writing.
 
@@ -103,6 +129,8 @@ class TodoStore:
         # (list order is priority).
         if len(self._items) > MAX_TODO_ITEMS:
             self._items = self._items[:MAX_TODO_ITEMS]
+        if notify:
+            self._notify_change()
         return self.read()
 
     def read(self) -> List[Dict[str, str]]:
@@ -112,6 +140,30 @@ class TodoStore:
     def has_items(self) -> bool:
         """Check if there are any items in the list."""
         return bool(self._items)
+
+    def requires_reconfirmation(self) -> bool:
+        """Whether tool execution must pause for explicit plan revalidation."""
+        return any(
+            item["status"] == "needs_reconfirmation" for item in self._items
+        )
+
+    def mark_active_for_reconfirmation(self, *, notify: bool = True) -> int:
+        """Invalidate active work plans at a context-compression boundary.
+
+        Compression can remove the user turn, skills, and evidence that made an
+        item actionable.  Keeping the old actionable status would turn a stale
+        plan into an instruction.  The item remains visible for continuity, but
+        must be explicitly restored to ``pending`` or ``in_progress`` by a
+        subsequent todo write after the model revalidates it.
+        """
+        changed = 0
+        for item in self._items:
+            if item["status"] in ACTIONABLE_STATUSES:
+                item["status"] = "needs_reconfirmation"
+                changed += 1
+        if changed and notify:
+            self._notify_change()
+        return changed
 
     def format_for_injection(self) -> Optional[str]:
         """
@@ -129,18 +181,30 @@ class TodoStore:
             "in_progress": "[>]",
             "pending": "[ ]",
             "cancelled": "[~]",
+            "needs_reconfirmation": "[?]",
         }
 
-        # Only inject pending/in_progress items — completed/cancelled ones
-        # cause the model to re-do finished work after compression.
+        # Keep reconfirmation items visible, but distinguish them from active
+        # work so the model cannot mistake a preserved plan for authorization.
         active_items = [
             item for item in self._items
-            if item["status"] in {"pending", "in_progress"}
+            if item["status"] in ACTIONABLE_STATUSES | {"needs_reconfirmation"}
         ]
         if not active_items:
             return None
 
         lines = [TODO_INJECTION_HEADER]
+        if any(item["status"] == "needs_reconfirmation" for item in active_items):
+            # State the boundary contract once rather than once per item. At the
+            # 256-item safety cap, per-item prose adds tens of thousands of
+            # characters to every compaction and works against compression.
+            lines.append(
+                "Items marked needs_reconfirmation are not actionable. "
+                "Action-capable tools are blocked until they are resolved; "
+                "evidence-gathering tools remain available. "
+                "Revalidate each against the latest user message and evidence, "
+                "then explicitly restore pending or in_progress before acting."
+            )
         for item in active_items:
             marker = markers.get(item["status"], "[?]")
             lines.append(f"- {marker} {item['id']}. {item['content']} ({item['status']})")
@@ -181,7 +245,11 @@ class TodoStore:
         else:
             content = TodoStore._cap_content(content)
 
-        status = str(item.get("status", "pending")).strip().lower()
+        status = (
+            "needs_reconfirmation"
+            if item.get("needs_reconfirmation") is True
+            else str(item.get("status", "pending")).strip().lower()
+        )
         if status not in VALID_STATUSES:
             status = "pending"
 
@@ -241,12 +309,31 @@ def todo_tool(
     completed = sum(1 for i in items if i["status"] == "completed")
     cancelled = sum(1 for i in items if i["status"] == "cancelled")
 
+    # Keep the wire status backward-compatible with independently upgraded
+    # Desktop/TUI clients. Older clients only accept the original four-state
+    # enum and would otherwise drop the entire reconfirmation row. New clients
+    # promote the additive boolean back to the internal non-actionable state.
+    wire_items = [
+        {
+            **item,
+            **(
+                {"status": "pending", "needs_reconfirmation": True}
+                if item["status"] == "needs_reconfirmation"
+                else {}
+            ),
+        }
+        for item in items
+    ]
+
     return json.dumps({
-        "todos": items,
+        "todos": wire_items,
         "summary": {
             "total": len(items),
             "pending": pending,
             "in_progress": in_progress,
+            "needs_reconfirmation": sum(
+                1 for i in items if i["status"] == "needs_reconfirmation"
+            ),
             "completed": completed,
             "cancelled": cancelled,
         },
@@ -276,6 +363,10 @@ TODO_SCHEMA = {
         "- merge=true: update existing items by id, add any new ones\n\n"
         "Each item: {id: string, content: string, "
         "status: pending|in_progress|completed|cancelled}\n"
+        "After context compression, active items may be returned with the "
+        "server-managed flag needs_reconfirmation=true. Revalidate those items "
+        "before explicitly restoring pending or in_progress; action-capable "
+        "tools remain blocked until no item has that flag.\n"
         "List order is priority. Only ONE item in_progress at a time.\n"
         "Mark items completed immediately when done. If something fails, "
         "cancel it and add a revised item.\n\n"

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -46,7 +46,11 @@ const diffSegmentBody = (msg: Msg): null | string => {
 const hasDetails = (msg: Msg): boolean => Boolean(msg.thinking || msg.tools?.length || msg.toolTokens)
 
 const isTodoStatus = (status: unknown): status is TodoItem['status'] =>
-  status === 'pending' || status === 'in_progress' || status === 'completed' || status === 'cancelled'
+  status === 'pending' ||
+  status === 'in_progress' ||
+  status === 'needs_reconfirmation' ||
+  status === 'completed' ||
+  status === 'cancelled'
 
 const parseTodos = (value: unknown): null | TodoItem[] => {
   if (!Array.isArray(value)) {
@@ -60,7 +64,7 @@ const parseTodos = (value: unknown): null | TodoItem[] => {
       }
 
       const row = item as Record<string, unknown>
-      const status = row.status
+      const status = row.needs_reconfirmation === true ? 'needs_reconfirmation' : row.status
 
       if (!isTodoStatus(status)) {
         return null

--- a/ui-tui/src/components/todoPanel.tsx
+++ b/ui-tui/src/components/todoPanel.tsx
@@ -67,7 +67,7 @@ export const TodoPanel = memo(function TodoPanel({
           {incomplete && pending > 0 && (
             <Text color={t.color.muted} dim>
               {' '}
-              · incomplete · {pending} still {pending === 1 ? 'pending' : 'pending/in_progress'}
+              · incomplete · {pending} still unresolved
             </Text>
           )}
         </Text>

--- a/ui-tui/src/lib/liveProgress.test.ts
+++ b/ui-tui/src/lib/liveProgress.test.ts
@@ -2,19 +2,37 @@ import { describe, expect, it } from 'vitest'
 
 import type { Msg } from '../types.js'
 
-import { appendToolShelfMessage, canHoldToolShelf, isTodoDone, mergeToolShelfInto } from './liveProgress.js'
+import {
+  appendToolShelfMessage,
+  canHoldToolShelf,
+  countPendingTodos,
+  isTodoDone,
+  mergeToolShelfInto
+} from './liveProgress.js'
 
 describe('isTodoDone', () => {
   it('only treats non-empty all-completed/cancelled lists as done', () => {
     expect(isTodoDone([])).toBe(false)
     expect(isTodoDone([{ content: 'x', id: 'x', status: 'completed' }])).toBe(true)
     expect(isTodoDone([{ content: 'x', id: 'x', status: 'in_progress' }])).toBe(false)
+    expect(isTodoDone([{ content: 'x', id: 'x', status: 'needs_reconfirmation' }])).toBe(false)
     expect(
       isTodoDone([
         { content: 'x', id: 'x', status: 'completed' },
         { content: 'y', id: 'y', status: 'cancelled' }
       ])
     ).toBe(true)
+  })
+})
+
+describe('countPendingTodos', () => {
+  it('counts reconfirmation items as unresolved', () => {
+    expect(
+      countPendingTodos([
+        { content: 'x', id: 'x', status: 'needs_reconfirmation' },
+        { content: 'y', id: 'y', status: 'completed' }
+      ])
+    ).toBe(1)
   })
 })
 

--- a/ui-tui/src/lib/liveProgress.ts
+++ b/ui-tui/src/lib/liveProgress.ts
@@ -1,7 +1,10 @@
 import type { Msg, TodoItem } from '../types.js'
 
 export const countPendingTodos = (todos: readonly TodoItem[]) =>
-  todos.filter(todo => todo.status === 'in_progress' || todo.status === 'pending').length
+  todos.filter(
+    todo =>
+      todo.status === 'in_progress' || todo.status === 'pending' || todo.status === 'needs_reconfirmation'
+  ).length
 
 export const isTodoDone = (todos: readonly TodoItem[]) =>
   todos.length > 0 && todos.every(todo => todo.status === 'completed' || todo.status === 'cancelled')

--- a/ui-tui/src/lib/todo.test.ts
+++ b/ui-tui/src/lib/todo.test.ts
@@ -7,6 +7,7 @@ describe('todoGlyph', () => {
     expect(todoGlyph('completed')).toBe('[x]')
     expect(todoGlyph('in_progress')).toBe('[>]')
     expect(todoGlyph('pending')).toBe('[ ]')
+    expect(todoGlyph('needs_reconfirmation')).toBe('[?]')
     expect(todoGlyph('cancelled')).toBe('[-]')
   })
 })

--- a/ui-tui/src/lib/todo.ts
+++ b/ui-tui/src/lib/todo.ts
@@ -3,7 +3,15 @@ import type { TodoItem } from '../types.js'
 export type TodoTone = 'active' | 'body' | 'dim'
 
 export const todoGlyph = (status: TodoItem['status']) =>
-  status === 'completed' ? '[x]' : status === 'cancelled' ? '[-]' : status === 'in_progress' ? '[>]' : '[ ]'
+  status === 'completed'
+    ? '[x]'
+    : status === 'cancelled'
+      ? '[-]'
+      : status === 'in_progress'
+        ? '[>]'
+        : status === 'needs_reconfirmation'
+          ? '[?]'
+          : '[ ]'
 
 export const todoTone = (status: TodoItem['status']): TodoTone =>
-  status === 'in_progress' ? 'active' : status === 'pending' ? 'body' : 'dim'
+  status === 'in_progress' ? 'active' : status === 'pending' || status === 'needs_reconfirmation' ? 'body' : 'dim'

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -9,7 +9,7 @@ export interface ActiveTool {
 export interface TodoItem {
   content: string
   id: string
-  status: 'cancelled' | 'completed' | 'in_progress' | 'pending'
+  status: 'cancelled' | 'completed' | 'in_progress' | 'needs_reconfirmation' | 'pending'
 }
 
 export interface ActivityItem {


### PR DESCRIPTION
## Summary

Fixes #84718.

Compaction is a provenance boundary: the conversation evidence, user framing, and skill policy that justified an active plan may have been summarized or pruned. Previously, however, active todo items crossed that boundary as executable `pending` / `in_progress` state. This allowed stale work to continue as though its original authorization and evidence were still present.

This change preserves the useful plan, but invalidates its authority. Active items become `needs_reconfirmation`, evidence-gathering remains available, and action-capable tools remain blocked until the model explicitly revalidates, cancels, or completes the preserved items.

## Root cause

The bug was not just missing reminder text. Three independent state paths treated stale plan state as current authority:

1. `TodoStore` had no non-actionable status for loss of provenance.
2. Post-compaction todo state only lived in synthetic prompt prose; a fresh agent could hydrate an older canonical tool result and resurrect actionable statuses.
3. Nothing enforced the reminder at dispatch time, so an action-capable tool could run without any todo transition.

A prompt-only solution therefore cannot close the bug class.

## Competing PR comparison

PR #84808 addresses the related skill-policy side by preserving a bounded textual rationale and asking the model to reload pruned skills. That is useful and complementary, but its preserved todo remains actionable and its safety property is advisory.

This PR handles the plan-authorization side as a state-machine and dispatch invariant:

- active work crosses compaction as non-actionable state;
- the state is durable across restart/resume;
- read-only evidence and skill inspection remain available;
- action-capable tools are blocked until explicit revalidation.

This is stronger for stale-plan continuation because correctness does not depend solely on the model following newly injected prose. It does not replace #84808's richer skill-provenance context; the two changes protect different halves of the same compaction boundary.

## Implementation

### State transition and atomicity

- Add server-managed `needs_reconfirmation` state.
- Transform only `pending` / `in_progress`; preserve terminal states.
- Build the downgraded snapshot without mutating live state early.
- Publish transcript and durable todo state at the same compression commit boundary.
- Restore the prior in-memory plan if child publication fails.
- Preserve strict message-role alternation and a byte-stable system prompt.

### Durable hydration

- Persist bounded todo state in the session's private `model_config` metadata.
- Update it whenever the todo store changes.
- Prefer trusted session state over caller-supplied or stale transcript history.
- Preserve authoritative empty state, preventing an older tool result from resurrecting cleared work.
- Hydrate resumed gateway turns even when no transcript rows are supplied.
- Preserve private model metadata during ACP saves using transactional config patching.
- Keep the persistence callback attached across CLI `/new`, `/resume`, and branch transitions.

### Hard execution barrier

- While any item needs reconfirmation, block action-capable tools centrally in the common dispatch path.
- Keep `todo`, clarification, skills, file/search/session lookup, vision, and web evidence tools available.
- Apply the barrier through sequential, concurrent, segmented, and tool-search dispatch because all paths converge on the guarded invocation.
- A read-only todo call does not unlock execution; the state must actually transition.

### Client compatibility

- Desktop and TUI parse, display, count, and retain `needs_reconfirmation` as unresolved work.
- ACP maps the internal state to its closest portable pending plan status while labeling it as requiring reconfirmation.
- The public wire format keeps the original `pending` enum plus an additive `needs_reconfirmation: true` flag. Independently upgraded older Desktop/TUI clients therefore retain the row instead of silently dropping an unknown enum; updated clients promote the flag to the internal state.

### Prompt/token cost

The original per-item revalidation paragraph was replaced with one list-level instruction. With the maximum 256-item plan used in the regression benchmark:

- original implementation: 48,338 characters;
- revised implementation: 9,449 characters;
- reduction: 38,889 characters (80.5%).

Bounds remain enforced before persistence or injection.

## Tests

Post-rebase verification against current `origin/main`:

- Canonical Python wrapper over todo, compression success/failure, ACP event/persistence, turn hydration, and CLI new/resume/branch paths:
  - 9 files, 98 tests passed.
- Focused run-agent hydration and dispatch barrier tests:
  - 8 tests passed.
- Desktop Vitest:
  - 2 files, 17 tests passed.
- TUI Vitest:
  - 2 files, 11 tests passed.
- Desktop and TUI TypeScript typechecks passed.
- Ruff passed for all changed Python files.
- `git diff --check` passed.
- Independent pre-commit review: PASS, no blocking logic or security findings.

## Risk and compatibility

- No dependency or user configuration change.
- The new status is internal/server-managed; model-authored todo inputs retain the existing public statuses.
- Existing terminal statuses remain unchanged.
- Metadata is bounded by existing todo item/content limits.
- Session metadata writes occur only on todo changes, not every turn; hydration avoids redundant rewrites.
- Caller-supplied legacy transcript history can hydrate the current turn but is not promoted into trusted durable session metadata.
- The ACP metadata change replaces a race-prone read/replace pattern with an in-transaction patch, preserving unrelated private state.

## Checklist

- [x] Reproduced and traced the stale-plan lifecycle.
- [x] Compared the competing implementation and identified complementary scope.
- [x] Fixed state semantics rather than adding prompt text alone.
- [x] Added durable restart/resume coverage.
- [x] Added dispatch-level enforcement and concurrent-path review.
- [x] Covered ACP, Desktop, TUI, CLI session transitions, and failed publication rollback.
- [x] Preserved prompt-cache and role-alternation invariants.
- [x] Rebased onto current `origin/main` and reran focused validation.
