### PR TITLE
fix: honor cron approval mode under gateway exec ask

### DIFF
--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -274,6 +274,37 @@ class TestCronDenyModeAllGuards:
             result = check_all_command_guards("rm -rf /tmp/stuff", "local")
             assert result["approved"]
 
+    def test_cron_approve_takes_precedence_over_gateway_exec_ask(self, monkeypatch):
+        """Gateway's process-wide exec-ask flag must not strand cron jobs."""
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        from unittest.mock import patch as mock_patch
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="approve"):
+            result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+
+        assert result["approved"]
+        assert result.get("status") != "approval_required"
+
+    def test_cron_deny_takes_precedence_over_gateway_exec_ask(self, monkeypatch):
+        """Cron deny remains fail-closed when gateway exec-ask leaks in."""
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        from unittest.mock import patch as mock_patch
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+            result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+
+        assert not result["approved"]
+        assert "BLOCKED" in result["message"]
+        assert result.get("status") != "approval_required"
+
     def test_tirith_content_threat_blocked_in_cron_deny(self, monkeypatch):
         """Content-level threats caught only by tirith (not the regex patterns)
         are blocked in cron-deny mode. Regression for #22070: previously the

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4075,12 +4075,16 @@ def check_all_command_guards(command: str, env_type: str,
     is_cli = _is_interactive_cli()
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
+    is_cron = _is_cron_approval_context()
 
     # Preserve the existing non-interactive behavior: outside CLI/gateway/ask
     # flows, we do not block on approvals and we skip external guard work.
-    if not is_cli and not is_gateway and not is_ask:
+    # Cron context takes precedence over the gateway's process-wide
+    # HERMES_EXEC_ASK flag: scheduled jobs have no listener that can resolve a
+    # queued approval, so cron_mode must remain the authoritative policy.
+    if not is_cli and not is_gateway and (is_cron or not is_ask):
         # Cron sessions: respect cron_mode config
-        if _is_cron_approval_context():
+        if is_cron:
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)


### PR DESCRIPTION
## Problem

The messaging gateway sets process-wide `HERMES_EXEC_ASK=1`. Cron jobs running inside that process inherit the flag, so `check_all_command_guards()` skips its non-interactive cron branch and queues `approval_required` for Tirith/dangerous-command findings. No user is attached to a cron run to resolve that queue, so jobs configured with `approvals.cron_mode: approve` become stranded.

## Fix

Treat an explicit cron context as authoritative before the inherited gateway exec-ask flag, while preserving:

- hardline and user-deny blocks
- `cron_mode: deny` fail-closed behaviour
- normal interactive/gateway approval routing

## Tests

- Added approve-mode regression with `HERMES_EXEC_ASK=1`
- Added deny-mode regression with `HERMES_EXEC_ASK=1`
- `HERMES_PYTHON=/usr/local/lib/hermes-agent/venv/bin/python scripts/run_tests.sh tests/tools/test_cron_approval_mode.py -q` — 32 passed

## Manual configuration / access requirements

None identified.