### PR TITLE
fix(agent): clarify structured tool failures

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1312,6 +1312,8 @@ class KawaiiSpinner:
 # =========================================================================
 
 _ERROR_SUFFIX_MAX_LEN = 48
+_TOOL_FAILURE_SUMMARY_MAX_LEN = 500
+_FAILED_OPERATION_STATES = frozenset({"failed", "error", "cancelled", "canceled"})
 
 
 def _trim_error(msg: str) -> str:
@@ -1330,6 +1332,59 @@ def _trim_error(msg: str) -> str:
     if len(msg) > _ERROR_SUFFIX_MAX_LEN:
         msg = msg[: _ERROR_SUFFIX_MAX_LEN - 3] + "..."
     return msg
+
+
+def _structured_error_fields(error: Any) -> tuple[str | None, str | None]:
+    if isinstance(error, dict):
+        code = error.get("code") or error.get("type")
+        message = error.get("message") or error.get("detail")
+        return (
+            str(code) if code is not None else None,
+            str(message) if message is not None else None,
+        )
+    if error is not None:
+        return None, str(error)
+    return None, None
+
+
+def _operation_state(data: dict[str, Any]) -> str | None:
+    payload = data.get("data")
+    if not isinstance(payload, dict):
+        return None
+    state = payload.get("state") or payload.get("status")
+    return str(state).lower() if state is not None else None
+
+
+def _summarize_tool_failure(result: Any) -> str:
+    """Return a bounded, redacted summary of a failed tool result."""
+    data = safe_json_loads(result)
+    if isinstance(data, dict):
+        payload = data.get("data") if isinstance(data.get("data"), dict) else {}
+        state = _operation_state(data)
+        operation_failed = state in _FAILED_OPERATION_STATES
+        outcome = "operation_failed" if operation_failed else "tool_error"
+        error = payload.get("error") if operation_failed else data.get("error")
+        if error is None:
+            error = payload.get("message") if operation_failed else data.get("message")
+        code, message = _structured_error_fields(error)
+        fields = [f"outcome={outcome}"]
+        for key, value in (
+            ("request_id", payload.get("request_id") or data.get("request_id")),
+            ("provider", payload.get("provider") or data.get("provider")),
+            ("model", payload.get("model") or data.get("model")),
+            ("state", state),
+            ("code", code),
+            ("message", message),
+        ):
+            if value is not None:
+                safe_value = redact_sensitive_text(str(value), force=True)
+                fields.append(f"{key}={safe_value}")
+        summary = " ".join(fields)
+    else:
+        summary = redact_sensitive_text(str(result), force=True)
+    if len(summary) > _TOOL_FAILURE_SUMMARY_MAX_LEN:
+        return summary[: _TOOL_FAILURE_SUMMARY_MAX_LEN - 3] + "..."
+    return summary
 
 
 def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]:
@@ -1366,9 +1421,22 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
 
     # Structured error in JSON result (any tool that surfaces {"error": ...}).
     if isinstance(data, dict):
+        state = _operation_state(data)
+        if data.get("ok") is False or data.get("success") is False:
+            err = data.get("error") or data.get("message") or "tool reported failure"
+            _, message = _structured_error_fields(err)
+            return True, f" [{_trim_error(message or str(err))}]"
+        if state in _FAILED_OPERATION_STATES:
+            payload = data.get("data")
+            err = payload.get("error") or payload.get("message") or state
+            _, message = _structured_error_fields(err)
+            return True, f" [{_trim_error(message or str(err))}]"
+        if data.get("ok") is True or data.get("success") is True:
+            return False, ""
         err = data.get("error") or data.get("message")
