### PR TITLE
fix(tests): mock get_hermes_home with Path, not str, across tui_gateway tests

### DIFF
--- a/tests/tui_gateway/test_compaction_status.py
+++ b/tests/tui_gateway/test_compaction_status.py
@@ -7,6 +7,7 @@ silently reset mid-turn.
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 import importlib
 
@@ -23,7 +24,7 @@ def server():
         "sys.modules",
         {
             "hermes_constants": MagicMock(
-                get_hermes_home=MagicMock(return_value="/tmp/hermes_test_compaction")
+                get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test_compaction"))
             ),
             "hermes_cli.env_loader": MagicMock(),
             "hermes_cli.banner": MagicMock(),

--- a/tests/tui_gateway/test_inline_rpc_gil_starvation.py
+++ b/tests/tui_gateway/test_inline_rpc_gil_starvation.py
@@ -20,6 +20,7 @@ import sys
 import threading
 import time
 from unittest.mock import MagicMock, patch
+from pathlib import Path
 
 import pytest
 
@@ -38,7 +39,7 @@ def server():
     # the whole test would poison modules first imported inside test bodies
     # (see tests/tui_gateway/test_protocol.py for the full rationale).
     with patch.dict("sys.modules", {
-        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test"))),
         "hermes_cli.env_loader": MagicMock(),
         "hermes_cli.banner": MagicMock(),
         "hermes_state": MagicMock(),

--- a/tests/tui_gateway/test_moa_reference_emit.py
+++ b/tests/tui_gateway/test_moa_reference_emit.py
@@ -8,6 +8,7 @@ thinking block tagged with its source model.
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 from unittest.mock import MagicMock, patch
 
@@ -22,7 +23,7 @@ def server():
         "sys.modules",
         {
             "hermes_constants": MagicMock(
-                get_hermes_home=MagicMock(return_value="/tmp/hermes_test_moa_emit")
+                get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test_moa_emit"))
             ),
             "hermes_cli.env_loader": MagicMock(),
             "hermes_cli.banner": MagicMock(),

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -7,6 +7,7 @@ import threading
 import time
 import types
 from unittest.mock import MagicMock, patch
+from pathlib import Path
 
 import pytest
 
@@ -28,7 +29,7 @@ def server():
     # (a fixed shared path) forever, leaking active-session registry entries
     # across every later test in the process. Scope the patch to the import.
     with patch.dict("sys.modules", {
-        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test"))),
         "hermes_cli.env_loader": MagicMock(),
         "hermes_cli.banner": MagicMock(),
         "hermes_state": MagicMock(),

--- a/tests/tui_gateway/test_review_summary_callback.py
+++ b/tests/tui_gateway/test_review_summary_callback.py
@@ -10,6 +10,7 @@ transcript line.
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 from unittest.mock import MagicMock, patch
 
@@ -24,7 +25,7 @@ def server():
         "sys.modules",
         {
             "hermes_constants": MagicMock(
-                get_hermes_home=MagicMock(return_value="/tmp/hermes_test_review_summary")
+                get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test_review_summary"))
             ),
             "hermes_cli.env_loader": MagicMock(),
             "hermes_cli.banner": MagicMock(),

--- a/tests/tui_gateway/test_slash_worker_profile_home.py
+++ b/tests/tui_gateway/test_slash_worker_profile_home.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 from unittest.mock import MagicMock, patch, call
+from pathlib import Path
 
 import pytest
 
@@ -11,7 +12,7 @@ import pytest
 def test_slash_worker_accepts_profile_home():
     """_SlashWorker.__init__ accepts profile_home parameter."""
     with patch.dict("sys.modules", {
-        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test"))),
     }):
         with patch("subprocess.Popen") as mock_popen:
             mock_popen.return_value.stdout = MagicMock()

--- a/tests/tui_gateway/test_subagent_child_mirror.py
+++ b/tests/tui_gateway/test_subagent_child_mirror.py
@@ -9,6 +9,7 @@ shows a real midstream turn instead of sitting silent until persistence.
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 from unittest.mock import MagicMock, patch
 
@@ -23,7 +24,7 @@ def server():
         "sys.modules",
         {
             "hermes_constants": MagicMock(
-                get_hermes_home=MagicMock(return_value="/tmp/hermes_test_child_mirror")
+                get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test_child_mirror"))
             ),
             "hermes_cli.env_loader": MagicMock(),
             "hermes_cli.banner": MagicMock(),

--- a/tests/tui_gateway/test_subprocess_encoding.py
+++ b/tests/tui_gateway/test_subprocess_encoding.py
@@ -13,6 +13,7 @@ the crash class cannot silently regress.
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 import subprocess
 from unittest.mock import MagicMock, patch
@@ -42,7 +43,7 @@ def test_slash_worker_popen_uses_utf8_replace():
     """
     with patch.dict("sys.modules", {
         "hermes_constants": MagicMock(
-            get_hermes_home=MagicMock(return_value="/tmp/hermes_test")
+            get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test"))
         ),
     }):
         with patch("subprocess.Popen") as mock_popen:


### PR DESCRIPTION
## Summary
Fixes the tui_gateway test failure currently breaking main CI: 8 test files mocked `hermes_constants.get_hermes_home` with a **str**, and importing `hermes_state` (which evaluates `DEFAULT_DB_PATH = get_hermes_home() / "state.db"` at module level) now blows up with `TypeError: unsupported operand type(s) for /: 'str' and 'str'`.

## Root cause
Commit 56a41715dc added `from hermes_state import _BARE_BILLING_PROVIDERS` to `tui_gateway/server.py`. That import chain reaches `hermes_state`'s module-level `get_hermes_home() / "state.db"` while the test's `sys.modules` stub is active — and the stub returned a plain string. The real function returns a `Path`; str-returning mocks were latent landmines in every file using this pattern.

## Changes
- tests/tui_gateway/ (8 files): `get_hermes_home=MagicMock(return_value="...")` → `MagicMock(return_value=Path("..."))`, adding the `pathlib.Path` import where missing. Whole class fixed, not just the one failing file.

## Validation
| | Before | After |
|---|---|---|
| `test_slash_worker_profile_home.py` at origin/main tip (clean worktree) | FAILED (TypeError) | — |
| Same test with this change | — | passed |
| All 82 tests across the 8 touched files | 1 failed | 82 passed |
| ruff on tests/tui_gateway/ | — | clean |

Bisected in clean worktrees: passes at 16b54e2a0f/4bbc6f258a, fails at 56a41715dc — the trigger is the new hermes_state import, the defect is the str mocks.

## Infographic

![fix the mock fix the class](https://files.catbox.moe/r3vk2i.png)
