### PR TITLE
fix(agent): exclude stale thinking from preflight token estimate

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -35,6 +35,7 @@ from agent.context_engine import ContextEngine, sanitize_memory_context
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
+    _last_assistant_index,
     get_model_context_length,
     estimate_messages_tokens_rough,
     estimate_tokens_rough,
@@ -1068,19 +1069,6 @@ def _estimate_msg_budget_tokens(msg: dict, charge_stale_thinking: bool = True) -
             // _CHARS_PER_TOKEN
         )
     return tokens
-
-
-def _last_assistant_index(messages: "List[Dict[str, Any]]") -> int:
-    """Index of the newest assistant message, or -1.
-
-    The one turn whose thinking fields every transport may still replay —
-    see ``_NEWEST_TURN_ONLY_BUDGET_KEYS``.
-    """
-    for i in range(len(messages) - 1, -1, -1):
-        msg = messages[i]
-        if isinstance(msg, dict) and msg.get("role") == "assistant":
-            return i
-    return -1
 
 
 def _content_text_for_contains(content: Any) -> str:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3197,7 +3197,27 @@ def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     """
     _IMAGE_TOKEN_COST = 1500
     total = 0
-    for msg in messages:
+    # Only the NEWEST assistant turn's thinking fields are replayed on the
+    # wire; every older turn's reasoning/reasoning_content is stripped or
+    # padded at send time (#73624). Charging stale thinking inflated rough
+    # preflight estimates by ~69% on reasoning-heavy sessions (deepseek:
+    # 376KB of thinking across 755 old assistant rows) and re-triggered
+    # compression every couple of turns while the real prompt sat far below
+    # the threshold. Mirror _estimate_msg_budget_tokens'
+    # charge_stale_thinking semantics so preflight and the tail-budget walk
+    # agree on the same transcript.
+    newest_asst_idx = -1
+    for i in range(len(messages) - 1, -1, -1):
+        _m = messages[i]
+        if isinstance(_m, dict) and _m.get("role") == "assistant":
+            newest_asst_idx = i
+            break
+    for idx, msg in enumerate(messages):
+        if idx != newest_asst_idx and isinstance(msg, dict):
+            msg = {
+                k: v for k, v in msg.items()
+                if k not in ("reasoning", "reasoning_content")
+            }
         total += _estimate_message_tokens_cached(msg, _IMAGE_TOKEN_COST)
     return total
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3181,6 +3181,21 @@ def estimate_tokens_rough(text: str) -> int:
     return dense + ((sparse + 3) // 4)
 
 
+def _last_assistant_index(messages: "List[Dict[str, Any]]") -> int:
+    """Index of the newest assistant message, or -1.
+
+    The one turn whose thinking fields every transport may still replay —
+    see ``_NEWEST_TURN_ONLY_BUDGET_KEYS``. Shared with ContextCompressor's
+    tail-budget walks so preflight and budget accounting always agree on
+    the same "newest" definition (#73624).
+    """
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            return i
+    return -1
+
+
 def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     """Rough token estimate for a message list (pre-flight only).
 
@@ -3206,14 +3221,13 @@ def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     # the threshold. Mirror _estimate_msg_budget_tokens'
     # charge_stale_thinking semantics so preflight and the tail-budget walk
     # agree on the same transcript.
-    newest_asst_idx = -1
-    for i in range(len(messages) - 1, -1, -1):
-        _m = messages[i]
-        if isinstance(_m, dict) and _m.get("role") == "assistant":
-            newest_asst_idx = i
-            break
+    newest_asst_idx = _last_assistant_index(messages)
     for idx, msg in enumerate(messages):
-        if idx != newest_asst_idx and isinstance(msg, dict):
+        if (
+            idx != newest_asst_idx
+            and isinstance(msg, dict)
+            and ("reasoning" in msg or "reasoning_content" in msg)
+        ):
             msg = {
                 k: v for k, v in msg.items()
                 if k not in ("reasoning", "reasoning_content")

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -144,6 +144,103 @@ class TestEstimateMessagesTokensRough:
         # Raw base64 would be ~100K tokens; the flat per-image model is ~1.5K.
         assert estimate_messages_tokens_rough([msg]) < 5_000
 
+    def test_stale_thinking_not_charged_but_newest_is(self):
+        """Only the NEWEST assistant turn's thinking is replayed on the wire.
+
+        Transports strip ``reasoning``/``reasoning_content`` from every older
+        assistant message before sending (#73624). The preflight estimator
+        must mirror that: charging 376KB of stale thinking across 755 old
+        assistant rows inflated rough estimates by ~69% on reasoning-heavy
+        sessions (deepseek), which re-triggered compression every couple of
+        turns even though the real prompt sat far below the threshold.
+        """
+        big_thinking = "思考内容" * 2000  # ~10K chars ≈ ~10K CJK tokens
+        old_asst = {"role": "assistant", "content": "回复",
+                    "reasoning_content": big_thinking, "reasoning": big_thinking}
+        old_asst_no_thinking = {"role": "assistant", "content": "回复"}
+        newest_asst = {"role": "assistant", "content": "最新回复",
+                       "reasoning_content": big_thinking, "reasoning": big_thinking}
+        newest_asst_no_thinking = {"role": "assistant", "content": "最新回复"}
+        user = {"role": "user", "content": "问题"}
+
+        # Old assistant thinking must NOT be charged: swapping the old turn's
+        # thinking for nothing changes the estimate by ~0.
+        with_old_thinking = estimate_messages_tokens_rough(
+            [user, old_asst, user, newest_asst_no_thinking]
+        )
+        without_old_thinking = estimate_messages_tokens_rough(
+            [user, old_asst_no_thinking, user, newest_asst_no_thinking]
+        )
+        assert abs(with_old_thinking - without_old_thinking) < 1_000, (
+            f"stale thinking charged: {with_old_thinking} vs {without_old_thinking}"
+        )
+
+        # Newest assistant thinking IS charged: swapping it out must drop the
+        # estimate by roughly the thinking size (~10K CJK chars ≈ ~10K tokens).
+        newest_charged = estimate_messages_tokens_rough(
+            [user, old_asst_no_thinking, user, newest_asst]
+        )
+        newest_not_charged = estimate_messages_tokens_rough(
+            [user, old_asst_no_thinking, user, newest_asst_no_thinking]
+        )
+        assert newest_charged - newest_not_charged > 5_000, (
+            f"newest thinking not charged: {newest_charged} vs {newest_not_charged}"
+        )
+
+    def test_stale_thinking_charge_matches_budget_walk_semantics(self):
+        """Rough estimator agrees with the tail-budget walk's
+        ``charge_stale_thinking=False`` on the same transcript.
+
+        Regression guard for the 2026-08-14 compression-loop incident:
+        preflight (rough) said ~527K, the tail walk (budget) said ~147K for
+        the same 1519-message session — 3.3x divergence driven entirely by
+        stale thinking fields. Both sides must exclude old thinking.
+        """
+        from agent.context_compressor import _estimate_msg_budget_tokens
+
+        msgs = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1",
+             "reasoning_content": "旧思维链" * 500, "reasoning": "旧思维链" * 500},
+            {"role": "tool", "content": "t1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2",
+             "reasoning_content": "新思维链" * 500, "reasoning": "新思维链" * 500},
+        ]
+        # Old thinking must not inflate rough: replacing the old turn's
+        # thinking with nothing must be a no-op for the rough estimator.
+        msgs_no_old_thinking = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "tool", "content": "t1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2",
+             "reasoning_content": "新思维链" * 500, "reasoning": "新思维链" * 500},
+        ]
+        rough_with = estimate_messages_tokens_rough(msgs)
+        rough_without = estimate_messages_tokens_rough(msgs_no_old_thinking)
+        assert abs(rough_with - rough_without) < 1_000, (
+            f"old thinking inflated rough: {rough_with} vs {rough_without}"
+        )
+        # Newest thinking still charged (rough side): stripping it must drop.
+        msgs_no_new_thinking = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "tool", "content": "t1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+        ]
+        assert rough_without - estimate_messages_tokens_rough(msgs_no_new_thinking) > 2_000
+        # Budget walk with charge_stale_thinking=False for the old turn stays
+        # consistent with the rough estimator's exclusion of old thinking.
+        budget = sum(
+            _estimate_msg_budget_tokens(m, charge_stale_thinking=(i == 4))
+            for i, m in enumerate(msgs)
+        )
+        # Old thinking (≈2.5K CJK tokens each side) must not inflate rough.
+        assert abs(rough_with - budget) < 5_000, f"rough={rough_with} budget={budget}"
+
+
 
 
 class TestEstimateRequestTokensRough:

--- a/tests/agent/test_replay_budget_accounting.py
+++ b/tests/agent/test_replay_budget_accounting.py
@@ -17,8 +17,8 @@ from agent.context_compressor import (
     _NEWEST_TURN_ONLY_BUDGET_KEYS,
     _REPLAY_BUDGET_KEYS,
     _estimate_msg_budget_tokens,
-    _last_assistant_index,
 )
+from agent.model_metadata import _last_assistant_index
 
 
 BIG_THINKING = "deliberation " * 400  # ~1.3K tokens of stale thinking text


### PR DESCRIPTION
## What

`estimate_messages_tokens_rough()` (preflight token estimator) was charging `reasoning` / `reasoning_content` on **every** assistant message — but transports only replay the **newest** turn's thinking; every older turn's thinking is stripped or padded at send time (#73624). The tail-budget walk already implements this correctly via `charge_stale_thinking=False`; the rough estimator did not.

## Why (real incident, 2026-08-14)

On a long reasoning-heavy session (deepseek-v4-flash, 755 assistant rows, ~376KB of stale thinking vs ~32KB of real content):

- Rough preflight estimate: **~527K tokens**
- After stripping stale thinking: **~163K tokens** (69% overcount)
- Real provider-confirmed prompt: **~430K tokens** — the session was *below* the 50% threshold in reality

The overcount made `Preflight compression` fire **every couple of turns** on a session that genuinely had room, and because each pass could only reclaim 10–25K tokens (the stale thinking was in the protected tail), the rough estimate stayed above threshold after every pass → a compression loop with no real progress (log shows `made insufficient progress`, `middle_window_tokens: 0`).

## How

`estimate_messages_tokens_rough` now finds the newest assistant message once, and excludes `reasoning`/`reasoning_content` from every *other* assistant message before estimating — mirroring the budget walk's `charge_stale_thinking` semantics, so preflight and the tail-budget walk agree on the same transcript.

The memoized per-message cache (`_MSG_TOKENS_CACHE`) is unaffected: the stripped dict is a fresh object, so fingerprints differ from the raw row and cache correctly.

## Tests

Added 2 regression tests in `tests/agent/test_model_metadata.py`:

1. `test_stale_thinking_not_charged_but_newest_is` — old-turn thinking contributes ~0 to the estimate; newest-turn thinking is still charged
2. `test_stale_thinking_charge_matches_budget_walk_semantics` — rough estimator agrees with `_estimate_msg_budget_tokens(charge_stale_thinking=False)` on the same transcript

```
83 passed in 2.65s   (tests/agent/test_model_metadata.py, full module)
13 passed            (compression-related modules: cjk_token_estimation, protected_tail_pressure_61932, compaction_anti_thrash, preflight_compression_cap_e2e)
```

## Scope

- `agent/model_metadata.py` (+21/-1)
- `tests/agent/test_model_metadata.py` (+97)
