### PR TITLE
fix(tests): tui_gateway hermes_constants mocks must return Path, not str (repairs red main, slice 5/12)

### DIFF
--- a/tests/tui_gateway/test_compaction_status.py
+++ b/tests/tui_gateway/test_compaction_status.py
@@ -7,6 +7,7 @@ silently reset mid-turn.
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 import importlib
 
@@ -23,7 +24,7 @@ def server():
         "sys.modules",
         {
             "hermes_constants": MagicMock(
-                get_hermes_home=MagicMock(return_value="/tmp/hermes_test_compaction")
+                get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test_compaction"))
             ),
             "hermes_cli.env_loader": MagicMock(),
             "hermes_cli.banner": MagicMock(),

--- a/tests/tui_gateway/test_inline_rpc_gil_starvation.py
+++ b/tests/tui_gateway/test_inline_rpc_gil_starvation.py
@@ -14,6 +14,7 @@ The fix routes all frontend-polled RPCs through ``_LONG_HANDLERS`` so
 the WS read loop is never blocked.
 """
 
+from pathlib import Path
 import io
 import json
 import sys
@@ -38,7 +39,7 @@ def server():
     # the whole test would poison modules first imported inside test bodies
     # (see tests/tui_gateway/test_protocol.py for the full rationale).
     with patch.dict("sys.modules", {
-        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test"))),
         "hermes_cli.env_loader": MagicMock(),
         "hermes_cli.banner": MagicMock(),
         "hermes_state": MagicMock(),

--- a/tests/tui_gateway/test_moa_reference_emit.py
+++ b/tests/tui_gateway/test_moa_reference_emit.py
@@ -8,6 +8,7 @@ thinking block tagged with its source model.
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 from unittest.mock import MagicMock, patch
 
@@ -22,7 +23,7 @@ def server():
         "sys.modules",
         {
             "hermes_constants": MagicMock(
-                get_hermes_home=MagicMock(return_value="/tmp/hermes_test_moa_emit")
+                get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test_moa_emit"))
             ),
             "hermes_cli.env_loader": MagicMock(),
             "hermes_cli.banner": MagicMock(),

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1,5 +1,6 @@
 """Tests for tui_gateway JSON-RPC protocol plumbing."""
 
+from pathlib import Path
 import io
 import json
 import sys
@@ -28,7 +29,7 @@ def server():
     # (a fixed shared path) forever, leaking active-session registry entries
     # across every later test in the process. Scope the patch to the import.
     with patch.dict("sys.modules", {
-        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test"))),
         "hermes_cli.env_loader": MagicMock(),
         "hermes_cli.banner": MagicMock(),
         "hermes_state": MagicMock(),

--- a/tests/tui_gateway/test_review_summary_callback.py
+++ b/tests/tui_gateway/test_review_summary_callback.py
@@ -10,6 +10,7 @@ transcript line.
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 from unittest.mock import MagicMock, patch
 
@@ -24,7 +25,7 @@ def server():
         "sys.modules",
         {
             "hermes_constants": MagicMock(
-                get_hermes_home=MagicMock(return_value="/tmp/hermes_test_review_summary")
+                get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test_review_summary"))
             ),
             "hermes_cli.env_loader": MagicMock(),
             "hermes_cli.banner": MagicMock(),

--- a/tests/tui_gateway/test_slash_worker_profile_home.py
+++ b/tests/tui_gateway/test_slash_worker_profile_home.py
@@ -1,5 +1,6 @@
 """Tests for TUI gateway slash_worker profile_home propagation (#40677)."""
 
+from pathlib import Path
 import os
 import subprocess
 import sys
@@ -11,7 +12,7 @@ import pytest
 def test_slash_worker_accepts_profile_home():
     """_SlashWorker.__init__ accepts profile_home parameter."""
     with patch.dict("sys.modules", {
-        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test"))),
     }):
         with patch("subprocess.Popen") as mock_popen:
             mock_popen.return_value.stdout = MagicMock()

--- a/tests/tui_gateway/test_subagent_child_mirror.py
+++ b/tests/tui_gateway/test_subagent_child_mirror.py
@@ -9,6 +9,7 @@ shows a real midstream turn instead of sitting silent until persistence.
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 from unittest.mock import MagicMock, patch
 
@@ -23,7 +24,7 @@ def server():
         "sys.modules",
         {
             "hermes_constants": MagicMock(
-                get_hermes_home=MagicMock(return_value="/tmp/hermes_test_child_mirror")
+                get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test_child_mirror"))
             ),
             "hermes_cli.env_loader": MagicMock(),
             "hermes_cli.banner": MagicMock(),

--- a/tests/tui_gateway/test_subprocess_encoding.py
+++ b/tests/tui_gateway/test_subprocess_encoding.py
@@ -13,6 +13,7 @@ the crash class cannot silently regress.
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 import subprocess
 from unittest.mock import MagicMock, patch
@@ -42,7 +43,7 @@ def test_slash_worker_popen_uses_utf8_replace():
     """
     with patch.dict("sys.modules", {
         "hermes_constants": MagicMock(
-            get_hermes_home=MagicMock(return_value="/tmp/hermes_test")
+            get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test"))
         ),
     }):
         with patch("subprocess.Popen") as mock_popen:


### PR DESCRIPTION
## Summary
Repairs the red on `main`: eight `tests/tui_gateway/` files stub `hermes_constants.get_hermes_home` with a **str** return, and since commit 56a41715dc `hermes_state.py` computes `DEFAULT_DB_PATH = get_hermes_home() / "state.db"` at import time — so any test importing `tui_gateway.server` dies at collection with `TypeError: unsupported operand type(s) for /: 'str' and 'str'` (tests.yml slice 5/12 failing on main and on every PR branched from it, e.g. #86019).

Root cause: the mocks didn't match the real contract — `get_hermes_home()` returns a `Path`. Fixed the class at all 8 sibling sites, not just the one file the CI red named.

## Changes
- `tests/tui_gateway/` (8 files): `MagicMock(return_value="/tmp/...")` → `MagicMock(return_value=Path("/tmp/..."))`, with `from pathlib import Path` added where missing (placed after `from __future__` where present).

## Validation
| | Before | After |
|---|---|---|
| `pytest tests/tui_gateway/` | 5 collection errors (TypeError str/str) | 421 passed |
| ruff check | — | clean (format-check deltas are pre-existing on main for all 8 files) |

## Infographic

![Path not string infographic](https://files.catbox.moe/morom9.png)
