### PR TITLE
fix(skills): add trivial one-off exception to TDD skill

### DIFF
--- a/skills/software-development/test-driven-development/SKILL.md
+++ b/skills/software-development/test-driven-development/SKILL.md
@@ -33,8 +33,9 @@ Write the test first. Watch it fail. Write minimal code to pass.
 - Throwaway prototypes
 - Generated code
 - Configuration files
+- Trivial one-off scripts the user explicitly describes as small / throwaway and that do not need a release pipeline (e.g., a single-file mod, a one-time zip upload) — the user's own framing is the permission to skip.
 
-Thinking "skip TDD just this once"? Stop. That's rationalization.
+Thinking "skip TDD just this once" for a task that is not in the When to Use exceptions? Stop. That's rationalization.
 
 ## The Iron Law
 
@@ -42,15 +43,17 @@ Thinking "skip TDD just this once"? Stop. That's rationalization.
 NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
 ```
 
+This applies to production or deliverable code. Tasks that fall under `When to Use > Exceptions` may skip the cycle entirely.
+
 Write code before the test? Delete it. Start over.
 
-**No exceptions:**
+**No exceptions to this rule:**
 - Don't keep it as "reference"
 - Don't "adapt" it while writing tests
 - Don't look at it
 - Delete means delete
 
-Implement fresh from tests. Period.
+Implement fresh from tests, unless the task is in `When to Use > Exceptions`.
 
 ## Red-Green-Refactor Cycle
 
@@ -244,7 +247,7 @@ Tests-after are biased by your implementation. You test what you built, not what
 
 | Excuse | Reality |
 |--------|---------|
-| "Too simple to test" | Simple code breaks. Test takes 30 seconds. |
+| "Too simple to test" | If the user described it as a trivial one-off with no release pipeline, see When to Use exceptions. Otherwise, simple code still breaks — test it. |
 | "I'll test after" | Tests passing immediately prove nothing. |
 | "Tests after achieve same goals" | Tests-after = "what does this do?" Tests-first = "what should this do?" |
 | "Already manually tested" | Ad-hoc ≠ systematic. No record, can't re-run. |
@@ -270,7 +273,6 @@ If you catch yourself doing any of these, delete the code and restart with TDD:
 - "Tests after achieve the same purpose"
 - "Keep as reference" or "adapt existing code"
 - "Already spent X hours, deleting is wasteful"
-- "TDD is dogmatic, I'm being pragmatic"
 - "This is different because..."
 
 **All of these mean: Delete code. Start over with TDD.**
@@ -288,7 +290,7 @@ Before marking work complete:
 - [ ] Tests use real code (mocks only if unavoidable)
 - [ ] Edge cases and errors covered
 
-Can't check all boxes? You skipped TDD. Start over.
+Can't check all boxes? You skipped TDD — unless the task is in `When to Use > Exceptions`, in which case document why TDD was skipped.
 
 ## When Stuck
 
@@ -359,4 +361,4 @@ Production code → test exists and failed first
 Otherwise → not TDD
 ```
 
-No exceptions without the user's explicit permission.
+No exceptions beyond those in `When to Use` without the user's explicit permission.

--- a/tests/tools/test_tdd_skill_trivial_exception.py
+++ b/tests/tools/test_tdd_skill_trivial_exception.py
@@ -1,40 +1,32 @@
 """Regression: the TDD skill must exempt trivial one-off tasks from the iron law.
 
 Issue #83532: the TDD skill was so dogmatic that trivial programs triggered a
-full red-green-refactor release process, wasting tokens. The skill is a runtime
-instruction artifact; this test guards that the exemption appears in the
-"When to Use" exception list so the model sees it.
+full red-green-refactor release process. Guard the exemption through the same
+frontmatter parser the prompt builder uses, not a raw source-file scan.
 """
 
-import re
 from pathlib import Path
 
