### PR TITLE
fix: normalize Skills Hub install paths on macOS

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -737,7 +737,10 @@ def do_install(identifier: str, category: str = "", force: bool = False,
                          bundle.trust_level, "invalid_path", str(exc))
         return
     from tools.skills_hub import SKILLS_DIR
-    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
+    # ``install_dir`` is resolved by the install security boundary.  Resolve
+    # the root as well so filesystem aliases (macOS /var -> /private/var) are
+    # compared in the same namespace.
+    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR.resolve())}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
 
     # Blueprint detection: if the installed skill declares a

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1655,6 +1655,60 @@ class TestInstallPathSafety:
         assert installed.is_dir()
         record_installed.assert_called_once_with("good-skill")
 
+    def test_install_from_quarantine_handles_symlinked_skills_root(self, tmp_path):
+        """Resolved install paths must remain relative to an aliased root.
+
+        macOS exposes ``/var`` through ``/private/var``.  Resolving only the
+        install target made a successful install fail while recording the lock
+        entry because ``/private/var/...`` is not lexically below ``/var/...``.
+        A symlinked temporary root reproduces the same path-shape mismatch on
+        every platform.
+        """
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        real_skills_dir = tmp_path / "real" / "skills"
+        real_skills_dir.mkdir(parents=True)
+        skills_dir = tmp_path / "skills-alias"
+        try:
+            skills_dir.symlink_to(real_skills_dir, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("directory symlinks unsupported on this platform")
+
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir(parents=True)
+        skill_md = "---\nname: good-skill\n---\n\n# Good skill\n"
+        (q_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+        bundle = hub.SkillBundle(
+            name="good-skill",
+            files={"SKILL.md": skill_md},
+            source="community",
+            identifier="good/source",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="good-skill",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root), \
+             patch("tools.skill_usage.record_installed"):
+            installed = hub.install_from_quarantine(
+                q_dir,
+                "good-skill",
+                "",
+                bundle,
+                scan_result,
+            )
+
+        assert installed == real_skills_dir / "good-skill"
+        lock = json.loads((skills_dir / ".hub" / "lock.json").read_text())
+        assert lock["installed"]["good-skill"]["install_path"] == "good-skill"
+
 
 # ---------------------------------------------------------------------------
 # parallel_search_sources — overall_timeout must be honoured even when a

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3998,7 +3998,10 @@ def install_from_quarantine(
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
         skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(_skills_dir())),
+        # ``install_dir`` is resolved by _resolve_lock_install_path().  Resolve
+        # the root too so platform aliases such as macOS /var -> /private/var
+        # do not turn a valid install into a spurious ``relative_to`` failure.
+        install_path=str(install_dir.relative_to(_skills_dir().resolve())),
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,
         scan_provenance=scan_provenance or getattr(scan_result, "scan_provenance", None),


### PR DESCRIPTION
## Summary

- resolve the Skills Hub root before deriving lock-file install paths
- use the same resolved root for the CLI success display
- cover symlinked filesystem roots, reproducing macOS `/var` → `/private/var`

## Problem

`install_from_quarantine()` resolves the destination as part of its security boundary, but later compares that resolved path to an unresolved Skills Hub root. On macOS, a temporary `HERMES_HOME` under `/var` becomes `/private/var` after resolution, so a valid install is copied and then reported as blocked by `Path.relative_to()`.

## Validation

- `scripts/run_tests.sh tests/tools/test_skills_hub.py` — 71 passed
- `ruff check hermes_cli/skills_hub.py tools/skills_hub.py tests/tools/test_skills_hub.py`
- reproduced against Hermes v0.20.0 with an isolated `HERMES_HOME`; the new symlink-root regression test exercises the same alias mismatch portably