### PR TITLE
fix(slack): recognize app bot ID mentions

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -932,6 +932,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._app: Optional[Any] = None
         self._handler: Optional[Any] = None
         self._bot_user_id: Optional[str] = None
+        self._bot_id: Optional[str] = None
         # Bot identity per workspace, used to ground the agent ("you are @X on
         # Slack") so it never mistakes a human's mention for a self-mention.
         self._bot_display_name: Optional[str] = None  # primary workspace bot name
@@ -955,6 +956,7 @@ class SlackAdapter(BasePlatformAdapter):
         # Multi-workspace support
         self._team_clients: Dict[str, Any] = {}  # team_id → WebClient
         self._team_bot_user_ids: Dict[str, str] = {}  # team_id → bot_user_id
+        self._team_bot_ids: Dict[str, str] = {}  # team_id → app bot_id
         # channel_id → team_id. Grows with every channel AND every DM the bot
         # sees (DM channel IDs are per-user), so it must be bounded on busy
         # multi-workspace installs. Eviction is safe: entries are re-learned
@@ -1941,11 +1943,13 @@ class SlackAdapter(BasePlatformAdapter):
 
             # Reset multi-workspace state before re-populating it so a
             # reconnect that drops a workspace (or rotates the primary bot
-            # token) doesn't carry stale ``_bot_user_id`` / ``_team_clients``
-            # / ``_team_bot_user_ids`` entries from the prior session.
+            # token) doesn't carry stale bot identities or clients from the
+            # prior session.
             self._bot_user_id = None
+            self._bot_id = None
             self._team_clients = {}
             self._team_bot_user_ids = {}
+            self._team_bot_ids = {}
             self._bot_display_name = None
             self._team_bot_names = {}
 
@@ -1968,11 +1972,13 @@ class SlackAdapter(BasePlatformAdapter):
                 auth_response = await client.auth_test()
                 team_id = auth_response.get("team_id", "")
                 bot_user_id = auth_response.get("user_id", "")
+                bot_id = auth_response.get("bot_id", "")
                 bot_name = auth_response.get("user", "unknown")
                 team_name = auth_response.get("team", "unknown")
 
                 self._team_clients[team_id] = client
                 self._team_bot_user_ids[team_id] = bot_user_id
+                self._team_bot_ids[team_id] = bot_id
                 self._team_bot_names[team_id] = bot_name
 
                 # First token always wins as the primary bot user id; we
@@ -1980,6 +1986,7 @@ class SlackAdapter(BasePlatformAdapter):
                 # token's identity even on reconnect.
                 if self._bot_user_id is None:
                     self._bot_user_id = bot_user_id
+                    self._bot_id = bot_id
                 if self._bot_display_name is None:
                     self._bot_display_name = bot_name
 
@@ -2352,8 +2359,10 @@ class SlackAdapter(BasePlatformAdapter):
         self._app_token = None
         self._proxy_url = None
         self._bot_user_id = None
+        self._bot_id = None
         self._team_clients = {}
         self._team_bot_user_ids = {}
+        self._team_bot_ids = {}
         self._channel_team = {}
         self._dm_conversation_cache = {}
 
@@ -5849,11 +5858,12 @@ class SlackAdapter(BasePlatformAdapter):
             elif allow_bots == "mentions":
                 # Include Block-Kit-only mentions, not just the flat text (#52387)
                 text_check = _slack_mention_detection_text(event)
-                if self._bot_user_id and f"<@{self._bot_user_id}>" not in text_check:
+                team_id = str(event.get("team") or event.get("team_id") or "")
+                self_ids = self._slack_self_ids(team_id)
+                if self_ids and not self._slack_message_mentions_self(text_check, self_ids):
                     logger.debug(
                         "[Slack] Dropping bot message under allow_bots=mentions: "
-                        "no <@%s> mention in flat text or blocks",
-                        self._bot_user_id,
+                        "no self mention in flat text or blocks",
                     )
                     return
             # "all" falls through to process the message
@@ -6121,10 +6131,11 @@ class SlackAdapter(BasePlatformAdapter):
         #   3. The message is in a thread where the bot was previously @mentioned, OR
         #   4. There's an existing session for this thread (survives restarts)
         bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
+        self_uids = self._slack_self_ids(team_id)
         # Detect mentions authored only inside Block Kit blocks too (#52387)
         routing_text = _slack_mention_detection_text(event) or original_text or ""
         is_mentioned = bool(
-            (bot_uid and f"<@{bot_uid}>" in routing_text)
+            self._slack_message_mentions_self(routing_text, self_uids)
             or self._slack_message_matches_mention_patterns(routing_text)
         )
         event_thread_ts = event.get("thread_ts")