-import pytest
+from agent.skill_utils import parse_frontmatter
 
 
-SKILL_PATH = Path(__file__).parents[2] / "skills" / "software-development" / "test-driven-development" / "SKILL.md"
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "software-development"
+    / "test-driven-development"
+    / "SKILL.md"
+)
 
 
-@pytest.fixture
-def skill_text():
-    return SKILL_PATH.read_text(encoding="utf-8")
-
-
-def test_tdd_skill_has_when_to_use_exceptions(skill_text):
-    """The skill must have an Exceptions list under When to Use."""
-    match = re.search(r"## When to Use\n(.+?)(?:\n## |\Z)", skill_text, re.S)
-    assert match, "When to Use section not found"
-    section = match.group(1)
-    assert re.search(r"^\*\*Exceptions", section, re.M), "Exceptions list not found under When to Use"
-
-
-def test_tdd_skill_exempts_trivial_one_off_tasks(skill_text):
-    """The exceptions must mention trivial / one-off / small scripts that don't need a release pipeline."""
-    match = re.search(r"## When to Use\n(.+?)(?:\n## |\Z)", skill_text, re.S)
-    assert match
-    section = match.group(1)
-    assert re.search(
-        r"\b(trivial|one-off|one off|small script|no release|single file|single-file)\b",
-        section,
-        re.I,
-    ), "Trivial one-off task exemption is missing from When to Use exceptions"
+def test_tdd_skill_loads_trivial_one_off_exception():
+    """The shipped skill must parse and expose the When to Use exemption."""
+    frontmatter, body = parse_frontmatter(SKILL_PATH.read_text(encoding="utf-8"))
+    assert frontmatter.get("name"), "TDD skill frontmatter must include a name"
+    assert "When to Use" in body
+    assert "Exceptions" in body
+    lowered = body.lower()
+    assert any(
+        token in lowered
+        for token in ("trivial", "one-off", "one off", "small script", "single-file")
+    ), "Trivial one-off exemption missing from the loaded TDD skill body"

--- a/tests/tools/test_tdd_skill_trivial_exception.py
+++ b/tests/tools/test_tdd_skill_trivial_exception.py
@@ -1,0 +1,40 @@
+"""Regression: the TDD skill must exempt trivial one-off tasks from the iron law.
+
+Issue #83532: the TDD skill was so dogmatic that trivial programs triggered a
+full red-green-refactor release process, wasting tokens. The skill is a runtime
+instruction artifact; this test guards that the exemption appears in the
+"When to Use" exception list so the model sees it.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+SKILL_PATH = Path(__file__).parents[2] / "skills" / "software-development" / "test-driven-development" / "SKILL.md"
+
+
+@pytest.fixture
+def skill_text():
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def test_tdd_skill_has_when_to_use_exceptions(skill_text):
+    """The skill must have an Exceptions list under When to Use."""
+    match = re.search(r"## When to Use\n(.+?)(?:\n## |\Z)", skill_text, re.S)
+    assert match, "When to Use section not found"
+    section = match.group(1)
+    assert re.search(r"^\*\*Exceptions", section, re.M), "Exceptions list not found under When to Use"
+
+
+def test_tdd_skill_exempts_trivial_one_off_tasks(skill_text):
+    """The exceptions must mention trivial / one-off / small scripts that don't need a release pipeline."""
+    match = re.search(r"## When to Use\n(.+?)(?:\n## |\Z)", skill_text, re.S)
+    assert match
+    section = match.group(1)
+    assert re.search(
+        r"\b(trivial|one-off|one off|small script|no release|single file|single-file)\b",
+        section,
+        re.I,
+    ), "Trivial one-off task exemption is missing from When to Use exceptions"


### PR DESCRIPTION
## What does this PR do?

The bundled TDD skill was too absolute: it treated every program, including trivial one-off scripts, as requiring a full red-green-refactor release process. The issue reports that this caused the agent to spend millions of tokens and several hours on a trivial mod upload.

This PR adds an explicit `When to Use` exception for trivial one-off scripts the user already describes as small / throwaway and that do not need a release pipeline (e.g., a single-file mod, a one-time zip upload). It also reconciles the rest of the skill so the exception is not self-contradictory.

## Related Issue

Fixes #83532

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `skills/software-development/test-driven-development/SKILL.md`:
  - Added a `When to Use > Exceptions` bullet for trivial one-off scripts.
  - Qualified the "skip TDD just this once" warning so it only applies to tasks not in the exceptions list.
  - Scoped the Iron Law to production/deliverable code and exempted `When to Use > Exceptions`.
  - Updated the "Too simple to test" rationalization to point to the new exception first.
  - Removed the `Red Flags` bullet "TDD is dogmatic, I'm being pragmatic", which would directly undermine the exception.
  - Updated the `Verification Checklist` fallback to allow documented exceptions.
  - Updated the `Final Rule` to "No exceptions beyond those in `When to Use` without the user's explicit permission."
- `tests/tools/test_tdd_skill_trivial_exception.py` (new):
  - Regression test that loads the skill through `parse_frontmatter` (the prompt-builder parser) and asserts the When to Use exemption is present.

## How to Test

1. `cd worktrees/hermes-agent/83532`
2. `uv run --extra dev python -m tools.skill_linter skills/software-development/test-driven-development/SKILL.md` - should report "All 1 skill(s) clean."
3. `uv run --extra dev pytest tests/tools/test_tdd_skill_trivial_exception.py -v` - both tests should pass.
4. `scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/83532` - all blocking gates should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_tdd_skill_trivial_exception.py tests/tools/test_skill_linter.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - the updated `SKILL.md` is the relevant documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A