### PR TITLE
fix(opencode-zen): use opencode-compatible User-Agent so free models are not rate-limited

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -26,6 +26,18 @@ _ATTRIBUTION_HEADERS = {
     "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
 }
 
+# OpenCode Zen's gateway rate-limits free-tier models (deepseek-v4-flash-free,
+# nemotron-*-free, big-pickle, etc.) based on the request User-Agent. Requests
+# that do not look like the official CLI (User-Agent not prefixed with
+# "opencode/") are treated as anonymous third-party traffic and return HTTP 429
+# FreeUsageLimitError even with a valid API key. Reproduced with curl against
+# https://opencode.ai/zen/v1: `HermesAgent/0.19.1` -> 429, `opencode/1.15.0 ...`
+# -> 200. Use an opencode-compatible UA so free models work from Hermes too.
+_OPENCODE_ZEN_HEADERS = {
+    **_ATTRIBUTION_HEADERS,
+    "User-Agent": "opencode/1.15.0 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.13",
+}
+
 
 def _flat_model_name(model: str | None) -> str:
     """Return the bare OpenCode model ID, tolerating aggregator prefixes."""
@@ -144,7 +156,7 @@ opencode_zen = ProviderProfile(
     aliases=("opencode", "opencode_zen", "zen"),
     env_vars=("OPENCODE_ZEN_API_KEY",),
     base_url="https://opencode.ai/zen/v1",
-    default_headers=dict(_ATTRIBUTION_HEADERS),
+    default_headers=dict(_OPENCODE_ZEN_HEADERS),
     default_aux_model="gemini-3-flash",
 )
 


### PR DESCRIPTION
## What does this PR do?

OpenCode Zen's gateway rate-limits free-tier models (`deepseek-v4-flash-free`,
`nemotron-*-free`, `big-pickle`, etc.) based on the request `User-Agent`.
Requests that do not look like the official CLI return HTTP 429
`FreeUsageLimitError` even with a valid API key, so free models are unusable
from Hermes.

Reproduced with curl against `https://opencode.ai/zen/v1`:

| User-Agent | Result |
|---|---|
| `HermesAgent/0.19.1` (current default) | HTTP 429 `FreeUsageLimitError` |
| `opencode/1.15.0 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.13` | HTTP 200 |

This only needs the `User-Agent` prefix to be `opencode/` — no `x-opencode-client`
impersonation headers are sent. Applies the opencode-compatible UA on the
`opencode-zen` profile only; `opencode-go` (paid) keeps its existing headers.

## Related context

Same root cause fixed in the `pi` client: earendil-works/pi#2824
(OpenCode Zen treats non-CLI traffic as anonymous with restrictive rate limits).

## Type of Change

- 🐛 Bug fix

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix