### PR TITLE
ci(js-tests): cache the installed node_modules tree, not just the npm tarball cache

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -20,7 +20,9 @@ jobs:
 
       - name: grab npm 12
         run: |
-          npm i -g npm@12
+          # No-op once the bundled npm is already 12.x — saves ~5-15s/job and
+          # keeps the installed major aligned with the npm12 cache-key tag.
+          npm --version | grep -q '^12\.' || npm i -g npm@12
 
       # ``setup-node``'s ``cache: npm`` only caches the ~/.npm tarball cache;
       # every job still re-extracts the full workspace node_modules and reruns
@@ -93,12 +95,16 @@ jobs:
 
       - name: grab npm 12
         run: |
-          npm i -g npm@12
+          # No-op once the bundled npm is already 12.x — saves ~5-15s/job and
+          # keeps the installed major aligned with the npm12 cache-key tag.
+          npm --version | grep -q '^12\.' || npm i -g npm@12
 
       # Same rationale as the discovery job's cache above, but this ``npm ci``
       # runs WITH install scripts, so the tree includes postinstall artifacts
-      # and the Electron binary is fetched to ~/.cache/electron — cache both
-      # under a key distinct from the -noscripts one.
+      # (electron's postinstall unpacks its binary into node_modules/electron/
+      # dist, which lives inside the cached tree — the ~/.cache/electron
+      # download cache is deliberately NOT cached: with npm ci skipped on hit
+      # it would never be read, only inflate the archive).
       - name: Restore node_modules
         id: node-modules-cache
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -110,7 +116,6 @@ jobs:
             ui-tui/packages/*/node_modules
             tests-js/node_modules
             web/node_modules
-            ~/.cache/electron
           key: node-modules-scripts-${{ runner.os }}-node26-npm12-${{ hashFiles('package-lock.json') }}
 
       - uses: ./.github/actions/retry

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -22,7 +22,29 @@ jobs:
         run: |
           npm i -g npm@12
 
+      # ``setup-node``'s ``cache: npm`` only caches the ~/.npm tarball cache;
+      # every job still re-extracts the full workspace node_modules and reruns
+      # postinstalls (including the Electron binary fetch). Cache the installed
+      # tree itself, keyed on the lockfile, and skip ``npm ci`` on an exact
+      # hit. No restore-keys: a partial hit would leave a stale tree, so
+      # anything but an exact lockfile match reinstalls from scratch.
+      # The discovery job installs with --ignore-scripts, so its tree differs
+      # from the check jobs' — hence the distinct ``-noscripts`` key.
+      - name: Restore node_modules
+        id: node-modules-cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            ui-tui/node_modules
+            ui-tui/packages/*/node_modules
+            tests-js/node_modules
+            web/node_modules
+          key: node-modules-noscripts-${{ runner.os }}-node26-npm12-${{ hashFiles('package-lock.json') }}
+
       - uses: ./.github/actions/retry
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         with:
           command: npm ci --ignore-scripts
       - id: set-matrix
@@ -73,7 +95,26 @@ jobs:
         run: |
           npm i -g npm@12
 
+      # Same rationale as the discovery job's cache above, but this ``npm ci``
+      # runs WITH install scripts, so the tree includes postinstall artifacts
+      # and the Electron binary is fetched to ~/.cache/electron — cache both
+      # under a key distinct from the -noscripts one.
+      - name: Restore node_modules
+        id: node-modules-cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            ui-tui/node_modules
+            ui-tui/packages/*/node_modules
+            tests-js/node_modules
+            web/node_modules
+            ~/.cache/electron
+          key: node-modules-scripts-${{ runner.os }}-node26-npm12-${{ hashFiles('package-lock.json') }}
+
       - uses: ./.github/actions/retry
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         with:
           command: npm ci
       - run: npm run --prefix ${{ matrix.package }} ${{ matrix.script }}


### PR DESCRIPTION
## What real-world problem does this solve?

Every job in the js-tests matrix (~10 jobs per PR run, 13 after #85933's UI-suite sharding) runs a full `npm ci` that deletes and re-extracts the entire workspace `node_modules` and reruns all postinstalls — including the Electron binary fetch (~100MB from GitHub releases) — on every single job, every single run. `setup-node`'s `cache: npm` only caches the `~/.npm` tarball cache, not the installed tree.

This was flagged during the review pass on #85933 (sharding tripled the desktop-ui jobs, tripling this waste), but it affects the whole matrix, so it's its own PR.

## Change

Add an `actions/cache` step (the same SHA-pinned v4.2.4 already used by `e2e-desktop.yml`) for the installed `node_modules` trees, keyed on the exact `package-lock.json` hash, and skip `npm ci` on a hit.

Safety properties (the stale-tree traps are designed out):

- **No `restore-keys`** — a partial hit would restore a stale tree with `npm ci` skipped and nothing to repair it. Anything but an exact lockfile match reinstalls from scratch. This is the npm analog of "don't cache the .venv with fallback keys".
- **Toolchain in the key** (`runner.os`-node26-npm12) — a Node/npm bump never reuses a tree built by the old toolchain. If the workflow's node-version changes, the key must be bumped in the same diff (it's 2 lines apart in the same file).
- **Two distinct keys**: the discovery job installs with `--ignore-scripts` (no postinstall artifacts) while the check jobs install with scripts and need `~/.cache/electron` — different trees, never cross-contaminated.
- `npm ci`'s all-or-nothing semantics make skip-on-hit sound: an exact-lockfile-keyed tree written by the same toolchain IS the `npm ci` result.

## Expected effect

From run 31783969717: the `npm ci` step is 30-45s per check job. Warm-cache restore is a few seconds → roughly **5-8 runner-minutes saved per PR run**, ~1GB less registry/GitHub-releases traffic, and ~35s off every job on the merge-gate critical path (stacks with #85933: gate ≈ 2m40s → ~2m05s).

First run on any lockfile change is unchanged (cold cache, full `npm ci`, then saves).

## Verification

- `yaml.safe_load` + `actionlint` pass.
- `actions/cache@0400d5f6...` (v4.2.4) is the exact pin already vetted in `e2e-desktop.yml`.
- This PR's own CI run is cold (new cache key); the follow-up run after merge-or-rebase demonstrates the warm path. I'll post before/after step timings from live runs.

Note: this touches a workflow file, so the CI review-label gate will hold it for maintainer review — expected.