### PR TITLE
fix(desktop): let Windows ARM64 install without get-windows

### DIFF
--- a/apps/desktop/electron/get-windows.d.ts
+++ b/apps/desktop/electron/get-windows.d.ts
@@ -1,12 +1,11 @@
 // Type declarations for the get-windows optionalDependency.
 //
-// get-windows ships no bundled types and is an optionalDependency: on Linux
-// `npm ci` skips it when its node-pre-gyp install script fails (no Linux
-// prebuilt; the node-gyp fallback needs `gyp` in the active Python), so the
-// package is legitimately absent from node_modules on Linux builds. Declaring
-// the module here keeps the typecheck independent of whether the package
-// installed — the runtime import in window-below.ts degrades to null when it
-// is absent.
+// get-windows ships no bundled types and is an optionalDependency. `npm ci`
+// can skip it when its native install fails, including Linux and Windows ARM64
+// where 9.3.0 has no prebuilt, so it can legitimately be absent from
+// node_modules. Declaring the module here keeps typecheck independent of
+// whether the package installed. The runtime import in window-below.ts
+// degrades to null when it is absent.
 
 declare module 'get-windows' {
   export interface GetWindowsWindow {

--- a/apps/desktop/electron/get-windows.d.ts
+++ b/apps/desktop/electron/get-windows.d.ts
@@ -1,0 +1,23 @@
+// Type declarations for the get-windows optionalDependency.
+//
+// get-windows ships no bundled types and is an optionalDependency: on Linux
+// `npm ci` skips it when its node-pre-gyp install script fails (no Linux
+// prebuilt; the node-gyp fallback needs `gyp` in the active Python), so the
+// package is legitimately absent from node_modules on Linux builds. Declaring
+// the module here keeps the typecheck independent of whether the package
+// installed — the runtime import in window-below.ts degrades to null when it
+// is absent.
+
+declare module 'get-windows' {
+  export interface GetWindowsWindow {
+    bounds?: { height?: number; width?: number; x?: number; y?: number }
+    id?: number
+    owner?: { name?: string; processId?: number }
+    title?: string
+  }
+
+  export function openWindows(options?: {
+    accessibilityPermission?: boolean
+    screenRecordingPermission?: boolean
+  }): Promise<GetWindowsWindow[]>
+}

--- a/apps/desktop/electron/window-below.ts
+++ b/apps/desktop/electron/window-below.ts
@@ -125,11 +125,11 @@ type GetWindowsModule = {
 let getWindowsModule: Promise<GetWindowsModule | null> | null = null
 
 const loadGetWindows = (): Promise<GetWindowsModule | null> => {
-  // get-windows is an optionalDependency: on Linux `npm ci` skips it when its
-  // node-pre-gyp install script fails (no Linux prebuilt, and the node-gyp
-  // fallback needs `gyp` in the active Python). A missing module is therefore
-  // a normal state, so the lazy import resolves to null instead of rejecting;
-  // enumeration then degrades to the failure note instead of an uncaught error.
+  // get-windows is an optionalDependency: `npm ci` can skip it when its native
+  // install fails, including Linux and Windows ARM64 where 9.3.0 has no
+  // prebuilt. A missing module is therefore a normal state on those targets,
+  // so the lazy import resolves to null instead of rejecting; enumeration then
+  // degrades to the failure note instead of an uncaught error.
   getWindowsModule ??= import('get-windows').catch(() => null)
 
   return getWindowsModule

--- a/apps/desktop/electron/window-below.ts
+++ b/apps/desktop/electron/window-below.ts
@@ -122,10 +122,15 @@ type GetWindowsModule = {
   >
 }
 
-let getWindowsModule: Promise<GetWindowsModule> | null = null
+let getWindowsModule: Promise<GetWindowsModule | null> | null = null
 
-const loadGetWindows = (): Promise<GetWindowsModule> => {
-  getWindowsModule ??= import('get-windows')
+const loadGetWindows = (): Promise<GetWindowsModule | null> => {
+  // get-windows is an optionalDependency: on Linux `npm ci` skips it when its
+  // node-pre-gyp install script fails (no Linux prebuilt, and the node-gyp
+  // fallback needs `gyp` in the active Python). A missing module is therefore
+  // a normal state, so the lazy import resolves to null instead of rejecting;
+  // enumeration then degrades to the failure note instead of an uncaught error.
+  getWindowsModule ??= import('get-windows').catch(() => null)
 
   return getWindowsModule
 }
@@ -143,7 +148,13 @@ async function enumerateViaGetWindows(titlesAvailable: boolean): Promise<Enumera
   let raw
 
   try {
-    const { openWindows } = await loadGetWindows()
+    const getWindows = await loadGetWindows()
+
+    if (!getWindows) {
+      return null
+    }
+
+    const { openWindows } = getWindows
     raw = await openWindows(
       process.platform === 'darwin'
         ? { accessibilityPermission: false, screenRecordingPermission: titlesAvailable }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -112,7 +112,6 @@
     "emojibase-data": "16.0.3",
     "fflate": "0.8.3",
     "frimousse": "0.3.0",
-    "get-windows": "9.3.0",
     "hast-util-from-html-isomorphic": "2.0.0",
     "hast-util-to-text": "4.0.2",
     "ignore": "7.0.6",
@@ -142,6 +141,9 @@
     "use-stick-to-bottom": "1.1.6",
     "vfile": "6.0.3",
     "web-haptics": "0.0.6"
+  },
+  "optionalDependencies": {
+    "get-windows": "9.3.0"
   },
   "devDependencies": {
     "@electron/rebuild": "4.2.0",

--- a/apps/desktop/scripts/before-pack.mjs
+++ b/apps/desktop/scripts/before-pack.mjs
@@ -144,11 +144,10 @@ export default async function beforePack(context) {
         await stageNodePty({ platform, arch: archName })
         console.log(`[before-pack] re-staged node-pty for target ${platform}-${archName}`)
       }
-      // get-windows' native payload is per-platform, not per-arch (the macOS
-      // helper is universal, Windows stages every prebuilt binding dir), so
-      // it re-stages for the universal target too.
-      stageGetWindows({ platform })
-      console.log(`[before-pack] re-staged get-windows for target ${platform}`)
+      // The macOS helper is universal, while Windows bindings are arch-specific.
+      // Pass the target arch so an ARM64 package never stages an x64 binding.
+      stageGetWindows({ platform, arch: archName })
+      console.log(`[before-pack] re-staged get-windows for target ${platform}-${archName}`)
     }
   } catch (err) {
     // This one SHOULD fail the build — a missing/wrong native binary for the

--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -407,12 +407,20 @@ export function openWindowsSync() {
 `
 
 function resolveGetWindowsRoot() {
-  // get-windows' exports map doesn't expose ./package.json; resolve the entry
-  // (index.js sits at the package root) and take its directory.
-  const entryPath = require.resolve('get-windows', {
-    paths: [projectRoot]
-  })
-  return dirname(entryPath)
+  // get-windows is an optionalDependency (its node-pre-gyp install script has
+  // no Linux prebuilt and the node-gyp fallback needs `gyp` in the active
+  // Python, so `npm ci` may skip it entirely on Linux). Return null when it is
+  // absent; the caller decides whether that is fatal per platform.
+  try {
+    // get-windows' exports map doesn't expose ./package.json; resolve the entry
+    // (index.js sits at the package root) and take its directory.
+    const entryPath = require.resolve('get-windows', {
+      paths: [projectRoot]
+    })
+    return dirname(entryPath)
+  } catch {
+    return null
+  }
 }
 
 /**
@@ -537,9 +545,32 @@ function rebuildGetWindowsViaNpm() {
   }
 }
 
-export function stageGetWindows({ platform = process.platform } = {}) {
-  const srcRoot = resolveGetWindowsRoot()
+export function stageGetWindows(
+  { platform = process.platform, resolveRoot = resolveGetWindowsRoot } = {}
+) {
+  const srcRoot = resolveRoot()
   const destRoot = resolve(projectRoot, 'dist/node_modules/get-windows')
+
+  if (!srcRoot) {
+    // get-windows is an optionalDependency: `npm ci` on Linux skips it when the
+    // install script fails (no Linux prebuilt, node-gyp needs `gyp` in the
+    // active Python), so absence here is a normal state, not a broken checkout.
+    // On Linux it only backs read_window_below over X11 (lib/linux.js shells
+    // out to xprop); skipping it degrades that tool to Hyprland IPC or an
+    // "unavailable" note instead of failing the whole desktop build. On
+    // darwin/win32 the native payload is required, so fail loudly.
+    if (platform === 'linux') {
+      console.warn(
+        '[stage-native-deps] get-windows not installed (optional dep skipped on ' +
+          'Linux); read_window_below will be unavailable in this build'
+      )
+      return undefined
+    }
+    throw new Error(
+      `[stage-native-deps] get-windows is not installed; cannot stage its ${platform} native payload`
+    )
+  }
+
   // Only a win32 host can produce the win32 binding, so a cross-platform pack
   // has nothing to gain from the rebuild.
   const rebuild =

--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -437,7 +437,7 @@ const GET_WINDOWS_VERSION = '9.3.0'
 export function stageGetWindowsInto(
   srcRoot,
   destRoot,
-  { platform = process.platform, rebuild } = {}
+  { platform = process.platform, arch = process.arch, rebuild } = {}
 ) {
   // The STAGED_WINDOWS_JS rewrite mirrors this exact version's export surface.
   // A version bump must fail the build here until the rewrite is re-verified —
@@ -490,11 +490,20 @@ export function stageGetWindowsInto(
         ? readdirSync(bindingRoot).filter(
             (dir) =>
               dir.includes(`-${platform}-`) &&
+              dir.endsWith(`-${arch}`) &&
               existsSync(join(bindingRoot, dir, 'node-get-windows.node'))
           )
         : []
     let bindingDirs = scanBindingDirs()
-    if (bindingDirs.length === 0 && typeof rebuild === 'function') {
+    if (bindingDirs.length === 0 && arch === 'arm64') {
+      // get-windows 9.3.0 publishes win32 prebuilds for ia32/x64 only.
+      // The staged windows.js deliberately fails soft when binding/ is absent,
+      // so preserve the desktop build and disable only window enumeration.
+      console.warn(
+        '[stage-native-deps] get-windows has no win32-arm64 prebuilt binding; ' +
+          'staging the fail-soft JS surface without native window enumeration.'
+      )
+    } else if (bindingDirs.length === 0 && typeof rebuild === 'function') {
       // A plain `npm install` won't re-run an install script for a package
       // that is already on disk, so every checkout that installed while
       // get-windows was missing from allowScripts stays bricked even after
@@ -505,9 +514,9 @@ export function stageGetWindowsInto(
       rebuild()
       bindingDirs = scanBindingDirs()
     }
-    if (bindingDirs.length === 0) {
+    if (bindingDirs.length === 0 && arch !== 'arm64') {
       throw new Error(
-        '[stage-native-deps] get-windows has no win32 prebuilt binding under lib/binding. ' +
+        `[stage-native-deps] get-windows has no win32-${arch} prebuilt binding under lib/binding. ` +
           'Recover from the checkout root with:\n' +
           '  npm install-scripts approve get-windows\n' +
           '  npm rebuild get-windows'
@@ -546,7 +555,11 @@ function rebuildGetWindowsViaNpm() {
 }
 
 export function stageGetWindows(
-  { platform = process.platform, resolveRoot = resolveGetWindowsRoot } = {}
+  {
+    platform = process.platform,
+    arch = process.arch,
+    resolveRoot = resolveGetWindowsRoot
+  } = {}
 ) {
   const srcRoot = resolveRoot()
   const destRoot = resolve(projectRoot, 'dist/node_modules/get-windows')
@@ -575,12 +588,12 @@ export function stageGetWindows(
   // has nothing to gain from the rebuild.
   const rebuild =
     platform === 'win32' && process.platform === 'win32' ? rebuildGetWindowsViaNpm : undefined
-  return stageGetWindowsInto(srcRoot, destRoot, { platform, rebuild })
+  return stageGetWindowsInto(srcRoot, destRoot, { platform, arch, rebuild })
 }
 
 // Allow direct CLI invocation: node scripts/stage-native-deps.mjs [platform] [arch]
 if (isMain(import.meta.url)) {
   const [platform, arch] = process.argv.slice(2)
   stageNodePty({ platform, arch })
-  stageGetWindows({ platform })
+  stageGetWindows({ platform, arch })
 }

--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -408,9 +408,9 @@ export function openWindowsSync() {
 
 function resolveGetWindowsRoot() {
   // get-windows is an optionalDependency (its node-pre-gyp install script has
-  // no Linux prebuilt and the node-gyp fallback needs `gyp` in the active
-  // Python, so `npm ci` may skip it entirely on Linux). Return null when it is
-  // absent; the caller decides whether that is fatal per platform.
+  // no Linux or Windows ARM64 prebuilt and its node-gyp fallback may fail, so
+  // `npm ci` can skip it entirely on those targets). Return null when it is
+  // absent; the caller decides whether that is fatal per platform and arch.
   try {
     // get-windows' exports map doesn't expose ./package.json; resolve the entry
     // (index.js sits at the package root) and take its directory.
@@ -565,22 +565,22 @@ export function stageGetWindows(
   const destRoot = resolve(projectRoot, 'dist/node_modules/get-windows')
 
   if (!srcRoot) {
-    // get-windows is an optionalDependency: `npm ci` on Linux skips it when the
-    // install script fails (no Linux prebuilt, node-gyp needs `gyp` in the
-    // active Python), so absence here is a normal state, not a broken checkout.
-    // On Linux it only backs read_window_below over X11 (lib/linux.js shells
-    // out to xprop); skipping it degrades that tool to Hyprland IPC or an
-    // "unavailable" note instead of failing the whole desktop build. On
-    // darwin/win32 the native payload is required, so fail loudly.
-    if (platform === 'linux') {
+    // npm may omit an optional dependency whose install script fails. That is
+    // expected on Linux and win32-arm64 because get-windows 9.3.0 publishes no
+    // native prebuilt for either target. The runtime import already fails soft,
+    // so disable only window enumeration instead of failing the Desktop build.
+    // Other Windows architectures and macOS have supported native payloads and
+    // remain fail-closed so a broken package cannot ship silently.
+    const canDegrade = platform === 'linux' || (platform === 'win32' && arch === 'arm64')
+    if (canDegrade) {
       console.warn(
-        '[stage-native-deps] get-windows not installed (optional dep skipped on ' +
-          'Linux); read_window_below will be unavailable in this build'
+        `[stage-native-deps] get-windows not installed (optional dep skipped for ${platform}-${arch}); ` +
+          'read_window_below will be unavailable in this build'
       )
       return undefined
     }
     throw new Error(
-      `[stage-native-deps] get-windows is not installed; cannot stage its ${platform} native payload`
+      `[stage-native-deps] get-windows is not installed; cannot stage its ${platform}-${arch} native payload`
     )
   }
 

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -391,7 +391,7 @@ test('win32 staging skips the darwin binding the tarball bundles on every platfo
       ]
     })
 
-    stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32' })
+    stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', arch: 'x64' })
 
     assert.ok(existsSync(join(destRoot, 'lib', 'binding', 'napi-9-win32-unknown-x64', 'node-get-windows.node')))
     assert.ok(!existsSync(join(destRoot, 'lib', 'binding', 'napi-9-darwin-unknown-arm64')))
@@ -411,7 +411,7 @@ test('win32 staging rejects a binding dir that claims win32 but holds a foreign 
     })
 
     assert.throws(
-      () => stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32' }),
+      () => stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', arch: 'x64' }),
       /expected win32, got darwin/
     )
   } finally {
@@ -419,7 +419,7 @@ test('win32 staging rejects a binding dir that claims win32 but holds a foreign 
   }
 })
 
-test('win32 staging fails when only foreign bindings exist', () => {
+test('win32-x64 staging fails when only foreign bindings exist', () => {
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
   try {
     const srcRoot = join(tmp, 'get-windows')
@@ -430,9 +430,31 @@ test('win32 staging fails when only foreign bindings exist', () => {
     })
 
     assert.throws(
-      () => stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32' }),
-      /no win32 prebuilt binding/
+      () => stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', arch: 'x64' }),
+      /no win32-x64 prebuilt binding/
     )
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('win32-arm64 staging omits incompatible bindings and keeps the fail-soft JS surface', () => {
+  const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
+  try {
+    const srcRoot = join(tmp, 'get-windows')
+    const destRoot = join(tmp, 'dest')
+
+    makeFakeGetWindows(srcRoot, {
+      bindings: [
+        { dir: 'napi-9-darwin-unknown-arm64', platform: 'darwin' },
+        { dir: 'napi-9-win32-unknown-x64', platform: 'win32' }
+      ]
+    })
+
+    stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', arch: 'arm64' })
+
+    assert.ok(existsSync(join(destRoot, 'lib', 'windows.js')))
+    assert.ok(!existsSync(join(destRoot, 'lib', 'binding')))
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true })
   }
@@ -457,7 +479,7 @@ test('win32 staging self-heals through the rebuild hook when the binding is miss
       )
     }
 
-    stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', rebuild })
+    stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', arch: 'x64', rebuild })
 
     assert.equal(calls, 1)
     assert.ok(
@@ -477,7 +499,12 @@ test('win32 staging reports the recovery steps when the rebuild hook produces no
     makeFakeGetWindows(srcRoot, { bindings: [] })
 
     assert.throws(
-      () => stageGetWindowsInto(srcRoot, destRoot, { platform: 'win32', rebuild: () => {} }),
+      () =>
+        stageGetWindowsInto(srcRoot, destRoot, {
+          platform: 'win32',
+          arch: 'x64',
+          rebuild: () => {}
+        }),
       /npm rebuild get-windows/
     )
   } finally {

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -551,10 +551,10 @@ test('darwin staging ships the Swift helper executable and the rewritten windows
 // ─── stageGetWindows (optionalDependency gate) ──────────────────────
 //
 // get-windows is an optionalDependency: on Linux its node-pre-gyp install
-// script fails (no Linux prebuilt; the node-gyp fallback needs `gyp` in the
-// active Python), so npm skips the package and `npm ci` must still succeed.
-// The staging step mirrors that: absent package on Linux is a skip, on
-// darwin/win32 it is a hard failure because the native payload is required.
+// script fails because no prebuilt exists. Windows ARM64 has the same package
+// state: its prebuilt URL returns 404 and npm may omit the optional dependency.
+// Staging skips those unsupported targets, but supported native targets remain
+// a hard failure when the package is missing.
 
 test('linux staging skips when get-windows is absent (optional dep skipped by npm)', () => {
   assert.equal(stageGetWindows({ platform: 'linux', resolveRoot: () => null }), undefined)
@@ -562,14 +562,21 @@ test('linux staging skips when get-windows is absent (optional dep skipped by np
 
 test('darwin staging fails when get-windows is absent', () => {
   assert.throws(
-    () => stageGetWindows({ platform: 'darwin', resolveRoot: () => null }),
+    () => stageGetWindows({ platform: 'darwin', arch: 'arm64', resolveRoot: () => null }),
     /get-windows is not installed/
   )
 })
 
-test('win32 staging fails when get-windows is absent', () => {
+test('win32-arm64 staging skips when get-windows is absent after its optional install fails', () => {
+  assert.equal(
+    stageGetWindows({ platform: 'win32', arch: 'arm64', resolveRoot: () => null }),
+    undefined
+  )
+})
+
+test('win32-x64 staging fails when get-windows is absent', () => {
   assert.throws(
-    () => stageGetWindows({ platform: 'win32', resolveRoot: () => null }),
+    () => stageGetWindows({ platform: 'win32', arch: 'x64', resolveRoot: () => null }),
     /get-windows is not installed/
   )
 })

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url'
 import { test } from 'vitest'
 
 import {
+  stageGetWindows,
   stageGetWindowsInto,
   stageNodePtyInto,
   classifyNativeBinary
@@ -518,4 +519,30 @@ test('darwin staging ships the Swift helper executable and the rewritten windows
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true })
   }
+})
+
+// ─── stageGetWindows (optionalDependency gate) ──────────────────────
+//
+// get-windows is an optionalDependency: on Linux its node-pre-gyp install
+// script fails (no Linux prebuilt; the node-gyp fallback needs `gyp` in the
+// active Python), so npm skips the package and `npm ci` must still succeed.
+// The staging step mirrors that: absent package on Linux is a skip, on
+// darwin/win32 it is a hard failure because the native payload is required.
+
+test('linux staging skips when get-windows is absent (optional dep skipped by npm)', () => {
+  assert.equal(stageGetWindows({ platform: 'linux', resolveRoot: () => null }), undefined)
+})
+
+test('darwin staging fails when get-windows is absent', () => {
+  assert.throws(
+    () => stageGetWindows({ platform: 'darwin', resolveRoot: () => null }),
+    /get-windows is not installed/
+  )
+})
+
+test('win32 staging fails when get-windows is absent', () => {
+  assert.throws(
+    () => stageGetWindows({ platform: 'win32', resolveRoot: () => null }),
+    /get-windows is not installed/
+  )
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,6 @@
         "emojibase-data": "16.0.3",
         "fflate": "0.8.3",
         "frimousse": "0.3.0",
-        "get-windows": "9.3.0",
         "hast-util-from-html-isomorphic": "2.0.0",
         "hast-util-to-text": "4.0.2",
         "ignore": "7.0.6",
@@ -167,6 +166,9 @@
       },
       "engines": {
         "node": ">=22.22.0"
+      },
+      "optionalDependencies": {
+        "get-windows": "9.3.0"
       }
     },
     "apps/desktop/node_modules/@electron/get": {
@@ -11004,6 +11006,7 @@
       "integrity": "sha512-DrOfQSmIcsFax28FfSUjbLTfeOkAG7yeh6NCb/9zzRkDuClXaqYqHuQBPUqcqd1uYS70ygYERSooacMAwvbyVw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18.18"
       },


### PR DESCRIPTION
## What does this PR do?

Makes the Desktop dependency and packaging path tolerate `get-windows` being unavailable on Windows ARM64.

`get-windows@9.3.0` does not publish a `win32-arm64` prebuilt. Its install script receives a 404, falls back to `node-gyp`, and can fail or be omitted by npm. When it was a required dependency, that aborted `npm ci`; after making it optional, native staging still treated a completely omitted package as fatal on every Windows architecture.

This consolidates the complementary work in #82352 and #85414. It preserves both contributors' commits, then closes the gap between them: package absence is allowed only for Linux and Windows ARM64, while macOS and supported Windows architectures remain fail-closed. On unsupported targets, only native window enumeration is unavailable; the rest of Desktop still installs and builds.

## Related Issue

Consolidates and supersedes #82352 and #85414. No separate GitHub issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Move `get-windows` from required to optional Desktop dependencies and update the root lockfile.
- Lazy-load the optional module so missing native support degrades window enumeration instead of crashing Electron.
- Pass the electron-builder target architecture into native staging and filter Windows bindings by both platform and architecture.
- Allow missing packages or bindings only on Linux and Windows ARM64; preserve hard failures for macOS and supported Windows architectures.
- Add behavioral coverage for missing-package and wrong-architecture staging paths.

## How to Test

1. Run the focused native-staging cases:
   `node_modules/.bin/vitest run apps/desktop/scripts/stage-native-deps.test.mjs --testNamePattern="win32|linux staging skips" --maxWorkers=4`
2. Run the packaging-hook and runtime-fallback tests:
   `node_modules/.bin/vitest run apps/desktop/scripts/before-pack.test.mjs apps/desktop/electron/window-below.test.ts --maxWorkers=4`
3. Run the three Desktop TypeScript configurations with `tsc --noEmit`.
4. On Windows ARM64, run `npm ci` and package Desktop. The missing `get-windows` prebuilt should no longer abort installation or packaging; `read_window_below` should report enumeration as unavailable.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows x64 with Node 22.22.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused Windows/Linux native-staging cases: 10 passed. Packaging-hook and runtime-fallback files passed. All three Desktop TypeScript configurations passed.

A combined three-file run passed 49 tests, skipped 1, and hit one pre-existing platform-only failure: the macOS helper executable-bit assertion observes Windows copy-mode semantics (`0o666` instead of `0o755`). No physical Windows ARM64 machine was available locally, so the exact ARM64 `npm ci` reproduction remains for CI or reporter verification.
