### PR TITLE
fix(desktop): resolve the packed app by its configured product name

### DIFF
--- a/hermes_cli/gui_uninstall.py
+++ b/hermes_cli/gui_uninstall.py
@@ -35,6 +35,7 @@ import time so the Electron main process can shell out to
 ``hermes uninstall --gui`` (and friends) without paying for the full CLI.
 """
 
+import json
 import os
 import shutil
 import sys
@@ -67,24 +68,47 @@ def _agent_root(hermes_home: Path) -> Path:
     return hermes_home / "hermes-agent"
 
 
+def _desktop_product_name() -> str:
+    """The product name the installed desktop build packs and stores under.
+
+    electron-builder names the app bundle, the NSIS install directory and
+    Electron's own ``userData`` directory after ``build.productName`` in
+    ``apps/desktop/package.json``. Reading it back from the checkout keeps
+    uninstall honest for a build that sets it; a packaged-only install with no
+    checkout falls back to the stock name, which is what that install has.
+    """
+    try:
+        pkg_path = _agent_root(get_hermes_home()) / "apps" / "desktop" / "package.json"
+        pkg = json.loads(pkg_path.read_text(encoding="utf-8"))
+        build = pkg.get("build") if isinstance(pkg, dict) else None
+        name = (build or {}).get("productName") or (pkg or {}).get("productName")
+        if isinstance(name, str) and name:
+            return name
+    except (OSError, json.JSONDecodeError, AttributeError):
+        pass
+    return "Hermes"
+
+
 def desktop_userdata_dir() -> Path:
     """Return the Electron ``userData`` directory for the desktop app.
 
-    Mirrors Electron's ``app.getPath('userData')`` for an app named "Hermes"
-    on each platform. This is GUI-only state (connection.json, updates.json,
-    Chromium cache) and never holds agent config or sessions.
+    Mirrors Electron's ``app.getPath('userData')``, which is keyed on the
+    packed product name, on each platform. This is GUI-only state
+    (connection.json, updates.json, Chromium cache) and never holds agent
+    config or sessions.
     """
     home = Path.home()
+    product = _desktop_product_name()
     if sys.platform == "darwin":
-        return home / "Library" / "Application Support" / "Hermes"
+        return home / "Library" / "Application Support" / product
     if sys.platform == "win32":
         appdata = os.environ.get("APPDATA")
         base = Path(appdata) if appdata else (home / "AppData" / "Roaming")
-        return base / "Hermes"
+        return base / product
     # Linux / other POSIX — XDG config home.
     xdg = os.environ.get("XDG_CONFIG_HOME")
     base = Path(xdg) if xdg else (home / ".config")
-    return base / "Hermes"
+    return base / product
 
 
 def source_built_gui_artifacts(hermes_home: Path) -> "list[Path]":
@@ -113,28 +137,29 @@ def packaged_gui_app_paths() -> "list[Path]":
 
     Returns every candidate for the current OS; the caller filters to those
     that actually exist. We never glob system-wide — only the well-known
-    electron-builder output locations for the "Hermes" product.
+    electron-builder output locations for the configured product name.
     """
     home = Path.home()
+    product = _desktop_product_name()
     paths: list[Path] = []
     if sys.platform == "darwin":
         paths += [
-            Path("/Applications/Hermes.app"),
-            home / "Applications" / "Hermes.app",
+            Path("/Applications") / f"{product}.app",
+            home / "Applications" / f"{product}.app",
         ]
     elif sys.platform == "win32":
         local = os.environ.get("LOCALAPPDATA")
         local_base = Path(local) if local else (home / "AppData" / "Local")
         paths += [
-            # NSIS per-user install (perMachine=false → Programs\Hermes).
-            local_base / "Programs" / "Hermes",
+            # NSIS per-user install (perMachine=false → Programs\<Product>).
+            local_base / "Programs" / product,
             # Older / alternate layout some builds used.
             local_base / "hermes-desktop",
         ]
         program_files = os.environ.get("ProgramFiles")
         if program_files:
             # NSIS per-machine fallback (needs admin to remove).
-            paths.append(Path(program_files) / "Hermes")
+            paths.append(Path(program_files) / product)
     else:
         # Linux: AppImage is a single file the user placed somewhere; we can
         # only reliably clean the desktop entry + icon we know the name of.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6092,23 +6092,54 @@ def _write_desktop_build_stamp(project_root: Path, *, source_mode: bool) -> None
         logger.debug("Failed to write desktop build stamp: %s", exc)
 
 
