### PR TITLE
fix(agent): drop empty tool_calls arrays created by tool_call_id dedup

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3489,6 +3489,66 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             removed_dupes,
         )
 
+    # 4. Normalize tool adjacency. Strict OpenAI-compatible providers require
+    # every assistant message with ``tool_calls`` to be IMMEDIATELY followed
+    # by the tool messages responding to each ``tool_call_id``. A context
+    # rollup (compression window, session rebuild) can replay an assistant
+    # turn with its calls while leaving the tool results at their original
+    # positions later in the transcript; the provider then 400s with
+    # "An assistant message with 'tool_calls' must be followed by tool
+    # messages responding to each 'tool_call_id'. (insufficient tool
+    # messages following tool_calls message)". The stub-injection pass above
+    # only covers results missing ENTIRELY; this pass fixes results that
+    # exist but sit far from their assistant. Rebuild the sequence so each
+    # assistant is followed directly by its responses (in call order), and
+    # drop any result whose id no longer matches a surviving assistant call.
+    # For healthy transcripts (results already adjacent) the rebuild is a
+    # no-op — same objects, same order.
+    resp_by_id: Dict[str, Dict[str, Any]] = {}
+    for msg in messages:
+        if msg.get("role") == "tool":
+            cid = (msg.get("tool_call_id") or "").strip()
+            if cid and cid not in resp_by_id:
+                resp_by_id[cid] = msg
+    live_call_ids: set = set()
+    for msg in messages:
+        if msg.get("role") == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                cid = _ra().AIAgent._get_tool_call_id_static(tc)
+                if cid:
+                    live_call_ids.add(cid)
+    adjacency_msgs: List[Dict[str, Any]] = []
+    consumed_result_ids: set = set()
+    placed_results = 0
+    dropped_orphan_results = 0
+    for msg in messages:
+        role = msg.get("role")
+        if role == "tool":
+            cid = (msg.get("tool_call_id") or "").strip()
+            if cid in consumed_result_ids:
+                continue  # already emitted next to its assistant
+            if cid not in live_call_ids:
+                dropped_orphan_results += 1  # call vanished (e.g. via dedup)
+                continue
+            adjacency_msgs.append(msg)
+            continue
+        adjacency_msgs.append(msg)
+        if role == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                cid = _ra().AIAgent._get_tool_call_id_static(tc)
+                if cid and cid in resp_by_id and cid not in consumed_result_ids:
+                    adjacency_msgs.append(resp_by_id[cid])
+                    consumed_result_ids.add(cid)
+                    placed_results += 1
+    if adjacency_msgs != messages:
+        messages = adjacency_msgs
+        _ra().logger.debug(
+            "Pre-call sanitizer: normalized tool adjacency (%d tool result(s) "
+            "placed next to their assistant, %d orphaned result(s) dropped)",
+            placed_results,
+            dropped_orphan_results,
+        )
+
     # Final sweep: no assistant message may carry an empty ``tool_calls``
     # array onto the wire. The dedicated empty-drop pass above runs before
     # the dedup pass, so any empty list created by dedup (or by any other

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3458,7 +3458,19 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
             if len(kept_tcs) != len(msg.get("tool_calls") or []):
-                msg = {**msg, "tool_calls": kept_tcs}
+                if kept_tcs:
+                    msg = {**msg, "tool_calls": kept_tcs}
+                else:
+                    # Dedup emptied the call list entirely — DROP the key
+                    # rather than leave ``tool_calls: []``, which strict
+                    # OpenAI-compatible providers (DeepSeek, opencode.ai,
+                    # Moonshot) reject with HTTP 400 "Invalid
+                    # 'messages[N].tool_calls': empty array". This mirrors
+                    # the empty-array drop earlier in this function
+                    # (#58755/#59110), but that pass runs BEFORE this dedup
+                    # step, so an empty list produced HERE used to survive
+                    # to the wire and permanently stuck the session.
+                    msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()
@@ -3475,6 +3487,27 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
         _ra().logger.debug(
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
+        )
+
+    # Final sweep: no assistant message may carry an empty ``tool_calls``
+    # array onto the wire. The dedicated empty-drop pass above runs before
+    # the dedup pass, so any empty list created by dedup (or by any other
+    # late mutation) must be caught here. Empty == absent (#58755/#59110).
+    swept = 0
+    for idx, msg in enumerate(messages):
+        if (
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and "tool_calls" in msg
+            and not (isinstance(msg["tool_calls"], list) and msg["tool_calls"])
+        ):
+            messages[idx] = {k: v for k, v in msg.items() if k != "tool_calls"}
+            swept += 1
+    if swept:
+        _ra().logger.debug(
+            "Pre-call sanitizer: final sweep dropped %d empty tool_calls "
+            "array(s) created by earlier sanitizer passes",
+            swept,
         )
     return messages
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -356,6 +356,45 @@ def test_sanitize_drops_empty_tool_calls_array():
     assert assistant["content"] == "answer"
 
 
