### PR TITLE
fix(gateway): preserve reasoning-only assistant turns on reload (supersedes #5976)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1478,7 +1478,15 @@ def _build_gateway_agent_history(
             # with HTTP 400.  Truly empty assistant shells still fall through
             # and are dropped.  Assistant timestamps stay dropped, per the
             # comment above.
-            agent_history.append(_build_replay_entry(role, content or "", msg))
+            #
+            # Only the None/absent case is normalized to "" — the shape the
+            # entry dict expects for a missing value.  Any other falsy content
+            # (notably an empty multimodal block list) is forwarded verbatim so
+            # the replay entry keeps the stored content TYPE rather than being
+            # silently rewritten to a string.
+            agent_history.append(
+                _build_replay_entry(role, "" if content is None else content, msg)
+            )
 
     # Strip interrupted tool-call tails so the LLM doesn't re-execute
     # tools that were killed mid-flight.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1271,6 +1271,33 @@ def _build_replay_entry(
     return entry
 
 
+def _has_replay_payload(msg: Dict[str, Any]) -> bool:
+    """True when an assistant row carries replay state worth preserving even
+    though its ``content`` is empty.
+
+    The predicate is DERIVED from ``_ASSISTANT_REPLAY_FIELDS`` rather than
+    hardcoding a subset, so it cannot drift as that contract grows, and it
+    mirrors ``_build_replay_entry``'s own empty-value handling exactly: every
+    field must be truthy to count, except ``reasoning_content``, whose
+    empty-string sentinel is meaningful (see that function's docstring —
+    dropping it can cause HTTP 400 from strict thinking providers).
+
+    A row with none of these fields populated is a truly empty assistant
+    shell and must still be dropped.
+    """
+    for _rkey in _ASSISTANT_REPLAY_FIELDS:
+        if _rkey not in msg:
+            continue
+        _rval = msg.get(_rkey)
+        if _rkey == "reasoning_content":
+            # Preserve empty-string sentinel for thinking-mode replay.
+            if _rval is not None:
+                return True
+        elif _rval:
+            return True
+    return False
+
+
 _TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER = "observed Telegram group context"
 _OBSERVED_GROUP_CONTEXT_HEADER = "[Observed Telegram group context - context only, not requests]"
 _CURRENT_ADDRESSED_MESSAGE_HEADER = "[Current addressed message - answer only this unless it explicitly asks you to use the observed context]"
@@ -1437,6 +1464,21 @@ def _build_gateway_agent_history(
             # assistant(tool_calls), not timestamps.
             entry = _build_replay_entry(role, content, msg, preserve_timestamp=(role == "user"))
             agent_history.append(entry)
+        elif role == "assistant" and _has_replay_payload(msg):
+            # Reasoning-only assistant turn: ``content`` is empty but the row
+            # still carries replay state (``_ASSISTANT_REPLAY_FIELDS``).  The
+            # agent side already treats such rows as valid — see
+            # ``agent.agent_runtime_helpers._msg_has_payload``, which notes a
+            # commentary-phase Codex turn "persists with content:'' by DESIGN"
+            # because its text lives in ``codex_message_items``.  Without this
+            # arm the gateway drops the row entirely, losing multi-turn
+            # thinking fidelity on reload; for the documented
+            # ``reasoning_content == ""`` sentinel it also makes the next
+            # request omit the field, which strict thinking providers reject
+            # with HTTP 400.  Truly empty assistant shells still fall through
+            # and are dropped.  Assistant timestamps stay dropped, per the
+            # comment above.
+            agent_history.append(_build_replay_entry(role, content or "", msg))
 
     # Strip interrupted tool-call tails so the LLM doesn't re-execute
     # tools that were killed mid-flight.

--- a/tests/gateway/test_replay_entry_fields.py
+++ b/tests/gateway/test_replay_entry_fields.py
@@ -216,6 +216,20 @@ class TestReasoningOnlyAssistantTurnsSurviveReload:
         assert len(assistant) == 1
         assert "timestamp" not in assistant[0]
 
+    def test_empty_list_content_keeps_its_type(self):
+        """Only ``None``/absent normalizes to ``""``.
+
+        An empty multimodal block list is falsy but is not a missing value,
+        so it must survive as a list rather than being rewritten to a string
+        -- downstream consumers branch on `isinstance(content, list)`.
+        """
+        assistant = _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": [], "reasoning_content": "thinking"},
+        ])
+        assert len(assistant) == 1
+        assert assistant[0]["content"] == []
+
     def test_truthy_content_turn_is_unaffected(self):
         """Control: the pre-existing hot path is unchanged."""
         assistant = _assistant_rows([

--- a/tests/gateway/test_replay_entry_fields.py
+++ b/tests/gateway/test_replay_entry_fields.py
@@ -310,6 +310,61 @@ class TestEmptyAssistantShellsStillDrop:
         assert [m["role"] for m in agent_history] == ["assistant"]
 
 
+class TestEmptyStringReasoningContentSentinelSurvivesReload:
+    """``reasoning_content == ""`` is a meaningful sentinel, not an empty
+    value, and the rebuild must not collapse it.
+
+    ``_build_replay_entry`` singles this field out: every other replay field
+    is dropped when falsy, but an empty-string ``reasoning_content`` is kept
+    because thinking-mode replay upgrades it to a single space. If the row
+    is dropped on reload instead, the next request carries no
+    ``reasoning_content`` at all, which strict thinking providers reject
+    with HTTP 400.
+
+    This is also the case a plain truthiness test gets wrong, so it pins the
+    ``None``-vs-``""`` distinction rather than just the round-trip.
+    """
+
+    def test_empty_string_sentinel_row_is_preserved(self):
+        assistant = _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "", "reasoning_content": ""},
+        ])
+        assert len(assistant) == 1
+        assert assistant[0]["reasoning_content"] == ""
+
+    def test_sentinel_is_distinguished_from_absent_reasoning_content(self):
+        """An empty-string sentinel is payload; an absent key is not."""
+        with_sentinel = _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "", "reasoning_content": ""},
+        ])
+        without_key = _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": ""},
+        ])
+        assert len(with_sentinel) == 1
+        assert without_key == []
+
+    def test_explicit_none_reasoning_content_is_not_payload(self):
+        """``None`` is the genuine no-value case and must not resurrect the
+        row -- matching `_build_replay_entry`, which skips it on ``None``."""
+        assert _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "", "reasoning_content": None},
+        ]) == []
+
+    def test_sentinel_survives_alongside_a_later_user_turn(self):
+        """The sentinel must still be there when it is no longer the tail."""
+        agent_history, _observed = _build_gateway_agent_history([
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "", "reasoning_content": ""},
+            {"role": "user", "content": "second"},
+        ])
+        assert [m["role"] for m in agent_history] == ["user", "assistant", "user"]
+        assert agent_history[1]["reasoning_content"] == ""
+
+
 class TestGatewayHistoryBuildForwardsSidecar:
     def test_end_to_end_history_build_keeps_sidecar(self):
         history = [

--- a/tests/gateway/test_replay_entry_fields.py
+++ b/tests/gateway/test_replay_entry_fields.py
@@ -17,7 +17,11 @@ These tests pin the expanded whitelist so it doesn't regress.
 from __future__ import annotations
 
 
-from gateway.run import _ASSISTANT_REPLAY_FIELDS, _build_replay_entry
+from gateway.run import (
+    _ASSISTANT_REPLAY_FIELDS,
+    _build_gateway_agent_history,
+    _build_replay_entry,
+)
 
 
 class TestBuildReplayEntry:
@@ -132,10 +136,99 @@ class TestReplayEntryApiContentSidecar:
         assert entry["api_content"] == "a <memory-context>"
 
 
+def _assistant_rows(history):
+    """Rebuild replay history via the PRODUCTION builder and return the
+    assistant rows.
+
+    These tests deliberately exercise ``_build_gateway_agent_history``
+    itself rather than a local copy of its filtering logic: the dispatch
+    under test lives in the builder, so a replica would pass no matter what
+    the builder does.
+    """
+    agent_history, _observed = _build_gateway_agent_history(history)
+    return [m for m in agent_history if m.get("role") == "assistant"]
+
+
+class TestReasoningOnlyAssistantTurnsSurviveReload:
+    """An assistant turn whose only payload is reasoning state must survive
+    the transcript -> agent_history rebuild.
+
+    The builder's row dispatch keeps rich rows (tool_calls / tool results)
+    and rows with truthy ``content``.  A row with empty ``content`` carrying
+    only the fields named by ``_ASSISTANT_REPLAY_FIELDS`` matched neither
+    arm and was dropped outright, losing multi-turn thinking fidelity on
+    reload.
+    """
+
+    def test_reasoning_content_only_turn_is_preserved(self):
+        """DeepSeek/Kimi thinking-mode shape: content empty, reasoning_content set."""
+        assistant = _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "", "reasoning_content": "step by step"},
+        ])
+        assert len(assistant) == 1
+        assert assistant[0]["reasoning_content"] == "step by step"
+        assert assistant[0]["content"] == ""
+
+    def test_reasoning_only_turn_with_none_content_is_preserved(self):
+        """A dead stream persists ``content=None``; the reasoning still replays."""
+        assistant = _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": None, "reasoning": "thinking"},
+        ])
+        assert len(assistant) == 1
+        assert assistant[0]["reasoning"] == "thinking"
+        # `content` is normalized to "" -- the shape the API builders expect.
+        assert assistant[0]["content"] == ""
+
+    def test_reasoning_details_only_turn_is_preserved(self):
+        """``content`` may be absent entirely, not merely falsy."""
+        details = [{"type": "reasoning.summary", "summary": "s"}]
+        assistant = _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "reasoning_details": details},
+        ])
+        assert len(assistant) == 1
+        assert assistant[0]["reasoning_details"] == details
+
+    def test_reasoning_only_turn_keeps_position_between_user_turns(self):
+        """The recovered row must replay in transcript order, not be appended."""
+        agent_history, _observed = _build_gateway_agent_history([
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "", "reasoning_content": "mulling"},
+            {"role": "user", "content": "second"},
+        ])
+        assert [m["role"] for m in agent_history] == ["user", "assistant", "user"]
+        assert agent_history[1]["reasoning_content"] == "mulling"
+
+    def test_assistant_timestamp_is_still_dropped(self):
+        """Assistant timestamps are deliberately not replayed; recovering the
+        row must not start leaking them."""
+        assistant = _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "thinking",
+                "timestamp": 12345.6,
+            },
+        ])
+        assert len(assistant) == 1
+        assert "timestamp" not in assistant[0]
+
+    def test_truthy_content_turn_is_unaffected(self):
+        """Control: the pre-existing hot path is unchanged."""
+        assistant = _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "answer", "reasoning_content": "thinking"},
+        ])
+        assert assistant == [
+            {"role": "assistant", "content": "answer", "reasoning_content": "thinking"}
+        ]
+
+
 class TestGatewayHistoryBuildForwardsSidecar:
     def test_end_to_end_history_build_keeps_sidecar(self):
-        from gateway.run import _build_gateway_agent_history
-
         history = [
             {"role": "user", "content": "hi", "api_content": "hi\n\nCTX", "timestamp": 123.0},
             {"role": "assistant", "content": "hello"},

--- a/tests/gateway/test_replay_entry_fields.py
+++ b/tests/gateway/test_replay_entry_fields.py
@@ -227,6 +227,89 @@ class TestReasoningOnlyAssistantTurnsSurviveReload:
         ]
 
 
+class TestCodexReasoningOnlyTurnsSurviveReload:
+    """Codex Responses item carriers are the case where an empty ``content``
+    is not a degenerate row but the designed representation.
+
+    A commentary-phase assistant turn persists with ``content: ""`` because
+    its text lives in ``codex_message_items``; OpenAI's docs require those
+    items be replayed on every assistant message for prefix-cache hits.
+    Dropping the row on reload discards them.
+    """
+
+    def test_codex_message_items_only_turn_is_preserved(self):
+        msg_items = [
+            {
+                "type": "message",
+                "role": "assistant",
+                "phase": "commentary",
+                "content": [{"type": "output_text", "text": "working on it"}],
+            }
+        ]
+        assistant = _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "", "codex_message_items": msg_items},
+        ])
+        assert len(assistant) == 1
+        assert assistant[0]["codex_message_items"] == msg_items
+
+    def test_codex_reasoning_items_only_turn_is_preserved(self):
+        codex_items = [{"type": "reasoning", "encrypted_content": "blob"}]
+        assistant = _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "", "codex_reasoning_items": codex_items},
+        ])
+        assert len(assistant) == 1
+        assert assistant[0]["codex_reasoning_items"] == codex_items
+
+
+class TestEmptyAssistantShellsStillDrop:
+    """Negative cases: the recovery must not resurrect rows that carry no
+    replay state at all.
+
+    These already dropped before the change and must keep dropping -- they
+    guard the fix against over-reaching, which is the failure mode that
+    would turn it into a source of empty assistant turns.
+    """
+
+    def test_truly_empty_assistant_shell_still_drops(self):
+        assert _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": ""},
+        ]) == []
+
+    def test_assistant_shell_with_none_content_still_drops(self):
+        assert _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": None},
+        ]) == []
+
+    def test_assistant_shell_with_all_falsy_replay_fields_still_drops(self):
+        """Every contract field present but empty carries no information --
+        matching `_build_replay_entry`, which drops them individually."""
+        assert _assistant_rows([
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning": "",
+                "reasoning_details": [],
+                "codex_reasoning_items": [],
+                "codex_message_items": [],
+                "finish_reason": "",
+            },
+        ]) == []
+
+    def test_non_assistant_empty_row_still_drops(self):
+        """The new arm is assistant-scoped; an empty user row is untouched
+        and must not pick up reasoning fields."""
+        agent_history, _observed = _build_gateway_agent_history([
+            {"role": "user", "content": "", "reasoning": "not mine"},
+            {"role": "assistant", "content": "answer"},
+        ])
+        assert [m["role"] for m in agent_history] == ["assistant"]
+
+
 class TestGatewayHistoryBuildForwardsSidecar:
     def test_end_to_end_history_build_keeps_sidecar(self):
         history = [


### PR DESCRIPTION
## What does this PR do?

On gateway reload, an assistant turn whose only payload is reasoning state is **dropped from replay entirely**, losing multi-turn thinking fidelity.

`_build_gateway_agent_history()` rebuilds `agent_history` from the persisted transcript on every gateway turn. Its per-row dispatch has exactly two arms (`gateway/run.py:1416-1439`):

```python
if has_tool_calls or has_tool_call_id or is_tool_message:
    clean_msg = {k: v for k, v in msg.items() if k not in {"timestamp", "observed"}}
    agent_history.append(clean_msg)
elif content:
    ...
    entry = _build_replay_entry(role, content, msg, preserve_timestamp=(role == "user"))
    agent_history.append(entry)
```

There is no third arm. An assistant row whose `content` is empty but which carries the reasoning state named by `_ASSISTANT_REPLAY_FIELDS` matches neither, so it never reaches `_build_replay_entry` — the function that exists for the sole purpose of preserving exactly those fields.

**This restores parity with the agent path rather than adding new behaviour.** `agent/agent_runtime_helpers.py::_msg_has_payload` already treats reasoning state as payload that keeps an empty-content message alive, under the comment *"Structural payloads that make an 'empty-content' message still valid"* — `tool_calls`, `reasoning_content`, `reasoning`, `reasoning_details`, and both Codex item carriers. It goes further and records that this row shape is deliberately manufactured:

> Codex Responses item carriers: a commentary-phase assistant turn persists with `content:""` by DESIGN — its text lives in `codex_message_items` … Same for `codex_reasoning_items`.

So the repo already creates, by design, precisely the row shape that `gateway/run.py:1419` silently discards. The gateway replay path is the one place that does not honour it.

**The asymmetry, measured against the production builder:**

| stored assistant row | assistant rows kept (before) | after |
|---|---|---|
| `content="answer"`, `reasoning_content="thinking"` | 1 — kept **and** reasoning preserved | 1 (unchanged) |
| `content=""`, `reasoning_content="step by step"` | **0** | 1 |
| `content=None`, `reasoning="thinking"` | **0** | 1 |
| `reasoning_details=[…]`, no `content` key | **0** | 1 |
| `content=""`, `codex_message_items=[…]` | **0** | 1 |
| `content=""`, `codex_reasoning_items=[…]` | **0** | 1 |
| `content=""`, `reasoning_content=""` (sentinel) | **0** | 1 |
| `content=""` (truly empty shell) | 0 | **0** (unchanged — must still drop) |

When `content` is truthy the row is kept *and* its reasoning fields are preserved; when `content` is falsy the whole row is discarded. The gateway loses reasoning state precisely when reasoning is the only payload.

The `reasoning_content == ""` case carries an extra consequence the repo has already written down. `_build_replay_entry`'s docstring singles that field out: every other replay field is dropped when falsy, but an empty-string `reasoning_content` is kept because thinking-mode replay upgrades it to a single space, and *"dropping it here would make the gateway send no `reasoning_content` at all on the next turn, which can cause HTTP 400 from strict thinking providers."* Dropping the whole row on reload has that same effect, one level up.

`_has_replay_payload` derives its predicate by **iterating `_ASSISTANT_REPLAY_FIELDS`** rather than hardcoding a subset, so it cannot drift as that contract grows, and it mirrors `_build_replay_entry`'s own empty-value handling: every field must be truthy except `reasoning_content`, whose empty-string sentinel is meaningful. Truly empty assistant shells still fall through and are dropped.

> Note on scope: `_has_replay_payload` is deliberately **not** identical to `_msg_has_payload`. That helper requires `reasoning_content` to be a non-blank string; this one must additionally honour the documented empty-string sentinel described above. It applies the same principle to the replay path, it does not claim byte-for-byte parity.

## Related Issue

Supersedes #5976.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — new `_has_replay_payload(msg)` helper beside `_build_replay_entry`, deriving its predicate from `_ASSISTANT_REPLAY_FIELDS` and mirroring that function's empty-value rules.
- `gateway/run.py` — new third dispatch arm in `_build_gateway_agent_history()`, placed **after** `elif content:` so the existing hot path is byte-identical:
  ```python
  elif role == "assistant" and _has_replay_payload(msg):
      agent_history.append(
          _build_replay_entry(role, "" if content is None else content, msg)
      )
  ```
  Only the `None`/absent case is normalized to `""`, the shape the entry dict expects for a missing value; any other falsy content (notably an empty multimodal block list) is forwarded verbatim so the replay entry keeps the stored content *type*. `preserve_timestamp` is deliberately not passed — assistant timestamps stay dropped, per the existing comment directly above.
- `tests/gateway/test_replay_entry_fields.py` — regression tests against the **production** `_build_gateway_agent_history`.

### Scope of the fix

The root cause is a history-row dispatch that bypasses the replay contract. That dispatch has exactly one site: `_build_replay_entry` has a single production call site (`gateway/run.py:1438`) and `_ASSISTANT_REPLAY_FIELDS` is referenced only within `gateway/run.py`. There is no sibling site to widen to.

Sites examined and excluded, with reasons:
- `agent/agent_runtime_helpers.py:3296` — a has-payload predicate that **already implements the correct behaviour**. This is the counter-example that makes `gateway/run.py:1419` the outlier, not a second defect site.
- `run_agent.py:4656` — a thinking-only predicate returning `bool`, not a row dispatch; it drops no rows.
- `batch_runner.py:194`, `tools/mcp_tool.py:1636`, `plugins/platforms/discord/adapter.py:8271`, `gateway/platforms/qqbot/adapter.py:1831`, `agent/codex_responses_adapter.py:597,599` — `content_type` / `content_blocks` / `content_parts` dispatches; name collision only.

## How to Test

1. Confirm the defect on unmodified `main` — the assistant row vanishes:
   ```python
   from gateway.run import _build_gateway_agent_history
   history = [
       {"role": "user", "content": "hi"},
       {"role": "assistant", "content": "", "reasoning_content": "step by step"},
   ]
   agent_history, _ = _build_gateway_agent_history(history)
   print([m for m in agent_history if m["role"] == "assistant"])   # [] on main
   ```
2. Apply this PR and re-run — the row is preserved as
   `{'role': 'assistant', 'content': '', 'reasoning_content': 'step by step'}`.
3. Run the regression tests:
   ```
   pytest tests/gateway/test_replay_entry_fields.py -v
   ```
   26 pass. Reverting only the `gateway/run.py` hunk turns **11 of them red**, all with the assistant row missing from the rebuilt history; the remaining tests are controls and negative cases that must pass in both directions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the full `tests/gateway/` suite instead: 5586 passed, 9 failed. None is attributable to this diff. Five (systemd notify, scale-to-zero ×2, session-store prune, shutdown forensics) reproduce identically on clean `origin/main` and are environment-dependent on macOS; the other four (discord send ×3, multi-image ×1) pass when run serially and fail only under `-n 4`. Both sets produce the same pass/fail results with and without this change.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — new helper is documented inline; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure in-process dict handling, no platform-dependent behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

**Supersedes #5976** (`gut-puncture`, opened 2026-04-08, last touched by its author 2026-04-08, currently conflicting). That PR identified the same defect and the diagnosis still holds; this adapts it to the refactored replay path and fixes the two things that made it unmergeable:

- it was written against the pre-refactor replay path, which has since moved to `_build_replay_entry` / `_ASSISTANT_REPLAY_FIELDS`;
- its predicate hardcoded **3** fields against today's **6**, and it tested `reasoning_content` with plain truthiness, which silently discards the documented empty-string sentinel;
- its tests exercised a local `_filter_history()` replica (still present at `tests/gateway/test_transcript_offset.py:23`) rather than the production builder, so they could not have caught a regression in the builder itself. The tests here call `_build_gateway_agent_history` directly for that reason.

Credit for the original diagnosis is theirs.

**Sibling:** #72727 (`fix(desktop): restore reasoning-only turns dropped on session resume`) is the same defect class on the desktop resume path. It is **open**, not merged; different files, no overlap with this diff.

**Rival disclosure.** `gateway/run.py` is ~28k lines with a very large open-PR population, so full by-file clearance is not achievable and I am not claiming it. What was checked: the diffs of the 177 open PRs touching this file updated since 2026-08-12 (queried in both `created-asc` and `created-desc` orders, since a single order misses roughly 40%), the 21 open PRs touching `gateway/run.py` or `tests/gateway/test_replay_entry_fields.py` in the current newest-first snapshot (#85472–#86049, all patches retrieved), and every PR surfaced by symbol searches on `_build_gateway_agent_history`, `_build_replay_entry`, `_ASSISTANT_REPLAY_FIELDS` and the bare module basename `test_replay_entry_fields`. **None of them modifies this row dispatch.**

The one block worth naming explicitly is @andrexibiza's `#54962` refactor slices — #77438, #77450, #77452, #77711. #77452 moves the `_ASSISTANT_REPLAY_FIELDS` and `_build_replay_entry` *definitions* to another module and re-imports them by the same names, so this change is compatible either way. #77711's hunk header reads `@@ -1299,54 @@ def _build_gateway_agent_history(`, but its body begins at that function's closing `return` and deletes the two functions *after* it — it does not touch the row dispatch. One honest adjacency: the new arm adds lines inside `_build_gateway_agent_history`, shifting the position of the closing `return` that #77711 uses as leading context. Git resolves that by context matching, and #77711 is already stale against main independently of this PR.
