### PR TITLE
fix(tests): resolve cost-guard fixture collision breaking main slice 6

### DIFF
--- a/tests/hermes_cli/test_model_cost_guard.py
+++ b/tests/hermes_cli/test_model_cost_guard.py
@@ -44,9 +44,13 @@ def test_warns_when_models_dev_input_price_exceeds_threshold():
 
 @pytest.mark.parametrize("provider", ["custom", "custom:routerai", "routerai"])
 def test_skips_foreign_models_dev_pricing_for_custom_or_unknown_providers(provider):
+    # NOTE: deliberately NOT openai/gpt-5.5-pro — that id carries an
+    # unconditional known-confusion warning (GPT55_PRO_OPENROUTER_ID) that is
+    # id-keyed and independent of pricing trust, so it would mask what this
+    # test asserts (foreign models.dev pricing being distrusted).
     info = ModelInfo(
-        id="openai/gpt-5.5-pro",
-        name="openai/gpt-5.5-pro",
+        id="vendor/priced-model",
+        name="vendor/priced-model",
         family="",
         provider_id="openrouter",
         cost_input=25.0,
@@ -55,7 +59,7 @@ def test_skips_foreign_models_dev_pricing_for_custom_or_unknown_providers(provid
 
     assert (
         expensive_model_warning(
-            "openai/gpt-5.5-pro",
+            "vendor/priced-model",
             provider=provider,
             model_info=info,
         )
@@ -78,13 +82,26 @@ def test_skips_untrusted_provider_pricing_lookup_for_custom_provider(monkeypatch
     monkeypatch.setattr("agent.usage_pricing.get_pricing_entry", fake_get_pricing_entry)
 
     warning = expensive_model_warning(
-        "openai/gpt-5.5-pro",
+        "vendor/priced-model",
         provider="custom:routerai",
         base_url="https://routerai.example/v1",
     )
 
     assert warning is None
     assert pricing_calls == []
+
+
+def test_known_confusing_model_still_warns_on_custom_provider():
+    """The gpt-5.5-pro confusion nudge is id-keyed, not pricing-keyed: it must
+    survive the custom-provider pricing distrust (54cc39aa15 x 83d373aae6)."""
+    warning = expensive_model_warning(
+        "openai/gpt-5.5-pro",
+        provider="custom:routerai",
+        base_url="https://routerai.example/v1",
+    )
+
+    assert warning is not None
+    assert "did you mean to select openai/gpt-5.5?" in warning.message
 
 
 def test_warns_when_pricing_entry_output_price_exceeds_threshold(monkeypatch):


### PR DESCRIPTION
## Summary

Main's slice 6 is red from a semantic collision between two commits that were each green in isolation: 54cc39aa15 (custom-provider pricing distrust, tested with `openai/gpt-5.5-pro` fixtures) and 83d373aae6 (salvaged #70324, which makes `openai/gpt-5.5-pro` warn UNCONDITIONALLY as a known-confusion id, regardless of pricing trust). The distrust tests now get the id-keyed nudge warning where they assert `None` — 4 failures on every main run and every PR since 3c5fd918e3.

Not a flake and not a regression in either fix's logic: the two behaviors are both correct, the test fixtures just collided on that one model id.

## Changes

- `tests/hermes_cli/test_model_cost_guard.py`: pricing-distrust tests use a neutral `vendor/priced-model` fixture id so they assert what they actually test (foreign pricing distrust), with a comment explaining why gpt-5.5-pro can't be the fixture
- New `test_known_confusing_model_still_warns_on_custom_provider`: pins the intended composed behavior — the id-keyed confusion nudge survives custom-provider pricing distrust

## Validation

| | Before | After |
|---|---|---|
| `tests/hermes_cli/test_model_cost_guard.py` | 4 failed, 6 passed (on main) | 10 passed |
| + `test_cli_startup_model_cost_guard.py` | — | 19/19 passed |

## Infographic

![CI fix infographic](https://files.catbox.moe/kxsyfq.png)
