### PR TITLE
fix(gateway): coalesce same-tick completion notifications into one turn

### DIFF
--- a/contributors/emails/yuzilong.leif@gmail.com
+++ b/contributors/emails/yuzilong.leif@gmail.com
@@ -1,0 +1,1 @@
+yuzilongleif-collab

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6554,6 +6554,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._completion_deliveries_inflight: set[tuple[str, str, object]] = set()
         self._completion_deliveries_delivered: "OrderedDict[tuple[str, str, object], None]" = OrderedDict()
         self._completion_delivery_retention = 2048
+        # Agent-triggered terminal completions from one conversation often land
+        # in the same scheduler tick.  Hold them briefly so the agent receives
+        # one synthetic turn instead of one turn per process (#70300).
+        self._completion_notification_batches: dict[tuple[str, ...], list[tuple[str, dict, asyncio.Future]]] = {}
+        self._completion_notification_batch_tasks: dict[tuple[str, ...], asyncio.Task] = {}
+        self._completion_notification_batch_window = 0.1
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -23922,6 +23928,135 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception:
                     logger.debug("Could not release durable completion claim", exc_info=True)
 
+    @staticmethod
+    def _completion_notification_batch_key(evt: dict) -> tuple[str, ...]:
+        """Return a routing-complete key for short-window process fan-in."""
+        return tuple(str(evt.get(field) or "") for field in (
+            "session_key",
+            "platform",
+            "chat_type",
+            "chat_id",
+            "thread_id",
+            "user_id",
+        ))
+
+    @staticmethod
+    def _format_coalesced_process_completions(entries: list[tuple[str, dict, asyncio.Future]]) -> str:
+        """Build one bounded synthetic event from several redacted completions."""
+        lines = [
+            f"[IMPORTANT: {len(entries)} background processes completed for this session.",
+            "Treat these results as one completion batch and send at most one "
+            "consolidated user-facing response.",
+        ]
+        shown = entries[:10]
+        for _text, evt, _future in shown:
+            session_id = str(evt.get("session_id") or "unknown")
+            exit_code = evt.get("exit_code")
+            reason = str(evt.get("completion_reason") or "exited")
+            output = str(evt.get("output") or "").strip()
+            if len(output) > 800:
+                output = f"[… truncated …]\n{output[-800:]}"
+            lines.append(
+                f"\n- {session_id}: exit_code={exit_code}, reason={reason}"
+            )
+            if output:
+                lines.append(output)
+        omitted = len(entries) - len(shown)
+        if omitted:
+            lines.append(
+                f"\n- … and {omitted} more completion(s); inspect them with "
+                "the process tool if they affect the conclusion."
+            )
+        lines.append(
+            "If a result does not change the current conclusion, absorb it silently.]"
+        )
+        return "\n".join(lines)
+
+    def _record_coalesced_completion_siblings(self, events: list[dict]) -> None:
+        """Extend a successful primary delivery claim to its batched siblings."""
+        with self._completion_delivery_lock:
+            for evt in events:
+                identity = self._completion_delivery_identity(evt)
+                if identity is None:
+                    continue
+                self._completion_deliveries_inflight.discard(identity)
+                self._completion_deliveries_delivered[identity] = None
+            while (
+                len(self._completion_deliveries_delivered)
+                > self._completion_delivery_retention
+            ):
+                self._completion_deliveries_delivered.popitem(last=False)
+
+    async def _flush_process_completion_batch(self, key: tuple[str, ...]) -> None:
+        """Deliver one short-window completion batch and resolve its waiters."""
+        current_task = asyncio.current_task()
+        entries: list[tuple[str, dict, asyncio.Future]] = []
+        delivered: Optional[bool] = False
+        try:
+            await asyncio.sleep(self._completion_notification_batch_window)
+            entries = self._completion_notification_batches.pop(key, [])
+            # Detach before adapter delivery.  A completion that arrives while
+            # this batch is in flight must be able to schedule the next flush.
+            if self._completion_notification_batch_tasks.get(key) is current_task:
+                self._completion_notification_batch_tasks.pop(key, None)
+            if not entries:
+                return
+            try:
+                if len(entries) == 1:
+                    synth_text = entries[0][0]
+                else:
+                    synth_text = self._format_coalesced_process_completions(entries)
+
+                # A duplicate primary can legitimately return None from the
+                # lifecycle dedupe seam.  Try the next batch identity so a
+                # fresh sibling is never discarded with that duplicate.
+                delivered = None
+                for _text, candidate_evt, _future in entries:
+                    delivered = await self._deliver_completion_notification(
+                        synth_text, candidate_evt,
+                    )
+                    if delivered is not None:
+                        break
+                if delivered is True and len(entries) > 1:
+                    self._record_coalesced_completion_siblings(
+                        [evt for _text, evt, _future in entries]
+                    )
+            except Exception:
+                logger.exception("Coalesced process completion delivery failed")
+                delivered = False
+            finally:
+                # Never strand watcher futures if formatting or delivery fails.
+                # False follows the existing watcher retry path.
+                for _text, _evt, future in entries:
+                    if not future.done():
+                        future.set_result(delivered)
+        finally:
+            # Do not remove a newer flush task that reused the same route key.
+            if self._completion_notification_batch_tasks.get(key) is current_task:
+                self._completion_notification_batch_tasks.pop(key, None)
+
+    async def _enqueue_process_completion_notification(
+        self, synth_text: str, evt: dict,
+    ) -> Optional[bool]:
+        """Fan in concurrent process completions that share one conversation."""
+        # Some unit tests construct GatewayRunner with object.__new__.  Keep the
+        # batching seam lazy so those focused lifecycle tests remain valid.
+        if not hasattr(self, "_completion_notification_batches"):
+            self._completion_notification_batches = {}
+            self._completion_notification_batch_tasks = {}
+            self._completion_notification_batch_window = 0.1
+
+        key = self._completion_notification_batch_key(evt)
+        future = asyncio.get_running_loop().create_future()
+        self._completion_notification_batches.setdefault(key, []).append(
+            (synth_text, evt, future)
+        )
+        if key not in self._completion_notification_batch_tasks:
+            self._completion_notification_batch_tasks[key] = asyncio.create_task(
+                self._flush_process_completion_batch(key)
+            )
+        return await future
+
     def _enrich_async_delegation_routing(self, evt: dict) -> None:
         """Fill platform/chat_id/thread_id/chat_type on an async-delegation event.
 
@@ -24094,7 +24229,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     synth_text = format_process_notification(completion_evt)
                     if not synth_text:
                         break
-                    delivered = await self._deliver_completion_notification(
+                    delivered = await self._enqueue_process_completion_notification(
                         synth_text, completion_evt,
                     )
                     if delivered is False:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6559,7 +6559,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # one synthetic turn instead of one turn per process (#70300).
         self._completion_notification_batches: dict[tuple[str, ...], list[tuple[str, dict, asyncio.Future]]] = {}
         self._completion_notification_batch_tasks: dict[tuple[str, ...], asyncio.Task] = {}
+        self._completion_notification_batch_flush_tasks: set[asyncio.Task] = set()
         self._completion_notification_batch_window = 0.1
+        self._completion_notification_batches_stopping = False
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -13878,6 +13880,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await self._cleanup_agent_resources_off_loop(
                         _agent, context="shutdown idle-cache"
                     )
+
+            # Completion flush tasks can be sleeping in their fan-in window or
+            # blocked in adapter delivery.  Cancel and await them while adapters
+            # are still alive so every watcher receives a retryable result
+            # before platform teardown begins.
+            cancel_completion_batches = getattr(
+                self, "_cancel_process_completion_batch_tasks", None
+            )
+            if cancel_completion_batches is not None:
+                await cancel_completion_batches()
 
             for platform, adapter in list(self.adapters.items()):
                 await self._bounded_adapter_teardown(adapter, platform)
@@ -24001,39 +24013,72 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._completion_notification_batch_tasks.pop(key, None)
             if not entries:
                 return
-            try:
-                if len(entries) == 1:
-                    synth_text = entries[0][0]
-                else:
-                    synth_text = self._format_coalesced_process_completions(entries)
+            if len(entries) == 1:
+                synth_text = entries[0][0]
+            else:
+                synth_text = self._format_coalesced_process_completions(entries)
 
-                # A duplicate primary can legitimately return None from the
-                # lifecycle dedupe seam.  Try the next batch identity so a
-                # fresh sibling is never discarded with that duplicate.
-                delivered = None
-                for _text, candidate_evt, _future in entries:
-                    delivered = await self._deliver_completion_notification(
-                        synth_text, candidate_evt,
-                    )
-                    if delivered is not None:
-                        break
-                if delivered is True and len(entries) > 1:
-                    self._record_coalesced_completion_siblings(
-                        [evt for _text, evt, _future in entries]
-                    )
-            except Exception:
-                logger.exception("Coalesced process completion delivery failed")
-                delivered = False
-            finally:
-                # Never strand watcher futures if formatting or delivery fails.
-                # False follows the existing watcher retry path.
-                for _text, _evt, future in entries:
-                    if not future.done():
-                        future.set_result(delivered)
+            # A duplicate primary can legitimately return None from the
+            # lifecycle dedupe seam.  Try the next batch identity so a
+            # fresh sibling is never discarded with that duplicate.
+            delivered = None
+            for _text, candidate_evt, _future in entries:
+                delivered = await self._deliver_completion_notification(
+                    synth_text, candidate_evt,
+                )
+                if delivered is not None:
+                    break
+            if delivered is True and len(entries) > 1:
+                self._record_coalesced_completion_siblings(
+                    [evt for _text, evt, _future in entries]
+                )
+        except asyncio.CancelledError:
+            # Shutdown may cancel us either during the fan-in window or while
+            # adapter delivery is blocked.  Recover entries that have not yet
+            # detached and resolve every waiter as retryable before adapters
+            # are torn down.
+            delivered = False
+            if not entries:
+                entries = self._completion_notification_batches.pop(key, [])
+            raise
+        except Exception:
+            logger.exception("Coalesced process completion delivery failed")
+            delivered = False
         finally:
+            # Never strand watcher futures if formatting, delivery, or task
+            # cancellation interrupts a batch.  False follows the existing
+            # watcher retry path; None remains the ordinary dedupe result.
+            for _text, _evt, future in entries:
+                if not future.done():
+                    future.set_result(delivered)
             # Do not remove a newer flush task that reused the same route key.
             if self._completion_notification_batch_tasks.get(key) is current_task:
                 self._completion_notification_batch_tasks.pop(key, None)
+
+    async def _cancel_process_completion_batch_tasks(self) -> None:
+        """Settle pending completion batches before adapter teardown."""
+        self._completion_notification_batches_stopping = True
+        tasks = {
+            task
+            for task in getattr(
+                self, "_completion_notification_batch_flush_tasks", set()
+            )
+            if not task.done()
+        }
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Defensive cleanup for an orphaned queue with no live flush task.
+        batches = getattr(self, "_completion_notification_batches", {})
+        for entries in batches.values():
+            for _text, _evt, future in entries:
+                if not future.done():
+                    future.set_result(False)
+        batches.clear()
+        getattr(self, "_completion_notification_batch_tasks", {}).clear()
+        getattr(self, "_completion_notification_batch_flush_tasks", set()).clear()
 
     async def _enqueue_process_completion_notification(
         self, synth_text: str, evt: dict,
@@ -24043,8 +24088,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # batching seam lazy so those focused lifecycle tests remain valid.
         if not hasattr(self, "_completion_notification_batches"):
             self._completion_notification_batches = {}
+        if not hasattr(self, "_completion_notification_batch_tasks"):
             self._completion_notification_batch_tasks = {}
+        if not hasattr(self, "_completion_notification_batch_flush_tasks"):
+            self._completion_notification_batch_flush_tasks = set()
+        if not hasattr(self, "_completion_notification_batch_window"):
             self._completion_notification_batch_window = 0.1
+        if not hasattr(self, "_completion_notification_batches_stopping"):
+            self._completion_notification_batches_stopping = False
+
+        if self._completion_notification_batches_stopping:
+            return False
 
         key = self._completion_notification_batch_key(evt)
         future = asyncio.get_running_loop().create_future()
@@ -24052,8 +24106,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             (synth_text, evt, future)
         )
         if key not in self._completion_notification_batch_tasks:
-            self._completion_notification_batch_tasks[key] = asyncio.create_task(
+            task = asyncio.create_task(
                 self._flush_process_completion_batch(key)
+            )
+            self._completion_notification_batch_tasks[key] = task
+            # Keep the flush alive and include it in the gateway's normal
+            # lifecycle accounting.  Focused tests that construct a runner via
+            # object.__new__ lazily receive the same ownership set.
+            if not hasattr(self, "_background_tasks"):
+                self._background_tasks = set()
+            self._background_tasks.add(task)
+            self._completion_notification_batch_flush_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+            task.add_done_callback(
+                self._completion_notification_batch_flush_tasks.discard
             )
         return await future
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23965,7 +23965,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_id = str(evt.get("session_id") or "unknown")
             exit_code = evt.get("exit_code")
             reason = str(evt.get("completion_reason") or "exited")
-            output = str(evt.get("output") or "").strip()
+            # Completion-event output is normally passed through the terminal
+            # redactor at the producer seam, but that redactor is deliberately
+            # configurable.  This synthetic turn is gateway user-facing input,
+            # so keep the unconditional gateway floor here as defence in depth.
+            # Redact before slicing: truncating first can leave a credential
+            # fragment that no longer matches the authoritative patterns.
+            output = _redact_gateway_user_facing_secrets(
+                str(evt.get("output") or "")
+            ).strip()
             if len(output) > 800:
                 output = f"[… truncated …]\n{output[-800:]}"
             lines.append(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24152,6 +24152,141 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if parsed.get("thread_id"):
             evt["thread_id"] = parsed["thread_id"]
 
+    @staticmethod
+    def _async_delegation_group_key(evt: dict) -> tuple[str, ...]:
+        """Return the same-session routing key for async completion coalescing.
+
+        Two events coalesce only when every routing dimension matches — the
+        originating session key, the parent session the result re-enters, and
+        the full gateway route. Events for different sessions never coalesce.
+        """
+        return tuple(str(evt.get(field) or "") for field in (
+            "session_key",
+            "parent_session_id",
+            "platform",
+            "chat_type",
+            "chat_id",
+            "thread_id",
+            "user_id",
+        ))
+
+    @staticmethod
+    def _format_coalesced_async_delegations(blocks: list[str]) -> str:
+        """Join per-delegation formatted blocks into one consolidated turn."""
+        header = (
+            f"[IMPORTANT: {len(blocks)} background subagent delegations "
+            "completed for this session. Treat these results as one "
+            "completion batch and send at most one consolidated user-facing "
+            "response. If a result does not change the current conclusion, "
+            "absorb it silently.]"
+        )
+        return "\n\n".join([header, *blocks])
+
+    async def _deliver_async_delegation_group(
+        self, group: list[dict],
+    ) -> Optional[bool]:
+        """Deliver a same-session batch of async completions as ONE turn.
+
+        A single-event group rides the existing per-event path unchanged. For
+        a multi-event group the primary event is delivered through
+        ``_deliver_completion_notification`` (which owns its durable claim,
+        the lifecycle dedupe, and the target preflight), carrying a
+        consolidated text that also contains every sibling result whose
+        durable row THIS runner successfully claimed up front. Only after
+        adapter acceptance are the sibling claims acknowledged — the durable
+        ledger never acks work that was not delivered, and a sibling claimed
+        by another consumer is excluded from the consolidated text entirely
+        so its content cannot be double-delivered.
+
+        Returns ``True`` after adapter acceptance, ``False`` when the caller
+        should requeue the group for retry, and ``None`` when nothing in the
+        group is deliverable by this runner (siblings that still need a retry
+        are requeued here before returning).
+        """
+        from tools.process_registry import process_registry as _pr
+
+        deliverable: list[tuple[dict, str]] = []
+        for evt in group:
+            synth_text = _format_gateway_process_notification(evt)
+            if not synth_text:
+                continue
+            identity = self._completion_delivery_identity(evt)
+            if identity is not None:
+                with self._completion_delivery_lock:
+                    if (
+                        identity in self._completion_deliveries_inflight
+                        or identity in self._completion_deliveries_delivered
+                    ):
+                        continue
+            deliverable.append((evt, synth_text))
+
+        if not deliverable:
+            return None
+        if len(deliverable) == 1:
+            evt, synth_text = deliverable[0]
+            return await self._deliver_completion_notification(synth_text, evt)
+
+        from tools.async_delegation import (
+            claim_event_delivery,
+            complete_event_delivery,
+            release_event_delivery,
+        )
+
+        primary_evt, primary_text = deliverable[0]
+        blocks = [primary_text]
+        siblings: list[tuple[dict, str]] = []
+        for evt, synth_text in deliverable[1:]:
+            claim_id = claim_event_delivery(evt, f"gateway-batch:{id(self)}")
+            if claim_id is None:
+                # Another consumer owns this row's delivery; keep its result
+                # out of our consolidated text so it is never double-injected.
+                continue
+            siblings.append((evt, claim_id))
+            blocks.append(synth_text)
+
+        if not siblings:
+            return await self._deliver_completion_notification(
+                primary_text, primary_evt,
+            )
+
+        consolidated = self._format_coalesced_async_delegations(blocks)
+        delivered: Optional[bool] = False
+        try:
+            delivered = await self._deliver_completion_notification(
+                consolidated, primary_evt,
+            )
+        finally:
+            if delivered is True:
+                for evt, claim_id in siblings:
+                    try:
+                        complete_event_delivery(evt, claim_id)
+                    except Exception:
+                        logger.debug(
+                            "Could not acknowledge coalesced durable completion",
+                            exc_info=True,
+                        )
+                self._record_coalesced_completion_siblings(
+                    [evt for evt, _claim_id in siblings]
+                )
+            else:
+                # Not delivered — release every sibling claim so a retry (or
+                # another consumer) can claim it, honestly leaving the durable
+                # rows pending.
+                for evt, claim_id in siblings:
+                    try:
+                        release_event_delivery(evt, claim_id)
+                    except Exception:
+                        logger.debug(
+                            "Could not release coalesced durable claim",
+                            exc_info=True,
+                        )
+                if delivered is None:
+                    # The primary was dropped/owned elsewhere but the siblings
+                    # still need delivery — requeue just them for the next tick.
+                    for evt, _claim_id in siblings:
+                        _pr.completion_queue.put(evt)
+        return delivered
+
     async def _async_delegation_watcher(self, interval: float = 2.0) -> None:
         """Drain async-delegation completions and inject them as new turns.
 
