### PR TITLE
fix(gateway): resume freshness uses last user activity

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -28,6 +28,11 @@ def _now() -> datetime:
     return datetime.now()
 
 
+def _activity_time(entry: "SessionEntry") -> datetime:
+    """User-activity clock for restart resume. Falls back to updated_at."""
+    return entry.last_activity_at or entry.updated_at
+
+
 # Default auto-continue freshness window in seconds (1 hour).  A session
 # interrupted by a restart is only auto-resumed — and only returned by
 # ``get_or_create_session`` — while it stays within this window of when
@@ -784,6 +789,9 @@ class SessionEntry:
     session_id: str
     created_at: datetime
     updated_at: datetime
+    # Last user-facing activity. Distinct from updated_at, which recover,
+    # repoint, and heal also stamp. Restart resume uses this (#85709).
+    last_activity_at: Optional[datetime] = None
     
     # Origin metadata for delivery routing
     origin: Optional[SessionSource] = None
@@ -877,6 +885,11 @@ class SessionEntry:
             "session_id": self.session_id,
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat(),
+            "last_activity_at": (
+                self.last_activity_at.isoformat()
+                if self.last_activity_at
+                else None
+            ),
             "display_name": self.display_name,
             "platform": self.platform.value if self.platform else None,
             "chat_type": self.chat_type,
@@ -931,6 +944,14 @@ class SessionEntry:
             except ValueError as e:
                 logger.debug("Unknown platform value %r: %s", data["platform"], e)
 
+        last_activity_at = None
+        _laa = data.get("last_activity_at")
+        if _laa:
+            try:
+                last_activity_at = datetime.fromisoformat(_laa)
+            except (TypeError, ValueError):
+                last_activity_at = None
+
         last_resume_marked_at = None
         _lrma = data.get("last_resume_marked_at")
         if _lrma:
@@ -977,6 +998,7 @@ class SessionEntry:
             session_id=session_id,
             created_at=datetime.fromisoformat(data["created_at"]),
             updated_at=datetime.fromisoformat(data["updated_at"]),
+            last_activity_at=last_activity_at,
             origin=origin,
             display_name=data.get("display_name"),
             platform=platform,
@@ -1932,6 +1954,7 @@ class SessionStore:
             session_id=str(row["id"]),
             created_at=created_at,
             updated_at=updated_at,
+            last_activity_at=updated_at,
             origin=source,
             display_name=source.chat_name,
             platform=source.platform,
@@ -2662,6 +2685,7 @@ class SessionStore:
                     # the prior user-activity clock used by reset policy.
                     if touch_activity:
                         entry.updated_at = now
+                        entry.last_activity_at = now
                     _needs_save = touch_activity or _healed
                     _metadata_only_save = touch_activity and not _healed
                 else:
@@ -2678,6 +2702,7 @@ class SessionStore:
                     else:
                         if touch_activity:
                             entry.updated_at = now
+                            entry.last_activity_at = now
                         _needs_save = touch_activity or _healed
                         _metadata_only_save = touch_activity and not _healed
             else:
@@ -2727,6 +2752,7 @@ class SessionStore:
                 session_id=session_id,
                 created_at=now,
                 updated_at=now,
+                last_activity_at=now,
                 origin=source,
                 display_name=source.chat_name,
                 platform=source.platform,
@@ -2850,7 +2876,9 @@ class SessionStore:
             if entry is None:
                 return
             if touch_activity:
-                entry.updated_at = _now()
+                now = _now()
+                entry.updated_at = now
+                entry.last_activity_at = now
             if last_prompt_tokens is not None:
                 entry.last_prompt_tokens = last_prompt_tokens
             # Snapshot peer fields while still holding _lock: a concurrent
@@ -3192,10 +3220,11 @@ class SessionStore:
 
         Called on gateway startup after a crash or fast restart to preserve
         in-flight sessions instead of destroying their conversation history
