### PR TITLE
fix(gateway,tools): gate background-process completions on spawning-session boundary

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23866,6 +23866,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 exc_info=True,
                             )
                     return False
+        elif evt.get("type") == "completion":
+            # Background-process completions carry only session_key (chat/
+            # thread routing), so after /new the notification from the OLD
+            # session would land in the chat's NEW session. Stamped events
+            # (spawn-time parent_session_id from terminal_tool) get the same
+            # session-boundary pre-flight as async delegations — one policy
+            # owner (_classify_completion_target), never a forked predicate.
+            # Legacy/unstamped events keep today's behavior and deliver.
+            parent_session_id = str(evt.get("parent_session_id") or "").strip()
+            if parent_session_id:
+                verdict = await self._classify_completion_target(parent_session_id)
+                if verdict == "terminal":
+                    logger.warning(
+                        "Background process %s completion targets "
+                        "permanently-gone session %s (user boundary such as "
+                        "/new); dropping notification (output remains "
+                        "available via process(action='log')).",
+                        evt.get("session_id") or "<unknown>", parent_session_id,
+                    )
+                    return None
+                if verdict == "retry":
+                    # Transient uncertainty (session DB unavailable or a
+                    # compression rotation mid-flight): signal the watcher to
+                    # re-poll and try again rather than dropping or
+                    # misrouting the result.
+                    return False
         if identity is not None:
             with self._completion_delivery_lock:
                 if (
@@ -24090,6 +24116,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "completion_reason": getattr(session, "completion_reason", "exited"),
                         "termination_source": getattr(session, "termination_source", ""),
                         "output": _out,
+                        # Spawning conversation's session-db id (stamped at
+                        # spawn time in terminal_tool). Lets the delivery
+                        # pre-flight drop this completion when the user closed
+                        # that session (/new) before the process finished.
+                        "parent_session_id": (
+                            watcher.get("parent_session_id")
+                            or getattr(session, "parent_session_id", "")
+                            or ""
+                        ),
                     }
                     synth_text = format_process_notification(completion_evt)
                     if not synth_text:

--- a/tests/gateway/test_completion_session_boundary.py
+++ b/tests/gateway/test_completion_session_boundary.py
@@ -1,0 +1,336 @@
+"""Session-boundary gating for background-process completion delivery.
+
+Plain ``type=completion`` events historically carried only ``session_key``
+(chat/thread routing), so a background process spawned in session A whose
+completion fired after ``/new`` was injected into the chat's NEW session.
+The fix stamps the spawning conversation's session-db id on the watcher at
+spawn time and routes stamped events through the SAME pre-flight policy the
+async-delegation path already uses (``_classify_completion_target``):
+
+- terminal (user boundary such as /new)  -> drop with a log
+- retry (transient DB uncertainty)       -> watcher re-polls
+- deliver (live / idle-ended parent)     -> proceed as today
+
+Unstamped legacy events keep today's deliver-always behavior.
+"""
+
+import asyncio
+import json
+from collections import OrderedDict
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from tools.process_registry import ProcessRegistry, ProcessSession
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import tools.process_registry as pr_module
+
+    monkeypatch.setattr(pr_module, "CHECKPOINT_PATH", tmp_path / "processes.json")
+    registry = pr_module.ProcessRegistry()
+    monkeypatch.setattr(pr_module, "process_registry", registry)
+    return registry
+
+
+class _SessionDB:
+    def __init__(self, row, tip=None):
+        self._row = row
+        self._tip = tip
+
+    async def get_session(self, session_id):
+        return self._row
+
+    async def get_compression_tip(self, session_id):
+        return self._tip
+
+
+def _runner(adapter, *, session_db=...):
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.session_store = SimpleNamespace(
+        _ensure_loaded=lambda: None,
+        _entries={},
+    )
+    runner._session_source_cache = {}
+    runner._completion_delivery_lock = __import__("threading").Lock()
+    runner._completion_deliveries_inflight = set()
+    runner._completion_deliveries_delivered = OrderedDict()
+    runner._completion_delivery_retention = 2048
+    if session_db is not ...:
+        runner._session_db = session_db
+    return runner
+
+
+def _finished_session(registry, session_id="proc_boundary", **kwargs):
+    session = ProcessSession(
+        id=session_id,
+        command="echo done",
+        task_id="task",
+        started_at=1234.5,
+        output_buffer="done\n",
+        exited=True,
+        exit_code=0,
+        notify_on_complete=True,
+        **kwargs,
+    )
+    registry._finished[session.id] = session
+    return session
+
+
+def _watcher(session_id, parent_session_id=None):
+    watcher = {
+        "session_id": session_id,
+        "check_interval": 0,
+        "session_key": "agent:main:telegram:dm:123",
+        "platform": "telegram",
+        "chat_type": "dm",
+        "chat_id": "123",
+        "notify_on_complete": True,
+    }
+    if parent_session_id is not None:
+        watcher["parent_session_id"] = parent_session_id
+    return watcher
+
+
+def _run_watcher(monkeypatch, runner, watcher):
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    asyncio.run(runner._run_process_watcher(watcher))
+
+
+def _completion_evt(parent_session_id=None, session_id="proc_x"):
+    evt = {
+        "type": "completion",
+        "session_id": session_id,
+        "session_key": "agent:main:telegram:dm:123",
+        "platform": "telegram",
+        "chat_type": "dm",
+        "chat_id": "123",
+        "started_at": 1234.5,
+        "command": "echo done",
+        "exit_code": 0,
+        "completion_reason": "exited",
+        "output": "done\n",
+    }
+    if parent_session_id is not None:
+        evt["parent_session_id"] = parent_session_id
+    return evt
+
+
+# ---------------------------------------------------------------------------
+# The stamp is threaded from the watcher into the completion event
+# ---------------------------------------------------------------------------
+
+def test_watcher_stamps_parent_session_id_on_completion_event(
+    monkeypatch, isolated_registry,
+):
+    _finished_session(isolated_registry)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+
+    captured = {}
+
+    async def _capture(_text, evt):
+        captured.update(evt)
+        return True
+
+    monkeypatch.setattr(runner, "_deliver_completion_notification", _capture)
+    _run_watcher(
+        monkeypatch, runner, _watcher("proc_boundary", "sess-spawner"),
+    )
+
+    assert captured.get("type") == "completion"
+    assert captured.get("parent_session_id") == "sess-spawner"
+
+
+def test_watcher_falls_back_to_process_session_stamp(
+    monkeypatch, isolated_registry,
+):
+    """Watchers recovered without the stamp still pick it up off the
+    ProcessSession (spawn-time stamp survives checkpoint/restore there)."""
+    _finished_session(
+        isolated_registry, parent_session_id="sess-from-registry",
+    )
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+
+    captured = {}
+
+    async def _capture(_text, evt):
+        captured.update(evt)
+        return True
+
+    monkeypatch.setattr(runner, "_deliver_completion_notification", _capture)
+    _run_watcher(monkeypatch, runner, _watcher("proc_boundary"))
+
+    assert captured.get("parent_session_id") == "sess-from-registry"
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight verdicts on stamped completion events
+# ---------------------------------------------------------------------------
+
+def test_completion_from_user_closed_session_is_dropped(
+    monkeypatch, isolated_registry,
+):
+    """/new closed the spawning session -> the stamped completion must NOT
+    land in the chat's new session."""
+    _finished_session(isolated_registry)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(
+        adapter,
+        session_db=_SessionDB(
+            {"ended_at": 1786288000.0, "end_reason": "session_reset"}
+        ),
+    )
+
+    _run_watcher(
+        monkeypatch, runner, _watcher("proc_boundary", "sess-closed"),
+    )
+
+    adapter.handle_message.assert_not_awaited()
+
+
+def test_completion_after_idle_end_still_delivers(
+    monkeypatch, isolated_registry,
+):
+    """Idle/timeout ends are the relay-plane norm — the chat stays routable
+    and the completion must deliver."""
+    _finished_session(isolated_registry)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(
+        adapter,
+        session_db=_SessionDB(
+            {"ended_at": 1786288000.0, "end_reason": "idle_timeout"}
+        ),
+    )
+
+    _run_watcher(
+        monkeypatch, runner, _watcher("proc_boundary", "sess-idle"),
+    )
+
+    adapter.handle_message.assert_awaited_once()
+
+
+def test_completion_from_live_session_delivers(monkeypatch, isolated_registry):
+    _finished_session(isolated_registry)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter, session_db=_SessionDB({"ended_at": None}))
+
+    _run_watcher(
+        monkeypatch, runner, _watcher("proc_boundary", "sess-live"),
+    )
+
+    adapter.handle_message.assert_awaited_once()
+
+
+def test_unstamped_legacy_completion_delivers(monkeypatch, isolated_registry):
+    """Events without the spawn-time stamp keep today's behavior even when a
+    session DB is present."""
+    _finished_session(isolated_registry)
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter, session_db=_SessionDB(None))
+
+    _run_watcher(monkeypatch, runner, _watcher("proc_boundary"))
+
+    adapter.handle_message.assert_awaited_once()
+
+
+def test_retry_verdict_returns_false_for_watcher_repoll():
+    """No session DB yet -> transient uncertainty -> retryable False, and no
+    adapter injection happens."""
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter, session_db=None)
+
+    result = asyncio.run(
+        runner._deliver_completion_notification(
+            "text", _completion_evt("sess-uncertain"),
+        )
+    )
+
+    assert result is False
+    adapter.handle_message.assert_not_awaited()
+
+
+def test_terminal_verdict_returns_none_without_injection():
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter, session_db=_SessionDB(None))
+
+    result = asyncio.run(
+        runner._deliver_completion_notification(
+            "text", _completion_evt("sess-gone"),
+        )
+    )
+
+    assert result is None
+    adapter.handle_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# The async-delegation path is unaffected
+# ---------------------------------------------------------------------------
+
+def test_async_delegation_gate_unchanged():
+    """A stamped async_delegation event still routes through the existing
+    delegation-owned gate (terminal verdict -> None), proving the completion
+    branch did not fork or shadow the delegation policy."""
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter, session_db=_SessionDB(None))
+
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "",
+        "session_key": "agent:main:telegram:dm:12345:678",
+        "parent_session_id": "sess-gone",
+        "status": "completed",
+    }
+    result = asyncio.run(runner._deliver_completion_notification("text", evt))
+
+    assert result is None
+    adapter.handle_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# The stamp survives checkpoint/restore
+# ---------------------------------------------------------------------------
+
+def test_parent_session_id_survives_checkpoint_recovery(tmp_path, monkeypatch):
+    import tools.process_registry as pr_module
+
+    checkpoint = tmp_path / "processes.json"
+    checkpoint.write_text(json.dumps([{
+        "session_id": "proc_recovered",
+        "command": "sleep 999",
+        "pid": 4242,
+        "pid_scope": "host",
+        "host_start_time": 111.0,
+        "started_at": 1234.5,
+        "task_id": "task",
+        "session_key": "agent:main:telegram:dm:123",
+        "watcher_platform": "telegram",
+        "watcher_chat_id": "123",
+        "watcher_interval": 5,
+        "notify_on_complete": True,
+        "parent_session_id": "sess-spawner",
+    }]), encoding="utf-8")
+    monkeypatch.setattr(pr_module, "CHECKPOINT_PATH", checkpoint)
+
+    registry = ProcessRegistry()
+    monkeypatch.setattr(registry, "_host_pid_is_ours", lambda *_a: True)
+    monkeypatch.setattr(
+        registry, "_write_checkpoint", lambda *_a, **_kw: None,
+    )
+
+    assert registry.recover_from_checkpoint() == 1
+    assert registry.get("proc_recovered").parent_session_id == "sess-spawner"
+    assert len(registry.pending_watchers) == 1
+    assert registry.pending_watchers[0]["parent_session_id"] == "sess-spawner"

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -393,6 +393,11 @@ class ProcessSession:
     watcher_thread_id: str = ""
     watcher_message_id: str = ""                # Triggering message id — reply anchor for topic routing
     watcher_interval: int = 0                   # 0 = no watcher configured