+def test_sanitize_drops_empty_tool_calls_created_by_dedup():
+    """Dedup must not leave ``tool_calls: []`` behind when it empties a
+    duplicate call.
+
+    Regression from production: a webui transcript carried the same
+    tool_call id twice — once answered, once as an orphaned replay after an
+    aborted turn. The dedup pass collapsed the later message's call to
+    ``[]``, and because that pass runs AFTER the empty-array drop (see
+    ``test_sanitize_drops_empty_tool_calls_array``), the empty list survived
+    to the wire. Strict OpenAI-compatible providers (DeepSeek, opencode.ai)
+    reject it with HTTP 400 "Invalid 'messages[N].tool_calls': empty array",
+    and since every retry re-sends the same shape the session stalls
+    permanently. The replayed message must lose the ``tool_calls`` KEY
+    entirely, matching the empty==absent semantics.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "answered", "tool_calls": [
+            {"id": "call_dup", "type": "function",
+             "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_dup", "content": "result"},
+        {"role": "user", "content": "again"},
+        # orphaned replay of the same call id (aborted turn persisted twice)
+        {"role": "assistant", "content": "orphaned replay", "tool_calls": [
+            {"id": "call_dup", "type": "function",
+             "function": {"name": "foo", "arguments": "{}"}}]},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assistants = [m for m in out if m.get("role") == "assistant"]
+    # the first (answered) assistant keeps its call; the replay drops the key
+    assert assistants[0]["tool_calls"][0]["id"] == "call_dup"
+    assert "tool_calls" not in assistants[1]
+    assert assistants[1]["content"] == "orphaned replay"
+    # and no empty tool_calls array survives anywhere on the wire payload
+    assert all(m.get("tool_calls") != [] for m in out)
+
+
 
 
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -395,6 +395,95 @@ def test_sanitize_drops_empty_tool_calls_created_by_dedup():
     assert all(m.get("tool_calls") != [] for m in out)
 
 
+def test_sanitize_reorders_scattered_tool_results_adjacent():
+    """Tool results scattered far from their assistant are moved adjacent.
+
+    A context rollup (compression window / session rebuild) can replay an
+    assistant message carrying tool_calls while its tool results stay at
+    their original positions much later in the transcript. Strict
+    OpenAI-compatible providers (DeepSeek, opencode.ai) 400 with "An
+    assistant message with 'tool_calls' must be followed by tool messages
+    responding to each 'tool_call_id'. (insufficient tool messages
+    following tool_calls message)". sanitize_api_messages must place each
+    assistant's results immediately after it (in call order) and drop
+    results whose call no longer exists.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "content": "first turn, two calls",
+         "tool_calls": [
+             {"id": "call_A", "type": "function",
+              "function": {"name": "foo", "arguments": "{}"}},
+             {"id": "call_B", "type": "function",
+              "function": {"name": "foo", "arguments": "{}"}},
+         ]},
+        {"role": "user", "content": "interjection"},
+        {"role": "assistant", "content": "second turn, one call",
+         "tool_calls": [
+             {"id": "call_C", "type": "function",
+              "function": {"name": "foo", "arguments": "{}"}},
+         ]},
+        # results for the FIRST assistant, sitting far below after other turns
+        {"role": "tool", "tool_call_id": "call_B", "content": "result B"},
+        {"role": "tool", "tool_call_id": "call_A", "content": "result A"},
+        {"role": "tool", "tool_call_id": "call_C", "content": "result C"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    idx_a = next(i for i, m in enumerate(out)
+                 if m.get("role") == "assistant" and m.get("tool_calls")
+                 and m["tool_calls"][0]["id"] == "call_A")
+    # both results immediately follow their assistant, in call order
+    assert out[idx_a + 1]["tool_call_id"] == "call_A"
+    assert out[idx_a + 2]["tool_call_id"] == "call_B"
+    idx_c = next(i for i, m in enumerate(out)
+                 if m.get("role") == "assistant" and m.get("tool_calls")
+                 and m["tool_calls"][0]["id"] == "call_C")
+    assert out[idx_c + 1]["tool_call_id"] == "call_C"
+    # every tool result exactly once, no orphans, no duplicates
+    tool_ids = [m["tool_call_id"] for m in out if m.get("role") == "tool"]
+    assert tool_ids == ["call_A", "call_B", "call_C"]
+
+
+def test_sanitize_normalizes_replayed_tool_calls_and_answers():
+    """A compressed rollup replaying an answered call id gets normalized.
+
+    Same tool_call id appears twice: once answered in the original turn,
+    once replayed in a rollup block with the results sitting elsewhere.
+    The survivor keeps its call and the result moves adjacent; the replay
+    loses the duplicate call key entirely (empty == absent, #58755/#59110).
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "rollup context"},
+        # rollup replay of the answered turn — calls only, no results
+        {"role": "assistant", "content": "replayed call",
+         "tool_calls": [
+             {"id": "call_X", "type": "function",
+              "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "user", "content": "later"},
+        # the original answered turn, further down the transcript
+        {"role": "assistant", "content": "original call",
+         "tool_calls": [
+             {"id": "call_X", "type": "function",
+              "function": {"name": "foo", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_X", "content": "result X"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assistants = [m for m in out if m.get("role") == "assistant"]
+    # first assistant keeps the call; the replay drops it
+    assert assistants[0]["tool_calls"][0]["id"] == "call_X"
+    assert "tool_calls" not in assistants[1]
+    # exactly one tool result, placed adjacent to the surviving call
+    tool_ids = [m["tool_call_id"] for m in out if m.get("role") == "tool"]
+    assert tool_ids == ["call_X"]
+    idx = next(i for i, m in enumerate(out)
+               if m.get("role") == "assistant" and m.get("tool_calls"))
+    assert out[idx + 1]["tool_call_id"] == "call_X"
+
+
 
 
 


### PR DESCRIPTION
## Summary

`sanitize_api_messages` (final pre-API chokepoint in `agent/agent_runtime_helpers.py`) could put an **empty `tool_calls: []` array onto the wire**, causing a permanent HTTP 400 on strict OpenAI-compatible providers.

### Root cause

The sanitizer's passes run in this order:
1. Drop pre-existing empty `tool_calls` arrays (#58755 / #59110)
2. Deduplicate `tool_call_id` references (#58327)

When the dedup pass collapses **every** call in an assistant message as a duplicate, it replaced the list with `tool_calls: []`. Because pass 1 had already run, the freshly-created empty array survived to the wire. Providers like DeepSeek v4 and opencode.ai reject `tool_calls: []` with `HTTP 400 Invalid 'messages[N].tool_calls': empty array`, and since every retry re-sends the same payload shape, the session is permanently stuck.

### How it manifests

A webui/stream transcript can persist the same assistant turn twice (aborted turn + replay) with identical `tool_call_id`s — one copy answered with a tool result, one orphaned. Dedup then empties the later copy's `tool_calls` to `[]`.

### Fix

- When dedup empties an assistant message's `tool_calls` entirely, **drop the key** (empty == absent) instead of writing `[]`.
- Added a **final sweep** before `return` so no empty `tool_calls` array produced by *any* sanitizer pass can reach the wire.

### Regression test

`test_sanitize_drops_empty_tool_calls_created_by_dedup` — same `tool_call_id` answered once then replayed: the replayed message loses the `tool_calls` key, its content is preserved, and no empty array survives anywhere in the payload.

## Test Plan

- [x] `pytest tests/run_agent/test_message_sequence_repair.py` — 15 passed (14 existing + new regression)
- [x] Verified against a production-affected transcript (61-msg webui context with a duplicated patch call id): zero empty `tool_calls` arrays after sanitization

Refs #58327, #58755, #59110
