### PR TITLE
fix(agent): reuse devnull sink across thread-routing proxy reinstalls

### DIFF
--- a/agent/thread_scoped_output.py
+++ b/agent/thread_scoped_output.py
@@ -111,12 +111,34 @@ def _ensure_installed(attr: str, passthrough: TextIO) -> "_ThreadRoutingStream":
         current = getattr(sys, attr, None)
         if proxy is not None and current is proxy:
             return proxy
-        # Capture whatever is currently bound as the passthrough. If a prior
-        # global redirect_stdout is active, route non-silenced threads to that
-        # stream to preserve the old behavior.
-        passthrough = current if current is not None else passthrough
-        sink = open(os.devnull, "w", encoding="utf-8")
-        proxy = _ThreadRoutingStream(passthrough, sink)
+        # Our proxy was displaced — almost always by a process-global
+        # redirect_stdout/redirect_stderr wrapping a worker body. Capture
+        # whatever is currently bound as the passthrough (preserving the
+        # redirect's routing for non-silenced threads), with two details that
+        # keep the reinstall itself from leaking:
+        #
+        # 1. Reuse the displaced proxy's sink instead of opening a fresh
+        #    os.devnull handle.  The sink is a stateless null writer that
+        #    every generation of the proxy can share; opening one per
+        #    reinstall pinned one more /dev/null fd for the life of the
+        #    process.
+        # 2. Never chain onto a stale proxy: a global redirect's __exit__ can
+        #    restore an older proxy over the one we registered, so the stream
+        #    we capture here may itself be a _ThreadRoutingStream.  Unwrap to
+        #    its passthrough instead of chaining — chained proxies keep every
+        #    older generation strongly referenced, which is how the leaked
+        #    sinks survived GC.
+        sink = (
+            proxy._sink
+            if proxy is not None
+            else open(os.devnull, "w", encoding="utf-8")
+        )
+        target: TextIO = current if current is not None else passthrough
+        seen: set[int] = set()
+        while isinstance(target, _ThreadRoutingStream) and id(target) not in seen:
+            seen.add(id(target))
+            target = target._passthrough
+        proxy = _ThreadRoutingStream(target, sink)
         setattr(sys, attr, proxy)
         _installed[attr] = proxy
         return proxy

--- a/tests/agent/test_thread_scoped_output.py
+++ b/tests/agent/test_thread_scoped_output.py
@@ -94,3 +94,76 @@ def test_repeated_contexts_never_write_to_a_closed_sink():
             sys.stdout.fileno()
     finally:
         sys.stdout = original
+
+
+def _displace_and_silence(cycles: int) -> None:
+    """Churn cycle: a process-global redirect displaces the proxy, a worker
+    then reinstalls it via thread_scoped_silence, and the redirect's exit
+    restores the stale binding — the pattern that used to leak one
+    /dev/null handle per cycle."""
+    for _ in range(cycles):
+        buf = io.StringIO()
+        saved = sys.stdout
+        sys.stdout = buf
+        try:
+            with thread_scoped_silence():
+                pass
+        finally:
+            sys.stdout = saved
+
+
+def test_proxy_reinstall_reuses_sink_and_never_chains():
+    """Reinstalls after displacement must reuse the first proxy's sink and
+    must not chain proxy -> proxy (chains keep every old sink referenced
+    and open for the process lifetime)."""
+    import agent.thread_scoped_output as tso
+
+    original = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        with thread_scoped_silence():
+            pass
+        first_sink = tso._installed["stdout"]._sink
+        _displace_and_silence(25)
+        # sys.stdout now points at a stale proxy (redirect-exit restore);
+        # the next reinstall must unwrap it, not chain onto it.
+        with thread_scoped_silence():
+            pass
+        current = tso._installed["stdout"]
+        assert current._sink is first_sink
+        assert not isinstance(current._passthrough, tso._ThreadRoutingStream)
+    finally:
+        sys.stdout = original
+
+
+def test_proxy_reinstall_churn_does_not_grow_devnull_fds():
+    """End-to-end fd invariant: repeated displacement cycles keep the
+    process's /dev/null descriptor count flat (Linux /proc only)."""
+    import os
+
+    import pytest
+
+    fd_dir = "/proc/self/fd"
+    if not os.path.isdir(fd_dir):
+        pytest.skip("needs /proc fd introspection")
+
+    def devnull_fds() -> int:
+        count = 0
+        for fd in os.listdir(fd_dir):
+            try:
+                if os.readlink(os.path.join(fd_dir, fd)) == os.devnull:
+                    count += 1
+            except OSError:
+                pass
+        return count
+
+    original = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        with thread_scoped_silence():
+            pass
+        baseline = devnull_fds()
+        _displace_and_silence(40)
+        assert devnull_fds() == baseline
+    finally:
+        sys.stdout = original


### PR DESCRIPTION
## Summary

`agent.thread_scoped_output._ensure_installed()` leaks one `/dev/null` file descriptor every time the thread-routing proxy is reinstalled after displacement.

The proxy installed by `thread_scoped_silence()` is deliberately never uninstalled, but a process-global `contextlib.redirect_stdout`/`redirect_stderr` (used by worker wrappers, e.g. `agent/curator.py`) displaces it. The next silenced worker reinstalls a fresh proxy, and each reinstall:

1. opened a **new** `os.devnull` handle for the sink, and
2. captured the *current* stream as its passthrough — which can be a displaced older proxy (a redirect's `__exit__` restores the stale binding), chaining proxy → proxy.

The chain keeps every older proxy — and therefore every old sink — strongly referenced, so the leaked descriptors survive GC. In a long-running multi-threaded process whose workers alternate global redirects with thread-scoped silencing, `/dev/null` fds grow without bound until the process hits its fd soft limit and starts failing every `open()` with `EMFILE` while staying alive (same outage class as the SessionDB read-connection leak fixed in 87aedbe7b — there the fds were `state.db`/`-wal`, here `/dev/null`).

## Fix

Reinstalls now:

- **reuse the displaced proxy's sink** instead of opening a fresh `os.devnull` handle — the sink is a stateless null writer that every proxy generation can share, capping `/dev/null` handles at one per stream (`stdout`/`stderr`) for the process lifetime;
- **unwrap stale proxies** when capturing the passthrough, so reinstalls never chain proxy → proxy (behavior for non-silenced threads is unchanged: they reach the same ultimate stream with one less hop).

## Tests

`tests/agent/test_thread_scoped_output.py` gains two regression tests:

- `test_proxy_reinstall_reuses_sink_and_never_chains` — after 25 displacement cycles plus a stale-proxy reinstall, the installed proxy still uses the *first* sink object and its passthrough is not another proxy.
- `test_proxy_reinstall_churn_does_not_grow_devnull_fds` — 40 displacement cycles leave the process's `/dev/null` fd count flat (Linux `/proc` gated).

Both fail on current `main` and pass with the fix; the three pre-existing tests pass on both.

## Validation

- `pytest tests/agent/test_thread_scoped_output.py` — 5/5 pass (2 new fail without the fix)
- `pytest tests/agent/ --ignore=tests/agent/lsp` — green (the `tests/agent/lsp` e2e failure reproduces identically on the untouched base; it needs a language-server binary this environment lacks)
- `ruff check` — clean; `ruff format --check` flags only pre-existing regions of the test file, untouched by this diff
