### PR TITLE
fix(desktop): agent avatar misses expire after 30s instead of caching forever

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -87,10 +87,14 @@ const PROCESS_NOTIFICATION_RE = /^\[IMPORTANT: Background process [\s\S]*\]$/
 export const AGENT_MESSAGE_RE =
   /^(?:Message from (?:🤖\s*)?([^:\n(]{1,64}?)(?:\s*\(@([a-z0-9][a-z0-9_-]{0,63})\))?:\s*|\[Message from agent '([^']{1,64})'\]\s*)([\s\S]*)$/u
 
-// sender handle -> avatar data URL (null = known absent). Module-level so a
-// chat full of notices from one bot resolves once. Profiles change rarely;
-// stale entries only persist for the window's lifetime.
+// sender handle -> avatar data URL. Module-level so a chat full of notices
+// from one bot resolves once. Hits are cached for the window's lifetime;
+// misses only briefly (30s) — an avatar can appear at any moment (bot just
+// created, art backfill still running), and a permanent negative cache
+// froze the 🤖 glyph until an app restart.
 export const agentAvatarCache = new Map<string, null | string>()
+const agentAvatarMissAt = new Map<string, number>()
+const AVATAR_MISS_TTL_MS = 30_000
 const agentAvatarInflight = new Map<string, Promise<null | string>>()
 
 export async function resolveAgentAvatar(handle: string): Promise<null | string> {
@@ -101,7 +105,18 @@ export async function resolveAgentAvatar(handle: string): Promise<null | string>
   }
 
   if (agentAvatarCache.has(key)) {
-    return agentAvatarCache.get(key) ?? null
+    const hit = agentAvatarCache.get(key) ?? null
+
+    if (hit !== null) {
+      return hit
+    }
+
+    // Negative entry: honor it only within the TTL, then re-probe.
+    if (Date.now() - (agentAvatarMissAt.get(key) ?? 0) < AVATAR_MISS_TTL_MS) {
+      return null
+    }
+
+    agentAvatarCache.delete(key)
   }
 
   const inflight = agentAvatarInflight.get(key)
@@ -152,6 +167,10 @@ export async function resolveAgentAvatar(handle: string): Promise<null | string>
   agentAvatarInflight.set(key, run)
   const out = await run
   agentAvatarCache.set(key, out)
+
+  if (out === null) {
+    agentAvatarMissAt.set(key, Date.now())
+  }
 
   return out
 }


### PR DESCRIPTION
Follow-up to #85855/#85888. `resolveAgentAvatar` cached negative results permanently (window lifetime). That's wrong for the moment that matters most: a freshly created bot's first inter-agent exchange renders its notices *before* the avatar art lands in the profile asset store (Bot Mode rasterizes+uploads it asynchronously) — the null gets cached, and the notice shows the 🤖 glyph forever even though `profiles.get_asset` has the pfp seconds later (user report, screenshot: two brand-new bots messaging each other, no avatars either side, asset store verified populated).

Fix: positive results keep window-lifetime caching (avatars rarely change); negative results expire after 30s and re-probe. Inflight de-dup unchanged, so the cost is at most one extra probe per sender per 30s window, only while a bot genuinely has no avatar.

Thread tests 12/12 green.