### PR TITLE
fix(delegation): reject non-durable async dispatches

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -124,6 +124,114 @@ def test_dispatch_returns_immediately_without_blocking():
     gate.set()
 
 
+def test_durable_dispatch_failure_releases_capacity_without_starting_worker(
+    monkeypatch,
+):
+    real_persist = ad._persist_dispatch
+    started = threading.Event()
+
+    def fail_persist(_record):
+        raise ad.sqlite3.OperationalError("database is locked")
+
+    def runner():
+        started.set()
+        return {"status": "completed", "summary": "should not run"}
+
+    monkeypatch.setattr(ad, "_persist_dispatch", fail_persist)
+    rejected = ad.dispatch_async_delegation(
+        goal="not durable",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="owner",
+        runner=runner,
+        max_async_children=1,
+    )
+
+    assert rejected == {
+        "status": "rejected",
+        "error": (
+            "Failed to persist async delegation; no background task was started."
+        ),
+    }
+    assert started.is_set() is False
+    assert ad.active_count() == 0
+
+    # The failed registration released the only slot, so a later durable
+    # dispatch can use it normally.
+    monkeypatch.setattr(ad, "_persist_dispatch", real_persist)
+    accepted = ad.dispatch_async_delegation(
+        goal="durable retry",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="owner",
+        runner=lambda: {"status": "completed", "summary": "done"},
+        max_async_children=1,
+    )
+    assert accepted["status"] == "dispatched"
+    assert _drain_for(accepted["delegation_id"]) is not None
+
+
+def test_batch_durable_dispatch_failure_releases_capacity_without_starting_worker(
+    monkeypatch,
+):
+    started = threading.Event()
+
+    def fail_persist(_record):
+        raise ad.sqlite3.OperationalError("database is locked")
+
+    def runner():
+        started.set()
+        return {"results": []}
+
+    monkeypatch.setattr(ad, "_persist_dispatch", fail_persist)
+    rejected = ad.dispatch_async_delegation_batch(
+        goals=["not durable"],
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="owner",
+        runner=runner,
+        max_async_children=1,
+    )
+
+    assert rejected == {
+        "status": "rejected",
+        "error": (
+            "Failed to persist async delegation batch; "
+            "no background task was started."
+        ),
+    }
+    assert started.is_set() is False
+    assert ad.active_count() == 0
+
+
+def test_durable_prune_failure_does_not_reject_committed_dispatch(monkeypatch):
+    monkeypatch.setattr(
+        ad,
+        "_prune_durable_records",
+        lambda: (_ for _ in ()).throw(OSError("retention unavailable")),
+    )
+
+    accepted = ad.dispatch_async_delegation(
+        goal="dispatch survives prune",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="owner",
+        runner=lambda: {"status": "completed", "summary": "done"},
+        max_async_children=1,
+    )
+
+    assert accepted["status"] == "dispatched"
+    assert _drain_for(accepted["delegation_id"]) is not None
+
+
 def test_async_executor_workers_are_daemon_threads():
     gate = threading.Event()
 

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -265,7 +265,53 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
              owner_started_at, json.dumps(task_payload),
              record.get("origin_session_id", "")),
         )
-    _prune_durable_records()
+    try:
+        _prune_durable_records()
+    except Exception:
+        # Retention maintenance is secondary to the dispatch row that was
+        # already committed. Rejecting here would claim the task never
+        # started even though restart recovery can now see it.
+        logger.debug(
+            "Async delegation %s: durable prune failed after dispatch",
+            record.get("delegation_id"),
+            exc_info=True,
+        )
+
+
+def _persist_dispatch_or_reject(
+    record: Dict[str, Any], *, is_batch: bool
+) -> Optional[Dict[str, str]]:
+    """Persist a registered dispatch before any worker can start.
+
+    The in-memory capacity record is installed before this call so admission
+    remains atomic. If the durable insert fails, roll that record back under
+    the same lock and return a structured rejection; otherwise a SQLite error
+    escapes to the tool caller while a ghost ``running`` record consumes an
+    async slot forever.
+    """
+    try:
+        _persist_dispatch(record)
+    except Exception as exc:
+        delegation_id = str(record.get("delegation_id") or "")
+        with _records_lock:
+            if _records.get(delegation_id) is record:
+                _records.pop(delegation_id, None)
+        kind = " batch" if is_batch else ""
+        logger.error(
+            "Async delegation%s %s: durable dispatch failed; worker not "
+            "started: %s",
+            kind,
+            delegation_id,
+            exc,
+        )
+        return {
+            "status": "rejected",
+            "error": (
+                f"Failed to persist async delegation{kind}; "
+                "no background task was started."
+            ),
+        }
+    return None
 
 
 def _delete_durable_delegation(delegation_id: str) -> None:
@@ -806,7 +852,8 @@ def dispatch_async_delegation(
     -------
     dict
         ``{"status": "dispatched", "delegation_id": ...}`` on success, or
-        ``{"status": "rejected", "error": ...}`` when at capacity.
+        ``{"status": "rejected", "error": ...}`` when at capacity or when
+        the durable dispatch record cannot be written.
     """
     delegation_id = _new_delegation_id()
     dispatched_at = time.time()
@@ -853,7 +900,9 @@ def dispatch_async_delegation(
             }
         _records[delegation_id] = record
 
-    _persist_dispatch(record)
+    rejected = _persist_dispatch_or_reject(record, is_batch=False)
+    if rejected is not None:
+        return rejected
     executor = _get_executor(max_async_children)
 
     def _worker() -> None:
@@ -1047,7 +1096,7 @@ def dispatch_async_delegation_batch(
 
     Returns ``{"status": "dispatched", "delegation_id": ...}`` on success or
     ``{"status": "rejected", "error": ...}`` when the async pool is at
-    capacity.
+    capacity or when the durable dispatch record cannot be written.
     """
     delegation_id = delegation_id or _new_delegation_id()
     dispatched_at = time.time()
@@ -1096,7 +1145,9 @@ def dispatch_async_delegation_batch(
             }
         _records[delegation_id] = record
 
-    _persist_dispatch(record)
+    rejected = _persist_dispatch_or_reject(record, is_batch=True)
+    if rejected is not None:
+        return rejected
     executor = _get_executor(max_async_children)
 
     def _worker() -> None:


### PR DESCRIPTION
## What does this PR do?

Async delegation installs its in-memory `running` record before writing the durable dispatch row. On current `main`, a SQLite/write failure escapes to the caller before executor submission, but the in-memory record remains. No worker exists to finalize it, so it permanently consumes an async slot and subsequent dispatches can be rejected at capacity.

This PR makes dispatch persistence an explicit admission boundary: if the durable write fails, remove the exact in-memory record under the record lock, return a structured rejection, and never start the worker. Retention pruning remains best-effort after a successful commit, so a maintenance failure cannot misreport an already-durable dispatch as rejected.

This is a focused follow-up to #68437. It covers dispatch-side persistence failure and does not overlap the completion/delivery-side work in #76606 / #76581 or post-fork handle rejection in #86085.

## Related Issue

Related to #68437

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add one shared persist-or-reject path for single and batch async delegation.
- Roll back only the exact in-memory admission record when durable persistence fails.
- Return a stable error without leaking the underlying database exception.
- Keep post-commit durable-record pruning best-effort.
- Add behavior tests for single dispatch, batch dispatch, capacity recovery, worker non-start, and post-commit prune failure.

## How to Test

1. Fault-inject `sqlite3.OperationalError` at `_persist_dispatch`.
2. Verify dispatch returns `status=rejected`, the runner never starts, and the only capacity slot is immediately reusable.
3. Fault-inject a prune failure after the durable insert and verify the accepted task still completes.

Validation on macOS:

- `scripts/run_tests.sh tests/tools/test_async_delegation.py` — 23 passed
- `scripts/run_tests.sh tests/tools/test_async_delegation_fd_leak.py tests/tools/test_restored_delegation_ownership.py tests/cli/test_cli_async_delegation_delivery.py tests/tui_gateway/test_delegation_session_lifecycle.py tests/gateway/test_async_delivery_capability.py` — 25 passed
- `scripts/run_tests.sh tests/tools/test_delegate.py tests/tools/test_delegate_apiserver_background.py` — 65 passed
- `ruff check tools/async_delegation.py tests/tools/test_async_delegation.py`
- `python -m compileall -q tools/async_delegation.py tests/tools/test_async_delegation.py`
- `git diff --check origin/main...HEAD`

Total non-overlapping test coverage executed: 113 passed, 0 failed.

## Checklist

### Code

- [x] I've read the Contributing Guide and repository instructions
- [x] My commit message follows Conventional Commits
- [x] I searched open PRs and confirmed this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added and run focused behavior tests for the bug and sibling batch path
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Relevant function docstrings were updated; user docs are N/A
- [x] Config example changes are N/A
- [x] Architecture/workflow documentation changes are N/A
- [x] Cross-platform impact considered: synchronization and SQLite behavior use existing portable primitives
- [x] Tool schema changes are N/A

## Risk and rollback

Risk is limited to the failure path before executor submission. Successful dispatch behavior is unchanged. Rollback is the single commit `012fe49ce7f0c3b06c8c70c9fe84844fef395fc5`.
