### PR TITLE
fix(desktop): isolate review submit to active composer

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -67,6 +67,7 @@ const cssEscape = (value: string): string => {
 }
 
 interface SubmitDetail {
+  surfaceId: string
   target: ComposerTarget
   text: string
 }
@@ -150,6 +151,30 @@ const dispatch = <T>(name: string, detail: T) => {
   }
 
   window.setTimeout(() => window.dispatchEvent(new CustomEvent<T>(name, { detail })), 0)
+}
+
+/** Submit is the one bus mutation that must preserve the chat visible at click
+ * time. Deferring it lets a parent click handler/tab reveal switch the active
+ * keep-alive pane before subscribers run, so the task is dropped or claimed by
+ * another `'main'` composer. Other bus events intentionally defer for focus
+ * restoration; submit has no such requirement. */
+const dispatchNow = <T>(name: string, detail: T) => {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent<T>(name, { detail }))
+  }
+}
+
+/** Unique mounted-composer identity stamped on the visible chat surface.
+ * Unlike a session key it is present for fresh chats and remains unique if the
+ * same session is rendered in two panes. */
+const visibleComposerSurfaceId = (target: ComposerTarget): string | null => {
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  const surface = queryVisible<HTMLElement>(`[data-composer-target="${cssEscape(target)}"]`)
+
+  return surface?.dataset.composerSurfaceId || null
 }
 
 const subscribe = <T>(name: string, handler: (detail: T) => void) => {
@@ -266,7 +291,20 @@ export const requestComposerSubmit = (
   const trimmed = text.trim()
 
   if (trimmed) {
-    dispatch<SubmitDetail>(SUBMIT_EVENT, { target: resolve(target), text: trimmed })
+    const resolvedTarget = resolve(target)
+    const surfaceId = visibleComposerSurfaceId(resolvedTarget)
+
+    // Fail closed: without an exact mounted surface identity, broadcasting a
+    // submit could make more than one keep-alive/new-chat composer claim it.
+    if (!surfaceId) {
+      return
+    }
+
+    dispatchNow<SubmitDetail>(SUBMIT_EVENT, {
+      surfaceId,
+      target: resolvedTarget,
+      text: trimmed
+    })
   }
 }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -1,6 +1,14 @@
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import {
+  type Dispatch,
+  type PropsWithChildren,
+  type SetStateAction,
+  useLayoutEffect,
+  useState
+} from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
 import { $clarifyRequests } from '@/store/clarify'
 import type { ComposerAttachment } from '@/store/composer'
 import { $gateway } from '@/store/gateway'
@@ -12,23 +20,32 @@ import {
   setSudoRequest
 } from '@/store/prompts'
 
+import { type ComposerTarget, requestComposerSubmit } from '../focus'
+import { ComposerScopeProvider, MAIN_COMPOSER_SCOPE } from '../scope'
+
 import { useComposerSubmit } from './use-composer-submit'
 
 interface SubmitHarnessOptions {
   attachments?: ComposerAttachment[]
   busy?: boolean
   compacting?: boolean
+  submitOnHide?: boolean
+  target?: ComposerTarget
   text?: string
+  visible?: boolean
 }
 
 function renderSubmitHook({
   attachments = [],
   busy = false,
   compacting = false,
-  text = ''
+  submitOnHide = false,
+  target = 'main',
+  text = '',
+  visible = true
 }: SubmitHarnessOptions = {}) {
   const draftRef = { current: text }
-  const editor = document.createElement('div')
+  const editor = window.document.createElement('div')
   editor.dataset.slot = 'composer-rich-input'
   editor.textContent = text
   const editorRef = { current: editor }
@@ -36,42 +53,115 @@ function renderSubmitHook({
   const onSteer = vi.fn(async () => true)
   const onSubmit = vi.fn(async () => true)
   const queueCurrentDraft = vi.fn(() => true)
+  let updatePaneVisible: Dispatch<SetStateAction<boolean>> | undefined
 
   const clearDraft = vi.fn(() => {
     draftRef.current = ''
     editorRef.current!.textContent = ''
   })
 
-  const hook = renderHook(() =>
-    useComposerSubmit({
-      activeQueueSessionKey: 'stored-session',
-      activeQueueSessionKeyRef: { current: 'stored-session' },
-      attachments,
-      busy,
-      compacting,
-      clearDraft,
-      disabled: false,
-      draftRef,
-      drainNextQueued: vi.fn(async () => false),
-      editorRef,
-      exitQueuedEdit: vi.fn(() => false),
-      focusInput: vi.fn(),
-      inputDisabled: false,
-      loadIntoComposer: vi.fn(),
-      onCancel,
-      onSteer,
-      onSubmit,
-      queueCurrentDraft,
-      queueEdit: null,
-      queuedPrompts: [],
-      sessionId: 'runtime-session',
-      setComposerText: vi.fn(),
-      stashAt: vi.fn()
-    })
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    const [paneVisible, setPaneVisible] = useState(visible)
+    updatePaneVisible = setPaneVisible
+
+    useLayoutEffect(() => {
+      if (submitOnHide && !paneVisible) {
+        requestComposerSubmit('ship while hiding', { target })
+      }
+    }, [paneVisible])
+
+    return (
+      <ComposerScopeProvider value={{ ...MAIN_COMPOSER_SCOPE, target }}>
+        <PaneVisibleContext.Provider value={paneVisible}>{children}</PaneVisibleContext.Provider>
+      </ComposerScopeProvider>
+    )
+  }
+
+  const hook = renderHook(
+    () =>
+      useComposerSubmit({
+        activeQueueSessionKey: 'stored-session',
+        activeQueueSessionKeyRef: { current: 'stored-session' },
+        attachments,
+        busy,
+        compacting,
+        clearDraft,
+        disabled: false,
+        draftRef,
+        drainNextQueued: vi.fn(async () => false),
+        editorRef,
+        exitQueuedEdit: vi.fn(() => false),
+        focusInput: vi.fn(),
+        inputDisabled: false,
+        loadIntoComposer: vi.fn(),
+        onCancel,
+        onSteer,
+        onSubmit,
+        queueCurrentDraft,
+        queueEdit: null,
+        queuedPrompts: [],
+        sessionId: 'runtime-session',
+        setComposerText: vi.fn(),
+        stashAt: vi.fn()
+      }),
+    { wrapper: Wrapper }
   )
 
-  return { clearDraft, hook, onCancel, onSteer, onSubmit, queueCurrentDraft }
+  return {
+    clearDraft,
+    hook,
+    onCancel,
+    onSteer,
+    onSubmit,
+    queueCurrentDraft,
+    setPaneVisible(nextVisible: boolean) {
+      if (!updatePaneVisible) {
+        throw new Error('Pane visibility setter was not initialized')
+      }
+
+      updatePaneVisible(nextVisible)
+    }
+  }
 }
+
+describe('useComposerSubmit external request routing', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('submits only through the visible composer whose target matches the request', async () => {
+    const visibleMain = renderSubmitHook()
+    const hiddenMain = renderSubmitHook({ visible: false })
+    const visibleTile = renderSubmitHook({ target: 'tile:other-session' })
+
+    requestComposerSubmit('ship this branch', { target: 'main' })
+
+    await waitFor(() =>
+      expect(visibleMain.onSubmit).toHaveBeenCalledWith('ship this branch', { composerScope: 'stored-session' })
+    )
+    expect(hiddenMain.onSubmit).not.toHaveBeenCalled()
+    expect(visibleTile.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('does not use a stale visible subscription while the pane is being hidden', () => {
+    const main = renderSubmitHook({ submitOnHide: true })
+
+    const runImmediately = ((handler: TimerHandler) => {
+      if (typeof handler === 'function') {
+        handler()
+      }
+
+      return 0
+    }) as unknown as typeof window.setTimeout
+
+    vi.spyOn(window, 'setTimeout').mockImplementationOnce(runImmediately)
+
+    act(() => main.setPaneVisible(false))
+
+    expect(main.onSubmit).not.toHaveBeenCalled()
+  })
+})
 
 describe('useComposerSubmit busy-turn routing', () => {
   afterEach(() => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/store/prompts'
 
 import { type ComposerTarget, requestComposerSubmit } from '../focus'
-import { ComposerScopeProvider, MAIN_COMPOSER_SCOPE } from '../scope'
+import { ComposerScopeProvider, ComposerSurfaceProvider, MAIN_COMPOSER_SCOPE } from '../scope'
 
 import { useComposerSubmit } from './use-composer-submit'
 
@@ -29,21 +29,30 @@ interface SubmitHarnessOptions {
   attachments?: ComposerAttachment[]
   busy?: boolean
   compacting?: boolean
+  inputDisabled?: boolean
+  sessionKey?: string | null
+  surfaceId?: string | null
   submitOnHide?: boolean
   target?: ComposerTarget
   text?: string
   visible?: boolean
 }
 
+let surfaceSequence = 0
+
 function renderSubmitHook({
   attachments = [],
   busy = false,
   compacting = false,
+  inputDisabled = false,
+  sessionKey = 'stored-session',
+  surfaceId,
   submitOnHide = false,
   target = 'main',
   text = '',
   visible = true
 }: SubmitHarnessOptions = {}) {
+  const resolvedSurfaceId = surfaceId === undefined ? `test-surface-${++surfaceSequence}` : surfaceId
   const draftRef = { current: text }
   const editor = window.document.createElement('div')
   editor.dataset.slot = 'composer-rich-input'
@@ -72,7 +81,17 @@ function renderSubmitHook({
 
     return (
       <ComposerScopeProvider value={{ ...MAIN_COMPOSER_SCOPE, target }}>
-        <PaneVisibleContext.Provider value={paneVisible}>{children}</PaneVisibleContext.Provider>
+        <ComposerSurfaceProvider value={resolvedSurfaceId}>
+          <PaneVisibleContext.Provider value={paneVisible}>
+            <div
+              data-composer-surface-id={resolvedSurfaceId ?? undefined}
+              data-composer-target={target}
+              data-pane-hidden={paneVisible ? undefined : ''}
+            >
+              {children}
+            </div>
+          </PaneVisibleContext.Provider>
+        </ComposerSurfaceProvider>
       </ComposerScopeProvider>
     )
   }
@@ -80,8 +99,8 @@ function renderSubmitHook({
   const hook = renderHook(
     () =>
       useComposerSubmit({
-        activeQueueSessionKey: 'stored-session',
-        activeQueueSessionKeyRef: { current: 'stored-session' },
+        activeQueueSessionKey: sessionKey,
+        activeQueueSessionKeyRef: { current: sessionKey },
         attachments,
         busy,
         compacting,
@@ -92,7 +111,7 @@ function renderSubmitHook({
         editorRef,
         exitQueuedEdit: vi.fn(() => false),
         focusInput: vi.fn(),
-        inputDisabled: false,
+        inputDisabled,
         loadIntoComposer: vi.fn(),
         onCancel,
         onSteer,
@@ -160,6 +179,64 @@ describe('useComposerSubmit external request routing', () => {
     act(() => main.setPaneVisible(false))
 
     expect(main.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('submits to the session visible at click time even when the same click switches tabs', async () => {
+    const hiddenA = renderSubmitHook({ sessionKey: 'session-a', visible: false })
+    const visibleB = renderSubmitHook({ sessionKey: 'session-b' })
+
+    act(() => {
+      requestComposerSubmit('ship session B', { target: 'main' })
+      visibleB.setPaneVisible(false)
+      hiddenA.setPaneVisible(true)
+    })
+
+    await waitFor(() =>
+      expect(visibleB.onSubmit).toHaveBeenCalledWith('ship session B', { composerScope: 'session-b' })
+    )
+    expect(hiddenA.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('uses the captured surface id when two main composers both report visible', async () => {
+    const firstMain = renderSubmitHook({ sessionKey: 'session-first' })
+    const secondMain = renderSubmitHook({ sessionKey: 'session-second' })
+
+    requestComposerSubmit('ship exactly one session', { target: 'main' })
+
+    await waitFor(() =>
+      expect(firstMain.onSubmit).toHaveBeenCalledWith('ship exactly one session', {
+        composerScope: 'session-first'
+      })
+    )
+    expect(secondMain.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('does not fan out when visible composers do not have queue session keys yet', async () => {
+    const firstNewSession = renderSubmitHook({ sessionKey: null })
+    const secondNewSession = renderSubmitHook({ sessionKey: null })
+
+    act(() => {
+      requestComposerSubmit('ship the visible new session', { target: 'main' })
+    })
+
+    await waitFor(() => expect(firstNewSession.onSubmit).toHaveBeenCalledTimes(1))
+    expect(secondNewSession.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the visible composer has no surface id', () => {
+    const unidentifiedMain = renderSubmitHook({ surfaceId: null })
+
+    requestComposerSubmit('do not broadcast this', { target: 'main' })
+
+    expect(unidentifiedMain.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('does not submit through a composer whose input is disabled', () => {
+    const disabledMain = renderSubmitHook({ inputDisabled: true })
+
+    requestComposerSubmit('do not send this', { target: 'main' })
+
+    expect(disabledMain.onSubmit).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -1,5 +1,6 @@
-import { type RefObject, useEffect, useRef } from 'react'
+import { type RefObject, useLayoutEffect, useRef } from 'react'
 
+import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { hasClarifyRequest, skipClarifyRequest } from '@/store/clarify'
@@ -76,6 +77,7 @@ export function useComposerSubmit({
   setComposerText,
   stashAt
 }: UseComposerSubmitArgs) {
+  const paneVisible = usePaneVisible()
   const scope = useComposerScope()
 
   // Shared send primitive: fire onSubmit, and if the gateway rejects (accepted
@@ -108,14 +110,14 @@ export function useComposerSubmit({
   const dispatchSubmitRef = useRef(dispatchSubmit)
   dispatchSubmitRef.current = dispatchSubmit
 
-  useEffect(
+  useLayoutEffect(
     () =>
       onComposerSubmitRequest(({ target, text }) => {
-        if (target === 'main' && !inputDisabled) {
+        if (target === scope.target && paneVisible && !inputDisabled) {
           dispatchSubmitRef.current(text)
         }
       }),
-    [inputDisabled]
+    [inputDisabled, paneVisible, scope.target]
   )
 
   const submitDraft = () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -14,7 +14,7 @@ import { cloneAttachments, type QueueEditState } from '../composer-utils'
 import { onComposerSubmitRequest } from '../focus'
 import { pathifyRefs } from '../path-refs'
 import { composerPlainText } from '../rich-editor'
-import { useComposerScope } from '../scope'
+import { useComposerScope, useComposerSurfaceId } from '../scope'
 import type { ChatBarProps } from '../types'
 
 interface UseComposerSubmitArgs {
@@ -79,6 +79,7 @@ export function useComposerSubmit({
 }: UseComposerSubmitArgs) {
   const paneVisible = usePaneVisible()
   const scope = useComposerScope()
+  const surfaceId = useComposerSurfaceId()
 
   // Shared send primitive: fire onSubmit, and if the gateway rejects (accepted
   // === false) or throws, re-load + re-stash the draft so the words survive.
@@ -112,12 +113,18 @@ export function useComposerSubmit({
 
   useLayoutEffect(
     () =>
-      onComposerSubmitRequest(({ target, text }) => {
-        if (target === scope.target && paneVisible && !inputDisabled) {
+      onComposerSubmitRequest(({ surfaceId: requestedSurfaceId, target, text }) => {
+        if (
+          target === scope.target &&
+          surfaceId !== null &&
+          requestedSurfaceId === surfaceId &&
+          paneVisible &&
+          !inputDisabled
+        ) {
           dispatchSubmitRef.current(text)
         }
       }),
-    [inputDisabled, paneVisible, scope.target]
+    [inputDisabled, paneVisible, scope.target, surfaceId]
   )
 
   const submitDraft = () => {

--- a/apps/desktop/src/app/chat/composer/scope.tsx
+++ b/apps/desktop/src/app/chat/composer/scope.tsx
@@ -43,3 +43,15 @@ const ComposerScopeContext = createContext<ComposerScope>(MAIN_COMPOSER_SCOPE)
 export const ComposerScopeProvider = ComposerScopeContext.Provider
 
 export const useComposerScope = (): ComposerScope => useContext(ComposerScopeContext)
+
+/**
+ * Unique identity for one mounted ChatView/composer pair. Session ids cannot
+ * fill this role: a fresh chat has no id yet, and the same stored session can
+ * be rendered in more than one layout pane. External submit requests pin this
+ * surface id at click time so exactly one composer can claim the task.
+ */
+const ComposerSurfaceContext = createContext<string | null>(null)
+
+export const ComposerSurfaceProvider = ComposerSurfaceContext.Provider
+
+export const useComposerSurfaceId = (): string | null => useContext(ComposerSurfaceContext)

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -3,7 +3,7 @@ import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import type { ReadableAtom } from 'nanostores'
 import type * as React from 'react'
-import { memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, Suspense, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router'
 
 import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
@@ -54,7 +54,7 @@ import { ChatSwapOverlay } from './chat-swap-overlay'
 import { ChatBar, ChatBarFallback } from './composer'
 import { requestComposerInsert } from './composer/focus'
 import { droppedFileInlineRefs } from './composer/inline-refs'
-import { useComposerScope } from './composer/scope'
+import { ComposerSurfaceProvider, useComposerScope } from './composer/scope'
 import type { ChatBarState } from './composer/types'
 import { type DroppedFile, partitionDroppedFiles } from './hooks/use-composer-actions'
 import { type DragKind, useFileDropZone } from './hooks/use-file-drop-zone'
@@ -308,6 +308,7 @@ export const ChatView = memo(function ChatView({
   onTranscribeAudio,
   onDismissError
 }: ChatViewProps) {
+  const composerSurfaceId = useId()
   const location = useLocation()
   const { t } = useI18n()
   // The view this surface renders: the primary route-driven session (global
@@ -511,15 +512,17 @@ export const ChatView = memo(function ChatView({
   const overlayKind: DragKind = dragKind === 'files' ? 'files' : sessionDragging && !sessionEdgeHover ? 'session' : null
 
   return (
-    <div
-      className={cn(
-        'relative isolate flex h-full min-w-0 flex-col overflow-hidden bg-(--ui-chat-surface-background)',
-        className
-      )}
-      data-chat-surface=""
-      data-composer-target={composerScope.target}
-      data-session-anchor={sessionAnchor}
-    >
+    <ComposerSurfaceProvider value={composerSurfaceId}>
+      <div
+        className={cn(
+          'relative isolate flex h-full min-w-0 flex-col overflow-hidden bg-(--ui-chat-surface-background)',
+          className
+        )}
+        data-chat-surface=""
+        data-composer-surface-id={composerSurfaceId}
+        data-composer-target={composerScope.target}
+        data-session-anchor={sessionAnchor}
+      >
       <Backdrop />
       {/* Tiles get their chrome from the layout zone (chip strip); the modal
           prompt overlays stay active-session-scoped in the primary surface. */}
@@ -635,6 +638,7 @@ export const ChatView = memo(function ChatView({
           </Suspense>
         )}
       </ChatRuntimeBoundary>
-    </div>
+      </div>
+    </ComposerSurfaceProvider>
   )
 })


### PR DESCRIPTION
## Summary

- route window-level external composer submit requests only to a composer whose target matches the request
- ignore hidden keep-alive panes so inactive sessions cannot submit the same Review prompt
- subscribe with `useLayoutEffect` so a pane visibility change cleans up the stale listener before an ancestor layout effect can emit
- add regression coverage for visible/hidden composers, target mismatches, and the visibility-transition race

## Problem

The Review pane's Ship action emits a window-level composer submit request targeting `main`. Desktop keeps inactive session panes mounted, and each mounted main composer previously accepted that event using only the `target === 'main'` and `!inputDisabled` checks. One click could therefore start the same prompt in both the visible session and a hidden keep-alive session.

## Verification

- `npm exec vitest -- run --project ui src/app/chat/composer/hooks/use-composer-submit.test.tsx src/app/skills/index.test.tsx src/app/settings/gateway-settings.test.tsx` — 25/25 passed
- independent focused review run including composer focus tests — 33/33 passed
- `npm run lint` — 0 errors (87 existing warnings)
- `npm run typecheck` — all renderer, Electron, and e2e checks passed
- `npm run build` — passed
- `git diff --check origin/main...HEAD` — passed
- privacy/credential scan of added lines — no findings

The full UI suite reports the same seven failures in the patched branch and a pristine `origin/main` worktree (the patched branch adds two passing regression tests), so this change introduces no additional suite failures.
