### PR TITLE
fix(slack): silence duplicate-token warning safely

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -52,6 +52,18 @@ except ImportError:  # pragma: no cover - plugin loaded outside package context
 
 logger = logging.getLogger(__name__)
 
+
+class _SuppressBoltDuplicateTokenWarning(logging.Filter):
+    """Drop Bolt's known duplicate-token warning for a prebuilt client only."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage().replace("`", "")
+        return "As you gave client as well, token will be unused." not in message
+
+
+_bolt_logger = logging.getLogger(f"{__name__}.bolt")
+_bolt_logger.addFilter(_SuppressBoltDuplicateTokenWarning())
+
 # User-Agent prefix (``HermesAgent/<version>``) for platform-partner attribution of API calls.
 try:
     from hermes_cli import __version__ as _HERMES_VERSION
@@ -1652,9 +1664,16 @@ class SlackAdapter(BasePlatformAdapter):
             # Reset so a reconnect with dropped/rotated tokens carries no stale identities.
             self._bot_user_id = self._bot_display_name = None
             self._team_clients, self._team_bot_user_ids, self._team_bot_names = {}, {}, {}
+            # AsyncWebClient already owns the token. Bolt reads SLACK_BOT_TOKEN
+            # when token=None, then warns that its duplicate token is unused.
+            # Keep the environment unchanged for concurrent profile connections
+            # and suppress only that known warning on this dedicated logger.
             self._app = AsyncApp(
-                token=bot_tokens[0], client=self._new_web_client(bot_tokens[0], proxy_url),
-                before_authorize=_slack_per_request_proxy_middleware(proxy_url))
+                token=None,
+                client=self._new_web_client(bot_tokens[0], proxy_url),
+                before_authorize=_slack_per_request_proxy_middleware(proxy_url),
+                logger=_bolt_logger,
+            )
             _apply_slack_proxy(self._app.client, proxy_url)
             for token in bot_tokens:
                 await self._authenticate_workspace(token, proxy_url)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -12,6 +12,7 @@ import asyncio
 import contextlib
 import importlib
 from importlib.machinery import PathFinder
+import logging
 import os
 import socket
 import sys
@@ -446,6 +447,34 @@ class TestAppMentionHandler:
             }
         )
 
+        def _construct_app(**kwargs):
+            # Bolt reads SLACK_BOT_TOKEN when token=None. The prebuilt client
+            # remains the owner of the configured adapter token.
+            assert os.environ["SLACK_BOT_TOKEN"] == "xoxb-env"
+            assert kwargs["token"] is None
+            assert kwargs["client"] is mock_web_client
+            duplicate = logging.LogRecord(
+                "slack_bolt.AsyncApp",
+                logging.WARNING,
+                __file__,
+                0,
+                "As you gave `client` as well, `token` will be unused.",
+                (),
+                None,
+            )
+            unrelated = logging.LogRecord(
+                "slack_bolt.AsyncApp",
+                logging.WARNING,
+                __file__,
+                0,
+                "another Bolt warning",
+                (),
+                None,
+            )
+            assert kwargs["logger"].filter(duplicate) is False
+            assert kwargs["logger"].filter(unrelated)
+            return mock_app
+
         created_handlers = []
 
         class FakeSocketModeHandler:
@@ -465,16 +494,23 @@ class TestAppMentionHandler:
         secret_scope.set_multiplex_active(True)
         try:
             with (
-                patch.object(_slack_mod, "AsyncApp", return_value=mock_app),
+                patch.object(_slack_mod, "AsyncApp", side_effect=_construct_app),
                 patch.object(_slack_mod, "AsyncWebClient", return_value=mock_web_client),
                 patch.object(
                     _slack_mod, "AsyncSocketModeHandler", FakeSocketModeHandler
                 ),
-                patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-default"}),
+                patch.dict(
+                    os.environ,
+                    {
+                        "SLACK_APP_TOKEN": "xapp-default",
+                        "SLACK_BOT_TOKEN": "xoxb-env",
+                    },
+                ),
                 patch("gateway.status.acquire_scoped_lock", return_value=(True, None)),
                 patch("asyncio.create_task", side_effect=_fake_create_task),
             ):
                 result = await adapter.connect()
+                assert os.environ["SLACK_BOT_TOKEN"] == "xoxb-env"
         finally:
             secret_scope.set_multiplex_active(False)
 


### PR DESCRIPTION
## Summary

Suppress only Slack Bolt's false duplicate-token warning when Hermes supplies a prebuilt `AsyncWebClient`. Keep `SLACK_BOT_TOKEN` unchanged, preserve proxy middleware, and leave unrelated Bolt warnings visible.

The earlier ACP invalid-escape portion is no longer part of this PR because current `main` already contains the raw-docstring fix.

## Current-main refresh

- Base: `b0d2148b437decfb060c03c82fc20777bc84aac8`
- Head: `98b7641a6e0ef3c6ebb184087c006c4c99fd0409`
- Scope: Slack startup warning only

## Verification

- `pytest -q tests/gateway/test_slack.py -k AppMentionHandler` — 2 passed
- Ruff on adapter/test — passed
- `py_compile plugins/platforms/slack/adapter.py` — passed
- `git diff --check` — passed

Closes #86028
