### PR TITLE
fix(skills): avoid setUid privilege false positive

### DIFF
--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -200,6 +200,26 @@ class TestScanFile:
         # Same pattern on same line should appear only once
         assert len(root_rm) == 1
 
+    def test_setuid_pattern_ignores_camel_case_setters(self, tmp_path):
+        f = tmp_path / "publication.md"
+        f.write_text("event.setUid(uid);\n")
+
+        findings = scan_file(f, "publication.md")
+
+        assert not any(fi.pattern_id == "setuid_setgid" for fi in findings)
+
+    @pytest.mark.parametrize(
+        "source",
+        ["os.setuid(1000)\n", "setgid 1000\n", "cap_setuid+ep\n"],
+    )
+    def test_setuid_pattern_still_detects_real_mechanisms(self, tmp_path, source):
+        f = tmp_path / "privilege.md"
+        f.write_text(source)
+
+        findings = scan_file(f, "privilege.md")
+
+        assert any(fi.pattern_id == "setuid_setgid" for fi in findings)
+
 
 # ---------------------------------------------------------------------------
 # scan_skill — directory scanning

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -447,7 +447,7 @@ THREAT_PATTERNS = [
     (r'\bsudo\b',
      "sudo_usage", "high", "privilege_escalation",
      "uses sudo (privilege escalation)"),
-    (r'setuid|setgid|cap_setuid',
+    (r'(?-i:\b(?:setuid|setgid|cap_setuid|SETUID|SETGID|CAP_SETUID)\b)',
      "setuid_setgid", "critical", "privilege_escalation",
      "setuid/setgid (privilege escalation mechanism)"),
     (r'NOPASSWD',


### PR DESCRIPTION
## Summary
- make the setuid/setgid threat pattern case-sensitive while preserving lowercase syscall and uppercase capability detection
- stop Java/Kotlin-style `.setUid(...)` and `.setGid(...)` setters from being classified as critical privilege escalation
- add regression coverage for both the false-positive and true-positive paths

## Reproduction
`event.setUid(uid);` in a Markdown reference currently produces a `setuid_setgid` critical finding because all threat patterns are evaluated with `re.IGNORECASE`.

## Test plan
- `uv run --no-project --with pytest python -m pytest -q --confcutdir=tests/tools tests/tools/test_skills_guard.py`
- standalone scan assertions for `event.setUid`, `os.setuid`, `setgid`, `cap_setuid`, and `CAP_SETUID`
