### PR TITLE
fix(agent): hide guardrail internals from users

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7814,11 +7814,16 @@ class AIAgent:
 
     def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
         tool = decision.tool_name or "a tool"
+        if decision.code == "loop_web_search_cap":
+            return (
+                "I reached the per-turn web search limit. I will stop searching "
+                "and answer from the available results; if evidence is still "
+                "missing, retry with a narrower scope."
+            )
         return (
-            f"I stopped retrying {tool} because it hit the tool-call guardrail "
-            f"({decision.code}) after {decision.count} repeated non-progressing "
-            "attempts. The last tool result explains the blocker; the next step is "
-            "to change strategy instead of repeating the same call."
+            f"I stopped {tool} after repeated failures. No unsafe or incomplete "
+            "action was executed. I will change strategy or explain the blocker "
+            "instead of repeating the same call."
         )
 
     def _append_guardrail_observation(

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -5,6 +5,7 @@ import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from agent.tool_guardrails import ToolCallGuardrailConfig
 from run_agent import AIAgent
 
 
@@ -411,7 +412,10 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
 
     assert result["turn_exit_reason"] == "guardrail_halt"
     halt_text = result["final_response"]
-    assert "stopped retrying" in halt_text
+    assert "repeated failures" in halt_text
+    assert "change strategy" in halt_text
+    assert "repeated_exact_failure_block" not in halt_text
+    assert "non-progressing" not in halt_text
 
     # The halt message must have been pushed through the callback at least
     # once.  Empty-queue SSE writers were the bug — clients saw no content
@@ -420,3 +424,39 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+
+def test_web_search_loop_cap_message_hides_internal_code_and_uses_available_results():
+    agent = _make_agent("web_search")
+    agent._tool_guardrails.config = ToolCallGuardrailConfig.from_mapping(
+        {"loop_caps": {"max_web_searches": 1}}
+    )
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("web_search", json.dumps({"query": "first"}), "c1")],
+        ),
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("web_search", json.dumps({"query": "second"}), "c2")],
+        ),
+    ]
+    agent.client.chat.completions.create.side_effect = responses
+    agent._disable_streaming = True
+
+    with (
+        patch("run_agent.handle_function_call", return_value=json.dumps({"results": ["usable"]})),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("compare two shops")
+
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    halt_text = result["final_response"]
+    assert "search limit" in halt_text
+    assert "available results" in halt_text
+    assert "loop_web_search_cap" not in halt_text
+    assert "non-progressing" not in halt_text


### PR DESCRIPTION
## Summary
- stop exposing internal guardrail codes and implementation terms in synthesized user responses
- give the web-search loop cap a specific recovery message that commits to answering from available results
- keep generic repeated-failure halts explicit that no unsafe or incomplete action was executed
- preserve internal codes in logs and structured guardrail metadata for diagnostics

## Root cause
The controlled halt response embedded values such as `repeated_exact_failure_block`, `loop_web_search_cap`, and “non-progressing attempts” directly in chat output. Those identifiers are useful for logs but not actionable for users, and the web-search cap message failed to tell the user that Hermes could continue from results already collected.

## Tests
- `PYTHONPATH=. python -m pytest -q tests/run_agent/test_tool_call_guardrail_runtime.py` — 11 passed
- `ruff check run_agent.py tests/run_agent/test_tool_call_guardrail_runtime.py`
- `git diff --check`

## Compatibility
Guardrail decisions, thresholds, halt behavior, and diagnostic metadata are unchanged. Only the synthesized user-facing wording changes.
