### PR TITLE
fix(approval): restore CLI Dangerous Command prompt when ask-mode leaks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2399,8 +2399,10 @@ except Exception as _bootstrap_exc:
 # Gateway runs in quiet mode - suppress debug output and use cwd directly (no temp dirs)
 os.environ["HERMES_QUIET"] = "1"
 
-# Enable interactive exec approval for dangerous commands on messaging platforms
-os.environ["HERMES_EXEC_ASK"] = "1"
+# HERMES_EXEC_ASK is set in start_gateway(), not at import time. Importing this
+# module from CLI tools (e.g. send_message → _gateway_runner_ref) must not flip
+# interactive CLI sessions into ask-mode, or Dangerous Command prompts become
+# silent pending_approval with no Approve/Deny UI.
 
 # Set terminal working directory for messaging platforms.
 # config.yaml terminal.cwd is the canonical source (bridged to TERMINAL_CWD
@@ -28805,6 +28807,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                  Useful for systemd services to avoid restart-loop deadlocks
                  when the previous process hasn't fully exited yet.
     """
+    # Enable interactive exec approval for dangerous commands on messaging
+    # platforms. Set here (not at module import) so incidental imports of
+    # gateway.run from CLI/tool code do not poison HERMES_EXEC_ASK.
+    os.environ["HERMES_EXEC_ASK"] = "1"
+
     from hermes_cli.resource_limits import apply_nofile_soft_limit
 
     apply_nofile_soft_limit()

--- a/tests/tools/test_cli_approval_exec_ask_leak.py
+++ b/tests/tools/test_cli_approval_exec_ask_leak.py
@@ -1,0 +1,113 @@
+"""Regression: interactive CLI must not lose the Dangerous Command panel.
+
+When ``HERMES_EXEC_ASK`` leaks into a classic CLI process (historically via
+``import gateway.run`` setting the flag at module import), the ask/gateway
+branch used to return ``pending_approval`` immediately with no notify
+listener and skip the CLI approval callback. Users saw tools "auto-block"
+with no Approve/Deny UI.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import tools.approval as approval_module
+from tools.approval import check_all_command_guards
+from tools.terminal_tool import set_approval_callback
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(autouse=True)
+def _clean_approval_env(monkeypatch):
+    for key in (
+        "HERMES_EXEC_ASK",
+        "HERMES_GATEWAY_SESSION",
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_CRON_SESSION",
+        "HERMES_YOLO_MODE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr(
+        approval_module,
+        "_get_approval_mode",
+        lambda: "manual",
+    )
+    monkeypatch.setattr(
+        "tools.tirith_security.check_command_security",
+        lambda _command: {"action": "allow", "findings": [], "summary": ""},
+    )
+    approval_module._session_approved.clear()
+    approval_module._permanent_approved.clear()
+    approval_module._pending.clear()
+    set_approval_callback(None)
+    yield
+    set_approval_callback(None)
+
+
+class TestCliApprovalSurvivesExecAskLeak:
+    def test_cli_callback_used_when_exec_ask_set_without_notifier(self, monkeypatch):
+        """Ask-mode with a CLI callback must prompt locally, not pending_approval."""
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        calls = []
+
+        def _cb(command, description, **kwargs):
+            calls.append((command, description))
+            return "once"
+
+        set_approval_callback(_cb)
+        result = check_all_command_guards("rm -rf /tmp/testdir", "local")
+
+        assert calls, "CLI approval callback was never invoked"
+        assert result.get("status") != "pending_approval"
+        assert result.get("approval_pending") is not True
+        assert result.get("approved") is True
+        assert result.get("user_approved") is True
+
+    def test_pending_approval_still_used_without_cli_callback(self, monkeypatch):
+        """Headless ask-mode without a CLI callback keeps the pending fallback."""
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        set_approval_callback(None)
+
+        result = check_all_command_guards("rm -rf /tmp/testdir", "local")
+
+        assert result.get("approved") is False
+        assert result.get("status") == "pending_approval"
+        assert result.get("approval_pending") is True
+
+
+class TestGatewayRunImportDoesNotSetExecAsk:
+    def test_importing_gateway_run_does_not_set_exec_ask(self):
+        """Incidental imports must not poison CLI ask-mode process-wide."""
+        script = r"""
+import os, sys
+os.environ.pop("HERMES_EXEC_ASK", None)
+sys.path.insert(0, %r)
+# Avoid starting the gateway; only import the module for _gateway_runner_ref
+# style side imports.
+import gateway.run  # noqa: F401
+print("EXEC_ASK=" + repr(os.environ.get("HERMES_EXEC_ASK")))
+""" % (str(REPO_ROOT),)
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "HERMES_HOME": str(REPO_ROOT / ".tmp-hermes-exec-ask-import"),
+            },
+            timeout=60,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "EXEC_ASK=None" in proc.stdout, proc.stdout + proc.stderr

