### PR TITLE
chore: map contributor email for @infocentr

### DIFF
--- a/contributors/emails/laura@localhost
+++ b/contributors/emails/laura@localhost
@@ -1,0 +1,1 @@
+infocentr


### PR DESCRIPTION
Maps `laura@localhost` → `infocentr` so #85998's check-attribution passes. #85998 fixes the `test_slash_worker_accepts_profile_home` TypeError currently breaking Python tests slice 3/12 on main (run 31786882691) and inheriting red into every open PR's merge ref.