### PR TITLE
fix(gateway): honor busy ack detail in heartbeats

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27421,13 +27421,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ):
                     break
                 _elapsed_mins = int((time.time() - _notify_start) // 60)
-                # Include agent activity context if available. Default
-                # heartbeat is terse: elapsed + current tool. Verbose
-                # iteration counter is gated on busy_ack_detail so users
-                # who want it can opt in per platform.
+                # Include agent activity context only when the platform opts
+                # into busy_ack_detail. The terse heartbeat is elapsed time
+                # only, so tool names and activity descriptions stay out of
+                # compact/shared chat surfaces.
                 _agent_ref = agent_holder[0]
                 _status_detail = ""
-                _want_iteration_detail = bool(
+                _want_activity_detail = bool(
                     resolve_display_setting(
                         user_config,
                         platform_key,
@@ -27439,13 +27439,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     try:
                         _a = _agent_ref.get_activity_summary()
                         _parts = []
-                        if _want_iteration_detail:
+                        if _want_activity_detail:
                             _parts.append(
                                 f"iteration {_a['api_call_count']}/{_a['max_iterations']}"
                             )
-                        _action = _a.get("current_tool") or _a.get("last_activity_desc")
-                        if _action:
-                            _parts.append(str(_action))
+                            _action = _a.get("current_tool") or _a.get("last_activity_desc")
+                            if _action:
+                                _parts.append(str(_action))
                         if _parts:
                             _status_detail = " — " + ", ".join(_parts)
                     except Exception:

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -143,6 +143,22 @@ class FailingAgent:
         }
 
 
+class SlowActivityAgent(ProgressAgent):
+    """Stays alive long enough for a long-running heartbeat to fire."""
+
+    def get_activity_summary(self):
+        return {
+            "api_call_count": 3,
+            "max_iterations": 60,
+            "current_tool": "terminal",
+            "last_activity_desc": "running terminal",
+        }
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        time.sleep(0.15)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
 def _make_runner(adapter):
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
@@ -204,6 +220,55 @@ def _install_fakes(
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_terse_long_running_heartbeat_hides_tool_name(monkeypatch, tmp_path):
+    """busy_ack_detail=false must leave only elapsed time in the heartbeat."""
+    adapter = CleanupCaptureAdapter(platform=Platform.DISCORD)
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(
+        monkeypatch,
+        SlowActivityAgent,
+        cleanup_on=False,
+        cleanup_platform=Platform.DISCORD,
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0.05")
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "platforms": {
+                    "discord": {
+                        "tool_progress": False,
+                        "long_running_notifications": True,
+                        "busy_ack_detail": False,
+                    }
+                }
+            }
+        },
+    )
+
+    source = SessionSource(platform=Platform.DISCORD, chat_id="discord-thread")
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-terse-heartbeat",
+        session_key="agent:main:discord:channel:discord-thread",
+    )
+
+    assert result["final_response"] == "done"
+    heartbeats = [
+        item["content"]
+        for item in adapter.sent
+        if item["content"].startswith("⏳ Working —")
+    ]
+    assert heartbeats
+    assert set(heartbeats) == {"⏳ Working — 0 min"}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -272,6 +272,108 @@ async def test_terse_long_running_heartbeat_hides_tool_name(monkeypatch, tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_detailed_heartbeat_keeps_iteration_and_current_tool(monkeypatch, tmp_path):
+    adapter = CleanupCaptureAdapter(platform=Platform.DISCORD)
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(
+        monkeypatch,
+        SlowActivityAgent,
+        cleanup_on=False,
+        cleanup_platform=Platform.DISCORD,
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0.05")
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "platforms": {
+                    "discord": {
+                        "tool_progress": False,
+                        "long_running_notifications": True,
+                        "busy_ack_detail": True,
+                    }
+                }
+            }
+        },
+    )
+
+    source = SessionSource(platform=Platform.DISCORD, chat_id="discord-thread")
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-detailed-heartbeat",
+        session_key="agent:main:discord:channel:discord-thread",
+    )
+
+    assert result["final_response"] == "done"
+    heartbeats = [
+        item["content"]
+        for item in adapter.sent
+        if item["content"].startswith("⏳ Working —")
+    ]
+    assert set(heartbeats) == {"⏳ Working — 0 min — iteration 3/60, terminal"}
+
+
+@pytest.mark.asyncio
+async def test_detailed_heartbeat_falls_back_to_last_activity(monkeypatch, tmp_path):
+    class LastActivityAgent(SlowActivityAgent):
+        def get_activity_summary(self):
+            summary = super().get_activity_summary()
+            summary["current_tool"] = None
+            return summary
+
+    adapter = CleanupCaptureAdapter(platform=Platform.DISCORD)
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(
+        monkeypatch,
+        LastActivityAgent,
+        cleanup_on=False,
+        cleanup_platform=Platform.DISCORD,
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0.05")
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "platforms": {
+                    "discord": {
+                        "tool_progress": False,
+                        "long_running_notifications": True,
+                        "busy_ack_detail": True,
+                    }
+                }
+            }
+        },
+    )
+
+    source = SessionSource(platform=Platform.DISCORD, chat_id="discord-thread")
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-last-activity-heartbeat",
+        session_key="agent:main:discord:channel:discord-thread",
+    )
+
+    assert result["final_response"] == "done"
+    heartbeats = [
+        item["content"]
+        for item in adapter.sent
+        if item["content"].startswith("⏳ Working —")
+    ]
+    assert set(heartbeats) == {
+        "⏳ Working — 0 min — iteration 3/60, running terminal"
+    }
+
+
+@pytest.mark.asyncio
 async def test_messaging_agent_forwards_checkpoint_config(monkeypatch, tmp_path):
     """Writable gateway agents must receive the configured checkpoint limits."""
     captured = {}


### PR DESCRIPTION
## Summary
- make `busy_ack_detail: false` suppress both iteration counters and tool/activity names in long-running gateway heartbeats
- keep detailed heartbeat behavior unchanged when the setting is enabled
- preserve `current_tool` → `last_activity_desc` fallback when details are enabled

## Root cause
The heartbeat path gated the iteration counter behind `busy_ack_detail`, but appended `current_tool` or `last_activity_desc` unconditionally. This made the documented/detail setting ineffective for the most sensitive part of the status text.

## Tests
- `PYTHONPATH=. python -m pytest -q tests/gateway/test_run_cleanup_progress.py` — 5 passed
- coverage includes terse elapsed-only output, detailed iteration/current-tool output, and last-activity fallback
- `ruff check gateway/run.py tests/gateway/test_run_cleanup_progress.py`
- `git diff --check`

## Compatibility
Default behavior is unchanged. Only platforms explicitly resolving `busy_ack_detail` to `false` become more compact.
