### PR TITLE
refactor(active_sessions): extract _pid_exists import into lazy _resolve_pid_exists

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -4,7 +4,6 @@ The session database records persisted conversations.  This module records
 currently open chat surfaces, including idle CLI/TUI sessions that have not
 written a transcript row yet.
 """
-
 from __future__ import annotations
 
 import json
@@ -79,7 +78,7 @@ def format_age(seconds: float) -> str:
 
 
 def summarize_holders(entries: list[dict[str, Any]]) -> str:
-    """Compact "who is holding the slots" phrase, e.g. ``desktop x4, cli``."""
+    """Compact "who is holding the slots" phrase, e.g. `desktop x4, cli`."""
     if not entries:
         return ""
     counts: dict[str, int] = {}
@@ -222,6 +221,36 @@ def _optional_float(value: Any) -> Optional[float]:
         return None
 
 
+def _resolve_pid_exists():
+    """Lazy import of the authoritative cross-platform PID-existence check.
+
+    Imported once at first call and cached as a module-global so subsequent
+    calls skip the import machinery entirely. On a transient import failure
+    in ``gateway.status`` (circular import, syntax error, missing transitive
+    dep, scaffold race) the ``RuntimeError`` is raised and then caught by
+    ``_pid_alive``'s own ``except Exception``, which returns ``False`` — same
+    behaviour as the old per-call import. The registry can still be wiped by
+    ``_prune_dead`` either way. The real benefit is that ``_resolve_pid_exists``
+    is now independently callable, so unit tests can exercise the import-failure
+    path without mocking inside ``_pid_alive``.
+    """
+
+    global _PID_EXISTS  # noqa: F823
+
+    try:
+        from gateway.status import _pid_exists as _pid_exists_fn
+    except ImportError as exc:
+        raise RuntimeError(
+            "active_sessions._pid_alive requires gateway.status._pid_exists; "
+            f"import failed: {exc}"
+        ) from exc
+
+    _PID_EXISTS = _pid_exists_fn
+
+
+_PID_EXISTS: Any = None  # noqa: F821
+
+
 def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
     try:
         pid_int = int(pid)
@@ -230,9 +259,9 @@ def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
     if pid_int <= 0:
         return False
     try:
-        from gateway.status import _pid_exists
-
-        exists = bool(_pid_exists(pid_int))
+        if _PID_EXISTS is None:
+            _resolve_pid_exists()
+        exists = bool(_PID_EXISTS(pid_int))
     except Exception:
         return False
     if not exists:


### PR DESCRIPTION
refactor(active_sessions): extract _pid_exists import into lazy _resolve_pid_exists

Refactors the per-call ``from gateway.status import _pid_exists`` inside
``_pid_alive``'s try/except into a lazy importer (``_resolve_pid_exists``)
that binds a module-global once and reuses it on subsequent calls.

What this changes: ``_resolve_pid_exists`` is now independently callable, so
unit tests can exercise the import-failure path without mocking the import
machinery inside ``_pid_alive``'s try/except.

What this does NOT change: on a normal install the import succeeds on the
first call and every subsequent call uses the cached reference — identical
to before.  If the import fails, ``_resolve_pid_exists`` raises
``RuntimeError`` but ``_pid_alive``'s own ``except Exception`` catches it
and returns ``False``, so callers see the same ``False`` they would have
seen before.  The registry can still be wiped by ``_prune_dead`` either
way.  This is a testability refactoring, not a bug fix.