### PR TITLE
feat(localization): add verified localization worker

### DIFF
--- a/optional-skills/productivity/localization-worker/SKILL.md
+++ b/optional-skills/productivity/localization-worker/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: localization-worker
+description: Run verified text-file localization workflows.
+version: 0.1.0
+author: Hyukjin, Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Localization, Translation, QA, Documents]
+    related_skills: [docx, xlsx, pdf]
+---
+
+# Localization Worker Skill
+
+Translate UTF-8 text files through the `localization_worker` native-plugin toolset. The model translates only leased segment payloads; the plugin owns state, persistence, output paths, validation, and authoritative completion.
+
+## When to Use
+
+- Use for resumable `.txt` or `.md` file translation that requires a verified artifact.
+- Do not use for casual sentence translation or formats not listed as supported in `references/formats.md`.
+
+## Prerequisites
+
+The `localization-worker` native plugin must be installed and enabled in a new Hermes session. Confirm that the eleven `localization_*` tools are available before creating a job. Source files must be located under a configured `plugins.entries.localization-worker.settings.source_roots` directory; the default is `<HERMES_HOME>/localization-input`.
+
+The plugin supports Linux and macOS only. It requires POSIX directory-fd operations, `O_DIRECTORY`, `O_NOFOLLOW`, and `O_NONBLOCK`; registration fails closed when these primitives are unavailable. `<HERMES_HOME>` and its SQLite plugin-data directory are an administrator-owned trust boundary. Do not place them in an attacker-writable parent directory or replace them while Hermes is running.
+
+## How to Run
+
+Start a new Hermes session with the installed native plugin enabled, then invoke the registered `localization_*` tools through normal tool calls. Do not use `terminal` or direct filesystem tools to emulate the workflow. A run is eligible for success reporting only after `localization_verify_output` returns `COMPLETED` with a receipt.
+
+## Quick Reference
+
+```text
+localization_create_job → localization_inspect_job → localization_extract_segments
+→ localization_create_chunks → (localization_claim_chunk → localization_submit_chunk
+→ localization_validate_chunk)×N → localization_assemble_output
+→ localization_verify_output → localization_get_job_status
+```
+
+Terminal states: `COMPLETED`, `FAILED`, `BLOCKED`, `NEEDS_REVIEW`, `ABORTED`.
+
+## Runtime Rules
+
+- Use only the registered `localization_*` tools during a localization job.
+- Never use shell commands, arbitrary code execution, or direct file writes to replace a failed localization tool.
+- Never invent a replacement workflow when a tool fails.
+- Stop when a job reaches `FAILED`, `BLOCKED`, `NEEDS_REVIEW`, or `ABORTED`.
+- Preserve every returned segment ID and placeholder exactly.
+- Never select an output path; the plugin owns its profile-scoped job directory.
+- Never claim completion from reasoning, an external API response, or file existence alone.
+- Report success only when `localization_verify_output` returns `COMPLETED` with a verification receipt.
+- Treat missing, malformed, oversized, unsupported, or unverifiable results as failures.
+- Network research may inform terminology but must not change job state or bypass validation.
+
+## Procedure
+
+1. Call `localization_create_job` with `source_path` and `target_locale`. Continue only from `CREATED`; record the returned `job_id` and authoritative `output_path`.
+2. Call `localization_inspect_job`, then `localization_extract_segments`. Extraction returns bounded metadata, not source text. Stop on `UNSUPPORTED_FORMAT`, `SOURCE_CHANGED`, `EMPTY_DOCUMENT`, or any terminal state.
+3. Call `localization_create_chunks`. Confirm returned `max_estimated_tokens` is at most 2,048. The response is bounded summary metadata; chunk IDs and source payloads are disclosed only by claims.
+4. Call `localization_claim_chunk` with a stable `worker_id`. Translate only its returned segments before `lease_expires_at`.
+5. Call `localization_submit_chunk` with the exact `chunk_id`, `fencing_token`, segment-ID set, and translated text.
+6. Call `localization_validate_chunk`. Repeat claim, submit, and validation while the state remains `PROCESSING`.
+7. Continue only when validation returns `VALIDATING`, which means every chunk is validated.
+8. Call `localization_assemble_output`, then `localization_verify_output`.
+9. Report completion only from the returned receipt. Later status checks can invalidate completion if the artifact changes.
+
+## Pitfalls
+
+- Only UTF-8 `.txt` and `.md` are currently supported. Markdown is treated as line-preserving text, not as a parsed Markdown AST.
+- UTF-8 BOM, uniform LF or uniform CRLF framing, and final-newline presence are preserved for supported fixtures. Bare-CR, mixed newline documents, U+0085, U+2028, U+2029, vertical tab, and form feed fail closed with `UNSUPPORTED_NEWLINE_STYLE`.
+- A single source line that exceeds the local 2,048-token estimate fails with `OVERSIZED_SEGMENT`; it is not split through placeholders or syntax.
+- Leases expire after five minutes. A replacement worker receives a new fencing token; submissions using an old or expired token fail.
+- Caller-provided `output_path` is rejected. Output artifacts remain under the active profile's plugin data directory.
+- Source and output artifact paths are opened component by component from directory fds with no-follow and nonblocking final-open semantics. Traversal, ancestor replacement, symlink escapes, FIFOs, sockets, devices, and other non-regular files fail closed without blocking.
+- Source text is disclosed only by a valid `localization_claim_chunk` lease. `localization_extract_segments` returns bounded counts and state metadata.
+- Existing completed jobs are keyed by source content hash, source path, and target locale.
+
+## Verification
+
+A successful job has all of the following:
+
+- every extracted segment translated and validated;
+- exact segment-ID and placeholder preservation;
+- an artifact in the profile-scoped job directory;
+- successful UTF-8 reopen with BOM and newline framing preserved;
+- content equal to the validated translations;
+- an output SHA-256 stored with a verification receipt;
+- authoritative state `COMPLETED`.
+
+`localization_get_job_status` rechecks a completed artifact. Modification or deletion invalidates the receipt and returns `OUTPUT_CHANGED_AFTER_VERIFICATION`. The receipt is a profile-local workflow completion token stored with the SQLite job state; it is not a cryptographic signature for verification by an external party.

--- a/optional-skills/productivity/localization-worker/references/formats.md
+++ b/optional-skills/productivity/localization-worker/references/formats.md
@@ -1,0 +1,26 @@
+# Verified Format Matrix
+
+| Extensions | Inspection | Extraction | Round trip | Verified guarantees |
+|---|---:|---:|---:|---|
+| `.txt` | yes | physical line units | yes | UTF-8 reopen, BOM, LF/CRLF, final newline, exact validated text |
+| `.md` | yes | physical line units | constrained | same text-framing guarantees as `.txt`; Markdown AST semantics are not parsed |
+| all other extensions | explicit unsupported | no | no | `UNSUPPORTED_FORMAT` |
+
+Support is declared only where native-plugin round-trip tests exist. The plugin never silently flattens an unsupported structure.
+
+## Current limits
+
+- UTF-8 only. Invalid byte sequences fail closed.
+- Newlines must be uniformly LF or uniformly CRLF. Bare-CR, mixed styles, U+0085, U+2028, U+2029, vertical tab, and form feed fail with `UNSUPPORTED_NEWLINE_STYLE`.
+- Markdown is line-preserving text. Front matter, fenced code, links, inline HTML, and other syntax are not independently parsed or protected.
+- Empty files fail with `EMPTY_DOCUMENT`.
+- A single line above the 2,048 estimated-token source budget fails with `OVERSIZED_SEGMENT`.
+- Multiple lines are grouped into deterministic chunks below that budget.
+- Output paths are plugin-owned and profile-scoped.
+- Input and output artifacts are opened component by component with POSIX directory fds plus no-follow and nonblocking final-open semantics; traversal, ancestor replacement, symlink escapes, FIFOs, sockets, devices, and other non-regular files are rejected without blocking.
+- Extraction returns bounded metadata. Source text is returned only for segments in a valid claimed chunk lease.
+- Linux and macOS are supported. The profile home and SQLite plugin-data directory are an administrator-owned trust boundary.
+
+## Planned adapters
+
+CSV, TSV, JSON, JSONL, YAML, properties, subtitles, Office, PDF, CAT, XML, HTML, and software-resource formats require dedicated inspect/extract/assemble/reparse/validate adapters and representative fidelity tests before they can move out of `UNSUPPORTED_FORMAT`.

--- a/plugins/localization-worker/__init__.py
+++ b/plugins/localization-worker/__init__.py
@@ -1,0 +1,738 @@
+"""Native localization worker for UTF-8 text and Markdown files."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import json
+import os
+import re
+import secrets
+import sqlite3
+import stat
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from hermes_constants import get_hermes_home
+
+MAX_RESULT_BYTES = 64_000
+LEASE_TTL_SECONDS = 300
+LOCAL_SOURCE_TOKEN_BUDGET = 2048
+TERMINAL_STATES = {"ABORTED", "FAILED", "BLOCKED", "NEEDS_REVIEW", "COMPLETED"}
+PLACEHOLDER_RE = re.compile(r"\{[^{}\r\n]+\}|%\([^)]+\)[a-zA-Z]|%[a-zA-Z]|\$\{[^{}\r\n]+\}")
+NUMBER_RE = re.compile(r"(?<![0-9.,])[+-]?(?:\d+(?:[.,]\d+)*|[.,]\d+)(?![0-9.,])")
+_SOURCE_ROOTS: tuple[Path, ...] = ()
+
+
+def _source_roots() -> tuple[Path, ...]:
+    return _SOURCE_ROOTS or ((get_hermes_home() / "localization-input").resolve(),)
+
+
+def _data_dir() -> Path:
+    path = get_hermes_home() / "plugins" / "localization-worker"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(_data_dir() / "localization-worker.sqlite3", timeout=5)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute("PRAGMA busy_timeout=5000")
+    mode = conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+    if str(mode).lower() != "wal":
+        conn.close()
+        raise RuntimeError("WAL_REQUIRED")
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS jobs(
+          id TEXT PRIMARY KEY, idempotency_key TEXT NOT NULL UNIQUE, source_path TEXT NOT NULL,
+          output_path TEXT NOT NULL, target_locale TEXT NOT NULL, state TEXT NOT NULL,
+          source_hash TEXT, bom INTEGER, newline TEXT, final_newline INTEGER,
+          output_hash TEXT, verification_receipt TEXT, created_at TEXT NOT NULL);
+        CREATE TABLE IF NOT EXISTS segments(
+          job_id TEXT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE, segment_id TEXT NOT NULL,
+          ordinal INTEGER NOT NULL, source_text TEXT NOT NULL, source_hash TEXT NOT NULL,
+          translation TEXT, PRIMARY KEY(job_id, segment_id));
+        CREATE TABLE IF NOT EXISTS chunks(
+          job_id TEXT NOT NULL REFERENCES jobs(id) ON DELETE CASCADE, id TEXT NOT NULL,
+          state TEXT NOT NULL, fencing_token TEXT, worker_id TEXT, lease_expires_at REAL,
+          submission_hash TEXT,
+          PRIMARY KEY(job_id, id));
+        CREATE TABLE IF NOT EXISTS chunk_segments(
+          job_id TEXT NOT NULL, chunk_id TEXT NOT NULL, segment_id TEXT NOT NULL,
+          PRIMARY KEY(job_id, chunk_id, segment_id),
+          FOREIGN KEY(job_id, chunk_id) REFERENCES chunks(job_id, id) ON DELETE CASCADE,
+          FOREIGN KEY(job_id, segment_id) REFERENCES segments(job_id, segment_id) ON DELETE CASCADE);
+        CREATE TABLE IF NOT EXISTS audit_events(
+          seq INTEGER PRIMARY KEY AUTOINCREMENT, job_id TEXT NOT NULL REFERENCES jobs(id),
+          event TEXT NOT NULL, detail TEXT NOT NULL, created_at TEXT NOT NULL);
+        """
+    )
+    version = conn.execute("PRAGMA user_version").fetchone()[0]
+    if version > 1:
+        conn.close()
+        raise RuntimeError("UNSUPPORTED_DATABASE_VERSION")
+    job_columns = {row[1] for row in conn.execute("PRAGMA table_info(jobs)")}
+    chunk_columns = {row[1] for row in conn.execute("PRAGMA table_info(chunks)")}
+    if "output_hash" not in job_columns:
+        conn.execute("ALTER TABLE jobs ADD COLUMN output_hash TEXT")
+    if "lease_expires_at" not in chunk_columns:
+        conn.execute("ALTER TABLE chunks ADD COLUMN lease_expires_at REAL")
+    conn.execute("PRAGMA user_version=1")
+    conn.commit()
+    return conn
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _epoch() -> float:
+    return time.time()
+
+
+def _estimate_tokens(text: str) -> int:
+    return max(1, (len(text.encode("utf-8")) + 3) // 4 + 8)
+
+
+def _dump(value: dict[str, Any]) -> str:
+    raw = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    if len(raw.encode("utf-8")) > MAX_RESULT_BYTES:
+        return json.dumps({"ok": False, "error": {"code": "RESULT_TOO_LARGE"}})
+    return raw
+
+
+def _error(code: str, message: str = "") -> str:
+    return _dump({"ok": False, "error": {"code": code, "message": message or code}})
+
+
+def _args(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _event(conn: sqlite3.Connection, job_id: str, event: str, detail: dict[str, Any] | None = None) -> None:
+    conn.execute(
+        "INSERT INTO audit_events(job_id,event,detail,created_at) VALUES(?,?,?,?)",
+        (job_id, event, json.dumps(detail or {}, sort_keys=True), _now()),
+    )
+
+
+def _job(conn: sqlite3.Connection, job_id: str) -> sqlite3.Row:
+    row = conn.execute("SELECT * FROM jobs WHERE id=?", (job_id,)).fetchone()
+    if row is None:
+        raise KeyError("JOB_NOT_FOUND")
+    return row
+
+
+def _require(row: sqlite3.Row, expected: str) -> None:
+    if row["state"] != expected:
+        raise ValueError(f"INVALID_TRANSITION:{row['state']}->{expected}")
+
+
+def _source_location(path: str) -> tuple[Path, tuple[str, ...]]:
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    normalized = Path(os.path.abspath(candidate))
+    for root in _source_roots():
+        root_abs = Path(os.path.abspath(root))
+        try:
+            relative = normalized.relative_to(root_abs)
+        except ValueError:
+            continue
+        if relative.parts and all(part not in {"", ".", ".."} for part in relative.parts):
+            return root_abs, relative.parts
+    raise ValueError("SOURCE_OUTSIDE_ALLOWED_ROOTS")
+
+
+def _read_source_no_follow(path: str) -> tuple[Path, bytes]:
+    root, parts = _source_location(path)
+    directory_fd: int | None = None
+    file_fd: int | None = None
+    flags = os.O_RDONLY | os.O_NOFOLLOW
+    try:
+        with _open_absolute_dir_no_follow(root) as trusted_root_fd:
+            directory_fd = os.dup(trusted_root_fd)
+        for component in parts[:-1]:
+            next_fd = os.open(component, flags | os.O_DIRECTORY, dir_fd=directory_fd)
+            os.close(directory_fd)
+            directory_fd = next_fd
+        final_mode = os.stat(parts[-1], dir_fd=directory_fd, follow_symlinks=False).st_mode
+        if stat.S_ISLNK(final_mode):
+            raise ValueError("SOURCE_OUTSIDE_ALLOWED_ROOTS")
+        if not stat.S_ISREG(final_mode):
+            raise ValueError("SOURCE_NOT_FILE")
+        file_fd = os.open(parts[-1], flags | os.O_NONBLOCK, dir_fd=directory_fd)
+        if not stat.S_ISREG(os.fstat(file_fd).st_mode):
+            raise ValueError("SOURCE_NOT_FILE")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(file_fd, 64 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return root.joinpath(*parts), b"".join(chunks)
+    except ValueError:
+        raise
+    except OSError as exc:
+        if getattr(exc, "errno", None) in {errno.ELOOP, errno.ENOTDIR}:
+            raise ValueError("SOURCE_OUTSIDE_ALLOWED_ROOTS") from None
+        if getattr(exc, "errno", None) == errno.EOPNOTSUPP:
+            raise ValueError("SOURCE_NOT_FILE") from None
+        if isinstance(exc, FileNotFoundError):
+            raise ValueError("SOURCE_PATH_INVALID") from None
+        raise ValueError("SOURCE_READ_FAILED") from None
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        if directory_fd is not None:
+            os.close(directory_fd)
+
+
+def _mark_source_failed(job_id: str, event: str) -> None:
+    with _connect() as failure_conn:
+        failure_conn.execute("UPDATE jobs SET state='FAILED',verification_receipt=NULL WHERE id=?", (job_id,))
+        _event(failure_conn, job_id, event)
+
+
+def _source_bytes_or_fail(conn: sqlite3.Connection, row: sqlite3.Row) -> bytes:
+    try:
+        _, raw = _read_source_no_follow(row["source_path"])
+    except ValueError as exc:
+        conn.rollback()
+        _mark_source_failed(row["id"], str(exc))
+        raise
+    if not row["source_hash"] or hashlib.sha256(raw).hexdigest() != row["source_hash"]:
+        conn.rollback()
+        _mark_source_failed(row["id"], "SOURCE_CHANGED")
+        raise ValueError("SOURCE_CHANGED")
+    return raw
+
+
+def _output_components(row: sqlite3.Row) -> tuple[Path, str, str]:
+    data_root = _data_dir()
+    output = Path(row["output_path"])
+    expected_parent = data_root / "jobs" / row["id"]
+    if output.parent != expected_parent or output.name in {"", ".", ".."}:
+        raise ValueError("OUTPUT_PATH_UNSAFE")
+    return data_root, row["id"], output.name
+
+
+def _mark_output_review(conn: sqlite3.Connection, row: sqlite3.Row, event: str) -> None:
+    conn.execute("UPDATE jobs SET state='NEEDS_REVIEW',verification_receipt=NULL WHERE id=?", (row["id"],))
+    _event(conn, row["id"], event)
+    conn.commit()
+
+
+@contextmanager
+def _open_absolute_dir_no_follow(path: Path):
+    if not path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts[1:]):
+        raise ValueError("OUTPUT_PATH_UNSAFE")
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    current_fd = os.open(path.anchor, flags)
+    try:
+        for component in path.parts[1:]:
+            next_fd = os.open(component, flags, dir_fd=current_fd)
+            os.close(current_fd)
+            current_fd = next_fd
+        yield current_fd
+    finally:
+        os.close(current_fd)
+
+
+@contextmanager
+def _output_dir_fd(conn: sqlite3.Connection, row: sqlite3.Row, *, create: bool):
+    data_root, job_id, output_name = _output_components(row)
+    data_fd: int | None = None
+    jobs_fd: int | None = None
+    job_fd: int | None = None
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    try:
+        with _open_absolute_dir_no_follow(data_root) as trusted_data_fd:
+            data_fd = os.dup(trusted_data_fd)
+        if create:
+            try:
+                os.mkdir("jobs", 0o700, dir_fd=data_fd)
+            except FileExistsError:
+                pass
+        jobs_fd = os.open("jobs", flags, dir_fd=data_fd)
+        if create:
+            try:
+                os.mkdir(job_id, 0o700, dir_fd=jobs_fd)
+            except FileExistsError:
+                pass
+        job_fd = os.open(job_id, flags, dir_fd=jobs_fd)
+    except (OSError, ValueError, AttributeError, TypeError):
+        for fd in (job_fd, jobs_fd, data_fd):
+            if fd is not None:
+                os.close(fd)
+        _mark_output_review(conn, row, "OUTPUT_PATH_UNSAFE")
+        raise ValueError("OUTPUT_PATH_UNSAFE") from None
+    try:
+        yield output_name, job_fd
+    finally:
+        for fd in (job_fd, jobs_fd, data_fd):
+            if fd is not None:
+                os.close(fd)
+
+
+def _write_output_atomic(conn: sqlite3.Connection, row: sqlite3.Row, raw: bytes) -> None:
+    temporary: str | None = None
+    try:
+        with _output_dir_fd(conn, row, create=True) as (output_name, dir_fd):
+            temporary = f".{output_name}.{secrets.token_hex(8)}.tmp"
+            file_fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600, dir_fd=dir_fd)
+            try:
+                view = memoryview(raw)
+                while view:
+                    written = os.write(file_fd, view)
+                    if written <= 0:
+                        raise OSError("short write")
+                    view = view[written:]
+                os.fsync(file_fd)
+            finally:
+                os.close(file_fd)
+            os.rename(temporary, output_name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+            temporary = None
+            os.fsync(dir_fd)
+    except ValueError:
+        raise
+    except (OSError, TypeError):
+        _mark_output_review(conn, row, "OUTPUT_WRITE_FAILED")
+        raise ValueError("OUTPUT_WRITE_FAILED") from None
+    finally:
+        if temporary is not None:
+            try:
+                with _output_dir_fd(conn, row, create=False) as (_, dir_fd):
+                    os.unlink(temporary, dir_fd=dir_fd)
+            except (OSError, ValueError):
+                pass
+
+
+def _read_output_no_follow(conn: sqlite3.Connection, row: sqlite3.Row) -> bytes:
+    try:
+        with _output_dir_fd(conn, row, create=False) as (output_name, dir_fd):
+            if not stat.S_ISREG(os.stat(output_name, dir_fd=dir_fd, follow_symlinks=False).st_mode):
+                raise OSError("output is not a regular file")
+            file_fd = os.open(output_name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=dir_fd)
+            try:
+                if not stat.S_ISREG(os.fstat(file_fd).st_mode):
+                    raise OSError("output is not a regular file")
+                chunks: list[bytes] = []
+                while True:
+                    chunk = os.read(file_fd, 64 * 1024)
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+                return b"".join(chunks)
+            finally:
+                os.close(file_fd)
+    except FileNotFoundError:
+        raise ValueError("OUTPUT_MISSING") from None
+    except OSError:
+        _mark_output_review(conn, row, "OUTPUT_PATH_UNSAFE")
+        raise ValueError("OUTPUT_PATH_UNSAFE") from None
+
+
+def _handler(fn: Callable[[dict[str, Any]], dict[str, Any]]) -> Callable[..., str]:
+    def wrapped(arguments: Any = None, **kwargs: Any) -> str:
+        try:
+            return _dump(fn({**_args(arguments), **kwargs}))
+        except KeyError as exc:
+            return _error(str(exc.args[0]))
+        except ValueError as exc:
+            text = str(exc)
+            code = text.split(":", 1)[0]
+            return _error(code, text)
+        except RuntimeError as exc:
+            return _error(str(exc))
+        except sqlite3.Error:
+            return _error("DATABASE_ERROR")
+        except (TypeError, AttributeError, IndexError):
+            return _error("INVALID_ARGUMENTS")
+        except (OSError, UnicodeError) as exc:
+            return _error("IO_ERROR", str(exc))
+    return wrapped
+
+
+@_handler
+def create_job(a: dict[str, Any]) -> dict[str, Any]:
+    if "output_path" in a:
+        raise ValueError("CALLER_CONTROLLED_OUTPUT_PATH")
+    source, source_raw = _read_source_no_follow(a["source_path"])
+    if source.suffix.lower() not in {".txt", ".md"}:
+        raise ValueError("UNSUPPORTED_FORMAT")
+    target_locale = a["target_locale"]
+    if not isinstance(target_locale, str) or not re.fullmatch(r"[A-Za-z]{2,8}(?:[-_][A-Za-z0-9]{2,8})*", target_locale):
+        raise ValueError("INVALID_TARGET_LOCALE")
+    source_hash = hashlib.sha256(source_raw).hexdigest()
+    key_material = json.dumps([str(source), source_hash, target_locale], separators=(",", ":"))
+    key = hashlib.sha256(key_material.encode()).hexdigest()
+    job_id = key[:24]
+    job_dir = _data_dir() / "jobs" / job_id
+    safe_locale = target_locale.replace("_", "-")
+    output = job_dir / f"{source.stem}.{safe_locale}{source.suffix.lower()}"
+    with _connect() as conn:
+        existing = conn.execute("SELECT id,state,output_path FROM jobs WHERE idempotency_key=?", (key,)).fetchone()
+        if existing:
+            return {"ok": True, "job_id": existing["id"], "state": existing["state"], "idempotent": True, "data_dir": str(_data_dir()), "output_path": existing["output_path"]}
+        conn.execute(
+            "INSERT INTO jobs(id,idempotency_key,source_path,output_path,target_locale,state,source_hash,created_at) VALUES(?,?,?,?,?,'CREATED',?,?)",
+            (job_id, key, str(source), str(output), target_locale, source_hash, _now()),
+        )
+        _event(conn, job_id, "JOB_CREATED")
+    return {"ok": True, "job_id": job_id, "state": "CREATED", "idempotent": False, "data_dir": str(_data_dir()), "output_path": str(output)}
+
+
+@_handler
+def inspect_job(a: dict[str, Any]) -> dict[str, Any]:
+    with _connect() as conn:
+        row = _job(conn, a["job_id"]); _require(row, "CREATED")
+        if Path(row["source_path"]).suffix.lower() not in {".txt", ".md"}: raise ValueError("UNSUPPORTED_FORMAT")
+        raw = _source_bytes_or_fail(conn, row); bom = raw.startswith(b"\xef\xbb\xbf")
+        try:
+            text = raw[3:].decode("utf-8") if bom else raw.decode("utf-8")
+        except UnicodeDecodeError:
+            conn.rollback()
+            _mark_source_failed(row["id"], "SOURCE_NOT_UTF8")
+            raise ValueError("SOURCE_NOT_UTF8") from None
+        unsupported_separators = {"\u0085", "\u2028", "\u2029", "\u000b", "\u000c"}
+        if any(separator in text for separator in unsupported_separators):
+            conn.rollback()
+            _mark_source_failed(row["id"], "UNSUPPORTED_NEWLINE_STYLE")
+            raise ValueError("UNSUPPORTED_NEWLINE_STYLE")
+        crlf_count = text.count("\r\n")
+        remainder = text.replace("\r\n", "")
+        if "\r" in remainder or (crlf_count and "\n" in remainder):
+            conn.execute("UPDATE jobs SET state='FAILED' WHERE id=?", (row["id"],))
+            _event(conn, row["id"], "UNSUPPORTED_NEWLINE_STYLE")
+            conn.commit()
+            raise ValueError("UNSUPPORTED_NEWLINE_STYLE")
+        newline = "\r\n" if crlf_count else "\n"
+        final = text.endswith(("\n", "\r"))
+        digest = hashlib.sha256(raw).hexdigest()
+        conn.execute("UPDATE jobs SET state='INSPECTED',bom=?,newline=?,final_newline=? WHERE id=?", (bom, newline, final, row["id"]))
+        _event(conn, row["id"], "JOB_INSPECTED", {"source_hash": digest})
+    return {"ok": True, "job_id": row["id"], "state": "INSPECTED", "source_hash": digest}
+
+
+@_handler
+def extract_segments(a: dict[str, Any]) -> dict[str, Any]:
+    with _connect() as conn:
+        row = _job(conn, a["job_id"]); _require(row, "INSPECTED")
+        raw = _source_bytes_or_fail(conn, row)
+        text = raw[3:].decode() if row["bom"] else raw.decode()
+        lines = text.splitlines()
+        if not lines:
+            conn.execute("UPDATE jobs SET state='FAILED' WHERE id=?", (row["id"],))
+            _event(conn, row["id"], "EMPTY_DOCUMENT")
+            conn.commit()
+            raise ValueError("EMPTY_DOCUMENT")
+        segments = []
+        for ordinal, text_line in enumerate(lines):
+            source_hash = hashlib.sha256(text_line.encode()).hexdigest()
+            segment_id = hashlib.sha256(f"{row['source_hash']}:{ordinal}:{source_hash}".encode()).hexdigest()[:24]
+            conn.execute("INSERT INTO segments VALUES(?,?,?,?,?,NULL)", (row["id"], segment_id, ordinal, text_line, source_hash))
+            segments.append({"segment_id": segment_id, "source_text": text_line, "source_hash": source_hash})
+        conn.execute("UPDATE jobs SET state='EXTRACTED' WHERE id=?", (row["id"],)); _event(conn, row["id"], "SEGMENTS_EXTRACTED", {"count": len(segments)})
+    return {"ok": True, "job_id": row["id"], "state": "EXTRACTED", "segment_count": len(segments)}
+
+
+@_handler
+def create_chunks(a: dict[str, Any]) -> dict[str, Any]:
+    with _connect() as conn:
+        row = _job(conn, a["job_id"]); _require(row, "EXTRACTED")
+        segments = list(conn.execute("SELECT segment_id,source_text FROM segments WHERE job_id=? ORDER BY ordinal", (row["id"],)))
+        groups: list[tuple[list[str], int]] = []
+        current: list[str] = []
+        current_tokens = 0
+        for segment in segments:
+            estimated = _estimate_tokens(segment["source_text"])
+            if estimated > LOCAL_SOURCE_TOKEN_BUDGET:
+                conn.rollback()
+                _mark_source_failed(row["id"], "OVERSIZED_SEGMENT")
+                raise ValueError("OVERSIZED_SEGMENT")
+            if current and current_tokens + estimated > LOCAL_SOURCE_TOKEN_BUDGET:
+                groups.append((current, current_tokens))
+                current, current_tokens = [], 0
+            current.append(segment["segment_id"])
+            current_tokens += estimated
+        if current:
+            groups.append((current, current_tokens))
+        chunks = []
+        for index, (segment_ids, estimated_tokens) in enumerate(groups):
+            chunk_id = hashlib.sha256(f"{row['id']}:{index}".encode()).hexdigest()[:24]
+            conn.execute("INSERT INTO chunks VALUES(?,?,'READY',NULL,NULL,NULL,NULL)", (row["id"], chunk_id))
+            conn.executemany("INSERT INTO chunk_segments VALUES(?,?,?)", [(row["id"], chunk_id, segment_id) for segment_id in segment_ids])
+            chunks.append({"chunk_id": chunk_id, "estimated_tokens": estimated_tokens, "segment_count": len(segment_ids)})
+        conn.execute("UPDATE jobs SET state='CHUNKED' WHERE id=?", (row["id"],)); _event(conn, row["id"], "CHUNKS_CREATED", {"count": len(chunks)})
+    return {
+        "ok": True,
+        "job_id": row["id"],
+        "state": "CHUNKED",
+        "chunk_count": len(chunks),
+        "max_estimated_tokens": max((chunk["estimated_tokens"] for chunk in chunks), default=0),
+    }
+
+
+@_handler
+def claim_chunk(a: dict[str, Any]) -> dict[str, Any]:
+    worker_id = a.get("worker_id")
+    if not isinstance(worker_id, str) or not worker_id.strip() or len(worker_id.encode("utf-8")) > 128:
+        raise ValueError("INVALID_WORKER_ID")
+    conn = _connect()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = _job(conn, a["job_id"])
+        if row["state"] not in {"CHUNKED", "PROCESSING"}: raise ValueError("INVALID_TRANSITION")
+        now = _epoch()
+        chunk = conn.execute(
+            "SELECT * FROM chunks WHERE job_id=? AND (state='READY' OR (state='LEASED' AND lease_expires_at<=?)) ORDER BY id LIMIT 1",
+            (row["id"], now),
+        ).fetchone()
+        if not chunk: raise ValueError("NO_CHUNK_AVAILABLE")
+        token = secrets.token_hex(16)
+        updated = conn.execute(
+            "UPDATE chunks SET state='LEASED',fencing_token=?,worker_id=?,lease_expires_at=? "
+            "WHERE job_id=? AND id=? AND (state='READY' OR (state='LEASED' AND lease_expires_at<=?))",
+            (token, worker_id, now + LEASE_TTL_SECONDS, row["id"], chunk["id"], now),
+        ).rowcount
+        if updated != 1: raise ValueError("NO_CHUNK_AVAILABLE")
+        conn.execute("UPDATE jobs SET state='PROCESSING' WHERE id=?", (row["id"],)); _event(conn, row["id"], "CHUNK_CLAIMED", {"chunk_id": chunk["id"], "worker_id": worker_id})
+        segments = [dict(x) for x in conn.execute("SELECT s.segment_id,s.source_text,s.source_hash FROM segments s JOIN chunk_segments c USING(job_id,segment_id) WHERE c.job_id=? AND c.chunk_id=? ORDER BY s.ordinal", (row["id"], chunk["id"]))]
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+    return {"ok": True, "job_id": row["id"], "state": "PROCESSING", "chunk_id": chunk["id"], "fencing_token": token, "lease_expires_at": now + LEASE_TTL_SECONDS, "segments": segments}
+
+
+@_handler
+def submit_chunk(a: dict[str, Any]) -> dict[str, Any]:
+    translations = a.get("translations") or []
+    canonical = json.dumps(translations, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    if len(canonical.encode("utf-8")) > MAX_RESULT_BYTES:
+        raise ValueError("SUBMISSION_TOO_LARGE")
+    submission_hash = hashlib.sha256(canonical.encode()).hexdigest()
+    conn = _connect()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = _job(conn, a["job_id"])
+        if row["state"] != "PROCESSING":
+            raise ValueError("INVALID_TRANSITION")
+        chunk = conn.execute("SELECT * FROM chunks WHERE job_id=? AND id=?", (row["id"], a["chunk_id"])).fetchone()
+        if not chunk: raise ValueError("CHUNK_NOT_FOUND")
+        if chunk["fencing_token"] != a.get("fencing_token"):
+            raise ValueError("STALE_LEASE")
+        if chunk["state"] == "SUBMITTED" and chunk["submission_hash"] == submission_hash:
+            conn.commit()
+            return {"ok": True, "accepted": True, "idempotent": True, "state": row["state"]}
+        if chunk["state"] != "LEASED" or chunk["lease_expires_at"] <= _epoch():
+            raise ValueError("STALE_LEASE")
+        expected = {x[0] for x in conn.execute("SELECT segment_id FROM chunk_segments WHERE job_id=? AND chunk_id=?", (row["id"], chunk["id"]))}
+        provided = [x.get("segment_id") for x in translations]
+        if len(provided) != len(set(provided)) or set(provided) != expected: raise ValueError("SEGMENT_ID_SET_MISMATCH")
+        for item in translations:
+            source = conn.execute("SELECT source_text FROM segments WHERE job_id=? AND segment_id=?", (row["id"], item["segment_id"])).fetchone()[0]
+            target = item["text"]
+            if not isinstance(target, str): raise ValueError("INVALID_TRANSLATION")
+            if source == "":
+                if target != "": raise ValueError("BLANK_LINE_CHANGED")
+            elif not target.strip():
+                raise ValueError("EMPTY_TRANSLATION")
+            if sorted(PLACEHOLDER_RE.findall(source)) != sorted(PLACEHOLDER_RE.findall(target)): raise ValueError("PLACEHOLDER_MISMATCH")
+            if NUMBER_RE.findall(source) != NUMBER_RE.findall(target): raise ValueError("NUMBER_MISMATCH")
+            conn.execute("UPDATE segments SET translation=? WHERE job_id=? AND segment_id=?", (target, row["id"], item["segment_id"]))
+        conn.execute("UPDATE chunks SET state='SUBMITTED',submission_hash=? WHERE job_id=? AND id=?", (submission_hash, row["id"], chunk["id"])); _event(conn, row["id"], "CHUNK_SUBMITTED", {"chunk_id": chunk["id"]})
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+    return {"ok": True, "accepted": True, "idempotent": False, "state": "PROCESSING"}
+
+
+@_handler
+def validate_chunk(a: dict[str, Any]) -> dict[str, Any]:
+    with _connect() as conn:
+        row = _job(conn, a["job_id"]); _require(row, "PROCESSING")
+        chunk = conn.execute("SELECT state FROM chunks WHERE job_id=? AND id=?", (row["id"], a["chunk_id"])).fetchone()
+        if not chunk or chunk["state"] != "SUBMITTED": raise ValueError("CHUNK_NOT_SUBMITTED")
+        conn.execute("UPDATE chunks SET state='VALIDATED' WHERE job_id=? AND id=?", (row["id"], a["chunk_id"]))
+        remaining = conn.execute("SELECT count(*) FROM chunks WHERE job_id=? AND state!='VALIDATED'", (row["id"],)).fetchone()[0]
+        next_state = "VALIDATING" if remaining == 0 else "PROCESSING"
+        conn.execute("UPDATE jobs SET state=? WHERE id=?", (next_state, row["id"]))
+        _event(conn, row["id"], "CHUNK_VALIDATED", {"chunk_id": a["chunk_id"], "remaining": remaining})
+    return {"ok": True, "job_id": row["id"], "state": next_state}
+
+
+@_handler
+def assemble_output(a: dict[str, Any]) -> dict[str, Any]:
+    with _connect() as conn:
+        row = _job(conn, a["job_id"]); _require(row, "VALIDATING")
+        _source_bytes_or_fail(conn, row)
+        if conn.execute("SELECT count(*) FROM chunks WHERE job_id=? AND state!='VALIDATED'", (row["id"],)).fetchone()[0]: raise ValueError("UNVALIDATED_CHUNKS")
+        translations = [x[0] for x in conn.execute("SELECT translation FROM segments WHERE job_id=? ORDER BY ordinal", (row["id"],))]
+        if any(x is None for x in translations): raise ValueError("MISSING_TRANSLATION")
+        text = row["newline"].join(translations) + (row["newline"] if row["final_newline"] else "")
+        raw = (("\ufeff" if row["bom"] else "") + text).encode("utf-8")
+        _write_output_atomic(conn, row, raw)
+        conn.execute("UPDATE jobs SET state='ASSEMBLING' WHERE id=?", (row["id"],)); _event(conn, row["id"], "OUTPUT_ASSEMBLED", {"output_hash": hashlib.sha256(raw).hexdigest()})
+    return {"ok": True, "job_id": row["id"], "state": "ASSEMBLING", "output_path": row["output_path"]}
+
+
+@_handler
+def verify_output(a: dict[str, Any]) -> dict[str, Any]:
+    with _connect() as conn:
+        row = _job(conn, a["job_id"]); _require(row, "ASSEMBLING")
+        _source_bytes_or_fail(conn, row)
+        try:
+            raw = _read_output_no_follow(conn, row)
+        except ValueError as exc:
+            code = str(exc)
+            event = "OUTPUT_MISSING_BEFORE_VERIFICATION" if code == "OUTPUT_MISSING" else "OUTPUT_PATH_UNSAFE"
+            conn.execute("UPDATE jobs SET state='NEEDS_REVIEW',verification_receipt=NULL WHERE id=?", (row["id"],))
+            _event(conn, row["id"], event)
+            conn.commit()
+            raise
+        conn.execute("UPDATE jobs SET state='VERIFYING' WHERE id=?", (row["id"],)); _event(conn, row["id"], "OUTPUT_VERIFYING")
+        bom = raw.startswith(b"\xef\xbb\xbf")
+        try:
+            text = (raw[3:] if bom else raw).decode("utf-8")
+        except UnicodeDecodeError:
+            conn.execute("UPDATE jobs SET state='NEEDS_REVIEW',verification_receipt=NULL WHERE id=?", (row["id"],))
+            _event(conn, row["id"], "OUTPUT_NOT_UTF8")
+            conn.commit()
+            raise ValueError("OUTPUT_NOT_UTF8") from None
+        payload = text[:-len(row["newline"])] if row["final_newline"] and text.endswith(row["newline"]) else text
+        reparsed = payload.split(row["newline"])
+        expected = [x[0] for x in conn.execute("SELECT translation FROM segments WHERE job_id=? ORDER BY ordinal", (row["id"],))]
+        without_expected_newlines = text.replace(row["newline"], "")
+        newline_ok = "\r" not in without_expected_newlines and "\n" not in without_expected_newlines
+        if reparsed != expected or not newline_ok or bom != bool(row["bom"]) or text.endswith(("\n", "\r")) != bool(row["final_newline"]):
+            conn.execute("UPDATE jobs SET state='NEEDS_REVIEW',verification_receipt=NULL WHERE id=?", (row["id"],)); _event(conn, row["id"], "OUTPUT_VERIFICATION_FAILED")
+            conn.commit()
+            raise ValueError("OUTPUT_REPARSE_MISMATCH")
+        output_hash = hashlib.sha256(raw).hexdigest()
+        receipt = hashlib.sha256((row["id"] + output_hash + _now()).encode()).hexdigest()
+        conn.execute("UPDATE jobs SET state='COMPLETED',output_hash=?,verification_receipt=? WHERE id=?", (output_hash, receipt, row["id"])); _event(conn, row["id"], "OUTPUT_VERIFIED", {"receipt": receipt, "output_hash": output_hash})
+    return {"ok": True, "job_id": row["id"], "state": "COMPLETED", "verification_receipt": receipt}
+
+
+@_handler
+def get_job_status(a: dict[str, Any]) -> dict[str, Any]:
+    with _connect() as conn:
+        row = _job(conn, a["job_id"])
+        if row["state"] == "COMPLETED":
+            try:
+                raw = _read_output_no_follow(conn, row)
+                actual_hash = hashlib.sha256(raw).hexdigest()
+            except ValueError as exc:
+                if str(exc) == "OUTPUT_MISSING":
+                    actual_hash = None
+                else:
+                    conn.execute("UPDATE jobs SET state='NEEDS_REVIEW',verification_receipt=NULL WHERE id=?", (row["id"],))
+                    _event(conn, row["id"], "OUTPUT_PATH_UNSAFE")
+                    conn.commit()
+                    raise
+            if not row["output_hash"] or actual_hash != row["output_hash"]:
+                conn.execute("UPDATE jobs SET state='NEEDS_REVIEW',verification_receipt=NULL WHERE id=?", (row["id"],))
+                _event(conn, row["id"], "OUTPUT_CHANGED_AFTER_VERIFICATION", {"expected_hash": row["output_hash"], "actual_hash": actual_hash})
+                conn.commit()
+                raise ValueError("OUTPUT_CHANGED_AFTER_VERIFICATION")
+        if row["state"] == "NEEDS_REVIEW" and conn.execute(
+            "SELECT 1 FROM audit_events WHERE job_id=? AND event='OUTPUT_CHANGED_AFTER_VERIFICATION' LIMIT 1",
+            (row["id"],),
+        ).fetchone():
+            raise ValueError("OUTPUT_CHANGED_AFTER_VERIFICATION")
+        count = conn.execute("SELECT count(*) FROM audit_events WHERE job_id=?", (row["id"],)).fetchone()[0]
+    return {"ok": True, "job_id": row["id"], "state": row["state"], "verification_receipt": row["verification_receipt"], "audit_event_count": count}
+
+
+@_handler
+def abort_job(a: dict[str, Any]) -> dict[str, Any]:
+    reason = a.get("reason", "")
+    if not isinstance(reason, str) or len(reason.encode("utf-8")) > 1024:
+        raise ValueError("ABORT_REASON_TOO_LARGE")
+    with _connect() as conn:
+        row = _job(conn, a["job_id"])
+        if row["state"] in TERMINAL_STATES: raise ValueError("INVALID_TRANSITION")
+        conn.execute("UPDATE jobs SET state='ABORTED' WHERE id=?", (row["id"],)); _event(conn, row["id"], "JOB_ABORTED", {"reason": reason})
+    return {"ok": True, "job_id": row["id"], "state": "ABORTED"}
+
+
+_HANDLERS = {name: globals()[name] for name in (
+    "create_job", "inspect_job", "extract_segments", "create_chunks", "claim_chunk",
+    "submit_chunk", "validate_chunk", "assemble_output", "verify_output", "get_job_status", "abort_job",
+)}
+
+
+def _schema(name: str) -> dict[str, Any]:
+    specs: dict[str, dict[str, Any]] = {
+        "create_job": {"source_path": {"type": "string", "minLength": 1}, "target_locale": {"type": "string", "minLength": 2}},
+        "inspect_job": {"job_id": {"type": "string", "minLength": 1}},
+        "extract_segments": {"job_id": {"type": "string", "minLength": 1}},
+        "create_chunks": {"job_id": {"type": "string", "minLength": 1}},
+        "claim_chunk": {"job_id": {"type": "string", "minLength": 1}, "worker_id": {"type": "string", "minLength": 1, "maxLength": 128}},
+        "submit_chunk": {
+            "job_id": {"type": "string", "minLength": 1},
+            "chunk_id": {"type": "string", "minLength": 1},
+            "fencing_token": {"type": "string", "minLength": 1},
+            "translations": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 2048,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["segment_id", "text"],
+                    "properties": {
+                        "segment_id": {"type": "string", "minLength": 1},
+                        "text": {"type": "string", "maxLength": 64000},
+                    },
+                },
+            },
+        },
+        "validate_chunk": {"job_id": {"type": "string", "minLength": 1}, "chunk_id": {"type": "string", "minLength": 1}},
+        "assemble_output": {"job_id": {"type": "string", "minLength": 1}},
+        "verify_output": {"job_id": {"type": "string", "minLength": 1}},
+        "get_job_status": {"job_id": {"type": "string", "minLength": 1}},
+        "abort_job": {"job_id": {"type": "string", "minLength": 1}, "reason": {"type": "string", "maxLength": 1024}},
+    }
+    properties = specs[name]
+    required = list(properties) if name != "abort_job" else ["job_id"]
+    return {
+        "name": f"localization_{name}",
+        "description": f"Localization worker: {name.replace('_', ' ')}.",
+        "parameters": {"type": "object", "additionalProperties": False, "required": required, "properties": properties},
+    }
+
+
+def _require_security_primitives() -> None:
+    required_flags = ("O_DIRECTORY", "O_NOFOLLOW", "O_NONBLOCK")
+    required_dir_fd = (os.open, os.mkdir, os.unlink, os.rename, os.stat)
+    if (
+        os.name != "posix"
+        or any(not hasattr(os, flag) for flag in required_flags)
+        or any(function not in os.supports_dir_fd for function in required_dir_fd)
+        or os.stat not in os.supports_follow_symlinks
+    ):
+        raise RuntimeError("UNSUPPORTED_PLATFORM_SECURITY_PRIMITIVES")
+
+
+def register(ctx: Any) -> None:
+    global _SOURCE_ROOTS
+    _require_security_primitives()
+    configured = ctx.get_config("source_roots", [str(get_hermes_home() / "localization-input")])
+    if not isinstance(configured, list) or not configured or not all(isinstance(item, str) and item.strip() for item in configured):
+        raise ValueError("INVALID_SOURCE_ROOTS")
+    _SOURCE_ROOTS = tuple(Path(item).expanduser().resolve() for item in configured)
+    for name, handler in _HANDLERS.items():
+        ctx.register_tool(name=f"localization_{name}", toolset="localization_worker", schema=_schema(name), handler=handler, emoji="🌐")

--- a/plugins/localization-worker/__init__.py
+++ b/plugins/localization-worker/__init__.py
@@ -135,10 +135,11 @@ def _require(row: sqlite3.Row, expected: str) -> None:
 
 def _source_location(path: str) -> tuple[Path, tuple[str, ...]]:
     candidate = Path(path).expanduser()
+    roots = _source_roots()
     if not candidate.is_absolute():
-        candidate = Path.cwd() / candidate
+        candidate = roots[0] / candidate
     normalized = Path(os.path.abspath(candidate))
-    for root in _source_roots():
+    for root in roots:
         root_abs = Path(os.path.abspath(root))
         try:
             relative = normalized.relative_to(root_abs)
@@ -524,15 +525,17 @@ def submit_chunk(a: dict[str, Any]) -> dict[str, Any]:
     try:
         conn.execute("BEGIN IMMEDIATE")
         row = _job(conn, a["job_id"])
-        if row["state"] != "PROCESSING":
+        if row["state"] not in {"PROCESSING", "VALIDATING"}:
             raise ValueError("INVALID_TRANSITION")
         chunk = conn.execute("SELECT * FROM chunks WHERE job_id=? AND id=?", (row["id"], a["chunk_id"])).fetchone()
         if not chunk: raise ValueError("CHUNK_NOT_FOUND")
         if chunk["fencing_token"] != a.get("fencing_token"):
             raise ValueError("STALE_LEASE")
-        if chunk["state"] == "SUBMITTED" and chunk["submission_hash"] == submission_hash:
+        if chunk["state"] in {"SUBMITTED", "VALIDATED"} and chunk["submission_hash"] == submission_hash:
             conn.commit()
             return {"ok": True, "accepted": True, "idempotent": True, "state": row["state"]}
+        if row["state"] != "PROCESSING":
+            raise ValueError("INVALID_TRANSITION")
         if chunk["state"] != "LEASED" or chunk["lease_expires_at"] <= _epoch():
             raise ValueError("STALE_LEASE")
         expected = {x[0] for x in conn.execute("SELECT segment_id FROM chunk_segments WHERE job_id=? AND chunk_id=?", (row["id"], chunk["id"]))}
@@ -542,6 +545,7 @@ def submit_chunk(a: dict[str, Any]) -> dict[str, Any]:
             source = conn.execute("SELECT source_text FROM segments WHERE job_id=? AND segment_id=?", (row["id"], item["segment_id"])).fetchone()[0]
             target = item["text"]
             if not isinstance(target, str): raise ValueError("INVALID_TRANSLATION")
+            if "\n" in target or "\r" in target: raise ValueError("TRANSLATION_CONTAINS_NEWLINE")
             if source == "":
                 if target != "": raise ValueError("BLANK_LINE_CHANGED")
             elif not target.strip():

--- a/plugins/localization-worker/plugin.yaml
+++ b/plugins/localization-worker/plugin.yaml
@@ -1,0 +1,16 @@
+name: localization-worker
+version: 0.1.0
+description: "Durable, profile-scoped localization workflow for UTF-8 .txt and .md files."
+author: NousResearch
+provides_tools:
+  - localization_create_job
+  - localization_inspect_job
+  - localization_extract_segments
+  - localization_create_chunks
+  - localization_claim_chunk
+  - localization_submit_chunk
+  - localization_validate_chunk
+  - localization_assemble_output
+  - localization_verify_output
+  - localization_get_job_status
+  - localization_abort_job

--- a/tests/plugins/test_localization_worker_plugin.py
+++ b/tests/plugins/test_localization_worker_plugin.py
@@ -1,0 +1,1405 @@
+"""Behavior tests for the native localization-worker plugin."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import socket
+import sqlite3
+import sys
+import tempfile
+import threading
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def worker(tmp_path, monkeypatch):
+    home = tmp_path / "profile-home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugin_dir = Path(__file__).resolve().parents[2] / "plugins" / "localization-worker"
+    package = "hermes_plugins.localization_worker"
+    parent = sys.modules.setdefault("hermes_plugins", types.ModuleType("hermes_plugins"))
+    parent.__path__ = []
+    spec = importlib.util.spec_from_file_location(
+        package, plugin_dir / "__init__.py", submodule_search_locations=[str(plugin_dir)]
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[package] = module
+    spec.loader.exec_module(module)
+    setattr(module, "_SOURCE_ROOTS", (tmp_path.resolve(),))
+    return module, home
+
+
+def call(fn, **args):
+    result = fn(args)
+    assert isinstance(result, str)
+    assert len(result.encode("utf-8")) <= 64_000
+    return json.loads(result)
+
+
+def claimed_job(plugin, tmp_path, text="Hello {name}"):
+    source = tmp_path / "source.txt"
+    source.write_text(text, encoding="utf-8")
+    job = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    job_id = job["job_id"]
+    call(plugin.inspect_job, job_id=job_id)
+    call(plugin.extract_segments, job_id=job_id)
+    call(plugin.create_chunks, job_id=job_id)
+    lease = call(plugin.claim_chunk, job_id=job_id, worker_id="translator")
+    lease["output_path"] = job["output_path"]
+    return job_id, lease
+
+
+def test_create_job_rejects_source_swapped_to_external_symlink(worker, tmp_path, monkeypatch):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_text("inside", encoding="utf-8")
+    outside = tmp_path.parent / f"{tmp_path.name}-outside.txt"
+    outside.write_text("external secret", encoding="utf-8")
+    original_open = plugin.os.open
+    swapped = False
+
+    def swapping_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if path == source.name and dir_fd is not None and not swapped:
+            swapped = True
+            source.unlink()
+            source.symlink_to(outside)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(plugin.os, "open", swapping_open)
+    rejected = call(plugin.create_job, source_path=str(source), target_locale="ko")
+
+    assert rejected["error"]["code"] == "SOURCE_OUTSIDE_ALLOWED_ROOTS"
+
+
+def test_source_resists_allowed_root_ancestor_swap(worker, tmp_path, monkeypatch):
+    plugin, _ = worker
+    trusted_parent = tmp_path / "trusted"
+    source_root = trusted_parent / "allowed"
+    source_root.mkdir(parents=True)
+    source = source_root / "source.txt"
+    source.write_text("inside", encoding="utf-8")
+    outside_parent = tmp_path / "outside-parent"
+    (outside_parent / "allowed").mkdir(parents=True)
+    (outside_parent / "allowed" / "source.txt").write_text("outside", encoding="utf-8")
+    plugin._SOURCE_ROOTS = (source_root,)
+    original_open = plugin.os.open
+    swapped = False
+
+    def swapping_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        hits_current_absolute_open = Path(path) == source_root
+        hits_component_open = path == trusted_parent.name and dir_fd is not None
+        if not swapped and (hits_current_absolute_open or hits_component_open):
+            swapped = True
+            trusted_parent.rename(tmp_path / "trusted-original")
+            trusted_parent.symlink_to(outside_parent, target_is_directory=True)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(plugin.os, "open", swapping_open)
+    rejected = call(plugin.create_job, source_path=str(source), target_locale="ko")
+
+    assert rejected["error"]["code"] == "SOURCE_OUTSIDE_ALLOWED_ROOTS"
+
+
+def test_source_read_failure_marks_job_failed(worker, tmp_path, monkeypatch):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_text("Hello", encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+
+    def fail_read(_fd, _size):
+        raise OSError("injected source read failure")
+
+    monkeypatch.setattr(plugin.os, "read", fail_read)
+    rejected = call(plugin.inspect_job, job_id=created["job_id"])
+
+    assert rejected["error"]["code"] == "SOURCE_READ_FAILED"
+    status = call(plugin.get_job_status, job_id=created["job_id"])
+    assert status["state"] == "FAILED"
+    assert status["verification_receipt"] is None
+
+
+def test_source_fifo_is_rejected_without_blocking(worker, tmp_path):
+    plugin, _ = worker
+    fifo = tmp_path / "source.txt"
+    os.mkfifo(fifo)
+    result: list[dict] = []
+    thread = threading.Thread(
+        target=lambda: result.append(call(plugin.create_job, source_path=str(fifo), target_locale="ko")),
+        daemon=True,
+    )
+
+    thread.start()
+    thread.join(timeout=1)
+
+    assert not thread.is_alive(), "source FIFO open blocked"
+    assert result[0]["error"]["code"] == "SOURCE_NOT_FILE"
+
+
+def test_source_unix_socket_is_rejected(worker, tmp_path):
+    plugin, _ = worker
+    short_tmp_root = Path(tempfile.gettempdir()).resolve()
+    with tempfile.TemporaryDirectory(prefix="lw-sock-", dir=short_tmp_root) as directory:
+        source_root = Path(directory)
+        plugin._SOURCE_ROOTS = (source_root,)
+        socket_path = source_root / "source.txt"
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            listener.bind(str(socket_path))
+            rejected = call(plugin.create_job, source_path=str(socket_path), target_locale="ko")
+        finally:
+            listener.close()
+
+    assert rejected["error"]["code"] == "SOURCE_NOT_FILE"
+
+
+def test_invalid_utf8_source_fails_durably(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "invalid.txt"
+    source.write_bytes(b"valid\n\xffinvalid")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+
+    rejected = call(plugin.inspect_job, job_id=created["job_id"])
+
+    assert rejected["error"]["code"] == "SOURCE_NOT_UTF8"
+    assert "codec" not in rejected["error"]["message"]
+    status = call(plugin.get_job_status, job_id=created["job_id"])
+    assert status["state"] == "FAILED"
+    assert status["verification_receipt"] is None
+
+
+def test_extract_large_document_returns_bounded_metadata(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "large.txt"
+    source.write_text("\n".join(f"line {i}" for i in range(10_000)), encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    call(plugin.inspect_job, job_id=created["job_id"])
+
+    extracted = call(plugin.extract_segments, job_id=created["job_id"])
+
+    assert extracted["state"] == "EXTRACTED"
+    assert extracted["segment_count"] == 10_000
+    assert "segments" not in extracted
+    assert call(plugin.get_job_status, job_id=created["job_id"])["state"] == "EXTRACTED"
+
+
+def test_unicode_line_separator_is_rejected(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "unicode-lines.txt"
+    source.write_text("A\u2028B", encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+
+    rejected = call(plugin.inspect_job, job_id=created["job_id"])
+
+    assert rejected["error"]["code"] == "UNSUPPORTED_NEWLINE_STYLE"
+    assert call(plugin.get_job_status, job_id=created["job_id"])["state"] == "FAILED"
+
+
+def test_txt_job_runs_end_to_end_and_preserves_text_framing(worker, tmp_path):
+    plugin, home = worker
+    source = tmp_path / "source.txt"
+    output = tmp_path / "translated.txt"
+    source.write_bytes(b"\xef\xbb\xbfHello {name}\r\nWorld\r\n")
+
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    repeated = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    output = Path(created["output_path"])
+    assert repeated["job_id"] == created["job_id"]
+    job_id = created["job_id"]
+    assert Path(created["data_dir"]).is_relative_to(home)
+
+    assert call(plugin.inspect_job, job_id=job_id)["state"] == "INSPECTED"
+    extracted = call(plugin.extract_segments, job_id=job_id)
+    assert extracted["state"] == "EXTRACTED"
+    assert extracted["segment_count"] == 2
+    assert "segments" not in extracted
+    chunked = call(plugin.create_chunks, job_id=job_id)
+    assert chunked["state"] == "CHUNKED"
+    lease = call(plugin.claim_chunk, job_id=job_id, worker_id="translator")
+    assert lease["state"] == "PROCESSING"
+    assert [segment["source_text"] for segment in lease["segments"]] == ["Hello {name}", "World"]
+    submitted = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[
+            {"segment_id": lease["segments"][0]["segment_id"], "text": "안녕 {name}"},
+            {"segment_id": lease["segments"][1]["segment_id"], "text": "세계"},
+        ],
+    )
+    assert submitted["accepted"] is True
+    repeated_submit = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[
+            {"segment_id": lease["segments"][0]["segment_id"], "text": "안녕 {name}"},
+            {"segment_id": lease["segments"][1]["segment_id"], "text": "세계"},
+        ],
+    )
+    assert repeated_submit["accepted"] is True
+    assert repeated_submit["idempotent"] is True
+    assert call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])["state"] == "VALIDATING"
+    assert call(plugin.assemble_output, job_id=job_id)["state"] == "ASSEMBLING"
+    verified = call(plugin.verify_output, job_id=job_id)
+    assert verified["state"] == "COMPLETED"
+    assert verified["verification_receipt"]
+    assert output.read_bytes() == "\ufeff안녕 {name}\r\n세계\r\n".encode("utf-8")
+    status = call(plugin.get_job_status, job_id=job_id)
+    assert status["state"] == "COMPLETED"
+    assert status["verification_receipt"] == verified["verification_receipt"]
+    assert status["audit_event_count"] >= 9
+
+
+def test_translation_unicode_separator_is_preserved_as_content(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    translated = "안녕\u2028세계"
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": translated}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    assembled = call(plugin.assemble_output, job_id=job_id)
+
+    verified = call(plugin.verify_output, job_id=job_id)
+
+    assert verified["state"] == "COMPLETED"
+    assert Path(assembled["output_path"]).read_text(encoding="utf-8") == translated
+
+
+def test_invalid_transition_fails_closed(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.md"
+    source.write_text("Hello", encoding="utf-8")
+    job = call(plugin.create_job, source_path=str(source), target_locale="fr")
+    assert call(plugin.inspect_job, job_id=job["job_id"])["state"] == "INSPECTED"
+
+    rejected = call(plugin.inspect_job, job_id=job["job_id"])
+
+    assert rejected["ok"] is False
+    assert rejected["error"]["code"] == "INVALID_TRANSITION"
+
+
+def test_stale_lease_submit_is_rejected(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path)
+
+    rejected = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token="stale-token",
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕 {name}"}],
+    )
+
+    assert rejected["error"]["code"] == "STALE_LEASE"
+
+
+def test_placeholder_mismatch_is_rejected(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path)
+
+    rejected = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+
+    assert rejected["error"]["code"] == "PLACEHOLDER_MISMATCH"
+
+
+def test_output_reparse_failure_withholds_receipt(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    call(plugin.assemble_output, job_id=job_id)
+    Path(lease["output_path"]).write_text("tampered", encoding="utf-8")
+
+    rejected = call(plugin.verify_output, job_id=job_id)
+    status = call(plugin.get_job_status, job_id=job_id)
+
+    assert rejected["error"]["code"] == "OUTPUT_REPARSE_MISMATCH"
+    assert status["state"] == "NEEDS_REVIEW"
+    assert status["verification_receipt"] is None
+
+
+def test_completed_job_detects_later_output_tampering(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    call(plugin.assemble_output, job_id=job_id)
+    verified = call(plugin.verify_output, job_id=job_id)
+    assert verified["state"] == "COMPLETED"
+
+    Path(lease["output_path"]).write_text("tampered after verification", encoding="utf-8")
+    status = call(plugin.get_job_status, job_id=job_id)
+
+    assert status["ok"] is False
+    assert status["error"]["code"] == "OUTPUT_CHANGED_AFTER_VERIFICATION"
+    assert call(plugin.get_job_status, job_id=job_id)["error"]["code"] == "OUTPUT_CHANGED_AFTER_VERIFICATION"
+
+
+def test_create_job_owns_output_path_inside_profile_data(worker, tmp_path):
+    plugin, home = worker
+    source = tmp_path / "source.txt"
+    source.write_text("Hello", encoding="utf-8")
+
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+
+    assert created["ok"] is True
+    output = Path(created["output_path"])
+    assert output.is_relative_to(home / "plugins" / "localization-worker" / "jobs" / created["job_id"])
+    assert output.name == "source.ko.txt"
+
+
+def test_create_job_rejects_caller_controlled_output_path(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    external = tmp_path / "external.txt"
+    source.write_text("Hello", encoding="utf-8")
+    external.write_text("do not overwrite", encoding="utf-8")
+
+    rejected = call(
+        plugin.create_job,
+        source_path=str(source),
+        output_path=str(external),
+        target_locale="ko",
+    )
+
+    assert rejected["error"]["code"] == "CALLER_CONTROLLED_OUTPUT_PATH"
+    assert external.read_text(encoding="utf-8") == "do not overwrite"
+
+
+def test_source_change_after_inspection_fails_closed(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_text("original", encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    call(plugin.inspect_job, job_id=created["job_id"])
+    source.write_text("changed", encoding="utf-8")
+
+    rejected = call(plugin.extract_segments, job_id=created["job_id"])
+
+    assert rejected["error"]["code"] == "SOURCE_CHANGED"
+    assert call(plugin.get_job_status, job_id=created["job_id"])["state"] == "FAILED"
+
+
+def test_expired_lease_is_reclaimed_with_new_fencing_token(worker, tmp_path, monkeypatch):
+    plugin, _ = worker
+    now = [1_000.0]
+    monkeypatch.setattr(plugin, "_epoch", lambda: now[0])
+    job_id, first = claimed_job(plugin, tmp_path, text="Hello")
+    now[0] += 301
+
+    second = call(plugin.claim_chunk, job_id=job_id, worker_id="replacement")
+
+    assert second["ok"] is True
+    assert second["fencing_token"] != first["fencing_token"]
+    rejected = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=first["chunk_id"],
+        fencing_token=first["fencing_token"],
+        translations=[{"segment_id": first["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    assert rejected["error"]["code"] == "STALE_LEASE"
+
+
+def test_concurrent_claim_allows_exactly_one_worker(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_text("Hello", encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    call(plugin.inspect_job, job_id=created["job_id"])
+    call(plugin.extract_segments, job_id=created["job_id"])
+    call(plugin.create_chunks, job_id=created["job_id"])
+    barrier = threading.Barrier(2)
+    results = []
+
+    def claim(worker_id):
+        barrier.wait()
+        results.append(call(plugin.claim_chunk, job_id=created["job_id"], worker_id=worker_id))
+
+    threads = [threading.Thread(target=claim, args=(f"worker-{i}",)) for i in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sum(result.get("ok") is True for result in results) == 1
+    assert sum(result.get("error", {}).get("code") == "NO_CHUNK_AVAILABLE" for result in results) == 1
+
+
+def test_chunks_respect_local_source_budget(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_text("\n".join(["x" * 400 for _ in range(30)]), encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    call(plugin.inspect_job, job_id=created["job_id"])
+    call(plugin.extract_segments, job_id=created["job_id"])
+
+    chunked = call(plugin.create_chunks, job_id=created["job_id"])
+
+    assert chunked["chunk_count"] > 1
+    assert chunked["max_estimated_tokens"] <= 2048
+    assert "chunks" not in chunked
+    assert "chunk_ids" not in chunked
+
+
+def test_large_chunk_plan_returns_bounded_summary(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "many-chunks.txt"
+    source.write_text("\n".join(["x" * 8000 for _ in range(1500)]), encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    call(plugin.inspect_job, job_id=created["job_id"])
+    call(plugin.extract_segments, job_id=created["job_id"])
+
+    chunked = call(plugin.create_chunks, job_id=created["job_id"])
+
+    assert chunked["state"] == "CHUNKED"
+    assert chunked["chunk_count"] == 1500
+    assert chunked["max_estimated_tokens"] <= 2048
+    assert "chunks" not in chunked
+    assert call(plugin.get_job_status, job_id=created["job_id"])["state"] == "CHUNKED"
+
+
+def test_many_short_segments_keep_every_claim_bounded(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "short-lines.txt"
+    source.write_text("\n".join(["x" for _ in range(2500)]), encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    call(plugin.inspect_job, job_id=created["job_id"])
+    call(plugin.extract_segments, job_id=created["job_id"])
+    chunked = call(plugin.create_chunks, job_id=created["job_id"])
+    claimed = 0
+
+    while True:
+        lease = call(plugin.claim_chunk, job_id=created["job_id"], worker_id="bounded-worker")
+        assert lease["ok"] is True
+        call(
+            plugin.submit_chunk,
+            job_id=created["job_id"],
+            chunk_id=lease["chunk_id"],
+            fencing_token=lease["fencing_token"],
+            translations=[{"segment_id": s["segment_id"], "text": s["source_text"]} for s in lease["segments"]],
+        )
+        validation = call(plugin.validate_chunk, job_id=created["job_id"], chunk_id=lease["chunk_id"])
+        claimed += 1
+        if validation["state"] == "VALIDATING":
+            break
+
+    assert claimed == chunked["chunk_count"]
+
+
+def test_oversized_single_segment_fails_closed(worker, tmp_path):
+    plugin, home = worker
+    source = tmp_path / "source.txt"
+    source.write_text("x" * 9000, encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    call(plugin.inspect_job, job_id=created["job_id"])
+    call(plugin.extract_segments, job_id=created["job_id"])
+
+    rejected = call(plugin.create_chunks, job_id=created["job_id"])
+
+    assert rejected["error"]["code"] == "OVERSIZED_SEGMENT"
+    status = call(plugin.get_job_status, job_id=created["job_id"])
+    assert status["state"] == "FAILED"
+    assert status["verification_receipt"] is None
+    db_path = home / "plugins" / "localization-worker" / "localization-worker.sqlite3"
+    with sqlite3.connect(db_path) as conn:
+        events = conn.execute(
+            "SELECT event FROM audit_events WHERE job_id=? ORDER BY seq",
+            (created["job_id"],),
+        ).fetchall()
+    assert ("OVERSIZED_SEGMENT",) in events
+
+
+def test_empty_document_fails_closed(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.md"
+    source.write_text("", encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    call(plugin.inspect_job, job_id=created["job_id"])
+
+    rejected = call(plugin.extract_segments, job_id=created["job_id"])
+
+    assert rejected["error"]["code"] == "EMPTY_DOCUMENT"
+
+
+def test_register_fails_closed_without_posix_path_primitives(worker, monkeypatch):
+    plugin, _ = worker
+
+    class Context:
+        def get_config(self, key, default=None):
+            return default
+
+        def register_tool(self, **kwargs):
+            raise AssertionError("tools must not register without security primitives")
+
+    monkeypatch.delattr(plugin.os, "O_NOFOLLOW")
+
+    with pytest.raises(RuntimeError, match="UNSUPPORTED_PLATFORM_SECURITY_PRIMITIVES"):
+        plugin.register(Context())
+
+
+def test_registered_tool_schemas_are_strict(worker):
+    plugin, _ = worker
+    registrations = []
+
+    class Context:
+        def get_config(self, key, default=None):
+            return default
+
+        def register_tool(self, **kwargs):
+            registrations.append(kwargs)
+
+    plugin.register(Context())
+
+    assert len(registrations) == 11
+    for registration in registrations:
+        parameters = registration["schema"]["parameters"]
+        assert parameters["additionalProperties"] is False
+        assert parameters["required"]
+        assert set(parameters["required"]).issubset(parameters["properties"])
+
+
+def test_empty_translation_is_rejected(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+
+    rejected = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": ""}],
+    )
+
+    assert rejected["error"]["code"] == "EMPTY_TRANSLATION"
+
+
+def test_number_change_is_rejected(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Version 2.5 costs 100 USD")
+
+    rejected = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "버전 2.6의 가격은 100 USD"}],
+    )
+
+    assert rejected["error"]["code"] == "NUMBER_MISMATCH"
+
+
+def test_changed_source_content_creates_a_new_job(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_text("first", encoding="utf-8")
+    first = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    source.write_text("second", encoding="utf-8")
+
+    second = call(plugin.create_job, source_path=str(source), target_locale="ko")
+
+    assert second["job_id"] != first["job_id"]
+    assert second["idempotent"] is False
+
+
+def test_source_change_before_assembly_fails_closed(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    (tmp_path / "source.txt").write_text("changed after validation", encoding="utf-8")
+
+    rejected = call(plugin.assemble_output, job_id=job_id)
+
+    assert rejected["error"]["code"] == "SOURCE_CHANGED"
+    assert call(plugin.get_job_status, job_id=job_id)["state"] == "FAILED"
+    assert not Path(lease["output_path"]).exists()
+
+
+def test_existing_database_schema_is_migrated_without_data_loss(worker):
+    plugin, home = worker
+    data_dir = home / "plugins" / "localization-worker"
+    db_path = data_dir / "localization-worker.sqlite3"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    db_path.unlink(missing_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE jobs(id TEXT PRIMARY KEY,idempotency_key TEXT NOT NULL UNIQUE,"
+            "source_path TEXT NOT NULL,output_path TEXT NOT NULL,target_locale TEXT NOT NULL,"
+            "state TEXT NOT NULL,source_hash TEXT,bom INTEGER,newline TEXT,final_newline INTEGER,"
+            "verification_receipt TEXT,created_at TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE chunks(job_id TEXT NOT NULL,id TEXT NOT NULL,state TEXT NOT NULL,"
+            "fencing_token TEXT,worker_id TEXT,submission_hash TEXT,PRIMARY KEY(job_id,id))"
+        )
+        conn.execute(
+            "INSERT INTO jobs VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
+            ("legacy", "key", "/source.txt", "/out.txt", "ko", "CREATED", None, None, None, None, None, "now"),
+        )
+        conn.execute("PRAGMA user_version=0")
+
+    conn = plugin._connect()
+    try:
+        job_columns = {row[1] for row in conn.execute("PRAGMA table_info(jobs)")}
+        chunk_columns = {row[1] for row in conn.execute("PRAGMA table_info(chunks)")}
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        legacy = conn.execute("SELECT id,state FROM jobs WHERE id='legacy'").fetchone()
+    finally:
+        conn.close()
+
+    assert "output_hash" in job_columns
+    assert "lease_expires_at" in chunk_columns
+    assert version >= 1
+    assert tuple(legacy) == ("legacy", "CREATED")
+
+
+def test_create_job_rejects_source_outside_configured_roots(worker, tmp_path):
+    plugin, _ = worker
+    outside = tmp_path.parent / f"{tmp_path.name}-outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    try:
+        result = call(plugin.create_job, source_path=str(outside), target_locale="ko")
+    finally:
+        outside.unlink(missing_ok=True)
+
+    assert result["error"]["code"] == "SOURCE_OUTSIDE_ALLOWED_ROOTS"
+
+
+def test_create_job_rejects_symlink_escape(worker, tmp_path):
+    plugin, _ = worker
+    outside = tmp_path.parent / f"{tmp_path.name}-outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    link = tmp_path / "link.txt"
+    try:
+        link.symlink_to(outside)
+        result = call(plugin.create_job, source_path=str(link), target_locale="ko")
+    finally:
+        link.unlink(missing_ok=True)
+        outside.unlink(missing_ok=True)
+
+    assert result["error"]["code"] == "SOURCE_OUTSIDE_ALLOWED_ROOTS"
+
+
+def test_register_uses_profile_scoped_default_source_root(worker):
+    plugin, home = worker
+
+    class Context:
+        def __init__(self):
+            self.tools = []
+
+        def get_config(self, key, default=None):
+            assert key == "source_roots"
+            return default
+
+        def register_tool(self, **kwargs):
+            self.tools.append(kwargs)
+
+    context = Context()
+    plugin.register(context)
+
+    assert plugin._SOURCE_ROOTS == ((home / "localization-input").resolve(),)
+    assert len(context.tools) == 11
+
+
+def test_source_replaced_by_symlink_before_inspection_fails_closed(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    outside = tmp_path.parent / f"{tmp_path.name}-outside.txt"
+    source.write_text("inside", encoding="utf-8")
+    outside.write_text("outside", encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    source.unlink()
+    try:
+        source.symlink_to(outside)
+        rejected = call(plugin.inspect_job, job_id=created["job_id"])
+    finally:
+        source.unlink(missing_ok=True)
+        outside.unlink(missing_ok=True)
+
+    assert rejected["error"]["code"] == "SOURCE_OUTSIDE_ALLOWED_ROOTS"
+
+
+def test_aborted_job_rejects_submit_from_existing_lease(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(plugin.abort_job, job_id=job_id, reason="stop")
+
+    rejected = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+
+    assert rejected["error"]["code"] == "INVALID_TRANSITION"
+    assert call(plugin.get_job_status, job_id=job_id)["state"] == "ABORTED"
+
+
+def test_missing_assembled_output_moves_job_to_review(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    assembled = call(plugin.assemble_output, job_id=job_id)
+    Path(assembled["output_path"]).unlink()
+
+    rejected = call(plugin.verify_output, job_id=job_id)
+    status = call(plugin.get_job_status, job_id=job_id)
+
+    assert rejected["error"]["code"] == "OUTPUT_MISSING"
+    assert status["state"] == "NEEDS_REVIEW"
+    assert status["verification_receipt"] is None
+
+
+def test_oversized_translation_payload_is_rejected(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+
+    rejected = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "가" * 30_000}],
+    )
+
+    assert rejected["error"]["code"] == "SUBMISSION_TOO_LARGE"
+
+
+def test_invalid_utf8_output_moves_job_to_review(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    assembled = call(plugin.assemble_output, job_id=job_id)
+    Path(assembled["output_path"]).write_bytes(b"\xff\xfe")
+
+    rejected = call(plugin.verify_output, job_id=job_id)
+    status = call(plugin.get_job_status, job_id=job_id)
+
+    assert rejected["error"]["code"] == "OUTPUT_NOT_UTF8"
+    assert status["state"] == "NEEDS_REVIEW"
+    assert status["verification_receipt"] is None
+
+
+def test_source_change_between_create_and_inspect_fails_closed(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_text("version A", encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    source.write_text("version B", encoding="utf-8")
+
+    rejected = call(plugin.inspect_job, job_id=created["job_id"])
+
+    assert rejected["error"]["code"] == "SOURCE_CHANGED"
+    assert call(plugin.get_job_status, job_id=created["job_id"])["state"] == "FAILED"
+
+
+def test_identical_replay_with_wrong_fencing_token_is_rejected(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    translations = [{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}]
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=translations,
+    )
+
+    rejected = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token="wrong-token",
+        translations=translations,
+    )
+
+    assert rejected["error"]["code"] == "STALE_LEASE"
+
+
+def test_assembly_rejects_output_directory_symlink_escape(worker, tmp_path):
+    plugin, home = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    job_dir = Path(lease["output_path"]).parent
+    outside = tmp_path / "outside-output"
+    outside.mkdir()
+    job_dir.parent.mkdir(parents=True, exist_ok=True)
+    job_dir.symlink_to(outside, target_is_directory=True)
+
+    rejected = call(plugin.assemble_output, job_id=job_id)
+
+    assert rejected["error"]["code"] == "OUTPUT_PATH_UNSAFE"
+    assert list(outside.iterdir()) == []
+    assert call(plugin.get_job_status, job_id=job_id)["state"] == "NEEDS_REVIEW"
+    assert Path(lease["output_path"]).is_relative_to(home)
+
+
+def test_blank_line_round_trip_completes(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_text("a\n\nb\n", encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    job_id = created["job_id"]
+    call(plugin.inspect_job, job_id=job_id)
+    call(plugin.extract_segments, job_id=job_id)
+    call(plugin.create_chunks, job_id=job_id)
+    lease = call(plugin.claim_chunk, job_id=job_id, worker_id="worker")
+    translations = [
+        {"segment_id": segment["segment_id"], "text": {"a": "A", "": "", "b": "B"}[segment["source_text"]]}
+        for segment in lease["segments"]
+    ]
+    call(plugin.submit_chunk, job_id=job_id, chunk_id=lease["chunk_id"], fencing_token=lease["fencing_token"], translations=translations)
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    assembled = call(plugin.assemble_output, job_id=job_id)
+    verified = call(plugin.verify_output, job_id=job_id)
+
+    assert verified["state"] == "COMPLETED"
+    assert Path(assembled["output_path"]).read_text(encoding="utf-8") == "A\n\nB\n"
+
+
+def test_bare_cr_newlines_are_rejected(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_bytes(b"a\rb\r")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+
+    rejected = call(plugin.inspect_job, job_id=created["job_id"])
+
+    assert rejected["error"]["code"] == "UNSUPPORTED_NEWLINE_STYLE"
+
+
+def test_mixed_newlines_are_rejected(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_bytes(b"a\r\nb\nc\r\n")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+
+    rejected = call(plugin.inspect_job, job_id=created["job_id"])
+
+    assert rejected["error"]["code"] == "UNSUPPORTED_NEWLINE_STYLE"
+
+
+def test_number_followed_by_korean_particle_is_preserved(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Version 2.5 costs 100 USD")
+
+    accepted = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "버전 2.5의 가격은 100 USD"}],
+    )
+
+    assert accepted["accepted"] is True
+
+
+def test_malformed_translation_item_returns_bounded_json(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+
+    rejected = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=["not-an-object"],
+    )
+
+    assert rejected["error"]["code"] == "INVALID_ARGUMENTS"
+
+
+def test_sqlite_failure_returns_bounded_json(worker, monkeypatch):
+    plugin, _ = worker
+
+    def broken_connect():
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(plugin, "_connect", broken_connect)
+    rejected = call(plugin.get_job_status, job_id="job")
+
+    assert rejected["error"]["code"] == "DATABASE_ERROR"
+    assert "locked" not in rejected["error"]["message"]
+
+
+def test_oversized_worker_id_is_rejected(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_text("Hello", encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    job_id = created["job_id"]
+    call(plugin.inspect_job, job_id=job_id)
+    call(plugin.extract_segments, job_id=job_id)
+    call(plugin.create_chunks, job_id=job_id)
+
+    rejected = call(plugin.claim_chunk, job_id=job_id, worker_id="w" * 300)
+
+    assert rejected["error"]["code"] == "INVALID_WORKER_ID"
+
+
+def test_oversized_abort_reason_is_rejected(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_text("Hello", encoding="utf-8")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+
+    rejected = call(plugin.abort_job, job_id=created["job_id"], reason="r" * 5000)
+
+    assert rejected["error"]["code"] == "ABORT_REASON_TOO_LARGE"
+    assert call(plugin.get_job_status, job_id=created["job_id"])["state"] == "CREATED"
+
+
+@pytest.mark.parametrize("failure_point", ["file_fsync", "rename", "directory_fsync"])
+def test_assembly_atomic_failure_points_move_job_to_review(worker, tmp_path, monkeypatch, failure_point):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    output = Path(lease["output_path"])
+    original_fsync = plugin.os.fsync
+    original_rename = plugin.os.rename
+    fsync_calls = 0
+
+    def failing_fsync(fd):
+        nonlocal fsync_calls
+        fsync_calls += 1
+        if (failure_point == "file_fsync" and fsync_calls == 1) or (
+            failure_point == "directory_fsync" and fsync_calls == 2
+        ):
+            raise OSError("injected fsync failure")
+        return original_fsync(fd)
+
+    def failing_rename(*args, **kwargs):
+        if failure_point == "rename":
+            raise OSError("injected rename failure")
+        return original_rename(*args, **kwargs)
+
+    monkeypatch.setattr(plugin.os, "fsync", failing_fsync)
+    monkeypatch.setattr(plugin.os, "rename", failing_rename)
+    rejected = call(plugin.assemble_output, job_id=job_id)
+
+    assert rejected["error"]["code"] == "OUTPUT_WRITE_FAILED"
+    status = call(plugin.get_job_status, job_id=job_id)
+    assert status["state"] == "NEEDS_REVIEW"
+    assert status["verification_receipt"] is None
+    if output.parent.exists() and not output.parent.is_symlink():
+        assert not any(path.name.endswith(".tmp") for path in output.parent.iterdir())
+
+
+def test_verify_output_read_failure_moves_job_to_review(worker, tmp_path, monkeypatch):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    call(plugin.assemble_output, job_id=job_id)
+    original_read = plugin.os.read
+    output = Path(lease["output_path"])
+    output_identity = (output.stat().st_dev, output.stat().st_ino)
+
+    def failing_read(fd, size):
+        identity = (plugin.os.fstat(fd).st_dev, plugin.os.fstat(fd).st_ino)
+        if identity == output_identity:
+            raise OSError("injected read failure")
+        return original_read(fd, size)
+
+    monkeypatch.setattr(plugin.os, "read", failing_read)
+    rejected = call(plugin.verify_output, job_id=job_id)
+    monkeypatch.setattr(plugin.os, "read", original_read)
+
+    assert rejected["error"]["code"] == "OUTPUT_PATH_UNSAFE"
+    status = call(plugin.get_job_status, job_id=job_id)
+    assert status["state"] == "NEEDS_REVIEW"
+    assert status["verification_receipt"] is None
+
+
+def test_assembly_write_failure_moves_job_to_review(worker, tmp_path, monkeypatch):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+
+    def fail_write(_fd, _data):
+        raise OSError("injected write failure")
+
+    monkeypatch.setattr(plugin.os, "write", fail_write)
+    rejected = call(plugin.assemble_output, job_id=job_id)
+
+    assert rejected["error"]["code"] == "OUTPUT_WRITE_FAILED"
+    status = call(plugin.get_job_status, job_id=job_id)
+    assert status["state"] == "NEEDS_REVIEW"
+    assert status["verification_receipt"] is None
+
+
+def test_output_dir_open_failure_closes_descriptors(worker, tmp_path, monkeypatch):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    original_close = plugin.os.close
+    opened: set[int] = set()
+    closed: set[int] = set()
+    original_open = plugin.os.open
+
+    def track_open(path, flags, mode=0o777, *, dir_fd=None):
+        if path == "jobs":
+            raise OSError("injected jobs open failure")
+        fd = original_open(path, flags, mode, dir_fd=dir_fd)
+        opened.add(fd)
+        return fd
+
+    def track_close(fd):
+        closed.add(fd)
+        return original_close(fd)
+
+    monkeypatch.setattr(plugin.os, "open", track_open)
+    monkeypatch.setattr(plugin.os, "close", track_close)
+    rejected = call(plugin.assemble_output, job_id=job_id)
+
+    assert rejected["error"]["code"] == "OUTPUT_PATH_UNSAFE"
+    assert opened <= closed
+
+
+def test_assembly_resists_profile_plugins_ancestor_swap(worker, tmp_path, monkeypatch):
+    plugin, home = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    plugins_root = home / "plugins"
+    data_root = plugins_root / "localization-worker"
+    outside_plugins = tmp_path / "outside-plugins"
+    (outside_plugins / "localization-worker" / "jobs" / job_id).mkdir(parents=True)
+    original_open = plugin.os.open
+    swapped = False
+
+    def swapping_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        hits_current_absolute_open = Path(path) == data_root
+        hits_component_open = path == "plugins" and dir_fd is not None
+        if not swapped and (hits_current_absolute_open or hits_component_open):
+            swapped = True
+            plugins_root.rename(home / "plugins-original")
+            plugins_root.symlink_to(outside_plugins, target_is_directory=True)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(plugin.os, "open", swapping_open)
+    result = call(plugin.assemble_output, job_id=job_id)
+
+    assert list((outside_plugins / "localization-worker" / "jobs" / job_id).iterdir()) == []
+    assert result.get("state") == "ASSEMBLING" or result["error"]["code"] == "OUTPUT_PATH_UNSAFE"
+
+
+def test_verify_rejects_fifo_without_reading(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    assembled = call(plugin.assemble_output, job_id=job_id)
+    output = Path(assembled["output_path"])
+    output.unlink()
+    os.mkfifo(output)
+    result: list[dict] = []
+    thread = threading.Thread(
+        target=lambda: result.append(call(plugin.verify_output, job_id=job_id)),
+        daemon=True,
+    )
+
+    thread.start()
+    thread.join(timeout=1)
+
+    assert not thread.is_alive(), "output FIFO open blocked"
+    assert result[0]["error"]["code"] == "OUTPUT_PATH_UNSAFE"
+    status = call(plugin.get_job_status, job_id=job_id)
+    assert status["state"] == "NEEDS_REVIEW"
+    assert status["verification_receipt"] is None
+
+
+def test_assembly_dirfd_resists_ancestor_symlink_swap(worker, tmp_path, monkeypatch):
+    plugin, home = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    jobs_root = home / "plugins" / "localization-worker" / "jobs"
+    outside_jobs = tmp_path / "outside-jobs"
+    (outside_jobs / job_id).mkdir(parents=True)
+    original_open = plugin.os.open
+    swapped = False
+
+    def swapping_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if path == "jobs" and dir_fd is not None and not swapped:
+            swapped = True
+            jobs_root.rename(jobs_root.with_name("jobs-original"))
+            jobs_root.symlink_to(outside_jobs, target_is_directory=True)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(plugin.os, "open", swapping_open)
+    result = call(plugin.assemble_output, job_id=job_id)
+
+    assert list((outside_jobs / job_id).iterdir()) == []
+    assert result.get("state") == "ASSEMBLING" or result["error"]["code"] == "OUTPUT_PATH_UNSAFE"
+
+
+def test_assembly_dirfd_resists_parent_symlink_swap(worker, tmp_path, monkeypatch):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    output = Path(lease["output_path"])
+    outside = tmp_path / "outside-race"
+    outside.mkdir()
+    original_open = plugin.os.open
+    swapped = False
+
+    def swapping_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if dir_fd is not None and isinstance(path, str) and path.startswith(".") and not swapped:
+            swapped = True
+            output.parent.rename(output.parent.with_name(output.parent.name + "-original"))
+            output.parent.symlink_to(outside, target_is_directory=True)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(plugin.os, "open", swapping_open)
+    result = call(plugin.assemble_output, job_id=job_id)
+
+    assert list(outside.iterdir()) == []
+    assert result.get("state") == "ASSEMBLING" or result["error"]["code"] == "OUTPUT_PATH_UNSAFE"
+
+
+def test_verify_unsafe_output_path_moves_job_to_review(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    assembled = call(plugin.assemble_output, job_id=job_id)
+    output = Path(assembled["output_path"])
+    outside = tmp_path / "outside.txt"
+    outside.write_text("external secret", encoding="utf-8")
+    output.unlink()
+    output.symlink_to(outside)
+
+    rejected = call(plugin.verify_output, job_id=job_id)
+
+    assert rejected["error"]["code"] == "OUTPUT_PATH_UNSAFE"
+    status = call(plugin.get_job_status, job_id=job_id)
+    assert status["state"] == "NEEDS_REVIEW"
+    assert status["verification_receipt"] is None
+
+
+def test_crlf_output_changed_to_lf_fails_verification(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_bytes(b"A\r\nB\r\n")
+    created = call(plugin.create_job, source_path=str(source), target_locale="ko")
+    job_id = created["job_id"]
+    call(plugin.inspect_job, job_id=job_id)
+    call(plugin.extract_segments, job_id=job_id)
+    call(plugin.create_chunks, job_id=job_id)
+    lease = call(plugin.claim_chunk, job_id=job_id, worker_id="worker")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[
+            {"segment_id": segment["segment_id"], "text": segment["source_text"]}
+            for segment in lease["segments"]
+        ],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    assembled = call(plugin.assemble_output, job_id=job_id)
+    Path(assembled["output_path"]).write_bytes(b"A\nB\n")
+
+    rejected = call(plugin.verify_output, job_id=job_id)
+
+    assert rejected["error"]["code"] == "OUTPUT_REPARSE_MISMATCH"
+    status = call(plugin.get_job_status, job_id=job_id)
+    assert status["state"] == "NEEDS_REVIEW"
+    assert status["verification_receipt"] is None
+
+
+def test_completed_output_replaced_by_symlink_is_rejected_without_reading_target(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}],
+    )
+    call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])
+    assembled = call(plugin.assemble_output, job_id=job_id)
+    call(plugin.verify_output, job_id=job_id)
+    output = Path(assembled["output_path"])
+    outside = tmp_path / "outside.txt"
+    outside.write_text("external secret", encoding="utf-8")
+    output.unlink()
+    output.symlink_to(outside)
+
+    rejected = call(plugin.get_job_status, job_id=job_id)
+
+    assert rejected["error"]["code"] == "OUTPUT_PATH_UNSAFE"
+    assert outside.read_text(encoding="utf-8") == "external secret"
+
+
+def test_unsupported_format_fails_closed(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.json"
+    source.write_text("{}", encoding="utf-8")
+
+    rejected = call(plugin.create_job, source_path=str(source), target_locale="fr")
+
+    assert rejected["error"]["code"] == "UNSUPPORTED_FORMAT"
+
+
+def test_abort_is_terminal_and_audited(worker, tmp_path):
+    plugin, _ = worker
+    source = tmp_path / "source.md"
+    source.write_text("Hello", encoding="utf-8")
+    job = call(plugin.create_job, source_path=str(source), target_locale="fr")
+
+    aborted = call(plugin.abort_job, job_id=job["job_id"], reason="operator request")
+    rejected = call(plugin.inspect_job, job_id=job["job_id"])
+    status = call(plugin.get_job_status, job_id=job["job_id"])
+
+    assert aborted["state"] == "ABORTED"
+    assert rejected["error"]["code"] == "INVALID_TRANSITION"
+    assert status["state"] == "ABORTED"
+    assert status["audit_event_count"] == 2
+
+
+def test_plugin_registers_only_declared_bounded_json_tools(worker):
+    plugin, _ = worker
+    registrations = []
+
+    class Context:
+        def get_config(self, key, default=None):
+            return default
+
+        def register_tool(self, **kwargs):
+            registrations.append(kwargs)
+
+    plugin.register(Context())
+
+    assert {item["name"] for item in registrations} == {
+        "localization_create_job", "localization_inspect_job", "localization_extract_segments",
+        "localization_create_chunks", "localization_claim_chunk", "localization_submit_chunk",
+        "localization_validate_chunk", "localization_assemble_output", "localization_verify_output",
+        "localization_get_job_status", "localization_abort_job",
+    }
+    assert {item["toolset"] for item in registrations} == {"localization_worker"}

--- a/tests/plugins/test_localization_worker_plugin.py
+++ b/tests/plugins/test_localization_worker_plugin.py
@@ -54,6 +54,22 @@ def claimed_job(plugin, tmp_path, text="Hello {name}"):
     return job_id, lease
 
 
+def test_relative_source_path_is_anchored_to_configured_root(worker, tmp_path, monkeypatch):
+    plugin, _ = worker
+    source = tmp_path / "source.txt"
+    source.write_text("Hello", encoding="utf-8")
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    created = call(plugin.create_job, source_path="source.txt", target_locale="ko")
+    repeated = call(plugin.create_job, source_path="source.txt", target_locale="ko")
+
+    assert created["ok"] is True
+    assert repeated["job_id"] == created["job_id"]
+    assert call(plugin.inspect_job, job_id=created["job_id"])["state"] == "INSPECTED"
+
+
 def test_create_job_rejects_source_swapped_to_external_symlink(worker, tmp_path, monkeypatch):
     plugin, _ = worker
     source = tmp_path / "source.txt"
@@ -277,6 +293,31 @@ def test_translation_unicode_separator_is_preserved_as_content(worker, tmp_path)
 
     assert verified["state"] == "COMPLETED"
     assert Path(assembled["output_path"]).read_text(encoding="utf-8") == translated
+
+
+def test_final_chunk_submit_retry_is_idempotent_after_validation(worker, tmp_path):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+    translations = [{"segment_id": lease["segments"][0]["segment_id"], "text": "안녕"}]
+    accepted = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=translations,
+    )
+    assert accepted["idempotent"] is False
+    assert call(plugin.validate_chunk, job_id=job_id, chunk_id=lease["chunk_id"])["state"] == "VALIDATING"
+
+    retried = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=translations,
+    )
+
+    assert retried == {"ok": True, "accepted": True, "idempotent": True, "state": "VALIDATING"}
 
 
 def test_invalid_transition_fails_closed(worker, tmp_path):
@@ -604,6 +645,22 @@ def test_empty_translation_is_rejected(worker, tmp_path):
     )
 
     assert rejected["error"]["code"] == "EMPTY_TRANSLATION"
+
+
+@pytest.mark.parametrize("translated", ["안녕\n세계", "안녕\r세계", "안녕\r\n세계"])
+def test_embedded_translation_newline_is_rejected_at_submission(worker, tmp_path, translated):
+    plugin, _ = worker
+    job_id, lease = claimed_job(plugin, tmp_path, text="Hello")
+
+    rejected = call(
+        plugin.submit_chunk,
+        job_id=job_id,
+        chunk_id=lease["chunk_id"],
+        fencing_token=lease["fencing_token"],
+        translations=[{"segment_id": lease["segments"][0]["segment_id"], "text": translated}],
+    )
+
+    assert rejected["error"]["code"] == "TRANSLATION_CONTAINS_NEWLINE"
 
 
 def test_number_change_is_rejected(worker, tmp_path):

--- a/tests/skills/test_localization_worker_skill.py
+++ b/tests/skills/test_localization_worker_skill.py
@@ -1,0 +1,52 @@
+"""Static contract tests for the localization-worker optional skill."""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = ROOT / "optional-skills" / "productivity" / "localization-worker"
+SKILL = SKILL_DIR / "SKILL.md"
+FORMATS = SKILL_DIR / "references" / "formats.md"
+PLUGIN = ROOT / "plugins" / "localization-worker" / "plugin.yaml"
+
+
+def _frontmatter(text: str):
+    assert text.startswith("---\n")
+    _, raw, body = text.split("---", 2)
+    return yaml.safe_load(raw), body
+
+
+def test_skill_frontmatter_and_description_follow_repository_contract():
+    metadata, body = _frontmatter(SKILL.read_text(encoding="utf-8"))
+
+    assert metadata["name"] == "localization-worker"
+    assert metadata["version"] == "0.1.0"
+    assert metadata["platforms"] == ["linux", "macos"]
+    assert metadata["description"].endswith(".")
+    assert len(metadata["description"]) <= 60
+    assert body.strip()
+
+
+def test_skill_describes_only_native_plugin_workflow():
+    skill = SKILL.read_text(encoding="utf-8")
+    formats = FORMATS.read_text(encoding="utf-8")
+
+    assert "scripts/localization_cli.py" not in skill
+    assert "localization_create_job" in skill
+    assert "localization_verify_output" in skill
+    assert "## How to Run" in skill
+    assert "## Quick Reference" in skill
+    assert "## Procedure" in skill
+    assert "## Pitfalls" in skill
+    assert "## Verification" in skill
+    assert "Only UTF-8 `.txt` and `.md`" in skill
+    assert "all other extensions | explicit unsupported" in formats
+
+
+def test_skill_and_plugin_versions_match():
+    skill_metadata, _ = _frontmatter(SKILL.read_text(encoding="utf-8"))
+    plugin_metadata = yaml.safe_load(PLUGIN.read_text(encoding="utf-8"))
+
+    assert skill_metadata["name"] == plugin_metadata["name"]
+    assert skill_metadata["version"] == plugin_metadata["version"]

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -190,6 +190,7 @@ hermes skills uninstall <skill-name>
 |-------|-------------|
 | [**canvas**](/docs/user-guide/skills/optional/productivity/productivity-canvas) | Fetch Canvas LMS courses and assignments via API token. |
 | [**here-now**](/docs/user-guide/skills/optional/productivity/productivity-here-now) | Publish sites to &#123;slug&#125;.here.now and store files in Drives. |
+| [**localization-worker**](/docs/user-guide/skills/optional/productivity/productivity-localization-worker) | Run verified text-file localization workflows. |
 | [**memento-flashcards**](/docs/user-guide/skills/optional/productivity/productivity-memento-flashcards) | Spaced-repetition flashcards: create, review, quiz, export. |
 | [**shop**](/docs/user-guide/skills/optional/productivity/productivity-shop) | Shop catalog search, checkout, order tracking, returns. |
 | [**shopify**](/docs/user-guide/skills/optional/productivity/productivity-shopify) | Query Shopify Admin/Storefront GraphQL APIs via curl. |

--- a/website/docs/user-guide/skills/optional/productivity/productivity-localization-worker.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-localization-worker.md
@@ -1,0 +1,110 @@
+---
+title: "Localization Worker — Run verified text-file localization workflows"
+sidebar_label: "Localization Worker"
+description: "Run verified text-file localization workflows"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Localization Worker
+
+Run verified text-file localization workflows.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/productivity/localization-worker` |
+| Path | `optional-skills/productivity/localization-worker` |
+| Version | `0.1.0` |
+| Author | Hyukjin, Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos |
+| Tags | `Localization`, `Translation`, `QA`, `Documents` |
+| Related skills | [`docx`](/docs/user-guide/skills/bundled/productivity/productivity-docx), [`xlsx`](/docs/user-guide/skills/bundled/productivity/productivity-xlsx), [`pdf`](/docs/user-guide/skills/bundled/productivity/productivity-pdf) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Localization Worker Skill
+
+Translate UTF-8 text files through the `localization_worker` native-plugin toolset. The model translates only leased segment payloads; the plugin owns state, persistence, output paths, validation, and authoritative completion.
+
+## When to Use
+
+- Use for resumable `.txt` or `.md` file translation that requires a verified artifact.
+- Do not use for casual sentence translation or formats not listed as supported in `references/formats.md`.
+
+## Prerequisites
+
+The `localization-worker` native plugin must be installed and enabled in a new Hermes session. Confirm that the eleven `localization_*` tools are available before creating a job. Source files must be located under a configured `plugins.entries.localization-worker.settings.source_roots` directory; the default is `<HERMES_HOME>/localization-input`.
+
+The plugin supports Linux and macOS only. It requires POSIX directory-fd operations, `O_DIRECTORY`, `O_NOFOLLOW`, and `O_NONBLOCK`; registration fails closed when these primitives are unavailable. `<HERMES_HOME>` and its SQLite plugin-data directory are an administrator-owned trust boundary. Do not place them in an attacker-writable parent directory or replace them while Hermes is running.
+
+## How to Run
+
+Start a new Hermes session with the installed native plugin enabled, then invoke the registered `localization_*` tools through normal tool calls. Do not use `terminal` or direct filesystem tools to emulate the workflow. A run is eligible for success reporting only after `localization_verify_output` returns `COMPLETED` with a receipt.
+
+## Quick Reference
+
+```text
+localization_create_job → localization_inspect_job → localization_extract_segments
+→ localization_create_chunks → (localization_claim_chunk → localization_submit_chunk
+→ localization_validate_chunk)×N → localization_assemble_output
+→ localization_verify_output → localization_get_job_status
+```
+
+Terminal states: `COMPLETED`, `FAILED`, `BLOCKED`, `NEEDS_REVIEW`, `ABORTED`.
+
+## Runtime Rules
+
+- Use only the registered `localization_*` tools during a localization job.
+- Never use shell commands, arbitrary code execution, or direct file writes to replace a failed localization tool.
+- Never invent a replacement workflow when a tool fails.
+- Stop when a job reaches `FAILED`, `BLOCKED`, `NEEDS_REVIEW`, or `ABORTED`.
+- Preserve every returned segment ID and placeholder exactly.
+- Never select an output path; the plugin owns its profile-scoped job directory.
+- Never claim completion from reasoning, an external API response, or file existence alone.
+- Report success only when `localization_verify_output` returns `COMPLETED` with a verification receipt.
+- Treat missing, malformed, oversized, unsupported, or unverifiable results as failures.
+- Network research may inform terminology but must not change job state or bypass validation.
+
+## Procedure
+
+1. Call `localization_create_job` with `source_path` and `target_locale`. Continue only from `CREATED`; record the returned `job_id` and authoritative `output_path`.
+2. Call `localization_inspect_job`, then `localization_extract_segments`. Extraction returns bounded metadata, not source text. Stop on `UNSUPPORTED_FORMAT`, `SOURCE_CHANGED`, `EMPTY_DOCUMENT`, or any terminal state.
+3. Call `localization_create_chunks`. Confirm returned `max_estimated_tokens` is at most 2,048. The response is bounded summary metadata; chunk IDs and source payloads are disclosed only by claims.
+4. Call `localization_claim_chunk` with a stable `worker_id`. Translate only its returned segments before `lease_expires_at`.
+5. Call `localization_submit_chunk` with the exact `chunk_id`, `fencing_token`, segment-ID set, and translated text.
+6. Call `localization_validate_chunk`. Repeat claim, submit, and validation while the state remains `PROCESSING`.
+7. Continue only when validation returns `VALIDATING`, which means every chunk is validated.
+8. Call `localization_assemble_output`, then `localization_verify_output`.
+9. Report completion only from the returned receipt. Later status checks can invalidate completion if the artifact changes.
+
+## Pitfalls
+
+- Only UTF-8 `.txt` and `.md` are currently supported. Markdown is treated as line-preserving text, not as a parsed Markdown AST.
+- UTF-8 BOM, uniform LF or uniform CRLF framing, and final-newline presence are preserved for supported fixtures. Bare-CR, mixed newline documents, U+0085, U+2028, U+2029, vertical tab, and form feed fail closed with `UNSUPPORTED_NEWLINE_STYLE`.
+- A single source line that exceeds the local 2,048-token estimate fails with `OVERSIZED_SEGMENT`; it is not split through placeholders or syntax.
+- Leases expire after five minutes. A replacement worker receives a new fencing token; submissions using an old or expired token fail.
+- Caller-provided `output_path` is rejected. Output artifacts remain under the active profile's plugin data directory.
+- Source and output artifact paths are opened component by component from directory fds with no-follow and nonblocking final-open semantics. Traversal, ancestor replacement, symlink escapes, FIFOs, sockets, devices, and other non-regular files fail closed without blocking.
+- Source text is disclosed only by a valid `localization_claim_chunk` lease. `localization_extract_segments` returns bounded counts and state metadata.
+- Existing completed jobs are keyed by source content hash, source path, and target locale.
+
+## Verification
+
+A successful job has all of the following:
+
+- every extracted segment translated and validated;
+- exact segment-ID and placeholder preservation;
+- an artifact in the profile-scoped job directory;
+- successful UTF-8 reopen with BOM and newline framing preserved;
+- content equal to the validated translations;
+- an output SHA-256 stored with a verification receipt;
+- authoritative state `COMPLETED`.
+
+`localization_get_job_status` rechecks a completed artifact. Modification or deletion invalidates the receipt and returns `OUTPUT_CHANGED_AFTER_VERIFICATION`. The receipt is a profile-local workflow completion token stored with the SQLite job state; it is not a cryptographic signature for verification by an external party.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -547,6 +547,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'user-guide/skills/optional/productivity/productivity-canvas',
                     'user-guide/skills/optional/productivity/productivity-here-now',
+                    'user-guide/skills/optional/productivity/productivity-localization-worker',
                     'user-guide/skills/optional/productivity/productivity-memento-flashcards',
                     'user-guide/skills/optional/productivity/productivity-shop',
                     'user-guide/skills/optional/productivity/productivity-shopify',


### PR DESCRIPTION
## Summary
- add a standalone native `localization-worker` plugin with 11 strict tools
- add deterministic UTF-8 TXT/Markdown extraction, chunk leasing, validation, atomic assembly, and verification receipts
- add a profile-scoped optional skill and generated documentation

## Safety and durability
- SQLite WAL state machine with explicit transitions, lease TTLs, fencing tokens, audit events, and fail-closed receipts
- component-by-component `dir_fd` traversal with `O_DIRECTORY`, `O_NOFOLLOW`, and nonblocking regular-file checks
- bounded public JSON results and source disclosure only through claimed chunk leases
- exact BOM, LF/CRLF, final-newline, placeholder, number, and output hash verification
- durable `FAILED`/`NEEDS_REVIEW` transitions for deterministic source and output failures

## Verification
- `ruff check` passed
- Plugin Doctor passed: 11 tools, 0 hooks
- direct plugin suite: 67 passed
- plugin/skill/CLI integration suites: 126 passed
- `git diff --check` passed
- fault injection covered open/read/write/file-fsync/rename/directory-fsync failures
- adversarial tests covered ancestor swaps, symlinks, FIFOs, Unix sockets, source drift, output tampering, stale leases, aborts, and replay fencing
- manual large-document lifecycle: 1,200 segments, 67 chunks, 492 KB byte-exact output
- process-level concurrent claim test produced exactly one lease winner
- real cloud `gpt-5.6-sol` and local Gemma 4 12B workflows both reached `COMPLETED` with receipts
- installed Towa-profile smoke run reached `COMPLETED`; DB hash, receipt, final newline, placeholder, and numbers were independently verified

## Scope
- supported platforms: Linux and macOS
- supported source formats: UTF-8 `.txt` and `.md`
- no core registry, agent-loop, or built-in tool override changes
