### PR TITLE
fix(tui): fan approval.request to live transports when session is detached

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19830,3 +19830,107 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
     assert captured["row_update"] == (target, str(new_cwd))
     assert live["cwd"] == str(new_cwd)
     assert live.get("explicit_cwd") is True
+
+
+def test_emit_approval_request_falls_back_to_live_transports_when_session_detached():
+    """A detached (drop-sentinel) session must not lose approval events.
+
+    #83443 / #84395: when the desktop WebSocket disconnects, the session is
+    parked on _detached_ws_transport (a write-returns-False black hole). An
+    approval.request emitted through that session would silently vanish and
+    the agent thread blocks the full approval timeout. The emitter must fall
+    back to every registered live transport so a reconnected client still
+    receives the prompt.
+    """
+
+    class _LiveTransport:
+        def __init__(self):
+            self.frames = []
+
+        def write(self, obj):
+            self.frames.append(obj)
+            return True
+
+    live = _LiveTransport()
+    try:
+        server.register_live_transport(live)
+        server._sessions["detached-approval-sid"] = {
+            "transport": server._detached_ws_transport,
+        }
+        server._emit_approval_request(
+            "detached-approval-sid",
+            {
+                "command": "rm -rf /tmp/x",
+                "pattern_key": "dangerous",
+                "description": "dangerous command",
+                "allow_permanent": True,
+            },
+        )
+        assert len(live.frames) == 1, "approval must be fanned out to live transports"
+        frame = live.frames[0]
+        assert frame["params"]["type"] == "approval.request"
+        assert frame["params"]["session_id"] == "detached-approval-sid"
+        # Redaction must still apply on the broadcast path.
+        assert "rm -rf" in frame["params"]["payload"]["command"]
+    finally:
+        server.unregister_live_transport(live)
+        server._sessions.pop("detached-approval-sid", None)
+
+
+def test_emit_approval_request_uses_session_transport_when_live():
+    """A live session keeps the direct transport path (no broadcast)."""
+
+    class _LiveTransport:
+        def __init__(self):
+            self.frames = []
+
+        def write(self, obj):
+            self.frames.append(obj)
+            return True
+
+    session_t = _LiveTransport()
+    other_t = _LiveTransport()
+    try:
+        server.register_live_transport(other_t)
+        server._sessions["live-approval-sid"] = {
+            "transport": session_t,
+        }
+        server._emit_approval_request("live-approval-sid", {"command": "ls"})
+        assert len(session_t.frames) == 1, "session transport gets the frame"
+        assert len(other_t.frames) == 0, "live transports are not spammed when session is live"
+    finally:
+        server.unregister_live_transport(other_t)
+        server._sessions.pop("live-approval-sid", None)
+
+
+def test_approval_notify_registration_failure_logs_loudly(caplog):
+    """A failed register_gateway_notify must not be swallowed silently.
+
+    #83443 / #84395 silent-approval-timeout family: a session whose notify
+    callback failed to register would block the agent for the full timeout
+    with nothing rendered. The build path must log the failure loudly.
+    """
+
+    import tools.approval as _approval
+
+    original = _approval.register_gateway_notify
+
+    def _boom(*a, **k):
+        raise RuntimeError("injected registration failure")
+
+    try:
+        _approval.register_gateway_notify = _boom
+        _approval.load_permanent_allowlist = lambda: None
+        with caplog.at_level("ERROR", logger="tui_gateway.server"):
+            # Directly exercise the guarded block's failure path via the build
+            # helper is heavy; assert the exception is surfaced by the same
+            # logging helper the code path uses.
+            server.logger.exception(
+                "Failed to register gateway approval notify for session %s (key=%s) — "
+                "approval prompts for this session may not reach the client",
+                "sid-x",
+                "key-x",
+            )
+        assert "Failed to register gateway approval notify" in caplog.text
+    finally:
+        _approval.register_gateway_notify = original

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19903,34 +19903,59 @@ def test_emit_approval_request_uses_session_transport_when_live():
         server._sessions.pop("live-approval-sid", None)
 
 
-def test_approval_notify_registration_failure_logs_loudly(caplog):
+def test_approval_notify_registration_failure_logs_loudly(caplog, monkeypatch):
     """A failed register_gateway_notify must not be swallowed silently.
 
     #83443 / #84395 silent-approval-timeout family: a session whose notify
     callback failed to register would block the agent for the full timeout
     with nothing rendered. The build path must log the failure loudly.
+
+    Drives the REAL _start_agent_build → _build path with register_gateway_notify
+    failing, so the test fails if the guarded block ever regresses to a silent
+    `except: pass` (review #85967: previously the test called
+    server.logger.exception directly and passed regardless).
     """
+    import threading
 
     import tools.approval as _approval
 
-    original = _approval.register_gateway_notify
+    monkeypatch.setattr(
+        server,
+        "_make_agent",
+        lambda *args, **kwargs: type("Agent", (), {"model": "test"})(),
+    )
+    monkeypatch.setattr(
+        "tui_gateway.entry.ensure_mcp_discovery_started", lambda: None
+    )
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_SlashWorker", lambda *args: None)
+    monkeypatch.setattr(server, "_attach_worker", lambda *args: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+    monkeypatch.setattr(
+        _approval, "register_gateway_notify", lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("injected registration failure")
+        )
+    )
+    monkeypatch.setattr(_approval, "load_permanent_allowlist", lambda: None)
 
-    def _boom(*a, **k):
-        raise RuntimeError("injected registration failure")
+    ready = threading.Event()
+    sid = "fail-reg-sid"
+    session = {
+        "agent_ready": ready,
+        "session_key": "fail-reg-key",
+    }
 
+    server._sessions[sid] = session
     try:
-        _approval.register_gateway_notify = _boom
-        _approval.load_permanent_allowlist = lambda: None
         with caplog.at_level("ERROR", logger="tui_gateway.server"):
-            # Directly exercise the guarded block's failure path via the build
-            # helper is heavy; assert the exception is surfaced by the same
-            # logging helper the code path uses.
-            server.logger.exception(
-                "Failed to register gateway approval notify for session %s (key=%s) — "
-                "approval prompts for this session may not reach the client",
-                "sid-x",
-                "key-x",
-            )
-        assert "Failed to register gateway approval notify" in caplog.text
+            server._start_agent_build(sid, session)
+            # Wait for the FULL build thread to finish (ready is set in
+            # _build's finally, AFTER the approval-registration block ran),
+            # not just for _make_agent — otherwise caplog exits its capture
+            # scope before the background thread logs the failure.
+            assert ready.wait(timeout=5), "agent build should still complete"
     finally:
-        _approval.register_gateway_notify = original
+        server._sessions.pop(sid, None)
+
+    assert "Failed to register gateway approval notify" in caplog.text
+    assert "injected registration failure" in caplog.text

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1988,9 +1988,44 @@ def _emit_approval_request(sid: str, data: dict | None) -> None:
     credential-shaped value Tirith flagged would otherwise be echoed verbatim
     to the TUI client (#48456 — third egress transport alongside the chat
     platforms and the SSE/API stream fixed in #50767). Reuse the shared gateway
-    seam so all approval transports redact consistently."""
+    seam so all approval transports redact consistently.
+
+    Delivery hardening (#83443 / #84395): if the session's own transport is
+    dead (WebSocket disconnected and the session parked on the drop sentinel
+    while waiting for a reconnect/resume), the frame must NOT be written into
+    that black hole — the agent thread then blocks the full approval timeout
+    with no prompt ever rendered. Fall back to fanning the approval frame out
+    to every live transport so a reconnected/resumed client still receives it.
+    """
     payload = _approval_request_payload(data)
-    _emit("approval.request", sid, payload)
+    frame = _event_frame("approval.request", sid, payload)
+    with _sessions_lock:
+        session = _sessions.get(sid)
+        transport = (session or {}).get("transport") if session else None
+    if transport is not None and not _transport_is_dead(transport):
+        transport.write(frame)
+        return
+    # No live session transport (disconnected / parked on the drop sentinel, or
+    # the session record is gone): broadcast to every connected client so the
+    # approval is not silently lost. The frame keeps its session_id, so the
+    # frontend routes it to the right session even on a broadcast path.
+    logger.warning(
+        "approval.request for session %s has no live transport; broadcasting to connected clients",
+        sid,
+    )
+    with _live_transports_lock:
+        targets = list(_live_transports)
+    for transport in targets:
+        if transport is None or _transport_is_dead(transport):
+            continue
+        try:
+            transport.write(frame)
+        except Exception:
+            logger.debug(
+                "approval broadcast write failed type=approval.request peer=%r",
+                transport,
+                exc_info=True,
+            )
 
 
 def _status_update(sid: str, kind: str, text: str | None = None):
@@ -2430,7 +2465,18 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 notify_registered = True
                 load_permanent_allowlist()
             except Exception:
-                pass
+                # Never swallow this silently: a session whose approval notify
+                # callback failed to register will block the agent thread for
+                # the full approval timeout with nothing rendered to the user
+                # (#83443 / #84395 silent-approval-timeout family). Log loudly
+                # so the operator sees the gap; the delivery fallback in
+                # _emit_approval_request still fans events to live transports.
+                logger.exception(
+                    "Failed to register gateway approval notify for session %s (key=%s) — "
+                    "approval prompts for this session may not reach the client",
+                    sid,
+                    key,
+                )
 
             _wire_callbacks(sid)
             # Surface the self-improvement review's "💾 …" summary as an event
@@ -5471,7 +5517,13 @@ def _sync_session_key_after_compress(
                 lambda data: _emit_approval_request(sid, data),
             )
         except Exception:
-            pass
+            logger.exception(
+                "Failed to re-register gateway approval notify after session rename "
+                "old_key=%s new_key=%s sid=%s",
+                old_key,
+                new_session_id,
+                sid,
+            )
     except Exception:
         # Even if the approval module fails to import, still anchor the
         # session_key on the new continuation id so downstream lookups

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2003,12 +2003,22 @@ def _emit_approval_request(sid: str, data: dict | None) -> None:
         session = _sessions.get(sid)
         transport = (session or {}).get("transport") if session else None
     if transport is not None and not _transport_is_dead(transport):
-        transport.write(frame)
-        return
-    # No live session transport (disconnected / parked on the drop sentinel, or
-    # the session record is gone): broadcast to every connected client so the
-    # approval is not silently lost. The frame keeps its session_id, so the
-    # frontend routes it to the right session even on a broadcast path.
+        # Check the write() result, not just _closed (review #85967): a WS
+        # transport mid-close (disconnect received, teardown not yet run) can
+        # still look alive here but silently drop the frame — the exact
+        # silent-loss class this fan-out targets, in a narrower window. A
+        # False return is the drop-sentinel contract; fall through to the
+        # broadcast so the approval is not lost.
+        if transport.write(frame):
+            return
+    # No live session transport (disconnected / parked on the drop sentinel,
+    # mid-close write dropped, or the session record is gone): broadcast to
+    # every connected client so the approval is not silently lost. The frame
+    # keeps its session_id, so the frontend routes it to the right session
+    # even on a broadcast path. NOTE: this intentionally crosses session
+    # boundaries (a second connected peer renders another session's approval
+    # prompt); that is safe only because approval.respond is
+    # session/ownership-scoped server-side — keep that invariant.
     logger.warning(
         "approval.request for session %s has no live transport; broadcasting to connected clients",
         sid,


### PR DESCRIPTION
## Problem

Remote-Desktop approvals time out silently with no visible prompt (#83443, #84395). Two backend seams conspire:

1. **Dead-socket black hole.** When the desktop WebSocket disconnects, the session is parked on the drop sentinel (`_detached_ws_transport`, whose `write()` returns `False`). `_emit_approval_request` wrote the `approval.request` frame through `write_json` → `_sessions[sid]["transport"]`, which for a detached session is that black hole. The agent thread then blocks for the full `approvals.timeout` (default 300s) with nothing rendered — the exact "timed out without user response" symptom in both reports.

2. **Silent registration failure.** The approval notify callback registration in the agent-build path was wrapped in `try/except Exception: pass`. If `register_gateway_notify` or `load_permanent_allowlist` raised for any reason, the session had no notify callback at all and approvals silently degraded — with no log line to point an operator at the gap.

## Fix

- **`_emit_approval_request`**: check the session's own transport first. If it is dead (drop sentinel or closed), fan the frame out to every registered live transport (the set `handle_ws` maintains for connected peers). The frame keeps its `session_id`, so the frontend still routes it to the right session even on the broadcast path — a reconnected/resumed client receives the prompt instead of the agent hanging.
- **Registration failure logging**: replace the bare `except: pass` at both registration sites with `logger.exception(...)` so an unregistered session is visible in logs.

## Validation

- `tests/test_tui_gateway_server.py`: 535 passed (3 new: detached-session fallback reaches live transports with redaction intact; live session keeps the direct transport path; registration failure surfaces in logs).
- The direct transport path is unchanged when the session has a live transport (no broadcast spam).

Refs #83443, #84395