### PR TITLE
fix: exclude launchd-managed gateway from orphan reaper on macOS

### DIFF
--- a/contributors/emails/seze@andrew.cmu.edu
+++ b/contributors/emails/seze@andrew.cmu.edu
@@ -1,0 +1,1 @@
+Shedrackeze002

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1555,6 +1555,16 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     own = {os.getpid()}
     if extra_exclude:
         own |= extra_exclude
+    # On macOS, exclude the launchd-managed gateway PID so the orphan reaper
+    # doesn't kill a supervised gateway when Hermes Desktop opens (the serve
+    # process calls this on startup).  supports_systemd_services() returns
+    # False on macOS, so without this the launchd gateway looks like an
+    # unsupervised orphan and gets SIGTERM'd, causing launchd to restart it.
+    if is_macos():
+        try:
+            own |= _get_service_pids()
+        except Exception:
+            pass
     try:
         # find_gateway_pids() includes no-supervisor `gateway restart` runtimes
         # for the current profile when no systemd supervisor is present.

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -427,6 +427,74 @@ class TestStopProfileGateway:
         assert killed_pid in reap_extra_excludes[0]
 
 
+class TestReapUnsupervisedGatewayOrphansMacOS:
+    """Tests that the orphan reaper excludes launchd-managed PIDs on macOS.
+
+    Regression guard: without the ``is_macos()`` exclusion of
+    ``_get_service_pids()``, the reaper would SIGTERM the launchd-supervised
+    gateway every time Hermes Desktop opens (``hermes serve`` calls
+    ``_reap_unsupervised_gateway_orphans`` during startup).
+    """
+
+    def test_macos_excludes_launchd_pid_from_kill(self, monkeypatch):
+        """A launchd-managed PID must not appear in the orphan kill list."""
+        launchd_pid = 52615
+
+        # Pretend we're on macOS — supports_systemd_services() returns False
+        # so the function does NOT short-circuit and proceeds to the scan.
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+
+        # _get_service_pids returns the launchd-managed gateway PID.
+        monkeypatch.setattr(gateway, "_get_service_pids", lambda: {launchd_pid})
+
+        # find_gateway_pids returns the launchd PID plus a real orphan.
+        # The reaper should only kill the orphan, not the launchd PID.
+        orphan_pid = 99998
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [p for p in [launchd_pid, orphan_pid] if p not in (exclude_pids or set())],
+        )
+
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        monkeypatch.setattr("time.monotonic", lambda: 1.0)
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert result is True  # at least one orphan was reaped
+        killed = [pid for pid, _ in killed_pids]
+        assert orphan_pid in killed       # the real orphan was killed
+        assert launchd_pid not in killed  # the launchd PID was NOT killed
+
+    def test_macos_no_orphans_when_only_launchd_gateway_running(self, monkeypatch):
+        """If the only gateway PID is launchd-managed, reaper returns False."""
+        launchd_pid = 52615
+
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "_get_service_pids", lambda: {launchd_pid})
+
+        # find_gateway_pids would return the launchd PID, but it's excluded.
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [p for p in [launchd_pid] if p not in (exclude_pids or set())],
+        )
+
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert result is False  # no orphans reaped
+        assert killed_pids == []  # nothing was killed
+
+
 def test_module_has_logger():
     """Verify module has a logger instance (regression guard for #27154)."""
     assert hasattr(gateway, "logger")


### PR DESCRIPTION
## Summary
On macOS, the orphan reaper no longer kills the launchd-managed gateway when Hermes Desktop opens — the launchd PID is excluded from the orphan scan, mirroring the existing systemd pattern.

## Changes
- `hermes_cli/gateway.py`: Add `is_macos()` guard in `_reap_unsupervised_gateway_orphans()` that calls `_get_service_pids()` (which returns launchd-managed PIDs on macOS) and adds them to the exclusion set before the orphan scan. `supports_systemd_services()` returns False on macOS, so without this the launchd gateway looks like an unsupervised orphan and gets SIGTERM'd on every Desktop open.
- `tests/hermes_cli/test_gateway.py`: 2 regression tests verifying launchd PIDs are excluded from the kill list and that no orphans are reaped when only the launchd gateway is running.
- `contributors/emails/seze@andrew.cmu.edu`: Contributor email mapping for @Shedrackeze002.

Salvage of #85616 by @Shedrackeze002 — cherry-picked with authorship preserved.

## Validation
| | Before | After |
|---|---|---|
| macOS Desktop open | launchd gateway SIGTERM'd + restarts | gateway stays running |
| Targeted tests | n/a | 3/3 pass (2 new + 1 existing) |
| E2E smoke (real imports) | n/a | pass — live call returns False, no crash |
| ruff lint | n/a | clean |
