### PR TITLE
feat(providers): GLM-5.3 reasoning-effort wiring for zai + GLM-5.2 level passthrough

### DIFF
--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -17,11 +17,27 @@ is omitted so the server default applies, matching prior behavior.  GLM
 models before 4.5 (e.g. ``glm-4-9b``) don't accept ``thinking`` and are left
 untouched.
 
-GLM-5.2 additionally exposes a native ``reasoning_effort`` knob with exactly
-two enabled levels — ``high`` and ``max`` — on the OpenAI-compatible endpoint
-(per Z.AI / BigModel docs).  Hermes' richer effort scale is collapsed onto
-those two so the user's effort preference actually reaches the model instead
-of being silently dropped.
+GLM-5.2 additionally exposes a native ``reasoning_effort`` knob with seven
+levels — ``max``, ``xhigh``, ``high``, ``medium``, ``low``, ``minimal``,
+``none`` — on the OpenAI-compatible endpoint (per Z.AI / BigModel docs).
+Hermes passes these through directly so the user's effort preference
+reaches the model unmodified.
+
+GLM-5.3 (released 2026-08-14) keeps the same seven ``reasoning_effort``
+levels but drops the on/off toggle semantics: the model *always* thinks.
+``thinking: {"type": "disabled"}`` is silently ignored on the Coding Plan
+endpoint (``/api/coding/paas/v4`` — the response still carries a full
+reasoning trace) and rejected with HTTP 400 (error 1210) on the standard
+PaaS endpoint (``/api/paas/v4``).  The profile therefore never emits the
+``thinking`` toggle for GLM >= 5.3 and instead maps Hermes'
+``{"enabled": False}`` onto ``reasoning_effort: "minimal"`` — the lowest
+effort the model actually honors (``"none"`` is accepted but behaves like
+the server default, not like "off").  All other Hermes effort levels pass
+through unchanged except ``ultra``, which maps to ``max``.
+
+Level acceptance verified against the live API on 2026-08-14: both glm-5.2
+and glm-5.3 accept ``none, minimal, low, medium, high, xhigh, max``
+(``light`` is rejected with error 1210 listing exactly those seven).
 """
 
 from __future__ import annotations
@@ -33,6 +49,10 @@ from providers import register_provider
 from providers.base import ProviderProfile
 
 _GLM_VERSION_RE = re.compile(r"^glm-(\d+)(?:\.(\d+))?")
+
+# Finds a GLM version anywhere in the model id (vendor prefixes included):
+# matches ``glm-5.3``, ``glm-5-3``, ``glm-5p3``, ``z-ai/glm-5.3`` etc.
+_GLM_VERSION_SEARCH_RE = re.compile(r"glm-(\d+)(?:[.\-p](\d+))?")
 
 
 def _model_supports_thinking(model: str | None) -> bool:
@@ -59,13 +79,65 @@ def _is_glm_5_2(model: str | None) -> bool:
     return any(token in m for token in ("glm-5.2", "glm-5-2", "glm-5p2"))
 
 
-def _glm_5_2_reasoning_effort(reasoning_config: dict | None) -> str | None:
-    """Map Hermes reasoning effort onto GLM-5.2's native ``high``/``max``.
+def _is_glm_5_3_plus(model: str | None) -> bool:
+    """Detect GLM-5.3 and later across alias spellings and vendor prefixes.
 
-    GLM-5.2 only supports two enabled effort levels. ``xhigh``/``max``/``ultra``
-    request the top tier; everything else that is enabled requests ``high``
-    (its minimum thinking level). When reasoning is explicitly disabled, or
-    no effort preference is supplied, the server default is left untouched.
+    Matches ``glm-5.3`` / ``glm-5-3`` / ``glm-5p3`` / ``z-ai/glm-5.3`` and any
+    future ``glm-<major>.<minor>`` >= 5.3.  Excludes 5.2 (handled separately).
+    """
+    m = (model or "").strip().lower()
+    if not m:
+        return False
+    for match in _GLM_VERSION_SEARCH_RE.finditer(m):
+        major = int(match.group(1))
+        minor = int(match.group(2) or 0)
+        if (major, minor) >= (5, 3):
+            return True
+    return False
+
+
+def _glm_5_3_reasoning_effort(reasoning_config: dict | None) -> str | None:
+    """Map Hermes reasoning config onto GLM-5.3's ``reasoning_effort``.
+
+    GLM-5.3 accepts ``none, minimal, low, medium, high, xhigh, max`` and
+    always thinks — there is no off switch.  Mapping:
+
+    * ``enabled: False`` (Hermes ``/reasoning none``) -> ``"minimal"``,
+      the lowest effort GLM-5.3 actually honors (``none`` behaves like the
+      server default, not like "off").
+    * ``ultra`` -> ``max`` (GLM's top tier).
+    * every other Hermes level passes through unchanged.
+    * no preference -> ``None`` (field omitted, server default = max).
+    """
+    if not isinstance(reasoning_config, dict):
+        return None
+
+    if reasoning_config.get("enabled") is False:
+        # GLM-5.3 cannot disable thinking; "minimal" is the real floor.
+        return "minimal"
+
+    effort = (reasoning_config.get("effort") or "").strip().lower()
+    if not effort or effort == "none":
+        return None
+
+    if effort == "ultra":
+        return "max"
+
+    # minimal, low, medium, high, xhigh, max — all native GLM-5.3 levels
+    return effort
+
+
+def _glm_5_2_reasoning_effort(reasoning_config: dict | None) -> str | None:
+    """Map Hermes reasoning effort onto GLM-5.2's native ``reasoning_effort``.
+
+    GLM-5.2 supports seven effort levels on the OpenAI-compatible endpoint
+    (per Z.AI / BigModel docs): ``max``, ``xhigh``, ``high``, ``medium``,
+    ``low``, ``minimal``, ``none``.  Hermes' effort scale maps directly onto
+    these — every level is passed through unchanged except ``ultra`` (which
+    GLM does not expose, so it maps to ``max``).
+
+    When reasoning is explicitly disabled, or no effort preference is
+    supplied, the server default is left untouched.
     """
     if not isinstance(reasoning_config, dict):
         return None
@@ -76,20 +148,30 @@ def _glm_5_2_reasoning_effort(reasoning_config: dict | None) -> str | None:
     if not effort or effort == "none":
         return None
 
-    if effort in {"xhigh", "max", "ultra"}:
+    # ultra is Hermes-only; GLM's top tier is "max"
+    if effort == "ultra":
         return "max"
-    # low / medium / minimal / high all clamp to GLM-5.2's minimum: high.
-    return "high"
+
+    # minimal, low, medium, high, xhigh, max — all native GLM-5.2 levels
+    return effort
 
 
 class ZaiProfile(ProviderProfile):
-    """Z.AI / GLM — extra_body.thinking on/off + GLM-5.2 reasoning_effort."""
+    """Z.AI / GLM — 5.3+: reasoning_effort only; <=5.2: thinking toggle + effort."""
 
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}
+
+        # GLM >= 5.3: never emit the thinking toggle (no-op on the Coding
+        # Plan endpoint, hard error 1210 on the PaaS endpoint).  Effort only.
+        if _is_glm_5_3_plus(model):
+            effort = _glm_5_3_reasoning_effort(reasoning_config)
+            if effort is not None:
+                top_level["reasoning_effort"] = effort
+            return extra_body, top_level
 
         if not _model_supports_thinking(model) and not _is_glm_5_2(model):
             return extra_body, top_level
@@ -116,6 +198,7 @@ zai = ZaiProfile(
     description="Z.AI / GLM — Zhipu AI models",
     signup_url="https://z.ai/",
     fallback_models=(
+        "glm-5.3",
         "glm-5.2",
         "glm-5",
         "glm-4-9b",

--- a/tests/plugins/model_providers/test_zai_profile.py
+++ b/tests/plugins/model_providers/test_zai_profile.py
@@ -6,9 +6,16 @@ request omits ``thinking``.  Before the profile emitted the parameter,
 Z.AI route — users who turned thinking off kept burning thinking tokens on
 every turn (the desktop "thinking reverts to medium" report).
 
-GLM-5.2 additionally exposes a native ``reasoning_effort`` knob with two
-enabled levels (high / max) on the OpenAI-compatible ``/api/paas/v4``
-endpoint; the Hermes effort scale is collapsed onto those.
+GLM-5.2 additionally exposes a native ``reasoning_effort`` knob with seven
+levels (max, xhigh, high, medium, low, minimal, none) on the OpenAI-
+compatible ``/api/paas/v4`` endpoint; Hermes passes these through directly.
+
+GLM-5.3 (2026-08-14) keeps those seven levels but always thinks: the
+``thinking`` on/off toggle is a silent no-op on the Coding Plan endpoint
+and a hard error (HTTP 400, code 1210) on the PaaS endpoint, so the profile
+must never emit it for GLM >= 5.3.  ``{"enabled": False}`` maps to
+``reasoning_effort: "minimal"`` — the lowest effort the model honors
+(``"none"`` behaves like the server default, not like "off").
 
 These tests pin the profile's wire-shape contract so Z.AI requests stay
 correctly shaped without going live.
@@ -66,7 +73,7 @@ class TestZaiThinkingWireShape:
 
 
 class TestZaiGLM52ReasoningEffort:
-    """GLM-5.2's native ``reasoning_effort`` knob (two enabled levels)."""
+    """GLM-5.2's native ``reasoning_effort`` knob (seven pass-through levels)."""
 
     def test_high_maps_to_high(self, zai_profile):
         extra_body, top_level = zai_profile.build_api_kwargs_extras(
@@ -77,20 +84,37 @@ class TestZaiGLM52ReasoningEffort:
         assert top_level == {"reasoning_effort": "high"}
 
     @pytest.mark.parametrize("effort", ["low", "medium", "minimal"])
-    def test_lower_efforts_clamp_up_to_high(self, zai_profile, effort):
-        """GLM-5.2's minimum thinking level is high — lower Hermes levels
-        clamp onto it."""
+    def test_lower_efforts_pass_through(self, zai_profile, effort):
+        """GLM-5.2 supports low/medium/minimal natively — pass through
+        unchanged instead of clamping up to high."""
         extra_body, top_level = zai_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort},
             model="glm-5.2",
         )
         assert extra_body == {"thinking": {"type": "enabled"}}
-        assert top_level == {"reasoning_effort": "high"}
+        assert top_level == {"reasoning_effort": effort}
 
-    @pytest.mark.parametrize("effort", ["xhigh", "max"])
-    def test_strong_efforts_map_to_max(self, zai_profile, effort):
+    def test_xhigh_maps_to_xhigh(self, zai_profile):
+        """xhigh is a native GLM-5.2 level — pass through, don't clamp to max."""
         extra_body, top_level = zai_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": effort},
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            model="glm-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": "xhigh"}
+
+    def test_max_maps_to_max(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model="glm-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": "max"}
+
+    def test_ultra_maps_to_max(self, zai_profile):
+        """ultra is Hermes-only; GLM-5.2's top tier is max."""
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "ultra"},
             model="glm-5.2",
         )
         assert extra_body == {"thinking": {"type": "enabled"}}
@@ -136,6 +160,92 @@ class TestZaiGLM52ReasoningEffort:
         assert top_level == {}
 
 