--- a/tests/tools/test_cli_approval_exec_ask_leak.py
+++ b/tests/tools/test_cli_approval_exec_ask_leak.py
@@ -10,8 +10,10 @@ with no Approve/Deny UI.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -87,7 +89,7 @@ class TestCliApprovalSurvivesExecAskLeak:
 
 
 class TestGatewayRunImportDoesNotSetExecAsk:
-    def test_importing_gateway_run_does_not_set_exec_ask(self):
+    def test_importing_gateway_run_does_not_set_exec_ask(self, tmp_path):
         """Incidental imports must not poison CLI ask-mode process-wide."""
         script = r"""
 import os, sys
@@ -98,6 +100,7 @@ sys.path.insert(0, %r)
 import gateway.run  # noqa: F401
 print("EXEC_ASK=" + repr(os.environ.get("HERMES_EXEC_ASK")))
 """ % (str(REPO_ROOT),)
+        hermes_home = tmp_path / "import-test-home"
         proc = subprocess.run(
             [sys.executable, "-c", script],
             cwd=str(REPO_ROOT),
@@ -105,7 +108,7 @@ print("EXEC_ASK=" + repr(os.environ.get("HERMES_EXEC_ASK")))
             text=True,
             env={
                 **os.environ,
-                "HERMES_HOME": str(REPO_ROOT / ".tmp-hermes-exec-ask-import"),
+                "HERMES_HOME": str(hermes_home),
             },
             timeout=60,
         )

--- a/tests/tui_gateway/test_slash_worker_profile_home.py
+++ b/tests/tui_gateway/test_slash_worker_profile_home.py
@@ -1,38 +1,35 @@
 """Tests for TUI gateway slash_worker profile_home propagation (#40677)."""
 
-import os
-import subprocess
-import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
-
-import pytest
+from unittest.mock import MagicMock, patch
 
 
 def test_slash_worker_accepts_profile_home():
     """_SlashWorker.__init__ accepts profile_home parameter."""
+    # hermes_state evaluates get_hermes_home() / "state.db" at import time, so
+    # the mock must return a Path (a bare str raises TypeError under per-file
+    # subprocess isolation).
     with patch.dict("sys.modules", {
-        # get_hermes_home() returns a Path in production; hermes_state.py's
-        # module-level DEFAULT_DB_PATH = get_hermes_home() / "state.db" does path
-        # division, so a str mock makes the import raise TypeError (str / str).
-        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test"))),
+        "hermes_constants": MagicMock(
+            get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test")),
+        ),
     }):
         with patch("subprocess.Popen") as mock_popen:
             mock_popen.return_value.stdout = MagicMock()
             mock_popen.return_value.stderr = MagicMock()
-            
+
             from tui_gateway.server import _SlashWorker
-            
+
             # Test initialization with profile_home
             worker = _SlashWorker(
                 session_key="test_key",
                 model="test-model",
                 profile_home="/home/luke/.hermes/profiles/work"
             )
-            
+
             # Verify Popen was called
             assert mock_popen.called
-            
+
             # Check that HERMES_HOME was set in the environment
             call_kwargs = mock_popen.call_args[1]
             assert "env" in call_kwargs

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -284,6 +284,38 @@ def _is_gateway_approval_context() -> bool:
         return True
     return bool(_get_session_platform())
 
+
+def _resolve_cli_approval_callback(approval_callback=None):
+    """Return an interactive CLI approval callback when one is available.
+
+    Prefers an explicitly passed callback, then the per-thread CLI callback
+    registered via ``tools.terminal_tool.set_approval_callback``.
+    """
+    if approval_callback is not None:
+        return approval_callback
+    try:
+        from tools.terminal_tool import _get_approval_callback
+        return _get_approval_callback()
+    except Exception:
+        return None
+
+
+def _should_fall_through_to_cli_approval(
+    *,
+    is_cli: bool,
+    approval_callback,
+    notify_cb,
+) -> bool:
+    """Prefer the classic CLI Dangerous Command panel over silent pending.
+
+    ``HERMES_EXEC_ASK`` (and sometimes a session platform marker) can leak into
+    an interactive CLI process — most commonly via ``import gateway.run``, which
+    historically set ask-mode as a module-level side effect. Without a gateway
+    notify listener, the ask/gateway branch used to return ``pending_approval``
+    immediately and skip the CLI panel the user can actually answer.
+    """
+    return bool(is_cli and approval_callback is not None and notify_cb is None)
+
 # Sensitive write targets that should trigger approval even when referenced
 # via shell expansions like $HOME or $HERMES_HOME, or by the resolved absolute
 # active profile home path such as /home/hermes/.hermes/config.yaml. The
