### PR TITLE
feat(session_search): add after/before SQL bounds and exclude_session_ids

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1333,6 +1333,21 @@ class SessionSearchMixin:
         ]
         return bool(tokens) and all(len(t) >= 3 for t in tokens)
 
+    @staticmethod
+    def _append_started_at_bounds(
+        where: List[str],
+        params: list,
+        after_ts: Optional[int] = None,
+        before_ts: Optional[int] = None,
+    ) -> None:
+        """Add session-start bounds to a query that already joins ``sessions s``."""
+        if after_ts is not None:
+            where.append("s.started_at >= ?")
+            params.append(int(after_ts))
+        if before_ts is not None:
+            where.append("s.started_at < ?")
+            params.append(int(before_ts))
+
     def _run_trigram_search(
         self,
         raw_query: str,
@@ -1343,6 +1358,8 @@ class SessionSearchMixin:
         source_filter: List[str] = None,
         exclude_sources: List[str] = None,
         role_filter: List[str] = None,
+        after_ts: Optional[int] = None,
+        before_ts: Optional[int] = None,
         limit: int = 20,
         offset: int = 0,
     ) -> Optional[List[Dict[str, Any]]]:
@@ -1384,6 +1401,7 @@ class SessionSearchMixin:
         if role_filter:
             tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
             tri_params.extend(role_filter)
+        self._append_started_at_bounds(tri_where, tri_params, after_ts, before_ts)
         tri_sql = f"""
             SELECT
                 m.id,
@@ -1423,6 +1441,8 @@ class SessionSearchMixin:
         sort: str = None,
         include_inactive: bool = False,
         fields: Optional[Collection[str]] = None,
+        after_ts: Optional[int] = None,
+        before_ts: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """Instrumented wrapper around :meth:`_search_messages_impl`.
 
@@ -1445,6 +1465,8 @@ class SessionSearchMixin:
                 sort=sort,
                 include_inactive=include_inactive,
                 fields=fields,
+                after_ts=after_ts,
+                before_ts=before_ts,
             )
             return rows
         finally:
@@ -1550,6 +1572,8 @@ class SessionSearchMixin:
         source_filter: Optional[List[str]],
         exclude_sources: Optional[List[str]],
         role_filter: Optional[List[str]],
+        after_ts: Optional[int] = None,
+        before_ts: Optional[int] = None,
         limit: int,
         offset: int,
         sort: Optional[str],
@@ -1574,6 +1598,7 @@ class SessionSearchMixin:
         if role_filter:
             where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
             params.extend(role_filter)
+        self._append_started_at_bounds(where, params, after_ts, before_ts)
 
         order = (
             "ASC"
@@ -1712,6 +1737,8 @@ class SessionSearchMixin:
         sort: str = None,
         include_inactive: bool = False,
         fields: Optional[Collection[str]] = None,
+        after_ts: Optional[int] = None,
+        before_ts: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -1760,6 +1787,8 @@ class SessionSearchMixin:
                 source_filter=source_filter,
                 exclude_sources=exclude_sources,
                 role_filter=role_filter,
+                after_ts=after_ts,
+                before_ts=before_ts,
                 limit=limit,
                 offset=offset,
                 sort=sort,
@@ -1813,6 +1842,7 @@ class SessionSearchMixin:
             role_placeholders = ",".join("?" for _ in role_filter)
             where_clauses.append(f"m.role IN ({role_placeholders})")
             params.extend(role_filter)
+        self._append_started_at_bounds(where_clauses, params, after_ts, before_ts)
 
         where_sql = " AND ".join(where_clauses)
         params.extend([limit, offset])
@@ -1907,6 +1937,7 @@ class SessionSearchMixin:
                 if role_filter:
                     cjk_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     cjk_params.extend(role_filter)
+                self._append_started_at_bounds(cjk_where, cjk_params, after_ts, before_ts)
                 cjk_sql = f"""
                     SELECT
                         m.id,
@@ -1996,6 +2027,7 @@ class SessionSearchMixin:
                 if role_filter:
                     tri_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     tri_params.extend(role_filter)
+                self._append_started_at_bounds(tri_where, tri_params, after_ts, before_ts)
                 tri_sql = f"""
                     SELECT
                         m.id,
@@ -2090,6 +2122,7 @@ class SessionSearchMixin:
                 if role_filter:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)
