### PR TITLE
fix(tests): return Path from get_hermes_home mock in slash_worker profile test (salvage #85998)

### DIFF
--- a/contributors/emails/laura@localhost
+++ b/contributors/emails/laura@localhost
@@ -1,0 +1,1 @@
+infocentr

--- a/tests/tui_gateway/test_slash_worker_profile_home.py
+++ b/tests/tui_gateway/test_slash_worker_profile_home.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch, call
 
 import pytest
@@ -11,7 +12,10 @@ import pytest
 def test_slash_worker_accepts_profile_home():
     """_SlashWorker.__init__ accepts profile_home parameter."""
     with patch.dict("sys.modules", {
-        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        # get_hermes_home() returns a Path in production; hermes_state.py's
+        # module-level DEFAULT_DB_PATH = get_hermes_home() / "state.db" does path
+        # division, so a str mock makes the import raise TypeError (str / str).
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test"))),
     }):
         with patch("subprocess.Popen") as mock_popen:
             mock_popen.return_value.stdout = MagicMock()


### PR DESCRIPTION
Salvage of #85998 by @infocentr — cherry-picked with authorship preserved, plus the contributor email mapping (`laura@localhost` → `infocentr`) so check-attribution passes in the same PR.

## What this fixes

`test_slash_worker_accepts_profile_home` is red on main (run [31786882691](https://github.com/NousResearch/hermes-agent/actions/runs/31786882691), Python tests slice 3/12) and inherits red into every open PR's merge ref.

The test mocks `hermes_constants.get_hermes_home` returning the **str** `"/tmp/hermes_test"`. Production returns a `Path`, and `hermes_state.py:348`'s module-level `DEFAULT_DB_PATH = get_hermes_home() / "state.db"` does path division — so importing `tui_gateway.server` under the str mock raises `TypeError: unsupported operand type(s) for /: 'str' and 'str'`.

Fix (@infocentr's, verbatim): return `Path("/tmp/hermes_test")` from the mock.

## Why a salvage instead of the original

#85998's CI required first-time-contributor workflow approval (done), then failed **check-attribution** because `laura@localhost` has no contributor mapping — a chore PR for the mapping (#86033) then couldn't merge because every PR inherits main's red from this very test (circular). Bundling fix + mapping in one PR breaks the cycle.

## Verification (targeted; full suite runs here on CI)

- PR head: `pytest tests/tui_gateway/test_slash_worker_profile_home.py` → **1 passed**
- Base control (main's version of the test file, same tree): → **1 failed** with the exact CI TypeError — confirms this PR is the fix
- Slice 2's `test_write_stdin_pty_surrogateescape_roundtrip` + `test_base_processing_stops_typing_before_hung_post_delivery_callback` (failed once on #86033's run): both **pass locally** on main — flaky, unrelated.

Credit: fix authored by @infocentr (#85998).