### PR TITLE
fix(gateway): route synthetic auto-TTS through platform adapters

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20871,6 +20871,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             guild_id = self._get_guild_id(event)
             play_in_voice_channel = getattr(adapter, "play_in_voice_channel", None)
             is_in_voice_channel = getattr(adapter, "is_in_voice_channel", None)
+            play_tts = getattr(adapter, "play_tts", None)
             send_voice = getattr(adapter, "send_voice", None)
             in_voice_channel = bool(
                 guild_id
@@ -20880,7 +20881,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             reply_anchor = self._reply_anchor_for_event(event)
             thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
-            if not in_voice_channel and callable(send_voice):
+            if not in_voice_channel and (callable(play_tts) or callable(send_voice)):
                 # Mark the auto voice reply as notify-worthy.  Mirrors the
                 # final-text path in gateway/platforms/base.py which sets
                 # ``notify=True`` so platform adapters that gate push
@@ -20897,6 +20898,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if in_voice_channel:
                     play_voice = cast(Callable[..., Awaitable[Any]], play_in_voice_channel)
                     await play_voice(guild_id, actual_path)
+                elif callable(play_tts):
+                    play_tts_call = cast(Callable[..., Awaitable[Any]], play_tts)
+                    await play_tts_call(
+                        chat_id=event.source.chat_id,
+                        audio_path=actual_path,
+                        reply_to=reply_anchor,
+                        metadata=thread_meta,
+                    )
                 elif callable(send_voice):
                     send_voice_call = cast(Callable[..., Awaitable[Any]], send_voice)
                     send_kwargs: Dict[str, Any] = {

--- a/tests/gateway/test_async_completion_voice_routing.py
+++ b/tests/gateway/test_async_completion_voice_routing.py
@@ -1,0 +1,167 @@
+"""Regression coverage for auto-TTS delivery after synthetic completions."""
+
+import json
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _runner(adapter):
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.DISCORD: adapter}
+    return runner
+
+
+def _synthetic_event():
+    return MessageEvent(
+        text="background completion",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="123",
+            user_id="user-1",
+            chat_type="channel",
+        ),
+        message_id="completion-1",
+        raw_message=None,
+    )
+
+
+def _fake_tts(monkeypatch, tmp_path):
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+
+    def fake_text_to_speech(*, text, output_path, **_kwargs):
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as audio:
+            audio.write(b"audio")
+        return json.dumps({"success": True, "file_path": output_path})
+
+    monkeypatch.setattr("tools.tts_tool.text_to_speech_tool", fake_text_to_speech)
+    monkeypatch.setattr("tools.tts_tool._strip_markdown_for_tts", lambda text: text)
+
+
+@pytest.mark.asyncio
+async def test_synthetic_completion_routes_tts_through_adapter_play_tts(monkeypatch, tmp_path):
+    """A synthetic event has no guild raw_message but still uses adapter routing."""
+    play_tts = AsyncMock()
+    send_voice = AsyncMock()
+    adapter = SimpleNamespace(
+        play_tts=play_tts,
+        send_voice=send_voice,
+        is_in_voice_channel=lambda _guild_id: False,
+    )
+    _fake_tts(monkeypatch, tmp_path)
+
+    await _runner(adapter)._send_voice_reply(_synthetic_event(), "Spoken result")
+
+    play_tts.assert_awaited_once()
+    kwargs = play_tts.await_args.kwargs
+    assert kwargs["chat_id"] == "123"
+    assert kwargs["reply_to"] == "completion-1"
+    assert kwargs["metadata"] == {"notify": True}
+    send_voice.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_synthetic_completion_reaches_real_discord_bound_voice_channel(
+    monkeypatch, tmp_path
+):
+    """Discord resolves a synthetic completion's text chat to its bound VC."""
+    from gateway.config import PlatformConfig
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    adapter = object.__new__(DiscordAdapter)
+    adapter.platform = Platform.DISCORD
+    adapter.config = PlatformConfig(enabled=True, extra={})
+    adapter._voice_text_channels = {456: 123}
+    voice_client = MagicMock()
+    voice_client.is_connected.return_value = True
+    adapter._voice_clients = {456: voice_client}
+    adapter.play_in_voice_channel = AsyncMock(return_value=True)
+    adapter.send_voice = AsyncMock()
+    _fake_tts(monkeypatch, tmp_path)
+
+    await _runner(adapter)._send_voice_reply(_synthetic_event(), "Spoken result")
+
+    adapter.play_in_voice_channel.assert_awaited_once()
+    guild_id, audio_path = adapter.play_in_voice_channel.await_args.args
+    assert guild_id == 456
+    assert audio_path.endswith(".mp3")
+    adapter.send_voice.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_raw_guild_completion_keeps_direct_voice_channel_playback(monkeypatch, tmp_path):
+    """Direct raw-guild delivery remains ahead of adapter auto-TTS routing."""
+    play_in_voice_channel = AsyncMock()
+    play_tts = AsyncMock()
+    send_voice = AsyncMock()
+    adapter = SimpleNamespace(
+        play_in_voice_channel=play_in_voice_channel,
+        play_tts=play_tts,
+        send_voice=send_voice,
+        is_in_voice_channel=lambda guild_id: guild_id == 456,
+    )
+    event = _synthetic_event()
+    event.raw_message = SimpleNamespace(guild_id=456, guild=None)
+    _fake_tts(monkeypatch, tmp_path)
+
+    await _runner(adapter)._send_voice_reply(event, "Spoken result")
+
+    play_in_voice_channel.assert_awaited_once()
+    guild_id, audio_path = play_in_voice_channel.await_args.args
+    assert guild_id == 456
+    assert audio_path.endswith(".mp3")
+    play_tts.assert_not_awaited()
+    send_voice.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_synthetic_completion_uses_play_tts_when_adapter_must_fallback(monkeypatch, tmp_path):
+    """The runner delegates no-binding fallback to the adapter play_tts seam."""
+    send_voice = AsyncMock()
+    play_in_voice_channel = AsyncMock()
+
+    async def _fallback_to_attachment(**kwargs):
+        await send_voice(**kwargs)
+
+    play_tts = AsyncMock(side_effect=_fallback_to_attachment)
+    adapter = SimpleNamespace(
+        play_in_voice_channel=play_in_voice_channel,
+        play_tts=play_tts,
+        send_voice=send_voice,
+        is_in_voice_channel=lambda _guild_id: False,
+    )
+    _fake_tts(monkeypatch, tmp_path)
+
+    await _runner(adapter)._send_voice_reply(_synthetic_event(), "Spoken result")
+
+    play_tts.assert_awaited_once()
+    play_in_voice_channel.assert_not_awaited()
+    send_voice.assert_awaited_once()
+    assert send_voice.await_args.kwargs["metadata"] == {"notify": True}
+
+
+@pytest.mark.asyncio
+async def test_adapter_without_play_tts_keeps_send_voice_compatibility(monkeypatch, tmp_path):
+    """Unusual legacy adapters retain their attachment fallback and notify metadata."""
+    send_voice = AsyncMock()
+    adapter = SimpleNamespace(
+        send_voice=send_voice,
+        is_in_voice_channel=lambda _guild_id: False,
+    )
+    _fake_tts(monkeypatch, tmp_path)
+
+    await _runner(adapter)._send_voice_reply(_synthetic_event(), "Spoken result")
+
+    send_voice.assert_awaited_once()
+    assert send_voice.await_args.kwargs["chat_id"] == "123"
+    assert send_voice.await_args.kwargs["metadata"] == {"notify": True}

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -49,8 +49,9 @@ class TestAutoVoiceReplyFormat:
             await runner._send_voice_reply(event, "hello from auto tts")
 
         assert requested_paths and requested_paths[0].endswith(".ogg")