+                self._append_started_at_bounds(like_where, like_params, after_ts, before_ts)
                 like_sql = f"""
                     SELECT m.id, m.session_id, m.role,
                            substr(m.content,
@@ -2149,6 +2182,8 @@ class SessionSearchMixin:
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
                     role_filter=role_filter,
+                    after_ts=after_ts,
+                    before_ts=before_ts,
                 )
                 seen_ids = {m["id"] for m in matches}
                 matches.extend(m for m in gap_matches if m["id"] not in seen_ids)
@@ -2187,6 +2222,8 @@ class SessionSearchMixin:
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
                     role_filter=role_filter,
+                    after_ts=after_ts,
+                    before_ts=before_ts,
                     limit=limit,
                     offset=offset,
                 )
@@ -2204,6 +2241,8 @@ class SessionSearchMixin:
                     source_filter=source_filter,
                     exclude_sources=exclude_sources,
                     role_filter=role_filter,
+                    after_ts=after_ts,
+                    before_ts=before_ts,
                     limit=limit,
                     offset=offset,
                 )
@@ -2221,6 +2260,8 @@ class SessionSearchMixin:
         source_filter: Optional[List[str]] = None,
         exclude_sources: Optional[List[str]] = None,
         role_filter: Optional[List[str]] = None,
+        after_ts: Optional[int] = None,
+        before_ts: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """LIKE-scan the rows the deferred rebuild hasn't indexed yet.
 
@@ -2266,6 +2307,7 @@ class SessionSearchMixin:
         if role_filter:
             where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
             params.extend(role_filter)
+        self._append_started_at_bounds(where, params, after_ts, before_ts)
 
         sql = f"""
             SELECT m.id, m.session_id, m.role,

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -885,6 +885,50 @@ class TestDiscoveryTemporalNarrowing:
         ))
         assert result["success"] is False
 
+    def test_window_finds_in_range_session_buried_by_fts_limit(self, db, monkeypatch):
+        """A June hit must survive even if FTS rank would fill the scan with August.
+
+        Teknium's ticket wants the bound in the search query (WHERE), not a
+        post-filter of the already-truncated FTS top-N.
+        """
+        monkeypatch.setattr(
+            "tools.session_search_tool._DISCOVER_SCAN_LIMIT", 2
+        )
+        august = _unix(2026, 8, 10)
+        for i in range(4):
+            sid = f"s_aug_{i}"
+            db.create_session(sid, source="cli")
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+                (august, f"August {i}", sid),
+            )
+            db.append_message(
+                sid, role="user", content="modpack modpack modpack modpack"
+            )
+            db.append_message(
+                sid, role="assistant", content=("modpack details " * 20)
+            )
+        db.create_session("s_june", source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+            (_unix(2026, 6, 15), "June quiet", "s_june"),
+        )
+        db.append_message("s_june", role="user", content="modpack")
+        db.append_message("s_june", role="assistant", content="ok")
+        db._conn.commit()
+
+        result = json.loads(session_search(
+            query="modpack",
+            limit=5,
+            after="2026-06-01",
+            before="2026-07-01",
+            db=db,
+        ))
+        assert result["success"] is True
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_june" in sids
+        assert all(not sid.startswith("s_aug_") for sid in sids)
+
 
 class TestDiscoverySessionExclusion:
     def test_exclude_session_ids_drops_named_session(self, db):

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -9,6 +9,7 @@ All run zero LLM calls.
 """
 import json
 import time
+from datetime import datetime, timezone
 
 import pytest
 
@@ -823,3 +824,106 @@ class TestLegacyContinuationPlusDelegation:
 
         # Delegation child must NOT appear
         assert "s_delegate" not in sids
