### PR TITLE
fix: harden LSP lifecycle and bound Pyright validation

### DIFF
--- a/agent/lsp/__init__.py
+++ b/agent/lsp/__init__.py
@@ -90,10 +90,28 @@ def get_service() -> Optional[LSPService]:
 
 
 def shutdown_service() -> None:
-    """Tear down the LSP service if one was started.
+    """Tear down the active profile's LSP service if one was started.
 
+    Explicit restart/shutdown commands run in one active Hermes profile and
+    must not terminate language servers owned by another multiplexed profile.
     Safe to call multiple times; safe to call when no service was created.
     """
+    global _service, _service_scope
+    scope = _current_scope()
+    with _service_lock:
+        service = _services.pop(scope, None)
+        if _service_scope == scope:
+            _service = None
+            _service_scope = None
+    if service is not None:
+        try:
+            service.shutdown()
+        except Exception as e:  # noqa: BLE001
+            logger.debug("LSP shutdown error: %s", e)
+
+
+def _shutdown_all_services() -> None:
+    """Tear down every profile service during process exit."""
     global _service, _service_scope
     with _service_lock:
         services = list(_services.values())
@@ -102,9 +120,9 @@ def shutdown_service() -> None:
         _services.clear()
         _service = None
         _service_scope = None
-    for svc in services:
+    for service in services:
         try:
-            svc.shutdown()
+            service.shutdown()
         except Exception as e:  # noqa: BLE001
             logger.debug("LSP shutdown error: %s", e)
 
@@ -114,7 +132,7 @@ def _atexit_shutdown() -> None:
     atexit fires the user has already seen the agent's final output —
     a noisy shutdown line on top of that is just clutter."""
     try:
-        shutdown_service()
+        _shutdown_all_services()
     except Exception as e:  # noqa: BLE001
         logger.debug("atexit LSP shutdown failed: %s", e)
 

--- a/agent/lsp/__init__.py
+++ b/agent/lsp/__init__.py
@@ -34,33 +34,45 @@ import threading
 from typing import Optional
 
 from agent.lsp.manager import LSPService
+from hermes_constants import hermes_home_key
 
 logger = logging.getLogger("agent.lsp")
 
 _service: Optional[LSPService] = None
+_service_scope: Optional[str] = None
+_services: dict[str, LSPService] = {}
 _atexit_registered = False
 _service_lock = threading.Lock()
 
 
+def _current_scope() -> str:
+    """Return the active profile/home key for service isolation."""
+    return hermes_home_key()
+
+
 def get_service() -> Optional[LSPService]:
-    """Return the process-wide LSP service singleton, or None when disabled.
+    """Return the active profile/home-scoped LSP service, or None when disabled.
 
     The service is created lazily on first call.  ``None`` is returned
     when LSP is disabled in config, when no workspace can be detected,
     or when the platform doesn't support subprocess-based LSP servers.
+    Services are shared within one Hermes home and isolated across homes,
+    so a multiplexed process cannot reuse another profile's clients.
 
     On first creation, registers an :mod:`atexit` handler that tears
     down spawned language servers on Python exit so a long-running
     CLI or gateway session doesn't leak pyright/gopls/etc. processes
     when it terminates.
     """
-    global _service, _atexit_registered
-    if _service is not None:
-        return _service if _service.is_active() else None
+    global _service, _service_scope, _atexit_registered
+    scope = _current_scope()
     with _service_lock:
-        if _service is not None:
-            return _service if _service.is_active() else None
-        _service = LSPService.create_from_config()
+        _service = _services.get(scope)
+        _service_scope = scope
+        if _service is None:
+            _service = LSPService.create_from_config()
+            if _service is not None:
+                _services[scope] = _service
         if not _atexit_registered:
             # ``atexit`` handlers run in LIFO order on normal Python
             # exit and on SystemExit, but NOT on os._exit() or
@@ -82,11 +94,15 @@ def shutdown_service() -> None:
 
     Safe to call multiple times; safe to call when no service was created.
     """
-    global _service
+    global _service, _service_scope
     with _service_lock:
-        svc = _service
+        services = list(_services.values())
+        if _service is not None and _service not in services:
+            services.append(_service)
+        _services.clear()
         _service = None
-    if svc is not None:
+        _service_scope = None
+    for svc in services:
         try:
             svc.shutdown()
         except Exception as e:  # noqa: BLE001

--- a/agent/lsp/cli.py
+++ b/agent/lsp/cli.py
@@ -15,6 +15,7 @@ The handlers are kept here (rather than in
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 
 
@@ -55,6 +56,41 @@ def register_subparser(subparsers: argparse._SubParsersAction) -> None:
         help="Even attempt servers marked manual-install (best effort)",
     )
 
+    sub_validate = sub.add_parser(
+        "validate",
+        help="Run an explicit bounded full-project Pyright check",
+    )
+    sub_validate.add_argument(
+        "--project",
+        dest="project_config",
+        help="Repository pyrightconfig.json or pyproject.toml",
+    )
+    sub_validate.add_argument(
+        "--include",
+        action="append",
+        default=[],
+        help="Include path relative to the repository (repeatable; default: repository root)",
+    )
+    sub_validate.add_argument(
+        "--exclude",
+        action="append",
+        dest="exclude",
+        default=None,
+        help="Exclude path relative to the repository (repeatable)",
+    )
+    sub_validate.add_argument(
+        "--timeout",
+        type=float,
+        default=300.0,
+        help="Maximum Pyright runtime in seconds",
+    )
+    sub_validate.add_argument(
+        "--term-grace",
+        type=float,
+        default=2.0,
+        help="Grace after TERM before KILL, in seconds",
+    )
+
     sub.add_parser(
         "restart",
         help="Tear down running LSP clients (next edit re-spawns)",
@@ -78,6 +114,14 @@ def run_lsp_command(args: argparse.Namespace) -> int:
             return _cmd_install(args.server)
         if sub == "install-all":
             return _cmd_install_all(getattr(args, "include_manual", False))
+        if sub == "validate":
+            return _cmd_validate(
+                getattr(args, "project_config", None),
+                getattr(args, "include", []),
+                getattr(args, "exclude", None),
+                getattr(args, "timeout", 300.0),
+                getattr(args, "term_grace", 2.0),
+            )
         if sub == "restart":
             return _cmd_restart()
         if sub == "which":
@@ -122,7 +166,9 @@ def _cmd_status(emit_json: bool) -> int:
         out.append(f"  wait_mode:       {info.get('wait_mode')}")
         out.append(f"  wait_timeout:    {info.get('wait_timeout')}s")
         out.append(f"  install_strategy:{info.get('install_strategy')}")
-        clients = info.get("clients") or []
+        clients = info.get("clients")
+        if not isinstance(clients, list):
+            clients = []
         if clients:
             out.append(f"  active clients:  {len(clients)}")
             for c in clients:
@@ -131,12 +177,16 @@ def _cmd_status(emit_json: bool) -> int:
                 )
         else:
             out.append("  active clients:  none")
-        broken = info.get("broken") or []
+        broken = info.get("broken")
+        if not isinstance(broken, list):
+            broken = []
         if broken:
             out.append(f"  broken pairs:    {len(broken)}")
             for b in broken:
                 out.append(f"    - {b}")
-        disabled = info.get("disabled_servers") or []
+        disabled = info.get("disabled_servers")
+        if not isinstance(disabled, list):
+            disabled = []
         if disabled:
             out.append(f"  disabled in cfg: {', '.join(disabled)}")
 
@@ -244,6 +294,42 @@ def _cmd_restart() -> int:
     shutdown_service()
     sys.stdout.write("LSP service shut down. Next edit will respawn clients.\n")
     return 0
+
+
+def _cmd_validate(
+    project_config: str | None,
+    include: list[str],
+    exclude: list[str] | None,
+    timeout: float,
+    term_grace: float,
+) -> int:
+    from agent.lsp.validation import DEFAULT_EXCLUDES, run_full_project_check
+    from agent.lsp.workspace import find_git_worktree
+
+    workspace = find_git_worktree(os.getcwd())
+    if workspace is None:
+        sys.stderr.write("lsp validate requires a git workspace\n")
+        return 2
+    try:
+        result = run_full_project_check(
+            workspace,
+            project_config=project_config,
+            include=include,
+            exclude=exclude if exclude is not None else DEFAULT_EXCLUDES,
+            timeout=timeout,
+            term_grace=term_grace,
+        )
+    except (FileNotFoundError, NotADirectoryError, ValueError) as exc:
+        sys.stderr.write(f"lsp validate: {exc}\n")
+        return 2
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    if result.timed_out:
+        sys.stderr.write("lsp validate: timed out; process group terminated\n")
+        return 124
+    return result.returncode
 
 
 def _cmd_which(server_id: str) -> int:

--- a/agent/lsp/cli.py
+++ b/agent/lsp/cli.py
@@ -315,7 +315,7 @@ def _cmd_validate(
             workspace,
             project_config=project_config,
             include=include,
-            exclude=exclude if exclude is not None else DEFAULT_EXCLUDES,
+            exclude=tuple(dict.fromkeys((*DEFAULT_EXCLUDES, *(exclude or ())))),
             timeout=timeout,
             term_grace=term_grace,
         )

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -55,7 +55,7 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Set
 from urllib.parse import quote, unquote
 
 import psutil
@@ -89,6 +89,45 @@ SHUTDOWN_GRACE = 1.0  # seconds between SIGTERM and SIGKILL
 # Retry policy for transient ContentModified errors.
 MAX_CONTENT_MODIFIED_RETRIES = 3
 RETRY_BASE_DELAY = 0.5  # 0.5, 1.0, 2.0 — exponential
+
+
+def _refresh_owned_descendants(
+    owner: Optional[psutil.Process],
+    known: Sequence[psutil.Process],
+) -> list[psutil.Process]:
+    """Re-collect the owned tree, including descendants of known children."""
+    if owner is None:
+        return list(known)
+    seeds = [owner, *known]
+    refreshed: list[psutil.Process] = []
+    seen: set[int] = set()
+    for seed in seeds:
+        try:
+            children = seed.children(recursive=True)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        for child in children:
+            child_pid = getattr(child, "pid", id(child))
+            if child_pid in seen:
+                continue
+            seen.add(child_pid)
+            refreshed.append(child)
+    for child in known:
+        child_pid = getattr(child, "pid", id(child))
+        if child_pid not in seen:
+            seen.add(child_pid)
+            refreshed.append(child)
+    return refreshed
+
+
+def _any_process_alive(processes: Sequence[psutil.Process]) -> bool:
+    for process in processes:
+        try:
+            if process.is_running() and process.status() != psutil.STATUS_ZOMBIE:
+                return True
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError, AttributeError):
+            continue
+    return False
 
 
 def file_uri(path: str) -> str:
@@ -536,41 +575,49 @@ class LSPClient:
         if proc is None:
             return
 
-        # Capture descendants before signaling the root.  Process groups are
-        # the primary POSIX cleanup mechanism, while the snapshot also covers
-        # a child that deliberately creates a new session and is required for
-        # Windows where process-group signals are unavailable.
-        descendants = []
-        try:
-            descendants = psutil.Process(proc.pid).children(recursive=True)
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            pass
-
+        pid = getattr(proc, "pid", None)
+        owner = None
+        if pid is not None:
+            try:
+                owner = psutil.Process(pid)
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        current = _refresh_owned_descendants(owner, ())
+        # Detached descendants are outside the process group, so signal the
+        # exact tree before terminating the owned group.  Re-collect during
+        # the grace window to catch a child that creates a grandchild after
+        # the first snapshot.
+        self._terminate_processes(current, force=False)
         if pgid is not None:
             try:
                 os.killpg(pgid, signal.SIGTERM)
             except (ProcessLookupError, OSError):
                 pass
         else:
-            self._terminate_processes([*descendants, proc], force=False)
+            self._terminate_processes([proc], force=False)
 
         deadline = asyncio.get_running_loop().time() + SHUTDOWN_GRACE
-        if proc.returncode is None:
-            try:
-                remaining = max(0.0, deadline - asyncio.get_running_loop().time())
-                await asyncio.wait_for(proc.wait(), timeout=remaining)
-            except (asyncio.TimeoutError, ProcessLookupError):
-                pass
-        remaining = max(0.0, deadline - asyncio.get_running_loop().time())
-        if remaining:
-            await asyncio.sleep(remaining)
+        while asyncio.get_running_loop().time() < deadline:
+            current = _refresh_owned_descendants(owner, current)
+            self._terminate_processes(current, force=False)
+            if proc.returncode is not None and not _any_process_alive(current):
+                break
+            await asyncio.sleep(
+                min(
+                    0.05,
+                    max(0.0, deadline - asyncio.get_running_loop().time()),
+                )
+            )
 
+        # Always take a latest snapshot immediately before KILL.  A detached
+        # child may have created a new session and a grandchild during TERM.
+        current = _refresh_owned_descendants(owner, current)
         if pgid is not None:
             try:
                 os.killpg(pgid, signal.SIGKILL)
             except (ProcessLookupError, OSError):
                 pass
-        self._terminate_processes([*descendants, proc], force=True)
+        self._terminate_processes(current, force=True)
         if proc.returncode is None:
             try:
                 await proc.wait()

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -355,20 +355,23 @@ class LSPClient:
         proc = self._proc
         if proc is None or os.name == "nt":
             return
+        pid = getattr(proc, "pid", None)
+        if pid is None:
+            return
         try:
-            pgid = os.getpgid(proc.pid)
+            pgid = os.getpgid(pid)
         except ProcessLookupError:
             # ``start_new_session`` makes the child PID its group ID.  If
             # the parent exited before getpgid(), retaining that ID still
-            # lets cleanup reap a descendant that outlived its parent.
-            pgid = proc.pid
+            # lets cleanup reap a descendant that outlived the parent.
+            pgid = pid
         except OSError:
             return
         try:
             # ``start_new_session`` owns the group whose id is the child PID.
             # Refuse to signal a group the child joined later because it may
             # contain unrelated processes.
-            if pgid == proc.pid and pgid != os.getpgrp():
+            if pgid == pid and pgid != os.getpgrp():
                 self._pgid = pgid
         except OSError:
             return

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -50,11 +50,15 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import signal
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
 from urllib.parse import quote, unquote
+
+import psutil
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 
@@ -205,6 +209,10 @@ class LSPClient:
 
         # Process + streams
         self._proc: Optional[asyncio.subprocess.Process] = None
+        # ``start_new_session`` gives POSIX servers an owned process group.
+        # Keep the group id as soon as the child is returned so cancellation
+        # during initialize can still reap descendants.
+        self._pgid: Optional[int] = None
         self._stderr_task: Optional[asyncio.Task] = None
         self._reader_task: Optional[asyncio.Task] = None
 
@@ -275,7 +283,7 @@ class LSPClient:
             await self._spawn()
             await self._initialize()
             self._state = "running"
-        except Exception:
+        except BaseException:
             self._state = "error"
             await self._cleanup_process()
             raise
@@ -302,16 +310,15 @@ class LSPClient:
         # a VS Code/Zed extension running the ACP adapter.
         # windows_hide_flags() is CREATE_NO_WINDOW on Windows, 0 on POSIX.
         creationflags = windows_hide_flags()
+        if sys.platform == "win32":
+            creationflags |= getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
 
-        try:
-            # start_new_session=True detaches the LSP server into its own
-            # process group / session. Without this, the LSP server inherits
-            # the gateway's pgid (= TUI parent PID). When mcp_tool's
-            # _kill_orphaned_mcp_children races with LSP spawn and sweeps the
-            # gateway's child set, it captures the LSP PID, records the
-            # inherited pgid, and killpg() then kills the TUI parent itself.
-            # See tui_gateway_crash.log "killpg → SIGTERM received" stacks.
-            self._proc = await asyncio.create_subprocess_exec(
+        # Shield process creation from cancellation.  ``create_subprocess_exec``
+        # can finish spawning after the caller is cancelled; awaiting the
+        # shielded task lets us record the PID and group before propagating the
+        # cancellation into ``start``'s cleanup path.
+        spawn_task = asyncio.create_task(
+            asyncio.create_subprocess_exec(
                 cmd[0],
                 *cmd[1:],
                 stdin=asyncio.subprocess.PIPE,
@@ -322,16 +329,49 @@ class LSPClient:
                 start_new_session=True,
                 creationflags=creationflags,
             )
+        )
+        try:
+            proc = await asyncio.shield(spawn_task)
+        except asyncio.CancelledError:
+            proc = await spawn_task
+            self._proc = proc
+            self._record_process_group()
+            raise
         except FileNotFoundError as e:
             raise LSPProtocolError(
                 f"LSP server binary not found: {cmd[0]} ({e})"
             ) from e
+        self._proc = proc
+        self._record_process_group()
 
         # Drain stderr at debug level — if we don't, the pipe buffer
         # fills and the server hangs.
         self._stderr_task = asyncio.create_task(self._drain_stderr())
         # Start the reader loop.
         self._reader_task = asyncio.create_task(self._reader_loop())
+
+    def _record_process_group(self) -> None:
+        """Record the process group owned by the just-spawned server."""
+        proc = self._proc
+        if proc is None or os.name == "nt":
+            return
+        try:
+            pgid = os.getpgid(proc.pid)
+        except ProcessLookupError:
+            # ``start_new_session`` makes the child PID its group ID.  If
+            # the parent exited before getpgid(), retaining that ID still
+            # lets cleanup reap a descendant that outlived its parent.
+            pgid = proc.pid
+        except OSError:
+            return
+        try:
+            # ``start_new_session`` owns the group whose id is the child PID.
+            # Refuse to signal a group the child joined later because it may
+            # contain unrelated processes.
+            if pgid == proc.pid and pgid != os.getpgrp():
+                self._pgid = pgid
+        except OSError:
+            return
 
     async def _drain_stderr(self) -> None:
         if self._proc is None or self._proc.stderr is None:
@@ -487,21 +527,68 @@ class LSPClient:
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
         proc = self._proc
+        pgid = self._pgid
         self._proc = None
+        self._pgid = None
         if proc is None:
             return
+
+        # Capture descendants before signaling the root.  Process groups are
+        # the primary POSIX cleanup mechanism, while the snapshot also covers
+        # a child that deliberately creates a new session and is required for
+        # Windows where process-group signals are unavailable.
+        descendants = []
+        try:
+            descendants = psutil.Process(proc.pid).children(recursive=True)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+        if pgid is not None:
+            try:
+                os.killpg(pgid, signal.SIGTERM)
+            except (ProcessLookupError, OSError):
+                pass
+        else:
+            self._terminate_processes([*descendants, proc], force=False)
+
+        deadline = asyncio.get_running_loop().time() + SHUTDOWN_GRACE
         if proc.returncode is None:
             try:
-                proc.terminate()
-                try:
-                    await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
-                except asyncio.TimeoutError:
-                    try:
-                        proc.kill()
-                        await proc.wait()
-                    except ProcessLookupError:
-                        pass
+                remaining = max(0.0, deadline - asyncio.get_running_loop().time())
+                await asyncio.wait_for(proc.wait(), timeout=remaining)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                pass
+        remaining = max(0.0, deadline - asyncio.get_running_loop().time())
+        if remaining:
+            await asyncio.sleep(remaining)
+
+        if pgid is not None:
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
+        self._terminate_processes([*descendants, proc], force=True)
+        if proc.returncode is None:
+            try:
+                await proc.wait()
             except ProcessLookupError:
+                pass
+
+    @staticmethod
+    def _terminate_processes(processes: list, *, force: bool) -> None:
+        """Best-effort fallback for descendants outside the process group."""
+        for process in processes:
+            try:
+                if isinstance(process, psutil.Process):
+                    if not process.is_running():
+                        continue
+                elif process.returncode is not None:
+                    continue
+                if force:
+                    process.kill()
+                else:
+                    process.terminate()
+            except (ProcessLookupError, psutil.NoSuchProcess, OSError, AttributeError):
                 pass
 
     # ------------------------------------------------------------------

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -112,8 +112,8 @@ INSTALL_RECIPES: Dict[str, Dict[str, Any]] = {
 }
 
 
-_install_locks: Dict[str, threading.Lock] = {}
-_install_results: Dict[str, Optional[str]] = {}
+_install_locks: Dict[tuple[str, str], threading.Lock] = {}
+_install_results: Dict[tuple[str, str], Optional[str]] = {}
 _install_lock_meta = threading.Lock()
 _WINDOWS_WRAPPER_SUFFIXES = (".cmd", ".exe", ".bat")
 
@@ -122,11 +122,17 @@ def _is_windows() -> bool:
     return os.name == "nt"
 
 
-def hermes_lsp_bin_dir() -> Path:
-    """Return the Hermes-owned bin staging dir for LSP servers."""
+def _home_key(hermes_home: Optional[str] = None) -> str:
+    if hermes_home is not None:
+        return os.path.abspath(os.path.expanduser(hermes_home))
     from hermes_constants import get_hermes_home
 
-    p = get_hermes_home() / "lsp" / "bin"
+    return str(get_hermes_home())
+
+
+def hermes_lsp_bin_dir(hermes_home: Optional[str] = None) -> Path:
+    """Return the Hermes-owned bin staging dir for LSP servers."""
+    p = Path(_home_key(hermes_home)) / "lsp" / "bin"
     p.mkdir(parents=True, exist_ok=True)
     return p
 
@@ -145,9 +151,9 @@ def _native_binary_candidates(base: Path) -> list[Path]:
     return candidates
 
 
-def _existing_binary(name: str) -> Optional[str]:
+def _existing_binary(name: str, hermes_home: Optional[str] = None) -> Optional[str]:
     """Probe the staging dir + PATH for a binary named ``name``."""
-    for staged in _native_binary_candidates(hermes_lsp_bin_dir() / name):
+    for staged in _native_binary_candidates(hermes_lsp_bin_dir(hermes_home) / name):
         if staged.exists() and os.access(staged, os.X_OK):
             return str(staged)
     on_path = shutil.which(name)
@@ -161,47 +167,55 @@ def _existing_binary(name: str) -> Optional[str]:
     return None
 
 
-def _get_lock(pkg: str) -> threading.Lock:
+def _get_lock(pkg: str, hermes_home: str) -> threading.Lock:
+    key = (hermes_home, pkg)
     with _install_lock_meta:
-        lock = _install_locks.get(pkg)
+        lock = _install_locks.get(key)
         if lock is None:
             lock = threading.Lock()
-            _install_locks[pkg] = lock
+            _install_locks[key] = lock
         return lock
 
 
-def try_install(pkg: str, strategy: str = "auto") -> Optional[str]:
+def try_install(
+    pkg: str,
+    strategy: str = "auto",
+    *,
+    hermes_home: Optional[str] = None,
+) -> Optional[str]:
     """Try to install ``pkg`` and return the binary path if successful.
 
     ``strategy`` is ``"auto"``, ``"manual"``, or ``"off"``.  In
     ``manual``/``off`` mode, this function only probes for an
     existing binary and returns ``None`` if not found.
 
-    The install is cached per-package — a second call returns the
-    same path (or ``None``) without reinstalling.  Concurrent calls
-    are serialized.
+    The install is cached per-package and per-Hermes home — a second
+    call returns the same path (or ``None``) without reinstalling.
+    Concurrent calls for one profile/package are serialized.
     """
+    home = _home_key(hermes_home)
+    cache_key = (home, pkg)
     if strategy not in {"auto",}:
         # Only ``auto`` triggers an actual install.  In manual/off,
         # we still check whether the binary already exists.
         recipe = INSTALL_RECIPES.get(pkg, {})
         bin_name = recipe.get("bin", pkg)
-        return _existing_binary(bin_name)
+        return _existing_binary(bin_name, home)
 
-    if pkg in _install_results:
-        return _install_results[pkg]
+    if cache_key in _install_results:
+        return _install_results[cache_key]
 
-    lock = _get_lock(pkg)
+    lock = _get_lock(pkg, home)
     with lock:
         # Double-check after acquiring lock.
-        if pkg in _install_results:
-            return _install_results[pkg]
-        result = _do_install(pkg)
-        _install_results[pkg] = result
+        if cache_key in _install_results:
+            return _install_results[cache_key]
+        result = _do_install(pkg, home)
+        _install_results[cache_key] = result
         return result
 
 
-def _do_install(pkg: str) -> Optional[str]:
+def _do_install(pkg: str, hermes_home: str) -> Optional[str]:
     recipe = INSTALL_RECIPES.get(pkg)
     if recipe is None:
         # Not in our registry — best-effort: just probe PATH.
@@ -211,7 +225,7 @@ def _do_install(pkg: str) -> Optional[str]:
     bin_name = recipe.get("bin", pkg)
 
     # Check if already present (shutil.which or staging dir)
-    existing = _existing_binary(bin_name)
+    existing = _existing_binary(bin_name, hermes_home)
     if existing:
         return existing
 
@@ -224,11 +238,12 @@ def _do_install(pkg: str) -> Optional[str]:
             recipe.get("pkg", pkg),
             bin_name,
             extra_pkgs=recipe.get("extra_pkgs") or [],
+            hermes_home=hermes_home,
         )
     if strategy == "go":
-        return _install_go(recipe.get("pkg", pkg), bin_name)
+        return _install_go(recipe.get("pkg", pkg), bin_name, hermes_home)
     if strategy == "pip":
-        return _install_pip(recipe.get("pkg", pkg), bin_name)
+        return _install_pip(recipe.get("pkg", pkg), bin_name, hermes_home)
 
     logger.warning("[install] unknown strategy %r for %s", strategy, pkg)
     return None
@@ -238,6 +253,8 @@ def _install_npm(
     pkg: str,
     bin_name: str,
     extra_pkgs: Optional[list] = None,
+    *,
+    hermes_home: Optional[str] = None,
 ) -> Optional[str]:
     """Install an npm package into our staging dir.
 
@@ -257,7 +274,7 @@ def _install_npm(
     if npm is None:
         logger.info("[install] cannot install %s: no usable npm found", pkg)
         return None
-    staging = hermes_lsp_bin_dir().parent  # <HERMES_HOME>/lsp/
+    staging = hermes_lsp_bin_dir(hermes_home).parent  # <HERMES_HOME>/lsp/
     install_targets = [pkg] + list(extra_pkgs or [])
     try:
         logger.info(
@@ -288,7 +305,7 @@ def _install_npm(
     for c in _native_binary_candidates(nm_bin):
         if c.exists():
             # Symlink into our `lsp/bin/` for stable PATH access.
-            link = hermes_lsp_bin_dir() / c.name
+            link = hermes_lsp_bin_dir(hermes_home) / c.name
             if not link.exists():
                 try:
                     link.symlink_to(c)
@@ -303,13 +320,15 @@ def _install_npm(
     return None
 
 
-def _install_go(pkg: str, bin_name: str) -> Optional[str]:
+def _install_go(
+    pkg: str, bin_name: str, hermes_home: Optional[str] = None
+) -> Optional[str]:
     """Install a Go module to GOBIN=<staging>."""
     go = shutil.which("go")
     if go is None:
         logger.info("[install] cannot install %s: go not on PATH", pkg)
         return None
-    staging = hermes_lsp_bin_dir()
+    staging = hermes_lsp_bin_dir(hermes_home)
     env = dict(os.environ)
     env["GOBIN"] = str(staging)
     try:
@@ -341,7 +360,9 @@ def _install_go(pkg: str, bin_name: str) -> Optional[str]:
     return None
 
 
-def _install_pip(pkg: str, bin_name: str) -> Optional[str]:
+def _install_pip(
+    pkg: str, bin_name: str, hermes_home: Optional[str] = None
+) -> Optional[str]:
     """Install a Python package into a hermes-owned target dir.
 
     We avoid polluting the user's site-packages by using
@@ -350,7 +371,7 @@ def _install_pip(pkg: str, bin_name: str) -> Optional[str]:
     ``<staging>/bin``.  Note: this only works for packages that ship a
     console script.
     """
-    pip_target = hermes_lsp_bin_dir().parent / "python-packages"
+    pip_target = hermes_lsp_bin_dir(hermes_home).parent / "python-packages"
     pip_target.mkdir(parents=True, exist_ok=True)
     try:
         logger.info("[install] pip install --target %s %s", pip_target, pkg)
@@ -376,7 +397,7 @@ def _install_pip(pkg: str, bin_name: str) -> Optional[str]:
     for script_dir in script_dirs:
         for bin_path in _native_binary_candidates(script_dir / bin_name):
             if bin_path.exists():
-                link = hermes_lsp_bin_dir() / bin_path.name
+                link = hermes_lsp_bin_dir(hermes_home) / bin_path.name
                 if not link.exists():
                     try:
                         link.symlink_to(bin_path)

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -55,6 +55,7 @@ from agent.lsp.workspace import (
     clear_cache,
     resolve_workspace_for_file,
 )
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger("agent.lsp.manager")
 
@@ -156,6 +157,7 @@ class LSPService:
         init_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
         disabled_servers: Optional[List[str]] = None,
         idle_timeout: float = DEFAULT_IDLE_TIMEOUT,
+        hermes_home: Optional[str] = None,
     ) -> None:
         self._enabled = enabled
         self._wait_mode = wait_mode if wait_mode in {"document", "full"} else "document"
@@ -166,6 +168,7 @@ class LSPService:
         self._init_overrides = init_overrides or {}
         self._disabled_servers = set(disabled_servers or [])
         self._idle_timeout = idle_timeout
+        self._hermes_home = hermes_home or str(get_hermes_home())
 
         self._loop = _BackgroundLoop()
         if self._enabled:
@@ -175,6 +178,7 @@ class LSPService:
         self._clients: Dict[Tuple[str, str], LSPClient] = {}
         self._broken: set = set()
         self._spawning: Dict[Tuple[str, str], asyncio.Future] = {}
+        self._spawn_tasks: Dict[Tuple[str, str], asyncio.Task] = {}
         self._last_used: Dict[Tuple[str, str], float] = {}
         self._state_lock = threading.Lock()
         self._idle_reaper_task: Optional[asyncio.Task] = None
@@ -196,6 +200,7 @@ class LSPService:
         itself returns ``is_active()`` False when LSP is disabled.
         """
         try:
+            hermes_home = str(get_hermes_home())
             from hermes_cli.config import load_config_readonly
             cfg = load_config_readonly()
         except Exception as e:  # noqa: BLE001
@@ -251,6 +256,7 @@ class LSPService:
             init_overrides=init_overrides,
             disabled_servers=disabled,
             idle_timeout=idle_timeout,
+            hermes_home=hermes_home,
         )
 
     # ------------------------------------------------------------------
@@ -526,8 +532,12 @@ class LSPService:
         srv = find_server_for_file(file_path)
         if not (ws and gated and srv):
             return []
+        try:
+            per_server_root = srv.resolve_root(file_path, ws) or ws
+        except Exception:  # noqa: BLE001
+            per_server_root = ws
         with self._state_lock:
-            client = self._clients.get((srv.server_id, ws))
+            client = self._clients.get((srv.server_id, per_server_root))
         if client is None:
             return []
         return list(client.diagnostics_for(file_path, fresh_only=True))
@@ -562,15 +572,35 @@ class LSPService:
             spawning = self._spawning.get(key)
         if spawning is not None:
             try:
-                return await spawning
+                # A cancelled waiter must not cancel the shared spawn future.
+                return await asyncio.shield(spawning)
+            except asyncio.CancelledError:
+                raise
             except Exception:  # noqa: BLE001
                 return None
 
-        # Begin spawn
+        # Begin one shared spawn.  The second check under the lock closes the
+        # race where two callers both observe no existing client/future.
         loop = asyncio.get_running_loop()
         spawn_future: asyncio.Future = loop.create_future()
         with self._state_lock:
-            self._spawning[key] = spawn_future
+            spawning = self._spawning.get(key)
+            if spawning is None:
+                self._spawning[key] = spawn_future
+                owner_task = asyncio.current_task()
+                if owner_task is not None:
+                    self._spawn_tasks[key] = owner_task
+            else:
+                spawn_future = spawning
+        if spawning is not None:
+            try:
+                return await asyncio.shield(spawning)
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                return None
+
+        client: Optional[LSPClient] = None
         try:
             ctx = ServerContext(
                 workspace_root=per_server_root,
@@ -578,6 +608,7 @@ class LSPService:
                 binary_overrides=self._binary_overrides,
                 env_overrides=self._env_overrides,
                 init_overrides=self._init_overrides,
+                hermes_home=self._hermes_home,
             )
             spec = srv.build_spawn(per_server_root, ctx)
             if spec is None:
@@ -587,33 +618,50 @@ class LSPService:
                 # the structured logger so the user can act on it.
                 eventlog.log_server_unavailable(srv.server_id, srv.server_id)
                 self._broken.add(key)
-                spawn_future.set_result(None)
+                self._resolve_spawn_future(spawn_future, None)
                 return None
+            client_env = dict(spec.env)
+            # LSP subprocesses must use the service's profile home even when
+            # the service was created from a context-local profile override.
+            client_env["HERMES_HOME"] = self._hermes_home
             client = LSPClient(
                 server_id=srv.server_id,
                 workspace_root=spec.workspace_root,
                 command=spec.command,
-                env=spec.env,
+                env=client_env,
                 cwd=spec.cwd,
                 initialization_options=spec.initialization_options,
                 seed_diagnostics_on_first_push=spec.seed_diagnostics_on_first_push or srv.seed_first_push,
             )
-            try:
-                await client.start()
-            except Exception as e:  # noqa: BLE001
-                eventlog.log_spawn_failed(srv.server_id, per_server_root, e)
-                self._broken.add(key)
-                spawn_future.set_result(None)
-                return None
+            await client.start()
             with self._state_lock:
                 self._clients[key] = client
                 self._last_used[key] = time.time()
             eventlog.log_active(srv.server_id, per_server_root)
-            spawn_future.set_result(client)
+            self._resolve_spawn_future(spawn_future, client)
             return client
+        except asyncio.CancelledError:
+            # ``LSPClient.start`` owns cancellation cleanup.  Resolve the
+            # shared future before propagating so concurrent waiters cannot
+            # remain pending after the owner times out.
+            self._resolve_spawn_future(spawn_future, None)
+            raise
+        except Exception as e:  # noqa: BLE001
+            eventlog.log_spawn_failed(srv.server_id, per_server_root, e)
+            self._broken.add(key)
+            self._resolve_spawn_future(spawn_future, None)
+            return None
         finally:
             with self._state_lock:
-                self._spawning.pop(key, None)
+                if self._spawning.get(key) is spawn_future:
+                    self._spawning.pop(key, None)
+                self._spawn_tasks.pop(key, None)
+
+    @staticmethod
+    def _resolve_spawn_future(future: asyncio.Future, value: Optional[LSPClient]) -> None:
+        """Complete a shared spawn future exactly once."""
+        if not future.done():
+            future.set_result(value)
 
     async def _start_idle_reaper(self) -> None:
         self._idle_reaper_task = asyncio.create_task(self._idle_reaper_loop())
@@ -673,10 +721,23 @@ class LSPService:
             reaper.cancel()
             await asyncio.gather(reaper, return_exceptions=True)
         with self._state_lock:
+            spawn_tasks = list(self._spawn_tasks.values())
+            spawn_futures = list(self._spawning.values())
+        for task in spawn_tasks:
+            if not task.done():
+                task.cancel()
+        for future in spawn_futures:
+            if not future.done():
+                future.cancel()
+        if spawn_tasks:
+            await asyncio.gather(*spawn_tasks, return_exceptions=True)
+        with self._state_lock:
             clients = list(self._clients.values())
             self._clients.clear()
             self._broken.clear()
             self._last_used.clear()
