### PR TITLE
fix(desktop): yield shell context menu on links so Copy Link works

### DIFF
--- a/apps/desktop/src/app/shell/shell-context-menu.test.tsx
+++ b/apps/desktop/src/app/shell/shell-context-menu.test.tsx
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { shouldYieldShellContextMenu } from './shell-context-menu'
+
+afterEach(() => {
+  window.getSelection()?.removeAllRanges()
+})
+
+function mount(html: string): HTMLElement {
+  document.body.innerHTML = html
+  return document.body.firstElementChild as HTMLElement
+}
+
+describe('shouldYieldShellContextMenu', () => {
+  it('stands down on a chat / markdown link so Electron can offer Copy Link', () => {
+    const link = mount('<a href="https://docs.google.com/spreadsheets/d/abc">docs.google.com/spreadsheets</a>')
+    expect(shouldYieldShellContextMenu(link)).toBe(true)
+  })
+
+  it('stands down when the click lands on a child of the anchor (brand icon, pretty label)', () => {
+    mount('<a href="https://example.com/path"><span class="label">example.com/path</span></a>')
+    expect(shouldYieldShellContextMenu(document.querySelector('.label'))).toBe(true)
+  })
+
+  it('does not treat a non-link chrome click as owned', () => {
+    const pane = mount('<div data-slot="thread">empty pane</div>')
+    expect(shouldYieldShellContextMenu(pane)).toBe(false)
+  })
+
+  it('ignores an anchor with no href', () => {
+    const fake = mount('<a>not a link</a>')
+    expect(shouldYieldShellContextMenu(fake)).toBe(false)
+  })
+
+  it('ignores empty and hash-only placeholder anchors', () => {
+    expect(shouldYieldShellContextMenu(mount('<a href="">empty</a>'))).toBe(false)
+    expect(shouldYieldShellContextMenu(mount('<a href="#">hash</a>'))).toBe(false)
+  })
+
+  it('stands down on image/media so Electron can offer Copy Image / Save Image As', () => {
+    expect(shouldYieldShellContextMenu(mount('<img src="https://example.com/a.png" alt="">'))).toBe(true)
+    mount('<picture><img class="shot" src="https://example.com/a.png" alt=""></picture>')
+    expect(shouldYieldShellContextMenu(document.querySelector('.shot'))).toBe(true)
+    expect(shouldYieldShellContextMenu(mount('<canvas></canvas>'))).toBe(true)
+  })
+
+  it('stands down for a nested Radix menu that is not the shell fallback', () => {
+    mount('<div data-slot="context-menu-trigger"><span class="row">session</span></div>')
+    expect(shouldYieldShellContextMenu(document.querySelector('.row'))).toBe(true)
+  })
+
+  it('does not treat the shell fallback trigger as an owner', () => {
+    mount('<div data-slot="context-menu-trigger" data-shell-context-menu=""><span class="chrome">titlebar</span></div>')
+    expect(shouldYieldShellContextMenu(document.querySelector('.chrome'))).toBe(false)
+  })
+
+  it('stands down for an editable', () => {
+    const input = mount('<textarea></textarea>')
+    expect(shouldYieldShellContextMenu(input)).toBe(true)
+  })
+
+  it('stands down when the user has a live text selection', () => {
+    const pane = mount('<p id="copy-me">selectable prose</p>')
+    const range = document.createRange()
+    range.selectNodeContents(pane)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    expect(shouldYieldShellContextMenu(pane)).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/shell/shell-context-menu.tsx
+++ b/apps/desktop/src/app/shell/shell-context-menu.tsx
@@ -19,8 +19,9 @@ import { navigateToWorkspacePage, NEW_CHAT_ROUTE, SETTINGS_ROUTE } from '../rout
  *
  * It wraps the whole shell, so the guard below is what keeps it a FALLBACK: a
  * right-click that lands inside a surface with its own context menu, on an
- * editable, or on a live selection is stopped before Radix's trigger sees it,
- * leaving that surface's menu — or Electron's native edit menu — in charge.
+ * editable, on a live selection, on an `<a href>`, or on image/media is
+ * stopped before Radix's trigger sees it, leaving that surface's menu — or
+ * Electron's native edit / Open Link / Copy Link / image menu — in charge.
  * `stopPropagation` (never `preventDefault`) is the mechanism, because
  * preventing the default is what would swallow the native menu.
  */
@@ -83,19 +84,46 @@ export function ShellContextMenu({ children }: { children: React.ReactNode }) {
 
 /** Right-clicks that already have an owner keep it: a surface with its own
  *  context menu, an editable, a live selection (Electron's native edit menu),
- *  or an image/media element (Electron's native image menu — Copy Image,
- *  Save Image As...). Never `preventDefault` — that is what would swallow the
+ *  a real link (Open Link / Copy Link), or image/media (Copy Image, Save
+ *  Image As...). Never `preventDefault` — that is what would swallow the
  *  native menu. */
 function guard(event: React.MouseEvent<HTMLDivElement>) {
-  const target = event.target as HTMLElement | null
-  const owner = target?.closest('[data-slot="context-menu-trigger"]')
-
-  if (
-    (owner && !owner.hasAttribute('data-shell-context-menu')) ||
-    target?.closest('img, picture, video, canvas') ||
-    isEditableTarget(target) ||
-    hasTextSelection()
-  ) {
+  if (shouldYieldShellContextMenu(event.target)) {
     event.stopPropagation()
   }
+}
+
+/** True when this right-click already has an owner, so the shell fallback
+ *  must stand down and leave the native Electron menu (or another Radix menu)
+ *  in charge. Exported for tests. */
+export function shouldYieldShellContextMenu(target: EventTarget | null): boolean {
+  // Text nodes / the document are not a menu owner — fall through to the
+  // shell fallback, same as a chrome click.
+  const el = target instanceof Element ? target : null
+  if (!el) {
+    return false
+  }
+
+  const owner = el.closest('[data-slot="context-menu-trigger"]')
+  if (owner && !owner.hasAttribute('data-shell-context-menu')) {
+    return true
+  }
+
+  return (
+    isEditableTarget(el) ||
+    hasTextSelection() ||
+    Boolean(el.closest('img, picture, video, canvas')) ||
+    isNativeLinkTarget(el)
+  )
+}
+
+/** Navigable anchors only. Empty / `#` placeholders have nothing for Electron
+ *  to open or copy, so the shell menu keeps them. */
+function isNativeLinkTarget(el: Element): boolean {
+  const anchor = el.closest('a[href]')
+  if (!(anchor instanceof HTMLAnchorElement)) {
+    return false
+  }
+  const href = anchor.getAttribute('href')
+  return Boolean(href && href !== '#')
 }


### PR DESCRIPTION
## What does this PR do?

Right-clicking a URL in Desktop chat currently opens the **window chrome menu** (New session, Command palette, Settings, Update Hermes) instead of Electron's native **Open Link / Copy Link**. Chat links are pretty-printed (host/path or a fetched title), so selecting the visible text also does not give you the real URL.

Electron already implements Copy Link / Open Link in `installContextMenu`. The shell fallback context menu wraps the whole window and was not treating `<a href>` as an owned surface, so Radix ate the right-click.

This makes the existing fallback guard stand down on real links (including clicks on a child brand icon / pretty label), matching how it already yields for editables, live selections, and nested Radix menus. `stopPropagation` only — never `preventDefault` — so the native menu still appears.

## Related Issue

Related: https://github.com/NousResearch/hermes-agent/issues/38744 (copyable-links slice; that issue also covers notarization / launchd, so this does not close it)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/app/shell/shell-context-menu.tsx` — yield the shell fallback when the click target is inside `a[href]`
- `apps/desktop/src/app/shell/shell-context-menu.test.tsx` — cover link, nested child, chrome, no-href, nested menu, editable, selection

## How to Test

1. Open Hermes Desktop and get an assistant message that contains a URL (or a pretty-printed Google Docs / Sheets link).
2. Right-click the link (or its shortened label).
3. Confirm the menu is **Open Link** / **Copy Link**, not New session / Settings.
4. Confirm Copy Link puts the full `https://…` URL on the clipboard.
5. Confirm right-clicking empty chrome still shows the window menu.
6. Unit: `cd apps/desktop && npx vitest run --project ui src/app/shell/shell-context-menu.test.tsx`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (Python suite N/A — desktop UI only)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 (unit tests green; native menu is existing Electron code)

### Documentation & Housekeeping

- [x] Documentation N/A
- [x] cli-config.yaml.example N/A
- [x] CONTRIBUTING.md / AGENTS.md N/A
- [x] Cross-platform: same renderer guard on macOS / Windows / Linux; native menu already existed
- [x] Tool schemas N/A
