### PR TITLE
feat(desktop): add searchable profile switcher

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import type { ProfileInfo } from '@/types/hermes'
+
+import { ProfileDropdown } from './profile-switcher'
+
+class TestResizeObserver {
+  disconnect() {}
+  observe() {}
+  unobserve() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      profiles: {
+        noSearchResults: 'No profiles found.',
+        search: 'Search profiles...',
+        title: 'Profiles'
+      }
+    }
+  })
+}))
+
+vi.mock('./use-profile-prewarm', () => ({
+  useProfilePrewarm: () => ({ cancelPrewarm: vi.fn(), startPrewarm: vi.fn() })
+}))
+
+const profile = (name: string): ProfileInfo => ({
+  has_env: false,
+  is_default: false,
+  model: null,
+  name,
+  path: `/profiles/${name}`,
+  provider: null,
+  skill_count: 0
+})
+
+const profiles = [profile('vps'), profile('agency-ai-engineer'), profile('agency-audio-designer')]
+
+describe('ProfileDropdown', () => {
+  it('filters profile suggestions case-insensitively and selects one', () => {
+    const onSelect = vi.fn()
+
+    render(<ProfileDropdown activeKey="vps" colors={{}} onSelect={onSelect} profiles={profiles} />)
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Profiles' }))
+
+    const input = screen.getByPlaceholderText('Search profiles...')
+    expect(input.ownerDocument.activeElement).toBe(input)
+
+    fireEvent.change(input, { target: { value: 'AUDIO' } })
+
+    expect(screen.getByRole('option', { name: 'agency-audio-designer' })).not.toBeNull()
+    expect(screen.queryByRole('option', { name: 'agency-ai-engineer' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('option', { name: 'agency-audio-designer' }))
+
+    expect(onSelect).toHaveBeenCalledWith('agency-audio-designer')
+    expect(screen.queryByPlaceholderText('Search profiles...')).toBeNull()
+  })
+
+  it('supports keyboard autocomplete selection', () => {
+    const onSelect = vi.fn()
+
+    render(<ProfileDropdown activeKey={null} colors={{}} onSelect={onSelect} profiles={profiles} />)
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Profiles' }))
+    const input = screen.getByPlaceholderText('Search profiles...')
+
+    fireEvent.change(input, { target: { value: 'engineer' } })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onSelect).toHaveBeenCalledWith('agency-ai-engineer')
+  })
+
+  it('shows an empty state and resets the query after closing', () => {
+    render(<ProfileDropdown activeKey={null} colors={{}} onSelect={vi.fn()} profiles={profiles} />)
+
+    const trigger = screen.getByRole('combobox', { name: 'Profiles' })
+    fireEvent.click(trigger)
+
+    const input = screen.getByPlaceholderText('Search profiles...')
+    fireEvent.change(input, { target: { value: 'missing-profile' } })
+
+    expect(screen.getByText('No profiles found.')).not.toBeNull()
+
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(screen.queryByPlaceholderText('Search profiles...')).toBeNull()
+
+    fireEvent.click(trigger)
+    expect((screen.getByPlaceholderText('Search profiles...') as HTMLInputElement).value).toBe('')
+    expect(screen.getAllByRole('option')).toHaveLength(profiles.length)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -26,11 +26,12 @@ import { CodeEditor } from '@/components/chat/code-editor'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { ColorSwatches } from '@/components/ui/color-swatches'
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
+import { controlVariants } from '@/components/ui/control'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { ProfileGlyph } from '@/components/ui/profile-glyph'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tip, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { getProfileSoul, updateProfileSoul } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -460,7 +461,7 @@ function ImportProfileButton({ label }: { label: string }) {
 // The condensed rail: every named profile in one compact select. The trigger
 // shows the active profile (tinted initial + name); on default/all scope it
 // falls back to the placeholder since the left toggle pill carries that state.
-function ProfileDropdown({
+export function ProfileDropdown({
   activeKey,
   colors,
   onSelect,
@@ -473,39 +474,115 @@ function ProfileDropdown({
 }) {
   const { t } = useI18n()
   const p = t.profiles
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
 
-  const value = activeKey ? (profiles.find(profile => normalizeProfileKey(profile.name) === activeKey)?.name ?? '') : ''
+  const activeProfile = activeKey
+    ? profiles.find(profile => normalizeProfileKey(profile.name) === activeKey)
+    : undefined
+
+  const query = search.trim().toLocaleLowerCase()
+  const filtered = query ? profiles.filter(profile => profile.name.toLocaleLowerCase().includes(query)) : profiles
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next)
+
+    if (!next) {
+      setSearch('')
+    }
+  }
+
+  const handleSelect = (name: string) => {
+    onSelect(name)
+    handleOpenChange(false)
+  }
 
   return (
-    <Select onValueChange={name => name && onSelect(name)} value={value}>
-      <SelectTrigger aria-label={p.title} className="min-w-0 flex-1" size="xs">
-        <SelectValue placeholder={p.title} />
-      </SelectTrigger>
-      <SelectContent collisionPadding={{ bottom: 44, left: 8, right: 8, top: 8 }} side="top">
-        {profiles.map(profile => (
-          <ProfileDropdownItem
-            color={resolveProfileColor(profile.name, colors)}
-            key={profile.name}
-            name={profile.name}
-          />
-        ))}
-      </SelectContent>
-    </Select>
+    <Popover onOpenChange={handleOpenChange} open={open}>
+      <PopoverTrigger asChild>
+        <button
+          aria-expanded={open}
+          aria-haspopup="listbox"
+          aria-label={p.title}
+          className={cn(
+            controlVariants({ size: 'xs' }),
+            'flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-2 whitespace-nowrap',
+            !activeProfile && 'text-muted-foreground'
+          )}
+          data-slot="profile-dropdown-trigger"
+          role="combobox"
+          type="button"
+        >
+          {activeProfile ? (
+            <span className="flex min-w-0 items-center gap-1.5">
+              <ProfileGlyph
+                aria-hidden="true"
+                color={resolveProfileColor(activeProfile.name, colors)}
+                isDefault={false}
+                name={activeProfile.name}
+              />
+              <span className="truncate">{activeProfile.name}</span>
+            </span>
+          ) : (
+            <span className="truncate">{p.title}</span>
+          )}
+          <Codicon className="shrink-0 opacity-60" name={open ? 'chevron-up' : 'chevron-down'} size="1rem" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-72 p-0"
+        collisionPadding={{ bottom: 44, left: 8, right: 8, top: 8 }}
+        side="top"
+      >
+        <Command className="bg-transparent" shouldFilter={false}>
+          <CommandInput autoFocus onValueChange={setSearch} placeholder={p.search} value={search} />
+          <CommandList className="max-h-72 p-1">
+            {filtered.length === 0 ? (
+              <CommandEmpty>{p.noSearchResults}</CommandEmpty>
+            ) : (
+              <CommandGroup>
+                {filtered.map(profile => (
+                  <ProfileDropdownItem
+                    active={profile === activeProfile}
+                    color={resolveProfileColor(profile.name, colors)}
+                    key={profile.name}
+                    name={profile.name}
+                    onSelect={() => handleSelect(profile.name)}
+                  />
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   )
 }
 
 // One dropdown row per profile — its own component so each row can own a
 // hover-intent prewarm timer (see useProfilePrewarm).
-function ProfileDropdownItem({ color, name }: { color: null | string; name: string }) {
+function ProfileDropdownItem({
+  active,
+  color,
+  name,
+  onSelect
+}: {
+  active: boolean
+  color: null | string
+  name: string
+  onSelect: () => void
+}) {
   const { cancelPrewarm, startPrewarm } = useProfilePrewarm(name)
 
   return (
-    <SelectItem onPointerEnter={startPrewarm} onPointerLeave={cancelPrewarm} value={name}>
-      <span className="flex min-w-0 items-center gap-1.5">
+    <CommandItem onPointerEnter={startPrewarm} onPointerLeave={cancelPrewarm} onSelect={onSelect} value={name}>
+      <span className="flex min-w-0 flex-1 items-center gap-1.5">
         <ProfileGlyph aria-hidden="true" color={color} isDefault={false} name={name} />
         <span className="truncate">{name}</span>
       </span>
-    </SelectItem>
+      <Codicon className={cn('shrink-0', active ? 'opacity-100' : 'opacity-0')} name="check" size="1rem" />
+    </CommandItem>
   )
 }
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1292,6 +1292,8 @@ export const ar = defineLocale({
     nameHint: 'اسم الملف الشخصي',
     title: 'الملفات الشخصية',
     count: count => `${count} ملف شخصي`,
+    search: 'البحث في الملفات الشخصية…',
+    noSearchResults: 'لم يتم العثور على ملفات شخصية مطابقة.',
     loading: 'جار التحميل...',
     newProfile: 'ملف شخصي جديد',
     importProfile: 'استيراد ملف شخصي…',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1584,6 +1584,7 @@ export const en: Translations = {
     title: 'Profiles',
     count: count => `${count} ${count === 1 ? 'profile' : 'profiles'}`,
     search: 'Search profiles...',
+    noSearchResults: 'No profiles found.',
     loading: 'Loading profiles...',
     newProfile: 'New profile',
     importProfile: 'Import profile…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1405,6 +1405,7 @@ export const ja = defineLocale({
     title: 'プロファイル',
     count: count => `${count} プロファイル`,
     search: 'プロファイルを検索...',
+    noSearchResults: '一致するプロファイルが見つかりません。',
     loading: 'プロファイルを読み込み中...',
     newProfile: '新しいプロファイル',
     importProfile: 'プロファイルをインポート…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1321,6 +1321,7 @@ export interface Translations {
     title: string
     count: (count: number) => string
     search: string
+    noSearchResults: string
     loading: string
     newProfile: string
     importProfile: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1354,6 +1354,7 @@ export const zhHant = defineLocale({
     title: '設定檔',
     count: count => `${count} 個設定檔`,
     search: '搜尋設定檔…',
+    noSearchResults: '找不到相符的設定檔。',
     loading: '正在載入設定檔…',
     newProfile: '新增設定檔',
     importProfile: '匯入設定檔…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1776,6 +1776,7 @@ export const zh: Translations = {
     title: '配置档案',
     count: count => `${count} 个配置档案`,
     search: '搜索配置档案…',
+    noSearchResults: '未找到匹配的配置档案。',
     loading: '正在加载配置档案…',
     newProfile: '新建配置档案',
     importProfile: '导入配置档案…',


### PR DESCRIPTION
## Summary

- turn the Desktop profile dropdown into a searchable, accessible combobox
- filter profile names case-insensitively while preserving profile order, glyphs, colors, selection state, and hover prewarming
- support mouse selection, arrow-key navigation, Enter, Escape, autofocus, query reset, and a localized no-results state
- add focused interaction coverage and translations for every supported Desktop language

## Validation

- `npm run typecheck`
- focused ESLint on all changed files
- `npx vitest run src/app/chat/sidebar/profile-switcher.test.tsx src/i18n/languages.test.ts src/i18n/runtime.test.ts`
- `npm run build`
- `npm run test:ui`
- packaged Linux Desktop app manually verified for autofocus, filtering, mouse and keyboard selection, no-results behavior, Escape, and query reset

## Platform tested

- Debian 13, packaged Linux x64 Desktop build

## Duplicate check

Searched open issues and open/all PRs for profile search, searchable profile switcher, and related terms; no duplicate implementation surfaced.
