### PR TITLE
test(session): match token flush interface

### DIFF
--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -147,6 +147,10 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
                 self.rows.append(m["content"])
             return list(range(1, len(messages) + 1))
 
+        def flush_token_counts(self):
+            """Match the SessionDB interface used after durable message writes."""
+            return None
+
     db = _BarrierDB()
     agent._session_db = db
     agent._session_db_created = True


### PR DESCRIPTION
## Summary
- update the `_BarrierDB` test double to implement `flush_token_counts()`
- keep the persistence-lock test focused on its intended marker-claim invariant
- eliminate an unhandled background-thread exception that pytest otherwise reports only as a warning

## Root cause
`AIAgent._persist_session()` now drains queued token-accounting deltas after durable message writes. The concurrency test's custom SessionDB double predates that interface, so its worker thread raises `AttributeError` while the test itself still reports pass under the default warning policy.

## Tests
- RED: `pytest -W error::pytest.PytestUnhandledThreadExceptionWarning tests/run_agent/test_run_agent.py::test_direct_session_db_flushes_share_marker_claim`
- GREEN: same command — 1 passed
- `ruff check tests/run_agent/test_run_agent.py`
- `git diff --check`

No production code changes.
