### PR TITLE
fix(mcp_oauth): preserve refresh_token when a refresh response omits it (supersedes #25876, #62431)

### DIFF
--- a/tests/tools/test_mcp_oauth_refresh_token_carry_forward.py
+++ b/tests/tools/test_mcp_oauth_refresh_token_carry_forward.py
@@ -1,0 +1,251 @@
+"""Tests for refresh_token preservation in ``HermesTokenStorage.set_tokens``.
+
+RFC 6749 §6 makes a new refresh token optional on the
+``grant_type=refresh_token`` exchange, and requires the client to replace its
+stored token only "if the authorization server issued a new refresh token". A
+response that omits ``refresh_token`` therefore obliges the client to keep the
+one it already has.
+
+``set_tokens`` used to violate that. It serialized with
+``model_dump(mode="json", exclude_none=True)`` and wrote the result over the
+token file unconditionally, so a refresh response without a ``refresh_token``
+erased the stored one — not even leaving an explicit null behind.
+
+Observed consequence, on a provider whose AS does not rotate (Asana returns
+``refresh_token`` only on the ``authorization_code`` grant, and its access
+tokens live one hour):
+
+    T+0h    login, connector healthy
+    T+1h    access token expires -> refresh succeeds -> stored refresh_token
+            is destroyed
+    T+2h    access token expires -> nothing to refresh with -> 401 -> the SDK
+            falls back to a full authorization_code grant
+
+Interactively that shows up as the OAuth browser dance repeating about one TTL
+after every successful login. On a headless gateway there is no browser, so
+the server is marked "failed initial OAuth authentication, not retrying
+automatically" and its tools vanish for the life of the process.
+
+The contract pinned here:
+
+- A refresh response that omits ``refresh_token`` must not reduce the stored
+  credential set.
+- A refresh response that carries a new ``refresh_token`` must still replace
+  the stored one (rotation keeps working).
+- The carry-forward must land on the ``OAuthToken`` the caller passed in, not
+  only on the serialized payload. The SDK's
+  ``OAuthClientProvider._handle_refresh_response`` assigns
+  ``context.current_tokens = token_response`` and then hands that same object
+  to ``storage.set_tokens``, so repairing only the payload leaves the live
+  provider with ``refresh_token=None``; ``context.can_refresh_token()`` is
+  then False at the next expiry and the connector still dies inside the
+  running process, recovering only on restart when ``_initialize`` re-reads
+  the file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+pytest.importorskip("mcp.client.auth.oauth2", reason="MCP SDK 1.26.0+ required")
+
+
+def _stored(tmp_path, server: str = "srv") -> dict:
+    return json.loads((tmp_path / "mcp-tokens" / f"{server}.json").read_text())
+
+
+class TestRefreshTokenCarryForward:
+    def test_omitted_refresh_token_preserves_the_stored_one(self, tmp_path, monkeypatch):
+        """A refresh response without refresh_token must not erase the stored one."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from mcp.shared.auth import OAuthToken
+        from tools.mcp_oauth import HermesTokenStorage
+
+        storage = HermesTokenStorage("srv")
+
+        # authorization_code grant: carries a refresh token.
+        asyncio.run(
+            storage.set_tokens(
+                OAuthToken(
+                    access_token="access-1",
+                    token_type="Bearer",
+                    expires_in=3600,
+                    refresh_token="refresh-1",
+                )
+            )
+        )
+        assert _stored(tmp_path)["refresh_token"] == "refresh-1"
+
+        # refresh_token grant, non-rotating AS: no refresh_token in the response.
+        asyncio.run(
+            storage.set_tokens(
+                OAuthToken(
+                    access_token="access-2",
+                    token_type="Bearer",
+                    expires_in=3600,
+                )
+            )
+        )
+
+        on_disk = _stored(tmp_path)
+        assert on_disk["refresh_token"] == "refresh-1", (
+            "A refresh response that omits refresh_token must leave the stored "
+            "one intact (RFC 6749 §6); otherwise the next expiry has nothing to "
+            "refresh with and forces a full browser re-authorization."
+        )
+        assert on_disk["access_token"] == "access-2", (
+            "The new access token must still be persisted."
+        )
+
+    def test_carry_forward_also_repairs_the_passed_token_object(self, tmp_path, monkeypatch):
+        """The live OAuthToken must be repaired, not just the serialized payload.
+
+        The SDK hands ``set_tokens`` the very object it has just assigned to
+        ``context.current_tokens``. Repairing only the JSON payload fixes the
+        file while leaving the running provider unable to refresh, so the
+        connector still dies at the next expiry and only recovers on restart.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from mcp.shared.auth import OAuthToken
+        from tools.mcp_oauth import HermesTokenStorage
+
+        storage = HermesTokenStorage("srv")
+        asyncio.run(
+            storage.set_tokens(
+                OAuthToken(
+                    access_token="access-1",
+                    token_type="Bearer",
+                    expires_in=3600,
+                    refresh_token="refresh-1",
+                )
+            )
+        )
+
+        refreshed = OAuthToken(
+            access_token="access-2", token_type="Bearer", expires_in=3600
+        )
+        asyncio.run(storage.set_tokens(refreshed))
+
+        assert refreshed.refresh_token == "refresh-1", (
+            "set_tokens must restore refresh_token on the OAuthToken it was "
+            "given, because that object is the SDK's context.current_tokens. "
+            "Without this, context.can_refresh_token() is False at the next "
+            "expiry even though the file on disk is correct."
+        )
+
+    def test_rotated_refresh_token_replaces_the_stored_one(self, tmp_path, monkeypatch):
+        """A rotating AS must still be able to replace the stored refresh token."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from mcp.shared.auth import OAuthToken
+        from tools.mcp_oauth import HermesTokenStorage
+
+        storage = HermesTokenStorage("srv")
+        asyncio.run(
+            storage.set_tokens(
+                OAuthToken(
+                    access_token="access-1",
+                    token_type="Bearer",
+                    expires_in=3600,
+                    refresh_token="refresh-1",
+                )
+            )
+        )
+
+        rotated = OAuthToken(
+            access_token="access-2",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="refresh-2",
+        )
+        asyncio.run(storage.set_tokens(rotated))
+
+        assert _stored(tmp_path)["refresh_token"] == "refresh-2", (
+            "An explicitly returned refresh_token must replace the stored one, "
+            "or rotation-based providers would be pinned to a consumed token."
+        )
+        assert rotated.refresh_token == "refresh-2", (
+            "Carry-forward must not overwrite a genuinely rotated token."
+        )
+
+    def test_consecutive_omitting_refreshes_keep_the_refresh_token(self, tmp_path, monkeypatch):
+        """The token must survive repeated refreshes, not just the first.
+
+        The original bug was only visible on the *second* expiry: the first
+        refresh succeeded and looked healthy while silently destroying the
+        credential it would need an hour later.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from mcp.shared.auth import OAuthToken
+        from tools.mcp_oauth import HermesTokenStorage
+
+        storage = HermesTokenStorage("srv")
+        asyncio.run(
+            storage.set_tokens(
+                OAuthToken(
+                    access_token="access-0",
+                    token_type="Bearer",
+                    expires_in=3600,
+                    refresh_token="refresh-1",
+                )
+            )
+        )
+
+        for i in range(1, 6):
+            token = OAuthToken(
+                access_token=f"access-{i}", token_type="Bearer", expires_in=3600
+            )
+            asyncio.run(storage.set_tokens(token))
+            assert token.refresh_token == "refresh-1", f"lost in-memory at refresh {i}"
+            assert _stored(tmp_path)["refresh_token"] == "refresh-1", (
+                f"lost on disk at refresh {i}"
+            )
+
+    def test_first_write_without_any_stored_refresh_token_is_clean(self, tmp_path, monkeypatch):
+        """A provider that issues no refresh token at all must still persist.
+
+        There is nothing to carry forward here; the write must succeed and must
+        not fabricate the field.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from mcp.shared.auth import OAuthToken
+        from tools.mcp_oauth import HermesTokenStorage
+
+        storage = HermesTokenStorage("srv")
+        asyncio.run(
+            storage.set_tokens(
+                OAuthToken(access_token="access-1", token_type="Bearer", expires_in=3600)
+            )
+        )
+
+        on_disk = _stored(tmp_path)
+        assert on_disk["access_token"] == "access-1"
+        assert "refresh_token" not in on_disk
+
+    def test_carry_forward_is_scoped_per_server(self, tmp_path, monkeypatch):
+        """One server's refresh token must never leak into another's file."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from mcp.shared.auth import OAuthToken
+        from tools.mcp_oauth import HermesTokenStorage
+
+        asyncio.run(
+            HermesTokenStorage("alpha").set_tokens(
+                OAuthToken(
+                    access_token="a",
+                    token_type="Bearer",
+                    expires_in=3600,
+                    refresh_token="alpha-refresh",
+                )
+            )
+        )
+
+        beta_token = OAuthToken(
+            access_token="b", token_type="Bearer", expires_in=3600
+        )
+        asyncio.run(HermesTokenStorage("beta").set_tokens(beta_token))
+
+        assert beta_token.refresh_token is None
+        assert "refresh_token" not in _stored(tmp_path, "beta")
+        assert _stored(tmp_path, "alpha")["refresh_token"] == "alpha-refresh"

--- a/tests/tools/test_mcp_oauth_refresh_token_carry_forward.py
+++ b/tests/tools/test_mcp_oauth_refresh_token_carry_forward.py
@@ -249,3 +249,51 @@ class TestRefreshTokenCarryForward:
         assert beta_token.refresh_token is None
         assert "refresh_token" not in _stored(tmp_path, "beta")
         assert _stored(tmp_path, "alpha")["refresh_token"] == "alpha-refresh"
+
+
+class TestCarryForwardDegradesGracefully:
+    """A damaged previous token file must not block persisting a good new one.
+
+    The carry-forward reads the stored token before writing. ``get_tokens``
+    tolerates a missing file and a schema-invalid payload, but not every shape:
+    ``_read_json`` returns whatever ``json.loads`` produced, so a file holding a
+    JSON list, or a string ``expires_at``, raises out of ``get_tokens`` before
+    the ``model_validate`` guard. Refresh must still land in that case —
+    degrading to the previous overwrite behaviour is strictly better than
+    failing the write and leaving the SDK believing it persisted a token.
+    """
+
+    def _seed(self, tmp_path, payload: str, server: str = "srv") -> None:
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir(parents=True, exist_ok=True)
+        (token_dir / f"{server}.json").write_text(payload)
+
+    @pytest.mark.parametrize(
+        "payload,label",
+        [
+            ('[1, 2, 3]', "json list instead of an object"),
+            ('"just-a-string"', "json string instead of an object"),
+            ('{"access_token": "a", "expires_at": "not-a-number"}', "non-numeric expires_at"),
+        ],
+    )
+    def test_damaged_previous_file_still_persists_the_new_token(
+        self, tmp_path, monkeypatch, payload, label
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from mcp.shared.auth import OAuthToken
+        from tools.mcp_oauth import HermesTokenStorage
+
+        self._seed(tmp_path, payload)
+        storage = HermesTokenStorage("srv")
+
+        asyncio.run(
+            storage.set_tokens(
+                OAuthToken(access_token="fresh", token_type="Bearer", expires_in=3600)
+            )
+        )
+
+        on_disk = _stored(tmp_path)
+        assert on_disk["access_token"] == "fresh", (
+            f"a {label} in the stored file must not prevent the refreshed access "
+            "token from being written"
+        )

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -493,34 +493,55 @@ class HermesTokenStorage:
             return None
 
     async def set_tokens(self, tokens: "OAuthToken") -> None:
-        payload = tokens.model_dump(mode="json", exclude_none=True)
-
-        # Per RFC 6749 §10.4, when a client uses ``grant_type=refresh_token``,
+        # Per RFC 6749 §6, when a client uses ``grant_type=refresh_token``,
         # the authorization server MAY rotate the refresh token (return a new
         # one) OR keep the existing one (return no refresh_token field in the
-        # response). Both are spec-compliant.
+        # response). Both are spec-compliant, and §6 is explicit that the
+        # client must replace its stored token only "if the authorization
+        # server issued a new refresh token".
         #
         # Bug: when the server's refresh response omits the refresh_token,
-        # ``model_dump(exclude_none=True)`` above drops the field from
-        # ``payload``, and the unconditional ``_write_json`` below overwrites
-        # the stored file with no refresh_token. The original refresh_token
-        # is lost. On the NEXT access-token expiry, the SDK has no
-        # refresh_token to use and falls back to a full ``authorization_code``
-        # browser flow — i.e. the user sees the OAuth dance again roughly
-        # one TTL after their last successful auth, every time.
+        # ``model_dump(exclude_none=True)`` below drops the field, and the
+        # unconditional ``_write_json`` overwrites the stored file with no
+        # refresh_token at all — not even an explicit null. The original
+        # refresh_token is lost. On the NEXT access-token expiry the SDK has
+        # nothing to refresh with and falls back to a full
+        # ``authorization_code`` browser flow, so the user re-does the OAuth
+        # dance roughly one TTL after their last successful auth, forever. On
+        # a headless gateway there is no browser, so the server is instead
+        # marked "failed initial OAuth authentication, not retrying
+        # automatically" and its tools disappear for the life of the process.
         #
-        # Fix: if the refresh response didn't include a refresh_token,
-        # preserve the existing one from on-disk storage. Standard
-        # well-behaved OAuth client behavior.
-        if "refresh_token" not in payload:
-            existing = _read_json(self._tokens_path())
-            if existing and existing.get("refresh_token"):
-                payload["refresh_token"] = existing["refresh_token"]
+        # Fix: if the refresh response carried no refresh_token, restore the
+        # stored one.
+        #
+        # This MUST be done on the ``tokens`` object and not merely on the
+        # serialized ``payload``. The MCP SDK's
+        # ``OAuthClientProvider._handle_refresh_response`` does::
+        #
+        #     token_response = OAuthToken.model_validate_json(content)
+        #     self.context.current_tokens = token_response
+        #     await self.context.storage.set_tokens(token_response)
+        #
+        # i.e. the object handed to us *is* ``context.current_tokens``.
+        # Repairing only the payload leaves the live provider holding
+        # ``refresh_token=None``, so ``context.can_refresh_token()`` is False
+        # at the next expiry and the connector still dies inside this
+        # process — it would only recover on restart, when ``_initialize``
+        # re-reads the file. Assigning through the model repairs both the
+        # running provider and the file, because ``payload`` is derived
+        # afterwards.
+        if not tokens.refresh_token:
+            previous = await self.get_tokens()
+            if previous is not None and previous.refresh_token:
+                tokens.refresh_token = previous.refresh_token
                 logger.debug(
                     "OAuth refresh response for %s omitted refresh_token; "
-                    "preserving existing one from disk",
+                    "preserving the existing one",
                     self._server_name,
                 )
+
+        payload = tokens.model_dump(mode="json", exclude_none=True)
 
         # Persist an absolute ``expires_at`` so a process restart can
         # reconstruct the correct remaining TTL. Without this the MCP SDK's

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -494,6 +494,34 @@ class HermesTokenStorage:
 
     async def set_tokens(self, tokens: "OAuthToken") -> None:
         payload = tokens.model_dump(mode="json", exclude_none=True)
+
+        # Per RFC 6749 §10.4, when a client uses ``grant_type=refresh_token``,
+        # the authorization server MAY rotate the refresh token (return a new
+        # one) OR keep the existing one (return no refresh_token field in the
+        # response). Both are spec-compliant.
+        #
+        # Bug: when the server's refresh response omits the refresh_token,
+        # ``model_dump(exclude_none=True)`` above drops the field from
+        # ``payload``, and the unconditional ``_write_json`` below overwrites
+        # the stored file with no refresh_token. The original refresh_token
+        # is lost. On the NEXT access-token expiry, the SDK has no
+        # refresh_token to use and falls back to a full ``authorization_code``
+        # browser flow — i.e. the user sees the OAuth dance again roughly
+        # one TTL after their last successful auth, every time.
+        #
+        # Fix: if the refresh response didn't include a refresh_token,
+        # preserve the existing one from on-disk storage. Standard
+        # well-behaved OAuth client behavior.
+        if "refresh_token" not in payload:
+            existing = _read_json(self._tokens_path())
+            if existing and existing.get("refresh_token"):
+                payload["refresh_token"] = existing["refresh_token"]
+                logger.debug(
+                    "OAuth refresh response for %s omitted refresh_token; "
+                    "preserving existing one from disk",
+                    self._server_name,
+                )
+
         # Persist an absolute ``expires_at`` so a process restart can
         # reconstruct the correct remaining TTL. Without this the MCP SDK's
         # ``_initialize`` reloads a relative ``expires_in`` which has no

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -493,6 +493,17 @@ class HermesTokenStorage:
             return None
 
     async def set_tokens(self, tokens: "OAuthToken") -> None:
+        """Persist *tokens*, preserving a refresh token the response omitted.
+
+        .. note::
+           ``tokens`` MAY BE MUTATED. When the incoming token carries no
+           ``refresh_token`` and one is already stored, it is assigned onto
+           ``tokens`` before serialization. This is deliberate: the MCP SDK
+           passes the same object it holds as ``context.current_tokens``, so
+           the assignment is what keeps the *live* provider able to refresh —
+           see the comment below. Callers that need an unmutated instance
+           should pass a copy.
+        """
         # Per RFC 6749 §6, when a client uses ``grant_type=refresh_token``,
         # the authorization server MAY rotate the refresh token (return a new
         # one) OR keep the existing one (return no refresh_token field in the
@@ -532,7 +543,26 @@ class HermesTokenStorage:
         # running provider and the file, because ``payload`` is derived
         # afterwards.
         if not tokens.refresh_token:
-            previous = await self.get_tokens()
+            # Never let reading the previous token block persisting the new
+            # one. ``get_tokens`` tolerates a missing file and a schema-invalid
+            # payload, but not every shape: ``_read_json`` returns whatever
+            # ``json.loads`` produced, so a file holding a JSON list, or a
+            # string ``expires_at``, raises before the ``model_validate``
+            # guard. Without this catch a damaged token file would fail the
+            # write and leave the SDK believing it had persisted a token it
+            # had not — strictly worse than the pre-carry-forward behaviour,
+            # which simply overwrote.
+            try:
+                previous = await self.get_tokens()
+            except Exception as exc:  # noqa: BLE001 — persistence must not fail.
+                logger.warning(
+                    "OAuth tokens for %s: could not read the stored token to "
+                    "preserve its refresh_token (%s); writing the new token "
+                    "without carry-forward",
+                    self._server_name,
+                    exc,
+                )
+                previous = None
             if previous is not None and previous.refresh_token:
                 tokens.refresh_token = previous.refresh_token
                 logger.debug(


### PR DESCRIPTION
Builds on #25876 (@jespey's commit is cherry-picked here, authorship intact) and completes it. Also supersedes the duplicate #62431 (@AlexFucuson9) and closes #62333.

Two things this adds over the existing PRs:

1. The regression coverage requested in review on #62431.
2. A fix for the half of the bug both PRs leave in place — carrying the token forward on the serialized payload repairs the file but **not** the running process, so a connector on a non-rotating AS still dies at the next expiry.

## The bug

`HermesTokenStorage.set_tokens` serializes with `model_dump(mode="json", exclude_none=True)` and writes the result over the token file unconditionally. When a refresh response omits `refresh_token`, the field is dropped and the stored one is erased — not even an explicit `null` survives.

RFC 6749 §6 makes the new refresh token optional and requires the client to replace its stored copy only "if the authorization server issued a new refresh token". An omitted `refresh_token` obliges the client to keep what it has.

Providers that do not rotate therefore break on a clock. Asana returns `refresh_token` only on the `authorization_code` grant, and its access tokens live one hour:

```
T+0h   login, connector healthy, tools registered
T+1h   access token expires -> refresh succeeds -> stored refresh_token destroyed
T+2h   access token expires -> nothing to refresh with -> 401 -> SDK falls back
       to a full authorization_code grant
```

Interactively that is the OAuth browser dance repeating about one TTL after every login. On a headless gateway there is no browser, so the server is marked *"failed initial OAuth authentication, not retrying automatically"* and its tools disappear for the life of the process. The first hour looks perfectly healthy, which is why this reads as flaky rather than deterministic.

## Why payload-only is not enough

The SDK's `OAuthClientProvider._handle_refresh_response`:

```python
token_response = OAuthToken.model_validate_json(content)
self.context.current_tokens = token_response
self.context.update_token_expiry(token_response)
await self.context.storage.set_tokens(token_response)
```

The object handed to `set_tokens` **is** `context.current_tokens`. `model_dump()` returns a copy, so mutating `payload` never reaches the provider. `context.current_tokens.refresh_token` stays `None`, `context.can_refresh_token()` is False one TTL later, no `Authorization` header is sent, the server answers 401, and the SDK enters a full authorization-code grant. `_initialized` is still True at that point (the earlier refresh returned success), so the corrected file is never re-read — the fix only takes effect on the next process start.

Measured against the real `HermesTokenStorage` and the real SDK `OAuthToken`, scenario "gateway up, access token just expired, refresh succeeded, response carried no refresh_token":

| variant | file | live token object | `can_refresh_token()` at next expiry |
|---|---|---|---|
| payload-only (#25876, #62431) | ok | `None` | **False** |
| assignment through the model (this PR) | ok | restored | True |

So the carry-forward is applied to the `OAuthToken` before serialization; `payload` is derived afterwards, and one assignment leaves both the provider and the file correct. It reads through the public `get_tokens()` rather than `_read_json` + `_tokens_path`, inheriting its missing/corrupt-file handling — its `expires_in` rewriting is irrelevant here because only `refresh_token` is read off the result.

## Scope and safety

- Only fills a **missing** value. A rotating AS sends a new token, we leave it alone, and rotation keeps working — which is also what §6 requires.
- Cannot resurrect a revoked grant across logins: `hermes mcp login` calls `HermesTokenStorage.clear()` first, unlinking the token, client-info and metadata files, so a re-login always starts clean.
- No races: the SDK calls `set_tokens` under `context.lock`, and each server has its own token file.
- Per-server scoped; one server's refresh token cannot leak into another's file (covered by a test).
- No config surface, no new env var, no new tool. Behaviour-only change inside an existing method.

## Tests

New file `tests/tools/test_mcp_oauth_refresh_token_carry_forward.py`. The pre-existing round trip in `tests/tools/test_mcp_oauth.py` only exercises a token that already contains `refresh_token`, which is the gap called out in review. Six behaviour contracts:

- a refresh response omitting `refresh_token` must not reduce the stored credential set
- the passed `OAuthToken` must be repaired too — the one that distinguishes a live fix from a file-only fix
- an explicitly rotated `refresh_token` must still replace the stored one
- five consecutive omitting refreshes must all hold, since the original bug only became visible on the second expiry
- a provider that issues no refresh token at all must persist cleanly, without a fabricated field
- carry-forward must be scoped per server

They discriminate between all three states, via `scripts/run_tests.sh`:

```
upstream main, no fix          3 failed, 3 passed
payload-only carry-forward     2 failed, 4 passed
this PR                        6 passed
```

The two failures under payload-only are exactly the in-memory assertions.

No regressions in the neighbouring suites — `test_mcp_oauth.py` + `test_mcp_oauth_cold_load_expiry.py` + `test_mcp_oauth_bidirectional.py`: **60 passed**.

## Field evidence

A gateway running the equivalent fix stayed up 15h45m on a single process (`NRestarts=0`) across **15 consecutive hourly Asana refreshes**, every one of them omitting `refresh_token` and every one carried forward:

```
INFO ...: MCP OAuth 'asana': refresh response omitted refresh_token;
carried the existing one forward (RFC 6749 §6).
```

Before the fix the connector died at refresh #2, every time, about two hours after each login. Grouping those log lines by server gave **15 asana and zero** for atlassian, dot, glean and granola — which also confirms the code path is inert for providers that do rotate. Live round-trips through the agent (`get_my_tasks` against Asana) returned real data afterwards.

## Credit

- @jespey — original diagnosis and fix (#25876), cherry-picked here.
- @AlexFucuson9 — independent report and equivalent patch (#62431).

Happy to reshape this as a review-suggestion on #25876 instead if you'd rather keep that PR as the landing branch.
