### PR TITLE
fix(desktop): normalize terminal subagent statuses

### DIFF
--- a/apps/desktop/src/store/subagents.test.ts
+++ b/apps/desktop/src/store/subagents.test.ts
@@ -27,6 +27,57 @@ describe('subagent store', () => {
     expect(item?.summary).toBe('done')
   })
 
+  it('treats a backend timeout as terminal failure instead of running forever', () => {
+    upsertSubagent(
+      's1',
+      {
+        goal: 'slow audit',
+        status: 'running',
+        subagent_id: 'a1',
+        task_index: 0,
+        tool_name: 'search_files'
+      },
+      true,
+      'subagent.start'
+    )
+    upsertSubagent(
+      's1',
+      { status: 'timeout', subagent_id: 'a1', task_index: 0, text: 'Timed out after 600s' },
+      false,
+      'subagent.complete'
+    )
+
+    const items = listFor('s1')
+    expect(items[0]?.status).toBe('failed')
+    expect(items[0]?.currentTool).toBeUndefined()
+    expect(activeSubagentCount(items)).toBe(0)
+    expect(failedSubagentCount(items)).toBe(1)
+  })
+
+  it.each(['running', 'queued'] as const)(
+    'treats a completion event with %s payload status as terminal failure',
+    status => {
+      upsertSubagent(
+        's1',
+        {
+          goal: 'inconsistent completion',
+          status: 'running',
+          subagent_id: 'a1',
+          task_index: 0,
+          tool_name: 'search_files'
+        },
+        true,
+        'subagent.start'
+      )
+      upsertSubagent('s1', { status, subagent_id: 'a1', task_index: 0 }, false, 'subagent.complete')
+
+      const items = listFor('s1')
+      expect(items[0]?.status).toBe('failed')
+      expect(items[0]?.currentTool).toBeUndefined()
+      expect(activeSubagentCount(items)).toBe(0)
+    }
+  )
+
   it('builds parent/child trees', () => {
     upsertSubagent('s1', { goal: 'parent', status: 'running', subagent_id: 'p', task_index: 0 })
     upsertSubagent('s1', { goal: 'child', parent_id: 'p', status: 'queued', subagent_id: 'c', task_index: 1 })

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -55,8 +55,25 @@ const str = (v: unknown) => (isStr(v) ? v : '')
 const num = (v: unknown) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined)
 const strList = (v: unknown) => (Array.isArray(v) ? v.filter(isStr) : [])
 
-const asStatus = (v: unknown): SubagentStatus =>
-  v === 'completed' || v === 'failed' || v === 'interrupted' || v === 'queued' ? v : 'running'
+const asStatus = (value: unknown, eventType = ''): SubagentStatus => {
+  if (value === 'completed' || value === 'failed' || value === 'interrupted') {
+    return value
+  }
+
+  if (value === 'cancelled' || value === 'canceled') {
+    return 'interrupted'
+  }
+
+  if (value === 'error' || value === 'stalled' || value === 'timeout' || value === 'unknown') {
+    return 'failed'
+  }
+
+  if (eventType.endsWith('.complete')) {
+    return 'failed'
+  }
+
+  return value === 'queued' || value === 'running' ? value : 'running'
+}
 
 const compact = (text: string, max = PREVIEW_MAX) => {
   const line = text.replace(/\s+/g, ' ').trim()
@@ -148,7 +165,7 @@ function streamFromPayload(
 
 function toProgress(payload: SubagentPayload, prev: SubagentProgress | undefined, eventType = ''): SubagentProgress {
   const at = Date.now()
-  const status = asStatus(payload.status)
+  const status = asStatus(payload.status, eventType)
   const tool = str(payload.tool_name)
   const stream = streamFromPayload(payload, status, eventType, at).reduce(appendStream, prev?.stream ?? [])
   const filesRead = strList(payload.files_read)


### PR DESCRIPTION
## What changed

- Normalize backend terminal delegation statuses in the Desktop subagent store:
  - `timeout`, `error`, `stalled`, and `unknown` → `failed`
  - `cancelled` and `canceled` → `interrupted`
- Treat every `subagent.complete` event as terminal, even if an inconsistent payload still says `running`, `queued`, or provides an unrecognized status.
- Preserve legitimate `running` and `queued` states for non-completion events.
- Add regression coverage that verifies terminal events clear `currentTool` and no longer contribute to the active-subagent count.

## Why

The backend lifecycle added in #72300 emits terminal statuses such as `timeout`, `stalled`, and `error`. Desktop's `asStatus()` only recognized `completed`, `failed`, `interrupted`, and `queued`; every other value fell back to `running`.

As a result, a child that timed out after its configured limit could remain animated as active indefinitely in Desktop even though the backend and delegation manifest had already finalized it.

This is a focused Desktop follow-up to #51690 and #72300. It does not change the backend event contract.

## Reproduction

1. Insert a running subagent with a current tool.
2. Deliver `subagent.complete` with `status: "timeout"`.
3. Before this change, the store normalized that status back to `running`, retained the active count, and left the UI looking stuck.
4. After this change, the row is `failed`, `currentTool` is cleared, and the active count is zero.

The tests also cover malformed completion payloads that report `running` or `queued`; completion-event semantics take precedence and fail closed to a terminal state.

## Related work

- #73859 maps known timeout/error/cancel aliases, but its automated review identifies the remaining gap: unknown `subagent.complete` statuses still normalize to `running`.
- #80045 preserves `timeout` and `error` as new renderer statuses and adds a narrower fallback when an unknown completion follows a previously running item. An explicit `queued` completion or a completion received without that prior state can still remain nonterminal.
- This PR keeps the existing renderer status vocabulary, covers `stalled` and both cancel spellings, and makes the event contract authoritative: every `*.complete` event is terminal regardless of prior local state or inconsistent `running`/`queued` payload values.

## Validation

- `npm test -- --project ui src/store/subagents.test.ts` — 13/13 passed
- `npm run check:lint` — TypeScript passed; ESLint reported 0 errors
- `npm run check:test:ui` — 3,845/3,845 passed
- `npm run test:desktop:platforms` — 1,055 passed, 2 skipped
- `npm run test:desktop:all` — passed; built and signed the macOS app and DMG
- `git diff origin/main...HEAD --check`
- Two independent pre-commit logic/security reviews; the first identified the completion-event precedence edge case, which was fixed test-first, and the second passed with no logic or security findings

## Platform tested

- macOS 27.0, Apple Silicon
