### PR TITLE
fix(desktop): record interacted zone on click, not pointerdown (held-press focused-session flicker)

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/active-group-tracking.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/active-group-tracking.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Regression: the interacted-zone tracker must NOT switch on pointerdown.
+// It used to, and a held press on a sidebar row (pointerdown fires, release
+// hasn't happened yet) swapped `$activeTreeGroup` — and through it the
+// derived `$focusedStoredSessionId` — to whatever zone the row's DOM sat in.
+// With session tiles open, the focused session (statusbar workspace label +
+// sidebar row highlight) flickered to another session for the entire hold.
+// Tracking on `click` keeps the ⌘W semantics while the press is only
+// committed once the button is released.
+
+describe('trackActiveTreeGroup: click, not pointerdown, records the zone', () => {
+  let cleanup: (() => void) | undefined
+
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    cleanup?.()
+    cleanup = undefined
+    vi.resetModules()
+  })
+
+  async function setup() {
+    const tree = await import('@/components/pane-shell/tree/store')
+
+    const zone = document.createElement('div')
+    zone.setAttribute('data-tree-group', 'grp-side')
+    const target = document.createElement('button')
+    zone.appendChild(target)
+    document.body.appendChild(zone)
+
+    cleanup = tree.trackActiveTreeGroup()
+
+    return { target, tree }
+  }
+
+  it('a held press (pointerdown) does not move the active zone', async () => {
+    const { target, tree } = await setup()
+
+    target.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }))
+
+    expect(tree.$activeTreeGroup.get()).toBeNull()
+  })
+
+  it('a completed click records the interacted zone', async () => {
+    const { target, tree } = await setup()
+
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(tree.$activeTreeGroup.get()).toBe('grp-side')
+  })
+
+  it('focusin (keyboard navigation) still records the zone', async () => {
+    const { target, tree } = await setup()
+
+    target.dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+
+    expect(tree.$activeTreeGroup.get()).toBe('grp-side')
+  })
+
+  it('a press outside any zone leaves the previous zone untouched', async () => {
+    const { tree } = await setup()
+
+    tree.noteActiveTreeGroup('grp-side')
+
+    const stray = document.createElement('div')
+    document.body.appendChild(stray)
+
+    stray.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }))
+    stray.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(tree.$activeTreeGroup.get()).toBe('grp-side')
+  })
+
+  it('teardown removes the listeners', async () => {
+    const { target, tree } = await setup()
+
+    cleanup?.()
+    cleanup = undefined
+
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(tree.$activeTreeGroup.get()).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -325,7 +325,7 @@ export function invalidateStripTools() {
   $stripToolsRevision.set($stripToolsRevision.get() + 1)
 }
 
-/** Record the interacted zone (pointerdown / focusin). Idempotent. */
+/** Record the interacted zone (click / focusin). Idempotent. */
 export function noteActiveTreeGroup(groupId: null | string) {
   if (groupId !== $activeTreeGroup.get()) {
     $activeTreeGroup.set(groupId)
@@ -393,20 +393,30 @@ export function trackActiveTreeGroup(): () => void {
     }
   }
 
+  // `click` — not `pointerdown` — records the interacted zone. Pointerdown
+  // fires the instant a button is PRESSED, before the press has committed to
+  // anything, so switching `$activeTreeGroup` (and with it the derived
+  // `$focusedStoredSessionId`) on pointerdown made the focused session — and
+  // everything keyed off it (statusbar workspace label, sidebar row highlight)
+  // — flicker to another zone's tile for the whole duration of a held press.
+  // `click` keeps the same "last interacted zone" semantics for ⌘W (the click
+  // event's target is intact even when activeElement is `body` on
+  // non-focusable surfaces) but only after the press has completed.
+  //
   // `pointerover` fires on every element boundary crossing (not every mouse
   // move), so leaving the panes for the titlebar reports null and the override
   // lifts on its own.
   const trackHover = (event: Event) => noteHoveredTreeGroup(treeGroupOfEvent(event))
   const clearHover = () => noteHoveredTreeGroup(null)
 
-  window.addEventListener('pointerdown', trackActive, true)
+  window.addEventListener('click', trackActive, true)
   window.addEventListener('focusin', trackActive, true)
   window.addEventListener('pointerover', trackHover, true)
   document.documentElement.addEventListener('pointerleave', clearHover)
   window.addEventListener('blur', clearHover)
 
   return () => {
-    window.removeEventListener('pointerdown', trackActive, true)
+    window.removeEventListener('click', trackActive, true)
     window.removeEventListener('focusin', trackActive, true)
     window.removeEventListener('pointerover', trackHover, true)
     document.documentElement.removeEventListener('pointerleave', clearHover)


### PR DESCRIPTION
## Problem

Holding a press (mouse-down without releasing) on a sidebar session row makes two pieces of UI flicker for the entire duration of the press:

1. The **statusbar workspace label** (project directory name) briefly shows the directory of a *different* session.
2. The **sidebar row highlight** jumps to that other session's row (in another project group).

Both snap back the moment the button is released. Reproduced on the desktop app with session tiles (tabs) open; with all tiles closed the symptom disappears.

## Root cause

`trackActiveTreeGroup` recorded the interacted zone on **`pointerdown`** — which fires the instant the press starts, before the press has committed to anything:

```ts
window.addEventListener('pointerdown', trackActive, true)
window.addEventListener('focusin', trackActive, true)
```

That writes `$activeTreeGroup`, which feeds the derived `$focusedStoredSessionId` (an interacted zone's active `session-tile:*` pane names the "focused session"):

```ts
export const $focusedStoredSessionId = computed(
  [$activeTreeGroup, $layoutTree, $selectedStoredSessionId],
  (groupId, tree, selected) => {
    const active = groupId && tree ? findGroup(tree, groupId)?.active : undefined
    return active?.startsWith(TILE_PANE_PREFIX) ? active.slice(TILE_PANE_PREFIX.length) : selected
  }
)
```

The statusbar workspace item and the sidebar row highlight both follow the focused session (sidebar: `const selectedSessionId = useStore($focusedStoredSessionId)` in `app/chat/sidebar/index.tsx`). With session tiles open, a held press on a sidebar row retargets the focused session to the pressed zone's active tile; on release the click handler resumes the real session and everything snaps back.

## Fix

Track the interacted zone on **`click`** instead of `pointerdown`:

- Same "last interacted zone" semantics for the tab verbs (⌘W / ⌘T / ⌘⇧T / ⌘1…⌘9) — the `click` event's target is intact even on non-focusable surfaces where `activeElement` is `body`.
- The zone only changes once the press has completed, so a held press can no longer flicker the focused session.

`focusin` tracking is unchanged (keyboard navigation still records the zone).

## Tests

Added `active-group-tracking.test.ts` with 5 regression tests:

- a held press (pointerdown) does not move the active zone
- a completed click records the interacted zone
- focusin (keyboard navigation) still records the zone
- a press outside any zone leaves the previous zone untouched
- teardown removes the listeners

Full `pane-shell` suite: 21 files / 110 tests passing.
