### PR TITLE
fix(gateway): keep process notification routing off the event loop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23638,7 +23638,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         is not a transactional boundary: a process crash after adapter
         acceptance can still cause durable at-least-once replay.
         """
-        source = self._build_process_event_source(evt)
+        source = await asyncio.to_thread(self._build_process_event_source, evt)
         if not source:
             # API-server-originated sessions bind a RAW session key (the
             # X-Hermes-Session-Id value — see _bind_api_server_session), not a

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -9,6 +9,7 @@ Contributed by @PeterFile (PR #593), reimplemented on current main.
 
 import asyncio
 import queue
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -290,6 +291,46 @@ async def test_inject_watch_notification_carries_message_id_reply_anchor(monkeyp
     synth_event = adapter.handle_message.await_args.args[0]
     assert synth_event.message_id == "777"
     assert synth_event.source.thread_id == "24296"
+
+
+@pytest.mark.asyncio
+async def test_inject_watch_notification_loads_session_store_off_loop(monkeypatch, tmp_path):
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    runner.session_store._entries["agent:main:telegram:dm:123:24296"] = SimpleNamespace(
+        origin=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+            thread_id="24296",
+            user_id="1",
+            user_name="Fabio",
+        )
+    )
+    loop_thread = threading.get_ident()
+    load_threads = []
+    real_ensure_loaded = runner.session_store._ensure_loaded
+
+    def spy_ensure_loaded():
+        load_threads.append(threading.get_ident())
+        return real_ensure_loaded()
+
+    monkeypatch.setattr(runner.session_store, "_ensure_loaded", spy_ensure_loaded)
+
+    await runner._inject_watch_notification(
+        "[SYSTEM: Background process matched]",
+        {
+            "session_id": "proc_watch",
+            "session_key": "agent:main:telegram:dm:123:24296",
+            "message_id": "777",
+        },
+    )
+
+    adapter.handle_message.assert_awaited_once()
+    assert load_threads
+    assert all(thread_id != loop_thread for thread_id in load_threads)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Session-store reads in the gateway's notification-routing path now run off the event loop.

`_build_process_event_source` calls `session_store._ensure_loaded()` (sync lock + disk load) and was invoked inline on the gateway asyncio loop from `_inject_watch_notification` — a slow disk stalls every adapter. The lookup now runs via `asyncio.to_thread`, covering both the watch-injection and completion-delivery paths (the latter delegates to the former). Routing results are unchanged; only the wait moved.

Salvaged from PR #63380 by @necoweb3 (commit cherry-picked, authorship preserved); rebased onto post-#85877 main, stale hunks for refactored-away helpers dropped.

## Changes
- `gateway/run.py`: `_inject_watch_notification` resolves the event source via `asyncio.to_thread(self._build_process_event_source, evt)`.
- `tests/gateway/test_background_process_notifications.py`: regression test asserting `_ensure_loaded` never executes on the loop thread (verified to FAIL on unpatched main).

## Validation
| Suite | Result |
|---|---|
| test_background_process_notifications.py + test_completion_delivery.py | 25 passed, 0 failed |
| New regression test on unpatched main | fails (proves the bug) |
| ruff | clean |

Closes #63380 (salvage).

## Infographic

![Off-loop notification routing](https://files.catbox.moe/z9ai67.png)
