### PR TITLE
fix(docker): ship native CJK FTS5 tokenizer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -285,6 +285,27 @@ RUN cd web && npm run build && \
 # write so the build steps below don't need chmod u+w dances.
 COPY --link --chmod=a+rX,go-w . .
 
+# Build the CJK FTS5 tokenizer into the immutable application tree.  Keep the
+# artifact outside HERMES_HOME so the /opt/data runtime volume cannot mask it.
+# Compiling here (rather than copying a host binary) makes each buildx target
+# produce an extension for its own architecture.
+RUN install -d -m 0755 /opt/hermes/lib && \
+    gcc -shared -fPIC -O2 -Wall -Wextra \
+        -Inative/fts5_cjk/vendor \
+        native/fts5_cjk/fts5_cjk.c \
+        -o /opt/hermes/lib/libfts5_cjk.so && \
+    chmod 0644 /opt/hermes/lib/libfts5_cjk.so && \
+    /opt/hermes/.venv/bin/python -c "import sqlite3, sys; \
+path = '/opt/hermes/lib/libfts5_cjk.so'; \
+db = sqlite3.connect(':memory:'); \
+db.enable_load_extension(True); \
+db.load_extension(path); \
+db.enable_load_extension(False); \
+db.execute(\"CREATE VIRTUAL TABLE docs USING fts5(content, tokenize='cjk_unicode61')\"); \
+db.execute(\"INSERT INTO docs VALUES ('웅기가 말했다')\"); \
+sys.exit('CJK FTS5 tokenizer self-test failed') if db.execute(\"SELECT count(*) FROM docs WHERE docs MATCH '웅기'\").fetchone()[0] != 1 else None; \
+db.close()"
+
 # ---------- Permissions ----------
 # Link hermes-agent itself (editable). Deps are already installed in the
 # cached layer above; `--no-deps` makes this a fast egg-link creation with no
@@ -376,6 +397,7 @@ ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 # check. (A separate launcher hardening is tracked independently.)
 ENV HERMES_TUI_DIR=/opt/hermes/ui-tui
 ENV HERMES_HOME=/opt/data
+ENV HERMES_FTS5_CJK_SO=/opt/hermes/lib/libfts5_cjk.so
 ENV HERMES_WRITE_SAFE_ROOT=/opt/data
 ENV HERMES_DISABLE_LAZY_INSTALLS=1
 # The published image seals /opt/hermes (root-owned, read-only) so a runtime

--- a/tests/docker/test_sqlite_runtime.py
+++ b/tests/docker/test_sqlite_runtime.py
@@ -32,6 +32,41 @@ print(json.dumps({
 """
 
 
+_CJK_TOKENIZER_PROBE = r"""
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+path = os.environ["HERMES_FTS5_CJK_SO"]
+artifact = Path(path)
+db = sqlite3.connect(":memory:")
+try:
+    db.enable_load_extension(True)
+    db.load_extension(path)
+    db.enable_load_extension(False)
+    db.execute(
+        "CREATE VIRTUAL TABLE docs USING "
+        "fts5(content, tokenize='cjk_unicode61')"
+    )
+    db.execute("INSERT INTO docs VALUES ('웅기가 말했다')")
+    matches = db.execute(
+        "SELECT count(*) FROM docs WHERE docs MATCH '웅기'"
+    ).fetchone()[0]
+finally:
+    db.close()
+
+print(json.dumps({
+    "hermes_home": os.environ["HERMES_HOME"],
+    "cjk_so": path,
+    "artifact_is_file": artifact.is_file(),
+    "artifact_readable": os.access(artifact, os.R_OK),
+    "artifact_mode": oct(artifact.stat().st_mode & 0o777),
+    "matches": matches,
+}))
+"""
+
+
 def test_image_links_fixed_sqlite_with_fts5_trigram(built_image: str) -> None:
     result = subprocess.run(
         [
@@ -58,3 +93,40 @@ def test_image_links_fixed_sqlite_with_fts5_trigram(built_image: str) -> None:
     payload = json.loads(result.stdout)
     assert payload["wal_reset_vulnerable"] is False, payload
     assert payload["trigram_matches"] == 1, payload
+
+
+def test_image_ships_loadable_cjk_tokenizer_outside_data_volume(
+    built_image: str,
+) -> None:
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--user",
+            "hermes",
+            "--volume",
+            "/opt/data",
+            "--entrypoint",
+            "/opt/hermes/.venv/bin/python",
+            built_image,
+            "-c",
+            _CJK_TOKENIZER_PROBE,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, (
+        f"CJK tokenizer probe failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    payload = json.loads(result.stdout)
+    assert payload == {
+        "hermes_home": "/opt/data",
+        "cjk_so": "/opt/hermes/lib/libfts5_cjk.so",
+        "artifact_is_file": True,
+        "artifact_readable": True,
+        "artifact_mode": "0o644",
+        "matches": 1,
+    }


### PR DESCRIPTION
## What does this PR do?

Builds and ships the existing native `cjk_unicode61` FTS5 tokenizer in every Hermes Docker image.

Hermes already contains the tokenizer source, SessionDB integration, and a Docker compiler toolchain. The image, however, copied only the source and never produced the loadable extension, so short CJK searches silently used the slower fallback route.

### Root Cause

- `native/fts5_cjk/fts5_cjk.c` and its vendored SQLite headers were copied into `/opt/hermes`.
- No Docker build step compiled or installed `libfts5_cjk.so`.
- `HERMES_FTS5_CJK_SO` was unset, so SessionDB looked under `$HERMES_HOME/lib`; Docker sets `HERMES_HOME=/opt/data`, where no baked artifact existed.
- `/opt/data` is runtime state and a declared volume, so it is not a safe location for immutable image content.

### Fix

- Compile `native/fts5_cjk/fts5_cjk.c` with its vendored headers during the final target-image build.
- Install the target-native artifact at `/opt/hermes/lib/libfts5_cjk.so` with mode `0644`.
- Set `HERMES_FTS5_CJK_SO=/opt/hermes/lib/libfts5_cjk.so`.
- Run a build-time test with the final venv's Python/SQLite runtime that loads the extension, creates an FTS5 table with `tokenize='cjk_unicode61'`, inserts synthetic Korean text, and verifies the 2-character `웅기` query.

Because the artifact lives in immutable `/opt/hermes`, mounting `/opt/data` cannot hide it.

### Multi-arch

Locally tested: arm64.

The existing Docker workflow builds `linux/amd64` on an amd64 runner and `linux/arm64` on an arm64 runner. The compile step executes inside each final target-image build, so each image gets its own architecture-native `.so`; no host or precompiled binary is copied.

### Compatibility

- No schema migration.
- No change to non-Docker native packaging.
- No change to SessionDB fallback/search semantics.
- No user database rewrite caused by this patch.
- No new network dependency or precompiled artifact.
- PR #75266 remains independent and complementary: it owns the standalone `native/fts5_cjk/build.sh` path; this PR does not modify that script.

## Related Issue

Fixes #85979

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `Dockerfile`: compile, permission, load-test, and configure `/opt/hermes/lib/libfts5_cjk.so`.
- `tests/docker/test_sqlite_runtime.py`: verify the final runtime as `hermes` with `/opt/data` mounted, including path, readability, mode, extension loading, tokenizer creation, and a short CJK match.

## How to Test

1. Build the target image:

   `docker buildx build --load --platform linux/arm64 --build-arg HERMES_GIT_SHA=c896c09c42910c584c4c7d2325b58c14713ea42c -t hermes-agent-cjk-after:c896c09c4 .`

2. Run the final Python/SQLite runtime as `hermes` with an anonymous volume mounted at `/opt/data`, then load `$HERMES_FTS5_CJK_SO`, create an FTS5 table with `cjk_unicode61`, insert `웅기가 말했다`, and assert `MATCH '웅기'` returns one row.

3. Run the targeted suites:

   - `scripts/run_tests.sh tests/test_fts_cjk_bigram.py`
   - `HERMES_TEST_IMAGE=hermes-agent-cjk-after:c896c09c4 scripts/run_tests.sh tests/docker/test_sqlite_runtime.py --file-timeout 600`
   - `HERMES_TEST_IMAGE=hermes-agent-cjk-after:c896c09c4 HERMES_TEST_WORKERS=1 HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/docker/ --file-timeout 600`

### Validation

- ARM64 Docker build: passed, including the build-time extension load/table/query self-test.
- `tests/test_fts_cjk_bigram.py`: 9 passed.
- `tests/docker/test_sqlite_runtime.py`: 2 passed.
- Full serial `tests/docker/`: 53 passed; 2 host-tool failures in `test_tui_passthrough.py` because macOS BSD `script` rejects Linux-only `-qc` before Docker starts. No functional Docker test failed.
- Previously saturated dashboard/supervision/bootstrap/privilege files were rerun serially: 13 passed.
- `ruff check tests/docker/test_sqlite_runtime.py`: passed.
- `ruff format --check tests/docker/test_sqlite_runtime.py`: passed.
- Hadolint with `.hadolint.yaml`: passed.
- `scripts/check-windows-footguns.py --all`: 962 files scanned, passed.
- `git diff --check`: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 on Apple Silicon; Docker Desktop 29.6.2; `linux/arm64` target

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; Docker packaging and regression test only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; this uses the existing loader environment variable
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Docker remains Linux-only; existing amd64/arm64 target builds compile natively
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before, from an image built at upstream `c896c09c4`:

```text
source_present=yes
find / -name libfts5_cjk.so -> no output
HERMES_HOME=/opt/data
HERMES_FTS5_CJK_SO=<unset>
{"fts_cjk_loaded": false, "fts_cjk_available": false, "search_path": "like_scan", "matches": 1}
```

After, with an anonymous `/opt/data` volume mounted:

```text
/opt/hermes/lib/libfts5_cjk.so
mode=644 owner=root:root
container_arch=aarch64
Class: ELF64
Machine: AArch64
HERMES_HOME=/opt/data
HERMES_FTS5_CJK_SO=/opt/hermes/lib/libfts5_cjk.so
{"uid": 10000, "is_file": true, "readable": true, "mode": "0o644", "matches": 1}
{"fts_cjk_loaded": true, "fts_cjk_available": true, "search_path": "fts_cjk", "matches": 1}
find /opt/data -name libfts5_cjk.so -> no output
```