### PR TITLE
fix(desktop): scope dedicated remote resumes correctly

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8020,7 +8020,9 @@ async function ensureBackend(profile) {
 
     // A shared backend still owes the caller its profile scope, so renderer-side
     // WebSocket, filesystem, and cache routing target the selected profile.
-    return route.descriptorProfile ? { ...connection, profile: route.descriptorProfile } : connection
+    return route.descriptorProfile
+      ? { ...connection, profile: route.descriptorProfile, sharedPrimary: true }
+      : connection
   }
 
   const existing = backendPool.get(key)

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 
 import { getLatestSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { toChatMessages } from '@/lib/chat-messages'
+import { gatewayRpcProfile } from '@/store/gateway'
 import { publishSessionState, setSessionTileDelegate } from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
 
@@ -106,8 +107,11 @@ export function useSessionTileDelegate({
         // session from any profile, not just the active one; resuming (or
         // reading messages) without a profile lets the gateway fall back to the
         // launch-profile DB and fork the conversation into the wrong profile —
-        // the same cross-profile bleed the recovery resumes had (#67603).
+        // the same cross-profile bleed the recovery resumes had (#67603). REST
+        // keeps the Desktop owner; the gateway helper translates that owner into
+        // backend-internal scope for the WebSocket RPC.
         const profile = await resolveSessionProfile(storedSessionId)
+        const resumeProfile = await gatewayRpcProfile(profile)
 
         const [prefetch, resumed] = await Promise.all([
           getLatestSessionMessages(storedSessionId, profile).catch(() => null),
@@ -115,7 +119,7 @@ export function useSessionTileDelegate({
             session_id: storedSessionId,
             cols: 96,
             omit_messages: true,
-            ...(profile ? { profile } : {})
+            ...(resumeProfile ? { profile: resumeProfile } : {})
           })
         ])
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/resolve-target-session.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/resolve-target-session.ts
@@ -1,3 +1,5 @@
+import { gatewayRpcProfile } from '@/store/gateway'
+
 import { resolveSessionProfile } from '../use-session-actions/utils'
 
 import type { GatewayRequest } from './utils'
@@ -90,11 +92,12 @@ export async function resolveTargetSessionId(deps: ResolveTargetSessionDeps): Pr
   if (storedTarget) {
     try {
       const profile = await resolveSessionProfile(storedTarget)
+      const resumeProfile = await gatewayRpcProfile(profile)
 
       const resumed = await requestGateway<{ session_id?: string }>('session.resume', {
         session_id: storedTarget,
         source: 'desktop',
-        ...(profile ? { profile } : {})
+        ...(resumeProfile ? { profile: resumeProfile } : {})
       })
 
       return resumed?.session_id || null

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -18,6 +18,7 @@ import {
   type ComposerAttachment,
   terminalContextBlocksFromDraft
 } from '@/store/composer'
+import { gatewayRpcProfile } from '@/store/gateway'
 import { $hudMode } from '@/store/hud'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
@@ -479,15 +480,17 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // background queue drain only has the durable id). Continue that target
         // conversation; only a genuine new-chat draft may create a new session.
         try {
-          // Re-register on the session's OWNING profile — resuming on whichever
-          // profile is live would fork the conversation into the wrong DB (#67603).
+          // Resolve the session's Desktop owner first; the gateway helper keeps
+          // that scope only for a shared backend and omits aliases for dedicated
+          // per-profile backends (#67603).
           const resumeProfile = await resolveSessionProfile(targetStoredSessionId)
+          const gatewayProfile = await gatewayRpcProfile(resumeProfile)
 
           const resumed = await requestGateway<{ session_id: string }>('session.resume', {
             session_id: targetStoredSessionId,
             source: 'desktop',
             omit_messages: true,
-            ...(resumeProfile ? { profile: resumeProfile } : {})
+            ...(gatewayProfile ? { profile: gatewayProfile } : {})
           })
 
           const resumeDrift = sessionDriftReason()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -80,6 +80,7 @@ export interface SessionRecoveryDeps {
    * store and the REST layer: the default implementation reaches through
    * `resolveStoredSession` → `getSession()`, a real fetch that makes any unit
    * test of this helper depend on leftover `$sessions` / `$profiles` state.
+   * The returned value is backend RPC scope, not necessarily the Desktop alias.
    */
   resolveProfile?: (storedSessionId: string) => Promise<string | undefined>
   /**
@@ -100,8 +101,9 @@ export interface SessionRecoveryDeps {
 async function defaultResolveProfile(storedSessionId: string): Promise<string | undefined> {
   // Lazy so utils.ts has no init-time cycle with use-session-actions.
   const { resolveSessionProfile } = await import('../use-session-actions/utils')
+  const { gatewayRpcProfile } = await import('@/store/gateway')
 
-  return resolveSessionProfile(storedSessionId)
+  return gatewayRpcProfile(await resolveSessionProfile(storedSessionId))
 }
 
 /**

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -11,6 +11,7 @@ import { recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
+import { gatewayRpcProfile } from '@/store/gateway'
 import { $pinnedSessionIds } from '@/store/layout'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile, normalizeProfileKey } from '@/store/profile'
@@ -655,6 +656,7 @@ export function useSessionActions({
       // id loads as fast as a sidebar click instead of hanging on a list scan.
       const storedForProfile = await resolveStoredSession(storedSessionId)
       const sessionProfile = storedForProfile?.profile
+      const resumeProfile = await gatewayRpcProfile(sessionProfile)
 
       if (resumeRequestRef.current !== requestId) {
         return
@@ -922,7 +924,7 @@ export function useSessionActions({
           // (MCP discovery / prompt build), and the agent pre-warms in the
           // background while the prefetch above paints the transcript.
           ...(watchWindow ? { lazy: true } : { omit_messages: true }),
-          ...(sessionProfile ? { profile: sessionProfile } : {})
+          ...(resumeProfile ? { profile: resumeProfile } : {})
         })
 
         // The rejection is consumed by the `await` below; this guard only

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -534,6 +534,9 @@ export interface HermesConnection {
   // Set for pool (non-primary) backends so the renderer knows which profile a
   // connection belongs to.
   profile?: string
+  // True only when a profile is scoped inside the window's shared primary
+  // backend. Profile-owned pool descriptors remain unmarked.
+  sharedPrimary?: boolean
   windowButtonPosition: { x: number; y: number } | null
 }
 

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -21,7 +21,8 @@ vi.mock('@/hermes', () => ({
 vi.mock('@/store/session', () => ({ setGatewayState: vi.fn() }))
 vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
 
-const { $gateway, configureGatewayRegistry, ensureGatewayForProfile, setPrimaryGateway } = await import('./gateway')
+const { $gateway, configureGatewayRegistry, ensureGatewayForProfile, gatewayRpcProfile, setPrimaryGateway } =
+  await import('./gateway')
 
 type DesktopStub = { getConnection: ReturnType<typeof vi.fn> }
 
@@ -51,8 +52,8 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')
     installDesktop({
-      // Shared descriptor: primary connection tagged with the profile.
-      getConnection: vi.fn(async () => ({ port: 4242, profile: 'venture', token: 't' }))
+      // Shared descriptor: primary connection explicitly tagged as shared.
+      getConnection: vi.fn(async () => ({ port: 4242, profile: 'venture', sharedPrimary: true, token: 't' }))
     })
 
     await ensureGatewayForProfile('venture')
@@ -60,12 +61,12 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
     expect($gateway.get()).toBe(primary)
   })
 
-  it('still pools a socket for profiles with their own descriptor (untagged)', async () => {
+  it('still pools a socket for profile-owned descriptors that carry a profile', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')
     installDesktop({
-      // Own descriptor: no profile tag → normal pooled path (dial attempted).
-      getConnection: vi.fn(async () => ({ port: 5151, token: 't2' }))
+      // Pool descriptors identify their Desktop owner but are not shared-primary.
+      getConnection: vi.fn(async () => ({ port: 5151, profile: 'worker', token: 't2' }))
     })
 
     await ensureGatewayForProfile('worker')
@@ -74,5 +75,26 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
     // reconnect is scheduled) — the important part is it did NOT silently
     // reuse the primary.
     expect($gateway.get()).not.toBe(primary)
+  })
+})
+
+describe('gatewayRpcProfile', () => {
+  it('keeps the profile tag for a shared global-remote descriptor', async () => {
+    installDesktop({
+      getConnection: vi.fn(async () => ({ port: 4242, profile: 'venture', sharedPrimary: true, token: 't' }))
+    })
+
+    await expect(gatewayRpcProfile('venture')).resolves.toBe('venture')
+  })
+
+  it('omits a Desktop alias when its backend descriptor is already dedicated', async () => {
+    installDesktop({
+      // Per-profile URL override or local pooled backend: the descriptor itself
+      // is already scoped, so forwarding `profile: worker` would address a
+      // nonexistent profile inside that backend.
+      getConnection: vi.fn(async () => ({ port: 5151, profile: 'worker', token: 't2' }))
+    })
+
+    await expect(gatewayRpcProfile('worker')).resolves.toBeUndefined()
   })
 })

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -249,8 +249,8 @@ function createSecondary(profile: string): Secondary {
 
 // True when `profile`'s backend route resolves to the SHARED primary backend
 // (global-remote case 3 in resolveProfileBackendRoute): the descriptor comes
-// back as the primary connection tagged with `profile`. Own-remote-override
-// and local pooled descriptors are never tagged. Dialing a second socket at
+// back as the primary connection tagged with `sharedPrimary`. Own-remote-override
+// and local pooled descriptors are never marked. Dialing a second socket at
 // that descriptor is wrong — over SSH the second dial fails (tunnel/token are
 // per-backend) and the closed socket poisons the active gateway with
 // "not connected" even though the primary is open right next to it.
@@ -264,9 +264,43 @@ async function sharedPrimaryRoute(profile: string): Promise<boolean> {
   try {
     const conn = await desktop.getConnection(profile)
 
-    return Boolean(conn && typeof conn === 'object' && (conn as { profile?: string }).profile)
+    return Boolean(conn && typeof conn === 'object' && (conn as { sharedPrimary?: boolean }).sharedPrimary === true)
   } catch {
     return false
+  }
+}
+
+/**
+ * Profile scope to send inside a gateway RPC for a Desktop-owned profile.
+ *
+ * A `sharedPrimary` descriptor is the shared global-remote route: one backend
+ * serves several profiles, so the RPC must carry the descriptor's profile.
+ * Unmarked descriptors are already dedicated (local pool or per-profile URL override),
+ * and forwarding the Desktop alias would incorrectly address a profile inside
+ * that backend. On descriptor lookup failure, retain the caller's scope rather
+ * than risking a cross-profile write on a shared backend.
+ */
+export async function gatewayRpcProfile(profile: null | string | undefined): Promise<string | undefined> {
+  const key = normKey(profile)
+  const desktop = window.hermesDesktop
+
+  if (!profile?.trim() || !desktop) {
+    return profile?.trim() || undefined
+  }
+
+  try {
+    const conn = await desktop.getConnection(key)
+
+    const descriptorProfile =
+      conn && typeof conn === 'object' && (conn as { sharedPrimary?: boolean }).sharedPrimary === true
+        ? String((conn as { profile?: string }).profile ?? '').trim()
+        : ''
+
+    return descriptorProfile || undefined
+  } catch {
+    const fallbackProfile = key
+
+    return fallbackProfile
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes Desktop sessions that load their transcript from a per-profile remote but fail WebSocket resume with `session not found`.

A Desktop profile alias and a backend-internal profile are not always the same thing:

- shared global remote: one backend serves several profiles, so gateway RPCs must carry the selected profile;
- per-profile remote override or local pooled backend: the descriptor is already dedicated, so forwarding the Desktop alias addresses a nonexistent profile inside that backend.

This change adds an explicit `sharedPrimary` route discriminator, uses it for socket selection, and translates Desktop ownership into the correct `session.resume` RPC scope across every resume entry point.

Fixes #85834.

## Root cause

`HermesConnection.profile` was overloaded with two meanings:

1. logical Desktop owner / pool descriptor identity;
2. profile scope inside a shared backend.

Per-profile remote descriptors carry their Desktop alias, but the remote backend may expose only its own `default` profile. The renderer forwarded the alias in `session.resume`; the correctly selected remote backend then rejected it as an unknown profile. The same overloaded field also made dedicated pooled descriptors look like shared-primary routes.

## RED proof

Before the implementation, the new routing tests failed:

```text
FAIL src/store/gateway-shared-remote.test.ts > gatewayRpcProfile
TypeError: gatewayRpcProfile is not a function

Test Files  1 failed (1)
Tests       2 failed | 2 passed (4)
```

The failing cases pin both required semantics: keep scope for an explicitly shared-primary descriptor and omit a Desktop alias for a dedicated descriptor.

## Changes

- mark only truly shared-primary descriptors with `sharedPrimary: true`;
- stop inferring shared routing from the presence of `profile`;
- add `gatewayRpcProfile()` to translate Desktop owner aliases into backend RPC scope;
- apply the translation to cold open, tile open, slash-target recovery, queued-submit recovery, and stale-runtime recovery;
- preserve the logical Desktop profile for REST transcript prefetching;
- retain caller scope if descriptor lookup fails, avoiding an unsafe cross-profile fallback.

## Widening audit

Searched all Desktop `session.resume` callers. The profile-bearing paths are covered:

- normal cold session open;
- session tile delegation;
- routed slash/target recovery;
- direct submit rebind;
- generic stale-runtime recovery.

Profile-free test paths and new-session creation are unchanged.

Related work: #85750 and #85778 identify the same descriptor-field ambiguity for socket selection. This PR carries the explicit discriminator through that routing decision and the inner `session.resume` payload, which is the remaining failure observed when the remote socket itself is correct.

## Verification

```text
npm run typecheck
PASS

npm run lint
0 errors (88 pre-existing warnings)

npm run test:ui
428 files passed; 3844 tests passed

npx vitest run --project electron electron/connection-config.test.ts
1 file passed; 75 tests passed

npx vitest run --project ui \
  src/store/gateway-shared-remote.test.ts \
  src/app/contrib/hooks/use-session-tile-delegate.test.ts \
  src/app/session/hooks/use-prompt-actions/resolve-target-session.test.ts \
  src/app/session/hooks/use-prompt-actions/index.test.tsx
4 files passed; 118 tests passed

npm run build
PASS
```

## Safety

No session data, credentials, hostnames, or connection URLs are included. The change is renderer/Electron routing only; backend storage and API contracts are unchanged.
