### PR TITLE
fix(state): recover from malformed legacy FTS index during rebuild

### DIFF
--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -538,7 +538,7 @@ class SessionSchemaMixin:
             cursor.executescript(recovery_sql)
         except sqlite3.DatabaseError as fallback_exc:
             with contextlib.suppress(sqlite3.Error):
-                self._conn.rollback()
+                cursor.connection.rollback()
             # A rolled-back recovery leaves the original malformed table
             # intact, but a script that died after CREATE can leave the table
             # empty-but-valid: a later integrity-check would pass it and stamp

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -395,6 +395,33 @@ class SessionSchemaMixin:
             )
         )
 
+    _FTS_INTEGRITY_ENGINE_KEY = "fts_integrity_engine"
+
+    def _fts_integrity_engine_id(self, cursor: sqlite3.Cursor) -> str:
+        try:
+            row = cursor.execute("SELECT sqlite_version()").fetchone()
+        except sqlite3.DatabaseError:
+            return "fts5:unknown"
+        return f"fts5:{row[0] if row else 'unknown'}"
+
+    def _legacy_fts_integrity_probe_needed(self, cursor: sqlite3.Cursor) -> bool:
+        """True until a clean integrity-check has run on this SQLite engine."""
+        try:
+            row = cursor.execute(
+                "SELECT value FROM state_meta WHERE key = ?",
+                (self._FTS_INTEGRITY_ENGINE_KEY,),
+            ).fetchone()
+        except sqlite3.DatabaseError:
+            return True
+        return not row or str(row[0] or "") != self._fts_integrity_engine_id(cursor)
+
+    def _record_legacy_fts_integrity_engine(self, cursor: sqlite3.Cursor) -> None:
+        cursor.execute(
+            "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (self._FTS_INTEGRITY_ENGINE_KEY, self._fts_integrity_engine_id(cursor)),
+        )
+
     def _legacy_fts_index_corrupt(
         self, cursor: sqlite3.Cursor, *, include_trigram: bool
     ) -> bool:
@@ -1195,8 +1222,9 @@ class SessionSchemaMixin:
                     # Trigram is optional; without it CJK search falls back to LIKE.
                     trigram_enabled = self._ensure_fts_schema(cursor, "messages_fts_trigram", trigram_sql)
                     self._trigram_available = trigram_enabled
+                    probe_needed = legacy_fts and self._legacy_fts_integrity_probe_needed(cursor)
                     if (trigram_enabled and trigram_triggers_missing) or (
-                        legacy_fts
+                        probe_needed
                         and self._legacy_fts_index_corrupt(cursor, include_trigram=trigram_enabled)
                     ):
                         self._run_admitted_startup_rebuild(
@@ -1205,6 +1233,8 @@ class SessionSchemaMixin:
                                 cursor, legacy=legacy_fts, include_trigram=trigram_enabled,
                             ),
                         )
+                    if probe_needed:
+                        self._record_legacy_fts_integrity_engine(cursor)
             if self._fts_enabled and not legacy_fts and not base_triggers_missing:
                 # CJK-bigram index: strictly additive, gated on the loadable tokenizer.
                 self._ensure_fts_cjk_schema(cursor)

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -383,20 +383,30 @@ class SessionSchemaMixin:
         """True when *exc* is the corrupt-inline-index class that justifies a
         drop-and-recreate rebuild, rather than a transient lock/busy/IO error.
 
-        Class-based split (replaces the earlier message-string classifier,
-        adopted from #86183's review round): corruption — ``SQLITE_CORRUPT``
-        and the FTS5 corrupt-structure class — surfaces as plain
-        ``sqlite3.DatabaseError``, never ``OperationalError``, while
-        ``database is locked`` / ``database is busy`` / disk-IO / readonly
-        surface as ``sqlite3.OperationalError`` (a subclass). An isinstance
-        check therefore classifies both directions with no dependence on
-        SQLite's error wording; verified against a really-corrupt index,
-        which also produced a ``fts5: corrupt structure record`` DELETE
-        failure that the previous string list missed, and a real
-        ``database is locked``.
+        Prefer SQLite's primary result code: FTS5 corruption reports
+        ``SQLITE_CORRUPT`` (including extended codes such as
+        ``SQLITE_CORRUPT_VTAB``), while lock/busy/disk-IO/readonly use
+        distinct result codes. Python added ``sqlite_errorcode`` in 3.11;
+        retain a narrow message fallback for synthetic exceptions and older
+        runtimes, including the ``fts5: corrupt structure record`` wording
+        observed during the #86183 review round.
         """
-        return isinstance(exc, sqlite3.DatabaseError) and not isinstance(
+        if not isinstance(exc, sqlite3.DatabaseError) or isinstance(
             exc, sqlite3.OperationalError
+        ):
+            return False
+        error_code = getattr(exc, "sqlite_errorcode", None)
+        if isinstance(error_code, int):
+            return error_code & 0xFF == sqlite3.SQLITE_CORRUPT
+        message = str(exc).lower()
+        return any(
+            marker in message
+            for marker in (
+                "malformed inverted index",
+                "database disk image is malformed",
+                "malformed database schema",
+                "fts5: corrupt structure record",
+            )
         )
 
     _FTS_INTEGRITY_ENGINE_KEY = "fts_integrity_engine"

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -379,32 +379,95 @@ class SessionSchemaMixin:
             logger.debug("Could not drop residual CJK UPDATE trigger after quarantine", exc_info=True)
 
     @staticmethod
+    def _is_malformed_fts_index_error(exc: BaseException) -> bool:
+        """True when *exc* is the corrupt-inline-index class that justifies a
+        drop-and-recreate rebuild, rather than a transient lock/busy/IO error.
+        """
+        if not isinstance(exc, sqlite3.DatabaseError):
+            return False
+        message = str(exc).lower()
+        return any(
+            marker in message
+            for marker in (
+                "malformed inverted index",
+                "database disk image is malformed",
+                "malformed database schema",
+            )
+        )
+
+    def _legacy_fts_index_corrupt(
+        self, cursor: sqlite3.Cursor, *, include_trigram: bool
+    ) -> bool:
+        """True when a legacy inline FTS index fails FTS5's integrity-check.
+
+        Runs the cheap, non-mutating ``'integrity-check'`` command against each
+        legacy inline index. A corrupt shadow table (e.g. ``malformed inverted
+        index``) raises there even when ordinary reads and trigger-driven
+        writes still succeed, which is exactly the class #86027 reports on a
+        trigger-complete legacy install.
+        """
+        tables = ["messages_fts"]
+        if include_trigram:
+            tables.append("messages_fts_trigram")
+        for table in tables:
+            try:
+                cursor.execute(
+                    f"INSERT INTO {table}({table}) VALUES('integrity-check')"
+                )
+            except sqlite3.DatabaseError as exc:
+                if self._is_malformed_fts_index_error(exc):
+                    return True
+                raise
+            except sqlite3.OperationalError as exc:
+                # Missing table or tokenizer — not the corruption class.
+                if "no such table" in str(exc).lower() or "no such module" in str(exc).lower():
+                    continue
+                raise
+        return False
+
+    @staticmethod
     def _rebuild_fts_indexes(cursor: sqlite3.Cursor, *, legacy: bool = False, include_trigram: bool = True) -> None:
         """v23+ external-content 'rebuild'. It indexes EVERY row, so the deferred-backfill
         markers are cleared or the worker would re-insert covered rows (duplicates).
         ``legacy`` (pre-v23 inline layout) has no external-content 'rebuild' source, so it
-        DELETEs + reinserts the concatenated content the legacy triggers produced. A malformed
-        legacy FTS index (e.g. from a legacy schema) raises ``DatabaseError`` on the DELETE;
-        it is dropped and recreated from its DDL before the reinsert."""
+        DELETEs + reinserts the concatenated content the legacy triggers produced. When the
+        DELETE raises the malformed-index class (``malformed inverted index`` / ``database
+        disk image is malformed``) the whole index is atomically dropped + recreated +
+        backfilled inside one ``BEGIN IMMEDIATE`` transaction — the same shape
+        ``_recover_stale_fts`` uses — so a concurrent writer can never observe a
+        half-dropped index. Lock/busy/disk-IO errors are re-raised so the outer open retry
+        still applies. Never touches the v23 shape."""
         SessionSchemaMixin._stamp_fts_tool_high_water(cursor)
         tables = ("messages_fts", "messages_fts_trigram") if include_trigram else ("messages_fts",)
-        for tbl in tables:
-            is_trigram = "_trigram" in tbl
-            triggers = _FTS_TRIGRAM_TRIGGERS if is_trigram else _FTS_BASE_TRIGGERS
-            ddl = _FTS_DDL[legacy][1 if is_trigram else 0]
-            if legacy:
-                try:
-                    cursor.execute(f"DELETE FROM {tbl}")
-                except sqlite3.DatabaseError:
-                    for trigger in triggers:
-                        cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
-                    cursor.execute(f"DROP TABLE IF EXISTS {tbl}")
-                    cursor.executescript(ddl)
-                cursor.execute(f"INSERT INTO {tbl}(rowid, content) SELECT id, {_LEGACY_INLINE_CONCAT_SQL}FROM messages")
-            else:
-                cursor.execute(f"INSERT INTO {tbl}({tbl}) VALUES('rebuild')")
         if not legacy:
+            for tbl in tables:
+                cursor.execute(f"INSERT INTO {tbl}({tbl}) VALUES('rebuild')")
             cursor.execute(_CLEAR_REBUILD_MARKERS_SQL)
+            return
+        # Legacy inline path: fast path DELETEs + reinserts; on malformed-index
+        # error falls through to an atomic drop + recreate + backfill.
+        try:
+            for tbl in tables:
+                cursor.execute(f"DELETE FROM {tbl}")
+                cursor.execute(f"INSERT INTO {tbl}(rowid, content) SELECT id, {_LEGACY_INLINE_CONCAT_SQL}FROM messages")
+            return
+        except sqlite3.DatabaseError as exc:
+            if not SessionSchemaMixin._is_malformed_fts_index_error(exc):
+                raise
+        # Corrupt inline index: atomically drop triggers + vtable, recreate the
+        # legacy schema, and backfill, in a single write transaction.
+        drop_sql = "".join(f"DROP TRIGGER IF EXISTS {trigger};" for trigger in _FTS_TRIGGERS)
+        if include_trigram:
+            drop_sql += "DROP TABLE IF EXISTS messages_fts_trigram;"
+        drop_sql += "DROP TABLE IF EXISTS messages_fts;"
+        rebuild_sql = LEGACY_FTS_SQL
+        if include_trigram:
+            rebuild_sql += LEGACY_FTS_TRIGRAM_SQL
+        rebuild_sql += _legacy_inline_reinsert_sql("messages_fts", 12)
+        if include_trigram:
+            rebuild_sql += _legacy_inline_reinsert_sql("messages_fts_trigram", 12)
+        recovery_sql = "BEGIN IMMEDIATE;" + drop_sql + rebuild_sql + "COMMIT;"
+        cursor.executescript(recovery_sql)
 
     def _fts_table_probe(self, cursor: sqlite3.Cursor, table_name: str) -> Optional[bool]:
         """True = queryable, False = absent, None = FTS module/tokenizer missing or content
@@ -1132,7 +1195,10 @@ class SessionSchemaMixin:
                     # Trigram is optional; without it CJK search falls back to LIKE.
                     trigram_enabled = self._ensure_fts_schema(cursor, "messages_fts_trigram", trigram_sql)
                     self._trigram_available = trigram_enabled
-                    if trigram_enabled and trigram_triggers_missing:
+                    if (trigram_enabled and trigram_triggers_missing) or (
+                        legacy_fts
+                        and self._legacy_fts_index_corrupt(cursor, include_trigram=trigram_enabled)
+                    ):
                         self._run_admitted_startup_rebuild(
                             cursor,
                             lambda: self._rebuild_fts_indexes(

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -383,12 +383,23 @@ class SessionSchemaMixin:
         """v23+ external-content 'rebuild'. It indexes EVERY row, so the deferred-backfill
         markers are cleared or the worker would re-insert covered rows (duplicates).
         ``legacy`` (pre-v23 inline layout) has no external-content 'rebuild' source, so it
-        DELETEs + reinserts the concatenated content the legacy triggers produced."""
+        DELETEs + reinserts the concatenated content the legacy triggers produced. A malformed
+        legacy FTS index (e.g. from a legacy schema) raises ``DatabaseError`` on the DELETE;
+        it is dropped and recreated from its DDL before the reinsert."""
         SessionSchemaMixin._stamp_fts_tool_high_water(cursor)
         tables = ("messages_fts", "messages_fts_trigram") if include_trigram else ("messages_fts",)
         for tbl in tables:
+            is_trigram = "_trigram" in tbl
+            triggers = _FTS_TRIGRAM_TRIGGERS if is_trigram else _FTS_BASE_TRIGGERS
+            ddl = _FTS_DDL[legacy][1 if is_trigram else 0]
             if legacy:
-                cursor.execute(f"DELETE FROM {tbl}")
+                try:
+                    cursor.execute(f"DELETE FROM {tbl}")
+                except sqlite3.DatabaseError:
+                    for trigger in triggers:
+                        cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+                    cursor.execute(f"DROP TABLE IF EXISTS {tbl}")
+                    cursor.executescript(ddl)
                 cursor.execute(f"INSERT INTO {tbl}(rowid, content) SELECT id, {_LEGACY_INLINE_CONCAT_SQL}FROM messages")
             else:
                 cursor.execute(f"INSERT INTO {tbl}({tbl}) VALUES('rebuild')")
@@ -602,7 +613,7 @@ class SessionSchemaMixin:
             rebuild_sql = LEGACY_FTS_SQL + (LEGACY_FTS_TRIGRAM_SQL if include_trigram else "")
             rebuild_sql += _legacy_inline_reinsert_sql("messages_fts", 16)
             if include_trigram:
-                rebuild_sql += _legacy_inline_reinsert_sql("messages_fts_trigram", 20, delete_first=True)
+                rebuild_sql += _legacy_inline_reinsert_sql("messages_fts_trigram", 20)
         else:
             rebuild_sql = FTS_SQL + (FTS_TRIGRAM_SQL if include_trigram else "")
             rebuild_sql += "INSERT INTO messages_fts(messages_fts) VALUES('rebuild');"

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -382,27 +382,52 @@ class SessionSchemaMixin:
     def _is_malformed_fts_index_error(exc: BaseException) -> bool:
         """True when *exc* is the corrupt-inline-index class that justifies a
         drop-and-recreate rebuild, rather than a transient lock/busy/IO error.
+
+        Class-based split (replaces the earlier message-string classifier,
+        adopted from #86183's review round): corruption — ``SQLITE_CORRUPT``
+        and the FTS5 corrupt-structure class — surfaces as plain
+        ``sqlite3.DatabaseError``, never ``OperationalError``, while
+        ``database is locked`` / ``database is busy`` / disk-IO / readonly
+        surface as ``sqlite3.OperationalError`` (a subclass). An isinstance
+        check therefore classifies both directions with no dependence on
+        SQLite's error wording; verified against a really-corrupt index,
+        which also produced a ``fts5: corrupt structure record`` DELETE
+        failure that the previous string list missed, and a real
+        ``database is locked``.
         """
-        if not isinstance(exc, sqlite3.DatabaseError):
-            return False
-        message = str(exc).lower()
-        return any(
-            marker in message
-            for marker in (
-                "malformed inverted index",
-                "database disk image is malformed",
-                "malformed database schema",
-            )
+        return isinstance(exc, sqlite3.DatabaseError) and not isinstance(
+            exc, sqlite3.OperationalError
         )
 
     _FTS_INTEGRITY_ENGINE_KEY = "fts_integrity_engine"
 
     def _fts_integrity_engine_id(self, cursor: sqlite3.Cursor) -> str:
+        """Engine id plus a capability signature (adopted from #86183).
+
+        A bare version string mis-judges hosts that share a SQLite version
+        but differ in tokenizer availability (e.g. one built without the
+        trigram/cjk tokenizer extension): the incapable host sweeps once and
+        stamps the version, then the capable host reads a matching stamp and
+        skips its own sweep of indexes the incapable host never checked.
+        Appending ``|missing=<tables>`` when a probe returns None makes the
+        stamp an engine+capability pair: an incapable host still sweeps at
+        most once per pair, while a capable host reading its stamp sees the
+        signature mismatch and re-verifies — an incapable host never vouches,
+        on behalf of a capable one, for indexes it could not check.
+        """
         try:
             row = cursor.execute("SELECT sqlite_version()").fetchone()
         except sqlite3.DatabaseError:
             return "fts5:unknown"
-        return f"fts5:{row[0] if row else 'unknown'}"
+        stamp = f"fts5:{row[0] if row else 'unknown'}"
+        missing = sorted(
+            table
+            for table in ("messages_fts_trigram", "messages_fts_cjk")
+            if self._fts_table_probe(cursor, table) is None
+        )
+        if missing:
+            stamp = f"{stamp}|missing={','.join(missing)}"
+        return stamp
 
     def _legacy_fts_integrity_probe_needed(self, cursor: sqlite3.Cursor) -> bool:
         """True until a clean integrity-check has run on this SQLite engine."""
@@ -436,6 +461,10 @@ class SessionSchemaMixin:
         tables = ["messages_fts"]
         if include_trigram:
             tables.append("messages_fts_trigram")
+        # The optional CJK inline index participates in the same engine-mismatch
+        # failure class (#86183); probe first so absent installs stay untouched.
+        if self._fts_table_probe(cursor, "messages_fts_cjk"):
+            tables.append("messages_fts_cjk")
         for table in tables:
             try:
                 cursor.execute(
@@ -444,16 +473,17 @@ class SessionSchemaMixin:
             except sqlite3.DatabaseError as exc:
                 if self._is_malformed_fts_index_error(exc):
                     return True
-                raise
-            except sqlite3.OperationalError as exc:
-                # Missing table or tokenizer — not the corruption class.
-                if "no such table" in str(exc).lower() or "no such module" in str(exc).lower():
+                # Missing table or tokenizer — not the corruption class. The
+                # previous separate `except sqlite3.OperationalError` arm was
+                # unreachable: the subclass is caught by the DatabaseError arm
+                # above, so its conditions belong here.
+                message = str(exc).lower()
+                if "no such table" in message or "no such module" in message:
                     continue
                 raise
         return False
 
-    @staticmethod
-    def _rebuild_fts_indexes(cursor: sqlite3.Cursor, *, legacy: bool = False, include_trigram: bool = True) -> None:
+    def _rebuild_fts_indexes(self, cursor: sqlite3.Cursor, *, legacy: bool = False, include_trigram: bool = True) -> None:
         """v23+ external-content 'rebuild'. It indexes EVERY row, so the deferred-backfill
         markers are cleared or the worker would re-insert covered rows (duplicates).
         ``legacy`` (pre-v23 inline layout) has no external-content 'rebuild' source, so it
@@ -464,7 +494,7 @@ class SessionSchemaMixin:
         ``_recover_stale_fts`` uses — so a concurrent writer can never observe a
         half-dropped index. Lock/busy/disk-IO errors are re-raised so the outer open retry
         still applies. Never touches the v23 shape."""
-        SessionSchemaMixin._stamp_fts_tool_high_water(cursor)
+        self._stamp_fts_tool_high_water(cursor)
         tables = ("messages_fts", "messages_fts_trigram") if include_trigram else ("messages_fts",)
         if not legacy:
             for tbl in tables:
@@ -479,7 +509,7 @@ class SessionSchemaMixin:
                 cursor.execute(f"INSERT INTO {tbl}(rowid, content) SELECT id, {_LEGACY_INLINE_CONCAT_SQL}FROM messages")
             return
         except sqlite3.DatabaseError as exc:
-            if not SessionSchemaMixin._is_malformed_fts_index_error(exc):
+            if not self._is_malformed_fts_index_error(exc):
                 raise
         # Corrupt inline index: atomically drop triggers + vtable, recreate the
         # legacy schema, and backfill, in a single write transaction.
@@ -494,7 +524,37 @@ class SessionSchemaMixin:
         if include_trigram:
             rebuild_sql += _legacy_inline_reinsert_sql("messages_fts_trigram", 12)
         recovery_sql = "BEGIN IMMEDIATE;" + drop_sql + rebuild_sql + "COMMIT;"
-        cursor.executescript(recovery_sql)
+        try:
+            cursor.executescript(recovery_sql)
+        except sqlite3.DatabaseError as fallback_exc:
+            with contextlib.suppress(sqlite3.Error):
+                self._conn.rollback()
+            # A rolled-back recovery leaves the original malformed table
+            # intact, but a script that died after CREATE can leave the table
+            # empty-but-valid: a later integrity-check would pass it and stamp
+            # the engine marker, freezing a silently-dead index (adopted from
+            # #86183). Persist the ``fts_stale`` breadcrumb and detach FTS
+            # instead — same ordering contract as the deferred branch of
+            # ``_run_admitted_startup_rebuild``: triggers must never be live
+            # over an index with an unrebuilt gap, and the next open routes
+            # through ``_recover_stale_fts`` (full drop/recreate/backfill). FTS
+            # degrades visibly rather than staying silently empty forever.
+            cursor.execute(
+                "INSERT INTO state_meta (key, value) VALUES (?, '1') "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (FTS_STALE_KEY,),
+            )
+            self._drop_all_fts_triggers(cursor)
+            self._fts_stale = True
+            self._fts_enabled = False
+            self._trigram_available = False
+            self._fts_cjk_available = False
+            logger.error(
+                "Could not recreate legacy FTS index (%s); marked FTS stale "
+                "for full recovery on next open — run `hermes sessions "
+                "repair` to rebuild it now",
+                fallback_exc,
+            )
 
     def _fts_table_probe(self, cursor: sqlite3.Cursor, table_name: str) -> Optional[bool]:
         """True = queryable, False = absent, None = FTS module/tokenizer missing or content

--- a/tests/state/test_legacy_fts_malformed_rebuild.py
+++ b/tests/state/test_legacy_fts_malformed_rebuild.py
@@ -150,14 +150,19 @@ class TestLegacyFtsMalformedRebuild:
         locked = sqlite3.OperationalError("database is locked")
         busy = sqlite3.OperationalError("database is busy")
         io_error = sqlite3.OperationalError("disk I/O error")
+        integrity = sqlite3.IntegrityError("constraint failed")
+        programming = sqlite3.ProgrammingError("unsupported operation")
+        unrelated = sqlite3.DatabaseError("unrelated database failure")
         malformed = sqlite3.DatabaseError(
             "malformed inverted index for FTS5 table main.messages_fts_trigram"
         )
         disk_image = sqlite3.DatabaseError("database disk image is malformed")
+        corrupt_code = sqlite3.DatabaseError("localized corruption wording")
+        corrupt_code.sqlite_errorcode = sqlite3.SQLITE_CORRUPT_VTAB
 
-        for exc in (locked, busy, io_error):
+        for exc in (locked, busy, io_error, integrity, programming, unrelated):
             assert SessionDB._is_malformed_fts_index_error(exc) is False
-        for exc in (malformed, disk_image):
+        for exc in (malformed, disk_image, corrupt_code):
             assert SessionDB._is_malformed_fts_index_error(exc) is True
 
     def test_corrupt_structure_record_variant_classified_as_corruption(self):
@@ -169,7 +174,7 @@ class TestLegacyFtsMalformedRebuild:
         variant = sqlite3.DatabaseError("fts5: corrupt structure record")
         assert SessionDB._is_malformed_fts_index_error(variant) is True
 
-    def test_failed_fallback_leaves_stale_breadcrumb(self, tmp_path):
+    def test_failed_fallback_leaves_stale_breadcrumb(self, tmp_path, monkeypatch):
         """When the drop/recreate recovery itself cannot complete, the open
         must not fail and must not leave a silently-empty index: it persists
         the fts_stale breadcrumb, detaches FTS (triggers down, same ordering
@@ -198,7 +203,7 @@ class TestLegacyFtsMalformedRebuild:
             finally:
                 hermes_state_schema.LEGACY_FTS_SQL = original_ddl
 
-        SessionDB._rebuild_fts_indexes = _flaky_rebuild
+        monkeypatch.setattr(SessionDB, "_rebuild_fts_indexes", _flaky_rebuild)
         db = SessionDB(db_path=db_path)
         try:
             breadcrumb = db._conn.execute(
@@ -214,7 +219,6 @@ class TestLegacyFtsMalformedRebuild:
             assert trigger_count == 0, "triggers must be down over an unrebuilt gap"
         finally:
             db.close()
-            SessionDB._rebuild_fts_indexes = original_rebuild
 
         # With the recovery DDL restored, the next open performs the full
         # recovery and clears the breadcrumb.

--- a/tests/state/test_legacy_fts_malformed_rebuild.py
+++ b/tests/state/test_legacy_fts_malformed_rebuild.py
@@ -17,6 +17,13 @@ from hermes_state_common import SCHEMA_SQL
 from hermes_state_schema import LEGACY_FTS_SQL, LEGACY_FTS_TRIGRAM_SQL
 
 
+def _connection(db: SessionDB) -> sqlite3.Connection:
+    """The live connection of an open ``SessionDB``; ``_conn`` is ``None`` once closed."""
+    conn = db._conn
+    assert conn is not None
+    return conn
+
+
 def _create_legacy_db(db_path):
     """Create a database with legacy inline FTS5 schema."""
     conn = sqlite3.connect(str(db_path))
@@ -79,10 +86,10 @@ class TestLegacyFtsMalformedRebuild:
         # rebuild the corrupt index, not skip the rebuild gate.
         db = SessionDB(db_path=db_path)
         try:
-            assert db._db_has_legacy_inline_fts(db._conn)
-            quick_check = [r[0] for r in db._conn.execute("PRAGMA quick_check").fetchall()]
+            assert db._db_has_legacy_inline_fts(_connection(db).cursor())
+            quick_check = [r[0] for r in _connection(db).execute("PRAGMA quick_check").fetchall()]
             assert quick_check == ["ok"]
-            matches = db._conn.execute(
+            matches = _connection(db).execute(
                 "SELECT COUNT(*) FROM messages_fts_trigram "
                 "WHERE messages_fts_trigram MATCH 'keyword'"
             ).fetchone()[0]
@@ -103,10 +110,10 @@ class TestLegacyFtsMalformedRebuild:
 
         db = SessionDB(db_path=db_path)
         try:
-            assert db._db_has_legacy_inline_fts(db._conn)
-            quick_check = [r[0] for r in db._conn.execute("PRAGMA quick_check").fetchall()]
+            assert db._db_has_legacy_inline_fts(_connection(db).cursor())
+            quick_check = [r[0] for r in _connection(db).execute("PRAGMA quick_check").fetchall()]
             assert quick_check == ["ok"]
-            matches = db._conn.execute(
+            matches = _connection(db).execute(
                 "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'keyword'"
             ).fetchone()[0]
             assert matches == 10
@@ -120,7 +127,7 @@ class TestLegacyFtsMalformedRebuild:
         calls = {"n": 0}
         original = SessionDB._legacy_fts_index_corrupt
 
-        def _counting(self, cursor, *, include_trigram):
+        def _counting(self, cursor: sqlite3.Cursor, *, include_trigram: bool) -> bool:
             calls["n"] += 1
             return original(self, cursor, include_trigram=include_trigram)
 
@@ -203,13 +210,13 @@ class TestLegacyFtsMalformedRebuild:
         monkeypatch.setattr(SessionDB, "_rebuild_fts_indexes", _flaky_rebuild)
         db = SessionDB(db_path=db_path)
         try:
-            breadcrumb = db._conn.execute(
+            breadcrumb = _connection(db).execute(
                 "SELECT value FROM state_meta WHERE key = 'fts_stale'"
             ).fetchone()
             assert breadcrumb is not None, "fts_stale breadcrumb must persist"
             assert db._fts_stale is True
             assert db._fts_enabled is False
-            trigger_count = db._conn.execute(
+            trigger_count = _connection(db).execute(
                 "SELECT COUNT(*) FROM sqlite_master WHERE type='trigger' "
                 "AND name LIKE 'messages_ai%'"
             ).fetchone()[0]
@@ -222,11 +229,11 @@ class TestLegacyFtsMalformedRebuild:
         db2 = SessionDB(db_path=db_path)
         try:
             assert db2._fts_enabled is True
-            breadcrumb = db2._conn.execute(
+            breadcrumb = _connection(db2).execute(
                 "SELECT value FROM state_meta WHERE key = 'fts_stale'"
             ).fetchone()
             assert breadcrumb is None, "breadcrumb must clear after recovery"
-            matches = db2._conn.execute(
+            matches = _connection(db2).execute(
                 "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'keyword'"
             ).fetchone()[0]
             assert matches == 10
@@ -251,7 +258,7 @@ class TestLegacyFtsMalformedRebuild:
                 return original(self, cursor, table_name)
 
             monkeypatch.setattr(SessionDB, "_fts_table_probe", _incapable)
-            cursor = db._conn.cursor()
+            cursor = _connection(db).cursor()
             stamp = db._fts_integrity_engine_id(cursor)
             assert stamp.startswith("fts5:")
             assert stamp.endswith(

--- a/tests/state/test_legacy_fts_malformed_rebuild.py
+++ b/tests/state/test_legacy_fts_malformed_rebuild.py
@@ -6,6 +6,7 @@ FTS5 table created under an older SQLite version (e.g. 3.46.1).
 
 SessionDB._rebuild_fts_indexes (legacy mode) must catch this error, drop the corrupt virtual
 table and triggers, recreate the schema, and repopulate cleanly from canonical messages.
+A trigger-complete legacy DB whose index is corrupt must self-heal on SessionDB open.
 """
 
 import sqlite3
@@ -63,62 +64,71 @@ def _corrupt_base_fts(db_path):
 
 
 class TestLegacyFtsMalformedRebuild:
-    def test_rebuild_legacy_fts_indexes_recovers_from_corrupt_trigram(self, tmp_path):
+    def test_session_open_heals_corrupt_trigram_index(self, tmp_path):
+        """A trigger-complete legacy DB whose trigram index is corrupt must
+        self-heal on a normal SessionDB open, preserving the inline FTS shape
+        (not silently demoting to the v23 external-content schema)."""
         db_path = tmp_path / "state.db"
         _create_legacy_db(db_path)
         _corrupt_trigram_fts(db_path)
 
-        # Verify that DELETE FROM messages_fts_trigram fails on the corrupt table
+        # Verify the corruption manifests on a raw connection before opening.
         conn = sqlite3.connect(str(db_path))
         with pytest.raises(sqlite3.DatabaseError):
             conn.execute("DELETE FROM messages_fts_trigram")
         conn.close()
 
-        # Rebuild using SessionDB._rebuild_fts_indexes (legacy mode)
-        conn = sqlite3.connect(str(db_path))
-        cursor = conn.cursor()
-        SessionDB._rebuild_fts_indexes(cursor, legacy=True, include_trigram=True)
-        conn.commit()
+        # A production-shaped open (all six triggers present) must notice and
+        # rebuild the corrupt index, not skip the rebuild gate.
+        db = SessionDB(db_path=db_path)
+        try:
+            assert db._db_has_legacy_inline_fts(db._conn)
+            quick_check = [r[0] for r in db._conn.execute("PRAGMA quick_check").fetchall()]
+            assert quick_check == ["ok"]
+            matches = db._conn.execute(
+                "SELECT COUNT(*) FROM messages_fts_trigram "
+                "WHERE messages_fts_trigram MATCH 'keyword'"
+            ).fetchone()[0]
+            assert matches == 10
+        finally:
+            db.close()
 
-        # Verify index is healthy and populated
-        quick_check = [r[0] for r in conn.execute("PRAGMA quick_check").fetchall()]
-        assert quick_check == ["ok"]
-
-        # Verify search queries work
-        matches = conn.execute(
-            "SELECT COUNT(*) FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'keyword'"
-        ).fetchone()[0]
-        assert matches == 10
-
-        base_matches = conn.execute(
-            "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'keyword'"
-        ).fetchone()[0]
-        assert base_matches == 10
-        conn.close()
-
-    def test_rebuild_legacy_fts_indexes_recovers_from_corrupt_base_fts(self, tmp_path):
+    def test_session_open_heals_corrupt_base_fts_index(self, tmp_path):
+        """Same self-heal for the base messages_fts inline index."""
         db_path = tmp_path / "state.db"
         _create_legacy_db(db_path)
         _corrupt_base_fts(db_path)
 
-        # Verify that DELETE FROM messages_fts fails on the corrupt table
         conn = sqlite3.connect(str(db_path))
         with pytest.raises(sqlite3.DatabaseError):
             conn.execute("DELETE FROM messages_fts")
         conn.close()
 
-        # Rebuild using SessionDB._rebuild_fts_indexes (legacy mode)
-        conn = sqlite3.connect(str(db_path))
-        cursor = conn.cursor()
-        SessionDB._rebuild_fts_indexes(cursor, legacy=True, include_trigram=True)
-        conn.commit()
+        db = SessionDB(db_path=db_path)
+        try:
+            assert db._db_has_legacy_inline_fts(db._conn)
+            quick_check = [r[0] for r in db._conn.execute("PRAGMA quick_check").fetchall()]
+            assert quick_check == ["ok"]
+            matches = db._conn.execute(
+                "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'keyword'"
+            ).fetchone()[0]
+            assert matches == 10
+        finally:
+            db.close()
 
-        # Verify index is healthy and populated
-        quick_check = [r[0] for r in conn.execute("PRAGMA quick_check").fetchall()]
-        assert quick_check == ["ok"]
+    def test_non_malformed_error_is_not_classified_as_corruption(self):
+        """Only the malformed-index class justifies a destructive rebuild; a
+        transient lock/busy/IO DatabaseError must fall through to the caller's
+        retry path untouched."""
+        locked = sqlite3.OperationalError("database is locked")
+        busy = sqlite3.OperationalError("database is busy")
+        io_error = sqlite3.OperationalError("disk I/O error")
+        malformed = sqlite3.DatabaseError(
+            "malformed inverted index for FTS5 table main.messages_fts_trigram"
+        )
+        disk_image = sqlite3.DatabaseError("database disk image is malformed")
 
-        base_matches = conn.execute(
-            "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'keyword'"
-        ).fetchone()[0]
-        assert base_matches == 10
-        conn.close()
+        for exc in (locked, busy, io_error):
+            assert SessionDB._is_malformed_fts_index_error(exc) is False
+        for exc in (malformed, disk_image):
+            assert SessionDB._is_malformed_fts_index_error(exc) is True

--- a/tests/state/test_legacy_fts_malformed_rebuild.py
+++ b/tests/state/test_legacy_fts_malformed_rebuild.py
@@ -12,12 +12,9 @@ A trigger-complete legacy DB whose index is corrupt must self-heal on SessionDB 
 import sqlite3
 import pytest
 
-from hermes_state import (
-    LEGACY_FTS_SQL,
-    LEGACY_FTS_TRIGRAM_SQL,
-    SCHEMA_SQL,
-    SessionDB,
-)
+from hermes_state import SessionDB
+from hermes_state_common import SCHEMA_SQL
+from hermes_state_schema import LEGACY_FTS_SQL, LEGACY_FTS_TRIGRAM_SQL
 
 
 def _create_legacy_db(db_path):

--- a/tests/state/test_legacy_fts_malformed_rebuild.py
+++ b/tests/state/test_legacy_fts_malformed_rebuild.py
@@ -120,7 +120,7 @@ class TestLegacyFtsMalformedRebuild:
         finally:
             db.close()
 
-    def test_integrity_probe_runs_once_per_sqlite_engine(self, tmp_path):
+    def test_integrity_probe_runs_once_per_sqlite_engine(self, tmp_path, monkeypatch):
         """A healthy legacy DB must not rerun FTS integrity-check on every open."""
         db_path = tmp_path / "state.db"
         _create_legacy_db(db_path)
@@ -131,21 +131,18 @@ class TestLegacyFtsMalformedRebuild:
             calls["n"] += 1
             return original(self, cursor, include_trigram=include_trigram)
 
-        SessionDB._legacy_fts_index_corrupt = _counting
-        try:
-            first = SessionDB(db_path=db_path)
-            first.close()
-            assert calls["n"] == 1
-            marker = sqlite3.connect(str(db_path)).execute(
-                "SELECT value FROM state_meta WHERE key = 'fts_integrity_engine'"
-            ).fetchone()
-            assert marker and str(marker[0]).startswith("fts5:")
+        monkeypatch.setattr(SessionDB, "_legacy_fts_index_corrupt", _counting)
+        first = SessionDB(db_path=db_path)
+        first.close()
+        assert calls["n"] == 1
+        marker = sqlite3.connect(str(db_path)).execute(
+            "SELECT value FROM state_meta WHERE key = 'fts_integrity_engine'"
+        ).fetchone()
+        assert marker and str(marker[0]).startswith("fts5:")
 
-            second = SessionDB(db_path=db_path)
-            second.close()
-            assert calls["n"] == 1
-        finally:
-            SessionDB._legacy_fts_index_corrupt = original
+        second = SessionDB(db_path=db_path)
+        second.close()
+        assert calls["n"] == 1
 
     def test_non_malformed_error_is_not_classified_as_corruption(self):
         """Only the malformed-index class justifies a destructive rebuild; a

--- a/tests/state/test_legacy_fts_malformed_rebuild.py
+++ b/tests/state/test_legacy_fts_malformed_rebuild.py
@@ -159,3 +159,102 @@ class TestLegacyFtsMalformedRebuild:
             assert SessionDB._is_malformed_fts_index_error(exc) is False
         for exc in (malformed, disk_image):
             assert SessionDB._is_malformed_fts_index_error(exc) is True
+
+    def test_corrupt_structure_record_variant_classified_as_corruption(self):
+        """A really-corrupt index can fail with 'fts5: corrupt structure
+        record', which none of the historical message-string markers matched.
+        The class-based split must classify it as corruption (verified against
+        a live corrupt index during the #86183 review round); the previous
+        string classifier would have re-raised it on every open instead."""
+        variant = sqlite3.DatabaseError("fts5: corrupt structure record")
+        assert SessionDB._is_malformed_fts_index_error(variant) is True
+
+    def test_failed_fallback_leaves_stale_breadcrumb(self, tmp_path):
+        """When the drop/recreate recovery itself cannot complete, the open
+        must not fail and must not leave a silently-empty index: it persists
+        the fts_stale breadcrumb, detaches FTS (triggers down, same ordering
+        contract as the deferred rebuild branch), and the next open routes
+        through _recover_stale_fts for the full recovery."""
+        db_path = tmp_path / "state.db"
+        _create_legacy_db(db_path)
+        _corrupt_base_fts(db_path)
+
+        # Make only the recovery script fail mid-flight: patch the DDL for
+        # the duration of the rebuild call (not the earlier _ensure_fts_schema
+        # pass), appending a statement after the CREATE that references a
+        # nonexistent table. The rollback in the failure path then undoes the
+        # script's DROP/CREATE.
+        import hermes_state_schema
+
+        original_rebuild = SessionDB._rebuild_fts_indexes
+        original_ddl = hermes_state_schema.LEGACY_FTS_SQL
+
+        def _flaky_rebuild(self, cursor, *, legacy=False, include_trigram=True):
+            hermes_state_schema.LEGACY_FTS_SQL = (
+                original_ddl + "\nINSERT INTO no_such_recovery_table VALUES (1);"
+            )
+            try:
+                return original_rebuild(self, cursor, legacy=legacy, include_trigram=include_trigram)
+            finally:
+                hermes_state_schema.LEGACY_FTS_SQL = original_ddl
+
+        SessionDB._rebuild_fts_indexes = _flaky_rebuild
+        db = SessionDB(db_path=db_path)
+        try:
+            breadcrumb = db._conn.execute(
+                "SELECT value FROM state_meta WHERE key = 'fts_stale'"
+            ).fetchone()
+            assert breadcrumb is not None, "fts_stale breadcrumb must persist"
+            assert db._fts_stale is True
+            assert db._fts_enabled is False
+            trigger_count = db._conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='trigger' "
+                "AND name LIKE 'messages_ai%'"
+            ).fetchone()[0]
+            assert trigger_count == 0, "triggers must be down over an unrebuilt gap"
+        finally:
+            db.close()
+            SessionDB._rebuild_fts_indexes = original_rebuild
+
+        # With the recovery DDL restored, the next open performs the full
+        # recovery and clears the breadcrumb.
+        db2 = SessionDB(db_path=db_path)
+        try:
+            assert db2._fts_enabled is True
+            breadcrumb = db2._conn.execute(
+                "SELECT value FROM state_meta WHERE key = 'fts_stale'"
+            ).fetchone()
+            assert breadcrumb is None, "breadcrumb must clear after recovery"
+            matches = db2._conn.execute(
+                "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'keyword'"
+            ).fetchone()[0]
+            assert matches == 10
+        finally:
+            db2.close()
+
+    def test_engine_stamp_includes_capability_signature(self, tmp_path, monkeypatch):
+        """The engine stamp is an engine+capability pair: a host whose probes
+        return None (e.g. missing tokenizer extensions) appends
+        |missing=<tables>, so a later capable host sees a signature mismatch
+        and re-runs its own sweep instead of trusting the incapable host's
+        stamp (#86183)."""
+        db_path = tmp_path / "state.db"
+        _create_legacy_db(db_path)
+        db = SessionDB(db_path=db_path)
+        try:
+            original = SessionDB._fts_table_probe
+
+            def _incapable(self, cursor, table_name):
+                if table_name in ("messages_fts_trigram", "messages_fts_cjk"):
+                    return None
+                return original(self, cursor, table_name)
+
+            monkeypatch.setattr(SessionDB, "_fts_table_probe", _incapable)
+            cursor = db._conn.cursor()
+            stamp = db._fts_integrity_engine_id(cursor)
+            assert stamp.startswith("fts5:")
+            assert stamp.endswith(
+                "|missing=messages_fts_cjk,messages_fts_trigram"
+            ), stamp
+        finally:
+            db.close()

--- a/tests/state/test_legacy_fts_malformed_rebuild.py
+++ b/tests/state/test_legacy_fts_malformed_rebuild.py
@@ -116,6 +116,33 @@ class TestLegacyFtsMalformedRebuild:
         finally:
             db.close()
 
+    def test_integrity_probe_runs_once_per_sqlite_engine(self, tmp_path):
+        """A healthy legacy DB must not rerun FTS integrity-check on every open."""
+        db_path = tmp_path / "state.db"
+        _create_legacy_db(db_path)
+        calls = {"n": 0}
+        original = SessionDB._legacy_fts_index_corrupt
+
+        def _counting(self, cursor, *, include_trigram):
+            calls["n"] += 1
+            return original(self, cursor, include_trigram=include_trigram)
+
+        SessionDB._legacy_fts_index_corrupt = _counting
+        try:
+            first = SessionDB(db_path=db_path)
+            first.close()
+            assert calls["n"] == 1
+            marker = sqlite3.connect(str(db_path)).execute(
+                "SELECT value FROM state_meta WHERE key = 'fts_integrity_engine'"
+            ).fetchone()
+            assert marker and str(marker[0]).startswith("fts5:")
+
+            second = SessionDB(db_path=db_path)
+            second.close()
+            assert calls["n"] == 1
+        finally:
+            SessionDB._legacy_fts_index_corrupt = original
+
     def test_non_malformed_error_is_not_classified_as_corruption(self):
         """Only the malformed-index class justifies a destructive rebuild; a
         transient lock/busy/IO DatabaseError must fall through to the caller's

--- a/tests/state/test_legacy_fts_malformed_rebuild.py
+++ b/tests/state/test_legacy_fts_malformed_rebuild.py
@@ -1,0 +1,124 @@
+"""Regression test for legacy inline FTS rebuild on malformed index error (#86027).
+
+SQLite 3.53+ reports 'malformed inverted index for FTS5 table main.messages_fts_trigram'
+or 'database disk image is malformed' on DELETE FROM an existing legacy inline
+FTS5 table created under an older SQLite version (e.g. 3.46.1).
+
+SessionDB._rebuild_fts_indexes (legacy mode) must catch this error, drop the corrupt virtual
+table and triggers, recreate the schema, and repopulate cleanly from canonical messages.
+"""
+
+import sqlite3
+import pytest
+
+from hermes_state import (
+    LEGACY_FTS_SQL,
+    LEGACY_FTS_TRIGRAM_SQL,
+    SCHEMA_SQL,
+    SessionDB,
+)
+
+
+def _create_legacy_db(db_path):
+    """Create a database with legacy inline FTS5 schema."""
+    conn = sqlite3.connect(str(db_path))
+    # Base tables from schema
+    conn.executescript(SCHEMA_SQL)
+    # Legacy inline FTS
+    conn.executescript(LEGACY_FTS_SQL)
+    conn.executescript(LEGACY_FTS_TRIGRAM_SQL)
+    conn.execute(
+        "INSERT INTO sessions(id, title, started_at, source) VALUES('sess-1', 'Test', 1000.0, 'cli')"
+    )
+    for i in range(1, 11):
+        conn.execute(
+            "INSERT INTO messages(id, session_id, role, content, tool_name, tool_calls, timestamp) "
+            "VALUES(?, 'sess-1', 'user', ?, NULL, NULL, ?)",
+            (i, f"Message content {i} with searchable keyword", 1000.0 + i),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _corrupt_trigram_fts(db_path):
+    """Corrupt the trigram FTS shadow table to simulate malformed inverted index."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "UPDATE messages_fts_trigram_data "
+        "SET block = X'DEADBEEFDEADBEEFDEADBEEFDEADBEEF'"
+    )
+    conn.commit()
+    conn.close()
+
+
+def _corrupt_base_fts(db_path):
+    """Corrupt the base FTS shadow table to simulate malformed inverted index."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "UPDATE messages_fts_data "
+        "SET block = X'DEADBEEFDEADBEEFDEADBEEFDEADBEEF'"
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestLegacyFtsMalformedRebuild:
+    def test_rebuild_legacy_fts_indexes_recovers_from_corrupt_trigram(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        _create_legacy_db(db_path)
+        _corrupt_trigram_fts(db_path)
+
+        # Verify that DELETE FROM messages_fts_trigram fails on the corrupt table
+        conn = sqlite3.connect(str(db_path))
+        with pytest.raises(sqlite3.DatabaseError):
+            conn.execute("DELETE FROM messages_fts_trigram")
+        conn.close()
+
+        # Rebuild using SessionDB._rebuild_fts_indexes (legacy mode)
+        conn = sqlite3.connect(str(db_path))
+        cursor = conn.cursor()
+        SessionDB._rebuild_fts_indexes(cursor, legacy=True, include_trigram=True)
+        conn.commit()
+
+        # Verify index is healthy and populated
+        quick_check = [r[0] for r in conn.execute("PRAGMA quick_check").fetchall()]
+        assert quick_check == ["ok"]
+
+        # Verify search queries work
+        matches = conn.execute(
+            "SELECT COUNT(*) FROM messages_fts_trigram WHERE messages_fts_trigram MATCH 'keyword'"
+        ).fetchone()[0]
+        assert matches == 10
+
+        base_matches = conn.execute(
+            "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'keyword'"
+        ).fetchone()[0]
+        assert base_matches == 10
+        conn.close()
+
+    def test_rebuild_legacy_fts_indexes_recovers_from_corrupt_base_fts(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        _create_legacy_db(db_path)
+        _corrupt_base_fts(db_path)
+
+        # Verify that DELETE FROM messages_fts fails on the corrupt table
+        conn = sqlite3.connect(str(db_path))
+        with pytest.raises(sqlite3.DatabaseError):
+            conn.execute("DELETE FROM messages_fts")
+        conn.close()
+
+        # Rebuild using SessionDB._rebuild_fts_indexes (legacy mode)
+        conn = sqlite3.connect(str(db_path))
+        cursor = conn.cursor()
+        SessionDB._rebuild_fts_indexes(cursor, legacy=True, include_trigram=True)
+        conn.commit()
+
+        # Verify index is healthy and populated
+        quick_check = [r[0] for r in conn.execute("PRAGMA quick_check").fetchall()]
+        assert quick_check == ["ok"]
+
+        base_matches = conn.execute(
+            "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'keyword'"
+        ).fetchone()[0]
+        assert base_matches == 10
+        conn.close()

--- a/tests/state/test_legacy_fts_malformed_rebuild.py
+++ b/tests/state/test_legacy_fts_malformed_rebuild.py
@@ -127,7 +127,7 @@ class TestLegacyFtsMalformedRebuild:
         calls = {"n": 0}
         original = SessionDB._legacy_fts_index_corrupt
 
-        def _counting(self, cursor: sqlite3.Cursor, *, include_trigram: bool) -> bool:
+        def _counting(self: SessionDB, cursor: sqlite3.Cursor, *, include_trigram: bool) -> bool:
             calls["n"] += 1
             return original(self, cursor, include_trigram=include_trigram)
 


### PR DESCRIPTION
## What does this PR do?

When the SQLite FTS trigram index is malformed (e.g. from a legacy schema), the rebuild previously failed. This PR:

1. Detects malformed legacy FTS indexes during rebuild and recovers by dropping+recreating
2. Narrows recovery to malformed-index errors only (classified by SQLite result code)
3. Heals on open via an integrity-check probe in `_init_fts` (once per SQLite engine)
4. Persists `fts_stale` breadcrumb and detaches FTS on failed recovery
5. Adds capability stamp to engine stamp

## Related Issue

Fixes #86027

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_state_schema.py`: Malformed FTS index recovery, narrowed error classification, engine-scoped integrity probe, stale breadcrumb, capability stamp.
- `tests/state/test_legacy_fts_malformed_rebuild.py`: Tests updated to use HEAD's `_rebuild_fts_indexes` API.

## How to Test

1. `scripts/run_tests.sh tests/state/test_legacy_fts_malformed_rebuild.py` — FTS recovery tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing