### PR TITLE
fix(gateway): detect supervisor via cgroup unit, not INVOCATION_ID

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -39,8 +39,23 @@ def is_gateway_supervisor_process(
 ) -> bool:
     """Return whether this gateway process is owned by a supervisor."""
     env = os.environ if environ is None else environ
-    if env.get("INVOCATION_ID"):
-        return True
+    # ⛔ INVOCATION_ID 不是充分条件 (2026-08-14 实锤回归):
+    #    GNOME/ptyxis 桌面会话的每个进程都带 INVOCATION_ID (gnome-session /
+    #    ptyxis-spawn-*.scope 都是 systemd 单元), 导致终端里跑的 CLI 会话被
+    #    误判为 "gateway supervisor" → spawn_local 走 systemd scope 路径
+    #    (start_new_session=False) → bash -lic 继承用户终端的进程组/会话/tty
+    #    → 交互式 bash 初始化 job control 抢终端前台 (tcsetpgrp) → 用户 shell
+    #    的其他 hermes job 全部被 SIGTSTP。v2026.8.3 #70716 引入。
+    # ✅ 精确判定: 自己的 systemd cgroup 单元名是否就是 hermes-gateway.service
+    #    (真正的 gateway 一定在该单元内; CLI/桌面会话在 ptyxis-spawn-*.scope
+    #    或其它单元, 返回 False → 走旧的 start_new_session=True 安全路径)
+    try:
+        with open("/proc/self/cgroup") as _f:
+            _unit = _f.read().rstrip().split("/")[-1]
+        if "hermes-gateway" in _unit:
+            return True
+    except Exception:
+        pass
     if env.get("HERMES_S6_SUPERVISED_CHILD"):
         return True
     xpc_service = env.get("XPC_SERVICE_NAME", "")


### PR DESCRIPTION
## Summary

`is_gateway_supervisor_process()` treats any process with `INVOCATION_ID` in its environment as a gateway supervised by systemd. That check is wrong for desktop sessions: **every process of a GNOME/ptyxis terminal session carries `INVOCATION_ID`** (gnome-session and `ptyxis-spawn-*.scope` are themselves systemd units). An interactive CLI launched from such a terminal is therefore misclassified as a gateway supervisor.

Consequence (regression from #70716, shipped in v2026.8.3): `spawn_local()` takes the systemd-scope path (`start_new_session=False`), the background `bash -lic` inherits the CLI's controlling terminal and process group, interactive bash steals the terminal foreground via `TIOCSPGRP`, and **every other hermes job in the user's shell is suspended** (SIGTSTP/SIGTTOU). This is the same bug reported in #82705 — which claims "current main already contains the production fix"; that claim is incorrect (verified against main HEAD `56a41715dc`, 2026-08-14: the `INVOCATION_ID` check is still present).

## Reproduced evidence (local, v2026.8.3 era main, 2026-08-14)

- Desktop session (ptyxis): user shell `bash` and `hermes -c` both have `INVOCATION_ID` → `is_gateway_supervisor_process()` returns True for the CLI.
- `terminal(background=true)` spawned worker observed with `PGID=90171` (the hermes CLI's process group), `SID=69364` (user shell session), `TTY=pts/2` (user terminal) — i.e. `start_new_session=False` path taken, no session isolation.
- User shell reported `[1] 已停止 hermes / [2]- 已停止 hermes -c / [3]+ 已停止 hermes -c` immediately on spawn; a re-entered session was stopped again (SIGTTIN) while a leftover worker still held the terminal foreground.

## Fix

Check the process's **own systemd cgroup unit name** (`/proc/self/cgroup`) instead of `INVOCATION_ID`:

- real gateway → runs inside `hermes-gateway.service` → still returns True (OOM-isolation behavior from #70716 preserved)
- desktop CLI session → `ptyxis-spawn-*.scope` (or any non-gateway unit) → returns False → falls back to the safe `start_new_session=True` path

Verified locally:
- ptyxis session with INVOCATION_ID → False ✅
- simulated `hermes-gateway.service` cgroup → True ✅
- no systemd → False ✅

## Notes

- PR #82709 adds a PTY regression test for this bug class; it can be rebased/kept alongside this production fix (or its expectations will now pass for the right reason).
- `INVOCATION_ID` remains useful as a *positive* signal in containers/s6 (the `HERMES_S6_SUPERVISED_CHILD` and external-supervisor env checks are untouched).

Fixes #82705