### PR TITLE
fix(image-gen): honor 16:9 and 9:16 OpenAI presets

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -109,7 +109,7 @@ _MODELS: Dict[str, Dict[str, Any]] = {
 DEFAULT_MODEL = "gpt-image-2-medium"
 
 _SIZES = {
-    "landscape": "1536x1024",
+    "landscape": "1792x1008",
     "square": "1024x1024",
     "portrait": "1024x1536",
 }

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -111,7 +111,7 @@ DEFAULT_MODEL = "gpt-image-2-medium"
 _SIZES = {
     "landscape": "1792x1008",
     "square": "1024x1024",
-    "portrait": "1024x1536",
+    "portrait": "1008x1792",
 }
 
 # Codex Responses surface used for the request. The chat model itself is only

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -76,7 +76,7 @@ _MODELS: Dict[str, Dict[str, Any]] = {
 DEFAULT_MODEL = "gpt-image-2-medium"
 
 _SIZES = {
-    "landscape": "1536x1024",
+    "landscape": "1792x1008",
     "square": "1024x1024",
     "portrait": "1024x1536",
 }

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -78,7 +78,7 @@ DEFAULT_MODEL = "gpt-image-2-medium"
 _SIZES = {
     "landscape": "1792x1008",
     "square": "1024x1024",
-    "portrait": "1024x1536",
+    "portrait": "1008x1792",
 }
 
 

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -154,7 +154,7 @@ class TestGenerate:
         assert tool["type"] == "image_generation"
         assert tool["model"] == "gpt-image-2"
         assert tool["quality"] == "medium"
-        assert tool["size"] == "1024x1536"
+        assert tool["size"] == "1008x1792"
         assert tool["output_format"] == "png"
         assert tool["background"] == "opaque"
         assert tool["partial_images"] == 1

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -112,6 +112,7 @@ class TestGenerate:
         assert result["model"] == "gpt-image-2-medium"
         assert result["provider"] == "openai-codex"
         assert result["quality"] == "medium"
+        assert result["size"] == "1792x1008"
 
         saved = Path(result["image"])
         assert saved.exists()

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -167,7 +167,7 @@ class TestGenerate:
         # All tiers hit the single underlying API model.
         assert call_kwargs["model"] == "gpt-image-2"
         assert call_kwargs["quality"] == "medium"
-        assert call_kwargs["size"] == "1536x1024"
+        assert call_kwargs["size"] == "1792x1008"
         # gpt-image-2 rejects response_format — we must NOT send it.
         assert "response_format" not in call_kwargs
 
@@ -191,7 +191,7 @@ class TestGenerate:
         assert fake_client.images.generate.call_args.kwargs["model"] == "gpt-image-2"
 
     @pytest.mark.parametrize("aspect,expected_size", [
-        ("landscape", "1536x1024"),
+        ("landscape", "1792x1008"),
         ("square", "1024x1024"),
         ("portrait", "1024x1536"),
     ])

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -193,7 +193,7 @@ class TestGenerate:
     @pytest.mark.parametrize("aspect,expected_size", [
         ("landscape", "1792x1008"),
         ("square", "1024x1024"),
-        ("portrait", "1024x1536"),
+        ("portrait", "1008x1792"),
     ])
     def test_aspect_ratio_mapping(self, provider, aspect, expected_size):
         fake_client = MagicMock()


### PR DESCRIPTION
## Summary
- map `aspect_ratio="landscape"` to `1792x1008` for both OpenAI API-key and OpenAI Codex image providers
- map `aspect_ratio="portrait"` to `1008x1792`
- keep square at `1024x1024`
- cover both request paths with regression assertions

## Root cause
Hermes documents the unified presets as landscape 16:9 and portrait 9:16, but the two GPT Image 2 providers requested `1536x1024` (3:2) and `1024x1536` (2:3). Output framing therefore changed depending on authentication/provider selection.

GPT Image 2 supports custom dimensions when each edge is a multiple of 16, the long edge is below 3840, total pixels are within the documented range, and the aspect ratio is no wider than 3:1. `1792x1008` and `1008x1792` satisfy those constraints and are exact 16:9/9:16 counterparts.

Reference: https://platform.openai.com/docs/guides/image-generation

## Tests
- `PYTHONPATH=. python -m pytest -q tests/plugins/image_gen/test_openai_provider.py tests/plugins/image_gen/test_openai_codex_provider.py` — 43 passed
- `ruff check` on the four touched provider/test files
- `git diff --check`

## Scope
This PR fixes the requested generation size. It does not post-process returned images; provider-side output dimension verification/normalization is a separate concern.
