### PR TITLE
fix(stt): stop endpoint updates from causing 401s in running processes

### DIFF
--- a/tests/tools/test_transcription_dotenv_fallback.py
+++ b/tests/tools/test_transcription_dotenv_fallback.py
@@ -24,6 +24,9 @@ def isolate_env(monkeypatch):
     """
     for key in (
         "GROQ_API_KEY",
+        "VOICE_TOOLS_OPENAI_KEY",
+        "OPENAI_API_KEY",
+        "STT_OPENAI_BASE_URL",
         "MISTRAL_API_KEY",
         "XAI_API_KEY",
         "XAI_STT_BASE_URL",
@@ -112,6 +115,27 @@ class TestTranscribeCallSitesReadDotenv:
     """The actual transcribe functions must forward the dotenv-resolved
     key into the provider SDK / HTTP call. We mock ``get_env_value`` and
     capture what gets passed through."""
+
+    def test_openai_endpoint_and_key_follow_post_import_dotenv_update(self):
+        """A running process must not pair a live key with a stale endpoint."""
+        import importlib
+        from tools import transcription_tools as tt
+
+        tt = importlib.reload(tt)
+        try:
+            with patch.object(tt, "_load_stt_config", return_value={}), patch(
+                "hermes_cli.config.load_env",
+                return_value={
+                    "VOICE_TOOLS_OPENAI_KEY": "updated-key",
+                    "STT_OPENAI_BASE_URL": "https://stt.example/v1",
+                },
+            ):
+                assert tt._resolve_openai_audio_client_config() == (
+                    "updated-key",
+                    "https://stt.example/v1",
+                )
+        finally:
+            importlib.reload(tt)
 
     def test_transcribe_groq_forwards_dotenv_key(self):
         from tools import transcription_tools as tt

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -118,7 +118,7 @@ LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
-OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
+OPENAI_BASE_URL = "https://api.openai.com/v1"
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
 ELEVENLABS_STT_BASE_URL = os.getenv("ELEVENLABS_STT_BASE_URL", "https://api.elevenlabs.io/v1")
 # DeepInfra STT base URL now resolved via hermes_cli.models.deepinfra_base_url (shared).
@@ -3265,8 +3265,11 @@ def _resolve_openai_audio_client_config() -> tuple[str, str]:
     openai_cfg = stt_config.get("openai") or {}
     cfg_api_key = openai_cfg.get("api_key", "")
     cfg_base_url = openai_cfg.get("base_url", "")
+    env_base_url = str(
+        get_env_value("STT_OPENAI_BASE_URL") or OPENAI_BASE_URL
+    ).strip()
     if cfg_api_key:
-        return cfg_api_key, (cfg_base_url or OPENAI_BASE_URL)
+        return cfg_api_key, (cfg_base_url or env_base_url)
 
     # A local OpenAI-compatible server needs no key — send a placeholder so
     # the SDK doesn't refuse to construct a client (#25193, credit @nnnet).
@@ -3275,7 +3278,7 @@ def _resolve_openai_audio_client_config() -> tuple[str, str]:
 
     direct_api_key = resolve_openai_audio_api_key()
     if direct_api_key:
-        return direct_api_key, OPENAI_BASE_URL
+        return direct_api_key, env_base_url
 
     managed_gateway = resolve_managed_tool_gateway("openai-audio")
     if managed_gateway is None:


### PR DESCRIPTION
## What does this PR do?

This PR lets long-running Hermes processes observe updated `STT_OPENAI_BASE_URL` values at the same call-time boundary as OpenAI-compatible STT credentials. Without the fix, adding an endpoint and its matching key after startup can send the new third-party key to the stale OpenAI endpoint and make transcription fail with a 401 until Hermes restarts.

### Symptom

After Hermes starts, adding `STT_OPENAI_BASE_URL` and `VOICE_TOOLS_OPENAI_KEY` to `.env` still sends the next transcription request to `https://api.openai.com/v1` with the newly loaded key. The request fails with `401 Incorrect API key provided`.

### Impact

Operators who update an OpenAI-compatible STT endpoint in a running gateway or dashboard cannot use transcription until they restart the process or move both values into `config.yaml`.

### Bug Cause

**Trigger:** `tools/transcription_tools.py:3263` / `_resolve_openai_audio_client_config()` after `.env` changes in an already-running process

**Causal chain:**
1. The module snapshots `STT_OPENAI_BASE_URL` during import, before the operator updates `.env`.
2. A later transcription resolves `VOICE_TOOLS_OPENAI_KEY` from the updated secret scope but pairs it with the old module-level endpoint.
3. Hermes sends the updated third-party key to the stale OpenAI endpoint, which rejects it with a 401.

**Why it is wrong:** The endpoint and credential are resolved at different lifecycle boundaries, so one request can combine values from different configuration generations.

**Working sibling / contrast:** `stt.openai.base_url` already works because `_load_stt_config()` resolves it per call and the configured endpoint takes precedence.

**Ruled out:** Managed OpenAI audio routing is not affected because it returns its endpoint and token together after the direct and configured credential paths are exhausted.

### Fix

Keep the public OpenAI endpoint as the static default, but resolve `STT_OPENAI_BASE_URL` inside `_resolve_openai_audio_client_config()` for every request. Both config-backed and direct-key paths now pair credentials with the live endpoint value, while local-server and managed-gateway behavior remains unchanged. A regression test reloads the module before simulating the `.env` update and verifies that the resolver returns the updated key and endpoint together.

## Related Issue

Closes #86071

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/transcription_tools.py` - resolve the OpenAI-compatible STT endpoint per request alongside the credential.
- `tests/tools/test_transcription_dotenv_fallback.py` - cover endpoint and key updates made after module import.

## How to Test

1. Run the `.env` fallback regression suite (8 passed):

```bash
scripts/run_tests.sh tests/tools/test_transcription_dotenv_fallback.py
```

2. Run the local OpenAI-compatible endpoint compatibility tests (2 passed):

```bash
scripts/run_tests.sh tests/tools/test_transcription_tools.py -k TestLocalBaseUrlNoApiKey
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example` update: N/A - no configuration key was added or changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); resolution uses the existing profile-aware environment loader
- [x] Tool descriptions/schemas update: N/A - the transcription tool contract is unchanged

## Screenshots / Logs

N/A - automated resolver tests cover the configuration update boundary.