+    # Session-db id of the conversation that spawned this process. Lets the
+    # gateway's completion pre-flight (_classify_completion_target) drop
+    # notifications whose spawning session was closed at an explicit user
+    # boundary (/new), instead of injecting them into the chat's NEW session.
+    parent_session_id: str = ""
     notify_on_complete: bool = False             # Queue agent notification on exit
     # Watch patterns — trigger agent notification when output matches any pattern
     watch_patterns: List[str] = field(default_factory=list)
@@ -2517,6 +2522,7 @@ class ProcessRegistry:
                             "watcher_thread_id": s.watcher_thread_id,
                             "watcher_message_id": s.watcher_message_id,
                             "watcher_interval": s.watcher_interval,
+                            "parent_session_id": s.parent_session_id,
                             "notify_on_complete": s.notify_on_complete,
                             "watch_patterns": s.watch_patterns,
                         })
@@ -2613,6 +2619,7 @@ class ProcessRegistry:
                 watcher_thread_id=entry.get("watcher_thread_id", ""),
                 watcher_message_id=entry.get("watcher_message_id", ""),
                 watcher_interval=entry.get("watcher_interval", 0),
+                parent_session_id=entry.get("parent_session_id", ""),
                 notify_on_complete=entry.get("notify_on_complete", False),
                 watch_patterns=entry.get("watch_patterns", []),
             )
