### PR TITLE
fix(gateway): rebind TypeHandler after lazy telegram dep install

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -415,7 +415,7 @@ def check_telegram_requirements() -> bool:
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
-    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global CommandHandler, CallbackQueryHandler, TypeHandler, TelegramMessageHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -434,7 +434,7 @@ def check_telegram_requirements() -> bool:
         from telegram.ext import (
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
-            MessageHandler as _MH,
+            MessageHandler as _MH, TypeHandler as _TH,
             ContextTypes as _CT, filters as _filters,
         )
         from telegram.constants import ParseMode as _PM, ChatType as _CtT
@@ -451,6 +451,7 @@ def check_telegram_requirements() -> bool:
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
     TelegramMessageHandler = _MH
+    TypeHandler = _TH
     ContextTypes = _CT
     filters = _filters
     ParseMode = _PM


### PR DESCRIPTION
### Problem

`TypeError: Any cannot be instantiated` on every Telegram connect after the
adapter takes the lazy-dependency-install path. Telegram crash-loops in the
reconnection watcher; Discord/WhatsApp unaffected.

### Root cause

When `python-telegram-bot` is not importable at module load, the adapter stubs
its class aliases (`Update = Any`, `TypeHandler = Any`, ...). The lazy installer
`check_telegram_requirements()` rebinds all aliases to the real SDK classes
except `TypeHandler`. `_register_handlers()` then instantiates
`TypeHandler(Update, ...)` — `Any(...)` — which raises, and the poisoned module
globals make every retry fail identically.

Trigger observed in the wild: gateway restarted by `hermes update` while the
venv was mid pip-refresh, so the module import failed exactly once.

### Fix

Add `TypeHandler` to the rebind in `check_telegram_requirements()` (global
declaration, `_TH` import, and assignment) — 3 lines, same pattern as every
other alias.

### Testing

- Reproduced the failure with a 10-line in-process script (stub state →
  `check_telegram_requirements()` → instantiate `TypeHandler`), confirmed the
  fix resolves it.
- End-to-end: gateway restart → `[Telegram] Connected to Telegram (polling
  mode)`, 3/3 platforms connected.
- Platforms tested: Windows 11, Python 3.11.15, python-telegram-bot 22.8.

### Related

- `#79812` (lazy-install gate in `create_adapter()`) — this is the first
  adapter bug that surfaced once the installer actually runs.
