### PR TITLE
fix(tests): return Path from get_hermes_home mock in slash_worker profile test

### DIFF
--- a/tests/tui_gateway/test_slash_worker_profile_home.py
+++ b/tests/tui_gateway/test_slash_worker_profile_home.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch, call
 
 import pytest
@@ -11,7 +12,10 @@ import pytest
 def test_slash_worker_accepts_profile_home():
     """_SlashWorker.__init__ accepts profile_home parameter."""
     with patch.dict("sys.modules", {
-        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        # get_hermes_home() returns a Path in production; hermes_state.py's
+        # module-level DEFAULT_DB_PATH = get_hermes_home() / "state.db" does path
+        # division, so a str mock makes the import raise TypeError (str / str).
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test"))),
     }):
         with patch("subprocess.Popen") as mock_popen:
             mock_popen.return_value.stdout = MagicMock()


### PR DESCRIPTION
test_slash_worker_accepts_profile_home mocks hermes_constants with get_hermes_home=MagicMock(return_value="/tmp/hermes_test") — a str. In production get_hermes_home() returns a Path, and hermes_state.py's module-level DEFAULT_DB_PATH = get_hermes_home() / "state.db" does path division.

Under the str mock that becomes str / str, so importing tui_gateway.server inside the patch raises `TypeError: unsupported operand type(s) for /: 'str' and 'str'` and the test fails on every main run (Python tests slice 4/12).

Wrap the mock return in Path(...) so it matches the real return type. Test-only change; no production code touched.

Verified: the test passes on current main with this one-line fix.