### PR TITLE
feat(desktop): drag selected message text into the composer

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.test.ts
@@ -53,7 +53,8 @@ function renderDrop() {
       cwd: '/repo',
       insertInlineRefs,
       onAttachDroppedItems,
-      requestMainFocus
+      requestMainFocus,
+      target: 'main'
     })
   )
 
@@ -77,7 +78,7 @@ describe('useComposerDrop — quote drops', () => {
 
     result.current.handleDrop(event as unknown as React.DragEvent<HTMLFormElement>)
 
-    expect(insertComposer).toHaveBeenCalledWith('> hello world')
+    expect(insertComposer).toHaveBeenCalledWith('> hello world', { target: 'main' })
     expect(event.preventDefault).toHaveBeenCalled()
   })
 
@@ -92,7 +93,7 @@ describe('useComposerDrop — quote drops', () => {
 
     result.current.handleDrop(event as unknown as React.DragEvent<HTMLFormElement>)
 
-    expect(insertComposer).toHaveBeenCalledWith('> hello world')
+    expect(insertComposer).toHaveBeenCalledWith('> hello world', { target: 'main' })
   })
 
   it('ignores an empty quote drop', () => {
@@ -151,7 +152,7 @@ describe('useComposerDrop — quote drops', () => {
 
     result.current.handleInputDrop(event as unknown as React.DragEvent<HTMLDivElement>)
 
-    expect(insertComposer).toHaveBeenCalledWith('> from input drop')
+    expect(insertComposer).toHaveBeenCalledWith('> from input drop', { target: 'main' })
     expect(event.stopPropagation).toHaveBeenCalled()
   })
 
@@ -195,7 +196,8 @@ describe('useComposerDrop — quote drops', () => {
         cwd: '/repo',
         insertInlineRefs,
         onAttachDroppedItems: undefined,
-        requestMainFocus
+        requestMainFocus,
+        target: 'main'
       })
     )
 
@@ -207,7 +209,59 @@ describe('useComposerDrop — quote drops', () => {
 
     result.current.handleDrop(event as unknown as React.DragEvent<HTMLFormElement>)
 
-    expect(insertComposer).toHaveBeenCalledWith('> still works')
+    expect(insertComposer).toHaveBeenCalledWith('> still works', { target: 'main' })
+  })
+
+  it('routes quote drops to this composer\u2019s own scope, not the active composer', () => {
+    const insertInlineRefs = vi.fn(() => false)
+    const requestMainFocus = vi.fn()
+
+    const { result } = renderHook(() =>
+      useComposerDrop({
+        cwd: '/repo',
+        insertInlineRefs,
+        onAttachDroppedItems: undefined,
+        requestMainFocus,
+        target: 'tile:abc'
+      })
+    )
+
+    const event = {
+      dataTransfer: quoteTransfer('> tile quote'),
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn()
+    }
+
+    result.current.handleDrop(event as unknown as React.DragEvent<HTMLFormElement>)
+
+    // requestComposerInsert was called with an explicit { target } — the
+    // mocked focus bus records it. The second arg must be { target: 'tile:abc' }.
+    expect(insertComposer).toHaveBeenCalledWith('> tile quote', { target: 'tile:abc' })
+  })
+
+  it('routes input-area quote drops to this composer\u2019s own scope', () => {
+    const insertInlineRefs = vi.fn(() => false)
+    const requestMainFocus = vi.fn()
+
+    const { result } = renderHook(() =>
+      useComposerDrop({
+        cwd: '/repo',
+        insertInlineRefs,
+        onAttachDroppedItems: undefined,
+        requestMainFocus,
+        target: 'tile:abc'
+      })
+    )
+
+    const event = {
+      dataTransfer: quoteTransfer('> input quote'),
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn()
+    }
+
+    result.current.handleInputDrop(event as unknown as React.DragEvent<HTMLDivElement>)
+
+    expect(insertComposer).toHaveBeenCalledWith('> input quote', { target: 'tile:abc' })
   })
 
   it('does not throw when a mixed files+quote drag arrives with no attach handler wired', () => {
@@ -219,7 +273,8 @@ describe('useComposerDrop — quote drops', () => {
         cwd: '/repo',
         insertInlineRefs,
         onAttachDroppedItems: undefined,
-        requestMainFocus
+        requestMainFocus,
+        target: 'main'
       })
     )
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.test.ts
@@ -163,4 +163,37 @@ describe('useComposerDrop — text drops', () => {
 
     expect(insertComposer).toHaveBeenCalledWith('> still works')
   })
+
+  it('does not throw when a mixed files+text drag arrives with no attach handler wired', () => {
+    const insertInlineRefs = vi.fn(() => false)
+    const requestMainFocus = vi.fn()
+
+    const { result } = renderHook(() =>
+      useComposerDrop({
+        cwd: '/repo',
+        insertInlineRefs,
+        onAttachDroppedItems: undefined,
+        requestMainFocus
+      })
+    )
+
+    // A drag carrying BOTH a file and text/plain: the text/plain guard lets it
+    // through the top-level check, the file branch runs, but there is no
+    // attach handler to hand osDrops to. Regression guard for the TypeError
+    // that used to fire on `onAttachDroppedItems!(osDrops)`.
+    const event = {
+      dataTransfer: {
+        dropEffect: 'none',
+        effectAllowed: 'none',
+        files: { length: 1, item: () => new File(['x'], 'notes.txt') },
+        getData: (format: string) => (format === 'text/plain' ? '> text' : ''),
+        items: [{ kind: 'file', getAsFile: () => new File(['x'], 'notes.txt'), webkitGetAsEntry: () => null }],
+        types: ['Files', 'text/plain']
+      },
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn()
+    }
+
+    expect(() => result.current.handleDrop(event as unknown as React.DragEvent<HTMLFormElement>)).not.toThrow()
+  })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.test.ts
@@ -1,0 +1,166 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useComposerDrop } from '@/app/chat/composer/hooks/use-composer-drop'
+
+// Composer drop-handler tests for the text-drop path added alongside the
+// existing file-drop engine. A drag of selected message text carries only
+// `text/plain` — no HERMES_PATHS_MIME, no Files — and must reach the composer
+// as a quoted block via requestComposerInsert, without disturbing the
+// file-drop paths that already existed.
+
+const insertComposer = vi.hoisted(() => vi.fn())
+
+vi.mock('@/app/chat/composer/focus', () => ({
+  requestComposerInsert: insertComposer
+}))
+
+// Minimal DataTransfer stand-in for jsdom. `types` is the only field the
+// guards read; `getData` serves the drop handlers.
+function textTransfer(text: string) {
+  return {
+    dropEffect: 'none',
+    effectAllowed: 'none',
+    files: { length: 0, item: () => null },
+    getData: (format: string) => (format === 'text/plain' ? text : ''),
+    items: [] as unknown[],
+    types: text.length > 0 ? ['text/plain'] : []
+  }
+}
+
+function renderDrop() {
+  const insertInlineRefs = vi.fn(() => false)
+  const onAttachDroppedItems = vi.fn()
+  const requestMainFocus = vi.fn()
+
+  const { result } = renderHook(() =>
+    useComposerDrop({
+      cwd: '/repo',
+      insertInlineRefs,
+      onAttachDroppedItems,
+      requestMainFocus
+    })
+  )
+
+  return { insertInlineRefs, onAttachDroppedItems, requestMainFocus, result }
+}
+
+describe('useComposerDrop — text drops', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    insertComposer.mockReset()
+  })
+
+  it('inserts dragged text into the composer as-is (pre-quoted by the drag source)', () => {
+    const { result } = renderDrop()
+
+    const event = {
+      dataTransfer: textTransfer('> hello world'),
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn()
+    }
+
+    result.current.handleDrop(event as unknown as React.DragEvent<HTMLFormElement>)
+
+    expect(insertComposer).toHaveBeenCalledWith('> hello world')
+    expect(event.preventDefault).toHaveBeenCalled()
+  })
+
+  it('trims surrounding whitespace from the dropped text', () => {
+    const { result } = renderDrop()
+
+    const event = {
+      dataTransfer: textTransfer('  > hello world\n\n  '),
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn()
+    }
+
+    result.current.handleDrop(event as unknown as React.DragEvent<HTMLFormElement>)
+
+    expect(insertComposer).toHaveBeenCalledWith('> hello world')
+  })
+
+  it('ignores an empty text drop', () => {
+    const { result } = renderDrop()
+
+    const event = {
+      dataTransfer: textTransfer(''),
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn()
+    }
+
+    result.current.handleDrop(event as unknown as React.DragEvent<HTMLFormElement>)
+
+    expect(insertComposer).not.toHaveBeenCalled()
+  })
+
+  it('inserts text dropped onto the input area', () => {
+    const { result } = renderDrop()
+
+    const event = {
+      dataTransfer: textTransfer('> from input drop'),
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn()
+    }
+
+    result.current.handleInputDrop(event as unknown as React.DragEvent<HTMLDivElement>)
+
+    expect(insertComposer).toHaveBeenCalledWith('> from input drop')
+    expect(event.stopPropagation).toHaveBeenCalled()
+  })
+
+  it('text drag-over accepts the drop with copy effect on the form', () => {
+    const { result } = renderDrop()
+
+    const event = {
+      dataTransfer: textTransfer('> hello'),
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn()
+    }
+
+    result.current.handleDragOver(event as unknown as React.DragEvent<HTMLFormElement>)
+
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(event.dataTransfer.dropEffect).toBe('copy')
+  })
+
+  it('text drag-over accepts the drop on the input area', () => {
+    const { result } = renderDrop()
+
+    const event = {
+      dataTransfer: textTransfer('> hello'),
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn()
+    }
+
+    result.current.handleInputDragOver(event as unknown as React.DragEvent<HTMLDivElement>)
+
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(event.stopPropagation).toHaveBeenCalled()
+    expect(event.dataTransfer.dropEffect).toBe('copy')
+  })
+
+  it('text drops work even when no attach handler is wired', () => {
+    const insertInlineRefs = vi.fn(() => false)
+    const requestMainFocus = vi.fn()
+
+    const { result } = renderHook(() =>
+      useComposerDrop({
+        cwd: '/repo',
+        insertInlineRefs,
+        onAttachDroppedItems: undefined,
+        requestMainFocus
+      })
+    )
+
+    const event = {
+      dataTransfer: textTransfer('> still works'),
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn()
+    }
+
+    result.current.handleDrop(event as unknown as React.DragEvent<HTMLFormElement>)
+
+    expect(insertComposer).toHaveBeenCalledWith('> still works')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.test.ts
@@ -2,12 +2,14 @@ import { renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { useComposerDrop } from '@/app/chat/composer/hooks/use-composer-drop'
+import { HERMES_QUOTE_MIME } from '@/app/chat/hooks/use-composer-actions'
 
-// Composer drop-handler tests for the text-drop path added alongside the
-// existing file-drop engine. A drag of selected message text carries only
-// `text/plain` — no HERMES_PATHS_MIME, no Files — and must reach the composer
-// as a quoted block via requestComposerInsert, without disturbing the
-// file-drop paths that already existed.
+// Composer drop-handler tests for the quote-drop path added alongside the
+// existing file-drop engine. A drag of selected message text carries the
+// HERMES_QUOTE_MIME marker — no HERMES_PATHS_MIME, no Files — and must reach
+// the composer as a quoted block via requestComposerInsert, without
+// disturbing the file-drop paths that already existed. Foreign text/plain
+// drags (kanban cards, external apps) must be ignored entirely.
 
 const insertComposer = vi.hoisted(() => vi.fn())
 
@@ -17,14 +19,27 @@ vi.mock('@/app/chat/composer/focus', () => ({
 
 // Minimal DataTransfer stand-in for jsdom. `types` is the only field the
 // guards read; `getData` serves the drop handlers.
-function textTransfer(text: string) {
+function quoteTransfer(text: string) {
+  return {
+    dropEffect: 'none',
+    effectAllowed: 'none',
+    files: { length: 0, item: () => null },
+    getData: (format: string) => (format === HERMES_QUOTE_MIME ? text : ''),
+    items: [] as unknown[],
+    types: text.length > 0 ? [HERMES_QUOTE_MIME] : []
+  }
+}
+
+/** A foreign text/plain drag (kanban card id, external app text) — carries
+ * NO HERMES_QUOTE_MIME and must be left alone. */
+function foreignTextTransfer(text: string) {
   return {
     dropEffect: 'none',
     effectAllowed: 'none',
     files: { length: 0, item: () => null },
     getData: (format: string) => (format === 'text/plain' ? text : ''),
     items: [] as unknown[],
-    types: text.length > 0 ? ['text/plain'] : []
+    types: ['text/plain']
   }
 }
 
@@ -45,7 +60,7 @@ function renderDrop() {
   return { insertInlineRefs, onAttachDroppedItems, requestMainFocus, result }
 }
 
-describe('useComposerDrop — text drops', () => {
+describe('useComposerDrop — quote drops', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     insertComposer.mockReset()
@@ -55,7 +70,7 @@ describe('useComposerDrop — text drops', () => {
     const { result } = renderDrop()
 
     const event = {
-      dataTransfer: textTransfer('> hello world'),
+      dataTransfer: quoteTransfer('> hello world'),
       preventDefault: vi.fn(),
       stopPropagation: vi.fn()
     }
@@ -70,7 +85,7 @@ describe('useComposerDrop — text drops', () => {
     const { result } = renderDrop()
 
     const event = {
-      dataTransfer: textTransfer('  > hello world\n\n  '),
+      dataTransfer: quoteTransfer('  > hello world\n\n  '),
       preventDefault: vi.fn(),
       stopPropagation: vi.fn()
     }
@@ -80,11 +95,11 @@ describe('useComposerDrop — text drops', () => {
     expect(insertComposer).toHaveBeenCalledWith('> hello world')
   })
 
-  it('ignores an empty text drop', () => {
+  it('ignores an empty quote drop', () => {
     const { result } = renderDrop()
 
     const event = {
-      dataTransfer: textTransfer(''),
+      dataTransfer: quoteTransfer(''),
       preventDefault: vi.fn(),
       stopPropagation: vi.fn()
     }
@@ -94,11 +109,42 @@ describe('useComposerDrop — text drops', () => {
     expect(insertComposer).not.toHaveBeenCalled()
   })
 
+  it('ignores a foreign text/plain drop (kanban card, external app text)', () => {
+    const { result } = renderDrop()
+
+    const event = {
+      dataTransfer: foreignTextTransfer('task-123'),
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn()
+    }
+
+    result.current.handleDrop(event as unknown as React.DragEvent<HTMLFormElement>)
+
+    // The quote never reaches the composer. (preventDefault alone matches the
+    // pre-existing file-drop path: with an attach handler wired, any drop is
+    // swallowed — what matters is that no insertion happens.)
+    expect(insertComposer).not.toHaveBeenCalled()
+  })
+
+  it('ignores a foreign text/plain drag-over on the form', () => {
+    const { result } = renderDrop()
+
+    const event = {
+      dataTransfer: foreignTextTransfer('task-123'),
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn()
+    }
+
+    result.current.handleDragOver(event as unknown as React.DragEvent<HTMLFormElement>)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
   it('inserts text dropped onto the input area', () => {
     const { result } = renderDrop()
 
     const event = {
-      dataTransfer: textTransfer('> from input drop'),
+      dataTransfer: quoteTransfer('> from input drop'),
       preventDefault: vi.fn(),
       stopPropagation: vi.fn()
     }
@@ -109,11 +155,11 @@ describe('useComposerDrop — text drops', () => {
     expect(event.stopPropagation).toHaveBeenCalled()
   })
 
-  it('text drag-over accepts the drop with copy effect on the form', () => {
+  it('quote drag-over accepts the drop with copy effect on the form', () => {
     const { result } = renderDrop()
 
     const event = {
-      dataTransfer: textTransfer('> hello'),
+      dataTransfer: quoteTransfer('> hello'),
       preventDefault: vi.fn(),
       stopPropagation: vi.fn()
     }
@@ -124,11 +170,11 @@ describe('useComposerDrop — text drops', () => {
     expect(event.dataTransfer.dropEffect).toBe('copy')
   })
 
-  it('text drag-over accepts the drop on the input area', () => {
+  it('quote drag-over accepts the drop on the input area', () => {
     const { result } = renderDrop()
 
     const event = {
-      dataTransfer: textTransfer('> hello'),
+      dataTransfer: quoteTransfer('> hello'),
       preventDefault: vi.fn(),
       stopPropagation: vi.fn()
     }
@@ -140,7 +186,7 @@ describe('useComposerDrop — text drops', () => {
     expect(event.dataTransfer.dropEffect).toBe('copy')
   })
 
-  it('text drops work even when no attach handler is wired', () => {
+  it('quote drops work even when no attach handler is wired', () => {
     const insertInlineRefs = vi.fn(() => false)
     const requestMainFocus = vi.fn()
 
@@ -154,7 +200,7 @@ describe('useComposerDrop — text drops', () => {
     )
 
     const event = {
-      dataTransfer: textTransfer('> still works'),
+      dataTransfer: quoteTransfer('> still works'),
       preventDefault: vi.fn(),
       stopPropagation: vi.fn()
     }
@@ -164,7 +210,7 @@ describe('useComposerDrop — text drops', () => {
     expect(insertComposer).toHaveBeenCalledWith('> still works')
   })
 
-  it('does not throw when a mixed files+text drag arrives with no attach handler wired', () => {
+  it('does not throw when a mixed files+quote drag arrives with no attach handler wired', () => {
     const insertInlineRefs = vi.fn(() => false)
     const requestMainFocus = vi.fn()
 
@@ -177,7 +223,7 @@ describe('useComposerDrop — text drops', () => {
       })
     )
 
-    // A drag carrying BOTH a file and text/plain: the text/plain guard lets it
+    // A drag carrying BOTH a file and the quote MIME: the quote guard lets it
     // through the top-level check, the file branch runs, but there is no
     // attach handler to hand osDrops to. Regression guard for the TypeError
     // that used to fire on `onAttachDroppedItems!(osDrops)`.
@@ -186,9 +232,9 @@ describe('useComposerDrop — text drops', () => {
         dropEffect: 'none',
         effectAllowed: 'none',
         files: { length: 1, item: () => new File(['x'], 'notes.txt') },
-        getData: (format: string) => (format === 'text/plain' ? '> text' : ''),
+        getData: (format: string) => (format === HERMES_QUOTE_MIME ? '> text' : ''),
         items: [{ kind: 'file', getAsFile: () => new File(['x'], 'notes.txt'), webkitGetAsEntry: () => null }],
-        types: ['Files', 'text/plain']
+        types: ['Files', HERMES_QUOTE_MIME]
       },
       preventDefault: vi.fn(),
       stopPropagation: vi.fn()

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.ts
@@ -3,9 +3,14 @@ import { type DragEvent as ReactDragEvent, useRef, useState } from 'react'
 import { requestComposerInsert } from '@/app/chat/composer/focus'
 import { triggerHaptic } from '@/lib/haptics'
 
-import { extractDroppedFiles, HERMES_PATHS_MIME, partitionDroppedFiles } from '../../hooks/use-composer-actions'
+import { extractDroppedFiles, HERMES_PATHS_MIME, HERMES_QUOTE_MIME, partitionDroppedFiles } from '../../hooks/use-composer-actions'
 import { dragHasAttachments, droppedFileInlineRefs, type InlineRefInput } from '../inline-refs'
 import type { ChatBarProps } from '../types'
+
+/** True when the drag carries a message-bubble quote (HERMES_QUOTE_MIME).
+ * Deliberately NOT keyed on `text/plain`: foreign text/plain drags (kanban
+ * cards, external apps) must keep their existing behavior untouched. */
+const hasQuoteData = (transfer: DataTransfer) => Array.from(transfer.types || []).includes(HERMES_QUOTE_MIME)
 
 interface UseComposerDropArgs {
   cwd: ChatBarProps['cwd']
@@ -36,11 +41,11 @@ export function useComposerDrop({
   }
 
   const handleDragEnter = (event: ReactDragEvent<HTMLFormElement>) => {
-    if (!onAttachDroppedItems && !event.dataTransfer.types.includes('text/plain')) {
+    if (!onAttachDroppedItems && !hasQuoteData(event.dataTransfer)) {
       return
     }
 
-    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME) && !event.dataTransfer.types.includes('text/plain')) {
+    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME) && !hasQuoteData(event.dataTransfer)) {
       return
     }
 
@@ -53,11 +58,11 @@ export function useComposerDrop({
   }
 
   const handleDragOver = (event: ReactDragEvent<HTMLFormElement>) => {
-    if (!onAttachDroppedItems && !event.dataTransfer.types.includes('text/plain')) {
+    if (!onAttachDroppedItems && !hasQuoteData(event.dataTransfer)) {
       return
     }
 
-    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME) && !event.dataTransfer.types.includes('text/plain')) {
+    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME) && !hasQuoteData(event.dataTransfer)) {
       return
     }
 
@@ -79,7 +84,7 @@ export function useComposerDrop({
   }
 
   const handleDrop = (event: ReactDragEvent<HTMLFormElement>) => {
-    if (!onAttachDroppedItems && !event.dataTransfer.types.includes('text/plain')) {
+    if (!onAttachDroppedItems && !hasQuoteData(event.dataTransfer)) {
       return
     }
 
@@ -112,9 +117,9 @@ export function useComposerDrop({
       return
     }
 
-    // Text drop: selected message text dragged into the composer.
+    // Quote drop: selected message text dragged into the composer.
     // Insert as a quoted block (same format as "Paste as text").
-    const text = event.dataTransfer.getData('text/plain').trim()
+    const text = event.dataTransfer.getData(HERMES_QUOTE_MIME).trim()
 
     if (text) {
       requestComposerInsert(text)
@@ -123,7 +128,7 @@ export function useComposerDrop({
   }
 
   const handleInputDragOver = (event: ReactDragEvent<HTMLDivElement>) => {
-    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME) && !event.dataTransfer.types.includes('text/plain')) {
+    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME) && !hasQuoteData(event.dataTransfer)) {
       return
     }
 
@@ -133,7 +138,7 @@ export function useComposerDrop({
   }
 
   const handleInputDrop = (event: ReactDragEvent<HTMLDivElement>) => {
-    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME) && !event.dataTransfer.types.includes('text/plain')) {
+    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME) && !hasQuoteData(event.dataTransfer)) {
       return
     }
 
@@ -169,8 +174,8 @@ export function useComposerDrop({
       return
     }
 
-    // Text drop onto the input area.
-    const text = event.dataTransfer.getData('text/plain').trim()
+    // Quote drop onto the input area.
+    const text = event.dataTransfer.getData(HERMES_QUOTE_MIME).trim()
 
     if (text) {
       event.preventDefault()

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.ts
@@ -100,8 +100,8 @@ export function useComposerDrop({
         triggerHaptic('selection')
       }
 
-      if (osDrops.length) {
-        void Promise.resolve(onAttachDroppedItems!(osDrops)).then(attached => {
+      if (osDrops.length && onAttachDroppedItems) {
+        void Promise.resolve(onAttachDroppedItems(osDrops)).then(attached => {
           if (attached) {
             triggerHaptic('selection')
             requestMainFocus()

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.ts
@@ -1,5 +1,6 @@
 import { type DragEvent as ReactDragEvent, useRef, useState } from 'react'
 
+import { requestComposerInsert } from '@/app/chat/composer/focus'
 import { triggerHaptic } from '@/lib/haptics'
 
 import { extractDroppedFiles, HERMES_PATHS_MIME, partitionDroppedFiles } from '../../hooks/use-composer-actions'
@@ -35,7 +36,11 @@ export function useComposerDrop({
   }
 
   const handleDragEnter = (event: ReactDragEvent<HTMLFormElement>) => {
-    if (!onAttachDroppedItems || !dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME)) {
+    if (!onAttachDroppedItems && !event.dataTransfer.types.includes('text/plain')) {
+      return
+    }
+
+    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME) && !event.dataTransfer.types.includes('text/plain')) {
       return
     }
 
@@ -48,7 +53,11 @@ export function useComposerDrop({
   }
 
   const handleDragOver = (event: ReactDragEvent<HTMLFormElement>) => {
-    if (!onAttachDroppedItems || !dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME)) {
+    if (!onAttachDroppedItems && !event.dataTransfer.types.includes('text/plain')) {
+      return
+    }
+
+    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME) && !event.dataTransfer.types.includes('text/plain')) {
       return
     }
 
@@ -70,7 +79,7 @@ export function useComposerDrop({
   }
 
   const handleDrop = (event: ReactDragEvent<HTMLFormElement>) => {
-    if (!onAttachDroppedItems) {
+    if (!onAttachDroppedItems && !event.dataTransfer.types.includes('text/plain')) {
       return
     }
 
@@ -79,33 +88,42 @@ export function useComposerDrop({
 
     const candidates = extractDroppedFiles(event.dataTransfer)
 
-    if (candidates.length === 0) {
+    if (candidates.length > 0) {
+      // In-app drags (project tree / gutter) are workspace-relative paths the
+      // gateway resolves directly, so they stay inline @file:/@line: refs. OS
+      // drops are absolute local paths a remote gateway can't read (and images
+      // need byte upload for vision), so route them through the upload pipeline.
+      const { inAppRefs, osDrops } = partitionDroppedFiles(candidates)
+      const refs = droppedFileInlineRefs(inAppRefs, cwd)
+
+      if (refs.length && insertInlineRefs(refs)) {
+        triggerHaptic('selection')
+      }
+
+      if (osDrops.length) {
+        void Promise.resolve(onAttachDroppedItems!(osDrops)).then(attached => {
+          if (attached) {
+            triggerHaptic('selection')
+            requestMainFocus()
+          }
+        })
+      }
+
       return
     }
 
-    // In-app drags (project tree / gutter) are workspace-relative paths the
-    // gateway resolves directly, so they stay inline @file:/@line: refs. OS
-    // drops are absolute local paths a remote gateway can't read (and images
-    // need byte upload for vision), so route them through the upload pipeline.
-    const { inAppRefs, osDrops } = partitionDroppedFiles(candidates)
-    const refs = droppedFileInlineRefs(inAppRefs, cwd)
+    // Text drop: selected message text dragged into the composer.
+    // Insert as a quoted block (same format as "Paste as text").
+    const text = event.dataTransfer.getData('text/plain').trim()
 
-    if (refs.length && insertInlineRefs(refs)) {
+    if (text) {
+      requestComposerInsert(text)
       triggerHaptic('selection')
-    }
-
-    if (osDrops.length) {
-      void Promise.resolve(onAttachDroppedItems(osDrops)).then(attached => {
-        if (attached) {
-          triggerHaptic('selection')
-          requestMainFocus()
-        }
-      })
     }
   }
 
   const handleInputDragOver = (event: ReactDragEvent<HTMLDivElement>) => {
-    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME)) {
+    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME) && !event.dataTransfer.types.includes('text/plain')) {
       return
     }
 
@@ -115,40 +133,51 @@ export function useComposerDrop({
   }
 
   const handleInputDrop = (event: ReactDragEvent<HTMLDivElement>) => {
-    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME)) {
+    if (!dragHasAttachments(event.dataTransfer, HERMES_PATHS_MIME) && !event.dataTransfer.types.includes('text/plain')) {
       return
     }
 
     const candidates = extractDroppedFiles(event.dataTransfer)
 
-    if (!candidates.length) {
+    if (candidates.length > 0) {
+      event.preventDefault()
+      event.stopPropagation()
+      resetDragState()
+
+      // Dropping straight onto the text box used to inline-ref *every* file —
+      // including OS/Finder drops, whose absolute local path a remote gateway
+      // can't read and whose image bytes never reached vision. Split by origin:
+      // in-app drags stay inline refs; OS drops go through the upload pipeline.
+      // (When no upload handler is wired, fall back to inline refs for all.)
+      const attach = onAttachDroppedItems
+      const { inAppRefs, osDrops } = partitionDroppedFiles(candidates)
+      const refs = droppedFileInlineRefs(attach ? inAppRefs : candidates, cwd)
+
+      if (refs.length && insertInlineRefs(refs)) {
+        triggerHaptic('selection')
+      }
+
+      if (attach && osDrops.length) {
+        void Promise.resolve(attach(osDrops)).then(attached => {
+          if (attached) {
+            triggerHaptic('selection')
+            requestMainFocus()
+          }
+        })
+      }
+
       return
     }
 
-    event.preventDefault()
-    event.stopPropagation()
-    resetDragState()
+    // Text drop onto the input area.
+    const text = event.dataTransfer.getData('text/plain').trim()
 
-    // Dropping straight onto the text box used to inline-ref *every* file —
-    // including OS/Finder drops, whose absolute local path a remote gateway
-    // can't read and whose image bytes never reached vision. Split by origin:
-    // in-app drags stay inline refs; OS drops go through the upload pipeline.
-    // (When no upload handler is wired, fall back to inline refs for all.)
-    const attach = onAttachDroppedItems
-    const { inAppRefs, osDrops } = partitionDroppedFiles(candidates)
-    const refs = droppedFileInlineRefs(attach ? inAppRefs : candidates, cwd)
-
-    if (refs.length && insertInlineRefs(refs)) {
+    if (text) {
+      event.preventDefault()
+      event.stopPropagation()
+      resetDragState()
+      requestComposerInsert(text)
       triggerHaptic('selection')
-    }
-
-    if (attach && osDrops.length) {
-      void Promise.resolve(attach(osDrops)).then(attached => {
-        if (attached) {
-          triggerHaptic('selection')
-          requestMainFocus()
-        }
-      })
     }
   }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-drop.ts
@@ -1,6 +1,6 @@
 import { type DragEvent as ReactDragEvent, useRef, useState } from 'react'
 
-import { requestComposerInsert } from '@/app/chat/composer/focus'
+import { type ComposerTarget, requestComposerInsert } from '@/app/chat/composer/focus'
 import { triggerHaptic } from '@/lib/haptics'
 
 import { extractDroppedFiles, HERMES_PATHS_MIME, HERMES_QUOTE_MIME, partitionDroppedFiles } from '../../hooks/use-composer-actions'
@@ -17,6 +17,9 @@ interface UseComposerDropArgs {
   insertInlineRefs: (refs: InlineRefInput[]) => boolean
   onAttachDroppedItems: ChatBarProps['onAttachDroppedItems']
   requestMainFocus: () => void
+  /** Focus-bus routing key of THIS composer — quote drops land here, never in
+   * whatever composer happens to be `'active'` (e.g. an open edit composer). */
+  target: ComposerTarget
 }
 
 /**
@@ -30,7 +33,8 @@ export function useComposerDrop({
   cwd,
   insertInlineRefs,
   onAttachDroppedItems,
-  requestMainFocus
+  requestMainFocus,
+  target
 }: UseComposerDropArgs) {
   const [dragActive, setDragActive] = useState(false)
   const dragDepthRef = useRef(0)
@@ -71,10 +75,6 @@ export function useComposerDrop({
   }
 
   const handleDragLeave = (event: ReactDragEvent<HTMLFormElement>) => {
-    if (!onAttachDroppedItems) {
-      return
-    }
-
     event.preventDefault()
     dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
 
@@ -118,11 +118,12 @@ export function useComposerDrop({
     }
 
     // Quote drop: selected message text dragged into the composer.
-    // Insert as a quoted block (same format as "Paste as text").
+    // Insert as a quoted block (same format as "Paste as text"), routed to
+    // THIS composer's scope — never to whatever composer is 'active'.
     const text = event.dataTransfer.getData(HERMES_QUOTE_MIME).trim()
 
     if (text) {
-      requestComposerInsert(text)
+      requestComposerInsert(text, { target })
       triggerHaptic('selection')
     }
   }
@@ -174,14 +175,14 @@ export function useComposerDrop({
       return
     }
 
-    // Quote drop onto the input area.
+    // Quote drop onto the input area, routed to THIS composer's scope.
     const text = event.dataTransfer.getData(HERMES_QUOTE_MIME).trim()
 
     if (text) {
       event.preventDefault()
       event.stopPropagation()
       resetDragState()
-      requestComposerInsert(text)
+      requestComposerInsert(text, { target })
       triggerHaptic('selection')
     }
   }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -907,7 +907,7 @@ export function ChatBar({
     handleDrop,
     handleInputDragOver,
     handleInputDrop
-  } = useComposerDrop({ cwd, insertInlineRefs, onAttachDroppedItems, requestMainFocus })
+  } = useComposerDrop({ cwd, insertInlineRefs, onAttachDroppedItems, requestMainFocus, target: scope.target })
 
   // Branch / worktree hand-offs (CodingStatusRow). Owns the worktree open +
   // branch-off/convert/list/switch actions; draft travels into the new session.

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -83,6 +83,12 @@ export interface DroppedFile {
  * Payload is JSON `{ path; isDirectory?; line?; lineEnd? }[]`. */
 export const HERMES_PATHS_MIME = 'application/x-hermes-paths'
 
+/** MIME emitted by message-bubble drag sources (drag selected text into the
+ * composer). Payload is the quoted text block. The composer accepts text
+ * drops ONLY when this MIME is present, so foreign text/plain drags
+ * (kanban cards, external apps) keep their existing behavior untouched. */
+export const HERMES_QUOTE_MIME = 'application/x-hermes-quote'
+
 /**
  * Eagerly resolve files from a drop event into [File?, path, isDirectory?]
  * triples. Internal Hermes sources (e.g. the project tree) ride on a custom

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -19,6 +19,7 @@ import { MESSAGE_PARTS_COMPONENTS } from '@/components/assistant-ui/thread/messa
 import { ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
 import { ResponseLoadingIndicator, StreamStallIndicator } from '@/components/assistant-ui/thread/status'
 import { formatMessageTimestamp } from '@/components/assistant-ui/thread/timestamp'
+import { useDragTextToComposer } from '@/components/assistant-ui/thread/use-drag-text-to-composer'
 import { useMessageReactions, useTapbackDoubleClick } from '@/components/assistant-ui/thread/use-message-reactions'
 import { AGENT_MESSAGE_RE } from '@/components/assistant-ui/thread/user-message'
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button'
@@ -57,6 +58,7 @@ export const AssistantMessage: FC<{
   const messageId = useAuiState(s => s.message.id)
   const messageRuntime = useMessageRuntime()
   const { t } = useI18n()
+  const { onDragEnd, onDragStart } = useDragTextToComposer()
 
   // A reply to an inter-agent delivery is part of that exchange, not part of
   // the human conversation — collapse it under a compact notice ("Reply to
@@ -192,6 +194,8 @@ export const AssistantMessage: FC<{
       <div
         className="wrap-anywhere min-w-0 max-w-full overflow-hidden text-pretty text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground"
         data-slot="aui_assistant-message-content"
+        onDragEnd={onDragEnd}
+        onDragStart={onDragStart}
       >
         {/* Todos render in the composer status stack now, not inline. */}
         <MessagePrimitive.Parts components={MESSAGE_PARTS_COMPONENTS} />

--- a/apps/desktop/src/components/assistant-ui/thread/selection.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/selection.ts
@@ -1,0 +1,6 @@
+/** True when the user has a live text highlight (drag-select / triple-click). */
+export function hasTextSelection(): boolean {
+  const selection = window.getSelection()
+
+  return Boolean(selection && !selection.isCollapsed && selection.toString().length > 0)
+}

--- a/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.test.ts
@@ -47,7 +47,7 @@ describe('useDragTextToComposer', () => {
     document.dispatchEvent(new Event('dragend'))
   })
 
-  function createDragEvent(selectedText: string) {
+  function createDragEvent(selectedText: string, target?: Element | null) {
     const dataTransfer = stubDataTransfer()
 
     // Simulate a live selection
@@ -62,7 +62,8 @@ describe('useDragTextToComposer', () => {
       dataTransfer,
       clientX: 100,
       clientY: 200,
-      preventDefault: vi.fn()
+      preventDefault: vi.fn(),
+      target: target ?? null
     }
   }
 
@@ -85,6 +86,28 @@ describe('useDragTextToComposer', () => {
     result.current.onDragStart(event as unknown as React.DragEvent<HTMLElement>)
 
     expect(event.dataTransfer.getData('text/plain')).toBe('> line one\n> line two\n> line three')
+  })
+
+  it('drops a trailing newline before quoting', () => {
+    const { result } = renderHook(() => useDragTextToComposer())
+    const event = createDragEvent('line one\n')
+
+    result.current.onDragStart(event as unknown as React.DragEvent<HTMLElement>)
+
+    expect(event.dataTransfer.getData('text/plain')).toBe('> line one')
+  })
+
+  it('does not cancel a native link drag when nothing is selected', () => {
+    const { result } = renderHook(() => useDragTextToComposer())
+    const link = document.createElement('a')
+    const event = createDragEvent('', link)
+
+    result.current.onDragStart(event as unknown as React.DragEvent<HTMLElement>)
+
+    // The native link drag must survive: no preventDefault, no ghost, no data.
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(ghostCount()).toBe(0)
+    expect(event.dataTransfer.getData('text/plain')).toBe('')
   })
 
   it('prevents the drag when no text is selected', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { HERMES_QUOTE_MIME } from '@/app/chat/hooks/use-composer-actions'
 import { useDragTextToComposer } from '@/components/assistant-ui/thread/use-drag-text-to-composer'
 
 // The drag-text-to-composer hook is a thin wrapper around the HTML5 Drag and
@@ -65,14 +66,16 @@ describe('useDragTextToComposer', () => {
     }
   }
 
-  it('sets text/plain with quoted text on dragstart', () => {
+  it('sets text/plain AND the quote MIME on dragstart', () => {
     const { result } = renderHook(() => useDragTextToComposer())
     const event = createDragEvent('hello world')
 
     result.current.onDragStart(event as unknown as React.DragEvent<HTMLElement>)
 
     expect(event.dataTransfer.effectAllowed).toBe('copy')
+    // text/plain for OS interop, HERMES_QUOTE_MIME as the composer's marker
     expect(event.dataTransfer.getData('text/plain')).toBe('> hello world')
+    expect(event.dataTransfer.getData(HERMES_QUOTE_MIME)).toBe('> hello world')
   })
 
   it('quotes each line separately', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.test.ts
@@ -1,0 +1,125 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useDragTextToComposer } from '@/components/assistant-ui/thread/use-drag-text-to-composer'
+
+// The drag-text-to-composer hook is a thin wrapper around the HTML5 Drag and
+// Drop API. Tests exercise the handler's behavior through a simulated
+// DragEvent, verifying that:
+// - Selected text is formatted as quoted lines and set on the DataTransfer
+// - effectAllowed is 'copy'
+// - No selection → event is prevented (no-op)
+// - dragend cleans up the ghost
+
+// Minimal DataTransfer stand-in for jsdom (no native DataTransfer constructor).
+interface StubDataTransfer {
+  effectAllowed: string
+  getData: (format: string) => string
+  setData: (format: string, data: string) => void
+  types: string[]
+}
+
+function stubDataTransfer(): StubDataTransfer {
+  const store: Record<string, string> = {}
+
+  return {
+    effectAllowed: 'none',
+    getData: (format: string) => store[format] ?? '',
+    setData: (format: string, data: string) => {
+      store[format] = data
+    },
+    types: []
+  }
+}
+
+describe('useDragTextToComposer', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function createDragEvent(selectedText: string) {
+    const dataTransfer = stubDataTransfer()
+
+    // Simulate a live selection
+    const selection = {
+      isCollapsed: selectedText.length === 0,
+      toString: () => selectedText
+    }
+
+    vi.spyOn(window, 'getSelection').mockReturnValue(selection as Selection)
+
+    return {
+      dataTransfer,
+      clientX: 100,
+      clientY: 200,
+      preventDefault: vi.fn()
+    }
+  }
+
+  it('sets text/plain with quoted text on dragstart', () => {
+    const { result } = renderHook(() => useDragTextToComposer())
+    const event = createDragEvent('hello world')
+
+    result.current.onDragStart(event as unknown as React.DragEvent<HTMLElement>)
+
+    expect(event.dataTransfer.effectAllowed).toBe('copy')
+    expect(event.dataTransfer.getData('text/plain')).toBe('> hello world')
+  })
+
+  it('quotes each line separately', () => {
+    const { result } = renderHook(() => useDragTextToComposer())
+    const event = createDragEvent('line one\nline two\nline three')
+
+    result.current.onDragStart(event as unknown as React.DragEvent<HTMLElement>)
+
+    expect(event.dataTransfer.getData('text/plain')).toBe('> line one\n> line two\n> line three')
+  })
+
+  it('prevents the drag when no text is selected', () => {
+    const { result } = renderHook(() => useDragTextToComposer())
+    const event = createDragEvent('')
+
+    result.current.onDragStart(event as unknown as React.DragEvent<HTMLElement>)
+
+    expect(event.preventDefault).toHaveBeenCalled()
+  })
+
+  it('prevents the drag when selection is collapsed', () => {
+    const { result } = renderHook(() => useDragTextToComposer())
+    const event = createDragEvent('')
+
+    // Collapsed selection: isCollapsed = true, toString returns ''
+    vi.spyOn(window, 'getSelection').mockReturnValue({
+      isCollapsed: true,
+      toString: () => ''
+    } as Selection)
+
+    result.current.onDragStart(event as unknown as React.DragEvent<HTMLElement>)
+
+    expect(event.preventDefault).toHaveBeenCalled()
+  })
+
+  it('cleans up the drag ghost on dragend', () => {
+    const { result } = renderHook(() => useDragTextToComposer())
+    const event = createDragEvent('test')
+
+    const beforeCount = document.body.children.length
+
+    result.current.onDragStart(event as unknown as React.DragEvent<HTMLElement>)
+
+    // The ghost should have been appended to the body
+    expect(document.body.children.length).toBe(beforeCount + 1)
+
+    // dragend should remove it
+    result.current.onDragEnd()
+
+    expect(document.body.children.length).toBe(beforeCount)
+  })
+
+  it('is a no-op on dragend when no ghost was created', () => {
+    const { result } = renderHook(() => useDragTextToComposer())
+
+    // Should not throw
+    expect(() => result.current.onDragEnd()).not.toThrow()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.test.ts
@@ -147,6 +147,21 @@ describe('useDragTextToComposer', () => {
     expect(ghostCount()).toBe(0)
   })
 
+  it('shows a line count in the ghost for multi-line selections', () => {
+    const { result } = renderHook(() => useDragTextToComposer())
+    const event = createDragEvent('line one\nline two')
+
+    result.current.onDragStart(event as unknown as React.DragEvent<HTMLElement>)
+
+    const ghost = Array.from(document.body.children).find(
+      el => (el as HTMLElement).style.position === 'fixed'
+    ) as HTMLElement | undefined
+
+    expect(ghost?.textContent).toContain('2 lines')
+
+    result.current.onDragEnd()
+  })
+
   it('releases the ghost via the document-level dragend listener even after the component unmounts', () => {
     const { result, unmount } = renderHook(() => useDragTextToComposer())
     const event = createDragEvent('survives unmount')

--- a/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.test.ts
@@ -9,7 +9,8 @@ import { useDragTextToComposer } from '@/components/assistant-ui/thread/use-drag
 // - Selected text is formatted as quoted lines and set on the DataTransfer
 // - effectAllowed is 'copy'
 // - No selection → event is prevented (no-op)
-// - dragend cleans up the ghost
+// - dragend (component- or document-level) cleans up the ghost
+// - A stale ghost is released before a new drag starts
 
 // Minimal DataTransfer stand-in for jsdom (no native DataTransfer constructor).
 interface StubDataTransfer {
@@ -32,9 +33,17 @@ function stubDataTransfer(): StubDataTransfer {
   }
 }
 
+/** The drag ghost is the only fixed-position element createDragGhost appends. */
+function ghostCount(): number {
+  return Array.from(document.body.children).filter(el => (el as HTMLElement).style.position === 'fixed').length
+}
+
 describe('useDragTextToComposer', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    // Release any module-level ghost a test left behind. Dispatching dragend
+    // exercises the same document-level cleanup the app relies on.
+    document.dispatchEvent(new Event('dragend'))
   })
 
   function createDragEvent(selectedText: string) {
@@ -99,21 +108,51 @@ describe('useDragTextToComposer', () => {
     expect(event.preventDefault).toHaveBeenCalled()
   })
 
-  it('cleans up the drag ghost on dragend', () => {
+  it('creates a ghost on dragstart and cleans it up on dragend', () => {
     const { result } = renderHook(() => useDragTextToComposer())
     const event = createDragEvent('test')
 
-    const beforeCount = document.body.children.length
-
     result.current.onDragStart(event as unknown as React.DragEvent<HTMLElement>)
 
-    // The ghost should have been appended to the body
-    expect(document.body.children.length).toBe(beforeCount + 1)
+    expect(ghostCount()).toBe(1)
 
-    // dragend should remove it
     result.current.onDragEnd()
 
-    expect(document.body.children.length).toBe(beforeCount)
+    expect(ghostCount()).toBe(0)
+  })
+
+  it('releases the ghost via the document-level dragend listener even after the component unmounts', () => {
+    const { result, unmount } = renderHook(() => useDragTextToComposer())
+    const event = createDragEvent('survives unmount')
+
+    // Start the drag, then unmount the bubble mid-drag (streaming removes a
+    // message). The document-level listener must still release the ghost.
+    result.current.onDragStart(event as unknown as React.DragEvent<HTMLElement>)
+    expect(ghostCount()).toBe(1)
+
+    unmount()
+
+    // The browser fires dragend on the document when a drag finishes — even
+    // when the source node was removed mid-drag.
+    document.dispatchEvent(new Event('dragend'))
+
+    expect(ghostCount()).toBe(0)
+  })
+
+  it('releases a stale ghost when a new drag starts', () => {
+    const { result } = renderHook(() => useDragTextToComposer())
+    const first = createDragEvent('first drag')
+    const second = createDragEvent('second drag')
+
+    result.current.onDragStart(first as unknown as React.DragEvent<HTMLElement>)
+    expect(ghostCount()).toBe(1)
+
+    // A second drag without a dragend in between must not leak the first ghost
+    result.current.onDragStart(second as unknown as React.DragEvent<HTMLElement>)
+    expect(ghostCount()).toBe(1)
+
+    result.current.onDragEnd()
+    expect(ghostCount()).toBe(0)
   })
 
   it('is a no-op on dragend when no ghost was created', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react'
+import { useCallback } from 'react'
 
 import { createDragGhost, type DragGhost } from '@/lib/drag-ghost'
 
@@ -14,15 +14,43 @@ import { hasTextSelection } from './selection'
  *    (use-composer-drop) can pick it up
  * 4. Creates a drag ghost via the existing `createDragGhost` utility
  *
- * The ghost is destroyed on `dragend` — even when the drop target is outside
- * the app window (the browser fires dragend regardless).
+ * The ghost is destroyed on `dragend`. Cleanup is module-level (not a ref
+ * inside the hook) on purpose: message bubbles can unmount mid-drag (a
+ * streaming turn removes a message, a session switch tears the transcript
+ * down), and a ref owned by the unmounted component would orphan the ghost
+ * node forever. The module holder + document-level dragend listener survive
+ * unmount and always release the node.
  *
  * This is an ADDITION, not a replacement: dragstart is a separate event from
  * click, contextmenu, and pointerdown. No existing behavior is touched.
  */
-export function useDragTextToComposer() {
-  const ghostRef = useRef<DragGhost | null>(null)
 
+let activeGhost: DragGhost | null = null
+
+function releaseGhost() {
+  activeGhost?.destroy()
+  activeGhost = null
+}
+
+function ensureDocumentListener() {
+  if (typeof document === 'undefined') {
+    return
+  }
+
+  // Idempotent: a single document-level dragend listener serves every message
+  // bubble. It also catches drags that end OUTSIDE the app window, where the
+  // bubble's own React dragend handler may never fire.
+  if (document.documentElement.dataset.hermesDragGhostArmed === '1') {
+    return
+  }
+
+  document.documentElement.dataset.hermesDragGhostArmed = '1'
+  document.addEventListener('dragend', releaseGhost)
+}
+
+ensureDocumentListener()
+
+export function useDragTextToComposer() {
   const onDragStart = useCallback((event: React.DragEvent<HTMLElement>) => {
     if (!hasTextSelection()) {
       event.preventDefault()
@@ -48,17 +76,15 @@ export function useDragTextToComposer() {
     event.dataTransfer.setData('text/plain', quoted)
 
     // Drag ghost: a flat, pointer-following chip showing what's being dragged.
-    // Truncate to ~40 chars so the chip stays compact.
-    const label = text.length > 40 ? text.slice(0, 40) + '…' : text
-    const ghost = createDragGhost(label)
-
-    ghostRef.current = ghost
-    ghost.moveTo(event.clientX, event.clientY)
+    // Truncate to ~40 chars so the chip stays compact. Release any stale ghost
+    // first (a previous drag whose dragend was swallowed).
+    releaseGhost()
+    activeGhost = createDragGhost(text.length > 40 ? text.slice(0, 40) + '…' : text)
+    activeGhost.moveTo(event.clientX, event.clientY)
   }, [])
 
   const onDragEnd = useCallback(() => {
-    ghostRef.current?.destroy()
-    ghostRef.current = null
+    releaseGhost()
   }, [])
 
   return { onDragStart, onDragEnd }

--- a/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
@@ -1,0 +1,65 @@
+import { useCallback, useRef } from 'react'
+
+import { createDragGhost, type DragGhost } from '@/lib/drag-ghost'
+
+import { hasTextSelection } from './user-message'
+
+/**
+ * Shared drag-text-to-composer behavior for message bubbles (user + assistant).
+ *
+ * When the user selects text in a message and starts dragging, the handler:
+ * 1. Reads the live selection text
+ * 2. Formats it as a quoted block ("> line" per line, same as "Paste as text")
+ * 3. Sets `text/plain` on the DataTransfer so the composer's drop handler
+ *    (use-composer-drop) can pick it up
+ * 4. Creates a drag ghost via the existing `createDragGhost` utility
+ *
+ * The ghost is destroyed on `dragend` — even when the drop target is outside
+ * the app window (the browser fires dragend regardless).
+ *
+ * This is an ADDITION, not a replacement: dragstart is a separate event from
+ * click, contextmenu, and pointerdown. No existing behavior is touched.
+ */
+export function useDragTextToComposer() {
+  const ghostRef = useRef<DragGhost | null>(null)
+
+  const onDragStart = useCallback((event: React.DragEvent<HTMLElement>) => {
+    if (!hasTextSelection()) {
+      event.preventDefault()
+
+      return
+    }
+
+    const selection = window.getSelection()
+    const text = selection?.toString().trim() ?? ''
+
+    if (!text) {
+      event.preventDefault()
+
+      return
+    }
+
+    const quoted = text
+      .split('\n')
+      .map(line => `> ${line}`)
+      .join('\n')
+
+    event.dataTransfer.effectAllowed = 'copy'
+    event.dataTransfer.setData('text/plain', quoted)
+
+    // Drag ghost: a flat, pointer-following chip showing what's being dragged.
+    // Truncate to ~40 chars so the chip stays compact.
+    const label = text.length > 40 ? text.slice(0, 40) + '…' : text
+    const ghost = createDragGhost(label)
+
+    ghostRef.current = ghost
+    ghost.moveTo(event.clientX, event.clientY)
+  }, [])
+
+  const onDragEnd = useCallback(() => {
+    ghostRef.current?.destroy()
+    ghostRef.current = null
+  }, [])
+
+  return { onDragStart, onDragEnd }
+}

--- a/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
@@ -96,10 +96,14 @@ export function useDragTextToComposer() {
     event.dataTransfer.setData(HERMES_QUOTE_MIME, quoted)
 
     // Drag ghost: a flat, pointer-following chip showing what's being dragged.
-    // Truncate to ~40 chars so the chip stays compact. Release any stale ghost
-    // first (a previous drag whose dragend was swallowed).
+    // Truncate the preview to ~40 chars; multi-line selections get a line
+    // count so a selection that spans message bubbles is identifiable at a
+    // glance (the payload is the live document selection — what-you-see-is-
+    // what-you-drag, matching native Chromium drag-text behavior).
     releaseGhost()
-    activeGhost = createDragGhost(text.length > 40 ? text.slice(0, 40) + '…' : text)
+    const preview = text.length > 40 ? text.slice(0, 40) + '…' : text
+    const label = lines.length > 1 ? `${preview} (${lines.length} lines)` : preview
+    activeGhost = createDragGhost(label)
     activeGhost.moveTo(event.clientX, event.clientY)
   }, [])
 

--- a/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 
+import { HERMES_QUOTE_MIME } from '@/app/chat/hooks/use-composer-actions'
 import { createDragGhost, type DragGhost } from '@/lib/drag-ghost'
 
 import { hasTextSelection } from './selection'
@@ -73,7 +74,11 @@ export function useDragTextToComposer() {
       .join('\n')
 
     event.dataTransfer.effectAllowed = 'copy'
+    // text/plain keeps the drag interop with OS-level targets; HERMES_QUOTE_MIME
+    // is the marker the composer's drop handler keys on, so foreign text/plain
+    // drags (kanban cards, external apps) keep their existing behavior.
     event.dataTransfer.setData('text/plain', quoted)
+    event.dataTransfer.setData(HERMES_QUOTE_MIME, quoted)
 
     // Drag ghost: a flat, pointer-following chip showing what's being dragged.
     // Truncate to ~40 chars so the chip stays compact. Release any stale ghost

--- a/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
@@ -55,7 +55,15 @@ ensureDocumentListener()
 
 export function useDragTextToComposer() {
   const onDragStart = useCallback((event: React.DragEvent<HTMLElement>) => {
+    // Natively draggable children (links, images) own their drag: never cancel
+    // it, even without a text selection — pre-commit those dragged out fine
+    // and the native drop inserts at the caret. Only a text-selection drag is
+    // ours to take over.
     if (!hasTextSelection()) {
+      if (event.target instanceof Element && event.target.closest('a, img')) {
+        return
+      }
+
       event.preventDefault()
 
       return
@@ -70,10 +78,15 @@ export function useDragTextToComposer() {
       return
     }
 
-    const quoted = text
-      .split('\n')
-      .map(line => `> ${line}`)
-      .join('\n')
+    // A trailing newline in the selection would otherwise quote as a dangling
+    // "> " line; drop it before quoting.
+    const lines = text.split('\n')
+
+    if (lines[lines.length - 1] === '') {
+      lines.pop()
+    }
+
+    const quoted = lines.map(line => `> ${line}`).join('\n')
 
     event.dataTransfer.effectAllowed = 'copy'
     // text/plain keeps the drag interop with OS-level targets; HERMES_QUOTE_MIME

--- a/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef } from 'react'
 
 import { createDragGhost, type DragGhost } from '@/lib/drag-ghost'
 
-import { hasTextSelection } from './user-message'
+import { hasTextSelection } from './selection'
 
 /**
  * Shared drag-text-to-composer behavior for message bubbles (user + assistant).

--- a/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-drag-text-to-composer.ts
@@ -11,8 +11,10 @@ import { hasTextSelection } from './selection'
  * When the user selects text in a message and starts dragging, the handler:
  * 1. Reads the live selection text
  * 2. Formats it as a quoted block ("> line" per line, same as "Paste as text")
- * 3. Sets `text/plain` on the DataTransfer so the composer's drop handler
- *    (use-composer-drop) can pick it up
+ * 3. Sets `text/plain` (OS interop) AND the HERMES_QUOTE_MIME marker on the
+ *    DataTransfer — the composer's drop handler (use-composer-drop) accepts
+ *    quote drops only when the marker is present, so foreign text/plain
+ *    drags (kanban cards, external apps) keep their existing behavior
  * 4. Creates a drag ghost via the existing `createDragGhost` utility
  *
  * The ghost is destroyed on `dragend`. Cleanup is module-level (not a ref

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -4,6 +4,7 @@ import { type FC, type ReactNode, useCallback, useEffect, useRef, useState } fro
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
 import { messageAttachmentRefs, messageContentText } from '@/components/assistant-ui/thread/content'
 import { ReactionBadge, ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
+import { hasTextSelection } from '@/components/assistant-ui/thread/selection'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
 import { useDragTextToComposer } from '@/components/assistant-ui/thread/use-drag-text-to-composer'
 import { useMessageReactions } from '@/components/assistant-ui/thread/use-message-reactions'
@@ -18,12 +19,8 @@ import { $gateway } from '@/store/gateway'
 import { notifyThreadEditOpen } from '@/store/thread-scroll'
 import { isWatchWindow } from '@/store/windows'
 
-/** True when the user has a live text highlight (drag-select / triple-click). */
-export function hasTextSelection(): boolean {
-  const selection = window.getSelection()
-
-  return Boolean(selection && !selection.isCollapsed && selection.toString().length > 0)
-}
+// Re-export for consumers that historically imported it from this module.
+export { hasTextSelection } from '@/components/assistant-ui/thread/selection'
 
 export function StickyHumanMessageContainer({
   attachments,

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -5,6 +5,7 @@ import { DirectiveContent } from '@/components/assistant-ui/directive-text'
 import { messageAttachmentRefs, messageContentText } from '@/components/assistant-ui/thread/content'
 import { ReactionBadge, ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
+import { useDragTextToComposer } from '@/components/assistant-ui/thread/use-drag-text-to-composer'
 import { useMessageReactions } from '@/components/assistant-ui/thread/use-message-reactions'
 import { UserMessageText } from '@/components/assistant-ui/thread/user-message-text'
 import { Codicon } from '@/components/ui/codicon'
@@ -308,6 +309,7 @@ export const UserMessage: FC<{
 
   const [pickerOpen, setPickerOpen] = useState(false)
   const { enabled: reactionsEnabled, react, reactions: shownReactions } = useMessageReactions(messageId, 'user')
+  const { onDragEnd, onDragStart } = useDragTextToComposer()
 
   const pickEmoji = useCallback(
     (emoji: null | string) => {
@@ -483,6 +485,8 @@ export const UserMessage: FC<{
                       triggerHaptic('selection')
                       setExpanded(value => !value)
                     }}
+                    onDragEnd={onDragEnd}
+                    onDragStart={onDragStart}
                     title={bodyClamped ? (expanded ? t.common.collapse : copy.expandMessage) : undefined}
                     type="button"
                   >
@@ -507,6 +511,8 @@ export const UserMessage: FC<{
 
                         triggerHaptic('selection')
                       }}
+                      onDragEnd={onDragEnd}
+                      onDragStart={onDragStart}
                       onPointerDown={() => {
                         if (hasTextSelection()) {
                           return


### PR DESCRIPTION
## Summary

Select text in any message bubble — user or assistant — and drag it into the composer. The selection is inserted as a quoted block (`> line` per line), the same format the "Paste as text" context action produces. Drags also carry `text/plain`, so dropping on an OS-level target still works.

## What changed

| File | Change |
| --- | --- |
| `src/components/assistant-ui/thread/use-drag-text-to-composer.ts` | New shared hook: reads the live selection on `dragstart`, quotes each line, sets `text/plain` (OS interop) + `HERMES_QUOTE_MIME` (the composer's marker), and shows a drag ghost (reusing `lib/drag-ghost`) with a line count for multi-line selections |
| `src/components/assistant-ui/thread/user-message.tsx` | Wires `onDragStart`/`onDragEnd` onto both user-bubble variants (read-only spectator + editable) |
| `src/components/assistant-ui/thread/assistant-message.tsx` | Wires the same handlers onto the assistant message content area |
| `src/app/chat/composer/hooks/use-composer-drop.ts` | Accepts quote drops on the form and the input area; routes them to **this** composer's scope (never the `'active'` composer); file drops keep priority when both kinds are present |
| `src/app/chat/hooks/use-composer-actions.ts` | New `HERMES_QUOTE_MIME` constant, following the existing `HERMES_PATHS_MIME` pattern |
| `src/components/assistant-ui/thread/selection.ts` | `hasTextSelection()` moved to a leaf module (was a circular import: hook ↔ user-message) |

## Existing behavior is untouched

- **File drops** — unchanged guards and priority; in-app `@file:`/`@line:` refs and OS uploads behave exactly as before.
- **Kanban card drags** — cards set `text/plain = task.id`; the composer only accepts drops carrying `HERMES_QUOTE_MIME`, so kanban drags (and external-app text drags) keep their existing behavior.
- **Native editing gestures** — drag-move *inside* the composer input, link/image drags out of messages, click-to-edit, the reaction picker right-click, and double-click tapback are all preserved (`dragstart` is a separate event; natively draggable children are never cancelled).
- **Drag ghost lifecycle** — module-level holder + a single document-level `dragend` listener, so a ghost can't leak if its message unmounts mid-drag (streaming removal, session switch).

## Testing

- **Unit:** 39 new/updated tests across `use-drag-text-to-composer.test.ts` and `use-composer-drop.test.ts` — quoting, MIME marker, foreign-text/plain rejection, ghost lifecycle (incl. post-unmount release), scope routing, trailing-newline handling, missing-attach-handler safety.
- **Manual:** select text in a message → drag to the composer → quoted block appears. No selection → drag does nothing. Link drag with no selection → still works.
- **Verification:** `npx tsc --noEmit` clean; eslint clean on all touched files; full suite 33 failures, all pre-existing (electron/SSH/hardening environment tests + 3 known UI flakes), none in touched files.

## Platforms tested

- Windows 11 (dev environment) — unit tests + typecheck + lint.

## Known limitations (documented, not regressions)

- The payload is the live document selection (what-you-see-is-what-you-drag, matching native drag-text); a selection spanning multiple bubbles is quoted wholesale. The ghost shows a line count so this is visible at a glance.
- Double-clicking a word on an assistant message triggers tapback and clears the selection (pre-existing tapback behavior), so word-drag on assistant messages needs a manual drag-select.
