### PR TITLE
fix(scripts): gate Node version in desktop rebuild path

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -38,7 +38,7 @@ set -u
 ORIGINAL_ARGS=("$@")
 INSTALL_ROOT="" BRANCH="main" DESKTOP_PID=0 RELAUNCH_TARGET=""
 RELAUNCH_CWD="" SANDBOX_FALLBACK=0 RELAUNCH_ARGS=()
-NO_UI=0 NO_MARKER_CLEANUP=0 SELF_TEST_UI=0 SELF_TEST_GATE=0 SELF_TEST_MARKER=0
+NO_UI=0 NO_MARKER_CLEANUP=0 SELF_TEST_UI=0 SELF_TEST_GATE=0 SELF_TEST_MARKER=0 SELF_TEST_NODE_GATE=0 NODE_VERSION_ARG=""
 SELF_TEST_TCC_HEAL=0
 HANDOFF_DAEMONIZED=0
 while [ $# -gt 0 ]; do
@@ -56,11 +56,13 @@ while [ $# -gt 0 ]; do
     --self-test-tcc-heal) SELF_TEST_TCC_HEAL=1; shift ;;
     --daemonized) HANDOFF_DAEMONIZED=1; shift ;;
     --self-test-marker) SELF_TEST_MARKER=1; NO_UI=1; NO_MARKER_CLEANUP=1; shift ;;
+    --self-test-node-gate) SELF_TEST_NODE_GATE=1; shift ;;
+    --node-version) NODE_VERSION_ARG="$2"; shift 2 ;;
     --) shift; RELAUNCH_ARGS=("$@"); shift $# ;;
     *) echo "unknown arg: $1" >&2; exit 64 ;;
   esac
 done
-[ "$SELF_TEST_UI" -eq 1 ] || [ -n "$INSTALL_ROOT" ] || { echo "--install-root is required" >&2; exit 64; }
+[ "$SELF_TEST_UI" -eq 1 ] || [ "$SELF_TEST_NODE_GATE" -eq 1 ] || [ -n "$INSTALL_ROOT" ] || { echo "--install-root is required" >&2; exit 64; }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HERMES_HOME="${INSTALL_ROOT:+$(dirname "$INSTALL_ROOT")}"
@@ -157,6 +159,62 @@ notify_fallback() { # status message — renderer-free recovery surface.
 write_status() { # status message -- atomic replace; the server reads per poll
   printf '{"status":"%s","message":"%s"}' "$(json_escape "$1")" "$(json_escape "$2")" > "$STATUS.tmp" \
     && mv -f "$STATUS.tmp" "$STATUS" 2>/dev/null || true
+}
+
+# ── node build-toolchain gate ────────────────────────────────────────────────
+# The desktop dependency tree (nanoid@6 and friends) only accepts Node
+# 22.22+/24/26+; odd-numbered releases (23/25) pass the root `engines.node:
+# >=22.22.0` floor but then die in `npm ci` with EBADENGINE. `hermes update`
+# makes the GUI build failure non-fatal, so a bad Node silently leaves the
+# user on the previous build with a generic "rebuild failed — retry" message.
+#
+# The version predicate is not hardcoded here: node-version-check.js reads
+# apps/desktop/package.json's `engines.node` fresh on every call, so when the
+# official dependency declaration changes the gate follows automatically —
+# no manual copy to keep in sync, no drift window.
+#
+# Unlike the install path (install.sh, which replaces an unsupported system
+# Node with the Hermes-managed one), this is the REBUILD path: prefer an
+# already-installed compatible Node on PATH, and if the system Node is
+# incompatible, look for a Homebrew/usr-local Node to prepend to PATH —
+# zero-download and immediate, so existing installs don't need a fresh
+# toolchain. Falls back to reporting the version clearly if nothing
+# compatible is found.
+node_satisfies_build() {
+  local ver="${1#v}"
+  local node_bin="${2:-}"
+  if [ -z "$node_bin" ]; then
+    command -v node >/dev/null 2>&1 || return 1
+    node_bin="$(command -v node)"
+  fi
+  "$node_bin" "$SCRIPT_DIR/../lib/node-version-check.js" "$ver" "$SCRIPT_DIR/../../apps/desktop/package.json" >/dev/null 2>&1
+}
+
+prepare_node_for_build() {
+  # Already-good Node on PATH? Leave it alone.
+  if command -v node >/dev/null 2>&1 && node_satisfies_build "$(node --version 2>/dev/null)"; then
+    return 0
+  fi
+  # Otherwise look for a compatible installed Node and prepend its bin dir
+  # to PATH for the build. Default candidates are the Homebrew versioned
+  # formulae and /usr/local; HERMES_NODE_CANDIDATE_DIRS overrides the list
+  # (space-separated) for custom install layouts and tests.
+  # A candidate only counts if BOTH node and npm are present — a node
+  # binary without its npm (partial/keg-only install) would still fail
+  # `npm ci` later, just with a more confusing error.
+  local cand v
+  for cand in ${HERMES_NODE_CANDIDATE_DIRS:-/opt/homebrew/opt/node@22/bin /opt/homebrew/opt/node@24/bin \
+              /opt/homebrew/opt/node@26/bin /usr/local/opt/node@22/bin \
+              /usr/local/opt/node@24/bin /usr/local/opt/node@26/bin}; do
+    [ -x "$cand/node" ] && [ -x "$cand/npm" ] || continue
+    v="$("$cand/node" --version 2>/dev/null)"
+    if node_satisfies_build "$v" "$cand/node"; then
+      log "build Node: system $(command -v node >/dev/null 2>&1 && node --version || echo none) is not compatible; using $cand ($v)"
+      export PATH="$cand:$PATH"
+      return 0
+    fi
+  done
+  log "WARNING: no compatible Node found for desktop rebuild (see apps/desktop/package.json engines.node; system: $(command -v node >/dev/null 2>&1 && node --version || echo none))"
 }
 
 publish_stage() { # a long wait the orchestrator is already gating on. No poll
@@ -627,6 +685,17 @@ if [ "$SELF_TEST_GATE" -eq 1 ]; then
   exit 0
 fi
 
+if [ "$SELF_TEST_NODE_GATE" -eq 1 ]; then
+  # Prints the node-build-compat decision and exits. Used by
+  # tests-js/desktop-rebuild-node-gate.test.ts to assert the version
+  # predicate without sourcing internals.
+  # Usage: posix.sh --self-test-node-gate --node-version <v>
+  trap - EXIT
+  [ -n "$NODE_VERSION_ARG" ] || { echo "usage: --self-test-node-gate --node-version <v>" >&2; exit 64; }
+  if node_satisfies_build "$NODE_VERSION_ARG"; then echo "compatible"; else echo "incompatible"; fi
+  exit 0
+fi
+
 if [ "$SELF_TEST_UI" -eq 1 ]; then
   start_ui
   log "SELF-TEST: shim simulation (no update will run)"
@@ -730,6 +799,12 @@ tcc_pick_update_invoke "$INSTALL_ROOT/venv/bin"
 if [ "${UPDATE_INVOKE[0]}" != "$HERMES_BIN" ]; then
   log "venv/bin/python3 still unbootable; invoking the update via ${UPDATE_INVOKE[*]}"
 fi
+# The desktop build inside `hermes update` runs `npm ci` with whatever Node
+# is on PATH. Gate it here so an incompatible system Node (e.g. 23/25, which
+# nanoid@6 rejects) gets swapped for an installed compatible one BEFORE the
+# build runs — otherwise the failure is silent and the user is left on the
+# previous build with a generic retry message.
+prepare_node_for_build
 
 # Run FROM the install root: `hermes update` resolves the tree it mutates
 # from the working directory, and we inherit the Desktop's cwd (which can be
@@ -789,7 +864,11 @@ if [ "$CODE" -eq 0 ] && printf '%s' "$OUT" | grep -q "Desktop build failed"; the
   log "desktop build failed inside hermes update; retrying build"
   publish_stage "Rebuilding Desktop"
   "${UPDATE_INVOKE[@]}" desktop --force-build --build-only >> "$LOG" 2>&1 || {
-    FINAL_CODE=6 FINAL_MSG="Code and dependencies updated, but the Desktop app rebuild failed - you are running the previous build. Run hermes desktop --force-build from a terminal to retry."
+    # Include the Node actually used for the build: if prepare_node_for_build
+    # auto-selected a compatible Node and the build still failed, the user
+    # needs to see WHICH Node was used to diagnose (e.g. a partial install).
+    build_node_ver="$(command -v node >/dev/null 2>&1 && node --version 2>/dev/null || echo none)"
+    FINAL_CODE=6 FINAL_MSG="Code and dependencies updated, but the Desktop app rebuild failed - you are running the previous build (build Node: $build_node_ver). Run hermes desktop --force-build from a terminal to retry."
     exit 6
   }
 fi

--- a/scripts/lib/node-version-check.js
+++ b/scripts/lib/node-version-check.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// node-version-check.js -- dependency-free semver-range gate for the desktop
+// Node floor. Read by node-version-check.sh (and, via posix.sh, by the
+// desktop rebuild flow). The single source of truth is
+// apps/desktop/package.json's `engines.node`: every run reads that file fresh,
+// so when the official dependency declaration changes the gate follows
+// automatically -- no manual copy to keep in sync.
+//
+// Usage:
+//   node node-version-check.js <node_version> <path-to-apps/desktop/package.json>
+// Exits 0 when <node_version> satisfies engines.node, 1 otherwise.
+//
+// The range grammar handled here is the practical subset npm uses for
+// engines.node: `||` (OR), whitespace (AND), and comparators `^`, `>=`, `>`,
+// `<=`, `<`, `=`/bare. Prerelease versions are treated as lower than their
+// release counterpart (standard semver), matching npm's behavior for the
+// floors Hermes ships.
+'use strict'
+
+const fs = require('fs')
+
+function parseVersion(raw) {
+  const v = String(raw).replace(/^v/, '').trim()
+  const m = v.match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([0-9A-Za-z.-]+))?$/)
+  if (!m) return null
+  return {
+    major: parseInt(m[1], 10),
+    minor: m[2] === undefined ? 0 : parseInt(m[2], 10),
+    patch: m[3] === undefined ? 0 : parseInt(m[3], 10),
+    pre: m[4] || '',
+  }
+}
+
+function compareVersions(a, b) {
+  if (a.major !== b.major) return a.major - b.major
+  if (a.minor !== b.minor) return a.minor - b.minor
+  if (a.patch !== b.patch) return a.patch - b.patch
+  if (!a.pre && !b.pre) return 0
+  if (!a.pre) return 1 // release > prerelease
+  if (!b.pre) return -1
+  return a.pre < b.pre ? -1 : a.pre > b.pre ? 1 : 0
+}
+
+// Parse one comparator like "^22.22.0", ">=26", "22.22.0".
+function parseComparator(part) {
+  const m = part.trim().match(/^(\^|>=|>|<=|<|=)?\s*v?(\d+(?:\.\d+)?(?:\.\d+)?)$/)
+  if (!m) return null
+  const op = m[1] || '='
+  const ver = parseVersion(m[2])
+  if (!ver) return null
+  // Upper bound for caret: ^X.Y.Z => <(X+1).0.0 (X>0) or <X.(Y+1).0 (X==0).
+  let upper = null
+  if (op === '^') {
+    if (ver.major > 0) {
+      upper = { major: ver.major + 1, minor: 0, patch: 0, pre: '' }
+    } else if (ver.minor > 0) {
+      upper = { major: 0, minor: ver.minor + 1, patch: 0, pre: '' }
+    } else {
+      upper = { major: 0, minor: 0, patch: ver.patch + 1, pre: '' }
+    }
+  }
+  return { op, ver, upper }
+}
+
+function comparatorSatisfies(version, cmp) {
+  const d = compareVersions(version, cmp.ver)
+  switch (cmp.op) {
+    case '=': return d === 0
+    case '>=': return d >= 0
+    case '>': return d > 0
+    case '<=': return d <= 0
+    case '<': return d < 0
+    case '^': return d >= 0 && compareVersions(version, cmp.upper) < 0
+    default: return false
+  }
+}
+
+function satisfies(version, range) {
+  const ver = parseVersion(version)
+  if (!ver) return false
+  for (const orPart of String(range).split('||')) {
+    const andParts = orPart.split(/\s+/).filter((s) => s.length > 0)
+    let groupOk = true
+    for (const part of andParts) {
+      const cmp = parseComparator(part)
+      if (!cmp || !comparatorSatisfies(ver, cmp)) {
+        groupOk = false
+        break
+      }
+    }
+    if (groupOk) return true
+  }
+  return false
+}
+
+function main() {
+  const version = process.argv[2]
+  const pkgPath = process.argv[3]
+  if (!version || !pkgPath) {
+    process.stderr.write('usage: node-version-check.js <node_version> <package.json>\n')
+    process.exit(2)
+  }
+  let range
+  try {
+    range = JSON.parse(fs.readFileSync(pkgPath, 'utf8')).engines.node
+  } catch (err) {
+    process.stderr.write(`node-version-check: cannot read ${pkgPath}: ${err.message}\n`)
+    process.exit(2)
+  }
+  if (!range) {
+    process.stderr.write(`node-version-check: ${pkgPath} has no engines.node\n`)
+    process.exit(2)
+  }
+  process.exit(satisfies(version, range) ? 0 : 1)
+}
+
+main()

