### PR TITLE
fix: redeliver failed final responses after a platform reconnects

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -17,8 +17,12 @@ bounded retention). The gateway writes three checkpoints around the send:
     mark_failed()         state='failed'      on a definitive rejection
 
 On startup, ``sweep_recoverable()`` claims rows whose owning process is
-dead and hands them to the gateway for redelivery. Crash semantics are
-explicit about ambiguity (the contract review of the earlier
+dead and hands them to the gateway for redelivery. At runtime,
+``sweep_failed_for_runtime()`` claims a platform's ``failed`` rows when
+that platform reconnects after an outage, so a rejection that happened
+while the gateway stayed alive (typically during the same network trouble
+that dropped the adapter) is retried without waiting for a restart. Crash
+semantics are explicit about ambiguity (the contract review of the earlier
 delivery-outbox attempt, #61790, closed it for silently resending
 ambiguous sends):
 
@@ -301,6 +305,75 @@ def sweep_recoverable(
                     # pending = send never started, redeliver plainly;
                     # attempting/failed = ambiguous or rejected, carry marker.
                     "needs_marker": state != "pending",
+                    "attempts": attempts + 1,
+                })
+    return claimed
+
+
+def sweep_failed_for_runtime(
+    platform: str,
+    now: Optional[float] = None,
+) -> List[Dict[str, Any]]:
+    """Claim 'failed' rows for a platform so a just-reconnected gateway can
+    retry them without waiting for a restart.
+
+    The startup sweep (``sweep_recoverable``) only claims rows owned by a
+    DEAD process, so a final response definitively rejected while this
+    gateway stayed alive — typically during the network outage that also
+    dropped the adapter — would otherwise sit undelivered until the next
+    boot. Firing after a successful reconnect closes that gap: the platform
+    is known-good again, so a rejected send is worth one more attempt.
+
+    Claiming atomically re-stamps the owner to THIS process, sets
+    ``state='attempting'`` and increments ``attempts`` (the redelivery
+    budget), so a concurrent sweep cannot double-claim. Rows over the
+    attempts cap or older than the stale cutoff transition to 'abandoned'
+    instead of being returned, and rows owned by a DIFFERENT live process
+    are left untouched (that process owns their retry budget).
+    """
+    now = now if now is not None else time.time()
+    pid, started = _owner_stamp()
+    claimed: List[Dict[str, Any]] = []
+    with _DB_LOCK, _transaction() as conn:
+        rows = conn.execute(
+            """SELECT obligation_id, session_key, platform, chat_id, thread_id,
+                      content, state, attempts, created_at,
+                      owner_pid, owner_started_at
+               FROM delivery_obligations
+               WHERE state='failed' AND platform=?""",
+            (platform,),
+        ).fetchall()
+        for (oid, session_key, row_platform, chat_id, thread_id, content, state,
+             attempts, created_at, owner_pid, owner_started_at) in rows:
+            if attempts >= MAX_ATTEMPTS or (now - created_at) > STALE_AFTER_SECONDS:
+                conn.execute(
+                    """UPDATE delivery_obligations
+                       SET state='abandoned', updated_at=? WHERE obligation_id=?""",
+                    (now, oid),
+                )
+                continue
+            if _owner_alive(owner_pid, owner_started_at) and owner_pid != pid:
+                # Another live gateway still owns this row — it owns the
+                # retry budget and will redeliver (or abandon) it.
+                continue
+            cursor = conn.execute(
+                """UPDATE delivery_obligations
+                   SET owner_pid=?, owner_started_at=?, state='attempting',
+                       attempts=attempts+1, updated_at=?
+                   WHERE obligation_id=? AND (owner_pid IS ? OR owner_pid=?)""",
+                (pid, started, now, oid, owner_pid, owner_pid),
+            )
+            if cursor.rowcount:
+                claimed.append({
+                    "obligation_id": oid,
+                    "session_key": session_key,
+                    "platform": row_platform,
+                    "chat_id": chat_id,
+                    "thread_id": thread_id,
+                    "content": content,
+                    # failed = definitively rejected once; a resend may
+                    # duplicate, so the marker labels the at-least-once retry.
+                    "needs_marker": True,
                     "attempts": attempts + 1,
                 })
     return claimed

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10805,10 +10805,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         try:
             from gateway.delivery_ledger import (
-                RECOVERED_MARKER,
                 ledger_enabled,
-                mark_delivered,
-                mark_failed,
                 sweep_recoverable,
             )
 
