### PR TITLE
fix(sec): bump electron to 43.4.0 to close GHSA-9f4c-93c8-jc8g

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -61,3 +61,7 @@ min-release-age-exclude[]=@oxc-project/types
 # ink needs
 min-release-age-exclude[]=lightningcss
 min-release-age-exclude[]=postcss
+
+# electron 43.4.0 fixes GHSA-9f4c-93c8-jc8g (sandboxed iframe allow-popups).
+# remove when 43.4.0 is > 2wks old (rel 2026-08-11)
+min-release-age-exclude[]=electron

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -159,7 +159,7 @@
     "bippy": "0.5.43",
     "concurrently": "10.0.4",
     "cross-env": "10.1.0",
-    "electron": "40.10.2",
+    "electron": "43.4.0",
     "electron-builder": "26.15.3",
     "esbuild": "0.28.1",
     "jsdom": "29.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -153,7 +153,7 @@
         "bippy": "0.5.43",
         "concurrently": "10.0.4",
         "cross-env": "10.1.0",
-        "electron": "40.10.2",
+        "electron": "43.4.0",
         "electron-builder": "26.15.3",
         "esbuild": "0.28.1",
         "jsdom": "29.1.1",
@@ -169,57 +169,6 @@
         "node": ">=22.22.0"
       }
     },
-    "apps/desktop/node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
-        "progress": "^2.0.3",
-        "semver": "^6.2.0",
-        "sumchecker": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "global-agent": "^3.0.0"
-      }
-    },
-    "apps/desktop/node_modules/electron": {
-      "version": "40.10.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.2.tgz",
-      "integrity": "sha512-Xj3Hy0Imbu4g0gDIW55w/jJYz94nMO2JRSGYA3LyAn5SwaERCelgZrA21vfH+Bi//SWAWQXddHsMwCqauyMT8g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
-      },
-      "bin": {
-        "electron": "cli.js"
-      },
-      "engines": {
-        "node": ">= 12.20.55"
-      }
-    },
-    "apps/desktop/node_modules/electron/node_modules/@types/node": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
     "apps/desktop/node_modules/ignore": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
@@ -228,13 +177,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "apps/desktop/node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
-      "license": "MIT"
     },
     "apps/shared": {
       "name": "@hermes/shared",
@@ -1364,6 +1306,16 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
@@ -1493,6 +1445,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
+      "integrity": "sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@electron/notarize": {
@@ -6523,17 +6522,6 @@
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.64.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
@@ -9578,6 +9566,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/electron": {
+      "version": "43.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.0.tgz",
+      "integrity": "sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
     "node_modules/electron-builder": {
       "version": "26.15.3",
       "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
@@ -9954,6 +9961,23 @@
       "engines": {
         "node": ">=6 <7 || >=8"
       }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
@@ -10490,27 +10514,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10771,21 +10774,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -15073,13 +15061,6 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -18937,19 +18918,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
-      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {


### PR DESCRIPTION
## Summary

Bumps the desktop app's Electron from `40.10.2` to `43.4.0` to close the last high-severity advisory `npm audit` reports on a fresh checkout:

- **GHSA-9f4c-93c8-jc8g** — Sandboxed iframe can bypass the allow-popups restriction via the OpenURL navigation path (affects electron `40.0.0-alpha.2 - 41.10.2`).
- Also closes **GHSA-r4w5-6pfg-jxp5** (ProtocolResponse.url session cache) and **GHSA-jmr9-qjv8-65gv** (extract-zip symlink traversal) for the desktop workspace.

This is a deliberate major bump (40.x → 43.x), previously deferred in #86127 pending a user decision. Verified before opening:

- `npm install` clean; electron 43.4.0 binary downloaded.
- `npm run build` in `apps/desktop` passes: vite renderer build, `electron-main.mjs` bundle, `electron-preload.js` bundle, and native dep staging (node-pty, get-windows) all succeed.

## Notes for Reviewers

- `.npmrc` adds `min-release-age-exclude[]=electron` because 43.4.0 (rel 2026-08-11) is inside the repo's 14-day release-age gate. Remove once it's > 2 weeks old.
- The remaining advisory on this branch (GHSA-2v37-7h3g-55p8, nanoid chain) is addressed by **#86127** (nanoid@^3 override 3.3.17 → 3.3.18 + electron 40.10.6 patch) — the two PRs are independent but complementary.
- Electron 43 is a runtime/API major; the build passing is a compile-level check. A runtime smoke test of Hermes Desktop on 43.x is recommended before shipping a release with it.
