### PR TITLE
test: validate PR #78485 against current main

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5513,7 +5513,50 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=500,
                 )
 
-        final_response = _resolve_media_to_data_urls(result.get("final_response", ""))
+        final_response = _resolve_media_to_data_urls(result.get("final_response") or "")
+        is_partial = bool(result.get("partial"))
+        is_failed = bool(result.get("failed"))
+        completed = bool(result.get("completed", True))
+        raw_err_msg = result.get("error")
+        err_msg = _redact_api_error_text(raw_err_msg) if raw_err_msg else raw_err_msg
+
+        # Resolve the effective session ID before handling failures. Successful
+        # responses persist it for future chaining, while failure responses are not
+        # stored but still expose the same session metadata in response headers.
+        # This also prevents previous_response_id chaining from resuming a
+        # pre-rotation session after compression.
+        _effective_session_id = session_id
+        _result_sid = result.get("session_id") if isinstance(result, dict) else None
+        if isinstance(_result_sid, str) and _result_sid:
+            _effective_session_id = _result_sid
+
+        response_headers = {"X-Hermes-Session-Id": _effective_session_id}
+        if gateway_session_key:
+            response_headers["X-Hermes-Session-Key"] = gateway_session_key
+
+        # Return an OpenAI-style error envelope when the agent reports a failed
+        # run, rather than rendering its internal failure text as assistant output.
+        if is_failed:
+            err_body = _openai_error(
+                err_msg or "Agent run did not produce a response.",
+                err_type="server_error",
+                code="agent_incomplete",
+            )
+            err_body["error"]["hermes"] = {
+                "completed": completed,
+                "partial": is_partial,
+                "failed": is_failed,
+            }
+            response_headers["X-Hermes-Completed"] = "false"
+            response_headers["X-Hermes-Partial"] = (
+                "true" if is_partial else "false"
+            )
+            return web.json_response(
+                err_body,
+                status=502,
+                headers=response_headers,
+            )
+
         if not final_response:
             final_response = _redact_api_error_text(result.get("error", "(No response generated)"))
 
@@ -5528,16 +5571,6 @@ class APIServerAdapter(BasePlatformAdapter):
             result,
             final_response,
         )
-
-        # Persist the effective session ID surfaced by _run_agent so that
-        # compression-triggered session rotations propagate to the stored
-        # response and the X-Hermes-Session-Id header.  Without this,
-        # previous_response_id chaining keeps resuming the pre-rotation
-        # session and re-triggers compression on every subsequent request.
-        _effective_session_id = session_id
-        _result_sid = result.get("session_id") if isinstance(result, dict) else None
-        if isinstance(_result_sid, str) and _result_sid:
-            _effective_session_id = _result_sid
 
         # Build output items from the current turn only.  AIAgent returns a
         # full transcript in result["messages"], while older/mocked paths may
@@ -5576,9 +5609,6 @@ class APIServerAdapter(BasePlatformAdapter):
             if conversation:
                 self._response_store.set_conversation(conversation, response_id)
 
-        response_headers = {"X-Hermes-Session-Id": _effective_session_id}
-        if gateway_session_key:
-            response_headers["X-Hermes-Session-Key"] = gateway_session_key
         return web.json_response(response_data, headers=response_headers)
 
     # ------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1352,6 +1352,51 @@ class TestResponsesEndpoint:
 
 
     @pytest.mark.asyncio
+    async def test_failed_response_returns_502_error_envelope(self, adapter):
+        """A failed agent run returns an OpenAI error envelope."""
+        mock_result = {
+            "final_response": "API call failed after 3 retries: Connection error.",
+            "completed": False,
+            "failed": True,
+            "error": "Connection error.",
+            "failure_reason": "timeout",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "total_tokens": 0,
+                    },
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Reply with only the word hello.",
+                        "stream": False,
+                        "store": False,
+                    },
+                )
+
+            assert resp.status == 502
+            data = await resp.json()
+            assert data["error"]["code"] == "agent_incomplete"
+            assert "connection error" in data["error"]["message"].lower()
+            assert data["error"]["hermes"]["completed"] is False
+            assert data["error"]["hermes"]["partial"] is False
+            assert data["error"]["hermes"]["failed"] is True
+            assert resp.headers.get("X-Hermes-Completed") == "false"
+            assert resp.headers.get("X-Hermes-Partial") == "false"
+
+
+    @pytest.mark.asyncio
     async def test_previous_response_id_stores_compressed_transcript_directly(self, adapter):
         """After compression, stored history is the compressed transcript, not prior + compressed."""
         prior_history = [


### PR DESCRIPTION
## Purpose

Validation-only PR for NousResearch/hermes-agent#78485 (`fix(api): return 502 for failed responses runs`).

This branch was created from the current upstream `main` (`56a41715d`) and cherry-picks the original PR commit onto it without conflicts.

The goal is to run the repository's current GitHub Actions CI on `ubuntu-latest`, especially the Python test suite, to distinguish the WSL2-specific `tests/tools/test_termux_api_detection.py` failure observed locally from an actual regression.

## Validation target

- Base: current `main`
- Original PR: NousResearch/hermes-agent#78485
- Change: `/v1/responses` returns HTTP 502 with `agent_incomplete` when the agent explicitly reports `failed=true`
- This PR is for CI validation only and should not be merged.