### PR TITLE
feat(gateway): non_conversational profile guard for cron-only runners

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -974,6 +974,16 @@ class GatewayConfig:
     # historical serve-all behavior; [] serves only the default profile.
     multiplex_profile_allowlist: Optional[List[str]] = None
 
+    # Cron-only / non-conversational profile guard (opt-in; default off).
+    # When True, this profile is declared to have NO chat surface: the gateway
+    # refuses to start if any messaging platform is enabled, and the profile
+    # multiplexer aborts if a secondary profile with this flag enables a
+    # platform. A gateway with zero platforms still ticks cron, so operators can
+    # split request intake (a conversational profile) from scheduled execution
+    # (this profile) with a first-class, non-bypassable guarantee instead of
+    # relying on documentation or systemd ExecStartPre alone. See #85792.
+    non_conversational: bool = False
+
     # Opt-in systemd event-loop watchdog. Zero preserves Type=simple and
     # disables sd_notify at runtime.
     systemd_watchdog_seconds: int = 0
@@ -1122,6 +1132,7 @@ class GatewayConfig:
             "max_concurrent_sessions": self.max_concurrent_sessions,
             "multiplex_profiles": self.multiplex_profiles,
             "multiplex_profile_allowlist": self.multiplex_profile_allowlist,
+            "non_conversational": self.non_conversational,
             "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
             "loop_watchdog": self.loop_watchdog,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
@@ -1223,6 +1234,14 @@ class GatewayConfig:
         env_multiplex = _env_multiplex_profiles_override()
         if env_multiplex is not None:
             multiplex_profiles = env_multiplex
+
+        # Non-conversational (cron-only) guard. Top-level key wins; the nested
+        # gateway.non_conversational form (written by
+        # ``hermes config set gateway.non_conversational true``) is the fallback,
+        # mirroring the multiplex_profiles precedence above.
+        non_conversational = data.get("non_conversational")
+        if non_conversational is None and isinstance(nested_gateway, dict):
+            non_conversational = nested_gateway.get("non_conversational")
         if "max_concurrent_sessions" in data:
             max_concurrent_raw = data.get("max_concurrent_sessions")
             max_concurrent_key = "max_concurrent_sessions"
@@ -1267,6 +1286,7 @@ class GatewayConfig:
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
             multiplex_profile_allowlist=multiplex_profile_allowlist,
+            non_conversational=_coerce_bool(non_conversational, False),
             systemd_watchdog_seconds=systemd_watchdog_seconds,
             loop_watchdog=loop_watchdog,
             max_concurrent_sessions=max_concurrent_sessions,
@@ -1421,6 +1441,18 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["multiplex_profile_allowlist"] = gateway_section[
                     "multiplex_profile_allowlist"
                 ]
+
+            # Non-conversational (cron-only) guard: accept the top-level key and
+            # the nested gateway.non_conversational form (written by
+            # ``hermes config set gateway.non_conversational true``), mirroring
+            # the multiplex_profiles parity above.
+            if "non_conversational" in yaml_cfg:
+                gw_data["non_conversational"] = yaml_cfg["non_conversational"]
+            elif (
+                isinstance(gateway_section, dict)
+                and "non_conversational" in gateway_section
+            ):
+                gw_data["non_conversational"] = gateway_section["non_conversational"]
 
             # Profile-based routing rules: accept either top-level
             # ``profile_routes`` or the nested ``gateway.profile_routes`` form

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2551,6 +2551,31 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
     return None
 
 
+def _non_conversational_startup_violation(config) -> Optional[str]:
+    """Return a startup-abort reason when a non_conversational profile has a
+    messaging platform enabled, else ``None``.
+
+    A ``gateway.non_conversational: true`` profile is declared to have no chat
+    surface — it exists to tick cron only. Any enabled ``platforms.*`` entry
+    contradicts that contract, so the gateway must fail closed rather than
+    quietly expose a chat channel on a profile the operator intended to be
+    execution-only. See #85792.
+    """
+    if not getattr(config, "non_conversational", False):
+        return None
+    enabled = sorted(
+        platform.value
+        for platform, platform_config in getattr(config, "platforms", {}).items()
+        if getattr(platform_config, "enabled", False)
+    )
+    if not enabled:
+        return None
+    return (
+        "non_conversational profile has messaging platform(s) enabled: "
+        f"{', '.join(enabled)}"
+    )
+
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -11746,7 +11771,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
             self._request_clean_exit(reason)
             return True
-        
+
+        # Cron-only guard: a gateway.non_conversational profile must have no
+        # chat surface. Fail closed BEFORE any adapter is created if a messaging
+        # platform is enabled, so a profile the operator declared execution-only
+        # can never quietly come up serving a chat channel (#85792). This runs
+        # before platform adapter creation and cannot be bypassed by
+        # ``hermes --profile <name> gateway run`` the way documentation or a
+        # systemd ExecStartPre could.
+        nc_reason = _non_conversational_startup_violation(self.config)
+        if nc_reason:
+            logger.error(
+                "Refusing to start: gateway.non_conversational is set but %s. "
+                "A non_conversational profile ticks cron only — remove the "
+                "platform entries from this profile's config.yaml, or unset "
+                "gateway.non_conversational to allow a chat surface.",
+                nc_reason,
+            )
+            try:
+                from gateway.status import write_runtime_status
+                write_runtime_status(
+                    gateway_state="startup_failed", exit_reason=nc_reason
+                )
+            except Exception:
+                pass
+            self._exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE
+            self._request_clean_exit(nc_reason)
+            return True
+
         # Discover Python plugins before shell hooks so plugin block
         # decisions take precedence in tie cases.  The CLI startup path
         # does this via an explicit call in hermes_cli/main.py; the
@@ -14239,6 +14291,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "Enable GATEWAY_ALLOW_ALL_USERS or the platform allow-all flag "
                 "for that profile, or change dm_policy/group_policy away from "
                 "'open'."
+            )
+
+        # A non_conversational secondary profile must not expose a chat surface.
+        # This is a fatal multiplexer config error (not a per-profile skip): the
+        # operator explicitly declared the profile cron-only, so serving a
+        # platform for it would silently violate that contract. Aborting the
+        # whole multiplexer forces the config to be fixed rather than running a
+        # gateway that half-honors the guard (#85792).
+        nc_reason = _non_conversational_startup_violation(profile_cfg)
+        if nc_reason:
+            raise MultiplexConfigError(
+                f"Profile '{profile_name}' sets gateway.non_conversational but "
+                f"{nc_reason}. Remove the platform entries from that profile's "
+                "config.yaml, or unset gateway.non_conversational to allow a "
+                "chat surface."
             )
 
         port_binding_platforms = sorted(

--- a/tests/gateway/test_non_conversational_startup_gate.py
+++ b/tests/gateway/test_non_conversational_startup_gate.py
@@ -1,0 +1,213 @@
+"""Regression tests for the ``gateway.non_conversational`` startup gate.
+
+See #85792. A ``gateway.non_conversational: true`` profile is declared to
+have no chat surface — it exists to tick cron only. Any enabled
+``platforms.*`` entry contradicts that contract, so the gateway must fail
+closed at startup rather than quietly expose a chat channel on a profile
+the operator intended to be execution-only.
+
+The gate has two entry points:
+
+* :func:`gateway.run.GatewayRunner.start` — the single-profile path
+  (``hermes gateway run``). Must set ``exit_code`` to the fatal-config
+  code, request a clean exit, and never actually start any adapter.
+* :func:`gateway.run.GatewayRunner._start_one_profile_adapters` — the
+  multiplex secondary-profile path. Must raise
+  :class:`gateway.run.MultiplexConfigError` so the whole multiplexer
+  aborts (rather than half-honor the guard by silently skipping the
+  offending profile).
+
+Both entry points call a shared helper,
+:func:`gateway.run._non_conversational_startup_violation`, which the
+first block of tests covers as a pure function.
+"""
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.restart import GATEWAY_FATAL_CONFIG_EXIT_CODE
+from gateway.run import (
+    GatewayRunner,
+    _non_conversational_startup_violation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure helper: _non_conversational_startup_violation
+# ---------------------------------------------------------------------------
+
+
+class TestNonConversationalViolationHelper:
+    """Contract of the pure helper both start paths call."""
+
+    def test_flag_off_returns_none_regardless_of_platforms(self):
+        cfg = GatewayConfig(
+            non_conversational=False,
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True)},
+        )
+        assert _non_conversational_startup_violation(cfg) is None
+
+    def test_flag_on_with_no_enabled_platform_returns_none(self):
+        cfg = GatewayConfig(
+            non_conversational=True,
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=False)},
+        )
+        assert _non_conversational_startup_violation(cfg) is None
+
+    def test_flag_on_with_empty_platforms_returns_none(self):
+        cfg = GatewayConfig(non_conversational=True, platforms={})
+        assert _non_conversational_startup_violation(cfg) is None
+
+    def test_flag_on_single_enabled_platform_names_it(self):
+        cfg = GatewayConfig(
+            non_conversational=True,
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True)},
+        )
+        reason = _non_conversational_startup_violation(cfg)
+        assert reason is not None
+        assert "telegram" in reason
+
+    def test_flag_on_multiple_enabled_platforms_sorted_deterministically(self):
+        cfg = GatewayConfig(
+            non_conversational=True,
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(enabled=True),
+                Platform.DISCORD: PlatformConfig(enabled=True),
+                Platform.SLACK: PlatformConfig(enabled=False),
+            },
+        )
+        reason = _non_conversational_startup_violation(cfg)
+        assert reason is not None
+        # Sorted alphabetically so the message is stable in logs / status.
+        assert "discord, telegram" in reason
+        assert "slack" not in reason
+
+
+# ---------------------------------------------------------------------------
+# Single-profile path: GatewayRunner.start
+# ---------------------------------------------------------------------------
+
+
+class TestStartRefusesNonConversationalWithPlatforms:
+    """The single-profile ``gateway run`` path must fail closed."""
+
+    @pytest.mark.asyncio
+    async def test_start_refuses_when_platform_enabled(
+        self, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config = GatewayConfig(
+            non_conversational=True,
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True)},
+            sessions_dir=tmp_path / "sessions",
+        )
+        runner = GatewayRunner(config)
+
+        ok = await runner.start()
+
+        assert ok is True
+        assert runner.should_exit_cleanly is True
+        assert runner.exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE
+        reason = (runner.exit_reason or "").lower()
+        assert "non_conversational" in reason
+        assert "telegram" in reason
+
+    @pytest.mark.asyncio
+    async def test_start_allows_flag_off_with_platforms(
+        self, monkeypatch, tmp_path,
+    ):
+        """The guard must not fire when the flag is off — otherwise every
+        existing conversational profile would break."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config = GatewayConfig(
+            non_conversational=False,
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=False)},
+            sessions_dir=tmp_path / "sessions",
+        )
+        runner = GatewayRunner(config)
+
+        ok = await runner.start()
+
+        # The runner may still exit for other reasons (no adapters connected,
+        # etc.) but must NOT be aborting for the non_conversational violation.
+        reason = (runner.exit_reason or "").lower()
+        assert "non_conversational" not in reason
+
+    @pytest.mark.asyncio
+    async def test_start_allows_flag_on_with_all_platforms_disabled(
+        self, monkeypatch, tmp_path,
+    ):
+        """A cron-only profile with no enabled platform is the intended
+        happy path — must not trip the guard."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config = GatewayConfig(
+            non_conversational=True,
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=False)},
+            sessions_dir=tmp_path / "sessions",
+        )
+        runner = GatewayRunner(config)
+
+        ok = await runner.start()
+
+        # Ditto the previous test — no non_conversational violation, whatever
+        # else the runner does with a platform-less config.
+        reason = (runner.exit_reason or "").lower()
+        assert "non_conversational" not in reason
+
+
+# ---------------------------------------------------------------------------
+# Multiplex secondary path: _start_one_profile_adapters
+# ---------------------------------------------------------------------------
+
+
+class TestMultiplexSecondaryProfileGuard:
+    """The multiplexer must abort — not just skip — the offending profile."""
+
+    @pytest.mark.asyncio
+    async def test_secondary_profile_non_conversational_with_platform_raises(
+        self, monkeypatch, tmp_path,
+    ):
+        """A secondary profile setting ``non_conversational: true`` while
+        enabling a platform must raise ``MultiplexConfigError``.
+
+        Aborting the whole multiplexer forces the config to be fixed rather
+        than running a gateway that half-honors the guard.
+        """
+        from gateway.run import MultiplexConfigError
+
+        profile_home = tmp_path / "profiles" / "bad"
+        profile_home.mkdir(parents=True)
+
+        secondary_cfg = GatewayConfig(
+            non_conversational=True,
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True)},
+        )
+
+        # Bypass the disk-backed config load and the plugin discovery / runtime
+        # scope machinery — the guard only reads the loaded GatewayConfig, and
+        # this test only cares that it raises on the offending config.
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config", lambda: secondary_cfg,
+        )
+        monkeypatch.setattr(
+            "gateway.run._load_gateway_runtime_config", lambda: None,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.discover_plugins", lambda: None,
+        )
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner.adapters = {}
+        runner._profile_adapters = {}
+        runner._snapshot_profile_busy_modes = lambda *a, **kw: None
+
+        with pytest.raises(MultiplexConfigError) as excinfo:
+            await runner._start_one_profile_adapters(
+                "bad", profile_home, claimed={},
+            )
+
+        msg = str(excinfo.value)
+        assert "bad" in msg
+        assert "non_conversational" in msg
+        assert "telegram" in msg


### PR DESCRIPTION
## Summary

Adds a first-class `gateway.non_conversational: true` config option that declares a profile has no chat surface — it exists to tick cron only. Any enabled `platforms.*` entry now fails gateway startup closed rather than quietly serving a chat channel on a profile the operator intended to be execution-only.

Fixes #85792.

## Design

Two entry points share a small pure helper — `_non_conversational_startup_violation(config) -> Optional[str]` — matching the pattern of the adjacent open-policy guard:

- **Single-profile path (`GatewayRunner.start`)** — checked *before* plugin discovery / adapter creation. On violation it writes `gateway_state=startup_failed` via `write_runtime_status`, sets `self._exit_code = GATEWAY_FATAL_CONFIG_EXIT_CODE`, and requests a clean exit. Running before adapter instantiation is what closes the `hermes --profile <name> gateway run` bypass called out in the issue (documentation or systemd `ExecStartPre` alone can't enforce this).
- **Multiplex secondary path (`_start_one_profile_adapters`)** — raises `MultiplexConfigError`. This is deliberately fatal to the whole multiplexer rather than skip-and-warn: the operator explicitly declared the profile cron-only, so continuing with the rest of the fleet while quietly ignoring the offending config would half-honor the guard.

Config reads (`GatewayConfig.from_dict` / `load_gateway_config`) accept both top-level (`non_conversational: true`) and nested (`gateway.non_conversational: true`) placement, mirroring how `multiplex_profiles` is resolved. Zero-config default is `False`, so no existing profile changes behaviour.

## Tests

New `tests/gateway/test_non_conversational_startup_gate.py` (9 tests, all passing):

- **Helper contract** — flag off, flag on w/ no enabled platform, flag on w/ single enabled platform, flag on w/ multiple platforms (sorted deterministically for stable log/status output).
- **Single-profile `start()` path** — asserts `exit_code == GATEWAY_FATAL_CONFIG_EXIT_CODE` on violation; asserts flag-off and flag-on-with-no-platforms happy paths are untouched.
- **Multiplex path** — asserts `MultiplexConfigError` is raised and the message names both the profile and the offending platform, so the operator can locate and fix the config.

Regression sweep on adjacent test files (`test_config.py`, `test_own_policy_startup_gate.py`, `test_allowlist_startup_check.py`, `test_multiplex_adapter_registry.py`): 72/72 pass.

## Test plan

- [x] `pytest tests/gateway/test_non_conversational_startup_gate.py` — 9/9 pass
- [x] `pytest tests/gateway/test_config.py tests/gateway/test_own_policy_startup_gate.py tests/gateway/test_allowlist_startup_check.py tests/gateway/test_multiplex_adapter_registry.py` — 72/72 pass, no regressions
- [x] Manually verified config roundtrip: top-level `non_conversational: true` → `True`, nested `gateway.non_conversational: 'true'` → `True`, absent → `False`, `to_dict` includes the field
- [ ] CI green on this PR