### PR TITLE
feat(desktop): sender-side delivery notices — 'Messaged X' / 'Message from X'

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/agent-delivery.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/agent-delivery.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { deliveryTargetFromCommand, replyTextFromResult } from './agent-delivery'
+
+// Sender-side inter-agent deliveries render as "Messaged X" / "Message from
+// X" notices instead of terminal transcript rows. This pins the detection
+// (the canonical Bot Mode command shape) and the reply extraction.
+describe('delivery command detection', () => {
+  it('matches the canonical delivery command', () => {
+    const cmd =
+      'hermes -p turqoise chat --in ~ -c "Bot Chat" -Q -q "Message from 🤖 Hermes (@hermes): hi there"'
+
+    expect(deliveryTargetFromCommand(cmd)).toBe('turqoise')
+  })
+
+  it('matches with a cd prefix and timeout wrapper', () => {
+    const cmd =
+      'cd ~ && timeout 240 hermes -p mr-tester chat --in "~" -Q -q "Message from 🤖 Hermes: hello"'
+
+    expect(deliveryTargetFromCommand(cmd)).toBe('mr-tester')
+  })
+
+  it('ignores ordinary terminal commands', () => {
+    expect(deliveryTargetFromCommand('ls -la')).toBeNull()
+    expect(deliveryTargetFromCommand('hermes -p turqoise chat -q "plain question"')).toBeNull()
+    expect(deliveryTargetFromCommand('hermes sessions list')).toBeNull()
+  })
+})
+
+describe('reply extraction', () => {
+  it('strips session_id bookkeeping and keeps the reply', () => {
+    const output = 'session_id: 20260813_220347_f69ac6\nHi Hermes! Good to hear from you.'
+
+    expect(replyTextFromResult({ output })).toBe('Hi Hermes! Good to hear from you.')
+  })
+
+  it('unwraps JSON-shaped terminal results', () => {
+    const result = JSON.stringify({ exit_code: 0, output: 'session_id: abc\nack' })
+
+    expect(replyTextFromResult(result)).toBe('ack')
+  })
+
+  it('returns empty for empty results', () => {
+    expect(replyTextFromResult(undefined)).toBe('')
+    expect(replyTextFromResult({ output: '' })).toBe('')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/agent-delivery.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/agent-delivery.tsx
@@ -1,0 +1,136 @@
+import { type ToolCallMessagePartProps } from '@assistant-ui/react'
+import { type FC, useEffect, useState } from 'react'
+
+import {
+  AGENT_MESSAGE_RE,
+  agentAvatarCache,
+  resolveAgentAvatar
+} from '@/components/assistant-ui/thread/user-message'
+
+// Sender-side inter-agent delivery: `hermes -p <agent> chat … -q "Message
+// from 🤖 <sender>…"` run through the terminal tool IS the messaging
+// pipeline (the Bot Mode / multi-profile convention shipped with #85855).
+// Rendering it as a terminal transcript makes the sending bot's chat read
+// like ops tooling; the user-facing truth is "Messaged X" and, when the
+// quiet run returns the recipient's reply, "Message from X" — the same
+// compact event notices the receiving chat shows.
+const DELIVERY_COMMAND_RE =
+  /(?:^|[;&|]\s*|\bhermes\s+)-p\s+("?)([a-z0-9][a-z0-9_-]{0,63})\1\s+chat\b[\s\S]*?-q\s+["']Message from/iu
+
+export function deliveryTargetFromCommand(command: string): null | string {
+  const match = DELIVERY_COMMAND_RE.exec(command)
+
+  return match ? match[2].toLowerCase() : null
+}
+
+/** Extract the recipient's reply text from the terminal result payload. */
+export function replyTextFromResult(result: unknown): string {
+  const container = (result ?? {}) as { content?: unknown; output?: unknown }
+  let raw = ''
+
+  if (typeof result === 'string') {
+    raw = result
+  } else if (typeof container.output === 'string') {
+    raw = container.output
+  } else if (Array.isArray(container.content)) {
+    raw = container.content
+      .map(entry => (typeof (entry as { text?: unknown })?.text === 'string' ? (entry as { text: string }).text : ''))
+      .join('\n')
+  }
+
+  // Terminal results may be JSON-wrapped: {"output": "...", "exit_code": 0}
+  if (raw.trimStart().startsWith('{')) {
+    try {
+      const parsed = JSON.parse(raw) as { output?: unknown }
+
+      if (typeof parsed.output === 'string') {
+        raw = parsed.output
+      }
+    } catch {
+      /* not JSON — use as-is */
+    }
+  }
+
+  // Drop session_id bookkeeping lines; what remains is the reply.
+  return raw
+    .split('\n')
+    .filter(line => !/^session_id:\s/.test(line.trim()))
+    .join('\n')
+    .trim()
+}
+
+const NOTICE_CLASS =
+  'flex max-w-[min(86%,44rem)] flex-col gap-0.5 self-center px-2 py-0.5 text-[0.6875rem] leading-5 text-muted-foreground/60'
+
+const AgentGlyph: FC<{ handle: string }> = ({ handle }) => {
+  const [avatar, setAvatar] = useState<null | string>(() => agentAvatarCache.get(handle.toLowerCase()) ?? null)
+
+  useEffect(() => {
+    let live = true
+
+    void resolveAgentAvatar(handle).then(url => {
+      if (live && url) {
+        setAvatar(url)
+      }
+    })
+
+    return () => {
+      live = false
+    }
+  }, [handle])
+
+  return avatar ? (
+    <img alt="" aria-hidden className="size-4 shrink-0 rounded-full object-cover" src={avatar} />
+  ) : (
+    <span aria-hidden className="text-[0.8125rem] leading-none">
+      🤖
+    </span>
+  )
+}
+
+/** "Messaged X" (+ "Message from X" once the reply lands) for a delivery
+ *  command run via the terminal tool. Returns null when the command is not
+ *  a delivery — caller falls through to the normal terminal row. */
+export const AgentDeliveryNotice: FC<ToolCallMessagePartProps> = props => {
+  const command = typeof props.args?.command === 'string' ? props.args.command : ''
+  const target = deliveryTargetFromCommand(command)
+
+  if (!target || props.isError) {
+    return null
+  }
+
+  const pending = props.result === undefined
+  const reply = pending ? '' : replyTextFromResult(props.result)
+  // Strip a leading agent-message prefix if the recipient echoed one back.
+  const replyBody = AGENT_MESSAGE_RE.exec(reply)?.[4] ?? reply
+
+  return (
+    <div className="flex w-full min-w-0 flex-col items-stretch gap-0.5">
+      <div className={NOTICE_CLASS} data-slot="aui_agent-delivery-notice">
+        <span className="flex items-center justify-center gap-1.5">
+          <AgentGlyph handle={target} />
+          <span className="wrap-anywhere">
+            {pending ? 'Messaging' : 'Messaged'} {target}
+            {pending ? '…' : ''}
+          </span>
+        </span>
+      </div>
+      {!pending && replyBody && (
+        <div className={NOTICE_CLASS} data-slot="aui_agent-reply-notice">
+          <span className="flex items-center justify-center gap-1.5">
+            <AgentGlyph handle={target} />
+            <span className="wrap-anywhere">Message from {target}</span>
+          </span>
+          <details className="self-center">
+            <summary className="cursor-pointer select-none text-center text-muted-foreground/45 hover:text-muted-foreground/70">
+              show message
+            </summary>
+            <div className="mt-1 max-w-[36rem] whitespace-pre-wrap rounded-lg border border-(--ui-stroke-tertiary) px-3 py-2 text-left text-[0.75rem] leading-5 text-foreground/85">
+              {replyBody}
+            </div>
+          </details>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -9,6 +9,7 @@ import { type ComponentProps, type FC, type ReactNode, useEffect, useRef, useSta
 import { ClarifyTool } from '@/components/assistant-ui/clarify-tool'
 import { MarkdownText, MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
 import { McpSetupTool } from '@/components/assistant-ui/mcp-setup-tool'
+import { AgentDeliveryNotice, deliveryTargetFromCommand } from '@/components/assistant-ui/thread/agent-delivery'
 import { DelegateTool } from '@/components/assistant-ui/tool/delegate'
 import { ToolFallback, ToolGroupSlot } from '@/components/assistant-ui/tool/fallback'
 import { formatElapsed, useElapsedSeconds, useMeasuredDuration } from '@/components/chat/activity-timer'
@@ -53,6 +54,18 @@ const ChainToolFallback: FC<ToolCallMessagePartProps> = props => {
   // todo parts are hoisted to a dedicated panel above the message content.
   if (props.toolName === 'todo') {
     return null
+  }
+
+  // An inter-agent delivery run through the terminal tool renders as the
+  // compact "Messaged X" / "Message from X" notices, not a transcript row
+  // (Grok-bots parity; the receiving side already renders notices via
+  // AGENT_MESSAGE_RE). Non-delivery terminal calls fall through unchanged.
+  if (props.toolName === 'terminal' && !props.isError) {
+    const command = typeof props.args?.command === 'string' ? props.args.command : ''
+
+    if (deliveryTargetFromCommand(command)) {
+      return <AgentDeliveryNotice {...props} />
+    }
   }
 
   // A reaction's UI is the emoji landing on the bubble (message.reaction

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -90,10 +90,10 @@ export const AGENT_MESSAGE_RE =
 // sender handle -> avatar data URL (null = known absent). Module-level so a
 // chat full of notices from one bot resolves once. Profiles change rarely;
 // stale entries only persist for the window's lifetime.
-const agentAvatarCache = new Map<string, null | string>()
+export const agentAvatarCache = new Map<string, null | string>()
 const agentAvatarInflight = new Map<string, Promise<null | string>>()
 
-async function resolveAgentAvatar(handle: string): Promise<null | string> {
+export async function resolveAgentAvatar(handle: string): Promise<null | string> {
   const key = handle.trim().toLowerCase()
 
   if (!key) {


### PR DESCRIPTION
Completes the inter-agent messaging visual language started in #85855 (receiver-side delivery notice + avatar) and #85884 (receiver-side reply collapse) — this is the SENDER side. Maintainer screenshots show the target: in Grok's bot UI the sending chat shows **'Messaged 🔺 Hermes'** and **'Message from 🔺 Hermes'** event notices, never the transport.

Today a delivery is a raw terminal tool row — the `hermes -p <agent> chat --in ~ -c "Bot Chat" -Q -q "Message from …"` command and its output transcript. Plumbing, not conversation.

When a `terminal` tool call matches the delivery convention, it renders as compact centered notices instead: **'Messaging <agent>…'** while running → **'Messaged <agent>'** on completion → **'Message from <agent>'** with the reply behind a 'show message' expander when the quiet (`-Q`) run returns one. Avatar resolution reuses the exported #85855 helper with the same glyph fallback ladder.

Deliberately narrow: failed commands keep the real terminal row (errors stay debuggable); the detection requires both the `-p <agent> chat` shape AND a `-q "Message from` payload, so ordinary `hermes` invocations and all other terminal calls are untouched; reply extraction strips `session_id:` bookkeeping and unwraps JSON-shaped results.

Validation: agent-delivery tests 6/6 (command detection incl. cd/timeout wrappers and negatives; reply extraction incl. JSON unwrap); full thread suite 20 files / 117 tests green.