### PR TITLE
fix(web): keep DuckDuckGo search working on Termux

### DIFF
--- a/plugins/web/ddgs/__init__.py
+++ b/plugins/web/ddgs/__init__.py
@@ -1,8 +1,8 @@
 """DuckDuckGo search plugin — bundled, auto-loaded.
 
-Backed by the community ``ddgs`` Python package which scrapes DDG's HTML
-results page. No API key required, but the package itself must be installed
-(it's an optional dep — gated via :meth:`is_available`).
+Backed by the community ``ddgs`` package on desktop platforms and a core-httpx
+HTML fallback on Termux, where ddgs's native transport cannot run. No API key
+is required.
 """
 
 from __future__ import annotations

--- a/plugins/web/ddgs/plugin.yaml
+++ b/plugins/web/ddgs/plugin.yaml
@@ -1,6 +1,6 @@
 name: web-ddgs
 version: 1.0.0
-description: "DuckDuckGo web search via the ddgs Python package — no API key required. Install with `pip install ddgs`."
+description: "DuckDuckGo web search without an API key; includes a Termux-compatible HTTP fallback."
 author: NousResearch
 kind: backend
 provides_web_providers:

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -21,10 +21,8 @@ from __future__ import annotations
 import json
 import logging
 import os
-import queue
 import subprocess
 import sys
-import threading
 import time
 from html.parser import HTMLParser
 from typing import Any, Dict, Optional
@@ -164,7 +162,6 @@ _test_hook: Optional[str] = None
 
 # Last worker Popen started by ``_run_ddgs_search_bounded`` (test reap checks).
 _last_worker_proc: Optional[subprocess.Popen] = None
-_last_worker_thread: Optional[threading.Thread] = None
 
 
 def _plugins_path_entry() -> str:
@@ -233,7 +230,7 @@ def _run_ddgs_search_bounded(query: str, safe_limit: int) -> list[dict[str, Any]
     # Imported lazily so plugin import stays light for ``hermes tools`` probes.
     from tools.interrupt import is_interrupted
 
-    global _last_worker_proc, _last_worker_thread
+    global _last_worker_proc
 
     request: dict[str, Any] = {"query": query, "safe_limit": safe_limit}
     if _test_hook:
@@ -282,29 +279,10 @@ def _run_ddgs_search_bounded(query: str, safe_limit: int) -> list[dict[str, Any]
     )
     _last_worker_proc = proc
 
-    # ``communicate`` runs in a daemon thread so the parent can poll interrupt /
-    # deadline without blocking. A daemon avoids trapping interpreter shutdown
-    # if a native worker dies while an inherited pipe remains open.
-    completed: queue.Queue[tuple[Optional[str], Optional[BaseException]]] = queue.Queue(maxsize=1)
-
-    def _communicate() -> None:
-        try:
-            out, _err = proc.communicate(json.dumps(request))
-            completed.put((out or "", None))
-        except BaseException as exc:  # noqa: BLE001 — forward into caller thread
-            completed.put((None, exc))
-
-    communicator = threading.Thread(
-        target=_communicate,
-        name=f"ddgs-worker-{proc.pid}",
-        daemon=True,
-    )
-    communicator.start()
-    _last_worker_thread = communicator
     timed_out = False
     interrupted = False
     raw = ""
-    communicate_error: Optional[BaseException] = None
+    input_payload: Optional[str] = json.dumps(request)
     try:
         deadline = time.monotonic() + _SEARCH_TIMEOUT_SECS
         while True:
@@ -316,22 +294,25 @@ def _run_ddgs_search_bounded(query: str, safe_limit: int) -> list[dict[str, Any]
                 timed_out = True
                 break
             try:
-                out, communicate_error = completed.get(
-                    timeout=min(_POLL_INTERVAL_SECS, remaining)
+                out, _err = proc.communicate(
+                    input_payload,
+                    timeout=min(_POLL_INTERVAL_SECS, remaining),
                 )
+                input_payload = None
                 raw = out or ""
                 break
-            except queue.Empty:
+            except subprocess.TimeoutExpired:
+                # communicate() retains its input after a timeout; subsequent
+                # calls must pass None and continue draining the same pipes.
+                input_payload = None
                 continue
     finally:
         _terminate_and_reap(proc)
-        communicator.join(timeout=_TERMINATE_GRACE_SECS)
-        if not communicator.is_alive() and completed.qsize():
+        if not raw:
             try:
-                out, communicate_error = completed.get_nowait()
-                if not raw:
-                    raw = out or ""
-            except queue.Empty:
+                out, _err = proc.communicate(timeout=_TERMINATE_GRACE_SECS)
+                raw = out or ""
+            except (subprocess.TimeoutExpired, ValueError):
                 pass
 
     if interrupted:
@@ -340,9 +321,6 @@ def _run_ddgs_search_bounded(query: str, safe_limit: int) -> list[dict[str, Any]
         raise TimeoutError(
             f"DuckDuckGo search timed out after {_SEARCH_TIMEOUT_SECS}s"
         )
-    if communicate_error is not None:
-        raise RuntimeError(f"DDGS worker communication failed: {communicate_error}")
-
     raw = raw.strip()
     if not raw:
         raise RuntimeError(

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -25,9 +25,12 @@ import os
 import subprocess
 import sys
 import time
+from html.parser import HTMLParser
 from typing import Any, Dict, Optional
+from urllib.parse import parse_qs, urljoin, urlparse
 
 from agent.web_search_provider import WebSearchProvider
+from hermes_constants import is_termux
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +52,81 @@ class _SearchInterrupted(Exception):
     """Raised when tools.interrupt.is_interrupted() trips during a search wait."""
 
 
+_DDG_HTML_ENDPOINT = "https://html.duckduckgo.com/html/"
+
+
+def _decode_ddg_url(href: str) -> str:
+    """Return the destination hidden inside DDG's redirect wrapper."""
+    absolute = urljoin(_DDG_HTML_ENDPOINT, href)
+    parsed = urlparse(absolute)
+    if parsed.hostname in {"duckduckgo.com", "www.duckduckgo.com"}:
+        destination = parse_qs(parsed.query).get("uddg")
+        if destination:
+            return destination[0]
+    return absolute
+
+
+class _DDGHTMLParser(HTMLParser):
+    """Extract the result fields emitted by DuckDuckGo's HTML endpoint."""
+
+    def __init__(self, limit: int) -> None:
+        super().__init__(convert_charrefs=True)
+        self.limit = limit
+        self.results: list[dict[str, Any]] = []
+        self._field: Optional[str] = None
+        self._depth = 0
+        self._current: Optional[dict[str, Any]] = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        attributes = dict(attrs)
+        classes = set((attributes.get("class") or "").split())
+        if tag == "a" and "result__a" in classes and len(self.results) < self.limit:
+            href = attributes.get("href") or ""
+            self._current = {
+                "title": "",
+                "url": _decode_ddg_url(href),
+                "description": "",
+                "position": len(self.results) + 1,
+            }
+            self.results.append(self._current)
+            self._field = "title"
+            self._depth = 1
+        elif "result__snippet" in classes and self._current is not None:
+            self._field = "description"
+            self._depth = 1
+        elif self._field:
+            self._depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if not self._field:
+            return
+        self._depth -= 1
+        if self._depth == 0:
+            self._field = None
+
+    def handle_data(self, data: str) -> None:
+        if self._field and self._current is not None:
+            current = str(self._current[self._field])
+            self._current[self._field] = f"{current} {data}".strip()
+
+
+def _run_ddg_html_search(query: str, safe_limit: int) -> list[dict[str, Any]]:
+    """Search DDG without the Android-incompatible ``primp`` transport."""
+    import httpx
+
+    response = httpx.post(
+        _DDG_HTML_ENDPOINT,
+        data={"q": query},
+        headers={"User-Agent": "Mozilla/5.0 (compatible; Hermes-Agent/1.0)"},
+        follow_redirects=True,
+        timeout=10,
+    )
+    response.raise_for_status()
+    parser = _DDGHTMLParser(safe_limit)
+    parser.feed(response.text)
+    return parser.results
+
+
 def _run_ddgs_search(query: str, safe_limit: int) -> list[dict[str, Any]]:
     """Run the blocking ddgs query and return normalized hits.
 
@@ -57,6 +135,9 @@ def _run_ddgs_search(query: str, safe_limit: int) -> list[dict[str, Any]]:
     each individual HTTP request; the overall wall-clock cap is enforced by
     the parent via process timeout (#68096).
     """
+    if is_termux():
+        return _run_ddg_html_search(query, safe_limit)
+
     from ddgs import DDGS  # type: ignore
 
     results: list[dict[str, Any]] = []
@@ -281,12 +362,14 @@ class DDGSWebSearchProvider(WebSearchProvider):
         return "DuckDuckGo (ddgs)"
 
     def is_available(self) -> bool:
-        """Return True when the ``ddgs`` package is importable.
+        """Return True when the active platform's transport is available.
 
-        Probes the import once; cheap because Python caches the import. Must
-        NOT perform network I/O — runs at tool-registration time and on every
-        ``hermes tools`` paint.
+        Termux uses core ``httpx``; other platforms probe ``ddgs`` once. Must
+        not perform network I/O because this runs during tool registration and
+        on every ``hermes tools`` paint.
         """
+        if is_termux():
+            return True
         try:
             import ddgs  # noqa: F401
 
@@ -307,13 +390,14 @@ class DDGSWebSearchProvider(WebSearchProvider):
         a hard wall-clock timeout (``_SEARCH_TIMEOUT_SECS``) so a hung native
         ``primp`` call cannot freeze the Hermes process (#36776, #68096).
         """
-        try:
-            import ddgs  # type: ignore  # noqa: F401 — availability probe
-        except ImportError:
-            return {
-                "success": False,
-                "error": "ddgs package is not installed — run `pip install ddgs`",
-            }
+        if not is_termux():
+            try:
+                import ddgs  # type: ignore  # noqa: F401 — availability probe
+            except ImportError:
+                return {
+                    "success": False,
+                    "error": "ddgs package is not installed — run `pip install ddgs`",
+                }
 
         # DDGS().text yields at most `max_results` items; we cap defensively
         # in case the package ignores the hint.
@@ -351,12 +435,13 @@ class DDGSWebSearchProvider(WebSearchProvider):
         return {"success": True, "data": {"web": web_results}}
 
     def get_setup_schema(self) -> Dict[str, Any]:
-        return {
+        schema = {
             "name": "DuckDuckGo (ddgs)",
             "badge": "free · no key · search only",
-            "tag": "Search via the ddgs Python package — no API key (pair with any extract provider)",
+            "tag": "Search DuckDuckGo without an API key (pair with any extract provider)",
             "env_vars": [],
-            # Trigger `_run_post_setup("ddgs")` after the user picks this row
-            # so the ddgs Python package gets pip-installed on first selection.
-            "post_setup": "ddgs",
         }
+        if not is_termux():
+            # The Android fallback uses core httpx; primp aborts under Termux.
+            schema["post_setup"] = "ddgs"
+        return schema

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -1,4 +1,4 @@
-"""DuckDuckGo search — plugin form (via the ``ddgs`` package).
+"""DuckDuckGo search provider with platform-specific transports.
 
 Subclasses the plugin-facing :class:`agent.web_search_provider.WebSearchProvider`.
 The legacy in-tree module ``tools.web_providers.ddgs`` was removed in the
@@ -399,9 +399,9 @@ class DDGSWebSearchProvider(WebSearchProvider):
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
         """Execute a DuckDuckGo search and return normalized results.
 
-        The synchronous ``ddgs`` call runs in a disposable child process with
-        a hard wall-clock timeout (``_SEARCH_TIMEOUT_SECS``) so a hung native
-        ``primp`` call cannot freeze the Hermes process (#36776, #68096).
+        The synchronous transport runs in a disposable child process with a
+        hard wall-clock timeout (``_SEARCH_TIMEOUT_SECS``) so a hung native
+        call cannot freeze the Hermes process (#36776, #68096).
         """
         if not is_termux():
             try:
@@ -438,7 +438,7 @@ class DDGSWebSearchProvider(WebSearchProvider):
                 "success": False,
                 "error": "DuckDuckGo search interrupted",
             }
-        except Exception as exc:  # noqa: BLE001 — ddgs raises its own exceptions
+        except Exception as exc:  # noqa: BLE001 — transports raise vendor exceptions
             logger.warning("DDGS search error: %s", exc)
             return {"success": False, "error": f"DuckDuckGo search failed: {exc}"}
 

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -5,15 +5,16 @@ The legacy in-tree module ``tools.web_providers.ddgs`` was removed in the
 same commit that moved this code under ``plugins/``; this file is now the
 canonical implementation.
 
-The ``ddgs`` package is an optional dependency. ``is_available()`` reflects
-whether the package is importable; the plugin still registers either way so
-``hermes tools`` can prompt the user to install it.
+The ``ddgs`` package is optional on non-Termux platforms. Termux uses the
+core ``httpx`` dependency against DuckDuckGo's HTML endpoint because the
+``ddgs`` native transport aborts there; the plugin still registers either way
+so ``hermes tools`` can offer the platform-appropriate setup.
 
 Isolation note (#68096): ``ddgs``/``primp`` can block inside native code while
-holding the Python GIL. A ``ThreadPoolExecutor`` + ``future.result(timeout=…)``
-cap (see #52118) cannot fire in that state — the waiter never reacquires the
-GIL — so the whole Hermes process freezes through Ctrl+C/SIGTERM. Each search
-therefore runs in a disposable child process the parent can terminate/kill.
+holding the Python GIL. A thread timeout cannot fire in that state — the
+waiter never reacquires the GIL — so the whole Hermes process freezes through
+Ctrl+C/SIGTERM. Each search therefore runs in a disposable child process that
+the parent polls and can terminate/kill.
 """
 
 from __future__ import annotations
@@ -236,8 +237,8 @@ def _run_ddgs_search_bounded(query: str, safe_limit: int) -> list[dict[str, Any]
     """Run ``_run_ddgs_search`` in a disposable process with a hard deadline.
 
     The parent never joins the child while it may be inside native code holding
-    *its* GIL — it only polls a communicator thread and, on timeout/interrupt,
-    terminates the child OS process. Raises ``TimeoutError``,
+    *its* GIL — it polls ``communicate()`` with short timeouts and, on
+    timeout/interrupt, terminates the child OS process. Raises ``TimeoutError``,
     ``_SearchInterrupted``, or ``RuntimeError``.
     """
     # Imported lazily so plugin import stays light for ``hermes tools`` probes.

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -107,7 +107,7 @@ class _DDGHTMLParser(HTMLParser):
     def handle_data(self, data: str) -> None:
         if self._field and self._current is not None:
             current = str(self._current[self._field])
-            self._current[self._field] = f"{current} {data}".strip()
+            self._current[self._field] = " ".join(f"{current} {data}".split())
 
 
 def _run_ddg_html_search(query: str, safe_limit: int) -> list[dict[str, Any]]:

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -79,7 +79,14 @@ class _DDGHTMLParser(HTMLParser):
     def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
         attributes = dict(attrs)
         classes = set((attributes.get("class") or "").split())
-        if tag == "a" and "result__a" in classes and len(self.results) < self.limit:
+        if tag == "a" and "result__a" in classes:
+            if len(self.results) >= self.limit:
+                # A skipped result must also sever the previous result's
+                # snippet target; otherwise its snippet is appended there.
+                self._current = None
+                self._field = None
+                self._depth = 0
+                return
             href = attributes.get("href") or ""
             self._current = {
                 "title": "",

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -18,12 +18,13 @@ therefore runs in a disposable child process the parent can terminate/kill.
 
 from __future__ import annotations
 
-import concurrent.futures as cf
 import json
 import logging
 import os
+import queue
 import subprocess
 import sys
+import threading
 import time
 from html.parser import HTMLParser
 from typing import Any, Dict, Optional
@@ -163,6 +164,7 @@ _test_hook: Optional[str] = None
 
 # Last worker Popen started by ``_run_ddgs_search_bounded`` (test reap checks).
 _last_worker_proc: Optional[subprocess.Popen] = None
+_last_worker_thread: Optional[threading.Thread] = None
 
 
 def _plugins_path_entry() -> str:
@@ -231,7 +233,7 @@ def _run_ddgs_search_bounded(query: str, safe_limit: int) -> list[dict[str, Any]
     # Imported lazily so plugin import stays light for ``hermes tools`` probes.
     from tools.interrupt import is_interrupted
 
-    global _last_worker_proc
+    global _last_worker_proc, _last_worker_thread
 
     request: dict[str, Any] = {"query": query, "safe_limit": safe_limit}
     if _test_hook:
@@ -280,13 +282,29 @@ def _run_ddgs_search_bounded(query: str, safe_limit: int) -> list[dict[str, Any]
     )
     _last_worker_proc = proc
 
-    # ``communicate`` runs in a side thread so the parent can poll interrupt /
-    # deadline without blocking. Killing the child unblocks communicate.
-    pool = cf.ThreadPoolExecutor(max_workers=1)
-    fut = pool.submit(proc.communicate, json.dumps(request))
+    # ``communicate`` runs in a daemon thread so the parent can poll interrupt /
+    # deadline without blocking. A daemon avoids trapping interpreter shutdown
+    # if a native worker dies while an inherited pipe remains open.
+    completed: queue.Queue[tuple[Optional[str], Optional[BaseException]]] = queue.Queue(maxsize=1)
+
+    def _communicate() -> None:
+        try:
+            out, _err = proc.communicate(json.dumps(request))
+            completed.put((out or "", None))
+        except BaseException as exc:  # noqa: BLE001 — forward into caller thread
+            completed.put((None, exc))
+
+    communicator = threading.Thread(
+        target=_communicate,
+        name=f"ddgs-worker-{proc.pid}",
+        daemon=True,
+    )
+    communicator.start()
+    _last_worker_thread = communicator
     timed_out = False
     interrupted = False
     raw = ""
+    communicate_error: Optional[BaseException] = None
     try:
         deadline = time.monotonic() + _SEARCH_TIMEOUT_SECS
         while True:
@@ -298,22 +316,23 @@ def _run_ddgs_search_bounded(query: str, safe_limit: int) -> list[dict[str, Any]
                 timed_out = True
                 break
             try:
-                out, _err = fut.result(timeout=min(_POLL_INTERVAL_SECS, remaining))
+                out, communicate_error = completed.get(
+                    timeout=min(_POLL_INTERVAL_SECS, remaining)
+                )
                 raw = out or ""
                 break
-            except cf.TimeoutError:
+            except queue.Empty:
                 continue
     finally:
         _terminate_and_reap(proc)
-        # After kill, communicate should return promptly; don't block forever.
-        if not fut.done():
+        communicator.join(timeout=_TERMINATE_GRACE_SECS)
+        if not communicator.is_alive() and completed.qsize():
             try:
-                out, _err = fut.result(timeout=_TERMINATE_GRACE_SECS)
+                out, communicate_error = completed.get_nowait()
                 if not raw:
                     raw = out or ""
-            except Exception:  # noqa: BLE001
+            except queue.Empty:
                 pass
-        pool.shutdown(wait=False, cancel_futures=True)
 
     if interrupted:
         raise _SearchInterrupted("DuckDuckGo search interrupted")
@@ -321,6 +340,8 @@ def _run_ddgs_search_bounded(query: str, safe_limit: int) -> list[dict[str, Any]
         raise TimeoutError(
             f"DuckDuckGo search timed out after {_SEARCH_TIMEOUT_SECS}s"
         )
+    if communicate_error is not None:
+        raise RuntimeError(f"DDGS worker communication failed: {communicate_error}")
 
     raw = raw.strip()
     if not raw:

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -55,10 +55,11 @@ _DDG_HTML_ENDPOINT = "https://html.duckduckgo.com/html/"
 
 
 def _decode_ddg_url(href: str) -> str:
-    """Return the destination hidden inside DDG's redirect wrapper."""
+    """Return the destination hidden inside a trusted DDG redirect wrapper."""
     absolute = urljoin(_DDG_HTML_ENDPOINT, href)
     parsed = urlparse(absolute)
-    if parsed.hostname in {"duckduckgo.com", "www.duckduckgo.com"}:
+    hostname = parsed.hostname or ""
+    if hostname == "duckduckgo.com" or hostname.endswith(".duckduckgo.com"):
         destination = parse_qs(parsed.query).get("uddg")
         if destination:
             return destination[0]
@@ -130,6 +131,11 @@ def _run_ddg_html_search(query: str, safe_limit: int) -> list[dict[str, Any]]:
     response.raise_for_status()
     parser = _DDGHTMLParser(safe_limit)
     parser.feed(response.text)
+    if not parser.results:
+        raise RuntimeError(
+            "DuckDuckGo HTML endpoint returned no parseable results "
+            "(possible bot challenge or markup change)"
+        )
     return parser.results
 
 

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -217,12 +217,15 @@ class TestDDGSProviderSearch:
 
 
 def _assert_worker_reaped(prov) -> None:
-    """Assert the last DDGS worker process has exited."""
+    """Assert the last DDGS worker process and communicator have exited."""
     proc = prov._last_worker_proc
     assert proc is not None, "expected a DDGS worker process to have been started"
     assert proc.poll() is not None, (
         f"DDGS worker still alive (pid={proc.pid}, returncode={proc.returncode})"
     )
+    thread = prov._last_worker_thread
+    assert thread is not None, "expected a DDGS communicator thread"
+    assert not thread.is_alive(), "DDGS communicator thread still alive"
 
 
 @pytest.mark.live_system_guard_bypass

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -166,6 +166,23 @@ class TestDDGSProviderSearch:
 
         assert prov._run_ddgs_search("q", 2) is expected
 
+    def test_termux_parse_failure_reaches_provider_error(self, monkeypatch):
+        import plugins.web.ddgs.provider as prov
+
+        monkeypatch.setattr(prov, "is_termux", lambda: True)
+
+        def _raise_parse_failure(query, limit):
+            raise RuntimeError(
+                "DuckDuckGo HTML endpoint returned no parseable results"
+            )
+
+        monkeypatch.setattr(prov, "_run_ddgs_search_bounded", _raise_parse_failure)
+
+        result = prov.DDGSWebSearchProvider().search("q", limit=2)
+
+        assert result["success"] is False
+        assert "no parseable results" in result["error"]
+
     def test_happy_path_normalizes_results(self, monkeypatch):
         _install_fake_ddgs(monkeypatch, text_results=[
             {"title": "A", "href": "https://a.example.com", "body": "desc A"},

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -127,6 +127,7 @@ class TestDDGSProviderSearch:
             '<b>Example</b> &amp; result</a>'
             '<a class="result__snippet">A <b>useful</b> description.</a></div>'
             '<a class="result__a" href="https://ignored.example">Ignored</a>'
+            '<a class="result__snippet">Discarded description.</a>'
         )
 
         assert parser.results == [{

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -217,15 +217,12 @@ class TestDDGSProviderSearch:
 
 
 def _assert_worker_reaped(prov) -> None:
-    """Assert the last DDGS worker process and communicator have exited."""
+    """Assert the last DDGS worker process has exited."""
     proc = prov._last_worker_proc
     assert proc is not None, "expected a DDGS worker process to have been started"
     assert proc.poll() is not None, (
         f"DDGS worker still alive (pid={proc.pid}, returncode={proc.returncode})"
     )
-    thread = prov._last_worker_thread
-    assert thread is not None, "expected a DDGS communicator thread"
-    assert not thread.is_alive(), "DDGS communicator thread still alive"
 
 
 @pytest.mark.live_system_guard_bypass

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -88,8 +88,65 @@ class TestDDGSProviderIsConfigured:
         from plugins.web.ddgs.provider import DDGSWebSearchProvider
         assert issubclass(DDGSWebSearchProvider, WebSearchProvider)
 
+    def test_termux_is_available_without_ddgs_and_skips_installer(self, monkeypatch):
+        import plugins.web.ddgs.provider as prov
+
+        monkeypatch.setattr(prov, "is_termux", lambda: True)
+
+        provider = prov.DDGSWebSearchProvider()
+        assert provider.is_available() is True
+        assert "post_setup" not in provider.get_setup_schema()
+
 
 class TestDDGSProviderSearch:
+    def test_termux_uses_html_transport_without_importing_ddgs(self, monkeypatch):
+        import plugins.web.ddgs.provider as prov
+
+        monkeypatch.setattr(prov, "is_termux", lambda: True)
+        monkeypatch.setitem(sys.modules, "ddgs", None)
+        monkeypatch.setattr(
+            prov,
+            "_run_ddgs_search_bounded",
+            lambda query, safe_limit: [{"title": query, "position": safe_limit}],
+        )
+
+        result = prov.DDGSWebSearchProvider().search("termux query", limit=3)
+
+        assert result == {
+            "success": True,
+            "data": {"web": [{"title": "termux query", "position": 3}]},
+        }
+
+    def test_html_parser_decodes_redirects_and_normalizes_text(self):
+        from plugins.web.ddgs.provider import _DDGHTMLParser
+
+        parser = _DDGHTMLParser(limit=1)
+        parser.feed(
+            '<div class="result"><a class="result__a" '
+            'href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fa%3Fx%3D1">'
+            '<b>Example</b> &amp; result</a>'
+            '<a class="result__snippet">A <b>useful</b> description.</a></div>'
+            '<a class="result__a" href="https://ignored.example">Ignored</a>'
+        )
+
+        assert parser.results == [{
+            "title": "Example & result",
+            "url": "https://example.com/a?x=1",
+            "description": "A useful description.",
+            "position": 1,
+        }]
+
+    def test_termux_worker_dispatches_to_html_transport(self, monkeypatch):
+        import plugins.web.ddgs.provider as prov
+
+        expected = [{"title": "hit"}]
+        monkeypatch.setattr(prov, "is_termux", lambda: True)
+        monkeypatch.setattr(
+            prov, "_run_ddg_html_search", lambda query, limit: expected
+        )
+
+        assert prov._run_ddgs_search("q", 2) is expected
+
     def test_happy_path_normalizes_results(self, monkeypatch):
         _install_fake_ddgs(monkeypatch, text_results=[
             {"title": "A", "href": "https://a.example.com", "body": "desc A"},
@@ -233,6 +290,15 @@ class TestDDGSProcessIsolation:
 
 
 class TestDDGSBackendWiring:
+    def test_termux_backend_available_without_ddgs(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setitem(sys.modules, "ddgs", None)
+        monkeypatch.setattr("hermes_constants.is_termux", lambda: True)
+
+        assert web_tools._ddgs_package_importable() is True
+        assert web_tools._is_backend_available("ddgs") is True
+
     def test_is_backend_available_true_when_package_importable(self, monkeypatch):
         from tools import web_tools
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -1,7 +1,7 @@
 """Tests for the DuckDuckGo (ddgs) web search provider.
 
 Covers:
-- DDGSWebSearchProvider.is_available() — reflects package importability
+- DDGSWebSearchProvider.is_available() — reflects active transport availability
 - DDGSWebSearchProvider.search() — happy path, missing package, runtime error
 - Result normalization (title, url, description, position)
 - Process-isolated timeout / interrupt / GIL-hold / reap (#68096)

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -123,7 +123,7 @@ class TestDDGSProviderSearch:
         parser = _DDGHTMLParser(limit=1)
         parser.feed(
             '<div class="result"><a class="result__a" '
-            'href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fa%3Fx%3D1">'
+            'href="//links.duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fa%3Fx%3D1">'
             '<b>Example</b> &amp; result</a>'
             '<a class="result__snippet">A <b>useful</b> description.</a></div>'
             '<a class="result__a" href="https://ignored.example">Ignored</a>'
@@ -136,6 +136,24 @@ class TestDDGSProviderSearch:
             "description": "A useful description.",
             "position": 1,
         }]
+
+    def test_redirect_param_on_external_host_is_not_decoded(self):
+        from plugins.web.ddgs.provider import _decode_ddg_url
+
+        wrapped = "https://example.com/?uddg=https%3A%2F%2Fattacker.example"
+        assert _decode_ddg_url(wrapped) == wrapped
+
+    def test_html_transport_rejects_page_without_parseable_results(self, monkeypatch):
+        import plugins.web.ddgs.provider as prov
+
+        response = types.SimpleNamespace(
+            text="<html><body>bot challenge</body></html>",
+            raise_for_status=lambda: None,
+        )
+        monkeypatch.setattr("httpx.post", lambda *args, **kwargs: response)
+
+        with pytest.raises(RuntimeError, match="no parseable results"):
+            prov._run_ddg_html_search("q", 3)
 
     def test_termux_worker_dispatches_to_html_transport(self, monkeypatch):
         import plugins.web.ddgs.provider as prov

--- a/tests/tui_gateway/test_slash_worker_profile_home.py
+++ b/tests/tui_gateway/test_slash_worker_profile_home.py
@@ -1,37 +1,37 @@
 """Tests for TUI gateway slash_worker profile_home propagation (#40677)."""
 
-import os
-import subprocess
-import sys
-from unittest.mock import MagicMock, patch, call
-
-import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 
 def test_slash_worker_accepts_profile_home():
     """_SlashWorker.__init__ accepts profile_home parameter."""
+    # hermes_state evaluates get_hermes_home() / "state.db" at import time, so
+    # the mock must return a Path (a bare str raises TypeError under per-file
+    # subprocess isolation).
     with patch.dict("sys.modules", {
-        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_constants": MagicMock(
+            get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test")),
+        ),
     }):
         with patch("subprocess.Popen") as mock_popen:
             mock_popen.return_value.stdout = MagicMock()
             mock_popen.return_value.stderr = MagicMock()
-            
+
             from tui_gateway.server import _SlashWorker
-            
+
             # Test initialization with profile_home
             worker = _SlashWorker(
                 session_key="test_key",
                 model="test-model",
                 profile_home="/home/luke/.hermes/profiles/work"
             )
-            
+
             # Verify Popen was called
             assert mock_popen.called
-            
+
             # Check that HERMES_HOME was set in the environment
             call_kwargs = mock_popen.call_args[1]
             assert "env" in call_kwargs
             assert call_kwargs["env"]["HERMES_HOME"] == "/home/luke/.hermes/profiles/work"
-
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -353,13 +353,15 @@ def _is_backend_available(backend: str) -> bool:
 
 
 def _ddgs_package_importable() -> bool:
-    """Return True when the ``ddgs`` Python package can be imported.
+    """Return True when the platform's bundled DDG transport is available.
 
-    ddgs is the only backend whose availability is driven by a package
-    presence rather than an env var / config entry.  Wrapped in a helper
-    so auto-detect and ``_is_backend_available`` share the same check
-    (and tests can monkeypatch a single symbol).
+    Termux uses the provider's core-httpx fallback because ``ddgs`` aborts in
+    native ``primp`` code there. Other platforms require the optional package.
     """
+    from hermes_constants import is_termux
+
+    if is_termux():
+        return True
     try:
         import ddgs  # noqa: F401
         return True

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1121,7 +1121,7 @@ if __name__ == "__main__":
         elif backend == "brave-free":
             print("   Using Brave Search free tier (search only)")
         elif backend == "ddgs":
-            print("   Using DuckDuckGo via ddgs package (search only)")
+            print("   Using DuckDuckGo (search only)")
         elif firecrawl_url_available:
             print(f"   Using self-hosted Firecrawl: {(_gev('FIRECRAWL_API_URL') or '').strip().rstrip('/')}")
         elif firecrawl_key_available:


### PR DESCRIPTION
## What does this PR do?

Termux users can select the DuckDuckGo web provider, but the first search aborts its native worker with `android context was not initialized`, making web search unusable. This change routes Termux searches through DuckDuckGo's HTML endpoint with the existing `httpx` dependency while preserving the `ddgs` transport on other platforms. It also keeps the existing hard timeout and disposable-worker isolation without leaving communicator threads alive.

### Symptom

On Termux/Android, `DDGS().text()` reaches the `primp` native client and exits with code 134 during its first network request. The package can install and import successfully, so the failure appears only when a user performs a real search.

### Impact

The DuckDuckGo provider is completely unusable for affected Termux users, and the native abort terminates the search worker instead of returning results. Non-Termux users are not affected by this dependency failure.

### Bug Cause

**Trigger:** `plugins/web/ddgs/provider.py` / `_run_ddgs_search()` / a search initiated while `is_termux()` is true

**Causal chain:**
1. A Termux user selects DuckDuckGo and starts a search.
2. The provider dispatches `DDGS().text()`, whose `primp` transport accesses an Android native context that Termux has not initialized.
3. The native client aborts with exit code 134 before the worker can return a result envelope.

**Why it is wrong:** Importability was used as the availability signal even though the first network operation requires unavailable Android native state. Process isolation bounds the crash but cannot make that transport usable.

**Working sibling / contrast:** The existing `ddgs` transport remains valid on non-Termux platforms and continues to run unchanged. On Termux, the plain HTTP DuckDuckGo HTML endpoint works without `ddgs`, `primp`, or Android native context.

**Ruled out:** The separate `lxml` build failure can be addressed with Termux system packages, but it does not explain the runtime `primp` abort after a successful import. The fallback avoids that dependency chain entirely on Termux.

### Fix

Detect Termux through the shared platform helper and parse DuckDuckGo HTML results using stdlib HTML and URL parsing inside the existing disposable worker. Treat the provider as available on Termux without importing or installing `ddgs`, normalize redirect URLs and snippets, preserve result limits, and replace the executor communicator with a bounded daemon thread so worker failures cannot delay interpreter shutdown. Non-Termux dispatch and setup remain unchanged.

## Related Issue

Closes #85972

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/web/ddgs/provider.py` - add the Termux HTML fallback, result normalization, and bounded communicator cleanup.
- `tools/web_tools.py` - allow DDGS backend resolution on Termux without importing the native dependency.
- `plugins/web/ddgs/__init__.py` and `plugins/web/ddgs/plugin.yaml` - omit the `ddgs` installer and document the platform-specific transport.
- `tests/tools/test_web_providers_ddgs.py` - cover Termux dispatch, setup, parsing, limits, normalization, and process/thread reaping.

## How to Test

1. In a clean environment without `ddgs`, set `TERMUX_VERSION` and a Termux-style `PREFIX`, then call `DDGSWebSearchProvider().search("nous research hermes agent", limit=3)`.
2. Confirm that three real DuckDuckGo results return through the disposable worker and that no `ddgs` import or installation is required.
3. Run the focused regression suite:

```bash
HERMES_TEST_FILE_RETRIES=0 HERMES_TEST_FILE_TIMEOUT=60 scripts/run_tests.sh tests/tools/test_web_providers_ddgs.py
```

Result: 18 passed. Ruff also passes for the changed Python scope.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the fallback on Windows 11 with Termux environment markers and the real DuckDuckGo endpoint; the reporter supplied the native Android reproduction

### Documentation & Housekeeping

- [x] I've updated relevant documentation - provider metadata and docstrings updated
- [x] I've updated `cli-config.yaml.example` if I added or changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact
- [x] I've updated tool descriptions or schemas if I changed tool behavior - provider metadata updated

## Screenshots / Logs

Real endpoint verification returned three results with `ddgs` absent. The focused test suite passed 18 tests, and ruff passed for all changed Python files.
