### PR TITLE
feat(compression): preserve epistemic stance of uncertain claims through compaction (arXiv:2608.06953)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -327,6 +327,37 @@ _SUMMARY_END_MARKER = (
     "respond to the message below, not the summary above ---"
 )
 
+# Epistemic-stance preservation rule appended to the summarizer preamble, plus
+# the summary section it feeds. Compression is built to shed words, and hedges
+# ("probably", "I suspect", "unconfirmed") are the first words shed — which
+# either hardens an unverified hypothesis into a fact the resumed agent then
+# acts on, or drops the hypothesis entirely and loses the investigative
+# thread. arXiv:2608.06953 found that writing stance as an explicit labelled
+# field (rather than an inline aside) raises stance retention through
+# compression by ~15 points across models; an A/B on real Hermes transcripts
+# (weak generator, judge-classified, 64 claims/arm) reproduced the direction:
+# uncertain-claim survival 53% -> 86% with this rule + section, with zero
+# hardening in either arm. These are prompt-template constants for the
+# summarizer call — the system prompt and cached prefix are untouched.
+_EPISTEMIC_STANCE_RULE = (
+    "EPISTEMIC STATUS PRESERVATION: The source turns may contain claims whose "
+    "truth status is uncertain — suspicions, working hypotheses, unverified "
+    "inferences. NEVER restate an uncertain claim as an established fact. "
+    "Record each one as an explicit labelled entry of the form "
+    '"UNVERIFIED: <claim> — <basis>" under the '
+    "'## Unverified / Working Hypotheses' section. A qualifier like "
+    "'probably', 'I suspect', or 'unconfirmed' in the source is load-bearing "
+    "information: preserving the claim while dropping its qualifier is a "
+    "summarization ERROR."
+)
+
+_UNVERIFIED_HYPOTHESES_SECTION = """
+
+## Unverified / Working Hypotheses
+[Every claim from the source whose truth status was uncertain, each written as
+"UNVERIFIED: <claim> — <basis/evidence so far>". Do not promote these to facts.
+If none, write "None."]"""
+
 # When the summary must be merged into the first tail message (the alternation
 # corner case where a standalone summary role would collide with both head and
 # tail), the tail message's own prior content is preserved BEFORE the summary,
@@ -4062,7 +4093,8 @@ Describe agent/tool work only as completed actions, state, or historical work.]"
             "NEVER include API keys, tokens, passwords, secrets, credentials, "
             "or connection strings in the summary — replace any that appear "
             "with [REDACTED]. Note that credentials were present, but do not "
-            "preserve their values."
+            "preserve their values. "
+            + _EPISTEMIC_STANCE_RULE
         )
 
         # Temporal anchoring directive. Rewrites relative / still-pending-sounding
@@ -4124,6 +4156,7 @@ Be specific with file paths, commands, line numbers, and results.]
 
 ## Critical Context
 [Any specific values, error messages, configuration details, or data that would be lost without explicit preservation. NEVER include API keys, tokens, passwords, or credentials — write [REDACTED] instead.]