-        if err and (data.get("success") is False or "error" in data):
-            return True, f" [{_trim_error(str(err))}]"
+        if err and "error" in data:
+            _, message = _structured_error_fields(err)
+            return True, f" [{_trim_error(message or str(err))}]"
 
     # Generic heuristic for non-terminal tools
     # Multimodal tool results (dicts with _multimodal=True) are not strings —

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -31,6 +31,7 @@ from agent.display import (
     get_tool_emoji as _get_tool_emoji,
     redact_tool_args_for_display as _redact_tool_args_for_display,
     _detect_tool_failure,
+    _summarize_tool_failure,
 )
 from agent.tool_dispatch_helpers import (
     _is_destructive_command,
@@ -51,6 +52,15 @@ from tools.tool_result_storage import (
 from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context_window
 
 logger = logging.getLogger(__name__)
+
+
+def _log_tool_failure(function_name: str, duration: float, result: Any) -> None:
+    logger.warning(
+        "Tool %s failed (%.2fs): %s",
+        function_name,
+        duration,
+        _summarize_tool_failure(_multimodal_text_summary(result)),
+    )
 
 
 def _ensure_file_checkpoint(
@@ -1435,6 +1445,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if blocked:
                 effect_disposition = "none"
 
+            if is_error:
+                _log_tool_failure(function_name, tool_duration, function_result)
+
             if not blocked:
                 function_result = agent._append_guardrail_observation(
                     function_name,
@@ -1442,11 +1455,6 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     function_result,
                     failed=is_error,
                 )
-
-            if is_error:
-                _err_text = _multimodal_text_summary(function_result)
-                result_preview = _err_text[:200] if len(_err_text) > 200 else _err_text
-                logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
 
             # Track file-mutation outcome for the turn-end verifier.
             # `blocked` calls never actually ran — don't let a guardrail
@@ -2233,6 +2241,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 duration_ms=int(tool_duration * 1000),
                 middleware_trace=list(middleware_trace),
             )
+        if _is_error_result:
+            _log_tool_failure(function_name, tool_duration, function_result)
         if not _execution_blocked:
             function_result = agent._append_guardrail_observation(
                 function_name,
@@ -2243,9 +2253,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             result_preview = function_result if agent.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result
             )
-        if _is_error_result:
-            logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
-        else:
+        if not _is_error_result:
             logger.info("tool %s completed (%.2fs, %d chars)", function_name, tool_duration, _result_len)
 
         # Track file-mutation outcome for the turn-end verifier.  See

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -7,13 +7,16 @@ not a generic "[error]".
 """
 
 import json
+import logging
 
 from agent.display import (
     _detect_tool_failure,
+    _summarize_tool_failure,
     _trim_error,
     _ERROR_SUFFIX_MAX_LEN,
     get_cute_tool_message,
 )
+from agent.tool_executor import _log_tool_failure
 
 
 class TestTrimError:
@@ -96,6 +99,113 @@ class TestDetectToolFailureStructured:
         result = json.dumps({"success": True, "data": "hello"})
         assert _detect_tool_failure("web_search", result) == (False, "")
 
+    def test_explicit_ok_true_is_not_failed_by_nested_error_metadata(self):
+        result = json.dumps({
+            "ok": True,
+            "data": {
+                "request_id": "video-123",
+                "state": "completed",
+                "error": {"code": "old_attempt", "message": "prior attempt failed"},
+            },
+        })
+        assert _detect_tool_failure("siren_video_gen", result) == (False, "")
+
+    def test_explicit_ok_true_with_failed_operation_is_failure(self):
+        result = json.dumps({
+            "ok": True,
+            "data": {
+                "request_id": "video-123",
+                "state": "failed",
+                "error": {"code": "permission_denied", "message": "provider returned 403"},
+            },
+        })
+        assert _detect_tool_failure("siren_video_gen", result)[0] is True
+
+    def test_explicit_ok_false_is_failure(self):
+        result = json.dumps({
+            "ok": False,
+            "error": {"code": "request_conflict", "message": "request id is reserved"},
+        })
+        assert _detect_tool_failure("siren_video_gen", result)[0] is True
+
+
+class TestSummarizeToolFailure:
+    def test_summarizes_top_level_contract_error(self):
+        result = json.dumps({
+            "ok": False,
+            "error": {"code": "request_conflict", "message": "request id is reserved"},
+        })
+        assert _summarize_tool_failure(result) == (
+            "outcome=tool_error code=request_conflict message=request id is reserved"
+        )
+
+    def test_summarizes_failed_operation_receipt(self):
+        result = json.dumps({
+            "ok": True,
+            "data": {
+                "request_id": "video-123",
+                "provider": "google",
+                "model": "gemini-omni-flash-preview",
+                "state": "failed",
+                "error": {"code": "permission_denied", "message": "provider returned 403"},
+            },
+        })
+        assert _summarize_tool_failure(result) == (
+            "outcome=operation_failed request_id=video-123 provider=google "
+            "model=gemini-omni-flash-preview state=failed code=permission_denied "
+            "message=provider returned 403"
+        )
+
+    def test_falls_back_to_bounded_redacted_text(self):
+        secret = "AIza" + ("x" * 35)
+        result = f"Error {secret} " + ("x" * 600)
+        summary = _summarize_tool_failure(result)
+        assert secret not in summary
+        assert len(summary) <= 500
+
+    def test_structured_summary_is_bounded_and_redacted(self):
+        secret = "AIza" + ("x" * 35)
+        result = json.dumps({
+            "ok": True,
+            "data": {
+                "request_id": "video-123",
+                "provider": "google",
+                "model": "gemini-omni-flash-preview",
+                "state": "failed",
+                "error": {
+                    "code": "permission_denied",
+                    "message": secret + (" details" * 100),
+                },
+            },
+        })
+        summary = _summarize_tool_failure(result)
+        assert summary.startswith("outcome=operation_failed request_id=video-123")
+        assert secret not in summary
+        assert summary.endswith("...")
+        assert len(summary) == 500
+
+
+class TestLogToolFailure:
+    def test_logs_structured_receipt_before_guardrail_annotation(self, caplog):
+        result = json.dumps({
+            "ok": True,
+            "data": {
+                "request_id": "video-123",
+                "provider": "google",
+                "model": "gemini-omni-flash-preview",
+                "state": "failed",
+                "error": {"code": "permission_denied", "message": "provider returned 403"},
+            },
+        })
+        with caplog.at_level(logging.WARNING, logger="agent.tool_executor"):
+            _log_tool_failure("siren_video_gen", 0.92, result)
+
+        assert caplog.messages == [
+            "Tool siren_video_gen failed (0.92s): outcome=operation_failed "
+            "request_id=video-123 provider=google model=gemini-omni-flash-preview "
+            "state=failed code=permission_denied message=provider returned 403"
+        ]
+
 
 
 class TestGetCuteToolMessageFailureSuffix:
@@ -118,4 +228,3 @@ class TestGetCuteToolMessageFailureSuffix:
         ok = json.dumps({"success": True, "data": "hi"})
         line = get_cute_tool_message("web_search", {"query": "hi"}, 0.2, result=ok)
         assert "[" not in line.split("0.2s", 1)[1]
-


### PR DESCRIPTION
## What does this PR do?

Hermes now distinguishes a failed tool contract from a failed asynchronous operation when it logs structured plugin results. Explicit successful receipts are no longer marked as errors because they contain nested historical error metadata, while terminal generation receipts still produce actionable warnings with request, provider, model, state, code, and message fields. The warning is bounded and forcibly redacted, and it is emitted before guardrail annotations can turn valid JSON into opaque text.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Make explicit `ok` and `success` contracts authoritative while recognizing terminal nested operation states.
- Replace raw 200-character JSON prefixes with a shared, redacted 500-character failure summary in both executor paths.
- Cover contract errors, failed operation receipts, successful receipts with historical errors, structured redaction, bounding, and emitted log content.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_display_tool_failure.py tests/agent/test_tool_guardrails.py tests/agent/test_tool_executor_checkpoint_paths.py -q`.
2. Run `ruff check agent/display.py agent/tool_executor.py tests/agent/test_display_tool_failure.py`.
3. Confirm a failed structured receipt logs `outcome=operation_failed` and a completed receipt with nested historical error metadata does not warn.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused CI-parity verification passed: 27 tests across three files. Ruff, bytecode compilation, and `git diff --check` also passed. No live provider or paid generation call was made.

## Post-Deploy Monitoring & Validation

- Search `agent.tool_executor` warnings for `outcome=tool_error` and `outcome=operation_failed`.
- Healthy: completed receipts do not warn; failed generation receipts include request ID, provider, model, state, code, and a redacted message.
- Failure: warnings contain raw JSON, omit the terminal state/code, exceed the bound, or classify `state=completed` as failed.
- Validate during the first DJ Doot and Dizzy video attempts after deployment. Roll back this commit if successful receipts regress or sensitive values appear in logs.
- Owner: Hermes operator.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
