### PR TITLE
fix(citations): count explicit non-web provenance

### DIFF
--- a/skills/research/grounded-citations/SKILL.md
+++ b/skills/research/grounded-citations/SKILL.md
@@ -20,9 +20,11 @@ so the numbers and URLs come from retrieval, never from memory — the model onl
 ever emits small integers it was handed.
 
 For high-stakes work the same ledger doubles as a fact-checking chain: verbatim
-quotes are attached to each source (rejected unless they literally appear in
-the fetched page text), claims from model knowledge are flagged `[unverified]`,
-and `verify --evidence` fails any draft whose cited sources carry no evidence.
+quotes are attached to each URL source (rejected unless they literally appear
+in the fetched page text), deterministic tool facts carry `[tool:<name>]`,
+user/skill rules carry `[policy]`, and model knowledge is flagged
+`[unverified]`. `verify --evidence` requires quotes only for numeric URL
+citations.
 
 This skill covers answers in chat, written documents (markdown, PDF, docx,
 slides), and research reports. It does not cover academic BibTeX pipelines —
@@ -46,7 +48,10 @@ Mention a URL only if the user would plausibly want the link.
 
 ## Prerequisites
 
-None beyond the standard toolset. `scripts/sources.py` is stdlib-only Python 3.
+None beyond the standard toolset. `scripts/sources.py` is stdlib-only and requires
+Python 3.10+ because it imports current Hermes modules that use PEP 604 type syntax.
+On macOS, check `python3 --version`; if Apple’s Python 3.9 is first on PATH, invoke
+all examples as `python3.11 "$S" ...` (or another installed 3.10+ interpreter).
 Retrieval comes from whatever is configured: `web_search`, `web_extract`,
 `browser_navigate`, or `terminal` (curl, CLIs).
 
@@ -106,7 +111,10 @@ Ice floats because it is less dense than liquid water.[1][2]
 - No space before the bracket; each id in its own brackets.
 - Max 3 ids per sentence. Cite per sentence, not one dump at the end.
 - Only ids the ledger returned. Never invent an id or a URL.
-- Claims from your own knowledge get no citation.
+- Deterministic facts read from a tool use `[tool:<name>]`; user- or
+  skill-supplied rules use `[policy]`. These declare non-URL provenance and do
+  not create a Sources entry.
+- Claims from your own knowledge get no numeric citation.
 - Conflicting sources: present both readings, each with its own id.
 - Quote exact figures, dates, and names as the source states them; flag gaps
   explicitly ("no source found for X") instead of smoothing them over.
@@ -147,18 +155,30 @@ Copy-paste from the fetched text; never retype. Quote the sentence as the
 reader sees it — the matcher sees through the extractor's markup for you, so
 you don't have to reproduce link syntax or escaped asterisks in your quote.
 
-② **Flag model-knowledge claims with `[unverified]`.** A load-bearing claim
-you could not source gets an explicit marker instead of a citation:
+② **Declare non-URL provenance exactly.** Use one of these markers at the
+end of the sentence:
+
+- `[tool:<name>]` for a deterministic fact returned by a named tool. `<name>`
+  must be a non-empty safe token matching `[A-Za-z0-9][A-Za-z0-9_.-]*`, for
+  example `[tool:TradingView]` or
+  `[tool:mcp__tradingview__data_get_ohlcv]`. Bare `[tool]`, `[tool:]`, and
+  names containing spaces do not count.
+- `[policy]` for a rule supplied by the user or an active skill/playbook.
+- `[unverified]` for a load-bearing model-knowledge claim that could not be
+  sourced.
 
 ```
+The live close came from the chart.[tool:TradingView]
+The playbook requires confirmation before entry.[policy]
 The refactor likely predates the 2.0 release.[unverified]
 ```
 
