### PR TITLE
fix(state): reject inherited SQLite handles after fork

### DIFF
--- a/hermes_cli/sqlite_safe_read.py
+++ b/hermes_cli/sqlite_safe_read.py
@@ -66,6 +66,7 @@ import logging
 import os
 import sqlite3
 import threading
+import weakref
 from pathlib import Path
 from typing import Optional
 
@@ -81,6 +82,32 @@ _HEADER_PAGE_COUNT_OFFSET = 28
 _live_lock = threading.RLock()
 # canonical path -> number of live connections opened by this process
 _live_connections: dict[str, int] = {}
+# Weak references avoid changing normal connection lifetime, while still
+# letting the at-fork callback promote every live handle to child-owned strong
+# retention — including a reader checked out by a different parent thread.
+_tracked_connection_objects: "weakref.WeakValueDictionary[int, sqlite3.Connection]" = (
+    weakref.WeakValueDictionary()
+)
+_fork_retained_connections: list[sqlite3.Connection] = []
+
+
+def _reset_tracking_lock_after_fork() -> None:
+    """Replace a potentially orphaned registry lock in a fork child.
+
+    Another thread may own ``_live_lock`` when the process forks. That thread
+    does not exist in the child, so reusing the inherited lock can deadlock the
+    child's first tracked connection forever. Keep the inherited connection
+    counts — their file descriptors remain open until child exit — but give
+    the child an unlocked registry guard for connections it opens itself.
+    """
+    global _live_lock, _tracked_connection_objects
+    _fork_retained_connections.extend(_tracked_connection_objects.values())
+    _tracked_connection_objects = weakref.WeakValueDictionary()
+    _live_lock = threading.RLock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_tracking_lock_after_fork)
 
 
 class UntrackableConnectionError(RuntimeError):
@@ -161,6 +188,7 @@ class _TrackingMixin:
             super().close()  # type: ignore[misc]
             if path is not None:
                 self._hermes_tracked_path = None
+                _tracked_connection_objects.pop(id(self), None)
                 untrack_connection(path)
 
 
@@ -262,6 +290,7 @@ def connect_tracked(
                 conn = _retrofit_tracking(conn, resolved)
             conn._hermes_tracked_path = resolved
             _live_connections[resolved] = _live_connections.get(resolved, 0) + 1
+            _tracked_connection_objects[id(conn)] = conn
             return conn
         except Exception:
             try:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -29,6 +29,7 @@ import sqlite3
 import sys
 import threading
 import time
+import weakref
 from collections import deque
 from contextlib import contextmanager
 from pathlib import Path
@@ -92,6 +93,54 @@ logger = logging.getLogger(__name__)
 
 MAX_SAFE_RESUME_MESSAGES = 20_000
 MAX_SAFE_EXPORT_MESSAGES = 20_000
+
+
+_SESSION_DB_INSTANCES: "weakref.WeakSet[SessionDB]" = weakref.WeakSet()
+# A child must not sqlite3_close() handles inherited from a multi-threaded
+# parent: another parent thread may have been inside SQLite when fork happened.
+# Keep the original writer connection and read pool alive until child exit;
+# the SessionDB instance itself is rebound to a fail-fast sentinel below.
+_FORK_RETAINED_SESSION_DB_RESOURCES: List[Tuple[Any, Any]] = []
+
+
+class _ForkedSessionDBConnection:
+    """Reject use of a SQLite connection inherited across ``fork()``."""
+
+    def __init__(self, owner_pid: int, child_pid: int) -> None:
+        self.owner_pid = owner_pid
+        self.child_pid = child_pid
+
+    def __getattr__(self, _name):
+        raise RuntimeError(
+            "SessionDB instances cannot be reused after fork; "
+            "construct a new SessionDB in the child process"
+        )
+
+
+def _invalidate_sessiondb_instances_after_fork() -> None:
+    """Make inherited SessionDB instances unusable without closing their FDs."""
+    child_pid = os.getpid()
+    for db in list(_SESSION_DB_INSTANCES):
+        try:
+            if getattr(db, "_owner_pid", child_pid) == child_pid:
+                continue
+            inherited_conn = getattr(db, "_conn", None)
+            inherited_read_pool = getattr(db, "_read_pool", None)
+            _FORK_RETAINED_SESSION_DB_RESOURCES.append(
+                (inherited_conn, inherited_read_pool)
+            )
+            db._conn = _ForkedSessionDBConnection(db._owner_pid, child_pid)
+            # A vanished parent thread may have owned the instance lock. Some
+            # older/direct read helpers take it before touching _conn, so reset
+            # it as defense in depth; the sentinel then raises deterministically.
+            db._lock = threading.Lock()
+        except Exception:
+            # An at-fork callback must never prevent the child from starting.
+            pass
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_invalidate_sessiondb_instances_after_fork)
 
 
 def _configured_transcript_limit(key: str, fallback: int) -> int:
@@ -2810,6 +2859,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # live-DB test-isolation guard block near _default_db_path().
         _ensure_test_isolation(self.db_path)
         self.read_only = read_only
+        self._owner_pid = os.getpid()
+        _SESSION_DB_INSTANCES.add(self)
 
         self._lock = threading.Lock()
         # Read-path split (WAL only): recall/browse queries borrow a
@@ -3100,6 +3151,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
     # ── Read-path split ──
 
+    def _assert_owner_process(self) -> None:
+        """Fail before an inherited SQLite handle or Python lock is touched."""
+        if self._owner_pid != os.getpid():
+            raise RuntimeError(
+                "SessionDB instances cannot be reused after fork; "
+                "construct a new SessionDB in the child process"
+            )
+
     def _get_read_conn(self) -> Optional[sqlite3.Connection]:
         """Open a fresh read-only connection, or None when unavailable.
 
@@ -3116,6 +3175,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         query observes everything committed so far — read-your-writes holds
         for the flush-then-search patterns in a turn.
         """
+        self._assert_owner_process()
         if not self._wal_active or self.read_only:
             return None
         with self._read_conns_lock:
@@ -3272,6 +3332,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         slower under a burst, and the alternative is EMFILE, which takes the
         whole process down in a way a restart-on-exit supervisor cannot see.
         """
+        self._assert_owner_process()
         conn = self._checkout_read_conn()
         if conn is not None:
             try:
@@ -3568,6 +3629,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         Returns whatever *fn* returns.
         """
+        self._assert_owner_process()
         if patience_s is None:
             patience_s = self._WRITE_PATIENCE_S
         deadline = time.monotonic() + patience_s
@@ -3932,6 +3994,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         races the gateway's live writer and tears B-tree pages — issue
         #45383). Read-only connections never request a checkpoint.
         """
+        if self._owner_pid != os.getpid():
+            # The original connection and pooled readers are intentionally
+            # retained until child exit. sqlite3_close() is unsafe after a
+            # multi-threaded fork and the child does not own these handles.
+            return
         self._stop_token_writer()
         # The atexit hook holds a strong reference to this instance (bound
         # method); without unregistering, every closed SessionDB stays
@@ -6256,6 +6323,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         API call.  After close() has stopped the writer, falls back to the
         synchronous path and may raise like :meth:`update_token_counts`.
         """
