### PR TITLE
feat(cron): add `resnapshot` flag to re-baseline drift-guard snapshots

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1856,7 +1856,15 @@ def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
 
 
 def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """Update a job by ID, refreshing derived schedule fields when needed."""
+    """Update a job by ID, refreshing derived schedule fields when needed.
+
+    ``updates`` may carry a ``resnapshot`` boolean control flag (consumed here,
+    never persisted): when true, an unpinned agent job's provider/model
+    snapshots are re-resolved against the current global default, re-baselining
+    the #44585 drift guard so the job keeps following ``cron.model`` /
+    ``model.default`` without being pinned. Pinned and no-agent jobs carry no
+    snapshots, so the flag is a no-op for them.
+    """
     # Block mutation of immutable fields. ``id`` in particular is a filesystem
     # path component under OUTPUT_DIR — letting an update change it leaks
     # path-escape values into output writes/deletes.
@@ -1890,6 +1898,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates[_mon_field] = _mv or None
 
             previous_inference_axes = _normalized_inference_axes(job)
+            # ``resnapshot`` is a control flag, not a persisted field: re-baseline
+            # the drift-guard snapshots of an unpinned job to the current global
+            # default without pinning it (#75375). Pop it before the merge so it
+            # never lands in the stored record.
+            resnapshot_requested = bool(updates.pop("resnapshot", False))
             updated = _apply_skill_fields({**job, **updates})
 
             # Re-check execution-mode invariants on the MERGED record when
@@ -1955,7 +1968,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                         )
                     updated["next_run_at"] = updated_next_run
 
