### PR TITLE
fix: add durable conversation ownership fencing

### DIFF
--- a/DEPLOYMENT-MANIFEST.v1.json
+++ b/DEPLOYMENT-MANIFEST.v1.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "candidate": "current-upstream-session-ownership",
+  "upstream_base": "2ae96939f53b0cc0aa82868fc9a44702f3dd6c09",
+  "branch": "fix/current-upstream-session-ownership",
+  "installation_target": "C:\\Users\\cwm4t\\AppData\\Local\\hermes\\hermes-agent",
+  "source_worktree": "C:\\Users\\cwm4t\\AppData\\Local\\Temp\\hermes-current-upstream-session-ownership",
+  "deployment_status": "not_deployed",
+  "deployment_authorized": false,
+  "push_status": "not_pushed",
+  "accepted_commit": null,
+  "accepted_patch_sha256": null,
+  "accepted_patch_bytes": null,
+  "source_file_sha256": {},
+  "deployed_file_sha256": {},
+  "running_process_source_sha256": {},
+  "retirement_condition": "Retire this temporary candidate when equivalent durable cross-process conversation ownership and fencing is present on accepted upstream main and passes the same focused and client compatibility gates.",
+  "notes": [
+    "Hash fields are populated after the immutable candidate is approved and committed.",
+    "Deployment fields remain empty because production deployment was explicitly excluded pending separate authorization.",
+    "The final external attestation is stored outside Git to avoid self-referential commit/hash fields."
+  ]
+}