+class TestZaiGLM53ReasoningEffort:
+    """GLM-5.3: effort-only wiring, never a ``thinking`` toggle.
+
+    Verified against the live Z.AI API on 2026-08-14: ``thinking:
+    disabled`` is ignored on the Coding Plan endpoint and rejected with
+    400/1210 on the PaaS endpoint; accepted effort levels are
+    ``none, minimal, low, medium, high, xhigh, max`` (``light`` -> 1210).
+    """
+
+    @pytest.mark.parametrize(
+        "effort", ["minimal", "low", "medium", "high", "xhigh", "max"]
+    )
+    def test_native_levels_pass_through(self, zai_profile, effort):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="glm-5.3",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": effort}
+
+    def test_disabled_maps_to_minimal(self, zai_profile):
+        """GLM-5.3 always thinks — Hermes "off" becomes the real floor."""
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="glm-5.3",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "minimal"}
+
+    def test_disabled_with_effort_still_maps_to_minimal(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "high"},
+            model="glm-5.3",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "minimal"}
+
+    def test_ultra_maps_to_max(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "ultra"},
+            model="glm-5.3",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "max"}
+
+    def test_no_preference_omits_everything(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config=None,
+            model="glm-5.3",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "glm-5.3",
+            "glm-5-3",
+            "glm-5p3",
+            "z-ai/glm-5.3",
+            "GLM-5.3",  # case-insensitive
+            "glm-5.4",  # future versions take the same path
+        ],
+    )
+    def test_alias_spellings_and_future_versions(self, zai_profile, model):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model=model,
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "high"}
+
+    @pytest.mark.parametrize(
+        "model",
+        ["glm-5.2", "glm-5.1", "glm-5", "glm-4.7", "glm-4-9b"],
+    )
+    def test_older_models_keep_thinking_toggle(self, zai_profile, model):
+        """Only >= 5.3 loses the toggle; 4.5–5.2 behavior is unchanged."""
+        extra_body, _ = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model=model,
+        )
+        expected = {} if model in {"glm-4-9b"} else {"thinking": {"type": "disabled"}}
+        assert extra_body == expected
+
+
 class TestZaiModelGating:
     """GLM 4.5+ get thinking; earlier GLM models are left untouched."""
 
@@ -176,3 +286,18 @@ class TestZaiFullKwargsIntegration:
         )
         assert kwargs["reasoning_effort"] == "max"
         assert kwargs["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_glm_5_3_effort_reaches_top_level_without_thinking(self, zai_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="glm-5.3",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=zai_profile,
+            reasoning_config={"enabled": False},
+            base_url="https://api.z.ai/api/coding/paas/v4",
+            provider_name="zai",
+        )
+        assert kwargs["reasoning_effort"] == "minimal"
+        assert "thinking" not in kwargs.get("extra_body", {})


### PR DESCRIPTION
## What does this PR do?

Updates the bundled **Z.AI / GLM provider profile** for GLM-5.3 (released 2026-08-14) and fixes the GLM-5.2 effort mapping:

1. **GLM ≥ 5.3: effort-only wiring, never a `thinking` toggle.** GLM-5.3 always thinks — there is no off switch. Verified against the live API on 2026-08-14:
   - `thinking: {"type": "disabled"}` is **rejected with HTTP 400 (error 1210)** on the standard PaaS endpoint (`/api/paas/v4`) and **silently ignored** on the Coding Plan endpoint (`/api/coding/paas/v4`) — the response still carries a full reasoning trace. Hermes users who set `/reasoning none` would either get hard API errors or keep burning max-level thinking tokens while believing thinking is off.
   - The profile now omits `thinking` for GLM ≥ 5.3 and maps Hermes `{"enabled": False}` to `reasoning_effort: "minimal"` — the lowest effort the model actually honors (`"none"` is accepted but behaves like the server default, not like "off"; measured ~200 vs ~32 reasoning tokens on an identical probe prompt).
   - Accepted levels (verified): `none, minimal, low, medium, high, xhigh, max` — `light` is rejected with 1210 listing exactly those seven. Hermes' `ultra` maps to `max`.
   - Version detection is prefix-safe (`glm-5.3`, `glm-5-3`, `glm-5p3`, `z-ai/glm-5.3`, …) and future-proof (`glm-5.4+` takes the same path).