-`verify --min-coverage` counts `[unverified]` sentences as covered — the goal
-is declared provenance for every claim, not a citation on every sentence.
-If a key claim can be checked, check it; `[unverified]` is for what genuinely
-cannot be, and a fact-check deliverable dominated by `[unverified]` markers
-should say so in its summary.
+All three markers count toward `verify --min-coverage`, but `[tool:<name>]` and
+`[policy]` are provenance declarations, not numeric URL citations and not
+synonyms for `[unverified]`. They do not add Sources entries or satisfy a claim
+that actually came from the web. If a key model-knowledge claim can be checked,
+check it; `[unverified]` is for what genuinely cannot be, and a fact-check
+deliverable dominated by `[unverified]` markers should say so in its summary.
 
 ③ **Cross-check disputed facts against a second independent source.** When two
 sources disagree, cite both readings with their own ids and quotes, and say
@@ -184,9 +204,13 @@ to stdout instead. Both emit the heading `## Sources` (`--style plain` emits
 `sentences with declared provenance / prose sentences`. A prose sentence is a
 non-empty line fragment of 4+ words after the Sources block, headings (`#`),
 table rows (`|`), and fenced code are dropped; blockquote markers are stripped.
-Provenance is declared by either a `[n]` citation or an `[unverified]` marker,
-so a sentence carrying both counts once. Run `verify` without a threshold first
-and read the `info: stats:` line to see the counts before picking a number.
+Provenance is declared by a numeric `[n]` URL citation, a valid
+`[tool:<name>]` marker, `[policy]`, or `[unverified]`. A sentence carrying more
+than one kind counts once in the coverage numerator, while stats report the
+cited, tool-verified, policy, and unverified category counts separately. The
+`--evidence` quote gate remains limited to numeric `[n]` URL citations. Run
+`verify` without a threshold first and read the `info: stats:` line before
+picking a number.
 
 ## Pitfalls
 
@@ -226,7 +250,7 @@ python "$S" verify report.md --strict --min-coverage 0.5
 ```
 
 Green means: every `[n]` in the draft exists in the ledger, the Sources block
-lists exactly the cited ids with the ledger's URLs, and the cited share of
-source-bearing sentences meets the threshold. Read the warnings even when the
+lists exactly the cited ids with the ledger's URLs, and the declared-provenance
+share of prose sentences meets the threshold. Read the warnings even when the
 exit code is 0 — uncited registered sources usually mean a claim lost its
 attribution during editing.

--- a/skills/research/grounded-citations/scripts/sources.py
+++ b/skills/research/grounded-citations/scripts/sources.py
@@ -20,8 +20,9 @@ Fact-checking is evidence-backed citation: ``quote`` only accepts text that
 literally appears in the fetched page text you point it at, ``verify
 --evidence`` requires every cited source to carry at least one such quote, and
 ``render --style evidence`` prints the quotes under each source so the reader
-can check the chain themselves.  Claims from model knowledge are declared with
-an ``[unverified]`` marker rather than silently blended in.
+can check the chain themselves.  Non-URL provenance is declared with ``[tool:<name>]`` for deterministic tool
+facts, ``[policy]`` for user/skill rules, or ``[unverified]`` for model
+knowledge rather than silently blending any of them into sourced prose.
 
 Ledger path resolution (first wins):
   --ledger PATH
@@ -48,13 +49,26 @@ SCHEMA_VERSION = 1
 # A citation marker in prose: [12].  Markdown links ([text](url)) and
 # reference-style labels are excluded by requiring digits only and no
 # following "(" or ":".
-_CITE_RE = re.compile(r"\[(\d{1,4})\](?![(:])")
+_CITE_RE = re.compile(r"(?<![\w\[])\[(\d{1,4})\](?![\w\](:])")
 _SOURCES_HEADER_RE = re.compile(r"^\s*(?:#{1,6}\s*)?(?:\*\*)?sources:?(?:\*\*)?\s*$", re.IGNORECASE)
 _SOURCE_LINE_RE = re.compile(r"^\s*\[(\d{1,4})\]\s*[-–:]?\s*(\S+)")
 _URL_IN_TEXT_RE = re.compile(r"https?://[^\s\"'<>)\]}]+")
 _FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
-# Explicit declaration that a claim comes from model knowledge, not a source.
-_UNVERIFIED_RE = re.compile(r"\[unverified\]", re.IGNORECASE)
+# Explicit declarations of non-URL provenance. Tool names are restricted to
+# non-empty tokens so bare or free-form markers cannot claim verification.
+_TOOL_NAME_PATTERN = r"[A-Za-z0-9][A-Za-z0-9_.-]*"
+_TOOL_RE = re.compile(
+    rf"(?<![\w\[])\[tool:({_TOOL_NAME_PATTERN})\](?![\w\]])", re.IGNORECASE
+)
+_POLICY_RE = re.compile(r"(?<![\w\[])\[policy\](?![\w\]])", re.IGNORECASE)
+_UNVERIFIED_RE = re.compile(
+    r"(?<![\w\[])\[unverified\](?![\w\]])", re.IGNORECASE
+)
+_VALID_PROVENANCE_AT_RE = re.compile(
+    rf"(?:\[\d{{1,4}}\]|\[tool:{_TOOL_NAME_PATTERN}\]|\[policy\]|\[unverified\])",
+    re.IGNORECASE,
+)
+_PROVENANCE_CLOSERS = frozenset("*_~`\"'”’)]}）】")
 
 
 # ---------------------------------------------------------------------------
@@ -383,6 +397,19 @@ def _strip_sources_block(text: str) -> str:
     return "\n".join(lines[:header_idx])
 
 
+def _is_internal_period(text: str, index: int) -> bool:
+    """Keep decimal points and ordinary domain-like tokens unsplit."""
+    if text[index] != "." or index == 0 or index + 1 >= len(text):
+        return False
+    left, right = text[index - 1], text[index + 1]
+    if left.isdigit() and right.isdigit():
+        return True
+    if left.isalnum() and right.isalnum():
+        token = re.match(r"[A-Za-z0-9_-]+", text[index + 1 :])
+        return bool(token and len(token.group(0)) >= 2)
+    return False
+
+
 def _sentences(prose: str) -> list[str]:
     """Rough sentence split over prose lines, skipping headings and tables."""
     out: list[str] = []
@@ -392,10 +419,47 @@ def _sentences(prose: str) -> list[str]:
             continue
         if stripped.startswith(">"):
             stripped = stripped.lstrip("> ").strip()
-        for part in re.split(r"(?<=[.!?])\s+", stripped):
-            part = part.strip()
+        start = 0
+        cursor = 0
+        while cursor < len(stripped):
+            if stripped[cursor] not in ".!?":
+                cursor += 1
+                continue
+
+            punctuation_end = cursor + 1
+            marker_start = punctuation_end
+            while (
+                marker_start < len(stripped)
+                and stripped[marker_start] in _PROVENANCE_CLOSERS
+            ):
+                marker_start += 1
+
+            end = marker_start
+            while marker := _VALID_PROVENANCE_AT_RE.match(stripped, end):
+                end = marker.end()
+
+            if end < len(stripped) and not stripped[end].isspace():
+                # A bracket immediately after terminal punctuation looks like
+                # provenance but is malformed. Split before it so a later valid
+                # marker cannot cover the preceding unsupported sentence.
+                if stripped[marker_start] == "[":
+                    end = punctuation_end
+                elif _is_internal_period(stripped, cursor):
+                    cursor += 1
+                    continue
+                else:
+                    end = punctuation_end
+
+            part = stripped[start:end].strip()
             if len(part.split()) >= 4:
                 out.append(part)
+            start = end
+            while start < len(stripped) and stripped[start].isspace():
+                start += 1
+            cursor = start
+        remainder = stripped[start:].strip()
+        if len(remainder.split()) >= 4:
+            out.append(remainder)
     return out
 
 