+
+
+def _unix(year, month, day):
+    return int(datetime(year, month, day, tzinfo=timezone.utc).timestamp())
+
+
+class TestDiscoveryTemporalNarrowing:
+    def test_schema_exposes_after_before_and_exclude(self):
+        params = SESSION_SEARCH_SCHEMA["parameters"]["properties"]
+        assert "after" in params
+        assert "before" in params
+        assert "exclude_session_ids" in params
+        assert params["exclude_session_ids"]["type"] == "array"
+
+    def test_after_before_keep_only_sessions_inside_the_interval(self, db):
+        _seed_modpack_sessions(db)
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (_unix(2026, 6, 15), "s_oldest"),
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (_unix(2026, 7, 15), "s_middle"),
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (_unix(2026, 8, 10), "s_newest"),
+        )
+        db._conn.commit()
+
+        result = json.loads(session_search(
+            query="modpack",
+            limit=5,
+            after="2026-06-01",
+            before="2026-07-01",
+            db=db,
+        ))
+        assert result["success"] is True
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_oldest" in sids
+        assert "s_middle" not in sids
+        assert "s_newest" not in sids
+
+    def test_missing_bounds_leave_existing_discovery_unchanged(self, db):
+        _seed_modpack_sessions(db)
+        unbounded = json.loads(session_search(query="modpack", limit=5, db=db))
+        bounded = json.loads(session_search(
+            query="modpack", limit=5, after=None, before=None, db=db,
+        ))
+        assert unbounded["success"] is True
+        assert {r["session_id"] for r in unbounded["results"]} == {
+            r["session_id"] for r in bounded["results"]
+        }
+
+    def test_invalid_after_returns_error(self, db):
+        _seed_modpack_sessions(db)
+        result = json.loads(session_search(
+            query="modpack", after="not-a-date", db=db,
+        ))
+        assert result["success"] is False
+
+
+class TestDiscoverySessionExclusion:
+    def test_exclude_session_ids_drops_named_session(self, db):
+        _seed_modpack_sessions(db)
+        result = json.loads(session_search(
+            query="modpack",
+            limit=5,
+            exclude_session_ids=["s_newest"],
+            db=db,
+        ))
+        assert result["success"] is True
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_newest" not in sids
+        assert "s_middle" in sids or "s_oldest" in sids
+
+    def test_exclude_session_ids_drops_whole_lineage(self, db):
+        db.create_session("s_root", source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+            (_unix(2026, 6, 1), "Lineage Root", "s_root"),
+        )
+        db.append_message("s_root", role="user", content="unique lineage token alpha")
+        db.append_message("s_root", role="assistant", content="noted unique lineage token alpha")
+
+        db.create_session("s_child", source="cli", parent_session_id="s_root")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+            (_unix(2026, 6, 2), "Lineage Child", "s_child"),
+        )
+        db.append_message("s_child", role="user", content="follow-up unique lineage token alpha")
+        db.append_message("s_child", role="assistant", content="child unique lineage token alpha")
+        db._conn.commit()
+
+        excluded = json.loads(session_search(
+            query="unique lineage token alpha",
+            limit=5,
+            exclude_session_ids=["s_child"],
+            db=db,
+        ))
+        sids = [r["session_id"] for r in excluded["results"]]
+        assert "s_child" not in sids
+        assert "s_root" not in sids

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -31,6 +31,7 @@ support.
 
 import json
 import logging
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Union
 
 # Sources that are excluded from session browsing/searching by default.
@@ -54,6 +55,7 @@ _DEMOTED_SESSION_SOURCES = ("cron",)
 # interactive matches buried under a wall of cron hits, so this is well above
 # the handful of distinct sessions a typical query returns.
 _DISCOVER_SCAN_LIMIT = 300
+_EXCLUDE_SESSION_IDS_CAP = 20
 
 # Raw FTS rows are only a discovery-plan input. The final response hydrates
 # its own anchored message window and bookends after lineage deduplication.
@@ -149,6 +151,104 @@ def _resolve_to_parent(db, session_id: str) -> tuple[str, bool]:
 def _resolve_lineage(db, session_id: str) -> str:
     """Convenience: return only the lineage root (ignores compression hop)."""
     return _resolve_to_parent(db, session_id)[0]
