### PR TITLE
fix(approval): hardline blocklist bypassable via escaped quote in command text

### DIFF
--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -235,6 +235,30 @@ def test_grep_pcre_pattern_with_grouped_root_delete_text_stays_safe():
     assert detect_hardline_command(command) == (False, None)
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        r'cd ~/.hermes/hermes-agent && grep -n "^from\|^__all__\|^    \"" tools/environments/__init__.py | head -15',
+        r'egrep -n "alpha\"beta|gamma" input.txt',
+    ],
+)
+def test_quoted_grep_patterns_with_escaped_double_quotes_stay_safe(command):
+    assert detect_hardline_command(command) == (False, None)
+    assert detect_dangerous_command(command) == (False, None, None)
+
+
+def test_unterminated_quoted_grep_pattern_fails_closed():
+    assert detect_hardline_command('grep -n "unterminated file') == (
+        True,
+        "command parser limit or malformed executable payload",
+    )
+
+
+def test_escaped_quotes_in_grep_pattern_do_not_hide_following_hardline_command():
+    command = r'grep -n "prefix \"quoted\" suffix" input.txt; reboot'
+    assert detect_hardline_command(command) == (True, "system shutdown/reboot")
+
+
 def test_interpreter_heredoc_keeps_legacy_approval_key_compatibility():
     from tools.approval import _approval_key_aliases
 

--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -259,6 +259,52 @@ def test_escaped_quotes_in_grep_pattern_do_not_hide_following_hardline_command()
     assert detect_hardline_command(command) == (True, "system shutdown/reboot")
 
 
+@pytest.mark.parametrize(
+    ("command", "description"),
+    [
+        (r'echo "a\"b"; reboot', "system shutdown/reboot"),
+        (
+            r'echo "a\"b" && rm -rf --no-preserve-root /',
+            "recursive delete of root filesystem",
+        ),
+        (r'printf "x\"y"; shutdown -h now', "system shutdown/reboot"),
+        (r'cat "file\"name.txt"; rm -rf ~/', "recursive delete of home directory"),
+    ],
+)
+def test_faithful_quote_state_marks_following_hardline_command(command, description):
+    assert detect_hardline_command(command) == (True, description)
+
+
+def test_faithful_quote_state_marker_survives_backslash_line_normalization():
+    # Two backslashes leave a literal backslash before the real newline command
+    # boundary; normalization must not consume the inserted start marker too.
+    command = r"printf \\" + "\nreboot"
+    assert detect_hardline_command(command) == (True, "system shutdown/reboot")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'grep -n "; reboot" f.txt',
+        'echo "; reboot"',
+    ],
+)
+def test_quoted_hardline_text_remains_data(command):
+    assert detect_hardline_command(command) == (False, None)
+
+
+@pytest.mark.parametrize(
+    ("command", "description"),
+    [
+        ('echo "ab"; reboot', "system shutdown/reboot"),
+        ("reboot", "system shutdown/reboot"),
+        ("rm -rf --no-preserve-root /", "recursive delete of root filesystem"),
+    ],
+)
+def test_plain_hardline_commands_remain_blocked(command, description):
+    assert detect_hardline_command(command) == (True, description)
+
+
 def test_interpreter_heredoc_keeps_legacy_approval_key_compatibility():
     from tools.approval import _approval_key_aliases
 

--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -305,6 +305,57 @@ def test_plain_hardline_commands_remain_blocked(command, description):
     assert detect_hardline_command(command) == (True, description)
 
 
+@pytest.mark.parametrize(
+    ("command", "description"),
+    [
+        (
+            r'echo "a\"b"; rm${IFS}-rf${IFS}--no-preserve-root${IFS}/',
+            "recursive delete of root filesystem",
+        ),
+        (
+            r'echo "a\"b"; echo${IFS}x; rm${IFS}-rf${IFS}/',
+            "recursive delete of root filesystem",
+        ),
+        (
+            r'rm${IFS}-rf${IFS}--no-preserve-root${IFS}/',
+            "recursive delete of root filesystem",
+        ),
+        (r'echo "a\"b"; ${IFS}reboot', "system shutdown/reboot"),
+        (
+            r'echo "a\"b"; rm ${IFS:0:1}-rf --no-preserve-root /',
+            "recursive delete of root filesystem",
+        ),
+        (r'echo "a\"b"; reboot', "system shutdown/reboot"),
+        (
+            r'echo "a\"b" && rm -rf --no-preserve-root /',
+            "recursive delete of root filesystem",
+        ),
+        (r'cat "file\"name.txt"; rm -rf ~/', "recursive delete of home directory"),
+        ('echo "ab"; reboot', "system shutdown/reboot"),
+        ("reboot", "system shutdown/reboot"),
+        ("rm -rf --no-preserve-root /", "recursive delete of root filesystem"),
+    ],
+)
+def test_parameter_expansions_preserve_hardline_command_starts(command, description):
+    assert detect_hardline_command(command) == (True, description)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        r'cd ~/.hermes/hermes-agent && grep -n "^from\|^__all__\|^    \"" tools/environments/__init__.py | head -15',
+        r'egrep -n "alpha\"beta|gamma" input.txt',
+        "grep -P '(?:safe|rm -rf --no-preserve-root /)' audit.log",
+        'grep -n "; reboot" f.txt',
+        'echo "; reboot"',
+        'echo "${IFS}"',
+        'echo "value is ${HOME}/x"',
+    ],
+)
+def test_parameter_expansion_marking_avoids_false_positives(command):
+    assert detect_hardline_command(command) == (False, None)
+
+
 def test_interpreter_heredoc_keeps_legacy_approval_key_compatibility():
     from tools.approval import _approval_key_aliases
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -550,8 +550,12 @@ def detect_hardline_command(command: str) -> tuple:
     """
     if _command_parser_limit_exceeded(command):
         return (True, _PARSER_LIMIT_DESCRIPTION)
-    normalized = _normalize_command_for_detection(command)
-    _, malformed_grep = _grep_safe_detection_variant(normalized)
+    # Grep syntax must be validated against faithful shell quote state:
+    # normalization strips escapes such as \" before the grep parser sees
+    # them. Quoted newlines are data, so mask those without altering quoting.
+    _, malformed_grep = _grep_safe_detection_variant(
+        _mask_quoted_newlines(command)
+    )
     if malformed_grep:
         return (True, _MALFORMED_EXEC_DESCRIPTION)
     for command_variant in _command_detection_variants(command):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1794,6 +1794,45 @@ def _scan_dollar_paren_end(command: str, start: int) -> int | None:
     return None
 
 
+def _scan_parameter_expansion_end(
+    command: str, start: int, end: int | None = None
+) -> int | None:
+    """Return the offset after a balanced ``${...}`` parameter expansion."""
+    depth = 1
+    quote: str | None = None
+    limit = len(command) if end is None else min(end, len(command))
+    i = start + 2
+    while i < limit:
+        ch = command[i]
+        if quote:
+            if ch == "\\" and quote == '"' and i + 1 < limit:
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            continue
+        if ch == "\\" and i + 1 < limit:
+            i += 2
+            continue
+        if command.startswith("${", i):
+            depth += 1
+            i += 2
+            continue
+        if ch == "}":
+            depth -= 1
+            i += 1
+            if depth == 0:
+                return i
+            continue
+        i += 1
+    return None
+
+
 def _scan_backtick_end(command: str, start: int) -> int | None:
     i = start + 1
     while i < len(command):
@@ -2026,6 +2065,12 @@ def _iter_shell_command_starts(command: str):
                 nested_end = _scan_backtick_end(command, i)
                 starts.append(i + 1)
                 scan(i + 1, nested_end - 1 if nested_end is not None else end)
+                i = nested_end if nested_end is not None else end
+                continue
+            # Parameter-expansion braces are shell word syntax, not command
+            # group openers. The quoted branch never treats `{` as an opener.
+            if command.startswith("${", i):
+                nested_end = _scan_parameter_expansion_end(command, i, end)
                 i = nested_end if nested_end is not None else end
                 continue
             if ch in ("(", "{"):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2049,7 +2049,7 @@ def _iter_shell_command_starts(command: str):
             yield start
 
 
-def _mark_command_starts(command: str) -> str:
+def _mark_command_starts(command: str, marker: str = "\n") -> str:
     """Insert a newline before each real (quote-aware) command start.
 
     ``\\n`` is already a ``_CMDPOS`` separator, so this rewrites subshell
@@ -2071,7 +2071,7 @@ def _mark_command_starts(command: str) -> str:
     parts: list[str] = []
     previous = 0
     for offset in offsets:
-        parts.extend((command[previous:offset], "\n"))
+        parts.extend((command[previous:offset], marker))
         previous = offset
     parts.append(command[previous:])
     return "".join(parts)
@@ -2241,6 +2241,16 @@ def _command_detection_variants(command: str):
             continue
         seen.add(variant)
         yield variant
+    # Locate command starts before escape normalization can corrupt shell quote
+    # state. The leading space keeps the inserted newline from being consumed
+    # as a backslash-newline continuation when the preceding text ends in `\`.
+    faithful_marked = _mark_command_starts(
+        _mask_quoted_newlines(command), marker=" \n"
+    )
+    faithful_marked = _normalize_command_for_detection(faithful_marked)
+    if faithful_marked not in seen:
+        seen.add(faithful_marked)
+        yield faithful_marked
 
 
 def _is_verification_artifact_cleanup(command: str) -> bool:


### PR DESCRIPTION
## Summary

The hardline blocklist — documented as unbypassable, "not even with `--yolo`, `/yolo`, `approvals.mode=off`" — can be bypassed by placing one escaped double quote in front of any hardline command:

```python
>>> check_dangerous_command('cat "f\\"n.txt"; rm -rf --no-preserve-root /', "local")
{'approved': True, ...}
```

Reproduced on current `main` (`6c40300f9`). The same root cause also produces a false positive that blocks ordinary read-only commands, which is how I found it:

```
grep -n "^from\|^__all__\|^    \"" tools/environments/__init__.py
BLOCKED (hardline): command parser limit or malformed executable payload
```

Three commits, one root cause: shell quote state is evaluated against text that normalization has already rewritten.

## Root cause

`_normalize_command_for_detection` strips backslash escapes (`\"` → `"`) so that `r\m` cannot hide `rm`. That is correct for pattern matching, but two consumers need *faithful* quote state and currently receive the normalized string:

**1. Grep operand parsing (false positive).** `detect_hardline_command` passes normalized text to `_grep_safe_detection_variant`. After escape stripping, a valid pattern like `"^from\|^    \""` has an odd number of quotes, the parse is reported malformed, and the call fails closed. Legitimate `grep` invocations get hardline-blocked with a message about "malformed executable payload".

**2. Command-start marking (bypass).** `_CMDPOS`-anchored hardline patterns do not match `; reboot` on their own — they fire only after `_mark_command_starts` splices a separator at each quote-aware command start. With an escaped quote present, normalization leaves the quote open:

```
raw         echo "a\"b"; reboot
normalized  echo "a"b"; reboot          <- quote never closes
segments    ['echo "a"b"; reboot']      <- one unterminated segment
```

No start is marked, so the floor never fires. Any hardline command after such a prefix executes.

**3. `${IFS}` interaction (second bypass).** `_iter_shell_command_starts` treats `{` as a command-start opener, so it marks a start *inside* `${IFS}`, producing `${ \nIFS}`. That token no longer matches the IFS-collapse regex in normalization, so the expansion is never applied:

```
echo "a\"b"; rm${IFS}-rf${IFS}--no-preserve-root${IFS}/
```

Confirmed executable with a safe analogue (`echo${IFS}BYPASS_EXECUTED`, rc=0, second statement ran).

## Fix

Each commit is additive — variant generation is any-match, so adding a variant can only tighten the floor, never loosen it.

1. **`parse raw grep quote state before hardline checks`** — validate grep syntax against `_mask_quoted_newlines(command)` rather than normalized text. Quoted newlines are still masked (they are data), but escapes are left intact so quote counting is correct.

2. **`mark command starts from faithful quote state`** — emit an *additional* detection variant whose command starts are marked before normalization runs. The marker is `" \n"` rather than `"\n"`: a preceding backslash would otherwise absorb the inserted newline as a line continuation during normalization, silently undoing the marking. `_mark_command_starts` gains an optional `marker` parameter defaulting to `"\n"`, so existing callers are unchanged.

3. **`don't mark command starts inside parameter expansions`** — add `_scan_parameter_expansion_end` and skip the whole `${...}` span in `_iter_shell_command_starts` before the `(`/`{` opener check. Depth-tracked, quote-aware, escape-aware; an unterminated expansion is handled like the existing `$(`/backtick `None` cases.

## Verification

- **RED/GREEN per commit**: 14 → 0, 12 → 0, 4 → 0 failing tests.
- **Suite**: `222 passed, 1 skipped` across `test_execution_flag_detection.py`, `test_approval.py`, `test_blocked_command_guidance.py`.
- **Mutation-tested**: reverting each of the three source changes while keeping the tests fails 14, 12, and 4 tests respectively — no change is unprotected.
- **30 hand-checked cases** with `HERMES_YOLO_MODE=1`, asserting both `detect_hardline_command` and `check_dangerous_command(...)["approved"]`:
  - 10 bypass variants (escaped quote before `rm -rf /`, `reboot`, `shutdown`, `systemctl reboot`, `${IFS}`, `${IFS:0:1}`, `&&` and `;` separators) — all blocked.
  - 8 valid commands (the original `grep` false positive, `egrep` with escaped quote, PCRE data containing hardline text, quoted separators, quoted `${IFS}`) — all pass.
  - 11 non-regression cases (`reboot`, `rm -rf /`, `(reboot)`, `{ shutdown -h now; }`, `$(reboot)`, backticks, `bash -c "reboot"`, line continuation, bare `${IFS}` expansion) — identical results before and after.
  - Fail-closed preserved: `grep -n "unterminated file` still reports malformed.

## Notes

- A single-quote analogue (`echo 'a\'b'; reboot`) was investigated and is **not** a bypass — bash rejects it with rc=2 (unterminated quote), so it cannot execute.
- No existing detection was weakened and no existing test was modified; all changes to `tools/approval.py` are new code paths or a strict narrowing of a false-positive path.
