### PR TITLE
feat(tools): cap deferred tool result persistence

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -86,7 +86,18 @@ def _budget_for_agent(agent) -> BudgetConfig:
     """
     try:
         ctx = getattr(getattr(agent, "context_compressor", None), "context_length", None)
-        return budget_for_context_window(int(ctx)) if ctx else DEFAULT_BUDGET
+        try:
+            from hermes_cli.config import load_config
+
+            root_config = load_config() or {}
+            tools_config = root_config.get("tools") or {}
+            result_budget_config = tools_config.get("result_budget") or {}
+        except Exception:
+            result_budget_config = None
+        return budget_for_context_window(
+            int(ctx) if ctx else None,
+            result_budget_config=result_budget_config,
+        )
     except Exception:
         return DEFAULT_BUDGET
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2517,6 +2517,11 @@ DEFAULT_CONFIG = {
             # estimate), regardless of context size. Range 200..60000.
             "listing_max_tokens": 4000,
         },
+        "result_budget": {
+            # Optional cap for tools deferred behind tool_search. ``null``
+            # preserves the registry/context-scaled threshold.
+            "deferred_result_size_chars": None,
+        },
     },
 
     # Logging — controls file logging to ~/.hermes/logs/.

--- a/tests/agent/test_tool_executor_budget_config.py
+++ b/tests/agent/test_tool_executor_budget_config.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.tool_executor import _budget_for_agent
+
+
+def test_budget_for_agent_loads_deferred_result_cap_from_config():
+    agent = SimpleNamespace(
+        context_compressor=SimpleNamespace(context_length=1_000_000)
+    )
+    config = {
+        "tools": {
+            "result_budget": {
+                "deferred_result_size_chars": 20_000,
+            }
+        }
+    }
+
+    with patch("hermes_cli.config.load_config", return_value=config):
+        budget = _budget_for_agent(agent)
+
+    assert budget.deferred_result_size == 20_000
+
+
+def test_budget_for_agent_ignores_infinity_without_disabling_context_scaling():
+    agent = SimpleNamespace(
+        context_compressor=SimpleNamespace(context_length=65_536),
+    )
+    config = {
+        "tools": {
+            "result_budget": {"deferred_result_size_chars": float("inf")}
+        }
+    }
+
+    with patch("hermes_cli.config.load_config", return_value=config):
+        budget = _budget_for_agent(agent)
+
+    assert budget.deferred_result_size is None
+    assert budget.default_result_size == int(65_536 * 0.6)
+    assert budget.turn_budget == int(65_536 * 1.2)

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -111,6 +111,17 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "script_timeout_seconds: 600" in _read_config(_isolated_hermes_home)
 
+    def test_deferred_result_budget_is_recognized(
+        self, _isolated_hermes_home, capsys
+    ):
+        set_config_value("tools.result_budget.deferred_result_size_chars", "20000")
+
+        import yaml
+
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["tools"]["result_budget"]["deferred_result_size_chars"] == 20_000
+        assert "not a recognized config key" not in capsys.readouterr().out
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)

--- a/tests/tools/test_progressive_result_budget.py
+++ b/tests/tools/test_progressive_result_budget.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch
+
+from tools.budget_config import BudgetConfig, budget_for_context_window
+
+
+def test_deferred_result_size_is_opt_in():
+    assert BudgetConfig().deferred_result_size is None
+
+
+@patch("tools.tool_search.is_deferrable_tool_name", return_value=True)
+@patch("tools.registry.registry")
+def test_deferred_tool_uses_smaller_opt_in_cap(mock_registry, _mock_deferred):
+    mock_registry.get_max_result_size.return_value = 100_000
+    cfg = BudgetConfig(deferred_result_size=20_000)
+    assert cfg.resolve_threshold("mcp__agentmemory__memory_sessions") == 20_000
+
+
+@patch("tools.tool_search.is_deferrable_tool_name", return_value=True)
+@patch("tools.registry.registry")
+def test_exact_override_wins_over_deferred_cap(mock_registry, _mock_deferred):
+    mock_registry.get_max_result_size.return_value = 100_000
+    cfg = BudgetConfig(
+        deferred_result_size=20_000,
+        tool_overrides={"mcp__agentmemory__memory_sessions": 30_000},
+    )
+    assert cfg.resolve_threshold("mcp__agentmemory__memory_sessions") == 30_000
+
+
+@patch("tools.tool_search.is_deferrable_tool_name", return_value=True)
+@patch("tools.registry.registry")
+def test_deferred_cap_constrains_registry_infinity(mock_registry, _mock_deferred):
+    mock_registry.get_max_result_size.return_value = float("inf")
+    cfg = BudgetConfig(deferred_result_size=20_000)
+    assert cfg.resolve_threshold("mcp__example__unbounded") == 20_000
+
+
+@patch("tools.tool_search.is_deferrable_tool_name", return_value=False)
+@patch("tools.registry.registry")
+def test_core_tool_is_unchanged_by_deferred_cap(mock_registry, _mock_deferred):
+    mock_registry.get_max_result_size.return_value = 100_000
+    cfg = BudgetConfig(deferred_result_size=20_000)
+    assert cfg.resolve_threshold("terminal") == 100_000
+
+
+def test_user_config_applies_deferred_cap():
+    cfg = budget_for_context_window(
+        1_000_000,
+        result_budget_config={"deferred_result_size_chars": 20_000},
+    )
+    assert cfg.deferred_result_size == 20_000
+
+
+def test_invalid_deferred_cap_is_ignored():
+    cfg = budget_for_context_window(
+        1_000_000,
+        result_budget_config={"deferred_result_size_chars": "not-an-int"},
+    )
+    assert cfg.deferred_result_size is None
+
+
+def test_infinite_deferred_cap_is_ignored_without_losing_context_scaling():
+    cfg = budget_for_context_window(
+        65_536,
+        result_budget_config={"deferred_result_size_chars": float("inf")},
+    )
+
+    assert cfg.deferred_result_size is None
+    assert cfg.default_result_size == int(65_536 * 0.6)
+    assert cfg.turn_budget == int(65_536 * 1.2)

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -1,10 +1,10 @@
 """Configurable budget constants for tool result persistence.
 
-Per-tool resolution: pinned > config overrides > registry > default.
+Per-tool resolution: pinned > exact overrides > deferred cap > registry > default.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Any, Dict, Mapping
 
 # Tools whose thresholds must never be overridden.
 # read_file=inf prevents infinite persist->read->persist loops.
@@ -32,12 +32,14 @@ class BudgetConfig:
     default_result_size: int = DEFAULT_RESULT_SIZE_CHARS
     turn_budget: int = DEFAULT_TURN_BUDGET_CHARS
     preview_size: int = DEFAULT_PREVIEW_SIZE_CHARS
+    deferred_result_size: int | None = None
     tool_overrides: Dict[str, int] = field(default_factory=dict)
 
     def resolve_threshold(self, tool_name: str) -> int | float:
         """Resolve the persistence threshold for a tool.
 
-        Priority: pinned -> tool_overrides -> registry per-tool -> default.
+        Priority: pinned -> tool_overrides -> deferred-tool cap -> registry
+        per-tool/default.
 
         The registry per-tool value is capped at ``default_result_size`` so a
         context-scaled budget (small model) actually constrains tools that
@@ -52,9 +54,22 @@ class BudgetConfig:
             return self.tool_overrides[tool_name]
         from tools.registry import registry
         registry_value = registry.get_max_result_size(tool_name, default=self.default_result_size)
-        if registry_value == float("inf"):
-            return registry_value
-        return min(registry_value, self.default_result_size)
+        threshold = (
+            registry_value
+            if registry_value == float("inf")
+            else min(registry_value, self.default_result_size)
+        )
+        if self.deferred_result_size is not None:
+            try:
+                from tools.tool_search import is_deferrable_tool_name
+
+                if is_deferrable_tool_name(tool_name):
+                    threshold = min(threshold, self.deferred_result_size)
+            except Exception:
+                # Classification is best effort. Retain the normal cap rather
+                # than accidentally constraining an unknown core tool.
+                pass
+        return threshold
 
 
 # Default config -- matches current hardcoded behavior exactly.
@@ -81,7 +96,35 @@ _MIN_RESULT_SIZE_CHARS: int = 8_000
 _MIN_TURN_BUDGET_CHARS: int = 16_000
 
 
-def budget_for_context_window(context_length: int | None) -> BudgetConfig:
+def _with_result_budget_config(
+    base: BudgetConfig,
+    result_budget_config: Mapping[str, Any] | None,
+) -> BudgetConfig:
+    """Apply validated user-facing result-budget overrides to *base*."""
+    if not isinstance(result_budget_config, Mapping):
+        return base
+    raw_cap = result_budget_config.get("deferred_result_size_chars")
+    if raw_cap is None or isinstance(raw_cap, bool):
+        return base
+    try:
+        deferred_cap = int(raw_cap)
+    except (TypeError, ValueError, OverflowError):
+        return base
+    if deferred_cap <= 0:
+        return base
+    return BudgetConfig(
+        default_result_size=base.default_result_size,
+        turn_budget=base.turn_budget,
+        preview_size=base.preview_size,
+        deferred_result_size=deferred_cap,
+        tool_overrides=base.tool_overrides,
+    )
+
+
+def budget_for_context_window(
+    context_length: int | None,
+    result_budget_config: Mapping[str, Any] | None = None,
+) -> BudgetConfig:
     """Return a BudgetConfig scaled to the active model's context window.
 
     The fixed defaults (100K result / 200K turn chars) are correct for large
@@ -96,7 +139,7 @@ def budget_for_context_window(context_length: int | None) -> BudgetConfig:
     always survives.
     """
     if not context_length or context_length <= 0:
-        return DEFAULT_BUDGET
+        return _with_result_budget_config(DEFAULT_BUDGET, result_budget_config)
 
     window_chars = context_length * _CHARS_PER_TOKEN
     per_result = int(window_chars * _PER_RESULT_WINDOW_FRACTION)
@@ -107,8 +150,9 @@ def budget_for_context_window(context_length: int | None) -> BudgetConfig:
     per_result = max(_MIN_RESULT_SIZE_CHARS, min(per_result, DEFAULT_RESULT_SIZE_CHARS))
     per_turn = max(_MIN_TURN_BUDGET_CHARS, min(per_turn, DEFAULT_TURN_BUDGET_CHARS))
 
-    return BudgetConfig(
+    base = BudgetConfig(
         default_result_size=per_result,
         turn_budget=per_turn,
         preview_size=DEFAULT_PREVIEW_SIZE_CHARS,
     )
+    return _with_result_budget_config(base, result_budget_config)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -745,6 +745,23 @@ tool_output:
   max_lines: 500
 ```
 
+### Deferred Tool Result Persistence
+
+Plugin and MCP tools loaded through `tool_search` can return provider-native
+payloads much larger than the active task needs. Set an opt-in cap to persist
+those oversized results to disk earlier while returning a compact preview and
+file handle to the agent:
+
+```yaml
+tools:
+  result_budget:
+    deferred_result_size_chars: 20000
+```
+
+The cap applies only to deferred/plugin tool names. Core tools keep their
+normal context-scaled thresholds, and exact per-tool overrides still take
+precedence. Omit the key to preserve the default behavior.
+
 ## Global Toolset Disable
 
 To suppress specific toolsets across the CLI and every gateway platform in one


### PR DESCRIPTION
## Summary
- add optional `tools.result_budget.deferred_result_size_chars`
- declare the key in default config as `null`, preserving existing behavior
- apply the cap only to deferred/plugin/MCP tool names discovered through `tool_search`
- preserve pinned thresholds and exact per-tool overrides
- retain context-window scaling for all other tools
- document the config key and invalid-value behavior

## Motivation
Deferred tools can return provider-native payloads far larger than the active task needs. Their registry thresholds may be 80–100K characters or unbounded, so one MCP/plugin result can consume a large portion of the next request even on otherwise context-aware budgets.

This change lets users persist those results to disk earlier and return the existing compact preview/file handle without globally shrinking core tool output.

## Configuration
```yaml
tools:
  result_budget:
    deferred_result_size_chars: 20000
```

The feature is opt-in. Missing, `null`, non-positive, non-numeric, boolean, and infinite values are ignored.

## Resolution order
`pinned threshold → exact tool override → deferred cap → registry/default context-scaled threshold`

## Tests
- `PYTHONPATH=. python -m pytest -q tests/agent/test_tool_executor_budget_config.py tests/tools/test_progressive_result_budget.py tests/tools/test_budget_config.py tests/hermes_cli/test_set_config_value.py::TestConfigYamlRouting::test_deferred_result_budget_is_recognized` — 27 passed
- verifies `hermes config set tools.result_budget.deferred_result_size_chars 20000` is a recognized key
- `ruff check` on all touched Python/test files
- `git diff --check`

## Scope
This is intentionally narrower than closed #47771: no LSP lifecycle changes, no global result-budget redesign, and no default behavior change.
