### PR TITLE
fix(credential-pool): don't block healthy pool entries on per-account quota exhaustion

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3977,10 +3977,30 @@ def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None
     """Mark ``provider`` as recently-402'd, hidden from chain iteration
     until the TTL expires. Called from the payment-fallback branches in
     ``call_llm`` and ``acall_llm`` after a confirmed payment error.
+
+    If the provider has a credential pool with other available entries
+    (e.g. a multi-account pool where one account hit a weekly quota but
+    another is healthy), do NOT mark the provider unhealthy.  The pool
+    rotation will handle the per-credential failure; marking the whole
+    provider unhealthy would block the healthy accounts too.
     """
     label = _normalize_chain_label(provider)
     if not label:
         return
+    # Skip marking if the provider's credential pool still has available
+    # entries — the failure is per-account, not provider-wide.
+    try:
+        pool = load_pool(label)
+        if pool and pool.has_available():
+            logger.info(
+                "Auxiliary: NOT marking %s unhealthy — credential pool "
+                "still has available entries (per-account failure, not "
+                "provider-wide). Pool rotation will handle it.",
+                label,
+            )
+            return
+    except Exception:
+        pass  # No pool or pool check failed — fall through to marking
     expires_at = time.time() + (ttl if ttl is not None else _AUX_UNHEALTHY_TTL_SECONDS)
     _aux_unhealthy_until[label] = expires_at
     logger.warning(

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -160,7 +160,7 @@ def aux_probe_mode():
     finally:
         _aux_probe_state.active = prev
 
-from agent.credential_pool import load_pool
+from agent.credential_pool import load_pool, BILLING_QUOTA_SIGNALS
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -4082,14 +4082,7 @@ def _is_payment_error(exc: Exception) -> bool:
             "model_not_supported_on_free_tier",
             "not available on the free tier",
             "requires a subscription", "upgrade for access",
-            "upgrade for higher limits", "reached your session usage limit",
-            # Daily / monthly / weekly quota exhaustion keywords
-            "quota exceeded", "quota_exceeded",
-            "too many tokens per day", "daily limit",
-            "tokens per day", "daily quota",
-            "resource exhausted",  # Vertex AI / gRPC quota errors
-            "weekly usage limit", "weekly limit",  # OpenCode Go weekly subscription cap
-        )):
+        ) + tuple(BILLING_QUOTA_SIGNALS)):
             return True
     return False
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9612,7 +9612,12 @@ def _call_llm_impl(
                     # alternative providers can still serve the request.
                     if (_is_payment_error(retry2_err) or _is_auth_error(retry2_err)
                             or _is_rate_limit_error(retry2_err)):
-                        _recover_provider_pool(pool_provider, retry2_err)
+                        # Pass the key used for the retry so
+                        # mark_exhausted_and_rotate targets the correct entry.
+                        # Without this, the pool falls back to pool.current()
+                        # which may point at a DIFFERENT healthy entry, marking
+                        # it exhausted with the wrong account's error (#43747).
+                        _recover_provider_pool(pool_provider, retry2_err, failed_api_key=resolved_api_key or "")
                         first_err = retry2_err
                     else:
                         raise
@@ -10308,7 +10313,12 @@ async def _async_call_llm_impl(
                 except Exception as retry2_err:
                     if (_is_payment_error(retry2_err) or _is_auth_error(retry2_err)
                             or _is_rate_limit_error(retry2_err)):
-                        _recover_provider_pool(pool_provider, retry2_err)
+                        # Pass the key used for the retry so
+                        # mark_exhausted_and_rotate targets the correct entry.
+                        # Without this, the pool falls back to pool.current()
+                        # which may point at a DIFFERENT healthy entry, marking
+                        # it exhausted with the wrong account's error (#43747).
+                        _recover_provider_pool(pool_provider, retry2_err, failed_api_key=resolved_api_key or "")
                         first_err = retry2_err
                     else:
                         raise

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3999,7 +3999,8 @@ def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None
                 label,
             )
             return
-    except Exception:
+    except Exception as exc:
+        logger.debug("Auxiliary: pool availability check for %s failed (%s) — falling through to marking unhealthy", label, exc)
         pass  # No pool or pool check failed — fall through to marking
     expires_at = time.time() + (ttl if ttl is not None else _AUX_UNHEALTHY_TTL_SECONDS)
     _aux_unhealthy_until[label] = expires_at

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -131,6 +131,27 @@ EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
 # the short 401 cooldown above. Provider-supplied reset_at still overrides.
 EXHAUSTED_TTL_SOLE_CREDENTIAL_SECONDS = 60   # 1 minute
 
+# Shared billing/quota-exhaustion signal keywords.
+#
+# Used by both ``error_classifier._429_BILLING_SIGNALS`` (429 path) and
+# ``auxiliary_client._is_payment_error`` (payment-error detection) so the
+# two paths never drift apart.  Keep quota/usage-limit keywords here;
+# 402-specific keywords (``"credits"``, ``"payment required"``, etc.) stay
+# inline in ``_is_payment_error`` because they are never relevant on a 429.
+BILLING_QUOTA_SIGNALS = [
+    "weekly usage limit",
+    "weekly limit",
+    "upgrade for higher limits",
+    "reached your session usage limit",
+    "quota exceeded",
+    "quota_exceeded",
+    "resource exhausted",
+    "too many tokens per day",
+    "daily limit",
+    "tokens per day",
+    "daily quota",
+]
+
 # ``FailoverReason.billing`` as a bare string. The pool stores classified
 # failure semantics as plain text (it persists to JSON and must not import
 # the classifier), so the value is duplicated here rather than referenced.

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -205,6 +205,32 @@ _USAGE_LIMIT_PATTERNS = [
     "key limit exceeded",
 ]
 
+# Patterns that indicate a 429 is actually billing/quota exhaustion, not a
+# transient rate limit.  Some providers return HTTP 429 for hard quota caps
+# — e.g. "you have reached your weekly usage limit, upgrade for higher
+# limits" — which is semantically billing exhaustion: the account cannot
+# serve requests until the quota window resets (days, not seconds).  Without
+# this check the 429 falls through to ``rate_limit``, which retries the same
+# dead credential once before rotating (wasting an API call) and sizes the
+# cooldown as a transient 1-hour TTL instead of the full billing bench.
+#
+# Mirrors the keywords already recognised by
+# ``auxiliary_client._is_payment_error`` so the classifier and the auxiliary
+# client agree on the verdict.
+_429_BILLING_SIGNALS = [
+    "weekly usage limit",
+    "weekly limit",
+    "upgrade for higher limits",
+    "reached your session usage limit",
+    "quota exceeded",
+    "quota_exceeded",
+    "resource exhausted",
+    "too many tokens per day",
+    "daily limit",
+    "tokens per day",
+    "daily quota",
+]
+
 # Patterns confirming usage limit is transient (not billing)
 _USAGE_LIMIT_TRANSIENT_SIGNALS = [
     "try again",
@@ -1213,6 +1239,20 @@ def _classify_by_status(
                 should_rotate_credential=False,
                 should_fallback=True,
                 error_context=ctx,
+            )
+        # Some providers return HTTP 429 for hard quota / billing exhaustion
+        # (e.g. "weekly usage limit", "too many tokens per day",
+        # "resource exhausted").  These are not transient rate limits — the
+        # account cannot serve requests until the quota window resets (hours
+        # or days).  Classify as ``billing`` so the recovery path rotates
+        # immediately instead of retrying the same dead credential, and the
+        # cooldown gets the full billing bench.
+        if any(p in error_msg for p in _429_BILLING_SIGNALS):
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
             )
         return result_fn(
             FailoverReason.rate_limit,

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -16,6 +16,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
+from agent.credential_pool import BILLING_QUOTA_SIGNALS
+
 logger = logging.getLogger(__name__)
 
 
@@ -216,20 +218,9 @@ _USAGE_LIMIT_PATTERNS = [
 #
 # Mirrors the keywords already recognised by
 # ``auxiliary_client._is_payment_error`` so the classifier and the auxiliary
-# client agree on the verdict.
-_429_BILLING_SIGNALS = [
-    "weekly usage limit",
-    "weekly limit",
-    "upgrade for higher limits",
-    "reached your session usage limit",
-    "quota exceeded",
-    "quota_exceeded",
-    "resource exhausted",
-    "too many tokens per day",
-    "daily limit",
-    "tokens per day",
-    "daily quota",
-]
+# client agree on the verdict.  Both paths import the shared
+# ``BILLING_QUOTA_SIGNALS`` constant from ``credential_pool`` to prevent drift.
+_429_BILLING_SIGNALS = BILLING_QUOTA_SIGNALS
 
 # Patterns confirming usage limit is transient (not billing)
 _USAGE_LIMIT_TRANSIENT_SIGNALS = [

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1247,7 +1247,19 @@ def _classify_by_status(
         # or days).  Classify as ``billing`` so the recovery path rotates
         # immediately instead of retrying the same dead credential, and the
         # cooldown gets the full billing bench.
+        #
+        # But first check for transient signals — a 429 that says "daily limit,
+        # try again in 5 minutes" is a periodic quota that resets, not billing
+        # exhaustion.  Mirrors the disambiguation already done in
+        # ``_classify_402`` and ``_classify_by_message``.
         if any(p in error_msg for p in _429_BILLING_SIGNALS):
+            if any(p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS):
+                return result_fn(
+                    FailoverReason.rate_limit,
+                    retryable=True,
+                    should_rotate_credential=True,
+                    should_fallback=True,
+                )
             return result_fn(
                 FailoverReason.billing,
                 retryable=False,


### PR DESCRIPTION
## Problem

A single exhausted account blocks **all** healthy accounts in the same credential pool. When account A hits its weekly usage limit (HTTP 429), three bugs prevent account B from serving requests:

### Bug 1: Error classifier misroutes billing 429s as rate_limit

`error_classifier.py` — HTTP 429 with billing/quota messages like `"you have reached your weekly usage limit, upgrade for higher limits"` falls through to `rate_limit` instead of `billing`.

**Impact:** The recovery path retries the same dead credential once before rotating (wasting an API call + ~3s), and the cooldown gets the transient 1-hour TTL instead of the full billing bench.

### Bug 2: Auxiliary client marks entire provider unhealthy

`auxiliary_client.py` — `_mark_provider_unhealthy` marks the **entire provider** unhealthy for 600s after a payment error, even when the credential pool has other healthy accounts.

**Impact:** All auxiliary calls (title generation, classification, compression) skip that provider for 10 minutes — including calls that would use a healthy account. Log evidence:

```
Auxiliary: marking <provider> unhealthy for 600s (payment / credit error). Subsequent auxiliary calls will skip it until 08:37:14.
```

The comment at the call site assumes "payment errors are provider-wide — the credentials or account behind every model on that provider are the same." This is wrong for multi-account credential pools.

### Bug 3: retry2 recovery marks the wrong pool entry exhausted

`auxiliary_client.py` — When a retried auxiliary call fails after credential-pool rotation, `_recover_provider_pool` is called **without** `failed_api_key`. This causes `mark_exhausted_and_rotate` to fall back to `pool.current()`, which after the first rotation points at the NEXT healthy entry — marking it exhausted with the wrong account's error.

**Impact:** A single rate-limited account takes down all healthy accounts in the pool. The pool reports "no available entries (all exhausted or empty)" even though only one account actually hit its limit.

## Fix

### Fix 1: Classify billing 429s correctly

Add `_429_BILLING_SIGNALS` pattern list to `error_classifier.py`. When a 429 message contains billing/quota keywords (`"weekly usage limit"`, `"quota exceeded"`, `"resource exhausted"`, etc.), classify as `billing` instead of `rate_limit`.

Keywords mirror those already recognised by `auxiliary_client._is_payment_error` so both paths agree on the verdict.

### Fix 2: Check pool availability before marking provider unhealthy

In `_mark_provider_unhealthy`, check if the provider's credential pool still has available entries via `pool.has_available()`. If yes, skip marking — the failure is per-account, not provider-wide, and pool rotation will handle it.

### Fix 3: Pass failed_api_key on retry2 recovery

Pass `resolved_api_key` (the key used for the retry) to `_recover_provider_pool` on the retry2 error path, so `mark_exhausted_and_rotate` targets the correct entry instead of falling back to `pool.current()`.

## Test Plan

- [ ] Existing credential pool tests pass
- [ ] Verify: 429 + "weekly usage limit" → classified as `billing` (not `rate_limit`)
- [ ] Verify: `_mark_provider_unhealthy` skips when pool has available entries
- [ ] Verify: `_mark_provider_unhealthy` still marks when pool is fully exhausted (no available entries)
- [ ] Verify: retry2 `_recover_provider_pool` marks the correct entry, not `pool.current()`