@@ -10826,8 +10823,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.debug("delivery ledger sweep failed", exc_info=True)
             return 0
+        return await self._redeliver_claimed_rows(claimed)
+
+    async def _redeliver_claimed_rows(
+        self, claimed: List[Dict[str, Any]]
+    ) -> int:
+        """Send claimed ledger rows and update their state.
+
+        Shared by the startup sweep (``_redeliver_pending_obligations``) and
+        the runtime reconnect path
+        (``_redeliver_failed_obligations_for_platform``): each row is
+        already claimed (owner re-stamped, attempts spent), so this only
+        performs the send and records delivered/failed. Returns the number
+        of successful redeliveries.
+        """
         if not claimed:
             return 0
+        from gateway.delivery_ledger import (
+            RECOVERED_MARKER,
+            mark_delivered,
+            mark_failed,
+        )
 
         redelivered = 0
         for row in claimed:
@@ -10841,8 +10857,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
             adapter = self.adapters.get(platform)
             if adapter is None:
-                # Platform not connected this boot — leave the row claimed;
-                # attempts cap + stale cutoff bound the retries on later boots.
+                # Platform not connected — leave the row claimed; attempts
+                # cap + stale cutoff bound the retries on later sweeps/boots.
                 continue
             content = row["content"]
             if row.get("needs_marker"):
@@ -10893,6 +10909,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         exc_info=True,
                     )
         return redelivered
+
+    async def _redeliver_failed_obligations_for_platform(self, platform) -> int:
+        """Retry final responses that were definitively rejected for a
+        platform which just reconnected — the runtime counterpart of the
+        startup sweep.
+
+        The startup sweep only redelivers rows owned by a DEAD process, so a
+        rejection that happened while this gateway stayed alive (e.g. the
+        network outage that also dropped the adapter) would otherwise sit in
+        the ledger until the next restart. Firing after a successful
+        reconnect closes that gap: the platform is known-good again, so the
+        failed send is worth one more attempt. Returns the number of
+        redeliveries attempted.
+        """
+        try:
+            from gateway.delivery_ledger import (
+                ledger_enabled,
+                sweep_failed_for_runtime,
+            )
+
+            if not await asyncio.to_thread(ledger_enabled):
+                return 0
+            claimed = await asyncio.to_thread(
+                sweep_failed_for_runtime,
+                getattr(platform, "value", str(platform)),
+            )
+        except Exception:
+            logger.debug(
+                "delivery ledger runtime sweep failed", exc_info=True
+            )
+            return 0
+        return await self._redeliver_claimed_rows(claimed)
 
     def _schedule_resume_pending_sessions(self, platform=None) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.
@@ -13067,6 +13115,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         except Exception:
                             logger.debug(
                                 "resume-pending reschedule after %s reconnect failed",
+                                platform.value,
+                                exc_info=True,
+                            )
+                        # Final responses that were definitively rejected
+                        # while this platform was down are now retryable. The
+                        # delivery ledger only redelivers on restart, so
+                        # without this a rejection during a live gateway's
+                        # outage (the same outage that dropped the adapter)
+                        # would sit undelivered until the next boot.
+                        try:
+                            await self._redeliver_failed_obligations_for_platform(
+                                platform
+                            )
+                        except Exception:
+                            logger.debug(
+                                "failed-obligation redelivery after %s "
+                                "reconnect failed",
                                 platform.value,
                                 exc_info=True,
                             )

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -9,6 +9,7 @@ id stability, and the startup redelivery sweep's contract:
 - poison rows abandon at the attempts cap / stale cutoff
 """
 
+import os
 import time
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -220,6 +221,171 @@ class TestGatewayRedeliverySweep:
             )
 
         assert blocked_event_loop == []
+
+
+class TestRuntimeFailedSweep:
+    """``sweep_failed_for_runtime``: the runtime redelivery path that fires
+    after a platform reconnects, without waiting for a restart.
+
+    The startup sweep only claims rows owned by a DEAD process, so a final
+    response definitively rejected while this gateway stayed alive (e.g. the
+    network outage that also dropped the adapter) would otherwise sit in the
+    ledger until the next boot. This sweep claims exactly those rows for a
+    platform that just reconnected. The attempts cap and stale cutoff still
+    bound poison rows, and a different live process's rows are never stolen.
+    """
+
+    def _failed(self, oid="ob-1", **kw):
+        _record(oid=oid, **kw)
+        dl.mark_failed(oid, "send_path_degraded")
+
+    def test_failed_row_claimed_for_platform_with_marker(self):
+        self._failed()
+
+        claimed = dl.sweep_failed_for_runtime("slack")
+
+        assert len(claimed) == 1
+        assert claimed[0]["obligation_id"] == "ob-1"
+        # A previous rejection means a resend MIGHT duplicate — the marker
+        # keeps the at-least-once contract honest (same as the startup path).
+        assert claimed[0]["needs_marker"] is True
+        assert claimed[0]["attempts"] == 1
+        row = _row("ob-1")
+        assert row["state"] == "attempting"  # claimed → about to send
+        # Claim re-stamps ownership: a second sweep must not double-claim.
+        assert dl.sweep_failed_for_runtime("slack") == []
+
+    def test_other_platform_failed_rows_not_claimed(self):
+        self._failed(oid="ob-slack", platform="slack")
+        self._failed(
+            oid="ob-tg", platform="telegram",
+            session_key="agent:main:telegram:group:1",
+        )
+
+        claimed = dl.sweep_failed_for_runtime("slack")
+
+        assert [c["obligation_id"] for c in claimed] == ["ob-slack"]
+        assert _row("ob-tg")["state"] == "failed"
+
+    def test_other_live_process_rows_not_stolen(self):
+        """A failed row owned by a DIFFERENT live process is left alone —
+        that process owns the retry budget and will redeliver (or abandon)
+        it. Only rows owned by ourselves or by a dead process are claimed."""
+        self._failed()
+        with dl._connect() as conn:
+            conn.execute(
+                "UPDATE delivery_obligations SET owner_pid=?, owner_started_at=NULL "
+                "WHERE obligation_id=?",
+                (os.getppid(), "ob-1"),  # our parent is alive for this test
+            )
+
+        assert dl.sweep_failed_for_runtime("slack") == []
+        assert _row("ob-1")["state"] == "failed"
+
+    def test_rows_over_attempts_cap_abandoned_not_claimed(self):
+        self._failed()
+        with dl._connect() as conn:
+            conn.execute(
+                "UPDATE delivery_obligations SET attempts=? WHERE obligation_id=?",
+                (dl.MAX_ATTEMPTS, "ob-1"),
+            )
+
+        assert dl.sweep_failed_for_runtime("slack") == []
+        assert _row("ob-1")["state"] == "abandoned"
+
+    def test_stale_failed_row_abandoned_not_claimed(self):
+        self._failed()
+        with dl._connect() as conn:
+            conn.execute(
+                "UPDATE delivery_obligations SET created_at=? WHERE obligation_id=?",
+                (time.time() - dl.STALE_AFTER_SECONDS - 60, "ob-1"),
+            )
+
+        assert dl.sweep_failed_for_runtime("slack") == []
+        assert _row("ob-1")["state"] == "abandoned"
+
+
+class TestRuntimeFailedRedelivery:
+    """Drive GatewayRunner._redeliver_failed_obligations_for_platform — the
+    runtime counterpart of the startup sweep, fired when a platform
+    reconnects after an outage. Uses the same real ledger + real adapter
+    harness as TestGatewayRedeliverySweep."""
+
+    @staticmethod
+    def _runner(adapter=None):
+        from gateway.config import Platform
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.adapters = {Platform.SLACK: adapter} if adapter else {}
+        _store = MagicMock()
+        _store.clear_resume_pending = AsyncMock()
+        _store._store = None
+        runner.session_store = None
+        runner._async_session_store = _store
+        return runner
+
+    @staticmethod
+    def _adapter(success=True):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=MagicMock(success=success, error="" if success else "nope")
+        )
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_failed_row_redelivered_with_marker(self):
+        from gateway.config import Platform
+
+        _record()  # slack, pending
+        dl.mark_failed("ob-1", "send_path_degraded")
+        adapter = self._adapter()
+        runner = self._runner(adapter)
+
+        n = await runner._redeliver_failed_obligations_for_platform(Platform.SLACK)
+
+        assert n == 1
+        sent = adapter.send.call_args.kwargs
+        assert sent["content"].startswith(dl.RECOVERED_MARKER)
+        assert sent["content"].endswith("the final answer")
+        assert _row("ob-1")["state"] == "delivered"
+        runner._async_session_store.clear_resume_pending.assert_awaited_once_with(
+            "agent:main:slack:channel:C1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_failed_send_marks_failed_again_without_crash(self):
+        from gateway.config import Platform
+
+        _record()
+        dl.mark_failed("ob-1", "send_path_degraded")
+        adapter = self._adapter(success=False)
+        runner = self._runner(adapter)
+
+        n = await runner._redeliver_failed_obligations_for_platform(Platform.SLACK)
+
+        assert n == 0
+        assert _row("ob-1")["state"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_other_platform_failed_rows_not_redelivered(self):
+        from gateway.config import Platform
+
+        _record(oid="ob-slack", platform="slack")
+        _record(
+            oid="ob-tg", platform="telegram",
+            session_key="agent:main:telegram:group:1",
+        )
+        dl.mark_failed("ob-slack", "x")
+        dl.mark_failed("ob-tg", "x")
+        adapter = self._adapter()
+        runner = self._runner(adapter)  # only the slack adapter is connected
+
+        n = await runner._redeliver_failed_obligations_for_platform(Platform.SLACK)
+
+        assert n == 1
+        assert _row("ob-slack")["state"] == "delivered"
+        assert _row("ob-tg")["state"] == "failed"
 
 
 class TestAttemptsOnlySpentOnRealSends:

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -11,6 +11,19 @@ from gateway.platforms.base import BasePlatformAdapter, SendResult
 from gateway.run import GatewayRunner
 
 
+@pytest.fixture(autouse=True)
+def _fresh_ledger_db(tmp_path, monkeypatch):
+    """Isolated state.db for ledger-backed reconnect tests (the conftest
+    HERMES_HOME redirect already isolates get_hermes_home; make the redirect
+    explicit and per-test, matching tests/gateway/test_delivery_ledger.py)."""
+    from gateway import delivery_ledger as dl
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(dl, "_db_path", lambda: home / "state.db")
+    yield
+
+
 class StubAdapter(BasePlatformAdapter):
     """Adapter whose connect() result can be controlled."""
 
@@ -262,6 +275,79 @@ class TestPlatformReconnectWatcher:
             platform=Platform.TELEGRAM
         )
 
+    @pytest.mark.asyncio
+    async def test_reconnect_redelivers_failed_obligations_for_platform(self):
+        """A successful reconnect retries final responses that were rejected
+        while the platform was down.
+
+        Regression: the delivery ledger only redelivered rows owned by a DEAD
+        process at startup, so a definitive rejection during a live gateway's
+        network outage (the very outage that also dropped the adapter) sat
+        undelivered until the next restart. The watcher now sweeps the
+        platform's failed obligations right after it reconnects.
+        """
+        from gateway import delivery_ledger as dl
+
+        dl.record_obligation(
+            obligation_id="ob-tg-1",
+            session_key="agent:main:telegram:group:1",
+            platform="telegram",
+            chat_id="123",
+            thread_id=None,
+            content="final answer",
+        )
+        dl.mark_failed("ob-tg-1", "send_path_degraded")
+
+        runner = _make_runner()
+        runner._sync_voice_mode_state_to_adapter = MagicMock()
+        runner._schedule_resume_pending_sessions = MagicMock(return_value=1)
+        _store = MagicMock()
+        _store.clear_resume_pending = AsyncMock()
+        runner._async_session_store = _store
+
+        platform_config = PlatformConfig(enabled=True, token="test")
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 1,
+            "next_retry": time.monotonic() - 1,
+        }
+
+        succeed_adapter = StubAdapter(succeed=True)
+        succeed_adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="redelivered")
+        )
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter", return_value=succeed_adapter):
+            with patch("gateway.run.build_channel_directory", create=True):
+                async def run_one_iteration():
+                    runner._running = True
+                    call_count = 0
+
+                    async def fake_sleep(n):
+                        nonlocal call_count
+                        call_count += 1
+                        if call_count > 1:
+                            runner._running = False
+                        await real_sleep(0)
+
+                    with patch("asyncio.sleep", side_effect=fake_sleep):
+                        await runner._platform_reconnect_watcher()
+
+                await run_one_iteration()
+
+        assert Platform.TELEGRAM in runner.adapters
+        succeed_adapter.send.assert_awaited_once()
+        sent = succeed_adapter.send.call_args.kwargs
+        assert sent["chat_id"] == "123"
+        assert sent["content"].startswith(dl.RECOVERED_MARKER)
+        assert sent["content"].endswith("final answer")
+        with dl._connect() as conn:
+            state = conn.execute(
+                "SELECT state FROM delivery_obligations WHERE obligation_id=?",
+                ("ob-tg-1",),
+            ).fetchone()[0]
+        assert state == "delivered"
 
     @pytest.mark.asyncio
     async def test_reconnect_never_auto_pauses_retryable_failures(self):


### PR DESCRIPTION
## What

When a gateway's Telegram adapter dropped during a network outage and a final agent response was rejected with `send_path_degraded`, the reply sat in the delivery ledger (`state='failed'`) for ~37 minutes — until a gateway restart triggered redelivery.

## Root cause

The delivery ledger only redelivers at startup:

- `sweep_recoverable()` in `gateway/delivery_ledger.py` claims rows owned by a **dead** process (`_owner_alive()` check).
- `GatewayRunner._redeliver_pending_obligations()` runs once at startup (`gateway/run.py`).

A definitive rejection that happens while the gateway stays alive — typically during the same network trouble that dropped the adapter — is never retried until the next boot.

## Fix

- **`gateway/delivery_ledger.py`** — new `sweep_failed_for_runtime(platform)` that atomically claims the platform's `failed` rows (owner re-stamp, `attempts+1`, `state='attempting'`, `needs_marker=True`). Rows over `MAX_ATTEMPTS` or the stale cutoff transition to `abandoned` instead of being returned, and rows owned by a *different* live process are never stolen.
- **`gateway/run.py`** — the reconnect watcher now calls `_redeliver_failed_obligations_for_platform(platform)` right after a successful reconnect, resending claimed rows with the recovered-reply marker (honest at-least-once, same contract as the startup path). The startup send loop is extracted into `_redeliver_claimed_rows()` so both paths share the send/update code.

## Tests

All written test-first (RED → GREEN):

- **Ledger** (`sweep_failed_for_runtime`): claim with marker, platform scoping, attempts-cap abandonment, stale abandonment, other-live-owner rows not stolen (guard proven by temporarily disabling it).
- **Runner** (`_redeliver_failed_obligations_for_platform`): redelivery sends marked content and clears `resume_pending`; a failed resend re-marks `failed`; platform scoping.
- **Watcher end-to-end** (`_platform_reconnect_watcher`): a failed Telegram obligation is resent and marked `delivered` when the reconnect watcher brings the platform back.

## Verification

- `tests/gateway/test_delivery_ledger.py`, `test_platform_reconnect.py`: all green.
- Ledger-adjacent + restart/redelivery files: all green.
- Full `tests/gateway/` suite: no regression attributable to this change — the same timing-sensitive tests (`test_session_hygiene`, `test_73771_media_resend_dedup`, `test_pending_drain_no_recursion`, etc.) fail identically on clean `main`.
