### PR TITLE
fix(agent): report truncated tool calls safely

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1647,6 +1647,12 @@ def run_conversation(
     codex_ack_continuations = 0
     length_continue_retries = 0
     truncated_tool_call_retries = 0
+    truncated_tool_call_message = (
+        "⚠️ **Tool Call Was Not Executed**\n\n"
+        "The model's tool-call output was too large and was cut off before its "
+        "arguments were complete. Hermes did not execute the incomplete action.\n\n"
+        "Please retry the operation in smaller steps or with a shorter payload."
+    )
     truncated_response_parts: List[str] = []
     compression_attempts = 0
     # One resolved per-turn compression attempt cap, shared by every site that
@@ -3602,7 +3608,12 @@ def run_conversation(
                                 "Stream repeatedly dropped mid tool-call (network); "
                                 "the tool was not executed"
                                 if _is_stub_stall
-                                else "Response truncated due to output length limit"
+                                else truncated_tool_call_message
+                            )
+                            _error = (
+                                _final_response
+                                if _is_stub_stall
+                                else "tool_call_output_truncated"
                             )
                             # Prior successful tool batches (or injected tool
                             # errors) can leave a tool-result tail; this path
@@ -3615,7 +3626,7 @@ def run_conversation(
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
-                                "error": _final_response,
+                                "error": _error,
                             }
 
                     # If we have prior messages, roll back to last complete state
@@ -6651,7 +6662,7 @@ def run_conversation(
                         )
                         agent._invalid_json_retries = 0
                         agent._cleanup_task_resources(effective_task_id)
-                        _final_response = "Response truncated due to output length limit"
+                        _final_response = truncated_tool_call_message
                         # Same tool-tail close as interrupt / invalid-tool
                         # exhaustion — this path never reaches finalize_turn.
                         close_interrupted_tool_sequence(messages, _final_response)
@@ -6662,7 +6673,7 @@ def run_conversation(
                             "api_calls": api_call_count,
                             "completed": False,
                             "partial": True,
-                            "error": _final_response,
+                            "error": "tool_call_output_truncated",
                         }
 
                     # Track retries for invalid JSON arguments

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3996,7 +3996,7 @@ class TestRunConversation:
         assert "/thinkon" in result["final_response"]
 
 
-    def test_length_with_tool_calls_returns_partial_without_executing_tools(self, agent):
+    def test_length_with_tool_calls_exhaustion_returns_actionable_retry_message(self, agent):
         self._setup_agent(agent)
         bad_tc = _mock_tool_call(
             name="write_file",
@@ -4016,7 +4016,38 @@ class TestRunConversation:
 
         assert result["completed"] is False
         assert result["partial"] is True
-        assert "truncated due to output length limit" in result["error"]
+        assert result["error"] == "tool_call_output_truncated"
+        assert "Response truncated due to output length limit" not in result["final_response"]
+        assert "output was too large" in result["final_response"]
+        assert "smaller steps" in result["final_response"]
+        mock_handle_function_call.assert_not_called()
+
+    def test_finish_reason_tool_calls_with_cutoff_json_uses_same_actionable_message(self, agent):
+        """Routers may hide output truncation behind finish_reason=tool_calls."""
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("write_file")
+        bad_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"partial',
+            call_id="c1",
+        )
+        resp = _mock_response(content="", finish_reason="tool_calls", tool_calls=[bad_tc])
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch("run_agent.handle_function_call") as mock_handle_function_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("write the report")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert result["error"] == "tool_call_output_truncated"
+        assert "Response truncated due to output length limit" not in result["final_response"]
+        assert "output was too large" in result["final_response"]
+        assert "smaller steps" in result["final_response"]
         mock_handle_function_call.assert_not_called()
 
     def test_truncated_tool_call_retries_once_before_refusing(self, agent):
@@ -4174,9 +4205,10 @@ class TestRunConversation:
             result = agent.run_conversation("write then truncate")
 
         assert result.get("partial") is True
+        assert result.get("error") == "tool_call_output_truncated"
         msgs = result.get("messages") or []
         assert msgs[-1].get("role") == "assistant"
-        assert "truncated" in (msgs[-1].get("content") or "").lower()
+        assert "output was too large" in (msgs[-1].get("content") or "").lower()
         assert any(isinstance(m, dict) and m.get("role") == "tool" for m in msgs)
 
 


### PR DESCRIPTION
## Summary
- keep refusing incomplete tool-call JSON without executing it
- replace the generic output-length string with an actionable user-facing response
- expose a stable `tool_call_output_truncated` error code for callers while preserving the network-stall diagnosis
- handle both `finish_reason="length"` and routers that report cut-off JSON as `finish_reason="tool_calls"`
- preserve message alternation when truncation happens after an earlier successful tool batch

## Root cause
Hermes already detected and refused incomplete tool arguments, but returned the same generic text as an ordinary truncated prose response. Users could not tell whether an action ran, and programmatic callers had no stable way to distinguish this safety refusal from other output truncation.

## Tests
- `PYTHONPATH=. python -m pytest -q tests/run_agent/test_run_agent.py -k 'truncated_tool or length_with_tool_calls or zero_byte_tool_args_stub'` — 6 passed
- `ruff check agent/conversation_loop.py tests/run_agent/test_run_agent.py`
- `git diff --check`

## Safety
The patch does not relax retries or execute any new tool call. It makes the existing fail-closed path explicit: the incomplete action was not executed, and the user should retry with a smaller payload.
