### PR TITLE
fix(termux): use distro python-cryptography to avoid PyLong_Type dlopen crash

### DIFF
--- a/hermes_cli/termux_crypto_fix.py
+++ b/hermes_cli/termux_crypto_fix.py
@@ -1,0 +1,117 @@
+"""Termux/Android cryptography overlay fix.
+
+PyPI's cryptography>=50.0.0 links PyLong_Type / PyExc_Warning expecting them in
+the main executable. Termux's CPython does not re-export those symbols from the
+main binary — they live only in libpython3.x.so — so cryptography's abi3
+extension fails to dlopen at runtime with::
+
+    ImportError: dlopen failed: cannot locate symbol "PyLong_Type"
+
+The Termux dpkg ``python-cryptography`` is patched (NEEDED libpython3.x.so +
+RUNPATH -> $PREFIX/lib), so it loads. This module copies the distro build over
+the broken pip overlay after any venv rebuild (installer or ``hermes update``),
+which would otherwise re-introduce the overlay.
+
+The smoke test imports a hazmat submodule. A shallow ``import cryptography``
+does NOT load ``_rust`` and falsely passes.
+
+See NousResearch/hermes-agent#83680 / #85972.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+def _hazmat_ok(venv_py: str) -> bool:
+    """Return True when the venv's cryptography can load the abi3 extension."""
+    result = subprocess.run(
+        [venv_py, "-c", "from cryptography.hazmat.primitives import hashes"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=60,
+    )
+    return result.returncode == 0
+
+
+def fix_termux_cryptography_overlay(venv_path: "str | os.PathLike[str]") -> bool:
+    """Replace the pip cryptography overlay with the Termux distro build.
+
+    Returns True when the working build is in place (or was already fine),
+    False when the hazmat smoke test still fails after the copy. Callers may
+    choose to abort setup/update on False.
+    """
+    venv_path = str(venv_path)
+    venv_py = os.path.join(venv_path, "bin", "python")
+    if not os.path.isfile(venv_py):
+        return True
+
+    # PREFIX is always set on Termux; fall back to the canonical path otherwise.
+    prefix = os.environ.get("PREFIX") or "/data/data/com.termux/files/usr"
+    try:
+        pyminor = subprocess.run(
+            [venv_py, "-c", 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")'],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        return True
+    if not pyminor:
+        return True
+
+    sys_site = os.path.join(prefix, "lib", f"python{pyminor}", "site-packages")
+    venv_site = os.path.join(venv_path, "lib", f"python{pyminor}", "site-packages")
+    sys_crypto = os.path.join(sys_site, "cryptography")
+    if not os.path.isdir(sys_crypto) or not os.path.isdir(venv_site):
+        return True
+
+    if _hazmat_ok(venv_py):
+        return True
+
+    logger.info("Termux: replacing pip cryptography with distro build (PyLong_Type fix)")
+    try:
+        subprocess.run(
+            [venv_py, "-m", "pip", "uninstall", "-y", "cryptography"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        for entry in os.listdir(venv_site):
+            if entry.startswith("cryptography"):
+                path = os.path.join(venv_site, entry)
+                if os.path.isdir(path):
+                    shutil.rmtree(path)
+                else:
+                    os.remove(path)
+        shutil.copytree(sys_crypto, os.path.join(venv_site, "cryptography"))
+        for dist in os.listdir(sys_site):
+            if dist.startswith("cryptography-") and dist.endswith(".dist-info"):
+                shutil.copytree(
+                    os.path.join(sys_site, dist),
+                    os.path.join(venv_site, dist),
+                    dirs_exist_ok=True,
+                )
+    except (subprocess.CalledProcessError, OSError) as exc:
+        logger.warning("Termux cryptography overlay copy failed: %s", exc)
+        return False
+
+    if _hazmat_ok(venv_py):
+        logger.info("cryptography Termux build in place (PyLong_Type resolved)")
+        return True
+    logger.error(
+        "cryptography Termux build still failing — Hermes will crash on "
+        "Bitwarden/secret sources at startup. Manual fix: cp -r %s/cryptography* %s/",
+        sys_site,
+        venv_site,
+    )
+    return False

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -988,6 +988,14 @@ def _update_via_zip(args):
     # #70636).
     _m()._refresh_active_memory_provider_dependencies()
 
+    # Termux/Android: the pip reinstall above re-introduces the broken PyPI
+    # cryptography overlay (NousResearch/hermes-agent#83680). Replace it with the
+    # distro python-cryptography before the import check, so the update ships a
+    # working install instead of one that crashes on Bitwarden at startup.
+    if _m()._is_termux_env():
+        from hermes_cli.termux_crypto_fix import fix_termux_cryptography_overlay
+        fix_termux_cryptography_overlay(_m().PROJECT_ROOT / "venv")
+
     # Now that dependencies are installed, verify the tree actually imports.
     # The copy loop above replaces top-level entries one at a time in
     # os.listdir order, so an interruption between (say) `agent/` and `tools/`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -396,6 +396,45 @@ is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
 }
 
+# Replace the pip-installed cryptography overlay with the Termux dpkg build.
+#
+# PyPI cryptography>=50.0.0 links PyLong_Type/PyExc_Warning expecting them in
+# the main executable; Termux's CPython keeps them only in libpython3.x.so, so
+# the abi3 extension fails to dlopen at runtime (NousResearch/hermes-agent#83680).
+# The distro python-cryptography is patched with NEEDED libpython3.x.so +
+# RUNPATH, so it loads. We copy it over the broken overlay. The smoke test
+# imports a hazmat submodule (not a shallow `import cryptography`, which does
+# not trigger the dlopen and falsely passes). Exits 1 on persistent failure so
+# setup aborts loudly instead of shipping a broken install.
+_fix_termux_cryptography_overlay() {
+    [ -n "${VIRTUAL_ENV:-}" ] || return 0
+    local _pyminor
+    _pyminor="$("$PIP_PYTHON" -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null)" || return 0
+    local _sysdir="$PREFIX/lib/python${_pyminor}/site-packages"
+    local _vsite="$VIRTUAL_ENV/lib/python${_pyminor}/site-packages"
+    [ -d "$_sysdir/cryptography" ] || { log_info "Termux python-cryptography not found — skipping overlay fix."; return 0; }
+    [ -d "$_vsite" ] || return 0
+
+    if "$VIRTUAL_ENV/bin/python" -c 'from cryptography.hazmat.primitives import hashes' 2>/dev/null; then
+        log_info "Termux cryptography already working (distro build) — skipping overlay fix."
+        return 0
+    fi
+
+    log_info "Android: replacing pip cryptography with Termux distro build (PyLong_Type fix)..."
+    "$PIP_PYTHON" -m pip uninstall -y cryptography >/dev/null 2>&1 || true
+    rm -rf "$_vsite/cryptography" "$_vsite"/cryptography-*.dist-info
+    cp -r "$_sysdir/cryptography" "$_vsite/"
+    cp -r "$_sysdir"/cryptography-*.dist-info "$_vsite/" 2>/dev/null || true
+
+    if "$VIRTUAL_ENV/bin/python" -c 'from cryptography.hazmat.primitives import hashes; import cryptography; print("cryptography", cryptography.__version__, "ok")' 2>&1; then
+        log_success "cryptography Termux build in place (PyLong_Type resolved)"
+    else
+        log_error "cryptography Termux build still failing — Hermes will crash on Bitwarden/secret sources at startup."
+        log_info "Manual fix: cp -r $PREFIX/lib/python${_pyminor}/site-packages/cryptography* $VIRTUAL_ENV/lib/python${_pyminor}/site-packages/"
+        return 1
+    fi
+}
+
 # Decide where the repo checkout + venv live, and where the `hermes` command
 # symlink goes.  Called after detect_os so $OS/$DISTRO are known.
 #
@@ -1499,6 +1538,27 @@ install_deps() {
             if ! "$PIP_PYTHON" "$INSTALL_DIR/scripts/install_psutil_android.py" --pip "$PIP_PYTHON -m pip"; then
                 log_warn "psutil Android prebuild failed — package install will likely fail next."
                 log_info "Workaround: manually rerun 'python scripts/install_psutil_android.py' once your toolchain is set up."
+            fi
+        fi
+
+        # On Termux/Android, PyPI's cryptography>=50.0.0 fails at runtime with
+        # "ImportError: dlopen failed: cannot locate symbol PyLong_Type" (or
+        # PyExc_Warning). Cause: Termux's CPython does not re-export those
+        # symbols from the main executable — they live only in libpython3.x.so.
+        # PyPI's _rust.abi3.so expects them in the main exe and carries no
+        # NEEDED libpython3.x.so, so dlopen dies. The Termux dpkg
+        # python-cryptography is patched (NEEDED libpython3.x.so + RUNPATH), so
+        # it loads. Copy it over the broken pip overlay. Covers BOTH Termux
+        # platform reports: modern Termux reports sys.platform == "android",
+        # older (<3.13) reports "linux" (see agent/skill_utils.py) — gate on
+        # is_termux, not on sys.platform. A shallow `import cryptography` does
+        # NOT load _rust and falsely passes; the smoke test MUST import a hazmat
+        # submodule. See NousResearch/hermes-agent#83680 / #85972.
+        if is_termux; then
+            if ! _fix_termux_cryptography_overlay; then
+                # Smoke test failed after the distro copy — abort setup loudly
+                # rather than ship an install that crashes on Bitwarden at startup.
+                exit 1
             fi
         fi
 

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -114,6 +114,23 @@ If you only want the minimal core agent, this also works:
 python -m pip install -e '.' -c constraints-termux.txt
 ```
 
+> **cryptography on Termux:** PyPI's `cryptography>=50.0.0` fails at runtime with
+> `ImportError: dlopen failed: cannot locate symbol "PyLong_Type"` because Termux's
+> CPython does not re-export that symbol from the main executable (it lives only in
+> `libpython3.x.so`). The installer and `hermes update` auto-detect Termux and copy
+> the distro `python-cryptography` package over the broken pip overlay. If you
+> install manually, run `pkg install python-cryptography` first, then after the pip
+> step copy it over:
+>
+> ```bash
+> pkg install python-cryptography
+> rm -rf venv/lib/python*/site-packages/cryptography*
+> cp -r "$PREFIX/lib/python*/site-packages/cryptography"* venv/lib/python*/site-packages/
+> ```
+>
+> Verify with `venv/bin/python -c 'from cryptography.hazmat.primitives import hashes'`
+> (a plain `import cryptography` does **not** trigger the failing `dlopen`).
+
 ### 5. Put `hermes` on your Termux PATH
 
 ```bash


### PR DESCRIPTION
## Summary

On Termux/Android, `pip install -e '.[termux]'` pulls PyPI `cryptography>=50.0.0`, whose abi3 extension fails at runtime with `ImportError: dlopen failed: cannot locate symbol "PyLong_Type"` (surfaced via `agent.secret_sources.bitwarden` at startup). Cause: Termux's CPython does not re-export `PyLong_Type`/`PyExc_Warning` from the main executable — they live only in `libpython3.x.so` — so `_rust.abi3.so` (which expects them in the main exe, with no `NEEDED libpython3.x.so`) cannot resolve them. The Termux dpkg `python-cryptography` is patched (`NEEDED libpython3.x.so` + `RUNPATH -> $PREFIX/lib`) and loads fine.

This PR copies the distro build over the broken pip overlay on the supported install paths.

## Addresses the sweeper review on #73620

- **Both Termux platform reports:** gates on `is_termux()` (the `$PREFIX`/TERMUX_VERSION check), not `sys.platform == "android"`, because pre-3.13 Termux reports `sys.platform == "linux"` (`agent/skill_utils.py:263-266`). The stale PR only covered `android`.
- **All supported paths:** applied in `scripts/install.sh` (curl/manual path) **and** the `hermes update` reinstall path (`hermes_cli/update_cmd.py` → new `hermes_cli/termux_crypto_fix.py`), because the pip step re-introduces the overlay on every update.
- **Real smoke test:** imports a hazmat submodule (`from cryptography.hazmat.primitives import hashes`) — a shallow `import cryptography` does not load `_rust` and falsely passes (flagged in #83680).
- **Hard failure:** the installer aborts with `exit 1` when the distro copy still fails, rather than shipping a broken install (the stale PR only printed guidance).

## Test plan

- [x] `bash -n scripts/install.sh` — syntax OK
- [x] `termux_crypto_fix.fix_termux_cryptography_overlay` parses + imports OK
- [x] Verified on-device (Termux, aarch64, Python 3.14.6): distro copy makes `from cryptography.hazmat.primitives import hashes` pass and `hermes` starts cleanly
- [x] Full `curl .../install.sh | bash` on a fresh Termux (CI can't easily run this)

## Notes

- Supersedes PR #73620: `psutil` is already handled on `main` via `scripts/install_psutil_android.py`, so this keeps only the `cryptography` fix (same pattern), avoiding the conflict the sweeper noted.
- Related: #85972 (the stock `ddgs` web provider crashes on Android for the same Rust/NDK reason — different dependency).

Closes #83680.