### PR TITLE
fix(mcp): keep colliding MCP servers available to tool search

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -55,6 +55,22 @@ class TestGetToolset:
         assert ts is not None
         assert set(ts["tools"]) == {"web_search", "web_extract", "web_search_plus"}
 
+    def test_merges_colliding_mcp_alias_into_builtin_toolset(self, monkeypatch):
+        reg = ToolRegistry()
+        reg.register(
+            name="mcp__memory__read_graph",
+            toolset="mcp-memory",
+            schema=_make_schema("mcp__memory__read_graph", "Read graph"),
+            handler=_dummy_handler,
+        )
+        reg.register_toolset_alias("memory", "mcp-memory")
+
+        monkeypatch.setattr("tools.registry.registry", reg)
+
+        tools = resolve_toolset("memory")
+        assert "memory" in tools
+        assert "mcp__memory__read_graph" in tools
+
 
 
 class TestResolveToolset:

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -460,6 +460,43 @@ class TestRegression_ToolsetScoping:
         # core tools are never deferrable
         assert "terminal" not in names
 
+    def test_builtin_name_collision_keeps_mcp_alias_searchable(self):
+        from tools.registry import registry
+        import model_tools
+
+        self._register("mcp__memory__read_graph", "mcp-memory")
+        registry.register_toolset_alias("memory", "mcp-memory")
+
+        source_result = model_tools.handle_function_call(
+            function_name="tool_search",
+            function_args={"query": "unrelated capability", "limit": 5},
+            enabled_toolsets=["memory"],
+        )
+
+        source_payload = json.loads(source_result)
+        assert {source["name"] for source in source_payload["available_sources"]} == {
+            "memory"
+        }
+
+        match_result = model_tools.handle_function_call(
+            function_name="tool_search",
+            function_args={"query": "read graph", "limit": 5},
+            enabled_toolsets=["memory"],
+        )
+        assert "mcp__memory__read_graph" in {
+            match["name"] for match in json.loads(match_result)["matches"]
+        }
+
+        call_result = model_tools.handle_function_call(
+            function_name="tool_call",
+            function_args={"name": "mcp__memory__read_graph", "arguments": {}},
+            enabled_toolsets=["memory"],
+        )
+        assert json.loads(call_result) == {
+            "ok": True,
+            "tool": "mcp__memory__read_graph",
+        }
+
 
 # ---------------------------------------------------------------------------
 # Catalog listing (skills-style progressive disclosure)

--- a/toolsets.py
+++ b/toolsets.py
@@ -693,9 +693,17 @@ def get_toolset(name: str, *, include_registry: bool = True) -> Optional[Dict[st
         return toolset if toolset else None
 
     if toolset:
+        registry_toolsets = {name}
+        alias_target = registry.get_toolset_alias_target(name)
+        if alias_target:
+            registry_toolsets.add(alias_target)
         merged_tools = sorted(
-            set(toolset.get("tools", []))
-            | set(registry.get_tool_names_for_toolset(name))
+            set(toolset.get("tools", [])).union(
+                *(
+                    registry.get_tool_names_for_toolset(toolset_name)
+                    for toolset_name in registry_toolsets
+                )
+            )
         )
         return {**toolset, "tools": merged_tools}
 


### PR DESCRIPTION
## What does this PR do?

MCP servers whose configured names collide with built-in toolsets now remain available through scoped Tool Search. Previously, these servers could connect and register successfully while all of their tools disappeared from `available_sources`, search results, and guarded direct invocation, leaving the connected server unusable in that session.

### Symptom

A server configured as `memory` registers tools such as `mcp__memory__read_graph`, but a session enabled with the `memory` toolset exposes only the built-in memory tools. `tool_search` cannot discover the MCP tools, and `tool_call` rejects them as unavailable for the current session.

### Impact

Users cannot invoke any tool from an affected MCP server even though `hermes mcp list`, connection tests, and registration logs report that the server is healthy. The failure applies when an MCP server name matches an existing built-in toolset name; non-colliding server names continue to work.

### Bug Cause

**Trigger:** `toolsets.py:get_toolset` when a static toolset name is also a registered MCP alias.

**Causal chain:**
1. MCP registration stores the server tools under a canonical toolset such as `mcp-memory` and records the alias `memory -> mcp-memory`.
2. Session setup enables the configured name `memory`, but `get_toolset("memory")` takes the static built-in branch and merges registry tools owned only by `memory`.
3. The canonical `mcp-memory` schemas never enter the session definitions, so Tool Search cannot catalog or invoke them.

**Why it is wrong:** A live registry alias must still participate in resolution when its bare name collides with a static toolset. Static lookup precedence was silently discarding the alias target.

**Working sibling / contrast:** A non-colliding MCP server such as `github` follows its registry alias because no static toolset intercepts the lookup.

**Ruled out:** MCP registration and availability checks are not failing; the registry already owns the affected schemas under the canonical `mcp-memory` toolset. Tool Search classification also works once those schemas reach the scoped definitions.

### Fix

When resolving a built-in toolset, merge registry tools from both the built-in name and any live alias target. This preserves the built-in tools while making the colliding MCP server's tools searchable and callable. Regression coverage exercises direct resolution, scoped source listing, search results, and guarded invocation.

## Related Issue

Closes #86012

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `toolsets.py` - merge a colliding registry alias target into the static toolset result.
- `tests/test_toolsets.py` - cover combined built-in and MCP alias resolution.
- `tests/tools/test_tool_search.py` - cover scoped Tool Search discovery and invocation for the collision case.

## How to Test

1. Run the related resolver and Tool Search suites:

```bash
scripts/run_tests.sh tests/test_toolsets.py tests/tools/test_tool_search.py
```

2. Confirm all 54 tests pass, including the collision regression.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the related tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; the public interface is unchanged
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; resolution is platform-independent
- [x] Tool description and schema updates are N/A; existing registered schemas are restored unchanged