+            self._spawn_tasks.clear()
+            self._spawning.clear()
         await asyncio.gather(
             *(c.shutdown() for c in clients),
             return_exceptions=True,

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -198,6 +198,34 @@ def _which(*names: str) -> Optional[str]:
     return None
 
 
+def _pyright_langserver_candidates(path: str) -> list[str]:
+    """Return a configured Pyright path only when it names an LSP server."""
+    name = os.path.basename(path).lower()
+    if name in {
+        "pyright-langserver",
+        "pyright-langserver.cmd",
+        "pyright-langserver.exe",
+        "pyright-langserver.bat",
+    }:
+        return [path]
+    if name not in {"pyright", "pyright.cmd", "pyright.exe", "pyright.bat"}:
+        return []
+    directory = os.path.dirname(path)
+    return [
+        os.path.join(directory, f"pyright-langserver{suffix}")
+        for suffix in ("", ".cmd", ".exe", ".bat")
+    ]
+
+
+def _existing_pyright_langserver(path: Optional[str]) -> Optional[str]:
+    if path is None:
+        return None
+    for candidate in _pyright_langserver_candidates(path):
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
 def _root_or_workspace(file_path: str, workspace: str, markers: Sequence[str], excludes: Sequence[str] = ()) -> Optional[str]:
     """Common pattern: try ``nearest_root``, fall back to workspace root.
 
@@ -231,20 +259,34 @@ def _root_or_workspace(file_path: str, workspace: str, markers: Sequence[str], e
 
 
 def _spawn_pyright(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
-    bin_path = _resolve_override(ctx, "pyright") or _which(
-        "pyright-langserver", "pyright"
+    bin_path = _existing_pyright_langserver(
+        _resolve_override(ctx, "pyright-langserver")
     )
     if bin_path is None:
+        bin_path = _existing_pyright_langserver(
+            _which(
+                "pyright-langserver",
+                "pyright-langserver.cmd",
+                "pyright-langserver.exe",
+                "pyright-langserver.bat",
+            )
+        )
+    if bin_path is None:
+        bin_path = _existing_pyright_langserver(
+            _resolve_override(ctx, "pyright")
+            or _which("pyright", "pyright.cmd", "pyright.exe", "pyright.bat")
+        )
+    if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("pyright", ctx.install_strategy, hermes_home=ctx.hermes_home)
-        if bin_path is None:
-            return None
-    # If we got the cli ``pyright``, the langserver is its sibling.
-    base = os.path.basename(bin_path)
-    if base in {"pyright", "pyright.exe"}:
-        sibling = os.path.join(os.path.dirname(bin_path), "pyright-langserver")
-        if os.path.exists(sibling):
-            bin_path = sibling
+
+        installed = try_install("pyright", ctx.install_strategy, hermes_home=ctx.hermes_home)
+        bin_path = _existing_pyright_langserver(installed)
+    if bin_path is None:
+        logger.warning(
+            "pyright LSP unavailable: pyright-langserver --stdio was not found; "
+            "the official pyright CLI is not a language-server substitute"
+        )
+        return None
     init: Dict[str, Any] = {}
     # Pick the project's venv interpreter if there is one — otherwise
     # pyright defaults to "python on PATH" which is rarely the venv.

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -167,6 +167,7 @@ class ServerContext:
     binary_overrides: Dict[str, List[str]] = field(default_factory=dict)
     env_overrides: Dict[str, Dict[str, str]] = field(default_factory=dict)
     init_overrides: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    hermes_home: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -206,7 +207,7 @@ def _root_or_workspace(file_path: str, workspace: str, markers: Sequence[str], e
         file_path,
         markers,
         excludes=excludes,
-        ceiling=os.path.dirname(workspace) if workspace else None,
+        ceiling=workspace or None,
     )
     if found is None and excludes:
         # Distinguish "no marker found" from "exclude hit": when
@@ -216,7 +217,7 @@ def _root_or_workspace(file_path: str, workspace: str, markers: Sequence[str], e
         recheck = nearest_root(
             file_path,
             markers,
-            ceiling=os.path.dirname(workspace) if workspace else None,
+            ceiling=workspace or None,
         )
         if recheck is not None:
             return None  # exclude triggered
@@ -235,7 +236,7 @@ def _spawn_pyright(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
     if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("pyright", ctx.install_strategy)
+        bin_path = try_install("pyright", ctx.install_strategy, hermes_home=ctx.hermes_home)
         if bin_path is None:
             return None
     # If we got the cli ``pyright``, the langserver is its sibling.
@@ -278,7 +279,7 @@ def _spawn_typescript(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "typescript") or _which("typescript-language-server")
     if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("typescript-language-server", ctx.install_strategy)
+        bin_path = try_install("typescript-language-server", ctx.install_strategy, hermes_home=ctx.hermes_home)
         if bin_path is None:
             return None
     return SpawnSpec(
@@ -295,7 +296,7 @@ def _spawn_gopls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "gopls") or _which("gopls")
     if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("gopls", ctx.install_strategy)
+        bin_path = try_install("gopls", ctx.install_strategy, hermes_home=ctx.hermes_home)
         if bin_path is None:
             return None
     return SpawnSpec(
@@ -311,7 +312,7 @@ def _spawn_rust_analyzer(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "rust-analyzer") or _which("rust-analyzer")
     if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("rust-analyzer", ctx.install_strategy)
+        bin_path = try_install("rust-analyzer", ctx.install_strategy, hermes_home=ctx.hermes_home)
         if bin_path is None:
             return None
     return SpawnSpec(
@@ -327,7 +328,7 @@ def _spawn_clangd(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "clangd") or _which("clangd")
     if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("clangd", ctx.install_strategy)
+        bin_path = try_install("clangd", ctx.install_strategy, hermes_home=ctx.hermes_home)
         if bin_path is None:
             return None
     return SpawnSpec(
@@ -346,7 +347,7 @@ def _spawn_bash_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "bash-language-server") or _which("bash-language-server")
     if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("bash-language-server", ctx.install_strategy)
+        bin_path = try_install("bash-language-server", ctx.install_strategy, hermes_home=ctx.hermes_home)
         if bin_path is None:
             return None
     # bash-language-server delegates diagnostics to ``shellcheck``.  Without
@@ -374,7 +375,7 @@ def _spawn_yaml_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "yaml-language-server") or _which("yaml-language-server")
     if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("yaml-language-server", ctx.install_strategy)
+        bin_path = try_install("yaml-language-server", ctx.install_strategy, hermes_home=ctx.hermes_home)
         if bin_path is None:
             return None
     return SpawnSpec(
@@ -390,7 +391,7 @@ def _spawn_lua_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "lua-language-server") or _which("lua-language-server")
     if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("lua-language-server", ctx.install_strategy)
+        bin_path = try_install("lua-language-server", ctx.install_strategy, hermes_home=ctx.hermes_home)
         if bin_path is None:
             return None
     return SpawnSpec(
@@ -406,7 +407,7 @@ def _spawn_intelephense(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "intelephense") or _which("intelephense")
     if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("intelephense", ctx.install_strategy)
+        bin_path = try_install("intelephense", ctx.install_strategy, hermes_home=ctx.hermes_home)
         if bin_path is None:
             return None
     init = {"telemetry": {"enabled": False}}
@@ -437,7 +438,7 @@ def _spawn_dockerfile_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "dockerfile-ls") or _which("docker-langserver")
     if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("dockerfile-language-server-nodejs", ctx.install_strategy)
+        bin_path = try_install("dockerfile-language-server-nodejs", ctx.install_strategy, hermes_home=ctx.hermes_home)
         if bin_path is None:
             return None
     return SpawnSpec(
@@ -631,7 +632,7 @@ def _spawn_vue(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
     if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("@vue/language-server", ctx.install_strategy)
+        bin_path = try_install("@vue/language-server", ctx.install_strategy, hermes_home=ctx.hermes_home)
         if bin_path is None:
             return None
     return SpawnSpec(
@@ -649,7 +650,7 @@ def _spawn_svelte(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
     if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("svelte-language-server", ctx.install_strategy)
+        bin_path = try_install("svelte-language-server", ctx.install_strategy, hermes_home=ctx.hermes_home)
         if bin_path is None:
             return None
     return SpawnSpec(
@@ -667,7 +668,7 @@ def _spawn_astro(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
     if bin_path is None:
         from agent.lsp.install import try_install
-        bin_path = try_install("@astrojs/language-server", ctx.install_strategy)
+        bin_path = try_install("@astrojs/language-server", ctx.install_strategy, hermes_home=ctx.hermes_home)
         if bin_path is None:
             return None
     return SpawnSpec(
@@ -710,9 +711,12 @@ def _find_pses_bundle(ctx: ServerContext) -> Optional[str]:
     env_path = os.environ.get("PSES_BUNDLE_PATH")
     if env_path:
         candidates.append(env_path)
-    from hermes_constants import get_hermes_home
+    if ctx.hermes_home is not None:
+        home = ctx.hermes_home
+    else:
+        from hermes_constants import get_hermes_home
 
-    home = str(get_hermes_home())
+        home = str(get_hermes_home())
     candidates.append(os.path.join(home, "lsp", "PowerShellEditorServices"))
 
     for cand in candidates:
@@ -759,10 +763,11 @@ def _spawn_powershell_es(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
         bundle, "PowerShellEditorServices", "Start-EditorServices.ps1"
     )
     # Session details file: PSES writes connection info here on startup.
+    session_dir = hermes_lsp_session_dir(ctx.hermes_home)
     session_path = os.path.join(
-        hermes_lsp_session_dir(), f"pses-session-{os.getpid()}.json"
+        session_dir, f"pses-session-{os.getpid()}.json"
     )
-    log_path = os.path.join(hermes_lsp_session_dir(), "pses.log")
+    log_path = os.path.join(session_dir, "pses.log")
     inner = (
         f"& '{start_script}' "
         f"-BundledModulesPath '{bundle}' "
@@ -794,12 +799,13 @@ def _spawn_powershell_es(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def hermes_lsp_session_dir() -> str:
+def hermes_lsp_session_dir(hermes_home: Optional[str] = None) -> str:
     """Return (and create) the dir for PSES session/log scratch files."""
-    from hermes_constants import get_hermes_home
+    if hermes_home is None:
+        from hermes_constants import get_hermes_home
 
-    home = str(get_hermes_home())
-    d = os.path.join(home, "lsp", "pses")
+        hermes_home = str(get_hermes_home())
+    d = os.path.join(hermes_home, "lsp", "pses")
     os.makedirs(d, exist_ok=True)
     return d
 
@@ -917,7 +923,7 @@ def _root_clojure(file_path: str, workspace: str) -> Optional[str]:
 
 
 def _root_nix(file_path: str, workspace: str) -> str:
-    found = nearest_root(file_path, ["flake.nix"])
+    found = nearest_root(file_path, ["flake.nix"], ceiling=workspace)
     return found or workspace
 
 

--- a/agent/lsp/validation.py
+++ b/agent/lsp/validation.py
@@ -8,6 +8,7 @@ config.
 """
 from __future__ import annotations
 
+import copy
 import json
 import math
 import os
@@ -27,6 +28,8 @@ import psutil
 DEFAULT_EXCLUDES = (".venv", "venv", "node_modules", "generated", "build", "cache")
 DEFAULT_TIMEOUT = 300.0
 DEFAULT_TERM_GRACE = 2.0
+POST_TIMEOUT_DRAIN = 0.5
+POST_TIMEOUT_WAIT = 0.2
 
 
 @dataclass(frozen=True)
@@ -40,21 +43,60 @@ class ValidationResult:
     stderr: str
 
 
-def _as_config_relative(config_dir: Path, root: Path, values: Iterable[str]) -> list[str]:
+def _resolve_scoped_path(
+    root: Path,
+    value: str,
+    *,
+    base_dir: Optional[Path] = None,
+    label: str = "path",
+) -> Path:
+    """Resolve a config path and require it to stay inside ``root``."""
+    anchor = (base_dir or root).resolve()
+    raw = Path(value).expanduser()
+    candidate = raw if raw.is_absolute() else anchor / raw
+    try:
+        resolved = candidate.resolve(strict=False)
+        resolved.relative_to(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ValueError(f"{label} outside workspace: {value}") from exc
+    return resolved
+
+
+def _as_config_relative(
+    config_dir: Path,
+    root: Path,
+    values: Iterable[str],
+    *,
+    base_dir: Optional[Path] = None,
+    label: str = "path",
+) -> list[str]:
     result = []
     for value in values:
-        path = Path(value)
-        absolute = path if path.is_absolute() else root / path
-        result.append(os.path.relpath(absolute, config_dir))
+        resolved = _resolve_scoped_path(
+            root,
+            value,
+            base_dir=base_dir,
+            label=label,
+        )
+        result.append(os.path.relpath(resolved, config_dir))
     return result
 
 
+def _merge_excludes(exclude: Optional[Sequence[str]]) -> tuple[str, ...]:
+    """Keep mandatory dependency/generated-tree exclusions in every overlay."""
+    values: list[str] = list(DEFAULT_EXCLUDES)
+    if exclude:
+        values.extend(exclude)
+    return tuple(dict.fromkeys(values))
+
+
 def _repository_config(root: Path, project_config: Optional[str]) -> Optional[Path]:
+    root = root.resolve()
     if project_config:
         path = Path(project_config).expanduser()
         if not path.is_absolute():
             path = root / path
-        path = path.absolute()
+        path = _resolve_scoped_path(root, str(path), label="project config")
         if not path.is_file():
             raise FileNotFoundError(f"Pyright project config not found: {path}")
         return path
@@ -65,22 +107,129 @@ def _repository_config(root: Path, project_config: Optional[str]) -> Optional[Pa
     return None
 
 
-def _config_options(config: Optional[Path]) -> dict:
+def _rebase_config_path(
+    value: str,
+    *,
+    source_dir: Path,
+    root: Path,
+    target_dir: Path,
+    label: str,
+) -> str:
+    return _as_config_relative(
+        target_dir,
+        root,
+        [value],
+        base_dir=source_dir,
+        label=label,
+    )[0]
+
+
+def _rebase_pyright_options(
+    options: dict,
+    *,
+    source_dir: Path,
+    root: Path,
+    target_dir: Path,
+) -> dict:
+    """Keep path-valued TOML options anchored to their source config."""
+    options = copy.deepcopy(options)
+    for key in ("extraPaths", "include", "exclude"):
+        values = options.get(key)
+        if isinstance(values, list):
+            options[key] = [
+                _rebase_config_path(
+                    value,
+                    source_dir=source_dir,
+                    root=root,
+                    target_dir=target_dir,
+                    label=f"pyright {key}",
+                )
+                for value in values
+                if isinstance(value, str)
+            ]
+    for key in ("stubPath", "typeshedPath", "venvPath"):
+        value = options.get(key)
+        if isinstance(value, str):
+            options[key] = _rebase_config_path(
+                value,
+                source_dir=source_dir,
+                root=root,
+                target_dir=target_dir,
+                label=f"pyright {key}",
+            )
+    environments = options.get("executionEnvironments")
+    if isinstance(environments, list):
+        for environment in environments:
+            if not isinstance(environment, dict):
+                continue
+            if isinstance(environment.get("root"), str):
+                environment["root"] = _rebase_config_path(
+                    environment["root"],
+                    source_dir=source_dir,
+                    root=root,
+                    target_dir=target_dir,
+                    label="pyright execution environment root",
+                )
+            values = environment.get("extraPaths")
+            if isinstance(values, list):
+                environment["extraPaths"] = [
+                    _rebase_config_path(
+                        value,
+                        source_dir=source_dir,
+                        root=root,
+                        target_dir=target_dir,
+                        label="pyright execution environment extraPaths",
+                    )
+                    for value in values
+                    if isinstance(value, str)
+                ]
+    if isinstance(options.get("extends"), str):
+        options["extends"] = _rebase_config_path(
+            options["extends"],
+            source_dir=source_dir,
+            root=root,
+            target_dir=target_dir,
+            label="pyright extends",
+        )
+    return options
+
+
+def _config_options(
+    config: Optional[Path],
+    *,
+    root: Optional[Path] = None,
+    target_dir: Optional[Path] = None,
+) -> dict:
     if config is None:
         return {}
+    config = config.resolve()
+    root = (root or config.parent).resolve()
+    target_dir = (target_dir or config.parent).resolve()
     if config.suffix.lower() == ".json":
         payload = json.loads(config.read_text(encoding="utf-8"))
         if not isinstance(payload, dict):
             raise ValueError(f"Pyright config must contain an object: {config}")
         # Keep path resolution and inherited options anchored to the repository
-        # config instead of copying a relative `extends` into /tmp.
+        # config instead of copying a relative `extends` into /tmp.  Validate
+        # every path-valued option before inheriting the original JSON file.
+        _rebase_pyright_options(
+            dict(payload),
+            source_dir=config.parent,
+            root=root,
+            target_dir=config.parent,
+        )
         return {"extends": str(config)}
     if config.name == "pyproject.toml":
         payload = tomllib.loads(config.read_text(encoding="utf-8"))
         options = payload.get("tool", {}).get("pyright", {})
         if not isinstance(options, dict):
             raise ValueError(f"[tool.pyright] must be a table: {config}")
-        return dict(options)
+        return _rebase_pyright_options(
+            dict(options),
+            source_dir=config.parent,
+            root=root,
+            target_dir=target_dir,
+        )
     raise ValueError(f"Unsupported Pyright config format: {config}")
 
 
@@ -92,12 +241,24 @@ def _temporary_project_config(
     exclude: Sequence[str],
 ):
     """Create an explicit overlay config and remove it on every exit path."""
-    options = _config_options(config)
+    root = root.resolve()
+    config = config.resolve() if config is not None else None
     with tempfile.TemporaryDirectory(prefix=".hermes-pyright-", dir=root) as temp_dir:
         path = Path(temp_dir) / "pyrightconfig.json"
-        config_dir = Path(temp_dir)
-        options["include"] = _as_config_relative(config_dir, root, include or (".",))
-        options["exclude"] = _as_config_relative(config_dir, root, exclude)
+        config_dir = Path(temp_dir).resolve()
+        options = _config_options(config, root=root, target_dir=config_dir)
+        options["include"] = _as_config_relative(
+            config_dir,
+            root,
+            include or (".",),
+            label="include",
+        )
+        options["exclude"] = _as_config_relative(
+            config_dir,
+            root,
+            _merge_excludes(exclude),
+            label="exclude",
+        )
         path.write_text(json.dumps(options, indent=2) + "\n", encoding="utf-8")
         yield path
 
@@ -122,11 +283,61 @@ def _group_alive(pgid: Optional[int]) -> bool:
         return False
 
 
-def _snapshot_descendants(pid: int) -> list[psutil.Process]:
+def _process_identity(pid: int) -> Optional[psutil.Process]:
     try:
-        return psutil.Process(pid).children(recursive=True)
+        return psutil.Process(pid)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return None
+
+
+def _snapshot_descendants(
+    pid: int,
+    owner: Optional[psutil.Process] = None,
+) -> list[psutil.Process]:
+    owner = owner or _process_identity(pid)
+    if owner is None:
+        return []
+    try:
+        return owner.children(recursive=True)
     except (psutil.NoSuchProcess, psutil.AccessDenied):
         return []
+
+
+def _refresh_descendants(
+    owner: Optional[psutil.Process],
+    known: Sequence[psutil.Process],
+) -> list[psutil.Process]:
+    """Re-collect the owned tree, including descendants of known children."""
+    seeds = [owner, *known] if owner is not None else list(known)
+    refreshed: list[psutil.Process] = []
+    seen: set[int] = set()
+    for seed in seeds:
+        try:
+            children = seed.children(recursive=True)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        for child in children:
+            child_pid = getattr(child, "pid", id(child))
+            if child_pid in seen:
+                continue
+            seen.add(child_pid)
+            refreshed.append(child)
+    for child in known:
+        child_pid = getattr(child, "pid", id(child))
+        if child_pid not in seen:
+            seen.add(child_pid)
+            refreshed.append(child)
+    return refreshed
+
+
+def _any_process_alive(processes: Sequence[psutil.Process]) -> bool:
+    for process in processes:
+        try:
+            if process.is_running() and process.status() != psutil.STATUS_ZOMBIE:
+                return True
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError, AttributeError):
+            continue
+    return False
 
 
 def _signal_descendants(descendants: Sequence[psutil.Process], *, force: bool) -> None:
@@ -144,24 +355,36 @@ def _cleanup_process(
     pgid: Optional[int],
     descendants: Sequence[psutil.Process],
     term_grace: float,
+    owner: Optional[psutil.Process] = None,
 ) -> None:
-    """TERM the owned group, then KILL after a bounded grace period."""
-    used_group = _signal_group(pgid, signal.SIGTERM)
-    if not used_group:
-        _signal_descendants(descendants, force=False)
-        if process.poll() is None:
-            try:
-                process.terminate()
-            except OSError:
-                pass
+    """TERM the owned tree/group, then KILL after a bounded grace period."""
+    owner = owner or _process_identity(process.pid)
+    current = _refresh_descendants(owner, descendants)
+    # Detached descendants are outside the process group, so signal the exact
+    # process-tree snapshot before terminating the owned group.  Re-collect
+    # during the grace window to catch a child that creates a grandchild after
+    # the first snapshot.
+    _signal_descendants(current, force=False)
+    _signal_group(pgid, signal.SIGTERM)
+    if pgid is None and process.poll() is None:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+
     deadline = time.monotonic() + term_grace
     while time.monotonic() < deadline:
-        if process.poll() is not None and not _group_alive(pgid):
+        current = _refresh_descendants(owner, current)
+        _signal_descendants(current, force=False)
+        if process.poll() is not None and not _group_alive(pgid) and not _any_process_alive(current):
             break
         time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
-    if _group_alive(pgid):
-        _signal_group(pgid, signal.SIGKILL)
-    _signal_descendants(descendants, force=True)
+
+    # Always take one latest snapshot immediately before KILL.  A detached
+    # child may have created a new session and a grandchild during TERM/grace.
+    current = _refresh_descendants(owner, current)
+    _signal_group(pgid, signal.SIGKILL)
+    _signal_descendants(current, force=True)
     if process.poll() is None:
         try:
             process.kill()
@@ -173,6 +396,47 @@ def _cleanup_process(
         # The final group/process signals above are best effort; communicate
         # below still drains pipes and reaps the root where possible.
         pass
+
+
+def _decode_output(value: object) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value or "")
+
+
+def _close_output_pipes(process: subprocess.Popen) -> None:
+    for stream in (process.stdout, process.stderr):
+        if stream is None:
+            continue
+        try:
+            stream.close()
+        except OSError:
+            pass
+
+
+def _drain_after_timeout(
+    process: subprocess.Popen,
+    stdout: object,
+    stderr: object,
+) -> tuple[str, str]:
+    """Drain briefly, then close inherited pipes instead of waiting forever."""
+    fallback_stdout = _decode_output(stdout)
+    fallback_stderr = _decode_output(stderr)
+    try:
+        drained_stdout, drained_stderr = process.communicate(timeout=POST_TIMEOUT_DRAIN)
+        return (
+            _decode_output(drained_stdout) or fallback_stdout,
+            _decode_output(drained_stderr) or fallback_stderr,
+        )
+    except subprocess.TimeoutExpired as exc:
+        drained_stdout = _decode_output(exc.output) or fallback_stdout
+        drained_stderr = _decode_output(exc.stderr) or fallback_stderr
+        _close_output_pipes(process)
+        try:
+            process.wait(timeout=POST_TIMEOUT_WAIT)
+        except (subprocess.TimeoutExpired, ChildProcessError, OSError):
+            pass
+        return drained_stdout, drained_stderr
 
 
 def _resolve_executable(executable: Optional[str]) -> str:
@@ -207,7 +471,7 @@ def run_full_project_check(
         raise ValueError("timeout must be a finite positive number")
     if not math.isfinite(term_grace) or term_grace < 0:
         raise ValueError("term_grace must be a finite non-negative number")
-    root = Path(workspace_root).expanduser().absolute()
+    root = Path(workspace_root).expanduser().resolve()
     if not root.is_dir():
         raise NotADirectoryError(root)
     config = _repository_config(root, project_config)
@@ -242,25 +506,18 @@ def run_full_project_check(
                     pgid = candidate
             except (ProcessLookupError, OSError):
                 pass
-        descendants = _snapshot_descendants(process.pid)
+        owner = _process_identity(process.pid)
+        descendants = _snapshot_descendants(process.pid, owner)
         timed_out = False
         try:
             stdout, stderr = process.communicate(timeout=timeout)
         except subprocess.TimeoutExpired as exc:
             timed_out = True
-            _cleanup_process(process, pgid, descendants, term_grace)
-            stdout, stderr = process.communicate()
-            extra_stdout = exc.output or ""
-            extra_stderr = exc.stderr or ""
-            if isinstance(extra_stdout, bytes):
-                extra_stdout = extra_stdout.decode("utf-8", errors="replace")
-            if isinstance(extra_stderr, bytes):
-                extra_stderr = extra_stderr.decode("utf-8", errors="replace")
-            stdout = stdout or extra_stdout
-            stderr = stderr or extra_stderr
+            _cleanup_process(process, pgid, descendants, term_grace, owner)
+            stdout, stderr = _drain_after_timeout(process, exc.output, exc.stderr)
         finally:
             if process.poll() is None or _group_alive(pgid):
-                _cleanup_process(process, pgid, descendants, term_grace)
+                _cleanup_process(process, pgid, descendants, term_grace, owner)
         return ValidationResult(
             command=command,
             returncode=process.returncode if process.returncode is not None else 124,

--- a/agent/lsp/validation.py
+++ b/agent/lsp/validation.py
@@ -1,0 +1,279 @@
+"""Explicit, bounded full-project Pyright validation.
+
+The write/patch LSP hook intentionally validates only the edited document.
+This module is a separate opt-in path for a final repository-wide check:
+it derives a temporary Pyright config from the repository config, adds explicit
+include/exclude boundaries, and always tears down its subprocess and temporary
+config.
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+import tomllib
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+import psutil
+
+DEFAULT_EXCLUDES = (".venv", "venv", "node_modules", "generated", "build", "cache")
+DEFAULT_TIMEOUT = 300.0
+DEFAULT_TERM_GRACE = 2.0
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Result of one bounded full-project validation process."""
+
+    command: tuple[str, ...]
+    returncode: int
+    timed_out: bool
+    stdout: str
+    stderr: str
+
+
+def _as_config_relative(config_dir: Path, root: Path, values: Iterable[str]) -> list[str]:
+    result = []
+    for value in values:
+        path = Path(value)
+        absolute = path if path.is_absolute() else root / path
+        result.append(os.path.relpath(absolute, config_dir))
+    return result
+
+
+def _repository_config(root: Path, project_config: Optional[str]) -> Optional[Path]:
+    if project_config:
+        path = Path(project_config).expanduser()
+        if not path.is_absolute():
+            path = root / path
+        path = path.absolute()
+        if not path.is_file():
+            raise FileNotFoundError(f"Pyright project config not found: {path}")
+        return path
+    for name in ("pyrightconfig.json", "pyproject.toml"):
+        candidate = root / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _config_options(config: Optional[Path]) -> dict:
+    if config is None:
+        return {}
+    if config.suffix.lower() == ".json":
+        payload = json.loads(config.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"Pyright config must contain an object: {config}")
+        # Keep path resolution and inherited options anchored to the repository
+        # config instead of copying a relative `extends` into /tmp.
+        return {"extends": str(config)}
+    if config.name == "pyproject.toml":
+        payload = tomllib.loads(config.read_text(encoding="utf-8"))
+        options = payload.get("tool", {}).get("pyright", {})
+        if not isinstance(options, dict):
+            raise ValueError(f"[tool.pyright] must be a table: {config}")
+        return dict(options)
+    raise ValueError(f"Unsupported Pyright config format: {config}")
+
+
+@contextmanager
+def _temporary_project_config(
+    root: Path,
+    config: Optional[Path],
+    include: Sequence[str],
+    exclude: Sequence[str],
+):
+    """Create an explicit overlay config and remove it on every exit path."""
+    options = _config_options(config)
+    with tempfile.TemporaryDirectory(prefix=".hermes-pyright-", dir=root) as temp_dir:
+        path = Path(temp_dir) / "pyrightconfig.json"
+        config_dir = Path(temp_dir)
+        options["include"] = _as_config_relative(config_dir, root, include or (".",))
+        options["exclude"] = _as_config_relative(config_dir, root, exclude)
+        path.write_text(json.dumps(options, indent=2) + "\n", encoding="utf-8")
+        yield path
+
+
+def _signal_group(pgid: Optional[int], sig: signal.Signals) -> bool:
+    if pgid is None or os.name == "nt":
+        return False
+    try:
+        os.killpg(pgid, sig)
+        return True
+    except (ProcessLookupError, OSError):
+        return False
+
+
+def _group_alive(pgid: Optional[int]) -> bool:
+    if pgid is None or os.name == "nt":
+        return False
+    try:
+        os.killpg(pgid, 0)
+        return True
+    except (ProcessLookupError, OSError):
+        return False
+
+
+def _snapshot_descendants(pid: int) -> list[psutil.Process]:
+    try:
+        return psutil.Process(pid).children(recursive=True)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return []
+
+
+def _signal_descendants(descendants: Sequence[psutil.Process], *, force: bool) -> None:
+    for child in descendants:
+        try:
+            if not child.is_running():
+                continue
+            (child.kill if force else child.terminate)()
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+            pass
+
+
+def _cleanup_process(
+    process: subprocess.Popen,
+    pgid: Optional[int],
+    descendants: Sequence[psutil.Process],
+    term_grace: float,
+) -> None:
+    """TERM the owned group, then KILL after a bounded grace period."""
+    used_group = _signal_group(pgid, signal.SIGTERM)
+    if not used_group:
+        _signal_descendants(descendants, force=False)
+        if process.poll() is None:
+            try:
+                process.terminate()
+            except OSError:
+                pass
+    deadline = time.monotonic() + term_grace
+    while time.monotonic() < deadline:
+        if process.poll() is not None and not _group_alive(pgid):
+            break
+        time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+    if _group_alive(pgid):
+        _signal_group(pgid, signal.SIGKILL)
+    _signal_descendants(descendants, force=True)
+    if process.poll() is None:
+        try:
+            process.kill()
+        except OSError:
+            pass
+    try:
+        process.wait(timeout=max(1.0, term_grace))
+    except (subprocess.TimeoutExpired, ChildProcessError, OSError):
+        # The final group/process signals above are best effort; communicate
+        # below still drains pipes and reaps the root where possible.
+        pass
+
+
+def _resolve_executable(executable: Optional[str]) -> str:
+    if executable:
+        return executable
+    resolved = shutil.which("pyright")
+    if resolved:
+        return resolved
+    raise FileNotFoundError("pyright CLI is not installed or not on PATH")
+
+
+def run_full_project_check(
+    workspace_root: str,
+    *,
+    project_config: Optional[str] = None,
+    executable: Optional[str] = None,
+    include: Sequence[str] = (),
+    exclude: Sequence[str] = DEFAULT_EXCLUDES,
+    timeout: float = DEFAULT_TIMEOUT,
+    term_grace: float = DEFAULT_TERM_GRACE,
+    env: Optional[dict[str, str]] = None,
+) -> ValidationResult:
+    """Run a bounded repository-wide Pyright check.
+
+    This function is never used by the post-write document loop.  It is an
+    explicit final-validation operation and therefore scans the repository
+    root (or the supplied include paths) using a temporary config overlay.
+    The repository's ``pyrightconfig.json`` or ``[tool.pyright]`` settings are
+    retained, while the include/exclude boundary is made explicit.
+    """
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError("timeout must be a finite positive number")
+    if not math.isfinite(term_grace) or term_grace < 0:
+        raise ValueError("term_grace must be a finite non-negative number")
+    root = Path(workspace_root).expanduser().absolute()
+    if not root.is_dir():
+        raise NotADirectoryError(root)
+    config = _repository_config(root, project_config)
+    command: tuple[str, ...]
+    with _temporary_project_config(root, config, include, exclude) as overlay:
+        command = (_resolve_executable(executable), "--project", str(overlay))
+        child_env = dict(os.environ)
+        if env:
+            child_env.update(env)
+        process = subprocess.Popen(
+            list(command),
+            cwd=str(root),
+            env=child_env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            start_new_session=os.name != "nt",
+            creationflags=(
+                getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                if os.name == "nt"
+                else 0
+            ),
+        )
+        pgid = None
+        if os.name != "nt":
+            try:
+                candidate = os.getpgid(process.pid)
+                if candidate == process.pid and candidate != os.getpgrp():
+                    pgid = candidate
+            except (ProcessLookupError, OSError):
+                pass
+        descendants = _snapshot_descendants(process.pid)
+        timed_out = False
+        try:
+            stdout, stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired as exc:
+            timed_out = True
+            _cleanup_process(process, pgid, descendants, term_grace)
+            stdout, stderr = process.communicate()
+            extra_stdout = exc.output or ""
+            extra_stderr = exc.stderr or ""
+            if isinstance(extra_stdout, bytes):
+                extra_stdout = extra_stdout.decode("utf-8", errors="replace")
+            if isinstance(extra_stderr, bytes):
+                extra_stderr = extra_stderr.decode("utf-8", errors="replace")
+            stdout = stdout or extra_stdout
+            stderr = stderr or extra_stderr
+        finally:
+            if process.poll() is None or _group_alive(pgid):
+                _cleanup_process(process, pgid, descendants, term_grace)
+        return ValidationResult(
+            command=command,
+            returncode=process.returncode if process.returncode is not None else 124,
+            timed_out=timed_out,
+            stdout=stdout or "",
+            stderr=stderr or "",
+        )
+
+
+__all__ = [
+    "DEFAULT_EXCLUDES",
+    "DEFAULT_TERM_GRACE",
+    "DEFAULT_TIMEOUT",
+    "ValidationResult",
+    "run_full_project_check",
+]

--- a/agent/lsp/workspace.py
+++ b/agent/lsp/workspace.py
@@ -136,6 +136,10 @@ def nearest_root(
     except (OSError, RuntimeError, ValueError):
         return None
     ceiling_path = Path(normalize_path(ceiling)) if ceiling else None
+    if ceiling_path is not None and not is_inside_workspace(
+        str(start_path), str(ceiling_path)
+    ):
+        return None
 
     markers_list = list(markers)
     excludes_list = list(excludes) if excludes else []
@@ -178,9 +182,9 @@ def resolve_workspace_for_file(
     """Resolve the workspace root for a file.
 
     Returns ``(workspace_root, gated_in)`` where ``gated_in`` is True
-    iff LSP should run for this file at all.  Currently the gate is
-    "file is inside a git worktree found by walking up from cwd OR
-    from the file itself".
+    iff LSP should run for this file at all.  The active cwd worktree
+    is the boundary; when cwd is outside a worktree, the file's own
+    location is used as a fallback anchor.
 
     The cwd path takes precedence — if the agent was launched in a
     git project, that worktree is the workspace, and any edit inside
@@ -195,9 +199,9 @@ def resolve_workspace_for_file(
     if cwd_root is not None:
         if is_inside_workspace(file_path, cwd_root):
             return cwd_root, True
-        # File is outside the cwd's worktree — try the file's own
-        # location as a secondary anchor.  Useful for monorepos where
-        # the user opens an unrelated checkout.
+        # The active cwd worktree is the task/profile boundary.  Do not
+        # let a file in another checkout select a different project root.
+        return None, False
     file_root = find_git_worktree(file_path)
     if file_root is not None:
         return file_root, True

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import time
 
@@ -64,6 +65,7 @@ def write_message(obj):
 
 def main():
     script = os.environ.get("MOCK_LSP_SCRIPT", "clean")
+    child = None
 
     while True:
         msg = read_message()
@@ -88,6 +90,16 @@ def main():
             )
             if script == "crash":
                 return 0
+            child_pid_file = os.environ.get("MOCK_LSP_CHILD_PID_FILE")
+            if child_pid_file and child is None:
+                child = subprocess.Popen(
+                    [sys.executable, "-c", "import time; time.sleep(60)"],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                with open(child_pid_file, "w", encoding="ascii") as f:
+                    f.write(str(child.pid))
             continue
 
         if msg.get("method") == "initialized":

--- a/tests/agent/lsp/test_client_process_cleanup.py
+++ b/tests/agent/lsp/test_client_process_cleanup.py
@@ -1,0 +1,108 @@
+"""Regression tests for LSP process ownership and cancellation cleanup."""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import psutil
+import pytest
+
+from agent.lsp.client import LSPClient
+
+
+MOCK_SERVER = str(Path(__file__).parent / "_mock_lsp_server.py")
+
+
+async def _wait_for_file(path: Path, timeout: float = 2.0) -> str:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if path.exists():
+            value = path.read_text(encoding="ascii").strip()
+            if value:
+                return value
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"timed out waiting for {path}")
+
+
+def _is_live(pid: int) -> bool:
+    try:
+        process = psutil.Process(pid)
+        return process.is_running() and process.status() != psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return False
+
+
+async def _wait_until_stopped(pid: int, timeout: float = 2.0) -> bool:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if not _is_live(pid):
+            return True
+        await asyncio.sleep(0.01)
+    return not _is_live(pid)
+
+
+def _force_stop(pid: int) -> None:
+    if not _is_live(pid):
+        return
+    try:
+        process = psutil.Process(pid)
+        process.kill()
+        process.wait(timeout=2.0)
+    except (psutil.NoSuchProcess, psutil.TimeoutExpired):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_start_cancellation_reaps_spawned_process(tmp_path: Path):
+    """Cancelling initialize after spawn must not leave the child alive."""
+    pid_file = tmp_path / "server.pid"
+    code = (
+        "import os, sys, time; "
+        "open(sys.argv[1], 'w', encoding='ascii').write(str(os.getpid())); "
+        "time.sleep(60)"
+    )
+    client = LSPClient(
+        server_id="pyright",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, "-c", code, str(pid_file)],
+    )
+
+    task = asyncio.create_task(client.start())
+    pid = int(await _wait_for_file(pid_file))
+    task.cancel()
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert await _wait_until_stopped(pid) is True
+    finally:
+        await client._cleanup_process()
+
+
+@pytest.mark.linux_only
+@pytest.mark.asyncio
+async def test_shutdown_reaps_process_group_descendants(tmp_path: Path):
+    """Graceful shutdown must also terminate descendants in the owned group."""
+    child_pid_file = tmp_path / "child.pid"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {
+        "MOCK_LSP_SCRIPT": "clean",
+        "MOCK_LSP_CHILD_PID_FILE": str(child_pid_file),
+    }
+    client = LSPClient(
+        server_id="pyright",
+        workspace_root=str(repo),
+        command=[sys.executable, MOCK_SERVER],
+        env=env,
+        cwd=str(repo),
+    )
+
+    await client.start()
+    child_pid = int(await _wait_for_file(child_pid_file))
+    try:
+        await client.shutdown()
+        assert await _wait_until_stopped(child_pid) is True
+    finally:
+        _force_stop(child_pid)
+        await client.shutdown()

--- a/tests/agent/lsp/test_client_process_cleanup.py
+++ b/tests/agent/lsp/test_client_process_cleanup.py
@@ -106,3 +106,68 @@ async def test_shutdown_reaps_process_group_descendants(tmp_path: Path):
     finally:
         _force_stop(child_pid)
         await client.shutdown()
+
+
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.linux_only
+@pytest.mark.asyncio
+async def test_cleanup_reaps_detached_grandchild_created_after_snapshot(tmp_path: Path):
+    """Cleanup must catch a detached descendant created during TERM/grace."""
+    child_pid_file = tmp_path / "detached-child.pid"
+    child_ready_file = tmp_path / "detached-child.ready"
+    grandchild_pid_file = tmp_path / "detached-grandchild.pid"
+
+    grandchild_code = "import time; time.sleep(60)"
+    child_code = "\n".join(
+        [
+            "import os, signal, subprocess, sys, time",
+            "from pathlib import Path",
+            "spawned = False",
+            "def spawn(_signum, _frame):",
+            "    global spawned",
+            "    if spawned:",
+            "        return",
+            "    spawned = True",
+            f"    child = subprocess.Popen([{sys.executable!r}, '-c', {grandchild_code!r}])",
+            "    Path(sys.argv[1]).write_text(str(child.pid), encoding='ascii')",
+            "signal.signal(signal.SIGTERM, spawn)",
+            "Path(sys.argv[2]).write_text('ready', encoding='ascii')",
+            "time.sleep(0.2)",
+            "spawn(None, None)",
+            "time.sleep(60)",
+        ]
+    )
+    root_code = "\n".join(
+        [
+            "import subprocess, sys, time",
+            f"child = subprocess.Popen([{sys.executable!r}, '-c', {child_code!r}, sys.argv[2], sys.argv[3]], start_new_session=True)",
+            "open(sys.argv[1], 'w', encoding='ascii').write(str(child.pid))",
+            "time.sleep(60)",
+        ]
+    )
+    client = LSPClient(
+        server_id="pyright",
+        workspace_root=str(tmp_path),
+        command=[
+            sys.executable,
+            "-c",
+            root_code,
+            str(child_pid_file),
+            str(grandchild_pid_file),
+            str(child_ready_file),
+        ],
+    )
+
+    try:
+        await client._spawn()
+        child_pid = int(await _wait_for_file(child_pid_file))
+        await _wait_for_file(child_ready_file)
+        await client._cleanup_process()
+        grandchild_pid = int(await _wait_for_file(grandchild_pid_file))
+        assert await _wait_until_stopped(child_pid) is True
+        assert await _wait_until_stopped(grandchild_pid) is True
+    finally:
+        for pid_file in (child_pid_file, grandchild_pid_file):
+            if pid_file.exists():
+                _force_stop(int(pid_file.read_text(encoding="ascii")))
+        await client._cleanup_process()

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -59,6 +59,28 @@ def test_install_npm_works_without_extras(tmp_path, monkeypatch):
     assert install_targets == ["pyright"]
 
 
+def test_install_cache_is_scoped_to_hermes_home(tmp_path, monkeypatch):
+    """A cached staged binary from one profile must not serve another."""
+    from agent.lsp import install as install_mod
+
+    calls = []
+
+    def fake_install(pkg, home):
+        calls.append((pkg, home))
+        return str(tmp_path / home / pkg)
+
+    monkeypatch.setattr(install_mod, "_do_install", fake_install)
+    home_a = str(tmp_path / "profile-a")
+    home_b = str(tmp_path / "profile-b")
+    pkg = "profile-cache-regression"
+
+    assert install_mod.try_install(pkg, hermes_home=home_a) != install_mod.try_install(
+        pkg, hermes_home=home_b
+    )
+    assert len(calls) == 2
+    assert install_mod.try_install(pkg, hermes_home=home_a) == calls[0][1] + "/" + pkg
+
+
 
 
 @pytest.mark.windows_only

--- a/tests/agent/lsp/test_lifecycle.py
+++ b/tests/agent/lsp/test_lifecycle.py
@@ -69,7 +69,7 @@ def test_atexit_shutdown_swallows_exceptions(monkeypatch):
     def boom():
         raise RuntimeError("server already dead")
 
-    monkeypatch.setattr(lsp_module, "shutdown_service", boom)
+    monkeypatch.setattr(lsp_module, "_shutdown_all_services", boom)
     # Must not raise.
     lsp_module._atexit_shutdown()
 
@@ -90,6 +90,42 @@ def test_shutdown_service_idempotent(monkeypatch):
     lsp_module.shutdown_service()  # must not raise
 
     assert fake_svc.shutdown.call_count == 1
+
+
+def test_shutdown_service_only_stops_active_profile(monkeypatch, tmp_path):
+    """An explicit profile restart must not stop another profile's service."""
+    services: list[MagicMock] = []
+
+    def make_service(cls):
+        fake = MagicMock()
+        fake.is_active.return_value = True
+        services.append(fake)
+        return fake
+
+    monkeypatch.setattr(
+        lsp_module.LSPService, "create_from_config", classmethod(make_service)
+    )
+    monkeypatch.setattr(atexit, "register", lambda fn: None)
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+
+    monkeypatch.setenv("HERMES_HOME", str(home_a))
+    service_a = lsp_module.get_service()
+    scope_a = lsp_module._current_scope()
+    monkeypatch.setenv("HERMES_HOME", str(home_b))
+    service_b = lsp_module.get_service()
+    scope_b = lsp_module._current_scope()
+
+    monkeypatch.setenv("HERMES_HOME", str(home_a))
+    lsp_module.shutdown_service()
+
+    services[0].shutdown.assert_called_once()
+    services[1].shutdown.assert_not_called()
+    assert service_a is not None
+    assert service_b is not None
+    assert scope_a not in lsp_module._services
+    assert lsp_module._services[scope_b] is service_b
+    assert len(services) == 2
 
 
 def test_get_service_isolated_by_hermes_home(monkeypatch, tmp_path):

--- a/tests/agent/lsp/test_lifecycle.py
+++ b/tests/agent/lsp/test_lifecycle.py
@@ -23,9 +23,13 @@ def _reset_singleton():
     after every test so order doesn't matter.
     """
     lsp_module._service = None
+    lsp_module._service_scope = None
+    lsp_module._services.clear()
     lsp_module._atexit_registered = False
     yield
     lsp_module._service = None
+    lsp_module._service_scope = None
+    lsp_module._services.clear()
     lsp_module._atexit_registered = False
 
 
@@ -86,6 +90,33 @@ def test_shutdown_service_idempotent(monkeypatch):
     lsp_module.shutdown_service()  # must not raise
 
     assert fake_svc.shutdown.call_count == 1
+
+
+def test_get_service_isolated_by_hermes_home(monkeypatch, tmp_path):
+    """Profile-scoped service accessors must not share client state."""
+    services = []
+
+    def make_service(cls):
+        fake = MagicMock()
+        fake.is_active.return_value = True
+        services.append(fake)
+        return fake
+
+    monkeypatch.setattr(
+        lsp_module.LSPService, "create_from_config", classmethod(make_service)
+    )
+    monkeypatch.setattr(atexit, "register", lambda fn: None)
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    monkeypatch.setenv("HERMES_HOME", str(home_a))
+    service_a = lsp_module.get_service()
+    monkeypatch.setenv("HERMES_HOME", str(home_b))
+    service_b = lsp_module.get_service()
+
+    assert service_a is not service_b
+    monkeypatch.setenv("HERMES_HOME", str(home_a))
+    assert lsp_module.get_service() is service_a
+    assert len(services) == 2
 
 
 

--- a/tests/agent/lsp/test_servers.py
+++ b/tests/agent/lsp/test_servers.py
@@ -1,0 +1,70 @@
+"""Regression tests for LSP executable resolution."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.lsp.servers import ServerContext, _spawn_pyright
+
+
+@pytest.mark.parametrize("suffix", [".cmd", ".exe"])
+def test_pyright_uses_native_langserver_sibling(tmp_path: Path, monkeypatch, suffix: str):
+    official = tmp_path / "pyright"
+    sibling = tmp_path / f"pyright-langserver{suffix}"
+    official.write_text("#!/bin/sh\n", encoding="utf-8")
+    sibling.write_text("#!/bin/sh\n", encoding="utf-8")
+    official.chmod(0o755)
+    sibling.chmod(0o755)
+
+    def fake_which(name: str):
+        return str(official) if name == "pyright" else None
+
+    monkeypatch.setattr("agent.lsp.servers.shutil.which", fake_which)
+    monkeypatch.setattr("agent.lsp.install.try_install", lambda *args, **kwargs: None)
+
+    spec = _spawn_pyright(
+        str(tmp_path),
+        ServerContext(workspace_root=str(tmp_path), install_strategy="off"),
+    )
+
+    assert spec is not None
+    assert spec.command == [str(sibling), "--stdio"]
+
+
+def test_pyright_does_not_fallback_to_official_cli(tmp_path: Path, monkeypatch):
+    official = tmp_path / "pyright"
+    official.write_text("#!/bin/sh\n", encoding="utf-8")
+    official.chmod(0o755)
+
+    monkeypatch.setattr(
+        "agent.lsp.servers.shutil.which",
+        lambda name: str(official) if name == "pyright" else None,
+    )
+    monkeypatch.setattr("agent.lsp.install.try_install", lambda *args, **kwargs: None)
+
+    spec = _spawn_pyright(
+        str(tmp_path),
+        ServerContext(workspace_root=str(tmp_path), install_strategy="off"),
+    )
+
+    assert spec is None
+
+
+def test_pyright_rejects_noncanonical_langserver_wrapper(tmp_path: Path, monkeypatch):
+    wrapper = tmp_path / "pyright-langserver-wrapper"
+    wrapper.write_text("#!/bin/sh\n", encoding="utf-8")
+    wrapper.chmod(0o755)
+
+    monkeypatch.setattr(
+        "agent.lsp.servers.shutil.which",
+        lambda name: str(wrapper) if name == "pyright-langserver" else None,
+    )
+    monkeypatch.setattr("agent.lsp.install.try_install", lambda *args, **kwargs: None)
+
+    spec = _spawn_pyright(
+        str(tmp_path),
+        ServerContext(workspace_root=str(tmp_path), install_strategy="off"),
+    )
+
+    assert spec is None

--- a/tests/agent/lsp/test_validation.py
+++ b/tests/agent/lsp/test_validation.py
@@ -2,7 +2,11 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
 import stat
+import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -36,6 +40,46 @@ print('fake pyright ok')
 """
 
 
+DETACHED_FAKE_PYRIGHT = """#!/usr/bin/env python3
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+project = Path(sys.argv[sys.argv.index('--project') + 1])
+Path(os.environ['ROOT_PID']).write_text(str(os.getpid()), encoding='ascii')
+if os.environ.get('MODE') == 'detached_hang':
+    child_code = '''
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+spawned = False
+def spawn(_signum, _frame):
+    global spawned
+    if spawned:
+        return
+    spawned = True
+    grandchild = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)'])
+    Path(sys.argv[1]).write_text(str(grandchild.pid), encoding='ascii')
+
+signal.signal(signal.SIGTERM, spawn)
+time.sleep(60)
+'''
+    child = subprocess.Popen(
+        [sys.executable, '-c', child_code, os.environ['GRANDCHILD_PID']],
+        start_new_session=True,
+    )
+    Path(os.environ['CHILD_PID']).write_text(str(child.pid), encoding='ascii')
+    time.sleep(60)
+print('detached fake pyright ok')
+"""
+
+
 def _write_fake_pyright(tmp_path: Path) -> Path:
     path = tmp_path / "fake-pyright"
     path.write_text(FAKE_PYRIGHT, encoding="utf-8")
@@ -58,6 +102,17 @@ def _wait_stopped(pid: int, timeout: float = 2.0) -> bool:
             return True
         time.sleep(0.01)
     return not _live(pid)
+
+
+def _force_stop(pid: int) -> None:
+    if not _live(pid):
+        return
+    try:
+        process = psutil.Process(pid)
+        process.kill()
+        process.wait(timeout=2.0)
+    except (psutil.NoSuchProcess, psutil.TimeoutExpired):
+        pass
 
 
 def test_full_check_uses_repository_config_and_cleans_overlay(tmp_path: Path):
@@ -112,3 +167,170 @@ def test_full_check_terminates_process_group_after_timeout(tmp_path: Path):
     assert result.returncode is not None
     child_pid = int(child_pid_file.read_text(encoding="ascii"))
     assert _wait_stopped(child_pid) is True
+
+
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.linux_only
+def test_full_check_timeout_is_bounded_with_detached_pipe_holder(tmp_path: Path):
+    """A detached grandchild must not make post-timeout drain unbounded."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    fake = tmp_path / "detached-fake-pyright"
+    fake.write_text(DETACHED_FAKE_PYRIGHT, encoding="utf-8")
+    fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+    root_pid_file = tmp_path / "root.pid"
+    child_pid_file = tmp_path / "child.pid"
+    grandchild_pid_file = tmp_path / "grandchild.pid"
+    result_file = tmp_path / "result.json"
+    wrapper = """
+import json
+import sys
+from agent.lsp.validation import run_full_project_check
+
+result = run_full_project_check(
+    sys.argv[1],
+    executable=sys.argv[2],
+    timeout=0.2,
+    term_grace=0.1,
+)
+with open(sys.argv[3], 'w', encoding='utf-8') as f:
+    json.dump({'timed_out': result.timed_out, 'returncode': result.returncode}, f)
+"""
+    env = os.environ.copy()
+    env.update(
+        {
+            "MODE": "detached_hang",
+            "ROOT_PID": str(root_pid_file),
+            "CHILD_PID": str(child_pid_file),
+            "GRANDCHILD_PID": str(grandchild_pid_file),
+        }
+    )
+    worker = subprocess.Popen(
+        [sys.executable, "-c", wrapper, str(root), str(fake), str(result_file)],
+        cwd=str(Path(__file__).resolve().parents[3]),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        worker.wait(timeout=3.0)
+    except subprocess.TimeoutExpired:
+        worker.kill()
+        worker.wait(timeout=2.0)
+        pytest.fail("full-project validation did not return after its timeout")
+    finally:
+        for pid_file in (root_pid_file, child_pid_file, grandchild_pid_file):
+            if pid_file.exists():
+                _force_stop(int(pid_file.read_text(encoding="ascii")))
+
+    payload = json.loads(result_file.read_text(encoding="utf-8"))
+    assert payload["timed_out"] is True
+    assert payload["returncode"] is not None
+    assert _wait_stopped(int(child_pid_file.read_text(encoding="ascii"))) is True
+    assert _wait_stopped(int(grandchild_pid_file.read_text(encoding="ascii"))) is True
+
+
+def test_full_check_rejects_include_outside_workspace(tmp_path: Path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("x = 1\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="outside workspace"):
+        run_full_project_check(
+            str(root),
+            executable=sys.executable,
+            include=[str(outside)],
+        )
+
+
+def test_full_check_rejects_project_config_outside_workspace(tmp_path: Path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    outside = tmp_path / "pyrightconfig.json"
+    outside.write_text("{}\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="outside workspace"):
+        run_full_project_check(
+            str(root),
+            executable=sys.executable,
+            project_config=str(outside),
+        )
+
+
+def test_full_check_rejects_json_config_paths_outside_workspace(tmp_path: Path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyrightconfig.json").write_text(
+        json.dumps({"extends": "../outside-pyrightconfig.json"}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="outside workspace"):
+        run_full_project_check(str(root), executable=sys.executable)
+
+
+def test_full_check_preserves_mandatory_excludes_with_custom_overlay(tmp_path: Path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    capture = tmp_path / "capture.json"
+    project_path = tmp_path / "project-path.txt"
+    fake = _write_fake_pyright(tmp_path)
+
+    run_full_project_check(
+        str(root),
+        executable=str(fake),
+        env={"CAPTURE": str(capture), "PROJECT_PATH": str(project_path)},
+        exclude=["user-only-exclude"],
+    )
+
+    options = json.loads(capture.read_text(encoding="utf-8"))
+    overlay_dir = Path(project_path.read_text(encoding="utf-8")).parent
+    resolved_excludes = {
+        (overlay_dir / value).resolve()
+        for value in options["exclude"]
+    }
+    assert {root / item for item in DEFAULT_EXCLUDES}.issubset(resolved_excludes)
+    assert (overlay_dir / "../user-only-exclude").resolve() in resolved_excludes
+
+
+def test_full_check_rebases_pyproject_relative_extra_paths(tmp_path: Path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "src" / "pkg").mkdir(parents=True)
+    (root / "src" / "pkg" / "__init__.py").write_text("\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text(
+        "[tool.pyright]\nextraPaths = ['src']\n",
+        encoding="utf-8",
+    )
+    capture = tmp_path / "capture.json"
+    project_path = tmp_path / "project-path.txt"
+    fake = _write_fake_pyright(tmp_path)
+
+    run_full_project_check(
+        str(root),
+        executable=str(fake),
+        env={"CAPTURE": str(capture), "PROJECT_PATH": str(project_path)},
+    )
+
+    options = json.loads(capture.read_text(encoding="utf-8"))
+    overlay_dir = Path(project_path.read_text(encoding="utf-8")).parent
+    assert options["extraPaths"] == [os.path.relpath(root / "src", overlay_dir)]
+
+
+@pytest.mark.skipif(shutil.which("pyright") is None, reason="pyright is not installed")
+def test_full_check_runs_installed_pyright_with_relative_project_options(tmp_path: Path):
+    root = tmp_path / "repo"
+    source = root / "src"
+    source.mkdir(parents=True)
+    (source / "helper.py").write_text("VALUE: int = 1\n", encoding="utf-8")
+    (root / "main.py").write_text(
+        "from helper import VALUE\nresult: int = VALUE\n",
+        encoding="utf-8",
+    )
+    (root / "pyproject.toml").write_text(
+        "[tool.pyright]\nextraPaths = ['src']\ntypeCheckingMode = 'strict'\n",
+        encoding="utf-8",
+    )
+
+    result = run_full_project_check(str(root), timeout=15)
+
+    assert result.timed_out is False
+    assert result.returncode == 0, result.stderr

--- a/tests/agent/lsp/test_validation.py
+++ b/tests/agent/lsp/test_validation.py
@@ -1,0 +1,114 @@
+"""Tests for the explicit bounded full-project validation path."""
+from __future__ import annotations
+
+import json
+import stat
+import time
+from pathlib import Path
+
+import psutil
+import pytest
+
+from agent.lsp.validation import DEFAULT_EXCLUDES, run_full_project_check
+
+
+FAKE_PYRIGHT = """#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+project = Path(sys.argv[sys.argv.index('--project') + 1])
+Path(os.environ['PROJECT_PATH']).write_text(str(project), encoding='utf-8')
+Path(os.environ['CAPTURE']).write_text(
+    json.dumps(json.loads(project.read_text(encoding='utf-8'))),
+    encoding='utf-8',
+)
+if os.environ.get('MODE') == 'hang':
+    child = subprocess.Popen([
+        sys.executable, '-c', 'import time; time.sleep(60)'
+    ])
+    Path(os.environ['CHILD_PID']).write_text(str(child.pid), encoding='ascii')
+    time.sleep(60)
+print('fake pyright ok')
+"""
+
+
+def _write_fake_pyright(tmp_path: Path) -> Path:
+    path = tmp_path / "fake-pyright"
+    path.write_text(FAKE_PYRIGHT, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+def _live(pid: int) -> bool:
+    try:
+        process = psutil.Process(pid)
+        return process.is_running() and process.status() != psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return False
+
+
+def _wait_stopped(pid: int, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _live(pid):
+            return True
+        time.sleep(0.01)
+    return not _live(pid)
+
+
+def test_full_check_uses_repository_config_and_cleans_overlay(tmp_path: Path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    config = root / "pyrightconfig.json"
+    config.write_text('{"typeCheckingMode": "strict"}\n', encoding="utf-8")
+    capture = tmp_path / "capture.json"
+    project_path = tmp_path / "project-path.txt"
+    fake = _write_fake_pyright(tmp_path)
+
+    result = run_full_project_check(
+        str(root),
+        executable=str(fake),
+        env={"CAPTURE": str(capture), "PROJECT_PATH": str(project_path)},
+        timeout=3.0,
+    )
+
+    assert result.returncode == 0
+    assert result.timed_out is False
+    assert "fake pyright ok" in result.stdout
+    overlay_path = json.loads(capture.read_text(encoding="utf-8"))
+    assert overlay_path["extends"] == str(config)
+    assert overlay_path["include"] == [".."]
+    assert overlay_path["exclude"] == [f"../{item}" for item in DEFAULT_EXCLUDES]
+    assert not Path(project_path.read_text(encoding="utf-8")).exists()
+
+
+@pytest.mark.linux_only
+def test_full_check_terminates_process_group_after_timeout(tmp_path: Path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    capture = tmp_path / "capture.json"
+    project_path = tmp_path / "project-path.txt"
+    child_pid_file = tmp_path / "child.pid"
+    fake = _write_fake_pyright(tmp_path)
+
+    result = run_full_project_check(
+        str(root),
+        executable=str(fake),
+        env={
+            "CAPTURE": str(capture),
+            "PROJECT_PATH": str(project_path),
+            "MODE": "hang",
+            "CHILD_PID": str(child_pid_file),
+        },
+        timeout=0.2,
+        term_grace=0.1,
+    )
+
+    assert result.timed_out is True
+    assert result.returncode is not None
+    child_pid = int(child_pid_file.read_text(encoding="ascii"))
+    assert _wait_stopped(child_pid) is True

--- a/tests/agent/lsp/test_workspace.py
+++ b/tests/agent/lsp/test_workspace.py
@@ -14,6 +14,7 @@ from agent.lsp.workspace import (
     normalize_path,
     resolve_workspace_for_file,
 )
+from agent.lsp.servers import _root_python
 
 
 @pytest.fixture(autouse=True)
@@ -63,6 +64,33 @@ def test_resolve_workspace_for_file_uses_cwd_first(tmp_path: Path, monkeypatch):
     root, gated = resolve_workspace_for_file(str(file_path))
     assert root == str(repo)
     assert gated is True
+
+
+def test_resolve_workspace_does_not_escape_current_worktree(
+    tmp_path: Path, monkeypatch
+):
+    current = tmp_path / "current"
+    other = tmp_path / "other"
+    (current / ".git").mkdir(parents=True)
+    (other / ".git").mkdir(parents=True)
+    file_path = other / "outside.py"
+    file_path.write_text("")
+
+    monkeypatch.chdir(str(current))
+
+    assert resolve_workspace_for_file(str(file_path)) == (None, False)
+
+
+def test_python_root_does_not_escape_worktree_ceiling(tmp_path: Path):
+    parent = tmp_path / "parent"
+    workspace = parent / "workspace"
+    source = workspace / "src" / "module.py"
+    source.parent.mkdir(parents=True)
+    (parent / "pyproject.toml").write_text("")
+    (workspace / ".git").mkdir()
+    source.write_text("")
+
+    assert _root_python(str(source), str(workspace)) == str(workspace)
 
 
 


### PR DESCRIPTION
## Summary

- keep ordinary file-write diagnostics on `pyright-langserver --stdio`
- make spawn/init cancellation and owned process-group cleanup deterministic
- bound explicit Pyright validation scope/runtime and clean temporary resources
- enforce worktree ceilings and HERMES_HOME-scoped LSP service reuse

## Validation

- `scripts/run_tests.sh tests/agent/lsp/ -q` — 68 passed, 1 Linux-host skip
- `ruff check` — passed
- `ty check` — passed
- `npx pyright --pythonpath .venv/bin/python ...` — 0 errors, 0 warnings
- profile-shutdown sabotage test — failed as expected, then restored; positive test passed
- `npm run check` — not green because this checkout has no `node_modules`; no JS files changed

## Provenance boundary

The observed `/tmp/h4v3-pyrightconfig.json` points to an external H4V3 worktree and is not produced by Hermes source/history. Hermes' development-loop server argv remains `pyright-langserver --stdio`; external live Docker/runtime and exact incident PID attribution remain unverified.

Human merge only; do not merge automatically.
