### PR TITLE
fix(plugins): handle a capability declared with no legacy gate path

### DIFF
--- a/hermes_cli/plugin_capabilities.py
+++ b/hermes_cli/plugin_capabilities.py
@@ -221,7 +221,16 @@ def granted_capabilities(
 
 
 def _legacy_gate_set(entry: Mapping[str, Any], spec: CapabilitySpec) -> bool:
-    """True when the deprecated ``allow_*`` key for *spec* is truthy."""
+    """True when the deprecated ``allow_*`` key for *spec* is truthy.
+
+    A capability with no deprecated predecessor (``legacy_path=()``) has no
+    legacy gate to open, so it is never granted this way. Without this guard
+    the loop below never runs, ``node`` is still the plugin's whole config
+    entry, and ``bool(node)`` grants the capability to any plugin that has a
+    config block at all — a default-off gate that is on (ground rule 4).
+    """
+    if not spec.legacy_path:
+        return False
     node: Any = entry
     for part in spec.legacy_path:
         if not isinstance(node, Mapping):
@@ -329,8 +338,13 @@ def record_consent(
 
     # Bridge: mirror each granted capability into its legacy gate so the
     # existing enforcement sites (which still read allow_*) honor the grant.
+    # A capability with no deprecated predecessor has no key to mirror into —
+    # without this guard ``legacy_path[-1]`` raises IndexError and consent
+    # cannot be recorded at all. Its enforcing surface reads the grant.
     for cap in entry[GRANTED_KEY]:
         spec = CAPABILITY_REGISTRY[cap]
+        if not spec.legacy_path:
+            continue
         node = entry
         for part in spec.legacy_path[:-1]:
             child = node.setdefault(part, {})

--- a/tests/hermes_cli/test_plugin_capabilities.py
+++ b/tests/hermes_cli/test_plugin_capabilities.py
@@ -16,6 +16,8 @@ import yaml
 from hermes_cli.plugin_capabilities import (
     CAPABILITY_REGISTRY,
     VALID_CAPABILITY_IDS,
+    CapabilitySpec,
+    _legacy_gate_set,
     capability_set_hash,
     consent_hash,
     declared_set_changed,
@@ -346,6 +348,65 @@ class TestLegacyGateCompat:
         manifest = PluginManifest(name="oldplug", source="user", key="oldplug")
         ctx = PluginContext(manifest, PluginManager())
         assert ctx._tool_override_allowed("write_file") is True
+
+    def test_empty_legacy_path_has_no_legacy_gate(self):
+        """A capability with no deprecated predecessor never opens this way.
+
+        The walk over an empty ``legacy_path`` leaves ``node`` pointing at the
+        plugin's whole config entry, so the truthiness check at the end would
+        grant on any non-empty entry.
+        """
+        spec = CapabilitySpec(
+            id="llm.no_predecessor",
+            legacy_path=(),
+            description="A capability with no deprecated allow_* key",
+        )
+        assert _legacy_gate_set({"enabled": True}, spec) is False
+
+    def test_capability_without_legacy_path_stays_denied(
+        self, hermes_home, monkeypatch
+    ):
+        """End to end: a config block alone must not grant the capability."""
+        spec = CapabilitySpec(
+            id="llm.no_predecessor",
+            legacy_path=(),
+            description="A capability with no deprecated allow_* key",
+        )
+        monkeypatch.setitem(CAPABILITY_REGISTRY, spec.id, spec)
+        (hermes_home / "config.yaml").write_text(
+            "plugins:\n  entries:\n    newplug:\n      enabled: true\n",
+            encoding="utf-8",
+        )
+        assert plugin_capability_granted("newplug", spec.id) is False
+
+    def test_consent_records_a_capability_without_a_legacy_path(
+        self, hermes_home, monkeypatch
+    ):
+        """Consent must still be recordable with no allow_* key to mirror into.
+
+        The bridge writes ``legacy_path[-1]`` for every granted capability;
+        an empty path made that an IndexError, so consenting to such a
+        capability failed outright. The grant itself is the enforcing state.
+        """
+        import hermes_cli.plugin_capabilities as pc
+
+        spec = CapabilitySpec(
+            id="llm.no_predecessor",
+            legacy_path=(),
+            description="A capability with no deprecated allow_* key",
+        )
+        monkeypatch.setitem(CAPABILITY_REGISTRY, spec.id, spec)
+        monkeypatch.setattr(
+            pc, "VALID_CAPABILITY_IDS", frozenset(CAPABILITY_REGISTRY)
+        )
+
+        record_consent("newplug", [spec.id], [spec.id])
+
+        entry = _read_cfg(hermes_home)["plugins"]["entries"]["newplug"]
+        assert entry["granted_capabilities"] == [spec.id]
+        # Nothing invented in place of the absent legacy key.
+        assert set(entry) == {"granted_capabilities", "capabilities_consent"}
+        assert plugin_capability_granted("newplug", spec.id) is True
 
     def test_bundled_plugin_trusted(self, hermes_home):
         from hermes_cli.plugins import PluginContext, PluginManifest, PluginManager


### PR DESCRIPTION
## What does this PR do?

`CapabilitySpec.legacy_path` is effectively required today, because every capability in the registry maps 1:1 to a deprecated `allow_*` predecessor. Two places in `hermes_cli/plugin_capabilities.py` assume that will always hold, and both break for a capability declared without one.

**1. The legacy gate fails OPEN.** `_legacy_gate_set()` walks `spec.legacy_path` and then returns `bool(node)`. With an empty path the loop body never runs, `node` is still the plugin's *whole config entry*, and the capability is granted to any plugin that has a config block at all. `plugin_capability_granted()` reports it as a legitimate grant, with `evidence=legacy key plugins.entries.<plugin>. (deprecated)` in the decision log. A capability minted without a legacy predecessor would therefore ship a default-off gate that is actually on — the inverse of the module's fail-closed ground rule (ground rule 4), for that capability.

**2. Consent cannot be recorded at all.** `record_consent()` mirrors every granted capability into its legacy key via `spec.legacy_path[-1]`, which raises `IndexError: tuple index out of range` on an empty tuple. Granting such a capability fails outright, so there is no way to reach the correct state either.

Both halves are the same defect class — "a capability always has a deprecated predecessor" — so they are fixed together here rather than split across two PRs.

**Scope, honestly:** no shipped capability declares an empty `legacy_path` today, and `test_every_capability_has_legacy_gate` pins that, so this is a latent bug rather than a live user-facing break. It fires the first time a capability is minted without a deprecated predecessor — a policy the module docstring states ("We deliberately do not mint capability ids without an enforcing gate") but nothing enforces at the type level — and it fires in the fail-open direction. That combination seemed worth closing before the capability exists rather than after.

**Security note** (per CONTRIBUTING § Security Considerations): the first half is a fail-open in a trust gate. It does not breach the sandbox boundary — capabilities govern which host API surfaces are handed out, and in-process plugins remain trusted code — but it inverts the documented default-off posture for the affected capability, and the audit log records the grant as if a user had opted in.

The fix is two guards, one sentence each: a capability with no deprecated predecessor has no legacy gate to open, and no key to mirror into. Its entry in `granted_capabilities` is the enforcing state.

## Related Issue

No existing issue covers this. Searched open and closed issues and PRs for `legacy_path`, `capability legacy gate`, and `plugin capability` before writing the fix — no matches. Happy to file a tracker entry if you would rather have one to link.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugin_capabilities.py` — `_legacy_gate_set()`: return `False` when `spec.legacy_path` is empty, instead of falling through to `bool(entry)`. Docstring records why the empty case is not a no-op.
- `hermes_cli/plugin_capabilities.py` — `record_consent()`: skip the legacy-key mirror for a capability with no `legacy_path`, instead of indexing `[-1]` into an empty tuple. The grant itself is already persisted by that point.
- `tests/hermes_cli/test_plugin_capabilities.py` — three cases in `TestLegacyGateCompat`:
  - `test_empty_legacy_path_has_no_legacy_gate` — the unit case, straight on `_legacy_gate_set`.
  - `test_capability_without_legacy_path_stays_denied` — end to end through `plugin_capability_granted()` for a plugin that has a config entry and no grant.
  - `test_consent_records_a_capability_without_a_legacy_path` — the consent round-trip, asserting the grant persists and that no legacy key is invented in place of the absent one.

No behavior changes for any capability that has a `legacy_path` — every existing registry entry takes the same path it does today.

## How to Test

1. **See the fail-open directly**, no test harness — drop this in the repo root and run it on `main`, then on this branch:
   ```python
   import logging; logging.basicConfig(level=logging.DEBUG)
   from hermes_cli.plugin_capabilities import (
       CAPABILITY_REGISTRY, CapabilitySpec, plugin_capability_granted)

   spec = CapabilitySpec(id="llm.no_predecessor", legacy_path=(),
                         description="A capability with no deprecated allow_* key")
   CAPABILITY_REGISTRY[spec.id] = spec
   # a plugin that has a config block and was granted nothing at all
   config = {"plugins": {"entries": {"newplug": {"enabled": True}}}}
   print(plugin_capability_granted("newplug", spec.id, config=config))
   ```
   On `main` it prints `True`; on this branch, `False`. Output of both runs is in the log block below.
2. Run the file: `scripts/run_tests.sh tests/hermes_cli/test_plugin_capabilities.py -q` → **42 passed**.
3. Prove each case fails without the fix — keep the new tests, revert only the source:
   ```bash
   git checkout HEAD~1 -- hermes_cli/plugin_capabilities.py
   pytest tests/hermes_cli/test_plugin_capabilities.py -q \
     -k "empty_legacy_path or without_legacy_path or without_a_legacy_path"
   # 3 failed  (fail-open grant x2, IndexError x1 — output below)
   git checkout HEAD -- hermes_cli/plugin_capabilities.py   # restore
   ```
4. Full suite: `scripts/run_tests.sh` — see the checklist below for the result on this machine.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(plugins): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — one commit, two files
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the full suite via `scripts/run_tests.sh` and it is not literally all-green on this machine, so here is the exact accounting instead of a checked box: **2873 files, 31540 passed, 76 failed, 311 skipped**. All 76 are in 21 files this PR does not touch (`tests/tools/`, `tests/plugins/`, `tests/gateway/` — optional-dependency and local-environment failures), and re-running exactly those 21 files on a pristine `9166530942` worktree on the same machine reproduces **76 failed** as well. This branch introduces zero new failures; `tests/hermes_cli/test_plugin_capabilities.py` is 42/42 green.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the two guards are documented in the docstrings/comments at each site; no user-facing docs surface changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys added or changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture change
- [x] I've considered cross-platform impact (Windows, macOS) — N/A, pure config-state logic with no OS-dependent behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The standalone repro from step 1, on `main` — a plugin that was granted nothing is handed the capability, and the decision log attributes it to a legacy key whose path is empty:

```
INFO capability_check plugin=newplug capability=llm.no_predecessor decision=allow
     checked_by=plugin_capability_granted evidence=legacy key plugins.entries.newplug. (deprecated)

plugin_capability_granted('newplug', 'llm.no_predecessor') -> True
```

Same script, same machine, on this branch:

```
INFO capability_check plugin=newplug capability=llm.no_predecessor decision=deny
     checked_by=plugin_capability_granted evidence=not granted

plugin_capability_granted('newplug', 'llm.no_predecessor') -> False
```

Test file with the fix:

```
$ scripts/run_tests.sh tests/hermes_cli/test_plugin_capabilities.py -q
Discovered 1 test files (~42 tests) under ['tests/hermes_cli/test_plugin_capabilities.py']
[100.0% |    42/~42 | ✓42 | ✗ 0] ✓ tests/hermes_cli/test_plugin_capabilities.py (42✓, 1.1s)
=== Summary: 1 files, 42 tests passed, 0 failed (100% complete) in 1.1s ===
```

Source reverted, tests kept — both regressions reproduce:

```
$ git checkout HEAD~1 -- hermes_cli/plugin_capabilities.py
$ pytest tests/hermes_cli/test_plugin_capabilities.py -q -k "empty_legacy_path or without_legacy_path or without_a_legacy_path"

        for cap in entry[GRANTED_KEY]:
            spec = CAPABILITY_REGISTRY[cap]
            node = entry
            for part in spec.legacy_path[:-1]:
                ...
>           node[spec.legacy_path[-1]] = True
                 ^^^^^^^^^^^^^^^^^^^^
E           IndexError: tuple index out of range

hermes_cli/plugin_capabilities.py:341: IndexError
=========================== short test summary info ============================
FAILED tests/hermes_cli/test_plugin_capabilities.py::TestLegacyGateCompat::test_empty_legacy_path_has_no_legacy_gate
FAILED tests/hermes_cli/test_plugin_capabilities.py::TestLegacyGateCompat::test_capability_without_legacy_path_stays_denied
FAILED tests/hermes_cli/test_plugin_capabilities.py::TestLegacyGateCompat::test_consent_records_a_capability_without_a_legacy_path
3 failed, 39 deselected
```