+        self._assert_owner_process()
         with self._token_queue_cond:
             thread = self._token_writer_thread
             writer_stopped = self._token_writer_stop and (
@@ -6299,6 +6367,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         deltas — no worse than reading before the flush existed).
         Never raises: apply failures are logged by the writer.
         """
+        self._assert_owner_process()
         # Fast path — nothing queued, nothing in flight.
         if not self._token_queue and not self._token_writer_busy:
             return True
@@ -6472,6 +6541,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     self._token_queue_cond.notify_all()
 
     def _drain_token_queue_at_exit(self) -> None:
+        if self._owner_pid != os.getpid():
+            return
         try:
             self._stop_token_writer()
         except Exception:

--- a/tests/hermes_state/test_sessiondb_fork_safety.py
+++ b/tests/hermes_state/test_sessiondb_fork_safety.py
@@ -1,0 +1,75 @@
+"""Process-boundary contracts for ``SessionDB`` SQLite handles."""
+
+import os
+import signal
+import threading
+
+import pytest
+
+from hermes_cli import sqlite_safe_read
+from hermes_state import SessionDB
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+def test_inherited_sessiondb_fails_fast_and_child_can_reopen(tmp_path):
+    """A fork child must reject inherited handles but may open its own."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    tracking_lock_held = threading.Event()
+    release_tracking_lock = threading.Event()
+
+    def hold_tracking_lock():
+        # Fork at the hostile boundary: both guards are owned by a thread that
+        # will not exist in the child. Neither inherited instance rejection
+        # nor the child's fresh tracked open may wait on these orphaned locks.
+        with sqlite_safe_read._live_lock, db._lock:
+            tracking_lock_held.set()
+            release_tracking_lock.wait(timeout=10)
+
+    holder = threading.Thread(target=hold_tracking_lock)
+    holder.start()
+    assert tracking_lock_held.wait(timeout=10)
+
+    child_pid = os.fork()  # windows-footgun: ok — test is skip-gated above
+    if child_pid == 0:  # pragma: no cover - assertions execute in child
+        try:
+            signal.alarm(10)
+            try:
+                db.create_session("unsafe-child-write", source="test")
+            except RuntimeError as exc:
+                if "cannot be reused after fork" not in str(exc):
+                    os._exit(2)
+            else:
+                os._exit(3)
+
+            try:
+                db.get_session("parent")
+            except RuntimeError as exc:
+                if "cannot be reused after fork" not in str(exc):
+                    os._exit(4)
+            else:
+                os._exit(5)
+
+            # Closing an inherited instance must not sqlite3_close() the
+            # parent's handle. The child owns only handles it opens itself.
+            db.close()
+            child_db = SessionDB(db_path=db_path)
+            child_db.create_session("child", source="test")
+            child_db.close()
+            os._exit(0)
+        except BaseException:
+            os._exit(6)
+
+    try:
+        _, status = os.waitpid(child_pid, 0)
+        assert os.waitstatus_to_exitcode(status) == 0
+    finally:
+        release_tracking_lock.set()
+        holder.join(timeout=10)
+
+    try:
+        db.create_session("parent", source="test")
+        assert db.get_session("parent") is not None
+        assert db.get_session("child") is not None
+    finally:
+        db.close()


### PR DESCRIPTION
## What does this PR do?

This focused follow-up to #68437 rejects `SessionDB` instances and SQLite handles inherited across `fork()`.

On current `main`, a child process can successfully write through the parent's `SessionDB`. If another parent thread owned an instance or connection-tracking lock at fork time, the child can instead deadlock on a lock whose owner no longer exists. Closing an inherited SQLite handle is also unsafe: the existing `not a database` recovery path already identifies a forked curator closing an inherited writer FD as one source of long-lived connection damage.

The fix binds each `SessionDB` to its creating PID, invalidates inherited instances in an `after_in_child` handler, and keeps inherited SQLite resources alive without calling `sqlite3_close()`. A child can still construct and use a fresh `SessionDB`. This intentionally does not revive the broader writer-coordinator or background-maintenance architecture from #68437.

## Related Issue

Related: #68437

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`
  - Track the process that created each `SessionDB`.
  - Replace inherited writer handles with a fail-fast sentinel after fork.
  - Retain inherited writer/read-pool resources until child exit rather than closing them.
  - Reject inherited read, write, token-accounting, and close paths before touching stale locks or SQLite.
- `hermes_cli/sqlite_safe_read.py`
  - Reset the connection-registry lock in fork children.
  - Weakly track live connections so an in-flight reader owned by a vanished parent thread can be retained safely in the child.
- `tests/hermes_state/test_sessiondb_fork_safety.py`
  - Exercise a real multi-threaded `os.fork()`: inherited reads/writes fail fast, orphaned Python locks do not deadlock the child, a fresh child DB works, and the parent remains usable.

## How to Test

1. On unmodified `main`, run `scripts/run_tests.sh tests/hermes_state/test_sessiondb_fork_safety.py -q`: the child exits with code 3 because its inherited write succeeds.
2. On this branch, run:
   ```bash
   scripts/run_tests.sh \
     tests/hermes_state \
     tests/test_hermes_state.py \
     tests/test_session_db_read_conn_pool.py \
     tests/test_sqlite_lock_safe_inspection.py -q
   ```
   Result: **326 passed, 13 skipped, 0 failed** across 18 files.
3. Run `python3 -m ruff check hermes_state.py hermes_cli/sqlite_safe_read.py tests/hermes_state/test_sessiondb_fork_safety.py`, `python3 scripts/check-windows-footguns.py --diff origin/main`, bytecode compilation, and `git diff --check origin/main...HEAD`. All pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the focused 18-file state/SQLite matrix passes; full CI is pending
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5, Python 3.12.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; internal safety behavior is documented in code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide; runtime fork hooks are capability-gated and the Windows-footgun scan passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable.