### PR TITLE
fix: render deferred update notice through prompt_toolkit, not raw stdout

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -633,7 +633,20 @@ def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
             behind = _update_result
             if behind is None or behind == 0:
                 return
-            console.print(_format_update_notice(behind))
+            # Render rich markup to ANSI in memory, then print through
+            # prompt_toolkit's renderer. console.print() writes raw escapes
+            # to stdout, which patch_stdout's StdoutProxy mangles into
+            # visible "[1;33m..." artifacts (see #2262 / #2448; this
+            # callsite was missed by both fixes). Lazy imports keep this
+            # module off the gateway startup path (see module docstring).
+            from io import StringIO
+            from rich.console import Console as _RichConsole
+            buf = StringIO()
+            _RichConsole(
+                file=buf, force_terminal=True, color_system="truecolor", highlight=False
+            ).print(_format_update_notice(behind))
+            for line in buf.getvalue().rstrip("\n").split("\n"):
+                cprint(line)
         except Exception:
             pass  # never break the session over an update notice
 

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -83,3 +83,36 @@ def test_build_welcome_banner_non_moa_unchanged(tmp_path, monkeypatch):
     out = console.export_text()
     assert "claude-opus-4.8" in out
     assert "MoA:" not in out
+
+
+def test_defer_update_notice_routes_through_cprint_not_raw_console():
+    """Deferred update notice must render via prompt_toolkit (cprint), never
+    console.print — raw ANSI to stdout gets mangled by patch_stdout's
+    StdoutProxy into visible "[1;33m..." artifacts (#83969, cf. #2262/#2448)."""
+    import threading
+    import time
+    from unittest.mock import Mock, patch
+
+    import hermes_cli.banner as banner
+
+    console = Mock()
+    done = threading.Event()
+    done.set()
+
+    with (
+        patch.object(banner, "_update_check_done", done),
+        patch.object(banner, "_update_result", 5),
+        patch.object(banner, "_deferred_update_notice_started", False),
+        patch.object(banner, "cprint") as mock_cprint,
+    ):
+        banner._defer_update_notice(console, max_wait=1.0)
+        deadline = time.time() + 2.0
+        while time.time() < deadline and mock_cprint.call_count == 0:
+            time.sleep(0.01)
+
+    console.print.assert_not_called()
+    assert mock_cprint.call_count >= 1, "deferred notice never printed via cprint"
+    for call in mock_cprint.call_args_list:
+        line = call.args[0]
+        assert "\x1b[" in line, f"expected ANSI-rendered line, got: {line!r}"
+        assert "[bold yellow]" not in line, f"rich markup leaked through: {line!r}"


### PR DESCRIPTION
Fixes #83969

## Problem

The deferred update notice (`⚠ N commits behind — run hermes update to update`) renders as garbled ANSI escape codes in the interactive CLI:

```
?[1;33m⚠ ?[0m?[1;33m231?[0m?[1;33m commits behind?[0m?[2;33m — run ?[0m?[1;2;33mhermes update?[0m?[2;33m to update?[0m
```

`banner._defer_update_notice` prints the rich markup via `console.print()`, which writes raw ANSI escapes to stdout. Under the interactive CLI, `patch_stdout`'s `StdoutProxy` strips the ESC bytes, leaving the bare `[1;33m...[0m` text visible.

This is the same class of bug as #2262 (fixed by #2448), but the `_defer_update_notice` callsite in `banner.py` was not covered by that fix.

## Fix

Render the rich markup to ANSI in memory (rich `Console` → `StringIO` with `force_terminal=True`), then print each line through `banner.cprint()`, which routes through prompt_toolkit's native renderer and already has a plain-print fallback for consoles without a screen buffer.

The imports stay inside the function (lazy) to keep this module off the gateway startup path, per the module docstring.

## Tests

- New regression test `test_defer_update_notice_routes_through_cprint_not_raw_console`: asserts the deferred notice goes through `cprint` (never `console.print`) and that every line is ANSI-rendered with no rich markup leakage.
- Full `tests/hermes_cli/test_banner*.py` + `tests/test_cli_skin_integration.py`: 20 passed.
- Smoke test of the real path with a non-TTY stdout: clean plain-text output, no ESC leaks.