### PR TITLE
plugins install caps manifest_version at 1 while the runtime loader supports 2

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -71,12 +71,6 @@ class PluginOperationError(Exception):
     """Recoverable plugin install/update failure (CLI exits; HTTP maps to 4xx)."""
 
 
-# Minimum manifest version this installer understands.
-# Plugins may declare ``manifest_version: 1`` in plugin.yaml;
-# future breaking changes to the manifest schema bump this.
-_SUPPORTED_MANIFEST_VERSION = 1
-
-
 def _plugins_dir() -> Path:
     """Return the user plugins directory, creating it if needed."""
     plugins = get_hermes_home() / "plugins"
@@ -743,12 +737,16 @@ def _install_plugin_core(
                     f"Plugin '{plugin_name}' has invalid manifest_version "
                     f"'{mv}' (expected an integer).",
                 ) from None
-            if mv_int > _SUPPORTED_MANIFEST_VERSION:
+            # Shared with the runtime loader so the installer can never
+            # drift behind what the loader accepts (#85879).
+            from hermes_cli.plugins import SUPPORTED_MANIFEST_VERSION
+
+            if mv_int > SUPPORTED_MANIFEST_VERSION:
                 from hermes_cli.config import recommended_update_command
 
                 raise PluginOperationError(
                     f"Plugin '{plugin_name}' requires manifest_version {mv}, "
-                    f"but this installer only supports up to {_SUPPORTED_MANIFEST_VERSION}. "
+                    f"but this Hermes supports up to {SUPPORTED_MANIFEST_VERSION}. "
                     f"Run {recommended_update_command()} to update Hermes.",
                 ) from None
 

--- a/tests/hermes_cli/test_plugin_install_manifest_version.py
+++ b/tests/hermes_cli/test_plugin_install_manifest_version.py
@@ -1,0 +1,84 @@
+"""Installer accepts every manifest_version the runtime loader supports (#85879).
+
+The installer used to carry its own private manifest-version cap, which
+drifted behind the loader's ``SUPPORTED_MANIFEST_VERSION`` and refused v2
+plugins the runtime happily loads. These tests install through the real
+clone path so the two can never split again on the next bump.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli.plugins import SUPPORTED_MANIFEST_VERSION
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def _plugin_repo(root: Path, manifest: dict) -> Path:
+    repo = root / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "fixture@example.com")
+    _git(repo, "config", "user.name", "Fixture")
+    (repo / "plugin.yaml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "init")
+    return repo
+
+
+@pytest.mark.parametrize(
+    "manifest_version", list(range(1, SUPPORTED_MANIFEST_VERSION + 1))
+)
+def test_install_accepts_every_loader_supported_manifest_version(
+    monkeypatch, tmp_path, manifest_version
+):
+    from hermes_cli.plugins_cmd import _install_plugin_core
+
+    repo = _plugin_repo(
+        tmp_path,
+        {"name": "demo", "version": "1.0.0", "manifest_version": manifest_version},
+    )
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    target, manifest, name = _install_plugin_core(repo.as_uri(), force=False)
+
+    assert name == "demo"
+    assert target.exists()
+    assert int(manifest["manifest_version"]) == manifest_version
+
+
+def test_manifest_version_above_shared_support_is_refused_cleanly(
+    monkeypatch, tmp_path
+):
+    from hermes_cli.plugins_cmd import PluginOperationError, _install_plugin_core
+
+    repo = _plugin_repo(
+        tmp_path,
+        {
+            "name": "demo",
+            "version": "1.0.0",
+            "manifest_version": SUPPORTED_MANIFEST_VERSION + 1,
+        },
+    )
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    with pytest.raises(
+        PluginOperationError,
+        match=rf"supports up to {SUPPORTED_MANIFEST_VERSION}\b",
+    ):
+        _install_plugin_core(repo.as_uri(), force=False)
+
+    assert not (home / "plugins" / "demo").exists()
+    assert not (home / "plugins" / ".install-metadata.json").exists()


### PR DESCRIPTION
Fixes #85879.

I hit this shipping a plugin. The manifest says manifest_version 2, the runtime loader supports 2, and `hermes plugins install` still refused it. The installer keeps its own private cap: `_SUPPORTED_MANIFEST_VERSION = 1` in plugins_cmd.py. Two constants for the same fact, and they drifted.

## What

I deleted the installer's private constant and pointed the check at the loader's `SUPPORTED_MANIFEST_VERSION` from `hermes_cli.plugins`. The lazy import matches how plugins_cmd already pulls from that module everywhere else, and plugins.py never imports plugins_cmd, so there's no cycle.

The installer still refuses anything above the shared constant. I left that on purpose. The loader warns and loads on newer versions, but install time is the right place to stay strict about a schema this Hermes doesn't understand yet. The bug was the drift, not the strictness. The error message now names the shared cap instead of the stale private one.

## Why

One fact, one constant. The next time SUPPORTED_MANIFEST_VERSION bumps, the installer follows automatically and the front door can't fall behind the house it guards again.

## Testing

New file tests/hermes_cli/test_plugin_install_manifest_version.py, 3 tests, all through the real install path: `_install_plugin_core` cloning a local fixture repo, same idiom as test_plugin_install_ref.py.

- v1 and v2 manifests install. The accept case is parametrized over every version the loader supports, so a future bump extends the coverage by itself.
- manifest_version above the shared constant is still refused, the message names the shared cap, and no install state is left behind.

I wrote them red first. The v2 install failed with "installer only supports up to 1" before the fix, 3/3 after. The neighboring plugin suites (test_plugin_install_ref, test_plugins_cmd, test_plugins_cmd_list, test_plugins_cmd_category_discovery, test_plugins_cmd_enable_disable_nested, test_plugins, test_plugin_manifest_v2) pass 167/167. ruff check is clean on both touched files.
