### PR TITLE
fix(tools): browserbase post-setup verifies agent-browser CLI before reporting success

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2048,6 +2048,7 @@ def _run_post_setup(post_setup_key: str):
         return
 
     if post_setup_key in {"agent_browser", "browserbase"}:
+        rerun_command = f"`hermes tools post-setup {post_setup_key}`"
         # Every non-Camofox browser backend drives through the Browser Use
         # CLI when it's runnable — install it here too, not only on the
         # explicit "Browser Use" picker row.
@@ -2065,10 +2066,11 @@ def _run_post_setup(post_setup_key: str):
                 _find_agent_browser,
                 _resolve_npx_bin,
                 _is_npx_agent_browser_sentinel,
+                warm_agent_browser_npx_cache,
                 AGENT_BROWSER_NPX_SPEC,
             )
         except Exception as exc:  # pragma: no cover — defensive
-            _print_warning(f"    Could not check Chromium status: {exc}")
+            _print_warning(f"    Could not check browser dependency status: {exc}")
             return
 
         # Reuse the same resolution cascade browser tools use at runtime
@@ -2079,15 +2081,47 @@ def _run_post_setup(post_setup_key: str):
         try:
             browser_cmd = _find_agent_browser(validate=False)
         except FileNotFoundError:
+            if post_setup_key == "browserbase":
+                # Cloud providers still need the agent-browser CLI itself.
+                # If it's not resolvable at all, fail rather than silently
+                # reporting success (issue #86117).
+                raise RuntimeError(
+                    "agent-browser CLI not found and npx is unavailable. "
+                    "Install Node.js (https://nodejs.org) and re-run "
+                    f"{rerun_command}."
+                )
             _print_warning(
                 "    npx not found - browser tools require Node.js: https://nodejs.org"
             )
             return
 
-        # Step 1: only the local browser provider actually needs Chromium on
-        # disk. Cloud providers (Browserbase, Browser Use, Firecrawl) host
-        # their own Chromium and don't need the local install.
+        # Cloud providers (Browserbase, Browser Use, Firecrawl) host their
+        # own Chromium and don't need the local install — but they still
+        # need the agent-browser CLI itself. Verify it's actually runnable
+        # so a dangling symlink or missing npx doesn't report success
+        # (issue #86117).
         if post_setup_key != "agent_browser":
+            if _is_npx_agent_browser_sentinel(browser_cmd):
+                # npx fallback: warm the cache so the first real browser
+                # call doesn't fail. This also verifies npx can resolve
+                # and execute the agent-browser package.
+                _print_info("    Verifying agent-browser via npx...")
+                if not warm_agent_browser_npx_cache():
+                    raise RuntimeError(
+                        "agent-browser could not be resolved via npx. "
+                        "Check your Node.js installation and network "
+                        f"connectivity, then re-run {rerun_command}."
+                    )
+                _print_success("    agent-browser verified via npx")
+            else:
+                from hermes_constants import agent_browser_runnable
+                if not agent_browser_runnable(browser_cmd):
+                    raise RuntimeError(
+                        f"agent-browser at {browser_cmd} is not runnable "
+                        "(exit code non-zero or binary missing). "
+                        "Re-install it: npm install -g agent-browser"
+                    )
+                _print_success("    agent-browser already installed")
             return
 
         # Step 2: ensure the Chromium / headless-shell build agent-browser

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -406,16 +406,90 @@ class TestAgentBrowserPostSetup:
 
     def test_browserbase_returns_before_any_chromium_check(self):
         """browserbase hosts its own Chromium; it must never reach the
-        agent-browser-only Chromium-install branch."""
-        with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+        agent-browser-only Chromium-install branch. It must still verify
+        the agent-browser CLI is runnable (issue #86117)."""
+        with patch("shutil.which", return_value=None), patch(
             "subprocess.run"
         ) as run, patch(
             "tools.browser_tool._chromium_installed"
-        ) as chromium_check:
+        ) as chromium_check, patch(
+            "tools.browser_tool._find_agent_browser",
+            return_value="npx agent-browser",
+        ), patch(
+            "tools.browser_tool.warm_agent_browser_npx_cache",
+            return_value=True,
+        ), patch(
+            "hermes_cli.tools_config._print_success"
+        ) as success:
             _run_post_setup("browserbase")
 
         run.assert_not_called()
         chromium_check.assert_not_called()
