### PR TITLE
fix(compaction): gate checkpoint replay/prune on current request eligibility

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1500,8 +1500,15 @@ class _CodexCompletionsAdapter:
         # build_kwargs, so they need the same guard applied independently.
         _host_for_input = str(getattr(self._client, "base_url", "") or "")
         _is_github_for_input = base_url_host_matches(_host_for_input, "githubcopilot.com")
+        # Auxiliary calls never send ``context_management`` (native
+        # compaction is a main-turn feature), so they must never replay a
+        # compaction checkpoint from the replayed history nor let one
+        # restructure this request — the summarizer/aggregator model is
+        # usually not even the one that minted the blob.
         input_items = _chat_messages_to_responses_input(
-            replay_messages, is_github_responses=_is_github_for_input,
+            replay_messages,
+            is_github_responses=_is_github_for_input,
+            native_compaction_eligible=False,
         )
 
         resp_kwargs: Dict[str, Any] = {

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -414,6 +414,7 @@ def _chat_messages_to_responses_input(
     is_github_responses: bool = False,
     replay_encrypted_reasoning: bool = True,
     current_issuer_kind: Optional[str] = None,
+    native_compaction_eligible: bool = False,
 ) -> List[Dict[str, Any]]:
     """Convert internal chat-style messages to Responses input items.
 
@@ -458,6 +459,24 @@ def _chat_messages_to_responses_input(
     ``replay_encrypted_reasoning=False`` is the session-wide kill switch
     (drops ALL replay); ``current_issuer_kind`` is the per-item filter
     that runs only when replay is still enabled.
+
+    ``native_compaction_eligible`` mirrors, for THIS request, the decision
+    made by ``native_compaction.native_compaction_context_management`` — it
+    is True only when that gate returned a payload, i.e. when the request
+    actually carries ``context_management``. It controls two things that
+    must never outlive the gate: replaying ``type: "compaction"`` checkpoint
+    items, and restructuring the wire around them
+    (``prune_pre_checkpoint_items``). Checkpoints are persisted in the
+    ``codex_reasoning_items`` sidecar and survive a mid-session model swap,
+    a ``compression.enabled: false`` flip, the rejection kill switch and a
+    resumed session; without this flag a single captured checkpoint would
+    keep deleting every pre-checkpoint item from every later request, on a
+    model that cannot decrypt the blob (#85914). Default False = pre-feature
+    wire, which is also correct for every caller that never sends
+    ``context_management`` (auxiliary/compression client, ad-hoc
+    ``convert_messages``). Dropping the checkpoint costs nothing: Hermes'
+    local history is never truncated by native compaction, so the full
+    conversation is still on the wire.
     """
     items: List[Dict[str, Any]] = []
     seen_item_ids: set = set()
@@ -498,6 +517,20 @@ def _chat_messages_to_responses_input(
                         if isinstance(ri, dict) and ri.get("encrypted_content"):
                             item_id = ri.get("id")
                             if item_id and item_id in seen_item_ids:
+                                continue
+                            # Native-compaction gate: a checkpoint is only
+                            # meaningful to the endpoint/model that minted it
+                            # AND only while this request still asks for
+                            # server-side compaction. Once the gate closes
+                            # (model swapped out of the gpt-5.6 family,
+                            # compression disabled, rejection kill switch),
+                            # the persisted checkpoint must not be replayed —
+                            # replaying it is what makes the wire restructure
+                            # below erase pre-checkpoint history forever.
+                            if (
+                                ri.get("type") == "compaction"
+                                and not native_compaction_eligible
+                            ):
                                 continue
                             # Cross-issuer guard: drop reasoning blocks that
                             # were minted by a different Responses endpoint.
@@ -697,8 +730,13 @@ def _chat_messages_to_responses_input(
     # from before the boundary silently vanish from the model's view. Keep
     # the newest checkpoint first, retain pre-checkpoint USER messages
     # verbatim within a token budget (Codex CLI parity), and leave the
-    # post-checkpoint tail untouched. Self-gating: histories without a
-    # checkpoint (every non-native session) return unchanged.
+    # post-checkpoint tail untouched. Gated on the CURRENT request's native
+    # eligibility, not merely on the presence of a checkpoint: a persisted
+    # checkpoint outlives the gate, and pruning for a request that carries no
+    # ``context_management`` deletes history the server never compacted.
+    if not native_compaction_eligible:
+        return items
+
     from agent.native_compaction import prune_pre_checkpoint_items
 
     return prune_pre_checkpoint_items(items)

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -263,6 +263,21 @@ def _is_post_tool_replay(messages: Optional[List[Dict[str, Any]]]) -> bool:
     return False
 
 
+def _native_compaction_active(context_management: Any) -> bool:
+    """Is THIS request natively compacted?
+
+    True only when the caller's eligibility gate
+    (``native_compaction.native_compaction_context_management``) produced a
+    non-empty payload. Every native-compaction side effect on the wire —
+    sending ``context_management``, replaying a ``type: "compaction"``
+    checkpoint, restructuring the input around it — hangs off this one
+    predicate, so a checkpoint that outlives the gate (model swapped out of
+    the gpt-5.6 family, compression disabled, rejection kill switch, resumed
+    session) cannot keep reshaping requests on its own.
+    """
+    return isinstance(context_management, list) and bool(context_management)
+
+
 class ResponsesApiTransport(ProviderTransport):
     """Transport for api_mode='codex_responses'.
 
@@ -303,6 +318,9 @@ class ResponsesApiTransport(ProviderTransport):
                 kwargs.get("replay_encrypted_reasoning", True)
             ),
             current_issuer_kind=issuer,
+            native_compaction_eligible=_native_compaction_active(
+                kwargs.get("context_management")
+            ),
         )
 
     def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
@@ -377,6 +395,12 @@ class ResponsesApiTransport(ProviderTransport):
         # agent.native_compaction.native_compaction_context_management();
         # None means the field is never added to the request.
         context_management = params.get("context_management")
+        # Single source of truth for "this request is natively compacted":
+        # the same value decides whether the field goes out AND whether the
+        # converter may replay/prune around a compaction checkpoint. Keeping
+        # them derived from one expression is what stops a persisted
+        # checkpoint from restructuring the wire after the gate closes.
+        native_compaction_active = _native_compaction_active(context_management)
 
         # Resolve the issuing endpoint for this call. Stashed on the
         # transport so normalize_response can stamp it onto reasoning
@@ -471,6 +495,7 @@ class ResponsesApiTransport(ProviderTransport):
                 is_github_responses=is_github_responses,
                 replay_encrypted_reasoning=replay_encrypted_reasoning,
                 current_issuer_kind=issuer_kind,
+                native_compaction_eligible=native_compaction_active,
             ),
             "store": False,
         }
@@ -478,7 +503,7 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs["tools"] = response_tools
             kwargs["tool_choice"] = "auto"
             kwargs["parallel_tool_calls"] = True
-        if isinstance(context_management, list) and context_management:
+        if native_compaction_active:
             kwargs["context_management"] = context_management
 
         session_id = params.get("session_id")

--- a/tests/run_agent/test_native_compaction.py
+++ b/tests/run_agent/test_native_compaction.py
@@ -349,6 +349,7 @@ class TestResponseCapture:
                 {"role": "user", "content": "next"},
             ],
             current_issuer_kind="codex_backend",
+            native_compaction_eligible=True,
         )
         replayed = [item for item in items if item.get("type") == "compaction"]
         assert len(replayed) == 1
@@ -375,6 +376,7 @@ class TestResponseCapture:
                 {"role": "user", "content": "next"},
             ],
             current_issuer_kind="xai_responses",
+            native_compaction_eligible=True,
         )
         assert all(item.get("type") != "compaction" for item in items)
 
@@ -549,7 +551,7 @@ class TestPrunePreCheckpointItems:
             },
             {"role": "user", "content": "follow-up"},
         ]
-        items = _chat_messages_to_responses_input(msgs)
+        items = _chat_messages_to_responses_input(msgs, native_compaction_eligible=True)
         assert items[0] == {"type": "compaction", "encrypted_content": "blob"}
         users = [i["content"] for i in items if i.get("role") == "user"]
         assert users == ["the goal", "follow-up"]
@@ -569,3 +571,141 @@ class TestPrunePreCheckpointItems:
         ]
         items = _chat_messages_to_responses_input(msgs)
         assert [i.get("role") for i in items] == ["user", "assistant", "user"]
+
+
+class TestCheckpointGatedOnCurrentEligibility:
+    """A captured checkpoint must not outlive the native gate.
+
+    The checkpoint is persisted in the ``codex_reasoning_items`` sidecar, so
+    it survives a mid-session model swap, ``compression.enabled: false``, the
+    rejection kill switch and a resumed session. Every one of those closes the
+    gate; if the wire kept being restructured around the stale checkpoint,
+    pre-checkpoint history would be deleted from requests that were never
+    natively compacted — on a model that cannot even decrypt the blob.
+    """
+
+    def _history(self):
+        return [
+            {"role": "user", "content": "goal: ship the migration"},
+            {"role": "assistant", "content": "on it"},
+            {"role": "user", "content": "detail A"},
+            {
+                "role": "assistant",
+                "content": "checkpointed turn",
+                "codex_reasoning_items": [
+                    {
+                        "type": "compaction",
+                        "encrypted_content": "blob",
+                        "_issuer_kind": "codex_backend",
+                    }
+                ],
+            },
+            {"role": "user", "content": "next ask"},
+        ]
+
+    def test_ineligible_request_keeps_pre_feature_wire(self):
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+        history = self._history()
+        items = _chat_messages_to_responses_input(
+            history,
+            current_issuer_kind="codex_backend",
+            native_compaction_eligible=False,
+        )
+        pre_feature = _chat_messages_to_responses_input(
+            [
+                {k: v for k, v in msg.items() if k != "codex_reasoning_items"}
+                for msg in history
+            ],
+        )
+        assert items == pre_feature
+        # Specifically: no checkpoint on the wire, no deleted history.
+        assert all(i.get("type") != "compaction" for i in items)
+        assert {"role": "assistant", "content": "on it"} in items
+
+    def test_eligible_request_still_restructures(self):
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+        items = _chat_messages_to_responses_input(
+            self._history(),
+            current_issuer_kind="codex_backend",
+            native_compaction_eligible=True,
+        )
+        assert items[0]["type"] == "compaction"
+        assert {"role": "assistant", "content": "on it"} not in items
+
+    def test_converter_defaults_to_ineligible(self):
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+        items = _chat_messages_to_responses_input(self._history())
+        assert all(i.get("type") != "compaction" for i in items)
+        assert {"role": "assistant", "content": "on it"} in items
+
+    def test_build_kwargs_without_field_does_not_prune(self):
+        """Model swapped out of the gpt-5.6 family / kill switch fired:
+        the gate returns None, so the wire must be the pre-feature one."""
+        from agent.transports.codex import ResponsesApiTransport
+
+        kwargs = ResponsesApiTransport().build_kwargs(
+            model="gpt-5.2",
+            messages=self._history(),
+            context_management=None,
+        )
+        assert "context_management" not in kwargs
+        assert all(i.get("type") != "compaction" for i in kwargs["input"])
+        assert {"role": "assistant", "content": "on it"} in kwargs["input"]
+
+    def test_build_kwargs_with_field_prunes(self):
+        from agent.transports.codex import ResponsesApiTransport
+
+        kwargs = ResponsesApiTransport().build_kwargs(
+            model="gpt-5.6",
+            messages=self._history(),
+            is_codex_backend=True,
+            context_management=[{"type": "compaction", "compact_threshold": 4000}],
+        )
+        assert kwargs["input"][0]["type"] == "compaction"
+        assert {"role": "assistant", "content": "on it"} not in kwargs["input"]
+
+    def test_convert_messages_defaults_to_ineligible(self):
+        from agent.transports.codex import ResponsesApiTransport
+
+        items = ResponsesApiTransport().convert_messages(
+            self._history(), is_codex_backend=True
+        )
+        assert all(i.get("type") != "compaction" for i in items)
+        assert {"role": "assistant", "content": "on it"} in items
+
+    def test_auxiliary_responses_adapter_never_prunes(self, monkeypatch):
+        """Auxiliary calls (compression, flush_memories, MoA) replay real
+        session history but never send ``context_management`` — so a
+        checkpoint in that history must not restructure their request."""
+        import agent.codex_responses_adapter as adapter
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        seen = {}
+        real = adapter._chat_messages_to_responses_input
+
+        def _spy(messages, **kw):
+            seen.update(kw)
+            return real(messages, **kw)
+
+        monkeypatch.setattr(adapter, "_chat_messages_to_responses_input", _spy)
+
+        class _Responses:
+            def create(self, **kwargs):
+                seen["input"] = kwargs.get("input")
+                raise RuntimeError("stop before network")
+
+        class _Client:
+            base_url = "https://chatgpt.com/backend-api/codex"
+            responses = _Responses()
+
+        with pytest.raises(RuntimeError, match="stop before network"):
+            _CodexCompletionsAdapter(_Client(), "gpt-5.2").create(
+                messages=self._history()
+            )
+
+        assert seen.get("native_compaction_eligible") is False
+        assert all(i.get("type") != "compaction" for i in seen["input"])
+        assert {"role": "assistant", "content": "on it"} in seen["input"]


### PR DESCRIPTION
Fixes #85914

## Problem

A native-compaction checkpoint is captured into the persisted `codex_reasoning_items` sidecar. The wire restructure that follows it (`prune_pre_checkpoint_items`) ran **unconditionally**: the native gate (`native_compaction_context_management`) only decided whether `context_management` went into the request, and no signal from it ever reached `_chat_messages_to_responses_input`.

So one checkpoint kept deleting every pre-checkpoint item from **all** later requests:

```
gate: native_compaction_context_management(model="gpt-5.2", base_url="https://api.openai.com/v1") -> None

input (messages)                              output (input items)
  user      "goal: ship the migration"          {'type': 'compaction', 'encrypted_content': 'blob'}
  assistant "on it"                       -->   {'role': 'user',      'content': 'goal: ship the migration'}
  user      "detail A"                          {'role': 'user',      'content': 'detail A'}
  assistant "checkpointed turn" (+sidecar)      {'role': 'assistant', 'content': 'checkpointed turn'}
  user      "next ask"                          {'role': 'user',      'content': 'next ask'}

=> assistant "on it" deleted from a request that never asked for native compaction
```

Reachable in production after: a mid-session model swap out of the gpt-5.6 family, `compression.enabled: false`, the rejection kill switch (`conversation_loop.py` clearing `codex_responses_native_compaction`), or a session resume that reloads the sidecar from `state.db`. Streaming and non-streaming both converge on `_chat_messages_to_responses_input`, so both were affected. Silent — no log, no user-visible warning — and the model receiving the opaque blob is no longer the one that can decode it.

The `prune_pre_checkpoint_items` docstring claimed the opposite ("self-gating: non-native routes and kill-switched sessions never see a restructured wire"). That self-gating only ever held for sessions that **never** captured a checkpoint.

## Root cause

Eligibility was computed in one place (`native_compaction_context_management`) and consumed in another (`build_kwargs`, for the request field only). The wire restructure inferred eligibility from **history state** (is there a checkpoint?) instead of **request state** (is this request natively compacted?). History outlives the gate; request state does not.

## Fix

One boolean, `native_compaction_eligible`, derived from the same value that gates the `context_management` field, threaded into the converter. When ineligible:

- `type: "compaction"` items are not replayed;
- `prune_pre_checkpoint_items` is skipped.

Safe by design: native compaction never truncates Hermes' local history — the local compressor stays the fallback owner — so an unreplayed checkpoint costs nothing but a larger, complete request.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[Session History + Persisted Checkpoint] --> B{Native Gate<br/>context_management payload?}
    B -->|Eligible| C[Replay Checkpoint]
    C --> D[Restructure Wire<br/>prune_pre_checkpoint_items]
    B -->|Ineligible: model swap / compression off<br/>/ kill switch / resumed session| E[Pre-Feature Wire<br/>Full History Preserved]
    D --> F[Request Sent]
    E --> F
    B -.->|BEFORE: no signal reached converter| G[Unconditional Prune<br/>Pre-Checkpoint History Deleted]
    G -.->|Fixed by propagating eligibility| E
```

## Coverage of duplicate / adjacent implementations

Every Responses call site that reaches the shared converter is handled by the same single predicate, so the two decisions cannot drift apart again:

| Call site | Behavior |
| --- | --- |
| `ResponsesApiTransport.build_kwargs` | `_native_compaction_active(context_management)` now gates **both** the request field and the converter |
| `ResponsesApiTransport.convert_messages` | same derivation from its own kwargs |
| `_CodexCompletionsAdapter.create` (auxiliary: compression, `flush_memories`, MoA) | explicitly ineligible — these calls replay real session history but never send `context_management` |
| `_chat_messages_to_responses_input` (any future caller) | default `False` = pre-feature wire, safe by construction |

Untouched on purpose: `prune_pre_checkpoint_items` and the sidecar custody helpers (`has_compaction_checkpoint`, `merge_interim_reasoning_items`) keep their semantics — the checkpoint is still captured, persisted and merged exactly as before. Only its effect on the wire is now scoped to requests that actually asked for server-side compaction.

## Tests

New `TestCheckpointGatedOnCurrentEligibility` in `tests/run_agent/test_native_compaction.py`:

- ineligible request produces a wire **byte-identical** to the pre-feature one (compared against the converter output of the same history with the sidecar stripped);
- eligible request still replays and restructures (feature intact);
- converter default is ineligible;
- `build_kwargs` without the field does not prune, with the field does;
- `convert_messages` defaults to ineligible;
- auxiliary Responses adapter never prunes (behavioral: spies on the converter kwargs and on the built `input`).

Three pre-existing tests that relied on the implicit-always-on behavior now pass the flag explicitly.

```
tests/run_agent/test_native_compaction.py                52 passed
tests/agent/test_codex_responses_adapter.py
tests/agent/transports/test_codex_transport.py
tests/run_agent/test_run_agent_codex_responses.py
tests/run_agent/test_codex_app_server_compaction.py
tests/providers/test_transport_parity.py
tests/agent/test_message_sanitization_policy.py         195 passed
tests/run_agent/test_codex_xai_oauth_recovery.py
tests/run_agent/test_codex_multimodal_tool_result.py
tests/run_agent/test_run_agent_multimodal_prologue.py
tests/agent/test_memory_provider.py
tests/agent/test_compressed_summary_metadata.py         103 passed
```

## Test plan

- [x] Regression test reproducing the bug (checkpoint + ineligible model → pre-feature wire)
- [x] Feature-intact test (eligible model still prunes)
- [x] All four Responses call sites covered
- [x] Adjacent Codex/Responses suites green (350 tests)
- [ ] Live check on a gpt-5.6 → gpt-5.2 mid-session swap against `api.openai.com` (needs a real key; the HTTP-400-on-`type: "compaction"` risk noted in the issue is still unverified offline)

## Infographic :

<img width="1376" height="768" alt="infographic_compaction_fix_85919" src="https://github.com/user-attachments/assets/4f015304-4d40-49fb-bd0b-e6e86c64d648" />

 