### PR TITLE
fix(title): never let a truncated fenced-JSON response become the session title

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -288,6 +288,16 @@ def _extract_title_text(content: str) -> str:
     fenced = re.match(r"^```(?:json)?\s*(.*?)\s*```$", raw, re.DOTALL)
     if fenced:
         raw = fenced.group(1).strip()
+    else:
+        # Unterminated fence: a max_tokens-truncated response often ends
+        # mid-fence, with the JSON payload (or its ``"title": "..."`` core)
+        # still present after the opener. Drop the `````json`` opener so
+        # the parse/loose-scan below sees the payload, not the fence.
+        unterminated = re.match(r"^```(?:json)?\s*(.*)$", raw, re.DOTALL)
+        if unterminated:
+            inner = unterminated.group(1).strip()
+            if inner:
+                raw = inner
     try:
         parsed = json.loads(raw)
         if isinstance(parsed, dict) and isinstance(parsed.get("title"), str):
@@ -309,7 +319,16 @@ def _extract_title_text(content: str) -> str:
         raw = strip_think_blocks(None, raw).strip()
     except Exception:
         logger.debug("strip_think_blocks unavailable for title output", exc_info=True)
-    raw = next((ln.strip() for ln in raw.splitlines() if ln.strip()), "")
+    raw = next(
+        (
+            ln.strip()
+            for ln in raw.splitlines()
+            if ln.strip()
+            and not ln.strip().startswith("```")
+            and not ln.strip().startswith("{")
+        ),
+        "",
+    )
     if raw.lower().startswith("title:"):
         raw = raw[6:].strip()
     return raw.strip("\"'").strip()
@@ -395,9 +414,12 @@ def generate_title(
         response = call_llm(
             task="title_generation",
             messages=messages,
-            # A title is a handful of tokens. The old 500-token ceiling let a
-            # chatty model burn seconds generating prose we then threw away.
-            max_tokens=64,
+            # A title is a handful of tokens, but providers that wrap the
+            # JSON in a markdown fence (or emit a short preamble before it)
+            # need headroom past the object itself. The old 64-token ceiling
+            # truncated those responses mid-fence, and the truncated fence
+            # opener (`````json```) became the session title (#83903).
+            max_tokens=256,
             temperature=0.3,
             timeout=timeout,
             main_runtime=main_runtime,

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -91,6 +91,39 @@ class TestGenerateTitle:
             assert title.endswith("...")
 
 
+    def test_extracts_title_from_truncated_fenced_json(self):
+        """A response cut mid-fence (max_tokens truncation) must still yield
+        the title. The bare fence opener is the #83903 garbage title."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            '```json\n{"title": "Fix login button"'
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("login is broken")
+            assert title == "Fix login button"
+
+    def test_fence_marker_never_becomes_the_title(self):
+        """Worst case: nothing parseable survives truncation. The fence
+        opener must not be persisted as the session title (#83903)."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "```json"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("hello") is None
+
+    def test_truncated_json_fragment_never_becomes_the_title(self):
+        """A value cut mid-string reads as a JSON fragment, not a title."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = '```json\n{"title": "Fix login bu'
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("login is broken") is None
+
+
 
     def test_invokes_failure_callback_on_exception(self):
         """failure_callback must fire so the user sees a warning (issue #15775)."""


### PR DESCRIPTION
Fixes the auto-title garbage reported in #83903: sessions titled ` ```json ` or ` ``` ` — a provider that wraps structured output in a markdown fence gets its response cut by the 64-token title ceiling mid-fence, and the truncated fence opener (or the truncated JSON fragment) is what lands in the sidebar.

## Root cause

`generate_title()` asks for `{"title": "..."}` with `max_tokens=64`. Providers that don't honor `response_format` (e.g. DeepSeek, #84976) wrap the JSON in ```json fences or emit a short preamble. 64 tokens is enough for the fence opener but not the whole payload, so the response arrives truncated. `_extract_title_text()` only recognizes a *complete* fence (`^...```$`); a truncated one falls through `json.loads` and the loose `"title": "..."` scan straight into the prose fallback, which takes the first non-empty line — ` ```json `.

## Fix

- **Raise the ceiling 64 → 256 tokens.** A fenced `{"title": ...}` response fits whole; 256 still bounds the old "chatty model burns seconds" case.
- **`_extract_title_text`: strip an unterminated fence opener** before parsing, so the JSON payload (or its `"title": "..."` core) is seen by `json.loads` / the loose scan instead of the fence.
- **Prose fallback: never select a line starting with ``` or `{`** — a fence marker or a truncated JSON fragment can no longer become the title; the session falls back to the derived title instead.

## Tests

3 new regression cases in `tests/agent/test_title_generator.py`: truncated fence with intact title value, bare fence marker, truncated mid-value fragment. Full file: 36 passed.

## Notes

Complements the earlier attempts at this bug class (the response-format fallback story from #84976): this makes the *receiver* robust regardless of which provider gets hit.