--- a/tests-js/desktop-rebuild-node-gate.test.ts
+++ b/tests-js/desktop-rebuild-node-gate.test.ts
@@ -1,0 +1,130 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, test } from 'vitest'
+
+const POSIX = resolve(process.env.POSIX_SH_PATH ?? '../scripts/desktop-update/posix.sh')
+const LIB_JS = resolve(process.env.NODE_VERSION_CHECK_PATH ?? '../scripts/lib/node-version-check.js')
+const PKG = resolve('../apps/desktop/package.json')
+
+/** Run posix.sh --self-test-node-gate and return the decision line. */
+function gate(version: string): string {
+  return execFileSync('bash', [POSIX, '--self-test-node-gate', '--node-version', version], {
+    encoding: 'utf8',
+  }).trim()
+}
+
+/** Run the shared .js evaluator directly and return its decision. */
+function jsGate(version: string): string {
+  try {
+    execFileSync('node', [LIB_JS, version, PKG], { encoding: 'utf8', stdio: 'pipe' })
+    return 'compatible'
+  } catch {
+    return 'incompatible'
+  }
+}
+
+describe('posix.sh node build gate (--self-test-node-gate)', () => {
+  test('accepts supported lines (22.22+, 24.11+, 26+)', () => {
+    expect(gate('v22.22.0')).toBe('compatible')
+    expect(gate('v22.99.0')).toBe('compatible')
+    expect(gate('v24.11.0')).toBe('compatible')
+    expect(gate('v26.0.0')).toBe('compatible')
+  })
+
+  test('rejects odd-numbered releases (23, 25) and too-old 22.x', () => {
+    expect(gate('v23.0.0')).toBe('incompatible')
+    expect(gate('v25.9.0')).toBe('incompatible')
+    expect(gate('v22.21.0')).toBe('incompatible')
+    expect(gate('v20.19.0')).toBe('incompatible')
+  })
+
+  test('boundary matrix stays stable (#84397 alignment)', () => {
+    // The install path (install.sh) gates on the same lines; keep the
+    // boundary exact so the two paths can't drift apart.
+    const expected: Record<string, string> = {
+      'v22.21.0': 'incompatible',
+      'v22.22.0': 'compatible',
+      'v23.0.0': 'incompatible',
+      'v24.0.0': 'incompatible',
+      'v24.11.0': 'compatible',
+      'v25.0.0': 'incompatible',
+      'v26.0.0': 'compatible',
+    }
+
+    for (const [v, want] of Object.entries(expected)) {
+      expect(gate(v), `version ${v}`).toBe(want)
+    }
+  })
+})
+
+describe('posix.sh script exists', () => {
+  test('desktop-update/posix.sh is present', () => {
+    expect(existsSync(POSIX)).toBe(true)
+  })
+})
+
+describe('shared evaluator node-version-check.js (single source of truth)', () => {
+  test('evaluator exists', () => {
+    expect(existsSync(LIB_JS)).toBe(true)
+  })
+
+  test('evaluator predicate matches posix.sh self-test gate', () => {
+    const versions = ['v22.21.0', 'v22.22.0', 'v23.0.0', 'v24.0.0', 'v25.0.0', 'v26.0.0']
+
+    for (const v of versions) {
+      expect(jsGate(v), `js gate ${v}`).toBe(gate(v))
+    }
+  })
+})
+
+describe('prepare_node_for_build candidate selection', () => {
+  const TMP = '/tmp/hermes-node-gate-test'
+
+  /** Extract the node-gate functions into a temp file, then run them. */
+  function runPrepare(prelude: string): string {
+    const script = `
+set -u
+log() { echo "LOG: $1"; }
+SCRIPT_DIR="$(cd "$(dirname "$2")" && pwd)"
+source "$1"
+${prelude}
+prepare_node_for_build
+echo "FINAL_PATH=$PATH"
+`
+
+    // Extract node_satisfies_build and prepare_node_for_build to a temp file
+    // so bash sources them as code (command substitution would word-split
+    // the multi-line functions).
+    const fnFile = `${TMP}/node_gate.sh`
+    execFileSync('bash', ['-c', `sed -n '/^node_satisfies_build() {/,/^}/p; /^prepare_node_for_build() {/,/^}/p' "$1" > "$2"`, 'bash', POSIX, fnFile])
+
+    return execFileSync('bash', ['-c', script, 'bash', fnFile, POSIX], { encoding: 'utf8' })
+  }
+
+  test('skips a candidate that has node but no npm', () => {
+    execFileSync('bash', ['-c', `rm -rf ${TMP} && mkdir -p ${TMP}/node-only/bin`])
+    execFileSync('bash', ['-c', `printf '#!/bin/sh\\necho v24.0.0\\n' > ${TMP}/node-only/bin/node && chmod +x ${TMP}/node-only/bin/node`])
+
+    const out = runPrepare(`
+      export HERMES_NODE_CANDIDATE_DIRS="${TMP}/node-only/bin"
+      export PATH="/nonexistent:/usr/bin:/bin"
+    `)
+
+    expect(out).toContain('WARNING: no compatible Node found')
+  })
+
+  test('accepts a candidate that has both node and npm', () => {
+    execFileSync('bash', ['-c', `rm -rf ${TMP} && mkdir -p ${TMP}/full/bin`])
+    execFileSync('bash', ['-c', `printf '#!/bin/sh\\necho v24.0.0\\n' > ${TMP}/full/bin/node && printf '#!/bin/sh\\necho npm\\n' > ${TMP}/full/bin/npm && chmod +x ${TMP}/full/bin/node ${TMP}/full/bin/npm`])
+
+    const out = runPrepare(`
+      export HERMES_NODE_CANDIDATE_DIRS="${TMP}/full/bin"
+      export PATH="/nonexistent:/usr/bin:/bin"
+    `)
+
+    expect(out).toContain(`using ${TMP}/full/bin`)
+    expect(out).toContain(`FINAL_PATH=${TMP}/full/bin`)
+  })
+})


