### PR TITLE
feat(skills): add category-first prompt index

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1480,9 +1480,9 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-# v2: entries gained org provenance fields (org_id/org_author/rel_dir) for M2
-# org-shared skills; older snapshots are discarded and rebuilt.
-_SKILLS_SNAPSHOT_VERSION = 2
+# v3: entries include org provenance plus progressive-disclosure metadata.
+# Older snapshots are discarded and rebuilt.
+_SKILLS_SNAPSHOT_VERSION = 3
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1603,8 +1603,10 @@ def _build_snapshot_entry(
     if len(parts) >= 2:
         skill_name = parts[-2]
         category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
+        discovery_category = parts[0] if len(parts) > 2 else "general"
     else:
         category = "general"
+        discovery_category = "general"
         skill_name = skill_file.parent.name
 
     platforms = frontmatter.get("platforms") or []
@@ -1614,6 +1616,7 @@ def _build_snapshot_entry(
     entry = {
         "skill_name": skill_name,
         "category": category,
+        "discovery_category": discovery_category,
         "frontmatter_name": str(frontmatter.get("name", skill_name)),
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
@@ -1718,6 +1721,8 @@ def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
+    index_mode: str | None = None,
+    pinned_skills: "frozenset[str] | None" = None,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -1738,9 +1743,21 @@ def build_skills_system_prompt(
     the rendered index. Nothing is ever hidden: every skill name stays
     visible and loadable via ``skill_view`` / ``skills_list``; only the
     descriptions are dropped, and a footer note explains the demotion.
+
+    ``index_mode='categories'`` is an explicit progressive-disclosure mode:
+    only category names/counts and configured pinned skills are rendered. The
+    remaining catalog stays discoverable through ``skills_list(category=...)``
+    and ``skill_view(name=...)``.
     """
     skills_dir = get_skills_dir()
     external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
+
+    normalized_index_mode = str(index_mode or "full").strip().lower()
+    if normalized_index_mode not in {"full", "categories"}:
+        normalized_index_mode = "full"
+    normalized_pins = frozenset(
+        str(name).strip() for name in (pinned_skills or ()) if str(name).strip()
+    )
 
     if not skills_dir.exists() and not external_dirs:
         return ""
@@ -1758,6 +1775,8 @@ def build_skills_system_prompt(
         _platform_hint,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        normalized_index_mode,
+        tuple(sorted(normalized_pins)),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1769,11 +1788,40 @@ def build_skills_system_prompt(
     snapshot = _load_skills_snapshot(skills_dir)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
+    skills_by_discovery_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
     # Unified visible-entry list (both paths) so the org labeling +
     # fail-loud collision pass below runs identically for snapshot and scan.
     visible_entries: list[dict] = []
     skill_entries: list[dict] = []
+
+    def _add_indexed_entry(
+        entry: dict,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        category: str | None = None,
+        discovery_category: str | None = None,
+    ) -> None:
+        """Index one resolved entry for full and category-only render modes."""
+        resolved_name = str(
+            name or entry.get("frontmatter_name") or entry.get("skill_name") or ""
+        )
+        resolved_description = str(
+            description if description is not None else entry.get("description") or ""
+        )
+        resolved_category = str(category or entry.get("category") or "general")
+        resolved_discovery_category = str(
+            discovery_category
+            or entry.get("discovery_category")
+            or resolved_category.split("/", 1)[0]
+            or "general"
+        )
+        item = (resolved_name, resolved_description)
+        skills_by_category.setdefault(resolved_category, []).append(item)
+        skills_by_discovery_category.setdefault(
+            resolved_discovery_category, []
+        ).append(item)
 
     if snapshot is not None:
         # Fast path: use pre-parsed metadata from disk
@@ -1818,12 +1866,8 @@ def build_skills_system_prompt(
             visible_entries.append(entry)
 
     # ── M2 org labeling + FAIL-LOUD collisions ─────────────────────────
-    # An org skill lists with an explicit provenance tag. When a personal and
-    # an org skill share a name, NEITHER silently wins: both list qualified
-    # (personal keeps the bare name is the wrong default — silent divergence
-    # from the org set; org winning silently shadows the user's own work) —
-    # so both entries carry a [name collision] flag and skill_view refuses
-    # the ambiguous bare name (its existing multi-candidate guard).
+    # Preserve the upstream org/personal provenance contract before rendering
+    # either the full index or the local category-only progressive index.
     name_owners: dict[str, set[str]] = {}
     for entry in visible_entries:
         fm = entry.get("frontmatter_name") or entry.get("skill_name") or ""
@@ -1839,11 +1883,27 @@ def build_skills_system_prompt(
             tag = f"[org-shared{': by ' + author if author else ''}]"
             desc = f"{tag} {desc}".strip()
             category = f"org:{org_id}"
+            discovery_category = category
         else:
             category = entry.get("category") or "general"
+            discovery_category = (
+                entry.get("discovery_category")
+                or str(category).split("/", 1)[0]
+                or "general"
+            )
         if collided:
-            desc = f"[name collision — also exists {'personally' if org_id else 'in your org'}; load via category path] {desc}".strip()
-        skills_by_category.setdefault(category, []).append((fm, desc))
+            desc = (
+                f"[name collision — also exists "
+                f"{'personally' if org_id else 'in your org'}; "
+                f"load via category path] {desc}"
+            ).strip()
+        _add_indexed_entry(
+            entry,
+            name=fm,
+            description=desc,
+            category=str(category),
+            discovery_category=str(discovery_category),
+        )
 
     if snapshot is None:
         # (continuation of the cold path below: category descriptions + write)
@@ -1899,9 +1959,7 @@ def build_skills_system_prompt(
                 ):
                     continue
                 seen_skill_names.add(frontmatter_name)
-                skills_by_category.setdefault(entry["category"], []).append(
-                    (frontmatter_name, entry["description"])
-                )
+                _add_indexed_entry(entry, name=frontmatter_name)
             except Exception as e:
                 logger.debug("Error reading external skill %s: %s", skill_file, e)
 
@@ -1943,6 +2001,47 @@ def build_skills_system_prompt(
 
     if not skills_by_category:
         result = ""
+    elif normalized_index_mode == "categories":
+        category_lines = []
+        all_skills: dict[str, str] = {}
+        for category in sorted(skills_by_discovery_category):
+            unique_names = {
+                name for name, _desc in skills_by_discovery_category[category]
+            }
+            count = len(unique_names)
+            noun = "skill" if count == 1 else "skills"
+            category_lines.append(f"  {category} ({count} {noun})")
+            for name, desc in skills_by_discovery_category[category]:
+                all_skills.setdefault(name, desc)
+
+        pinned_lines = []
+        for name in sorted(normalized_pins):
+            if name not in all_skills:
+                continue
+            desc = all_skills[name]
+            pinned_lines.append(f"  - {name}: {desc}" if desc else f"  - {name}")
+
+        pinned_block = "\n".join(pinned_lines) if pinned_lines else "  (none)"
+        result = (
+            "## Skills (mandatory; progressive disclosure)\n"
+            "Only categories and pinned high-use skills are shown to keep the "
+            "system context small. Before acting, scan the categories below. "
+            "If one is relevant, call `skills_list(category='...')`, then load "
+            "the matching procedure with `skill_view(name='...')`. Load a pinned "
+            "skill directly when it matches. If persistent memory contains a "
+            "`skill:X` pointer for the task, load X before acting. For Hermes "
+            "Agent configuration or troubleshooting, load `hermes-agent`. Only "
+            "proceed without a skill after checking the relevant category and "
+            "finding no match.\n\n"
+            "<available_skills>\n"
+            "<skill_categories>\n"
+            + "\n".join(category_lines)
+            + "\n</skill_categories>\n\n"
+            "<pinned_skills>\n"
+            + pinned_block
+            + "\n</pinned_skills>\n"
+            "</available_skills>"
+        )
     else:
         index_lines = []
         for category in sorted(skills_by_category.keys()):

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -431,10 +431,24 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             )
         except Exception:
             _compact_cats = frozenset()
+        _skill_index_mode = "full"
+        _pinned_skills = frozenset()
+        try:
+            from hermes_cli.config import load_config
+
+            _skills_config = (load_config() or {}).get("skills") or {}
+            _skill_index_mode = str(_skills_config.get("index_mode") or "full")
+            _raw_pins = _skills_config.get("pinned") or []
+            if isinstance(_raw_pins, (list, tuple, set, frozenset)):
+                _pinned_skills = frozenset(str(name) for name in _raw_pins)
+        except Exception:
+            pass
         skills_prompt = _r.build_skills_system_prompt(
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
+            index_mode=_skill_index_mode,
+            pinned_skills=_pinned_skills or None,
         )
     else:
         skills_prompt = ""

--- a/tests/agent/test_org_skill_namespace.py
+++ b/tests/agent/test_org_skill_namespace.py
@@ -130,6 +130,29 @@ class TestListingCollisionsAndLabels:
         assert "[org-shared: by bens-macbook]" in out
         assert "personal-a" in out
 
+    def test_category_mode_preserves_org_category_and_pinned_provenance(
+        self, tmp_path, monkeypatch
+    ):
+        skills, pb = self._render(tmp_path, monkeypatch)
+        _mk_skill(skills, "personal-a")
+        _mk_skill(
+            skills,
+            f"{sku.ORG_MIRROR_DIR_NAME}/org-1/shared-x",
+            name="shared-x",
+        )
+        (skills / sku.ORG_MIRROR_DIR_NAME / "org-1" / sku.ORG_PROVENANCE_FILE).write_text(
+            json.dumps({"author_device": "bens-macbook"}), encoding="utf-8"
+        )
+        _mark_active(skills, "org-1")
+
+        out = pb.build_skills_system_prompt(
+            index_mode="categories",
+            pinned_skills=frozenset({"shared-x"}),
+        )
+
+        assert "org:org-1 (1 skill)" in out
+        assert "shared-x: [org-shared: by bens-macbook]" in out
+
     def test_collision_flags_both_sides(self, tmp_path, monkeypatch):
         skills, pb = self._render(tmp_path, monkeypatch)
         _mk_skill(skills, "k8s-debug", body="personal version\n")

--- a/tests/agent/test_progressive_skills_index.py
+++ b/tests/agent/test_progressive_skills_index.py
@@ -1,0 +1,207 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.context_breakdown import _SKILLS_BLOCK_RE
+from agent.prompt_builder import (
+    _build_skills_manifest,
+    _skills_prompt_snapshot_path,
+    build_skills_system_prompt,
+    clear_skills_system_prompt_cache,
+)
+from tools.skills_tool import skills_list
+
+
+@pytest.fixture(autouse=True)
+def _clear_skills_cache():
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    yield
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+
+
+def _write_skill(root, category, name, description):
+    skill_dir = root / "skills" / category / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n"
+    )
+
+
+def test_category_index_hides_unpinned_names_and_keeps_pinned_details(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_skill(tmp_path, "devops", "hermes-agent", "Operate Hermes safely")
+    _write_skill(tmp_path, "devops", "rare-infra", "Rare infrastructure procedure")
+    _write_skill(tmp_path, "research", "deep-research", "Research obscure topics")
+
+    result = build_skills_system_prompt(
+        index_mode="categories",
+        pinned_skills=frozenset({"hermes-agent"}),
+    )
+
+    assert "devops (2 skills)" in result
+    assert "research (1 skill)" in result
+    assert "hermes-agent: Operate Hermes safely" in result
+    assert "rare-infra" not in result
+    assert "Rare infrastructure procedure" not in result
+    assert "deep-research" not in result
+    assert "skills_list(category" in result
+    assert "skill_view(name" in result
+    assert "<available_skills>" in result
+    assert "</available_skills>" in result
+    parsed_block = _SKILLS_BLOCK_RE.search(result)
+    assert parsed_block is not None
+    assert "<skill_categories>" in parsed_block.group(0)
+    assert "<pinned_skills>" in parsed_block.group(0)
+
+
+def test_category_index_cache_isolated_by_mode_and_pins(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_skill(tmp_path, "tools", "skill-one", "Description for skill-one")
+    _write_skill(tmp_path, "tools", "skill-two", "Description for skill-two")
+
+    compact = build_skills_system_prompt(
+        index_mode="categories",
+        pinned_skills=frozenset({"skill-one"}),
+    )
+    assert "skill-one" in compact and "skill-two" not in compact
+
+    other_pin = build_skills_system_prompt(
+        index_mode="categories",
+        pinned_skills=frozenset({"skill-two"}),
+    )
+    assert "skill-two" in other_pin and "skill-one" not in other_pin
+
+    full = build_skills_system_prompt(index_mode="full")
+    assert "skill-one" in full and "skill-two" in full
+
+
+def test_invalid_index_mode_falls_back_to_full(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_skill(tmp_path, "tools", "visible-skill", "Must remain visible")
+
+    result = build_skills_system_prompt(index_mode="typo")
+    assert "visible-skill" in result
+    assert "Must remain visible" in result
+
+
+def test_rendered_nested_category_is_queryable_via_skills_list(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_skill(tmp_path, "mlops/models", "clip", "Vision-language models")
+
+    result = build_skills_system_prompt(index_mode="categories")
+    listing = json.loads(skills_list(category="mlops"))
+
+    assert "mlops (1 skill)" in result
+    assert "mlops/models" not in result
+    assert [skill["name"] for skill in listing["skills"]] == ["clip"]
+
+
+def test_category_mode_does_not_change_full_mode_nested_grouping(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_skill(tmp_path, "mlops/models", "clip", "Vision-language models")
+
+    full = build_skills_system_prompt(index_mode="full")
+    compact = build_skills_system_prompt(index_mode="categories")
+
+    assert "  mlops/models:" in full
+    assert "  mlops:" not in full
+    assert "mlops (1 skill)" in compact
+
+
+def test_rendered_general_category_is_queryable_via_skills_list(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_skill(tmp_path, "", "flat-skill", "A root-level skill")
+
+    result = build_skills_system_prompt(index_mode="categories")
+    listing = json.loads(skills_list(category="general"))
+
+    assert "general (1 skill)" in result
+    assert [skill["name"] for skill in listing["skills"]] == ["flat-skill"]
+
+
+def test_discovery_category_schema_invalidates_version_two_snapshot(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_skill(tmp_path, "mlops/models", "clip", "Vision-language models")
+    skills_dir = tmp_path / "skills"
+    stale_snapshot = {
+        "version": 2,
+        "manifest": _build_skills_manifest(skills_dir),
+        "skills": [
+            {
+                "skill_name": "clip",
+                "category": "mlops/models",
+                "frontmatter_name": "clip",
+                "description": "Vision-language models",
+                "platforms": [],
+                "conditions": {},
+            }
+        ],
+        "category_descriptions": {},
+    }
+    _skills_prompt_snapshot_path().write_text(json.dumps(stale_snapshot))
+
+    result = build_skills_system_prompt(index_mode="categories")
+
+    assert "mlops (1 skill)" in result
+    assert "mlops/models" not in result
+
+
+def test_system_prompt_passes_category_mode_and_pins_from_config():
+    from agent.system_prompt import build_system_prompt_parts
+
+    agent = SimpleNamespace(
+        load_soul_identity=False,
+        skip_context_files=False,
+        valid_tool_names={"skills_list", "skill_view"},
+        _task_completion_guidance=False,
+        _tool_use_enforcement=False,
+        _environment_probe=False,
+        _kanban_worker_guidance="",
+        _memory_store=None,
+        _memory_manager=None,
+        _platform_hint_overrides={},
+        model="",
+        provider="",
+        platform="cli",
+        pass_session_id=False,
+        session_id="",
+    )
+
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+        patch("run_agent.get_toolset_for_tool", return_value="skills"),
+        patch("run_agent.build_skills_system_prompt", return_value="CATEGORY INDEX") as build,
+        patch("hermes_cli.config.load_config", return_value={
+            "skills": {
+                "index_mode": "categories",
+                "pinned": ["hermes-agent", "github-development-workflows"],
+            }
+        }),
+        patch(
+            "agent.coding_context.coding_compact_skill_categories",
+            return_value=frozenset(),
+        ),
+        patch(
+            "agent.coding_context.coding_system_prompt_parts",
+            return_value=([], [], []),
+        ),
+    ):
+        parts = build_system_prompt_parts(agent)
+
+    assert "CATEGORY INDEX" in parts["volatile"]
+    build.assert_called_once_with(
+        available_tools=agent.valid_tool_names,
+        available_toolsets={"skills"},
+        compact_categories=None,
+        index_mode="categories",
+        pinned_skills=frozenset(
+            {"hermes-agent", "github-development-workflows"}
+        ),
+    )

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -832,16 +832,30 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                 ensure_ascii=False,
             )
 
-        # Filter by category if specified
+        # Filter by category if specified. Root-level skills historically carry
+        # category=None; expose them through the synthetic "general" category
+        # used by the compact system-prompt index. Nested categories are routed
+        # by their top-level discovery category (for example mlops/models via
+        # skills_list(category="mlops")).
         if category:
-            all_skills = [s for s in all_skills if s.get("category") == category]
+            if category == "general":
+                all_skills = [
+                    s for s in all_skills if s.get("category") in (None, "general")
+                ]
+            else:
+                all_skills = [
+                    s
+                    for s in all_skills
+                    if s.get("category") == category
+                    or str(s.get("category") or "").startswith(f"{category}/")
+                ]
 
         # Sort by category then name
         all_skills = _sort_skills(all_skills)
 
         # Extract unique categories
         categories = sorted(
-            {s.get("category") for s in all_skills if s.get("category")}
+            {str(s["category"]) for s in all_skills if s.get("category")}
         )
 
         return json.dumps(

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -151,10 +151,31 @@ applies if you have it on.
 Skills use a token-efficient loading pattern:
 
 ```
-Level 0: skills_list()           → [{name, description, category}, ...]   (~3k tokens)
-Level 1: skill_view(name)        → Full content + metadata       (varies)
-Level 2: skill_view(name, path)  → Specific reference file       (varies)
+Level 0: system prompt category map + pinned skills (with skills.index_mode: categories)
+Level 1: skills_list(category)  → matching names + descriptions
+Level 2: skill_view(name)       → Full content + metadata
+Level 3: skill_view(name, path) → Specific reference file
 ```
+
+By default, `skills.index_mode` is `full`, which keeps every installed skill
+name and description in the system prompt for maximum discoverability. Large
+skill collections can opt into category-first discovery:
+
+```yaml
+skills:
+  index_mode: categories
+  pinned:
+    - hermes-agent
+    - github-development-workflows
+```
+
+In category mode, the system prompt contains top-level category names/counts and
+the full entries for pinned high-use skills. Nested paths such as `mlops/models`
+are queried as `mlops`, while root-level skills use the synthetic `general`
+category. All other skills remain available through `skills_list(category)` and
+`skill_view(name)`; their content is not deleted or disabled. Pin critical
+routing/meta skills and keep durable `skill:X` pointers in compact memory when a
+procedure must be loaded before acting.
 
 The agent only loads the full skill content when it actually needs it.
 


### PR DESCRIPTION
## Summary
- add opt-in `skills.index_mode: categories`
- render top-level category names/counts plus full entries for configured `skills.pinned`
- keep the existing full skill catalog as the default
- make rendered nested categories queryable through their top-level category and expose root skills through `general`
- include mode/pins in the prompt cache key and snapshot schema
- preserve org-shared provenance and collision behavior

## Configuration
```yaml
skills:
  index_mode: categories
  pinned:
    - hermes-agent
    - github-development-workflows
```

## Why
Large installations currently inject every eligible skill name and description into the system prompt. Most turns need only one domain. Category-first mode keeps the prompt small while retaining deterministic discovery through the existing `skills_list(category=...)` and `skill_view(name=...)` tools.

The system prompt remains byte-stable for the life of a conversation: the setting is resolved while the prompt is built, and no mid-conversation tool/schema mutation is introduced.

## Compatibility and related work
- default `index_mode` is `full`; existing users see no change
- no FTS index, embeddings, semantic router, section API, or load-dedup contract
- compatible in scope with the broader retrieval work in #67688 and the selective-tool work in #62727; this PR is only a small prompt-catalog mode and can stand alone or be reused by a consolidated design

## Tests
- `PYTHONPATH=. python -m pytest -q tests/agent/test_progressive_skills_index.py tests/agent/test_org_skill_namespace.py tests/tools/test_skills_tool.py` — 76 passed
- `tests/agent/test_prompt_builder.py` with the focused set — 136 passed, 1 unrelated current-main failure (`test_agents_md_no_git_root_stays_cwd_only`), reproduced on a clean current-main worktree
- `ruff check` on all touched Python/test files
- `git diff --check`