@@ -6172,7 +6183,6 @@ class SlackAdapter(BasePlatformAdapter):
             # that person. Stay silent unless we are also mentioned — this
             # overrides free-response and mentioned-thread auto-follow so the
             # bot does not butt in on chatter aimed at someone else.
-            self_uids = {u for u in (bot_uid, self._bot_user_id) if u}
             if (
                 self._slack_ignore_other_user_mentions()
                 and not is_mentioned
@@ -8844,6 +8854,22 @@ class SlackAdapter(BasePlatformAdapter):
         if not match:
             return False
         return match.group(1) not in self_uids
+
+    def _slack_self_ids(self, team_id: str) -> set:
+        """Return this app's Slack user and bot IDs for one workspace."""
+        team_bot_user_ids = getattr(self, "_team_bot_user_ids", {})
+        team_bot_ids = getattr(self, "_team_bot_ids", {})
+        bot_user_id = (
+            team_bot_user_ids[team_id]
+            if team_id in team_bot_user_ids
+            else getattr(self, "_bot_user_id", None)
+        )
+        bot_id = (
+            team_bot_ids[team_id]
+            if team_id in team_bot_ids
+            else getattr(self, "_bot_id", None)
+        )
+        return {identity for identity in (bot_user_id, bot_id) if identity}
 
     def _slack_message_mentions_self(self, text: str, self_uids: set) -> bool:
         """Return True when ``text`` @-mentions this bot anywhere in the message.

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -660,6 +660,7 @@ class TestSlackSocketWatchdog:
         mock_web_client.auth_test = AsyncMock(
             return_value={
                 "user_id": "U_BOT",
+                "bot_id": "B_BOT",
                 "user": "testbot",
                 "team_id": "T_FAKE",
                 "team": "FakeTeam",
@@ -783,8 +784,10 @@ class TestSlackSocketWatchdog:
 
         # Pre-seed stale multi-workspace state as if a prior connect had run.
         adapter._bot_user_id = "U_OLD_BOT"
+        adapter._bot_id = "B_OLD_BOT"
         adapter._team_clients = {"T_OLD": MagicMock(name="old-client")}
         adapter._team_bot_user_ids = {"T_OLD": "U_OLD_BOT"}
+        adapter._team_bot_ids = {"T_OLD": "B_OLD_BOT"}
 
         with contextlib.ExitStack() as stack:
             for p in self._patch_stack(factory):
@@ -795,10 +798,13 @@ class TestSlackSocketWatchdog:
 
                 # State must reflect the fresh auth, not the stale seed.
                 assert adapter._bot_user_id == "U_BOT"
+                assert adapter._bot_id == "B_BOT"
                 assert "T_OLD" not in adapter._team_clients
                 assert "T_OLD" not in adapter._team_bot_user_ids
+                assert "T_OLD" not in adapter._team_bot_ids
                 assert "T_FAKE" in adapter._team_clients
                 assert adapter._team_bot_user_ids["T_FAKE"] == "U_BOT"
+                assert adapter._team_bot_ids["T_FAKE"] == "B_BOT"
             finally:
                 await adapter.disconnect()
 
@@ -1930,6 +1936,23 @@ class TestMessageRouting:
         await adapter._handle_slack_message(event)
 
         adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allow_bots_mentions_accepts_own_bot_id_mention(self, adapter):
+        adapter.config.extra["allow_bots"] = "mentions"
+        adapter._bot_id = "B_BOT"
+        event = {
+            "subtype": "bot_message",
+            "text": "<@B_BOT> hello",
+            "user": "U_PEER_BOT",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "123.457",
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_awaited_once()
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_slack_ignore_other_user_mentions.py
+++ b/tests/gateway/test_slack_ignore_other_user_mentions.py
@@ -58,6 +58,7 @@ from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
 
 
 BOT_USER_ID = "U_BOT_123"
+BOT_ID = "B_BOT_123"
 OTHER_USER_ID = "U_OTHER_456"
 CHANNEL_ID = "C0AQWDLHY9M"
 
@@ -131,6 +132,7 @@ def adapter():
     a._app = MagicMock()
     a._app.client = AsyncMock()
     a._bot_user_id = BOT_USER_ID
+    a._bot_id = BOT_ID
     a._running = True
     a.handle_message = AsyncMock()
     return a
@@ -184,6 +186,20 @@ async def test_free_response_replies_when_bot_also_mentioned(adapter):
     )
 
     adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_channel_replies_when_own_bot_id_is_mentioned(adapter):
+    await _run(adapter, _event(f"<@{BOT_ID}> hello", ts="1700000000.000020"))
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_channel_ignores_other_app_bot_id(adapter):
+    await _run(adapter, _event("<@B_OTHER_APP> hello", ts="1700000000.000021"))
+
+    adapter.handle_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -55,6 +55,7 @@ from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
 # ---------------------------------------------------------------------------
 
 BOT_USER_ID = "U_BOT_123"
+BOT_ID = "B_BOT_123"
 CHANNEL_ID = "C0AQWDLHY9M"
 OTHER_CHANNEL_ID = "C9999999999"
 
@@ -77,7 +78,9 @@ def _make_adapter(require_mention=None, strict_mention=None, free_response_chann
     adapter.platform = Platform.SLACK
     adapter.config = PlatformConfig(enabled=True, extra=extra)
     adapter._bot_user_id = BOT_USER_ID
+    adapter._bot_id = BOT_ID
     adapter._team_bot_user_ids = {}
+    adapter._team_bot_ids = {}
     return adapter
 
 
@@ -276,6 +279,56 @@ def test_reaction_guard_pinned_to_production_expression():
 def test_mentioned_message_always_processed():
     adapter = _make_adapter(require_mention=True)
     assert _would_process(adapter, mentioned=True, text="what's up") is True
+
+
+def test_bot_id_mention_matches_this_slack_app():
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._slack_message_mentions_self(
+        f"<@{BOT_ID}> hello", adapter._slack_self_ids("T1")
+    ) is True
+
+
+def test_other_app_bot_id_does_not_match_this_slack_app():
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._slack_message_mentions_self(
+        "<@B_OTHER_APP> hello", adapter._slack_self_ids("T1")
+    ) is False
+
+
+def test_bot_id_mentions_are_scoped_per_workspace():
+    adapter = _make_adapter(require_mention=True)
+    adapter._team_bot_user_ids = {"T1": "U_BOT_T1", "T2": "U_BOT_T2"}
+    adapter._team_bot_ids = {"T1": "B_BOT_T1", "T2": "B_BOT_T2"}
+
+    assert adapter._slack_message_mentions_self(
+        "<@B_BOT_T2> hello", adapter._slack_self_ids("T2")
+    ) is True
+    assert adapter._slack_message_mentions_self(
+        "<@B_BOT_T2> hello", adapter._slack_self_ids("T1")
+    ) is False
+
+
+def test_workspace_without_bot_id_does_not_fall_back_to_primary_bot_id():
+    adapter = _make_adapter(require_mention=True)
+    adapter._team_bot_user_ids = {"T1": "U_BOT_T1"}
+    adapter._team_bot_ids = {"T1": ""}
+
+    assert adapter._slack_message_mentions_self(
+        f"<@{BOT_ID}> hello", adapter._slack_self_ids("T1")
+    ) is False
+
+
+def test_block_kit_bot_id_mention_matches_this_slack_app():
+    adapter = _make_adapter(require_mention=True)
+    routing_text = _slack_mention_detection_text(
+        _blockkit_mention_event(bot_user_id=BOT_ID)
+    )
+
+    assert adapter._slack_message_mentions_self(
+        routing_text, adapter._slack_self_ids("T1")
+    ) is True
 
 
 def test_thread_reply_with_active_session_processed():


### PR DESCRIPTION
## What does this PR do?

Slack mobile can encode a mention selected from its app entry as the app's `bot_id` (`B...`) instead of the bot user ID (`U...`). The Slack adapter currently recognizes only the user ID, so those messages fail the channel mention gate.

This change captures `bot_id` from `auth.test`, scopes it per workspace alongside the existing bot user identity, and accepts either identity through the existing Slack mention parser. Other apps' bot IDs remain ignored, including across multi-workspace connections.

## Related Issue

Fixes #85835

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Capture and clear primary and per-workspace Slack `bot_id` identities in `plugins/platforms/slack/adapter.py`.
- Reuse a workspace-scoped self-identity set for channel mention routing and `allow_bots=mentions` filtering.
- Add regression coverage for mobile-style `B...` mentions, Block Kit mentions, other-app rejection, workspace isolation, reconnect cleanup, and the bot-message sibling path.

## How to Test

1. Configure Slack channel mention routing and send a message whose selected app mention is encoded as `<@B...>`.
2. Run `HERMES_PYTHON=/usr/bin/python3 scripts/run_tests.sh tests/gateway/test_slack*.py -q`.
3. Confirm the current app's bot ID routes the message while another app's bot ID remains silent; the suite reports 362 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, using the repository Slack gateway test suite

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`tests/gateway/test_slack*.py`: 362 passed, 0 failed. Ruff, Windows footgun, whitespace, and contributor attribution checks also pass.
