### PR TITLE
feat(image-gen): optionally enforce output dimensions

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -56,6 +56,21 @@ VALID_ASPECT_RATIOS: Tuple[str, ...] = ("landscape", "square", "portrait")
 DEFAULT_ASPECT_RATIO = "landscape"
 
 
+def resolve_output_size_enforcement(config: Any, provider_name: str) -> bool:
+    """Resolve the opt-in output-size normalization flag for a provider."""
+    if not isinstance(config, dict):
+        return False
+    provider_config = config.get(provider_name)
+    value = None
+    if isinstance(provider_config, dict):
+        value = provider_config.get("enforce_output_size")
+    if value is None:
+        value = config.get("enforce_output_size", False)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
 # ---------------------------------------------------------------------------
 # ABC
 # ---------------------------------------------------------------------------
@@ -260,6 +275,69 @@ def save_b64_image(
     path = _images_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"
     path.write_bytes(raw)
     return path
+
+
+def normalize_image_file_size(path: Path, expected_size: str) -> Dict[str, Any]:
+    """Normalize a cached raster image to an exact ``WIDTHxHEIGHT`` target.
+
+    The provider response may differ slightly from the requested dimensions
+    (notably through hosted-tool image generation paths).  This helper uses a
+    centered cover fit so the final file honors the requested canvas without
+    letterboxing or stretching.  Exact-size inputs are left byte-for-byte
+    untouched.
+    """
+    try:
+        parts = expected_size.lower().split("x")
+        if len(parts) != 2:
+            raise ValueError
+        width, height = (int(part) for part in parts)
+        if width <= 0 or height <= 0:
+            raise ValueError
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Expected image size in positive WIDTHxHEIGHT form, got {expected_size!r}."
+        ) from exc
+
+    from PIL import Image, ImageOps
+
+    with Image.open(path) as source:
+        source_width, source_height = source.size
+        source_size = f"{source_width}x{source_height}"
+        if source.size == (width, height):
+            return {
+                "source_size": source_size,
+                "size": expected_size,
+                "output_size_normalized": False,
+            }
+
+        image_format = source.format or "PNG"
+        fitted = ImageOps.fit(
+            source,
+            (width, height),
+            method=Image.Resampling.LANCZOS,
+            centering=(0.5, 0.5),
+        )
+        save_kwargs: Dict[str, Any] = {}
+        icc_profile = source.info.get("icc_profile")
+        if icc_profile:
+            save_kwargs["icc_profile"] = icc_profile
+
+        temp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+        try:
+            fitted.save(temp_path, format=image_format, **save_kwargs)
+            temp_path.replace(path)
+        finally:
+            fitted.close()
+            try:
+                temp_path.unlink()
+            except FileNotFoundError:
+                pass
+
+    return {
+        "source_size": source_size,
+        "size": expected_size,
+        "output_size_normalized": True,
+    }
 
 
 # Extension inference for save_url_image — keep small and explicit.  We don't

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4941,6 +4941,9 @@ _OPEN_DICT_TOP_LEVEL_KEYS = frozenset({
     "server_actions",
     "secrets",
     "goals",
+    # Backend plugins own their provider-specific config surface.
+    "image_gen",
+    "video_gen",
 })
 
 # Top-level keys whose sub-keys are partially schema-defined (e.g. on a

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -31,8 +31,10 @@ from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
     error_response,
+    normalize_image_file_size,
     normalize_reference_images,
     resolve_aspect_ratio,
+    resolve_output_size_enforcement,
     save_b64_image,
     success_response,
 )
@@ -550,6 +552,10 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
 
         tier_id, meta = _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
+        enforce_output_size = resolve_output_size_enforcement(
+            _load_image_gen_config(),
+            "openai-codex",
+        )
 
         token = _read_codex_access_token()
         if not token:
@@ -608,6 +614,9 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
 
         try:
             saved_path = save_b64_image(b64, prefix=f"openai_codex_{tier_id}")
+            normalization_meta: Dict[str, Any] = {}
+            if enforce_output_size:
+                normalization_meta = normalize_image_file_size(saved_path, size)
         except Exception as exc:
             return error_response(
                 error=f"Could not save image to cache: {exc}",
@@ -625,7 +634,12 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             aspect_ratio=aspect,
             provider="openai-codex",
             modality="image" if input_images else "text",
-            extra={"size": size, "quality": meta["quality"], "input_image_count": len(input_images)},
+            extra={
+                "size": size,
+                "quality": meta["quality"],
+                "input_image_count": len(input_images),
+                **normalization_meta,
+            },
         )
 
 

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -32,8 +32,10 @@ from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
     error_response,
