### PR TITLE
fix(agent): don't report a file the model wrote via an unwatched tool

### DIFF
--- a/agent/tool_result_classification.py
+++ b/agent/tool_result_classification.py
@@ -3,10 +3,66 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+import os
+from typing import Any, Optional, Tuple
 
 
 FILE_MUTATING_TOOL_NAMES = frozenset({"write_file", "patch"})
+
+
+# A cheap, comparable snapshot of a path's on-disk state: (exists, mtime_ns, size).
+PathFingerprint = Tuple[bool, int, int]
+
+
+def path_change_fingerprint(
+    path: str,
+    base: Optional[str] = None,
+) -> Optional[PathFingerprint]:
+    """Snapshot *path*'s on-disk state so a later call can detect a change.
+
+    This exists because ``FILE_MUTATING_TOOL_NAMES`` is — and can only ever
+    be — an incomplete list.  ``write_file`` and ``patch`` are the tools the
+    verifier can *watch*; they are not the only tools that can *write*.
+    ``terminal`` (``python -c``, ``sed -i``, a shell redirect), the
+    code-execution tool, an MCP server, and any plugin can all land a file
+    without the verifier seeing a thing.  When a watched write fails and an
+    unwatched one then succeeds on the same path, tool-level bookkeeping
+    alone reports "NOT modified" about a file that was in fact modified — a
+    false negative that teaches the user to ignore the footer, which is
+    strictly worse than having no verifier at all.
+
+    So the verifier asks the filesystem rather than the tool registry:
+    fingerprint the path when a write fails, re-fingerprint when the footer
+    renders, and drop the entry only if the two differ.
+
+    Returns ``None`` when the path cannot be resolved or stat'd for any
+    reason other than "does not exist".  Callers MUST treat ``None`` as
+    *unknown* and keep warning — a verifier that goes quiet when confused is
+    the exact failure mode this helper exists to prevent.  A path that simply
+    does not exist is a perfectly comparable state and is reported as
+    ``(False, 0, 0)``, so a failed create followed by a successful
+    out-of-band create is still detected.
+    """
+    candidates = []
+    if os.path.isabs(path):
+        candidates.append(path)
+    else:
+        for anchor in (base, os.environ.get("TERMINAL_CWD"), os.getcwd()):
+            if anchor:
+                candidates.append(os.path.join(anchor, path))
+        candidates.append(path)
+
+    saw_missing = False
+    for candidate in candidates:
+        try:
+            st = os.stat(candidate)
+        except (FileNotFoundError, NotADirectoryError):
+            saw_missing = True
+            continue
+        except Exception:
+            return None
+        return (True, st.st_mtime_ns, st.st_size)
+    return (False, 0, 0) if saw_missing else None
 
 
 # Tools whose interrupted/dangling execution is safe to discard because they

--- a/run_agent.py
+++ b/run_agent.py
@@ -202,6 +202,7 @@ from agent.tool_guardrails import (
 from agent.tool_result_classification import (
     FILE_MUTATING_TOOL_NAMES as _FILE_MUTATING_TOOLS,
     file_mutation_result_landed,
+    path_change_fingerprint,
 )
 from agent.trajectory import (
     convert_scratchpad_to_think,
@@ -3493,6 +3494,12 @@ class AIAgent:
                     state[path] = {
                         "tool": tool_name,
                         "error_preview": preview,
+                        # On-disk state at the moment the write failed.  The
+                        # footer re-checks this before accusing the model of
+                        # over-claiming, so a path that a NON-watched tool
+                        # (terminal, execute_code, an MCP server, a plugin)
+                        # went on to write is not reported as unmodified.
+                        "fingerprint": path_change_fingerprint(path),
                     }
         else:
             for path in targets:
@@ -3554,6 +3561,31 @@ class AIAgent:
             return text
         return cls._FOOTER_PATH_RE.sub(lambda m: f"`{m.group(0)}`", text)
 
+    @staticmethod
+    def _file_mutation_still_unwritten(path: str, info: Dict[str, Any]) -> bool:
+        """Return True when *path* still looks genuinely unmodified.
+
+        Compares the fingerprint taken when the write failed against the
+        path's state right now.  Any difference means something landed a
+        write through a tool the verifier does not watch, so the failure
+        should not be reported.
+
+        Fails SAFE in both unknown cases — a missing recorded fingerprint
+        (older state, or a test constructing the dict by hand) and an
+        unreadable path both return True and keep the warning.  A verifier
+        that suppresses when it cannot tell is worse than no verifier.
+        """
+        recorded = info.get("fingerprint")
+        if recorded is None:
+            return True
+        try:
+            current = path_change_fingerprint(path)
+        except Exception:
+            return True
+        if current is None:
+            return True
+        return tuple(current) == tuple(recorded)
+
     @classmethod
     def _format_file_mutation_failure_footer(cls, failed: Dict[str, Dict[str, Any]]) -> str:
         """Render the per-turn failed-mutation dict as a user-facing footer.
@@ -3568,6 +3600,20 @@ class AIAgent:
         bare-path media extractor can never auto-attach a protected file
         (e.g. ``~/.hermes/config.yaml``) to a messaging channel (#35584).
         """
+        if not failed:
+            return ""
+        # Drop any path that changed on disk since the write failed.  The
+        # tracked tools (``write_file`` / ``patch``) are not the only writers
+        # in the system: a model that gets a ``patch`` denied and then lands
+        # the same edit through ``terminal`` has NOT over-claimed, and saying
+        # it did trains the user to ignore this footer.  Entries recorded
+        # without a fingerprint, or whose path can no longer be stat'd, are
+        # kept — unknown must never mean silent.
+        failed = {
+            path: info
+            for path, info in failed.items()
+            if cls._file_mutation_still_unwritten(path, info)
+        }
         if not failed:
             return ""
         lines = [

--- a/tests/run_agent/test_file_mutation_verifier_out_of_band.py
+++ b/tests/run_agent/test_file_mutation_verifier_out_of_band.py
@@ -1,0 +1,187 @@
+"""The file-mutation verifier must not report a file that DID change.
+
+``FILE_MUTATING_TOOL_NAMES`` only covers ``write_file`` and ``patch``, but
+those are not the only tools that write.  A model whose ``patch`` is denied
+(e.g. by the credential-file guard) and which then lands the same edit via
+``terminal`` / ``python -c`` has not over-claimed — yet the tool-level
+bookkeeping alone still had the path marked failed, so the footer accused it
+of lying about a file that was, in fact, modified.
+
+A verifier that cries wolf gets ignored, which defeats the point of having
+one.  These tests pin the filesystem-truth check that fixes it, and — just as
+importantly — pin that it still fires when the file really is untouched.
+"""
+
+import os
+
+import pytest
+
+from agent.tool_result_classification import path_change_fingerprint
+from run_agent import AIAgent
+
+
+def _footer(failed):
+    return AIAgent._format_file_mutation_failure_footer(failed)
+
+
+class TestOutOfBandWriteSuppression:
+
+    def test_untouched_file_still_warns(self, tmp_path):
+        """The original contract: a genuinely failed write is still reported."""
+        target = tmp_path / "untouched.py"
+        target.write_text("original\n")
+
+        failed = {
+            str(target): {
+                "tool": "patch",
+                "error_preview": "Could not find old_string",
+                "fingerprint": path_change_fingerprint(str(target)),
+            }
+        }
+
+        footer = _footer(failed)
+        assert "File-mutation verifier" in footer
+        assert "untouched.py" in footer
+
+    def test_out_of_band_write_suppresses_the_warning(self, tmp_path):
+        """THE BUG: patch denied, terminal wrote it anyway → no false alarm."""
+        target = tmp_path / "written_elsewhere.env"
+        target.write_text("BEFORE=1\n")
+
+        failed = {
+            str(target): {
+                "tool": "patch",
+                "error_preview": "Write denied: protected system/credential file",
+                "fingerprint": path_change_fingerprint(str(target)),
+            }
+        }
+
+        # Something the verifier does not watch lands the write.
+        os.utime(target, ns=(0, 0))
+        target.write_text("AFTER=1\nAND_MORE=2\n")
+
+        assert _footer(failed) == ""
+
+    def test_failed_create_then_out_of_band_create_suppresses(self, tmp_path):
+        """A path that did not exist is still a comparable state."""
+        target = tmp_path / "created_elsewhere.txt"
+
+        failed = {
+            str(target): {
+                "tool": "write_file",
+                "error_preview": "denied",
+                "fingerprint": path_change_fingerprint(str(target)),
+            }
+        }
+        assert failed[str(target)]["fingerprint"] == (False, 0, 0)
+
+        target.write_text("landed via terminal\n")
+        assert _footer(failed) == ""
+
+    def test_failed_create_that_stayed_missing_still_warns(self, tmp_path):
+        target = tmp_path / "never_created.txt"
+
+        failed = {
+            str(target): {
+                "tool": "write_file",
+                "error_preview": "denied",
+                "fingerprint": path_change_fingerprint(str(target)),
+            }
+        }
+        assert "never_created.txt" in _footer(failed)
+
+    def test_mixed_batch_reports_only_the_real_failure(self, tmp_path):
+        landed = tmp_path / "landed.py"
+        stalled = tmp_path / "stalled.py"
+        landed.write_text("a\n")
+        stalled.write_text("b\n")
+
+        failed = {
+            str(p): {
+                "tool": "patch",
+                "error_preview": "boom",
+                "fingerprint": path_change_fingerprint(str(p)),
+            }
+            for p in (landed, stalled)
+        }
+
+        landed.write_text("a changed out of band\n")
+
+        footer = _footer(failed)
+        assert "stalled.py" in footer
+        assert "landed.py" not in footer
+        assert "1 file(s)" in footer
+
+
+class TestFailsSafeWhenUnknown:
+    """Unknown must never mean silent — that is the whole point."""
+
+    def test_entry_without_fingerprint_still_warns(self, tmp_path):
+        """Back-compat: older state, and hand-built dicts in other tests."""
+        target = tmp_path / "legacy.py"
+        target.write_text("x\n")
+
+        failed = {str(target): {"tool": "patch", "error_preview": "boom"}}
+        assert "legacy.py" in _footer(failed)
+
+    def test_unstattable_path_still_warns(self, monkeypatch, tmp_path):
+        target = tmp_path / "weird.py"
+        target.write_text("x\n")
+
+        failed = {
+            str(target): {
+                "tool": "patch",
+                "error_preview": "boom",
+                "fingerprint": (True, 1, 1),
+            }
+        }
+
+        import run_agent as ra
+
+        def _explode(*_a, **_kw):
+            raise PermissionError("nope")
+
+        monkeypatch.setattr(ra, "path_change_fingerprint", _explode)
+        assert "weird.py" in _footer(failed)
+
+    def test_unreadable_path_reports_unknown_and_still_warns(self, monkeypatch, tmp_path):
+        """``path_change_fingerprint`` returning None must not suppress."""
+        target = tmp_path / "opaque.py"
+        target.write_text("x\n")
+
+        failed = {
+            str(target): {
+                "tool": "patch",
+                "error_preview": "boom",
+                "fingerprint": (True, 1, 1),
+            }
+        }
+
+        import run_agent as ra
+
+        monkeypatch.setattr(ra, "path_change_fingerprint", lambda *_a, **_k: None)
+        assert "opaque.py" in _footer(failed)
+
+
+class TestPathChangeFingerprint:
+
+    def test_detects_content_change_at_identical_mtime(self, tmp_path):
+        """Size catches a same-mtime rewrite; mtime_ns catches same-size."""
+        target = tmp_path / "f.txt"
+        target.write_text("aaa")
+        before = path_change_fingerprint(str(target))
+
+        target.write_text("aaaa")
+        os.utime(target, ns=(before[1], before[1]))
+
+        assert path_change_fingerprint(str(target)) != before
+
+    def test_relative_path_resolves_against_terminal_cwd(self, tmp_path, monkeypatch):
+        (tmp_path / "rel.txt").write_text("hello")
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+        fp = path_change_fingerprint("rel.txt")
+        assert fp is not None and fp[0] is True and fp[2] == 5
+
+    def test_missing_path_is_a_comparable_state_not_none(self, tmp_path):
+        assert path_change_fingerprint(str(tmp_path / "nope")) == (False, 0, 0)


### PR DESCRIPTION
## The bug

`FILE_MUTATING_TOOL_NAMES` covers `write_file` and `patch`. Those are not the only tools that write.

`terminal` (`sed -i`, `python -c`, a shell redirect), the code-execution tool, MCP servers and plugins can all land a file without the verifier seeing anything.

So when a model's `patch` is denied -- e.g. by the credential-file guard -- and it then lands the same edit through `terminal`, it has **not** over-claimed. But tool-level bookkeeping alone still had the path marked failed, so the footer accused it of lying about a file that was in fact modified.

A verifier that cries wolf gets ignored, which defeats the point of having one. A false negative here is strictly worse than having no verifier at all.

## The fix

Ask the filesystem instead of the tool registry.

`path_change_fingerprint()` snapshots `(exists, mtime_ns, size)` when a write fails. The footer re-fingerprints before rendering and drops an entry only when the two differ.

### Fails safe

Both unknown cases keep the warning:

- a missing recorded fingerprint (older state, or a test constructing the dict by hand)
- a path that cannot be stat'd for any reason other than "does not exist"

A verifier that goes quiet when it cannot tell is the exact failure mode this is meant to prevent.

A path that simply does not exist is a perfectly comparable state and is reported as `(False, 0, 0)`, so a failed create followed by a successful out-of-band create is still detected.

## Tests

New `tests/run_agent/test_file_mutation_verifier_out_of_band.py` -- 11 tests covering:

- untouched file still warns (the verifier must keep working)
- out-of-band write suppresses the warning
- failed create then out-of-band create suppresses
- failed create that stayed missing still warns
- mixed batch reports only the real failure
- entry without fingerprint still warns
- unstattable / unreadable path still warns
- content change detected at identical mtime
- relative path resolves against `TERMINAL_CWD`
- missing path is a comparable state, not `None`

`11 passed`.

---
Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGLv7LyNrpaPm4ciGqhyxD