-            if inference_fields_changed:
+            if inference_fields_changed or resnapshot_requested:
                 provider_snapshot, model_snapshot = _compute_provider_model_snapshots(
                     provider=updated.get("provider"),
                     model=updated.get("model"),

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -41,6 +41,22 @@ logger = logging.getLogger(__name__)
 from hermes_time import now as _hermes_now
 from utils import atomic_replace, atomic_write_text
 
+
+def _strict_bool(value: Any) -> bool:
+    """Coerce a control-flag value to bool without Python's truthiness trap.
+
+    bool("false") is True, which has silently flipped update flags sent as
+    strings (CLI/query/dashboard payloads). Real bools pass through; strings
+    are matched case-insensitively ("true"/"1"/"yes"/"on" => True,
+    "false"/"0"/"no"/"off" => False); anything else is False, so a control
+    flag can never accidentally turn itself on.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "1", "yes", "on")
+    return bool(value)
+
 # ``croniter`` compiles ~15 ms of regexes at import and only matters for
 # 5-field cron expressions. Resolve lazily; ``HAS_CRONITER`` stays a module
 # attribute (tests monkeypatch it, and a monkeypatched value wins because
@@ -1902,7 +1918,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             # the drift-guard snapshots of an unpinned job to the current global
             # default without pinning it (#75375). Pop it before the merge so it
             # never lands in the stored record.
-            resnapshot_requested = bool(updates.pop("resnapshot", False))
+            resnapshot_requested = _strict_bool(updates.pop("resnapshot", False))
             updated = _apply_skill_fields({**job, **updates})
 
             # Re-check execution-mode invariants on the MERGED record when

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -432,6 +432,7 @@ def cron_edit(args):
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
+        resnapshot=getattr(args, "resnapshot", False),
         no_agent=getattr(args, "no_agent", None),
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
@@ -458,6 +459,16 @@ def cron_edit(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
+    if getattr(args, "resnapshot", False):
+        if updated.get("model") or updated.get("provider"):
+            print("  Model routing: pinned (resnapshot is a no-op for pinned jobs)")
+        elif updated.get("no_agent"):
+            print("  Model routing: no-agent job (no drift snapshots)")
+        else:
+            print(
+                "  Model routing: following the global default "
+                "(drift-guard snapshots re-baselined)"
+            )
     return 0
 
 

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -197,6 +197,16 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         dest="model_provider",
         help="Inference provider paired with --model. Pass empty string to clear.",
     )
+    cron_edit.add_argument(
+        "--resnapshot",
+        action="store_true",
+        help=(
+            "Re-baseline this job's model/provider drift-guard snapshots to the "
+            "current global default (cron.model / model.default) without pinning "
+            "it. For an unpinned job this clears a model-drift skip so it keeps "
+            "following the default; no-op for pinned or no-agent jobs."
+        ),
+    )
 
     # lifecycle actions
     cron_pause = cron_subparsers.add_parser("pause", help="Pause a scheduled job")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11859,6 +11859,10 @@ def _normalize_dashboard_cron_updates(
         normalized["context_from"] = _cron_string_list(normalized["context_from"])
     if "enabled_toolsets" in normalized:
         normalized["enabled_toolsets"] = _cron_string_list(normalized["enabled_toolsets"])
+    if "resnapshot" in normalized:
+        # Control flag consumed by update_job() (never persisted). Kept a
+        # strict boolean so the dashboard cannot smuggle arbitrary values.
+        normalized["resnapshot"] = bool(normalized["resnapshot"])
     return normalized
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11841,6 +11841,8 @@ def _normalize_dashboard_cron_updates(
     """
     normalized = dict(updates or {})
 
+    from cron import jobs as _cron_jobs
+
     for key in ("model", "provider", "workdir"):
         if key in normalized:
             normalized[key] = _cron_optional_text(normalized[key])
@@ -11862,7 +11864,7 @@ def _normalize_dashboard_cron_updates(
     if "resnapshot" in normalized:
         # Control flag consumed by update_job() (never persisted). Kept a
         # strict boolean so the dashboard cannot smuggle arbitrary values.
-        normalized["resnapshot"] = bool(normalized["resnapshot"])
+        normalized["resnapshot"] = _cron_jobs._strict_bool(normalized["resnapshot"])
     return normalized
 
 

--- a/tests/cron/test_cron_resnapshot.py
+++ b/tests/cron/test_cron_resnapshot.py
@@ -1,0 +1,205 @@
+"""``resnapshot`` control flag on cron job updates (#75375).
+
+An UNPINNED job follows the global default at fire time; the #44585 drift
+guard snapshots that default at job creation and fails closed when the global
+default later changes. ``update_job(..., {"resnapshot": True})`` re-baselines
+the snapshots to the CURRENT global default without pinning the job, so it
+keeps following ``cron.model`` / ``model.default``.
+
+The flag is user-owned (CLI/dashboard/programmatic callers only — it is
+deliberately absent from the agent-facing ``cronjob`` tool schema, mirroring
+the model/provider pin policy) and is never persisted to the job record.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure project root is importable.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.jobs import load_jobs, update_job
+
+DEFAULT_MODEL = "deepseek/deepseek-v4-flash-0731"
+DEFAULT_PROVIDER = "nous"
+
+
+def _write_config(home: Path) -> None:
+    (home / "config.yaml").write_text(
+        "model:\n"
+        f"  default: {DEFAULT_MODEL}\n"
+        f"  provider: {DEFAULT_PROVIDER}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_jobs(home: Path, jobs: list) -> None:
+    cron_dir = home / "cron"
+    cron_dir.mkdir(exist_ok=True)
+    (cron_dir / "jobs.json").write_text(
+        json.dumps({"jobs": jobs}), encoding="utf-8"
+    )
+
+
+def _base_job(**overrides) -> dict:
+    job = {
+        "id": "resnap-test",
+        "name": "resnapshot test",
+        "prompt": "hello",
+        "skills": [],
+        "skill": None,
+        "model": None,
+        "provider": None,
+        "provider_snapshot": "openai-codex",
+        "model_snapshot": "gpt-5.6-terra",
+        "base_url": None,
+        "no_agent": False,
+        "script": None,
+        "schedule": {"kind": "cron", "expr": "0 9 * * *", "display": "0 9 * * *"},
+        "schedule_display": "0 9 * * *",
+        "repeat": {"times": None, "completed": 0},
+        "enabled": True,
+        "state": "scheduled",
+        "next_run_at": "2026-08-15T09:00:00+00:00",
+        "created_at": "2026-08-01T00:00:00+00:00",
+    }
+    job.update(overrides)
+    return job
+
+
+def _resolved_provider(*args, **kwargs):
+    """Deterministic runtime-provider resolution for snapshot capture."""
+    return {
+        "api_key": "test-key",
+        "base_url": "https://example.invalid/v1",
+        "provider": DEFAULT_PROVIDER,
+        "api_mode": "chat_completions",
+    }
+
+
+class TestResnapshot:
+    def test_unpinned_job_resnapshot_refreshes_snapshots(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_config(tmp_path)
+        _write_jobs(tmp_path, [_base_job()])
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_resolved_provider,
+        ):
+            updated = update_job("resnap-test", {"resnapshot": True})
+
+        assert updated is not None
+        assert updated["model"] is None
+        assert updated["provider"] is None
+        assert updated["provider_snapshot"] == DEFAULT_PROVIDER
+        assert updated["model_snapshot"] == DEFAULT_MODEL
+
+        # The control flag must never be persisted.
+        stored = load_jobs()[0]
+        assert "resnapshot" not in stored
+
+    def test_unpinned_job_without_resnapshot_keeps_stale_snapshots(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_config(tmp_path)
+        _write_jobs(tmp_path, [_base_job()])
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_resolved_provider,
+        ):
+            updated = update_job("resnap-test", {"name": "renamed"})
+
+        assert updated["name"] == "renamed"
+        assert updated["provider_snapshot"] == "openai-codex"
+        assert updated["model_snapshot"] == "gpt-5.6-terra"
+
+    def test_pinned_job_resnapshot_is_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_config(tmp_path)
+        _write_jobs(
+            tmp_path,
+            [
+                _base_job(
+                    model="anthropic/claude-sonnet-4",
+                    provider="anthropic",
+                )
+            ],
+        )
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_resolved_provider,
+        ):
+            updated = update_job("resnap-test", {"resnapshot": True})
+
+        # Pinned axes carry no snapshot; the flag must not unpin the job.
+        assert updated["model"] == "anthropic/claude-sonnet-4"
+        assert updated["provider"] == "anthropic"
+        assert updated["provider_snapshot"] is None
+        assert updated["model_snapshot"] is None
+
+    def test_no_agent_job_resnapshot_is_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_config(tmp_path)
+        _write_jobs(tmp_path, [_base_job(no_agent=True, script="watch.py")])
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_resolved_provider,
+        ):
+            updated = update_job("resnap-test", {"resnapshot": True})
+
+        assert updated["no_agent"] is True
+        assert updated["provider_snapshot"] is None
+        assert updated["model_snapshot"] is None
+
+    def test_resnapshot_true_false_values(self, tmp_path, monkeypatch):
+        """Only a truthy flag triggers a re-baseline; false leaves state alone."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_config(tmp_path)
+        _write_jobs(tmp_path, [_base_job()])
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_resolved_provider,
+        ):
+            updated = update_job("resnap-test", {"resnapshot": False})
+
+        assert updated["provider_snapshot"] == "openai-codex"
+        assert updated["model_snapshot"] == "gpt-5.6-terra"
+
+    def test_programmatic_tool_call_supports_resnapshot(self, tmp_path, monkeypatch):
+        """cronjob(action='update', resnapshot=True) works for programmatic callers."""
+        from tools.cronjob_tools import CRONJOB_SCHEMA, cronjob
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_config(tmp_path)
+        _write_jobs(tmp_path, [_base_job()])
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_resolved_provider,
+        ):
+            result = json.loads(
+                cronjob(action="update", job_id="resnap-test", resnapshot=True)
+            )
+
+        assert result.get("success") is True
+        job = result["job"]
+        assert job["model"] is None
+        # The tool's formatted output omits snapshot fields; verify the store.
+        stored = load_jobs()[0]
+        assert stored["provider_snapshot"] == DEFAULT_PROVIDER
+        assert stored["model_snapshot"] == DEFAULT_MODEL
+        assert "resnapshot" not in stored
+
+        # The agent-facing schema must NOT expose the flag (user-owned, like
+        # model/provider pins): an agent must not silently re-baseline a
+        # drift guard that is blocking unattended spend.
+        assert "resnapshot" not in CRONJOB_SCHEMA["parameters"]["properties"]