2. **GLM-5.2: pass through the seven native effort levels instead of collapsing to high/max.** The previous code clamped every enabled Hermes effort to `high` or `max`, silently discarding e.g. `xhigh`. The API accepts all seven levels for glm-5.2 (validated live: invalid levels fail with 400/1210 *before* billing, valid ones pass validation). Note: acceptance is verified; whether 5.2 internally honors every level with distinct reasoning budgets could not be measured without PaaS balance — 5.3 measurements show distinct budgets per level.

3. **`fallback_models` gains `glm-5.3`** (curated list shown in the `/model` picker when the live model fetch fails — the endpoint's `/models` listing currently lags and doesn't list 5.3 yet, so this matters right now).

GLM-5.2 and older behavior is otherwise unchanged (thinking toggle still emitted for 4.5–5.2, pre-4.5 models untouched).

## Related Issue

N/A — no tracking issue; self-contained provider-profile wiring, verified against the live provider API.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

(bug-fix character for the 5.2 clamping and for `/reasoning none` breaking against GLM-5.3)

## Changes Made

- `plugins/model-providers/zai/__init__.py` — `_is_glm_5_3_plus()` + `_glm_5_3_reasoning_effort()`; early GLM ≥ 5.3 branch in `build_api_kwargs_extras` (effort-only, no thinking toggle); GLM-5.2 seven-level passthrough; `glm-5.3` added to `fallback_models`; docstrings document the verified wire behavior.
- `tests/plugins/model_providers/test_zai_profile.py` — updated 5.2 passthrough tests; new `TestZaiGLM53ReasoningEffort` class (14 tests: level passthrough, disabled→minimal, ultra→max, no-preference omits everything, alias spellings incl. future versions, older-model regression); new transport-level integration test proving `reasoning_effort` reaches the built kwargs without a `thinking` key.

## How to Test

1. `pytest tests/plugins/model_providers/test_zai_profile.py -v` → 52 passed (also with a clean `HERMES_HOME`, proving the bundled profile; broader provider/model-switch/catalog suites: 232 passed).
2. Full local suite: `pytest tests/ -q` — the 9 failures in `tests/gateway/` (e.g. the systemd abstract-socket test on macOS) reproduce identically on unmodified `origin/main` (baseline comparison: 9 failed / 5552 passed on both), i.e. pre-existing local-environment issues, no regression from this change.
3. Live verification (needs a Z.AI key): `reasoning_effort` levels accepted per the table below; `thinking: disabled` → 400/1210 on `/api/paas/v4` with glm-5.3.
4. With a GLM Coding Plan endpoint configured, `/reasoning none` against `glm-5.3` now yields `reasoning_effort: minimal` instead of an API error.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` — all tests pass except 9 `tests/gateway/` failures that reproduce identically on unmodified `origin/main` in this local environment (no CI signal affected)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated; no user-facing config change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure mapping logic, no OS interaction)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Live API verification, 2026-08-14 (GLM Coding Plan endpoint, probe prompt `Compute 127 * 343 …`):

| `reasoning_effort` | HTTP | reasoning_tokens |
|---|---|---|
| `minimal` / `low` | 200 | ~32 |
| `medium` | 200 | ~69 |
| `high` | 200 | ~166 |
| `xhigh` | 200 | ~369 |
| `max` | 200 | ~291 |
| `none` | 200 | ~193 (≈ server default — **not** "off") |
| `ultra` | 200 | ~241 (tolerated, ≈ max) |
| `light` | **400** | error 1210: `must be one of: none, minimal, low, medium, high, xhigh, max` |
| `thinking: disabled` (glm-5.3, PaaS endpoint) | **400** | error 1210: `always engages in thinking` |
| `thinking: disabled` (glm-5.3, Coding Plan endpoint) | 200 | ~335 (ignored — still thinks) |
