### PR TITLE
feat(whatsapp): expose delivery receipt queue

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -65,6 +65,34 @@ logger = logging.getLogger(__name__)
 _OWNER_REPLY_PREFIX = "[owner reply] "
 
 
+def _set_owner_message_secret_permissions(descriptor: int, secret_path: Path) -> None:
+    """Restrict a secret file using the safest chmod available on this platform."""
+    descriptor_stat = os.fstat(descriptor)
+    if not stat.S_ISREG(descriptor_stat.st_mode):
+        raise ValueError("owner message secret must be a regular file")
+
+    fchmod = getattr(os, "fchmod", None)
+    if callable(fchmod):
+        fchmod(descriptor, 0o600)
+        return
+
+    # Windows Python 3.11/3.12 does not expose os.fchmod. Before falling back
+    # to path-based chmod, reject symlinks and prove the path still identifies
+    # the open regular file. Recheck afterward so a concurrent replacement is
+    # detected rather than accepted as the protected secret.
+    path_stat = os.stat(secret_path, follow_symlinks=False)
+    if not stat.S_ISREG(path_stat.st_mode) or not os.path.samestat(
+        descriptor_stat, path_stat
+    ):
+        raise ValueError("owner message secret must be a regular file")
+    os.chmod(secret_path, 0o600)
+    protected_stat = os.stat(secret_path, follow_symlinks=False)
+    if not stat.S_ISREG(protected_stat.st_mode) or not os.path.samestat(
+        descriptor_stat, protected_stat
+    ):
+        raise ValueError("owner message secret changed while securing permissions")
+
+
 def _load_or_create_owner_message_secret(
     secret_path: Path, allowed_parent: Optional[Path] = None
 ) -> str:
@@ -87,15 +115,13 @@ def _load_or_create_owner_message_secret(
         )
         try:
             os.write(descriptor, (secret + "\n").encode("utf-8"))
-            os.fchmod(descriptor, 0o600)
+            _set_owner_message_secret_permissions(descriptor, secret_path)
         finally:
             os.close(descriptor)
         return secret
     try:
-        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-            raise ValueError("owner message secret must be a regular file")
+        _set_owner_message_secret_permissions(descriptor, secret_path)
         secret = os.read(descriptor, 4096).decode("utf-8").strip()
-        os.fchmod(descriptor, 0o600)
     finally:
         os.close(descriptor)
     if len(secret.encode("utf-8")) < 32:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -16,11 +16,14 @@ with different backends via a bridge pattern.
 """
 
 import asyncio
+import hashlib
 import logging
 import os
 import platform
 import re
+import secrets
 import signal
+import stat
 import subprocess
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -60,6 +63,44 @@ logger = logging.getLogger(__name__)
 # Inbound owner-typed WhatsApp text is prefixed at MessageEvent construction so
 # transcripts stay disambiguated even if downstream plugins fail before silent_ingest.
 _OWNER_REPLY_PREFIX = "[owner reply] "
+
+
+def _load_or_create_owner_message_secret(
+    secret_path: Path, allowed_parent: Optional[Path] = None
+) -> str:
+    """Return a private, stable high-entropy bearer secret for one session."""
+    if allowed_parent is not None:
+        allowed_parent.mkdir(parents=True, exist_ok=True)
+        if secret_path.parent.is_symlink() or (
+            secret_path.parent.resolve(strict=False) != allowed_parent.resolve(strict=True)
+        ):
+            raise ValueError("owner message secret must be inside the WhatsApp session directory")
+    secret_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        descriptor = os.open(secret_path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    except FileNotFoundError:
+        secret = secrets.token_urlsafe(32)
+        descriptor = os.open(
+            secret_path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        try:
+            os.write(descriptor, (secret + "\n").encode("utf-8"))
+            os.fchmod(descriptor, 0o600)
+        finally:
+            os.close(descriptor)
+        return secret
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise ValueError("owner message secret must be a regular file")
+        secret = os.read(descriptor, 4096).decode("utf-8").strip()
+        os.fchmod(descriptor, 0o600)
+    finally:
+        os.close(descriptor)
+    if len(secret.encode("utf-8")) < 32:
+        raise ValueError("owner message secret must contain at least 32 bytes")
+    return secret
 
 
 def _listener_pids_on_port(port: int) -> list:
@@ -455,6 +496,21 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             read_receipts if isinstance(read_receipts, bool)
             else str(read_receipts or "").strip().lower() in {"1", "true", "yes", "on"}
         )
+        forward_owner = config.extra.get(
+            "forward_owner_messages", _wenv("WHATSAPP_FORWARD_OWNER_MESSAGES", "false")
+        )
+        self._forward_owner_messages = (
+            forward_owner if isinstance(forward_owner, bool)
+            else str(forward_owner or "").strip().lower() in {"1", "true", "yes", "on"}
+        )
+        self._owner_messages_external_consumer = bool(
+            config.extra.get("owner_messages_external_consumer", False)
+        )
+        self._owner_message_secret_file = Path(config.extra.get(
+            "owner_message_secret_file",
+            self._session_path / "owner-messages.secret",
+        ))
+        self._owner_message_secret: Optional[str] = None
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
@@ -505,6 +561,21 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not math.isfinite(parsed) or parsed < 0:
             return float(default)
         return parsed
+
+    def _ensure_owner_message_secret(self) -> Optional[str]:
+        if not getattr(self, "_forward_owner_messages", False):
+            return None
+        secret = getattr(self, "_owner_message_secret", None)
+        if secret is None:
+            secret_file = getattr(
+                self,
+                "_owner_message_secret_file",
+                self._session_path / "owner-messages.secret",
+            )
+            secret = _load_or_create_owner_message_secret(secret_file, self._session_path)
+            self._owner_message_secret_file = secret_file
+            self._owner_message_secret = secret
+        return secret
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """
@@ -623,6 +694,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
             # Ensure session directory exists
             self._session_path.mkdir(parents=True, exist_ok=True)
+            owner_message_secret = self._ensure_owner_message_secret()
+            owner_message_auth_fingerprint = (
+                hashlib.sha256(owner_message_secret.encode("utf-8")).hexdigest()[:16]
+                if owner_message_secret else ""
+            )
             
             # Check if bridge is already running and connected
             import aiohttp
@@ -648,7 +724,24 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 running_hash = data.get("scriptHash", "")
                                 disk_hash = _file_content_hash(bridge_path)
                                 running_read_receipts = bool(data.get("sendReadReceipts", False))
-                                config_matches = running_read_receipts == self._send_read_receipts
+                                running_owner_forwarding = bool(
+                                    data.get("forwardOwnerMessages", False)
+                                )
+                                running_owner_external_consumer = bool(
+                                    data.get("ownerMessagesExternalConsumer", False)
+                                )
+                                running_owner_auth_fingerprint = str(
+                                    data.get("ownerMessageAuthFingerprint", "")
+                                )
+                                config_matches = (
+                                    running_read_receipts == self._send_read_receipts
+                                    and running_owner_forwarding
+                                    == getattr(self, "_forward_owner_messages", False)
+                                    and running_owner_external_consumer
+                                    == getattr(self, "_owner_messages_external_consumer", False)
+                                    and running_owner_auth_fingerprint
+                                    == owner_message_auth_fingerprint
+                                )
                                 if (
                                     running_hash
                                     and disk_hash
@@ -664,7 +757,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 stale_reason = (
                                     f"running={running_hash or 'unversioned'}, disk={disk_hash}"
                                     if running_hash != disk_hash
-                                    else "send_read_receipts config changed"
+                                    else "WhatsApp bridge config changed"
                                 )
                                 print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
                             else:
@@ -695,6 +788,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
                 "true" if self._send_read_receipts else "false"
             )
+            bridge_env["WHATSAPP_FORWARD_OWNER_MESSAGES"] = (
+                "true" if getattr(self, "_forward_owner_messages", False) else "false"
+            )
+            bridge_env["WHATSAPP_OWNER_MESSAGES_EXTERNAL_CONSUMER"] = (
+                "true" if getattr(self, "_owner_messages_external_consumer", False) else "false"
+            )
+            if owner_message_secret:
+                bridge_env["WHATSAPP_OWNER_MESSAGE_SECRET"] = owner_message_secret
+            else:
+                bridge_env.pop("WHATSAPP_OWNER_MESSAGE_SECRET", None)
             # Under multiplexing, the bridge subprocess runs with a copy of
             # os.environ that does NOT contain the secondary profile's .env
             # vars.  Inject the resolved WHATSAPP_* values so the Node bridge
@@ -712,7 +815,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 # Full set bridge.js consumes -- without these a secondary
                 # profile's bridge silently reverts to defaults for debug,
                 # forwarding, prefixes, and send pacing.
-                "WHATSAPP_DEBUG", "WHATSAPP_FORWARD_OWNER_MESSAGES",
+                "WHATSAPP_DEBUG",
                 "WHATSAPP_REPLY_PREFIX", "WHATSAPP_MAX_MESSAGE_LENGTH",
                 "WHATSAPP_CHUNK_DELAY_MS", "WHATSAPP_SEND_TIMEOUT_MS",
             ):
@@ -923,6 +1026,19 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._close_bridge_log()
         print(f"[{self.name}] Disconnected")
     
+    def _apply_provider_send_intent(
+        self,
+        payload: Dict[str, Any],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Fence automatic provider sends only in external-consumer mode."""
+        if not getattr(self, "_owner_messages_external_consumer", False):
+            return
+        payload["sendIntent"] = "automatic"
+        sequence = (metadata or {}).get("whatsapp_owner_fence_sequence")
+        if isinstance(sequence, int) and not isinstance(sequence, bool) and sequence >= 0:
+            payload["expectedOwnerFenceSequence"] = sequence
+
     async def send(
         self,
         chat_id: str,
@@ -964,6 +1080,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     # Only reply-to on the first text chunk, even if the bridge
                     # response omits a parseable message id.
                     payload["replyTo"] = reply_to
+                self._apply_provider_send_intent(payload, metadata)
 
                 async with self._http_session.post(
                     f"http://127.0.0.1:{self._bridge_port}/send",

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -7,6 +7,7 @@
  *
  * Endpoints (matches gateway/platforms/whatsapp.py expectations):
  *   GET  /messages       - Long-poll for new incoming messages
+ *   GET  /receipts       - Poll outbound delivery/read receipts
  *   POST /send           - Send a message { chatId, message, replyTo? }
  *   POST /edit           - Edit a sent message { chatId, messageId, message }
  *   POST /send-media     - Send media natively { chatId, filePath, mediaType?, caption?, fileName? }
@@ -35,11 +36,14 @@ import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
   buildPollPayload,
+  acknowledgeDeliveryReceipts,
   createReconnectScheduler,
   createVersionResolver,
   buildLocationPayload,
   buildTextSendPayload,
   createBoundedMessageStore,
+  deliveryReceiptFromMessageUpdate,
+  deliveryReceiptFromUserReceiptUpdate,
   extractBridgeEvent,
   inboundReadReceiptKeys,
   inferMediaType,
@@ -269,7 +273,9 @@ const logger = pino({ level: 'warn' });
 
 // Message queue for polling
 const messageQueue = [];
+const receiptQueue = [];
 const MAX_QUEUE_SIZE = 100;
+const MAX_RECEIPT_QUEUE_SIZE = 1000;
 
 // Track recently sent message IDs.  Two purposes:
 //   1. Prevent echo-back loops with media in self-chat mode.
@@ -280,7 +286,17 @@ const MAX_QUEUE_SIZE = 100;
 // sustained sending.
 const recentlySentIds = createOutboundIdTracker(512);
 const recentlyProcessedPollUpdates = createOutboundIdTracker(512);
+const recentlyProcessedReceipts = createOutboundIdTracker(2048);
 const messageStore = createBoundedMessageStore(512);
+
+function enqueueDeliveryReceipt(receipt) {
+  if (!receipt) return;
+  const dedupeId = `${receipt.messageId}:${receipt.status}`;
+  if (recentlyProcessedReceipts.has(dedupeId)) return;
+  recentlyProcessedReceipts.remember(dedupeId);
+  receiptQueue.push(receipt);
+  if (receiptQueue.length > MAX_RECEIPT_QUEUE_SIZE) receiptQueue.shift();
+}
 
 function normalizePollUpdateOptions(aggregation, pollUpdateMessage, meId) {
   const selected = [];
@@ -480,6 +496,7 @@ async function startSocket() {
 
   sock.ev.on('messages.update', async (updates) => {
     for (const { key, update } of updates || []) {
+      enqueueDeliveryReceipt(deliveryReceiptFromMessageUpdate({ key, update }));
       if (!update?.pollUpdates) continue;
       const pollCreationId = key?.id || update.pollUpdates?.[0]?.pollCreationMessageKey?.id;
       const pollCreation = messageStore.get(pollCreationId);
@@ -526,6 +543,12 @@ async function startSocket() {
         aggregation,
       });
       enqueuePollUpdateEvent({ key, update: { ...update, pollUpdates }, selectedOptions, aggregation });
+    }
+  });
+
+  sock.ev.on('message-receipt.update', (updates) => {
+    for (const { key, receipt } of updates || []) {
+      enqueueDeliveryReceipt(deliveryReceiptFromUserReceiptUpdate({ key, receipt }));
     }
   });
 
@@ -817,6 +840,32 @@ app.use((req, res, next) => {
 app.get('/messages', (req, res) => {
   const msgs = messageQueue.splice(0, messageQueue.length);
   res.json(msgs);
+});
+
+// Poll outbound delivery/read receipts independently from inbound messages.
+app.get('/receipts', (req, res) => {
+  res.json(receiptQueue.slice(0, MAX_QUEUE_SIZE));
+});
+
+app.post('/receipts/ack', (req, res) => {
+  const acknowledgements = req.body?.receipts;
+  if (!Array.isArray(acknowledgements) || acknowledgements.length > MAX_QUEUE_SIZE) {
+    return res.status(400).json({ error: 'receipts must be a bounded array' });
+  }
+  for (const acknowledgement of acknowledgements) {
+    if (
+      !acknowledgement
+      || typeof acknowledgement !== 'object'
+      || Object.keys(acknowledgement).sort().join(',') !== 'messageId,status'
+      || typeof acknowledgement.messageId !== 'string'
+      || !/^[A-Za-z0-9_-]{1,191}$/.test(acknowledgement.messageId)
+      || !['sent', 'delivered', 'read'].includes(acknowledgement.status)
+    ) {
+      return res.status(400).json({ error: 'invalid receipt acknowledgement' });
+    }
+  }
+  const acknowledged = acknowledgeDeliveryReceipts(receiptQueue, acknowledgements);
+  return res.json({ success: true, acknowledged });
 });
 
 // Send a message

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -36,7 +36,7 @@ import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
   buildPollPayload,
-  acknowledgeDeliveryReceipts,
+  createDeliveryReceiptQueue,
   createReconnectScheduler,
   createVersionResolver,
   buildLocationPayload,
@@ -273,9 +273,12 @@ const logger = pino({ level: 'warn' });
 
 // Message queue for polling
 const messageQueue = [];
-const receiptQueue = [];
 const MAX_QUEUE_SIZE = 100;
 const MAX_RECEIPT_QUEUE_SIZE = 1000;
+const receiptQueue = createDeliveryReceiptQueue({
+  capacity: MAX_RECEIPT_QUEUE_SIZE,
+  pageSize: MAX_QUEUE_SIZE,
+});
 
 // Track recently sent message IDs.  Two purposes:
 //   1. Prevent echo-back loops with media in self-chat mode.
@@ -286,16 +289,10 @@ const MAX_RECEIPT_QUEUE_SIZE = 1000;
 // sustained sending.
 const recentlySentIds = createOutboundIdTracker(512);
 const recentlyProcessedPollUpdates = createOutboundIdTracker(512);
-const recentlyProcessedReceipts = createOutboundIdTracker(2048);
 const messageStore = createBoundedMessageStore(512);
 
 function enqueueDeliveryReceipt(receipt) {
-  if (!receipt) return;
-  const dedupeId = `${receipt.messageId}:${receipt.status}`;
-  if (recentlyProcessedReceipts.has(dedupeId)) return;
-  recentlyProcessedReceipts.remember(dedupeId);
-  receiptQueue.push(receipt);
-  if (receiptQueue.length > MAX_RECEIPT_QUEUE_SIZE) receiptQueue.shift();
+  if (receipt) receiptQueue.add(receipt);
 }
 
 function normalizePollUpdateOptions(aggregation, pollUpdateMessage, meId) {
@@ -844,7 +841,7 @@ app.get('/messages', (req, res) => {
 
 // Poll outbound delivery/read receipts independently from inbound messages.
 app.get('/receipts', (req, res) => {
-  res.json(receiptQueue.slice(0, MAX_QUEUE_SIZE));
+  res.json(receiptQueue.snapshot());
 });
 
 app.post('/receipts/ack', (req, res) => {
@@ -864,7 +861,7 @@ app.post('/receipts/ack', (req, res) => {
       return res.status(400).json({ error: 'invalid receipt acknowledgement' });
     }
   }
-  const acknowledged = acknowledgeDeliveryReceipts(receiptQueue, acknowledgements);
+  const acknowledged = receiptQueue.acknowledge(acknowledgements);
   return res.json({ success: true, acknowledged });
 });
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -8,6 +8,7 @@
  * Endpoints (matches gateway/platforms/whatsapp.py expectations):
  *   GET  /messages       - Long-poll for new incoming messages
  *   GET  /receipts       - Poll outbound delivery/read receipts
+ *   GET  /owner-messages - Peek messages typed on the owner device
  *   POST /send           - Send a message { chatId, message, replyTo? }
  *   POST /edit           - Edit a sent message { chatId, messageId, message }
  *   POST /send-media     - Send media natively { chatId, filePath, mediaType?, caption?, fileName? }
@@ -32,12 +33,18 @@ import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
-import { createOutboundIdTracker } from './outbound_ids.js';
+import {
+  createDurableOutboundIdTracker,
+  createOutboundIdTracker,
+  sendWithProvenance,
+} from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
   buildPollPayload,
   createDeliveryReceiptQueue,
+  createOwnerMessageQueue,
   createReconnectScheduler,
+  createSerializedSendQueue,
   createVersionResolver,
   buildLocationPayload,
   buildTextSendPayload,
@@ -48,6 +55,11 @@ import {
   inboundReadReceiptKeys,
   inferMediaType,
   mediaPayloadForFile,
+  ownerMessageTokenMatches,
+  ownerMessageDeliveryMode,
+  ownerSendFenceStatus,
+  providerSendErrorResponse,
+  providerSendIntentStatus,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
@@ -71,16 +83,20 @@ const WHATSAPP_DEBUG =
 // "owner just typed in this customer chat" — needed for handover / sliding
 // TTL flows. Default OFF: existing deployments see no behavior change.
 //
-// Heuristic limitation: we distinguish bot-API-sent from owner-typed by
-// looking up `key.id` in `recentlySentIds` (populated when /send returns).
-// On bridge restart that set is empty, so a few in-flight bot replies may
-// briefly look like owner-typed until they age out. Acceptable; we don't
-// persist the set.
+// Connector-originated IDs are reserved and written to the session directory
+// before sock.sendMessage starts. This closes both the upsert-before-return race
+// and the restart window: fromMe echoes can never be mistaken for owner input.
 const FORWARD_OWNER_MESSAGES =
   typeof process !== 'undefined' &&
   process.env &&
   typeof process.env.WHATSAPP_FORWARD_OWNER_MESSAGES === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_FORWARD_OWNER_MESSAGES.toLowerCase());
+const OWNER_MESSAGES_EXTERNAL_CONSUMER =
+  FORWARD_OWNER_MESSAGES
+  && typeof process.env.WHATSAPP_OWNER_MESSAGES_EXTERNAL_CONSUMER === 'string'
+  && ['1', 'true', 'yes', 'on'].includes(
+    process.env.WHATSAPP_OWNER_MESSAGES_EXTERNAL_CONSUMER.toLowerCase(),
+  );
 
 const SEND_READ_RECEIPTS =
   typeof process !== 'undefined' &&
@@ -90,6 +106,13 @@ const SEND_READ_RECEIPTS =
 
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
+const OWNER_MESSAGE_SECRET = String(process.env.WHATSAPP_OWNER_MESSAGE_SECRET || '');
+if (FORWARD_OWNER_MESSAGES && Buffer.byteLength(OWNER_MESSAGE_SECRET, 'utf8') < 32) {
+  throw new Error('WHATSAPP_OWNER_MESSAGE_SECRET must contain at least 32 bytes');
+}
+const OWNER_MESSAGE_AUTH_FINGERPRINT = OWNER_MESSAGE_SECRET
+  ? createHash('sha256').update(OWNER_MESSAGE_SECRET).digest('hex').slice(0, 16)
+  : '';
 // Cache directories: the Python gateway passes the profile-aware paths via
 // env (HERMES_HOME-aware, new cache/ layout).  Fall back to the legacy
 // hardcoded locations for bridges launched outside the gateway.
@@ -128,36 +151,38 @@ const CHUNK_DELAY_MS = parseInt(process.env.WHATSAPP_CHUNK_DELAY_MS || '300', 10
 // which pins the bridge's HTTP handler until the upstream aiohttp timeout
 // fires. Fail fast instead so the gateway can surface a real error and retry.
 const SEND_TIMEOUT_MS = parseInt(process.env.WHATSAPP_SEND_TIMEOUT_MS || '60000', 10);
+// The Python connector gives provider HTTP calls 30 seconds. An absolute
+// bridge-owned 25-second queue deadline guarantees a request cannot outlive
+// its caller merely because another provider call still owns the socket.
+const SEND_QUEUE_WAIT_TIMEOUT_MS = 25_000;
 
 // --- Send queue: serialise all sock.sendMessage() calls across concurrent
 //     HTTP handlers so a single Baileys socket never has overlapping sends.
 //     Overlapping sends are the root cause of cross-chat contamination
 //     (#33360) — the WhatsApp protocol-level routing can misdeliver when
 //     two sendMessage() Promises race on the same socket. ---
-let _sendQueue = Promise.resolve();
-
-function enqueueSend(fn) {
-  const task = _sendQueue.then(() => fn(), () => fn());
-  _sendQueue = task.catch(() => {});
-  return task;
-}
+const { enqueueSend } = createSerializedSendQueue();
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function sendWithTimeout(chatId, payload, options = {}, timeoutMs = SEND_TIMEOUT_MS) {
-  let timer;
-  const timeoutPromise = new Promise((_, reject) => {
-    timer = setTimeout(
-      () => reject(new Error(`sendMessage timed out after ${timeoutMs / 1000}s`)),
-      timeoutMs,
-    );
+function sendWithTimeout(
+  chatId, payload, options = {}, timeoutMs = SEND_TIMEOUT_MS, beforeSend = undefined,
+  queueContext = {},
+) {
+  const messageId = randomBytes(12).toString('hex').toUpperCase();
+  return enqueueSend(() => sendWithProvenance({
+    tracker: recentlySentIds,
+    messageId,
+    send: () => sock.sendMessage(chatId, payload, { ...options, messageId }),
+  }), {
+    beforeRun: beforeSend,
+    timeoutMs,
+    timeoutError: () => new Error(`sendMessage timed out after ${timeoutMs / 1000}s`),
+    queueDeadlineAt: queueContext.queueDeadlineAt,
+    isAbandoned: queueContext.isAbandoned,
   });
-  return enqueueSend(() =>
-    Promise.race([sock.sendMessage(chatId, payload, options), timeoutPromise])
-      .finally(() => clearTimeout(timer))
-  );
 }
 
 function formatOutgoingMessage(message) {
@@ -279,15 +304,20 @@ const receiptQueue = createDeliveryReceiptQueue({
   capacity: MAX_RECEIPT_QUEUE_SIZE,
   pageSize: MAX_QUEUE_SIZE,
 });
+const ownerMessageQueue = createOwnerMessageQueue({
+  directory: SESSION_DIR,
+  pageSize: MAX_QUEUE_SIZE,
+});
 
 // Track recently sent message IDs.  Two purposes:
 //   1. Prevent echo-back loops with media in self-chat mode.
 //   2. (When WHATSAPP_FORWARD_OWNER_MESSAGES=true) distinguish our own
 //      bot-API outbound messages from owner-typed messages on the linked
 //      device so we can forward only the latter.
-// Capacity bounded (see outbound_ids.js) to keep memory flat under
-// sustained sending.
-const recentlySentIds = createOutboundIdTracker(512);
+// Connector-originated IDs are durable in the session directory. They are
+// reserved before sock.sendMessage begins, so the set survives restart and is
+// already populated if Baileys emits an echo before the send promise resolves.
+const recentlySentIds = createDurableOutboundIdTracker({ directory: SESSION_DIR });
 const recentlyProcessedPollUpdates = createOutboundIdTracker(512);
 const messageStore = createBoundedMessageStore(512);
 
@@ -780,7 +810,24 @@ async function startSocket() {
       }
 
       messageStore.remember(msg);
-      messageQueue.push(event);
+      const ownerDeliveryMode = ownerMessageDeliveryMode(
+        fromOwner, OWNER_MESSAGES_EXTERNAL_CONSUMER,
+      );
+      if (ownerDeliveryMode === 'external') {
+        if (!ownerMessageQueue.add(event)) {
+          emitDebugEvent({
+            stage: 'ignored',
+            reason: 'invalid_or_duplicate_owner_message',
+            messageId: msg.key.id,
+          });
+          continue;
+        }
+      } else {
+        if (!fromOwner) {
+          event.ownerFenceSequence = ownerMessageQueue.lastSequence(chatId);
+        }
+        messageQueue.push(event);
+      }
       emitDebugEvent({
         stage: 'queued',
         chatId: redactWhatsAppId(chatId),
@@ -789,7 +836,9 @@ async function startSocket() {
         bodyLength: event.body.length,
         hasMedia: event.hasMedia,
         mediaType: event.mediaType,
-        queueLength: messageQueue.length,
+        queueLength: ownerDeliveryMode === 'external'
+          ? ownerMessageQueue.size()
+          : messageQueue.length,
       });
       if (messageQueue.length > MAX_QUEUE_SIZE) {
         messageQueue.shift();
@@ -844,6 +893,43 @@ app.get('/receipts', (req, res) => {
   res.json(receiptQueue.snapshot());
 });
 
+function requireOwnerMessageAccess(req, res, next) {
+  if (!FORWARD_OWNER_MESSAGES) return res.status(404).json({ error: 'Not found' });
+  if (!ownerMessageTokenMatches(OWNER_MESSAGE_SECRET, req.headers.authorization)) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  return next();
+}
+
+app.get('/owner-messages', requireOwnerMessageAccess, (req, res) => {
+  const cursor = req.query.cursor === undefined ? '0' : String(req.query.cursor);
+  const limit = req.query.limit === undefined ? MAX_QUEUE_SIZE : Number(req.query.limit);
+  if (!/^\d+$/.test(cursor) || !Number.isSafeInteger(limit) || limit < 1 || limit > MAX_QUEUE_SIZE) {
+    return res.status(400).json({ error: 'invalid cursor or limit' });
+  }
+  return res.json(ownerMessageQueue.page({ cursor, limit }));
+});
+
+app.post('/owner-messages/ack', requireOwnerMessageAccess, (req, res) => {
+  const acknowledgements = req.body?.messages;
+  if (!Array.isArray(acknowledgements) || acknowledgements.length > MAX_QUEUE_SIZE) {
+    return res.status(400).json({ error: 'messages must be a bounded array' });
+  }
+  for (const acknowledgement of acknowledgements) {
+    if (
+      !acknowledgement
+      || typeof acknowledgement !== 'object'
+      || Object.keys(acknowledgement).join(',') !== 'messageId'
+      || typeof acknowledgement.messageId !== 'string'
+      || !/^[A-Za-z0-9_-]{1,191}$/.test(acknowledgement.messageId)
+    ) {
+      return res.status(400).json({ error: 'invalid owner message acknowledgement' });
+    }
+  }
+  const acknowledged = ownerMessageQueue.acknowledge(acknowledgements);
+  return res.json({ success: true, acknowledged });
+});
+
 app.post('/receipts/ack', (req, res) => {
   const acknowledgements = req.body?.receipts;
   if (!Array.isArray(acknowledgements) || acknowledgements.length > MAX_QUEUE_SIZE) {
@@ -865,6 +951,54 @@ app.post('/receipts/ack', (req, res) => {
   return res.json({ success: true, acknowledged });
 });
 
+function prepareProviderSend(req, res, chatId) {
+  let abandoned = false;
+  req.once('aborted', () => { abandoned = true; });
+  res.once('close', () => {
+    if (!res.writableEnded) abandoned = true;
+  });
+  const queueDeadlineAt = Date.now() + SEND_QUEUE_WAIT_TIMEOUT_MS;
+  const intentStatus = providerSendIntentStatus({
+    externalConsumer: OWNER_MESSAGES_EXTERNAL_CONSUMER,
+    sendIntent: req.body?.sendIntent,
+    expectedOwnerFenceSequence: req.body?.expectedOwnerFenceSequence,
+    expectedSecret: OWNER_MESSAGE_SECRET,
+    authorizationHeader: req.headers.authorization,
+  });
+  if (intentStatus === 'unauthorized') {
+    res.status(401).json({ error: 'Unauthorized' });
+    return null;
+  }
+  if (intentStatus === 'invalid') {
+    res.status(400).json({
+      error: 'external consumer sends require authenticated human intent or automatic intent with expectedOwnerFenceSequence',
+    });
+    return null;
+  }
+  const beforeSend = intentStatus === 'automatic'
+    ? () => {
+      if (ownerSendFenceStatus(
+        ownerMessageQueue, chatId, req.body.expectedOwnerFenceSequence,
+      ) !== 'allowed') {
+        const error = new Error('Owner intervention fenced this send');
+        error.code = 'OWNER_FENCED';
+        throw error;
+      }
+    }
+    : undefined;
+  return {
+    beforeSend,
+    intentStatus,
+    queueDeadlineAt,
+    isAbandoned: () => abandoned,
+  };
+}
+
+function respondToProviderSendError(res, error, messageIds = []) {
+  const { statusCode, body } = providerSendErrorResponse(error, messageIds);
+  return res.status(statusCode).json(body);
+}
+
 // Send a message
 app.post('/send', async (req, res) => {
   if (!sock || connectionState !== 'connected') {
@@ -875,17 +1009,21 @@ app.post('/send', async (req, res) => {
   if (!chatId || !message) {
     return res.status(400).json({ error: 'chatId and message are required' });
   }
+  const sendContext = prepareProviderSend(req, res, chatId);
+  if (!sendContext) return undefined;
 
+  const chunks = splitLongMessage(formatOutgoingMessage(message));
+  const messageIds = [];
   try {
-    const chunks = splitLongMessage(formatOutgoingMessage(message));
-    const messageIds = [];
     for (let i = 0; i < chunks.length; i += 1) {
       const { content: payload, options } = buildTextSendPayload(chunks[i], {
         chatId,
         replyTo: i === 0 ? replyTo : undefined,
         messageStore,
       });
-      const sent = await sendWithTimeout(chatId, payload, options);
+      const sent = await sendWithTimeout(
+        chatId, payload, options, SEND_TIMEOUT_MS, sendContext.beforeSend, sendContext,
+      );
       trackSentMessageId(sent);
       messageStore.remember(sent);
       if (sent?.key?.id) messageIds.push(sent.key.id);
@@ -900,7 +1038,7 @@ app.post('/send', async (req, res) => {
       messageIds,
     });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    return respondToProviderSendError(res, err, messageIds);
   }
 });
 
@@ -915,17 +1053,31 @@ app.post('/edit', async (req, res) => {
     return res.status(400).json({ error: 'chatId, messageId, and message are required' });
   }
 
+  const sendContext = prepareProviderSend(req, res, chatId);
+  if (!sendContext) return undefined;
+
+  const completedMessageIds = [];
   try {
     const key = { id: messageId, fromMe: true, remoteJid: chatId };
     const chunks = splitLongMessage(formatOutgoingMessage(message));
     const messageIds = [];
 
-    await sendWithTimeout(chatId, { text: chunks[0], edit: key });
+    await sendWithTimeout(
+      chatId, { text: chunks[0], edit: key }, {}, SEND_TIMEOUT_MS,
+      sendContext.beforeSend, sendContext,
+    );
+    completedMessageIds.push(messageId);
     if (chunks.length > 1) {
       for (let i = 1; i < chunks.length; i += 1) {
-        const sent = await sendWithTimeout(chatId, { text: chunks[i] });
+        const sent = await sendWithTimeout(
+          chatId, { text: chunks[i] }, {}, SEND_TIMEOUT_MS,
+          sendContext.beforeSend, sendContext,
+        );
         trackSentMessageId(sent);
-        if (sent?.key?.id) messageIds.push(sent.key.id);
+        if (sent?.key?.id) {
+          messageIds.push(sent.key.id);
+          completedMessageIds.push(sent.key.id);
+        }
         if (i < chunks.length - 1) {
           await sleep(CHUNK_DELAY_MS);
         }
@@ -934,7 +1086,7 @@ app.post('/edit', async (req, res) => {
 
     res.json({ success: true, messageIds });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    return respondToProviderSendError(res, err, completedMessageIds);
   }
 });
 
@@ -948,6 +1100,8 @@ app.post('/send-media', async (req, res) => {
   if (!chatId || !filePath) {
     return res.status(400).json({ error: 'chatId and filePath are required' });
   }
+  const sendContext = prepareProviderSend(req, res, chatId);
+  if (!sendContext) return undefined;
 
   try {
     if (!existsSync(filePath)) {
@@ -1028,12 +1182,14 @@ app.post('/send-media', async (req, res) => {
         break;
     }
 
-    const sent = await sendWithTimeout(chatId, msgPayload);
+    const sent = await sendWithTimeout(
+      chatId, msgPayload, {}, SEND_TIMEOUT_MS, sendContext.beforeSend, sendContext,
+    );
     trackSentMessageId(sent);
     messageStore.remember(sent);
     res.json({ success: true, messageId: sent?.key?.id });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    return respondToProviderSendError(res, err);
   }
 });
 
@@ -1050,14 +1206,19 @@ app.post('/send-poll', async (req, res) => {
     return res.status(400).json({ error: 'chatId, question, and options are required' });
   }
 
+  const sendContext = prepareProviderSend(req, res, chatId);
+  if (!sendContext) return undefined;
+
   try {
     const payload = buildPollPayload({ question, options, selectableCount });
-    const sent = await sendWithTimeout(chatId, payload);
+    const sent = await sendWithTimeout(
+      chatId, payload, {}, SEND_TIMEOUT_MS, sendContext.beforeSend, sendContext,
+    );
     trackSentMessageId(sent);
     rememberSentMessage(sent, payload);
     res.json({ success: true, messageId: sent?.key?.id });
   } catch (err) {
-    res.status(400).json({ error: err.message });
+    return respondToProviderSendError(res, err);
   }
 });
 
@@ -1072,14 +1233,19 @@ app.post('/send-location', async (req, res) => {
     return res.status(400).json({ error: 'chatId, latitude, and longitude are required' });
   }
 
+  const sendContext = prepareProviderSend(req, res, chatId);
+  if (!sendContext) return undefined;
+
   try {
     const payload = buildLocationPayload({ latitude, longitude, name, address });
-    const sent = await sendWithTimeout(chatId, payload);
+    const sent = await sendWithTimeout(
+      chatId, payload, {}, SEND_TIMEOUT_MS, sendContext.beforeSend, sendContext,
+    );
     trackSentMessageId(sent);
     messageStore.remember(sent);
     res.json({ success: true, messageId: sent?.key?.id });
   } catch (err) {
-    res.status(400).json({ error: err.message });
+    return respondToProviderSendError(res, err);
   }
 });
 
@@ -1153,7 +1319,24 @@ app.get('/chat/:id', async (req, res) => {
 app.get('/health', (req, res) => {
   res.json({
     status: connectionState,
+    forwardOwnerMessages: FORWARD_OWNER_MESSAGES,
+    ownerMessagesExternalConsumer: OWNER_MESSAGES_EXTERNAL_CONSUMER,
+    ownerMessageAuthFingerprint: OWNER_MESSAGE_AUTH_FINGERPRINT,
     queueLength: messageQueue.length,
+    ownerMessageQueueLength: ownerMessageQueue.size(),
+    receiptQueueLength: receiptQueue.size(),
+    capabilities: {
+      deliveryReceipts: true,
+      inboundReadReceipts: true,
+      ownerMessages: FORWARD_OWNER_MESSAGES ? {
+        version: 2,
+        auth: 'bearer',
+        durable: true,
+        pagination: 'cursor',
+        externalConsumer: OWNER_MESSAGES_EXTERNAL_CONSUMER,
+        payload: 'text-only-with-intervention-records',
+      } : false,
+    },
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
     sendReadReceipts: SEND_READ_RECEIPTS,

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -7,7 +7,7 @@
 
 import { strict as assert } from 'node:assert';
 import { createHash } from 'node:crypto';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { getAggregateVotesInPollMessage } from '@whiskeysockets/baileys';
@@ -17,6 +17,12 @@ import {
   buildTextSendPayload,
   acknowledgeDeliveryReceipts,
   createDeliveryReceiptQueue,
+  createOwnerMessageQueue,
+  ownerMessageTokenMatches,
+  ownerMessageDeliveryMode,
+  ownerSendFenceStatus,
+  providerSendErrorResponse,
+  providerSendIntentStatus,
   createBoundedMessageStore,
   deliveryReceiptFromMessageUpdate,
   deliveryReceiptFromUserReceiptUpdate,
@@ -27,6 +33,254 @@ import {
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
+
+// -- provider-send intent policy ------------------------------------------
+{
+  const base = { expectedSecret: 'secret-value', authorizationHeader: undefined };
+  assert.equal(providerSendIntentStatus({ ...base, externalConsumer: false }), 'standard');
+  assert.equal(providerSendIntentStatus({
+    ...base, externalConsumer: true, sendIntent: 'automatic', expectedOwnerFenceSequence: 0,
+  }), 'automatic');
+  assert.equal(providerSendIntentStatus({
+    ...base, externalConsumer: true, sendIntent: 'automatic', expectedOwnerFenceSequence: undefined,
+  }), 'invalid');
+  assert.equal(providerSendIntentStatus({
+    ...base, externalConsumer: true, sendIntent: 'human', authorizationHeader: 'Bearer secret-value',
+  }), 'human');
+  assert.equal(providerSendIntentStatus({
+    ...base, externalConsumer: true, sendIntent: 'human', authorizationHeader: 'Bearer wrong',
+  }), 'unauthorized');
+  assert.equal(providerSendIntentStatus({ ...base, externalConsumer: true }), 'invalid');
+  assert.deepEqual(providerSendErrorResponse(
+    Object.assign(new Error('Owner intervention fenced this send'), { code: 'OWNER_FENCED' }),
+    ['sent-1'],
+  ), {
+    statusCode: 409,
+    body: {
+      error: 'Owner intervention fenced this send',
+      code: 'OWNER_FENCED',
+      retryable: false,
+      partial: true,
+      messageId: 'sent-1',
+      messageIds: ['sent-1'],
+    },
+  });
+  assert.deepEqual(providerSendErrorResponse(
+    Object.assign(new Error('queue expired'), { code: 'SEND_QUEUE_EXPIRED' }),
+  ), {
+    statusCode: 503,
+    body: {
+      error: 'queue expired',
+      code: 'SEND_QUEUE_EXPIRED',
+      retryable: true,
+      partial: false,
+      messageId: undefined,
+      messageIds: [],
+    },
+  });
+  console.log('  ✓ expired bridge queue waits return a retryable provider-safe response');
+  console.log('  ✓ partial owner fences are terminal conflicts with sent IDs');
+  console.log('  ✓ send intent fails closed only for external consumers and authenticates humans');
+}
+
+// -- owner-device messages -------------------------------------------------
+{
+  assert.equal(ownerMessageDeliveryMode(true, false), 'inbound');
+  assert.equal(ownerMessageDeliveryMode(true, true), 'external');
+  assert.equal(ownerMessageDeliveryMode(false, true), 'inbound');
+  console.log('  ✓ generic owner forwarding and external durable consumption stay distinct');
+}
+
+{
+  assert.equal(ownerMessageTokenMatches('secret-value', 'Bearer secret-value'), true);
+  assert.equal(ownerMessageTokenMatches('secret-value', 'Bearer secret-valuE'), false);
+  assert.equal(ownerMessageTokenMatches('secret-value', ''), false);
+  assert.equal(ownerMessageTokenMatches('', 'Bearer secret-value'), false);
+  console.log('  ✓ owner-device API bearer tokens use exact authenticated matching');
+}
+
+{
+  const queueDir = mkdtempSync(path.join(tmpdir(), 'hermes-owner-queue-'));
+  const queue = createOwnerMessageQueue({ directory: queueDir, pageSize: 1 });
+  const first = {
+    messageId: 'owner-1',
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15551234567@s.whatsapp.net',
+    fromOwner: true,
+    type: 'text',
+    body: 'Assumi o atendimento.',
+    timestamp: 1_723_636_800,
+  };
+  assert.equal(queue.add(first), true);
+  assert.equal(queue.add({ ...first }), false);
+  const firstQueued = { ...first, ownerFenceSequence: 1 };
+  assert.deepEqual(queue.snapshot(), [firstQueued]);
+  const reopened = createOwnerMessageQueue({ directory: queueDir, pageSize: 1 });
+  assert.deepEqual(reopened.snapshot(), [firstQueued]);
+  assert.equal(reopened.lastSequence(first.chatId), 1);
+  assert.match(readFileSync(path.join(queueDir, 'owner-messages.json'), 'utf8'), /owner-1/);
+  assert.equal(reopened.acknowledge([{ messageId: 'owner-1' }]), 1);
+  const afterAck = createOwnerMessageQueue({ directory: queueDir });
+  assert.deepEqual(afterAck.snapshot(), []);
+  assert.equal(afterAck.lastSequence(first.chatId), 1);
+  console.log('  ✓ owner-device messages persist across restart until exact acknowledgement');
+}
+
+{
+  const queueDir = mkdtempSync(path.join(tmpdir(), 'hermes-owner-tombstone-'));
+  let currentTime = 1_723_636_800_000;
+  const retentionMs = 30 * 24 * 60 * 60 * 1000;
+  const options = { directory: queueDir, now: () => currentTime, tombstoneRetentionMs: retentionMs };
+  const event = {
+    messageId: 'owner-replayed-after-ack',
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15551234567@s.whatsapp.net',
+    fromOwner: true,
+    type: 'text',
+    body: 'Handled already.',
+    timestamp: 1_723_636_800,
+  };
+  const queue = createOwnerMessageQueue(options);
+  assert.equal(queue.add(event), true);
+  assert.equal(queue.acknowledge([{ messageId: event.messageId }]), 1);
+  const persisted = JSON.parse(readFileSync(path.join(queueDir, 'owner-messages.json'), 'utf8'));
+  assert.equal(persisted.tombstones[event.messageId].sequence, 1);
+
+  const reopened = createOwnerMessageQueue(options);
+  assert.equal(reopened.add(event), false);
+  assert.equal(reopened.lastSequence(event.chatId), 1);
+  assert.deepEqual(reopened.snapshot(), []);
+
+  currentTime += retentionMs + 1;
+  const afterReplayWindow = createOwnerMessageQueue(options);
+  assert.equal(afterReplayWindow.add(event), true);
+  assert.equal(afterReplayWindow.snapshot()[0].ownerFenceSequence, 2);
+  console.log('  ✓ ACK tombstones survive restart, preserve sequence, and expire only by replay age');
+}
+
+{
+  const queue = createOwnerMessageQueue({
+    directory: mkdtempSync(path.join(tmpdir(), 'hermes-owner-fence-')),
+  });
+  const chatId = '15551234567@s.whatsapp.net';
+  assert.equal(ownerSendFenceStatus(queue, chatId, 0), 'allowed');
+  assert.equal(queue.add({
+    messageId: 'owner-fence-1', chatId, senderId: chatId, fromOwner: true,
+    type: 'text', body: 'Assumi.', timestamp: 1_723_636_800,
+  }), true);
+  assert.equal(ownerSendFenceStatus(queue, chatId, 0), 'fenced');
+  assert.equal(ownerSendFenceStatus(queue, chatId, 1), 'allowed');
+  assert.equal(ownerSendFenceStatus(queue, chatId, 2), 'fenced');
+  assert.equal(ownerSendFenceStatus(queue, chatId, undefined), 'invalid');
+  console.log('  ✓ owner sequence fences stale automatic sends before provider dispatch');
+}
+
+{
+  const queueDir = mkdtempSync(path.join(tmpdir(), 'hermes-owner-alias-fence-'));
+  const queue = createOwnerMessageQueue({ directory: queueDir });
+  const lidChatId = '267383306489914@lid';
+  const canonicalChatId = '19175395595@s.whatsapp.net';
+  const base = {
+    senderId: lidChatId, fromOwner: true, type: 'text', timestamp: 1_723_636_800,
+  };
+
+  assert.equal(queue.add({
+    ...base, messageId: 'owner-alias-lid', chatId: lidChatId, body: 'LID first',
+  }), true);
+  assert.equal(ownerSendFenceStatus(queue, canonicalChatId, 0), 'fenced');
+  assert.equal(ownerSendFenceStatus(queue, '15550001111@s.whatsapp.net', 0), 'fenced');
+  assert.equal(ownerSendFenceStatus(
+    createOwnerMessageQueue({ directory: queueDir }), canonicalChatId, 0,
+  ), 'fenced');
+  assert.equal(queue.acknowledge([{ messageId: 'owner-alias-lid' }]), 1);
+  assert.equal(ownerSendFenceStatus(
+    createOwnerMessageQueue({ directory: queueDir }), '15550001111@s.whatsapp.net', 0,
+  ), 'fenced');
+
+  // Baileys can persist this exact mapping only after the owner event arrives.
+  writeFileSync(
+    path.join(queueDir, 'lid-mapping-19175395595.json'),
+    JSON.stringify('267383306489914'),
+  );
+  writeFileSync(
+    path.join(queueDir, 'lid-mapping-267383306489914_reverse.json'),
+    JSON.stringify('19175395595'),
+  );
+
+  assert.equal(ownerSendFenceStatus(queue, canonicalChatId, 0), 'fenced');
+  assert.equal(ownerSendFenceStatus(queue, canonicalChatId, 1), 'allowed');
+  assert.equal(ownerSendFenceStatus(queue, canonicalChatId, 2), 'fenced');
+  assert.equal(ownerSendFenceStatus(queue, '15550001111@s.whatsapp.net', 0), 'allowed');
+  assert.equal(queue.add({
+    ...base,
+    messageId: 'owner-alias-canonical',
+    chatId: canonicalChatId,
+    senderId: canonicalChatId,
+    body: 'canonical second',
+  }), true);
+  assert.equal(ownerSendFenceStatus(queue, lidChatId, 1), 'fenced');
+  assert.equal(ownerSendFenceStatus(queue, lidChatId, 2), 'allowed');
+  assert.equal(ownerSendFenceStatus(queue, lidChatId, 3), 'fenced');
+
+  assert.equal(queue.acknowledge([
+    { messageId: 'owner-alias-lid' },
+    { messageId: 'owner-alias-canonical' },
+  ]), 1);
+  const reopened = createOwnerMessageQueue({ directory: queueDir });
+  assert.equal(ownerSendFenceStatus(reopened, canonicalChatId, 2), 'allowed');
+  assert.equal(ownerSendFenceStatus(reopened, lidChatId, 2), 'allowed');
+  console.log('  ✓ owner fences use exact persisted LID/canonical aliases across mapping, ACK, and restart');
+}
+
+{
+  const queue = createOwnerMessageQueue({
+    directory: mkdtempSync(path.join(tmpdir(), 'hermes-owner-invalid-')),
+    pageSize: 2,
+  });
+  assert.equal(queue.add({ messageId: 'bad', fromOwner: false }), false);
+  assert.equal(queue.add({
+    messageId: 'owner-group', chatId: '123@g.us', senderId: '123@g.us', fromOwner: true,
+    type: 'text', body: 'no', timestamp: 1,
+  }), false);
+  assert.equal(queue.add({
+    messageId: 'owner-image', chatId: '15551234567@s.whatsapp.net',
+    senderId: '15551234567@s.whatsapp.net', fromOwner: true,
+    hasMedia: true, mediaType: 'image', body: '', timestamp: 1,
+  }), true);
+  assert.deepEqual(queue.snapshot(), [{
+    messageId: 'owner-image', chatId: '15551234567@s.whatsapp.net',
+    senderId: '15551234567@s.whatsapp.net', fromOwner: true,
+    type: 'image', body: '', timestamp: 1,
+    ownerFenceSequence: 1,
+    disposition: 'unsupported_media', requiresIntervention: true,
+  }]);
+  assert.equal(queue.size(), 1);
+  console.log('  ✓ owner-device queue rejects non-owner/non-personal and quarantines media');
+}
+
+{
+  const queue = createOwnerMessageQueue({
+    directory: mkdtempSync(path.join(tmpdir(), 'hermes-owner-pages-')),
+    pageSize: 1,
+  });
+  const base = {
+    chatId: '15551234567@s.whatsapp.net', senderId: '15551234567@s.whatsapp.net',
+    fromOwner: true, type: 'text', timestamp: 1,
+  };
+  assert.equal(queue.add({ ...base, messageId: 'page-1', body: 'first' }), true);
+  assert.equal(queue.add({ ...base, messageId: 'page-2', body: 'second' }), true);
+  assert.equal(queue.add({ ...base, messageId: 'page-3', body: 'x'.repeat(25_000) }), true);
+  const firstPage = queue.page();
+  assert.equal(firstPage.messages[0].messageId, 'page-1');
+  assert.equal(firstPage.hasMore, true);
+  const secondPage = queue.page({ cursor: firstPage.nextCursor });
+  assert.equal(secondPage.messages[0].messageId, 'page-2');
+  const thirdPage = queue.page({ cursor: secondPage.nextCursor });
+  assert.equal(thirdPage.messages[0].messageId, 'page-3');
+  assert.equal(thirdPage.messages[0].body.length, 25_000);
+  assert.equal(thirdPage.hasMore, false);
+  console.log('  ✓ owner-device cursor reaches later and oversized text without ACKing earlier pages');
+}
 
 // -- outbound delivery/read receipts --------------------------------------
 {

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -127,6 +127,42 @@ import {
 }
 
 {
+  const malformedJsonDir = mkdtempSync(path.join(tmpdir(), 'hermes-owner-malformed-json-'));
+  writeFileSync(path.join(malformedJsonDir, 'owner-messages.json'), '{not-json');
+  assert.throws(
+    () => createOwnerMessageQueue({ directory: malformedJsonDir }),
+    SyntaxError,
+  );
+
+  const invalidSchemaDir = mkdtempSync(path.join(tmpdir(), 'hermes-owner-invalid-schema-'));
+  writeFileSync(path.join(invalidSchemaDir, 'owner-messages.json'), JSON.stringify({
+    nextSequence: 2,
+    entries: [{ sequence: 1, event: { messageId: 'owner-lost' } }],
+    lastSequenceByChat: {},
+    unresolvedLidFences: {},
+    tombstones: {},
+  }));
+  assert.throws(
+    () => createOwnerMessageQueue({ directory: invalidSchemaDir }),
+    /Invalid owner message queue state/,
+  );
+
+  const invalidNestedMapDir = mkdtempSync(path.join(tmpdir(), 'hermes-owner-invalid-map-'));
+  writeFileSync(path.join(invalidNestedMapDir, 'owner-messages.json'), JSON.stringify({
+    nextSequence: 1,
+    entries: [],
+    lastSequenceByChat: { '15551234567@s.whatsapp.net': '1' },
+    unresolvedLidFences: {},
+    tombstones: {},
+  }));
+  assert.throws(
+    () => createOwnerMessageQueue({ directory: invalidNestedMapDir }),
+    /Invalid owner message queue state/,
+  );
+  console.log('  ✓ readable corrupt owner queue state fails closed instead of resetting');
+}
+
+{
   const queueDir = mkdtempSync(path.join(tmpdir(), 'hermes-owner-tombstone-'));
   let currentTime = 1_723_636_800_000;
   const retentionMs = 30 * 24 * 60 * 60 * 1000;
@@ -389,7 +425,14 @@ import {
 }
 
 {
-  const receipts = createDeliveryReceiptQueue({ capacity: 2, pageSize: 1 });
+  let currentTime = 1_723_636_800_000;
+  const retentionMs = 30 * 24 * 60 * 60 * 1000;
+  const receipts = createDeliveryReceiptQueue({
+    capacity: 2,
+    pageSize: 1,
+    tombstoneRetentionMs: retentionMs,
+    now: () => currentTime,
+  });
   const delivered = {
     messageId: 'outbound-queue-1', status: 'delivered', occurredAt: '2026-08-14T12:00:00Z',
   };
@@ -407,9 +450,46 @@ import {
   assert.deepEqual(receipts.snapshot(), [read]);
   assert.equal(receipts.acknowledge([{ messageId: read.messageId, status: read.status }]), 1);
   assert.deepEqual(receipts.snapshot(), [other]);
-  assert.equal(receipts.add(delivered), true);
+  assert.equal(receipts.add(read), false);
+  assert.equal(receipts.add(delivered), false);
+
+  const monotonic = {
+    messageId: 'outbound-monotonic', status: 'delivered', occurredAt: '2026-08-14T12:02:30Z',
+  };
+  assert.equal(receipts.add(monotonic), true);
+  assert.equal(receipts.acknowledge([
+    { messageId: monotonic.messageId, status: monotonic.status },
+  ]), 1);
+  assert.equal(receipts.add({
+    ...monotonic, status: 'read', occurredAt: '2026-08-14T12:02:45Z',
+  }), true);
+
+  const unmatched = {
+    messageId: 'outbound-unmatched-ack', status: 'sent', occurredAt: '2026-08-14T12:03:00Z',
+  };
+  assert.equal(receipts.acknowledge([
+    { messageId: unmatched.messageId, status: unmatched.status },
+  ]), 0);
+  assert.equal(receipts.add(unmatched), true);
+
+  const outOfOrder = createDeliveryReceiptQueue({ capacity: 4, pageSize: 4 });
+  const lower = {
+    messageId: 'outbound-out-of-order', status: 'sent', occurredAt: '2026-08-14T12:03:10Z',
+  };
+  const higher = {
+    messageId: lower.messageId, status: 'read', occurredAt: '2026-08-14T12:03:20Z',
+  };
+  assert.equal(outOfOrder.add(lower), true);
+  assert.equal(outOfOrder.add(higher), true);
+  assert.equal(outOfOrder.acknowledge([
+    { messageId: higher.messageId, status: higher.status },
+  ]), 2);
+  assert.deepEqual(outOfOrder.snapshot(), []);
+
+  currentTime += retentionMs + 1;
+  assert.equal(receipts.add(read), true);
   assert.equal(receipts.size(), 2);
-  console.log('  ✓ receipt queue bounds, deduplicates, paginates, and acknowledges exact states');
+  console.log('  ✓ receipt ACK tombstones suppress replay/regression, expire by age, and ignore unmatched ACKs');
 }
 
 // -- inbound read receipts ------------------------------------------------

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -15,7 +15,10 @@ import { getAggregateVotesInPollMessage } from '@whiskeysockets/baileys';
 import {
   buildPollPayload,
   buildTextSendPayload,
+  acknowledgeDeliveryReceipts,
   createBoundedMessageStore,
+  deliveryReceiptFromMessageUpdate,
+  deliveryReceiptFromUserReceiptUpdate,
   appendMediaFailureNote,
   extractBridgeEvent,
   inboundReadReceiptKeys,
@@ -23,6 +26,80 @@ import {
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
+
+// -- outbound delivery/read receipts --------------------------------------
+{
+  const key = { id: 'outbound-1', remoteJid: '15551234567@s.whatsapp.net', fromMe: true };
+  const now = () => '2026-08-14T12:00:00.000Z';
+
+  assert.deepEqual(deliveryReceiptFromMessageUpdate({ key, update: { status: 2 }, now }), {
+    messageId: 'outbound-1',
+    status: 'sent',
+    occurredAt: '2026-08-14T12:00:00.000Z',
+  });
+  assert.equal(
+    deliveryReceiptFromMessageUpdate({ key, update: { status: 3 }, now }).status,
+    'delivered',
+  );
+  assert.equal(
+    deliveryReceiptFromMessageUpdate({ key, update: { status: 4 }, now }).status,
+    'read',
+  );
+  assert.equal(
+    deliveryReceiptFromMessageUpdate({ key, update: { status: 5 }, now }).status,
+    'read',
+  );
+  assert.equal(
+    deliveryReceiptFromMessageUpdate({ key: { ...key, fromMe: false }, update: { status: 4 }, now }),
+    null,
+  );
+  assert.equal(
+    deliveryReceiptFromMessageUpdate({ key: { ...key, id: '' }, update: { status: 4 }, now }),
+    null,
+  );
+  assert.equal(deliveryReceiptFromMessageUpdate({ key, update: { status: 1 }, now }), null);
+
+  assert.deepEqual(
+    deliveryReceiptFromUserReceiptUpdate({
+      key,
+      receipt: { receiptTimestamp: 1_723_636_800 },
+      now,
+    }),
+    {
+      messageId: 'outbound-1',
+      status: 'delivered',
+      occurredAt: '2024-08-14T12:00:00.000Z',
+    },
+  );
+  assert.equal(
+    deliveryReceiptFromUserReceiptUpdate({
+      key,
+      receipt: { receiptTimestamp: 1, readTimestamp: 1_723_636_900 },
+      now,
+    }).status,
+    'read',
+  );
+  assert.equal(
+    deliveryReceiptFromUserReceiptUpdate({ key, receipt: {}, now }),
+    null,
+  );
+  console.log('  ✓ outbound delivery receipts are normalized without recipient identifiers');
+}
+
+{
+  const queue = [
+    { messageId: 'outbound-1', status: 'delivered', occurredAt: '2026-08-14T12:00:00Z' },
+    { messageId: 'outbound-1', status: 'read', occurredAt: '2026-08-14T12:01:00Z' },
+  ];
+  const acknowledged = acknowledgeDeliveryReceipts(queue, [
+    { messageId: 'outbound-1', status: 'delivered' },
+  ]);
+  assert.equal(acknowledged, 1);
+  assert.deepEqual(queue, [
+    { messageId: 'outbound-1', status: 'read', occurredAt: '2026-08-14T12:01:00Z' },
+  ]);
+  console.log('  ✓ receipts remain queued until their exact status is acknowledged');
+}
 
 // -- inbound read receipts ------------------------------------------------
 {

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -54,6 +54,14 @@ import {
     null,
   );
   assert.equal(
+    deliveryReceiptFromMessageUpdate({
+      key: { ...key, remoteJid: '120363001234567890@g.us' },
+      update: { status: 4 },
+      now,
+    }),
+    null,
+  );
+  assert.equal(
     deliveryReceiptFromMessageUpdate({ key: { ...key, id: '' }, update: { status: 4 }, now }),
     null,
   );
@@ -81,6 +89,14 @@ import {
   );
   assert.equal(
     deliveryReceiptFromUserReceiptUpdate({ key, receipt: {}, now }),
+    null,
+  );
+  assert.equal(
+    deliveryReceiptFromUserReceiptUpdate({
+      key: { ...key, remoteJid: '120363001234567890@g.us' },
+      receipt: { readTimestamp: 1_723_636_900 },
+      now,
+    }),
     null,
   );
   console.log('  ✓ outbound delivery receipts are normalized without recipient identifiers');

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -16,6 +16,7 @@ import {
   buildPollPayload,
   buildTextSendPayload,
   acknowledgeDeliveryReceipts,
+  createDeliveryReceiptQueue,
   createBoundedMessageStore,
   deliveryReceiptFromMessageUpdate,
   deliveryReceiptFromUserReceiptUpdate,
@@ -115,6 +116,30 @@ import {
     { messageId: 'outbound-1', status: 'read', occurredAt: '2026-08-14T12:01:00Z' },
   ]);
   console.log('  ✓ receipts remain queued until their exact status is acknowledged');
+}
+
+{
+  const receipts = createDeliveryReceiptQueue({ capacity: 2, pageSize: 1 });
+  const delivered = {
+    messageId: 'outbound-queue-1', status: 'delivered', occurredAt: '2026-08-14T12:00:00Z',
+  };
+  const read = {
+    messageId: 'outbound-queue-1', status: 'read', occurredAt: '2026-08-14T12:01:00Z',
+  };
+  const other = {
+    messageId: 'outbound-queue-2', status: 'sent', occurredAt: '2026-08-14T12:02:00Z',
+  };
+  assert.equal(receipts.add(delivered), true);
+  assert.equal(receipts.add(delivered), false);
+  assert.equal(receipts.add(read), true);
+  assert.equal(receipts.add(other), true);
+  assert.equal(receipts.size(), 2);
+  assert.deepEqual(receipts.snapshot(), [read]);
+  assert.equal(receipts.acknowledge([{ messageId: read.messageId, status: read.status }]), 1);
+  assert.deepEqual(receipts.snapshot(), [other]);
+  assert.equal(receipts.add(delivered), true);
+  assert.equal(receipts.size(), 2);
+  console.log('  ✓ receipt queue bounds, deduplicates, paginates, and acknowledges exact states');
 }
 
 // -- inbound read receipts ------------------------------------------------

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -63,6 +63,22 @@ import {
     null,
   );
   assert.equal(
+    deliveryReceiptFromMessageUpdate({
+      key: { ...key, remoteJid: 'status@broadcast' },
+      update: { status: 4 },
+      now,
+    }),
+    null,
+  );
+  assert.equal(
+    deliveryReceiptFromUserReceiptUpdate({
+      key: { ...key, remoteJid: 'status@broadcast' },
+      receipt: { readTimestamp: 1_723_636_900 },
+      now,
+    }),
+    null,
+  );
+  assert.equal(
     deliveryReceiptFromMessageUpdate({ key: { ...key, id: '' }, update: { status: 4 }, now }),
     null,
   );

--- a/scripts/whatsapp-bridge/bridge.sendqueue.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.sendqueue.test.mjs
@@ -11,6 +11,7 @@
  */
 
 import { strict as assert } from 'node:assert';
+import { createSerializedSendQueue } from './bridge_helpers.js';
 
 // ------------------------------------------------------------------
 // 1.  Unit test for the queue primitives
@@ -21,17 +22,7 @@ import { strict as assert } from 'node:assert';
  * isolation without importing the full module (which would trigger
  * Baileys / express side effects).
  */
-function createSendQueue() {
-  let _sendQueue = Promise.resolve();
-
-  function enqueueSend(fn) {
-    const task = _sendQueue.then(() => fn(), () => fn());
-    _sendQueue = task.catch(() => {});
-    return task;
-  }
-
-  return { enqueueSend };
-}
+const createSendQueue = createSerializedSendQueue;
 
 // -- serial ordering -------------------------------------------------
 {
@@ -107,6 +98,109 @@ function createSendQueue() {
   assert.strictEqual(maxConcurrent, 1, 'never more than one in-flight');
   assert.strictEqual(concurrent, 0, 'all finished');
   console.log('  ✓ single-consumer concurrency');
+}
+
+// -- client timeout does not release queue occupancy -------------------
+{
+  const { enqueueSend } = createSendQueue();
+  let releaseProvider;
+  let secondProviderCalls = 0;
+  const first = enqueueSend(
+    () => new Promise(resolve => { releaseProvider = resolve; }),
+    { timeoutMs: 10, timeoutError: () => new Error('client timed out') },
+  );
+  const second = enqueueSend(async () => { secondProviderCalls += 1; return 'second'; });
+
+  await assert.rejects(first, /client timed out/);
+  await new Promise(resolve => setTimeout(resolve, 20));
+  assert.equal(secondProviderCalls, 0, 'timed-out provider still owns the queue');
+  releaseProvider('late provider result');
+  assert.equal(await second, 'second');
+  assert.equal(secondProviderCalls, 1);
+  console.log('  ✓ client timeout keeps queue occupied until provider settlement');
+}
+
+// -- preflight happens after dequeue, immediately before send ----------
+{
+  const { enqueueSend } = createSendQueue();
+  let releaseFirst;
+  let signalStarted;
+  const started = new Promise(resolve => { signalStarted = resolve; });
+  let fence = 0;
+  let providerCalls = 0;
+  const first = enqueueSend(() => {
+    signalStarted();
+    return new Promise(resolve => { releaseFirst = resolve; });
+  });
+  const second = enqueueSend(
+    async () => { providerCalls += 1; },
+    { beforeRun: () => {
+      if (fence > 0) throw new Error('fenced');
+    } },
+  );
+  await started;
+  fence = 1;
+  releaseFirst();
+  await first;
+  await assert.rejects(() => second, /fenced/);
+  assert.equal(providerCalls, 0);
+  console.log('  ✓ send preflight runs after dequeue and blocks provider call');
+}
+
+// -- queued requests expire before preflight/provider --------------------
+{
+  let currentTime = 100;
+  const { enqueueSend } = createSerializedSendQueue({ now: () => currentTime });
+  let releaseFirst;
+  let signalFirstStarted;
+  const firstStarted = new Promise(resolve => { signalFirstStarted = resolve; });
+  let preflightCalls = 0;
+  let providerCalls = 0;
+  const first = enqueueSend(() => {
+    signalFirstStarted();
+    return new Promise(resolve => { releaseFirst = resolve; });
+  });
+  const expired = enqueueSend(
+    async () => { providerCalls += 1; },
+    {
+      beforeRun: () => { preflightCalls += 1; },
+      queueDeadlineAt: 110,
+      queueError: () => Object.assign(new Error('queued request expired'), { code: 'SEND_QUEUE_EXPIRED' }),
+    },
+  );
+  await firstStarted;
+  currentTime = 111;
+  releaseFirst();
+  await first;
+  await assert.rejects(expired, error => error?.code === 'SEND_QUEUE_EXPIRED');
+  assert.equal(preflightCalls, 0);
+  assert.equal(providerCalls, 0);
+  console.log('  ✓ expired queued request never reaches preflight or provider');
+}
+
+// -- disconnected queued requests are abandoned before send -------------
+{
+  const { enqueueSend } = createSerializedSendQueue();
+  let releaseFirst;
+  let signalFirstStarted;
+  const firstStarted = new Promise(resolve => { signalFirstStarted = resolve; });
+  let disconnected = false;
+  let providerCalls = 0;
+  const first = enqueueSend(() => {
+    signalFirstStarted();
+    return new Promise(resolve => { releaseFirst = resolve; });
+  });
+  const abandoned = enqueueSend(
+    async () => { providerCalls += 1; },
+    { isAbandoned: () => disconnected },
+  );
+  await firstStarted;
+  disconnected = true;
+  releaseFirst();
+  await first;
+  await assert.rejects(abandoned, error => error?.code === 'SEND_QUEUE_ABANDONED');
+  assert.equal(providerCalls, 0);
+  console.log('  ✓ disconnected queued request never reaches provider');
 }
 
 console.log('\n✅ All send-queue tests passed.');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -18,6 +18,82 @@ export function normalizeWhatsAppId(value) {
   return String(value).replace(':', '@');
 }
 
+const DELIVERY_STATUS = new Map([
+  [2, 'sent'],
+  [3, 'delivered'],
+  [4, 'read'],
+  [5, 'read'],
+  ['SERVER_ACK', 'sent'],
+  ['DELIVERY_ACK', 'delivered'],
+  ['READ', 'read'],
+  ['PLAYED', 'read'],
+]);
+
+function validOutboundReceiptKey(key) {
+  return key?.fromMe === true
+    && typeof key.id === 'string'
+    && /^[A-Za-z0-9_-]{1,191}$/.test(key.id);
+}
+
+function timestampIso(value) {
+  if (value === null || value === undefined) return null;
+  const seconds = typeof value?.toNumber === 'function' ? value.toNumber() : Number(value);
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  try {
+    return new Date(seconds * 1000).toISOString();
+  } catch {
+    return null;
+  }
+}
+
+export function deliveryReceiptFromMessageUpdate({ key, update, now = () => new Date().toISOString() }) {
+  if (!validOutboundReceiptKey(key)) return null;
+  const rawStatus = update?.status;
+  const numericStatus = typeof rawStatus === 'string' && /^\d+$/.test(rawStatus)
+    ? Number(rawStatus)
+    : rawStatus;
+  const status = DELIVERY_STATUS.get(numericStatus);
+  if (!status) return null;
+  return { messageId: key.id, status, occurredAt: now() };
+}
+
+export function deliveryReceiptFromUserReceiptUpdate({
+  key,
+  receipt,
+  now = () => new Date().toISOString(),
+}) {
+  if (!validOutboundReceiptKey(key) || !receipt || typeof receipt !== 'object') return null;
+  const readAt = timestampIso(receipt.playedTimestamp) || timestampIso(receipt.readTimestamp);
+  if (readAt) return { messageId: key.id, status: 'read', occurredAt: readAt };
+  const deliveredAt = timestampIso(receipt.receiptTimestamp);
+  const hasDeliveredDevice = Array.isArray(receipt.deliveredDeviceJid)
+    && receipt.deliveredDeviceJid.length > 0;
+  if (deliveredAt || hasDeliveredDevice) {
+    return { messageId: key.id, status: 'delivered', occurredAt: deliveredAt || now() };
+  }
+  return null;
+}
+
+export function acknowledgeDeliveryReceipts(queue, acknowledgements) {
+  const keys = new Set();
+  for (const acknowledgement of acknowledgements || []) {
+    const messageId = acknowledgement?.messageId;
+    const status = acknowledgement?.status;
+    if (typeof messageId !== 'string' || !/^[A-Za-z0-9_-]{1,191}$/.test(messageId)) continue;
+    if (!['sent', 'delivered', 'read'].includes(status)) continue;
+    keys.add(`${messageId}:${status}`);
+  }
+  let removed = 0;
+  for (let index = queue.length - 1; index >= 0; index -= 1) {
+    const receipt = queue[index];
+    if (keys.has(`${receipt?.messageId}:${receipt?.status}`)) {
+      queue.splice(index, 1);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
 export function getMessageContent(msg) {
   const content = msg?.message || {};
   if (content.ephemeralMessage?.message) return content.ephemeralMessage.message;

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -32,7 +32,8 @@ const DELIVERY_STATUS = new Map([
 function validOutboundReceiptKey(key) {
   return key?.fromMe === true
     && typeof key.id === 'string'
-    && /^[A-Za-z0-9_-]{1,191}$/.test(key.id);
+    && /^[A-Za-z0-9_-]{1,191}$/.test(key.id)
+    && !(typeof key.remoteJid === 'string' && key.remoteJid.endsWith('@g.us'));
 }
 
 function timestampIso(value) {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -1,6 +1,10 @@
 import path from 'path';
-import { mkdirSync, writeFileSync } from 'fs';
-import { randomBytes } from 'crypto';
+import { closeSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync } from 'fs';
+import { createHash, randomBytes, timingSafeEqual } from 'crypto';
+import {
+  expandWhatsAppIdentifiers,
+  normalizeWhatsAppIdentifier,
+} from './allowlist.js';
 
 export const MIME_MAP = {
   jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',
@@ -132,6 +136,366 @@ export function createDeliveryReceiptQueue({ capacity = 1000, pageSize = 100 } =
     },
     size() {
       return queue.length;
+    },
+  };
+}
+
+export function ownerMessageTokenMatches(expectedSecret, authorizationHeader) {
+  if (typeof expectedSecret !== 'string' || expectedSecret.length < 1) return false;
+  if (typeof authorizationHeader !== 'string' || !authorizationHeader.startsWith('Bearer ')) {
+    return false;
+  }
+  const expected = createHash('sha256').update(expectedSecret, 'utf8').digest();
+  const supplied = createHash('sha256').update(authorizationHeader.slice(7), 'utf8').digest();
+  return timingSafeEqual(expected, supplied);
+}
+
+export function providerSendIntentStatus({
+  externalConsumer,
+  sendIntent,
+  expectedOwnerFenceSequence,
+  expectedSecret,
+  authorizationHeader,
+} = {}) {
+  if (!externalConsumer) return 'standard';
+  if (sendIntent === 'human') {
+    return ownerMessageTokenMatches(expectedSecret, authorizationHeader) ? 'human' : 'unauthorized';
+  }
+  if (sendIntent === 'automatic') {
+    return Number.isSafeInteger(expectedOwnerFenceSequence) && expectedOwnerFenceSequence >= 0
+      ? 'automatic' : 'invalid';
+  }
+  return 'invalid';
+}
+
+export function providerSendErrorResponse(error, messageIds = []) {
+  const ids = Array.isArray(messageIds) ? messageIds.filter(id => typeof id === 'string' && id) : [];
+  if (error?.code === 'OWNER_FENCED') {
+    return {
+      statusCode: 409,
+      body: {
+        error: error.message,
+        code: 'OWNER_FENCED',
+        retryable: false,
+        partial: ids.length > 0,
+        messageId: ids[ids.length - 1],
+        messageIds: ids,
+      },
+    };
+  }
+  if (error?.code === 'SEND_QUEUE_EXPIRED' || error?.code === 'SEND_QUEUE_ABANDONED') {
+    return {
+      statusCode: 503,
+      body: {
+        error: error.message,
+        code: error.code,
+        retryable: true,
+        partial: ids.length > 0,
+        messageId: ids[ids.length - 1],
+        messageIds: ids,
+      },
+    };
+  }
+  return {
+    statusCode: 500,
+    body: {
+      error: error?.message || 'Provider send failed',
+      partial: ids.length > 0,
+      messageId: ids[ids.length - 1],
+      messageIds: ids,
+    },
+  };
+}
+
+export function ownerMessageDeliveryMode(fromOwner, externalConsumer) {
+  return fromOwner && externalConsumer ? 'external' : 'inbound';
+}
+
+export function ownerSendFenceStatus(queue, chatId, expectedSequence) {
+  if (!queue || typeof queue.lastSequence !== 'function') return 'invalid';
+  if (!Number.isSafeInteger(expectedSequence) || expectedSequence < 0) return 'invalid';
+  if (typeof queue.hasUnresolvedFence === 'function' && queue.hasUnresolvedFence()) return 'fenced';
+  return queue.lastSequence(chatId) === expectedSequence ? 'allowed' : 'fenced';
+}
+
+export function createSerializedSendQueue({ now = Date.now } = {}) {
+  if (typeof now !== 'function') throw new TypeError('now must be a function');
+  let queue = Promise.resolve();
+  function enqueueSend(fn, {
+    beforeRun,
+    timeoutMs,
+    timeoutError = () => new Error('send timed out'),
+    queueDeadlineAt,
+    queueError = () => Object.assign(
+      new Error('send expired while waiting in the bridge queue'),
+      { code: 'SEND_QUEUE_EXPIRED' },
+    ),
+    isAbandoned,
+  } = {}) {
+    let signalStart;
+    const started = new Promise(resolve => { signalStart = resolve; });
+    const run = async () => {
+      try {
+        if (typeof isAbandoned === 'function' && isAbandoned()) {
+          throw Object.assign(
+            new Error('request disconnected while waiting in the bridge queue'),
+            { code: 'SEND_QUEUE_ABANDONED' },
+          );
+        }
+        if (Number.isFinite(queueDeadlineAt) && now() >= queueDeadlineAt) throw queueError();
+        if (beforeRun) await beforeRun();
+        const providerPromise = Promise.resolve().then(fn);
+        signalStart({ providerPromise });
+        return await providerPromise;
+      } catch (error) {
+        signalStart({ error });
+        throw error;
+      }
+    };
+    const occupancy = queue.then(run, run);
+    queue = occupancy.catch(() => {});
+    if (!Number.isFinite(timeoutMs) || timeoutMs < 0) return occupancy;
+    return started.then(({ providerPromise, error }) => {
+      if (error) throw error;
+      let timer;
+      const timeoutPromise = new Promise((_, reject) => {
+        timer = setTimeout(() => reject(timeoutError()), timeoutMs);
+      });
+      return Promise.race([providerPromise, timeoutPromise]).finally(() => clearTimeout(timer));
+    });
+  }
+  return { enqueueSend };
+}
+
+export function createOwnerMessageQueue({
+  directory,
+  pageSize = 100,
+  tombstoneRetentionMs = 30 * 24 * 60 * 60 * 1000,
+  now = Date.now,
+} = {}) {
+  if (typeof directory !== 'string' || !directory) {
+    throw new TypeError('directory is required for durable owner messages');
+  }
+  if (!Number.isInteger(pageSize) || pageSize < 1) throw new RangeError('pageSize must be positive');
+  if (!Number.isFinite(tombstoneRetentionMs) || tombstoneRetentionMs < 30 * 24 * 60 * 60 * 1000) {
+    throw new RangeError('tombstoneRetentionMs must cover at least 30 days');
+  }
+  if (typeof now !== 'function') throw new TypeError('now must be a function');
+  mkdirSync(directory, { recursive: true });
+  const statePath = path.join(directory, 'owner-messages.json');
+  let state = {
+    nextSequence: 1,
+    entries: [],
+    lastSequenceByChat: {},
+    unresolvedLidFences: {},
+    tombstones: {},
+  };
+  try {
+    const parsed = JSON.parse(readFileSync(statePath, 'utf8'));
+    if (Number.isSafeInteger(parsed?.nextSequence) && Array.isArray(parsed?.entries)) {
+      state = {
+        nextSequence: parsed.nextSequence,
+        entries: parsed.entries,
+        lastSequenceByChat: parsed.lastSequenceByChat && typeof parsed.lastSequenceByChat === 'object'
+          ? parsed.lastSequenceByChat : {},
+        unresolvedLidFences:
+          parsed.unresolvedLidFences && typeof parsed.unresolvedLidFences === 'object'
+            ? parsed.unresolvedLidFences : {},
+        tombstones: parsed.tombstones && typeof parsed.tombstones === 'object'
+          ? parsed.tombstones : {},
+      };
+      for (const entry of state.entries) {
+        const chat = entry?.event?.chatId;
+        if (typeof chat === 'string' && Number.isSafeInteger(entry?.sequence)) {
+          state.lastSequenceByChat[chat] = Math.max(
+            Number(state.lastSequenceByChat[chat] || 0), entry.sequence,
+          );
+        }
+      }
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  const queuedIds = state.entries.map(entry => entry?.event?.messageId).filter(Boolean);
+  const seen = new Set([...queuedIds, ...Object.keys(state.tombstones)]);
+
+  function persist() {
+    const temporaryPath = `${statePath}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`;
+    const descriptor = openSync(temporaryPath, 'w', 0o600);
+    try {
+      writeFileSync(descriptor, `${JSON.stringify(state)}\n`, { encoding: 'utf8' });
+      fsyncSync(descriptor);
+    } finally {
+      closeSync(descriptor);
+    }
+    renameSync(temporaryPath, statePath);
+    let directoryDescriptor;
+    try {
+      directoryDescriptor = openSync(directory, 'r');
+      fsyncSync(directoryDescriptor);
+    } finally {
+      if (directoryDescriptor !== undefined) closeSync(directoryDescriptor);
+    }
+  }
+
+  function pruneExpiredTombstones(referenceTime = now()) {
+    const cutoff = referenceTime - tombstoneRetentionMs;
+    let changed = false;
+    for (const [messageId, tombstone] of Object.entries(state.tombstones)) {
+      if (!Number.isFinite(tombstone?.acknowledgedAt) || tombstone.acknowledgedAt <= cutoff) {
+        delete state.tombstones[messageId];
+        seen.delete(messageId);
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  if (pruneExpiredTombstones()) persist();
+
+  function mappedIdentifiers(chatId) {
+    const identifier = normalizeWhatsAppIdentifier(chatId);
+    if (!identifier) return [];
+    return [...expandWhatsAppIdentifiers(identifier, directory)]
+      .filter(alias => alias !== identifier);
+  }
+
+  function reconcileUnresolvedLidFences() {
+    let changed = false;
+    for (const [lidChatId, sequence] of Object.entries(state.unresolvedLidFences)) {
+      const aliases = mappedIdentifiers(lidChatId);
+      if (aliases.length === 0) continue;
+      state.lastSequenceByChat[lidChatId] = Math.max(
+        Number(state.lastSequenceByChat[lidChatId] || 0), sequence,
+      );
+      for (const alias of aliases) {
+        const aliasChatId = `${alias}@s.whatsapp.net`;
+        state.lastSequenceByChat[aliasChatId] = Math.max(
+          Number(state.lastSequenceByChat[aliasChatId] || 0), sequence,
+        );
+      }
+      delete state.unresolvedLidFences[lidChatId];
+      changed = true;
+    }
+    // Persist exact alias keys and remove the conservative fence in the same
+    // atomic replacement before any automatic send is released.
+    if (changed) persist();
+  }
+
+  return {
+    add(event) {
+      const messageId = event?.messageId;
+      const chatId = event?.chatId;
+      const messageType = event?.type || (event?.hasMedia ? event?.mediaType : 'text');
+      const timestamp = typeof event?.timestamp === 'number'
+        ? event.timestamp
+        : Number(event?.timestamp?.toString?.());
+      if (event?.fromOwner !== true) return false;
+      if (typeof messageId !== 'string' || !/^[A-Za-z0-9_-]{1,191}$/.test(messageId)) return false;
+      if (typeof chatId !== 'string' || !/^\d{7,20}@(s\.whatsapp\.net|lid)$/.test(chatId)) return false;
+      if (typeof event.senderId !== 'string' || !event.senderId) return false;
+      if (typeof event.body !== 'string') return false;
+      if (!Number.isFinite(timestamp) || timestamp <= 0) return false;
+      const prunedTombstones = pruneExpiredTombstones();
+      if (seen.has(messageId)) {
+        if (prunedTombstones) persist();
+        return false;
+      }
+      const queuedEvent = {
+        messageId,
+        chatId,
+        senderId: event.senderId,
+        fromOwner: true,
+        type: messageType,
+        body: event.body,
+        timestamp,
+        ownerFenceSequence: state.nextSequence,
+      };
+      if (messageType !== 'text') {
+        queuedEvent.disposition = 'unsupported_media';
+        queuedEvent.requiresIntervention = true;
+      }
+      seen.add(messageId);
+      state.entries.push({ sequence: state.nextSequence, event: queuedEvent });
+      state.lastSequenceByChat[chatId] = state.nextSequence;
+      if (chatId.endsWith('@lid') && mappedIdentifiers(chatId).length === 0) {
+        state.unresolvedLidFences[chatId] = state.nextSequence;
+      }
+      state.nextSequence += 1;
+      persist();
+      return true;
+    },
+    snapshot() {
+      return state.entries.slice(0, pageSize).map(entry => entry.event);
+    },
+    page({ cursor = '0', limit = pageSize } = {}) {
+      const afterSequence = Number(cursor || 0);
+      const boundedLimit = Number.isInteger(limit) && limit > 0 ? Math.min(limit, pageSize) : pageSize;
+      const available = state.entries.filter(entry => entry.sequence > afterSequence);
+      const selected = available.slice(0, boundedLimit);
+      return {
+        messages: selected.map(entry => entry.event),
+        nextCursor: selected.length ? String(selected[selected.length - 1].sequence) : String(afterSequence),
+        hasMore: available.length > selected.length,
+      };
+    },
+    acknowledge(acknowledgements) {
+      const ids = new Set();
+      for (const acknowledgement of acknowledgements || []) {
+        const messageId = acknowledgement?.messageId;
+        if (typeof messageId === 'string' && /^[A-Za-z0-9_-]{1,191}$/.test(messageId)) {
+          ids.add(messageId);
+        }
+      }
+      let removed = 0;
+      const retained = [];
+      const acknowledgedAt = now();
+      for (const entry of state.entries) {
+        if (ids.has(entry?.event?.messageId)) {
+          state.tombstones[entry.event.messageId] = {
+            sequence: entry.sequence,
+            acknowledgedAt,
+          };
+          removed += 1;
+        } else retained.push(entry);
+      }
+      if (removed) {
+        state.entries = retained;
+        persist();
+      }
+      return removed;
+    },
+    size() {
+      return state.entries.length;
+    },
+    lastSequence(chatId) {
+      reconcileUnresolvedLidFences();
+      const exactChatId = String(chatId);
+      const requestedIdentifier = normalizeWhatsAppIdentifier(exactChatId);
+      let maximum = Number(state.lastSequenceByChat[exactChatId] || 0);
+      if (!requestedIdentifier) return maximum;
+
+      const aliases = expandWhatsAppIdentifiers(requestedIdentifier, directory);
+      for (const [persistedChatId, sequence] of Object.entries(state.lastSequenceByChat)) {
+        if (persistedChatId === exactChatId || !Number.isSafeInteger(sequence)) continue;
+        const persistedIdentifier = normalizeWhatsAppIdentifier(persistedChatId);
+        // The exact JID is always eligible. A different JID is eligible only
+        // when an exact persisted session mapping reaches a different local
+        // identifier; never infer that equal local parts across JID types are
+        // aliases.
+        if (
+          persistedIdentifier
+          && persistedIdentifier !== requestedIdentifier
+          && aliases.has(persistedIdentifier)
+        ) {
+          maximum = Math.max(maximum, sequence);
+        }
+      }
+      return maximum;
+    },
+    hasUnresolvedFence() {
+      reconcileUnresolvedLidFences();
+      return Object.keys(state.unresolvedLidFences).length > 0;
     },
   };
 }

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -100,22 +100,61 @@ export function acknowledgeDeliveryReceipts(queue, acknowledgements) {
   return removed;
 }
 
-export function createDeliveryReceiptQueue({ capacity = 1000, pageSize = 100 } = {}) {
+const DELIVERY_STATUS_RANK = new Map([
+  ['sent', 1],
+  ['delivered', 2],
+  ['read', 3],
+]);
+
+export function createDeliveryReceiptQueue({
+  capacity = 1000,
+  pageSize = 100,
+  tombstoneRetentionMs = 30 * 24 * 60 * 60 * 1000,
+  now = Date.now,
+} = {}) {
   if (!Number.isInteger(capacity) || capacity < 1) throw new RangeError('capacity must be positive');
   if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > capacity) {
     throw new RangeError('pageSize must be within capacity');
   }
+  if (!Number.isFinite(tombstoneRetentionMs) || tombstoneRetentionMs <= 0) {
+    throw new RangeError('tombstoneRetentionMs must be positive');
+  }
+  if (typeof now !== 'function') throw new TypeError('now must be a function');
   const queue = [];
   const seen = new Set();
+  const tombstones = new Map();
+
+  function pruneExpiredTombstones(referenceTime = now()) {
+    const cutoff = referenceTime - tombstoneRetentionMs;
+    for (const [messageId, tombstone] of tombstones) {
+      if (!Number.isFinite(tombstone?.acknowledgedAt) || tombstone.acknowledgedAt <= cutoff) {
+        tombstones.delete(messageId);
+      }
+    }
+  }
+
+  function highestKnownRank(messageId) {
+    let rank = 0;
+    for (const receipt of queue) {
+      if (receipt.messageId === messageId) {
+        rank = Math.max(rank, DELIVERY_STATUS_RANK.get(receipt.status));
+      }
+    }
+    rank = Math.max(rank, tombstones.get(messageId)?.rank || 0);
+    return rank;
+  }
+
   return {
     add(receipt) {
       const messageId = receipt?.messageId;
       const status = receipt?.status;
       if (typeof messageId !== 'string' || !/^[A-Za-z0-9_-]{1,191}$/.test(messageId)) return false;
-      if (!['sent', 'delivered', 'read'].includes(status)) return false;
+      if (!DELIVERY_STATUS_RANK.has(status)) return false;
       if (typeof receipt.occurredAt !== 'string' || !receipt.occurredAt) return false;
+      pruneExpiredTombstones();
       const key = `${messageId}:${status}`;
       if (seen.has(key)) return false;
+      if (highestKnownRank(messageId) >= DELIVERY_STATUS_RANK.get(status)) return false;
       seen.add(key);
       queue.push(receipt);
       if (queue.length > capacity) {
@@ -128,11 +167,41 @@ export function createDeliveryReceiptQueue({ capacity = 1000, pageSize = 100 } =
       return queue.slice(0, pageSize);
     },
     acknowledge(acknowledgements) {
-      const removed = acknowledgeDeliveryReceipts(queue, acknowledgements);
+      const acknowledgedKeys = new Set();
       for (const acknowledgement of acknowledgements || []) {
-        seen.delete(`${acknowledgement?.messageId}:${acknowledgement?.status}`);
+        const messageId = acknowledgement?.messageId;
+        const status = acknowledgement?.status;
+        if (typeof messageId === 'string' && DELIVERY_STATUS_RANK.has(status)) {
+          const key = `${messageId}:${status}`;
+          if (seen.has(key)) acknowledgedKeys.add(key);
+        }
       }
-      return removed;
+      const removedExact = acknowledgeDeliveryReceipts(queue, acknowledgements);
+      const removedKeys = new Set(acknowledgedKeys);
+      if (removedExact) {
+        const acknowledgedRanks = new Map();
+        for (const key of acknowledgedKeys) {
+          const separator = key.lastIndexOf(':');
+          const messageId = key.slice(0, separator);
+          const rank = DELIVERY_STATUS_RANK.get(key.slice(separator + 1));
+          acknowledgedRanks.set(messageId, Math.max(acknowledgedRanks.get(messageId) || 0, rank));
+        }
+        for (let index = queue.length - 1; index >= 0; index -= 1) {
+          const receipt = queue[index];
+          const acknowledgedRank = acknowledgedRanks.get(receipt.messageId) || 0;
+          if (DELIVERY_STATUS_RANK.get(receipt.status) <= acknowledgedRank) {
+            queue.splice(index, 1);
+            removedKeys.add(`${receipt.messageId}:${receipt.status}`);
+          }
+        }
+        const acknowledgedAt = now();
+        for (const key of removedKeys) seen.delete(key);
+        for (const [messageId, rank] of acknowledgedRanks) {
+          const previousRank = tombstones.get(messageId)?.rank || 0;
+          tombstones.set(messageId, { rank: Math.max(previousRank, rank), acknowledgedAt });
+        }
+      }
+      return removedKeys.size;
     },
     size() {
       return queue.length;
@@ -267,6 +336,72 @@ export function createSerializedSendQueue({ now = Date.now } = {}) {
   return { enqueueSend };
 }
 
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function validSequenceMap(value, keyPattern) {
+  return isPlainObject(value) && Object.entries(value).every(([key, sequence]) => (
+    keyPattern.test(key) && Number.isSafeInteger(sequence) && sequence > 0
+  ));
+}
+
+function validateOwnerMessageState(parsed) {
+  const invalid = () => { throw new Error('Invalid owner message queue state'); };
+  if (!isPlainObject(parsed) || !Number.isSafeInteger(parsed.nextSequence)
+    || parsed.nextSequence < 1 || !Array.isArray(parsed.entries)) invalid();
+
+  const lastSequenceByChat = parsed.lastSequenceByChat ?? {};
+  const unresolvedLidFences = parsed.unresolvedLidFences ?? {};
+  const tombstones = parsed.tombstones ?? {};
+  if (!validSequenceMap(lastSequenceByChat, /^\d{7,20}@(s\.whatsapp\.net|lid)$/)
+    || !validSequenceMap(unresolvedLidFences, /^\d{7,20}@lid$/)
+    || !isPlainObject(tombstones)) invalid();
+
+  const messageIds = new Set();
+  const sequences = new Set();
+  let maximumSequence = 0;
+  for (const entry of parsed.entries) {
+    const event = entry?.event;
+    const valid = isPlainObject(entry)
+      && Number.isSafeInteger(entry.sequence) && entry.sequence > 0
+      && isPlainObject(event)
+      && typeof event.messageId === 'string' && /^[A-Za-z0-9_-]{1,191}$/.test(event.messageId)
+      && typeof event.chatId === 'string' && /^\d{7,20}@(s\.whatsapp\.net|lid)$/.test(event.chatId)
+      && typeof event.senderId === 'string' && event.senderId.length > 0
+      && event.fromOwner === true
+      && typeof event.type === 'string' && event.type.length > 0
+      && typeof event.body === 'string'
+      && Number.isFinite(event.timestamp) && event.timestamp > 0
+      && event.ownerFenceSequence === entry.sequence
+      && !messageIds.has(event.messageId)
+      && !sequences.has(entry.sequence);
+    if (!valid) invalid();
+    messageIds.add(event.messageId);
+    sequences.add(entry.sequence);
+    maximumSequence = Math.max(maximumSequence, entry.sequence);
+  }
+  for (const [messageId, tombstone] of Object.entries(tombstones)) {
+    const valid = /^[A-Za-z0-9_-]{1,191}$/.test(messageId)
+      && !messageIds.has(messageId)
+      && isPlainObject(tombstone)
+      && Number.isSafeInteger(tombstone.sequence) && tombstone.sequence > 0
+      && Number.isFinite(tombstone.acknowledgedAt) && tombstone.acknowledgedAt > 0;
+    if (!valid) invalid();
+    messageIds.add(messageId);
+    maximumSequence = Math.max(maximumSequence, tombstone.sequence);
+  }
+  for (const sequence of Object.values(lastSequenceByChat)) {
+    maximumSequence = Math.max(maximumSequence, sequence);
+  }
+  for (const sequence of Object.values(unresolvedLidFences)) {
+    maximumSequence = Math.max(maximumSequence, sequence);
+  }
+  if (parsed.nextSequence <= maximumSequence) invalid();
+
+  return { ...parsed, lastSequenceByChat, unresolvedLidFences, tombstones };
+}
+
 export function createOwnerMessageQueue({
   directory,
   pageSize = 100,
@@ -292,26 +427,12 @@ export function createOwnerMessageQueue({
   };
   try {
     const parsed = JSON.parse(readFileSync(statePath, 'utf8'));
-    if (Number.isSafeInteger(parsed?.nextSequence) && Array.isArray(parsed?.entries)) {
-      state = {
-        nextSequence: parsed.nextSequence,
-        entries: parsed.entries,
-        lastSequenceByChat: parsed.lastSequenceByChat && typeof parsed.lastSequenceByChat === 'object'
-          ? parsed.lastSequenceByChat : {},
-        unresolvedLidFences:
-          parsed.unresolvedLidFences && typeof parsed.unresolvedLidFences === 'object'
-            ? parsed.unresolvedLidFences : {},
-        tombstones: parsed.tombstones && typeof parsed.tombstones === 'object'
-          ? parsed.tombstones : {},
-      };
-      for (const entry of state.entries) {
-        const chat = entry?.event?.chatId;
-        if (typeof chat === 'string' && Number.isSafeInteger(entry?.sequence)) {
-          state.lastSequenceByChat[chat] = Math.max(
-            Number(state.lastSequenceByChat[chat] || 0), entry.sequence,
-          );
-        }
-      }
+    state = validateOwnerMessageState(parsed);
+    for (const entry of state.entries) {
+      const chat = entry.event.chatId;
+      state.lastSequenceByChat[chat] = Math.max(
+        Number(state.lastSequenceByChat[chat] || 0), entry.sequence,
+      );
     }
   } catch (error) {
     if (error?.code !== 'ENOENT') throw error;

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -33,7 +33,8 @@ function validOutboundReceiptKey(key) {
   return key?.fromMe === true
     && typeof key.id === 'string'
     && /^[A-Za-z0-9_-]{1,191}$/.test(key.id)
-    && !(typeof key.remoteJid === 'string' && key.remoteJid.endsWith('@g.us'));
+    && !(typeof key.remoteJid === 'string'
+      && (key.remoteJid.endsWith('@g.us') || key.remoteJid.endsWith('@broadcast')));
 }
 
 function timestampIso(value) {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -95,6 +95,46 @@ export function acknowledgeDeliveryReceipts(queue, acknowledgements) {
   return removed;
 }
 
+export function createDeliveryReceiptQueue({ capacity = 1000, pageSize = 100 } = {}) {
+  if (!Number.isInteger(capacity) || capacity < 1) throw new RangeError('capacity must be positive');
+  if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > capacity) {
+    throw new RangeError('pageSize must be within capacity');
+  }
+  const queue = [];
+  const seen = new Set();
+  return {
+    add(receipt) {
+      const messageId = receipt?.messageId;
+      const status = receipt?.status;
+      if (typeof messageId !== 'string' || !/^[A-Za-z0-9_-]{1,191}$/.test(messageId)) return false;
+      if (!['sent', 'delivered', 'read'].includes(status)) return false;
+      if (typeof receipt.occurredAt !== 'string' || !receipt.occurredAt) return false;
+      const key = `${messageId}:${status}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      queue.push(receipt);
+      if (queue.length > capacity) {
+        const evicted = queue.shift();
+        seen.delete(`${evicted.messageId}:${evicted.status}`);
+      }
+      return true;
+    },
+    snapshot() {
+      return queue.slice(0, pageSize);
+    },
+    acknowledge(acknowledgements) {
+      const removed = acknowledgeDeliveryReceipts(queue, acknowledgements);
+      for (const acknowledgement of acknowledgements || []) {
+        seen.delete(`${acknowledgement?.messageId}:${acknowledgement?.status}`);
+      }
+      return removed;
+    },
+    size() {
+      return queue.length;
+    },
+  };
+}
+
 export function getMessageContent(msg) {
   const content = msg?.message || {};
   if (content.ephemeralMessage?.message) return content.ephemeralMessage.message;

--- a/scripts/whatsapp-bridge/outbound_ids.js
+++ b/scripts/whatsapp-bridge/outbound_ids.js
@@ -1,3 +1,9 @@
+import path from 'node:path';
+import {
+  closeSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync,
+} from 'node:fs';
+import { randomBytes } from 'node:crypto';
+
 /**
  * Bounded FIFO set of outbound message IDs.
  *
@@ -42,4 +48,144 @@ export function createOutboundIdTracker(maxSize = 512) {
   }
 
   return { remember, has, size };
+}
+
+export function createDurableOutboundIdTracker({
+  directory,
+  maxSize = 10000,
+  retentionMs = 30 * 24 * 60 * 60 * 1000,
+  now = Date.now,
+} = {}) {
+  if (typeof directory !== 'string' || !directory) {
+    throw new TypeError('directory is required for durable outbound provenance');
+  }
+  if (!Number.isInteger(maxSize) || maxSize < 1) {
+    throw new RangeError('maxSize must be a positive integer');
+  }
+  if (!Number.isFinite(retentionMs) || retentionMs < 1) {
+    throw new RangeError('retentionMs must be positive');
+  }
+  if (typeof now !== 'function') throw new TypeError('now must be a function');
+  mkdirSync(directory, { recursive: true });
+  const statePath = path.join(directory, 'connector-outbound-ids.json');
+  const ids = new Map();
+  let journalEntries = 0;
+  let needsMigration = false;
+
+  function syncDirectory() {
+    let descriptor;
+    try {
+      descriptor = openSync(directory, 'r');
+      fsyncSync(descriptor);
+    } finally {
+      if (descriptor !== undefined) closeSync(descriptor);
+    }
+  }
+
+  function compact() {
+    const temporaryPath = `${statePath}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`;
+    const descriptor = openSync(temporaryPath, 'w', 0o600);
+    try {
+      for (const [id, rememberedAt] of ids) {
+        writeFileSync(descriptor, `${JSON.stringify({ id, rememberedAt })}\n`, { encoding: 'utf8' });
+      }
+      fsyncSync(descriptor);
+    } finally {
+      closeSync(descriptor);
+    }
+    renameSync(temporaryPath, statePath);
+    syncDirectory();
+    journalEntries = ids.size;
+  }
+
+  function append(id, rememberedAt) {
+    const descriptor = openSync(statePath, 'a', 0o600);
+    try {
+      writeFileSync(descriptor, `${JSON.stringify({ id, rememberedAt })}\n`, { encoding: 'utf8' });
+      fsyncSync(descriptor);
+    } finally {
+      closeSync(descriptor);
+    }
+    syncDirectory();
+    journalEntries += 1;
+  }
+
+  function pruneExpired(referenceTime) {
+    const cutoff = referenceTime - retentionMs;
+    let removed = false;
+    for (const [id, rememberedAt] of ids) {
+      if (rememberedAt <= cutoff) {
+        ids.delete(id);
+        removed = true;
+      }
+    }
+    return removed;
+  }
+
+  try {
+    const raw = readFileSync(statePath, 'utf8');
+    try {
+      const legacy = JSON.parse(raw);
+      if (Array.isArray(legacy?.ids)) {
+        for (const id of legacy.ids) {
+          if (typeof id === 'string' && id) ids.set(id, now());
+        }
+        needsMigration = true;
+      } else if (typeof legacy?.id === 'string' && Number.isFinite(legacy.rememberedAt)) {
+        ids.set(legacy.id, legacy.rememberedAt);
+        journalEntries = 1;
+      }
+    } catch {
+      const lines = raw.split('\n');
+      for (let index = 0; index < lines.length; index += 1) {
+        const line = lines[index];
+        if (!line) continue;
+        let entry;
+        try {
+          entry = JSON.parse(line);
+        } catch (error) {
+          const isIncompleteTail = index === lines.length - 1 && !raw.endsWith('\n');
+          if (!isIncompleteTail) throw error;
+          needsMigration = true;
+          break;
+        }
+        if (typeof entry?.id === 'string' && entry.id && Number.isFinite(entry.rememberedAt)) {
+          ids.set(entry.id, entry.rememberedAt);
+          journalEntries += 1;
+        }
+      }
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  const removedAtStartup = pruneExpired(now());
+  if (needsMigration || removedAtStartup) compact();
+
+  return {
+    remember(id) {
+      if (typeof id !== 'string' || !id || ids.has(id)) return;
+      const rememberedAt = now();
+      const removed = pruneExpired(rememberedAt);
+      ids.set(id, rememberedAt);
+      append(id, rememberedAt);
+      if (removed || (journalEntries > maxSize * 2 && journalEntries > ids.size * 2)) compact();
+    },
+    has(id) {
+      if (typeof id !== 'string') return false;
+      pruneExpired(now());
+      return ids.has(id);
+    },
+    size() {
+      pruneExpired(now());
+      return ids.size;
+    },
+  };
+}
+
+export async function sendWithProvenance({ tracker, messageId, send }) {
+  if (!tracker || typeof tracker.remember !== 'function') throw new TypeError('tracker is required');
+  if (typeof messageId !== 'string' || !messageId) throw new TypeError('messageId is required');
+  if (typeof send !== 'function') throw new TypeError('send is required');
+  tracker.remember(messageId);
+  return send(messageId);
 }

--- a/scripts/whatsapp-bridge/outbound_ids.test.mjs
+++ b/scripts/whatsapp-bridge/outbound_ids.test.mjs
@@ -1,7 +1,67 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { appendFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
-import { createOutboundIdTracker } from './outbound_ids.js';
+import {
+  createDurableOutboundIdTracker,
+  createOutboundIdTracker,
+  sendWithProvenance,
+} from './outbound_ids.js';
+
+test('durable outbound ids survive a bridge restart', () => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'hermes-outbound-'));
+  const tracker = createDurableOutboundIdTracker({ directory });
+  tracker.remember('connector-1');
+
+  assert.equal(createDurableOutboundIdTracker({ directory }).has('connector-1'), true);
+});
+
+test('durable tracker never evicts ids that are still inside the replay window', () => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'hermes-outbound-window-'));
+  const tracker = createDurableOutboundIdTracker({
+    directory,
+    maxSize: 2,
+    retentionMs: 60_000,
+    now: () => 1_000,
+  });
+  tracker.remember('connector-a');
+  tracker.remember('connector-b');
+  tracker.remember('connector-c');
+
+  assert.equal(tracker.has('connector-a'), true);
+  assert.equal(tracker.size(), 3);
+});
+
+test('durable tracker repairs an incomplete final journal record after crash', () => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'hermes-outbound-tail-'));
+  const tracker = createDurableOutboundIdTracker({ directory });
+  tracker.remember('connector-valid');
+  appendFileSync(path.join(directory, 'connector-outbound-ids.json'), '{"id":"partial');
+
+  const reopened = createDurableOutboundIdTracker({ directory });
+  assert.equal(reopened.has('connector-valid'), true);
+  reopened.remember('connector-after-repair');
+  assert.equal(createDurableOutboundIdTracker({ directory }).has('connector-after-repair'), true);
+});
+
+test('send provenance is durable before the connector send starts and remains after failure', async () => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'hermes-outbound-race-'));
+  const tracker = createDurableOutboundIdTracker({ directory });
+  await assert.rejects(
+    sendWithProvenance({
+      tracker,
+      messageId: 'reserved-1',
+      send: async () => {
+        assert.equal(createDurableOutboundIdTracker({ directory }).has('reserved-1'), true);
+        throw new Error('simulated send failure');
+      },
+    }),
+    /simulated send failure/,
+  );
+  assert.equal(createDurableOutboundIdTracker({ directory }).has('reserved-1'), true);
+});
 
 test('remembers and recognises an outbound id', () => {
   const tracker = createOutboundIdTracker();

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -172,12 +172,14 @@ class TestSendChunking:
         adapter = _make_adapter()
         adapter._owner_messages_external_consumer = True
         resp = MagicMock(status=400)
-        resp.json = AsyncMock(return_value={"error": "expectedOwnerFenceSequence required"})
+        resp.text = AsyncMock(return_value="expectedOwnerFenceSequence required")
         adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
 
         result = await adapter.send("chat1", "unfenced automatic reply")
 
         assert not result.success
+        assert result.error == "expectedOwnerFenceSequence required"
+        resp.text.assert_awaited_once_with()
         payload = adapter._http_session.post.call_args.kwargs["json"]
         assert payload["sendIntent"] == "automatic"
         assert "expectedOwnerFenceSequence" not in payload

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -149,6 +149,55 @@ class TestSendChunking:
         assert adapter._http_session.post.call_count == 1
 
     @pytest.mark.asyncio
+    async def test_external_consumer_send_carries_automatic_owner_fence(self):
+        adapter = _make_adapter()
+        adapter._owner_messages_external_consumer = True
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.send(
+            "chat1",
+            "automatic reply",
+            metadata={"whatsapp_owner_fence_sequence": 7},
+        )
+
+        assert result.success
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["sendIntent"] == "automatic"
+        assert payload["expectedOwnerFenceSequence"] == 7
+
+    @pytest.mark.asyncio
+    async def test_external_consumer_send_without_explicit_fence_fails_closed(self):
+        adapter = _make_adapter()
+        adapter._owner_messages_external_consumer = True
+        resp = MagicMock(status=400)
+        resp.json = AsyncMock(return_value={"error": "expectedOwnerFenceSequence required"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.send("chat1", "unfenced automatic reply")
+
+        assert not result.success
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["sendIntent"] == "automatic"
+        assert "expectedOwnerFenceSequence" not in payload
+
+    @pytest.mark.asyncio
+    async def test_standard_owner_forwarding_send_omits_intent_fields(self):
+        adapter = _make_adapter()
+        adapter._forward_owner_messages = True
+        adapter._owner_messages_external_consumer = False
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        await adapter.send("chat1", "ordinary reply")
+
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert "sendIntent" not in payload
+        assert "expectedOwnerFenceSequence" not in payload
+
+    @pytest.mark.asyncio
     async def test_long_message_chunked(self):
         adapter = _make_adapter()
         resp = MagicMock(status=200)

--- a/tests/gateway/test_whatsapp_from_owner.py
+++ b/tests/gateway/test_whatsapp_from_owner.py
@@ -2,23 +2,27 @@
 
 The Node bridge sets ``fromOwner: true`` on inbound `fromMe` messages that
 look owner-typed (linked-device send, not echoed from /send) when the
-operator opts into ``WHATSAPP_FORWARD_OWNER_MESSAGES``.  These tests pin
+operator opts into ``forward_owner_messages`` (projected internally to the
+bridge environment). These tests pin
 the adapter's responsibility: lift that flag onto
 ``MessageEvent.metadata["whatsapp_from_owner"]``, prefix ``MessageEvent.text``
 with ``[owner reply] ``, and otherwise leave metadata absent and text
-unchanged.  The env-var gate itself lives in the bridge — the adapter just
-trusts the payload.
+unchanged.  The gate itself lives in the bridge; the adapter owns its resolved config.
 """
 
 from __future__ import annotations
 
 import asyncio
+import stat
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+from plugins.platforms.whatsapp.adapter import (
+    WhatsAppAdapter,
+    _load_or_create_owner_message_secret,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -77,6 +81,64 @@ def test_metadata_flag_set_when_payload_has_from_owner():
     assert event.metadata.get("whatsapp_from_owner") is True
     assert event.text.startswith("[owner reply] ")
     assert event.text == "[owner reply] hi from the linked phone"
+
+
+def test_yaml_owner_forwarding_setting_overrides_internal_environment(monkeypatch):
+    monkeypatch.setenv("WHATSAPP_FORWARD_OWNER_MESSAGES", "false")
+    config = PlatformConfig(enabled=True, extra={"forward_owner_messages": True})
+
+    adapter = WhatsAppAdapter(config)
+
+    assert adapter._forward_owner_messages is True
+
+
+def test_owner_message_secret_is_strong_private_and_stable_per_session(tmp_path):
+    secret_path = tmp_path / "consumer.secret"
+
+    first = _load_or_create_owner_message_secret(secret_path)
+    second = _load_or_create_owner_message_secret(secret_path)
+
+    assert first == second
+    assert len(first) >= 43
+    assert stat.S_IMODE(secret_path.stat().st_mode) == 0o600
+
+
+def test_owner_message_consumer_secret_file_is_configurable(tmp_path):
+    secret_path = tmp_path / "integrations" / "owner-consumer.secret"
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "forward_owner_messages": True,
+            "session_path": str(secret_path.parent),
+            "owner_message_secret_file": str(secret_path),
+        },
+    )
+
+    adapter = WhatsAppAdapter(config)
+    adapter._ensure_owner_message_secret()
+
+    assert adapter._owner_message_secret_file == secret_path
+    assert adapter._owner_message_secret == secret_path.read_text(encoding="utf-8").strip()
+
+
+def test_owner_message_secret_rejects_symlinked_parent_outside_session(tmp_path):
+    session_path = tmp_path / "session"
+    outside = tmp_path / "outside"
+    session_path.mkdir()
+    outside.mkdir()
+    linked_parent = session_path / "linked"
+    linked_parent.symlink_to(outside, target_is_directory=True)
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "forward_owner_messages": True,
+            "session_path": str(session_path),
+            "owner_message_secret_file": str(linked_parent / "owner.secret"),
+        },
+    )
+
+    with pytest.raises(ValueError, match="inside the WhatsApp session directory"):
+        WhatsAppAdapter(config)._ensure_owner_message_secret()
 
 
 def test_from_owner_does_not_double_prefix_when_already_tagged():

--- a/tests/gateway/test_whatsapp_from_owner.py
+++ b/tests/gateway/test_whatsapp_from_owner.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import Platform, PlatformConfig
+from plugins.platforms.whatsapp import adapter as whatsapp_adapter
 from plugins.platforms.whatsapp.adapter import (
     WhatsAppAdapter,
     _load_or_create_owner_message_secret,
@@ -94,6 +95,20 @@ def test_yaml_owner_forwarding_setting_overrides_internal_environment(monkeypatc
 
 def test_owner_message_secret_is_strong_private_and_stable_per_session(tmp_path):
     secret_path = tmp_path / "consumer.secret"
+
+    first = _load_or_create_owner_message_secret(secret_path)
+    second = _load_or_create_owner_message_secret(secret_path)
+
+    assert first == second
+    assert len(first) >= 43
+    assert stat.S_IMODE(secret_path.stat().st_mode) == 0o600
+
+
+def test_owner_message_secret_uses_path_chmod_when_fchmod_is_unavailable(
+    tmp_path, monkeypatch
+):
+    secret_path = tmp_path / "consumer.secret"
+    monkeypatch.delattr(whatsapp_adapter.os, "fchmod")
 
     first = _load_or_create_owner_message_secret(secret_path)
     second = _load_or_create_owner_message_secret(secret_path)

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -151,6 +151,39 @@ class TestStaleBridgeHandshake:
 
         mock_popen.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_restarts_bridge_when_owner_forwarding_config_changed(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        adapter._forward_owner_messages = True
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+        health = _mock_health({
+            "status": "connected",
+            "scriptHash": disk_hash,
+            "sendReadReceipts": False,
+            "forwardOwnerMessages": False,
+        })
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", health), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_popen.assert_called_once()
+
 
 class TestDepRefreshStamp:
     @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -181,9 +181,23 @@ whatsapp:
   reply_prefix: ""                          # Empty string disables the header
   # reply_prefix: "🤖 *My Bot*\n──────\n"  # Custom prefix (supports \n for newlines)
   send_read_receipts: false                 # Mark accepted inbound messages as read (blue ticks)
+  forward_owner_messages: false             # Forward linked-device sends (advanced)
+  owner_messages_external_consumer: false   # Use durable peek/ACK instead of normal Hermes polling
+  # owner_message_secret_file: ~/.hermes/whatsapp/session/owner-messages.secret
 ```
 
 When `send_read_receipts` is `true`, the adapter marks policy-accepted inbound messages as read after DM/group/mention filtering passes. Rejected messages (e.g., from non-allowlisted senders) are not marked read. Disabled by default for privacy. Changing this setting automatically restarts the bridge subprocess on the next connection.
+
+`forward_owner_messages` is an advanced, text-only integration option. By default, allowed personal-chat messages typed on the owner/linked device remain compatible with the normal Hermes `/messages` polling flow. An integration that durably persists and reconciles those messages itself must also set `owner_messages_external_consumer: true`; only then are owner messages kept out of the inbound bot queue and written to the authenticated peek/ACK queue under the WhatsApp session directory. The queue never silently evicts entries and removes an entry only after an exact acknowledgement. Connector sends reserve and persist their WhatsApp message ID before transmission, so an echo cannot be misclassified as owner input during a send race or after bridge restart. Read receipts and self-chat loopback keep their existing behavior.
+
+Both owner endpoints require `Authorization: Bearer <secret>`. The adapter generates a high-entropy per-session secret in `owner-messages.secret` with mode `0600`. A configured `owner_message_secret_file` must resolve inside the session root without symlinked ancestors. The bridge health response reports only a short SHA-256 fingerprint, never the secret.
+
+- `GET /owner-messages?cursor=<cursor>&limit=<1..100>` returns `{ messages, nextCursor, hasMore }`. Pass `nextCursor` to reach later entries even while an earlier entry remains unacknowledged.
+- `POST /owner-messages/ack` accepts `{ "messages": [{ "messageId": "..." }] }` and deletes only those exact durable entries. Persist/process an event before acknowledging it.
+- With an external consumer enabled, that connector owns durable owner-message consumption, reconciliation, and automatic-send fence propagation. Automatic `/send` calls must use `sendIntent: "automatic"` plus `expectedOwnerFenceSequence`; the bridge revalidates that sequence inside the serialized send queue immediately before every provider chunk. The standard Hermes adapter deliberately does not invent a fence: sends without an explicit `whatsapp_owner_fence_sequence` are rejected in external-consumer mode (fail closed). Human CRM sends use `sendIntent: "human"` and the same Bearer secret, and are not blocked as automatic replies.
+- Text bodies are retained in full, including bodies larger than 20,000 characters. Media is **not** forwarded as media by this contract; instead the queue contains a durable intervention record with `disposition: "unsupported_media"` and `requiresIntervention: true`, allowing a coordinator to advance rather than blocking the queue.
+
+The option is disabled by default so owner-device sends cannot accidentally enter an AI reply loop.
 
 ---
 

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -205,6 +205,16 @@ The option is disabled by default so owner-device sends cannot accidentally ente
 
 WhatsApp supports **streaming (progressive) responses** — the bot edits its message in real-time as the AI generates text, just like Discord and Telegram. Internally, WhatsApp is classified as a TIER_MEDIUM platform for delivery capabilities.
 
+### Delivery Receipt Consumer Contract
+
+The Baileys bridge exposes outbound `sent`, `delivered`, and `read` updates through a separate non-destructive receipt queue:
+
+- `GET /receipts` returns the oldest page as a JSON array of `{ "messageId", "status", "occurredAt" }` objects. A page contains at most **100** receipts.
+- `POST /receipts/ack` accepts `{ "receipts": [{ "messageId": "...", "status": "..." }] }`. Each ACK is exact on both message ID and status, and a request may acknowledge at most **100** receipts. The response reports the exact `acknowledged` count.
+- The bridge queue holds at most **1,000** unacknowledged receipts. Consumers must therefore poll promptly and ACK each bounded page rather than accumulating an oversized batch.
+- **Persist every receipt durably before ACKing it.** `GET` is a peek, so a crash before persistence leaves the receipt available; a crash after persistence but before ACK must be absorbed by the consumer's `(messageId, status)` deduplication.
+- ACKed states are replay-suppressed in the running bridge while a later monotonic state (for example `delivered` → `read`) remains eligible. An unmatched ACK does not suppress a future real receipt.
+
 ### Chunking
 
 Long responses are automatically split into multiple messages at **4,096 characters** per chunk (WhatsApp's practical display limit). You don't need to configure anything — the gateway handles splitting and sends chunks sequentially.


### PR DESCRIPTION
## Resumo
- captura ACKs reais de envio, entrega e leitura emitidos pelo Baileys
- expõe uma fila dedicada `/receipts`, sem JID ou telefone
- rejeita receipts de grupos, pois ACK individual não representa entrega/leitura do grupo inteiro
- usa protocolo peek → ACK, buffer bounded e deduplicação
- preserva o listener atual de enquetes e a fila `/messages`

## Contrato
```json
{
  "messageId": "<provider-id>",
  "status": "sent|delivered|read",
  "occurredAt": "<RFC3339>"
}
```

`PLAYED` é normalizado como `read`. Estados `ERROR` e `PENDING` são ignorados.

## Testes
- todos os `*.test.mjs` da bridge
- `node --check bridge.js`
- `node --check bridge_helpers.js`
- `git diff --check`

## Rollout
O consumidor deve persistir o lote antes de chamar `POST /receipts/ack`. Esta mudança é genérica e não contém código específico do VintruCRM.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable WhatsApp delivery and read-receipt tracking.
  * Added authenticated owner-message forwarding with durable queues, pagination, and acknowledgements.
  * Added support for secure external message consumption and automatic-send safeguards.
  * Improved handling of text, edits, media, polls, and locations with consistent delivery status.

* **Bug Fixes**
  * Improved recovery, deduplication, cancellation, and error handling for outbound messages.
  * Bridges now restart when owner-forwarding settings change.

* **Documentation**
  * Documented advanced owner-message forwarding and external consumption options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->