+def _desktop_product_names(desktop_dir: Path) -> "tuple[str, str]":
+    """Return ``(product_name, executable_name)`` electron-builder packs under.
+
+    electron-builder derives every packed path from ``build.productName`` /
+    ``build.executableName`` in ``apps/desktop/package.json`` — the same keys
+    ``scripts/before-pack.mjs`` reads back off the packager context. A build
+    that sets either one writes ``<productName>.app`` / ``<executableName>.exe``
+    and nothing named "Hermes", so the update chain has to read them too or it
+    concludes the rebuild produced no app. Stock names on any read failure.
+    """
+    try:
+        pkg = json.loads((desktop_dir / "package.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        pkg = {}
+    if not isinstance(pkg, dict):
+        pkg = {}
+    build = pkg.get("build")
+    if not isinstance(build, dict):
+        build = {}
+    product = build.get("productName") or pkg.get("productName") or "Hermes"
+    executable = build.get("executableName") or product
+    return str(product), str(executable)
+
+
 def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
     """Return the current platform's unpacked Electron app executable."""
     release_dir = desktop_dir / "release"
+    product, executable = _desktop_product_names(desktop_dir)
     if sys.platform == "darwin":
-        candidates = list(release_dir.glob("mac*/Hermes.app/Contents/MacOS/Hermes"))
+        candidates = [
+            mac_dir / f"{product}.app" / "Contents" / "MacOS" / executable
+            for mac_dir in sorted(release_dir.glob("mac*"))
+        ]
     elif sys.platform == "win32":
         candidates = [
-            release_dir / "win-unpacked" / "Hermes.exe",
-            release_dir / "win-ia32-unpacked" / "Hermes.exe",
-            release_dir / "win-arm64-unpacked" / "Hermes.exe",
+            release_dir / tree / f"{executable}.exe"
+            for tree in ("win-unpacked", "win-ia32-unpacked", "win-arm64-unpacked")
         ]
     else:
+        # electron-builder's Linux executable name comes from
+        # build.executableName, and older/default builds used the lowercase
+        # package name — probe both spellings, as this has always done for the
+        # stock pair.
+        names = list(dict.fromkeys([executable, executable.lower(), product, product.lower()]))
         candidates = [
-            release_dir / "linux-unpacked" / "hermes",
-            release_dir / "linux-unpacked" / "Hermes",
-            release_dir / "linux-arm64-unpacked" / "hermes",
-            release_dir / "linux-arm64-unpacked" / "Hermes",
+            release_dir / tree / name
+            for tree in ("linux-unpacked", "linux-arm64-unpacked")
+            for name in names
         ]
 
     existing = [p for p in candidates if p.exists()]
@@ -6439,7 +6470,7 @@ def _ensure_desktop_exe_launchable(
     if error is None:
         return packaged_executable, False
 
-    print(f"✗ The built Hermes.exe failed its integrity check: {error}")
+    print(f"✗ The built {packaged_executable.name} failed its integrity check: {error}")
     print(f"    at: {packaged_executable}")
 
     # Self-heal setup for the retry: drop the (likely corrupt) cached Electron
@@ -6453,7 +6484,7 @@ def _ensure_desktop_exe_launchable(
 
     restored = _rollback_desktop_from_backup(packaged_executable)
     if restored is not None:
-        print("  ↩ Update aborted — restored the previous working Hermes.exe from backup.")
+        print(f"  ↩ Update aborted — restored the previous working {restored.name} from backup.")
         print("    Your existing version was kept and still works. Run `hermes desktop`")
         print("    (or the in-app update) again to retry with a fresh Electron download.")
         return restored, True
@@ -6961,7 +6992,7 @@ def _desktop_macos_relaunchable_fixup(
     exe = _desktop_packaged_executable(desktop_dir)
     if exe is None:
         return True
-    # exe = .../Hermes.app/Contents/MacOS/Hermes  ->  app bundle = .../Hermes.app
+    # exe = .../<Product>.app/Contents/MacOS/<Exe>  ->  app bundle = .../<Product>.app
     app = exe.parents[2]
     if not str(app).endswith(".app") or not app.is_dir():
         return True

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -206,10 +206,24 @@ linux_gate() {
   GATE=manual GATE_MSG="Update complete, but the rebuilt app can't relaunch itself (its sandbox helper needs root ownership). Reopen Hermes to finish."
 }
 
+# The name electron-builder packed the app under (build.productName in
+# apps/desktop/package.json, electron-builder's own precedence). node produced
+# the tree we're looking for, so it is present wherever there is one to find;
+# the stock name is the fallback.
+desktop_product_name() {
+  local pkg="$INSTALL_ROOT/apps/desktop/package.json" name=""
+  if [ -f "$pkg" ] && command -v node >/dev/null 2>&1; then
+    name="$(node -p 'const p=require(process.argv[1]);(p.build&&p.build.productName)||p.productName||""' "$pkg" 2>/dev/null)"
+  fi
+  [ -n "$name" ] || name="Hermes"
+  printf '%s' "$name"
+}
+
 mac_swap() {
-  local rebuilt="" c
-  for c in "$INSTALL_ROOT/apps/desktop/release/mac-arm64/Hermes.app" \
-           "$INSTALL_ROOT/apps/desktop/release/mac/Hermes.app"; do
+  local rebuilt="" c product
+  product="$(desktop_product_name)"
+  for c in "$INSTALL_ROOT/apps/desktop/release/mac-arm64/$product.app" \
+           "$INSTALL_ROOT/apps/desktop/release/mac/$product.app"; do
     [ -d "$c" ] && { rebuilt="$c"; break; }
   done
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3465,6 +3465,24 @@ function Install-DesktopVoiceDeps {
     }
 }
 
+function Get-DesktopExecutableName {
+    param([Parameter(Mandatory = $true)][string]$DesktopDir)
+
+    # electron-builder names the packed exe after build.executableName (falling
+    # back to the product name). Read it back so a build that renames the
+    # product is still found here; stock name on any read failure. Windows
+    # PowerShell 5.1-safe: ConvertFrom-Json ships in 5.1.
+    try {
+        $pkg = Get-Content -LiteralPath "$DesktopDir\package.json" -Raw -ErrorAction Stop | ConvertFrom-Json
+        foreach ($candidate in @($pkg.build.executableName, $pkg.build.productName, $pkg.productName)) {
+            if ($candidate) { return [string]$candidate }
+        }
+    } catch {
+        # fall through to the stock name
+    }
+    return 'Hermes'
+}
+
 function Install-Desktop {
     # Build apps/desktop into a launchable Hermes.exe. Only called from
     # Stage-Desktop, which is itself only included in the manifest when
@@ -3714,9 +3732,10 @@ function Install-Desktop {
 
     # 3. Sanity-check the produced binary. Probe both arches so this works
     # on x64 and arm64 build machines.
+    $exeName = Get-DesktopExecutableName -DesktopDir $desktopDir
     $exeCandidates = @(
-        "$desktopDir\release\win-unpacked\Hermes.exe",
-        "$desktopDir\release\win-arm64-unpacked\Hermes.exe"
+        "$desktopDir\release\win-unpacked\$exeName.exe",
+        "$desktopDir\release\win-arm64-unpacked\$exeName.exe"
     )
     $found = $false
     $desktopExe = $null
@@ -3729,7 +3748,7 @@ function Install-Desktop {
         }
     }
     if (-not $found) {
-        throw "Desktop build completed but no Hermes.exe was found under $desktopDir\release\*-unpacked\"
+        throw "Desktop build completed but no $exeName.exe was found under $desktopDir\release\*-unpacked\"
     }
 
     # 3b. The Hermes icon + identity are stamped onto Hermes.exe by the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3165,18 +3165,30 @@ install_desktop() {
         return 1
     fi
 
+    # The names electron-builder packed under (build.productName /
+    # build.executableName). node just built the tree, so it is on PATH here.
+    local product="Hermes" exe_name=""
+    if [ -f "$desktop_dir/package.json" ] && command -v node >/dev/null 2>&1; then
+        product="$(node -p 'const p=require(process.argv[1]);(p.build&&p.build.productName)||p.productName||"Hermes"' "$desktop_dir/package.json" 2>/dev/null || echo Hermes)"
+        exe_name="$(node -p 'const p=require(process.argv[1]);(p.build&&p.build.executableName)||""' "$desktop_dir/package.json" 2>/dev/null)"
+    fi
+    [ -n "$product" ] || product="Hermes"
+    [ -n "$exe_name" ] || exe_name="$product"
+
     local app=""
     if [ "$OS" = "linux" ]; then
-        if [ -x "$desktop_dir/release/linux-unpacked/Hermes" ]; then
-            app="$desktop_dir/release/linux-unpacked/Hermes"
-        elif [ -x "$desktop_dir/release/linux-unpacked/hermes" ]; then
-            app="$desktop_dir/release/linux-unpacked/hermes"
-        fi
+        local lcand
+        for lcand in "$exe_name" "$(printf '%s' "$exe_name" | tr '[:upper:]' '[:lower:]')"; do
+            if [ -x "$desktop_dir/release/linux-unpacked/$lcand" ]; then
+                app="$desktop_dir/release/linux-unpacked/$lcand"
+                break
+            fi
+        done
     else
         local cand
         for cand in \
-            "$desktop_dir/release/mac-arm64/Hermes.app" \
-            "$desktop_dir/release/mac/Hermes.app"; do
+            "$desktop_dir/release/mac-arm64/$product.app" \
+            "$desktop_dir/release/mac/$product.app"; do
             if [ -d "$cand" ]; then
                 app="$cand"
                 break

--- a/tests/hermes_cli/test_desktop_exe_integrity.py
+++ b/tests/hermes_cli/test_desktop_exe_integrity.py
@@ -15,6 +15,7 @@ verdicts/rollbacks come out.
 from __future__ import annotations
 
 import argparse
+import json
 import struct
 import subprocess
 import sys
@@ -195,6 +196,74 @@ def test_expected_machines_prefers_user_runnable_api_over_arch_name(monkeypatch)
 # ─── _desktop_packaged_executable arch preference (win32) ───────────────────
 
 
+def _packed(desktop_dir: Path, rel: str) -> Path:
+    """Create a fake packed executable at ``release/<rel>``."""
+    exe = desktop_dir / "release" / rel
+    exe.parent.mkdir(parents=True, exist_ok=True)
+    exe.write_bytes(b"\x00")
+    return exe
+
+
+def _build_config(desktop_dir: Path, **build) -> None:
+    desktop_dir.mkdir(parents=True, exist_ok=True)
+    (desktop_dir / "package.json").write_text(json.dumps({"build": build}), encoding="utf-8")
+
+
+def test_mac_bundle_resolves_from_the_configured_product_name(tmp_path, monkeypatch):
+    """A renamed build packs <productName>.app; the checker has to find it or
+    `--build-only` reports a successful pack as "no app built" and rolls back."""
+    desktop_dir = tmp_path / "apps" / "desktop"
+    _build_config(desktop_dir, productName="Aurora", executableName="Aurora")
+    exe = _packed(desktop_dir, "mac-arm64/Aurora.app/Contents/MacOS/Aurora")
+
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+
+    assert cli_main._desktop_packaged_executable(desktop_dir) == exe
+
+
+def test_windows_exe_resolves_from_the_configured_executable_name(tmp_path, monkeypatch):
+    desktop_dir = tmp_path / "apps" / "desktop"
+    _build_config(desktop_dir, productName="Aurora", executableName="Aurora")
+    exe = _packed(desktop_dir, "win-unpacked/Aurora.exe")
+
+    monkeypatch.setattr(cli_main.sys, "platform", "win32")
+    monkeypatch.setattr(cli_main, "_expected_windows_pe_machines", lambda: set())
+
+    assert cli_main._desktop_packaged_executable(desktop_dir) == exe
+
+
+def test_linux_binary_resolves_from_either_spelling(tmp_path, monkeypatch):
+    """electron-builder writes the lowercase spelling on Linux; the probe has to
+    find it from the configured product name.
+
+    Compared by file identity, not by string: on a case-insensitive filesystem
+    (macOS APFS, NTFS) the "Aurora" probe opens the same file as "aurora", so
+    which spelling comes back is a property of the host filesystem, not of the
+    resolution being tested.
+    """
+    desktop_dir = tmp_path / "apps" / "desktop"
+    _build_config(desktop_dir, productName="Aurora")
+    exe = _packed(desktop_dir, "linux-unpacked/aurora")
+
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+
+    resolved = cli_main._desktop_packaged_executable(desktop_dir)
+
+    assert resolved is not None
+    assert resolved.samefile(exe)
+    assert resolved.parent == exe.parent
+    assert resolved.name.lower() == "aurora"
+
+
+def test_stock_names_still_resolve_without_a_build_config(tmp_path, monkeypatch):
+    """The stock tree keeps working when package.json is absent/unreadable —
+    the fallback every existing install depends on."""
+    desktop_dir = tmp_path / "apps" / "desktop"
+    exe = _packed(desktop_dir, "mac-arm64/Hermes.app/Contents/MacOS/Hermes")
+
+    monkeypatch.setattr(cli_main.sys, "platform", "darwin")
+
+    assert cli_main._desktop_packaged_executable(desktop_dir) == exe
 
 
 

--- a/tests/hermes_cli/test_gui_uninstall.py
+++ b/tests/hermes_cli/test_gui_uninstall.py
@@ -167,3 +167,19 @@ def test_uninstall_args_namespace_mode_mapping():
     full = uninstall._UninstallArgs(mode="full")
     assert full.gui is False and full.full is True and full.yes is True
 
+
+def test_packaged_paths_and_userdata_follow_the_build_product_name(tmp_path, monkeypatch):
+    """Uninstall has to find a renamed install: the bundle, the NSIS directory
+    and Electron's userData are all keyed on the packed product name."""
+    hermes_home = tmp_path / ".hermes"
+    desktop = hermes_home / "hermes-agent" / "apps" / "desktop"
+    desktop.mkdir(parents=True)
+    (desktop / "package.json").write_text('{"build": {"productName": "Aurora"}}', encoding="utf-8")
+
+    monkeypatch.setattr(gu, "get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr(gu.sys, "platform", "darwin")
+    monkeypatch.setattr(gu.Path, "home", classmethod(lambda cls: tmp_path / "home"))
+
+    assert Path("/Applications/Aurora.app") in gu.packaged_gui_app_paths()
+    assert gu.desktop_userdata_dir().name == "Aurora"
+


### PR DESCRIPTION
## What does this PR do?

The desktop build/update/uninstall chain looks for the app it just built under hardcoded stock names — `Hermes.app`, `Hermes.exe`, `hermes` — instead of the name electron-builder was configured to write. Any build whose `build.productName` / `build.executableName` differ from the stock values packs successfully and is then reported as *not built*: `hermes desktop --build-only` treats the rebuild as having produced no launchable app, exits nonzero, and the updater rolls back to the previous version.

The two halves of the same feature disagree about what the app is called:

- electron-builder derives every packed path from `build.productName` / `build.executableName` (`apps/desktop/package.json:172-186`).
- The repo already reads them back on the **build** side — `apps/desktop/scripts/before-pack.mjs:121` computes the exe name as `` `${context.packager?.appInfo?.productFilename || 'Hermes'}.exe` `` before preserving the rollback tree.
- The **update / launch / uninstall** side never got the same treatment and still hardcodes the stock spellings.

One changed string in `package.json` therefore turns one-click update into a permanent rollback loop, and it surfaces as "the update did not apply", which points nowhere near `package.json`. Who hits it: anyone testing a renamed build locally, distro packagers who set a different product name, OEM/white-label builds, and downstream redistributions.

This is a field report, not a hypothetical: it was hit on a renamed downstream build, where the first one-click update run aborted exactly here. Credit where it is due — the rollback path did its job and kept the machine on the previous working build with an honest dialog, which is why this is a fixable annoyance and not a brick.

Reproduction on a clean checkout:

```bash
# apps/desktop/package.json → "build": { "productName": "Aurora",
#                                        "executableName": "Aurora" }
cd apps/desktop && npm run pack     # succeeds, writes release/mac-arm64/Aurora.app
hermes desktop --build-only
# ✗ --build-only produced no launchable app at: apps/desktop/release   → exit 1
```

`scripts/install.sh` reports the same non-event as `Desktop build completed but no app was found under <dir>/release/`, and `install.ps1` as `Desktop build completed but no Hermes.exe was found …` — three different messages for one cause: the app is there, under a different name.

This PR does not rename anything or add a branding surface. It reads the two keys electron-builder already consumes, at the places that look for electron-builder's output. Stock builds are unaffected byte-for-byte: the stock names remain the fallback whenever `package.json` is missing, unreadable, or unparseable.

## Related Issue

No existing issue covers this. Searched open and closed issues and PRs for `productName`, `Hermes.exe`, and packaged-app resolution first — the nearby hits (#53040 before-pack cleanup, #37762 universal DMG) are different failures in the same area, and neither touches name resolution. Happy to file a tracker entry if you would rather have one to link.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

| File | Site | Change |
|---|---|---|
| `hermes_cli/main.py` | `_desktop_packaged_executable()` | new `_desktop_product_names()` helper; all three platform branches build their candidate list from it |
| `hermes_cli/main.py` | `_ensure_desktop_exe_launchable()`, `_desktop_macos_relaunchable_fixup()` | integrity-gate and rollback messages name the executable that actually exists |
| `hermes_cli/gui_uninstall.py` | `desktop_userdata_dir()`, `packaged_gui_app_paths()` | packaged-install locations and Electron's `userData` directory derive from the same product name |
| `scripts/desktop-update/posix.sh` | `mac_swap()` | the rebuilt bundle is located by the configured product name |
| `scripts/install.sh` | `install_desktop()` | post-pack app discovery on macOS and Linux uses the configured names |
| `scripts/install.ps1` | `Install-Desktop` | post-pack exe discovery uses `build.executableName` via a new `Get-DesktopExecutableName` |

Two derivation mechanisms, chosen per language, both reading the same source of truth:

- Python and PowerShell have a JSON reader in the standard library, so they read `build.executableName` / `build.productName` straight from `apps/desktop/package.json` — the keys electron-builder itself consumes. (`ConvertFrom-Json` ships in Windows PowerShell 5.1, so the installer stays 5.1-safe.)
- `install.sh` and `posix.sh` are POSIX shell and cannot assume a JSON parser, so they read the same keys through `node -p`. node is guaranteed present on any path that could have produced a packed tree — that tree is `npm run pack`'s output. Both fall back to the stock names when node is unreachable.

Two details worth a reviewer's eye:

- The macOS glob stays on the part upstream owns (`release/mac*`), and the product name is joined as a literal path segment, so a product name containing glob metacharacters cannot widen which trees are searched. Selection below the changed hunk (win32 arch preference, newest-mtime tiebreak) is untouched.
- The Linux branch probes `executableName`, its lowercase form, then the product name and its lowercase form — preserving the existing `hermes` / `Hermes` double-probe behavior for the stock pair rather than narrowing it.

`apps/desktop/electron/desktop-uninstall.ts` needs no change: it already resolves the bundle from the running executable's own path (`resolveRemovableAppPath`), which is name-independent.

## How to Test

1. **Stock behavior unchanged:** `scripts/run_tests.sh tests/hermes_cli/ -q` — every existing desktop-update and uninstall test passes unedited. `test_stock_names_still_resolve_without_a_build_config` pins the no-`package.json` fallback that every existing install depends on.
2. **Renamed build, macOS:** set `build.productName` / `build.executableName` to `Aurora` in `apps/desktop/package.json`, `cd apps/desktop && npm run pack`, then `hermes desktop --build-only`. Before: exits nonzero, "not built". After: exits 0 and reports the packed bundle.
3. **Renamed build, Windows:** same edit, `npm run pack`, then run install.ps1's desktop stage — before it throws "no Hermes.exe was found", after it finds `Aurora.exe` and writes the shortcuts against it.
4. **Renamed build, Linux:** same edit, `npm run pack`, then `bash scripts/install.sh --include-desktop` — before, no app is found; after, it resolves `release/linux-unpacked/aurora`.
5. **One-click update, end to end:** `npm run update:repro:fresh` from `apps/desktop` with the renamed `package.json` — the bundle swap in `posix.sh` finds the rebuilt app instead of leaving the old one in place.
6. **Uninstall:** with the renamed build installed, `hermes uninstall --gui --dry-run` lists the renamed bundle and userData directory.

New tests follow the existing shape in this area — synthetic release trees under `tmp_path`, platform faked with `monkeypatch.setattr(…sys, "platform", …)` — so they run on every host with no new marks or fixtures.

**One filesystem detail, handled rather than papered over:** `test_linux_binary_resolves_from_either_spelling` packs `release/linux-unpacked/aurora` and originally asserted that exact string back. On a **case-insensitive filesystem** (stock macOS APFS, NTFS) `Path("Aurora").exists()` is true after writing `aurora`, so the probe legitimately returns the capitalized spelling and a string comparison fails — a property of the host filesystem, not of the resolution under test. The test now compares by **file identity** (`resolved.samefile(exe)`, plus the parent directory and a case-folded name check), so it is green on both filesystem kinds without touching the production probe order:

- case-insensitive (this machine, stock APFS): **12 passed, 4 skipped**
- case-sensitive (same files, pytest `--basetemp` on a case-sensitive APFS volume): **12 passed, 4 skipped**

It still fails on unfixed code — with `hermes_cli/main.py` reverted to `main`, all three renamed-build cases fail on `assert resolved is not None`, while the stock-name control keeps passing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(desktop): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — one commit
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the full suite via `scripts/run_tests.sh` and it is not literally all-green on this machine, so here is the exact accounting instead of a checked box: **2873 files, 31542 passed, 77 failed, 310 skipped**. 76 of those 77 are in 21 files this PR does not touch (`tests/tools/`, `tests/plugins/`, `tests/gateway/`, optional-dependency and local-environment failures); re-running exactly those 21 files on a pristine `9166530942` worktree on the same machine reproduces **76 failed**, so they are pre-existing and unrelated. The 77th was the case-insensitive-filesystem comparison described above, fixed in the test since that run — this PR's own files are now green on both case-sensitive and case-insensitive filesystems.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (arm64), Python 3.11. The Windows and Linux branches are covered by the platform-faked unit tests; `bash -n scripts/install.sh`, `bash -n scripts/desktop-update/posix.sh`, and a `[Parser]::ParseFile` parse of `scripts/install.ps1` under pwsh are all clean. `python scripts/check-windows-footguns.py --all` (what CI runs) → **no footguns found, 962 files scanned**.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the derivation is documented in the docstrings/comments at each site; no user-facing docs surface changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys; the keys read are electron-builder's own
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture change
- [x] I've considered cross-platform impact (Windows, macOS) — this PR *is* the cross-platform fix: all three platform branches and both installers are covered, and per CONTRIBUTING rule 12 the `install.sh` and `install.ps1` changes were made in lockstep
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

On this machine's stock (case-insensitive) APFS:

```
$ scripts/run_tests.sh tests/hermes_cli/test_desktop_exe_integrity.py tests/hermes_cli/test_gui_uninstall.py -q
[100.0% |    16/~16 | ✓12 | ✗ 0] ✓ tests/hermes_cli/test_desktop_exe_integrity.py (5✓ 4s, 1.2s)
=== Summary: 2 files, 12 tests passed, 0 failed, 4 skipped (100% complete) in 1.2s ===
```

Same two files, same machine, with pytest's temp root on a case-sensitive APFS volume:

```
$ pytest tests/hermes_cli/test_desktop_exe_integrity.py tests/hermes_cli/test_gui_uninstall.py -q --basetemp=/Volumes/CSPROBE/pytest
ss.....ss.......                                                         [100%]
12 passed, 4 skipped in 0.21s
```

The three renamed-build cases against unfixed production code (`hermes_cli/main.py` reverted to `main`, tests kept) — the stock-name control still passes, which is what makes the other three meaningful:

```
E       assert None is not None
FAILED tests/hermes_cli/test_desktop_exe_integrity.py::test_mac_bundle_resolves_from_the_configured_product_name
FAILED tests/hermes_cli/test_desktop_exe_integrity.py::test_windows_exe_resolves_from_the_configured_executable_name
FAILED tests/hermes_cli/test_desktop_exe_integrity.py::test_linux_binary_resolves_from_either_spelling
3 failed, 1 passed, 5 deselected
```

## Notes for reviewers

- **Fallbacks are unchanged behavior, deliberately.** Every derivation falls back to the stock names, so an install with no reachable `package.json` (a packaged-only install with no checkout, a partially wiped tree) behaves exactly as it does today.
- **Known remaining gap, called out rather than hidden:** for a *packaged-only* install of a renamed build with no checkout on disk, `gui_uninstall` still falls back to the stock name and will not find the bundle. Closing that means reading the name from the installed app's own `package.json` inside the bundle — a different lookup with its own failure modes. Happy to add it here or in a follow-up, your call.
- **Why not glob `*.app` / `*-unpacked/*` by shape?** It needs no config read, but it makes the checker accept whatever is in the tree — including a stale bundle from a previous product name. Deriving from the build config keeps the check exact: the app we were configured to build, or nothing.
