### PR TITLE
feat(telegram): optionally reply to voice transcripts

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -621,6 +621,9 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
       languageCode: 'Optional ISO-639-3 language code. Blank lets ElevenLabs auto-detect.'
     }
   },
+  telegram: {
+    replyToTranscript: 'Reply to the visible transcript echo instead of the original Telegram voice note.'
+  },
   updates: {
     nonInteractiveLocalChanges:
       'When Hermes updates itself from the app (no terminal prompt), keep local source edits (stash) or throw them away (discard). Terminal updates always ask.'
@@ -707,6 +710,7 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.provider',
       'stt.enabled',
       'stt.echo_transcripts',
+      'telegram.reply_to_transcript',
       'stt.provider',
       'voice.auto_tts',
       'tts.edge.voice',

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1360,6 +1360,10 @@ platform_toolsets:
 #       # the active profile's scripts directory and receive webhook JSON on stdin.
 #       script_timeout_seconds: 30
 #
+# Telegram-specific settings (top-level; configurable with `hermes config set telegram.*`):
+# telegram:
+#   reply_to_transcript: false  # Reply to the visible STT echo instead of the voice-note bubble
+#
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #
 # discord:
@@ -1518,6 +1522,8 @@ platform_toolsets:
 # Set the corresponding API key in .env: GROQ_API_KEY, OPENAI_API_KEY, or MISTRAL_API_KEY.
 stt:
   enabled: true
+  # echo_transcripts: true        # show the recognized text in chat
+
   # provider: "local"          # auto-detected if omitted
   # --- Cloud pre-upload silence trim (groq/openai/mistral/xai/elevenlabs/deepinfra) ---
   # Local whisper gets Silero VAD; cloud endpoints otherwise receive raw audio —

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1819,13 +1819,17 @@ def load_gateway_config() -> GatewayConfig:
                     if entry.apply_yaml_config_fn is None:
                         continue
                     platform_cfg = yaml_cfg.get(entry.name)
-                    # Fall back to the platform's block under ``platforms`` /
-                    # ``gateway.platforms`` so adapter hooks still run when the
-                    # user configured the platform only under those nested paths
+                    # Fall back to the platform's block under ``gateway.<name>``,
+                    # ``platforms``, or ``gateway.platforms`` so adapter hooks
+                    # still run when the user configured the platform only there
                     # (e.g. ``platforms.discord.extra.allow_from``) and not via a
                     # top-level ``discord:`` block.
                     if not isinstance(platform_cfg, dict):
-                        for _src in (gateway_platforms, yaml_cfg.get("platforms")):
+                        for _src in (
+                            gateway_cfg,
+                            yaml_cfg.get("platforms"),
+                            gateway_platforms,
+                        ):
                             if isinstance(_src, dict):
                                 _candidate = _src.get(entry.name)
                                 if isinstance(_candidate, dict):

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -113,6 +113,7 @@ _HISTORY_MEDIA_LOOKUP_MAX_WORKERS = 2
 _HISTORY_MEDIA_LOOKUP_ADMISSION = threading.BoundedSemaphore(
     _HISTORY_MEDIA_LOOKUP_MAX_WORKERS
 )
+_REPLY_ANCHOR_UNSET = object()
 
 
 def _platform_name(platform) -> str:
@@ -131,7 +132,10 @@ def _float_env(name: str, default: float) -> float:
         return default
 
 
-def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) -> dict | None:
+def _thread_metadata_for_source(
+    source,
+    reply_to_message_id: object = _REPLY_ANCHOR_UNSET,
+) -> dict | None:
     """Build platform-aware thread metadata for adapter sends.
 
     Most platforms route threaded sends with a generic ``thread_id`` metadata
@@ -158,7 +162,11 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
         tid = str(thread_id)
         if tid and tid not in {"", "1"}:
             metadata["direct_messages_topic_id"] = tid
-        anchor = reply_to_message_id or getattr(source, "message_id", None)
+        anchor = (
+            getattr(source, "message_id", None)
+            if reply_to_message_id is _REPLY_ANCHOR_UNSET
+            else reply_to_message_id
+        )
         if anchor is not None:
             metadata["telegram_reply_to_message_id"] = str(anchor)
     # Routed Hermes profile for shared state.db namespaces (topic bindings
@@ -186,6 +194,15 @@ def _reply_anchor_for_event(event) -> str | None:
     stays attached to the active lane; synthetic/resumed sends fall back to
     ``direct_messages_topic_id`` metadata when no message id is available.
     """
+    # Handlers may create a more useful platform message to anchor the final
+    # reply to while processing the turn. STT uses this for Telegram's visible
+    # transcript echo. Keep it on the event so streaming and non-streaming
+    # delivery resolve the same late-bound anchor.
+    handler_anchor_key = "_gateway_stt_reply_anchor"
+    if hasattr(event, handler_anchor_key):
+        handler_anchor = getattr(event, handler_anchor_key)
+        return str(handler_anchor) if handler_anchor is not None else None
+
     source = getattr(event, "source", None)
     platform = _platform_name(getattr(source, "platform", None))
     thread_id = getattr(source, "thread_id", None)
@@ -4741,6 +4758,7 @@ class BasePlatformAdapter(ABC):
         images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