+    normalize_image_file_size,
     normalize_reference_images,
     resolve_aspect_ratio,
+    resolve_output_size_enforcement,
     save_b64_image,
     save_url_image,
     success_response,
@@ -261,6 +263,10 @@ class OpenAIImageGenProvider(ImageGenProvider):
 
         tier_id, meta = _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
+        enforce_output_size = resolve_output_size_enforcement(
+            _load_openai_config(),
+            "openai",
+        )
 
         # Collect source images (primary + references) for image-to-image.
         sources: List[str] = []
@@ -355,9 +361,12 @@ class OpenAIImageGenProvider(ImageGenProvider):
         url = getattr(first, "url", None)
         revised_prompt = getattr(first, "revised_prompt", None)
 
+        normalization_meta: Dict[str, Any] = {}
         if b64:
             try:
                 saved_path = save_b64_image(b64, prefix=f"openai_{tier_id}")
+                if enforce_output_size:
+                    normalization_meta = normalize_image_file_size(saved_path, size)
             except Exception as exc:
                 return error_response(
                     error=f"Could not save image to cache: {exc}",
@@ -375,6 +384,8 @@ class OpenAIImageGenProvider(ImageGenProvider):
             # it expires — same rationale as the xAI provider (#26942).
             try:
                 saved_path = save_url_image(url, prefix=f"openai_{tier_id}")
+                if enforce_output_size:
+                    normalization_meta = normalize_image_file_size(saved_path, size)
             except Exception as exc:
                 logger.warning(
                     "OpenAI image URL %s could not be cached (%s); falling back to bare URL.",
@@ -395,6 +406,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
             )
 
         extra: Dict[str, Any] = {"size": size, "quality": meta["quality"]}
+        extra.update(normalization_meta)
         if revised_prompt:
             extra["revised_prompt"] = revised_prompt
 

--- a/tests/agent/test_image_gen_output_size.py
+++ b/tests/agent/test_image_gen_output_size.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from agent.image_gen_provider import (
+    normalize_image_file_size,
+    resolve_output_size_enforcement,
+)
+
+
+def test_resolve_output_size_enforcement_prefers_provider_override():
+    config = {
+        "enforce_output_size": True,
+        "openai-codex": {"enforce_output_size": False},
+    }
+
+    assert resolve_output_size_enforcement(config, "openai") is True
+    assert resolve_output_size_enforcement(config, "openai-codex") is False
+
+
+def test_resolve_output_size_enforcement_accepts_yaml_style_strings():
+    assert resolve_output_size_enforcement(
+        {"openai": {"enforce_output_size": "yes"}},
+        "openai",
+    ) is True
+
+
+def test_normalize_image_file_size_crops_and_resizes_to_exact_target(tmp_path: Path):
+    path = tmp_path / "generated.png"
+    Image.new("RGB", (80, 80), color="navy").save(path)
+
+    result = normalize_image_file_size(path, "160x90")
+
+    with Image.open(path) as image:
+        assert image.size == (160, 90)
+    assert result == {
+        "source_size": "80x80",
+        "size": "160x90",
+        "output_size_normalized": True,
+    }
+
+
+def test_normalize_image_file_size_is_byte_stable_when_already_exact(tmp_path: Path):
+    path = tmp_path / "generated.png"
+    Image.new("RGB", (64, 36), color="navy").save(path)
+    before = path.read_bytes()
+
+    result = normalize_image_file_size(path, "64x36")
+
+    assert path.read_bytes() == before
+    assert result == {
+        "source_size": "64x36",
+        "size": "64x36",
+        "output_size_normalized": False,
+    }
+
+
+@pytest.mark.parametrize("value", ["", "16:9", "0x90", "160x0", "abcx90"])
+def test_normalize_image_file_size_rejects_invalid_target(value: str, tmp_path: Path):
+    path = tmp_path / "generated.png"
+    Image.new("RGB", (64, 36), color="navy").save(path)
+
+    with pytest.raises(ValueError, match="WIDTHxHEIGHT"):
+        normalize_image_file_size(path, value)

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -111,6 +111,17 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "script_timeout_seconds: 600" in _read_config(_isolated_hermes_home)
 
+    def test_image_gen_output_size_flag_is_recognized(
+        self, _isolated_hermes_home, capsys
+    ):
+        set_config_value("image_gen.enforce_output_size", "true")
+
+        import yaml
+
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["image_gen"]["enforce_output_size"] is True
+        assert "not a recognized config key" not in capsys.readouterr().out
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -120,6 +120,38 @@ class TestGenerate:
         # tell the two backends apart.
         assert saved.name.startswith("openai_codex_")
 
+    def test_enforce_output_size_normalizes_cached_image(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", lambda *a, **kw: _b64_png())
+        monkeypatch.setattr(
+            codex_plugin,
+            "_load_image_gen_config",
+            lambda: {"enforce_output_size": True},
+        )
+        calls = []
+
+        def _normalize(path, size):
+            calls.append((path, size))
+            return {
+                "source_size": "1672x941",
+                "size": size,
+                "output_size_normalized": True,
+            }
+
+        monkeypatch.setattr(
+            codex_plugin,
+            "normalize_image_file_size",
+            _normalize,
+            raising=False,
+        )
+
+        result = provider.generate("a cat", aspect_ratio="landscape")
+
+        assert calls == [(Path(result["image"]), "1536x1024")]
+        assert result["source_size"] == "1672x941"
+        assert result["size"] == "1536x1024"
+        assert result["output_size_normalized"] is True
+
     def test_codex_stream_request_shape(self, provider, monkeypatch):
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
 

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -171,6 +171,36 @@ class TestGenerate:
         # gpt-image-2 rejects response_format — we must NOT send it.
         assert "response_format" not in call_kwargs
 
+    def test_enforce_output_size_normalizes_cached_image(self, provider, monkeypatch):
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+        monkeypatch.setattr(
+            openai_plugin,
+            "_load_openai_config",
+            lambda: {"enforce_output_size": True},
+        )
+        normalize = MagicMock(
+            return_value={
+                "source_size": "1450x1280",
+                "size": "1536x1024",
+                "output_size_normalized": True,
+            }
+        )
+        monkeypatch.setattr(
+            openai_plugin,
+            "normalize_image_file_size",
+            normalize,
+            raising=False,
+        )
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat", aspect_ratio="landscape")
+
+        normalize.assert_called_once_with(Path(result["image"]), "1536x1024")
+        assert result["source_size"] == "1450x1280"
+        assert result["size"] == "1536x1024"
+        assert result["output_size_normalized"] is True
+
     @pytest.mark.parametrize("tier,expected_quality", [
         ("gpt-image-2-low", "low"),
         ("gpt-image-2-medium", "medium"),


### PR DESCRIPTION
## Summary
- add opt-in exact output-dimension normalization for the OpenAI API-key and OpenAI Codex image providers
- configure globally with `image_gen.enforce_output_size: true`, with provider-specific overrides supported
- center-crop and resize cached raster output to the requested `WIDTHxHEIGHT` using Pillow/LANCZOS
- leave already-exact files byte-for-byte untouched
- report `source_size`, final `size`, and `output_size_normalized` in the tool result
- recognize backend-owned `image_gen.*` / `video_gen.*` settings in `hermes config set`

## Root cause
Hosted image-generation paths can accept an exact requested size but return a nearby canvas. A live Codex request for `1792x1008` returned `1672x941`; Hermes still reported the requested size without inspecting the file. Workflows that require exact 16:9 pixels therefore received misleading metadata and an off-by-ratio artifact.

## Configuration
```yaml
image_gen:
  enforce_output_size: true
```

A provider can override the global value:
```yaml
image_gen:
  enforce_output_size: true
  openai-codex:
    enforce_output_size: false
```

The default remains `false`, so existing output bytes and generation quality are unchanged unless the user opts in.

## Tests
- `PYTHONPATH=. python -m pytest -q tests/agent/test_image_gen_output_size.py tests/plugins/image_gen/test_openai_provider.py tests/plugins/image_gen/test_openai_codex_provider.py` — 54 passed
- `PYTHONPATH=. python -m pytest -q tests/hermes_cli/test_set_config_value.py::TestConfigYamlRouting::test_image_gen_output_size_flag_is_recognized tests/hermes_cli/test_set_config_value.py::TestValidateConfigKey` — 16 passed
- `ruff check` on all touched Python/test files
- `git diff --check`

## Implementation notes
Normalization is atomic: the transformed image is written to a sibling temporary file and then replaces the cached artifact. Exact-size inputs skip image rewriting entirely.