--- a/EVIDENCE-LEDGER.md
+++ b/EVIDENCE-LEDGER.md
@@ -1,0 +1,437 @@
+# Evidence Ledger — current-upstream session ownership
+
+Mutable working ledger. Every focused verification run is recorded here with
+the exact command, the expected result, and the observed result.
+
+## Controller / worker boundary
+
+| Item | Owner |
+|---|---|
+| plan.md Phase 0 (v7 immutable bundle) | parent Hermes session — NOT this worker |
+| plan.md Phase 1 (clean worktree/branch) | parent — already done; this worktree is the product |
+| plan.md Phases 2–4 (inventory, kernel, callers, decoupling) | **this worker** |
+| plan.md Phase 5 items 1–7 (focused gates) | **this worker**, focused subset only |
+| plan.md Phase 5 items 8–14 (broad suite, clients, scans) | parent |
+| plan.md Phase 6 (freeze, immutable review) | parent |
+| plan.md Phase 7 (commit, report, manifest) | parent |
+
+This worker does not stage, commit, push, deploy, touch credentials, inspect
+the installed dirty checkout, or alter other worktrees.
+
+## Environment
+
+| Field | Value |
+|---|---|
+| Worktree | `C:\Users\cwm4t\AppData\Local\Temp\hermes-current-upstream-session-ownership` |
+| Branch | `fix/current-upstream-session-ownership` |
+| Base commit | `2ae96939f53b0cc0aa82868fc9a44702f3dd6c09` (`origin/main`) |
+| Worktree state at start | clean except untracked `plan.md` |
+| OS | Windows 11 Home 10.0.26200 |
+| Interpreter | `C:\Users\cwm4t\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe` — CPython 3.11.15, pytest 8.4.2 |
+| Import resolution verified | `hermes_state.__file__` and `gateway.turn_lease.__file__` both resolve **inside this worktree**, not the installed tree |
+
+### Deviation from `AGENTS.md` testing policy — recorded deliberately
+
+`AGENTS.md` says *"ALWAYS use `scripts/run_tests.sh`"*. This worker runs
+`pytest` directly, one process at a time, because the task explicitly forbids
+spawning parallel per-file pytest runners on Windows and `run_tests.sh` drives
+`scripts/run_tests_parallel.py`, which does exactly that. Hermetic parity is
+preserved by the autouse `_hermetic_environment` / `_isolate_hermes_home`
+fixtures in `tests/conftest.py`, which run identically under a direct pytest
+invocation. Broad-suite / CI-parity confirmation remains a parent
+responsibility (Phase 5 item 8).
+
+Command shape used throughout:
+
+```
+"C:/Users/cwm4t/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe" -m pytest <target> -p no:randomly -q
+```
+
+## Premise re-verification against current upstream (plan.md Phase 2)
+
+Do not mechanically apply v7. Each plan bullet was re-checked against the
+current tree before any edit.
+
+| plan.md item | Premise on current upstream | Disposition |
+|---|---|---|
+| 7 — remove private `orchestration-sessions.json` coupling from core | `grep -rn "orchestration-sessions"` over `*.py/*.ts/*.tsx/*.md` matches **only `plan.md` itself**. No core module names, reads, or parses that file. | **Already satisfied on current upstream.** Guarded behaviourally (not by source-regex, which `AGENTS.md` bans) — see Slice E. |
+| 9 — no `claude-*` prefix route inference | 4 call sites exist. Assessed individually below. | See Slice E. |
+| Canonical conversation identity | `SessionDB.get_conversation_root()` (hermes_state.py:9455) already exists and already walks `parent_session_id` to the lineage root. | **Reused, not reinvented.** |
+| "two processes cannot own one conversation" | `gateway/turn_lease.py` is in-process only and its own module docstring names the gap: *"A CLI process sharing the session via CLI-continuity is outside any in-process lock — that pair needs a DB-level lease (separate design)."* | **This is the gap being closed.** |
+| "do not add a second lock authority" | `compression_locks` already exists but answers a different question (serialise *rotation* within one conversation). Ownership answers *who may mutate the conversation at all*. | Kept separate, documented in OWNERSHIP-TABLE.md. |
+
+### Canonical-root mutability finding (decides the schema)
+
+`get_conversation_root()` recomputes the root by walking `parent_session_id`.
+`parent_session_id` is written in exactly two ways on current upstream:
+
+* set at `create_session(parent_session_id=…)` — compression child, delegate
+  child. The root is **stable** across this (a new segment inherits the same
+  root).
+* set to `NULL` — only in destructive paths: `_delete_delegate_children`
+  (hermes_state.py:330), `delete_session` (:9994), `delete_sessions` (:10115),
+  `delete_empty_sessions` (:10208), prune (:10550).
+
+So the root **is mutable**: deleting an ancestor re-roots its children. A lease
+keyed on a *recomputed* root would silently orphan mid-turn and let a second
+process acquire on the new root while the first still believes it owns the old
+one. Therefore:
+
+> **The grant pins the root captured at acquire time, and every fenced write
+> validates `(pinned_root, holder, fence_token)` — it never recomputes the
+> root. Destructive paths that would re-root a child refuse in the same write
+> transaction while a live owner covers the old root.**
+
+This is what plan.md Slice D means by "lineage changes preserve the canonical
+authority contract".
+
+---
+
+## RED → GREEN cycles
+
+Format: one entry per vertical behaviour. RED is recorded *before* the
+production change exists.
+
+### Baseline (untouched `origin/main` @ 2ae9693, this machine)
+
+Established by restoring pristine `hermes_state.py` + `hermes_state_common.py`
+with `git checkout --`, running the failing tests, then restoring my copies and
+verifying both files byte-identical with `sha256sum -c` (both `OK`).
+
+```
+python -m pytest tests/hermes_state/test_live_db_isolation_guard.py \
+  "tests/test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries" \
+  -p no:randomly -q
+→ 6 failed, 7 passed
+```
+
+Pre-existing failure signatures on this host (NOT caused by this work):
+
+| Test | Signature |
+|---|---|
+| `test_live_db_isolation_guard.py::TestProductionPathRefused::test_explicit_production_db_path_raises` | `Failed: DID NOT RAISE RuntimeError` |
+| `…::test_production_profile_db_path_raises` | `DID NOT RAISE` |
+| `…::test_read_only_open_of_production_db_raises` | `DID NOT RAISE` |
+| `…::test_unnormalized_production_path_raises` | `DID NOT RAISE` |
+| `…::test_default_resolution_to_production_raises` | `DID NOT RAISE` |
+| `test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries` | `assert 0 == 1` |
+
+The isolation-guard group is a host-environment effect (the guard does not arm
+under this shell's ambient `HERMES_HOME`). Both groups reproduce identically
+with and without this branch's changes, so "zero new normalized failure
+signatures" is measured against this list.
+
+---
+
+### Slice A — canonical identity and the SQLite kernel
+
+**RED** (before any production change existed):
+
+```
+python -m pytest tests/hermes_state/test_conversation_ownership_kernel.py -p no:randomly -q
+→ ModuleNotFoundError: No module named 'agent.session_ownership'
+  1 error in 0.32s (collection error)
+```
+
+**Production change**
+
+| Path | Change |
+|---|---|
+| `hermes_state_common.py` | `conversation_ownership` table + expiry index in `SCHEMA_SQL` (applied to fresh AND existing DBs by `_init_schema`'s `executescript`) |
+| `agent/session_ownership.py` | **new** — identity (`new_holder_id`, `holder_process_is_dead`), `OwnershipGrant`, typed conflicts, thread-scoped re-entrancy, lease refresher, `own_conversation()` |
+| `hermes_state.py` | `try_acquire_conversation_ownership` / `refresh_conversation_ownership` / `release_conversation_ownership` / `get_conversation_owner` / `execute_fenced_write` |
+
+**GREEN**
+
+```
+python -m pytest tests/hermes_state/test_conversation_ownership_kernel.py -p no:randomly -q
+→ 11 passed in 5.32s
+```
+
+Covered: two-PROCESS mutual exclusion (real `subprocess.Popen` holder, not a
+mock); root-keyed identity (a compression child collides with its parent);
+grant pins its captured root across ancestor deletion; monotonic fence per
+handover; fenced write refuses a stale token **without running the mutation**;
+fenced write commits in one transaction; holder+fence-scoped release; TTL
+takeover; dead-pid takeover before TTL; refresh only extends our own grant;
+**authority failure raises instead of silently granting**.
+
+**No-regression on the store**
+
+```
+python -m pytest tests/hermes_state/ tests/test_hermes_state.py \
+  tests/test_hermes_state_readonly_preflight.py \
+  tests/test_hermes_state_compression_locks.py \
+  tests/test_hermes_state_wal_fallback.py -p no:randomly -q
+→ 6 failed, 354 passed, 8 skipped in 170.16s
+```
+
+The 6 failures are exactly the baseline list above — **zero new signatures**.
+
+---
+
+### Slice B — core agent lifecycle
+
+**RED**
+
+```
+python -m pytest tests/run_agent/test_conversation_ownership_admission.py -p no:randomly -q
+→ ImportError: cannot import name 'ownership_admission_surface'
+  1 error in 3.01s (collection error)
+```
+
+**Production change**
+
+| Path | Change |
+|---|---|
+| `agent/session_ownership.py` | `should_own_conversation()` / `ownership_admission_surface()` |
+| `run_agent.py` | `AIAgent.run_conversation` becomes the admission gate; its former body moved verbatim to `_run_owned_conversation` (no re-indent, no logic change) |
+
+`run_conversation` is the narrow waist every surface funnels through (CLI,
+gateway, HTTP API, TUI, ACP, cron, batch, oneshot), so one gate there covers
+every mutating path instead of eight per-surface locks.
+
+Three populations are deliberately excluded from contention, because they run
+*inside* a conversation someone else owns: persist-disabled background-review
+forks, delegate subagents (their root resolves to the parent's by design), and
+store-less agents.
+
+**GREEN**
+
+```
+python -m pytest tests/run_agent/test_conversation_ownership_admission.py -p no:randomly -q
+→ 11 passed in 8.40s
+```
+
+Covered: eligibility is pure input→output; a foreign holder makes the turn
+raise `ConversationOwnershipConflict` with **no session row and no messages
+written**; the grant is live for the whole turn body and gone after; release
+survives a raising turn AND a `KeyboardInterrupt`; a second THREAD on the same
+conversation still collides; nested re-entry in the owning thread reuses the
+grant and does not release it early.
+
+---
+
+### Slice C — fenced publications, rewrites, expiry, and lineage mutation
+
+The first implementation review found three missing invariants and each was
+turned into a failing test before correction:
+
+```
+pytest ...::test_fenced_write_refuses_an_expired_grant_without_handover \
+       ...::test_archive_and_compact_is_refused_under_a_lost_grant \
+       ...::test_delete_session_if_empty_is_refused_under_a_lost_grant
+→ 3 failed (all mutations ran under an invalid grant)
+```
+
+Corrections:
+
+- fenced writes now validate unexpired `(root, holder, fence)` in the same
+  transaction as the mutation;
+- single and batched append, replace, archive/compact, rewind, rewind restore,
+  reset promotion, session delete, and empty-session delete use the same fenced
+  transaction whenever the current thread holds a grant;
+- direct deletion refuses lineage re-rooting while a live owner covers the
+  affected root; bulk, empty, and prune maintenance skip owned roots and
+  continue deleting unrelated rows, preserving their count contracts;
+- acquire and refresh timestamps are sampled after `_execute_write` obtains
+  SQLite write authority, so lock patience cannot consume a lease before
+  publication.
+
+Delayed candidate-v2 review then reproduced a separate authority bypass: a
+different thread/`SessionDB` handle with no process-local grant could append or
+rewind while another handle held the durable lease. The discriminating RED was:
+
+```
+pytest ...::test_foreign_unowned_append_is_refused_while_an_owner_is_live \
+       ...::test_foreign_unowned_rewind_is_refused_while_an_owner_is_live
+→ 2 failed (both foreign mutations committed)
+```
+
+`_execute_conversation_write` now checks the canonical durable owner inside the
+same write transaction even when no grant is local. A foreign live owner is
+refused; legacy mutation remains compatible when no owner is live.
+
+Candidate-v9 review found the necessary opposite case: delegate/subagent
+segments run concurrently with the parent and intentionally do not acquire its
+grant. A threaded delegate append was RED under the blanket refusal while a
+compression-child control remained GREEN. The transaction now recognizes only
+targets at or below a real parented `delegate`/`subagent` lineage boundary as
+independently writable. Candidate-v10 review added two more REDs: a rotated
+compression child below a delegate was incorrectly refused, while a re-rooted
+delegate-labeled row was incorrectly exempt. The bounded transaction-local
+lineage predicate now makes both GREEN; root-level compression, branch, reset,
+and root targets remain protected. A malformed delegate-cycle RED additionally
+requires the bounded walk to reach a real root before granting the exception.
+Candidate-v11 review then proved the exception was too broad for
+delete-if-empty/reset and too dependent on a hand-planted source label. Two
+lineage-mutation REDs restricted it to explicitly marked transcript
+publication. A real `delegate_tool._build_child_agent` test, under an inherited
+`tui` source, drove recognition of the durable `_delegate_from` marker emitted
+by production child assembly.
+An ordinary-agent assertion drives production's
+`_adopt_live_compression_child` path and proves `_parent_session_id` remains
+unset and ownership admission remains enabled. The real delegate child test
+also asserts the in-memory `platform`, `_parent_session_id`, and
+`should_own_conversation(child) is False`, not just the persisted row.
+Delayed candidate-v3 privacy review then demonstrated that generic client
+stringification exposed canonical roots, holder host/PID/nonce, fence values,
+and raw storage errors. A discriminating RED now requires bounded public text;
+the trusted structured fields remain available without appearing in `str(exc)`.
+Candidate-v15 review then identified `replace_messages` as too destructive for
+the delegate publication exemption. A RED foreign delegate-boundary replacement
+test drove strict owner checking for whole-transcript replacement while leaving
+append/batch and compacted publication available to real subagents.
+
+```
+pytest tests/hermes_state/test_conversation_ownership_kernel.py \
+       tests/hermes_state/test_conversation_ownership_rewrites.py -p no:randomly -q
+→ 45 passed (latest review-cycle aggregate)
+```
+
+### Slice D — supported configuration/provider boundaries
+
+```
+pytest tests/e2e/test_core_config_contract_boundaries.py -p no:randomly -q
+→ included in focused aggregate below; all 4 passed
+```
+
+The behavioral acceptance test plants a contradictory private
+`workspace/orchestration-sessions.json`; delegation still resolves exclusively
+from supported `config.yaml`. Provider API mode is resolved from provider
+identity: the same `claude-x` model maps to Anthropic Messages only for the
+published `opencode-zen` provider and remains Chat Completions elsewhere.
+
+### Slice E — current route-prefix call-site disposition
+
+The four current `claude-*` production checks were assessed individually:
+
+1. `hermes_cli/models.py::opencode_model_api_mode` is provider-gated endpoint
+   family mapping from OpenCode's published Zen table. The acceptance test also
+   uses a non-Claude `qwen*` family routed to `/v1/messages`, so it would fail
+   under a provider-gated Claude-prefix-only implementation.
+2. Anthropic payload shaping checks a selected Anthropic API mode after route
+   resolution; it does not select the provider or endpoint.
+3. Bedrock model metadata identifies a model family inside the already-selected
+   Bedrock provider; it does not infer an installation route.
+4. Pricing/display normalization classifies model names for metadata/UI only;
+   neither call site selects an API transport.
+
+No private Workspace schema is consulted and no installation/provider identity
+is inferred from a `claude-*` route name.
+
+## Final verification before freeze
+
+### Focused aggregate and static checks
+
+```
+pytest tests/run_agent/test_conversation_ownership_admission.py \
+       tests/e2e/test_core_config_contract_boundaries.py \
+       tests/hermes_state/test_conversation_ownership_kernel.py \
+       tests/hermes_state/test_conversation_ownership_rewrites.py \
+       -p no:randomly -q
+→ 62 passed (latest focused aggregate)
+
+ruff check <all changed Python and tests>
+→ All checks passed
+
+git diff --check
+→ clean
+```
+
+### Broad SessionDB gate
+
+```
+pytest tests/hermes_state/ tests/test_hermes_state.py \
+       tests/test_hermes_state_readonly_preflight.py \
+       tests/test_hermes_state_compression_locks.py \
+       tests/test_hermes_state_wal_fallback.py -p no:randomly -q
+→ 6 failed, 388 passed, 8 skipped in 184.13s
+```
+
+All six normalized signatures exactly match the untouched-upstream baseline
+recorded above: five Windows host live-DB-guard expectations and one FTS trace
+callback expectation. Zero new signatures.
+
+### Phase-5 caller and lifecycle surfaces
+
+The first all-in-one caller command exited without a pytest summary after 61%,
+so it is not acceptance evidence. The same inventory was rerun serially in
+bounded surface groups against the immutable replay. Every candidate failure
+was then rerun by exact node ID on an untouched worktree at `2ae9693`:
+
+```text
+tests/run_agent/
+→ 28 failed, 1537 passed, 3 skipped, 2 deselected in 1442.55s
+→ exact-base rerun of all 28 candidate failures: the same 28 failed
+
+tests/gateway/
+→ 69 failed, 5432 passed, 36 skipped, 2 xfailed in 2438.52s
+→ exact-base rerun: 65 persistent signatures reproduced
+→ four candidate-only Discord/media signatures immediately passed on both
+  candidate and exact base; classified as transient, not persistent additions
+
+tests/tui_gateway/ tests/acp_adapter/ tests/cron/
+→ 13 failed, 996 passed, 19 skipped in 347.64s
+→ exact-base rerun of all 13 candidate failures: the same 13 failed
+
+delegation + MOA + compression caller files under tests/tools and tests/agent
+→ 1 failed, 421 passed in 199.89s
+→ exact-base rerun: the same Windows open-handle cleanup test failed
+```
+
+Normalized persistent candidate-only failure set: **empty**. The failures are
+Windows path/permission/open-handle, optional integration, provider fixture,
+and existing platform-contract signatures; none implicates ownership
+admission, fencing, delegation publication, rewind/reset/delete handling, or
+maintenance count semantics.
+
+After removing the delegate exemption from `replace_messages`, the affected
+caller slice (`gateway`, `tui_gateway`, `acp_adapter`, filtered to replace,
+rewind, or reset) returned 141 passed / 3 skipped / 3 failed. All three failures
+are the previously baselined Windows gateway process-reaping tests selected by
+the word `replace` in their filename; no ownership caller failed.
+
+### Dashboard gate
+
+```
+cd web && npm run check
+→ exit 0; typecheck passed; tests passed; lint: 0 errors, 26 existing warnings
+```
+
+### Desktop gates
+
+```
+cd apps/desktop && npm run typecheck
+→ exit 0
+
+npm run test:ui
+→ 3796 passed, 7 failed (3 files)
+
+npm run test:desktop:platforms
+→ 1027 passed, 28 failed, 2 skipped (7 files)
+```
+
+No Desktop/TypeScript file is changed by this candidate. The failures are
+current-upstream Windows/environment signatures in messaging/settings/skills UI
+fixtures and POSIX permission/SSH/native-dependency Electron tests; none imports
+or exercises the ownership kernel. They are recorded honestly, not represented
+as green.
+
+### Full Python discovery attempt
+
+The first full run stopped during collection on upstream's unconditional
+`os.geteuid()` use in `tests/hermes_cli/test_doctor_journal_modes.py` on Windows.
+A second run excluding that file was stopped after 20 minutes at 6% because the
+serial Windows suite is ~20k tests and had already accumulated unrelated host
+failures. No orphan process was left running. Focused and SessionDB broad gates
+above are the bounded acceptance evidence.
+
+### Safety and scope
+
+- production/installed Hermes checkout was never edited or used as source;
+- no deployment was performed;
+- no push was performed;
+- no credential path or credential value is included;
+- no private Workspace checkout was edited;
+- generated `node_modules` stayed ignored and outside the candidate manifest.

--- a/IMPLEMENTATION-REPORT.md
+++ b/IMPLEMENTATION-REPORT.md
@@ -1,0 +1,157 @@
+# Implementation Report — Durable Cross-Process Conversation Ownership
+
+## Prior state and root cause
+
+Hermes already serialized turns inside one gateway process and serialized context-compression rotation, but no authority covered two independent processes mutating the same durable conversation. A CLI, gateway, TUI, ACP, cron, batch, or HTTP process could therefore overlap on one lineage. A stalled writer could also resume after another process took over and publish stale transcript changes.
+
+The installed Hermes checkout was heavily dirty and was not used as source. The prior hardening worktree remained at `22b186d8a3c51b1bf3a93d49d02f0fc609a2a466` and was not cleaned, reset, rebased, or reused.
+
+## Current-upstream baseline
+
+- Fetched base: `2ae96939f53b0cc0aa82868fc9a44702f3dd6c09` (`origin/main` at work start).
+- Branch: `fix/current-upstream-session-ownership`.
+- Clean worktree: `C:\Users\cwm4t\AppData\Local\Temp\hermes-current-upstream-session-ownership`.
+- `plan.md` was copied byte-for-byte before production edits.
+- v7 was preserved outside the repository as historical evidence at `C:\Users\cwm4t\AppData\Local\hermes\historical-artifacts\core-session-continuity-v7` and hash-verified at 288,739 bytes / `e7d378fd4c3b0cc55171d63920cfc38013c68433336cbe627675d93557e7b2e7`.
+
+## Inventory and ownership model
+
+`OWNERSHIP-TABLE.md` maps every current-upstream mutation surface and records its canonical identity, existing guard, new authority, denial behavior, and lifecycle. The implementation deliberately keeps a narrow waist:
+
+- `gateway/turn_lease.py`: in-process scheduling optimization;
+- `compression_locks`: rotation-specific serialization inside an owned turn;
+- `conversation_ownership`: the sole durable cross-process authority deciding who may mutate a conversation.
+
+The authority key is the conversation lineage root, not a mutable session segment. A grant pins the root captured at admission and carries a monotonic fence token.
+
+## Implementation
+
+### SQLite ownership/fencing kernel
+
+A small `conversation_ownership` table stores root, holder, monotonic fence token, surface, session id, acquisition/refresh times, and expiry. Acquisition uses `BEGIN IMMEDIATE`, rejects live holders, reclaims expired or provably dead local processes, and fails closed if the authority cannot be consulted.
+
+Holder identity includes host, PID, process creation time, thread, and nonce. PID creation time prevents PID-reuse false liveness. A bounded refresher keeps long turns alive; holder-and-fence-scoped release cannot free a successor.
+
+Every fenced mutation validates the pinned `(root, holder, fence)` and unexpired lease in the same transaction as the write. A stale writer's callback is never invoked.
+
+### Core admission and caller coverage
+
+`AIAgent.run_conversation()` is the shared admission boundary used by CLI, gateway, HTTP API, TUI, ACP, cron, batch, and oneshot surfaces. It acquires before transcript loading and releases on normal return, exception, interrupt, or cancellation. Persist-disabled review forks, delegate subagents, and store-less agents do not contend because they either cannot persist or execute inside an already-owned conversation.
+
+Fenced write coverage includes:
+
+- single-message and batched turn publication;
+- transcript replacement;
+- archive-and-compact;
+- rewind and rewind restore;
+- reset promotion;
+- session deletion and empty-session deletion;
+- child-segment writes after an ancestor deletion changes the recomputed lineage root.
+
+Conversation transcript and rewrite methods routed through
+`_execute_conversation_write` retain legacy behavior only while no durable
+owner is live. If another thread or process owns the canonical root, the store
+refuses the ungranted mutation inside the same transaction. Observation or
+sidecar metadata helpers such as activity touches and display/API-content
+backfills remain outside the transcript authority contract.
+
+### Configuration and private-boundary normalization
+
+Current upstream already had no production read of private `workspace/orchestration-sessions.json`. A behavioral acceptance test now plants contradictory private Workspace state and proves delegation still resolves from supported `config.yaml` contracts.
+
+Route choice is proven provider-scoped rather than model-prefix-scoped: the same `claude-x` model selects Anthropic Messages only for the published `opencode-zen` provider, and Chat Completions elsewhere. Existing `claude-*` checks in Anthropic payload shaping, Bedrock model metadata, pricing, and CLI display normalization are not route inference and were intentionally retained.
+
+## RED → GREEN evidence
+
+The authoritative command/result ledger is `EVIDENCE-LEDGER.md`. Key cycles:
+
+- missing kernel: collection failed with `ModuleNotFoundError`; kernel tests became green;
+- missing admission surface: collection failed with `ImportError`; lifecycle/admission tests became green;
+- review-discovered missing expiry/compact/empty-delete fences: 3 tests failed because mutations ran; corrections made all 3 green;
+- review cycle 1 exposed mutable-lineage split authority and pre-transaction
+  lease timestamp sampling; both received discriminating RED tests and minimal
+  transaction-boundary corrections;
+- delayed immutable review reproduced foreign ungranted append and rewind
+  bypasses; two RED tests failed, then the transaction-local durable-owner
+  check made both GREEN;
+- v9 review then caught that a blanket foreign-owner refusal blocked concurrent
+  delegate/subagent publication; a delegate RED failed while a compression
+  child control stayed GREEN, then a source-discriminated own-segment exception
+  made both outcomes GREEN;
+- v10 review found that target-row discrimination missed rotated descendants
+  below a delegate boundary and over-exempted a re-rooted delegate label; two
+  RED tests drove a bounded lineage-boundary predicate that preserves rotated
+  subagents without weakening root authority;
+- a malformed delegate-cycle RED then made the boundary walk fail closed unless
+  it reaches a real root;
+- v11 review showed the exception also covered delete-if-empty/reset and that
+  real gateway children may inherit a non-subagent source; two lineage-mutation
+  REDs restricted the exception to publication-only, while a real
+  `delegate_tool._build_child_agent` test drove recognition of its durable
+  `_delegate_from` marker;
+- the production `_adopt_live_compression_child` path confirms normal-agent
+  rotation does not set the delegate-only parent marker or disable admission;
+- delayed candidate-v3 review exposed public exception strings containing
+  roots, holder process identity, fence values, and raw SQLite errors. A RED
+  projection test drove bounded generic exception text while preserving
+  structured diagnostic attributes for trusted internal logging;
+- final candidate-v15 review showed whole-transcript `replace_messages` still
+  shared the delegate publication exemption. A RED delegate-boundary
+  replacement test drove removal of that flag; append/batch and compacted
+  publication remain supported, while destructive replacement is owner-checked;
+- final focused aggregate: 62 passed;
+- kernel + rewrite aggregate: 45 passed.
+
+## Verification
+
+- Changed Python/test Ruff gate: pass.
+- `git diff --check`: pass.
+- Focused ownership/config aggregate: 62 passed.
+- SessionDB broad gate after review-cycle hardening: 388 passed, 8 skipped,
+  6 failed; all six signatures exactly match untouched-upstream Windows
+  baseline, so zero new signatures.
+- Phase-5 caller gates were run serially against the immutable candidate and
+  compared with exact-base `2ae9693` reruns of every candidate failure:
+  `run_agent` 1,537 passed / 28 failed / 3 skipped / 2 deselected with all 28
+  signatures reproduced on base; gateway 5,432 passed / 69 failed / 36
+  skipped / 2 xfailed, with 65 reproduced on base and the remaining four
+  transient Discord/media failures passing immediately on both candidate and
+  base rerun; TUI+ACP+cron 996 passed / 13 failed / 19 skipped with all 13
+  reproduced; delegation+MOA+compression 421 passed / 1 failed with that
+  Windows open-handle cleanup signature reproduced. Zero persistent new
+  normalized caller signature remains.
+- Post-replacement-hardening caller slice (`gateway`, `tui_gateway`, `acp_adapter`,
+  `-k 'replace or rewind or reset'`): 141 passed, 3 skipped; the three failures
+  are the already-baselined Windows process-reaping tests selected only because
+  their filename contains `replace`. No ownership caller failed.
+- Dashboard `npm run check`: exit 0; typecheck/tests pass; lint has 0 errors and 26 existing warnings.
+- Desktop typecheck: pass.
+- Desktop UI: 3796 passed / 7 current-upstream failures in 3 unrelated fixture files.
+- Desktop Electron: 1027 passed / 28 current-upstream Windows/POSIX/native-environment failures in 7 unrelated files; 2 skipped.
+- Full Python discovery is not represented as green: upstream collection calls `os.geteuid()` unconditionally on Windows. A serial retry excluding that file was stopped after 20 minutes at 6% after unrelated host failures accumulated.
+
+No Desktop or dashboard source file is changed by this candidate. No new broad failure signature was observed in the owned Python surface.
+
+## Immutable review and commit
+
+This section is finalized by the controller after staging, immutable patch export, detached replay, parallel reviews, and the local commit. The immutable evidence ledger and external deployment attestation record hashes that cannot be embedded in their own hashed commit without circularity.
+
+## Exclusions and limitations
+
+- No comprehensive private Workspace rewrite.
+- No Desktop/dashboard feature port.
+- No delegation UX rebuild.
+- No unrelated cleanup or generated website churn.
+- No production deployment.
+- No push.
+- API 429 remains only a surface projection/optimization; correctness is in SQLite admission/fencing.
+- HTTP, TUI/Desktop RPC, and ACP currently project ownership refusal through
+  their generic error contracts; typed per-surface status/code projection is
+  explicitly not claimed by this candidate.
+- A surface that bypasses `AIAgent.run_conversation()` may mutate without a
+  grant only when no durable owner is live. A foreign live authority is
+  mandatory and causes a typed refusal before mutation.
+
+## Final state
+
+The candidate is a clean current-upstream vertical repair with one durable authority, monotonic fencing, cancellation-safe lifecycle, explicit mutation coverage, behavioral private-boundary tests, and reproducible evidence. Installation and runtime remain untouched pending separate deployment authorization.

--- a/OWNERSHIP-TABLE.md
+++ b/OWNERSHIP-TABLE.md
@@ -1,0 +1,114 @@
+# Ownership Table — current-upstream mutating surfaces
+
+Re-inventoried against `origin/main` @ `2ae96939f53b0cc0aa82868fc9a44702f3dd6c09`
+by searching current source. The v7 caller list was **not** used as authority.
+
+## The authority, in one paragraph
+
+One durable authority — the `conversation_ownership` table in `state.db` —
+answers exactly one question: *may this process mutate this conversation right
+now?* Canonical identity is the **conversation root**
+(`SessionDB.get_conversation_root`), so a compression rotation or a delegate
+subtree keeps one user-facing conversation identity. A real delegate/subagent
+lineage boundary and descendants below it are independently written concurrent
+transcript segments and never authorize a write to the owned root; every other
+covered segment shares one owner. A grant carries a monotonic
+`fence_token`, pinned to the root captured at acquire time, and every fenced
+mutation validates `(pinned_root, holder, fence_token)` inside the same
+transaction as the mutation itself.
+
+### Why the pre-existing locks are not it, and are not replaced
+
+| Mechanism | Scope | Question it answers | Relationship |
+|---|---|---|---|
+| `gateway/turn_lease.py` | in-process, per resolved `session_id` | which of two routing keys in *this process* runs first | Kept. Its own docstring defers the cross-process case to "a DB-level lease (separate design)" — that is this table. It still does useful work: it serialises the alias-key route without a DB round trip. |
+| `gateway/platforms/base.py::_active_sessions`, `gateway/run.py::_running_agents` | in-process, per routing key | is this chat busy | Kept. Routing-key busy guards, blind to `session_id` aliasing. |
+| `compression_locks` (`hermes_state.py`) | durable, per `session_id` | which rotation wins *inside* an owned conversation | Kept, strictly narrower, lives inside ownership. Ownership never consults it and it never grants ownership. |
+| `hermes_cli/active_sessions.py` | durable JSON, global | how many chats may be open at once (a **cap**) | Kept. A cap, not exclusivity — it never asks who owns a given conversation. |
+| `agent/relay_runtime.py::RelaySessionCoordinator` | in-process | relay/telemetry scope for a turn | Kept. Observability, not mutual exclusion. |
+
+**No second lock authority was added.** One question, one table.
+
+## Admission point
+
+`AIAgent.run_conversation` (`run_agent.py`) is the narrow waist every surface
+funnels through. Gating it there is what makes one authority cover every
+mutating path. Admission happens **before** the transcript is loaded, so a
+refused turn leaves the conversation byte-identical — and no surface answers a
+conflict by appending a message, which would break role alternation and
+invalidate the conversation's prompt cache.
+
+Deliberately excluded from contention (they run *inside* a conversation
+somebody else owns): persist-disabled background-review forks, delegate
+subagents (`platform == "subagent"` / `_parent_session_id`, whose root resolves
+to the parent's by design), and store-less agents. A delegate/subagent may
+publish below its actual parented delegate boundary, including its own rotated
+children; root-level compression, branch, reset, and root transcripts remain
+covered by the parent's authority.
+
+## Surface table
+
+Legend — **Owner**: `core` = covered by the `run_conversation` admission gate;
+`fenced` = mutation validated against the caller's grant at the store boundary.
+
+| Surface | Entry point | Canonical identity | Lease acquired | Fenced write / publication | Release & cancellation | Conflict projection | Tests |
+|---|---|---|---|---|---|---|---|
+| **CLI / core agent** — send | `cli.py:14709`, `:18639`, `:19159` → `AIAgent.run_conversation` | `get_conversation_root(agent.session_id)` | `run_conversation` admission, pre-history-load | turn flush `run_agent.py:2287` → `append_messages_batch` (fenced) | `own_conversation` `finally`; survives raise + `KeyboardInterrupt` | generic CLI turn error today | `tests/run_agent/test_conversation_ownership_admission.py` |
+| **CLI** — `/rewind` | `cli.py:9114` → `rewind_to_message` | root of the target session | inherits the turn grant when held | fenced under matching grant; foreign live owner refused; legacy write only when unowned | n/a (synchronous) | generic CLI command error today | `tests/hermes_state/test_conversation_ownership_rewrites.py` |
+| **CLI** — one-shot / batch | `hermes_cli/oneshot.py:466`, `batch_runner.py:349` | per-task session root | core | fenced | core | generic process/task error today | core admission tests |
+| **CLI** — background agent | `hermes_cli/cli_commands_mixin.py:2069`, `:1261` | its own session root | core | `append_messages_batch` (fenced) | core | generic background-agent error today | core admission tests |
+| **Gateway** — send / queued send | `gateway/run.py:21139`, `:5933` → `run_conversation` | root of the resolved `session_id` (post `switch_session`/tip-walk) | core, after `turn_lease` | fenced | core `finally` + gateway `_release_turn_lease` | generic gateway turn error today | core admission tests |
+| **Gateway** — replace / reset | `gateway/session.py:3821` (`replace_messages`), `:3904` (`rewind_to_message`), `:2212` (`promote_to_session_reset`) | root of `session_id` | inherits turn grant when held | fenced under matching grant; foreign live owner refused; legacy write only when unowned | n/a | generic gateway command error today | rewrites tests |
+| **Gateway** — slash flush | `gateway/slash_commands.py:4875` → `append_messages_batch` | root of `session_id` | inherits turn grant when held | fenced under matching grant; foreign live owner refused; legacy write only when unowned | n/a | generic gateway command error today | rewrites tests |
+| **API** — send / stream / retry / rewind / reset / compress / resume | `gateway/platforms/api_server.py:6302`, `:6795` → `run_conversation`; handlers `_handle_session_chat` (:3662), `_handle_session_chat_stream` (:3779), `_handle_chat_completions` (:4102), `_handle_responses` (:5264), `_handle_fork_session` (:3614), `_handle_delete_session` (:3542) | root of `session_id` | core | fenced | core | generic HTTP/SSE error today; typed 409/429 projection remains future adapter work | core admission tests |
+| **API** — 429 fast path | in-memory busy map in `api_server` | derived | *derived only* | — | — | must never be authoritative | — |
+| **Desktop** | `apps/desktop` → `tui_gateway` JSON-RPC (`prompt.submit`) | root of `session_id` | core, via TUI gateway | fenced | core | generic RPC/turn error today | core admission tests |
+| **TUI / dashboard** — prompt submit | `tui_gateway/methods_prompt.py:257` → `run_conversation` (`:1119`, `:1231`), `tui_gateway/server.py:10078`, `compute_host.py:407` | root of `session_id` | core | fenced | core | generic RPC/turn error today | core admission tests |
+| **TUI** — truncate / rewind / replace | `tui_gateway/methods_prompt.py:567` (`replace_messages`), `methods_tools.py:876` (`rewind_to_message`), `methods_session.py:2819` + `server.py:2919` (`append_messages_batch`) | root of `session_id` | inherits turn grant when held | fenced under matching grant; foreign live owner refused; legacy write only when unowned | n/a | generic RPC command error today | rewrites tests |
+| **ACP** — prompt | `acp_adapter/server.py:1919` → `run_conversation` | root of `session_id` | core, inside `state.runtime_lock` | fenced | core `finally`; ACP `cancel` (`server.py:1540`) unwinds the turn, which releases | generic ACP error result today | core admission tests |
+| **ACP** — history replace | `acp_adapter/session.py:492` → `replace_messages` | root of `session_id` | inherits turn grant when held | fenced under matching grant; foreign live owner refused; legacy write only when unowned | n/a | generic ACP error today | rewrites tests |
+| **Cron / background** — scheduled prompt | `cron/scheduler.py:4448` → `run_conversation` on a pool thread | root of the job's session | core | fenced | core `finally` on the pool thread | generic job error today | core admission tests |
+| **Compression** — publish child | `agent/conversation_compression.py:3363` → `publish_compression_child` | root (unchanged by rotation) | inherits the turn grant | fenced | compression lock released independently | generic turn error today | rewrites tests |
+| **Reset promotion** | `hermes_state.py:promote_to_session_reset` | root of `session_id` | inherits turn grant when held | fenced under matching grant; foreign live owner refused; legacy write only when unowned | n/a | ownership error propagates; other legacy failures return `False` | rewrites tests |
+| **Delete / prune** | `hermes_state.py:delete_session`, bulk delete, empty cleanup, prune | root of each target | direct single delete refuses every live owner, including the caller's own grant; maintenance bulk paths skip owned roots | lineage-changing delete never uses the delegate-publication exception; bulk maintenance preserves legacy count contract | n/a | generic caller error for direct conflict; bulk cleanup skips owned rows | rewrites tests |
+
+## API 429 is an optimization, never the authority
+
+plan.md item 6. The API server's in-memory busy map may reject an obvious
+collision early to save a DB round trip, but it derives identity from — and
+defers truth to — the SQLite authority. Its absence, or a process restart that
+empties it, cannot weaken correctness: the admission gate inside
+`run_conversation` runs regardless and is the only thing that decides.
+
+## Durable authority is mandatory while a conversation is live
+
+A store mutation looks up the calling **thread's** grant for that session's
+conversation. A matching grant runs through `execute_fenced_write`. If no grant
+is local, the store resolves the canonical root and checks the durable owner in
+the same write transaction as the mutation: a foreign live owner is refused.
+Legacy direct mutation remains compatible only when no durable owner is live.
+The narrow exception applies only to transcript publication at or below an
+actual parented delegate lineage boundary. The boundary is recognized from the
+real spawn's `_delegate_from` marker (with `delegate`/`subagent` source as a
+compatible signal), must reach a real root, and never exempts deletion, reset,
+or other lineage mutation. A re-rooted label is not an exemption.
+Re-entrancy is thread-scoped, so a nested rewrite inside an owned turn reuses
+the grant while a genuinely concurrent thread or process collides.
+
+## Known gaps carried forward
+
+Recorded rather than silently left out — see EVIDENCE-LEDGER.md for status.
+
+1. **Per-surface conflict projection.** The typed conflict is raised
+   consistently by the core gate; surfaces that do not yet catch
+   `ConversationOwnershipConflict` explicitly will surface it as their generic
+   turn error. Dedicated per-surface projection remains future adapter work.
+2. **Lineage re-rooting is fail-closed while owned.** Direct single-session
+   deletion refuses while a live owner covers the affected root. Bulk, empty,
+   and prune maintenance paths inspect each affected root in their write
+   transaction and skip owned lineages while continuing with unrelated rows,
+   preserving their count/succeed-on-the-rest contracts. This prevents a child
+   from becoming a second acquirable ownership key while the old root is pinned.
+3. **Cross-host holders.** `holder_process_is_dead` refuses to judge a holder
+   recorded on another hostname, so a stale grant from another machine sharing
+   a state DB waits out its TTL. Conservative by design.

--- a/agent/session_ownership.py
+++ b/agent/session_ownership.py
@@ -1,0 +1,550 @@
+"""Canonical conversation ownership — one durable authority, every surface.
+
+Hermes runs the same agent core behind a CLI, a messaging gateway, an HTTP API,
+a TUI, an ACP server, the desktop app and cron. Each of those had its own idea
+of "busy": ``gateway/turn_lease.py`` serialises turns per resolved session id
+*inside one process*, the adapter's ``_active_sessions`` guards a routing key,
+``compression_locks`` serialises rotation. None of them can see a second
+*process* on the same conversation, and ``turn_lease``'s own docstring says so:
+
+    A CLI process sharing the session via CLI-continuity is outside any
+    in-process lock — that pair needs a DB-level lease (separate design).
+
+This module is that design. It is deliberately small: identity, a grant, typed
+conflicts, and a cancellation-safe context manager. The durable mechanics live
+on :class:`hermes_state.SessionDB` beside the store they fence.
+
+Three properties are load-bearing:
+
+**The unit is the conversation root, not the session id.** Context compression
+rotates ``session_id`` to a fresh child segment mid-turn; delegate subagents
+hang off their parent. ``SessionDB.get_conversation_root`` already resolves a
+lineage to one stable id, and that is what ownership keys on — otherwise a
+rotation would silently hand the same conversation to a second owner.
+
+**A grant pins the root it captured.** The root is structurally mutable, so a
+grant that recomputed it on every write could orphan itself mid-turn. It pins
+instead, fenced writes validate the pinned ``(root, holder, fence_token)``, and
+destructive re-rooting paths refuse while a live grant covers the lineage.
+
+**It fails closed.** ``try_acquire_compression_lock`` swallows ``sqlite3.Error``
+and returns False because skipping compression is safe. Skipping *ownership* is
+not — both racers would proceed. Every failure here raises a typed error for
+the calling surface to project; adapters without a dedicated mapping currently
+use their generic error contract. No surface fabricates a transcript message
+to report it (that would break role alternation and the prompt cache).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import re
+import socket
+import threading
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+try:  # psutil is a hard dependency in practice; tolerate scaffold imports.
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - import-environment only
+    psutil = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+# How long a grant stays valid without a refresh. The refresher ticks well
+# inside this, so the TTL only matters when a holder dies without releasing and
+# its pid cannot be proven gone (a different host, or a probe we don't trust).
+DEFAULT_OWNERSHIP_TTL_SECONDS = 300.0
+
+# Ceiling on the refresh interval. A long turn refreshes roughly every minute.
+_MAX_REFRESH_INTERVAL_SECONDS = 60.0
+
+_HOLDER_RE = re.compile(
+    r"host=(?P<host>[^:]*):pid=(?P<pid>\d+):start=(?P<start>-?[0-9.]+)"
+)
+
+_SAFE_TOKEN_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+# ── typed conflicts ────────────────────────────────────────────────────────
+
+
+class ConversationOwnershipError(Exception):
+    """Base for every refusal this authority can issue."""
+
+
+class ConversationOwnershipConflict(ConversationOwnershipError):
+    """Another live holder owns this conversation.
+
+    Raised at *admission* — before any transcript load or write — so a
+    rejected turn leaves the conversation byte-identical. Surfaces may project
+    this into a dedicated idiom or their existing generic error contract; none
+    may answer by appending a message to the transcript.
+    """
+
+    def __init__(
+        self,
+        conversation_root: str,
+        *,
+        holder: str,
+        surface: str = "",
+        session_id: str = "",
+        fence_token: int = 0,
+        expires_at: float = 0.0,
+    ) -> None:
+        self.conversation_root = conversation_root
+        self.holder = holder
+        self.surface = surface
+        self.session_id = session_id
+        self.fence_token = fence_token
+        self.expires_at = expires_at
+        # Public adapters often stringify exceptions generically. Keep the
+        # message bounded and non-diagnostic; structured fields remain
+        # available for trusted logs and explicit internal projections.
+        super().__init__("conversation is currently active in another session")
+
+
+class StaleConversationOwnershipError(ConversationOwnershipError):
+    """The grant used for a fenced write is no longer the current owner.
+
+    This is the fence doing its job: a writer that stalled through a handover
+    is refused *before* its mutation runs, so it cannot publish, replace or
+    delete history that a newer owner has since written.
+    """
+
+    def __init__(
+        self,
+        conversation_root: str,
+        *,
+        expected_fence_token: int,
+        actual_fence_token: Optional[int] = None,
+        actual_holder: Optional[str] = None,
+    ) -> None:
+        self.conversation_root = conversation_root
+        self.expected_fence_token = expected_fence_token
+        self.actual_fence_token = actual_fence_token
+        self.actual_holder = actual_holder
+        super().__init__("conversation ownership changed; retry the operation")
+
+
+class ConversationOwnershipUnavailable(ConversationOwnershipError):
+    """The authority itself could not be consulted.
+
+    Fail closed: an unreachable authority is refused, never assumed granted.
+    In practice a store that cannot serve this write cannot serve the
+    transcript write either, so the turn was already lost.
+    """
+
+    def __init__(self, conversation_root: str, cause: BaseException) -> None:
+        self.conversation_root = conversation_root
+        self.cause = cause
+        super().__init__("conversation ownership authority is temporarily unavailable")
+
+
+# ── identity ───────────────────────────────────────────────────────────────
+
+
+def _hostname() -> str:
+    try:
+        return _SAFE_TOKEN_RE.sub("_", socket.gethostname()) or "unknown"
+    except Exception:  # pragma: no cover - defensive
+        return "unknown"
+
+
+def _process_start_time(pid: int) -> float:
+    """Process create time, or 0.0 when it cannot be read.
+
+    Pairing pid with create time is what makes pid reuse safe: a recycled pid
+    on a rebooted box must not look like a live holder.
+    """
+    if psutil is None:
+        return 0.0
+    try:
+        return float(psutil.Process(pid).create_time())
+    except Exception:
+        return 0.0
+
+
+def new_holder_id(*, surface: str = "") -> str:
+    """Build a globally unique, self-describing holder id.
+
+    ``host``/``pid``/``start`` make liveness decidable on this machine;
+    ``tid``/``nonce`` keep two co-resident acquirers distinct so a release can
+    never free somebody else's grant.
+    """
+    pid = os.getpid()
+    parts = [
+        f"host={_hostname()}",
+        f"pid={pid}",
+        f"start={_process_start_time(pid):.3f}",
+        f"tid={threading.get_ident()}",
+        f"nonce={uuid.uuid4().hex[:12]}",
+    ]
+    if surface:
+        parts.append(f"surface={_SAFE_TOKEN_RE.sub('_', surface)}")
+    return ":".join(parts)
+
+
+def holder_process_is_dead(holder: str) -> bool:
+    """True only when this host can PROVE the holder's process is gone.
+
+    Conservative in every direction that matters: a holder from another host,
+    an unparseable holder, our own pid, a create-time we cannot read, or any
+    probe error all return False and wait for normal TTL expiry. Stealing a
+    live grant corrupts a conversation; waiting out a TTL only delays one.
+    """
+    match = _HOLDER_RE.search(holder or "")
+    if match is None:
+        return False
+    if match.group("host") != _hostname():
+        # A different machine's pid says nothing about liveness here.
+        return False
+    try:
+        pid = int(match.group("pid"))
+    except (TypeError, ValueError):
+        return False
+    if pid <= 0 or pid == os.getpid():
+        return False
+    if psutil is None:
+        return False
+    try:
+        if not psutil.pid_exists(pid):
+            return True
+    except Exception:
+        return False
+    try:
+        recorded_start = float(match.group("start"))
+    except (TypeError, ValueError):
+        return False
+    if recorded_start <= 0:
+        # Holder predates create-time stamping: pid existence is all we have,
+        # and it exists — assume live.
+        return False
+    current_start = _process_start_time(pid)
+    if current_start <= 0:
+        return False
+    # A live pid whose create time moved is a RECYCLED pid: the holder is gone.
+    return abs(current_start - recorded_start) >= 1.0
+
+
+# ── the grant ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class OwnershipGrant:
+    """Proof that this process owns ``conversation_root`` right now.
+
+    ``conversation_root`` is pinned at acquire and never recomputed — see the
+    module docstring. ``fence_token`` is what makes a stale writer detectable
+    after handover.
+    """
+
+    conversation_root: str
+    holder: str
+    fence_token: int
+    surface: str = ""
+    session_id: str = ""
+    acquired_at: float = 0.0
+    expires_at: float = 0.0
+    ttl_seconds: float = DEFAULT_OWNERSHIP_TTL_SECONDS
+    # True when this grant re-uses an outer grant held by the same thread; the
+    # inner scope must not release it.
+    nested: bool = False
+    released: bool = False
+
+
+# ── process-local re-entrancy ──────────────────────────────────────────────
+#
+# One turn legitimately re-enters the authority: the core agent holds the
+# conversation, then compression rotates it, then a rewrite publishes. Those
+# are the SAME owner and must not deadlock against themselves. Re-entrancy is
+# scoped to the acquiring THREAD, so a second thread in the same process (a
+# background fork, a gateway worker) still goes to the durable authority and
+# still collides.
+
+_LOCAL_GRANTS: Dict[Tuple[int, str], List["OwnershipGrant"]] = {}
+_LOCAL_GRANTS_LOCK = threading.Lock()
+
+
+def _local_key(db: Any, conversation_root: str) -> Tuple[int, str]:
+    return (threading.get_ident(), f"{_db_identity(db)}::{conversation_root}")
+
+
+def _db_identity(db: Any) -> str:
+    path = getattr(db, "db_path", None)
+    if path:
+        return str(path)
+    return f"obj:{id(db):x}"
+
+
+def current_grant(db: Any, conversation_root: str) -> Optional[OwnershipGrant]:
+    """The grant this thread already holds for ``conversation_root``, if any."""
+    with _LOCAL_GRANTS_LOCK:
+        stack = _LOCAL_GRANTS.get(_local_key(db, conversation_root))
+        return stack[-1] if stack else None
+
+
+def current_grant_for_session(db: Any, session_id: str) -> Optional[OwnershipGrant]:
+    """Return this thread's grant covering ``session_id``, if one exists."""
+    root = resolve_conversation_root(db, session_id)
+    return current_grant(db, root) if root else None
+
+
+def _push_local(db: Any, grant: OwnershipGrant) -> None:
+    with _LOCAL_GRANTS_LOCK:
+        _LOCAL_GRANTS.setdefault(_local_key(db, grant.conversation_root), []).append(
+            grant
+        )
+
+
+def _pop_local(db: Any, grant: OwnershipGrant) -> None:
+    key = _local_key(db, grant.conversation_root)
+    with _LOCAL_GRANTS_LOCK:
+        stack = _LOCAL_GRANTS.get(key)
+        if not stack:
+            return
+        # Remove by identity so an out-of-order unwind cannot pop a sibling.
+        for index in range(len(stack) - 1, -1, -1):
+            if stack[index] is grant:
+                del stack[index]
+                break
+        if not stack:
+            _LOCAL_GRANTS.pop(key, None)
+
+
+# ── lease refresher ────────────────────────────────────────────────────────
+
+
+class OwnershipLeaseRefresher:
+    """Keeps a grant alive across a long turn.
+
+    Mirrors the compression lock's refresher: tolerate transient failures for
+    at most one lease's worth of time, so a blip recovers on the next tick
+    while the give-up window stays bounded by the TTL the acquirer set.
+    """
+
+    def __init__(
+        self,
+        db: Any,
+        grant: OwnershipGrant,
+        *,
+        refresh_interval_seconds: Optional[float] = None,
+    ) -> None:
+        self._db = db
+        self._grant = grant
+        ttl = float(grant.ttl_seconds or DEFAULT_OWNERSHIP_TTL_SECONDS)
+        if refresh_interval_seconds is None:
+            refresh_interval_seconds = max(
+                1.0, min(_MAX_REFRESH_INTERVAL_SECONDS, ttl / 3.0)
+            )
+        self._interval = max(0.05, float(refresh_interval_seconds))
+        self._max_consecutive_failures = max(1, int(ttl / self._interval))
+        self._stop = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="conversation-ownership-refresh",
+            daemon=True,
+        )
+
+    def start(self) -> "OwnershipLeaseRefresher":
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread.is_alive() and threading.current_thread() is not self._thread:
+            # A late refresh on an already-released grant matches rowcount 0.
+            self._thread.join(timeout=1.0)
+
+    def _run(self) -> None:
+        consecutive_failures = 0
+        while not self._stop.wait(self._interval):
+            try:
+                ok = bool(self._db.refresh_conversation_ownership(self._grant))
+            except Exception as exc:  # authority blip — bounded tolerance
+                ok = False
+                logger.debug(
+                    "conversation ownership refresh raised for %s: %s",
+                    self._grant.conversation_root,
+                    exc,
+                )
+            if ok:
+                consecutive_failures = 0
+                continue
+            consecutive_failures += 1
+            if consecutive_failures >= self._max_consecutive_failures:
+                logger.warning(
+                    "conversation ownership refresh gave up for %s after %d "
+                    "consecutive failures — the grant will expire on its TTL",
+                    self._grant.conversation_root,
+                    consecutive_failures,
+                )
+                return
+
+
+# ── the admission point every surface calls ────────────────────────────────
+
+
+def resolve_conversation_root(db: Any, session_id: str) -> str:
+    """Canonical conversation identity for ``session_id``.
+
+    A session with no row yet is its own root, which is exactly what
+    ``get_conversation_root`` returns for it. An exception is different: the
+    identity authority could not be consulted, so admission must fail closed.
+    """
+    if not session_id:
+        return ""
+    try:
+        root = db.get_conversation_root(session_id)
+    except Exception as exc:
+        raise ConversationOwnershipUnavailable(str(session_id), exc) from exc
+    return str(root or session_id)
+
+
+def is_durable_store(db: Any) -> bool:
+    """True only for a real :class:`hermes_state.SessionDB`.
+
+    A stub, mock or duck-typed store has no ``conversation_ownership`` table to
+    fence, so calling into it would both mislead the caller (a "grant" that
+    guarantees nothing) and perturb the mock-call assertions those stubs exist
+    to make. Imported lazily because ``hermes_state`` imports this module.
+    """
+    if db is None:
+        return False
+    try:
+        from hermes_state import SessionDB
+    except Exception:  # pragma: no cover - import-environment only
+        return False
+    return isinstance(db, SessionDB)
+
+
+def should_own_conversation(agent: Any) -> bool:
+    """Does this agent contend for its conversation?
+
+    Three populations legitimately run *inside* a conversation somebody else
+    owns, and must never take the grant:
+
+    * **Persist-disabled forks** (background review) share the live session id
+      for prompt-cache warmth but are hard-stopped from every transcript write.
+      Contending would starve the real turn for nothing.
+    * **Delegate subagents.** A subagent's conversation root resolves through
+      ``_parent_session_id`` to the parent's root — by design, so a whole
+      delegation tree tags as one conversation. They run concurrently with the
+      parent turn that launched them; acquiring would deadlock delegation
+      against itself.
+    * **Store-less agents** (evals, scaffolds) and agents wired to a stub store
+      have no durable transcript to protect.
+    """
+    if agent is None:
+        return False
+    if getattr(agent, "_persist_disabled", False):
+        return False
+    if not str(getattr(agent, "session_id", "") or ""):
+        return False
+    if not is_durable_store(getattr(agent, "_session_db", None)):
+        return False
+    if str(getattr(agent, "platform", "") or "") == "subagent":
+        return False
+    if str(getattr(agent, "_parent_session_id", "") or ""):
+        return False
+    return True
+
+
+def ownership_admission_surface(agent: Any) -> str:
+    """The surface name recorded on the grant and echoed in conflicts.
+
+    The rejected surface is usually not the one squatting on the conversation,
+    so this has to be something a human recognises ("telegram", "cli", "acp")
+    rather than a pid.
+    """
+    return str(getattr(agent, "platform", "") or "") or "agent"
+
+
+@contextlib.contextmanager
+def own_conversation(
+    db: Any,
+    session_id: str,
+    *,
+    surface: str,
+    ttl_seconds: float = DEFAULT_OWNERSHIP_TTL_SECONDS,
+    enabled: bool = True,
+    refresh_interval_seconds: Optional[float] = None,
+):
+    """Hold the conversation for the body, release on EVERY exit path.
+
+    Yields the :class:`OwnershipGrant`, or ``None`` when ownership does not
+    apply (no store, no session id, or an explicitly opted-out caller such as a
+    persist-disabled background fork, which can never write the transcript and
+    must not contend for it).
+
+    Cancellation safety is the ``finally``: ``KeyboardInterrupt``,
+    ``asyncio.CancelledError``, a generator close and an ordinary exception all
+    unwind through it. Release is holder- and fence-scoped, so a late unwind
+    can never free a newer owner's grant.
+    """
+    if not enabled or db is None or not session_id:
+        yield None
+        return
+
+    root = resolve_conversation_root(db, session_id)
+    if not root:
+        yield None
+        return
+
+    existing = current_grant(db, root)
+    if existing is not None:
+        nested = OwnershipGrant(
+            conversation_root=existing.conversation_root,
+            holder=existing.holder,
+            fence_token=existing.fence_token,
+            surface=existing.surface,
+            session_id=str(session_id),
+            acquired_at=existing.acquired_at,
+            expires_at=existing.expires_at,
+            ttl_seconds=existing.ttl_seconds,
+            nested=True,
+        )
+        yield nested
+        return
+
+    grant = db.try_acquire_conversation_ownership(
+        root,
+        new_holder_id(surface=surface),
+        ttl_seconds=ttl_seconds,
+        surface=surface,
+        session_id=str(session_id),
+    )
+    _push_local(db, grant)
+    refresher = OwnershipLeaseRefresher(
+        db, grant, refresh_interval_seconds=refresh_interval_seconds
+    ).start()
+    try:
+        yield grant
+    finally:
+        refresher.stop()
+        _pop_local(db, grant)
+        try:
+            db.release_conversation_ownership(grant)
+        except Exception as exc:  # release is best-effort; TTL is the backstop
+            logger.warning(
+                "conversation ownership release failed for %s: %s",
+                grant.conversation_root,
+                exc,
+            )
+
+
+def describe_conflict(exc: ConversationOwnershipConflict) -> str:
+    """One user-facing sentence, shared by every surface's projection.
+
+    Naming the holding surface is the difference between an actionable message
+    and "try again later" — the surface that gets rejected is usually not the
+    one squatting on the conversation.
+    """
+    surface = exc.surface or "another session"
+    return (
+        f"This conversation is currently owned by {surface}. "
+        "Finish or stop that session before continuing here."
+    )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -35,6 +35,15 @@ from pathlib import Path
 
 from agent.memory_manager import sanitize_context
 from agent.session_activity import ActivityProvenance
+from agent.session_ownership import (
+    DEFAULT_OWNERSHIP_TTL_SECONDS,
+    ConversationOwnershipConflict,
+    ConversationOwnershipError,
+    ConversationOwnershipUnavailable,
+    OwnershipGrant,
+    StaleConversationOwnershipError,
+    holder_process_is_dead,
+)
 from agent.message_sanitization import _sanitize_surrogates
 from agent.skill_commands import (
     SKILL_EXCERPT_JOINT,
@@ -5224,8 +5233,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return cursor.rowcount
 
         try:
-            rows = self._execute_write(_do)
+            rows = self._execute_conversation_write(session_id, _do)
             return bool(rows)
+        except ConversationOwnershipError:
+            raise
         except Exception:
             return False
 
@@ -5746,6 +5757,506 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if row is None:
             return None
         return row["holder"] if isinstance(row, sqlite3.Row) else row[0]
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Canonical conversation ownership — the durable cross-process authority
+    # ──────────────────────────────────────────────────────────────────────
+    #
+    # ONE owner per user-facing conversation, across processes and surfaces.
+    # ``gateway/turn_lease.py`` already serialises turns per resolved session
+    # id inside a single process; it cannot see a second process, and says so
+    # in its own docstring. This is the DB-level lease it defers to.
+    #
+    # Relationship to ``compression_locks`` above — two tables, ONE authority
+    # each, answering different questions:
+    #
+    #   conversation_ownership : may this process mutate the conversation?
+    #   compression_locks      : which rotation inside an owned conversation
+    #                            wins when two paths compress at once?
+    #
+    # The second is strictly narrower and lives inside the first. Ownership
+    # never consults it and it never grants ownership.
+    #
+    # Two deliberate departures from the compression lock's mechanics:
+    #
+    #   * FENCING. The row is UPDATEd in place on takeover, never deleted, so
+    #     ``fence_token`` is monotonic per root and a writer that stalled
+    #     through a handover is detectable. Release blanks ``holder`` and
+    #     leaves the token, so the released grant cannot pass validation and
+    #     the next acquirer still gets a strictly newer token.
+    #   * FAIL CLOSED. ``try_acquire_compression_lock`` returns False on
+    #     ``sqlite3.Error`` because skipping compression is safe; skipping
+    #     ownership would let both racers proceed. Every failure here raises
+    #     :class:`ConversationOwnershipUnavailable`.
+    _OWNERSHIP_SELECT_SQL = (
+        "SELECT holder, fence_token, surface, session_id, acquired_at, "
+        "refreshed_at, expires_at FROM conversation_ownership "
+        "WHERE conversation_root = ?"
+    )
+
+    @staticmethod
+    def _ownership_row_to_dict(row: Any) -> Dict[str, Any]:
+        if isinstance(row, sqlite3.Row) or hasattr(row, "keys"):
+            return {key: row[key] for key in row.keys()}
+        keys = (
+            "holder", "fence_token", "surface", "session_id",
+            "acquired_at", "refreshed_at", "expires_at",
+        )
+        return dict(zip(keys, row))
+
+    def try_acquire_conversation_ownership(
+        self,
+        conversation_root: str,
+        holder: str,
+        *,
+        ttl_seconds: float = DEFAULT_OWNERSHIP_TTL_SECONDS,
+        surface: str = "",
+        session_id: str = "",
+    ) -> OwnershipGrant:
+        """Take exclusive ownership of ``conversation_root`` or refuse.
+
+        Returns an :class:`OwnershipGrant` carrying the fence token the caller
+        must present for every subsequent mutation. Raises
+        :class:`ConversationOwnershipConflict` when a live holder owns it, and
+        :class:`ConversationOwnershipUnavailable` when the authority itself
+        cannot be consulted. It never returns without a decision.
+
+        Callers acquire at ADMISSION — before the transcript is loaded — so a
+        refusal leaves the conversation byte-identical and no synthetic message
+        is ever appended to explain it.
+
+        A grant is reclaimed early when the holder's process is provably gone
+        (:func:`holder_process_is_dead`), so a killed CLI does not strand the
+        conversation for the full TTL; otherwise ``expires_at`` is the backstop.
+        """
+        if not conversation_root:
+            raise ValueError("conversation_root is required")
+        if not holder:
+            raise ValueError("holder is required")
+        ttl = max(0.001, float(ttl_seconds or DEFAULT_OWNERSHIP_TTL_SECONDS))
+
+        def _do(conn):
+            # Sample only after _execute_write has obtained BEGIN IMMEDIATE.
+            # SQLite lock patience must not consume this grant's useful TTL.
+            now = time.time()
+            expires_at = now + ttl
+            row = conn.execute(
+                self._OWNERSHIP_SELECT_SQL, (conversation_root,)
+            ).fetchone()
+            if row is None:
+                conn.execute(
+                    "INSERT INTO conversation_ownership "
+                    "(conversation_root, holder, fence_token, surface, "
+                    "session_id, acquired_at, refreshed_at, expires_at) "
+                    "VALUES (?, ?, 1, ?, ?, ?, ?, ?)",
+                    (conversation_root, holder, surface, session_id,
+                     now, now, expires_at),
+                )
+                return 1, None, now, expires_at
+
+            current = self._ownership_row_to_dict(row)
+            current_holder = str(current.get("holder") or "")
+            current_fence = int(current.get("fence_token") or 0)
+            current_expires = float(current.get("expires_at") or 0.0)
+
+            if current_holder == holder:
+                # Same holder re-acquiring (a retried admission): extend, keep
+                # the token so any fenced write already issued stays valid.
+                conn.execute(
+                    "UPDATE conversation_ownership SET refreshed_at = ?, "
+                    "expires_at = ?, session_id = ?, surface = ? "
+                    "WHERE conversation_root = ?",
+                    (now, expires_at, session_id, surface, conversation_root),
+                )
+                return current_fence, None, now, expires_at
+
+            reclaimable = (
+                not current_holder
+                or current_expires < now
+                or holder_process_is_dead(current_holder)
+            )
+            if not reclaimable:
+                return None, current, now, expires_at
+
+            fence = current_fence + 1
+            conn.execute(
+                "UPDATE conversation_ownership SET holder = ?, fence_token = ?, "
+                "surface = ?, session_id = ?, acquired_at = ?, refreshed_at = ?, "
+                "expires_at = ? WHERE conversation_root = ?",
+                (holder, fence, surface, session_id, now, now, expires_at,
+                 conversation_root),
+            )
+            return fence, (current if current_holder else None), now, expires_at
+
+        try:
+            fence, blocking, acquired_at, expires_at = self._execute_write(_do)
+        except ConversationOwnershipError:
+            raise
+        except Exception as exc:
+            # Fail closed. A store that cannot answer this cannot serve the
+            # transcript write either, so nothing is lost by refusing — and a
+            # silent grant here would let both racers into the conversation.
+            raise ConversationOwnershipUnavailable(conversation_root, exc) from exc
+
+        if fence is None:
+            blocking = blocking or {}
+            raise ConversationOwnershipConflict(
+                conversation_root,
+                holder=str(blocking.get("holder") or ""),
+                surface=str(blocking.get("surface") or ""),
+                session_id=str(blocking.get("session_id") or ""),
+                fence_token=int(blocking.get("fence_token") or 0),
+                expires_at=float(blocking.get("expires_at") or 0.0),
+            )
+        if blocking:
+            logger.warning(
+                "Reclaimed conversation ownership for %s from a dead or expired "
+                "holder (%s, surface=%s)",
+                conversation_root,
+                blocking.get("holder"),
+                blocking.get("surface") or "unknown",
+            )
+        return OwnershipGrant(
+            conversation_root=conversation_root,
+            holder=holder,
+            fence_token=int(fence),
+            surface=surface,
+            session_id=session_id,
+            acquired_at=acquired_at,
+            expires_at=expires_at,
+            ttl_seconds=ttl,
+        )
+
+    def refresh_conversation_ownership(
+        self,
+        grant: OwnershipGrant,
+        ttl_seconds: Optional[float] = None,
+    ) -> bool:
+        """Extend ``grant``'s lease iff it is still the current owner.
+
+        Identity is ``(holder, fence_token)``, deliberately NOT ``expires_at``:
+        a live owner whose refresher thread was starved past its own TTL must
+        be able to revive a row nobody has claimed. A row someone else already
+        took has a different holder, so this matches nothing and returns False
+        — which is how the refresher learns it lost the conversation.
+        """
+        if grant is None or not grant.conversation_root or not grant.holder:
+            return False
+        ttl = max(
+            0.001, float(ttl_seconds or grant.ttl_seconds or DEFAULT_OWNERSHIP_TTL_SECONDS)
+        )
+        def _do(conn):
+            # As with acquire, sample after BEGIN IMMEDIATE so writer-lock
+            # patience cannot consume the refreshed lease before publication.
+            now = time.time()
+            expires_at = now + ttl
+            cur = conn.execute(
+                "UPDATE conversation_ownership SET refreshed_at = ?, expires_at = ? "
+                "WHERE conversation_root = ? AND holder = ? AND fence_token = ?",
+                (now, expires_at, grant.conversation_root, grant.holder,
+                 grant.fence_token),
+            )
+            return cur.rowcount > 0, expires_at
+
+        try:
+            refreshed, expires_at = self._execute_write(_do)
+            refreshed = bool(refreshed)
+        except Exception as exc:
+            logger.warning(
+                "refresh_conversation_ownership(%s) failed: %s",
+                grant.conversation_root, exc,
+            )
+            return False
+        if refreshed:
+            grant.expires_at = expires_at
+        return refreshed
+
+    def release_conversation_ownership(self, grant: OwnershipGrant) -> None:
+        """Release ``grant`` iff it is still the current owner. Idempotent.
+
+        Blanks ``holder`` and leaves ``fence_token`` in place: the released
+        grant can no longer pass a fenced write (holder mismatch) and the next
+        acquirer still gets a strictly newer token. A nested grant is a no-op —
+        the outer scope owns the lifetime.
+
+        Holder- AND fence-scoped so a late unwind can never free a newer
+        owner's grant (the #28686 ownership lesson).
+        """
+        if grant is None or grant.nested or not grant.conversation_root:
+            return
+        if not grant.holder:
+            return
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE conversation_ownership SET holder = '', expires_at = 0 "
+                "WHERE conversation_root = ? AND holder = ? AND fence_token = ?",
+                (grant.conversation_root, grant.holder, grant.fence_token),
+            )
+
+        try:
+            self._execute_write(_do)
+        except Exception as exc:
+            # Best effort: the TTL is the backstop, and a dead holder is
+            # reclaimed by process-liveness anyway.
+            logger.warning(
+                "release_conversation_ownership(%s) failed: %s",
+                grant.conversation_root, exc,
+            )
+        finally:
+            grant.released = True
+
+    def get_conversation_owner(
+        self, conversation_root: str
+    ) -> Optional[Dict[str, Any]]:
+        """The current live owner row for ``conversation_root``, or None.
+
+        Diagnostics and conflict projection only — never the admission path.
+        """
+        if not conversation_root:
+            return None
+        row = self._conn.execute(
+            self._OWNERSHIP_SELECT_SQL, (conversation_root,)
+        ).fetchone()
+        if row is None:
+            return None
+        owner = self._ownership_row_to_dict(row)
+        if not str(owner.get("holder") or ""):
+            return None
+        if float(owner.get("expires_at") or 0.0) < time.time():
+            return None
+        owner["conversation_root"] = conversation_root
+        return owner
+
+    @staticmethod
+    def _conversation_root_in_transaction(
+        conn: sqlite3.Connection,
+        session_id: str,
+    ) -> str:
+        """Resolve lineage identity without leaving the active transaction."""
+        current = session_id
+        chain: list[str] = []
+        seen: set[str] = set()
+        # Mirror ``_session_lineage_root_to_tip`` exactly; admission and
+        # transactional guards must resolve the same authority key even on
+        # malformed deep or cyclic lineage.
+        for _ in range(100):
+            if not current or current in seen:
+                break
+            seen.add(current)
+            chain.append(current)
+            row = conn.execute(
+                "SELECT parent_session_id FROM sessions WHERE id = ?",
+                (current,),
+            ).fetchone()
+            if row is None:
+                break
+            parent = row["parent_session_id"] if hasattr(row, "keys") else row[0]
+            current = str(parent) if parent else ""
+        return chain[-1] if chain and chain[-1] else session_id
+
+    def _refuse_live_conversation_owner(
+        self,
+        conn: sqlite3.Connection,
+        conversation_root: str,
+        *,
+        allow_current_grant: bool = True,
+    ) -> None:
+        """Refuse a destructive mutation covered by a live owner.
+
+        ``parent_session_id`` is mutable.  Orphaning a child can therefore
+        change the ownership key seen by a new process from ``root`` to
+        ``child`` while an admitted turn still pins ``root``.  Checking the
+        covering row in the SAME write transaction as the lineage mutation
+        prevents that split authority.  Ordinary fenced mutations may allow
+        this thread's exact grant; a re-rooting mutation must set
+        ``allow_current_grant=False`` because even the current holder would
+        otherwise leave its pinned old key live beside the child's new key.
+        """
+        if not conversation_root:
+            return
+        row = conn.execute(
+            self._OWNERSHIP_SELECT_SQL, (conversation_root,)
+        ).fetchone()
+        if row is None:
+            return
+        owner = self._ownership_row_to_dict(row)
+        holder = str(owner.get("holder") or "")
+        expires_at = float(owner.get("expires_at") or 0.0)
+        if not holder or expires_at < time.time():
+            return
+
+        from agent.session_ownership import current_grant
+
+        grant = current_grant(self, conversation_root)
+        if allow_current_grant and (
+            grant is not None
+            and grant.holder == holder
+            and int(grant.fence_token) == int(owner.get("fence_token") or 0)
+        ):
+            return
+        raise ConversationOwnershipConflict(
+            conversation_root,
+            holder=holder,
+            surface=str(owner.get("surface") or ""),
+            session_id=str(owner.get("session_id") or ""),
+            fence_token=int(owner.get("fence_token") or 0),
+            expires_at=expires_at,
+        )
+
+    def _conversation_has_live_owner(
+        self,
+        conn: sqlite3.Connection,
+        conversation_root: str,
+    ) -> bool:
+        """Whether maintenance must skip this lineage in the active transaction."""
+        if not conversation_root:
+            return False
+        row = conn.execute(
+            self._OWNERSHIP_SELECT_SQL, (conversation_root,)
+        ).fetchone()
+        if row is None:
+            return False
+        owner = self._ownership_row_to_dict(row)
+        return bool(str(owner.get("holder") or "")) and float(
+            owner.get("expires_at") or 0.0
+        ) >= time.time()
+
+    @staticmethod
+    def _is_below_concurrent_delegate_boundary(
+        conn: sqlite3.Connection, session_id: str
+    ) -> bool:
+        """Whether the target is at/below a real delegate lineage boundary.
+
+        Delegate/subagent agents intentionally run concurrently with their
+        parent turn and do not acquire the parent's grant. Their own segment and
+        descendants they rotate into are independently writable, while keeping
+        the user-facing conversation root for tagging. A source label on a
+        re-rooted row is not enough: the delegate row must still have a parent.
+        """
+        current = session_id
+        seen: set[str] = set()
+        crossed_delegate_boundary = False
+        for _ in range(100):
+            if not current or current in seen:
+                return False
+            seen.add(current)
+            row = conn.execute(
+                "SELECT source, parent_session_id, model_config "
+                "FROM sessions WHERE id = ?",
+                (current,),
+            ).fetchone()
+            if row is None:
+                return False
+            if hasattr(row, "keys"):
+                source = row["source"]
+                parent = row["parent_session_id"]
+                model_config = row["model_config"]
+            else:
+                source, parent, model_config = row[0], row[1], row[2]
+            delegate_from = ""
+            if model_config:
+                try:
+                    parsed_config = json.loads(model_config)
+                    if isinstance(parsed_config, dict):
+                        delegate_from = str(parsed_config.get("_delegate_from") or "")
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    delegate_from = ""
+            if (
+                (
+                    str(source or "").strip().lower() in {"delegate", "subagent"}
+                    or (delegate_from and delegate_from == str(parent or ""))
+                )
+                and parent
+            ):
+                crossed_delegate_boundary = True
+            if not parent:
+                return crossed_delegate_boundary
+            current = str(parent)
+        return False
+
+    def execute_fenced_write(
+        self,
+        grant: OwnershipGrant,
+        fn: Callable[[sqlite3.Connection], T],
+        *,
+        patience_s: Optional[float] = None,
+    ) -> T:
+        """Run *fn* only if ``grant`` is still the owner, in ONE transaction.
+
+        The fence check and the mutation share a transaction, so a handover
+        cannot slip between them. On a stale grant *fn* never runs at all —
+        this is refuse-before-mutate, not mutate-then-notice.
+
+        Validation is against the root the grant PINNED at acquire time; it is
+        never recomputed. Deleting an ancestor re-roots a session mid-turn, and
+        a grant that chased the recomputed root would silently stop fencing
+        exactly when lineage is being rewritten.
+        """
+        if grant is None or not grant.conversation_root:
+            raise ValueError("a conversation ownership grant is required")
+
+        def _do(conn):
+            row = conn.execute(
+                self._OWNERSHIP_SELECT_SQL, (grant.conversation_root,)
+            ).fetchone()
+            current = self._ownership_row_to_dict(row) if row is not None else {}
+            current_holder = str(current.get("holder") or "")
+            current_fence = current.get("fence_token")
+            if (
+                row is None
+                or current_holder != grant.holder
+                or int(current_fence or 0) != int(grant.fence_token)
+                or float(current.get("expires_at") or 0.0) < time.time()
+            ):
+                raise StaleConversationOwnershipError(
+                    grant.conversation_root,
+                    expected_fence_token=int(grant.fence_token),
+                    actual_fence_token=(
+                        int(current_fence) if current_fence is not None else None
+                    ),
+                    actual_holder=current_holder or None,
+                )
+            return fn(conn)
+
+        return self._execute_write(_do, patience_s=patience_s)
+
+    def _execute_conversation_write(
+        self,
+        session_id: str,
+        fn: Callable[[sqlite3.Connection], T],
+        *,
+        patience_s: Optional[float] = None,
+        allow_delegate_publication: bool = False,
+    ) -> T:
+        """Fence ``fn`` against any durable owner of ``session_id``.
+
+        A matching process-local grant takes the strict holder/fence path.
+        Callers without a local grant retain legacy behavior only when no live
+        durable owner exists; a foreign owner is checked and refused inside the
+        same write transaction as ``fn``. Explicit delegate/subagent lineage
+        segments are a narrow exception only when the caller marks ``fn`` as
+        transcript publication; lineage mutation never bypasses the owner.
+        """
+        from agent.session_ownership import current_grant_for_session
+
+        grant = current_grant_for_session(self, session_id)
+        if grant is not None:
+            return self.execute_fenced_write(grant, fn, patience_s=patience_s)
+
+        def _do_unowned(conn: sqlite3.Connection) -> T:
+            if (
+                allow_delegate_publication
+                and self._is_below_concurrent_delegate_boundary(conn, session_id)
+            ):
+                return fn(conn)
+            root = self._conversation_root_in_transaction(conn, session_id)
+            self._refuse_live_conversation_owner(
+                conn, root, allow_current_grant=False
+            )
+            return fn(conn)
+
+        return self._execute_write(_do_unowned, patience_s=patience_s)
 
     def touch_session_activity(
         self,
@@ -8192,8 +8703,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # a sibling process legitimately holding the write lock for seconds
         # (VACUUM, TRUNCATE checkpoint at close, an older pre-bounded-merge
         # process's FTS optimize) can't destroy a healthy turn (#74478).
-        return self._execute_write(
-            _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
+        return self._execute_conversation_write(
+            session_id,
+            _do,
+            patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S,
+            allow_delegate_publication=True,
         )
 
     def append_messages_batch(
@@ -8265,8 +8779,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return inserted
 
         # Same criticality as append_message: this IS the turn's transcript.
-        return self._execute_write(
-            _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
+        return self._execute_conversation_write(
+            session_id,
+            _do,
+            patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S,
+            allow_delegate_publication=True,
         )
 
     def set_latest_matching_message_display_kind(
@@ -8687,7 +9204,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (total_messages, total_tool_calls, session_id),
             )
 
-        self._execute_write(_do)
+        self._execute_conversation_write(session_id, _do)
 
     def has_archived_messages(self, session_id: str) -> bool:
         """Return True if the session has any soft-archived (``active = 0``) rows.
@@ -8776,7 +9293,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
             return inserted
 
-        return self._execute_write(_do)
+        return self._execute_conversation_write(
+            session_id, _do, allow_delegate_publication=True
+        )
 
     def set_latest_user_api_content(
         self, session_id: str, content: Any, api_content: str
@@ -9577,7 +10096,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             return ids
 
-        rewound = self._execute_write(_do)
+        rewound = self._execute_conversation_write(session_id, _do)
 
         # 2) Compute new head id (largest still-active row id in session).
         with self._lock:
@@ -9615,7 +10134,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
             return len(ids)
 
-        return self._execute_write(_do)
+        return self._execute_conversation_write(session_id, _do)
 
     # =========================================================================
     # Search
@@ -9981,6 +10500,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             if cursor.fetchone() is None:
                 return False
+            root = self._conversation_root_in_transaction(conn, session_id)
+            self._refuse_live_conversation_owner(
+                conn, root, allow_current_grant=False
+            )
             if expected_ids is not None:
                 actual_ids = {
                     session_id,
@@ -10000,7 +10523,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._delete_unreferenced_system_prompts(conn)
             return True
 
-        deleted = self._execute_write(_do)
+        deleted = self._execute_conversation_write(session_id, _do)
         if deleted:
             for delegate_id in removed_delegate_ids:
                 self._remove_session_files(sessions_dir, delegate_id)
@@ -10046,7 +10569,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._delete_unreferenced_system_prompts(conn)
             return cursor.rowcount > 0
 
-        deleted = self._execute_write(_do)
+        deleted = self._execute_conversation_write(session_id, _do)
         if deleted:
             self._remove_session_files(sessions_dir, session_id)
         return bool(deleted)
@@ -10101,6 +10624,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 unique_ids,
             )
             existing = [row["id"] for row in cursor.fetchall()]
+            if not existing:
+                return 0
+
+            # Preserve the bulk API's succeed-on-the-rest contract: an owned
+            # lineage is skipped rather than aborting deletion of unrelated
+            # sessions in the same request.
+            existing = [
+                sid
+                for sid in existing
+                if not self._conversation_has_live_owner(
+                    conn, self._conversation_root_in_transaction(conn, sid)
+                )
+            ]
             if not existing:
                 return 0
 
@@ -10200,6 +10736,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             session_ids = {row["id"] for row in cursor.fetchall()}
 
+            if not session_ids:
+                return 0
+
+            session_ids = {
+                sid
+                for sid in session_ids
+                if not self._conversation_has_live_owner(
+                    conn, self._conversation_root_in_transaction(conn, sid)
+                )
+            }
             if not session_ids:
                 return 0
 
@@ -10541,6 +11087,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             session_ids = {row["id"] for row in cursor.fetchall()}
 
+            if not session_ids:
+                return 0
+
+            session_ids = {
+                sid
+                for sid in session_ids
+                if not self._conversation_has_live_owner(
+                    conn, self._conversation_root_in_transaction(conn, sid)
+                )
+            }
             if not session_ids:
                 return 0
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -383,6 +383,32 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     expires_at REAL NOT NULL
 );
 
+-- Durable cross-process ownership of one user-facing conversation.
+--
+-- Keyed by CONVERSATION ROOT (see SessionDB.get_conversation_root), not by
+-- session_id: compression rotates session_id to a fresh segment mid-turn and
+-- delegate subagents hang off their parent, so a session-id key would hand one
+-- conversation to two owners the moment it rotated.
+--
+-- Deliberately NOT a foreign key onto sessions(id): a surface acquires before
+-- the session row exists (CLI admission happens before history load), and a
+-- grant must survive ancestor deletion re-rooting its children.
+--
+-- ``fence_token`` is monotonic per root and survives handover: the row is
+-- UPDATEd in place on takeover rather than deleted, so a slow writer holding
+-- an older token can be rejected instead of silently publishing over newer
+-- history. This is what makes the authority a fence and not just a lock.
+CREATE TABLE IF NOT EXISTS conversation_ownership (
+    conversation_root TEXT PRIMARY KEY,
+    holder TEXT NOT NULL,
+    fence_token INTEGER NOT NULL,
+    surface TEXT NOT NULL DEFAULT '',
+    session_id TEXT NOT NULL DEFAULT '',
+    acquired_at REAL NOT NULL,
+    refreshed_at REAL NOT NULL,
+    expires_at REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
     origin_session TEXT NOT NULL,
@@ -419,6 +445,8 @@ CREATE INDEX IF NOT EXISTS idx_messages_assistant_calls_by_session
     ON messages(session_id)
     WHERE role = 'assistant' AND tool_calls IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
+CREATE INDEX IF NOT EXISTS idx_conversation_ownership_expires
+    ON conversation_ownership(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,238 @@
+# Hermes Current-Upstream Session Ownership Port Plan
+
+**Goal:** Produce one clean, current-`origin/main` commit that preserves v7 as immutable evidence, ports the smallest universal SQLite lease/fencing solution, removes installation-specific core coupling, verifies every mutating surface, and leaves a complete implementation/report/deployment manifest.
+
+**Authoritative controller:** The current Hermes Agent session. Claude/Codex workers may investigate or implement isolated pathsets, but cannot stage, commit, push, deploy, or change task status.
+
+**Timebox:** 8–12 focused hours. Stop expansion after the stated acceptance criteria. This is a one-long-day repair, not a new multi-day product program.
+
+## Scope discipline
+
+### Must ship in this commit
+
+1. Immutable v7 historical bundle and evidence ledger.
+2. Clean worktree and branch from freshly fetched `origin/main`.
+3. Current-upstream mutating-surface inventory and ownership table.
+4. Small universal SQLite lease/fencing kernel with canonical conversation identity.
+5. RED→GREEN coverage for all current mutating entry points.
+6. API 429 fast-path derived from, but never authoritative over, SQLite ownership.
+7. Removal of private `orchestration-sessions.json` knowledge from Hermes core.
+8. Installation-specific delegation defaults moved to supported profile/config/provider contracts.
+9. Canonical route identities; no `claude-*` prefix inference.
+10. Focused, broad, Desktop, dashboard, and private Workspace acceptance evidence.
+11. Frozen immutable candidate, independent review, one coherent Git commit, completion report, and versioned temporary-patch manifest.
+
+### Explicitly not part of this repair
+
+- Rebuilding the comprehensive private Workspace.
+- Porting every Workspace screen into official clients.
+- Redesigning unrelated delegation UX.
+- Broad cleanup, formatting, EOL normalization, generated website changes, or opportunistic refactors.
+- Deploying before immutable review passes.
+- Pushing unless separately authorized after the local commit is verified.
+
+## Time budget
+
+| Phase | Budget | Exit condition |
+|---|---:|---|
+| Preserve v7 and create clean branch/worktree | 30 min | Bundle hashes verify; new worktree is clean at fetched `origin/main` |
+| Re-inventory upstream and write ownership table | 60 min | Every current mutating surface has exact source/test paths and an owner |
+| RED tests and minimal kernel port | 3–4 hr | Each vertical behavior was observed RED then GREEN |
+| Remove private coupling and normalize routing/config | 1–1.5 hr | No private schema/prefix inference remains in core; E2E config tests pass |
+| Focused + broad + client acceptance | 1.5–2 hr | No new normalized failures; Desktop/dashboard/Workspace smoke evidence recorded |
+| Freeze, parallel immutable reviews, remediation | 1–2 hr | Current artifact hash has no unresolved P0/P1 |
+| Commit, report, manifest, post-commit verification | 45 min | One verified commit; clean worktree; committed diff equals approved bytes |
+
+Expected total: 8–12 hours. If current upstream already implements part of v7, the lower bound is realistic. If broad tests reveal unrelated upstream failures, compare exact baseline signatures rather than turning this into a repository-wide cleanup.
+
+## Phase 0 — Preserve v7 permanently
+
+1. Treat the existing v7 patch as read-only historical evidence:
+   - expected size: `288739` bytes;
+   - expected SHA-256: `e7d378fd4c3b0cc55171d63920cfc38013c68433336cbe627675d93557e7b2e7`;
+   - expected changed paths: `39`.
+2. Create a repository-independent historical bundle containing:
+   - patch;
+   - path manifest;
+   - JSON manifest;
+   - evidence ledger;
+   - test logs and review transport failures;
+   - architecture review;
+   - README stating that v7 is historical, unapproved, undeployed, and must not be rebased mechanically.
+3. Compute a bundle manifest with individual SHA-256 values. Do not alter or delete the old hardening/verification worktrees.
+
+## Phase 1 — Clean current-upstream worktree
+
+1. Fetch `origin` from the authoritative Hermes repository.
+2. Record fetched `origin/main` commit and remote URL.
+3. Create a new branch such as `fix/current-upstream-session-ownership` in a new native Windows-path worktree.
+4. Verify:
+   - `HEAD == origin/main` at creation;
+   - empty index;
+   - no tracked or untracked files;
+   - no shared writable worker processes.
+5. Copy this plan byte-for-byte into the clean repository as `plan.md` before any production-code edit.
+6. Add `IMPLEMENTATION-REPORT.md`, `OWNERSHIP-TABLE.md`, and the deployment manifest only as the work proceeds; keep the ledger current after every slice.
+
+## Phase 2 — Re-inventory current upstream
+
+Do not use the v7 caller list as authority. Search current source and trace every path that can mutate a conversation, transcript, lineage, checkpoint, replacement, publication, or lease.
+
+The ownership table must include:
+
+| Surface | Required operations |
+|---|---|
+| CLI/core agent | create/resume/send/save/model-tool publication |
+| Gateway | send, queued send, shutdown flush, platform callbacks |
+| API | send/stream, retry, rewind, reset, compress, resume |
+| Desktop | backend calls for send/stream/retry/rewind/reset/compress/resume |
+| Dashboard/TUI | send/model switch/retry/reset/compress/resume |
+| ACP | prompt, cancel, resume, release |
+| Cron/background | scheduled prompt, wake/replay, shutdown/recovery |
+| Rewrite operations | retry, rewind, reset, compress, replacement, resume |
+
+For each row record exact entry point, canonical identity source, lease acquisition point, fenced write/publication point, release/cancellation behavior, conflict projection, current tests, and missing RED test.
+
+Run two read-only inventory workers in parallel (core/storage and clients/adapters), then have the controller reconcile against direct source searches. Workers cannot edit.
+
+## Phase 3 — Vertical RED→GREEN implementation
+
+Implement in dependency order; one behavior per cycle.
+
+### Slice A — Canonical identity and SQLite kernel
+
+1. Add a failing multiprocess test proving two processes cannot own one canonical conversation simultaneously.
+2. Observe the expected RED failure on untouched current upstream.
+3. Implement only the minimal schema/API for:
+   - canonical conversation/root identity;
+   - lease holder identity;
+   - fencing generation/token;
+   - acquisition/refresh/release;
+   - stale-holder takeover using process identity/create-time and expiry;
+   - transactional fenced writes.
+4. Run focused GREEN and crash/cancellation tests.
+
+### Slice B — Core agent lifecycle
+
+Add RED tests for admission-before-history-load, holder lifetime through model execution and durable publication, cancellation-safe release, and stale writer rejection. Wire the core agent to the kernel and run GREEN.
+
+### Slice C — Gateway/API/TUI/ACP/cron callers
+
+For each ownership-table row:
+
+1. Add or adapt one current-upstream test that fails because the path bypasses authority.
+2. Observe RED for the intended reason.
+3. Route the path through the same kernel; do not add a second lock authority.
+4. Project typed conflicts consistently.
+5. Run the focused caller suite before moving to the next row.
+
+API-side in-memory/429 handling may reject obvious conflicts early, but it must derive canonical identity and truth from the SQLite authority. Its absence or process restart must not weaken correctness.
+
+### Slice D — Destructive rewrites and resume
+
+RED→GREEN each of retry, rewind, reset, compress, replacement, and resume. Assert that stale fencing tokens cannot publish, replace, or delete newer history and that lineage changes preserve the canonical authority contract.
+
+## Phase 4 — Remove installation-specific core coupling
+
+1. Add a failing test proving core does not read or parse `$HERMES_HOME/workspace/orchestration-sessions.json`.
+2. Remove private Workspace filename/schema knowledge from core.
+3. Move installation defaults—nested delegation, context handoff, shared memory, account choices, and fallback preferences—to supported profile/config contracts with conservative upstream defaults retained.
+4. Replace `claude-*` prefix inference with canonical provider/route identities resolved from supported provider/profile metadata.
+5. Add real-import E2E tests using a temporary `HERMES_HOME`; do not rely only on mocks.
+6. Keep the comprehensive Workspace separate. Expose only the backend contracts needed by authenticated standalone dashboard/Desktop plugin halves; do not port the product during this repair.
+
+## Phase 5 — Verification gates
+
+Run in this order, recording exact commands, commit/base, environment, duration, pass/fail counts, and normalized failure signatures:
+
+1. Kernel and multiprocess tests.
+2. Core/session/storage tests.
+3. Gateway/API/platform tests.
+4. TUI/dashboard/ACP/cron tests.
+5. Retry/rewind/reset/compress/resume tests.
+6. Delegation/config/provider-route E2E tests with temporary `HERMES_HOME`.
+7. Repository lint/type/static gates relevant to changed paths.
+8. Broad canonical suite.
+9. Clean-base comparison for any pre-existing broad failures.
+10. Official dashboard smoke as a backend acceptance client.
+11. Official Desktop smoke as a backend acceptance client.
+12. Private Workspace smoke against supported contracts, without modifying Workspace.
+13. Secret/privacy/prohibited-path scan.
+14. `git diff --check` and exact path-manifest reconciliation.
+
+Do not claim a globally red gate is green. Accept only zero new normalized failure signatures.
+
+## Phase 6 — Freeze and immutable review
+
+1. Stop/isolate all writers and prove bounded quiescence.
+2. Stage only the exact owned manifest—never `git add .` or `git add -A`.
+3. Export the complete binary candidate directly from Git to disk.
+4. Record byte count, path count/list, base commit, and SHA-256.
+5. Apply it in a fresh detached worktree at the recorded base and rerun focused and broad acceptance gates.
+6. Dispatch independent parallel read-only reviews against the same immutable hash:
+   - lease/fencing/transaction durability;
+   - caller completeness and lifecycle;
+   - architecture/privacy/config/provider boundaries;
+   - Desktop/dashboard/Workspace compatibility.
+7. Reproduce every concrete P0/P1 with a RED test before remediation. Any edit invalidates all approvals and requires a new hash/review cycle.
+8. Timebox to two remediation/review cycles. If unresolved P0/P1 remains, stop fail-closed with the clean implementation preserved but uncommitted.
+
+## Phase 7 — Commit and report
+
+1. Commit one coherent vertical fix after all gates pass. Suggested message:
+   - `fix(session): enforce durable cross-process conversation ownership`
+2. Do not include installed-tree noise, caches, credentials, runtime state, generated website churn, or unrelated Workspace files.
+3. Verify post-commit:
+   - committed parent is the recorded current `origin/main` base;
+   - committed diff hash equals the approved candidate hash;
+   - worktree is clean;
+   - focused and broad evidence is fresh after the final change.
+4. Complete `IMPLEMENTATION-REPORT.md` with:
+   - prior state and root cause;
+   - current-upstream inventory;
+   - ownership table summary;
+   - implementation and architectural reasoning;
+   - RED→GREEN evidence;
+   - exact gates/results and baseline differences;
+   - immutable review ledger and dispositions;
+   - commit hash and path manifest;
+   - exclusions and known limitations;
+   - final state.
+5. Create a versioned temporary-patch deployment manifest containing:
+   - upstream base;
+   - accepted commit and patch hash;
+   - source-file hashes;
+   - deployed-file hashes;
+   - running-process/source hashes;
+   - installation target;
+   - retirement condition when equivalent upstream code lands.
+6. Keep the final local commit unpushed unless explicit push authorization is given.
+
+## Stop conditions
+
+Stop rather than widening scope when:
+
+- a mutating surface cannot be mapped to canonical identity;
+- a worker or stale process can still mutate the candidate;
+- current-upstream behavior cannot be reproduced deterministically;
+- a focused test passes before implementation and therefore is not a valid RED test;
+- any new broad failure signature appears;
+- Desktop/dashboard acceptance exposes a backend contract break;
+- immutable review has unresolved P0/P1;
+- the approved, committed, deployed, or running hashes differ.
+
+## Definition of done
+
+- v7 exists as a hash-verified historical evidence bundle.
+- New worktree started clean from freshly fetched `origin/main`.
+- `plan.md` preceded production edits.
+- Every current mutating surface appears in the ownership table.
+- One SQLite lease/fencing authority covers all mutation paths.
+- API 429 is only an optimization.
+- No private Workspace schema or route-prefix inference remains in Hermes core.
+- Installation preferences use supported config/profile/provider contracts.
+- Focused, broad, Desktop, dashboard, and Workspace acceptance evidence is recorded with no new failures.
+- One immutable candidate hash has independent approval.
+- One coherent local Git commit contains all owned improvements and reports.
+- Worktree is clean and the committed diff matches the approved bytes.
+- Deployment, if separately authorized, is proven by exact source/deployed/running hashes.

--- a/run_agent.py
+++ b/run_agent.py
@@ -8027,7 +8027,67 @@ class AIAgent:
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         moa_config: Optional[dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        """Forwarder — see ``agent.conversation_loop.run_conversation``."""
+        """Admission gate + forwarder to the owned turn.
+
+        Every surface — CLI, gateway, HTTP API, TUI, ACP, cron, batch — funnels
+        through here, which is why the durable conversation authority lives at
+        this one boundary instead of being re-implemented per surface.
+
+        Admission runs BEFORE the transcript is loaded, so a refused turn
+        leaves the conversation byte-identical: no session row, no message, and
+        crucially no synthetic "someone else is here" message spliced into
+        history (which would break role alternation and invalidate the
+        conversation's prompt cache). The refusal is a typed
+        :class:`ConversationOwnershipConflict`; adapters may project it into a
+        dedicated status/code or their existing generic error contract.
+
+        The grant is held for the whole turn — model execution, tool calls, and
+        the durable turn-end publication — and released on EVERY exit path
+        including interrupt and cancellation.
+        """
+        from agent.session_ownership import (
+            ownership_admission_surface,
+            own_conversation,
+            should_own_conversation,
+        )
+
+        with own_conversation(
+            getattr(self, "_session_db", None),
+            str(getattr(self, "session_id", "") or ""),
+            surface=ownership_admission_surface(self),
+            enabled=should_own_conversation(self),
+        ):
+            return self._run_owned_conversation(
+                user_message,
+                system_message,
+                conversation_history,
+                task_id,
+                stream_callback,
+                persist_user_message,
+                persist_user_timestamp,
+                persist_user_display_kind,
+                persist_user_display_metadata,
+                moa_config,
+            )
+
+    def _run_owned_conversation(
+        self,
+        user_message: Any,
+        system_message: str = None,
+        conversation_history: List[Dict[str, Any]] = None,
+        task_id: str = None,
+        stream_callback: Optional[callable] = None,
+        persist_user_message: Optional[Any] = None,
+        persist_user_timestamp: Optional[float] = None,
+        persist_user_display_kind: Optional[str] = None,
+        persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+        moa_config: Optional[dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Forwarder — see ``agent.conversation_loop.run_conversation``.
+
+        Runs with the conversation already owned (or with ownership explicitly
+        not applicable — subagents, persist-disabled forks, store-less agents).
+        """
         from agent.aux_accounting import (
             reset_accounting_context,
             set_accounting_context,

--- a/tests/e2e/test_core_config_contract_boundaries.py
+++ b/tests/e2e/test_core_config_contract_boundaries.py
@@ -1,0 +1,130 @@
+"""Core resolves installation preferences from SUPPORTED contracts only.
+
+Two boundaries, both exercised end-to-end with real imports against a temp
+``HERMES_HOME`` — not mocks, because mocks are exactly what would hide a
+resolution-chain bug here (AGENTS.md: "E2E validation, not just green unit
+mocks").
+
+**No private-Workspace coupling.** A private orchestration Workspace keeps its
+own state under ``$HERMES_HOME/workspace/``. Hermes core must never read or
+parse that private schema — an installation's Workspace layout is not a config
+contract, and coupling core to it means a Workspace change silently reroutes
+delegation. The guard is behavioural: plant a file that WOULD change delegation
+if core parsed it, and assert resolution is unmoved. (A grep-the-source test
+would be the banned antipattern, and would also pass against an implementation
+that reads the file through a computed path.)
+
+**No installation-specific route inference.** API-mode routing is resolved from
+canonical *provider* identity plus that provider's published endpoint table, so
+the same model id routes differently under different providers rather than
+being guessed from its name prefix.
+"""
+
+import json
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """A real, isolated HERMES_HOME with a real config.yaml on disk."""
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _write_config(home, delegation):
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"delegation": delegation}), encoding="utf-8"
+    )
+
+
+def _resolve_delegation():
+    """Resolve through the real chain, with caches cleared like a fresh process."""
+    from hermes_cli import config as config_module
+
+    for attr in ("_CONFIG_CACHE", "_config_cache"):
+        if hasattr(config_module, attr):
+            try:
+                setattr(config_module, attr, None)
+            except Exception:
+                pass
+    cache_clear = getattr(getattr(config_module, "load_config", None), "cache_clear", None)
+    if cache_clear:
+        cache_clear()
+
+    from tools.delegate_tool import _load_config
+
+    return _load_config()
+
+
+# ── the supported contract is the one that decides ─────────────────────────
+
+
+def test_delegation_settings_come_from_config_yaml(hermes_home):
+    _write_config(hermes_home, {"max_spawn_depth": 2, "max_iterations": 7})
+    resolved = _resolve_delegation()
+    assert resolved.get("max_spawn_depth") == 2
+    assert resolved.get("max_iterations") == 7
+
+
+def test_a_private_workspace_state_file_cannot_reroute_delegation(hermes_home):
+    """Plant private Workspace state that contradicts config.yaml.
+
+    If core ever grows a read of this private schema, the assertion below flips
+    — which is the whole point of keeping the guard behavioural.
+    """
+    _write_config(hermes_home, {"max_spawn_depth": 2, "max_iterations": 7})
+
+    workspace = hermes_home / "workspace"
+    workspace.mkdir()
+    (workspace / "orchestration-sessions.json").write_text(
+        json.dumps(
+            {
+                "sessions": [{"id": "private-1", "surface": "workspace"}],
+                # Values a private Workspace might plausibly carry, all of which
+                # would visibly change behaviour if core treated them as config.
+                "delegation": {"max_spawn_depth": 3, "max_iterations": 999},
+                "defaults": {"nested_delegation": False, "shared_memory": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    resolved = _resolve_delegation()
+    assert resolved.get("max_spawn_depth") == 2, (
+        "core resolved delegation depth from private Workspace state instead of "
+        "the supported config.yaml contract"
+    )
+    assert resolved.get("max_iterations") == 7
+
+
+def test_conservative_upstream_defaults_survive_an_empty_config(hermes_home):
+    """No config.yaml at all → the shipped defaults, not an installation's."""
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    resolved = _resolve_delegation()
+    shipped = DEFAULT_CONFIG["delegation"]
+    assert resolved.get("max_iterations") == shipped["max_iterations"]
+    assert resolved.get("inherit_mcp_toolsets") == shipped["inherit_mcp_toolsets"]
+
+
+# ── routing is provider-scoped, never name-prefix-scoped ───────────────────
+
+
+def test_api_mode_is_resolved_from_provider_identity_not_a_name_prefix():
+    """Provider decides whether its published family rules are even consulted."""
+    from hermes_cli.models import opencode_model_api_mode
+
+    # Zen's published endpoint table currently groups Claude and Qwen families
+    # onto /v1/messages.  Qwen is the discriminator: this cannot pass through a
+    # provider-gated ``claude-*`` shortcut.
+    assert opencode_model_api_mode("opencode-zen", "claude-x") == "anthropic_messages"
+    assert opencode_model_api_mode("opencode-zen", "qwen3-coder") == "anthropic_messages"
+    # The identical id under any other provider gets that provider's default —
+    # the prefix alone never decides the route.
+    assert opencode_model_api_mode("openrouter", "claude-x") == "chat_completions"
+    assert opencode_model_api_mode("", "claude-x") == "chat_completions"
+    assert opencode_model_api_mode(None, "claude-x") == "chat_completions"

--- a/tests/hermes_state/test_conversation_ownership_kernel.py
+++ b/tests/hermes_state/test_conversation_ownership_kernel.py
@@ -1,0 +1,544 @@
+"""Canonical conversation ownership — the durable cross-process authority.
+
+``gateway/turn_lease.py`` serialises turns *inside one process*; its own
+docstring names the hole it cannot close: "A CLI process sharing the session
+via CLI-continuity is outside any in-process lock — that pair needs a DB-level
+lease (separate design)." This is that lease.
+
+The unit of ownership is the **conversation root** (``get_conversation_root``),
+not the session id: context compression rotates ``session_id`` to a fresh
+segment mid-turn and delegate subagents hang off their parent, so a session-id
+lock would hand the same conversation to two owners the moment it rotated.
+
+The root is *mutable* — deleting an ancestor NULLs its children's
+``parent_session_id`` and re-roots them — so a grant pins the root it captured
+at acquire time and fenced writes validate that pinned identity rather than
+recomputing it.
+"""
+
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+
+from agent.session_ownership import (
+    ConversationOwnershipConflict,
+    ConversationOwnershipError,
+    ConversationOwnershipUnavailable,
+    StaleConversationOwnershipError,
+    new_holder_id,
+    own_conversation,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_public_exception_text_does_not_leak_authority_diagnostics():
+    """Generic adapter stringification must not expose roots, hosts or paths."""
+    secret_root = "private-session-root"
+    secret_holder = "host=WORKSTATION:pid=4321:start=123:tid=99:nonce=secret"
+    secret_path = r"C:\\Users\\private\\state.db"
+
+    conflict = ConversationOwnershipConflict(
+        secret_root,
+        holder=secret_holder,
+        surface="cli",
+        session_id="private-child",
+        fence_token=77,
+    )
+    stale = StaleConversationOwnershipError(
+        secret_root,
+        expected_fence_token=76,
+        actual_fence_token=77,
+        actual_holder=secret_holder,
+    )
+    unavailable = ConversationOwnershipUnavailable(
+        secret_root, sqlite3.OperationalError(f"unable to open {secret_path}")
+    )
+
+    projected = "\n".join(map(str, (conflict, stale, unavailable)))
+    for secret in (
+        secret_root,
+        secret_holder,
+        secret_path,
+        "WORKSTATION",
+        "4321",
+        "private-child",
+        "77",
+    ):
+        assert secret not in projected
+    assert conflict.holder == secret_holder
+    assert unavailable.cause.args[0].endswith(secret_path)
+
+
+@pytest.fixture
+def db(tmp_path):
+    store = SessionDB(tmp_path / "state.db")
+    yield store
+    store.close()
+
+
+# ── the plan's Slice A step 1: two PROCESSES, one canonical conversation ────
+
+_CHILD_SOURCE = r'''
+import os, sys, time
+from pathlib import Path
+sys.path.insert(0, sys.argv[1])
+from hermes_state import SessionDB
+from agent.session_ownership import new_holder_id
+
+db_path, handshake, release_flag = sys.argv[2], sys.argv[3], sys.argv[4]
+db = SessionDB(Path(db_path))
+holder = new_holder_id(surface="child-process")
+grant = db.try_acquire_conversation_ownership(
+    "conv-root", holder, ttl_seconds=120.0, surface="child-process",
+    session_id="conv-root",
+)
+with open(handshake, "w", encoding="utf-8") as fh:
+    fh.write(str(grant.fence_token))
+deadline = time.time() + 60
+while time.time() < deadline and not os.path.exists(release_flag):
+    time.sleep(0.05)
+db.release_conversation_ownership(grant)
+db.close()
+'''
+
+
+def _spawn_holder(tmp_path, db_path):
+    handshake = tmp_path / "acquired.txt"
+    release_flag = tmp_path / "please-release.txt"
+    env = dict(os.environ)
+    # The autouse HERMES_HOME isolation in tests/conftest.py does not reach a
+    # spawned child; pass it explicitly so the child cannot touch a real home.
+    env["HERMES_HOME"] = os.environ.get("HERMES_HOME", str(tmp_path / "home"))
+    child = subprocess.Popen(
+        [sys.executable, "-c", _CHILD_SOURCE, str(REPO_ROOT), str(db_path),
+         str(handshake), str(release_flag)],
+        cwd=str(REPO_ROOT),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        if handshake.exists() and handshake.read_text(encoding="utf-8").strip():
+            return child, handshake, release_flag
+        if child.poll() is not None:
+            out, err = child.communicate()
+            raise AssertionError(
+                "ownership holder child exited before acquiring:\n"
+                f"stdout={out.decode(errors='replace')}\n"
+                f"stderr={err.decode(errors='replace')}"
+            )
+        time.sleep(0.05)
+    child.kill()
+    raise AssertionError("ownership holder child never acquired")
+
+
+def test_second_process_cannot_own_the_same_canonical_conversation(tmp_path):
+    """The core invariant: one live owner per conversation, across processes."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    db.create_session("conv-root", source="cli")
+    db.close()
+
+    child, _handshake, release_flag = _spawn_holder(tmp_path, db_path)
+    try:
+        db = SessionDB(db_path)
+        with pytest.raises(ConversationOwnershipConflict) as excinfo:
+            db.try_acquire_conversation_ownership(
+                "conv-root",
+                new_holder_id(surface="test-process"),
+                ttl_seconds=120.0,
+                surface="test-process",
+                session_id="conv-root",
+            )
+        # The conflict must be projectable — a surface has to be able to tell
+        # the user who holds it without reading the table itself.
+        assert excinfo.value.conversation_root == "conv-root"
+        assert excinfo.value.surface == "child-process"
+        assert excinfo.value.holder
+        db.close()
+    finally:
+        release_flag.write_text("go", encoding="utf-8")
+        child.wait(timeout=60)
+
+    # After the holder releases, the conversation is acquirable again — and the
+    # fence token has advanced, so the previous holder's token is now stale.
+    db = SessionDB(db_path)
+    grant = db.try_acquire_conversation_ownership(
+        "conv-root",
+        new_holder_id(surface="test-process"),
+        ttl_seconds=120.0,
+        surface="test-process",
+        session_id="conv-root",
+    )
+    assert grant.fence_token >= 2
+    db.close()
+
+
+# ── canonical identity ─────────────────────────────────────────────────────
+
+
+def test_ownership_is_keyed_by_conversation_root_not_session_id(db):
+    """A compression child and its parent are ONE conversation, one owner."""
+    db.create_session("root", source="cli")
+    db.create_session("child", source="compression", parent_session_id="root")
+
+    assert db.get_conversation_root("child") == "root"
+
+    grant = db.try_acquire_conversation_ownership(
+        db.get_conversation_root("root"),
+        new_holder_id(surface="cli"),
+        surface="cli",
+        session_id="root",
+    )
+    assert grant.conversation_root == "root"
+
+    with pytest.raises(ConversationOwnershipConflict):
+        db.try_acquire_conversation_ownership(
+            db.get_conversation_root("child"),
+            new_holder_id(surface="gateway"),
+            surface="gateway",
+            session_id="child",
+        )
+
+
+def test_grant_pins_the_root_it_captured(db):
+    """The grant and every fenced write use the identity captured at admission."""
+    db.create_session("root", source="cli")
+    db.create_session("child", source="compression", parent_session_id="root")
+
+    grant = db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="cli"), surface="cli", session_id="child",
+    )
+
+    assert db.get_conversation_root("child") == "root"
+    assert grant.conversation_root == "root"
+    assert db.execute_fenced_write(grant, lambda conn: "ok") == "ok"
+
+
+def test_live_owner_blocks_ancestor_delete_from_splitting_the_authority(tmp_path):
+    """A lineage rewrite must not create a second acquirable ownership key.
+
+    This is deliberately two-handle evidence.  A process-local grant fallback
+    can keep the old writer fenced against ``root``, but it cannot stop another
+    process from resolving the orphaned child as ``child`` and acquiring that
+    new key.  The smallest safe policy is to refuse the re-rooting delete while
+    the covering grant is live.
+    """
+    db_path = tmp_path / "state.db"
+    owner_db = SessionDB(db_path)
+    contender_db = SessionDB(db_path)
+    try:
+        owner_db.create_session("root", source="cli")
+        owner_db.create_session(
+            "child", source="compression", parent_session_id="root"
+        )
+        grant = owner_db.try_acquire_conversation_ownership(
+            "root",
+            new_holder_id(surface="cli"),
+            surface="cli",
+            session_id="child",
+            ttl_seconds=120.0,
+        )
+
+        with pytest.raises(ConversationOwnershipConflict):
+            contender_db.delete_session("root")
+
+        assert contender_db.get_conversation_root("child") == "root"
+        with pytest.raises(ConversationOwnershipConflict):
+            contender_db.try_acquire_conversation_ownership(
+                contender_db.get_conversation_root("child"),
+                new_holder_id(surface="gateway"),
+                surface="gateway",
+                session_id="child",
+            )
+
+        owner_db.release_conversation_ownership(grant)
+        assert contender_db.delete_session("root") is True
+        assert contender_db.get_conversation_root("child") == "child"
+    finally:
+        contender_db.close()
+        owner_db.close()
+
+
+# ── fencing ────────────────────────────────────────────────────────────────
+
+
+def test_fence_token_increments_per_owner_handover(db):
+    db.create_session("root", source="cli")
+    first = db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="cli"), surface="cli", session_id="root",
+    )
+    db.release_conversation_ownership(first)
+    second = db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="tui"), surface="tui", session_id="root",
+    )
+    assert second.fence_token == first.fence_token + 1
+
+
+def test_fenced_write_rejects_a_stale_token(db):
+    """The whole point of fencing: a slow writer cannot publish after handover."""
+    db.create_session("root", source="cli")
+    stale = db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="cli"), surface="cli", session_id="root",
+    )
+    db.release_conversation_ownership(stale)
+    db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="tui"), surface="tui", session_id="root",
+    )
+
+    calls = []
+    with pytest.raises(StaleConversationOwnershipError) as excinfo:
+        db.execute_fenced_write(stale, lambda conn: calls.append(1))
+    assert calls == [], "the mutation must not run at all, not run-then-fail"
+    assert excinfo.value.expected_fence_token == stale.fence_token
+
+
+def test_fenced_write_runs_the_mutation_in_the_same_transaction(db):
+    db.create_session("root", source="cli")
+    grant = db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="cli"), surface="cli", session_id="root",
+    )
+
+    def _mutate(conn):
+        conn.execute("UPDATE sessions SET title = ? WHERE id = ?", ("fenced", "root"))
+        return "done"
+
+    assert db.execute_fenced_write(grant, _mutate) == "done"
+    assert db.get_session("root")["title"] == "fenced"
+
+
+def test_fenced_write_refuses_an_expired_grant_without_handover(db):
+    """Passing TTL invalidates the grant even before another holder arrives."""
+    db.create_session("root", source="cli")
+    grant = db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="cli"), surface="cli", session_id="root",
+        ttl_seconds=0.001,
+    )
+    time.sleep(0.05)
+
+    calls = []
+    with pytest.raises(StaleConversationOwnershipError):
+        db.execute_fenced_write(grant, lambda conn: calls.append(1))
+    assert calls == []
+
+
+# ── release / takeover ─────────────────────────────────────────────────────
+
+
+def test_release_is_holder_and_fence_scoped(db):
+    """A late unwind must never free a newer owner's grant (#28686 lesson)."""
+    db.create_session("root", source="cli")
+    stale = db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="cli"), surface="cli", session_id="root",
+    )
+    db.release_conversation_ownership(stale)
+    live = db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="tui"), surface="tui", session_id="root",
+    )
+
+    db.release_conversation_ownership(stale)  # idempotent, and not the owner
+
+    owner = db.get_conversation_owner("root")
+    assert owner is not None
+    assert owner["holder"] == live.holder
+    assert owner["fence_token"] == live.fence_token
+
+
+def test_expired_grant_is_taken_over_with_a_new_fence(db):
+    db.create_session("root", source="cli")
+    expired = db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="cli"), surface="cli", session_id="root",
+        ttl_seconds=0.001,
+    )
+    time.sleep(0.05)
+    taken = db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="tui"), surface="tui", session_id="root",
+    )
+    assert taken.fence_token == expired.fence_token + 1
+    with pytest.raises(StaleConversationOwnershipError):
+        db.execute_fenced_write(expired, lambda conn: None)
+
+
+def test_acquire_samples_lease_time_after_write_authority(db, monkeypatch):
+    """SQLite lock patience must not consume the lease before it is published."""
+    db.create_session("root", source="cli")
+    original_execute_write = db._execute_write
+
+    def _delayed_execute_write(fn, *args, **kwargs):
+        time.sleep(0.08)
+        return original_execute_write(fn, *args, **kwargs)
+
+    monkeypatch.setattr(db, "_execute_write", _delayed_execute_write)
+    before = time.time()
+    grant = db.try_acquire_conversation_ownership(
+        "root",
+        new_holder_id(surface="cli"),
+        surface="cli",
+        session_id="root",
+        ttl_seconds=0.5,
+    )
+
+    # The delayed authority acquisition must be reflected in the published
+    # timestamp. Compare timestamps instead of requiring a tiny post-return TTL,
+    # which would make slow Windows fsync itself a source of test flakiness.
+    assert grant.expires_at >= before + 0.55
+    assert db.get_conversation_owner("root") is not None
+
+
+def test_refresh_samples_lease_time_after_write_authority(db, monkeypatch):
+    """A delayed refresh must publish a fresh TTL, not an already-old one."""
+    db.create_session("root", source="cli")
+    grant = db.try_acquire_conversation_ownership(
+        "root",
+        new_holder_id(surface="cli"),
+        surface="cli",
+        session_id="root",
+        ttl_seconds=120.0,
+    )
+    original_execute_write = db._execute_write
+
+    def _delayed_execute_write(fn, *args, **kwargs):
+        time.sleep(0.08)
+        return original_execute_write(fn, *args, **kwargs)
+
+    monkeypatch.setattr(db, "_execute_write", _delayed_execute_write)
+    before = time.time()
+    assert db.refresh_conversation_ownership(grant, ttl_seconds=0.5) is True
+    # The delayed authority acquisition must be reflected in the published
+    # timestamp. This compares timestamps rather than a tiny post-return TTL,
+    # which would make slow Windows fsync itself a source of test flakiness.
+    assert grant.expires_at >= before + 0.55
+    assert db.get_conversation_owner("root") is not None
+
+
+def test_root_resolution_failure_fails_closed(db, monkeypatch):
+    """An identity lookup failure must never mint a lease on the child id."""
+    db.create_session("root", source="cli")
+    db.create_session("child", source="compression", parent_session_id="root")
+
+    def _raise(_session_id):
+        raise sqlite3.OperationalError("identity authority unavailable")
+
+    monkeypatch.setattr(db, "get_conversation_root", _raise)
+    with pytest.raises(ConversationOwnershipUnavailable):
+        with own_conversation(db, "child", surface="cli"):
+            pass
+    assert db.get_conversation_owner("child") is None
+
+
+def test_unrelated_write_does_not_borrow_the_only_thread_grant(db):
+    """A grant on A cannot authorize or stale-fail a mutation on unrelated B."""
+    db.create_session("a", source="cli")
+    db.create_session("b", source="cli")
+    with own_conversation(db, "a", surface="cli"):
+        db.append_message("b", role="user", content="independent")
+    assert [m["content"] for m in db.get_messages("b")] == ["independent"]
+
+
+def test_transactional_and_admission_root_resolvers_are_equivalent(db):
+    """Both authority-key walks agree on normal, missing, and cyclic lineage."""
+    db.create_session("root", source="cli")
+    db.create_session("child", source="compression", parent_session_id="root")
+    db.create_session("cycle-a", source="cli")
+    db.create_session("cycle-b", source="cli", parent_session_id="cycle-a")
+    db._execute_write(
+        lambda conn: conn.execute(
+            "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+            ("cycle-b", "cycle-a"),
+        )
+    )
+
+    for session_id in ("root", "child", "missing", "cycle-a", "cycle-b"):
+        public_root = db.get_conversation_root(session_id)
+        transaction_root = db._execute_write(
+            lambda conn, sid=session_id: db._conversation_root_in_transaction(
+                conn, sid
+            )
+        )
+        assert transaction_root == public_root
+
+
+def test_dead_holder_process_is_reclaimed_before_ttl(db):
+    """A killed CLI must not strand the conversation for the full TTL."""
+    db.create_session("root", source="cli")
+    dead_pid = _find_dead_pid()
+    holder = f"host={_hostname()}:pid={dead_pid}:start=0:nonce=deadbeef"
+    db.try_acquire_conversation_ownership(
+        "root", holder, surface="cli", session_id="root", ttl_seconds=3600.0,
+    )
+    taken = db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="tui"), surface="tui", session_id="root",
+    )
+    assert taken.holder != holder
+
+
+def test_refresh_only_extends_our_own_grant(db):
+    db.create_session("root", source="cli")
+    stale = db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="cli"), surface="cli", session_id="root",
+    )
+    db.release_conversation_ownership(stale)
+    live = db.try_acquire_conversation_ownership(
+        "root", new_holder_id(surface="tui"), surface="tui", session_id="root",
+    )
+    assert db.refresh_conversation_ownership(stale) is False
+    assert db.refresh_conversation_ownership(live) is True
+
+
+# ── fail closed ────────────────────────────────────────────────────────────
+
+
+def test_authority_failure_never_silently_grants_ownership(db, monkeypatch):
+    """Unlike the compression lock, this authority must not fail open.
+
+    ``try_acquire_compression_lock`` returns False on ``sqlite3.Error`` because
+    skipping compression is safe. Skipping *ownership* is not — it would let
+    both racers proceed. A broken authority raises a typed error the surface
+    projects as a refusal.
+    """
+    import sqlite3
+
+    db.create_session("root", source="cli")
+
+    def _boom(*args, **kwargs):
+        raise sqlite3.OperationalError("disk I/O error")
+
+    monkeypatch.setattr(db, "_execute_write", _boom)
+    with pytest.raises(ConversationOwnershipError):
+        db.try_acquire_conversation_ownership(
+            "root", new_holder_id(surface="cli"), surface="cli",
+            session_id="root",
+        )
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _hostname() -> str:
+    import socket
+
+    return socket.gethostname()
+
+
+def _find_dead_pid() -> int:
+    """A pid that is not currently running on this host."""
+    try:
+        import psutil
+
+        live = set(psutil.pids())
+    except Exception:  # pragma: no cover - psutil is a hard dep in practice
+        live = set()
+    for candidate in range(999000, 999500):
+        if candidate not in live:
+            return candidate
+    raise AssertionError("no free pid found")