@@ -3293,12 +3325,7 @@ def _run_approval_gate(
     if is_approved(session_key, pattern_key):
         return {"approved": True, "message": None}
 
-    if approval_callback is None:
-        try:
-            from tools.terminal_tool import _get_approval_callback
-            approval_callback = _get_approval_callback()
-        except Exception:
-            approval_callback = None
+    approval_callback = _resolve_cli_approval_callback(approval_callback)
 
     is_cli = _is_interactive_cli()
     is_gateway = _is_gateway_approval_context()
@@ -3407,24 +3434,32 @@ def _run_approval_gate(
                 save_permanent_allowlist(_permanent_approved)
             return {"approved": True, "message": None}
 
-        # No notify callback (e.g. API server without an attached chat):
-        # queue for /approve /deny review, agent sees approval_required.
-        submit_pending(session_key, {
-            "command": display_target,
-            "pattern_key": pattern_key,
-            "description": description,
-        })
-        return {
-            "approved": False,
-            "pattern_key": pattern_key,
-            "status": "approval_required",
-            "command": display_target,
-            "description": description,
-            "message": (
-                f"⚠️ This action is potentially dangerous ({description}). "
-                f"Asking the user for approval.\n\n**Target:**\n```\n{display_target}\n```"
-            ),
-        }
+        # No notify callback: interactive CLI with a panel callback should
+        # still prompt locally instead of queuing a pending approval nobody
+        # can see (HERMES_EXEC_ASK / platform-marker leaks into CLI).
+        if not _should_fall_through_to_cli_approval(
+            is_cli=is_cli,
+            approval_callback=approval_callback,
+            notify_cb=notify_cb,
+        ):
+            # No notify callback (e.g. API server without an attached chat):
+            # queue for /approve /deny review, agent sees approval_required.
+            submit_pending(session_key, {
+                "command": display_target,
+                "pattern_key": pattern_key,
+                "description": description,
+            })
+            return {
+                "approved": False,
+                "pattern_key": pattern_key,
+                "status": "approval_required",
+                "command": display_target,
+                "description": description,
+                "message": (
+                    f"⚠️ This action is potentially dangerous ({description}). "
+                    f"Asking the user for approval.\n\n**Target:**\n```\n{display_target}\n```"
+                ),
+            }
 
     _fire_approval_hook(
         "pre_approval_request",
@@ -4036,6 +4071,7 @@ def check_all_command_guards(command: str, env_type: str,
     if _command_matches_permanent_allowlist(command):
         return {"approved": True, "message": None}
 
+    approval_callback = _resolve_cli_approval_callback(approval_callback)
     is_cli = _is_interactive_cli()
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
@@ -4419,35 +4455,44 @@ def check_all_command_guards(command: str, env_type: str,
                     "user_approved": True, "description": combined_desc}
 
         # Fallback: no gateway callback registered (e.g. cron, batch).
-        # Return approval_required for backward compat. Redact secrets in the
-        # user-facing copy — the raw `command` is preserved for execution and
-        # the allowlist keys off pattern_key, so redaction is display-only.
-        from agent.redact import redact_sensitive_text
-        _disp_command = redact_sensitive_text(command)
-        _disp_combined_desc = redact_sensitive_text(combined_desc)
-        pending_data = {
-            "command": _disp_command,
-            "pattern_key": primary_key,
-            "pattern_keys": all_keys,
-            "description": _disp_combined_desc,
-        }
-        if smart_denied_for_owner:
-            pending_data.update(smart_denied=True, allow_permanent=False)
-        submit_pending(session_key, pending_data)
-        result = {
-            "approved": False,
-            "pattern_key": primary_key,
-            "status": "pending_approval",
-            "approval_pending": True,
-            "command": _disp_command,
-            "description": _disp_combined_desc,
-            "message": (
-                f"⚠️ {_disp_combined_desc}. Asking the user for approval.\n\n**Command:**\n```\n{_disp_command}\n```"
-            ),
-        }
-        if smart_denied_for_owner:
-            result.update(smart_denied=True, allow_permanent=False)
-        return result
+        # Interactive CLI with a Dangerous Command callback should still
+        # paint the local panel — ask-mode often leaks into CLI via
+        # importing gateway.run, and returning pending_approval here makes
+        # the agent look "auto-blocked" with no Approve/Deny UI.
+        if not _should_fall_through_to_cli_approval(
+            is_cli=is_cli,
+            approval_callback=approval_callback,
+            notify_cb=notify_cb,
+        ):
+            # Return approval_required for backward compat. Redact secrets in the
+            # user-facing copy — the raw `command` is preserved for execution and
+            # the allowlist keys off pattern_key, so redaction is display-only.
+            from agent.redact import redact_sensitive_text
+            _disp_command = redact_sensitive_text(command)
+            _disp_combined_desc = redact_sensitive_text(combined_desc)
+            pending_data = {
+                "command": _disp_command,
+                "pattern_key": primary_key,
+                "pattern_keys": all_keys,
+                "description": _disp_combined_desc,
+            }
+            if smart_denied_for_owner:
+                pending_data.update(smart_denied=True, allow_permanent=False)
+            submit_pending(session_key, pending_data)
+            result = {
+                "approved": False,
+                "pattern_key": primary_key,
+                "status": "pending_approval",
+                "approval_pending": True,
+                "command": _disp_command,
+                "description": _disp_combined_desc,
+                "message": (
+                    f"⚠️ {_disp_combined_desc}. Asking the user for approval.\n\n**Command:**\n```\n{_disp_command}\n```"
+                ),
+            }
+            if smart_denied_for_owner:
+                result.update(smart_denied=True, allow_permanent=False)
+            return result
 
     # CLI interactive: single combined prompt
     # Hide [a]lways when no persistable (non-tirith) warning is present
@@ -4602,6 +4647,10 @@ def check_execute_code_guard(code: str, env_type: str,
     #     (context now propagates into the RPC thread, #33057); a whole-script
     #     prompt would fire on every execute_code call.
     #   * Local non-interactive non-gateway: documented limitation above.
+    # Ask-mode (HERMES_EXEC_ASK) still takes this path even when INTERACTIVE
+    # is also set — that combination is how gateway/smart tests and messaging
+    # ask-mode drive whole-script approval. Terminal-command CLI leaks are
+    # handled in check_all_command_guards via the CLI callback fall-through.
     if not is_gateway and not is_ask:
         return {"approved": True, "message": None}
 


### PR DESCRIPTION
## Summary
Restores the CLI Dangerous Command prompt when `HERMES_EXEC_ASK` leaks into an interactive CLI process — previously the panel was silently replaced with `pending_approval` (no Approve/Deny UI).

Root cause: `gateway/run.py` set `HERMES_EXEC_ASK=1` at module import time, so any CLI tool that incidentally imports `gateway.run` (e.g. `send_message` → `_gateway_runner_ref`) poisoned the process into ask-mode without a gateway notify listener.

## Changes
- `gateway/run.py`: Move `HERMES_EXEC_ASK=1` from module-import to `start_gateway()` so incidental imports don't poison CLI sessions
- `tools/approval.py`: Add `_resolve_cli_approval_callback()` and `_should_fall_through_to_cli_approval()` helpers so ask-mode with a CLI callback but no notifier still prompts locally instead of returning silent `pending_approval`
- `tests/tools/test_cli_approval_exec_ask_leak.py`: Regression tests for CLI fall-through, headless pending fallback, and import side-effect
- `tests/tui_gateway/test_slash_worker_profile_home.py`: Fix Path mock (bare string caused TypeError in `hermes_state` import-time `/` operator)
- Follow-up: use pytest `tmp_path` fixture for the import test's `HERMES_HOME` instead of a repo-root subdir that was left as untracked artifact

Salvage of #86016 by @xxxigm — cherry-picked with authorship preserved, test artifact cleanup added as follow-up.

## Validation
| Check | Result |
|-------|--------|
| New tests (3) | All pass |
| Slash-worker test | Pass |
| E2E smoke (import, CLI callback, headless) | All pass |
| Ruff | Clean |
| Pre-existing failures (28) | Identical on main (environmental) |
| Repo root clean after test | No artifacts |

Closes #86016