+        reply_to: Optional[str] = None,
     ) -> None:
         """Send a batch of images.
 
@@ -4771,6 +4789,7 @@ class BasePlatformAdapter(ABC):
                         chat_id=chat_id,
                         image_path=_unquote(image_url[7:]),
                         caption=alt_text if alt_text else None,
+                        reply_to=reply_to,
                         metadata=metadata,
                     )
                 elif self._is_animation_url(image_url):
@@ -4778,6 +4797,7 @@ class BasePlatformAdapter(ABC):
                         chat_id=chat_id,
                         animation_url=image_url,
                         caption=alt_text if alt_text else None,
+                        reply_to=reply_to,
                         metadata=metadata,
                     )
                 else:
@@ -4785,12 +4805,47 @@ class BasePlatformAdapter(ABC):
                         chat_id=chat_id,
                         image_url=image_url,
                         caption=alt_text if alt_text else None,
+                        reply_to=reply_to,
                         metadata=metadata,
                     )
                 if not img_result.success:
                     logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
             except Exception as img_err:
                 logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
+
+    async def _send_multiple_images_with_optional_reply(
+        self,
+        *,
+        chat_id: str,
+        images: List[Tuple[str, str]],
+        metadata: Optional[Dict[str, Any]],
+        human_delay: float,
+        reply_to: Optional[str],
+    ) -> None:
+        """Pass ``reply_to`` when an adapter's batch override supports it.
+
+        Older third-party adapters may override ``send_multiple_images`` with
+        the pre-reply-anchor signature. Keep those overrides working while
+        allowing first-party adapters to preserve ordinary-DM reply anchors.
+        """
+        send_images = self.send_multiple_images
+        kwargs: Dict[str, Any] = {
+            "chat_id": chat_id,
+            "images": images,
+            "metadata": metadata,
+            "human_delay": human_delay,
+        }
+        try:
+            params = inspect.signature(send_images).parameters
+            accepts_reply_to = "reply_to" in params or any(
+                param.kind is inspect.Parameter.VAR_KEYWORD
+                for param in params.values()
+            )
+        except (TypeError, ValueError):
+            accepts_reply_to = False
+        if accepts_reply_to:
+            kwargs["reply_to"] = reply_to
+        await send_images(**kwargs)
 
     async def send_image(
         self,
@@ -5095,6 +5150,7 @@ class BasePlatformAdapter(ABC):
         media_path: str,
         *,
         is_voice: bool = False,
+        reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Send a user-visible notice when a MEDIA attachment could not be delivered.
@@ -5114,7 +5170,12 @@ class BasePlatformAdapter(ABC):
             file_name = os.path.basename(media_path)
             text = f"⚠️ Couldn't deliver the file attachment ({file_name})."
         try:
-            notice = await self.send(chat_id=chat_id, content=text, metadata=metadata)
+            notice = await self.send(
+                chat_id=chat_id,
+                content=text,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
             if not notice.success:
                 logger.debug(
                     "[%s] Could not send media-delivery-failure notice: %s",
@@ -6789,7 +6850,17 @@ class BasePlatformAdapter(ABC):
                 # the existing notify=True marker. Clone once so typing/status
                 # metadata stays unmarked and progress bubbles remain
                 # thread-strict.
-                _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                # The handler can create a late reply anchor (for example a
+                # Telegram transcript echo), so recompute final metadata after
+                # it returns instead of reusing the typing metadata captured
+                # before processing began.
+                _final_reply_anchor = _reply_anchor_for_event(event)
+                _final_thread_metadata = _mark_notify_metadata(
+                    _thread_metadata_for_source(
+                        event.source,
+                        _final_reply_anchor,
+                    )
+                )
 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
@@ -6867,6 +6938,7 @@ class BasePlatformAdapter(ABC):
                             chat_id=event.source.chat_id,
                             audio_path=_tts_path,
                             caption=telegram_tts_caption,
+                            reply_to=_final_reply_anchor,
                             metadata=_final_thread_metadata,
                         )
                         _record_delivery(tts_result)
@@ -6901,7 +6973,7 @@ class BasePlatformAdapter(ABC):
                         len(text_content),
                         event.source.chat_id,
                     )
-                    _reply_anchor = _reply_anchor_for_event(event)
+                    _reply_anchor = _final_reply_anchor
                     # Delivery-obligation ledger: durably record the final
                     # response BEFORE the send attempt so a gateway crash
                     # between finalize and platform ACK can redeliver it on
@@ -7025,11 +7097,12 @@ class BasePlatformAdapter(ABC):
                 if images:
                     logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
                     try:
-                        await self.send_multiple_images(
+                        await self._send_multiple_images_with_optional_reply(
                             chat_id=event.source.chat_id,
                             images=images,
                             metadata=_final_thread_metadata,
                             human_delay=human_delay,
+                            reply_to=_final_reply_anchor,
                         )
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
@@ -7067,11 +7140,12 @@ class BasePlatformAdapter(ABC):
                 if _image_paths:
                     try:
                         _batch = [(f"file://{_quote(p)}", "") for p in _image_paths]
-                        await self.send_multiple_images(
+                        await self._send_multiple_images_with_optional_reply(
                             chat_id=event.source.chat_id,
                             images=_batch,
                             metadata=_final_thread_metadata,
                             human_delay=human_delay,
+                            reply_to=_final_reply_anchor,
                         )
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
@@ -7091,6 +7165,7 @@ class BasePlatformAdapter(ABC):
                             media_result = await self.send_voice(
                                 chat_id=event.source.chat_id,
                                 audio_path=media_path,
+                                reply_to=_final_reply_anchor,
                                 metadata=_final_thread_metadata,
                                 is_voice=is_voice,
                             )
@@ -7104,12 +7179,14 @@ class BasePlatformAdapter(ABC):
                             media_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=media_path,
+                                reply_to=_final_reply_anchor,
                                 metadata=_final_thread_metadata,
                             )
                         else:
                             media_result = await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=media_path,
+                                reply_to=_final_reply_anchor,
                                 metadata=_final_thread_metadata,
                             )
 
@@ -7119,6 +7196,7 @@ class BasePlatformAdapter(ABC):
                                 event.source.chat_id,
                                 media_path,
                                 is_voice=is_voice,
+                                reply_to=_final_reply_anchor,
                                 metadata=_final_thread_metadata,
                             )
                     except Exception as media_err:
@@ -7134,12 +7212,14 @@ class BasePlatformAdapter(ABC):
                             file_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=file_path,
+                                reply_to=_final_reply_anchor,
                                 metadata=_final_thread_metadata,
                             )
                         else:
                             file_result = await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=file_path,
+                                reply_to=_final_reply_anchor,
                                 metadata=_final_thread_metadata,
                             )
                         if not file_result.success:
@@ -7152,6 +7232,7 @@ class BasePlatformAdapter(ABC):
                             await self._notify_media_delivery_failure(
                                 event.source.chat_id,
                                 file_path,
+                                reply_to=_final_reply_anchor,
                                 metadata=_final_thread_metadata,
                             )
                     except Exception as file_err:
@@ -7246,7 +7327,11 @@ class BasePlatformAdapter(ABC):
             try:
                 error_type = type(e).__name__
                 error_detail = str(e)[:300] if str(e) else "no details available"
-                _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+                _error_reply_anchor = _reply_anchor_for_event(event)
+                _thread_metadata = _thread_metadata_for_source(
+                    event.source,
+                    _error_reply_anchor,
+                )
                 await self.send(
                     chat_id=event.source.chat_id,
                     content=(
@@ -7254,6 +7339,7 @@ class BasePlatformAdapter(ABC):
                         f"{error_detail}\n"
                         "Try again or use /reset to start a fresh session."
                     ),
+                    reply_to=_error_reply_anchor,
                     metadata=_thread_metadata,
                 )
             except Exception as notify_err:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3300,6 +3300,8 @@ _CONVERSATION_SCOPED_STATE: tuple = (
 
 # Sentinel for "caller did not pass metadata" vs "caller passed None".
 _UNSET = object()
+# Sentinel for "use the source message id" vs an explicit no-reply tombstone.
+_REPLY_ANCHOR_UNSET = object()
 
 
 def _resolve_runtime_agent_kwargs() -> dict:
@@ -4732,6 +4734,42 @@ def _preserve_queued_followup_history_offset(
     merged = dict(followup_result)
     merged["history_offset"] = current_offset
     return merged
+
+
+def _propagate_pending_stt_reply_anchor(
+    pending_event,
+    followup_result: dict,
+    *,
+    effective_anchor: object = _REPLY_ANCHOR_UNSET,
+) -> dict:
+    """Carry the deepest queued event's effective reply anchor outward."""
+    if not isinstance(followup_result, dict):
+        return followup_result
+    anchor_key = "_gateway_stt_reply_anchor"
+    if anchor_key in followup_result:
+        return followup_result
+
+    if effective_anchor is _REPLY_ANCHOR_UNSET:
+        anchor = getattr(pending_event, anchor_key, None)
+        if not anchor:
+            anchor = getattr(pending_event, "message_id", None)
+    else:
+        anchor = effective_anchor
+
+    merged = dict(followup_result)
+    merged[anchor_key] = str(anchor) if anchor is not None else None
+    return merged
+
+
+def _consume_pending_stt_reply_anchor(event, agent_result: dict) -> None:
+    """Transfer a queued reply anchor to the event without exposing its private key."""
+    if not isinstance(agent_result, dict):
+        return
+    anchor_key = "_gateway_stt_reply_anchor"
+    if anchor_key not in agent_result:
+        return
+    anchor = agent_result.pop(anchor_key)
+    setattr(event, anchor_key, str(anchor) if anchor is not None else None)
 
 
 async def _dispose_unused_adapter(adapter: "BasePlatformAdapter | None") -> None:
@@ -20666,10 +20704,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _echo_adapter:
                         for _tx in _successful_transcripts:
                             try:
-                                await _echo_adapter.send(
+                                _echo_result = await _echo_adapter.send(
                                     source.chat_id,
                                     f'🎙️ "{_tx}"',
                                     metadata=_echo_meta,
+                                )
+                                self._remember_stt_reply_anchor(
+                                    event,
+                                    source,
+                                    _echo_result,
                                 )
                             except Exception as _echo_exc:
                                 logger.debug(
@@ -23204,6 +23247,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_display_kind=persist_user_display_kind,
                 message_type=event.message_type,
             )
+            _consume_pending_stt_reply_anchor(event, agent_result)
             _turn_seconds = time.monotonic() - _turn_started_monotonic
 
             # Stop persistent typing indicator now that the agent is done.
@@ -23808,10 +23852,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     try:
                         _foot_adapter = self._adapter_for_source(source)
                         if _foot_adapter:
+                            _footer_reply_to = self._reply_anchor_for_event(event)
                             await _foot_adapter.send(
                                 source.chat_id,
                                 _footer_line,
-                                metadata=self._thread_metadata_for_source(source, self._reply_anchor_for_event(event)),
+                                reply_to=_footer_reply_to,
+                                metadata=self._thread_metadata_for_source(
+                                    source,
+                                    _footer_reply_to,
+                                ),
                             )
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
@@ -25141,6 +25190,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Return whether inbound voice/STT transcripts should be echoed to chat."""
         return bool(getattr(self.config, "stt_echo_transcripts", True))
 
+    def _remember_stt_reply_anchor(self, event, source, send_result) -> None:
+        """Remember a Telegram transcript echo as this turn's reply anchor."""
+        adapter = self._adapter_for_source(source)
+        platform_extra = getattr(getattr(adapter, "config", None), "extra", None) or {}
+        if (
+            getattr(source, "platform", None) != Platform.TELEGRAM
+            or not bool(platform_extra.get("reply_to_transcript", False))
+            or not getattr(send_result, "success", False)
+            or not getattr(send_result, "message_id", None)
+        ):
+            return
+        setattr(
+            event,
+            "_gateway_stt_reply_anchor",
+            str(send_result.message_id),
+        )
+
+    def _pending_voice_echo_metadata(self, event, fallback_source):
+        """Build lane-safe metadata for a queued/interrupting transcript echo."""
+        pending_source = getattr(event, "source", None) or fallback_source
+        metadata = self._thread_metadata_for_source(
+            pending_source,
+            self._reply_anchor_for_event(event),
+        )
+        return metadata or None
+
     async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
         """Generate TTS audio and send as a voice message before the text reply."""
         audio_path = None
@@ -25284,12 +25359,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # stale inspected content), not an attachment request.
             adapter.extract_images(cleaned)
 
+            _reply_to = self._reply_anchor_for_event(event)
+
             _thread_meta = (
                 dict(thread_metadata)
                 if thread_metadata is not None
                 else self._thread_metadata_for_source(
                     event.source,
-                    self._reply_anchor_for_event(event),
+                    _reply_to,
                 )
             )
 
@@ -25314,10 +25391,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if image_paths:
                 try:
                     images = [(f"file://{_quote(p)}", "") for p in image_paths]
+                    _batch_kwargs = {
+                        "chat_id": event.source.chat_id,
+                        "images": images,
+                        "metadata": _thread_meta,
+                    }
+                    try:
+                        _batch_params = inspect.signature(
+                            adapter.send_multiple_images
+                        ).parameters
+                        _batch_accepts_reply_to = (
+                            "reply_to" in _batch_params
+                            or any(
+                                param.kind is inspect.Parameter.VAR_KEYWORD
+                                for param in _batch_params.values()
+                            )
+                        )
+                    except (TypeError, ValueError):
+                        _batch_accepts_reply_to = False
+                    if _batch_accepts_reply_to:
+                        _batch_kwargs["reply_to"] = _reply_to
                     await adapter.send_multiple_images(
-                        chat_id=event.source.chat_id,
-                        images=images,
-                        metadata=_thread_meta,
+                        **_batch_kwargs,
                     )
                 except Exception as e:
                     logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)