-        adapter.send_voice.assert_awaited_once()
-        assert adapter.send_voice.await_args.kwargs["audio_path"].endswith(".ogg")
+        adapter.play_tts.assert_awaited_once()
+        assert adapter.play_tts.await_args.kwargs["audio_path"].endswith(".ogg")
+        adapter.send_voice.assert_not_awaited()
 
     def test_should_send_voice_reply_streamed_global_auto_tts_fires(self):
         """Streamed reply + global voice.auto_tts (no /voice opt-in) sends voice.
@@ -104,6 +105,7 @@ def _make_runner() -> GatewayRunner:
 def _make_adapter(platform: Platform) -> MagicMock:
     adapter = MagicMock()
     adapter.platform = platform
+    adapter.play_tts = AsyncMock()
     adapter.send_voice = AsyncMock()
     return adapter
 

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -252,7 +252,7 @@ class TestAutoVoiceReply:
     # | Slack         | text  | all        | skip | yes    | 1 audio      |
     #
     # * skip_double: voice input → base already handles
-    # † Discord play_tts override skips when in VC
+    # † Discord base auto-TTS owns voice-input playback in VC
 
     # -- Telegram/Slack/Web: voice input, base handles ---------------------
 
@@ -296,10 +296,11 @@ class TestSendVoiceReply:
         return _make_runner(tmp_path)
 
     @pytest.mark.asyncio
-    async def test_calls_tts_and_send_voice(self, runner):
+    async def test_calls_tts_and_play_tts(self, runner):
         from gateway.config import Platform
 
         mock_adapter = AsyncMock()
+        mock_adapter.play_tts = AsyncMock()
         mock_adapter.send_voice = AsyncMock()
         event = _make_event()
         event.source.platform = Platform.TELEGRAM
@@ -314,9 +315,10 @@ class TestSendVoiceReply:
              patch("os.makedirs"):
             await runner._send_voice_reply(event, "Hello world")
 
-        mock_adapter.send_voice.assert_called_once()
+        mock_adapter.play_tts.assert_called_once()
+        mock_adapter.send_voice.assert_not_called()
         assert mock_tts.call_args.kwargs["output_path"].endswith(".ogg")
-        call_args = mock_adapter.send_voice.call_args
+        call_args = mock_adapter.play_tts.call_args
         assert call_args.kwargs.get("chat_id") == "123"
 
 
@@ -325,6 +327,7 @@ class TestSendVoiceReply:
         from gateway.config import Platform
 
         mock_adapter = AsyncMock()
+        mock_adapter.play_tts = AsyncMock()
         mock_adapter.send_voice = AsyncMock()
         event = _make_event()
         event.source.platform = Platform.TELEGRAM
@@ -342,8 +345,9 @@ class TestSendVoiceReply:
              patch("os.makedirs"):
             await runner._send_voice_reply(event, "Hello world")
 
-        mock_adapter.send_voice.assert_called_once()
-        call_kwargs = mock_adapter.send_voice.call_args.kwargs
+        mock_adapter.play_tts.assert_called_once()
+        mock_adapter.send_voice.assert_not_called()
+        call_kwargs = mock_adapter.play_tts.call_args.kwargs
         assert call_kwargs["reply_to"] == "462"
         assert call_kwargs["metadata"] == {
             "thread_id": "20197",
@@ -357,11 +361,11 @@ class TestSendVoiceReply:
 
 
 # =====================================================================
-# Discord play_tts skip when in voice channel
+# Discord play_tts routing when in voice channel
 # =====================================================================
 
-class TestDiscordPlayTtsSkip:
-    """Discord adapter skips play_tts when bot is in a voice channel."""
+class TestDiscordPlayTtsRouting:
+    """Discord adapter routes play_tts into a bound voice channel."""
 
     def _make_discord_adapter(self):
         from plugins.platforms.discord.adapter import DiscordAdapter


### PR DESCRIPTION
## What does this PR do?

Delayed/background completions are re-injected as synthetic `MessageEvent`s without a raw Discord guild object. `_send_voice_reply()` therefore could not use its direct guild playback path and called `send_voice()` directly, bypassing Discord's existing text-channel → connected-voice-channel binding.

This change delegates the no-direct-guild case through the platform adapter's existing `play_tts(chat_id, ...)` contract. Discord can then resolve its bound voice channel; platforms or Discord chats without an active binding retain their existing attachment fallback. Direct raw-guild playback remains first.

## Related Issue

No existing issue found after searching open and closed issues/PRs for synthetic, delayed, and background completion TTS/voice delivery. This fixes a live-reproduced gateway bug reported through Discord.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: use `adapter.play_tts()` when direct guild voice playback is unavailable, preserving `send_voice()` compatibility for legacy adapters.
- `tests/gateway/test_async_completion_voice_routing.py`: cover synthetic completion routing, real Discord bound-VC resolution, raw-guild priority, adapter attachment fallback, and legacy compatibility.
- `tests/gateway/test_auto_voice_reply_format.py`: assert auto-TTS uses the adapter playback contract.
- `tests/gateway/test_voice_command.py`: update gateway voice expectations and stale Discord routing descriptions.

## How to Test

1. Enable Discord auto-TTS and bind a text channel to a connected voice channel.
2. Trigger a background/sub-agent completion that returns after the initiating assistant turn has ended.
3. Confirm the delayed completion plays directly in the bound VC rather than appearing only as text or a `voice-message.ogg` attachment.
4. Disconnect the VC or remove the binding and confirm normal attachment fallback remains available.
5. Run `scripts/run_tests.sh` for CI parity.

Automated verification:

- Canonical `scripts/run_tests.sh` full-suite run completed in a clean external `[all,dev]` environment.
- Full-suite result: 22 unrelated failing files / 80 tests.
- Untouched parent commit, same environment and exact 22 files: the same 22 failing files / 81 tests. This PR introduces no new failing file; the one-test count difference is baseline nondeterminism.
- Post-rebase affected voice suite: `81 passed, 7 skipped`.
- Post-rebase completion delivery suites: `37 passed`.
- Independent focused verification before workflow correction: `88 passed`.
- Targeted Ruff, `compileall`, and `git diff --check` passed.

Manual proof:

- Ubuntu 24.04, Python 3.11.15, Discord voice channel.
- A completion delayed by approximately 65 seconds returned after the parent turn ended and played audibly in the bound VC without a `voice-message.ogg` attachment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite run completed; the untouched parent has the same 22 failing files, and this PR introduces no new failing file (details above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Python 3.11.15 / Discord

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing interface or configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no filesystem, subprocess, signal, or OS-specific behavior changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No sensitive runtime logs attached. The regression tests encode the routing proof; the live acceptance result is summarized above.

## Scope boundary

This PR does not change TTS generation, Discord voice reconnect handling, inbound voice decryption, or long-response timeout behavior.