### PR TITLE
fix(tests): mock get_hermes_home with Path to match real contract

### DIFF
--- a/tests/tui_gateway/test_slash_worker_profile_home.py
+++ b/tests/tui_gateway/test_slash_worker_profile_home.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch, call
 
 import pytest
@@ -11,7 +12,7 @@ import pytest
 def test_slash_worker_accepts_profile_home():
     """_SlashWorker.__init__ accepts profile_home parameter."""
     with patch.dict("sys.modules", {
-        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test"))),
     }):
         with patch("subprocess.Popen") as mock_popen:
             mock_popen.return_value.stdout = MagicMock()


### PR DESCRIPTION
Fixes #86023.

`tests/tui_gateway/test_slash_worker_profile_home.py` mocked `hermes_constants.get_hermes_home` with a plain `str`. But `hermes_state.py` evaluates `DEFAULT_DB_PATH = get_hermes_home() / "state.db"` at **module import time**, and the real `get_hermes_home()` returns a `Path` — so the mocked module load raised `TypeError: unsupported operand type(s) for /: 'str' and 'str'` as soon as any lazy `hermes_state` import ran inside the mock window (here: the mocked `Popen` worker's `_run` thread importing `SessionDB`).

This was failing on `main` itself (run 31786882691, head `56a41715dc`, slice 3), blocking every PR whose slice assignment landed this file — including #86014, whose diff doesn't touch anything related.

Change: one line — the mock now returns `Path("/tmp/hermes_test")`, matching the real function's contract (plus the `pathlib` import).

Verification:
- Before: `1 failed in 0.46s` on clean `origin/main`.
- After: `1 passed in 0.11s`.
- Full `tests/tui_gateway/` suite: 421 passed.
- `ruff check` clean.

Note from #86023: the same str-mock pattern exists in several other `tests/tui_gateway/*` files (`test_protocol.py`, `test_subagent_child_mirror.py`, `test_moa_reference_emit.py`, `test_review_summary_callback.py`, ...). They pass today only because nothing imports `hermes_state` inside their mock windows. A suite-wide sweep (str → `Path`) could be a follow-up; kept this PR minimal to unblock red main.
