### PR TITLE
fix(config): only warn deprecated TERMINAL_CWD when actually defined in .env

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2146,9 +2146,35 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
 
     These env vars are deprecated — the canonical setting is terminal.cwd
     in config.yaml.  Prints a migration hint to stderr.
+
+    Only warns when the variable is actually *defined in the profile's .env*.
+    ``TERMINAL_CWD`` legitimately reaches ``os.environ`` through several
+    non-.env paths: the CLI's config bridge exports it for the local backend,
+    the desktop app injects it into child processes, and any ``hermes``
+    process exports it for its own children (browser daemons, LSP servers,
+    shells) — a nested ``hermes`` then inherits it.  Warning on the bare env
+    presence produced false "found in .env" positives for those inherited /
+    bridged values.
     """
-    messaging_cwd = os.environ.get("MESSAGING_CWD")
-    terminal_cwd_env = os.environ.get("TERMINAL_CWD")
+    from hermes_cli.env_loader import _env_keys_defined_in_dotenv
+
+    try:
+        from hermes_constants import get_hermes_home
+
+        dotenv_keys = _env_keys_defined_in_dotenv(get_hermes_home() / ".env")
+    except Exception:
+        dotenv_keys = None  # early bootstrap — fall back to env-presence check
+
+    messaging_cwd = (
+        os.environ.get("MESSAGING_CWD")
+        if dotenv_keys is None or "MESSAGING_CWD" in dotenv_keys
+        else None
+    )
+    terminal_cwd_env = (
+        os.environ.get("TERMINAL_CWD")
+        if dotenv_keys is None or "TERMINAL_CWD" in dotenv_keys
+        else None
+    )
 
     if config is None:
         try:

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -4,7 +4,16 @@
 class TestDeprecatedCwdWarning:
     """Warn when MESSAGING_CWD or TERMINAL_CWD is set in .env."""
 
+    def _write_dotenv(self, monkeypatch, text):
+        """Write ``text`` to the sandboxed HERMES_HOME/.env and reload env."""
+        from hermes_constants import get_hermes_home
+
+        env_path = get_hermes_home() / ".env"
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+        env_path.write_text(text)
+
     def test_messaging_cwd_triggers_warning(self, monkeypatch, capsys):
+        self._write_dotenv(monkeypatch, "MESSAGING_CWD=/some/path\n")
         monkeypatch.setenv("MESSAGING_CWD", "/some/path")
         monkeypatch.delenv("TERMINAL_CWD", raising=False)
 
@@ -16,8 +25,10 @@ class TestDeprecatedCwdWarning:
         assert "deprecated" in captured.err.lower()
         assert "config.yaml" in captured.err
 
-
     def test_both_deprecated_vars_warn(self, monkeypatch, capsys):
+        self._write_dotenv(
+            monkeypatch, "MESSAGING_CWD=/msg/path\nTERMINAL_CWD=/term/path\n"
+        )
         monkeypatch.setenv("MESSAGING_CWD", "/msg/path")
         monkeypatch.setenv("TERMINAL_CWD", "/term/path")
 
@@ -27,3 +38,33 @@ class TestDeprecatedCwdWarning:
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
         assert "TERMINAL_CWD" in captured.err
+
+    def test_inherited_terminal_cwd_does_not_warn(self, monkeypatch, capsys):
+        """TERMINAL_CWD inherited from a parent process must not warn.
+
+        Hermes itself exports TERMINAL_CWD for its children (config bridge,
+        desktop app injection); a nested ``hermes`` inherits it.  The warning
+        claims the value is "found in .env", so it must only fire when the
+        key is actually defined in .env.
+        """
+        # No .env entry — env value is inherited/bridged, not from .env.
+        self._write_dotenv(monkeypatch, "SOME_OTHER_KEY=1\n")
+        monkeypatch.setenv("TERMINAL_CWD", "/home/user")
+        monkeypatch.delenv("MESSAGING_CWD", raising=False)
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={})
+
+        captured = capsys.readouterr()
+        assert "TERMINAL_CWD" not in captured.err
+
+    def test_inherited_messaging_cwd_does_not_warn(self, monkeypatch, capsys):
+        """MESSAGING_CWD exported in a shell (not .env) must not warn."""
+        self._write_dotenv(monkeypatch, "SOME_OTHER_KEY=1\n")
+        monkeypatch.setenv("MESSAGING_CWD", "/exported/in/shell")
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={})
+
+        captured = capsys.readouterr()
+        assert "MESSAGING_CWD" not in captured.err


### PR DESCRIPTION
## Problem

`hermes chat` (and gateway startup) prints a false deprecation warning at launch:

```
⚠ Deprecated .env settings detected:
  ⚠ TERMINAL_CWD=/home/seppe found in .env — this is deprecated.
  Move to config.yaml instead:  terminal:\n    cwd: /your/project/path
  Then remove the old entries from ~/.hermes/.env
```

...even when `TERMINAL_CWD` is **not** in `.env` at all.

## Root cause

`warn_deprecated_cwd_env_vars()` fires on bare `os.environ` presence of `TERMINAL_CWD`. But Hermes itself legitimately puts that var into the environment through several non-.env paths:

- the CLI config bridge exports `TERMINAL_CWD=os.getcwd()` for the local backend (cli.py ~line 692),
- the desktop app injects it into the backend child process (apps/desktop/electron/main.ts ~8200),
- any running `hermes` process exports it for its own children (browser harness daemons, LSP servers, shells), so a **nested `hermes` invocation inherits it**.

For every one of those cases the warning claims the value was "found in .env" and tells the user to remove entries that don't exist.

## Fix

Gate the warning on the key being **actually defined in the profile's `.env`**, reusing `env_loader._env_keys_defined_in_dotenv` (the same fast scanner the profile-managed-key cleanup uses). Falls back to the old env-presence behavior only when the scan is unavailable during very early bootstrap. `MESSAGING_CWD` gets the same gate so a plain shell export can no longer trigger a false "found in .env" line either.

## Tests

- The two existing tests now write the keys into the sandboxed `HERMES_HOME/.env` (matching what they claim to test — previously they only set `os.environ`, i.e. they encoded the false-positive path).
- New regression tests: inherited `TERMINAL_CWD` and shell-exported `MESSAGING_CWD` stay silent.

```
$ python -m pytest tests/hermes_cli/test_deprecated_cwd_warning.py -q -o addopts=
....                                                                     [100%]
4 passed in 0.13s
```

Verified end-to-end on a real install: launching `hermes chat` with an inherited `TERMINAL_CWD=/home/seppe` (reproducing the report) no longer prints the warning, while an actual `TERMINAL_CWD=` line in `.env` still does.