+{_UNVERIFIED_HYPOTHESES_SECTION}
 
 {_PRUNED_SKILLS_SECTION_HEADING}
 [If any [SKILL_PRUNED: ...reload with skill_view(...)] markers appear in the input,

--- a/tests/agent/test_context_compressor_stance_preservation.py
+++ b/tests/agent/test_context_compressor_stance_preservation.py
@@ -1,0 +1,100 @@
+"""Tests for epistemic-stance preservation in compaction summary prompts.
+
+The summarizer prompt must instruct the aux model to keep uncertain claims
+labelled as UNVERIFIED instead of hardening them into facts or dropping them
+(arXiv:2608.06953; validated on real transcripts — see PR body). These tests
+pin the behavior contract: the rule and its section reach the LLM prompt on
+both the first-compaction and iterative-update paths.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.context_compressor import ContextCompressor
+
+
+def _response(content: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def _user_turns() -> list[dict]:
+    return [
+        {"role": "user", "content": "Investigate the flaky gateway timeout."},
+        {
+            "role": "assistant",
+            "content": (
+                "I suspect the timeout is probably caused by DNS resolution "
+                "lag, though I haven't verified this yet. Digging further."
+            ),
+        },
+    ]
+
+
+@pytest.fixture()
+def compressor() -> ContextCompressor:
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        instance = ContextCompressor(
+            model="test/model",
+            threshold_percent=0.50,
+            protect_first_n=0,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+    instance.tail_token_budget = 80
+    return instance
+
+
+def _captured_prompt(compressor: ContextCompressor) -> str:
+    captured: dict = {}
+
+    def _capture(*args, **kwargs):
+        messages = kwargs.get("messages")
+        if messages is None:
+            for a in args:
+                if isinstance(a, list):
+                    messages = a
+                    break
+        captured["prompt"] = "\n".join(
+            str(m.get("content", "")) for m in (messages or []) if isinstance(m, dict)
+        )
+        return _response("## Goal\nStub summary.")
+
+    with patch("agent.context_compressor.call_llm", side_effect=_capture):
+        compressor._generate_summary(_user_turns())
+    return captured.get("prompt", "")
+
+
+def test_first_compaction_prompt_carries_stance_rule(compressor):
+    prompt = _captured_prompt(compressor)
+    assert "EPISTEMIC STATUS PRESERVATION" in prompt
+    assert "## Unverified / Working Hypotheses" in prompt
+    assert "UNVERIFIED:" in prompt
+
+
+def test_iterative_update_prompt_carries_stance_rule(compressor):
+    compressor._previous_summary = "## Goal\nEarlier summary."
+    prompt = _captured_prompt(compressor)
+    assert "EPISTEMIC STATUS PRESERVATION" in prompt
+    assert "## Unverified / Working Hypotheses" in prompt
+
+
+def test_stance_rule_does_not_touch_handoff_prefix(compressor):
+    """The stance rule lives in the summarizer prompt only — the handoff
+    prefix prepended to the persisted summary message must be unchanged, so
+    resume-time prefix stripping keeps matching."""
+    from agent.context_compressor import (
+        _EPISTEMIC_STANCE_RULE,
+        _HISTORICAL_SUMMARY_PREFIXES,
+        SUMMARY_PREFIX,
+    )
+
+    assert _EPISTEMIC_STANCE_RULE not in SUMMARY_PREFIX
+    for prefix in _HISTORICAL_SUMMARY_PREFIXES:
+        assert _EPISTEMIC_STANCE_RULE not in prefix


### PR DESCRIPTION
## Summary
Compaction summaries now preserve the epistemic stance of uncertain claims instead of silently dropping them or hardening them into facts.

Compression is built to shed words, and hedges ("probably", "I suspect", "unconfirmed") are the first words shed. When a working hypothesis from an investigation survives compaction without its qualifier, the resumed agent treats a guess as an established fact; more often the hedged claim vanishes entirely and the investigative thread is lost. arXiv:2608.06953 ("Explicit, Not Longer: What Makes Epistemic Stance Survive Memory Compression") found that writing stance as an explicit labelled field rather than an inline aside raises retention ~15 points across models.

## Changes
- `agent/context_compressor.py`: adds `_EPISTEMIC_STANCE_RULE` to the summarizer preamble and an `## Unverified / Working Hypotheses` labelled section (`UNVERIFIED: <claim> — <basis>` entries) to the shared structured template. Reaches both the first-compaction and iterative-update prompt paths (they share `_template_sections`).
- `tests/agent/test_context_compressor_stance_preservation.py`: pins the contract — rule + section present in the prompt sent to the aux model on both paths, and absent from the persisted-summary handoff prefixes (so resume-time prefix stripping keeps matching).

## Validation (live A/B on real Hermes transcripts)
Method: 8 real CLI sessions pulled from `state.db` (≥30 messages each), 4 uncertain claims injected per transcript as inline assistant asides, summarized with a deliberately weak generator (llama-3.3-70b — strong models mask prompt effects), 2 reps/arm, every claim classified by a JSON-mode judge (gemini-3.6-flash) as OMITTED / PRESERVED / HARDENED. Arm A = faithful replica of the current template; Arm B = A + this PR's rule and section. 64 judged claims per arm.

| | Arm A (current) | Arm B (this PR) |
|---|---|---|
| Uncertain claim survives compaction | 53% | **86%** |
| Omitted entirely | 47% | 14% |
| Hardened into fact | 0% | 0% |

The dominant failure mode on current main is silent omission, not hardening — the hypothesis and its evidence trail simply vanish from the checkpoint. The labelled section recovers most of those losses.

## Caching & invariants
Prompt-template-only change to the auxiliary summarizer call. System prompt, cached prefix, message roles, and the persisted-summary handoff prefixes are untouched (pinned by test). Targeted tests: 18/18 passing (`test_context_compressor_stance_preservation.py` + `test_context_compressor_zero_user_provenance.py`).

## References
- Paper: https://arxiv.org/abs/2608.06953 (CC-BY 4.0)
- A/B harness: weak-generator + JSON-judge recipe from the weekly paper-scout workflow

## Infographic

![Epistemic stance preservation infographic](https://files.catbox.moe/iub002.png)
