### PR TITLE
fix(desktop): preserve underscores in profile names

### DIFF
--- a/apps/desktop/src/lib/sanitize.test.ts
+++ b/apps/desktop/src/lib/sanitize.test.ts
@@ -20,13 +20,13 @@ describe('gitRef', () => {
 })
 
 describe('slug', () => {
-  it('lowercases and kebabs runs of non-alphanumerics', () => {
+  it('normalizes profile names while preserving underscores', () => {
     expect(slug('My Profile')).toBe('my-profile')
-    expect(slug('a__b  c')).toBe('a-b-c')
+    expect(slug('si_mon')).toBe('si_mon')
   })
 
   it('strips a leading separator but keeps a trailing one while typing', () => {
-    expect(slug('--x')).toBe('x')
+    expect(slug('_-x')).toBe('x')
     expect(slug('work ')).toBe('work-')
   })
 })

--- a/apps/desktop/src/lib/sanitize.ts
+++ b/apps/desktop/src/lib/sanitize.ts
@@ -13,9 +13,9 @@ export const gitRef = (raw: string): string =>
     .replace(/\.{2,}/g, '.')
     .replace(/^[-./]+/, '')
 
-/** A kebab slug: lowercase, runs of non-alphanumerics → a single "-". */
+/** A profile identifier: lowercase, preserve underscores, normalize other separators to "-". */
 export const slug = (raw: string): string =>
   raw
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+/, '')
+    .replace(/[^a-z0-9_]+/g, '-')
+    .replace(/^[-_]+/, '')


### PR DESCRIPTION
## What does this PR do?

Preserves underscores in Desktop profile names.

The create and rename dialogs say underscores are supported, and their validator accepts them, but the shared `slug` sanitizer converted `_` to `-`. Updating that sanitizer fixes both paths without adding another profile-specific formatter.

## Related Issue

Follow-up to the unresolved underscore review comments in #73013 ([create](https://github.com/NousResearch/hermes-agent/pull/73013#discussion_r3683398871), [rename](https://github.com/NousResearch/hermes-agent/pull/73013#discussion_r3683398806)).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Preserve underscores in `apps/desktop/src/lib/sanitize.ts`.
- Cover `si_mon` in the existing sanitizer test.

## How to Test

1. Open the create or rename profile dialog.
2. Enter `si_mon`.
3. Confirm it remains `si_mon` instead of becoming `si-mon`.

Automated checks:

- `npm run --prefix apps/desktop test:ui -- src/lib/sanitize.test.ts`
- `npm run --prefix apps/desktop check:lint`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant Desktop tests and checks
- [x] I've added a regression test for the change
- [x] I've tested on macOS 26.5.2

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] Config update: N/A
- [x] Architecture/workflow update: N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas update: N/A
