### PR TITLE
feat(providers): let provider plugins declare picker grouping

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1212,6 +1212,50 @@ PROVIDER_GROUPS: dict[str, tuple[str, str, list[str]]] = {
     "copilot":  ("GitHub Copilot",  "GitHub token API or copilot --acp process",       ["copilot", "copilot-acp"]),
 }
 
+# Extend PROVIDER_GROUPS with groups declared by provider profiles via
+# ``ProviderProfile.group = (group_id, label, description)``.  A plugin cannot
+# touch the dict above at import time — plugin modules execute inside
+# ``list_providers()`` in the auto-extend block, which runs before this
+# statement — so grouping is collected here instead.  Naming an existing
+# group_id joins that group (keeping its label/description); a new id creates
+# an entry.  Membership is restricted to slugs actually in CANONICAL_PROVIDERS,
+# and declaration order is preserved.  DISPLAY ONLY, exactly like the literals
+# above.
+def fold_profile_groups(profiles, canonical_slugs, groups) -> None:
+    """Merge ``ProviderProfile.group`` declarations into ``groups`` in place.
+
+    ``profiles`` is any iterable of provider profiles, ``canonical_slugs`` the
+    set of slugs the pickers actually render, and ``groups`` a ``PROVIDER_GROUPS``
+    shaped dict.  Malformed declarations are skipped rather than raised on: a
+    third-party plugin must not be able to break the picker.
+    """
+    for profile in profiles:
+        group = getattr(profile, "group", ()) or ()
+        slug = getattr(profile, "name", "")
+        if len(group) < 2 or slug not in canonical_slugs:
+            continue
+        gid = str(group[0] or "").strip()
+        if not gid:
+            continue
+        if gid in groups:
+            members = groups[gid][2]
+            if slug not in members:
+                members.append(slug)
+        else:
+            groups[gid] = (
+                str(group[1]),
+                str(group[2]) if len(group) > 2 else "",
+                [slug],
+            )
+
+
+try:
+    from providers import list_providers as _list_providers_for_groups
+
+    fold_profile_groups(_list_providers_for_groups(), _canonical_slugs, PROVIDER_GROUPS)
+except Exception:
+    pass
+
 # Reverse index: member slug -> group_id. Built once at import.
 _SLUG_TO_GROUP: dict[str, str] = {
     slug: gid for gid, (_label, _desc, members) in PROVIDER_GROUPS.items() for slug in members

--- a/providers/base.py
+++ b/providers/base.py
@@ -49,6 +49,16 @@ class ProviderProfile:
     description: str = ""        # e.g. "GMI Cloud (multi-model direct API)" — picker subtitle
     signup_url: str = ""         # e.g. "https://www.gmicloud.ai/" — shown during setup
 
+    # group: fold this provider under one collapsed row in the interactive
+    # pickers, as ("group_id", "Group Label", "group description").  DISPLAY
+    # ONLY — see PROVIDER_GROUPS in hermes_cli/models.py.  Vendors exposing
+    # several slugs (one per endpoint / tier / auth method) declare the same
+    # group_id on each profile and get a "Label ▸" row with a member
+    # sub-picker instead of N top-level rows.  Naming an existing group_id
+    # joins that group; label/description are then taken from the existing
+    # entry.  Empty (the default) leaves the provider as its own row.
+    group: tuple = ()
+
     # ── Auth & endpoints ─────────────────────────────────────
     env_vars: tuple = ()
     base_url: str = ""

--- a/tests/hermes_cli/test_provider_groups.py
+++ b/tests/hermes_cli/test_provider_groups.py
@@ -6,9 +6,12 @@ These are invariant tests, not catalog snapshots: they assert how
 vendors, which is expected to change over time.
 """
 
+from types import SimpleNamespace
+
 from hermes_cli.models import (
     CANONICAL_PROVIDERS,
     PROVIDER_GROUPS,
+    fold_profile_groups,
     group_providers,
     provider_group_for_slug,
 )
@@ -35,6 +38,46 @@ def test_reverse_index_matches_groups():
     assert provider_group_for_slug("") == ""
 
 
+
+
+def _profile(name, group=()):
+    return SimpleNamespace(name=name, group=group)
+
+
+def test_profile_declared_group_creates_a_group_row():
+    """A provider plugin can declare its own group via ProviderProfile.group."""
+    groups = {}
+    profiles = [
+        _profile("acme-eu", ("acme", "Acme", "EU & US endpoints")),
+        _profile("acme-us", ("acme", "Acme", "EU & US endpoints")),
+    ]
+    fold_profile_groups(profiles, {"acme-eu", "acme-us"}, groups)
+    assert groups == {"acme": ("Acme", "EU & US endpoints", ["acme-eu", "acme-us"])}
+
+
+def test_profile_declared_group_joins_an_existing_group():
+    """Naming an existing group_id appends to it, keeping its label/description."""
+    groups = {"qwen": ("Qwen", "Qwen endpoints", ["alibaba"])}
+    fold_profile_groups(
+        [_profile("acme-eu", ("qwen", "Ignored", "Ignored"))], {"acme-eu"}, groups
+    )
+    assert groups["qwen"] == ("Qwen", "Qwen endpoints", ["alibaba", "acme-eu"])
+
+
+def test_profile_declared_group_skips_bad_or_absent_declarations():
+    """Malformed declarations and non-canonical slugs never reach the picker."""
+    groups = {}
+    fold_profile_groups(
+        [
+            _profile("no-group"),
+            _profile("short-tuple", ("acme",)),
+            _profile("blank-id", ("", "Acme", "desc")),
+            _profile("not-canonical", ("acme", "Acme", "desc")),
+        ],
+        {"no-group", "short-tuple", "blank-id"},
+        groups,
+    )
+    assert groups == {}
 
 
 def test_multi_member_group_folds_to_one_row():


### PR DESCRIPTION
## What does this PR do?

Lets a provider plugin declare which picker group it belongs to, so plugin-supplied providers can fold into one collapsed row the same way in-tree vendors do.

`PROVIDER_GROUPS` in `hermes_cli/models.py` is a hardcoded literal, and there is no registration hook, so grouping has been available to in-tree providers only. A plugin cannot work around that either: plugin modules are imported by `list_providers()` in the `CANONICAL_PROVIDERS` auto-extend block, which runs before `PROVIDER_GROUPS` is defined further down the same module, so the name does not exist while a plugin is executing, and `_SLUG_TO_GROUP` is derived once at import.

This adds `ProviderProfile.group = (group_id, label, description)` and folds those declarations into `PROVIDER_GROUPS` immediately after the literals, before the reverse index is built. Naming an existing `group_id` joins that group and keeps its label and description, so a plugin can attach to an in-tree vendor's row where that is the honest place for it. A new id creates an entry.

The approach mirrors the two auto-extend blocks already in this file (`CANONICAL_PROVIDERS` from `list_providers()`, and `PROVIDER_REGISTRY` in `hermes_cli/auth.py`): a plugin declares metadata, core derives from it, and no core edit is needed per plugin. That matches `AGENTS.md` asking third-party provider integrations to ship as standalone plugin repos.

Nothing changes for existing providers. The field defaults to empty, the literal groups behave exactly as before, and grouping stays display only, so slugs, `--provider`, and `/model <provider>:<model>` are unaffected. All three picker surfaces get it for free because they already share `group_providers()`.

Malformed declarations are skipped rather than raised on, and membership is restricted to slugs actually in `CANONICAL_PROVIDERS`, so a third-party plugin cannot break the picker.

## Related Issue

Fixes #86137

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `providers/base.py`: new `ProviderProfile.group` field, defaulting to `()`, documented as display only.
- `hermes_cli/models.py`: new `fold_profile_groups(profiles, canonical_slugs, groups)` helper, called once at import between the `PROVIDER_GROUPS` literals and `_SLUG_TO_GROUP`, wrapped in the same defensive `try`/`except` the neighbouring auto-extend block uses so a provider-plugin import error cannot take out the picker.
- `tests/hermes_cli/test_provider_groups.py`: three tests covering a plugin-declared group, joining an existing group, and skipping malformed or non-canonical declarations.

3 files, +97/-0.

## How to Test

1. Register two profiles declaring the same group:

   ```python
   ProviderProfile(name="acme-eu", group=("acme", "Acme", "EU & US endpoints"), ...)
   ProviderProfile(name="acme-us", group=("acme", "Acme", "EU & US endpoints"), ...)
   ```

2. Run `hermes model`. The two providers now show as one `Acme ▸ (EU & US endpoints)` row; picking it opens the member sub-picker, same as `Qwen ▸` or `MiniMax ▸`.
3. Confirm it is display only: `hermes model --provider acme-us` and `/model acme-us:<model>` still resolve directly.
4. `pytest tests/hermes_cli/test_provider_groups.py -q` for the new tests.

I verified this on Ubuntu with a four-provider plugin (two tiers across two regional endpoints): four flat rows became one group row with four members, and the typed paths were unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64), Python 3.11

On the full suite: I ran `pytest tests/hermes_cli -q`, which is the suite covering the changed module, and the only failure was `test_dashboard_param_clamps.py::test_oversized_limit_rejected`, which passes on its own both with and without this change and looks order-dependent rather than related. I did not run the whole `tests/` tree to completion on this box, so I have left that box unticked rather than claim it. CI covers it.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new field and the helper are documented in place; no user-facing doc describes `PROVIDER_GROUPS`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, this adds an optional field to an existing extension point rather than changing the plugin workflow
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python dict handling, no paths, processes, or encodings
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool behaviour changed

## Screenshots / Logs

Before, with a four-endpoint provider plugin installed:

```
(O) Personal tier, Global/Singapore endpoint
(O) Team tier, Global/Singapore endpoint
(O) Personal tier, China/Beijing endpoint
(O) Team tier, China/Beijing endpoint
```

After:

```
(O) Alibaba Token Plan ▸ (Personal & Team tiers, Global & China)

    Select Alibaba Token Plan provider:
    → 1. Token Plan Personal
      2. Token Plan Team
      3. Token Plan Personal (China)
      4. Token Plan Team (China)
```

---

🤖 Generated with Claude Code (Claude Opus 5)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee
