### PR TITLE
fix: add bots.qq.com and api.sgroup.qq.com to SSRF trusted hosts (#86081)

### DIFF
--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -199,6 +199,8 @@ _ALWAYS_BLOCKED_NETWORKS = (
 # to 198.18.0.0/15 behind local proxy/benchmark infrastructure.
 _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
     "multimedia.nt.qq.com.cn",
+    "bots.qq.com",
+    "api.sgroup.qq.com",
 })
 
 _MAX_SSRF_CONNECT_IPS = 8


### PR DESCRIPTION
## Summary

QQ Bot adapter fails to connect in mainland China because DNS fake IP range (198.18.0.0/15) is blocked by SSRF protection.

Commit a97b08e added `multimedia.nt.qq.com.cn` to `_TRUSTED_PRIVATE_IP_HOSTS`, but QQ Bot also uses two other domains that resolve to the same benchmark IP range:

- `bots.qq.com` — OAuth token endpoint
- `api.sgroup.qq.com` — WebSocket gateway URL

Both are missing from the allowlist, causing `SSRFConnectionBlocked` errors that prevent QQ Bot from connecting entirely.

## Changes

- `tools/url_safety.py`: Add `bots.qq.com` and `api.sgroup.qq.com` to `_TRUSTED_PRIVATE_IP_HOSTS`

## Test Plan

- [ ] Verify syntax passes
- [ ] QQ Bot can connect on networks where `bots.qq.com` and `api.sgroup.qq.com` resolve to 198.18.0.0/15

Fixes #86081