--- a/tests/cron/test_cron_resnapshot.py
+++ b/tests/cron/test_cron_resnapshot.py
@@ -203,3 +203,15 @@ class TestResnapshot:
         # model/provider pins): an agent must not silently re-baseline a
         # drift guard that is blocking unattended spend.
         assert "resnapshot" not in CRONJOB_SCHEMA["parameters"]["properties"]
+
+    def test_strict_bool_rejects_string_false(self):
+        """bool("false") is True — the strict parser must reject string
+        falses so a dashboard/query payload can never flip the flag."""
+        from cron.jobs import _strict_bool
+
+        assert _strict_bool("false") is False
+        assert _strict_bool("FALSE") is False
+        assert _strict_bool("0") is False
+        assert _strict_bool("true") is True
+        assert _strict_bool(True) is True
+        assert _strict_bool(False) is False

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1114,6 +1114,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    resnapshot: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     task_id: str = None,
@@ -1463,6 +1464,13 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if resnapshot is not None:
+                # User-owned control flag (CLI/dashboard/programmatic callers
+                # only — see the registry handler note below): re-baseline the
+                # drift-guard snapshots of an unpinned job to the current
+                # global default without pinning it. update_job() consumes it
+                # and never persists it.
+                updates["resnapshot"] = bool(resnapshot)
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -1670,7 +1678,11 @@ registry.register(
         # agent's arguments: per-job inference pins are user-owned (dashboard,
         # `hermes cron create/edit --model`, or hand-edited jobs). The agent
         # must not be able to point unattended spend at a different model.
-        # Programmatic callers of cronjob() itself retain the parameters.
+        # The `resnapshot` control flag is user-owned for the same reason: an
+        # agent must not silently re-baseline a drift guard that is currently
+        # blocking a job (which would re-enable unattended spend under a new
+        # global default). Programmatic callers of cronjob() retain the
+        # parameter.
         reason=args.get("reason"),
         script=args.get("script"),
         context_from=args.get("context_from"),

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -39,6 +39,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cron.jobs import (
     AmbiguousJobReference,
+    _strict_bool,
     claim_job_for_fire,
     effective_job_state,
     get_job,
@@ -1470,7 +1471,7 @@ def cronjob(
                 # drift-guard snapshots of an unpinned job to the current
                 # global default without pinning it. update_job() consumes it
                 # and never persists it.
-                updates["resnapshot"] = bool(resnapshot)
+                updates["resnapshot"] = _strict_bool(resnapshot)
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.


### PR DESCRIPTION
feat(cron): add `resnapshot` flag to re-baseline drift-guard snapshots

## Problem

When the global default model/provider changes (e.g. via `/model` or
`hermes config set`), the #44585 drift guard fails closed on every UNPINNED
cron job whose creation-time `provider_snapshot` / `model_snapshot` no longer
matches: the run is skipped, no paid call is made, and an alert is delivered.
That is the intended spend-safety behaviour.

The gap is remediation. The only documented fix is to pin the job
(`hermes cron edit <id> --model ... --provider ...`), which permanently stops
the job from following `cron.model` / `model.default`. For an operator who
deliberately wants an unpinned job to keep following the (new) global default,
the only working path is an undocumented two-step update (pin, then clear the
pin) so the update path re-resolves the snapshots. Real reproduction: after
the main model moved to `deepseek/deepseek-v4-flash-0731` via `nous`, three
unpinned jobs were skipped; re-baselining them required that manual sequence.

## Fix

`update_job` now accepts a `resnapshot` boolean control flag in `updates`
(consumed, never persisted). When true, the job's provider/model snapshots are
re-resolved against the CURRENT global default via the same
`_compute_provider_model_snapshots` path used at create/update time — the job
stays unpinned and keeps following the default. Pinned and `no_agent` jobs
carry no snapshots, so the flag is a no-op for them.

Surfaces:

- `hermes cron edit <id> --resnapshot` (CLI, prints the resulting routing).
- `_normalize_dashboard_cron_updates` passes a strict boolean through so the
  dashboard adapter can use it (user-owned surface).
- The `cronjob()` tool gains the parameter for programmatic callers only. It
  is deliberately NOT added to the agent-facing `CRONJOB_SCHEMA` or registry
  handler, mirroring the existing model/provider pin policy: an agent must not
  silently re-baseline a drift guard that is currently blocking unattended
  spend under a new global default.

## Why not alternatives

- Pinning (the prior remediation) stops the job from following the global
  default — the opposite of what an unpinned job means.
- `cron.model` / `cron.model_provider` freezes the whole fleet on one model
  and is the deliberate "controlled fleet default" answer; it does not help an
  operator who wants individual jobs to keep tracking the chat default.
- Recreating jobs loses state (delivery, repeat counts, workdir, context).

## Validation

- 6 new tests in `tests/cron/test_cron_resnapshot.py`: unpinned refresh,
  no-op without the flag, pinned no-op, `no_agent` no-op, falsy flag no-op,
  programmatic tool call + agent-schema absence guard.
- Full `tests/cron/` + `tests/hermes_cli/test_cron_model_impact.py`: 609
  passed, 1 skipped.
- CLI E2E (`hermes cron edit <id> --resnapshot` against a temp HERMES_HOME):
  snapshots re-baselined to the current default, job remains unpinned, flag
  not persisted.

Part of #75375 (remediation slice for the cron model-drift migration UX).
