### PR TITLE
fix(gateway,tools): salvage background-notification cluster — off-mode gate, redaction, watch_overflow, compression guard

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -177,6 +177,7 @@ MAX_ITERATIONS_SUMMARY_REQUEST = (
     "Please provide a final response summarizing what you've found and accomplished so far, "
     "without calling any more tools."
 )
+_BACKGROUND_PROCESS_NOTIFICATION_PREFIX = "[IMPORTANT: Background process "
 
 
 def _fresh_compaction_message_copy(msg: Dict[str, Any]) -> Dict[str, Any]:
@@ -4582,7 +4583,8 @@ This compaction should PRIORITISE preserving all information related to the focu
         """Recognize internal user-role rows after SessionDB projection.
 
         SessionDB preserves role/content but not underscore-prefixed metadata,
-        so the stable todo and continuation content markers are authoritative.
+        so stable runtime-notification, todo, and continuation content markers
+        are authoritative.
         """
         if not isinstance(message, dict) or message.get("role") != "user":
             return False
@@ -4618,6 +4620,8 @@ This compaction should PRIORITISE preserving all information related to the focu
             _LENGTH_CONTINUATION_NETWORK_STUB,
             _LENGTH_CONTINUATION_OUTPUT_LIMIT,
         } or text.startswith(
+            _BACKGROUND_PROCESS_NOTIFICATION_PREFIX
+        ) or text.startswith(
             TODO_INJECTION_HEADER + "\n"
         ) or text.startswith(
             _LENGTH_CONTINUATION_DROPPED_TOOLS_PREFIX

--- a/contributors/emails/handnew@hotmail.com
+++ b/contributors/emails/handnew@hotmail.com
@@ -1,0 +1,1 @@
+handnewb

--- a/contributors/emails/handnewb@users.noreply.github.com
+++ b/contributors/emails/handnewb@users.noreply.github.com
@@ -1,0 +1,1 @@
+handnewb

--- a/contributors/emails/lidangjiang@gmail.com
+++ b/contributors/emails/lidangjiang@gmail.com
@@ -1,0 +1,1 @@
+Lidang-Jiang

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24158,6 +24158,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         new_output = redact_terminal_output(
                             new_output, getattr(session, "command", "") or ""
                         )
+                        # redact_terminal_output() is unforced, so it returns raw
+                        # text when security.redact_secrets is off.  This send
+                        # goes straight to the platform adapter, so it needs the
+                        # same unconditional floor as the agent-notify path.
+                        new_output = _redact_gateway_user_facing_secrets(new_output)
                     if notify_mode == "concise":
                         _cmd_disp = _redact_gateway_user_facing_secrets(
                             getattr(session, "command", "") or ""
@@ -24204,6 +24209,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     new_output = redact_terminal_output(
                         new_output, getattr(session, "command", "") or ""
                     )
+                    new_output = _redact_gateway_user_facing_secrets(new_output)
                 message_text = (
                     f"[Background process {session_id} is still running~ "
                     f"New output:\n{new_output}]"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24097,6 +24097,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _out = f"[… output truncated — showing last {len(_tail)} chars]\n{_tail}"
                     else:
                         _out = _raw
+                    _out = _redact_gateway_user_facing_secrets(_out)
                     completion_evt = {
                         "type": "completion",
                         "session_id": session_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19299,14 +19299,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # single consumer — so we leave them on the queue here.
             try:
                 from tools.process_registry import process_registry as _pr
-                _watch_events = _drain_gateway_watch_events(_pr.completion_queue)
-                for evt in _watch_events:
-                    synth_text = _format_gateway_process_notification(evt)
-                    if synth_text:
-                        try:
-                            await self._inject_watch_notification(synth_text, evt)
-                        except Exception as e2:
-                            logger.error("Watch notification injection error: %s", e2)
+                await self._drain_watch_notifications(_pr.completion_queue)
             except Exception as e:
                 logger.debug("Watch queue drain error: %s", e)
 
@@ -23557,6 +23550,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_name=str(evt.get("user_name") or "").strip() or None,
             scope_id=scope_id,
         )
+
+    async def _drain_watch_notifications(self, completion_queue) -> None:
+        """Consume queued watch events and inject them when notifications are enabled.
+
+        The queue is ALWAYS drained (so watch events don't rot or requeue-spin)
+        but injection is skipped entirely when
+        ``display.background_process_notifications`` is ``off`` (#9290).
+        """
+        watch_events = _drain_gateway_watch_events(completion_queue)
+        if self._load_background_notifications_mode() == "off":
+            return
+
+        for evt in watch_events:
+            synth_text = _format_gateway_process_notification(evt)
+            if not synth_text:
+                continue
+            try:
+                await self._inject_watch_notification(synth_text, evt)
+            except Exception as exc:
+                logger.error("Watch notification injection error: %s", exc)
 
     async def _inject_watch_notification(
         self, synth_text: str, evt: dict,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3540,6 +3540,12 @@ def _format_gateway_process_notification(evt: dict) -> "str | None":
     if evt_type == "watch_disabled":
         return f"[IMPORTANT: {evt.get('message', '')}]"
 
+    # Overflow events carry their human-readable summary in `message`,
+    # like watch_disabled — see the shared formatter in
+    # tools/process_registry.py.
+    if evt_type in ("watch_overflow_tripped", "watch_overflow_released"):
+        return f"[IMPORTANT: {evt.get('message', '')}]"
+
     if evt_type == "watch_match":
         _pat = evt.get("pattern", "?")
         _out = evt.get("output", "")
@@ -3581,7 +3587,12 @@ def _drain_gateway_watch_events(completion_queue) -> "list[dict]":
         except Exception:
             break
         evt_type = evt.get("type", "completion")
-        if evt_type in {"watch_match", "watch_disabled"}:
+        if evt_type in {
+            "watch_match",
+            "watch_disabled",
+            "watch_overflow_tripped",
+            "watch_overflow_released",
+        }:
             watch_events.append(evt)
         elif evt_type == "async_delegation":
             requeue.append(evt)

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -21,6 +21,7 @@ from agent.conversation_compression import (
     compress_context,
 )
 from hermes_state import SessionDB
+from tools.process_registry import format_process_notification
 from tools.todo_tool import TODO_INJECTION_HEADER
 
 
@@ -235,6 +236,52 @@ def test_real_task_wins_over_trailing_max_iterations_nudge(compressor):
     idx = compressor._find_last_user_message_idx(messages, head_end=0)
     assert idx == 0, "nudge was selected as the anchor instead of the human task"
     assert messages[idx]["content"] == human["content"]
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        pytest.param(
+            {
+                "type": "completion",
+                "session_id": "proc_build",
+                "command": "scripts/run_tests.sh tests/agent/",
+                "exit_code": 0,
+                "output": "42 passed",
+            },
+            id="completion",
+        ),
+        pytest.param(
+            {
+                "type": "watch_match",
+                "session_id": "proc_server",
+                "command": "python server.py",
+                "pattern": "Application startup complete",
+                "output": "Application startup complete",
+            },
+            id="watch_match",
+        ),
+    ],
+)
+def test_background_process_notifications_do_not_become_compaction_anchors(
+    compressor, event
+):
+    notification = format_process_notification(event)
+    assert notification is not None
+    process_turn = {"role": "user", "content": notification}
+    human = {"role": "user", "content": "Refactor the auth module and add tests."}
+    messages = [
+        human,
+        {"role": "assistant", "content": "Working on it."},
+        process_turn,
+    ]
+
+    assert ContextCompressor._is_synthetic_compression_user_turn(process_turn) is True
+    assert ContextCompressor._transcript_has_real_user_turn([process_turn]) is False
+    assert compressor._derive_auto_focus_topic(messages) == (
+        "Recent user focus:\n- Refactor the auth module and add tests."
+    )
+    assert compressor._find_last_user_message_idx(messages, head_end=0) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -8,6 +8,7 @@ Contributed by @PeterFile (PR #593), reimplemented on current main.
 """
 
 import asyncio
+import queue
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -64,6 +65,17 @@ def _watcher_dict(session_id="proc_test", thread_id=""):
     if thread_id:
         d["thread_id"] = thread_id
     return d
+
+
+def _watch_event(session_id="proc_watch", thread_id="42"):
+    return {
+        "type": "watch_match",
+        "session_id": session_id,
+        "session_key": f"agent:main:telegram:dm:123:{thread_id}",
+        "pattern": "READY",
+        "command": "build",
+        "output": "READY\n",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -199,6 +211,54 @@ async def test_inject_watch_notification_routes_from_session_store_origin(monkey
     assert synth_event.source.thread_id == "42"
     assert synth_event.source.user_id == "123"
     assert synth_event.source.user_name == "Emiliyan"
+
+
+@pytest.mark.asyncio
+async def test_post_turn_watch_drain_off_consumes_without_injecting(monkeypatch, tmp_path):
+    runner = _build_runner(monkeypatch, tmp_path, "off")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    completion_queue = queue.Queue()
+    completion_queue.put(_watch_event("proc_one"))
+    completion_queue.put(_watch_event("proc_two"))
+    async_event = {"type": "async_delegation", "session_id": "delegate_one"}
+    completion_queue.put(async_event)
+
+    await runner._drain_watch_notifications(completion_queue)
+
+    adapter.handle_message.assert_not_awaited()
+    assert completion_queue.qsize() == 1
+    assert completion_queue.get_nowait() is async_event
+
+
+@pytest.mark.asyncio
+async def test_post_turn_watch_drain_all_injects_from_queued_event_origin(monkeypatch, tmp_path):
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    runner.session_store._entries["agent:main:telegram:dm:123:42"] = SimpleNamespace(
+        origin=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+            thread_id="42",
+            user_id="proc_owner",
+            user_name="alice",
+        )
+    )
+    completion_queue = queue.Queue()
+    completion_queue.put(_watch_event())
+    async_event = {"type": "async_delegation", "session_id": "delegate_one"}
+    completion_queue.put(async_event)
+
+    await runner._drain_watch_notifications(completion_queue)
+
+    adapter.handle_message.assert_awaited_once()
+    synth_event = adapter.handle_message.await_args.args[0]
+    assert synth_event.source.thread_id == "42"
+    assert synth_event.source.user_id == "proc_owner"
+    assert completion_queue.qsize() == 1
+    assert completion_queue.get_nowait() is async_event
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -537,3 +537,38 @@ async def test_inject_watch_notification_origin_session_id_wins(monkeypatch, tmp
     result = await runner._inject_watch_notification("[SYSTEM: done]", evt)
     assert result is True
     assert posts == ["raw-origin-sid"]
+
+
+def test_gateway_drain_retains_and_formats_overflow_events():
+    """watch_overflow_* events must survive the gateway drain and render
+    their summary — previously they were discarded at the drain (only
+    watch_match/watch_disabled were retained) and had no formatter branch."""
+    import asyncio
+    from gateway.run import (
+        _drain_gateway_watch_events,
+        _format_gateway_process_notification,
+    )
+
+    queue = asyncio.Queue()
+    tripped = {
+        "type": "watch_overflow_tripped",
+        "message": "watch flood detected: 47 notifications suppressed for pattern 'ERROR'",
+        "session_id": "proc_a1b2",
+    }
+    released = {
+        "type": "watch_overflow_released",
+        "message": "watch flood released: notifications resumed for pattern 'ERROR'",
+        "session_id": "proc_a1b2",
+    }
+    queue.put_nowait(tripped)
+    queue.put_nowait(released)
+
+    retained = _drain_gateway_watch_events(queue)
+    assert retained == [tripped, released]
+
+    out_tripped = _format_gateway_process_notification(tripped)
+    assert "47 notifications suppressed" in out_tripped
+    assert "exit code" not in out_tripped
+    out_released = _format_gateway_process_notification(released)
+    assert "notifications resumed" in out_released
+    assert "exit code" not in out_released

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2284,3 +2284,69 @@ class TestSystemdCgroupIsolation:
         )
 
         assert pr._stop_systemd_unit("hermes-worker-gone.scope") is True
+
+
+class TestNotificationRedaction:
+    """Background-process notification delivery (completion_queue) applies the
+    same redaction as the explicit process tool — issue #43025 gap.
+
+    The _move_to_finished() and _check_watch_patterns() paths enqueue raw
+    output into the completion_queue.  After the fix, _redact_process_result()
+    is called before enqueueing so secrets are masked in the [IMPORTANT: ...]
+    messages delivered to the LLM.
+    """
+
+    def test_completion_notification_redacts_secret(self, monkeypatch):
+        """_move_to_finished completion notification redacts API keys."""
+        import agent.redact as _r
+        monkeypatch.setattr(_r, "_REDACT_ENABLED", True)
+        from tools import process_registry as pr
+
+        reg = ProcessRegistry()
+        sess = _make_session(sid="proc_notif1", command="env")
+        sess.output_buffer = "OPENAI_API_KEY=sk-proj-secret123\nHOME=/home/u"
+        sess.notify_on_complete = True
+        sess.exited = True
+        sess.exit_code = 0
+        reg._running[sess.id] = sess
+        monkeypatch.setattr(pr, "process_registry", reg)
+
+        reg._move_to_finished(sess)
+
+        # Drain and check the notification
+        results = reg.drain_notifications()
+        assert len(results) == 1
+        _evt, text = results[0]
+        assert "sk-proj-secret123" not in text
+        assert "REDACTED" in text or "sk-proj" not in text
+
+    def test_watch_match_notification_redacts_secret(self, monkeypatch):
+        """_check_watch_patterns watch_match notification redacts secrets."""
+        import agent.redact as _r
+        monkeypatch.setattr(_r, "_REDACT_ENABLED", True)
+        from tools import process_registry as pr
+
+        reg = ProcessRegistry()
+        sess = _make_session(sid="proc_notif2", command="python server.py")
+        sess.output_buffer = "Server started\nAPI_TOKEN=ghp_abc123def456\nListening on :8080"
+        sess.watch_patterns = ["API_TOKEN"]
+        sess._watch_disabled = False
+        sess._watch_hits = 0
+        sess._watch_suppressed = 0
+        sess.watcher_platform = None
+        sess.watcher_chat_id = None
+        sess.watcher_user_id = None
+        sess.watcher_user_name = None
+        sess.watcher_thread_id = None
+        sess.watcher_message_id = None
+        sess.exited = False
+        reg._running[sess.id] = sess
+        monkeypatch.setattr(pr, "process_registry", reg)
+
+        reg._check_watch_patterns(sess, "API_TOKEN=ghp_abc123def456\n")
+
+        results = reg.drain_notifications()
+        assert len(results) == 1
+        _evt, text = results[0]
+        assert "ghp_abc123def456" not in text
+        assert "ghp_" not in text or "REDACTED" in text

--- a/tests/tools/test_watch_patterns.py
+++ b/tests/tools/test_watch_patterns.py
@@ -336,3 +336,32 @@ class TestGlobalCircuitBreaker:
                 admitted = True
         assert released
         assert admitted
+
+
+class TestOverflowNotificationFormatting:
+    """watch_overflow_* events must surface their summary, not fall through
+    to the completion formatter as a phantom 'process exited (exit code ?)'."""
+
+    def test_overflow_tripped_formats_message(self):
+        from tools.process_registry import format_process_notification
+
+        evt = {
+            "type": "watch_overflow_tripped",
+            "message": "watch flood detected: 47 notifications suppressed for pattern 'ERROR'",
+            "session_id": "proc_a1b2",
+        }
+        out = format_process_notification(evt)
+        assert "47 notifications suppressed" in out
+        assert "exit code" not in out
+
+    def test_overflow_released_formats_message(self):
+        from tools.process_registry import format_process_notification
+
+        evt = {
+            "type": "watch_overflow_released",
+            "message": "watch flood released: notifications resumed for pattern 'ERROR'",
+            "session_id": "proc_a1b2",
+        }
+        out = format_process_notification(evt)
+        assert "notifications resumed" in out
+        assert "exit code" not in out

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -621,7 +621,7 @@ class ProcessRegistry:
         if not self._global_watch_admit(now):
             return
 
-        self.completion_queue.put({
+        notification = {
             "session_id": session.id,
             "session_key": session.session_key,
             "command": session.command,
@@ -635,7 +635,9 @@ class ProcessRegistry:
             "user_name": session.watcher_user_name,
             "thread_id": session.watcher_thread_id,
             "message_id": session.watcher_message_id,
-        })
+        }
+        _redact_process_result(notification)
+        self.completion_queue.put(notification)
 
     def _global_watch_admit(self, now: float) -> bool:
         """Return True if this watch_match event is allowed through the global breaker.
@@ -1563,7 +1565,7 @@ class ProcessRegistry:
         if was_running and session.notify_on_complete:
             from tools.ansi_strip import strip_ansi
             output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
-            self.completion_queue.put({
+            notification = {
                 "type": "completion",
                 "session_id": session.id,
                 "session_key": session.session_key,
@@ -1576,7 +1578,9 @@ class ProcessRegistry:
                 # a consumer-observed completion timestamp, this does not vary
                 # based on which watcher notices exit first.
                 "started_at": session.started_at,
-            })
+            }
+            _redact_process_result(notification)
+            self.completion_queue.put(notification)
 
     # ----- Query Methods -----
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2812,6 +2812,12 @@ def format_process_notification(evt: dict) -> "str | None":
     if evt_type == "watch_disabled":
         return f"[IMPORTANT: {evt.get('message', '')}]"
 
+    # Overflow events carry their human-readable summary in `message` —
+    # without this case they fall through to the completion formatter and
+    # surface as a phantom "process exited (exit code ?)" notification.
+    if evt_type in ("watch_overflow_tripped", "watch_overflow_released"):
+        return f"[IMPORTANT: {evt.get('message', '')}]"
+
     if evt_type == "watch_match":
         _pat = evt.get("pattern", "?")
         _out = evt.get("output", "")


### PR DESCRIPTION
## Summary
Salvages five valid open contributor fixes in the background-notification cluster onto current `main`, with original authorship preserved via cherry-pick.

All five were verified live against current `main` (post-#85877 concise-mode): each fixes a real remaining gap the concise-mode change did not cover.

## Changes
- **#9341** (@Lidang-Jiang): `display.background_process_notifications: off` now also suppresses watch-pattern reinjection — the post-turn drain consumed events but injected them regardless of mode (#9290). Queue is still drained so events don't rot.
- **#59858** (@necoweb3): redact secrets at the completion-queue enqueue sites (`_check_watch_patterns`, `_move_to_finished`) — watch/completion events previously carried raw output into agent context (#43025).
- **#73547** (@handnewb): unconditional user-facing redaction floor (`_redact_gateway_user_facing_secrets`) on the direct completion and running-output `adapter.send` paths, covering both the concise tail and legacy raw messages even when `security.redact_secrets` is off.
- **#75497** (@spfcraze): format `watch_overflow_tripped`/`watch_overflow_released` events instead of dropping them (gateway) or rendering a phantom "exited (exit code ?)" notice (CLI formatter).
- **#83295** (@fangliquanflq): compression recognizes `[IMPORTANT: Background process ...` synthetic turns so completions arriving mid-task no longer hijack compaction focus/tail-anchor selection.

Follow-up fixes on top (ours): conflict resolution against the merged concise-mode code, stale test-signature repair (`_check_watch_patterns` 2-arg form), contributor email mappings.

## Validation
| Suite | Result |
|---|---|
| tests/gateway/test_background_process_notifications.py | pass |
| tests/tools/test_process_registry.py | pass |
| tests/gateway/test_completion_delivery.py | pass |
| tests/agent/test_context_compressor.py | pass |
| Total | 240 passed, 0 failed |

Closes #9290. Contributes to #43025.

## Infographic

![Background notification cluster — 5 fixes salvaged](https://files.catbox.moe/6ajnyi.png)