@@ -24186,17 +24321,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         requeue.append(evt)
                 for evt in requeue:
                     _pr.completion_queue.put(evt)
+                # A same-tick drain often carries several completions for the
+                # SAME originating session (a fan-out of background subagents
+                # finishing together).  Delivering each one individually floods
+                # the session with N synthetic turns (#70300) — group by full
+                # gateway route + parent session and inject one consolidated
+                # turn per group.  Events for different sessions never coalesce.
+                groups: dict[tuple[str, ...], list[dict]] = {}
+                group_order: list[tuple[str, ...]] = []
                 for evt in async_events:
                     self._enrich_async_delegation_routing(evt)
-                    synth_text = _format_gateway_process_notification(evt)
-                    if not synth_text:
-                        continue
+                    key = self._async_delegation_group_key(evt)
+                    if key not in groups:
+                        groups[key] = []
+                        group_order.append(key)
+                    groups[key].append(evt)
+                for key in group_order:
+                    group = groups[key]
                     try:
-                        delivered = await self._deliver_completion_notification(synth_text, evt)
+                        delivered = await self._deliver_async_delegation_group(group)
                         if delivered is False:
-                            _pr.completion_queue.put(evt)
+                            for evt in group:
+                                _pr.completion_queue.put(evt)
                     except Exception as e:
-                        _pr.completion_queue.put(evt)
+                        for evt in group:
+                            _pr.completion_queue.put(evt)
                         logger.error("Async delegation injection error: %s", e)
             except Exception as e:
                 logger.debug("Async delegation watcher error: %s", e)

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -733,3 +733,154 @@ def test_shutdown_cancels_overlapping_flushes_for_same_route():
 
     asyncio.run(_exercise())
     adapter.handle_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Async-delegation same-tick coalescing (#70300)
+# ---------------------------------------------------------------------------
+
+
+def _distinct_async_event(delegation_id, session_key="agent:main:telegram:dm:12345:678"):
+    event = _async_event(delegation_id)
+    event["session_key"] = session_key
+    event["summary"] = f"Result for {delegation_id}"
+    return event
+
+
+def test_same_tick_async_batch_coalesces_into_one_turn_and_acks_all_rows(
+    monkeypatch, isolated_registry,
+):
+    """Three same-session async completions in one drain -> one synthetic turn.
+
+    All three durable delegation rows must be honestly acknowledged only
+    after the single consolidated injection was accepted by the adapter.
+    """
+    from tools import async_delegation
+
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    events = [_distinct_async_event(f"deleg_batch_{i}") for i in range(3)]
+    for event in events:
+        _persist_pending_completion(event)
+        isolated.put(dict(event))
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    adapter.handle_message.assert_awaited_once()
+    delivered = adapter.handle_message.await_args.args[0]
+    assert "3 background subagent delegations" in delivered.text
+    for i in range(3):
+        assert f"Result for deleg_batch_{i}" in delivered.text
+    for event in events:
+        row = async_delegation.get_durable_delegation(event["delegation_id"])
+        assert row is not None
+        assert row["delivery_state"] == "delivered"
+    assert isolated.empty()
+
+
+def test_same_tick_async_events_for_different_sessions_do_not_coalesce(
+    monkeypatch, isolated_registry,
+):
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    isolated.put(_distinct_async_event("deleg_route_a"))
+    isolated.put(_distinct_async_event(
+        "deleg_route_b", session_key="agent:main:telegram:dm:99999:678",
+    ))
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    assert adapter.handle_message.await_count == 2
+    texts = [call.args[0].text for call in adapter.handle_message.await_args_list]
+    assert not any("background subagent delegations" in text for text in texts)
+    assert any("deleg_route_a" in text for text in texts)
+    assert any("deleg_route_b" in text for text in texts)
+
+
+def test_single_async_event_latency_and_text_are_unchanged(
+    monkeypatch, isolated_registry,
+):
+    """A lone completion keeps the plain per-event formatter output."""
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    isolated.put(_distinct_async_event("deleg_single"))
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    adapter.handle_message.assert_awaited_once()
+    delivered = adapter.handle_message.await_args.args[0]
+    assert "background subagent delegations" not in delivered.text
+    assert "deleg_single" in delivered.text
+
+
+def test_failed_coalesced_async_batch_releases_claims_and_retries(
+    monkeypatch, isolated_registry,
+):
+    """A rejected consolidated injection leaves every durable row pending."""
+    from tools import async_delegation
+
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    events = [_distinct_async_event(f"deleg_retry_{i}") for i in range(2)]
+    for event in events:
+        _persist_pending_completion(event)
+        isolated.put(dict(event))
+
+    adapter = SimpleNamespace(
+        handle_message=AsyncMock(side_effect=[RuntimeError("temporary"), None])
+    )
+    runner = _runner(adapter)
+    _stop_after_sleeps(monkeypatch, runner, count=3)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    # First tick fails as one batch, second tick delivers the same batch.
+    assert adapter.handle_message.await_count == 2
+    for event in events:
+        row = async_delegation.get_durable_delegation(event["delegation_id"])
+        assert row is not None
+        assert row["delivery_state"] == "delivered"
+    assert isolated.empty()
+
+
+def test_sibling_claimed_by_other_consumer_is_not_double_delivered(
+    monkeypatch, isolated_registry,
+):
+    """A sibling owned elsewhere is excluded from the consolidated turn."""
+    from tools import async_delegation
+
+    isolated = queue.Queue()
+    monkeypatch.setattr(isolated_registry, "completion_queue", isolated)
+    events = [_distinct_async_event(f"deleg_owned_{i}") for i in range(2)]
+    for event in events:
+        _persist_pending_completion(event)
+        isolated.put(dict(event))
+    # Simulate another live consumer holding the second row's claim.
+    assert async_delegation.claim_completion_delivery(
+        events[1]["delegation_id"], "other-consumer:claim",
+    )
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    _stop_after_sleeps(monkeypatch, runner, count=2)
+
+    asyncio.run(runner._async_delegation_watcher(interval=0))
+
+    adapter.handle_message.assert_awaited_once()
+    delivered = adapter.handle_message.await_args.args[0]
+    assert "Result for deleg_owned_0" in delivered.text
+    assert "Result for deleg_owned_1" not in delivered.text
+    row = async_delegation.get_durable_delegation(events[1]["delegation_id"])
+    assert row["delivery_state"] == "pending"

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -494,6 +494,54 @@ def test_coalesced_format_bounds_details_and_reports_omitted_count():
     assert "and 2 more completion(s)" in text
 
 
+def test_coalesced_format_force_redacts_output_when_redaction_disabled(monkeypatch):
+    """A user setting cannot disable the gateway's outbound secret floor."""
+    import agent.redact as redact_module
+
+    secret = "abc123randomopaquetokenvalue999"
+    monkeypatch.setattr(redact_module, "_REDACT_ENABLED", False)
+
+    async def _format():
+        loop = asyncio.get_running_loop()
+        first = _completion_event(started_at=1.0, session_id="proc_secret")
+        first["output"] = (
+            f"MY_SERVICE_TOKEN={secret}\n"
+            "HOME=/home/user\n"
+        )
+        second = _completion_event(started_at=2.0, session_id="proc_control")
+        return GatewayRunner._format_coalesced_process_completions([
+            ("first", first, loop.create_future()),
+            ("second", second, loop.create_future()),
+        ])
+
+    text = asyncio.run(_format())
+
+    assert secret not in text
+    assert "HOME=/home/user" in text
+
+
+def test_coalesced_format_redacts_before_truncating_output(monkeypatch):
+    """Truncation cannot remove the prefix needed to recognize a secret."""
+    import agent.redact as redact_module
+
+    marker = "SHOULD_NOT_SURVIVE"
+    monkeypatch.setattr(redact_module, "_REDACT_ENABLED", False)
+
+    async def _format():
+        loop = asyncio.get_running_loop()
+        first = _completion_event(started_at=1.0, session_id="proc_long_secret")
+        first["output"] = f"MY_SERVICE_TOKEN={'x' * 900}{marker}\n"
+        second = _completion_event(started_at=2.0, session_id="proc_control")
+        return GatewayRunner._format_coalesced_process_completions([
+            ("first", first, loop.create_future()),
+            ("second", second, loop.create_future()),
+        ])
+
+    text = asyncio.run(_format())
+
+    assert marker not in text
+
+
 def test_duplicate_primary_does_not_discard_fresh_batch_sibling():
     adapter = SimpleNamespace(handle_message=AsyncMock())
     runner = _runner(adapter)

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -11,7 +11,7 @@ import json
 import queue
 from collections import OrderedDict
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -46,6 +46,7 @@ def _runner(adapter, *, origins=None):
     runner._completion_deliveries_inflight = set()
     runner._completion_deliveries_delivered = OrderedDict()
     runner._completion_delivery_retention = 2048
+    runner._background_tasks = set()
     return runner
 
 
@@ -469,6 +470,30 @@ def test_coalesced_success_records_every_completion_identity():
         assert identity in runner._completion_deliveries_delivered
 
 
+def test_coalesced_format_bounds_details_and_reports_omitted_count():
+    async def _format():
+        loop = asyncio.get_running_loop()
+        entries = [
+            (
+                f"event-{index}",
+                _completion_event(
+                    started_at=float(index), session_id=f"proc_bound_{index}"
+                ),
+                loop.create_future(),
+            )
+            for index in range(12)
+        ]
+        return GatewayRunner._format_coalesced_process_completions(entries)
+
+    text = asyncio.run(_format())
+
+    for index in range(10):
+        assert f"proc_bound_{index}" in text
+    assert "proc_bound_10" not in text
+    assert "proc_bound_11" not in text
+    assert "and 2 more completion(s)" in text
+
+
 def test_duplicate_primary_does_not_discard_fresh_batch_sibling():
     adapter = SimpleNamespace(handle_message=AsyncMock())
     runner = _runner(adapter)
@@ -511,3 +536,152 @@ def test_batch_format_failure_resolves_waiters_for_retry(monkeypatch):
 
     assert asyncio.run(_exercise()) == [False, False]
     adapter.handle_message.assert_not_awaited()
+
+
+def test_shutdown_cancels_batch_during_window_and_settles_waiter_for_retry():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    sleep_entered = asyncio.Event()
+    release_sleep = asyncio.Event()
+    real_sleep = asyncio.sleep
+    event = _completion_event(started_at=1.0, session_id="proc_cancel_window")
+
+    async def _controlled_sleep(delay):
+        if delay == runner._completion_notification_batch_window:
+            sleep_entered.set()
+            await release_sleep.wait()
+            return
+        await real_sleep(delay)
+
+    async def _exercise():
+        pending = asyncio.create_task(
+            runner._enqueue_process_completion_notification("completion", event)
+        )
+        await sleep_entered.wait()
+        flush_task = next(iter(runner._completion_notification_batch_tasks.values()))
+        assert flush_task in runner._background_tasks
+
+        await runner._cancel_process_completion_batch_tasks()
+
+        assert await asyncio.wait_for(pending, timeout=1.0) is False
+        assert flush_task.cancelled()
+        assert flush_task not in runner._background_tasks
+        assert runner._completion_notification_batches == {}
+        assert runner._completion_notification_batch_tasks == {}
+
+    with patch("gateway.run.asyncio.sleep", new=_controlled_sleep):
+        asyncio.run(_exercise())
+    adapter.handle_message.assert_not_awaited()
+
+
+def test_shutdown_cancels_blocked_batch_delivery_and_keeps_it_retryable():
+    delivery_entered = asyncio.Event()
+
+    async def _blocked_delivery(_event):
+        delivery_entered.set()
+        await asyncio.Event().wait()
+
+    adapter = SimpleNamespace(handle_message=AsyncMock(side_effect=_blocked_delivery))
+    runner = _runner(adapter)
+    runner._completion_notification_batch_window = 0
+    event = _completion_event(started_at=1.0, session_id="proc_cancel_delivery")
+
+    async def _exercise():
+        pending = asyncio.create_task(
+            runner._enqueue_process_completion_notification("completion", event)
+        )
+        await delivery_entered.wait()
+        flush_task = next(iter(runner._completion_notification_batch_flush_tasks))
+
+        await runner._cancel_process_completion_batch_tasks()
+
+        assert await asyncio.wait_for(pending, timeout=1.0) is False
+        assert flush_task.cancelled()
+        assert runner._completion_delivery_identity(event) not in runner._completion_deliveries_inflight
+        assert runner._completion_delivery_identity(event) not in runner._completion_deliveries_delivered
+        assert runner._completion_notification_batches == {}
+        assert runner._completion_notification_batch_tasks == {}
+
+    asyncio.run(_exercise())
+    adapter.handle_message.assert_awaited_once()
+
+
+def test_completion_enqueue_stays_retryable_after_shutdown_starts():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+
+    async def _exercise():
+        await runner._cancel_process_completion_batch_tasks()
+        return await runner._enqueue_process_completion_notification(
+            "completion",
+            _completion_event(started_at=1.0, session_id="proc_after_shutdown"),
+        )
+
+    assert asyncio.run(_exercise()) is False
+    assert runner._completion_notification_batches == {}
+    assert runner._completion_notification_batch_tasks == {}
+    adapter.handle_message.assert_not_awaited()
+
+
+def test_successful_batch_releases_all_lifecycle_task_references():
+    adapter = SimpleNamespace(handle_message=AsyncMock(return_value=None))
+    runner = _runner(adapter)
+    runner._completion_notification_batch_window = 0
+
+    async def _exercise():
+        result = await runner._enqueue_process_completion_notification(
+            "completion",
+            _completion_event(started_at=1.0, session_id="proc_success_cleanup"),
+        )
+        await asyncio.sleep(0)
+        return result
+
+    assert asyncio.run(_exercise()) is True
+    assert runner._completion_notification_batch_tasks == {}
+    assert runner._completion_notification_batch_flush_tasks == set()
+    assert runner._background_tasks == set()
+
+
+def test_shutdown_cancels_overlapping_flushes_for_same_route():
+    delivery_entered = asyncio.Event()
+
+    async def _blocked_delivery(_event):
+        delivery_entered.set()
+        await asyncio.Event().wait()
+
+    adapter = SimpleNamespace(handle_message=AsyncMock(side_effect=_blocked_delivery))
+    runner = _runner(adapter)
+    runner._completion_notification_batch_window = 0
+    first_event = _completion_event(started_at=1.0, session_id="proc_old_flush")
+    second_event = _completion_event(started_at=2.0, session_id="proc_new_flush")
+
+    async def _exercise():
+        first = asyncio.create_task(
+            runner._enqueue_process_completion_notification("first", first_event)
+        )
+        await delivery_entered.wait()
+
+        # The first task has detached from the route index while blocked in
+        # adapter delivery.  A new completion for the same route must create a
+        # second flush, and shutdown must still own and cancel both tasks.
+        assert runner._completion_notification_batch_tasks == {}
+        runner._completion_notification_batch_window = 3600
+        second = asyncio.create_task(
+            runner._enqueue_process_completion_notification("second", second_event)
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        flush_tasks = set(runner._completion_notification_batch_flush_tasks)
+        assert len(flush_tasks) == 2
+
+        await runner._cancel_process_completion_batch_tasks()
+
+        assert await asyncio.gather(first, second) == [False, False]
+        assert all(task.cancelled() for task in flush_tasks)
+        assert runner._completion_notification_batches == {}
+        assert runner._completion_notification_batch_tasks == {}
+        assert runner._completion_notification_batch_flush_tasks == set()
+        assert runner._background_tasks == set()
+
+    asyncio.run(_exercise())
+    adapter.handle_message.assert_awaited_once()

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -316,3 +316,198 @@ def test_autonomous_completion_redacts_real_command_and_output_secrets(monkeypat
     delivered = adapter.handle_message.await_args.args[0]
     assert secret not in delivered.text
     assert "HOME=/home/user" in delivered.text
+
+
+def test_concurrent_process_watchers_coalesce_one_session_completion_turn(monkeypatch):
+    """Concurrent terminal watchers for one session must re-enter the agent once."""
+    import tools.process_registry as pr_module
+
+    registry = ProcessRegistry()
+    watchers = []
+    for index in range(3):
+        session = ProcessSession(
+            id=f"proc_batch_{index}",
+            command=f"printf batch-{index}",
+            task_id=f"task-{index}",
+            started_at=1000.0 + index,
+            output_buffer=f"batch-{index}\n",
+            exited=True,
+            exit_code=0,
+            notify_on_complete=True,
+        )
+        registry._finished[session.id] = session
+        watchers.append({
+            "session_id": session.id,
+            "check_interval": 0,
+            "session_key": "agent:main:telegram:dm:123",
+            "platform": "telegram",
+            "chat_type": "dm",
+            "chat_id": "123",
+            "notify_on_complete": True,
+        })
+    monkeypatch.setattr(pr_module, "process_registry", registry)
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+
+    async def _exercise():
+        await asyncio.gather(*(
+            runner._run_process_watcher(watcher)
+            for watcher in watchers
+        ))
+
+    asyncio.run(_exercise())
+
+    adapter.handle_message.assert_awaited_once()
+    delivered = adapter.handle_message.await_args.args[0]
+    assert "3 background processes completed" in delivered.text
+    for index in range(3):
+        assert f"proc_batch_{index}" in delivered.text
+
+
+def test_completion_arriving_during_batch_delivery_schedules_next_flush():
+    """A new event cannot be stranded behind an in-flight batch for its route."""
+    first_delivery_entered = asyncio.Event()
+    release_first_delivery = asyncio.Event()
+    delivery_count = 0
+
+    async def _deliver(_event):
+        nonlocal delivery_count
+        delivery_count += 1
+        if delivery_count == 1:
+            first_delivery_entered.set()
+            await release_first_delivery.wait()
+
+    adapter = SimpleNamespace(handle_message=AsyncMock(side_effect=_deliver))
+    runner = _runner(adapter)
+
+    async def _exercise():
+        first = asyncio.create_task(runner._enqueue_process_completion_notification(
+            "first completion",
+            _completion_event(started_at=1.0, session_id="proc_first"),
+        ))
+        await first_delivery_entered.wait()
+        second = asyncio.create_task(runner._enqueue_process_completion_notification(
+            "second completion",
+            _completion_event(started_at=2.0, session_id="proc_second"),
+        ))
+        release_first_delivery.set()
+        assert await first is True
+        assert await asyncio.wait_for(second, timeout=1.0) is True
+
+    asyncio.run(_exercise())
+
+    assert adapter.handle_message.await_count == 2
+
+
+def test_completion_batches_do_not_cross_conversation_routes():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+
+    first = _completion_event(started_at=1.0, session_id="proc_route_a")
+    second = _completion_event(started_at=2.0, session_id="proc_route_b")
+    second["session_key"] = "agent:main:telegram:dm:456"
+    second["chat_id"] = "456"
+
+    async def _exercise():
+        return await asyncio.gather(
+            runner._enqueue_process_completion_notification("first", first),
+            runner._enqueue_process_completion_notification("second", second),
+        )
+
+    assert asyncio.run(_exercise()) == [True, True]
+    assert adapter.handle_message.await_count == 2
+
+
+def test_failed_coalesced_delivery_retries_all_entries():
+    attempts = 0
+
+    async def _deliver(_event):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("temporary adapter failure")
+
+    adapter = SimpleNamespace(handle_message=AsyncMock(side_effect=_deliver))
+    runner = _runner(adapter)
+    events = [
+        _completion_event(started_at=float(index), session_id=f"proc_retry_{index}")
+        for index in range(2)
+    ]
+
+    async def _enqueue_all():
+        return await asyncio.gather(*(
+            runner._enqueue_process_completion_notification(f"event-{index}", event)
+            for index, event in enumerate(events)
+        ))
+
+    async def _exercise():
+        assert await _enqueue_all() == [False, False]
+        assert await _enqueue_all() == [True, True]
+
+    asyncio.run(_exercise())
+    assert adapter.handle_message.await_count == 2
+
+
+def test_coalesced_success_records_every_completion_identity():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    events = [
+        _completion_event(started_at=float(index), session_id=f"proc_ledger_{index}")
+        for index in range(3)
+    ]
+
+    async def _exercise():
+        return await asyncio.gather(*(
+            runner._enqueue_process_completion_notification(f"event-{index}", event)
+            for index, event in enumerate(events)
+        ))
+
+    assert asyncio.run(_exercise()) == [True, True, True]
+    for event in events:
+        identity = runner._completion_delivery_identity(event)
+        assert identity in runner._completion_deliveries_delivered
+
+
+def test_duplicate_primary_does_not_discard_fresh_batch_sibling():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    duplicate = _completion_event(started_at=1.0, session_id="proc_duplicate")
+    fresh = _completion_event(started_at=2.0, session_id="proc_fresh")
+    duplicate_identity = runner._completion_delivery_identity(duplicate)
+    runner._completion_deliveries_delivered[duplicate_identity] = None
+
+    async def _exercise():
+        return await asyncio.gather(
+            runner._enqueue_process_completion_notification("duplicate", duplicate),
+            runner._enqueue_process_completion_notification("fresh", fresh),
+        )
+
+    assert asyncio.run(_exercise()) == [True, True]
+    adapter.handle_message.assert_awaited_once()
+    fresh_identity = runner._completion_delivery_identity(fresh)
+    assert fresh_identity in runner._completion_deliveries_delivered
+
+
+def test_batch_format_failure_resolves_waiters_for_retry(monkeypatch):
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    monkeypatch.setattr(
+        runner,
+        "_format_coalesced_process_completions",
+        MagicMock(side_effect=ValueError("bad batch")),
+    )
+    events = [
+        _completion_event(started_at=float(index), session_id=f"proc_format_{index}")
+        for index in range(2)
+    ]
+
+    async def _exercise():
+        pending = asyncio.gather(*(
+            runner._enqueue_process_completion_notification(f"event-{index}", event)
+            for index, event in enumerate(events)
+        ))
+        return await asyncio.wait_for(pending, timeout=1.0)
+
+    assert asyncio.run(_exercise()) == [False, False]
+    adapter.handle_message.assert_not_awaited()

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -105,6 +105,49 @@ async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks(
 
 
 @pytest.mark.asyncio
+async def test_gateway_stop_settles_completion_batch_before_adapter_disconnect():
+    runner, adapter = make_restart_runner()
+    runner._completion_notification_batch_window = 3600
+    event = {
+        "session_id": "shutdown-batch",
+        "started_at": 1.0,
+        "session_key": "telegram:dm:123456:u1",
+        "platform": "telegram",
+        "chat_type": "dm",
+        "chat_id": "123456",
+        "user_id": "u1",
+        "exit_code": 0,
+        "output": "done",
+    }
+    call_order: list[str] = []
+    original_cancel = runner._cancel_process_completion_batch_tasks
+
+    async def _tracked_cancel():
+        call_order.append("batch_cancel_start")
+        await original_cancel()
+        call_order.append("batch_cancel_done")
+
+    async def _disconnect():
+        call_order.append("disconnect")
+
+    runner._cancel_process_completion_batch_tasks = _tracked_cancel
+    adapter.disconnect = _disconnect
+    pending = asyncio.create_task(
+        runner._enqueue_process_completion_notification("completion", event)
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert runner._completion_notification_batch_flush_tasks
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    assert await asyncio.wait_for(pending, timeout=1.0) is False
+    assert call_order == ["batch_cancel_start", "batch_cancel_done", "disconnect"]
+    assert runner._completion_notification_batch_flush_tasks == set()
+
+
+@pytest.mark.asyncio
 async def test_in_chat_restart_skips_home_shutdown_even_with_active_session():
     runner, adapter = make_restart_runner()
     source = make_restart_source(thread_id="42")


### PR DESCRIPTION
## Summary
Same-tick background-process and async-delegation completions targeting the same session now arrive as ONE consolidated synthetic turn instead of N separate messages.

Fixes #70300: N processes/subagents finishing together each injected an individual turn, flooding the session. Two seams fixed:

- **Per-process completions** — salvaged from PR #71898 by @yuzilongleif-collab (3 commits cherry-picked, authorship preserved): a per-route 0.1s fan-in window in `_enqueue_process_completion_notification`; one flush task per route delivers one turn; shutdown cancels flushes safely.
- **Async delegations** (new commit on top): `_async_delegation_watcher` groups its drained batch by full routing key and delivers one consolidated turn per group via `_deliver_async_delegation_group`. Single-event groups ride the existing per-event path byte-identically.

Durable-ack honesty preserved: sibling delegation rows are acked only after adapter acceptance; failed batches release claims for retry; foreign-claimed siblings stay pending. Different sessions never coalesce.

## Changes
- `gateway/run.py`: batch collector + grouped async delivery
- `tests/gateway/test_completion_delivery.py` (+570 lines), `tests/gateway/test_gateway_shutdown.py`

## Validation
| Case | Result |
|---|---|
| 3 same-tick async events, one session | 1 injection, all 3 rows acked delivered |
| Events to 2 sessions | 2 injections, no batch header |
| Single event | latency/text unchanged |
| Failed batch | claims released, retried to delivered |
| Full suites (completion_delivery, async_delegation, bg-notifications, shutdown) | 46 passed, 0 failed |

Fixes #70300. Supersedes #71898 (salvaged with credit) and #72675.

## Infographic

![Completion coalescing](https://files.catbox.moe/y4c7ye.png)
