### PR TITLE
fix(acp): preserve SSE transport when registering client-provided MCP servers

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -989,17 +989,19 @@ class HermesACPAgent(acp.Agent):
                         "env": {item.name: item.value for item in server.env},
                     }
                 else:
+                    # McpServerHttp and McpServerSse share the url/headers shape, so
+                    # the transport has to be carried explicitly: the registrar
+                    # (tools/mcp_tool.py) picks the SSE client only when
+                    # config["transport"] == "sse", and an unmarked SSE server is
+                    # contacted as streamable-HTTP — the handshake fails, silently.
+                    # Both branches are marked so this does not depend on the
+                    # registrar's default for unmarked url servers; "sse"/"http" are
+                    # its own transport names (see mcp_tool.get_mcp_server_status).
                     config = {
                         "url": server.url,
                         "headers": {item.name: item.value for item in server.headers},
+                        "transport": "sse" if isinstance(server, McpServerSse) else "http",
                     }
-                    # McpServerHttp and McpServerSse share the url/headers shape, but
-                    # the downstream registrar (tools/mcp_tool.py) selects the SSE
-                    # client only when config["transport"] == "sse"; without this
-                    # marker an SSE server is contacted as streamable-HTTP and the
-                    # handshake fails.
-                    if isinstance(server, McpServerSse):
-                        config["transport"] = "sse"
                 config_map[name] = config
 
             await asyncio.to_thread(register_mcp_servers, config_map)

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -993,6 +993,13 @@ class HermesACPAgent(acp.Agent):
                         "url": server.url,
                         "headers": {item.name: item.value for item in server.headers},
                     }
+                    # McpServerHttp and McpServerSse share the url/headers shape, but
+                    # the downstream registrar (tools/mcp_tool.py) selects the SSE
+                    # client only when config["transport"] == "sse"; without this
+                    # marker an SSE server is contacted as streamable-HTTP and the
+                    # handshake fails.
+                    if isinstance(server, McpServerSse):
+                        config["transport"] = "sse"
                 config_map[name] = config
 
             await asyncio.to_thread(register_mcp_servers, config_map)

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -102,6 +102,7 @@ class TestMcpRegistrationE2E:
         api_cfg = registered_configs["test-api"]
         assert api_cfg["url"] == "https://api.example.com/mcp"
         assert api_cfg["headers"] == {"Authorization": "Bearer tok123"}
+        assert api_cfg["transport"] == "http"
 
         # Verify agent tool surface was refreshed
         assert state.agent.tools == fake_tools
@@ -111,13 +112,14 @@ class TestMcpRegistrationE2E:
 
     @pytest.mark.asyncio
     async def test_sse_server_preserves_transport_marker(self, acp_agent):
-        """An SSE MCP server must register with transport=sse, not as plain HTTP.
+        """Each url/headers server must register with its own transport marker.
 
         McpServerHttp and McpServerSse share the url/headers shape, so without an
         explicit ``transport`` marker the downstream registrar (``tools/mcp_tool.py``,
         which gates on ``config["transport"] == "sse"``) would contact an SSE endpoint
         as streamable-HTTP and the handshake fails — silently, since the registration
-        error is only logged.
+        error is only logged. Both transports are asserted so the SSE path cannot be
+        re-broken by a change to the registrar's default.
         """
         servers = [
             McpServerSse(
@@ -147,8 +149,9 @@ class TestMcpRegistrationE2E:
         assert sse_cfg["headers"] == {"Authorization": "Bearer sse-tok"}
         assert sse_cfg["transport"] == "sse"
 
-        # Streamable-HTTP stays unmarked — that is what the registrar defaults to.
-        assert "transport" not in registered_configs["test-http"]
+        # Streamable-HTTP is marked explicitly too, rather than relying on the
+        # registrar defaulting unmarked url servers to streamable-HTTP.
+        assert registered_configs["test-http"]["transport"] == "http"
 
     @pytest.mark.asyncio
     async def test_prompt_with_tool_calls_emits_acp_events(self, acp_agent, mock_manager):

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -16,6 +16,7 @@ from acp.schema import (
     EnvVariable,
     HttpHeader,
     McpServerHttp,
+    McpServerSse,
     McpServerStdio,
     NewSessionResponse,
     PromptResponse,
@@ -107,6 +108,47 @@ class TestMcpRegistrationE2E:
         assert state.agent.valid_tool_names == {
             "mcp_test_fs_read", "mcp_test_fs_write", "mcp_test_api_search", "terminal"
         }
+
+    @pytest.mark.asyncio
+    async def test_sse_server_preserves_transport_marker(self, acp_agent):
+        """An SSE MCP server must register with transport=sse, not as plain HTTP.
+
+        McpServerHttp and McpServerSse share the url/headers shape, so without an
+        explicit ``transport`` marker the downstream registrar (``tools/mcp_tool.py``,
+        which gates on ``config["transport"] == "sse"``) would contact an SSE endpoint
+        as streamable-HTTP and the handshake fails — silently, since the registration
+        error is only logged.
+        """
+        servers = [
+            McpServerSse(
+                name="test-sse",
+                url="https://sse.example.com/sse",
+                headers=[HttpHeader(name="Authorization", value="Bearer sse-tok")],
+            ),
+            McpServerHttp(
+                name="test-http",
+                url="https://api.example.com/mcp",
+                headers=[],
+            ),
+        ]
+
+        registered_configs = {}
+
+        def mock_register(config_map):
+            registered_configs.update(config_map)
+            return ["mcp_test_sse_query"]
+
+        with patch("tools.mcp_tool.register_mcp_servers", side_effect=mock_register), \
+             patch("model_tools.get_tool_definitions", return_value=[]):
+            await acp_agent.new_session(cwd="/tmp", mcp_servers=servers)
+
+        sse_cfg = registered_configs["test-sse"]
+        assert sse_cfg["url"] == "https://sse.example.com/sse"
+        assert sse_cfg["headers"] == {"Authorization": "Bearer sse-tok"}
+        assert sse_cfg["transport"] == "sse"
+
+        # Streamable-HTTP stays unmarked — that is what the registrar defaults to.
+        assert "transport" not in registered_configs["test-http"]
 
     @pytest.mark.asyncio
     async def test_prompt_with_tool_calls_emits_acp_events(self, acp_agent, mock_manager):


### PR DESCRIPTION
## What does this PR do?

Preserves the SSE transport discriminator when registering client-provided MCP servers over ACP.

`_register_session_mcp_servers` builds `{url, headers}` for every non-stdio server. `McpServerHttp` and `McpServerSse` share that shape, so the transport marker is lost. Downstream, `tools/mcp_tool.py` selects the SSE client **only** when `config["transport"] == "sse"` — otherwise it falls through to `streamablehttp_client`. So an SSE MCP server provided over ACP is contacted with the wrong wire protocol, the handshake fails, and its tools never reach the agent.

The failure is silent: `_discover_and_register_server` raises, the exception is caught and logged as a warning, and neither the ACP client nor the model can observe it. A server that failed to connect looks identical to one that was never configured.

`config.yaml`-configured SSE servers are unaffected — they already carry `transport: sse`. Only the ACP-provided path dropped it, which is why this went unnoticed.

## Related Issue

Fixes #86032.

This is the same fix as #51102, which was closed as stale on 2026-07-05 with:

> If the underlying issue is still live on current main, we'll re-file a fresh, focused fix.

Verified still live on `main` (2026-08-14) — re-filing as invited, rebased onto current `main` and with the regression test included.

## Reproduction

Register an SSE MCP server through `session/new`, then ask the agent to list its tools — the server's tools are absent. The endpoint's own behaviour confirms the wrong protocol is used:

```
GET  https://<sse-endpoint>/sse   → 200  (SSE stream, correct)
POST https://<sse-endpoint>/sse   → 405  Method Not Allowed (streamable-HTTP attempt)
```

A streamable-HTTP server registered through the same path works fine, which makes the diagnosis harder — "some MCP servers work" suggests the registration path is healthy.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes

- `acp_adapter/server.py` — the url/headers branch now sets `"transport": "sse" if isinstance(server, McpServerSse) else "http"`. Both transports are marked explicitly, so the SSE path does not depend on the registrar's default for unmarked url servers; `"sse"`/`"http"` are the registrar's own transport names (`get_mcp_server_status` defaults url-shaped configs to `"http"`). `McpServerSse` was already imported; no import change needed.
- `tests/acp/test_mcp_e2e.py` — `test_sse_server_preserves_transport_marker` asserts both markers reach `register_mcp_servers`, and `test_mcp_servers_registered_and_tools_refreshed` asserts the HTTP marker too, pinning the contract from both directions.

No behaviour change for HTTP servers: besides the SSE gate at `mcp_tool.py:3078`, the only other reader is the preflight gate at `mcp_tool.py:3411`, which tests `!= "sse"` — `"http"` and unmarked take the same path.

## Testing

`pytest tests/acp` — 127 passed. Removing the `transport` line reds both tests, so the change is genuinely covered in both directions. We have also been running this patch downstream against 0.19.0 (`3ef6bbd2`), where it resolves the problem end to end: SSE MCP tools appear in the agent's tool surface and are callable.

## Note

Registration failures in this path being invisible to the ACP client and the model is a separate issue — now filed as #89668.

