### PR TITLE
fix(memory): canonical LF memory serialization (salvage #85856)

### DIFF
--- a/hermes_cli/agent_import.py
+++ b/hermes_cli/agent_import.py
@@ -622,6 +622,7 @@ class AgentImporter:
                 atomic_write_text(
                     destination,
                     ENTRY_DELIMITER.join(merged) + ("\n" if merged else ""),
+                    newline="\n",
                 )
             except OSError as exc:
                 self.record(kind, source, destination, "error",

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -1322,7 +1322,11 @@ class Migrator:
                 return
             backup_path = self.maybe_backup(destination)
             ensure_parent(destination)
-            destination.write_text(ENTRY_DELIMITER.join(merged) + ("\n" if merged else ""), encoding="utf-8")
+            destination.write_text(
+                ENTRY_DELIMITER.join(merged) + ("\n" if merged else ""),
+                encoding="utf-8",
+                newline="\n",
+            )
             self.record(
                 kind,
                 source,
@@ -2080,7 +2084,11 @@ class Migrator:
                 return
             backup_path = self.maybe_backup(destination)
             ensure_parent(destination)
-            destination.write_text(ENTRY_DELIMITER.join(merged) + ("\n" if merged else ""), encoding="utf-8")
+            destination.write_text(
+                ENTRY_DELIMITER.join(merged) + ("\n" if merged else ""),
+                encoding="utf-8",
+                newline="\n",
+            )
             self.record(
                 "daily-memory",
                 source_dir,

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -447,7 +447,7 @@ class TestExistingMemoryStorePreserved:
             self, claude_tree, seeded_home):
         path = seeded_home / "memories" / "MEMORY.md"
         run_import("claude-code", claude_tree, seeded_home, execute=True)
-        assert bytes((13, 10)) not in path.read_bytes()
+        assert b"\r\n" not in path.read_bytes()
         entries = path.read_text(encoding="utf-8").split(ENTRY_DELIMITER)
         # The pre-existing store survives byte-intact as a SINGLE entry ...
         assert entries[0] == EXISTING_MEMORY.strip()

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -447,6 +447,7 @@ class TestExistingMemoryStorePreserved:
             self, claude_tree, seeded_home):
         path = seeded_home / "memories" / "MEMORY.md"
         run_import("claude-code", claude_tree, seeded_home, execute=True)
+        assert bytes((13, 10)) not in path.read_bytes()
         entries = path.read_text(encoding="utf-8").split(ENTRY_DELIMITER)
         # The pre-existing store survives byte-intact as a SINGLE entry ...
         assert entries[0] == EXISTING_MEMORY.strip()

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -523,7 +523,7 @@ def test_daily_memory_merged(tmp_path: Path):
     report = migrator.migrate()
     mem_path = target / "memories" / "MEMORY.md"
     assert mem_path.exists()
-    assert bytes((13, 10)) not in mem_path.read_bytes()
+    assert b"\r\n" not in mem_path.read_bytes()
     content = mem_path.read_text(encoding="utf-8")
     assert "dark mode" in content
     assert "migration project" in content

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -523,6 +523,7 @@ def test_daily_memory_merged(tmp_path: Path):
     report = migrator.migrate()
     mem_path = target / "memories" / "MEMORY.md"
     assert mem_path.exists()
+    assert bytes((13, 10)) not in mem_path.read_bytes()
     content = mem_path.read_text(encoding="utf-8")
     assert "dark mode" in content
     assert "migration project" in content

--- a/tests/test_atomic_write_text_newline.py
+++ b/tests/test_atomic_write_text_newline.py
@@ -1,0 +1,21 @@
+"""Behavior contracts for ``atomic_write_text`` newline handling."""
+
+import os
+
+from utils import atomic_write_text
+
+
+def test_explicit_lf_disables_platform_newline_translation(tmp_path):
+    target = tmp_path / "canonical.txt"
+
+    atomic_write_text(target, "first\nsecond", newline="\n")
+
+    assert target.read_bytes() == b"first\nsecond"
+
+
+def test_default_preserves_platform_native_newline_behavior(tmp_path):
+    target = tmp_path / "native.txt"
+
+    atomic_write_text(target, "first\nsecond")
+
+    assert target.read_bytes() == f"first{os.linesep}second".encode()

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -5,6 +5,7 @@ import pytest
 from pathlib import Path
 
 from tools.memory_tool import (
+    ENTRY_DELIMITER,
     MemoryStore,
     memory_tool,
     _scan_memory_content,
@@ -245,6 +246,47 @@ class TestMemoryConsolidationGracefulDegrade:
 
 
 class TestMemoryStorePersistence:
+    @pytest.mark.parametrize(
+        "delimiter",
+        [
+            pytest.param(ENTRY_DELIMITER, id="lf"),
+            pytest.param(
+                chr(13) + chr(10) + "§" + chr(13) + chr(10), id="crlf"
+            ),
+            pytest.param("\n§" + chr(13) + chr(10), id="mixed"),
+        ],
+    )
+    @pytest.mark.parametrize("action", ["replace", "remove"])
+    def test_line_endings_survive_parse_mutation_roundtrip(
+        self, tmp_path, monkeypatch, delimiter, action
+    ):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        path = tmp_path / "MEMORY.md"
+        raw = f"first entry{delimiter}second entry"
+        path.write_bytes(raw.encode("utf-8"))
+        store = MemoryStore()
+
+        # Parsing must be robust at the serialization boundary, even when the
+        # caller supplies raw decoded bytes rather than universal-newline text.
+        assert MemoryStore._parse_entries(raw) == ["first entry", "second entry"]
+        assert store._detect_external_drift("memory", raw) is None
+
+        store.load_from_disk()
+        assert store.memory_entries == ["first entry", "second entry"]
+
+        if action == "replace":
+            result = store.replace("memory", "first", "updated first entry")
+            expected = ["updated first entry", "second entry"]
+        else:
+            result = store.remove("memory", "first")
+            expected = ["second entry"]
+
+        assert result["success"] is True
+        persisted = path.read_bytes()
+        assert bytes((13, 10)) not in persisted
+        assert persisted.decode("utf-8") == ENTRY_DELIMITER.join(expected)
+        assert MemoryStore._parse_entries(persisted.decode("utf-8")) == expected
+
     def test_save_and_load_roundtrip(self, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
 

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -251,9 +251,9 @@ class TestMemoryStorePersistence:
         [
             pytest.param(ENTRY_DELIMITER, id="lf"),
             pytest.param(
-                chr(13) + chr(10) + "§" + chr(13) + chr(10), id="crlf"
+                "\r\n§\r\n", id="crlf"
             ),
-            pytest.param("\n§" + chr(13) + chr(10), id="mixed"),
+            pytest.param("\n§\r\n", id="mixed"),
         ],
     )
     @pytest.mark.parametrize("action", ["replace", "remove"])
@@ -283,7 +283,7 @@ class TestMemoryStorePersistence:
 
         assert result["success"] is True
         persisted = path.read_bytes()
-        assert bytes((13, 10)) not in persisted
+        assert b"\r\n" not in persisted
         assert persisted.decode("utf-8") == ENTRY_DELIMITER.join(expected)
         assert MemoryStore._parse_entries(persisted.decode("utf-8")) == expected
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -37,6 +37,7 @@ from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any, ClassVar
 from pathlib import Path
 from tools.binary_extensions import BINARY_EXTENSIONS
+from utils import normalize_newlines
 
 from agent.file_safety import (
     build_write_denied_paths,
@@ -103,19 +104,10 @@ def _detect_line_ending(sample: str) -> Optional[str]:
 def _normalize_line_endings(text: str, target: str) -> str:
     """Convert all line endings in ``text`` to ``target`` (``\\n`` or ``\\r\\n``).
 
-    Idempotent: ``_normalize_line_endings(_normalize_line_endings(x, "\\r\\n"), "\\r\\n") == _normalize_line_endings(x, "\\r\\n")``.
-    Strips lone ``\\r`` characters as well, so mixed-ending content is
-    homogenized in a single pass.
+    Thin alias for :func:`utils.normalize_newlines`, kept for the existing
+    call sites in this module.
     """
-    # First collapse to LF (handle CRLF and lone CR), then expand if target
-    # is CRLF.  Order matters: doing the replacements separately would
-    # double-convert a CRLF -> LFLF.
-    lf_normalized = text.replace("\r\n", "\n").replace("\r", "\n")
-    if target == "\n":
-        return lf_normalized
-    if target == "\r\n":
-        return lf_normalized.replace("\n", "\r\n")
-    return text
+    return normalize_newlines(text, target)
 
 
 # UTF-8 byte order mark. Some Windows editors (Notepad, older Visual Studio,

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -67,6 +67,11 @@ MEMORY_BLOCK_HEADERS = {
 ENTRY_DELIMITER = "\n§\n"
 
 
+def _normalize_line_endings(text: str) -> str:
+    """Return text with CRLF and legacy CR line endings normalized to LF."""
+    return text.replace(chr(13) + chr(10), "\n").replace(chr(13), "\n")
+
+
 # ---------------------------------------------------------------------------
 # Memory content scanning — lightweight check for injection/exfiltration
 # in content that gets injected into the system prompt.
@@ -783,9 +788,13 @@ class MemoryStore:
         """Split raw memory-file text into stripped, non-empty entries."""
         if not raw.strip():
             return []
-        # Use ENTRY_DELIMITER for consistency with _write_file. Splitting by "§"
-        # alone would incorrectly split entries that contain "§" in their content.
-        entries = [e.strip() for e in raw.split(ENTRY_DELIMITER)]
+        # Normalize before splitting so LF, CRLF, and mixed-line-ending files all
+        # recognize the same delimiter. Splitting by "§" alone would incorrectly
+        # split entries that contain it as content.
+        entries = [
+            e.strip()
+            for e in _normalize_line_endings(raw).split(ENTRY_DELIMITER)
+        ]
         return [e for e in entries if e]
 
     @staticmethod
@@ -825,9 +834,9 @@ class MemoryStore:
         The memory file is supposed to be a list of small entries the tool
         wrote, joined by §. Detect drift via two signals:
 
-        1. Round-trip mismatch — re-parsing and re-serializing the file
-           doesn't produce identical bytes (rare; would catch oddly-encoded
-           delimiters).
+        1. Semantic round-trip mismatch — after normalizing line endings,
+           re-parsing and re-serializing the file changes its content. LF and
+           CRLF delimiters are both valid input and are not treated as drift.
         2. Entry-size overflow — any single parsed entry exceeds the
            store's whole-file char limit. The tool budgets the ENTIRE store
            against that limit; no single tool-written entry can exceed it.
@@ -847,13 +856,14 @@ class MemoryStore:
         if not raw.strip():
             return None
 
-        parsed = [e.strip() for e in raw.split(ENTRY_DELIMITER) if e.strip()]
+        parsed = self._parse_entries(raw)
         roundtrip = ENTRY_DELIMITER.join(parsed)
+        normalized_raw = _normalize_line_endings(raw).strip()
 
         char_limit = self._char_limit(target)
         max_entry_len = max((len(e) for e in parsed), default=0)
 
-        drift_detected = (raw.strip() != roundtrip) or (max_entry_len > char_limit)
+        drift_detected = (normalized_raw != roundtrip) or (max_entry_len > char_limit)
         if not drift_detected:
             return None
 
@@ -875,11 +885,13 @@ class MemoryStore:
         Previous implementation used open("w") + flock, but "w" truncates the
         file *before* the lock is acquired, creating a race window where
         concurrent readers see an empty file. Atomic rename avoids this:
-        readers always see either the old complete file or the new one.
+        readers always see either the old complete file or the new one. Memory
+        files use canonical LF delimiters on every platform; the parser accepts
+        legacy CRLF files and normalizes them on the next successful mutation.
         """
         content = ENTRY_DELIMITER.join(entries) if entries else ""
         try:
-            atomic_write_text(path, content, tmp_prefix=".mem_")
+            atomic_write_text(path, content, tmp_prefix=".mem_", newline="\n")
         except (OSError, IOError) as e:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, Any, List, Optional, Tuple
 
-from utils import atomic_write_text
+from utils import atomic_write_text, normalize_newlines
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 msvcrt = None
@@ -65,11 +65,6 @@ MEMORY_BLOCK_HEADERS = {
 }
 
 ENTRY_DELIMITER = "\n§\n"
-
-
-def _normalize_line_endings(text: str) -> str:
-    """Return text with CRLF and legacy CR line endings normalized to LF."""
-    return text.replace(chr(13) + chr(10), "\n").replace(chr(13), "\n")
 
 
 # ---------------------------------------------------------------------------
@@ -788,12 +783,14 @@ class MemoryStore:
         """Split raw memory-file text into stripped, non-empty entries."""
         if not raw.strip():
             return []
-        # Normalize before splitting so LF, CRLF, and mixed-line-ending files all
-        # recognize the same delimiter. Splitting by "§" alone would incorrectly
-        # split entries that contain it as content.
+        # Defensive normalization: production reads decode via Path.read_text
+        # (universal newlines), so `raw` never contains \r on that path — but
+        # callers handing over raw decoded bytes (tests, future byte-level
+        # readers) still split on the canonical LF delimiter. Splitting by "§"
+        # alone would incorrectly split entries that contain it as content.
         entries = [
             e.strip()
-            for e in _normalize_line_endings(raw).split(ENTRY_DELIMITER)
+            for e in normalize_newlines(raw).split(ENTRY_DELIMITER)
         ]
         return [e for e in entries if e]
 
@@ -856,9 +853,12 @@ class MemoryStore:
         if not raw.strip():
             return None
 
-        parsed = self._parse_entries(raw)
+        # Normalize once and derive both the parse and the drift comparison
+        # from the same normalized snapshot (parse re-normalizing is an
+        # idempotent no-op).
+        normalized_raw = normalize_newlines(raw).strip()
+        parsed = self._parse_entries(normalized_raw)
         roundtrip = ENTRY_DELIMITER.join(parsed)
-        normalized_raw = _normalize_line_endings(raw).strip()
 
         char_limit = self._char_limit(target)
         max_entry_len = max((len(e) for e in parsed), default=0)
@@ -872,8 +872,11 @@ class MemoryStore:
         # the caller can refuse the mutation.
         ts = int(time.time())
         bak_path = path.with_suffix(path.suffix + f".bak.{ts}")
+        # Keep the snapshot on the same canonical-LF policy as the store
+        # itself so a restored .bak is byte-identical to what the parser
+        # round-trips (raw is already universal-newline decoded).
         try:
-            bak_path.write_text(raw, encoding="utf-8")
+            bak_path.write_text(raw, encoding="utf-8", newline="\n")
         except (OSError, IOError):
             return str(bak_path) + " (BACKUP FAILED — file unchanged on disk)"
         return str(bak_path)
@@ -886,8 +889,10 @@ class MemoryStore:
         file *before* the lock is acquired, creating a race window where
         concurrent readers see an empty file. Atomic rename avoids this:
         readers always see either the old complete file or the new one. Memory
-        files use canonical LF delimiters on every platform; the parser accepts
-        legacy CRLF files and normalizes them on the next successful mutation.
+        files use canonical LF delimiters on every platform (newline="\\n"
+        disables the text-mode translation that previously produced CRLF
+        bytes on Windows); reads normalize defensively, so a pre-existing
+        CRLF file is rewritten canonical on its next successful mutation.
         """
         content = ENTRY_DELIMITER.join(entries) if entries else ""
         try:

--- a/utils.py
+++ b/utils.py
@@ -284,6 +284,7 @@ def atomic_write_text(
     tmp_prefix: str = ".tmp_",
     preserve_mode: bool = False,
     create_mode: "int | None" = None,
+    newline: "str | None" = None,
 ) -> None:
     """Write *content* to *path* via temp file + fsync + atomic rename.
 
@@ -307,6 +308,9 @@ def atomic_write_text(
         create_mode: Permission bits to apply when the target does not yet
             exist (otherwise the new file keeps mkstemp's 0600).  Never
             applied to an existing file.
+        newline: Text newline translation policy passed to ``os.fdopen``.
+            The default preserves platform-native behavior; callers with a
+            canonical on-disk format can opt into ``"\n"`` explicitly.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -321,7 +325,7 @@ def atomic_write_text(
         dir=str(path.parent), prefix=tmp_prefix, suffix=".tmp"
     )
     try:
-        with os.fdopen(fd, "w", encoding=encoding) as handle:
+        with os.fdopen(fd, "w", encoding=encoding, newline=newline) as handle:
             if effective_mode is not None and hasattr(os, "fchmod"):
                 # fchmod the temp fd BEFORE the replace so the target never
                 # transits through mkstemp's 0600. fchmod is Unix-only; on

--- a/utils.py
+++ b/utils.py
@@ -276,6 +276,21 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     return real_path
 
 
+def normalize_newlines(text: str, target: str = "\n") -> str:
+    """Convert all line endings in ``text`` to ``target`` (``\\n`` or ``\\r\\n``).
+
+    Idempotent, and homogenizes mixed-ending content in a single pass.
+    Order matters: CRLF must collapse before lone CR, otherwise a CRLF would
+    double-convert to LFLF.
+    """
+    lf_normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    if target == "\n":
+        return lf_normalized
+    if target == "\r\n":
+        return lf_normalized.replace("\n", "\r\n")
+    return text
+
+
 def atomic_write_text(
     path: Union[str, Path],
     content: str,


### PR DESCRIPTION
## Summary

Memory stores (`MEMORY.md` / `USER.md`) are now persisted with canonical LF delimiters on every platform, and the parser/drift guard normalize line endings defensively — salvage of #85856 by @JoaoMarcos44 with a consolidation follow-up.

## What this actually fixes (reframed from #85856)

Issue #85825 claimed Windows CRLF writes caused `replace`/`remove` to wipe `MEMORY.md`. **That data-loss scenario is not reproducible on main**: every production reader decodes memory files via `Path.read_text` (universal-newline translation), so CRLF/CR on disk never reaches the `\n§\n` splitter. Verified with a deterministic side-by-side E2E probe (CRLF, lone-CR, BOM+CRLF × replace/remove/add — zero loss in all 9 combos on main).

What WAS real: on Windows, text-mode writes persisted the store with CRLF bytes, violating the format's documented LF contract. That's a latent hazard for any future byte-level reader and makes on-disk bytes platform-dependent. This PR pins every first-party writer to canonical LF and keeps the parser-side normalization as explicit defense-in-depth.

## Changes

- `utils.atomic_write_text`: optional `newline` policy (default unchanged — platform-native)
- `tools/memory_tool.py`: writers pin `newline="\n"` (store + drift `.bak`); `_parse_entries` and `_detect_external_drift` normalize CRLF/CR→LF defensively, deriving parse + drift comparison from one normalized snapshot
- `hermes_cli/agent_import.py`, OpenClaw `migrate_memory`/`migrate_daily_memory`: writers pin `newline="\n"`
- `utils.normalize_newlines()`: promoted shared helper — `tools/file_operations.py`'s behavior-identical private copy now delegates to it (repo previously had two copies of the same normalization)
- Comments/docstrings state the true mechanism (universal-newline reads were always safe; writes were the platform-dependent side)

## Validation

| Check | Result |
|---|---|
| Targeted suites (memory_tool, atomic_write, agent_import, openclaw, utils, file_operations) | 411+113 passed, 0 failed |
| Mutation check (revert memory_tool+utils to pre-fix base) | guard tests fail on base, pass on stack |
| E2E probe (9 scenario×action combos, main vs branch) | no data loss either side; branch writes LF bytes |
| Ruff on all changed files | clean |

## Credit

Based on #85856 by @JoaoMarcos44 — both commits cherry-picked with authorship preserved; follow-up consolidation commit is ours.

Closes #85856.