@@ -25329,6 +25424,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await adapter.send_voice(
                             chat_id=event.source.chat_id,
                             audio_path=media_path,
+                            reply_to=_reply_to,
                             metadata=_thread_meta,
                             is_voice=is_voice,
                         )
@@ -25336,12 +25432,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=media_path,
+                            reply_to=_reply_to,
                             metadata=_thread_meta,
                         )
                     else:
                         await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=media_path,
+                            reply_to=_reply_to,
                             metadata=_thread_meta,
                         )
                 except Exception as e:
@@ -25402,6 +25500,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await adapter.send(
                         source.chat_id,
                         text_content,
+                        reply_to=event_message_id,
                         metadata=metadata,
                     )
 
@@ -26778,15 +26877,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _thread_metadata_for_source(
         self,
         source,
-        reply_to_message_id: Optional[str] = None,
+        reply_to_message_id: Any = _REPLY_ANCHOR_UNSET,
     ) -> Optional[Dict[str, Any]]:
         """Build the metadata dict platforms need for thread-aware replies."""
+        reply_anchor = (
+            getattr(source, "message_id", None)
+            if reply_to_message_id is _REPLY_ANCHOR_UNSET
+            else reply_to_message_id
+        )
         metadata = self._thread_metadata_for_target(
             getattr(source, "platform", None),
             getattr(source, "chat_id", None),
             getattr(source, "thread_id", None),
             chat_type=getattr(source, "chat_type", None),
-            reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
+            reply_to_message_id=reply_anchor,
         )
         if getattr(source, "platform", None) == Platform.SLACK:
             # Per-turn egress identity (R3-5, connector PR gateway-gateway#210).
@@ -28027,18 +28131,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             or adapter is None
         ):
             return
-        already_echoed = int(getattr(event, "_gateway_pending_stt_echoed", 0) or 0)
-        unsent = transcripts[already_echoed:]
-        setattr(event, "_gateway_pending_stt_echoed", already_echoed + len(unsent))
-        for tx in unsent:
-            try:
-                await adapter.send(
-                    source.chat_id,
-                    f'🎙️ "{tx}"',
-                    metadata=metadata,
-                )
-            except Exception as echo_exc:
-                logger.debug("%s echo failed (non-fatal): %s", log_context, echo_exc)
+
+        # The interrupt monitor and completed-turn drain can reach the same
+        # pending event concurrently. Serialize echo delivery so the drain
+        # waits for an in-flight send to publish its reply anchor before it
+        # snapshots the queued turn's effective anchor. The count remains an
+        # at-most-once ledger: an unknown send outcome is never replayed.
+        echo_lock = getattr(event, "_gateway_pending_stt_echo_lock", None)
+        if echo_lock is None:
+            echo_lock = asyncio.Lock()
+            setattr(event, "_gateway_pending_stt_echo_lock", echo_lock)
+        async with echo_lock:
+            already_echoed = int(getattr(event, "_gateway_pending_stt_echoed", 0) or 0)
+            unsent = transcripts[already_echoed:]
+            setattr(event, "_gateway_pending_stt_echoed", already_echoed + len(unsent))
+            for tx in unsent:
+                try:
+                    echo_result = await adapter.send(
+                        source.chat_id,
+                        f'🎙️ "{tx}"',
+                        metadata=metadata,
+                    )
+                    self._remember_stt_reply_anchor(event, source, echo_result)
+                except Exception as echo_exc:
+                    logger.debug("%s echo failed (non-fatal): %s", log_context, echo_exc)
 
     async def _transcribe_and_echo_pending_voice(
         self,
@@ -32052,7 +32168,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         source,
                                         pending_text,
                                         log_context="Voice-interrupt",
-                                        metadata={"thread_id": source.thread_id} if source.thread_id else None,
+                                        metadata=self._pending_voice_echo_metadata(
+                                            _peek_event,
+                                            source,
+                                        ),
                                     )
                                 elif not pending_text and _media_urls:
                                     pending_text = _build_media_placeholder(_peek_event)
@@ -32622,7 +32741,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             source,
                             _pending_text,
                             log_context="Voice-drain",
-                            metadata={"thread_id": source.thread_id} if source.thread_id else None,
+                            metadata=self._pending_voice_echo_metadata(
+                                pending_event,
+                                source,
+                            ),
                         )
                         if not pending:
                             pending = _build_media_placeholder(pending_event)
@@ -32891,6 +33013,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
                     message_type=next_message_type,