@@ -461,13 +525,29 @@ def verify_draft(
 
     sentences = _sentences(prose)
     cited_sentences = [s for s in sentences if _CITE_RE.search(s)]
+    tool_verified_sentences = [s for s in sentences if _TOOL_RE.search(s)]
+    policy_sentences = [s for s in sentences if _POLICY_RE.search(s)]
     unverified_sentences = [s for s in sentences if _UNVERIFIED_RE.search(s)]
-    covered = [s for s in sentences if _CITE_RE.search(s) or _UNVERIFIED_RE.search(s)]
+    covered = [
+        s
+        for s in sentences
+        if _CITE_RE.search(s)
+        or _TOOL_RE.search(s)
+        or _POLICY_RE.search(s)
+        or _UNVERIFIED_RE.search(s)
+    ]
     coverage = (len(covered) / len(sentences)) if sentences else 0.0
+    provenance_breakdown = (
+        f"{len(cited_sentences)} cited, "
+        f"{len(tool_verified_sentences)} tool-verified, "
+        f"{len(policy_sentences)} policy, "
+        f"{len(unverified_sentences)} unverified"
+    )
     if min_coverage is not None and sentences and coverage < min_coverage:
         errors.append(
-            f"citation coverage {coverage:.0%} is below the required {min_coverage:.0%} "
-            f"({len(covered)}/{len(sentences)} sentences cited or marked [unverified])"
+            f"declared provenance coverage {coverage:.0%} is below the required "
+            f"{min_coverage:.0%} ({len(covered)}/{len(sentences)} sentences; "
+            f"{provenance_breakdown}; a sentence may carry multiple markers)"
         )
 
     if require_evidence:
@@ -488,8 +568,8 @@ def verify_draft(
     quoted = sum(1 for s in sources if s.get("quotes"))
     stats = (
         f"{len(sentences)} prose sentence(s), {len(covered)} with declared provenance "
-        f"({coverage:.0%}) — {len(cited_sentences)} cited, "
-        f"{len(unverified_sentences)} marked [unverified] (a sentence may be both); "
+        f"({coverage:.0%}) — {provenance_breakdown} "
+        f"(a sentence may carry multiple markers); "
         f"{len(cited_set)} distinct source(s) cited, "
         f"{len(by_id)} in ledger ({quoted} with evidence quotes)"
     )

--- a/tests/skills/test_grounded_citations_skill.py
+++ b/tests/skills/test_grounded_citations_skill.py
@@ -406,6 +406,196 @@ def test_evidence_gate_only_applies_to_cited_sources(sources_mod, ledger: Path, 
     assert (code, errors) == (0, [])
 
 
+def test_tool_and_policy_markers_count_toward_coverage(
+    sources_mod, ledger: Path, tmp_path: Path
+) -> None:
+    _seed(sources_mod, ledger)
+    text = (
+        "The chart reports a deterministic current value.[tool:TradingView]\n"
+        "The OHLCV payload came from the named MCP tool.[tool:mcp__tradingview__data_get_ohlcv]\n"
+        "The playbook requires waiting for confirmation.[policy]\n"
+    )
+    code, errors, warnings = _verify(
+        sources_mod, ledger, tmp_path, text, min_coverage=1.0
+    )
+    assert (code, errors) == (0, [])
+    assert "0 cited, 2 tool-verified, 1 policy, 0 unverified" in warnings[0]
+
+
+def test_tool_marker_requires_nonempty_safe_token(
+    sources_mod, ledger: Path, tmp_path: Path
+) -> None:
+    _seed(sources_mod, ledger)
+    text = (
+        "This sentence names a valid tool source.[tool:TradingView]\n"
+        "This sentence uses the forbidden bare marker.[tool]\n"
+        "This sentence has no tool name after the colon.[tool:]\n"
+        "This sentence puts whitespace inside the name.[tool:bad name]\n"
+    )
+    code, errors, warnings = _verify(
+        sources_mod, ledger, tmp_path, text, min_coverage=0.5
+    )
+    assert code == 1
+    assert any("1 tool-verified" in error for error in errors)
+    assert "0 cited, 1 tool-verified, 0 policy, 0 unverified" in warnings[0]
+
+
+def test_marker_after_punctuation_preserves_same_line_sentence_boundaries(
+    sources_mod, ledger: Path, tmp_path: Path
+) -> None:
+    _seed(sources_mod, ledger)
+    text = (
+        "A tool-backed sentence ends here.[tool:TradingView] "
+        "A separate sentence remains unmarked.\n"
+    )
+    code, errors, warnings = _verify(
+        sources_mod, ledger, tmp_path, text, min_coverage=0.75
+    )
+    assert code == 1
+    assert any("1/2 sentences" in error for error in errors)
+    assert "2 prose sentence(s), 1 with declared provenance (50%)" in warnings[0]
+
+
+def test_marker_after_markdown_closer_preserves_sentence_boundary(
+    sources_mod, ledger: Path, tmp_path: Path
+) -> None:
+    _seed(sources_mod, ledger)
+    text = (
+        "*A tool-backed sentence ends here.*[tool:TradingView] "
+        "A separate policy sentence is covered.[policy]\n"
+    )
+    code, errors, warnings = _verify(
+        sources_mod, ledger, tmp_path, text, min_coverage=1.0
+    )
+    assert (code, errors) == (0, [])
+    assert "2 prose sentence(s), 2 with declared provenance (100%)" in warnings[0]
+
+
+def test_malformed_marker_after_markdown_closer_fails_closed(
+    sources_mod, ledger: Path, tmp_path: Path
+) -> None:
+    _seed(sources_mod, ledger)
+    text = (
+        "*An unsupported sentence ends here.*[tool:]] "
+        "A separate policy sentence is covered.[policy]\n"
+    )
+    code, errors, warnings = _verify(
+        sources_mod, ledger, tmp_path, text, min_coverage=0.75
+    )
+    assert code == 1
+    assert any("1/2 sentences" in error for error in errors)
+    assert "0 tool-verified, 1 policy" in warnings[0]
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "[tool:]",
+        "[tool bad]",
+        "[tool=bad]",
+        "[tool:]]",
+        "[[policy]]",
+        "[policy]]",
+        "[policy:]",
+        "[unverified:bad]",
+        "[12345]",
+    ],
+)
+def test_malformed_marker_cannot_hide_following_sentence(
+    sources_mod, ledger: Path, tmp_path: Path, marker: str
+) -> None:
+    _seed(sources_mod, ledger)
+    text = (
+        f"A malformed marker must not claim provenance.{marker} "
+        "A separate policy sentence is covered.[policy]\n"
+    )
+    code, errors, warnings = _verify(
+        sources_mod, ledger, tmp_path, text, min_coverage=0.75
+    )
+    assert code == 1
+    assert any("1/2 sentences" in error for error in errors)
+    assert "0 tool-verified, 1 policy" in warnings[0]
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "[[policy]]",
+        "[policy]]",
+        "word[policy]",
+        "[[tool:TradingView]]",
+        "[tool:TradingView]]",
+        "[tool:TradingView]junk",
+        "[[1]]",
+        "[1]junk",
+    ],
+)
+def test_nested_or_embedded_markers_do_not_count_as_provenance(
+    sources_mod, ledger: Path, tmp_path: Path, marker: str
+) -> None:
+    _seed(sources_mod, ledger)
+    text = f"A factual claim uses malformed provenance {marker}.\n"
+    code, errors, warnings = _verify(
+        sources_mod, ledger, tmp_path, text, min_coverage=1.0
+    )
+    assert code == 1
+    assert any("0/1 sentences" in error for error in errors)
+    assert "0 cited, 0 tool-verified, 0 policy" in warnings[0]
+
+
+@pytest.mark.parametrize("suffix", [")", "x"])
+def test_nonspace_suffix_cannot_merge_following_policy_sentence(
+    sources_mod, ledger: Path, tmp_path: Path, suffix: str
+) -> None:
+    _seed(sources_mod, ledger)
+    text = (
+        f"An unsupported sentence ends right here.{suffix} "
+        "A separate policy sentence is covered.[policy]\n"
+    )
+    code, errors, warnings = _verify(
+        sources_mod, ledger, tmp_path, text, min_coverage=0.75
+    )
+    assert code == 1
+    assert any("1/2 sentences" in error for error in errors)
+    assert "2 prose sentence(s), 1 with declared provenance (50%)" in warnings[0]
+
+
+def test_coverage_failure_and_stats_distinguish_provenance_kinds(
+    sources_mod, ledger: Path, tmp_path: Path
+) -> None:
+    _seed(sources_mod, ledger)
+    text = (
+        "A web claim is supported by a URL citation.[1]\n"
+        "A deterministic fact came from a named tool.[tool:TradingView]\n"
+        "A trading constraint came from the active playbook.[policy]\n"
+        "A model-knowledge claim is explicitly uncertain.[unverified]\n"
+        "A remaining web claim has no provenance marker.\n\n"
+        "Sources:\n[1] https://a.example\n"
+    )
+    code, errors, warnings = _verify(
+        sources_mod, ledger, tmp_path, text, min_coverage=0.9
+    )
+    assert code == 1
+    breakdown = "1 cited, 1 tool-verified, 1 policy, 1 unverified"
+    assert any(breakdown in error for error in errors)
+    assert breakdown in warnings[0]
+
+
+def test_evidence_gate_remains_limited_to_numeric_url_citations(
+    sources_mod, ledger: Path, tmp_path: Path
+) -> None:
+    _seed(sources_mod, ledger)
+    text = (
+        "A deterministic fact came from a named tool.[tool:TradingView]\n"
+        "A trading constraint came from the active playbook.[policy]\n"
+        "A model-knowledge claim is explicitly uncertain.[unverified]\n"
+    )
+    code, errors, _ = _verify(
+        sources_mod, ledger, tmp_path, text, require_evidence=True, min_coverage=1.0
+    )
+    assert (code, errors) == (0, [])
+
+
 def test_unverified_marker_counts_toward_coverage(sources_mod, ledger: Path, tmp_path: Path) -> None:
     _seed(sources_mod, ledger)
     text = (

--- a/website/docs/user-guide/skills/bundled/research/research-grounded-citations.md
+++ b/website/docs/user-guide/skills/bundled/research/research-grounded-citations.md
@@ -37,9 +37,11 @@ so the numbers and URLs come from retrieval, never from memory — the model onl
 ever emits small integers it was handed.
 
 For high-stakes work the same ledger doubles as a fact-checking chain: verbatim
-quotes are attached to each source (rejected unless they literally appear in
-the fetched page text), claims from model knowledge are flagged `[unverified]`,
-and `verify --evidence` fails any draft whose cited sources carry no evidence.
+quotes are attached to each URL source (rejected unless they literally appear
+in the fetched page text), deterministic tool facts carry `[tool:<name>]`,
+user/skill rules carry `[policy]`, and model knowledge is flagged
+`[unverified]`. `verify --evidence` requires quotes only for numeric URL
+citations.
 
 This skill covers answers in chat, written documents (markdown, PDF, docx,
 slides), and research reports. It does not cover academic BibTeX pipelines —
@@ -63,7 +65,10 @@ Mention a URL only if the user would plausibly want the link.
 
 ## Prerequisites
 
-None beyond the standard toolset. `scripts/sources.py` is stdlib-only Python 3.
+None beyond the standard toolset. `scripts/sources.py` is stdlib-only and requires
+Python 3.10+ because it imports current Hermes modules that use PEP 604 type syntax.
+On macOS, check `python3 --version`; if Apple’s Python 3.9 is first on PATH, invoke
+all examples as `python3.11 "$S" ...` (or another installed 3.10+ interpreter).
 Retrieval comes from whatever is configured: `web_search`, `web_extract`,
 `browser_navigate`, or `terminal` (curl, CLIs).
 
@@ -75,12 +80,12 @@ Override per task with `--ledger <path>` or `HERMES_CITATION_LEDGER`.
 ```bash
 S=~/.hermes/skills/research/grounded-citations/scripts/sources.py
 
-python3 "$S" reset                                  # start a clean ledger
-python3 "$S" add https://example.com/a --title "A"  # prints: [1]
-python3 "$S" add https://example.com/b --title "B"  # prints: [2]
-python3 "$S" list                                   # ledger table
-python3 "$S" render                                 # Sources: block
-python3 "$S" verify draft.md                        # catch bad citations
+python "$S" reset                                  # start a clean ledger
+python "$S" add https://example.com/a --title "A"  # prints: [1]
+python "$S" add https://example.com/b --title "B"  # prints: [2]
+python "$S" list                                   # ledger table
+python "$S" render                                 # Sources: block
+python "$S" verify draft.md                        # catch bad citations
 ```
 
 `add` is idempotent and URL-normalized: the same page always returns the same
@@ -123,7 +128,10 @@ Ice floats because it is less dense than liquid water.[1][2]
 - No space before the bracket; each id in its own brackets.
 - Max 3 ids per sentence. Cite per sentence, not one dump at the end.
 - Only ids the ledger returned. Never invent an id or a URL.
-- Claims from your own knowledge get no citation.
+- Deterministic facts read from a tool use `[tool:<name>]`; user- or
+  skill-supplied rules use `[policy]`. These declare non-URL provenance and do
+  not create a Sources entry.
+- Claims from your own knowledge get no numeric citation.
 - Conflicting sources: present both readings, each with its own id.
 - Quote exact figures, dates, and names as the source states them; flag gaps
   explicitly ("no source found for X") instead of smoothing them over.
@@ -153,7 +161,7 @@ upgrade from citations to evidence:
 text to a file and attach the sentence(s) that carry each claim:
 
 ```bash
-python3 "$S" quote 1 --text "Ice is about 9% less dense than liquid water." --from page1.txt
+python "$S" quote 1 --text "Ice is about 9% less dense than liquid water." --from page1.txt
 ```
 
 The quote is rejected unless it appears verbatim in the evidence text
@@ -164,18 +172,30 @@ Copy-paste from the fetched text; never retype. Quote the sentence as the
 reader sees it — the matcher sees through the extractor's markup for you, so
 you don't have to reproduce link syntax or escaped asterisks in your quote.
 
-② **Flag model-knowledge claims with `[unverified]`.** A load-bearing claim
-you could not source gets an explicit marker instead of a citation:
+② **Declare non-URL provenance exactly.** Use one of these markers at the
+end of the sentence:
+
+- `[tool:<name>]` for a deterministic fact returned by a named tool. `<name>`
+  must be a non-empty safe token matching `[A-Za-z0-9][A-Za-z0-9_.-]*`, for
+  example `[tool:TradingView]` or
+  `[tool:mcp__tradingview__data_get_ohlcv]`. Bare `[tool]`, `[tool:]`, and
+  names containing spaces do not count.
+- `[policy]` for a rule supplied by the user or an active skill/playbook.
+- `[unverified]` for a load-bearing model-knowledge claim that could not be
+  sourced.
 
 ```
+The live close came from the chart.[tool:TradingView]
+The playbook requires confirmation before entry.[policy]
 The refactor likely predates the 2.0 release.[unverified]
 ```
 
-`verify --min-coverage` counts `[unverified]` sentences as covered — the goal
-is declared provenance for every claim, not a citation on every sentence.
-If a key claim can be checked, check it; `[unverified]` is for what genuinely
-cannot be, and a fact-check deliverable dominated by `[unverified]` markers
-should say so in its summary.
+All three markers count toward `verify --min-coverage`, but `[tool:<name>]` and
+`[policy]` are provenance declarations, not numeric URL citations and not
+synonyms for `[unverified]`. They do not add Sources entries or satisfy a claim
+that actually came from the web. If a key model-knowledge claim can be checked,
+check it; `[unverified]` is for what genuinely cannot be, and a fact-check
+deliverable dominated by `[unverified]` markers should say so in its summary.
 
 ③ **Cross-check disputed facts against a second independent source.** When two
 sources disagree, cite both readings with their own ids and quotes, and say
@@ -185,8 +205,8 @@ corroboration.
 ④ **Verify with the evidence gate and render the evidence block:**
 
 ```bash
-python3 "$S" verify report.md --evidence --min-coverage 0.5
-python3 "$S" render --style evidence --replace-in report.md
+python "$S" verify report.md --evidence --min-coverage 0.5
+python "$S" render --style evidence --replace-in report.md
 ```
 
 `--evidence` fails the draft if any cited source has no attached quote. The
@@ -201,9 +221,13 @@ to stdout instead. Both emit the heading `## Sources` (`--style plain` emits
 `sentences with declared provenance / prose sentences`. A prose sentence is a
 non-empty line fragment of 4+ words after the Sources block, headings (`#`),
 table rows (`|`), and fenced code are dropped; blockquote markers are stripped.
-Provenance is declared by either a `[n]` citation or an `[unverified]` marker,
-so a sentence carrying both counts once. Run `verify` without a threshold first
-and read the `info: stats:` line to see the counts before picking a number.
+Provenance is declared by a numeric `[n]` URL citation, a valid
+`[tool:<name>]` marker, `[policy]`, or `[unverified]`. A sentence carrying more
+than one kind counts once in the coverage numerator, while stats report the
+cited, tool-verified, policy, and unverified category counts separately. The
+`--evidence` quote gate remains limited to numeric `[n]` URL citations. Run
+`verify` without a threshold first and read the `info: stats:` line before
+picking a number.
 
 ## Pitfalls
 
@@ -239,11 +263,11 @@ and read the `info: stats:` line to see the counts before picking a number.
 ## Verification
 
 ```bash
-python3 "$S" verify report.md --strict --min-coverage 0.5
+python "$S" verify report.md --strict --min-coverage 0.5
 ```
 
 Green means: every `[n]` in the draft exists in the ledger, the Sources block
-lists exactly the cited ids with the ledger's URLs, and the cited share of
-source-bearing sentences meets the threshold. Read the warnings even when the
+lists exactly the cited ids with the ledger's URLs, and the declared-provenance
+share of prose sentences meets the threshold. Read the warnings even when the
 exit code is 0 — uncited registered sources usually mean a claim lost its
 attribution during editing.


### PR DESCRIPTION
## Summary
- add `[tool:<name>]` for deterministic tool reads and `[policy]` for user/skill rules
- count those markers toward `--min-coverage` without treating them as URL citations or `[unverified]`
- make sentence/provenance parsing fail closed for malformed, nested, embedded, and trailing-junk markers
- preserve evidence-quote requirements for valid numeric URL citations only
- document the contract and regenerate the bundled skill page

## Verification
- `73` grounded-citations tests pass
- Ruff and `git diff --check` pass
- malformed-marker fuzz: 2,810 variants, 0 sentence merges
- original RTH brief passes `--strict --min-coverage 0.5` at 93% declared provenance: 4 cited, 6 tool-verified, 4 policy, 0 unverified
- independent pre-commit review: PASS