### PR TITLE
fix(relaunch): preserve active venv for source launches

### DIFF
--- a/hermes_cli/relaunch.py
+++ b/hermes_cli/relaunch.py
@@ -11,6 +11,7 @@ Also works when ``hermes`` is not on PATH (e.g. ``nix run`` or ``python -m``).
 import os
 import shutil
 import sys
+from pathlib import Path
 from typing import Optional, Sequence
 
 from hermes_cli._parser import (
@@ -101,13 +102,28 @@ def resolve_hermes_bin() -> Optional[str]:
     def _is_python_script(p: str) -> bool:
         return p.lower().endswith((".py", ".pyc"))
 
+    # The repository's top-level ``hermes`` is a source launcher whose shebang
+    # selects ``python3`` from PATH. It is often invoked *through* a venv
+    # interpreter (for example by the Desktop backend); relaunching that source
+    # file directly would drop the venv and can select a system Python instead.
+    source_launcher = (Path(__file__).resolve().parent.parent / "hermes").resolve()
+    try:
+        argv0_is_source_launcher = Path(argv0).resolve() == source_launcher
+    except OSError:
+        argv0_is_source_launcher = False
+
     # Absolute path to an executable (covers nix store, venv wrappers, etc.)
-    if os.path.isabs(argv0) and os.path.isfile(argv0) and os.access(argv0, os.X_OK):
+    if (
+        not argv0_is_source_launcher
+        and os.path.isabs(argv0)
+        and os.path.isfile(argv0)
+        and os.access(argv0, os.X_OK)
+    ):
         if not (_is_windows and _is_python_script(argv0)):
             return argv0
 
     # Relative path — resolve against CWD
-    if not argv0.startswith("-") and os.path.isfile(argv0):
+    if not argv0_is_source_launcher and not argv0.startswith("-") and os.path.isfile(argv0):
         abs_path = os.path.abspath(argv0)
         if os.access(abs_path, os.X_OK):
             if not (_is_windows and _is_python_script(abs_path)):

--- a/tests/hermes_cli/test_relaunch.py
+++ b/tests/hermes_cli/test_relaunch.py
@@ -1,6 +1,8 @@
 """Tests for hermes_cli.relaunch — unified self-relaunch utility."""
 
+import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -31,6 +33,20 @@ class TestResolveHermesBin:
             relaunch_mod.shutil, "which", lambda name: "/usr/bin/hermes" if name == "hermes" else None
         )
         assert relaunch_mod.resolve_hermes_bin() == "/usr/bin/hermes"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX source launcher only")
+    def test_rejects_checked_in_source_launcher_without_path_entry(self, monkeypatch):
+        """A direct source launcher would re-run via its PATH-selected shebang.
+
+        When a Desktop backend starts ``venv/bin/python <repo>/hermes``,
+        ``sys.argv[0]`` names this executable source file.  Reusing it during
+        ``/update`` loses the active venv and can select a system Python.
+        """
+        source_launcher = Path(relaunch_mod.__file__).resolve().parent.parent / "hermes"
+        monkeypatch.setattr(sys, "argv", [str(source_launcher), "update"])
+        monkeypatch.setattr(relaunch_mod.shutil, "which", lambda _name: None)
+
+        assert relaunch_mod.resolve_hermes_bin() is None
 
 
 class TestExtractInheritedFlags:


### PR DESCRIPTION
## Summary
- avoid re-executing the checked-in source launcher during self-relaunch
- fall back to the active interpreter module invocation when no safe `hermes` executable is on `PATH`
- add a POSIX regression test covering Desktop-style source launches

## Reproduction
When a Desktop backend starts `venv/bin/python <repo>/hermes`, `/update` previously re-executed `<repo>/hermes`. Its `#!/usr/bin/env python3` shebang could then select the system Python from a minimal launchd PATH, losing the Hermes venv and failing on dependencies such as PyYAML.

## Test plan
- `uv run pytest tests/hermes_cli/test_relaunch.py -q`