### PR TITLE
fix(gateway): exclude wedged turns from the restart after-turn wait; default cap 6h -> 30min

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10876,6 +10876,50 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.debug("Failed to launch systemd planned-restart helper: %s", e)
 
+    def _wedged_agent_count(self) -> int:
+        """Count running chat agents already past the inactivity timeout.
+
+        A turn whose agent has recorded no activity (no API bytes, no tool
+        progress) for longer than ``agent.gateway_timeout`` is wedged — the
+        same threshold at which the turn reaper gives up on it. The restart
+        after-turn wait must not treat such turns as work worth waiting for:
+        a wedged agent pinned ``hermes update`` in "draining" for the full
+        ``restart_after_turn_timeout`` cap because the drain counted it as
+        active while its own inactivity watchdog had already declared it dead
+        (Aug 2026, WhatsApp turn idle 30+ min, drain waited on it anyway).
+
+        Returns 0 when the inactivity timeout is disabled (``gateway_timeout``
+        0/unset ⇒ the operator opted into unbounded turns; the after-turn cap
+        still bounds the wait). Cron/API-server work has no per-turn activity
+        clock and is never counted as wedged. Pending sentinels are brand-new
+        turns, never wedged. Fail-open per agent: an unreadable activity
+        summary means "not wedged".
+        """
+        timeout = _float_env("HERMES_AGENT_TIMEOUT", 1800)
+        if timeout <= 0:
+            return 0
+        wedged = 0
+        for agent in list((getattr(self, "_running_agents", None) or {}).values()):
+            if agent is None or agent is _AGENT_PENDING_SENTINEL:
+                continue
+            summary_fn = getattr(agent, "get_activity_summary", None)
+            if not callable(summary_fn):
+                continue
+            try:
+                summary = summary_fn()
+                if not isinstance(summary, dict):
+                    continue
+                idle = float(summary.get("seconds_since_activity", 0.0))
+            except Exception:
+                continue
+            if idle >= timeout:
+                wedged += 1
+        return wedged
+
+    def _awaitable_work_count(self) -> int:
+        """Active work minus wedged turns — what the restart wait waits on."""
+        return max(0, self._active_work_count() - self._wedged_agent_count())
+
     async def _await_active_work_before_restart(self) -> bool:
         """Wait for in-flight work to finish before entering ``stop()``.
 
@@ -10885,13 +10929,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         wait here for active agents/cron/api work to reach zero, then let
         ``stop()`` run against an idle gateway (drain is instant).
 
+        Turns already past the inactivity timeout are excluded from the wait
+        (``_wedged_agent_count``): restart is usually the *remedy* for a
+        wedged turn, so deferring it behind one inverts the point of the
+        graceful path. ``stop()``'s drain interrupts them under
+        ``restart_drain_timeout`` instead.
+
         Returns True when work drained to zero, False when the safety cap
-        elapsed with work still active (caller proceeds to ``stop()``, which
-        may then interrupt remaining runs under ``restart_drain_timeout``).
+        elapsed with work still active — or when only wedged work remains —
+        (caller proceeds to ``stop()``, which may then interrupt remaining
+        runs under ``restart_drain_timeout``).
         """
         active = self._active_work_count()
         if active <= 0:
             return True
+
+        awaitable = self._awaitable_work_count()
+        if awaitable <= 0:
+            logger.warning(
+                "Restart requested with %d active work unit(s), all wedged "
+                "past the inactivity timeout; skipping the after-turn wait "
+                "and proceeding to stop()/drain which will interrupt them",
+                active,
+            )
+            return False
 
         timeout = float(getattr(self, "_restart_after_turn_timeout", 0.0) or 0.0)
         if timeout <= 0:
@@ -10917,7 +10978,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
         last_status_at = 0.0
-        while self._active_work_count() > 0:
+        while self._awaitable_work_count() > 0:
             now = loop.time()
             if now >= deadline:
                 logger.warning(
@@ -10931,8 +10992,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if (now - last_status_at) >= 30.0:
                 logger.info(
                     "Restart deferred: waiting on %d active work unit(s) "
-                    "(%.0fs remaining before force drain)",
-                    self._active_work_count(),
+                    "(%d wedged and excluded; %.0fs remaining before force drain)",
+                    self._awaitable_work_count(),
+                    self._wedged_agent_count(),
                     deadline - now,
                 )
                 try:
@@ -10941,6 +11003,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     pass
                 last_status_at = now
             await asyncio.sleep(0.1)
+
+        if self._active_work_count() > 0:
+            logger.warning(
+                "Restart deferred wait: %d wedged work unit(s) remain; "
+                "proceeding to stop()/drain which will interrupt them",
+                self._active_work_count(),
+            )
+            return False
 
         logger.info(
             "Restart deferred wait complete — active work drained; "

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -83,8 +83,11 @@ DEFAULT_CONFIG = {
         # this cap for in-flight agents/cron/api runs to complete naturally
         # so the requesting turn is not amputated by restart_drain_timeout.
         # 0 = legacy behaviour (enter stop()/drain immediately). Default
-        # 6h is a safety valve for wedged agents, not a target latency.
-        "restart_after_turn_timeout": 21600,
+        # 30 min is a safety valve for wedged agents, not a target latency —
+        # an interactive `hermes gateway restart` must never block for hours
+        # on a turn that wedged (#79133). Long unattended turns can raise
+        # this in config.yaml.
+        "restart_after_turn_timeout": 1800,
         # Upper bound (seconds) a submitted prompt waits for the deferred
         # agent build (MCP discovery, model metadata, skills scan) before
         # failing with a visible error (#63078). The gateway's wait is

--- a/tests/gateway/test_restart_after_turn.py
+++ b/tests/gateway/test_restart_after_turn.py
@@ -17,6 +17,22 @@ def test_parse_restart_after_turn_timeout_defaults_and_clamps():
     assert parse_restart_after_turn_timeout("120") == 120.0
 
 
+def test_default_restart_after_turn_timeout_is_human_tolerable():
+    """The shipped default must not make interactive restarts block for hours.
+
+    A wedged turn must not pin `hermes gateway restart` for 6h — the
+    default is a safety valve for hung agents, not a target latency
+    (#79133). 900-1800s protects long autonomous turns while keeping
+    worst-case interactive restart in human-tolerable territory.
+    """
+    assert 900 <= DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT <= 1800
+    # An interactive restart's printed wait budget stays under ~32 min.
+    budget = resolve_restart_exit_wait_budget(
+        60, DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT, headroom=15
+    )
+    assert budget <= 1875
+
+
 def test_resolve_restart_exit_wait_budget_covers_both_phases():
     assert resolve_restart_exit_wait_budget(0, 0, headroom=15) == 15.0
     assert resolve_restart_exit_wait_budget(180, 21600, headroom=15) == 180 + 21600 + 15

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -375,3 +375,96 @@ async def test_drain_suppress_skips_home_channel_keeps_session_ping(tmp_path, mo
     assert "shutting down" in adapter.sent[0]
 
 
+
+
+def _wedged_agent(idle_seconds: float = 4000.0) -> MagicMock:
+    """Agent double whose activity summary reports it idle past the timeout."""
+    agent = MagicMock()
+    agent.get_activity_summary = MagicMock(
+        return_value={"seconds_since_activity": idle_seconds}
+    )
+    return agent
+
+
+def _live_agent(idle_seconds: float = 1.0) -> MagicMock:
+    agent = MagicMock()
+    agent.get_activity_summary = MagicMock(
+        return_value={"seconds_since_activity": idle_seconds}
+    )
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_request_restart_skips_wait_when_only_wedged_turns(monkeypatch):
+    """A turn idle past agent.gateway_timeout must not defer the restart.
+
+    Regression: a WhatsApp turn wedged for 30+ min pinned `hermes update`
+    in "draining" for the full restart_after_turn_timeout cap — the
+    after-turn wait counted the wedged agent as active work even though
+    the inactivity watchdog had already declared it dead (Aug 2026).
+    """
+    monkeypatch.delenv("HERMES_AGENT_TIMEOUT", raising=False)
+    runner, _adapter = make_restart_runner()
+    runner.stop = AsyncMock()
+    # A cap long enough that the test would hang without the wedge bypass.
+    runner._restart_after_turn_timeout = 300.0
+    runner._running_agents["agent:main:whatsapp:dm:1"] = _wedged_agent()
+
+    assert runner.request_restart(detached=False, via_service=True) is True
+    await asyncio.wait_for(runner._restart_task, timeout=5.0)
+
+    runner.stop.assert_awaited_once_with(
+        restart=True, detached_restart=False, service_restart=True
+    )
+    # Wedged agent stays in the map — stop() owns the interrupt from here.
+    assert runner._running_agents
+
+
+@pytest.mark.asyncio
+async def test_request_restart_still_waits_for_live_turn_alongside_wedged(monkeypatch):
+    """Mixed live + wedged: the live turn is honored, the wedged one ignored."""
+    monkeypatch.delenv("HERMES_AGENT_TIMEOUT", raising=False)
+    runner, _adapter = make_restart_runner()
+    runner.stop = AsyncMock()
+    runner._launch_detached_restart_command = AsyncMock()
+    runner._restart_after_turn_timeout = 300.0
+    live_key = "agent:main:telegram:dm:2"
+    runner._running_agents["agent:main:whatsapp:dm:1"] = _wedged_agent()
+    runner._running_agents[live_key] = _live_agent()
+
+    assert runner.request_restart(detached=False, via_service=True) is True
+
+    # Live turn active → stop() must not run yet, wedged turn notwithstanding.
+    await asyncio.sleep(0.25)
+    runner.stop.assert_not_awaited()
+
+    # Live turn finishes → restart proceeds without waiting on the wedged one.
+    del runner._running_agents[live_key]
+    await asyncio.wait_for(runner._restart_task, timeout=5.0)
+    runner.stop.assert_awaited_once()
+
+
+def test_wedged_agent_count_disabled_timeout_counts_nothing(monkeypatch):
+    """gateway_timeout=0 (unbounded turns) disables wedge detection."""
+    monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "0")
+    runner, _adapter = make_restart_runner()
+    runner._running_agents["agent:main:telegram:dm:1"] = _wedged_agent(10**6)
+    assert runner._wedged_agent_count() == 0
+
+
+def test_wedged_agent_count_ignores_sentinels_and_bad_summaries(monkeypatch):
+    monkeypatch.delenv("HERMES_AGENT_TIMEOUT", raising=False)
+    runner, _adapter = make_restart_runner()
+    broken = MagicMock()
+    broken.get_activity_summary = MagicMock(side_effect=RuntimeError("boom"))
+    non_dict = MagicMock()  # auto-attr summary returns a MagicMock, not a dict
+    runner._running_agents.update(
+        {
+            "pending": gateway_run._AGENT_PENDING_SENTINEL,
+            "broken": broken,
+            "non_dict": non_dict,
+            "wedged": _wedged_agent(),
+            "live": _live_agent(),
+        }
+    )
+    assert runner._wedged_agent_count() == 1


### PR DESCRIPTION
## Summary

`hermes update` / `hermes gateway restart` no longer blocks for hours behind a turn that is already dead — wedged turns (idle past `agent.gateway_timeout`) are excluded from the restart after-turn wait, and the shipped `restart_after_turn_timeout` default drops from 6h to 30min (#79133).

Root cause: the #77184 graceful-restart path waits for all `_active_work_count()` to reach zero before `stop()`, capped at `restart_after_turn_timeout` (default 21600s). A wedged agent — one the gateway's own inactivity watchdog had already declared dead ("Agent idle for 1803s" errors every 30 min) — still counted as active work, so the drain waited on it for the full cap. Live incident (Aug 2026): a WhatsApp turn idle 30+ min pinned `hermes update` in "draining (up to 21675s)" until a manual SIGTERM.

## Changes

- `gateway/run.py`: new `_wedged_agent_count()` — running agents whose `get_activity_summary()` reports inactivity ≥ `agent.gateway_timeout` (same threshold as the turn reaper). `_await_active_work_before_restart()` waits on `_awaitable_work_count()` (active minus wedged) instead of all active work; all-wedged short-circuits straight to `stop()`, whose bounded drain (`restart_drain_timeout`) interrupts them.
- `hermes_cli/config_defaults.py`: `restart_after_turn_timeout` 21600 → 1800 (salvaged from #80321 by @thatssoheil, closes #79133) — the 6h cap only ever mattered in the wedged case, where it is indistinguishable from "no cap" for an operator at a terminal.
- Safety: `gateway_timeout=0` (operator opted into unbounded turns) disables wedge detection; cron/API-server work has no per-turn activity clock and is never counted wedged; pending sentinels and unreadable summaries fail open (not wedged). Live turns are still honored — mixed live+wedged waits for the live turn only.

## Validation

| Scenario | Before | After |
|---|---|---|
| Only wedged turn active, restart requested | drain waits full after-turn cap (6h default) | proceeds to stop() immediately; bounded 60s drain interrupts it |
| Live + wedged turns | waits on both | waits on live only, wedged excluded |
| `gateway_timeout=0` | n/a | wedge detection disabled, cap still bounds wait |
| Sabotage run (fix reverted) | — | both new regression tests FAIL (TimeoutError), proving they exercise the bug |

`tests/gateway/test_restart_drain.py` + `test_restart_after_turn.py` + cron/API drain suites: 40 passed, 2 skipped.

## Infographic

![Restart never waits on a dead turn](https://files.catbox.moe/m4mqwz.png)
