### PR TITLE
fix(gateway): preserve reasoning budget guidance

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3694,7 +3694,19 @@ def _normalize_empty_agent_response(
             return ""
         if agent_result.get("partial"):
             err = agent_result.get("error", "processing incomplete")
-            return f"⚠️ Processing stopped: {str(err)[:200]}. Try again."
+            err_text = str(err)
+            if (
+                "used all output tokens on reasoning" in err_text.lower()
+                and "none left" in err_text.lower()
+            ):
+                return (
+                    "⚠️ **Thinking Budget Exhausted**\n\n"
+                    "The model used its output budget on reasoning and produced "
+                    "no visible answer.\n\n"
+                    "Try `/thinkon low` or `/thinkon minimal`, then send the "
+                    "request again."
+                )
+            return f"⚠️ Processing stopped: {err_text[:200]}. Try again."
         return (
             "⚠️ Processing completed but no response was generated. "
             "This may be a transient error — try sending your message again."

--- a/tests/gateway/test_run_progress_interrupt.py
+++ b/tests/gateway/test_run_progress_interrupt.py
@@ -219,6 +219,34 @@ async def test_partial_empty_agent_response_is_normalized(monkeypatch, tmp_path)
 
 
 @pytest.mark.asyncio
+async def test_reasoning_budget_exhaustion_is_not_wrapped_as_generic_processing_stopped(
+    monkeypatch, tmp_path,
+):
+    class ReasoningExhaustionAgent(PartialTruncationAgent):
+        def run_conversation(self, message, conversation_history=None, task_id=None):
+            return {
+                "final_response": None,
+                "messages": [],
+                "api_calls": 1,
+                "completed": False,
+                "partial": True,
+                "error": (
+                    "Model used all output tokens on reasoning with none left "
+                    "for the response."
+                ),
+            }
+
+    adapter, result = await _run_once(
+        monkeypatch, tmp_path, ReasoningExhaustionAgent, "sess-reasoning-exhausted"
+    )
+
+    assert result["final_response"].startswith("⚠️ **Thinking Budget Exhausted**")
+    assert "Processing stopped" not in result["final_response"]
+    assert "/thinkon" in result["final_response"]
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
 async def test_progress_suppressed_when_agent_is_interrupted(monkeypatch, tmp_path):
     """Post-interrupt tool.started events must not render as bubbles.
 


### PR DESCRIPTION
## Summary
- preserve the actionable thinking-budget-exhaustion diagnosis when an agent returns a partial result
- stop the gateway from replacing it with the generic `Processing stopped` wrapper
- retain existing generic handling for every other partial error

## Root cause
The conversation loop can correctly diagnose a reasoning-only output exhaustion and return an error such as:

`Model used all output tokens on reasoning with none left for the response.`

The gateway's result normalizer treated every partial response identically and rewrote that diagnosis to `⚠️ Processing stopped: ... Try again.` This hid the available recovery action (`/thinkon low` or `/thinkon minimal`) on every messaging platform.

## Tests
- `PYTHONPATH=. python -m pytest -q tests/gateway/test_run_progress_interrupt.py` — 4 passed
- `ruff check gateway/run.py tests/gateway/test_run_progress_interrupt.py`
- `git diff --check`

## Related
Complements #60126, which expands core detection to structured reasoning fields. This gateway fix is independently valid for the existing inline-`<think>` exhaustion path as well.
