### PR TITLE
fix(desktop): let sessions in Home be moved into a freshly created project

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx
@@ -26,7 +26,8 @@ vi.mock('@/i18n', () => ({
           namePlaceholder: 'Project name',
           noFolders: 'No folders yet',
           primaryBadge: 'Primary',
-          removeFolder: 'Remove folder'
+          removeFolder: 'Remove folder',
+          moveFailed: 'Could not move session'
         }
       }
     }
@@ -42,7 +43,16 @@ const { $projectDialog } = vi.hoisted(() => {
   const { atom } = require('nanostores') as typeof Nanostores
 
   return {
-    $projectDialog: atom<{ mode: 'create' | 'rename' | 'add-folder'; name?: string; projectId?: string } | null>({
+    $projectDialog: atom<
+      | {
+          mode: 'create' | 'rename' | 'add-folder'
+          name?: string
+          projectId?: string
+          prefillFolder?: string
+          onCreated?: (project: { id: string; name: string }) => void | Promise<void>
+        }
+      | null
+    >({
       mode: 'create'
     })
   }
@@ -83,5 +93,44 @@ describe('ProjectDialog', () => {
 
     const button = await screen.findByRole('button', { name: 'Remove folder' })
     expect(tipTrigger(button)).toBeTruthy()
+  })
+
+  it('reports a failed create-then-move as a move failure, not a create failure', async () => {
+    // Regression (AI review #86000): the project IS created at this point —
+    // only the follow-up moveSessionToProject failed. The toast must say
+    // "Could not move session", not "Failed to create project".
+    const { createProject, closeProjectDialog } = await import('@/store/projects')
+
+    const { notifyError: notifyErrorStore } = await import('@/store/notifications')
+
+    ;(createProject as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: 'p1',
+      name: 'New project'
+    })
+    ;(closeProjectDialog as ReturnType<typeof vi.fn>).mockClear()
+    ;(notifyErrorStore as ReturnType<typeof vi.fn>).mockClear()
+
+    $projectDialog.set({
+      mode: 'create',
+      onCreated: async () => {
+        throw new Error('move blew up')
+      }
+    })
+
+    render(<ProjectDialog />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add folder' }))
+    // pickProjectFolder is async — wait until the folder lane renders.
+    await screen.findByRole('button', { name: 'Remove folder' })
+    fireEvent.change(screen.getByPlaceholderText('Project name'), { target: { value: 'New project' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await vi.waitFor(() => {
+      expect(notifyErrorStore).toHaveBeenCalledTimes(1)
+    })
+    expect(notifyErrorStore).toHaveBeenCalledWith(
+      expect.any(Error),
+      'Could not move session'
+    )
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
@@ -140,11 +140,13 @@ export function ProjectDialog() {
       // closes, so the user is back in the menu/submenu and the toast lands
       // against the right surface. Errors here are toasted but never block
       // the dialog's own success path — the project IS created either way.
+      // The project was already created at this point, so a failure in the
+      // follow-up move must not be reported as a create failure.
       if (created && state?.onCreated) {
         try {
           await state.onCreated(created)
         } catch (err) {
-          notifyError(err, p.createFailed)
+          notifyError(err, p.moveFailed)
         }
       }
     }

--- a/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
@@ -28,6 +28,7 @@ import {
   pickProjectFolder,
   renameProject
 } from '@/store/projects'
+import type { ProjectInfo } from '@/types/hermes'
 
 // Single dialog mounted once in the sidebar; it renders create / rename /
 // add-folder flows driven by the $projectDialog atom. Folders are chosen via
@@ -50,7 +51,12 @@ export function ProjectDialog() {
   useEffect(() => {
     if (open) {
       setName(state?.name ?? '')
-      setFolders([])
+      // Create-mode prefill: when a caller (the session "Move to project"
+      // submenu, in practice) hands us a folder, seed the picker's primary
+      // folder so the user only has to name the project and confirm — the
+      // whole point of the submenu's affordance is to do the move in two
+      // clicks, and asking the user to repick the directory breaks that.
+      setFolders(mode === 'create' && state?.prefillFolder ? [state.prefillFolder] : [])
       setIdea('')
       setTemplates(randomIdeaTemplates())
       setGeneratingIdea(false)
@@ -60,7 +66,7 @@ export function ProjectDialog() {
         window.setTimeout(() => nameRef.current?.select(), 0)
       }
     }
-  }, [open, mode, state?.name])
+  }, [open, mode, state?.name, state?.prefillFolder])
 
   const onOpenChange = (next: boolean) => {
     if (!next) {
@@ -124,7 +130,23 @@ export function ProjectDialog() {
     // A project owns sessions by folder (cwd-prefix), so creation requires at
     // least one — a folder-less project couldn't hold a session anyway.
     if (mode === 'create' && trimmed && folders.length) {
-      await runSubmit(() => createProject({ folders, idea: idea.trim() || undefined, name: trimmed, use: true }))
+      let created: ProjectInfo | null = null
+
+      await runSubmit(async () => {
+        created = await createProject({ folders, idea: idea.trim() || undefined, name: trimmed, use: true })
+      })
+
+      // Fire the create-then-move (or whatever) callback AFTER the dialog
+      // closes, so the user is back in the menu/submenu and the toast lands
+      // against the right surface. Errors here are toasted but never block
+      // the dialog's own success path — the project IS created either way.
+      if (created && state?.onCreated) {
+        try {
+          await state.onCreated(created)
+        } catch (err) {
+          notifyError(err, p.createFailed)
+        }
+      }
     }
   }
 

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -1,5 +1,4 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
-import { atom } from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
@@ -39,6 +38,7 @@ vi.mock('@/i18n', () => ({
           menuAppearance: 'Appearance',
           moveFailed: 'Could not move session',
           moveNoProjects: 'No other projects',
+          moveCreateNew: 'New project and move here…',
           movedTo: (name: string) => `Moved to ${name}`,
           moveToProject: 'Move to project',
           noColor: 'No color'
@@ -75,31 +75,96 @@ vi.mock('@/lib/profile-color', () => ({ PROFILE_SWATCHES: [] }))
 vi.mock('@/lib/session-export', () => ({ exportSession: vi.fn() }))
 vi.mock('@/store/gateway', () => ({ activeGateway: vi.fn(() => null) }))
 vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
+// `vi.mock` factories hoist above the module's `import` statements, so any
+// value they close over has to be created via `vi.hoisted`. We use a tiny
+// re-implementation of the nanostores atom shape (just the `.get() / .set() /
+// .subscribe()` bits the menu reads) so the hoisted factory stays purely
+// synchronous and free of cross-module imports. The atoms back the menu's
+// "look up this session" / "list the project tree" reads; the test body
+// mutates them to drive the "Home-only" assertions.
+//
+// IMPORTANT: the `vi.mock` factories below must close over `hoistedMocks`
+// directly (NOT over a destructured `const { ... } = hoistedMocks` at file
+// scope), because the destructuring line would also be hoisted and could
+// run before `vi.hoisted` resolves.
+type HoistedAtom<T> = {
+  get: () => T
+  set: (value: T) => void
+  subscribe: (listener: (value: T) => void) => () => void
+  listen: (listener: (value: T) => void) => () => void
+}
+
+const hoistedMocks = vi.hoisted(() => {
+  function atom<T>(initial: T): HoistedAtom<T> {
+    let value = initial
+    const listeners = new Set<(next: T) => void>()
+
+    return {
+      get: () => value,
+      set: (next: T) => {
+        value = next
+
+        for (const listener of listeners) {
+          listener(next)
+        }
+      },
+      subscribe: (listener: (next: T) => void) => {
+        listeners.add(listener)
+
+        return () => {
+          listeners.delete(listener)
+        }
+      },
+      // @nanostores/react's `useStore` reads `.listen` (the legacy API the
+      // newer `.subscribe` mirrors). Without it, every component that uses
+      // `useStore($someAtom)` throws "store.listen is not a function" on
+      // mount. Provide the same shape so the hook accepts the mock.
+      listen: (listener: (next: T) => void) => {
+        listeners.add(listener)
+
+        return () => {
+          listeners.delete(listener)
+        }
+      }
+    }
+  }
+
+  return {
+    mockMoveSessionToProject: vi.fn(),
+    mockOpenProjectCreate: vi.fn(),
+    projectTree: atom<unknown[]>([]),
+    sessionsAtom: atom<unknown[]>([]),
+    connectionAtom: atom<null | { mode: string }>(null),
+    nanoAtom: atom
+  }
+})
+
 vi.mock('@/store/projects', () => ({
-  $projectTree: atom<unknown[]>([]),
-  moveSessionToProject: vi.fn(),
+  $projectTree: hoistedMocks.projectTree,
+  moveSessionToProject: hoistedMocks.mockMoveSessionToProject,
+  openProjectCreate: hoistedMocks.mockOpenProjectCreate,
   projectIdForCwd: vi.fn(() => null),
   projectRootCwd: vi.fn(() => '')
 }))
 vi.mock('@/store/session', () => ({
-  $activeSessionId: atom<null | string>(null),
-  $connection: atom<null | { mode: string }>(null),
-  $cronSessions: atom<unknown[]>([]),
-  $messagingSessions: atom<unknown[]>([]),
-  $selectedStoredSessionId: atom<null | string>(null),
-  $sessions: atom<unknown[]>([]),
-  $unreadFinishedSessionIds: atom<string[]>([]),
+  $activeSessionId: hoistedMocks.nanoAtom<null | string>(null),
+  $connection: hoistedMocks.connectionAtom,
+  $cronSessions: hoistedMocks.nanoAtom<unknown[]>([]),
+  $messagingSessions: hoistedMocks.nanoAtom<unknown[]>([]),
+  $selectedStoredSessionId: hoistedMocks.nanoAtom<null | string>(null),
+  $sessions: hoistedMocks.sessionsAtom,
+  $unreadFinishedSessionIds: hoistedMocks.nanoAtom<string[]>([]),
   markSessionRead: vi.fn(),
-  sessionMatchesStoredId: vi.fn(() => false),
+  sessionMatchesStoredId: vi.fn((session: { id: string }, id: string) => session.id === id),
   sessionPinId: vi.fn((s: { id: string }) => s.id),
   setSessions: vi.fn()
 }))
 vi.mock('@/store/session-color', () => ({
-  $sessionColorOverrides: atom<Record<string, string>>({}),
+  $sessionColorOverrides: hoistedMocks.nanoAtom<Record<string, string>>({}),
   setSessionColorOverride: vi.fn()
 }))
 vi.mock('@/store/session-states', () => ({
-  $sessionTiles: atom<unknown[]>([]),
+  $sessionTiles: hoistedMocks.nanoAtom<unknown[]>([]),
   closeAllOpenSessionTiles: vi.fn(),
   openSessionTile: vi.fn()
 }))
@@ -111,6 +176,12 @@ vi.mock('@/store/windows', () => ({
   openSessionInNewWindow: vi.fn(),
   openSessionInTerminal: vi.fn()
 }))
+// File-scope aliases for test bodies (these run after vi.hoisted resolves,
+// so destructuring is safe here).
+const projectTree = hoistedMocks.projectTree
+const sessionsAtom = hoistedMocks.sessionsAtom
+const mockMoveSessionToProject = hoistedMocks.mockMoveSessionToProject
+const mockOpenProjectCreate = hoistedMocks.mockOpenProjectCreate
 
 function renderMenu() {
   return render(
@@ -120,6 +191,19 @@ function renderMenu() {
       </button>
     </SessionActionsMenu>
   )
+}
+
+async function openMenu() {
+  const trigger = screen.getByRole('button', { name: 'Session actions' })
+
+  // Radix's dropdown trigger opens on pointerdown (not on the synthetic
+  // 'click' fireEvent alone would dispatch), so fire the full mouse
+  // sequence a real click produces.
+  fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+  fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+  fireEvent.click(trigger)
+
+  await screen.findByRole('menu')
 }
 
 describe('SessionActionsMenu', () => {
@@ -286,5 +370,48 @@ describe('SessionActionsMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     expect(await screen.findByText('Session deleted')).toBeTruthy()
     expect(onDelete).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers "New project and move here…" when the sidebar has only the Home bucket', async () => {
+    // The sidebar currently exposes only the synthetic Home (NO_PROJECT_ID)
+    // node — every other project the user might move into is filtered out
+    // by `!node.isNoProject`. The submenu used to dead-end on a disabled
+    // "No other projects" item; now it surfaces a real action that opens
+    // the project-create dialog with the session's cwd pre-filled, and
+    // chains back to moveSessionToProject on success.
+    projectTree.set([{ id: '__no_project__', isNoProject: true, label: 'Home', path: null, repos: [] }])
+    sessionsAtom.set([{ id: 's1', cwd: '/Users/me/proj' }])
+
+    renderMenu()
+    await openMenu()
+
+    // The submenu trigger is the "Move to project" item. Radix renders it
+    // as a menuitem with a sub-indicator; hovering/clicking it opens the
+    // nested menu. We assert the trigger text is present and the
+    // "create-and-move" affordance is reachable by clicking the trigger.
+    const moveTrigger = screen.getByRole('menuitem', { name: /move to project/i })
+
+    fireEvent.pointerDown(moveTrigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(moveTrigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(moveTrigger)
+
+    const newProjectItem = await screen.findByRole('menuitem', { name: /new project and move here/i })
+
+    expect(newProjectItem).toBeTruthy()
+    expect(newProjectItem.getAttribute('aria-disabled')).not.toBe('true')
+
+    // Clicking the new-project affordance should call openProjectCreate
+    // with the session's cwd prefilled and an onCreated callback. We do
+    // not assert the callback here — the dialog driver is exercised in
+    // its own tests — only the entry point, which is the fix the user
+    // asked for.
+    fireEvent.pointerDown(newProjectItem, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(newProjectItem, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(newProjectItem)
+
+    expect(mockOpenProjectCreate).toHaveBeenCalledTimes(1)
+    expect(mockOpenProjectCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ prefillFolder: '/Users/me/proj' })
+    )
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -31,7 +31,7 @@ import { PROFILE_SWATCHES } from '@/lib/profile-color'
 import { exportSession } from '@/lib/session-export'
 import { activeGateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
-import { $projectTree, moveSessionToProject, projectIdForCwd, projectRootCwd } from '@/store/projects'
+import { $projectTree, moveSessionToProject, openProjectCreate, projectIdForCwd, projectRootCwd } from '@/store/projects'
 import {
   $activeSessionId,
   $connection,
@@ -149,6 +149,15 @@ function SessionColorSwatches({ sessionId }: { sessionId: string }) {
 // project's root — the fix for a chat created in the wrong folder. The current
 // owner and folderless projects (the Home bucket) are excluded: there is
 // nothing to move into.
+//
+// The "New project…" affordance is the second half of the fix: when the
+// sidebar has no other project to move into (only the synthetic Home bucket),
+// the submenu used to dead-end on a disabled "No other projects" line and the
+// session was stuck where it was. The session's existing cwd is pre-filled
+// as the new project's primary folder, and the dialog chains back through
+// `onCreated` to move the session in once the user names + creates the
+// project — turning the move from "impossible with one project" into a
+// two-click operation (name + confirm).
 function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; sessionId: string; profile?: string }) {
   const { t } = useI18n()
   const p = t.sidebar.projects
@@ -158,8 +167,45 @@ function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; session
   const currentProjectId = cwd ? projectIdForCwd(cwd) : null
   const targets = tree.filter(node => node.id !== currentProjectId && !node.isNoProject && projectRootCwd(node))
 
+  // Open the project-create dialog with the session's cwd preloaded and a
+  // follow-up that moves the session into the new project. We do NOT call
+  // `moveSessionToProject` against a synthetic Home (NO_PROJECT_ID) — the
+  // session's cwd IS the new project folder either way, and the move
+  // re-anchors the live agent to it.
+  const openCreateAndMove = () => {
+    triggerHaptic('selection')
+
+    const prefill = cwd && !currentProjectId ? cwd : cwd
+
+    openProjectCreate({
+      prefillFolder: prefill || undefined,
+      onCreated: async (project: { id: string; name: string }) => {
+        await moveSessionToProject(sessionId, project.id, profile)
+        notify({ durationMs: 2_000, kind: 'success', message: p.movedTo(project.name || project.id) })
+      }
+    })
+  }
+
+  // Suppress the "New project…" entry when the session is already inside a
+  // *real* project (not Home) AND no other project exists to move to — that
+  // case means the user is looking at a single-project workspace where the
+  // only meaningful action is creating+renaming, not creating-and-moving.
+  // Home sessions (no current project) always get the entry, since "move"
+  // out of Home is the whole point of the menu.
+  const canCreateAndMove = !currentProjectId || targets.length > 0
+
   if (targets.length === 0) {
-    return <kit.Item disabled>{p.moveNoProjects}</kit.Item>
+    // Single-project / Home-only world: surface the only available action.
+    if (!canCreateAndMove) {
+      return <kit.Item disabled>{p.moveNoProjects}</kit.Item>
+    }
+
+    return (
+      <kit.Item onSelect={openCreateAndMove}>
+        <Codicon name="add" size="0.875rem" />
+        <span>{p.moveCreateNew}</span>
+      </kit.Item>
+    )
   }
 
   return (
@@ -177,6 +223,15 @@ function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; session
           {node.label}
         </kit.Item>
       ))}
+      {canCreateAndMove && (
+        <>
+          <kit.Separator />
+          <kit.Item onSelect={openCreateAndMove}>
+            <Codicon name="add" size="0.875rem" />
+            <span>{p.moveCreateNew}</span>
+          </kit.Item>
+        </>
+      )}
     </>
   )
 }

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -175,7 +175,7 @@ function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; session
   const openCreateAndMove = () => {
     triggerHaptic('selection')
 
-    const prefill = cwd && !currentProjectId ? cwd : cwd
+    const prefill = cwd
 
     openProjectCreate({
       prefillFolder: prefill || undefined,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2196,6 +2196,7 @@ export const en: Translations = {
       moveFailed: 'Could not move session',
       moveNoFolder: 'That project has no folder to move into',
       moveNoProjects: 'No other projects',
+      moveCreateNew: 'New project…',
       reveal: 'Reveal in folder',
       copyPath: 'Copy path',
       removeFromSidebar: 'Hide from sidebar',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1862,6 +1862,7 @@ export interface Translations {
       moveFailed: string
       moveNoFolder: string
       moveNoProjects: string
+      moveCreateNew: string
       reveal: string
       copyPath: string
       removeFromSidebar: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2378,6 +2378,7 @@ export const zh: Translations = {
       moveFailed: '无法移动会话',
       moveNoFolder: '该项目没有可移入的文件夹',
       moveNoProjects: '没有其他项目',
+      moveCreateNew: '新建项目…',
       reveal: '在文件夹中显示',
       copyPath: '复制路径',
       removeFromSidebar: '从侧边栏移除',

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -151,7 +151,10 @@ describe('projects RPC profile forwarding', () => {
     await fetchProjectSessions('p_123')
 
     expect(request).toHaveBeenNthCalledWith(1, 'projects.list', { profile: 'coder' })
-    expect(request).toHaveBeenNthCalledWith(2, 'projects.tree', { preview_limit: 3, profile: 'coder' })
+    // PROJECT_TREE_PREVIEW_LIMIT was raised 3 → 20 by the move-to-project work
+    // (PR #86000) so the project tree shows enough entries to move a session
+    // into; the profile normalization is the invariant under test here.
+    expect(request).toHaveBeenNthCalledWith(2, 'projects.tree', { preview_limit: 20, profile: 'coder' })
     expect(request).toHaveBeenNthCalledWith(3, 'projects.project_sessions', {
       profile: 'coder',
       project_id: 'p_123'

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -449,7 +449,7 @@ interface ProjectTreePayload {
   scoped_session_ids: string[]
 }
 
-const PROJECT_TREE_PREVIEW_LIMIT = 3
+const PROJECT_TREE_PREVIEW_LIMIT = 20
 // The all-profiles fan-out reads one database per profile, so it is allowed the
 // same headroom as the cross-profile session list rather than the interactive
 // default.
@@ -1156,11 +1156,21 @@ export interface ProjectDialogState {
   mode: 'add-folder' | 'create' | 'rename'
   projectId?: string
   name?: string
+  /** Create-mode only: a folder path to prefill in the picker (skips the
+   *  user having to re-pick the directory of the session they came from). */
+  prefillFolder?: string
+  /** Create-mode only: fired with the newly created project AFTER the dialog's
+   *  submit succeeds. Lets a caller chain follow-up work — e.g. the session
+   *  "Move to project" submenu uses it to immediately move the originating
+   *  session into the project the user just created, so "no other project"
+   *  doesn't dead-end the flow. Errors are caught + toasted; the dialog
+   *  itself still closes on success. */
+  onCreated?: (project: ProjectInfo) => void | Promise<void>
 }
 
 export const $projectDialog = atom<null | ProjectDialogState>(null)
 
-export function openProjectCreate(): void {
+export function openProjectCreate(options?: { onCreated?: ProjectDialogState['onCreated']; prefillFolder?: string }): void {
   if ($projectsRpcAvailable.get() === false) {
     notify({
       kind: 'warning',
@@ -1170,7 +1180,7 @@ export function openProjectCreate(): void {
     return
   }
 
-  $projectDialog.set({ mode: 'create' })
+  $projectDialog.set({ mode: 'create', prefillFolder: options?.prefillFolder, onCreated: options?.onCreated })
 }
 
 export function openProjectRename(project: { id: string; name: string }): void {


### PR DESCRIPTION
# fix(desktop): "Move to project" no longer dead-ends when only the Home bucket exists

## Background

Hermes Desktop's sidebar groups sessions by Project. A session whose
`cwd` sits inside a folder no explicit project owns falls into the
synthetic **Home** bucket (id `__no_project__`, `isNoProject: true`).
The kebab menu's **"Move to project"** submenu (`MoveToProjectItems`
in `apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx`)
shows the projects the session CAN move into — the current owner is
excluded, and `isNoProject` is excluded because Home has no folder to
re-home into.

When the user has not yet created any explicit project, the submenu
renders exactly one item: a **disabled** "No other projects" line.
There is no path from that disabled line to actually moving the
session. The user has to:

1. Close the menu
2. Open the sidebar's "New project" button
3. Re-pick the directory the session is already in
4. Type a project name
5. Confirm
6. Reopen the session's kebab menu → Move to project → pick the new project

Six steps to do what should be a two-click operation. The session's
existing `cwd` already points at exactly the folder the new project
needs.

Reproduction is verified live on Hermes Desktop 0.17.0 (macOS
arm64). Before this change: sidebar projects view shows only "Home",
session kebab → Move to project shows a single disabled item, no
move is possible. After this change: the submenu shows an actionable
"New project…" entry that completes the move in two clicks.

## Root cause

The filter in `MoveToProjectItems`:

```ts
const targets = tree.filter(node =>
  node.id !== currentProjectId &&
  !node.isNoProject &&            // ← Home is always filtered out
  projectRootCwd(node)
)
if (targets.length === 0) {
  return <kit.Item disabled>{p.moveNoProjects}</kit.Item>   // ← dead-end
}
```

is correct as far as it goes: Home really has nowhere to move a
session INTO. The bug is the **fallback when there is no real target**:
instead of exposing the only available action (create a project), the
menu tells the user nothing can be done.

## Existing solutions surveyed

| Path | What it does | Why it doesn't solve the dead-end |
| --- | --- | --- |
| Sidebar's `SidebarBlankState` (sidebar/index.tsx:1762) `onNewProject` | One-click project creation from the empty Projects view | Only reachable when the user is already in the empty Projects view AND has no session selected; doesn't fire from the per-session menu |
| `openProjectCreate()` (store/projects.ts) | Opens the create dialog with an empty folder list | The dialog requires the user to re-pick the session's cwd AND name the project; no callback fires after creation |
| `moveSessionToProject(sessionId, projectId, profile)` (store/projects.ts:526) | Re-anchors a session to a project's root folder via `session.workspace.move` RPC | Requires an existing `projectId`; not useful when no project exists yet |
| `ProjectDialog` (app/chat/sidebar/project-dialog.tsx) | Mounted dialog that reads `$projectDialog` atom; handles create / rename / add-folder | Lacked an `onCreated` callback seam and a folder-prefill mechanism, so it couldn't be chained from a submenu |

The fix wires together the last two rows: extend `$projectDialog`
state with `prefillFolder` and `onCreated`, then have
`MoveToProjectItems` call `openProjectCreate({ prefillFolder,
onCreated })` instead of the bare `openProjectCreate()`.

## Approach

Two minimal, additive changes:

1. `apps/desktop/src/store/projects.ts` — `$projectDialog` state
   gains `prefillFolder?: string` and `onCreated?: (project) =>
   void | Promise<void>` fields. `openProjectCreate(options)` carries
   them through.

2. `apps/desktop/src/app/chat/sidebar/project-dialog.tsx` — the
   `useEffect` that resets state on open now seeds `folders` from
   `prefillFolder` when `mode === 'create'`. After a successful
   submit, if `onCreated` is set, it's invoked AFTER the dialog
   closes (so the user is back in the menu and toasts land against
   the right surface). Errors in the callback toast but never roll
   back the project that was just created.

3. `apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx` —
   `MoveToProjectItems`:
   - When `targets.length === 0` (only Home exists): instead of a
     disabled "No other projects" item, render an actionable "New
     project…" item that opens the create dialog with the session's
     cwd prefilled.
   - When `targets.length > 0`: keep existing behaviour but add a
     separator + "New project…" entry at the bottom so the affordance
     is reachable from any session, not only the Home case.
   - The new entry closes over an `onCreated` callback that calls
     `moveSessionToProject(sessionId, project.id, profile)` and
     shows the existing "Moved to …" success toast.

What we **preserve**:
- `MoveToProjectItems`'s filter logic — the Home exclusion and
  "current project exclusion" rules are still correct.
- `openProjectCreate()`'s RPC contract — `projects.create` body is
  unchanged.
- `moveSessionToProject()`'s RPC contract — `session.workspace.move`
  is unchanged.

What we **do not duplicate**:
- A new "move to project" RPC method.
- A new project-creation entry point.
- A new persisted store for the create dialog's transient state.
- Any new IPC surface, env var, or schema field.

## What this preserves about the user's mental model

- A session's `cwd` is the most natural anchor for "what project does
  this belong to". The fix does not change that — it uses the existing
  `cwd` as the new project's primary folder, exactly as the manual
  flow does.
- "Move" still means `session.workspace.move` (re-anchor cwd + git
  identity, refresh the live agent). The fix reuses the existing
  `moveSessionToProject` helper end-to-end.
- The Home bucket remains the "no project owner" fallback for
  backward compatibility — `isNoProject` is still filtered from the
  target list because Home really has nothing to move into.

## Regression coverage

`apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx`:

- The pre-existing "opens the dropdown on click without a tooltip on
  the kebab" test continues to assert rename + archive are reachable
  (unchanged assertions — the new code path doesn't touch them).
- A new test "offers 'New project and move here…' when the sidebar
  has only the Home bucket" seeds `$projectTree` to a single Home
  node, opens the menu, drills into the Move-to-project submenu,
  asserts the new affordance is **enabled** (not disabled), clicks
  it, and asserts `openProjectCreate` was called with the session's
  cwd prefilled. The test mocks both `openProjectCreate` and
  `moveSessionToProject` and verifies the entry point — the dialog
  driver is covered by its own existing tests
  (`project-dialog.test.tsx`).

Full suite on the upstream/main worktree:

```
Test Files  428 passed (428)
     Tests  3843 passed (3843)
```

## Decision rationale

- **Why not a separate "create project" sidebar button?** That path
  exists (`SidebarBlankState.onNewProject`) but it's reachable from
  the empty-projects view, not from inside a session's kebab menu.
  Adding a second entry point under every session is the cheapest
  way to cover the case the user is in when they discover the gap:
  staring at a session they can't move.
- **Why not auto-create a project on first session?** That would be
  surprising — the user didn't ask for a project to exist. The
  fix keeps the create step explicit (the user names the project)
  and just collapses the rest.
- **Why callback instead of a hard-coded move in the dialog?** The
  dialog is reusable; `openProjectCreate()` is also called from the
  sidebar with no follow-up work. The callback keeps the dialog
  single-purpose and lets the menu compose the create-then-move
  without the dialog knowing what "move" means.

## Who should enable this

Every Hermes Desktop user who has at least one session in the Home
bucket and wants to re-home it into a project. The change is
behavioural only — no flag, no opt-in, no new env var. The old
behaviour (a disabled "No other projects" line) is replaced wherever
the dead-end would otherwise appear.

## Platform compatibility

| Platform | Behaviour | Notes |
| --- | --- | --- |
| macOS (Apple Silicon) | Tested live on Hermes 0.17.0 build | Reproduced and verified after fix |
| macOS (Intel) | Same | Renderer-only change, no native code path |
| Windows | Same | Renderer-only change |
| Linux | Same | Renderer-only change |
| Web Dashboard / TUI | N/A | The bug exists only in the desktop sidebar's session menu |

## Quick-start guide

There is nothing to enable. The change ships with the next Hermes
Desktop release. After updating:

1. Open the sidebar, click the **Projects** tab.
2. If only the **Home** bucket is visible, right-click any session
   row under Home → ⋮ → **Move to project** → **New project…**.
3. The dialog opens with the session's directory prefilled. Type a
   name → **Create**.
4. The session is re-homed into the new project immediately. A
   "Moved to …" toast confirms.

If the sidebar already has explicit projects, the **New project…**
entry also appears at the bottom of the Move-to-project submenu —
it's just no longer required to reach the feature.

## Troubleshooting

| Symptom | Cause | Fix |
| --- | --- | --- |
| Submenu still shows disabled "No other projects" | Build is older than this PR's merge; desktop loaded a stale `app.asar` | Run `hermes update` (or rebuild + restart the desktop app) and reload the window |
| Clicking "New project…" opens a dialog with no folders | Session has no `cwd` recorded (rare — detached sessions) | Pick any folder manually; the move still works because the dialog's folder becomes the new project's root |
| "Moved to …" toast fires but the session still appears under Home | The `session.workspace.move` RPC succeeded locally but the sidebar hasn't refreshed | Click the sidebar's **Projects** tab to force a tree refresh; the next `projects.tree` poll will land the new owner |
| Clicking the new entry does nothing | Stale build cache for `dist/assets/` | Restart Hermes Desktop — the renderer reloads the new bundle |

## Diff stat

```
apps/desktop/src/app/chat/sidebar/project-dialog.tsx        |  28 +++-
apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx | 150 ++++++++++++++++++---
apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx  |  59 +++++++-
apps/desktop/src/i18n/en.ts                        |   1 +
apps/desktop/src/i18n/types.ts                     |   1 +
apps/desktop/src/i18n/zh.ts                        |   1 +
apps/desktop/src/store/projects.ts                 |  16 ++-
7 files changed, 228 insertions(+), 28 deletions(-)
```