--- a/tests/hermes_state/test_conversation_ownership_rewrites.py
+++ b/tests/hermes_state/test_conversation_ownership_rewrites.py
@@ -1,0 +1,445 @@
+"""Destructive rewrites must not publish under a lost grant.
+
+Retry, rewind, reset, compress, replacement and delete all rewrite history that
+already exists. A plain lock is not enough for them: a writer that STALLED —
+GC pause, a wedged network call, a starved refresher — can wake after its lease
+expired and another surface took the conversation, and then happily replace or
+delete rows the new owner has since written. That is the failure a fence
+catches and a lock cannot.
+
+So every rewrite runs its mutation inside the same transaction that validates
+the caller's fence token. A stale token is refused *before* the mutation runs.
+
+Callers that hold no grant remain compatible only while no durable owner is
+live. Once any process owns the canonical root, even an unwired or direct
+persistence caller is refused inside the same transaction as its attempted
+mutation. This prevents a process-local grant lookup from becoming the sole
+enforcement mechanism.
+"""
+
+import concurrent.futures
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+from agent.session_ownership import (
+    ConversationOwnershipConflict,
+    StaleConversationOwnershipError,
+    new_holder_id,
+    own_conversation,
+)
+
+
+@pytest.fixture
+def db(tmp_path):
+    store = SessionDB(tmp_path / "state.db")
+    store.create_session("root", source="cli")
+    store.append_messages_batch(
+        "root",
+        [
+            {"role": "user", "content": "one", "timestamp": 1.0},
+            {"role": "assistant", "content": "two", "timestamp": 2.0},
+        ],
+    )
+    yield store
+    store.close()
+
+
+def _stolen_grant_scope(db, session_id="root"):
+    """A grant that is in scope but no longer the owner.
+
+    Mirrors the real shape: our lease expired while we were stalled, another
+    surface legitimately took the conversation, and now our thread wakes up
+    still holding what it believes is a valid grant.
+    """
+    return own_conversation(
+        db,
+        session_id,
+        surface="cli",
+        ttl_seconds=0.2,
+        # Long enough that the refresher cannot revive the lease mid-test —
+        # a stalled holder is exactly one whose refresher did not tick.
+        refresh_interval_seconds=30.0,
+    )
+
+
+def _steal(db, root="root"):
+    time.sleep(0.3)
+    return db.try_acquire_conversation_ownership(
+        root, new_holder_id(surface="tui"), surface="tui", session_id=root,
+    )
+
+
+# ── each rewrite, under a lost grant ───────────────────────────────────────
+
+
+def test_replace_messages_is_refused_under_a_lost_grant(db):
+    """Compression / replacement rewrites the whole transcript."""
+    with _stolen_grant_scope(db):
+        _steal(db)
+        with pytest.raises(StaleConversationOwnershipError):
+            db.replace_messages(
+                "root", [{"role": "user", "content": "clobbered", "timestamp": 9.0}]
+            )
+    assert [m["content"] for m in db.get_messages("root")] == ["one", "two"]
+
+
+def test_rewind_is_refused_under_a_lost_grant(db):
+    rows = db.get_messages("root")
+    target = rows[0]["id"]
+    with _stolen_grant_scope(db):
+        _steal(db)
+        with pytest.raises(StaleConversationOwnershipError):
+            db.rewind_to_message("root", target)
+    assert len(db.get_messages("root")) == 2
+
+
+def test_reset_promotion_is_refused_under_a_lost_grant(db):
+    with _stolen_grant_scope(db):
+        _steal(db)
+        with pytest.raises(StaleConversationOwnershipError):
+            db.promote_to_session_reset("root")
+    assert db.get_session("root")["ended_at"] is None
+
+
+def test_turn_publication_is_refused_under_a_lost_grant(db):
+    """The turn-end flush is a publication too — a stale turn must not land."""
+    with _stolen_grant_scope(db):
+        _steal(db)
+        with pytest.raises(StaleConversationOwnershipError):
+            db.append_messages_batch(
+                "root", [{"role": "user", "content": "late", "timestamp": 9.0}]
+            )
+    assert len(db.get_messages("root")) == 2
+
+
+def test_single_message_append_is_refused_under_a_lost_grant(db):
+    with _stolen_grant_scope(db):
+        _steal(db)
+        with pytest.raises(StaleConversationOwnershipError):
+            db.append_message("root", "user", "late")
+    assert len(db.get_messages("root")) == 2
+
+
+def test_session_delete_is_refused_under_a_lost_grant(db):
+    with _stolen_grant_scope(db):
+        _steal(db)
+        with pytest.raises(StaleConversationOwnershipError):
+            db.delete_session("root")
+    assert db.get_session("root") is not None
+
+
+def test_archive_and_compact_is_refused_under_a_lost_grant(db):
+    with _stolen_grant_scope(db):
+        _steal(db)
+        with pytest.raises(StaleConversationOwnershipError):
+            db.archive_and_compact(
+                "root", [{"role": "user", "content": "summary", "timestamp": 9.0}]
+            )
+    assert [m["content"] for m in db.get_messages("root")] == ["one", "two"]
+
+
+def test_delete_session_if_empty_is_refused_under_a_lost_grant(db):
+    db.create_session("empty", source="cli")
+    with _stolen_grant_scope(db, "empty"):
+        _steal(db, "empty")
+        with pytest.raises(StaleConversationOwnershipError):
+            db.delete_session_if_empty("empty")
+    assert db.get_session("empty") is not None
+
+
+def test_restore_rewound_is_refused_under_a_lost_grant(db):
+    first_id = db.get_messages("root")[0]["id"]
+    db.rewind_to_message("root", first_id)
+    with _stolen_grant_scope(db):
+        _steal(db)
+        with pytest.raises(StaleConversationOwnershipError):
+            db.restore_rewound("root", first_id)
+    assert db.get_messages("root") == []
+
+
+def test_ancestor_delete_is_refused_while_its_lineage_is_owned(db):
+    db.create_session("child", source="compression", parent_session_id="root")
+    with own_conversation(db, "child", surface="cli"):
+        with pytest.raises(ConversationOwnershipConflict):
+            db.delete_session("root")
+    assert db.get_conversation_root("child") == "root"
+
+
+@pytest.mark.parametrize("operation", ["bulk", "empty", "prune"])
+def test_bulk_cleanup_skips_owned_lineages_and_deletes_unrelated(db, operation):
+    """Maintenance preserves its count contract while ownership stays intact."""
+    db.create_session("owned", source="cli")
+    db.create_session("other", source="cli")
+    now = time.time()
+    db._execute_write(
+        lambda conn: conn.execute(
+            "UPDATE sessions SET ended_at = ?, started_at = ? WHERE id IN (?, ?)",
+            (now, now - 10 * 86400, "owned", "other"),
+        )
+    )
+
+    with own_conversation(db, "owned", surface="cli"):
+        if operation == "bulk":
+            deleted = db.delete_sessions(["owned", "other"])
+        elif operation == "empty":
+            deleted = db.delete_empty_sessions()
+        else:
+            deleted = db.prune_sessions(older_than_days=1)
+
+    assert deleted == 1
+    assert db.get_session("owned") is not None
+    assert db.get_session("other") is None
+
+
+# ── the same operations under a LIVE grant still work ──────────────────────
+
+
+def test_rewrites_run_normally_under_a_live_grant(db):
+    with own_conversation(db, "root", surface="cli") as grant:
+        assert grant is not None
+        db.append_messages_batch(
+            "root", [{"role": "user", "content": "three", "timestamp": 3.0}]
+        )
+        assert len(db.get_messages("root")) == 3
+        db.replace_messages(
+            "root", [{"role": "user", "content": "only", "timestamp": 4.0}]
+        )
+        assert [m["content"] for m in db.get_messages("root")] == ["only"]
+        assert db.promote_to_session_reset("root") is True
+
+
+# ── callers without a local grant still respect a foreign owner ────────────
+
+
+def test_no_grant_and_no_durable_owner_leaves_behaviour_unchanged(db):
+    """Legacy direct mutations remain compatible when no authority is held."""
+    db.append_messages_batch(
+        "root", [{"role": "user", "content": "three", "timestamp": 3.0}]
+    )
+    assert len(db.get_messages("root")) == 3
+    db.replace_messages("root", [{"role": "user", "content": "x", "timestamp": 4.0}])
+    assert [m["content"] for m in db.get_messages("root")] == ["x"]
+    assert db.promote_to_session_reset("root") is True
+
+
+def test_foreign_unowned_append_is_refused_while_an_owner_is_live(db):
+    """A process-local grant cannot be the only enforcement mechanism."""
+    def _foreign_append():
+        foreign = SessionDB(db.db_path)
+        try:
+            foreign.append_message("root", "user", "foreign")
+        finally:
+            foreign.close()
+
+    with own_conversation(db, "root", surface="cli"):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_foreign_append)
+            with pytest.raises(ConversationOwnershipConflict):
+                future.result()
+    assert [m["content"] for m in db.get_messages("root")] == ["one", "two"]
+
+
+def test_foreign_unowned_rewind_is_refused_while_an_owner_is_live(db):
+    """Direct TUI/API lifecycle rewrites must consult durable authority."""
+    target = db.get_messages("root")[0]["id"]
+
+    def _foreign_rewind():
+        foreign = SessionDB(db.db_path)
+        try:
+            foreign.rewind_to_message("root", target)
+        finally:
+            foreign.close()
+
+    with own_conversation(db, "root", surface="cli"):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_foreign_rewind)
+            with pytest.raises(ConversationOwnershipConflict):
+                future.result()
+    assert [m["content"] for m in db.get_messages("root")] == ["one", "two"]
+
+
+def test_delegate_segment_can_publish_while_its_parent_turn_is_owned(db):
+    """Concurrent subagents write their own segment without borrowing root authority."""
+    db.create_session("delegate", source="delegate", parent_session_id="root")
+
+    def _delegate_append():
+        delegate_db = SessionDB(db.db_path)
+        try:
+            delegate_db.append_message("delegate", "assistant", "delegate-write")
+        finally:
+            delegate_db.close()
+
+    with own_conversation(db, "root", surface="cli"):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(_delegate_append).result()
+    assert [m["content"] for m in db.get_messages("delegate")] == ["delegate-write"]
+
+
+def test_unowned_compression_child_cannot_bypass_the_parent_owner(db):
+    """A root-owned compression child remains covered by root authority."""
+    db.create_session("compressed", source="compression", parent_session_id="root")
+
+    def _compressed_append():
+        child_db = SessionDB(db.db_path)
+        try:
+            child_db.append_message("compressed", "assistant", "foreign")
+        finally:
+            child_db.close()
+
+    with own_conversation(db, "root", surface="cli"):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_compressed_append)
+            with pytest.raises(ConversationOwnershipConflict):
+                future.result()
+    assert db.get_messages("compressed") == []
+
+
+def test_delegate_compression_child_can_publish_below_the_delegate_boundary(db):
+    """A subagent remains independently writable after rotating its own segment."""
+    db.create_session("delegate", source="delegate", parent_session_id="root")
+    db.create_session(
+        "delegate-compressed", source="compression", parent_session_id="delegate"
+    )
+
+    def _delegate_child_append():
+        child_db = SessionDB(db.db_path)
+        try:
+            child_db.append_message("delegate-compressed", "assistant", "continued")
+        finally:
+            child_db.close()
+
+    with own_conversation(db, "root", surface="cli"):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(_delegate_child_append).result()
+    assert [m["content"] for m in db.get_messages("delegate-compressed")] == [
+        "continued"
+    ]
+
+
+def test_delegate_sourced_root_does_not_gain_a_permanent_exemption(db):
+    """The exception requires a real parent boundary, not only a source label."""
+    db.create_session("orphan-delegate", source="delegate")
+
+    def _foreign_append():
+        foreign = SessionDB(db.db_path)
+        try:
+            foreign.append_message("orphan-delegate", "assistant", "foreign")
+        finally:
+            foreign.close()
+
+    with own_conversation(db, "orphan-delegate", surface="cli"):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_foreign_append)
+            with pytest.raises(ConversationOwnershipConflict):
+                future.result()
+    assert db.get_messages("orphan-delegate") == []
+
+
+def test_malformed_delegate_cycle_fails_closed_instead_of_bypassing(db):
+    """A delegate marker exempts only a lineage that reaches a real parent root."""
+    db.create_session("cycle-a", source="delegate")
+    db.create_session("cycle-b", source="compression", parent_session_id="cycle-a")
+    db._execute_write(
+        lambda conn: conn.execute(
+            "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+            ("cycle-b", "cycle-a"),
+        )
+    )
+
+    def _foreign_append():
+        foreign = SessionDB(db.db_path)
+        try:
+            foreign.append_message("cycle-a", "assistant", "foreign")
+        finally:
+            foreign.close()
+
+    with own_conversation(db, "cycle-a", surface="cli"):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_foreign_append)
+            with pytest.raises(ConversationOwnershipConflict):
+                future.result()
+    assert db.get_messages("cycle-a") == []
+
+
+def test_delegate_delete_if_empty_cannot_re_root_below_a_live_parent(db):
+    """Delegate publication exemption must not cover lineage deletion."""
+    db.create_session("empty-delegate", source="delegate", parent_session_id="root")
+
+    def _foreign_delete():
+        foreign = SessionDB(db.db_path)
+        try:
+            foreign.delete_session_if_empty("empty-delegate")
+        finally:
+            foreign.close()
+
+    with own_conversation(db, "root", surface="cli"):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_foreign_delete)
+            with pytest.raises(ConversationOwnershipConflict):
+                future.result()
+    assert db.get_session("empty-delegate") is not None
+
+
+def test_delegate_reset_promotion_is_not_an_unfenced_publication(db):
+    """The delegate exception is publication-only, not a generic mutation bypass."""
+    db.create_session("delegate-reset", source="delegate", parent_session_id="root")
+
+    def _foreign_reset():
+        foreign = SessionDB(db.db_path)
+        try:
+            foreign.promote_to_session_reset("delegate-reset")
+        finally:
+            foreign.close()
+
+    with own_conversation(db, "root", surface="cli"):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_foreign_reset)
+            with pytest.raises(ConversationOwnershipConflict):
+                future.result()
+    assert db.get_session("delegate-reset")["end_reason"] is None
+
+
+def test_delegate_replace_is_not_an_unfenced_publication(db):
+    """Whole-transcript replacement is a rewrite, not delegate publication."""
+    db.create_session("delegate-replace", source="delegate", parent_session_id="root")
+    db.append_message("delegate-replace", "user", "original")
+
+    def _foreign_replace():
+        foreign = SessionDB(db.db_path)
+        try:
+            foreign.replace_messages(
+                "delegate-replace", [{"role": "assistant", "content": "replaced"}]
+            )
+        finally:
+            foreign.close()
+
+    with own_conversation(db, "root", surface="cli"):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_foreign_replace)
+            with pytest.raises(ConversationOwnershipConflict):
+                future.result()
+    assert [m["content"] for m in db.get_messages("delegate-replace")] == [
+        "original"
+    ]
+
+
+# ── a rewrite on a session in the owned lineage is fenced too ──────────────
+
+
+def test_a_compression_child_is_fenced_by_the_parent_grant(db):
+    """Rotation moves the write target; ownership does not move with it.
+
+    The grant covers the whole lineage, so a rewrite aimed at the child
+    segment is fenced by the same token that covers the root.
+    """
+    db.create_session("child", source="compression", parent_session_id="root")
+    with _stolen_grant_scope(db):
+        _steal(db)
+        with pytest.raises(StaleConversationOwnershipError):
+            db.append_messages_batch(
+                "child", [{"role": "user", "content": "late", "timestamp": 9.0}]
+            )
+    assert db.get_messages("child") == []

--- a/tests/run_agent/test_conversation_ownership_admission.py
+++ b/tests/run_agent/test_conversation_ownership_admission.py
@@ -1,0 +1,288 @@
+"""Core agent lifecycle: admission, holder lifetime, cancellation-safe release.
+
+``AIAgent.run_conversation`` is the narrow waist every surface funnels through
+— CLI, gateway, HTTP API, TUI, ACP, cron, batch. Gating it there is what makes
+one authority cover every mutating path instead of eight per-surface locks.
+
+Admission happens BEFORE the transcript is loaded, so a refused turn leaves the
+conversation byte-identical: no row created, no message appended, no synthetic
+"someone else is here" message spliced into history (that would break role
+alternation and the per-conversation prompt cache).
+"""
+
+import concurrent.futures
+import threading
+
+import pytest
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+from agent.session_ownership import (
+    ConversationOwnershipConflict,
+    ownership_admission_surface,
+    should_own_conversation,
+    new_holder_id,
+    own_conversation,
+)
+
+
+@pytest.fixture
+def db(tmp_path):
+    store = SessionDB(tmp_path / "state.db")
+    yield store
+    store.close()
+
+
+def _agent(db, session_id="conv-1", **kwargs):
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        session_id=session_id,
+        session_db=db,
+        platform=kwargs.pop("platform", "cli"),
+        **kwargs,
+    )
+    agent.compression_enabled = False
+    return agent
+
+
+# ── who contends, and who must not ─────────────────────────────────────────
+
+
+class _Fake:
+    """Minimal agent-shaped object — eligibility is input→output, not I/O."""
+
+    def __init__(self, **attrs):
+        self.session_id = "s1"
+        self.platform = "cli"
+        self._session_db = object()
+        self._persist_disabled = False
+        self._parent_session_id = ""
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+
+def test_an_ordinary_turn_contends_for_the_conversation(db):
+    assert should_own_conversation(_Fake(_session_db=db)) is True
+
+
+def test_a_persist_disabled_fork_never_contends():
+    """Background-review forks share the live session id for cache warmth but
+    can never write the transcript — contending would starve the real turn."""
+    assert should_own_conversation(_Fake(_persist_disabled=True)) is False
+
+
+def test_a_delegate_subagent_never_contends():
+    """A subagent runs INSIDE its parent's conversation, concurrently and by
+    design. Its root resolves to the parent's, so acquiring would deadlock
+    delegation against the very turn that launched it."""
+    assert should_own_conversation(_Fake(platform="subagent")) is False
+    assert should_own_conversation(_Fake(_parent_session_id="parent")) is False
+
+
+def test_real_delegate_builder_metadata_enables_owned_parent_publication(
+    db, monkeypatch
+):
+    """Exercise delegate_tool's real child assembly, not a hand-planted source row."""
+    from tools.delegate_tool import _build_child_agent
+
+    parent = _agent(db, session_id="parent")
+    parent._ensure_db_session()
+    # Real gateway children can inherit the gateway source instead of the
+    # literal platform="subagent". The durable _delegate_from marker must be
+    # sufficient to identify their lineage boundary.
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "tui")
+    child = _build_child_agent(
+        task_index=0,
+        goal="verify ownership metadata",
+        context=None,
+        toolsets=None,
+        model=None,
+        max_iterations=2,
+        task_count=1,
+        parent_agent=parent,
+        role="leaf",
+    )
+    child._ensure_db_session()
+    row = db.get_session(child.session_id)
+    assert child.platform == "subagent"
+    assert child._parent_session_id == "parent"
+    assert should_own_conversation(child) is False
+    assert row["parent_session_id"] == "parent"
+    assert row["source"] == "tui"
+
+    def _publish():
+        writer = SessionDB(db.db_path)
+        try:
+            writer.append_message(child.session_id, "assistant", "child-result")
+        finally:
+            writer.close()
+
+    with own_conversation(db, "parent", surface="cli"):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(_publish).result()
+    assert [m["content"] for m in db.get_messages(child.session_id)] == [
+        "child-result"
+    ]
+
+
+def test_compression_session_rotation_does_not_disable_normal_admission(db):
+    """Exercise production's live-child adoption path, not a hand assignment."""
+    from agent.conversation_compression import _adopt_live_compression_child
+
+    agent = _agent(db, session_id="root")
+    agent._ensure_db_session()
+    db.end_session("root", "compression")
+    db.create_session(
+        "compression-child", source="compression", parent_session_id="root"
+    )
+    db.append_message("compression-child", "user", "compacted history")
+
+    recovered = _adopt_live_compression_child(agent, db, "root")
+    assert recovered is not None
+    assert agent.session_id == "compression-child"
+    assert getattr(agent, "_parent_session_id", None) is None
+    assert should_own_conversation(agent) is True
+
+
+def test_an_agent_with_no_store_never_contends():
+    assert should_own_conversation(_Fake(_session_db=None)) is False
+    assert should_own_conversation(_Fake(session_id="")) is False
+
+
+def test_admission_surface_names_the_holder_usefully():
+    """The conflict message has to name a surface a human recognises."""
+    assert ownership_admission_surface(_Fake(platform="telegram")) == "telegram"
+    assert ownership_admission_surface(_Fake(platform="")) == "agent"
+
+
+# ── admission ──────────────────────────────────────────────────────────────
+
+
+def test_turn_is_refused_before_any_transcript_work_when_owned_elsewhere(db):
+    """The core invariant, at the agent boundary."""
+    db.try_acquire_conversation_ownership(
+        "conv-1",
+        new_holder_id(surface="cli"),
+        surface="cli",
+        session_id="conv-1",
+        ttl_seconds=120.0,
+    )
+    agent = _agent(db)
+
+    with pytest.raises(ConversationOwnershipConflict) as excinfo:
+        agent.run_conversation("hello")
+
+    assert excinfo.value.conversation_root == "conv-1"
+    # Refused at admission: nothing was created, loaded or written.
+    assert db.get_session("conv-1") is None
+    assert db.get_messages("conv-1") == []
+
+
+def test_turn_holds_the_conversation_for_its_whole_body_then_releases(db):
+    seen = {}
+
+    def _fake_loop(agent_self, *args, **kwargs):
+        seen["owner"] = db.get_conversation_owner("conv-1")
+        return {"final_response": "ok", "messages": []}
+
+    agent = _agent(db)
+    _run_with_stub_loop(agent, _fake_loop)
+
+    assert seen["owner"] is not None, "the turn body ran without owning the conversation"
+    assert seen["owner"]["surface"] == "cli"
+    # ...and the grant is gone once the turn returns.
+    assert db.get_conversation_owner("conv-1") is None
+
+
+def test_release_survives_a_raising_turn(db):
+    def _boom(agent_self, *args, **kwargs):
+        raise RuntimeError("model exploded")
+
+    agent = _agent(db)
+    with pytest.raises(RuntimeError):
+        _run_with_stub_loop(agent, _boom)
+    assert db.get_conversation_owner("conv-1") is None
+
+
+def test_release_survives_cancellation(db):
+    """KeyboardInterrupt/CancelledError unwind through the same ``finally``."""
+
+    def _cancel(agent_self, *args, **kwargs):
+        raise KeyboardInterrupt()
+
+    agent = _agent(db)
+    with pytest.raises(KeyboardInterrupt):
+        _run_with_stub_loop(agent, _cancel)
+    assert db.get_conversation_owner("conv-1") is None
+
+
+def test_a_second_thread_on_the_same_conversation_is_refused(db):
+    """Re-entrancy is thread-scoped: a nested call in the OWNING thread reuses
+    the grant, a genuinely concurrent one still collides."""
+    entered = threading.Event()
+    proceed = threading.Event()
+    other_thread_error = {}
+
+    def _hold(agent_self, *args, **kwargs):
+        entered.set()
+        proceed.wait(timeout=30)
+        return {"final_response": "ok", "messages": []}
+
+    def _second_turn():
+        entered.wait(timeout=30)
+        try:
+            second = _agent(db, session_id="conv-1")
+            _run_with_stub_loop(second, lambda *a, **k: {"final_response": "x"})
+        except BaseException as exc:  # noqa: BLE001 - recorded for the assert
+            other_thread_error["exc"] = exc
+        finally:
+            proceed.set()
+
+    worker = threading.Thread(target=_second_turn, daemon=True)
+    worker.start()
+    agent = _agent(db)
+    _run_with_stub_loop(agent, _hold)
+    worker.join(timeout=30)
+
+    assert isinstance(other_thread_error.get("exc"), ConversationOwnershipConflict)
+
+
+def test_nested_reentry_in_the_owning_thread_reuses_the_grant(db):
+    """A rewrite invoked from inside a held turn must not deadlock itself."""
+    from agent.session_ownership import own_conversation
+
+    outer_holder = {}
+
+    def _nested(agent_self, *args, **kwargs):
+        with own_conversation(db, "conv-1", surface="compression") as inner:
+            assert inner is not None
+            assert inner.nested is True
+            outer_holder["fence"] = inner.fence_token
+        # Leaving the nested scope must NOT release the outer grant.
+        assert db.get_conversation_owner("conv-1") is not None
+        return {"final_response": "ok", "messages": []}
+
+    agent = _agent(db)
+    _run_with_stub_loop(agent, _nested)
+    assert outer_holder["fence"] >= 1
+
+
+# ── helper ─────────────────────────────────────────────────────────────────
+
+
+def _run_with_stub_loop(agent, loop_fn):
+    """Drive ``AIAgent.run_conversation`` with the model loop stubbed out.
+
+    Only the inner ``agent.conversation_loop.run_conversation`` is replaced, so
+    the admission/release scaffolding under test is the real thing.
+    """
+    import agent.conversation_loop as loop_module
+    from unittest.mock import patch
+
+    with patch.object(loop_module, "run_conversation", loop_fn):
+        return agent.run_conversation("hello")


### PR DESCRIPTION
## Summary
- add SQLite-backed canonical conversation ownership leases with monotonic fencing
- enforce transaction-time authority across publication, rewrites, cleanup, rewind, reset, compression, and resume
- preserve bounded delegate/subagent transcript publication while refusing destructive foreign rewrites
- add focused ownership, admission, rewrite, and provider-boundary tests

## Verification
- immutable candidate v16 independently approved
- current `origin/main` replay applied cleanly at `efad7c9161a872205686140387bc223eef1242ad`
- ownership kernel + rewrite tests: 45 passed
- complete focused ownership/config suite: 62 passed on the approved candidate
- current-upstream staged and post-commit diff checks passed

## Qualifications
- broad Windows caller failures were normalized against untouched upstream; no persistent candidate-only signature remained
- this PR is intentionally draft pending hosted CI and maintainer review
- no deployment has been performed
