### PR TITLE
fix(config): read the on-disk .env for the deprecated-cwd warning

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2146,20 +2146,43 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
 
     These env vars are deprecated — the canonical setting is terminal.cwd
     in config.yaml.  Prints a migration hint to stderr.
+
+    The check reads the ON-DISK ``.env`` (via ``load_env()``), never
+    ``os.environ``.  Reading the process env cannot answer the question this
+    warning claims to answer:
+
+      * ``cli.py`` FORCE-EXPORTS ``terminal.cwd`` into
+        ``os.environ["TERMINAL_CWD"]`` on every CLI start, and for the
+        ``local`` backend it first rewrites that value to ``os.getcwd()``.
+        So an ordinary config.yaml carrying the default ``cwd: .`` always
+        produced ``TERMINAL_CWD=<current dir>`` in the process env, which the
+        old code then reported as "found in .env" — naming a file the user
+        never edited and a value that appears nowhere in it.  The
+        ``config_has_explicit_cwd`` guard below made this *worse*, not
+        better: the false positive fired precisely when config.yaml was at
+        its default, i.e. for every clean install.
+      * ``load_env()`` also skips commented-out lines, so the shipped
+        ``.env.example`` scaffold line ``# TERMINAL_CWD=.`` cannot trip the
+        warning either.
+
+    ``hermes doctor`` already gets this right — see
+    ``doctor._DEPRECATED_ENV_VARS``, whose comment reads "checked in the .env
+    file, not process env, so config→env bridges like terminal.cwd →
+    TERMINAL_CWD do not false-positive".  This brings startup into line with
+    doctor instead of contradicting it.
+
+    *config* is retained for signature compatibility with existing callers
+    and is deliberately no longer consulted: if the key really is in ``.env``
+    it shadows config.yaml and is worth reporting whatever ``terminal.cwd``
+    happens to say.
     """
-    messaging_cwd = os.environ.get("MESSAGING_CWD")
-    terminal_cwd_env = os.environ.get("TERMINAL_CWD")
+    try:
+        dotenv = load_env()
+    except Exception:
+        return
 
-    if config is None:
-        try:
-            config = load_config()
-        except Exception:
-            return
-
-    terminal_cfg = config.get("terminal", {})
-    config_cwd = terminal_cfg.get("cwd", ".") if isinstance(terminal_cfg, dict) else "."
-    # Only warn if config.yaml doesn't have an explicit path
-    config_has_explicit_cwd = config_cwd not in {".", "auto", "cwd", ""}
+    messaging_cwd = (dotenv.get("MESSAGING_CWD") or "").strip()
+    terminal_cwd_env = (dotenv.get("TERMINAL_CWD") or "").strip()
 
     lines: list[str] = []
     if messaging_cwd:
@@ -2167,8 +2190,7 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
             f"  \033[33m⚠\033[0m MESSAGING_CWD={messaging_cwd} found in .env — "
             f"this is deprecated."
         )
-    if terminal_cwd_env and not config_has_explicit_cwd:
-        # TERMINAL_CWD in env but not from config bridge — likely from .env
+    if terminal_cwd_env:
         lines.append(
             f"  \033[33m⚠\033[0m TERMINAL_CWD={terminal_cwd_env} found in .env — "
             f"this is deprecated."

--- a/tests/hermes_cli/test_deprecated_cwd_warning.py
+++ b/tests/hermes_cli/test_deprecated_cwd_warning.py
@@ -1,12 +1,30 @@
-"""Tests for warn_deprecated_cwd_env_vars() migration warning."""
+"""Tests for warn_deprecated_cwd_env_vars() migration warning.
+
+The warning claims a key was "found in .env", so it must read the on-disk
+.env — not ``os.environ``.  ``cli.py`` force-exports ``terminal.cwd`` into
+``os.environ["TERMINAL_CWD"]`` on every CLI start (rewriting it to
+``os.getcwd()`` for the local backend), so a process-env read reported the
+config bridge's own value as a user-authored .env entry on every clean
+install.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def fake_dotenv(monkeypatch):
+    """Patch the on-disk .env loader with a caller-supplied mapping."""
+    def _install(mapping):
+        import hermes_cli.config as cfg
+        monkeypatch.setattr(cfg, "load_env", lambda: dict(mapping))
+    return _install
 
 
 class TestDeprecatedCwdWarning:
     """Warn when MESSAGING_CWD or TERMINAL_CWD is set in .env."""
 
-    def test_messaging_cwd_triggers_warning(self, monkeypatch, capsys):
-        monkeypatch.setenv("MESSAGING_CWD", "/some/path")
-        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    def test_messaging_cwd_triggers_warning(self, fake_dotenv, capsys):
+        fake_dotenv({"MESSAGING_CWD": "/some/path"})
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
         warn_deprecated_cwd_env_vars(config={})
@@ -16,10 +34,8 @@ class TestDeprecatedCwdWarning:
         assert "deprecated" in captured.err.lower()
         assert "config.yaml" in captured.err
 
-
-    def test_both_deprecated_vars_warn(self, monkeypatch, capsys):
-        monkeypatch.setenv("MESSAGING_CWD", "/msg/path")
-        monkeypatch.setenv("TERMINAL_CWD", "/term/path")
+    def test_both_deprecated_vars_warn(self, fake_dotenv, capsys):
+        fake_dotenv({"MESSAGING_CWD": "/msg/path", "TERMINAL_CWD": "/term/path"})
 
         from hermes_cli.config import warn_deprecated_cwd_env_vars
         warn_deprecated_cwd_env_vars(config={})
@@ -27,3 +43,67 @@ class TestDeprecatedCwdWarning:
         captured = capsys.readouterr()
         assert "MESSAGING_CWD" in captured.err
         assert "TERMINAL_CWD" in captured.err
+
+    def test_terminal_cwd_in_dotenv_warns_even_with_explicit_config_cwd(
+        self, fake_dotenv, capsys
+    ):
+        """A real .env entry shadows config.yaml — report it either way.
+
+        The old code suppressed this whenever config.yaml named an explicit
+        path, which hid the one case that genuinely is split-brain.
+        """
+        fake_dotenv({"TERMINAL_CWD": "/from/dotenv"})
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={"terminal": {"cwd": "/from/config"}})
+
+        captured = capsys.readouterr()
+        assert "TERMINAL_CWD" in captured.err
+
+    # ── Regression: the config bridge must not look like a user .env entry ──
+
+    def test_bridged_process_env_does_not_warn(self, fake_dotenv, monkeypatch, capsys):
+        """THE BUG: config.yaml at its default ``cwd: .`` warned on every start.
+
+        cli.py sets ``os.environ["TERMINAL_CWD"] = os.getcwd()`` for the local
+        backend, then the warning reported that value as "found in .env" —
+        naming a file the user never edited and a value appearing nowhere in it.
+        """
+        fake_dotenv({})
+        monkeypatch.setenv("TERMINAL_CWD", "/current/working/dir")
+        monkeypatch.setenv("MESSAGING_CWD", "/also/bridged")
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={"terminal": {"cwd": "."}})
+
+        assert capsys.readouterr().err == ""
+
+    def test_commented_out_dotenv_line_does_not_warn(self, fake_dotenv, capsys):
+        """``# TERMINAL_CWD=.`` ships in .env.example; load_env skips comments."""
+        fake_dotenv({})  # load_env() never yields commented-out keys
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={"terminal": {"cwd": "."}})
+
+        assert capsys.readouterr().err == ""
+
+    def test_blank_value_does_not_warn(self, fake_dotenv, capsys):
+        """``TERMINAL_CWD=`` with an empty value is not a configured path."""
+        fake_dotenv({"TERMINAL_CWD": "   ", "MESSAGING_CWD": ""})
+
+        from hermes_cli.config import warn_deprecated_cwd_env_vars
+        warn_deprecated_cwd_env_vars(config={})
+
+        assert capsys.readouterr().err == ""
+
+    def test_unreadable_dotenv_is_silent(self, monkeypatch, capsys):
+        """A broken .env read must not spray a warning at startup."""
+        import hermes_cli.config as cfg
+
+        def _boom():
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(cfg, "load_env", _boom)
+        cfg.warn_deprecated_cwd_env_vars(config={})
+
+        assert capsys.readouterr().err == ""


### PR DESCRIPTION
## The bug

`warn_deprecated_cwd_env_vars()` claims a key was **"found in .env"**, but it read `os.environ`. The process env cannot answer the question the warning claims to answer.

`cli.py` force-exports `terminal.cwd` into `os.environ["TERMINAL_CWD"]` on every CLI start, and for the `local` backend it first rewrites that value to `os.getcwd()`.

So an ordinary `config.yaml` carrying the default `cwd: .` always produced `TERMINAL_CWD=<current dir>` in the process env -- which the warning then reported as "found in .env", naming a file the user never edited and a value that appears nowhere in it.

**This fired on every clean install.**

### The guard made it backwards

The `config_has_explicit_cwd` check was meant to reduce noise. It inverted the logic instead:

- it **suppressed** the one genuinely split-brain case -- a real `.env` entry shadowing `config.yaml`
- it **fired** precisely when `config.yaml` was at its default

## The fix

Read the on-disk `.env` via `load_env()`.

`hermes doctor` already gets this right -- see `doctor._DEPRECATED_ENV_VARS`, whose comment reads *"checked in the .env file, not process env, so config->env bridges like terminal.cwd -> TERMINAL_CWD do not false-positive"*. This brings startup into line with doctor instead of contradicting it.

`load_env()` also skips commented-out lines, so the shipped `.env.example` scaffold line `# TERMINAL_CWD=.` cannot trip the warning either.

`config` is retained for signature compatibility and deliberately no longer consulted: a key that really is in `.env` shadows `config.yaml` and is worth reporting whatever `terminal.cwd` happens to say.

## Tests

Extends `tests/hermes_cli/test_deprecated_cwd_warning.py` -- 7 tests, including regression coverage for:

- the bridged process env not looking like a user `.env` entry (**the bug**)
- a real `.env` entry warning even when `config.yaml` names an explicit cwd
- commented-out `.env` lines
- blank values
- an unreadable `.env` staying silent

`7 passed`.

---
Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGLv7LyNrpaPm4ciGqhyxD