### PR TITLE
feat(sdk): warmProfile — background gateway pre-dial for roster UIs

### DIFF
--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -24,7 +24,7 @@ import { openSession, type OpenSessionIntent } from '@/app/open-session'
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
 import { getLogs, getStatus } from '@/hermes'
-import { $gateway } from '@/store/gateway'
+import { $gateway, openGatewayForProfile } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, ensureGatewayProfile, newSessionInProfile, setShowAllProfiles } from '@/store/profile'
 import { $activeSessionId, $currentCwd, $currentModel, $gatewayState } from '@/store/session'
@@ -96,6 +96,23 @@ export const host = {
    *  unified all-profiles view instead of narrowing it to the target
    *  profile's sessions — a cross-profile open from a plugin surface is a
    *  navigation, not a scope choice; pass false to also scope the sidebar. */
+  /** Pre-dial a profile's gateway socket in the background — pool-only, no
+   *  activation, no navigation, no scope change (openGatewayForProfile; it
+   *  already no-ops for shared-remote routes and the primary). Roster UIs
+   *  call this after mount so the FIRST click on an agent doesn't pay the
+   *  whole backend spawn + socket dial latency. Fire-and-forget: failures
+   *  are swallowed — the click path re-runs its own ensure and surfaces
+   *  errors properly. */
+  warmProfile: (profile: string): void => {
+    const name = (profile ?? '').trim()
+
+    if (!name || name === $activeGatewayProfile.get()) {
+      return
+    }
+
+    void openGatewayForProfile(name).catch(() => undefined)
+  },
+
   openSession: async (
     storedSessionId: string,
     options: { intent?: OpenSessionIntent; keepAllProfilesScope?: boolean; profile?: null | string } = {}


### PR DESCRIPTION
Multi-profile roster UIs (Bot Mode) pay the full backend spawn + WebSocket dial cost on the FIRST click into an agent — several seconds of perceived 'session loading' (maintainer report). The connect machinery already has exactly the right primitive: `openGatewayForProfile` opens/pools a profile's socket **without** activating it, and already no-ops for the primary profile and global-remote shared routes (#85665).

This exposes it through the plugin SDK as `host.warmProfile(name)` — fire-and-forget, no navigation, no scope change, failures swallowed (the click path re-runs its own `ensureGatewayProfile` and surfaces errors properly). A roster calls it for its agents after mount; by the time the user clicks, the socket is pooled and open lands instantly.

Generic surface (any multi-profile UI benefits), narrow (one method, delegates entirely to existing machinery, no new state).