### PR TITLE
feat: label webui sessions as Hermex in desktop app

### DIFF
--- a/apps/desktop/src/app/messaging/platform-icon.tsx
+++ b/apps/desktop/src/app/messaging/platform-icon.tsx
@@ -67,6 +67,9 @@ const PLATFORM_ICONS: Record<string, PlatformIconSpec> = {
   sms: { Icon: MessageSquareText, color: '#F43F5E', kind: 'generic' },
   webhook: { Icon: LinkIcon, color: '#71717A', kind: 'generic' },
   api_server: { Icon: Globe, color: '#64748B', kind: 'generic' },
+  // Hermex — third-party iOS client for the Hermes web UI. No Simple Icons
+  // brand mark exists, so use a letter monogram (same pattern as Slack).
+  webui: { color: '#6D28D9', kind: 'brand', monogram: 'H' },
   weixin: { Icon: SiWechat, color: '#07C160', kind: 'brand' },
   qqbot: { Icon: SiQq, color: '#EB1923', kind: 'brand' },
   yuanbao: { Icon: SiBilibili, color: '#FB7299', kind: 'brand' }

--- a/apps/desktop/src/lib/session-source.ts
+++ b/apps/desktop/src/lib/session-source.ts
@@ -21,6 +21,7 @@ const SOURCE_LABELS: Record<string, string> = {
   telegram: 'Telegram',
   tui: 'TUI',
   webhook: 'Webhook',
+  webui: 'Hermex',
   weixin: 'WeChat',
   whatsapp: 'WhatsApp',
   yuanbao: 'Yuanbao'
@@ -64,6 +65,7 @@ export const MESSAGING_SESSION_SOURCE_IDS = [
   'sms',
   'webhook',
   'api_server',
+  'webui',
   'weixin',
   'wecom',
   'qqbot',


### PR DESCRIPTION
## Summary

Hermex is a third-party iOS client that connects to Hermes through the web UI, so its sessions arrive with `source='webui'`. The desktop app's messaging sidebar and platform icons had no entry for that source, so Hermex chats showed as an unknown source with no icon.

## Changes

- **`apps/desktop/src/lib/session-source.ts`** — add `webui: 'Hermex'` to `SOURCE_LABELS` and include `webui` in `MESSAGING_SESSION_SOURCE_IDS` so the sessions appear in the messaging sidebar.
- **`apps/desktop/src/app/messaging/platform-icon.tsx`** — add a purple 'H' monogram icon for `webui` (same pattern as Slack's monogram; no Simple Icons brand mark exists for Hermex).

## Testing

Verified locally on macOS: after a clean relaunch of the desktop app, Hermex chats appear in the messaging sidebar under the 'Hermex' label with the 'H' icon.