### PR TITLE
fix(gateway): spare Scheduled-Task-supervised gateway from orphan reaper on Windows

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1565,6 +1565,31 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
             own |= _get_service_pids()
         except Exception:
             pass
+    # On Windows there is no systemd/launchd service query to fall back on
+    # (_get_service_pids() returns an empty set), so a gateway supervised by
+    # a Scheduled Task / Startup VBS looks like an unsupervised orphan to the
+    # process scan.  Exempt the recorded healthy gateway PID and its parent
+    # chain: the Scheduled Task launches a ``gateway run`` bootstrap whose
+    # argv matches the gateway scan, and killing that bootstrap takes the
+    # detached gateway it spawned down with it (#86098).
+    if is_windows():
+        try:
+            from gateway.status import get_running_pid
+
+            recorded = get_running_pid()
+            if recorded and recorded > 0:
+                own.add(recorded)
+                try:
+                    import psutil  # type: ignore
+
+                    parent = psutil.Process(recorded).parent()
+                    while parent is not None:
+                        own.add(parent.pid)
+                        parent = parent.parent()
+                except Exception:
+                    pass
+        except Exception:
+            pass
     try:
         # find_gateway_pids() includes no-supervisor `gateway restart` runtimes
         # for the current profile when no systemd supervisor is present.

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1596,6 +1596,23 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
         orphans = [p for p in find_gateway_pids(exclude_pids=own) if p and p > 0]
     except Exception:
         return False
+    if is_windows():
+        # Stale/missing-pidfile hardening: the exemption above only knows the
+        # recorded PID, but service launchers stamp HERMES_GATEWAY_DETACHED=1
+        # on supervised gateway processes, so a live Scheduled-Task gateway is
+        # still identifiable even when gateway.pid is stale or missing.
+        # Best-effort: if the env can't be read, keep current behaviour.
+        try:
+            import psutil  # type: ignore
+
+            orphans = [
+                p
+                for p in orphans
+                if psutil.Process(p).environ().get("HERMES_GATEWAY_DETACHED", "").strip().lower()
+                != "1"
+            ]
+        except Exception:
+            pass
     if not orphans:
         return False
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -495,6 +495,112 @@ class TestReapUnsupervisedGatewayOrphansMacOS:
         assert killed_pids == []  # nothing was killed
 
 
+class TestReapUnsupervisedGatewayOrphansWindows:
+    """Tests that the orphan reaper spares the recorded gateway PID and its
+    supervision chain on Windows.
+
+    Regression guard: without the Windows exemption of the recorded healthy
+    gateway PID (and its parent chain), the reaper would SIGTERM/SIGKILL a
+    Scheduled-Task-supervised gateway every time Hermes Desktop opens
+    (``hermes serve`` calls ``_reap_unsupervised_gateway_orphans`` during
+    startup). The Scheduled-Task bootstrap's argv matches the gateway scan,
+    so it is reaped as an "orphan" — and when the bootstrap dies, the
+    detached gateway it spawned exits with it (#86098).
+    """
+
+    @staticmethod
+    def _install_fake_psutil(monkeypatch, chain):
+        """Install a fake psutil module exposing the given process chain."""
+        by_pid = {proc.pid: proc for proc in chain}
+        fake_psutil = SimpleNamespace(Process=lambda pid: by_pid[pid])
+        monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+    def test_windows_excludes_recorded_pid_and_bootstrap_from_kill(self, monkeypatch):
+        """The recorded gateway PID and its bootstrap parent must not be killed."""
+        recorded_pid = 52615   # detached gateway recorded in gateway.pid
+        bootstrap_pid = 52616  # Scheduled-Task bootstrap (argv matches scan)
+        orphan_pid = 99998     # a real orphan that should still be reaped
+
+        # Pretend we're on Windows — supports_systemd_services() returns
+        # False so the function does NOT short-circuit and proceeds to the
+        # scan, and is_macos() is False so the launchd branch is skipped.
+        monkeypatch.setattr(gateway, "is_windows", lambda: True)
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+
+        # gateway.pid records the detached gateway; its parent is the
+        # Scheduled-Task bootstrap whose argv matches the gateway scan.
+        bootstrap = SimpleNamespace(pid=bootstrap_pid, parent=lambda: None)
+        recorded = SimpleNamespace(pid=recorded_pid, parent=lambda: bootstrap)
+        self._install_fake_psutil(monkeypatch, [recorded, bootstrap])
+
+        # get_running_pid() returns the recorded healthy gateway PID.
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: recorded_pid)
+
+        # find_gateway_pids returns the recorded PID, its bootstrap parent
+        # and a real orphan. The reaper should only kill the orphan.
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [
+                p
+                for p in [recorded_pid, bootstrap_pid, orphan_pid]
+                if p not in (exclude_pids or set())
+            ],
+        )
+
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        monkeypatch.setattr("time.monotonic", lambda: 1.0)
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert result is True  # at least one orphan was reaped
+        killed = [pid for pid, _ in killed_pids]
+        assert orphan_pid in killed       # the real orphan was killed
+        assert recorded_pid not in killed  # the recorded gateway was NOT killed
+        assert bootstrap_pid not in killed  # its supervision chain was NOT killed
+
+    def test_windows_no_orphans_when_only_recorded_gateway_running(self, monkeypatch):
+        """If the only gateway processes are the recorded one and its
+        bootstrap parent, the reaper returns False and kills nothing."""
+        recorded_pid = 52615
+        bootstrap_pid = 52616
+
+        monkeypatch.setattr(gateway, "is_windows", lambda: True)
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+
+        bootstrap = SimpleNamespace(pid=bootstrap_pid, parent=lambda: None)
+        recorded = SimpleNamespace(pid=recorded_pid, parent=lambda: bootstrap)
+        self._install_fake_psutil(monkeypatch, [recorded, bootstrap])
+
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: recorded_pid)
+
+        # find_gateway_pids would return the recorded PID and its bootstrap
+        # parent, but both are excluded.
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [
+                p
+                for p in [recorded_pid, bootstrap_pid]
+                if p not in (exclude_pids or set())
+            ],
+        )
+
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert result is False  # no orphans reaped
+        assert killed_pids == []  # nothing was killed
+
+
 def test_module_has_logger():
     """Verify module has a logger instance (regression guard for #27154)."""
     assert hasattr(gateway, "logger")

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -509,10 +509,17 @@ class TestReapUnsupervisedGatewayOrphansWindows:
     """
 
     @staticmethod
-    def _install_fake_psutil(monkeypatch, chain):
+    def _install_fake_psutil(monkeypatch, chain, environ=None):
         """Install a fake psutil module exposing the given process chain."""
         by_pid = {proc.pid: proc for proc in chain}
-        fake_psutil = SimpleNamespace(Process=lambda pid: by_pid[pid])
+        envs = environ or {}
+
+        def _process(pid):
+            proc = by_pid[pid]
+            proc.environ = lambda: envs.get(pid, {})
+            return proc
+
+        fake_psutil = SimpleNamespace(Process=_process)
         monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
 
     def test_windows_excludes_recorded_pid_and_bootstrap_from_kill(self, monkeypatch):
@@ -599,6 +606,51 @@ class TestReapUnsupervisedGatewayOrphansWindows:
 
         assert result is False  # no orphans reaped
         assert killed_pids == []  # nothing was killed
+
+    def test_windows_spares_detached_marker_gateway_when_pidfile_stale(self, monkeypatch):
+        """Even with a stale/missing pidfile, a HERMES_GATEWAY_DETACHED=1
+        process must not be reaped (env-marker hardening, #86100 review)."""
+        detached_pid = 52617  # Scheduled-Task gateway (env marker set)
+        orphan_pid = 99998    # a real orphan that should still be reaped
+
+        monkeypatch.setattr(gateway, "is_windows", lambda: True)
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+
+        detached = SimpleNamespace(pid=detached_pid, parent=lambda: None)
+        orphan = SimpleNamespace(pid=orphan_pid, parent=lambda: None)
+        self._install_fake_psutil(
+            monkeypatch,
+            [detached, orphan],
+            environ={detached_pid: {"HERMES_GATEWAY_DETACHED": "1"}},
+        )
+
+        # Stale pidfile: get_running_pid() returns None, so no pidfile-based
+        # exemption applies — only the env marker protects the gateway.
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [
+                p
+                for p in [detached_pid, orphan_pid]
+                if p not in (exclude_pids or set())
+            ],
+        )
+
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        monkeypatch.setattr("time.monotonic", lambda: 1.0)
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert result is True  # the real orphan was reaped
+        killed = [pid for pid, _ in killed_pids]
+        assert orphan_pid in killed       # the real orphan was killed
+        assert detached_pid not in killed  # the detached-marked gateway survived
 
 
 def test_module_has_logger():


### PR DESCRIPTION
## What does this PR do?

Fixes #86098: on Windows, the orphan reaper (`_reap_unsupervised_gateway_orphans()`) kills a healthy, recorded gateway — and its Scheduled-Task bootstrap parent chain — every time the Desktop backend starts, because `_get_service_pids()` only implements systemd (Linux) and launchd (macOS) and returns an empty set on Windows. A gateway supervised by a Scheduled Task / Startup VBS is therefore indistinguishable from an unsupervised orphan.

This mirrors the macOS launchd exemption from #85913: on Windows, exempt the recorded healthy gateway PID (`get_running_pid()`) and its parent chain from the orphan scan. Exempting the recorded PID alone is not enough — the Scheduled-Task bootstrap's argv (`gateway run`) matches the gateway scan, and killing the bootstrap takes the detached gateway it spawned down with it.

## Related Issue

Fixes #86098

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: in `_reap_unsupervised_gateway_orphans()`, add an `is_windows()` branch that exempts the recorded healthy gateway PID and its parent chain (via psutil) before the orphan scan — the Windows counterpart of the macOS `_get_service_pids()` exemption. Linux/macOS behavior is untouched.
- `tests/hermes_cli/test_gateway.py`: 2 regression tests — (1) with a real orphan present, only the orphan is killed, never the recorded gateway or its bootstrap parent; (2) when only the recorded gateway and its bootstrap are running, nothing is reaped.

## How to Test

1. `uv run pytest tests/hermes_cli/test_gateway.py -k "ReapUnsupervised"` — 4/4 pass (2 new Windows + 2 existing macOS regression tests)
2. `uv run pytest tests/hermes_cli/test_gateway.py` — 14 passed, 5 skipped
3. Related gateway subset: `test_gateway_windows.py`, `test_gateway_proc_fallback.py`, `test_spawn_gateway_restart_reap.py`, `test_gateway_wsl.py` — 12 passed, 6 skipped
4. `ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway.py` — clean

Note: the full test suite was not run locally; the targeted gateway/status subset above was. Verified on Windows 11 (Python 3.14).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — targeted subset only (full suite not run locally)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no doc changes needed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — change is Windows-only; macOS (launchd) and Linux (systemd) paths are untouched