+                )
+                followup_result = _propagate_pending_stt_reply_anchor(
+                    pending_event,
+                    followup_result,
+                    effective_anchor=next_message_id,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2561,6 +2561,7 @@ DEFAULT_CONFIG = {
         "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
         "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
+        "reply_to_transcript": False,  # Reply to the visible STT echo instead of the voice-note bubble
         "extra": {
             "rich_messages": False,     # Bot API 10.1 rich messages (tables/task lists/details/math) render natively; set True to opt in. Default stays legacy MarkdownV2 because rich messages can be hard to copy as plain text in Telegram clients.
             "rich_drafts": False,       # Experimental Bot API 10.1 rich draft previews during Telegram DM streaming. Default off because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -11362,7 +11362,8 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
 
     # Resolve this platform-owned presentation option from every supported
     # Telegram config location in the same precedence order as gateway/config:
-    # gateway.platforms < platforms < top-level telegram. The plugin hook may
+    # gateway.platforms < platforms < gateway.telegram < top-level telegram.
+    # The plugin hook may
     # receive one of the nested blocks as a fallback, so blindly re-emitting
     # that block would otherwise clobber the already merged winner.
     _reply_to_transcript = None
@@ -11382,6 +11383,7 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
     for _candidate in (
         _gateway_platforms.get("telegram"),
         _platforms.get("telegram"),
+        _gateway.get("telegram"),
         yaml_cfg.get("telegram"),
     ):
         if not isinstance(_candidate, dict):

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8192,6 +8192,7 @@ class TelegramAdapter(BasePlatformAdapter):
         images: List[tuple],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
+        reply_to: Optional[str] = None,
     ) -> None:
         """Send a batch of images natively via Telegram's media group API.
 
@@ -8216,7 +8217,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] InputMediaPhoto unavailable, falling back to per-image send: %s",
                 self.name, exc,
             )
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
+            await super().send_multiple_images(
+                chat_id,
+                images,
+                metadata,
+                human_delay,
+                reply_to=reply_to,
+            )
             return
 
         # Peel off animations — they need send_animation, not send_media_group
@@ -8231,7 +8238,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # Animations: route through the base default (per-image send_animation)
         if animations:
             await super().send_multiple_images(
-                chat_id, animations, metadata, human_delay=human_delay,
+                chat_id,
+                animations,
+                metadata,
+                human_delay=human_delay,
+                reply_to=reply_to,
             )
 
         if not photos:
@@ -8274,7 +8285,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] Sending media group of %d photo(s) (chunk %d/%d)",
                     self.name, len(media), chunk_idx + 1, len(chunks),
                 )
-                reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
+                reply_to_id = self._reply_to_message_id_for_send(
+                    reply_to,
+                    metadata,
+                    reply_to_mode=self._reply_to_mode,
+                )
                 thread_kwargs = self._thread_kwargs_for_send(
                     chat_id,
                     _thread,
@@ -8313,7 +8328,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 # Fallback: send each photo in this chunk individually
                 await super().send_multiple_images(
-                    chat_id, chunk, metadata, human_delay=human_delay,
+                    chat_id,
+                    chunk,
+                    metadata,
+                    human_delay=human_delay,
+                    reply_to=reply_to,
                 )
             finally:
                 for fh in opened_files:
@@ -11332,9 +11351,56 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
         # extras seed intentionally omitted (shared-key loop bridges group_allowed_chats).
         if not _skip_env_bridge and not os.getenv("TELEGRAM_GROUP_ALLOWED_CHATS"):
             os.environ["TELEGRAM_GROUP_ALLOWED_CHATS"] = str(group_allowed_chats)
-    for _key in ("guest_mode", "disable_link_previews", "observe_unmentioned_group_messages", "free_response_topics"):
+    for _key in (
+        "guest_mode",
+        "disable_link_previews",
+        "observe_unmentioned_group_messages",
+        "free_response_topics",
+    ):
         if _key in telegram_cfg:
             extras.setdefault(_key, telegram_cfg[_key])
+
+    # Resolve this platform-owned presentation option from every supported
+    # Telegram config location in the same precedence order as gateway/config:
+    # gateway.platforms < platforms < top-level telegram. The plugin hook may
+    # receive one of the nested blocks as a fallback, so blindly re-emitting
+    # that block would otherwise clobber the already merged winner.
+    _reply_to_transcript = None
+    _reply_to_transcript_set = False
+    _gateway: dict = {}
+    _gateway_raw = yaml_cfg.get("gateway")
+    if isinstance(_gateway_raw, dict):
+        _gateway = _gateway_raw
+    _gateway_platforms: dict = {}
+    _gateway_platforms_raw = _gateway.get("platforms")
+    if isinstance(_gateway_platforms_raw, dict):
+        _gateway_platforms = _gateway_platforms_raw
+    _platforms: dict = {}
+    _platforms_raw = yaml_cfg.get("platforms")
+    if isinstance(_platforms_raw, dict):
+        _platforms = _platforms_raw
+    for _candidate in (
+        _gateway_platforms.get("telegram"),
+        _platforms.get("telegram"),
+        yaml_cfg.get("telegram"),
+    ):
+        if not isinstance(_candidate, dict):
+            continue
+        _candidate_extra = _candidate.get("extra")
+        if "reply_to_transcript" in _candidate:
+            _reply_to_transcript = _candidate["reply_to_transcript"]
+            _reply_to_transcript_set = True
+        elif isinstance(_candidate_extra, dict) and "reply_to_transcript" in _candidate_extra:
+            _reply_to_transcript = _candidate_extra["reply_to_transcript"]
+            _reply_to_transcript_set = True
+    if _reply_to_transcript_set:
+        if isinstance(_reply_to_transcript, str):
+            _reply_to_transcript = _reply_to_transcript.strip().lower() in {
+                "1", "true", "yes", "on",
+            }
+        else:
+            _reply_to_transcript = bool(_reply_to_transcript)
+        extras["reply_to_transcript"] = _reply_to_transcript
     # Pass through telegram-specific extra keys (e.g. base_url proxy override),
     # but EXCLUDE the generic shared-config keys that _merge_platform_map in
     # gateway/config.py already merges with correct top-level-over-nested

--- a/tests/gateway/test_73771_media_resend_dedup.py
+++ b/tests/gateway/test_73771_media_resend_dedup.py
@@ -500,6 +500,77 @@ async def test_streamed_explicit_media_resend_is_delivered(tmp_path, monkeypatch
     assert str(img) in sent_paths[0]
 
 
+@pytest.mark.asyncio
+async def test_streamed_media_replies_to_transcript_echo_in_ordinary_dm(
+    tmp_path,
+    monkeypatch,
+):
+    audio = _allowed_file(tmp_path, monkeypatch, "reply.mp3")
+    adapter = _stream_adapter()
+    event = MessageEvent(
+        text="voice follow-up",
+        message_type=MessageType.VOICE,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+        ),
+        message_id="voice-note-6",
+    )
+    event._gateway_stt_reply_anchor = "transcript-echo-7"
+    runner = SimpleNamespace(
+        _thread_metadata_for_source=lambda source, anchor=None: {},
+        _reply_anchor_for_event=lambda current_event: current_event._gateway_stt_reply_anchor,
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        runner,
+        f"MEDIA:{audio}",
+        event,
+        adapter,
+    )
+
+    adapter.send_voice.assert_awaited_once()
+    assert adapter.send_voice.await_args.kwargs["reply_to"] == "transcript-echo-7"
+
+
+@pytest.mark.asyncio
+async def test_streamed_image_batch_replies_to_transcript_echo_in_ordinary_dm(
+    tmp_path,
+    monkeypatch,
+):
+    image = _allowed_file(tmp_path, monkeypatch, "reply.png")
+    adapter = _stream_adapter()
+    event = MessageEvent(
+        text="voice follow-up",
+        message_type=MessageType.VOICE,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+        ),
+        message_id="voice-note-6",
+    )
+    event._gateway_stt_reply_anchor = "transcript-echo-7"
+    runner = SimpleNamespace(
+        _thread_metadata_for_source=lambda source, anchor=None: {},
+        _reply_anchor_for_event=lambda current_event: current_event._gateway_stt_reply_anchor,
+    )
+
+    await GatewayRunner._deliver_media_from_response(
+        runner,
+        f"MEDIA:{image}",
+        event,
+        adapter,
+    )
+
+    adapter.send_multiple_images.assert_awaited_once()
+    assert (
+        adapter.send_multiple_images.await_args.kwargs["reply_to"]
+        == "transcript-echo-7"
+    )
+
+
 def test_stream_rescan_accepts_no_history_dedup_input():
     """Contract pin for the run.py half of the fix: the explicit-only
     post-stream rescan must not accept a history-dedup set at all — with the

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -135,6 +135,153 @@ class TestBasePlatformTopicSessions:
             ("complete", "1", ProcessingOutcome.SUCCESS),
         ]
 
+    @pytest.mark.asyncio
+    async def test_final_reply_uses_anchor_added_by_handler(self):
+        """A transcript echo created during handling becomes the final anchor."""
+        adapter = DummyTelegramAdapter()
+        adapter.config.typing_indicator = False
+
+        async def handler(event):
+            event._gateway_stt_reply_anchor = "transcript-echo-7"
+            return "ack"
+
+        adapter.set_message_handler(handler)
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.VOICE,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="12345",
+                chat_type="dm",
+                thread_id="42",
+            ),
+            message_id="voice-note-6",
+        )
+
+        await adapter._process_message_background(
+            event,
+            build_session_key(event.source),
+        )
+
+        assert adapter.sent == [
+            {
+                "chat_id": "12345",
+                "content": "ack",
+                "reply_to": "transcript-echo-7",
+                "metadata": {
+                    "thread_id": "42",
+                    "telegram_dm_topic_reply_fallback": True,
+                    "direct_messages_topic_id": "42",
+                    "telegram_reply_to_message_id": "transcript-echo-7",
+                    "notify": True,
+                },
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_handler_error_replies_to_anchor_added_by_handler(self):
+        """A user-facing handler error replies to the successful transcript echo."""
+        adapter = DummyTelegramAdapter()
+        adapter.config.typing_indicator = False
+
+        async def handler(event):
+            event._gateway_stt_reply_anchor = "transcript-echo-7"
+            raise RuntimeError("provider failed")
+
+        adapter.set_message_handler(handler)
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.VOICE,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="12345",
+                chat_type="dm",
+            ),
+            message_id="voice-note-6",
+        )
+
+        await adapter._process_message_background(
+            event,
+            build_session_key(event.source),
+        )
+
+        assert len(adapter.sent) == 1
+        assert adapter.sent[0]["reply_to"] == "transcript-echo-7"
+        assert adapter.sent[0]["metadata"] is None
+        assert "provider failed" in adapter.sent[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_anchor_tombstone_does_not_restore_outer_message_id(self):
+        adapter = DummyTelegramAdapter()
+        adapter.config.typing_indicator = False
+
+        async def handler(event):
+            event._gateway_stt_reply_anchor = None
+            return "ack"
+
+        adapter.set_message_handler(handler)
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.VOICE,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="12345",
+                chat_type="dm",
+            ),
+            message_id="outer-voice-note-6",
+        )
+
+        await adapter._process_message_background(
+            event,
+            build_session_key(event.source),
+        )
+
+        assert adapter.sent == [
+            {
+                "chat_id": "12345",
+                "content": "ack",
+                "reply_to": None,
+                "metadata": {"notify": True},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_media_follow_on_replies_to_transcript_echo_in_ordinary_dm(
+        self,
+        tmp_path,
+    ):
+        adapter = DummyTelegramAdapter()
+        adapter.config.typing_indicator = False
+        adapter.send_voice = AsyncMock(
+            return_value=SendResult(success=True, message_id="voice-8")
+        )
+        audio_path = tmp_path / "reply.mp3"
+        audio_path.write_bytes(b"audio")
+
+        async def handler(event):
+            event._gateway_stt_reply_anchor = "transcript-echo-7"
+            return f"answer\nMEDIA:{audio_path}"
+
+        adapter.set_message_handler(handler)
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.VOICE,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="12345",
+                chat_type="dm",
+            ),
+            message_id="voice-note-6",
+        )
+
+        await adapter._process_message_background(
+            event,
+            build_session_key(event.source),
+        )
+
+        adapter.send_voice.assert_awaited_once()
+        assert adapter.send_voice.await_args.kwargs["reply_to"] == "transcript-echo-7"
+
 
 class TestTelegramAutoTtsCaptionDelivery:
     @staticmethod
