### PR TITLE
feat(cli): recover stale compression state

### DIFF
--- a/hermes_cli/compression_recovery.py
+++ b/hermes_cli/compression_recovery.py
@@ -1,0 +1,249 @@
+"""Safe inspection/recovery helpers for stuck session compression state."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_state import SessionDB, _compression_lock_holder_process_is_dead
+
+
+def _as_dict(row: Any) -> Optional[dict[str, Any]]:
+    if row is None:
+        return None
+    return dict(row) if isinstance(row, sqlite3.Row) else dict(row)
+
+
+def _iso(ts: Optional[float]) -> Optional[str]:
+    if ts is None:
+        return None
+    try:
+        return _dt.datetime.fromtimestamp(float(ts)).isoformat(timespec="seconds")
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _stamp() -> str:
+    return _dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+def _backup_live_db(db: SessionDB, backup_path: Optional[Path] = None) -> str:
+    """Create a consistent SQLite backup without raw-copying a live DB file."""
+
+    source = Path(db.db_path)
+    dest = backup_path or source.with_name(
+        f"{source.name}.compression-recovery-backup-{_stamp()}"
+    )
+    if dest.exists():
+        raise FileExistsError(f"backup path already exists: {dest}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with db._lock:  # SessionDB owns this connection; keep the backup atomic.
+        backup_conn = sqlite3.connect(dest)
+        try:
+            db._conn.backup(backup_conn)
+        finally:
+            backup_conn.close()
+    return str(dest)
+
+
+def inspect_stuck_compression(
+    db: SessionDB,
+    session_id: str,
+    *,
+    now: Optional[float] = None,
+) -> dict[str, Any]:
+    """Return diagnostics for a session that may be blocked by compression."""
+
+    now = float(time.time() if now is None else now)
+    with db._lock:
+        session = _as_dict(
+            db._conn.execute(
+                """
+                SELECT id, source, session_key, ended_at, end_reason,
+                       compression_failure_cooldown_until,
+                       compression_failure_error
+                FROM sessions WHERE id = ?
+                """,
+                (session_id,),
+            ).fetchone()
+        )
+        lock = _as_dict(
+            db._conn.execute(
+                """
+                SELECT session_id, holder, acquired_at, expires_at
+                FROM compression_locks WHERE session_id = ?
+                """,
+                (session_id,),
+            ).fetchone()
+        )
+        counts = _as_dict(
+            db._conn.execute(
+                """
+                SELECT COUNT(*) AS total_messages,
+                       SUM(CASE WHEN COALESCE(active, 1) = 1 THEN 1 ELSE 0 END)
+                           AS active_messages,
+                       SUM(CASE WHEN COALESCE(compacted, 0) = 1 THEN 1 ELSE 0 END)
+                           AS compacted_messages
+                FROM messages WHERE session_id = ?
+                """,
+                (session_id,),
+            ).fetchone()
+        )
+        route_rows = [
+            dict(r)
+            for r in db._conn.execute(
+                "SELECT scope, session_key, entry_json, updated_at FROM gateway_routing"
+            ).fetchall()
+        ]
+
+    route_matches: list[dict[str, Any]] = []
+    route_session_key = session.get("session_key") if session else None
+    for row in route_rows:
+        try:
+            entry = json.loads(row.get("entry_json") or "{}")
+        except json.JSONDecodeError:
+            entry = {}
+        if entry.get("session_id") == session_id or (
+            route_session_key and row.get("session_key") == route_session_key
+        ):
+            route_matches.append({
+                "scope": row.get("scope") or "",
+                "session_key": row.get("session_key"),
+                "entry_session_id": entry.get("session_id"),
+                "last_prompt_tokens": entry.get("last_prompt_tokens"),
+                "updated_at": row.get("updated_at"),
+            })
+
+    lock_state = "missing"
+    if lock:
+        expires_at = float(lock.get("expires_at") or 0.0)
+        holder = str(lock.get("holder") or "")
+        if expires_at < now:
+            lock_state = "expired"
+        elif _compression_lock_holder_process_is_dead(holder):
+            lock_state = "owner_dead"
+        else:
+            lock_state = "active"
+
+    cooldown_state = "missing"
+    cooldown_until = None
+    if session and session.get("compression_failure_cooldown_until") is not None:
+        cooldown_until = float(session["compression_failure_cooldown_until"])
+        cooldown_state = "active" if cooldown_until > now else "expired"
+
+    return {
+        "session_id": session_id,
+        "session_exists": session is not None,
+        "session": session,
+        "messages": counts or {},
+        "compression_lock": lock,
+        "compression_lock_state": lock_state,
+        "compression_failure_cooldown_state": cooldown_state,
+        "compression_failure_cooldown_until_iso": _iso(cooldown_until),
+        "gateway_routing_matches": route_matches,
+        "recoverable": bool(
+            session is not None
+            and lock_state in {"missing", "expired", "owner_dead"}
+            and cooldown_state in {"missing", "expired"}
+        ),
+    }
+
+
+def recover_stuck_compression(
+    db: SessionDB,
+    session_id: str,
+    *,
+    apply: bool = False,
+    backup: bool = True,
+    backup_path: Optional[Path] = None,
+    now: Optional[float] = None,
+) -> dict[str, Any]:
+    """Clear stale compression blockers and stale route token counters.
+
+    This deliberately does not summarize or delete transcript rows. It is the
+    small, safe runtime recovery step: remove stale compression state, preserve
+    history, and make the next normal compression/turn path possible.
+    """
+
+    now = float(time.time() if now is None else now)
+    before = inspect_stuck_compression(db, session_id, now=now)
+    report: dict[str, Any] = {
+        "session_id": session_id,
+        "applied": bool(apply),
+        "before": before,
+        "backup_path": None,
+        "compression_locks_removed": 0,
+        "cooldown_cleared": False,
+        "gateway_routing_entries_reset": 0,
+    }
+    if not before["session_exists"]:
+        report["error"] = "session not found"
+        return report
+    if before["compression_lock_state"] == "active":
+        report["error"] = "active compression lock is still owned; refusing recovery"
+        return report
+    if before["compression_failure_cooldown_state"] == "active":
+        report["error"] = "compression failure cooldown is still active; refusing recovery"
+        return report
+    if not apply:
+        return report
+
+    if backup:
+        report["backup_path"] = _backup_live_db(db, backup_path)
+
+    route_session_key = (before.get("session") or {}).get("session_key")
+
+    def _do(conn):
+        removed = conn.execute(
+            "DELETE FROM compression_locks WHERE session_id = ?",
+            (session_id,),
+        ).rowcount
+        cleared = conn.execute(
+            """
+            UPDATE sessions
+               SET compression_failure_cooldown_until = NULL,
+                   compression_failure_error = NULL
+             WHERE id = ?
+               AND compression_failure_cooldown_until IS NOT NULL
+            """,
+            (session_id,),
+        ).rowcount > 0
+
+        reset_routes = 0
+        rows = conn.execute(
+            "SELECT scope, session_key, entry_json FROM gateway_routing"
+        ).fetchall()
+        for row in rows:
+            scope = row["scope"] if isinstance(row, sqlite3.Row) else row[0]
+            session_key = row["session_key"] if isinstance(row, sqlite3.Row) else row[1]
+            raw = row["entry_json"] if isinstance(row, sqlite3.Row) else row[2]
+            try:
+                entry = json.loads(raw or "{}")
+            except json.JSONDecodeError:
+                continue
+            if entry.get("session_id") != session_id and session_key != route_session_key:
+                continue
+            if int(entry.get("last_prompt_tokens") or 0) <= 0:
+                continue
+            entry["last_prompt_tokens"] = 0
+            conn.execute(
+                """
+                UPDATE gateway_routing
+                   SET entry_json = ?, updated_at = ?
+                 WHERE scope = ? AND session_key = ?
+                """,
+                (json.dumps(entry, sort_keys=True), now, scope, session_key),
+            )
+            reset_routes += 1
+        return removed, cleared, reset_routes
+
+    removed, cleared, reset_routes = db._execute_write(_do)
+    report["compression_locks_removed"] = int(removed or 0)
+    report["cooldown_cleared"] = bool(cleared)
+    report["gateway_routing_entries_reset"] = int(reset_routes or 0)
+    report["after"] = inspect_stuck_compression(db, session_id, now=now)
+    return report

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12566,6 +12566,36 @@ def main():
         ),
     )
 
+    sessions_recover_compression = sessions_subparsers.add_parser(
+        "recover-compression",
+        help="Inspect or clear stale compression blockers for one session",
+        description=(
+            "Inspect a session that reports stuck context compression. With "
+            "--apply, safely clears stale/expired compression locks and "
+            "cooldowns, resets stale gateway routing prompt-token counters, "
+            "and makes a SQLite backup first unless --no-backup is passed."
+        ),
+    )
+    sessions_recover_compression.add_argument(
+        "session_id",
+        help="Session ID whose compression state should be inspected/recovered",
+    )
+    sessions_recover_compression.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the safe recovery changes (default: inspect only)",
+    )
+    sessions_recover_compression.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Do not create a SQLite backup before applying recovery",
+    )
+    sessions_recover_compression.add_argument(
+        "--backup-path",
+        type=Path,
+        help="Optional explicit backup path used with --apply",
+    )
+
     sessions_recover = sessions_subparsers.add_parser(
         "recover",
         help="Rebuild canonical session data into a separate clean database",

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -232,6 +232,24 @@ def cmd_sessions(args, sessions_parser=None):
         print("  Do not install it. Review the JSON report for partial data or errors.")
         return 1
 
+    if action == "recover-compression":
+        from hermes_cli.compression_recovery import recover_stuck_compression
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            report = recover_stuck_compression(
+                db,
+                args.session_id,
+                apply=bool(getattr(args, "apply", False)),
+                backup=not bool(getattr(args, "no_backup", False)),
+                backup_path=getattr(args, "backup_path", None),
+            )
+        finally:
+            db.close()
+        print(_json.dumps(report, indent=2, sort_keys=True))
+        return 1 if report.get("error") else 0
+
     try:
         from hermes_state import SessionDB
 

--- a/tests/hermes_cli/test_compression_recovery.py
+++ b/tests/hermes_cli/test_compression_recovery.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+
+from hermes_cli.compression_recovery import (
+    inspect_stuck_compression,
+    recover_stuck_compression,
+)
+from hermes_state import SessionDB
+
+
+def _db(tmp_path):
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+def test_inspect_stuck_compression_reports_expired_state(tmp_path):
+    db = _db(tmp_path)
+    try:
+        db.create_session("s1", "telegram", session_key="agent:telegram:chat")
+        db.append_message("s1", "user", "hello")
+        db.record_compression_failure_cooldown("s1", 900.0, "summary timed out")
+        db._conn.execute(
+            "INSERT INTO compression_locks "
+            "(session_id, holder, acquired_at, expires_at) VALUES (?, ?, ?, ?)",
+            ("s1", "old-holder", 800.0, 850.0),
+        )
+        db.save_gateway_routing_entry(
+            "agent:telegram:chat",
+            json.dumps({
+                "session_key": "agent:telegram:chat",
+                "session_id": "s1",
+                "last_prompt_tokens": 123456,
+            }),
+        )
+
+        report = inspect_stuck_compression(db, "s1", now=1000.0)
+
+        assert report["session_exists"] is True
+        assert report["compression_lock_state"] == "expired"
+        assert report["compression_failure_cooldown_state"] == "expired"
+        assert report["recoverable"] is True
+        assert report["messages"]["active_messages"] == 1
+        assert report["gateway_routing_matches"][0]["last_prompt_tokens"] == 123456
+    finally:
+        db.close()
+
+
+def test_recover_stuck_compression_clears_only_stale_state(tmp_path):
+    db = _db(tmp_path)
+    try:
+        db.create_session("s1", "telegram", session_key="agent:telegram:chat")
+        db.append_message("s1", "user", "hello")
+        db.record_compression_failure_cooldown("s1", 900.0, "summary timed out")
+        db._conn.execute(
+            "INSERT INTO compression_locks "
+            "(session_id, holder, acquired_at, expires_at) VALUES (?, ?, ?, ?)",
+            ("s1", "old-holder", 800.0, 850.0),
+        )
+        db._conn.commit()
+        db.save_gateway_routing_entry(
+            "agent:telegram:chat",
+            json.dumps({
+                "session_key": "agent:telegram:chat",
+                "session_id": "s1",
+                "last_prompt_tokens": 123456,
+                "input_tokens": 99,
+            }),
+        )
+
+        report = recover_stuck_compression(
+            db,
+            "s1",
+            apply=True,
+            backup=False,
+            now=1000.0,
+        )
+
+        assert "error" not in report
+        assert report["compression_locks_removed"] == 1
+        assert report["cooldown_cleared"] is True
+        assert report["gateway_routing_entries_reset"] == 1
+        assert report["after"]["compression_lock_state"] == "missing"
+        assert report["after"]["compression_failure_cooldown_state"] == "missing"
+        assert db.get_compression_failure_cooldown_row("s1")["cooldown_until"] is None
+        entry = json.loads(db.load_gateway_routing_entries()["agent:telegram:chat"])
+        assert entry["last_prompt_tokens"] == 0
+        assert entry["input_tokens"] == 99
+        assert [m["content"] for m in db.get_messages("s1")] == ["hello"]
+    finally:
+        db.close()
+
+
+def test_recover_stuck_compression_refuses_live_lock(tmp_path):
+    db = _db(tmp_path)
+    try:
+        db.create_session("s1", "cli")
+        assert db.try_acquire_compression_lock("s1", f"pid={os.getpid()}:test", ttl_seconds=60)
+
+        report = recover_stuck_compression(
+            db,
+            "s1",
+            apply=True,
+            backup=False,
+            now=time.time(),
+        )
+
+        assert report["error"] == "active compression lock is still owned; refusing recovery"
+        assert db.get_compression_lock_holder("s1") is not None
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary

- Adds `hermes sessions recover-compression <session_id>` as a safe first recovery path for stuck/stale context-compression state.
- Supports inspect-only by default, with `--apply` to clear stale/expired compression locks and expired compression-failure cooldowns.
- Creates a live SQLite backup before applying recovery unless `--no-backup` is passed.
- Resets stale `gateway_routing` `last_prompt_tokens` counters for the recovered session so external-platform routes do not keep acting oversized after recovery.
- Adds regression coverage for expired lock/cooldown recovery, route token reset, transcript preservation, and refusal when a live lock is still owned.

## Scope

This is intentionally a small CLI/runtime recovery primitive, not the full Desktop one-click UX. It gives the runtime a safe building block that Desktop can call or wrap later.

AI-assisted implementation/debugging.

Closes / follows up #85892.

## Test plan

- `scripts/run_tests.sh tests/hermes_cli/test_compression_recovery.py tests/state/test_compression_lineage_guard.py -k 'compression_recovery or reclaims_expired_lease'`
- `.venv/bin/ruff check hermes_cli/compression_recovery.py hermes_cli/main.py hermes_cli/sessions_cmd.py tests/hermes_cli/test_compression_recovery.py`
- `.venv/bin/hermes sessions recover-compression --help`
