### PR TITLE
fix(terminal): guard against TERMINAL_TIMEOUT=0 (instant timeout)

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1700,6 +1700,21 @@ def _get_env_config() -> Dict[str, Any]:
         ).lower() in {"true", "1", "yes"},
     }
 
+    # Guard against TERMINAL_TIMEOUT=0 (or negative), which silently makes
+    # every command instantly time out with "timed out after 0s". Users often
+    # set 0 expecting "infinite", but it means instant timeout. Fall back to
+    # the documented default (180s) with a warning (see issue #85809).
+    raw_timeout = config["timeout"]
+    if isinstance(raw_timeout, int) and raw_timeout <= 0:
+        logger.warning(
+            "TERMINAL_TIMEOUT=%s is invalid (must be > 0); falling back to the "
+            "default 180s. Note: 0 does NOT mean 'no timeout' — it means "
+            "'instant timeout'. If you want no timeout, set a very large value "
+            "(e.g. 86400) or unset TERMINAL_TIMEOUT to use the default.",
+            raw_timeout,
+        )
+        config["timeout"] = 180
+
 
 def _get_modal_backend_state(modal_mode: object | None) -> Dict[str, Any]:
     """Resolve direct vs managed Modal backend selection."""


### PR DESCRIPTION
## Summary
Closes #85809.

When users set TERMINAL_TIMEOUT=0 expecting 'no timeout', every command instantly fails with 'timed out after 0s' - a confusing error that looks like an IPC failure rather than a config issue.

## Changes
- Added validation guard after the terminal config dict is built
- If TERMINAL_TIMEOUT is 0 or negative, log a clear warning and fall back to 180s default
- Warning message explains that 0 does NOT mean infinite and tells users what to do

## Impact
- Prevents the confusing 'timed out after 0s' error
- 205 failures in 3 months on a single deployment were traced to this issue
- Users with TERMINAL_TIMEOUT=0 will now get a clear, actionable warning

## Test plan
- Setting TERMINAL_TIMEOUT=0 falls back to 180s with warning
- Setting TERMINAL_TIMEOUT=-1 falls back to 180s with warning
- Setting TERMINAL_TIMEOUT=60 still works as before
- Unset TERMINAL_TIMEOUT uses default 180s

Generated with CatPaw