+
+
+def _parse_iso_bound(value: Optional[str], *, as_exclusive_end: bool = False) -> Optional[int]:
+    """Parse an ISO date/datetime into a UTC unix timestamp.
+
+    A date-only value (``YYYY-MM-DD``) is midnight UTC on that day. When
+    ``as_exclusive_end`` is True, that midnight is the exclusive upper bound
+    (``before=2026-07-01`` keeps June, drops July 1 00:00).
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    normalized = text.replace("Z", "+00:00")
+    parsed: Optional[datetime] = None
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        parsed = None
+    if parsed is None:
+        raise ValueError(f"invalid ISO timestamp: {value!r}")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    if as_exclusive_end and len(text) == 10 and text[4] == "-" and text[7] == "-":
+        return int(parsed.timestamp())
+    return int(parsed.timestamp())
+
+
+def _coerce_started_ts(value: Any) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return int(float(text))
+    except (TypeError, ValueError):
+        pass
+    try:
+        return _parse_iso_bound(text)
+    except ValueError:
+        return None
+
+
+def _in_time_window(
+    started_ts: Optional[int],
+    after_ts: Optional[int],
+    before_ts: Optional[int],
+) -> bool:
+    if after_ts is None and before_ts is None:
+        return True
+    if started_ts is None:
+        return False
+    if after_ts is not None and started_ts < after_ts:
+        return False
+    if before_ts is not None and started_ts >= before_ts:
+        return False
+    return True
+
+
+def _normalize_exclude_session_ids(raw: Any) -> List[str]:
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        items = [raw]
+    elif isinstance(raw, (list, tuple)):
+        items = list(raw)
+    else:
+        return []
+    out: List[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if not isinstance(item, str):
+            continue
+        sid = item.strip()
+        if not sid or sid in seen:
+            continue
+        seen.add(sid)
+        out.append(sid)
+        if len(out) >= _EXCLUDE_SESSION_IDS_CAP:
+            break
+    return out
+
+
+def _excluded_lineage_roots(db, exclude_session_ids: List[str]) -> set[str]:
+    roots: set[str] = set()
+    for sid in exclude_session_ids:
+        roots.add(sid)
+        try:
+            roots.add(_resolve_lineage(db, sid) or sid)
+        except Exception:
+            roots.add(sid)
+    return roots
 
 
 def _is_compression_ended(db, session_id: str) -> bool:
@@ -695,11 +795,30 @@ def _discover(
     sort: Optional[str],
     current_session_id: str = None,
     link_profile: str = None,
+    after_ts: Optional[int] = None,
+    before_ts: Optional[int] = None,
+    exclude_session_ids: Optional[List[str]] = None,
 ) -> str:
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
+    excluded_roots = _excluded_lineage_roots(db, exclude_session_ids or [])
     title_result = _title_match_result(db, query, current_lineage_root)
+    if title_result:
+        title_sid = title_result.get("session_id")
+        title_root = title_result.get("_lineage_root") or title_sid
+        title_meta = {}
+        try:
+            title_meta = db.get_session(title_root) or db.get_session(title_sid) or {}
+        except Exception:
+            title_meta = {}
+        title_started = _coerce_started_ts(title_meta.get("started_at"))
+        if (
+            title_root in excluded_roots
+            or title_sid in excluded_roots
+            or not _in_time_window(title_started, after_ts, before_ts)
+        ):
+            title_result = None
 
     try:
         raw_results = db.search_messages(
@@ -752,6 +871,17 @@ def _discover(
             break
         raw_sid = r["session_id"]
         resolved_sid, _ = _resolve_to_parent(db, raw_sid)
+        if raw_sid in excluded_roots or resolved_sid in excluded_roots:
+            continue
+        started_ts = _coerce_started_ts(r.get("session_started"))
+        if started_ts is None:
+            try:
+                meta = db.get_session(raw_sid) or {}
+                started_ts = _coerce_started_ts(meta.get("started_at"))
+            except Exception:
+                started_ts = None
+        if not _in_time_window(started_ts, after_ts, before_ts):
+            continue
         # Skip the current session lineage — UNLESS the content has been
         # compression-summarised out of the live context (memory black hole
         # after compression). Two sub-cases:
@@ -857,6 +987,9 @@ def session_search(
     window: int = 5,
     # Discovery shape
     sort: str = None,
+    after: str = None,
+    before: str = None,
+    exclude_session_ids: Optional[List[str]] = None,
     # Cross-profile (any shape)
     profile: str = None,
 ) -> str:
@@ -959,6 +1092,12 @@ def session_search(
         if candidate in ("newest", "oldest"):
             sort_norm = candidate
 
+    try:
+        after_ts = _parse_iso_bound(after)
+        before_ts = _parse_iso_bound(before, as_exclusive_end=True)
+    except ValueError as e:
+        return tool_error(str(e), success=False)
+
     return _discover(
         db=db,
         query=query.strip(),
@@ -967,6 +1106,9 @@ def session_search(
         sort=sort_norm,
         current_session_id=current_session_id,
         link_profile=profile,
+        after_ts=after_ts,
+        before_ts=before_ts,
+        exclude_session_ids=_normalize_exclude_session_ids(exclude_session_ids),
     )
 
 
@@ -1088,6 +1230,32 @@ SESSION_SEARCH_SCHEMA = {
                     "and browse shapes."
                 ),
             },
+            "after": {
+                "type": "string",
+                "description": (
+                    "Discovery shape only. Inclusive lower bound on session start "
+                    "time (ISO date or datetime, e.g. 2026-06-01). Use only when the "
+                    "user names a time frame. sort is a ranking bias, not a bound."
+                ),
+            },
+            "before": {
+                "type": "string",
+                "description": (
+                    "Discovery shape only. Exclusive upper bound on session start "
+                    "time (ISO date or datetime, e.g. 2026-07-01). A date-only value "
+                    "is midnight UTC that day. Use only when the user names a time "
+                    "frame."
+                ),
+            },
+            "exclude_session_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Discovery shape only. Session ids already inspected this task. "
+                    "Those sessions and their lineage are omitted so a later query "
+                    "explores instead of repeating the same hit. Cap 20."
+                ),
+            },
             "session_id": {
                 "type": "string",
                 "description": (
@@ -1152,6 +1320,9 @@ registry.register(
         around_message_id=args.get("around_message_id"),
         window=args.get("window", 5),
         sort=args.get("sort"),
+        after=args.get("after"),
+        before=args.get("before"),
+        exclude_session_ids=args.get("exclude_session_ids"),
         profile=args.get("profile"),
         db=kw.get("db"),
         current_session_id=kw.get("current_session_id"),

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -831,6 +831,8 @@ def _discover(
             offset=0,
             sort=sort,
             fields=_DISCOVER_SEARCH_FIELDS,
+            after_ts=after_ts,
+            before_ts=before_ts,
         )
     except Exception as e:
         logging.error("FTS5 search failed: %s", e, exc_info=True)


### PR DESCRIPTION
## Summary

- Add optional `after` / `before` ISO bounds on `session_search` discovery.
- Apply those bounds in SQL (`s.started_at >= ? AND s.started_at < ?`) inside `search_messages`, so FTS `LIMIT` cannot be filled by out-of-range sessions.
- Add optional `exclude_session_ids` (cap 20, lineage-aware).
- `sort=newest|oldest` stays a ranking bias. Scroll / read / browse unchanged.

## Motivation

Closes #86021 (ReFind controls from arXiv:2608.12888).

Teknium asked to filter on the session timestamp **in the existing query**. A Python post-filter after FTS top-N is not enough: if August fills the scan, June never appears. The second commit puts the bound in `WHERE` on every search path (FTS5, CJK, trigram, LIKE, unindexed gap).

This is **not** #13058. That PR dumps messages inside a time window. This PR only decides *which sessions* appear in discovery.

## Changes

- `tools/session_search_tool.py` — schema + discovery wiring
- `hermes_state_search.py` — `_append_started_at_bounds` on all `search_messages` routes
- `tests/tools/test_session_search.py`
  - interval keeps June, drops July/August
  - FTS-limit burial: June still found when August would saturate scan=2
  - invalid `after` errors
  - exclude id + lineage

## Test Plan

- [x] `uv run python -m pytest tests/tools/test_session_search.py -q -o addopts=` → 46 passed
- [x] Burial test failed before SQL WHERE (`s_june in []`), passes after
- [x] Sabotage of `_append_started_at_bounds` fails that test; restore passes
- [x] `ruff check` clean on the three files
- [ ] CI on GitHub

## Notes for Reviewers

- Additive schema. Prompt cache unchanged mid-conversation.
- Post-filter on title-match / missing timestamps remains as a second gate.
- Date-only `before=YYYY-MM-DD` is exclusive midnight UTC.
