### PR TITLE
fix(cron): inactivity watchdog treated an unreadable activity summary as full activity

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -730,6 +730,31 @@ def _cron_inactivity_seconds() -> float:
         return 600.0
 
 
+def _cron_idle_seconds(agent, dispatched_at: float) -> float:
+    """Seconds the agent has been inactive, falling back to time since dispatch.
+
+    The watchdog previously seeded this at 0.0 and swallowed every failure, so any agent that
+    could not report activity — most importantly one still inside its own construction, before
+    `get_activity_summary` exists or its activity clock is set — was measured as fully active and
+    the inactivity limit was never evaluated. The reaper then only fired once the agent became
+    answerable, which can be far past the configured limit.
+
+    An agent that has never reported activity has not been active since it was dispatched, so
+    that is the floor. When the agent can answer, the reported value is used unchanged.
+    """
+    try:
+        summary = agent.get_activity_summary()
+    except Exception:
+        logger.debug("get_activity_summary() failed; ageing from dispatch", exc_info=True)
+        return max(0.0, time.time() - dispatched_at)
+    if not isinstance(summary, dict):
+        return max(0.0, time.time() - dispatched_at)
+    reported = summary.get("seconds_since_activity")
+    if not isinstance(reported, (int, float)):
+        return max(0.0, time.time() - dispatched_at)
+    return float(reported)
+
+
 def _cwd_lock_timeout_seconds() -> float:
     """Bound for the TERMINAL_CWD lock wait: inactivity limit + margin."""
     inactivity = _cron_inactivity_seconds()
@@ -4445,6 +4470,7 @@ def run_job(
         # Tag this fire and time the run_conversation call for the usage_audit.jsonl entry.
         _audit_fire_id = uuid.uuid4().hex
         _audit_t_start = time.monotonic()
+        _cron_dispatched_at = time.time()  # wall clock: the inactivity floor for an agent that cannot report
         _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
         _inactivity_timeout = False
         try:
@@ -4474,13 +4500,7 @@ def run_job(
                         break
                     _heartbeat_run_claim_if_due()
                     # Agent still running — check inactivity.
-                    _idle_secs = 0.0
-                    if hasattr(agent, "get_activity_summary"):
-                        try:
-                            _act = agent.get_activity_summary()
-                            _idle_secs = _act.get("seconds_since_activity", 0.0)
-                        except Exception:
-                            pass
+                    _idle_secs = _cron_idle_seconds(agent, _cron_dispatched_at)
                     if _idle_secs >= _cron_inactivity_limit:
                         _inactivity_timeout = True
                         break

--- a/tests/cron/test_cron_idle_seconds_fallback.py
+++ b/tests/cron/test_cron_idle_seconds_fallback.py
@@ -1,0 +1,84 @@
+"""The cron inactivity watchdog must not read "cannot measure" as "fully active".
+
+`_cron_idle_seconds` previously lived inline in `run_job` as `_idle_secs = 0.0` followed by a
+`try/except Exception: pass`. Every path that could not obtain a reading therefore produced 0.0 —
+indistinguishable from a perfectly active agent — so the configured inactivity limit was never
+evaluated for as long as the agent could not answer.
+
+The case that matters is an agent still inside its own construction: `get_activity_summary` may not
+exist yet, or its activity clock may be unset, exactly while the job is stuck. The reaper then only
+fires once the agent becomes answerable, which can be far past the limit.
+
+These tests call the helper directly rather than re-implementing the polling loop, so they fail if
+the production behaviour regresses.
+"""
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.scheduler import _cron_idle_seconds  # noqa: E402
+
+
+class _Reporting:
+    def __init__(self, idle):
+        self._idle = idle
+
+    def get_activity_summary(self):
+        return {"seconds_since_activity": self._idle}
+
+
+class _Raising:
+    def get_activity_summary(self):
+        raise RuntimeError("agent not ready")
+
+
+class _Constructing:
+    """No `get_activity_summary` at all — the shape an agent has mid-construction."""
+
+
+class _Malformed:
+    def get_activity_summary(self):
+        return {"seconds_since_activity": None}
+
+
+class _NotADict:
+    def get_activity_summary(self):
+        return "still working"
+
+
+def test_reported_idleness_is_used_unchanged():
+    assert _cron_idle_seconds(_Reporting(12.5), time.time() - 999) == 12.5
+
+
+def test_zero_idleness_is_still_zero():
+    """An agent that is genuinely active must not be aged from dispatch."""
+    assert _cron_idle_seconds(_Reporting(0.0), time.time() - 999) == 0.0
+
+
+def test_agent_without_the_method_ages_from_dispatch():
+    assert _cron_idle_seconds(_Constructing(), time.time() - 300) >= 299
+
+
+def test_raising_agent_ages_from_dispatch():
+    assert _cron_idle_seconds(_Raising(), time.time() - 300) >= 299
+
+
+def test_malformed_summary_ages_from_dispatch():
+    assert _cron_idle_seconds(_Malformed(), time.time() - 300) >= 299
+    assert _cron_idle_seconds(_NotADict(), time.time() - 300) >= 299
+
+
+def test_unmeasurable_agent_crosses_the_limit_it_used_to_ignore():
+    """The regression itself: 0.0 could never reach the limit, so nothing ever fired."""
+    limit = 600.0
+    dispatched_at = time.time() - 5610  # a stuck job, well past the limit
+    assert _cron_idle_seconds(_Raising(), dispatched_at) >= limit
+    assert _cron_idle_seconds(_Constructing(), dispatched_at) >= limit
+
+
+def test_fallback_is_never_negative():
+    """A clock adjustment must not produce a negative idleness that disables the watchdog."""
+    assert _cron_idle_seconds(_Raising(), time.time() + 60) == 0.0


### PR DESCRIPTION
## What does this PR do?

The cron inactivity watchdog could not distinguish *"the agent reports zero idle time"* from
*"the agent cannot tell me anything"*, and treated both as full activity — so for as long as the
agent was unreadable, the configured inactivity limit was not in force.

`cron/scheduler.py`, in `run_job`'s polling loop:

```python
_idle_secs = 0.0
if hasattr(agent, "get_activity_summary"):
    try:
        _act = agent.get_activity_summary()
        _idle_secs = _act.get("seconds_since_activity", 0.0)
    except Exception:
        pass                      # <- and _idle_secs stays 0.0
if _idle_secs >= _cron_inactivity_limit:
```

Every failure path yields `0.0`: the attribute missing, the call raising, the key absent, the value
malformed. `0.0 >= limit` is never true, so the watchdog polls every 5 s and decides nothing.

**The case that matters is an agent still inside its own construction** — `get_activity_summary`
may not exist yet, or its activity clock may be unset, *precisely while the job is stuck*. The
reaper then fires only once the agent becomes answerable, which can be far past the limit. Observed
in the wild: a job killed at roughly **9× its inactivity limit**, with the eventual log line
reporting the full idle duration that had accumulated unmeasured — the limit was never wrong, it
was never evaluated.

Because a stuck job holds its dispatch slot, the practical impact is larger than one job.

**Approach:** an agent that has never reported activity has not been active since it was
dispatched, so time-since-dispatch is used as the floor. When the agent *can* answer, the reported
value is used unchanged and behaviour is identical to today. The rule is extracted into
`_cron_idle_seconds()` so it can be tested directly instead of by re-implementing the polling loop.

## Related Issue

No issue filed for this specific defect. It may contribute to some existing reports of cron jobs
overrunning their timeout, but I have not reproduced those and am **not** claiming to close them —
they name different mechanisms and deserve their own diagnosis:

- #79244 — cron jobs stuck in `running`, interrupt never fires
- #70943 — cron agent hang, open stream never stale-kills
- #18004 — inactivity timeout marks a job failed while the thread keeps running (different direction)

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — added `_cron_idle_seconds(agent, dispatched_at)`, which returns the agent's
  reported idleness when it is readable and otherwise falls back to time since dispatch. Placed
  beside `_cron_inactivity_seconds()` so the two inactivity helpers stay together.
- `cron/scheduler.py` — `run_job` records `_cron_dispatched_at` (wall clock; the existing
  `_audit_t_start` is monotonic and used for durations) and the polling loop now calls the helper.
- `tests/cron/test_cron_idle_seconds_fallback.py` — new, 7 cases.

## How to Test

1. `pytest tests/cron/test_cron_idle_seconds_fallback.py -q` → 7 passed.
2. Revert `_cron_idle_seconds` to the previous semantics (`_idle_secs = 0.0` + `except: pass`) and
   re-run: **4 of the 7 fail**, including
   `test_unmeasurable_agent_crosses_the_limit_it_used_to_ignore` with `assert 0.0 >= 600.0` — i.e.
   the tests fail for the original reason, not incidentally.
3. `pytest tests/cron/ -q` → **598 passed, 1 skipped** on this branch.

The behaviour is also observable without the fix: give the loop an agent whose
`get_activity_summary` raises, and it will poll indefinitely without ever tripping the limit.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially: `tests/cron/` is green (598 passed, 1 skipped) and the new file passes. I could not complete the full `tests/` run locally: `tests/plugins/dashboard_auth/` fails at collection on my machine with a `cryptography` Rust-binding ImportError unrelated to this change, and the remainder is long enough that I'd rather flag this honestly than tick the box. Happy to iterate on CI results.**
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.3), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring on the new helper; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — `time.time()` only; no platform-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The shape of the failure, from a real run (job name redacted):

```
09:05:24  cron.scheduler: Running job '<job>'
          ... agent blocked in initialisation; watchdog polling every 5s, deciding nothing ...
11:15:13  run_agent: OpenAI client created (agent_init, shared=True)
11:17:03  cron.scheduler: Job '<job>' idle for 5610s (inactivity limit 600s)
                          | last_activity=initializing | iteration=0/90 | tool=none
```

`last_activity=initializing` and `iteration=0/90` are the tell: the agent never got far enough to
report activity, so the watchdog measured `0.0` for the whole window and only evaluated the limit
once the agent became answerable — about 110 s after the client was finally constructed.
