### PR TITLE
fix(agent): stop non-USD custom provider prices from inflating usage costs

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1142,9 +1142,22 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
                 if alias in normalized and normalized[alias] not in {None, ""}:
                     pricing[target] = normalized[alias]
                     break
+        for field in ("currency", "rate"):
+            if field in normalized and normalized[field] not in {None, ""}:
+                pricing[field] = normalized[field]
         if pricing:
             return pricing
     return {}
+
+
+def _copy_currency_metadata(
+    entry: Dict[str, Any],
+    payload: Dict[str, Any],
+) -> None:
+    if payload.get("currency") not in {None, ""}:
+        entry["currency"] = payload["currency"]
+        if payload.get("rate") not in {None, ""}:
+            entry["rate"] = payload["rate"]
 
 
 def _add_model_aliases(cache: Dict[str, Dict[str, Any]], model_id: str, entry: Dict[str, Any]) -> None:
@@ -1273,6 +1286,7 @@ def fetch_endpoint_model_metadata(
                     if not model_id:
                         continue
                     entry: Dict[str, Any] = {"name": model.get("name", model_id)}
+                    _copy_currency_metadata(entry, model)
 
                     context_length = None
                     for inst in model.get("loaded_instances", []) or []:
@@ -1344,6 +1358,7 @@ def fetch_endpoint_model_metadata(
                 if not model_id:
                     continue
                 entry: Dict[str, Any] = {"name": model.get("name", model_id)}
+                _copy_currency_metadata(entry, model)
                 context_length = _extract_context_length(model)
                 if context_length is not None:
                     entry["context_length"] = context_length

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1195,7 +1195,10 @@ def _openrouter_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
     )
 
 
-def _custom_provider_pricing_override(base_url: str) -> Dict[str, Any]:
+def _custom_provider_pricing_override(
+    base_url: str,
+    provider: str = "",
+) -> Dict[str, Any]:
     """Return explicit pricing semantics for the custom provider at *base_url*."""
     if not base_url:
         return {}
@@ -1207,11 +1210,17 @@ def _custom_provider_pricing_override(base_url: str) -> Dict[str, Any]:
         )
 
         target = normalize_route_base_url(base_url)
+        provider_key = provider.strip().lower()
+        matches = []
         for entry in get_compatible_custom_providers(load_config_readonly()):
             candidate = normalize_route_base_url(entry.get("base_url"))
             pricing = entry.get("pricing")
             if candidate == target and isinstance(pricing, dict):
-                return pricing
+                matches.append(entry)
+                if str(entry.get("provider_key") or "").strip().lower() == provider_key:
+                    return pricing
+        if len(matches) == 1:
+            return matches[0]["pricing"]
     except Exception:
         logger.debug("custom-provider pricing override resolution failed", exc_info=True)
     return {}
@@ -1312,7 +1321,10 @@ def get_pricing_entry(
             route.model,
             source_url=f"{route.base_url.rstrip('/')}/models",
             pricing_version="openai-compatible-models-api",
-            pricing_override=_custom_provider_pricing_override(route.base_url),
+            pricing_override=_custom_provider_pricing_override(
+                route.base_url,
+                route.provider,
+            ),
         )
         if entry:
             return entry

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_PRICING = {"input": 0.0, "output": 0.0}
 
 _ZERO = Decimal("0")
+_ONE = Decimal("1")
 _ONE_MILLION = Decimal("1000000")
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 
@@ -1194,16 +1195,65 @@ def _openrouter_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
     )
 
 
+def _custom_provider_pricing_override(base_url: str) -> Dict[str, Any]:
+    """Return explicit pricing semantics for the custom provider at *base_url*."""
+    if not base_url:
+        return {}
+    try:
+        from hermes_cli.config import (
+            get_compatible_custom_providers,
+            load_config_readonly,
+            normalize_route_base_url,
+        )
+
+        target = normalize_route_base_url(base_url)
+        for entry in get_compatible_custom_providers(load_config_readonly()):
+            candidate = normalize_route_base_url(entry.get("base_url"))
+            pricing = entry.get("pricing")
+            if candidate == target and isinstance(pricing, dict):
+                return pricing
+    except Exception:
+        logger.debug("custom-provider pricing override resolution failed", exc_info=True)
+    return {}
+
+
 def _pricing_entry_from_metadata(
     metadata: Dict[str, Dict[str, Any]],
     model_id: str,
     *,
     source_url: str,
     pricing_version: str,
+    pricing_override: Optional[Dict[str, Any]] = None,
 ) -> Optional[PricingEntry]:
     if model_id not in metadata:
         return None