### PR DESCRIPTION
# fix(scripts): gate Node version in desktop rebuild path

## Problem

`hermes update` on a machine whose default `node` is incompatible with the
desktop build (e.g. Node 25 + `nanoid@6`, which requires `^22 || ^24 || >=26`)
silently fails during the Electron rebuild step:

- `install.sh` already gates the Node version for installation (see #84397),
  but the **desktop rebuild path** (`scripts/desktop-update/posix.sh`) has no
  equivalent guard — `hermes update` reports a generic failure and leaves the
  user running the previous build, with no hint that the Node version is the
  cause.
- Same root cause also hits `hermes desktop --force-build --build-only`
  directly, as documented in the #84359 comment.

## Change

`scripts/desktop-update/posix.sh`:

1. **Node build gate** — new `node_satisfies_build()` evaluates a candidate
   Node against the desktop's declared floor. The predicate is NOT hardcoded:
   it reads `apps/desktop/package.json`'s `engines.node` fresh on every call
   via the dependency-free `scripts/lib/node-version-check.js` semver
   evaluator, so when the official dependency declaration changes the gate
   follows automatically — no manual copy to keep in sync.
2. **Engines declaration tightened** — `apps/desktop/package.json` now carries
   the real floor `^22.22.0 || ^24.0.0 || >=26.0.0` (matching `nanoid@6`),
   replacing the looser `>=22.22.0` that let odd-numbered releases 23/25 pass
   the root floor and then die in `npm ci` with EBADENGINE.
3. **Auto-select a compatible Node** — new `prepare_node_for_build()` runs
   before the update/rebuild: if PATH already has a compatible node, leave it
   alone; otherwise probe the standard Homebrew versioned installs
   (`/opt/homebrew/opt/node@22|24|26/bin`, `/usr/local/opt/...`) and prepend
   the first compatible one to PATH. `HERMES_NODE_CANDIDATE_DIRS` overrides
   the candidate list for custom layouts. A candidate only counts if both
   `node` and `npm` are present.
4. **Self-test mode** — `--self-test-node-gate --node-version <v>` prints
   `compatible`/`incompatible` for CI tests, mirroring the official
   `--self-test-gate` precedent.
5. **Diagnosable failure** — when the rebuild fails after auto-selection, the
   exit-6 message now includes the Node version actually used.

Tests (`tests-js/desktop-rebuild-node-gate.test.ts`, 8 tests) drive the
self-test gate over the version matrix, assert the shared evaluator matches
the gate, and cover candidate selection (node-without-npm is skipped, node+npm
candidate is picked). Full `tests-js` suite: 32/32 passing.

## Design note — install vs rebuild

The install path (#84397, since tightened further to require Node 26 with the
Hermes-managed toolchain) can afford to be strict on a fresh install; the
REBUILD path must be tolerant of existing machines, so this PR auto-selects an
already-installed compatible Node instead of failing. They are complementary:
the gate stays strict about what Node is used, while users with a valid Node
installed somewhere on the machine (very common on macOS via Homebrew versioned
formulae) aren't forced to edit their PATH just to run an update.

## Related

- #84397 — Node version gate for install.sh (install-path hardening context)
- #84359 — same root cause reported for the desktop rebuild / `--force-build` path