+        success.assert_called_with("    agent-browser verified via npx")
+
+    def test_browserbase_npx_warm_cache_fails_raises(self):
+        """When agent-browser resolves only to the npx sentinel and the
+        npx cache warm fails, post-setup must raise RuntimeError so
+        run_post_setup_command returns exit code 1 (issue #86117)."""
+        with patch("shutil.which", return_value=None), patch(
+            "tools.browser_tool._find_agent_browser",
+            return_value="npx agent-browser",
+        ), patch(
+            "tools.browser_tool.warm_agent_browser_npx_cache",
+            return_value=False,
+        ), patch(
+            "hermes_cli.tools_config._print_info"
+        ):
+            with pytest.raises(RuntimeError, match="could not be resolved via npx") as exc:
+                _run_post_setup("browserbase")
+
+        assert "`hermes tools post-setup browserbase`" in str(exc.value)
+
+    def test_browserbase_real_binary_verifies_and_succeeds(self):
+        """When agent-browser resolves to a real binary, post-setup
+        verifies it via agent_browser_runnable and reports success."""
+        with patch("shutil.which", return_value=None), patch(
+            "tools.browser_tool._find_agent_browser",
+            return_value="/usr/local/bin/agent-browser",
+        ), patch(
+            "hermes_constants.agent_browser_runnable",
+            return_value=True,
+        ), patch(
+            "hermes_cli.tools_config._print_success"
+        ) as success:
+            _run_post_setup("browserbase")
+
+        assert any("already installed" in c.args[0] for c in success.call_args_list)
+
+    def test_browserbase_real_binary_not_runnable_raises(self):
+        """When agent-browser resolves to a binary that fails --version,
+        post-setup must raise RuntimeError (issue #86117)."""
+        with patch("shutil.which", return_value=None), patch(
+            "tools.browser_tool._find_agent_browser",
+            return_value="/usr/local/bin/agent-browser",
+        ), patch(
+            "hermes_constants.agent_browser_runnable",
+            return_value=False,
+        ), patch(
+            "hermes_cli.tools_config._print_success"
+        ):
+            with pytest.raises(RuntimeError, match="not runnable"):
+                _run_post_setup("browserbase")
+
+    def test_browserbase_file_not_found_raises(self):
+        """When agent-browser cannot be resolved at all (no binary, no
+        npx), browserbase post-setup must raise RuntimeError instead of
+        silently reporting success (issue #86117)."""
+        with patch("shutil.which", return_value=None), patch(
+            "tools.browser_tool._find_agent_browser",
+            side_effect=FileNotFoundError("agent-browser CLI not found"),
+        ), patch(
+            "hermes_cli.tools_config._print_warning"
+        ):
+            with pytest.raises(RuntimeError, match="agent-browser CLI not found") as exc:
+                _run_post_setup("browserbase")
+
+        assert "`hermes tools post-setup browserbase`" in str(exc.value)
 
     def test_chromium_already_installed_skips_subprocess(self):
         with patch("shutil.which", return_value="/usr/bin/npx"), patch(
@@ -661,7 +735,14 @@ class TestBrowserUseCliInstalledForAllNonCamofoxBackends:
     def test_browser_post_setup_attempts_cli_install(self, key):
         with patch("hermes_cli.tools_config._ensure_browser_use_cli") as ensure, patch(
             "shutil.which", return_value=None
-        ), patch("subprocess.run"):
+        ), patch("subprocess.run"), patch(
+            "tools.browser_tool._find_agent_browser",
+            return_value="/usr/bin/agent-browser",
+        ), patch(
+            "hermes_constants.agent_browser_runnable", return_value=True
+        ), patch(
+            "tools.browser_tool._chromium_installed", return_value=True
+        ):
             _run_post_setup(key)
         ensure.assert_called_once()
 


### PR DESCRIPTION
## What does this PR do?

The `browserbase` post-setup hook (`hermes tools post-setup browserbase`) returned immediately without verifying that `agent-browser` was actually runnable. `run_post_setup_command` therefore always returned exit code 0 — even when npm had failed, npx was missing, or the resolved binary was a dangling symlink.

This caused operators and agents to incorrectly promote Browser Use from "configured" to "ready" when the dependency was not actually installed.

The fix adds verification to the `browserbase` path in `_run_post_setup`:
- **No binary and no npx** → raises `RuntimeError` (previously: warned and returned, which the caller interpreted as success)
- **npx sentinel resolved** → calls `warm_agent_browser_npx_cache()` to verify npx can resolve and execute `agent-browser`; raises `RuntimeError` if warm fails
- **Real binary path resolved** → calls `agent_browser_runnable(path)` (spawns `--version` with 10s timeout); raises `RuntimeError` if the binary is not executable
- **Verification passes** → prints that npx execution was verified; idempotent on rerun
- **Failure guidance** → names the actual post-setup key instead of hardcoding a provider command

The `agent_browser` local Chromium installation behavior is unchanged.

## Related Issue

Fixes #86117

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/tools_config.py`: Replaced the early `return` in the `browserbase` branch of `_run_post_setup` with verification logic that checks agent-browser is actually runnable before reporting success. Added `warm_agent_browser_npx_cache` to the lazy import block. `FileNotFoundError` from `_find_agent_browser` now raises `RuntimeError` for `browserbase` instead of silently returning. Failure guidance derives the rerun command from `post_setup_key`.
- `tests/hermes_cli/test_tools_config.py`: Covers npx success/failure, real-binary success/failure, missing npx, exact rerun guidance, verified success wording, and the shared Browser Use CLI setup path after rebasing current `main`.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_tools_config.py` — 49 passed, 6 skipped
2. `scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/86117` — all blocking gates pass
3. `uv lock --check` — clean
4. `ruff check .` — clean

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant pytest suite and all blocking local gates pass; the full cross-platform matrix runs in CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A