### PR TITLE
fix(state): force built-in memory enabled when external provider configured

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1254,6 +1254,28 @@ def _init_memory(agent, _agent_cfg, skip_memory, platform):
             agent._memory_enabled, agent._user_profile_enabled = get_builtin_memory_store_flags(
                 _agent_cfg
             )
+            # When an external memory provider is configured, the built-in
+            # MEMORY.md/USER.md store is always created and injected alongside
+            # the provider block — the documented contract is "additive, never
+            # replacing" (issue #85622).  Without this, a config left at
+            # memory_enabled: false by the blank-slate setup wizard suppresses
+            # built-in memory when the user later enables a provider, silently
+            # dropping durable notes from every new-chat system prompt.
+            _mem_provider_name = mem_config.get("provider", "") if mem_config else ""
+            _provider_configured = bool(
+                _mem_provider_name and str(_mem_provider_name).strip()
+            )
+            if _provider_configured:
+                if not agent._memory_enabled:
+                    agent._memory_enabled = True
+                    _ra().logger.info(
+                        "External memory provider '%s' configured; enabling "
+                        "built-in MEMORY.md injection (additive contract, "
+                        "issue #85622).",
+                        _mem_provider_name,
+                    )
+                if not agent._user_profile_enabled:
+                    agent._user_profile_enabled = True
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
             if agent._memory_enabled or agent._user_profile_enabled:
                 agent._memory_store = MemoryStore(

--- a/tests/agent/test_memory_provider_additive_85622.py
+++ b/tests/agent/test_memory_provider_additive_85622.py
@@ -1,0 +1,150 @@
+"""Regression test for issue #85622.
+
+When an external memory provider is configured (``memory.provider`` set to a
+non-empty value) but ``memory_enabled: false`` is in the config (e.g., left
+over from the blank-slate setup wizard), the built-in ``MemoryStore`` was never
+created.  The system-prompt renderer checks ``agent._memory_store`` before
+injecting ``MEMORY.md`` / ``USER.md``, so the built-in frozen snapshot was
+silently dropped from every new-chat system prompt — contradicting the
+documented "additive, never replacing" contract.
+
+The fix in ``agent_init.py`` forces ``memory_enabled`` / ``user_profile_enabled``
+to ``True`` when a provider is configured, ensuring the built-in store is
+always created and injected alongside the external provider block.
+"""
+
+import pytest
+
+from run_agent import AIAgent
+
+
+class _FakeOpenAI:
+    def __init__(self, **kw):
+        self.api_key = kw.get("api_key", "test")
+        self.base_url = kw.get("base_url", "http://test")
+
+    def close(self):
+        pass
+
+
+def _write_config(hermes_home, memory_section):
+    """Write a minimal config.yaml with the given memory section."""
+    import yaml
+
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    config = {"model": {"default": "test-model", "provider": "openrouter"}}
+    config["memory"] = memory_section
+    with open(hermes_home / "config.yaml", "w") as f:
+        yaml.dump(config, f)
+
+
+def _make_agent(monkeypatch, tmp_path, memory_section):
+    """Create an AIAgent with the given memory config section."""
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: [])
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+    hermes_home = tmp_path / "hm"
+    _write_config(hermes_home, memory_section)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return AIAgent(
+        api_key="test-key",
+        base_url="http://test",
+        provider="openrouter",
+        api_mode="chat_completions",
+        max_iterations=1,
+        quiet_mode=True,
+        skip_context_files=True,
+    )
+
+
+class TestProviderAdditiveBuiltinMemory:
+    """Verify built-in memory is active when a provider is configured."""
+
+    def test_provider_configured_forces_memory_enabled_true(self, monkeypatch, tmp_path):
+        """When memory.provider is set and memory_enabled is false, the
+        built-in store is still created and _memory_enabled is True."""
+        agent = _make_agent(
+            monkeypatch,
+            tmp_path,
+            {"memory_enabled": False, "user_profile_enabled": False, "provider": "fake"},
+        )
+        assert agent._memory_enabled is True, (
+            "memory_enabled must be forced True when a provider is configured "
+            "(additive contract, issue #85622)"
+        )
+        assert agent._memory_store is not None, (
+            "built-in MemoryStore must be created when a provider is configured "
+            "even if memory_enabled was false in config (issue #85622)"
+        )
+
+    def test_provider_configured_forces_user_profile_enabled_true(self, monkeypatch, tmp_path):
+        """When memory.provider is set and user_profile_enabled is false,
+        user_profile_enabled is forced True."""
+        agent = _make_agent(
+            monkeypatch,
+            tmp_path,
+            {"memory_enabled": False, "user_profile_enabled": False, "provider": "fake"},
+        )
+        assert agent._user_profile_enabled is True, (
+            "user_profile_enabled must be forced True when a provider is "
+            "configured (additive contract, issue #85622)"
+        )
+
+    def test_no_provider_respects_memory_enabled_false(self, monkeypatch, tmp_path):
+        """Without a provider, memory_enabled: false is respected — the
+        built-in store is NOT created.  This verifies the fix doesn't
+        over-trigger when no provider is configured."""
+        agent = _make_agent(
+            monkeypatch,
+            tmp_path,
+            {"memory_enabled": False, "user_profile_enabled": False, "provider": ""},
+        )
+        assert agent._memory_enabled is False, (
+            "memory_enabled must stay False when no provider is configured"
+        )
+        assert agent._memory_store is None, (
+            "built-in MemoryStore must NOT be created when memory_enabled is "
+            "false and no provider is configured"
+        )
+
+    def test_no_provider_respects_memory_enabled_true(self, monkeypatch, tmp_path):
+        """Without a provider, memory_enabled: true creates the store as usual."""
+        agent = _make_agent(
+            monkeypatch,
+            tmp_path,
+            {"memory_enabled": True, "user_profile_enabled": True, "provider": ""},
+        )
+        assert agent._memory_enabled is True
+        assert agent._memory_store is not None
+
+    def test_provider_with_memory_enabled_true_no_override_log(self, monkeypatch, tmp_path, caplog):
+        """When memory_enabled is already true and a provider is configured,
+        no override log message is emitted (the info log only fires on the
+        false→true override)."""
+        import logging
+
+        agent = _make_agent(
+            monkeypatch,
+            tmp_path,
+            {"memory_enabled": True, "user_profile_enabled": True, "provider": "fake"},
+        )
+        override_logs = [
+            r for r in caplog.records
+            if "enabling built-in MEMORY.md injection" in r.getMessage()
+        ]
+        assert len(override_logs) == 0, (
+            "no override log expected when memory_enabled was already true"
+        )
+        assert agent._memory_enabled is True
+
+    def test_empty_provider_string_does_not_force(self, monkeypatch, tmp_path):
+        """An empty/whitespace provider string must not trigger the override."""
+        agent = _make_agent(
+            monkeypatch,
+            tmp_path,
+            {"memory_enabled": False, "user_profile_enabled": False, "provider": "  "},
+        )
+        assert agent._memory_enabled is False, (
+            "whitespace-only provider must not force memory_enabled"
+        )
+        assert agent._memory_store is None


### PR DESCRIPTION
## What does this PR do?

When an external memory provider is configured (`memory.provider` set to a non-empty value) but `memory_enabled: false` is in the config (e.g. left over from the blank-slate setup wizard), the built-in `MemoryStore` was never created. The system-prompt renderer in `agent/system_prompt.py` checks `agent._memory_store` before injecting `MEMORY.md`/`USER.md` into the volatile tier, so the built-in frozen snapshot was silently dropped from every new-chat system prompt — contradicting the documented **"additive, never replacing"** contract.

The external provider block (`agent._memory_manager`) activates independently of `memory_enabled` in `agent_init.py`, so the provider's ambient-recall block appeared while the built-in files were absent. No error or warning was emitted.

This PR forces `memory_enabled` and `user_profile_enabled` to `True` when a provider is configured, ensuring the built-in store is always created and injected alongside the external provider block. An explicit `memory_enabled: false` with **no** provider is still respected.

## Related Issue

Fixes #85622

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`agent/agent_init.py`**: After resolving flags via `get_builtin_memory_store_flags()`, check if `memory.provider` is set to a non-empty value. If so, force both flags to `True` and log an info-level override message. The `MemoryStore` creation logic then proceeds as normal, ensuring `MEMORY.md`/`USER.md` are loaded and available for system-prompt injection alongside the provider block.
- **`tests/agent/test_memory_provider_additive_85622.py`**: 6 regression tests covering provider+disabled, no-provider+disabled, no-provider+enabled, provider+enabled (no log), and whitespace-only provider edge case.

## How to Test

1. `uv run python -m pytest tests/agent/test_memory_provider_additive_85622.py -v` — 6 tests, all pass
2. `uv run python -m pytest tests/agent/test_skip_memory_store_65429.py tests/agent/test_memory_provider.py tests/agent/test_memory_provider_unavailable_warning.py -q` — 72 tests, no regressions
3. `uv run ruff check agent/agent_init.py tests/agent/test_memory_provider_additive_85622.py` — clean
4. `uv lock --check` — clean

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A