@@ -2634,6 +2641,7 @@ class ProcessRegistry:
                     "thread_id": session.watcher_thread_id,
                     "message_id": session.watcher_message_id,
                     "notify_on_complete": session.notify_on_complete,
+                    "parent_session_id": session.parent_session_id,
                 })
 
         self._write_checkpoint(extra_entries=unresolved_scope_entries)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3179,6 +3179,15 @@ def terminal_tool(
                             proc_session.watcher_user_name = _gw_user_name
                             proc_session.watcher_thread_id = _gw_thread_id
                             proc_session.watcher_message_id = _gw_message_id
+                            # Stamp the spawning conversation's session-db id
+                            # so the gateway's completion pre-flight
+                            # (_classify_completion_target) can drop the
+                            # notification when the user closes this session
+                            # (/new) before the process finishes, instead of
+                            # injecting it into the chat's NEW session.
+                            proc_session.parent_session_id = _gse(
+                                "HERMES_SESSION_ID", ""
+                            )
 
                 # Mutual exclusion: if both notify_on_complete and watch_patterns
                 # are set, drop watch_patterns. The combination produces duplicate
@@ -3217,6 +3226,7 @@ def terminal_tool(
                             "thread_id": proc_session.watcher_thread_id,
                             "message_id": proc_session.watcher_message_id,
                             "notify_on_complete": True,
+                            "parent_session_id": proc_session.parent_session_id,
                         })
 
                 # Set watch patterns for output monitoring


### PR DESCRIPTION
## Summary
Background-process completions no longer land in the wrong conversation after `/new` — the spawning session id is stamped on the watcher at spawn and delivery is gated through the existing session-boundary policy.

Main already solved this class for async delegations (`_classify_completion_target` + `_USER_BOUNDARY_END_REASONS`); plain `type=completion` events carried only chat routing and bypassed the gate. This is the kernel salvage of PR #16455 by @Tosko4 (the original threaded boundary locks through 20 files; adapters/slash-commands/cron are deliberately untouched here).

## Changes
- `tools/terminal_tool.py` + `tools/process_registry.py`: stamp `parent_session_id` on watcher metadata at spawn; persists through checkpoint recovery.
- `gateway/run.py`: `_run_process_watcher` includes the stamp in `completion_evt`; `_deliver_completion_notification` runs the EXISTING `_classify_completion_target` for stamped completion events (terminal → drop with log, retry → re-poll, deliver → proceed). One policy owner — no forked predicate. Unstamped legacy events behave exactly as today.

## Validation
| Case | Result |
|---|---|
| Completion from /new-closed session | dropped |
| Completion after idle-end | delivered |
| Unstamped legacy event | delivered (unchanged) |
| async_delegation path | byte-untouched |
| New boundary tests + completion_delivery + bg-notifications + relay suites | 71 passed, 0 failed |
| ruff + Windows-footgun checker | clean |

(The one red in the mirror `test_process_registry.py` run — `test_checkpoint_redacts_command_with_inline_secret` — is proven pre-existing on pristine origin/main and unrelated.)

Based on the session-boundary approach from #16455 by @Tosko4.

## Infographic

![Session boundary guard](https://files.catbox.moe/7oivlu.png)