-    pricing = metadata[model_id].get("pricing") or {}
+    model_metadata = metadata[model_id]
+    pricing = model_metadata.get("pricing") or {}
+    if not isinstance(pricing, dict):
+        return None
+    pricing = dict(pricing)
+    # Some compatible catalogs place these beside ``pricing`` rather than
+    # inside it. Accept both shapes, with the nested value taking precedence.
+    for key in ("currency", "rate"):
+        if key not in pricing and key in model_metadata:
+            pricing[key] = model_metadata[key]
+    # A local provider config is an explicit user contract and therefore wins
+    # over incomplete or incorrect endpoint metadata.
+    if pricing_override:
+        for key in ("currency", "rate"):
+            if key in pricing_override:
+                pricing[key] = pricing_override[key]
+
+    currency = str(pricing.get("currency") or "USD").strip().upper()
+    usd_rate = _ONE
+    if currency != "USD":
+        usd_rate = _to_decimal(pricing.get("rate"))
+        if usd_rate is None or usd_rate <= _ZERO:
+            # The endpoint has told us the values are not USD, but has not
+            # supplied a safe conversion contract. Unknown is more honest than
+            # silently relabelling foreign currency as dollars.
+            return None
+
     prompt = _to_decimal(pricing.get("prompt"))
     completion = _to_decimal(pricing.get("completion"))
     request = _to_decimal(pricing.get("request"))
@@ -1223,14 +1273,14 @@ def _pricing_entry_from_metadata(
     def _per_token_to_per_million(value: Optional[Decimal]) -> Optional[Decimal]:
         if value is None:
             return None
-        return value * _ONE_MILLION
+        return value * usd_rate * _ONE_MILLION
 
     return PricingEntry(
         input_cost_per_million=_per_token_to_per_million(prompt),
         output_cost_per_million=_per_token_to_per_million(completion),
         cache_read_cost_per_million=_per_token_to_per_million(cache_read),
         cache_write_cost_per_million=_per_token_to_per_million(cache_write),
-        request_cost=request,
+        request_cost=request * usd_rate if request is not None else None,
         source="provider_models_api",
         source_url=source_url,
         pricing_version=pricing_version,
@@ -1262,6 +1312,7 @@ def get_pricing_entry(
             route.model,
             source_url=f"{route.base_url.rstrip('/')}/models",
             pricing_version="openai-compatible-models-api",
+            pricing_override=_custom_provider_pricing_override(route.base_url),
         )
         if entry:
             return entry

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1257,7 +1257,7 @@ def _pricing_entry_from_metadata(
     usd_rate = _ONE
     if currency != "USD":
         usd_rate = _to_decimal(pricing.get("rate"))
-        if usd_rate is None or usd_rate <= _ZERO:
+        if usd_rate is None or not usd_rate.is_finite() or usd_rate <= _ZERO:
             # The endpoint has told us the values are not USD, but has not
             # supplied a safe conversion contract. Unknown is more honest than
             # silently relabelling foreign currency as dollars.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1328,6 +1328,7 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
+        "pricing",
         "ssl_ca_cert", "ssl_verify",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -1456,6 +1457,10 @@ def _normalize_custom_provider_entry(
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
 
+    pricing = entry.get("pricing")
+    if isinstance(pricing, dict):
+        normalized["pricing"] = dict(pricing)
+
     # Per-provider extra HTTP headers (proxies, gateways, custom auth).
     # Values may carry credentials (e.g. CF-Access-Client-Secret) — never
     # log them anywhere downstream.
@@ -1501,6 +1506,7 @@ def _custom_provider_entry_to_provider_config(
         "discover_models",
         "extra_body",
         "extra_headers",
+        "pricing",
         "ssl_ca_cert",
         "ssl_verify",
     ):

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -567,6 +567,42 @@ class TestFetchEndpointModelMetadata:
         not_found.close.assert_called_once()
         success.close.assert_called_once()
 
+    def test_currency_semantics_survive_endpoint_metadata_normalization(self):
+        import agent.model_metadata as mm
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "data": [
+                {
+                    "id": "nested",
+                    "pricing": {
+                        "prompt": "0.000008137",
+                        "completion": "0.000020133",
+                        "currency": "RUB",
+                        "rate": "0.011",
+                    },
+                },
+                {
+                    "id": "top-level",
+                    "pricing": {
+                        "prompt": "0.000008137",
+                        "completion": "0.000020133",
+                    },
+                    "currency": "RUB",
+                    "rate": "0.011",
+                },
+            ]
+        }
+
+        with patch("agent.model_metadata.requests.get", return_value=response):
+            result = mm.fetch_endpoint_model_metadata("https://custom.example/v1")
+
+        assert result["nested"]["pricing"]["currency"] == "RUB"
+        assert result["nested"]["pricing"]["rate"] == "0.011"
+        assert result["top-level"]["currency"] == "RUB"
+        assert result["top-level"]["rate"] == "0.011"
+
 
 # =========================================================================
 # Nous Portal context-window resolution (provider="nous")

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -380,6 +380,38 @@ def test_custom_endpoint_uses_provider_currency_override(monkeypatch):
     assert entry.output_cost_per_million == Decimal("0.221463")
 
 
+def test_named_custom_provider_selects_its_own_same_url_override(monkeypatch):
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda *_args, **_kwargs: {
+            "model": {"pricing": {"prompt": "0.000001", "completion": "0.000002"}}
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "providers": {
+                "first": {
+                    "api": "https://router.example/v1",
+                    "pricing": {"currency": "RUB", "rate": "0.01"},
+                },
+                "second": {
+                    "api": "https://router.example/v1",
+                    "pricing": {"currency": "RUB", "rate": "0.02"},
+                },
+            }
+        },
+    )
+
+    entry = get_pricing_entry(
+        "model", provider="second", base_url="https://router.example/v1"
+    )
+
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("0.02")
+    assert entry.output_cost_per_million == Decimal("0.04")
+
+
 def test_custom_endpoint_rejects_non_usd_pricing_without_rate(monkeypatch):
     """Never relabel a declared foreign-currency amount as USD by guessing."""
     monkeypatch.setattr(

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -316,6 +316,110 @@ def test_vertex_default_model_estimates_cached_usage(monkeypatch):
     assert result.amount_usd is not None and result.amount_usd > 0
 
 
+def test_custom_endpoint_converts_declared_rub_pricing_to_usd(monkeypatch):
+    """A non-USD catalog rate must be converted before entering USD accounting."""
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda *_args, **_kwargs: {
+            "deepseek/deepseek-v4-flash": {
+                "pricing": {
+                    "prompt": "0.000008137",
+                    "completion": "0.000020133",
+                    "cache_read": "0.000001",
+                    "cache_write": "0.000002",
+                    "request": "1.5",
+                    "currency": "RUB",
+                    "rate": "0.011",
+                }
+            }
+        },
+    )
+
+    entry = get_pricing_entry(
+        "deepseek/deepseek-v4-flash",
+        provider="custom",
+        base_url="https://router.example/v1",
+    )
+
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("0.089507")
+    assert entry.output_cost_per_million == Decimal("0.221463")
+    assert entry.cache_read_cost_per_million == Decimal("0.011")
+    assert entry.cache_write_cost_per_million == Decimal("0.022")
+    assert entry.request_cost == Decimal("0.0165")
+
+
+def test_custom_endpoint_uses_provider_currency_override(monkeypatch):
+    """Provider config supplies currency semantics when /models omits them."""
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda *_args, **_kwargs: {
+            "model": {
+                "pricing": {"prompt": "0.000008137", "completion": "0.000020133"}
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "providers": {
+                "router": {
+                    "api": "https://router.example/v1/",
+                    "pricing": {"currency": "RUB", "rate": "0.011"},
+                }
+            }
+        },
+    )
+
+    entry = get_pricing_entry(
+        "model", provider="custom", base_url="https://router.example/v1"
+    )
+
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("0.089507")
+    assert entry.output_cost_per_million == Decimal("0.221463")
+
+
+def test_custom_endpoint_rejects_non_usd_pricing_without_rate(monkeypatch):
+    """Never relabel a declared foreign-currency amount as USD by guessing."""
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda *_args, **_kwargs: {
+            "model": {
+                "pricing": {
+                    "prompt": "0.000008137",
+                    "completion": "0.000020133",
+                    "currency": "RUB",
+                }
+            }
+        },
+    )
+
+    assert (
+        get_pricing_entry(
+            "model", provider="custom", base_url="https://router.example/v1"
+        )
+        is None
+    )
+
+
+def test_custom_endpoint_keeps_legacy_usd_pricing_unchanged(monkeypatch):
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda *_args, **_kwargs: {
+            "model": {"pricing": {"prompt": "0.000001", "completion": "0.000002"}}
+        },
+    )
+
+    entry = get_pricing_entry(
+        "model", provider="custom", base_url="https://usd.example/v1"
+    )
+
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("1")
+    assert entry.output_cost_per_million == Decimal("2")
+
+
 def test_normalize_usage_minimax_logs_cache_observability(caplog):
     """MiniMax providers on the Anthropic wire emit a debug-level
     cache-observability line recording the observable fields

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,4 +1,7 @@
+from decimal import Decimal
 from types import SimpleNamespace
+
+import pytest
 
 from agent.usage_pricing import (
     CanonicalUsage,
@@ -8,13 +11,6 @@ from agent.usage_pricing import (
     normalize_usage,
     resolve_billing_route,
 )
-from decimal import Decimal
-
-
-
-
-
-
 
 
 def test_normalize_usage_reads_deepseek_native_cache_hit_tokens():
@@ -422,6 +418,30 @@ def test_custom_endpoint_rejects_non_usd_pricing_without_rate(monkeypatch):
                     "prompt": "0.000008137",
                     "completion": "0.000020133",
                     "currency": "RUB",
+                }
+            }
+        },
+    )
+
+    assert (
+        get_pricing_entry(
+            "model", provider="custom", base_url="https://router.example/v1"
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("rate", ["NaN", "Infinity"])
+def test_custom_endpoint_rejects_nonfinite_currency_rate(monkeypatch, rate):
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda *_args, **_kwargs: {
+            "model": {
+                "pricing": {
+                    "prompt": "0.000008137",
+                    "completion": "0.000020133",
+                    "currency": "RUB",
+                    "rate": rate,
                 }
             }
         },

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -846,6 +846,7 @@ class TestCustomProviderCompatibility:
                             "extra_body": {
                                 "chat_template_kwargs": {"enable_thinking": False}
                             },
+                            "pricing": {"currency": "RUB", "rate": 0.011},
                         },
                         {
                             "name": "List Models",
@@ -876,6 +877,7 @@ class TestCustomProviderCompatibility:
         assert provider["extra_body"] == {
             "chat_template_kwargs": {"enable_thinking": False}
         }
+        assert provider["pricing"] == {"currency": "RUB", "rate": 0.011}
         assert raw["providers"]["list-models"]["models"] == {
             "alpha": {},
             "beta": {},
@@ -886,6 +888,10 @@ class TestCustomProviderCompatibility:
         )
         assert compatible_provider["models"] == model_map
         assert compatible_provider["key_env"] == "KIMI_CODING_API_KEY"
+        assert compatible_provider["pricing"] == {
+            "currency": "RUB",
+            "rate": 0.011,
+        }
 
     def test_providers_dict_resolves_at_runtime(self, tmp_path):
         """After migration deleted custom_providers, get_compatible_custom_providers

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1271,7 +1271,26 @@ providers:
     transport: anthropic_messages  # for Anthropic-compatible proxies
 ```
 
-Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accepted aliases), `name` (optional display name; defaults to the dict key), `key_env` or inline `api_key`, `transport` (`chat_completions` / `anthropic_messages` / `codex_responses`), `default_model`, `models`, `context_length`, `discover_models`, `extra_body`, `extra_headers`, `ssl_ca_cert` / `ssl_verify`, and `enabled: false` to hide an entry without deleting it.
+Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accepted aliases), `name` (optional display name; defaults to the dict key), `key_env` or inline `api_key`, `transport` (`chat_completions` / `anthropic_messages` / `codex_responses`), `default_model`, `models`, `context_length`, `discover_models`, `pricing`, `extra_body`, `extra_headers`, `ssl_ca_cert` / `ssl_verify`, and `enabled: false` to hide an entry without deleting it.
+
+If an endpoint's `/models` prices are denominated in a currency other than USD,
+declare the currency and the number of USD per one unit of that currency. Hermes
+applies the rate to prompt, completion, cache, and request prices before recording
+USD costs:
+
+```yaml
+providers:
+  router-ai:
+    api: https://router.example/v1
+    pricing:
+      currency: RUB
+      rate: 0.011  # USD per RUB; update when your billing conversion changes
+```
+
+An endpoint may publish the same `currency` and `rate` fields in each model's
+`pricing` object. Provider config takes precedence. If a catalog declares a
+non-USD currency without a positive rate, Hermes reports its pricing as unknown
+instead of incorrectly labelling the foreign-currency amount as USD.
 
 :::note Legacy format
 Older configs used a top-level `custom_providers:` list instead. It still works — Hermes reads both — and `hermes update` auto-migrates it to the `providers:` dict (config v12). Field names differ slightly in the dict format: legacy `model` is `default_model`, and legacy `api_mode` is `transport`.


### PR DESCRIPTION
## What does this PR do?

Custom OpenAI-compatible providers can publish per-token prices in a currency other than USD, but Hermes previously displayed those raw values as dollars. This change preserves explicit currency metadata, converts prices through a configured USD-per-currency-unit rate, and reports pricing as unknown rather than silently mislabelling non-USD amounts when no valid rate is available.

### Symptom

Router AI publishes prompt and completion prices of 0.000008137 RUB and 0.000020133 RUB per token. Hermes interpreted them as USD and displayed $8.137 and $20.133 per million tokens instead of approximately $0.09 and $0.22 at a 0.011 USD-per-RUB rate.

### Impact

Usage estimates for affected custom providers can be overstated by the currency conversion factor, making Hermes cost reporting unreliable for users billed outside USD.

### Bug Cause

**Trigger:** `agent/usage_pricing.py:1229` / `_pricing_entry_from_metadata`

**Causal chain:**
1. A custom OpenAI-compatible `/models` response supplies per-token pricing denominated outside USD.
2. Endpoint normalization discarded currency fields, and the pricing parser multiplied the remaining values by one million without applying currency semantics.
3. The resulting foreign-currency amount was stored and rendered as USD.

**Why it is wrong:** The metadata path had no explicit currency contract, so a correctly reported RUB price was silently relabelled as dollars.

**Working sibling / contrast:** Official pricing snapshots and OpenRouter metadata already use USD pricing and do not require conversion. Legacy custom endpoints that omit currency continue to use the existing USD interpretation.

**Ruled out:** Display formatting is not the cause; the incorrect dollar amount was already present in the canonical `PricingEntry` before rendering.

### Fix

Preserve endpoint `currency` and `rate` metadata through normalization, accept a provider-level `pricing` override in `config.yaml`, and apply the positive USD-per-currency-unit rate to prompt, completion, cache, and request prices. Provider identity now disambiguates overrides when named providers share a base URL. Explicit non-USD pricing without a usable rate fails closed as unknown.

## Related Issue

Closes #85883

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` - preserve nested and model-level currency metadata from compatible model catalogs.
- `agent/usage_pricing.py` - resolve provider-specific pricing contracts, convert all pricing buckets to USD, and fail closed on invalid non-USD rates.
- `hermes_cli/config.py` - retain custom provider pricing during compatibility normalization.
- `website/docs/integrations/providers.md` - document the `pricing.currency` and `pricing.rate` contract.
- `tests/agent/test_model_metadata.py`, `tests/agent/test_usage_pricing.py`, and `tests/hermes_cli/test_config.py` - cover metadata boundaries, RUB conversion, fail-closed behavior, legacy USD pricing, shared-URL provider identity, and config retention.

## How to Test

1. Configure a custom provider with `pricing.currency: RUB` and `pricing.rate: 0.011`.
2. Resolve metadata containing prompt price `0.000008137` and completion price `0.000020133`.
3. Confirm Hermes records approximately $0.089507 and $0.221463 per million tokens, while a non-USD declaration without a positive rate returns unknown pricing.
4. Run the focused test suites:

```bash
scripts/run_tests.sh tests/agent/test_usage_pricing.py tests/agent/test_model_metadata.py
scripts/run_tests.sh tests/hermes_cli/test_config.py -k TestCustomProviderCompatibility
```

The focused suites passed 130 tests on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry point on the relevant tests and all focused tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because the setting belongs to named custom-provider entries
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the conversion and metadata handling are platform-independent
- [x] Tool descriptions and schemas are N/A because no model tool changed
