### PR TITLE
feat(api): replay sanitized run events

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1377,6 +1377,9 @@ class APIServerAdapter(BasePlatformAdapter):
         self._stopping_run_ids: set[str] = set()
         # Pollable run status for dashboards and external control-plane UIs.
         self._run_statuses: Dict[str, Dict[str, Any]] = {}
+        # Bounded replay buffer for external UIs that cannot hold an SSE
+        # connection open continuously (for example a Cloudflare Worker).
+        self._run_events: Dict[str, List[Dict[str, Any]]] = {}
         # Active approval session key for each run_id.  The approval core
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
@@ -6157,6 +6160,13 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_statuses[run_id] = current
         return current
 
+    def _record_run_event(self, run_id: str, event: Dict[str, Any]) -> None:
+        """Retain a bounded, sanitized event timeline for polling UIs."""
+        events = self._run_events.setdefault(run_id, [])
+        events.append(dict(event))
+        if len(events) > 500:
+            del events[:-500]
+
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
         def _push(event: Dict[str, Any]) -> None:
@@ -6166,10 +6176,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 last_event=event.get("event"),
             )
             q = self._run_streams.get(run_id)
-            if q is None:
-                return
             try:
-                loop.call_soon_threadsafe(q.put_nowait, event)
+                def _record_and_stream() -> None:
+                    self._record_run_event(run_id, event)
+                    if q is not None:
+                        q.put_nowait(event)
+
+                loop.call_soon_threadsafe(_record_and_stream)
             except Exception:
                 pass
 
@@ -6197,7 +6210,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "event": "reasoning.available",
                     "run_id": run_id,
                     "timestamp": ts,
-                    "text": preview or "",
+                    "text": redact_sensitive_text(str(preview or ""), force=True),
                 })
             elif event_type in {"subagent.start", "subagent.complete"}:
                 event = {
@@ -6356,7 +6369,9 @@ class APIServerAdapter(BasePlatformAdapter):
         event_cb = self._make_run_event_callback(run_id, loop)
 
         def _put_event_if_active(event: Optional[Dict]) -> None:
-            """Enqueue only while this run still owns live transport state."""
+            """Record events and enqueue them while live transport still exists."""
+            if event is not None:
+                self._record_run_event(run_id, event)
             if self._run_streams.get(run_id) is q:
                 q.put_nowait(event)
 
@@ -6383,6 +6398,13 @@ class APIServerAdapter(BasePlatformAdapter):
             session_id=session_id,
             model=body.get("model", self._model_name),
         )
+        _put_event_if_active({
+            "event": "run.started",
+            "run_id": run_id,
+            "timestamp": created_at,
+            "session_id": session_id,
+            "model": body.get("model", self._model_name),
+        })
 
         # Background task outlives the HTTP response (and thus the middleware
         # profile scope). Capture now and re-enter inside the task/executor.
@@ -6442,7 +6464,11 @@ class APIServerAdapter(BasePlatformAdapter):
                         last_event="approval.request",
                     )
                     try:
-                        loop.call_soon_threadsafe(q.put_nowait, event)
+                        def _record_approval() -> None:
+                            self._record_run_event(run_id, event)
+                            q.put_nowait(event)
+
+                        loop.call_soon_threadsafe(_record_approval)
                     except Exception:
                         pass
 
@@ -6671,7 +6697,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 _openai_error(f"Run not found: {run_id}", code="run_not_found"),
                 status=404,
             )
-        return web.json_response(status)
+        return web.json_response({
+            **status,
+            "events": list(self._run_events.get(run_id, [])),
+        })
 
     async def _handle_run_events(self, request: "web.Request") -> "web.StreamResponse":
         """GET /v1/runs/{run_id}/events — SSE stream of structured agent lifecycle events."""
@@ -6796,13 +6825,15 @@ class APIServerAdapter(BasePlatformAdapter):
         q = self._run_streams.get(run_id)
         if q is not None:
             try:
-                q.put_nowait({
+                event = {
                     "event": "approval.responded",
                     "run_id": run_id,
                     "timestamp": time.time(),
                     "choice": choice,
                     "resolved": resolved,
-                })
+                }
+                self._record_run_event(run_id, event)
+                q.put_nowait(event)
             except Exception:
                 pass
 
@@ -6892,6 +6923,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ]
         for run_id in stale_statuses:
             self._run_statuses.pop(run_id, None)
+            self._run_events.pop(run_id, None)
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -267,6 +267,46 @@ class TestStartRun:
 class TestRunStatus:
 
     @pytest.mark.asyncio
+    async def test_status_replays_sanitized_lifecycle_and_tool_events(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _run(user_message=None, conversation_history=None, task_id=None):
+                    callback = mock_create.call_args.kwargs["tool_progress_callback"]
+                    callback("reasoning.available", preview="Inspect the failing route")
+                    callback("tool.started", tool_name="terminal", preview="pytest -q")
+                    callback("tool.completed", tool_name="terminal", duration=0.25, is_error=False)
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _run
+                mock_agent.session_prompt_tokens = 10
+                mock_agent.session_completion_tokens = 5
+                mock_agent.session_total_tokens = 15
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+                for _ in range(40):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert [event["event"] for event in status["events"]] == [
+                    "run.started",
+                    "reasoning.available",
+                    "tool.started",
+                    "tool.completed",
+                    "run.completed",
+                ]
+                assert status["events"][1]["text"] == "Inspect the failing route"
+                assert status["events"][2]["preview"] == "pytest -q"
+                assert "done" == status["output"]
+
+    @pytest.mark.asyncio
     async def test_status_reflects_explicit_session_id(self, adapter):
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:


### PR DESCRIPTION
## Summary
- retain a bounded sanitized timeline for detached Runs API monitors
- include lifecycle, tool, approval, completion, and failure events in run status polling
- remove replay state during stale-run cleanup

## Verification
- pytest tests/gateway/test_api_server_runs.py -q

This supports Cloudflare-hosted dashboards that cannot keep the original SSE connection open.