-        (#7536).  Only marks sessions updated within *max_age_seconds* to
-        avoid touching long-idle sessions.  Sets ``resume_pending=True`` so
-        the next incoming message on the same session_key auto-resumes from
-        the existing transcript.
+        (#7536).  Only marks sessions whose last user activity is within
+        *max_age_seconds* so recover/repoint bookkeeping cannot make a
+        long-idle session look fresh (#85709).  Sets ``resume_pending=True``
+        so the next incoming message on the same session_key auto-resumes
+        from the existing transcript.
 
         Entries already flagged ``resume_pending=True`` are skipped.  Entries
         explicitly ``suspended=True`` (from /stop or stuck-loop escalation)
@@ -3214,7 +3243,11 @@ class SessionStore:
             for entry in self._entries.values():
                 if entry.resume_pending:
                     continue
-                if not entry.suspended and entry.updated_at >= cutoff:
+                if entry.suspended:
+                    continue
+                # An in-flight turn is the actual crash-recovery case, even
+                # when last_activity_at is older than the 120s window.
+                if entry.active_turn_token or _activity_time(entry) >= cutoff:
                     entry.resume_pending = True
                     entry.resume_reason = "restart_interrupted"
                     entry.last_resume_marked_at = _now()
@@ -3246,6 +3279,7 @@ class SessionStore:
                 session_id=session_id,
                 created_at=now,
                 updated_at=now,
+                last_activity_at=now,
                 origin=old_entry.origin,
                 display_name=display_name if display_name is not None else old_entry.display_name,
                 platform=old_entry.platform,
@@ -3385,6 +3419,7 @@ class SessionStore:
                 session_id=target_session_id,
                 created_at=now,
                 updated_at=now,
+                last_activity_at=now,
                 origin=old_entry.origin,
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -51,6 +51,68 @@ class TestSuspendRecentlyActive:
         assert refreshed.resume_pending
         assert refreshed.session_id == entry.session_id  # same session preserved
 
+    def test_store_touch_does_not_mark_idle_session(self, tmp_path):
+        """Recover/repoint may stamp updated_at=now without user activity."""
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        idle = datetime.now() - timedelta(days=21)
+        with store._lock:
+            entry.last_activity_at = idle
+            entry.updated_at = datetime.now()
+            store._save()
+
+        count = store.suspend_recently_active(max_age_seconds=120)
+        assert count == 0
+        assert not store.get_or_create_session(source).resume_pending
+
+    def test_missing_last_activity_falls_back_to_updated_at(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        with store._lock:
+            entry.last_activity_at = None
+            entry.updated_at = datetime.now()
+            store._save()
+
+        count = store.suspend_recently_active(max_age_seconds=120)
+        assert count == 1
+
+    def test_recovered_row_copies_durable_activity_time(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+        started = datetime.now() - timedelta(days=21)
+        last_active_ts = (started + timedelta(hours=1)).timestamp()
+        entry = store._create_entry_from_recovered_row(
+            row={
+                "id": "20260724_094354_caf1ed0c",
+                "started_at": started.timestamp(),
+                "last_activity_at": last_active_ts,
+                "message_count": 4,
+            },
+            session_key="telegram:123",
+            source=source,
+            now=datetime.now(),
+        )
+        assert abs(entry.last_activity_at.timestamp() - last_active_ts) < 1
+        store._entries[entry.session_key] = entry
+        store._loaded = True
+        count = store.suspend_recently_active(max_age_seconds=120)
+        assert count == 0
+
+    def test_active_turn_is_marked_even_if_activity_is_old(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        with store._lock:
+            entry.last_activity_at = datetime.now() - timedelta(minutes=10)
+            entry.updated_at = datetime.now()
+            entry.active_turn_token = "in-flight"
+            store._save()
+
+        count = store.suspend_recently_active(max_age_seconds=120)
+        assert count == 1
+
 
 # ---------------------------------------------------------------------------
 # Clean shutdown marker integration


### PR DESCRIPTION
## What does this PR do?

Stop gateway restart from auto-resuming long-idle sessions whose `updated_at` was stamped by session-store bookkeeping (recover, repoint, turn-marker writes), not by a user.

`SessionStore.suspend_recently_active()` used `updated_at` as the 120s freshness clock. A 21-day idle session could then be marked `resume_pending`, and the next synthetic resume turn would retry unfinished work.

This change persists `last_activity_at` on `SessionEntry` (set on real user-facing activity and copied from the durable row on recover). The restart gate uses that clock, with a fallback to `updated_at` for old `sessions.json` rows. Sessions that still have an `active_turn_token` stay eligible, so a crash mid-turn still resumes.

## Related Issue

Fixes #85709

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/session.py`: add `last_activity_at` on `SessionEntry`; serialize/load it; set it from recover, `update_session(touch_activity=True)`, new/reset/switch session construction, and user-facing `get_or_create_session` touches; `suspend_recently_active` uses `_activity_time(entry)` and also treats an in-flight `active_turn_token` as recent.
- `tests/gateway/test_clean_shutdown_marker.py`: store-touch vs idle, missing-field fallback, recovered durable timestamp, in-flight turn.

## How to Test

1. Create a session, set `last_activity_at` 21 days ago and `updated_at` to now, call `suspend_recently_active(120)`. Expect count 0.
2. Create a session via `get_or_create_session` (recent activity) and call `suspend_recently_active()`. Expect count 1 and `resume_pending`.
3. Recover a row whose durable `last_activity_at` is 21 days old. Expect it is not marked.
4. Set an old `last_activity_at` plus `active_turn_token`. Expect it is marked.

Ran:

```text
scripts/run_tests.sh tests/gateway/test_clean_shutdown_marker.py tests/gateway/test_restart_resume_pending.py -q
```

40 passed, 0 failed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. Reproduction is the timestamp compare in the new tests.