@@ -198,4 +345,52 @@ class TestTelegramAutoTtsCaptionDelivery:
                 "metadata": {"thread_id": "17585", "notify": True},
             }
         ]
+
+    @pytest.mark.asyncio
+    async def test_short_caption_replies_to_transcript_echo_in_ordinary_dm(self, tmp_path):
+        adapter = DummyTelegramAdapter()
+        adapter.config.typing_indicator = False
+        adapter._should_auto_tts_for_chat = lambda chat_id: True
+        adapter.play_tts = AsyncMock(
+            return_value=SendResult(success=True, message_id="tts-1")
+        )
+
+        async def handler(event):
+            event._gateway_stt_reply_anchor = "transcript-echo-7"
+            return "short answer"
+
+        adapter.set_message_handler(handler)
+        tts_path = tmp_path / "reply.ogg"
+        tts_path.write_text("audio", encoding="utf-8")
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.VOICE,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="12345",
+                chat_type="dm",
+            ),
+            message_id="voice-note-6",
+        )
+
+        with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
+            "tools.tts_tool.text_to_speech_tool",
+            return_value=json.dumps({"file_path": str(tts_path)}),
+        ):
+            await adapter._process_message_background(
+                event,
+                build_session_key(event.source),
+            )
+
+        adapter.play_tts.assert_awaited_once()
+        assert adapter.play_tts.await_args is not None
+        assert adapter.play_tts.await_args.kwargs == {
+            "chat_id": "12345",
+            "audio_path": str(tts_path),
+            "caption": "short answer",
+            "reply_to": "transcript-echo-7",
+            "metadata": {"notify": True},
+        }
+        # A successful Telegram caption is the only final answer in this lane.
+        assert adapter.sent == []
 

--- a/tests/gateway/test_stream_final_contract.py
+++ b/tests/gateway/test_stream_final_contract.py
@@ -49,7 +49,13 @@ def _make_draft_adapter():
     a.send_draft = _send_draft
 
     async def _send(chat_id, content, reply_to=None, metadata=None, **kw):
-        a.send_calls.append({"content": content, "metadata": dict(metadata or {})})
+        a.send_calls.append(
+            {
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": dict(metadata or {}),
+            }
+        )
         return SendResult(success=True, message_id="sealed_ts_1")
     a.send = _send
 
@@ -260,9 +266,11 @@ class TestQueuedLaneReconcile:
             source=source,
             adapter=adapter,
             metadata=None,
+            event_message_id="transcript-echo-7",
             text_already_delivered=False,
             deliver_media=False,
             stream_consumer=sc,
         )
         assert adapter.edit_calls == []
         assert len(adapter.send_calls) == 1
+        assert adapter.send_calls[0]["reply_to"] == "transcript-echo-7"

--- a/tests/gateway/test_stt_transcript_echo_config.py
+++ b/tests/gateway/test_stt_transcript_echo_config.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from types import SimpleNamespace
 
-from gateway.config import GatewayConfig, load_gateway_config
+from gateway.config import GatewayConfig, Platform, load_gateway_config
 from gateway.run import GatewayRunner
 
 
@@ -10,7 +10,69 @@ def test_stt_echo_transcripts_defaults_on_for_backwards_compatibility():
 
     assert cfg.stt_enabled is True
     assert cfg.stt_echo_transcripts is True
+    assert not hasattr(cfg, "stt_reply_to_transcript")
     assert cfg.to_dict()["stt_echo_transcripts"] is True
+    assert "stt_reply_to_transcript" not in cfg.to_dict()
+
+
+def test_telegram_reply_to_transcript_loads_as_platform_extra(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "platforms:\n"
+        "  telegram:\n"
+        "    enabled: true\n"
+        "    token: test-token\n"
+        "telegram:\n"
+        "  reply_to_transcript: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    cfg = load_gateway_config()
+
+    assert cfg.platforms[Platform.TELEGRAM].extra["reply_to_transcript"] is True
+
+
+def test_platforms_telegram_reply_setting_beats_gateway_platforms(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "platforms:\n"
+        "  telegram:\n"
+        "    enabled: true\n"
+        "    token: test-token\n"
+        "    reply_to_transcript: true\n"
+        "gateway:\n"
+        "  platforms:\n"
+        "    telegram:\n"
+        "      reply_to_transcript: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    cfg = load_gateway_config()
+
+    assert cfg.platforms[Platform.TELEGRAM].extra["reply_to_transcript"] is True
+
+
+def test_telegram_reply_setting_coerces_quoted_false(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "platforms:\n"
+        "  telegram:\n"
+        "    enabled: true\n"
+        "    token: test-token\n"
+        "telegram:\n"
+        "  reply_to_transcript: 'false'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    cfg = load_gateway_config()
+
+    assert cfg.platforms[Platform.TELEGRAM].extra["reply_to_transcript"] is False
 
 
 def test_top_level_stt_echo_transcripts_takes_precedence():

--- a/tests/gateway/test_stt_transcript_echo_config.py
+++ b/tests/gateway/test_stt_transcript_echo_config.py
@@ -56,6 +56,26 @@ def test_platforms_telegram_reply_setting_beats_gateway_platforms(tmp_path, monk
     assert cfg.platforms[Platform.TELEGRAM].extra["reply_to_transcript"] is True
 
 
+def test_telegram_reply_to_transcript_loads_from_direct_gateway_block(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "gateway:\n"
+        "  telegram:\n"
+        "    enabled: true\n"
+        "    token: test-token\n"
+        "    reply_to_transcript: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    cfg = load_gateway_config()
+
+    assert cfg.platforms[Platform.TELEGRAM].extra["reply_to_transcript"] is True
+
+
 def test_telegram_reply_setting_coerces_quoted_false(tmp_path, monkeypatch):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()

--- a/tests/gateway/test_telegram_audio_vs_voice.py
+++ b/tests/gateway/test_telegram_audio_vs_voice.py
@@ -12,12 +12,14 @@ These tests confirm that:
   3. Mixed media lists (voice + audio) split correctly.
 """
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from gateway.config import GatewayConfig, Platform
-from gateway.platforms.base import MessageEvent, MessageType
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.run import _propagate_pending_stt_reply_anchor
 from gateway.session import SessionSource
 
 
@@ -78,6 +80,252 @@ async def test_voice_message_still_transcribed():
     # The transcript passes through as a plain quoted line — no "voice message"
     # meta-commentary in the LLM-visible prompt.
     assert "hello world" in result
+
+
+@pytest.mark.asyncio
+async def test_telegram_reply_can_anchor_to_transcript_echo():
+    runner = _make_runner(stt_enabled=True)
+    transcript_adapter = AsyncMock()
+    transcript_adapter.config = PlatformConfig(
+        enabled=True,
+        token="test-token",
+        extra={"reply_to_transcript": True},
+    )
+    transcript_adapter.send.return_value = SendResult(
+        success=True,
+        message_id="transcript-echo-7",
+    )
+    runner.adapters = {Platform.TELEGRAM: transcript_adapter}
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="1", chat_type="dm")
+    event = _voice_event("/tmp/voice.ogg")
+    event.message_id = "voice-note-6"
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "hello world", "provider": "whisper"},
+    ):
+        await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    transcript_adapter.send.assert_awaited_once()
+    assert runner._reply_anchor_for_event(event) == "transcript-echo-7"
+
+
+def test_pending_voice_echo_metadata_keeps_telegram_dm_topic_lane():
+    runner = _make_runner(stt_enabled=True)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="1",
+        chat_type="dm",
+        thread_id="42",
+    )
+    event = _voice_event()
+    event.source = source
+    event.message_id = "voice-note-6"
+
+    metadata = runner._pending_voice_echo_metadata(event, source)
+
+    assert metadata == {
+        "thread_id": "42",
+        "telegram_dm_topic_reply_fallback": True,
+        "direct_messages_topic_id": "42",
+        "telegram_reply_to_message_id": "voice-note-6",
+    }
+
+
+def test_latest_queued_transcript_anchor_propagates_to_outer_delivery():
+    pending_event = _voice_event()
+    setattr(pending_event, "_gateway_stt_reply_anchor", "transcript-echo-9")
+
+    result = _propagate_pending_stt_reply_anchor(
+        pending_event,
+        {"final_response": "queued answer"},
+    )
+
+    assert result["_gateway_stt_reply_anchor"] == "transcript-echo-9"
+
+
+def test_deeper_queued_transcript_anchor_wins_over_earlier_followup():
+    pending_event = _voice_event()
+    setattr(pending_event, "_gateway_stt_reply_anchor", "transcript-echo-8")
+
+    result = _propagate_pending_stt_reply_anchor(
+        pending_event,
+        {
+            "final_response": "latest queued answer",
+            "_gateway_stt_reply_anchor": "transcript-echo-9",
+        },
+    )
+
+    assert result["_gateway_stt_reply_anchor"] == "transcript-echo-9"
+
+
+def test_one_level_queued_text_uses_ordinary_message_id():
+    pending_event = MessageEvent(
+        text="latest text",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="1",
+            chat_type="dm",
+        ),
+        message_id="text-message-9",
+    )
+
+    result = _propagate_pending_stt_reply_anchor(
+        pending_event,
+        {"final_response": "queued answer"},
+    )
+
+    assert result["_gateway_stt_reply_anchor"] == "text-message-9"
+
+
+def test_queued_turn_preserves_effective_none_reply_anchor():
+    """Platform-specific top-level/topic routing must survive queued recursion."""
+    pending_event = MessageEvent(
+        text="latest text",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="1",
+            chat_type="group",
+            thread_id="42",
+        ),
+        message_id="topic-message-9",
+    )
+
+    result = _propagate_pending_stt_reply_anchor(
+        pending_event,
+        {"final_response": "queued answer"},
+        effective_anchor=None,
+    )
+
+    assert "_gateway_stt_reply_anchor" in result
+    assert result["_gateway_stt_reply_anchor"] is None
+
+
+@pytest.mark.parametrize(
+    "echo_result",
+    [
+        SendResult(success=False, error="echo failed"),
+        SendResult(success=True, message_id=None),
+    ],
+    ids=["failed", "missing-message-id"],
+)
+@pytest.mark.asyncio
+async def test_one_level_unanchored_voice_echo_uses_ordinary_message_id(echo_result):
+    runner = _make_runner(stt_enabled=True)
+    transcript_adapter = AsyncMock()
+    transcript_adapter.config = PlatformConfig(
+        enabled=True,
+        token="test-token",
+        extra={"reply_to_transcript": True},
+    )
+    transcript_adapter.send.return_value = echo_result
+    runner.adapters = {Platform.TELEGRAM: transcript_adapter}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="1",
+        chat_type="dm",
+    )
+    pending_event = _voice_event()
+    pending_event.message_id = "voice-message-9"
+
+    await runner._echo_pending_stt_transcripts_once(
+        pending_event,
+        transcript_adapter,
+        source,
+        ["latest voice"],
+    )
+    result = _propagate_pending_stt_reply_anchor(
+        pending_event,
+        {"final_response": "queued answer"},
+    )
+
+    assert not hasattr(pending_event, "_gateway_stt_reply_anchor")
+    assert result["_gateway_stt_reply_anchor"] == "voice-message-9"
+
+
+def test_multilevel_deeper_failed_echo_discards_earlier_successful_echo():
+    earlier_event = _voice_event()
+    earlier_event.message_id = "voice-message-8"
+    setattr(earlier_event, "_gateway_stt_reply_anchor", "transcript-echo-8")
+    deepest_event = _voice_event()
+    deepest_event.message_id = "voice-message-9"
+
+    deepest_result = _propagate_pending_stt_reply_anchor(
+        deepest_event,
+        {"final_response": "deepest queued answer"},
+    )
+    result = _propagate_pending_stt_reply_anchor(earlier_event, deepest_result)
+
+    assert result["_gateway_stt_reply_anchor"] == "voice-message-9"
+
+
+def test_multilevel_deepest_text_discards_earlier_successful_echo():
+    earlier_event = _voice_event()
+    earlier_event.message_id = "voice-message-8"
+    setattr(earlier_event, "_gateway_stt_reply_anchor", "transcript-echo-8")
+    deepest_event = MessageEvent(
+        text="deepest text",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="1",
+            chat_type="dm",
+        ),
+        message_id="text-message-9",
+    )
+
+    deepest_result = _propagate_pending_stt_reply_anchor(
+        deepest_event,
+        {"final_response": "deepest queued answer"},
+    )
+    result = _propagate_pending_stt_reply_anchor(earlier_event, deepest_result)
+
+    assert result["_gateway_stt_reply_anchor"] == "text-message-9"
+
+
+def test_consumed_queued_anchor_does_not_leak_in_agent_result():
+    event = _voice_event()
+    result = {
+        "final_response": "deepest queued answer",
+        "_gateway_stt_reply_anchor": "text-message-9",
+    }
+
+    consume_anchor = getattr(
+        gateway_run,
+        "_consume_pending_stt_reply_anchor",
+        None,
+    )
+    assert consume_anchor is not None
+    consume_anchor(event, result)
+
+    assert getattr(event, "_gateway_stt_reply_anchor") == "text-message-9"
+    assert result == {"final_response": "deepest queued answer"}
+
+
+def test_consumed_anchor_tombstone_clears_stale_outer_anchor():
+    event = _voice_event()
+    setattr(event, "_gateway_stt_reply_anchor", "transcript-echo-8")
+    result = {
+        "final_response": "deepest queued answer",
+        "_gateway_stt_reply_anchor": None,
+    }
+
+    consume_anchor = getattr(
+        gateway_run,
+        "_consume_pending_stt_reply_anchor",
+        None,
+    )
+    assert consume_anchor is not None
+    consume_anchor(event, result)
+
+    assert getattr(event, "_gateway_stt_reply_anchor") is None
+    assert result == {"final_response": "deepest queued answer"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -298,6 +298,44 @@ def test_base_gateway_metadata_marks_telegram_dm_topics_as_reply_fallback():
     }
 
 
+def test_base_gateway_metadata_preserves_explicit_none_reply_tombstone():
+    source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        thread_id="20189",
+        message_id="stale-source-anchor",
+    )
+
+    metadata = _thread_metadata_for_source(source, None)
+
+    assert metadata == {
+        "thread_id": "20189",
+        "telegram_dm_topic_reply_fallback": True,
+        "direct_messages_topic_id": "20189",
+    }
+
+
+def test_gateway_runner_metadata_preserves_explicit_none_reply_tombstone():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id="20189",
+        message_id="stale-source-anchor",
+    )
+
+    metadata = runner._thread_metadata_for_source(source, None)
+
+    assert metadata == {
+        "thread_id": "20189",
+        "telegram_dm_topic_reply_fallback": True,
+        "direct_messages_topic_id": "20189",
+    }
+
+
 @pytest.mark.asyncio
 async def test_gateway_runner_busy_ack_replies_to_triggering_message_for_telegram_dm_topic(monkeypatch, tmp_path):
     """GatewayRunner's duplicate thread metadata must match the base helper."""
@@ -499,6 +537,28 @@ async def test_media_group_dm_topic_reply_not_found_retry_drops_thread_id(tmp_pa
     assert call_log[1]["reply_to_message_id"] is None
     assert "message_thread_id" not in call_log[1]
     assert "direct_messages_topic_id" not in call_log[1]
+
+
+@pytest.mark.asyncio
+async def test_media_group_uses_explicit_reply_anchor_in_ordinary_dm(tmp_path):
+    adapter = _make_adapter()
+    image_path = tmp_path / "photo.png"
+    image_path.write_bytes(b"png-data")
+    call_log = []
+
+    async def mock_send_media_group(**kwargs):
+        call_log.append(dict(kwargs))
+        return [SimpleNamespace(message_id=783)]
+
+    adapter._bot = SimpleNamespace(send_media_group=mock_send_media_group)
+
+    await adapter.send_multiple_images(
+        chat_id="123",
+        images=[(f"file://{image_path}", "caption")],
+        reply_to="462",
+    )
+
+    assert call_log[0]["reply_to_message_id"] == 462
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_voice_v0_regressions.py
+++ b/tests/gateway/test_telegram_voice_v0_regressions.py
@@ -4,6 +4,7 @@ import threading
 import types
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -14,7 +15,13 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    _reply_anchor_for_event,
+)
 from plugins.platforms.telegram.adapter import TelegramAdapter
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
@@ -35,7 +42,7 @@ def _runner(adapter=None):
     runner._consume_pending_native_image_paths = lambda _key: []
     runner._session_key_for_source = lambda _source: "telegram:dm:12345"
     runner._thread_metadata_for_source = lambda *_args, **_kwargs: {}
-    runner._reply_anchor_for_event = lambda _event: None
+    runner._reply_anchor_for_event = _reply_anchor_for_event
     return runner
 
 
@@ -97,6 +104,64 @@ class _PendingVoiceAgent:
             }
         return {
             "final_response": "follow-up complete",
+            "messages": [],
+            "api_calls": 1,
+            "interrupted": False,
+        }
+
+
+class _NaturalCompletionDuringEchoAgent(_PendingVoiceAgent):
+    adapter: Any = None
+    followup_release = threading.Event()
+
+    def run_conversation(self, message, conversation_history=None, task_id=None, **kwargs):
+        type(self).messages.append(message)
+        adapter = type(self).adapter
+        assert adapter is not None
+        if len(type(self).messages) == 1:
+            assert adapter.echo_started.wait(timeout=3), "transcript echo did not start"
+            return {
+                "final_response": "first turn complete",
+                "messages": [],
+                "api_calls": 1,
+                "interrupted": False,
+            }
+        adapter.followup_started.set()
+        assert type(self).followup_release.wait(timeout=3), "follow-up was not released"
+        return {
+            "final_response": "follow-up complete",
+            "messages": [],
+            "api_calls": 1,
+            "interrupted": False,
+        }
+
+
+class _MultiPendingAgent(_PendingVoiceAgent):
+    adapter: Any = None
+    deepest_event: Any = None
+    session_key = ""
+
+    def run_conversation(self, message, conversation_history=None, task_id=None, **kwargs):
+        type(self).messages.append(message)
+        turn_number = len(type(self).messages)
+        if turn_number == 2:
+            adapter = type(self).adapter
+            deepest_event = type(self).deepest_event
+            assert adapter is not None
+            assert deepest_event is not None
+            adapter._pending_messages[type(self).session_key] = deepest_event
+            adapter._active_sessions[type(self).session_key].set()
+        if turn_number <= 2:
+            assert self._interrupted.wait(timeout=3), "queued interrupt was not delivered"
+            return {
+                "final_response": "interrupted",
+                "messages": [],
+                "api_calls": 1,
+                "interrupted": True,
+                "interrupt_message": self._interrupt_message,
+            }
+        return {
+            "final_response": "deepest follow-up complete",
             "messages": [],
             "api_calls": 1,
             "interrupted": False,
@@ -182,6 +247,7 @@ async def test_monitor_to_drain_transcribes_and_echoes_pending_voice_once(
     monkeypatch.setitem(sys.modules, "run_agent", types.SimpleNamespace(AIAgent=_PendingVoiceAgent))
 
     adapter = _PendingVoiceAdapter()
+    adapter.config.extra["reply_to_transcript"] = True
     runner = _run_agent_runner(adapter)
     source = _source()
     session_key = "telegram:dm:12345"
@@ -191,6 +257,7 @@ async def test_monitor_to_drain_transcribes_and_echoes_pending_voice_once(
         source=source,
         media_urls=["/tmp/telegram-pending-voice.ogg"],
         media_types=["audio/ogg"],
+        message_id="voice-note-6",
     )
     adapter._pending_messages[session_key] = event
     adapter._active_sessions[session_key] = asyncio.Event()
@@ -215,9 +282,164 @@ async def test_monitor_to_drain_transcribes_and_echoes_pending_voice_once(
         )
 
     assert result["final_response"] == "follow-up complete"
+    assert result["_gateway_stt_reply_anchor"] == "voice-echo"
     assert _PendingVoiceAgent.messages == ["initial turn", '"hello once"']
     mock_transcribe.assert_called_once_with("/tmp/telegram-pending-voice.ogg", None, "gateway")
     assert adapter.sent == [("12345", '🎙️ "hello once"', None)]
+
+
+@pytest.mark.asyncio
+async def test_natural_completion_waits_for_inflight_transcript_echo_anchor(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "off")
+    monkeypatch.setenv("HERMES_GATEWAY_NOTIFY_INTERVAL", "0")
+    monkeypatch.setitem(sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+    monkeypatch.setitem(
+        sys.modules,
+        "run_agent",
+        types.SimpleNamespace(AIAgent=_NaturalCompletionDuringEchoAgent),
+    )
+
+    class BlockingEchoAdapter(_PendingVoiceAdapter):
+        def __init__(self):
+            super().__init__()
+            self.echo_started = threading.Event()
+            self.followup_started = threading.Event()
+            self.echo_release = asyncio.Event()
+
+        async def send(self, chat_id, content, reply_to=None, metadata=None):
+            self.sent.append((chat_id, content, metadata))
+            if content.startswith("🎙️"):
+                self.echo_started.set()
+                await self.echo_release.wait()
+                return SendResult(success=True, message_id="voice-echo")
+            return SendResult(success=True, message_id="ordinary-response")
+
+    adapter = BlockingEchoAdapter()
+    adapter.config.extra["reply_to_transcript"] = True
+    runner = _run_agent_runner(adapter)
+    source = _source()
+    session_key = "telegram:dm:12345"
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/telegram-pending-voice.ogg"],
+        media_types=["audio/ogg"],
+        message_id="voice-note-6",
+    )
+    adapter._pending_messages[session_key] = event
+    adapter._active_sessions[session_key] = asyncio.Event()
+    adapter._active_sessions[session_key].set()
+    _NaturalCompletionDuringEchoAgent.messages = []
+    _NaturalCompletionDuringEchoAgent.adapter = adapter
+    _NaturalCompletionDuringEchoAgent.followup_release = threading.Event()
+
+    with (
+        patch("gateway.run._hermes_home", tmp_path),
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "fake"}),
+        patch(
+            "tools.transcription_tools.transcribe_audio",
+            return_value={"success": True, "transcript": "hello once", "provider": "mock"},
+        ),
+    ):
+        run_task = asyncio.create_task(
+            runner._run_agent(
+                message="initial turn",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="pending-voice-natural-completion",
+                session_key=session_key,
+            )
+        )
+        assert await asyncio.to_thread(adapter.echo_started.wait, 3)
+        # Give the completed-turn drain a chance to race the in-flight echo.
+        # Without single-flight coordination it starts the recursive turn and
+        # freezes the stale voice-note anchor; with the fix it waits here.
+        await asyncio.to_thread(adapter.followup_started.wait, 0.5)
+        adapter.echo_release.set()
+        assert await asyncio.to_thread(adapter.followup_started.wait, 3)
+        for _ in range(100):
+            if runner._reply_anchor_for_event(event) == "voice-echo":
+                break
+            await asyncio.sleep(0.01)
+        _NaturalCompletionDuringEchoAgent.followup_release.set()
+        result = await asyncio.wait_for(run_task, timeout=5)
+
+    assert runner._reply_anchor_for_event(event) == "voice-echo"
+    assert result["_gateway_stt_reply_anchor"] == "voice-echo"
+
+
+@pytest.mark.asyncio
+async def test_multilevel_pending_text_uses_deepest_message_anchor(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "off")
+    monkeypatch.setenv("HERMES_GATEWAY_NOTIFY_INTERVAL", "0")
+    monkeypatch.setitem(sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+    monkeypatch.setitem(sys.modules, "run_agent", types.SimpleNamespace(AIAgent=_MultiPendingAgent))
+
+    adapter = _PendingVoiceAdapter()
+    adapter.config.extra["reply_to_transcript"] = True
+    runner = _run_agent_runner(adapter)
+    source = _source()
+    session_key = "telegram:dm:12345"
+    earlier_voice = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/telegram-pending-voice.ogg"],
+        media_types=["audio/ogg"],
+        message_id="voice-message-8",
+    )
+    deepest_text = MessageEvent(
+        text="latest text",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="text-message-9",
+    )
+    adapter._pending_messages[session_key] = earlier_voice
+    adapter._active_sessions[session_key] = asyncio.Event()
+    adapter._active_sessions[session_key].set()
+    _MultiPendingAgent.messages = []
+    _MultiPendingAgent.adapter = adapter
+    _MultiPendingAgent.deepest_event = deepest_text
+    _MultiPendingAgent.session_key = session_key
+
+    with (
+        patch("gateway.run._hermes_home", tmp_path),
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "fake"}),
+        patch(
+            "tools.transcription_tools.transcribe_audio",
+            return_value={"success": True, "transcript": "earlier voice", "provider": "mock"},
+        ) as mock_transcribe,
+    ):
+        result = await runner._run_agent(
+            message="initial turn",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="multilevel-pending-session",
+            session_key=session_key,
+        )
+
+    assert result["final_response"] == "deepest follow-up complete"
+    assert result["_gateway_stt_reply_anchor"] == "text-message-9"
+    assert _MultiPendingAgent.messages == [
+        "initial turn",
+        '"earlier voice"',
+        "latest text",
+    ]
+    mock_transcribe.assert_called_once_with(
+        "/tmp/telegram-pending-voice.ogg",
+        None,
+        "gateway",
+    )
+    assert adapter.sent == [("12345", '🎙️ "earlier voice"', None)]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -81,6 +81,7 @@ async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_
     adapter.send_voice.assert_awaited_once_with(
         chat_id="chat-1",
         audio_path=str(media_file),
+        reply_to="msg-1",
         metadata={"notify": True},
         is_voice=True,
     )
@@ -181,6 +182,38 @@ async def test_non_streaming_media_failure_notifies_user(tmp_path, monkeypatch):
     assert adapter.notices == ["⚠️ Couldn't deliver the video attachment."]
 
 
+@pytest.mark.asyncio
+async def test_media_failure_notice_replies_to_transcript_echo_in_telegram_dm(
+    tmp_path,
+    monkeypatch,
+):
+    """A failed attachment notice stays anchored to the echoed transcript."""
+    adapter = _MediaRoutingAdapter()
+    event = _event()
+    setattr(event, "_gateway_stt_reply_anchor", "transcript-echo-7")
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "clip.mp4")
+    adapter._message_handler = AsyncMock(return_value=f"MEDIA:{media_file}")
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="notice"))
+    adapter.send_video = AsyncMock(
+        return_value=SendResult(success=False, error="upload rejected")
+    )
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    adapter.send_video.assert_awaited_once_with(
+        chat_id="chat-1",
+        video_path=str(media_file),
+        reply_to="transcript-echo-7",
+        metadata={"notify": True},
+    )
+    adapter.send.assert_awaited_once_with(
+        chat_id="chat-1",
+        content="⚠️ Couldn't deliver the video attachment.",
+        reply_to="transcript-echo-7",
+        metadata={"notify": True},
+    )
+
+
 class _DiscordMediaFailureAdapter(BasePlatformAdapter):
     """Minimal adapter to exercise non-streaming MEDIA failure notification."""
 
