### PR TITLE
fix(updater): let stale Desktop updates clear after retries

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -202,6 +202,8 @@ impl UpdateMarkerGuard {
         let pid = std::process::id();
         if let Some(owner) = live_marker_owner(&path) {
             if owner.pid == pid {
+                // Repeated acquisition in this process is intentionally
+                // re-entrant because the desktop may have pre-written our pid.
                 // The desktop races ahead and pre-writes our pid. Adopt that
                 // claim verbatim: rewriting started_at here lets retries reset
                 // a wedged updater's age before the stale ceiling can clear it.

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -134,17 +134,13 @@ struct MarkerOwner {
     age_secs: u64,
 }
 
-/// Read the marker and report a live *foreign* owner, if any. `None` for every
-/// "no live update" case — absent, unreadable, malformed, dead pid, past the
-/// ceiling, or a marker whose pid is **this** process — matching
-/// `readLiveUpdateMarker` in the Electron gate. Never panics.
+/// Read the marker and report a live owner, if any. `None` for every "no live
+/// update" case — absent, unreadable, malformed, dead pid, or past the ceiling
+/// — matching `readLiveUpdateMarker` in the Electron gate. Never panics.
 ///
-/// Self-PID is treated as non-ownership on purpose (#74761): since #50238 the
-/// desktop pre-writes this marker with the spawned updater's pid before the
-/// updater reaches `acquire`. Without the exclusion, `acquire` sees a live
-/// owner that is itself and aborts ("Another Hermes update is already
-/// running"), then the desktop relaunches and retries forever. A foreign live
-/// pid (e.g. a dashboard-spawned `hermes update`) still blocks.
+/// Self-PID is returned so `acquire` can adopt the desktop's pre-written claim
+/// without refreshing its acquisition time (#74761). A foreign live pid (e.g.
+/// a dashboard-spawned `hermes update`) still blocks.
 fn live_marker_owner(path: &Path) -> Option<MarkerOwner> {
     let raw = std::fs::read_to_string(path).ok()?;
     let mut lines = raw.lines();
@@ -156,11 +152,6 @@ fn live_marker_owner(path: &Path) -> Option<MarkerOwner> {
         .unwrap_or(0);
     let age_secs = now.saturating_sub(started_at);
     if age_secs > UPDATE_MARKER_MAX_AGE_SECS || !pid_is_alive(pid) {
-        return None;
-    }
-    // Desktop `writeUpdateMarker(hermesHome, child.pid)` races ahead of us;
-    // adopt that pre-claim rather than refusing our own marker.
-    if pid == std::process::id() {
         return None;
     }
     Some(MarkerOwner { pid, age_secs })
@@ -208,10 +199,16 @@ impl UpdateMarkerGuard {
     /// behavior), so we log and carry on with a guard that still attempts
     /// cleanup of whatever may exist at the path.
     fn acquire(path: PathBuf) -> Result<Self, MarkerOwner> {
+        let pid = std::process::id();
         if let Some(owner) = live_marker_owner(&path) {
+            if owner.pid == pid {
+                // The desktop races ahead and pre-writes our pid. Adopt that
+                // claim verbatim: rewriting started_at here lets retries reset
+                // a wedged updater's age before the stale ceiling can clear it.
+                return Ok(Self { path, owned: true });
+            }
             return Err(owner);
         }
-        let pid = std::process::id();
         let started_at = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -1327,8 +1324,8 @@ mod tests {
 
     /// Spawn a short-lived sibling process whose pid stands in for a foreign
     /// updater. Same-process double-acquire no longer models contention: since
-    /// #74761 `live_marker_owner` treats our own pid as adoptable (desktop
-    /// pre-writes it), so a second acquire in *this* process would succeed.
+    /// #74761 `acquire` treats our own pid as adoptable (desktop pre-writes it),
+    /// so a second acquire in *this* process would succeed.
     fn spawn_foreign_holder() -> std::process::Child {
         #[cfg(windows)]
         {
@@ -1385,7 +1382,8 @@ mod tests {
     fn acquire_adopts_a_marker_prewritten_with_our_own_pid() {
         // #74761: desktop writeUpdateMarker(hermesHome, child.pid) races ahead
         // of UpdateMarkerGuard::acquire. The marker names US; refusing it made
-        // every in-app desktop update loop forever. Adopt and rewrite.
+        // every in-app desktop update loop forever. Adopt it without resetting
+        // the holder age, so a wedged updater still reaches the stale ceiling.
         let dir = unique_tmp_dir("marker-own-pid");
         std::fs::create_dir_all(&dir).unwrap();
         let marker = dir.join(".hermes-update-in-progress");
@@ -1408,7 +1406,12 @@ mod tests {
         assert_eq!(
             body.lines().next().unwrap().trim().parse::<u32>().unwrap(),
             std::process::id(),
-            "acquire rewrites the marker with our pid + fresh started_at"
+            "acquire keeps the adopted marker owner"
+        );
+        assert_eq!(
+            body.lines().nth(1).unwrap().trim().parse::<u64>().unwrap(),
+            started_at,
+            "adopting an own-pid marker must preserve its original holder age"
         );
         drop(guard);
         assert!(

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3622,6 +3622,7 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
     let child
 
     if (scriptHandoff) {
+      const updateStartedAt = Math.floor(Date.now() / 1000)
       // A bare detached+hidden powershell spawn silently dies before -File
       // processing (console-subsystem init failure — see
       // wrapHandoffForDetachedConsole). Route through `cmd start` so the
@@ -3645,6 +3646,7 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
         env: {
           ...process.env,
           HERMES_HOME,
+          HERMES_UPDATE_STARTED_AT: String(updateStartedAt),
           PATH: pathWithHermesManagedNode(venvBin)
         },
         detached: true,
@@ -3659,7 +3661,7 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
       // The `hermes update` child adopts the SCRIPT's claim via
       // update_lock.py's process-ancestry rule; no mtime heuristics needed.
       if (Number.isInteger(child.pid)) {
-        writeUpdateMarker(HERMES_HOME, child.pid)
+        writeUpdateMarker(HERMES_HOME, child.pid, { startedAt: updateStartedAt })
       }
 
       rememberLog(
@@ -3998,6 +4000,7 @@ async function applyUpdatesPosixHandoff(opts: any) {
   }
 
   const args = [...handoff.args, '--install-root', updateRoot, '--branch', branch, '--desktop-pid', String(process.pid)]
+  const updateStartedAt = Math.floor(Date.now() / 1000)
 
   // Relaunch target: the running .app bundle on mac (script swaps the
   // rebuilt bundle over it), the running binary elsewhere. The script's gate
@@ -4030,6 +4033,7 @@ async function applyUpdatesPosixHandoff(opts: any) {
     env: {
       ...process.env,
       HERMES_HOME,
+      HERMES_UPDATE_STARTED_AT: String(updateStartedAt),
       PATH: pathWithHermesManagedNode(path.join(updateRoot, 'venv', 'bin'))
     },
     detached: true,
@@ -4040,7 +4044,7 @@ async function applyUpdatesPosixHandoff(opts: any) {
   // until the script claims the marker with its own pid as step 0. If the
   // script never starts, the dead pid reads as stale and self-deletes.
   if (Number.isInteger(child.pid)) {
-    writeUpdateMarker(HERMES_HOME, child.pid)
+    writeUpdateMarker(HERMES_HOME, child.pid, { startedAt: updateStartedAt })
   }
 
   rememberLog(`[updates] launched posix hand-off: ${handoff.scriptPath} (branch ${branch}); quitting to hand off`)

--- a/apps/desktop/electron/update-handoff-marker.test.ts
+++ b/apps/desktop/electron/update-handoff-marker.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..')
+const POSIX_SCRIPT = path.join(REPO_ROOT, 'scripts', 'desktop-update', 'posix.sh')
+const WINDOWS_SCRIPT = path.join(REPO_ROOT, 'scripts', 'desktop-update', 'windows.ps1')
+
+function sandbox(tag: string) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), `hermes-handoff-marker-${tag}-`))
+  const installRoot = path.join(home, 'hermes-agent')
+  fs.mkdirSync(installRoot)
+
+  return { home, installRoot }
+}
+
+function markerStartedAt(home: string): number {
+  const [, startedAt] = fs.readFileSync(path.join(home, '.hermes-update-in-progress'), 'utf8').split('\n')
+
+  return Number.parseInt(startedAt, 10)
+}
+
+function runPosix(installRoot: string, startedAt?: string) {
+  const env = { ...process.env }
+  if (startedAt === undefined) delete env.HERMES_UPDATE_STARTED_AT
+  else env.HERMES_UPDATE_STARTED_AT = startedAt
+
+  return spawnSync('/bin/bash', [POSIX_SCRIPT, '--install-root', installRoot, '--self-test-marker'], {
+    env,
+    encoding: 'utf8'
+  })
+}
+
+function runWindows(installRoot: string, startedAt?: string) {
+  const env = { ...process.env }
+  if (startedAt === undefined) delete env.HERMES_UPDATE_STARTED_AT
+  else env.HERMES_UPDATE_STARTED_AT = startedAt
+
+  return spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      WINDOWS_SCRIPT,
+      '-InstallRoot',
+      installRoot,
+      '-NoUi',
+      '-NoMarkerCleanup',
+      '-SelfTestMarker'
+    ],
+    { env, encoding: 'utf8' }
+  )
+}
+
+function assertScriptHandoff(run: (installRoot: string, startedAt?: string) => ReturnType<typeof spawnSync>) {
+  const preserved = sandbox('preserved')
+  const acquiredAt = Math.floor(Date.now() / 1000) - 300
+  const preservedResult = run(preserved.installRoot, String(acquiredAt))
+
+  assert.equal(preservedResult.status, 0, preservedResult.stderr || preservedResult.stdout)
+  assert.equal(markerStartedAt(preserved.home), acquiredAt, 'the script must preserve the Desktop acquisition time')
+
+  const refreshed = sandbox('refreshed')
+  fs.writeFileSync(path.join(refreshed.home, '.hermes-update-in-progress'), '999999\n1\n')
+  const before = Math.floor(Date.now() / 1000)
+  const refreshedResult = run(refreshed.installRoot, 'malformed')
+  const after = Math.floor(Date.now() / 1000)
+
+  assert.equal(refreshedResult.status, 0, refreshedResult.stderr || refreshedResult.stdout)
+  assert.ok(
+    markerStartedAt(refreshed.home) >= before && markerStartedAt(refreshed.home) <= after,
+    'an invalid hand-off timestamp must start a fresh claim'
+  )
+}
+
+test.skipIf(process.platform === 'win32')('POSIX hand-off preserves the Desktop marker acquisition time', () => {
+  assertScriptHandoff(runPosix)
+})
+
+test.skipIf(process.platform !== 'win32')('PowerShell hand-off preserves the Desktop marker acquisition time', () => {
+  assertScriptHandoff(runWindows)
+})

--- a/apps/desktop/electron/update-handoff-marker.test.ts
+++ b/apps/desktop/electron/update-handoff-marker.test.ts
@@ -63,7 +63,7 @@ function assertScriptHandoff(run: (installRoot: string, startedAt?: string) => R
   const acquiredAt = Math.floor(Date.now() / 1000) - 300
   const preservedResult = run(preserved.installRoot, String(acquiredAt))
 
-  assert.equal(preservedResult.status, 0, preservedResult.stderr || preservedResult.stdout)
+  assert.equal(preservedResult.status, 0, String(preservedResult.stderr || preservedResult.stdout))
   assert.equal(markerStartedAt(preserved.home), acquiredAt, 'the script must preserve the Desktop acquisition time')
 
   const refreshed = sandbox('refreshed')
@@ -72,7 +72,7 @@ function assertScriptHandoff(run: (installRoot: string, startedAt?: string) => R
   const refreshedResult = run(refreshed.installRoot, 'malformed')
   const after = Math.floor(Date.now() / 1000)
 
-  assert.equal(refreshedResult.status, 0, refreshedResult.stderr || refreshedResult.stdout)
+  assert.equal(refreshedResult.status, 0, String(refreshedResult.stderr || refreshedResult.stdout))
   assert.ok(
     markerStartedAt(refreshed.home) >= before && markerStartedAt(refreshed.home) <= after,
     'an invalid hand-off timestamp must start a fresh claim'

--- a/apps/desktop/electron/update-handoff-marker.test.ts
+++ b/apps/desktop/electron/update-handoff-marker.test.ts
@@ -32,10 +32,11 @@ function runPosix(installRoot: string, startedAt?: string) {
     env.HERMES_UPDATE_STARTED_AT = startedAt
   }
 
-  return spawnSync('/bin/bash', [POSIX_SCRIPT, '--install-root', installRoot, '--self-test-marker'], {
-    env,
-    encoding: 'utf8'
-  })
+  return spawnSync(
+    '/bin/bash',
+    [POSIX_SCRIPT, '--daemonized', '--install-root', installRoot, '--self-test-marker'],
+    { env, encoding: 'utf8' }
+  )
 }
 
 function runWindows(installRoot: string, startedAt?: string) {
@@ -82,6 +83,17 @@ function assertScriptHandoff(run: (installRoot: string, startedAt?: string) => R
   assert.ok(
     markerStartedAt(refreshed.home) >= before && markerStartedAt(refreshed.home) <= after,
     'an invalid hand-off timestamp must start a fresh claim'
+  )
+
+  const oversized = sandbox('oversized')
+  const oversizedBefore = Math.floor(Date.now() / 1000)
+  const oversizedResult = run(oversized.installRoot, '99999999999999999999')
+  const oversizedAfter = Math.floor(Date.now() / 1000)
+
+  assert.equal(oversizedResult.status, 0, String(oversizedResult.stderr || oversizedResult.stdout))
+  assert.ok(
+    markerStartedAt(oversized.home) >= oversizedBefore && markerStartedAt(oversized.home) <= oversizedAfter,
+    'an oversized hand-off timestamp must start a fresh claim'
   )
 }
 

--- a/apps/desktop/electron/update-handoff-marker.test.ts
+++ b/apps/desktop/electron/update-handoff-marker.test.ts
@@ -26,8 +26,11 @@ function markerStartedAt(home: string): number {
 
 function runPosix(installRoot: string, startedAt?: string) {
   const env = { ...process.env }
-  if (startedAt === undefined) delete env.HERMES_UPDATE_STARTED_AT
-  else env.HERMES_UPDATE_STARTED_AT = startedAt
+  if (startedAt === undefined) {
+    delete env.HERMES_UPDATE_STARTED_AT
+  } else {
+    env.HERMES_UPDATE_STARTED_AT = startedAt
+  }
 
   return spawnSync('/bin/bash', [POSIX_SCRIPT, '--install-root', installRoot, '--self-test-marker'], {
     env,
@@ -37,8 +40,11 @@ function runPosix(installRoot: string, startedAt?: string) {
 
 function runWindows(installRoot: string, startedAt?: string) {
   const env = { ...process.env }
-  if (startedAt === undefined) delete env.HERMES_UPDATE_STARTED_AT
-  else env.HERMES_UPDATE_STARTED_AT = startedAt
+  if (startedAt === undefined) {
+    delete env.HERMES_UPDATE_STARTED_AT
+  } else {
+    env.HERMES_UPDATE_STARTED_AT = startedAt
+  }
 
   return spawnSync(
     'powershell.exe',

--- a/apps/desktop/electron/update-marker.test.ts
+++ b/apps/desktop/electron/update-marker.test.ts
@@ -128,6 +128,17 @@ test('writeUpdateMarker preserves a live holder age across pid hand-off', () => 
   assert.equal(Number.parseInt(startedLine, 10), startedAt, 'the holder age must not restart during hand-off')
 })
 
+test('writeUpdateMarker uses the acquisition time passed to a detached script', () => {
+  const home = tmpHome('write-script-acquired-at')
+  const now = 1_000_000_000_000
+  const startedAt = Math.floor(now / 1000) - 300
+
+  writeUpdateMarker(home, 2020, { now: () => now, startedAt })
+
+  const [, startedLine] = fs.readFileSync(markerPath(home), 'utf8').split('\n')
+  assert.equal(Number.parseInt(startedLine, 10), startedAt)
+})
+
 test('writeUpdateMarker is best-effort (no throw on bad path)', () => {
   // A non-existent directory should not throw.
   const badHome = path.join(os.tmpdir(), 'hermes-marker-nonexistent-' + Date.now())

--- a/apps/desktop/electron/update-marker.test.ts
+++ b/apps/desktop/electron/update-marker.test.ts
@@ -115,6 +115,19 @@ test('writeUpdateMarker writes a marker that readLiveUpdateMarker accepts', () =
   assert.ok(fs.existsSync(markerPath(home)), 'marker file should exist after write')
 })
 
+test('writeUpdateMarker preserves a live holder age across pid hand-off', () => {
+  const home = tmpHome('write-handoff-age')
+  const now = 1_000_000_000_000
+  const startedAt = Math.floor(now / 1000) - 300
+
+  writeMarker(home, 1010, startedAt)
+  writeUpdateMarker(home, 2020, { kill: ALIVE, now: () => now })
+
+  const [pidLine, startedLine] = fs.readFileSync(markerPath(home), 'utf8').split('\n')
+  assert.equal(Number.parseInt(pidLine, 10), 2020, 'the hand-off records the new owner')
+  assert.equal(Number.parseInt(startedLine, 10), startedAt, 'the holder age must not restart during hand-off')
+})
+
 test('writeUpdateMarker is best-effort (no throw on bad path)', () => {
   // A non-existent directory should not throw.
   const badHome = path.join(os.tmpdir(), 'hermes-marker-nonexistent-' + Date.now())

--- a/apps/desktop/electron/update-marker.ts
+++ b/apps/desktop/electron/update-marker.ts
@@ -119,15 +119,30 @@ export function readLiveUpdateMarker(
  *
  * Fix: the desktop writes the marker itself, using the spawned updater's
  * PID, immediately after `spawn()`. The updater's `UpdateMarkerGuard` will
- * later overwrite it with its own PID — that's fine, the marker body is
- * the same format and `readLiveUpdateMarker` only cares that *some* live
- * pid owns it. When the updater finishes it deletes the marker as before.
+ * later adopt it or another hand-off stage may replace the PID. A live
+ * holder's original timestamp is preserved across those transfers so retries
+ * cannot keep resetting the 20-minute stale ceiling. When the updater finishes
+ * it deletes the marker as before.
  * If the updater never starts (spawn failure) the marker still contains a
  * real PID, so `readLiveUpdateMarker` will self-heal once that PID exits.
  */
-export function writeUpdateMarker(hermesHome, pid, { now = Date.now } = {}) {
+export function writeUpdateMarker(
+  hermesHome,
+  pid,
+  {
+    kill,
+    now = Date.now,
+    maxAgeMs = UPDATE_MARKER_MAX_AGE_MS
+  }: {
+    now?: () => number
+    maxAgeMs?: number
+    kill?: typeof process.kill
+  } = {}
+) {
   const file = markerPath(hermesHome)
-  const startedAt = Math.floor(now() / 1000)
+  const nowMs = now()
+  const owner = readLiveUpdateMarker(hermesHome, { kill, maxAgeMs, now: () => nowMs })
+  const startedAt = owner ? Math.floor((nowMs - owner.ageMs) / 1000) : Math.floor(nowMs / 1000)
 
   try {
     fs.writeFileSync(file, `${pid}\n${startedAt}\n`, 'utf8')

--- a/apps/desktop/electron/update-marker.ts
+++ b/apps/desktop/electron/update-marker.ts
@@ -132,20 +132,26 @@ export function writeUpdateMarker(
   {
     kill,
     now = Date.now,
-    maxAgeMs = UPDATE_MARKER_MAX_AGE_MS
+    maxAgeMs = UPDATE_MARKER_MAX_AGE_MS,
+    startedAt
   }: {
     now?: () => number
     maxAgeMs?: number
     kill?: typeof process.kill
+    startedAt?: number
   } = {}
 ) {
   const file = markerPath(hermesHome)
   const nowMs = now()
   const owner = readLiveUpdateMarker(hermesHome, { kill, maxAgeMs, now: () => nowMs })
-  const startedAt = owner ? Math.floor((nowMs - owner.ageMs) / 1000) : Math.floor(nowMs / 1000)
+  const acquiredAt = typeof startedAt === 'number' && Number.isInteger(startedAt)
+    ? startedAt
+    : owner
+      ? Math.floor((nowMs - owner.ageMs) / 1000)
+      : Math.floor(nowMs / 1000)
 
   try {
-    fs.writeFileSync(file, `${pid}\n${startedAt}\n`, 'utf8')
+    fs.writeFileSync(file, `${pid}\n${acquiredAt}\n`, 'utf8')
   } catch {
     // Best-effort: if we can't write the marker, proceed anyway. The
     // updater will write its own when it reaches run_update.

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -19,6 +19,7 @@
 #     [--sandbox-fallback]     linux: the caller vouches for a sandbox opt-out
 #                              (ELECTRON_DISABLE_SANDBOX / --no-sandbox launch)
 #     [--no-ui] [--no-marker-cleanup] [--self-test-ui] [--self-test-gate]
+#     [--self-test-marker]
 #     [-- <args...>]           linux: filtered launch args to replay
 #
 # The shim (ui.html in a chromeless browser app window) is decoration: it
@@ -36,7 +37,8 @@ set -u
 ORIGINAL_ARGS=("$@")
 INSTALL_ROOT="" BRANCH="main" DESKTOP_PID=0 RELAUNCH_TARGET=""
 RELAUNCH_CWD="" SANDBOX_FALLBACK=0 RELAUNCH_ARGS=()
-NO_UI=0 NO_MARKER_CLEANUP=0 SELF_TEST_UI=0 SELF_TEST_GATE=0 HANDOFF_DAEMONIZED=0
+NO_UI=0 NO_MARKER_CLEANUP=0 SELF_TEST_UI=0 SELF_TEST_GATE=0 SELF_TEST_MARKER=0
+HANDOFF_DAEMONIZED=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --install-root) INSTALL_ROOT="$2"; shift 2 ;;
@@ -50,6 +52,7 @@ while [ $# -gt 0 ]; do
     --self-test-ui) SELF_TEST_UI=1; shift ;;
     --self-test-gate) SELF_TEST_GATE=1; shift ;;
     --daemonized) HANDOFF_DAEMONIZED=1; shift ;;
+    --self-test-marker) SELF_TEST_MARKER=1; NO_UI=1; NO_MARKER_CLEANUP=1; shift ;;
     --) shift; RELAUNCH_ARGS=("$@"); shift $# ;;
     *) echo "unknown arg: $1" >&2; exit 64 ;;
   esac
@@ -453,7 +456,23 @@ rm -f "$RESULT" 2>/dev/null || true
 
 # Marker claim: same cross-process lock contract as windows.ps1 /
 # update_lock.py (the `hermes update` child adopts it via process ancestry).
-printf '%s\n%s\n' "$$" "$(date +%s)" > "$MARKER" 2>/dev/null || log "WARNING: could not write update marker"
+# The Desktop supplies one acquisition time for the whole ownership chain.
+NOW="$(date +%s)"
+STARTED_AT="${HERMES_UPDATE_STARTED_AT:-$NOW}"
+case "$STARTED_AT" in ''|*[!0-9]*) STARTED_AT="$NOW" ;; esac
+MIN_STARTED_AT=$((NOW - 1200))
+# Compare the validated decimal strings before doing arithmetic. Shell integer
+# expansion can wrap on an attacker-controlled value wider than signed 64-bit.
+if [ "${#STARTED_AT}" -ne "${#NOW}" ] \
+    || [[ "$STARTED_AT" > "$NOW" || "$STARTED_AT" < "$MIN_STARTED_AT" ]]; then
+  STARTED_AT="$NOW"
+fi
+printf '%s\n%s\n' "$$" "$STARTED_AT" > "$MARKER" 2>/dev/null || log "WARNING: could not write update marker"
+
+if [ "$SELF_TEST_MARKER" -eq 1 ]; then
+  trap - EXIT
+  exit 0
+fi
 
 # Wait out the Desktop (FAIL CLOSED: updating under live backends bricks).
 if [ "$DESKTOP_PID" -gt 0 ] 2>/dev/null; then

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -35,7 +35,8 @@
 #
 # Marker: we claim HERMES_HOME\.hermes-update-in-progress with OUR pid as
 # step 0 (the wrapper cmd.exe pid the Desktop saw is useless -- it exits
-# immediately). hermes_cli/update_lock.py's ancestry rule lets our
+# immediately), retaining HERMES_UPDATE_STARTED_AT from the Desktop hand-off.
+# hermes_cli/update_lock.py's ancestry rule lets our
 # `hermes update` child adopt the claim; electron/update-marker.ts parks a
 # relaunched Desktop on it. Cleanup only removes the marker while WE still
 # own it (a handoff partner that rewrote it keeps its claim).
@@ -47,7 +48,8 @@ param(
     [string]$RelaunchExe = "",
     [switch]$NoUi,
     [switch]$NoMarkerCleanup,
-    [switch]$SelfTestUi
+    [switch]$SelfTestUi,
+    [switch]$SelfTestMarker
 )
 
 if (-not $SelfTestUi -and -not $InstallRoot) {
@@ -624,12 +626,23 @@ try {
     # -- 0. Claim the update marker with OUR pid ---------------------------
     try {
         $epoch = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+        $startedAt = 0L
+        $hasStartedAt = [int64]::TryParse($env:HERMES_UPDATE_STARTED_AT, [ref]$startedAt)
+        if (-not $hasStartedAt -or $startedAt -gt $epoch -or ($epoch - $startedAt) -gt 1200) {
+            $startedAt = $epoch
+        }
         # WriteAllText for byte-exact LF framing: Set-Content emits CRLF and
         # the marker contract (Rust/TS/Python readers) is "<pid>\n<ts>\n".
-        [System.IO.File]::WriteAllText($MarkerPath, "$PID`n$epoch`n")
+        [System.IO.File]::WriteAllText($MarkerPath, "$PID`n$startedAt`n")
         Write-HandoffLog "claimed update marker (pid $PID)"
     } catch {
         Write-HandoffLog "WARNING: could not write update marker: $($_.Exception.Message)"
+    }
+
+    if ($SelfTestMarker) {
+        $finalCode = 0
+        $finalMsg = "marker self-test complete"
+        exit 0
     }
 
     # -- 1. Wait for the Desktop to exit (FAIL CLOSED) ----------------------


### PR DESCRIPTION
## What does this PR do?

A long-running Desktop updater could remain blocked indefinitely because each retry and ownership handoff refreshed the update marker timestamp. This change preserves one validated acquisition timestamp across the Desktop, POSIX or PowerShell handoff script, and updater process so the existing 20-minute stale ceiling can reliably release a wedged update while legitimate live owners still block concurrent updates.

### Symptom

After an updater becomes stuck, later Desktop update attempts can report that it started only seconds ago and refuse every retry, even though the original updater has been running far longer than the stale ceiling.

### Impact

Affected Desktop users cannot complete an in-app update without manually terminating the stale updater and stopping the associated gateway processes. The observed report remained blocked for approximately 13 hours.

### Bug Cause

**Trigger:** `apps/desktop/electron/main.ts` handoff spawning, `scripts/desktop-update/posix.sh` and `scripts/desktop-update/windows.ps1` marker claims, and `apps/bootstrap-installer/src-tauri/src/update.rs::UpdateMarkerGuard::acquire`.

**Causal chain:**
1. Desktop starts an updater or handoff script and pre-writes the update marker for the spawned process.
2. Each later ownership transfer rewrites `started_at` with the current time, including valid self-PID adoption by the Rust updater.
3. Retries repeatedly reset the holder age, so the shared 20-minute stale ceiling never observes the original updater lifetime and every later update remains blocked.

**Why it is wrong:** Marker ownership can move between cooperating processes, but acquisition age belongs to the whole update attempt. Refreshing that age during a transfer converts a bounded stale lock into an indefinitely renewable lock.

**Working sibling / contrast:** Electron, Python, and Rust already enforce the same 20-minute ceiling for dead, malformed, expired, or foreign owners. Those checks work when the marker retains the original acquisition timestamp.

**Ruled out:** Adding another timeout would not solve the failure because the existing ceiling already exists; its timestamp input was being reset before it could expire.

### Fix

Desktop now creates one acquisition timestamp and passes it through both script handoff paths. The POSIX and PowerShell scripts preserve only valid, non-future timestamps within the stale ceiling and refresh invalid or expired values. Electron marker transfers preserve a confirmed live holder's age, and the Rust updater adopts its own pre-written marker without rewriting it. Regression coverage exercises the Electron transfer, both production scripts, stale and malformed claims, self-adoption, and foreign live-owner refusal.

## Related Issue

Closes #85894

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.ts` - pass one acquisition timestamp through POSIX and Windows handoffs.
- `apps/desktop/electron/update-marker.ts` - preserve a valid live holder's timestamp when marker ownership changes.
- `scripts/desktop-update/posix.sh` - validate and retain the Desktop acquisition timestamp when claiming the marker.
- `scripts/desktop-update/windows.ps1` - use a UTC Unix epoch and validate the inherited acquisition timestamp.
- `apps/bootstrap-installer/src-tauri/src/update.rs` - adopt a valid own-PID marker without refreshing its age.
- `apps/desktop/electron/update-marker.test.ts` and `apps/desktop/electron/update-handoff-marker.test.ts` - cover marker transfers and both production handoff scripts.

## How to Test

1. Run each production handoff script with a valid `HERMES_UPDATE_STARTED_AT` and verify the claimed marker retains that timestamp.
2. Repeat with malformed, future, and older-than-20-minute values and verify each script writes a fresh timestamp.
3. Keep a foreign marker owner alive and verify a competing update is rejected without overwriting the marker.
4. Automated tests already run locally:

```bash
cd apps/desktop
npx vitest run electron/update-marker.test.ts electron/update-handoff-marker.test.ts

cd ../bootstrap-installer/src-tauri
cargo test --lib
```

The Desktop tests passed 37 tests with 1 host-specific skip, and the Rust library suite passed 54 tests. Phase B REAL_ENV verification also exercised both production handoff scripts and a real Python updater child.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant repository test entries and all related tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, including POSIX and PowerShell handoff scripts

### Documentation & Housekeeping

- [x] Relevant documentation updates are not applicable
- [x] `cli-config.yaml.example` updates are not applicable because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are not applicable because no architecture or workflow changed
- [x] I've considered cross-platform impact for Windows, macOS, and Linux handoff paths
- [x] Tool description and schema updates are not applicable because no model tool behavior changed
