### PR TITLE
fix(agent): skip the automatic background review inside delegation subagents

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1819,6 +1819,16 @@ class AIAgent:
         appended to the review prompt — e.g. "save the deploy workflow as a
         skill". The automatic post-turn triggers never set it.
         """
+        # A delegation subagent (``_delegate_depth > 0``) must not run the
+        # automatic post-turn review. Subagents are ephemeral workers already
+        # barred from writing shared MEMORY.md (``DELEGATE_BLOCKED_TOOLS``) and
+        # are spawned with ``skip_memory=True``, so a review here has little to
+        # persist — yet it inherits the subagent's (often premium) delegation
+        # model and replays the whole conversation at premium rates, silently
+        # inflating token cost (#85859). An explicit ``/refine`` (``focus`` set)
+        # is a deliberate user request and still runs.
+        if focus is None and getattr(self, "_delegate_depth", 0) > 0:
+            return
         from agent.background_review import spawn_background_review_thread
         from tools.thread_context import propagate_context_to_thread
         target, _prompt = spawn_background_review_thread(

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -125,6 +125,114 @@ def test_background_review_fork_opts_out_of_session_finalization(monkeypatch):
     assert seen.get("at_run_time") is False
 
 
+def test_background_review_skipped_in_delegation_subagent(monkeypatch):
+    """The automatic post-turn review must NOT fire inside a delegation
+    subagent (``_delegate_depth > 0``).
+
+    Regression for #85859: the fork inherits the subagent's live model, so in
+    a delegation subagent running a premium model it replayed the whole
+    conversation at premium rates. Subagents are already barred from writing
+    shared MEMORY.md, so there is nothing for the review to persist here.
+    """
+    forks = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            forks.append(kwargs)
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._delegate_depth = 1  # this agent IS a delegation subagent
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+        review_skills=True,
+    )
+
+    assert forks == [], "no review fork should be spawned inside a subagent"
+
+
+def test_background_review_runs_at_top_level(monkeypatch):
+    """Sibling guard for the subagent skip: at ``_delegate_depth == 0`` the
+    review still fires exactly as before (the cost guard is subagent-only)."""
+    forks = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            forks.append(kwargs)
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._delegate_depth = 0  # top-level agent
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert len(forks) == 1, "top-level review must still spawn the fork"
+
+
+def test_background_review_explicit_focus_runs_even_in_subagent(monkeypatch):
+    """An explicit ``/refine`` (``focus`` set) is a deliberate user request and
+    is honored regardless of depth — only the automatic post-turn review is
+    suppressed in subagents."""
+    forks = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            forks.append(kwargs)
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._delegate_depth = 2
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_skills=True,
+        focus="save the deploy workflow as a skill",
+    )
+
+    assert len(forks) == 1, "explicit focus review must run even in a subagent"
+
+
 def test_background_review_registers_on_active_children_for_interrupt(monkeypatch):
     """The review fork must be added to the parent's ``_active_children`` so
     ``AIAgent.interrupt()`` (which fans out to that list) can reach it, and


### PR DESCRIPTION
## What

Skip the **automatic** post-turn background review when the agent is a delegation subagent (`_delegate_depth > 0`).

Fixes #85859.

## Why

`AIAgent._spawn_background_review` forks a review agent that inherits the parent's live runtime by default. That's a cost win when the parent IS the main chat model (warm prompt cache → cheap), but the fork also fires inside **delegation subagents**, where it inherits the *subagent's* model. When a subagent runs a premium delegation model (e.g. `anthropic/claude-fable-5` via nous), the review silently replays the whole conversation and emits skill/memory-update output at premium rates — with nothing in the log or config flagging it.

Subagents are already treated as non-owners of shared persistent state: `memory` is in `DELEGATE_BLOCKED_TOOLS` (`tools/delegate_tool.py`, "no writes to shared MEMORY.md") and subagents are spawned with `skip_memory=True`. So an automatic review inside a subagent has little it can even persist, while paying full premium replay cost. Issue #85859 lists "skip the review in delegation/subagent sessions" as an accepted resolution.

## How

- Guard `_spawn_background_review` — the single choke point both the turn-finalizer and codex-runtime callers pass through — to `return` early when `focus is None and _delegate_depth > 0`.
- An explicit `/refine` (`focus` set) is a deliberate user request and still runs; the top-level (`_delegate_depth == 0`) path is byte-for-byte unchanged.

## Tests

`tests/run_agent/test_background_review.py`:
- `test_background_review_skipped_in_delegation_subagent` — depth=1 → no fork spawned.
- `test_background_review_runs_at_top_level` — depth=0 → fork still spawned (guard is subagent-only).
- `test_background_review_explicit_focus_runs_even_in_subagent` — `/refine` focus honored regardless of depth.

Full `test_background_review.py` (9) plus the sibling `test_background_review_cost_controls.py` / `_toolset_restriction.py` / `_cache_parity.py` and `test_curator.py` suites (44) pass locally; ruff + windows-footgun gates clean on the touched files.

## Alternatives considered

Routing the review to a cheap model in subagents (issue option 1/3) needs a cheap model to be configured, so it can't be a safe default; changing the documented `auxiliary.background_review` default would alter behavior for the main-chat case too. Skipping is the minimal change that fixes the cost bug without touching the (correct) top-level default, and it matches the existing "subagents don't own shared memory/skill state" design.