@@ -236,11 +269,13 @@ async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_ima
     adapter.send.assert_awaited_once_with(
         "chat-1",
         "Quote here",
+        reply_to="msg-1",
         metadata={"thread_id": "topic-1"},
     )
     adapter.send_multiple_images.assert_awaited_once_with(
         chat_id="chat-1",
         images=[(f"file://{media_file.as_posix()}", "")],
+        reply_to="msg-1",
         metadata={"thread_id": "topic-1"},
     )
 
@@ -286,11 +321,13 @@ async def test_queued_followup_delivery_reuses_routing_metadata_for_media(
     adapter.send.assert_awaited_once_with(
         "chat-1",
         "Threaded image",
+        reply_to="msg-1",
         metadata=routing_metadata,
     )
     adapter.send_multiple_images.assert_awaited_once_with(
         chat_id="chat-1",
         images=[(f"file://{media_file.as_posix()}", "")],
+        reply_to="msg-1",
         metadata=routing_metadata,
     )
 
@@ -327,6 +364,7 @@ async def test_queued_followup_delivery_keeps_remote_image_url_in_text():
     adapter.send.assert_awaited_once_with(
         "chat-1",
         response,
+        reply_to="msg-1",
         metadata={"thread_id": "topic-1"},
     )
     adapter.send_multiple_images.assert_not_awaited()
@@ -370,6 +408,7 @@ async def test_queued_followup_delivery_keeps_bare_local_path_in_text(
     adapter.send.assert_awaited_once_with(
         "chat-1",
         response,
+        reply_to="msg-1",
         metadata={"thread_id": "topic-1"},
     )
     adapter.send_multiple_images.assert_not_awaited()
@@ -409,6 +448,7 @@ async def test_queued_followup_delivery_preserves_protected_media_example():
     adapter.send.assert_awaited_once_with(
         "chat-1",
         response,
+        reply_to="msg-1",
         metadata={"thread_id": "topic-1"},
     )
     adapter.send_multiple_images.assert_not_awaited()

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -547,11 +547,19 @@ class TestValidateConfigKey:
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",
         "approvals.mode",
+        "telegram.reply_to_transcript",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key
         is_known, _ = _validate_config_key(key)
         assert is_known, f"Expected {key!r} to validate as known"
+
+    def test_platform_specific_transcript_reply_is_not_an_stt_key(self):
+        from hermes_cli.config import _validate_config_key
+
+        is_known, _ = _validate_config_key("stt.reply_to_transcript")
+
+        assert not is_known
 
     @pytest.mark.parametrize("key,expected_in_suggestion", [
         ("gateway.discord.gateway_restart_notification", None),  # no close suggestion

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2178,6 +2178,8 @@ Language resolution is the same for **every** STT provider (local, groq, openai,
 
 Set `stt.echo_transcripts: false` when the gateway should transcribe voice notes for the agent but must not post the raw transcript back to the chat (for example, customer-facing WhatsApp bots).
 
+On Telegram, set `telegram.reply_to_transcript: true` to anchor the agent's answer to the visible transcript echo instead of the original voice-note bubble. This makes the quoted reply show the recognized words, so the relationship is clearer at a glance. The option only takes effect when `stt.echo_transcripts` is enabled and the transcript echo was delivered successfully; otherwise Hermes keeps replying to the original voice note.
+
 Provider behavior:
 
 - `local` uses `faster-whisper` running on your machine. Install it separately with `pip install faster-whisper`. Silence-hallucination hardening is on by default: a Silero VAD filter keeps silence/noise from ever reaching Whisper, cross-window conditioning is disabled, and segments the model itself flags as probably-not-speech *and* low-confidence are dropped. Set `stt.local.vad: false` to transcribe non-speech audio (music, ambient) with the raw behavior. The model stays loaded in memory between voice messages for low-latency transcription; set `stt.local.unload_after_idle_seconds` (e.g. `300` for 5 minutes) to automatically release the model when idle. This frees GPU memory on CUDA hosts (the main win when a local LLM shares the GPU); on CPU the memory becomes reusable by the process, though the OS-visible footprint may not shrink until the process needs the space for something else. The next voice message reloads the model transparently.


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in Telegram setting that makes the agent's final response reply to the visible transcript echo instead of the original voice-note bubble.

This makes voice-note conversations easier to follow while preserving existing behavior by default. The alternate anchor is used only when transcript echoing succeeds and returns a message ID; otherwise Hermes falls back to the original voice-note anchor.

## Related Issue

No linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added the default-off `telegram.reply_to_transcript` config key in `hermes_cli/config_defaults.py`, with CLI validation, Desktop settings discovery, `cli-config.yaml.example`, and user-guide documentation.
- Updated `plugins/platforms/telegram/adapter.py` to normalize the setting and preserve the established precedence between supported Telegram config locations.
- Updated `gateway/run.py` and `gateway/platforms/base.py` so successful transcript echoes can become the late-bound reply anchor for streaming, non-streaming, and queued/pending voice turns.
- Preserved full Telegram DM-topic reply metadata and fallback to the original voice note when transcript echoing is disabled, fails, or has no message ID.
- Added regression coverage in the affected gateway and CLI test modules.

## How to Test

1. Enable transcript echoing and the new option:
   ```yaml
   stt:
     echo_transcripts: true
   telegram:
     reply_to_transcript: true
   ```
2. Restart the gateway and send the Telegram bot a voice note. Confirm the transcript is echoed and the final agent answer replies to that transcript message.
3. Disable `telegram.reply_to_transcript` (or simulate an echo send failure) and confirm the final answer continues to reply to the original voice note.
4. Run the focused regression suite:
   ```bash
   pytest -q \
     tests/gateway/test_base_topic_sessions.py \
     tests/gateway/test_stt_transcript_echo_config.py \
     tests/gateway/test_telegram_audio_vs_voice.py \
     tests/gateway/test_telegram_voice_v0_regressions.py \
     tests/hermes_cli/test_set_config_value.py
   ```
   Result: **103 passed**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted affected suite passes (103 tests); full suite not run locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 and Telegram

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the user configuration guide
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor workflow or architecture policy change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no OS-specific production behavior introduced
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool behavior or schema changed

## Screenshots / Logs

The agent's final response is visibly anchored to the echoed transcript rather than the original voice-note bubble:

![Telegram reply anchored to the transcribed voice message](https://github.com/user-attachments/assets/ac22f433-16b8-4b23-9e51-dca7d9b4ee89)

The focused automated suite completed with **103 passed**.
