### PR TITLE
fix(tools): empty execute_code capability set denies all sandbox tools

### DIFF
--- a/tests/agent/test_plugin_prompt_sections.py
+++ b/tests/agent/test_plugin_prompt_sections.py
@@ -41,7 +41,9 @@ def _install_test_section(manager: PluginManager, content) -> None:
     )
 
 
-def test_real_aiagent_freezes_section_within_life_and_rerenders_on_invalidate(monkeypatch):
+def test_real_aiagent_builds_section_once_and_keeps_it_out_of_static_prefix(
+    monkeypatch, tmp_path
+):
     # Pin the workspace snapshot: build_coding_workspace_block shells out to
     # live `git status`/`git log` on every build, and a git call failing or
     # timing out under xdist contention makes the two builds differ in the
@@ -61,6 +63,9 @@ def test_real_aiagent_freezes_section_within_life_and_rerenders_on_invalidate(mo
     manager = PluginManager()
     _install_test_section(manager, section)
     monkeypatch.setattr(plugins, "_plugin_manager", manager)
+    # CI merge checkouts are detached HEAD; a second git probe can drop the
+    # branch line. This test is about plugin-section caching, not live git.
+    monkeypatch.setattr("agent.system_prompt.resolve_context_cwd", lambda: tmp_path)
     agent = _real_agent()
 
     first = build_system_prompt(agent)

--- a/tests/agent/test_plugin_prompt_sections.py
+++ b/tests/agent/test_plugin_prompt_sections.py
@@ -173,10 +173,13 @@ def test_fresh_process_resume_restores_identical_full_prompt_without_callback(tm
     )
 
     outputs = []
+    child_cwd = tmp_path / "child-workspace"
+    child_cwd.mkdir()
     for phase in ("first", "resume"):
         env = os.environ.copy()
         env.update(
             HERMES_HOME=str(tmp_path / "hermes-home"),
+            TERMINAL_CWD=str(child_cwd),
             TEST_DB=str(db_path),
             TEST_CALLS=str(calls_path),
             TEST_PHASE=phase,

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -59,6 +59,7 @@ from tools.code_execution_tool import (
     _TOOL_DOC_LINES,
     _execute_remote,
     _format_interrupted_output,
+    _resolve_sandbox_tools,
 )
 from tools.registry import registry
 
@@ -737,6 +738,28 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
             ))
         self.assertEqual(result["status"], "success", msg=result)
         self.assertIn("mock output for: echo hi", result["output"])
+
+
+class TestResolveSandboxTools(unittest.TestCase):
+    """Shared helper used by both the local UDS and remote file-RPC paths."""
+
+    def test_none_is_legacy_default(self):
+        self.assertEqual(_resolve_sandbox_tools(None), SANDBOX_ALLOWED_TOOLS)
+
+    def test_empty_list_is_deny_all(self):
+        self.assertEqual(_resolve_sandbox_tools([]), frozenset())
+
+    def test_nonoverlapping_is_deny_all(self):
+        self.assertEqual(
+            _resolve_sandbox_tools(["vision_analyze", "browser_snapshot"]),
+            frozenset(),
+        )
+
+    def test_intersection_keeps_only_sandbox_tools(self):
+        self.assertEqual(
+            _resolve_sandbox_tools(["terminal", "vision_analyze"]),
+            frozenset(["terminal"]),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -861,11 +861,12 @@ class TestSandboxRpcAuthorization(unittest.TestCase):
         tool_call_counter = [0]
         stop_event = threading.Event()
 
-        with tempfile.TemporaryDirectory(prefix="hermes-rpc-") as temp_dir:
-            socket_path = os.path.join(temp_dir, "rpc.sock")
-            server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            server_sock.bind(socket_path)
-            server_sock.listen(1)
+        # A real Unix socket pair avoids sockaddr_un path limits in deeply
+        # nested CI/base checkouts while preserving the RPC authorization loop.
+        server_connection, client_socket = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+        with server_connection, client_socket:
+            server_sock = MagicMock(spec=socket.socket)
+            server_sock.accept.return_value = (server_connection, ("peer", 0))
 
             def run_server():
                 with patch(
@@ -890,7 +891,6 @@ class TestSandboxRpcAuthorization(unittest.TestCase):
                 with patch.dict(
                     os.environ,
                     {
-                        "HERMES_RPC_SOCKET": socket_path,
                         "HERMES_RPC_TOKEN": self._RPC_TOKEN,
                     },
                 ):
@@ -901,6 +901,7 @@ class TestSandboxRpcAuthorization(unittest.TestCase):
                         ),
                         namespace,
                     )
+                    namespace["_sock"] = client_socket
                     call = cast(
                         Callable[[str, dict[str, str]], dict[str, Any]],
                         namespace["_call"],

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -23,6 +23,7 @@ import shlex
 import socket
 import tempfile
 import time
+from typing import Any, Callable, cast
 
 os.environ["TERMINAL_ENV"] = "local"
 
@@ -773,6 +774,7 @@ class TestSandboxFailureHints(unittest.TestCase):
     def test_empty_grant_does_not_advertise_sandbox_tools(self):
         hint = _sandbox_failure_hint(self._IMPORT_ERROR, enabled_tools=[])
 
+        assert hint is not None
         self.assertIn("Importable tools here: none.", hint)
 
     def test_partial_grant_advertises_only_the_intersection(self):
@@ -781,6 +783,7 @@ class TestSandboxFailureHints(unittest.TestCase):
             enabled_tools=["terminal", "vision_analyze"],
         )
 
+        assert hint is not None
         self.assertIn("Importable tools here: terminal.", hint)
         self.assertNotIn("write_file", hint)
 
@@ -898,12 +901,16 @@ class TestSandboxRpcAuthorization(unittest.TestCase):
                         ),
                         namespace,
                     )
+                    call = cast(
+                        Callable[[str, dict[str, str]], dict[str, Any]],
+                        namespace["_call"],
+                    )
                     responses = [
-                        namespace["_call"](tool_name, args)
+                        call(tool_name, args)
                         for tool_name, args in requests
                     ]
             finally:
-                client_sock = namespace.get("_sock")
+                client_sock = cast(Any, namespace.get("_sock"))
                 if client_sock is not None:
                     client_sock.close()
                 stop_event.set()
@@ -962,8 +969,12 @@ class TestSandboxRpcAuthorization(unittest.TestCase):
                         ),
                         namespace,
                     )
+                    call = cast(
+                        Callable[[str, dict[str, str]], dict[str, Any]],
+                        namespace["_call"],
+                    )
                     responses = [
-                        namespace["_call"](tool_name, args)
+                        call(tool_name, args)
                         for tool_name, args in requests
                     ]
             finally:

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -853,7 +853,7 @@ class TestSandboxRpcAuthorization(unittest.TestCase):
         return dispatch
 
     def _run_uds_calls(self, enabled_tools, requests):
-        from tools.code_execution_tool import _rpc_server_loop
+        from tools.code_execution_rpc import _rpc_server_loop
 
         allowed_tools = _sandbox_tools_for(enabled_tools)
         dispatched = []

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -681,21 +681,62 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
 
 
     @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
-    def test_nonoverlapping_tools_fallback(self):
-        """When enabled_tools has no overlap with SANDBOX_ALLOWED_TOOLS,
-        should fall back to all allowed tools."""
-        code = (
-            "from hermes_tools import terminal\n"
-            "print('fallback ok')\n"
-        )
+    def test_empty_enabled_tools_denies_all(self):
+        """``enabled_tools=[]`` is an explicit deny-all: no sandbox tool stubs
+        are generated, so ``from hermes_tools import terminal`` raises
+        ImportError. Previously ``[]`` was conflated with ``None`` and
+        broadened to every sandbox tool (#84271)."""
+        code = "from hermes_tools import terminal\nprint('should not reach')\n"
         with patch("model_tools.handle_function_call",
-                    return_value=json.dumps({"ok": True})):
+                   side_effect=_mock_handle_function_call):
+            result = json.loads(execute_code(
+                code, task_id="test-empty-deny-all",
+                enabled_tools=[],
+            ))
+        self.assertEqual(result["status"], "error", msg=result)
+        self.assertIn(
+            "ImportError",
+            result.get("error", "") + result.get("output", ""),
+        )
+
+
+    @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
+    def test_nonoverlapping_tools_deny_all(self):
+        """A non-empty ``enabled_tools`` with no sandbox overlap must not fall
+        back to every sandbox tool — the exact authenticated manifest is used,
+        and an empty intersection denies all (#84271)."""
+        code = "from hermes_tools import terminal\nprint('fallback')\n"
+        with patch("model_tools.handle_function_call",
+                   side_effect=_mock_handle_function_call):
             result = json.loads(execute_code(
                 code, task_id="test-nonoverlap",
                 enabled_tools=["vision_analyze", "browser_snapshot"],
             ))
-        self.assertEqual(result["status"], "success")
-        self.assertIn("fallback ok", result["output"])
+        self.assertEqual(result["status"], "error", msg=result)
+        self.assertIn(
+            "ImportError",
+            result.get("error", "") + result.get("output", ""),
+        )
+
+
+    @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
+    def test_none_enabled_tools_legacy_default(self):
+        """``enabled_tools=None`` keeps the documented legacy default (every
+        sandbox tool) — the mode is explicit (``is None``), not derived from
+        truthiness, so the empty-list deny-all does not shadow it (#84271)."""
+        code = (
+            "from hermes_tools import terminal\n"
+            "r = terminal('echo hi')\n"
+            "print(r.get('output', ''))\n"
+        )
+        with patch("model_tools.handle_function_call",
+                   side_effect=_mock_handle_function_call):
+            result = json.loads(execute_code(
+                code, task_id="test-none-default",
+                enabled_tools=None,
+            ))
+        self.assertEqual(result["status"], "success", msg=result)
+        self.assertIn("mock output for: echo hi", result["output"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -886,7 +886,7 @@ class TestSandboxRpcAuthorization(unittest.TestCase):
 
             server_thread = threading.Thread(target=run_server, daemon=True)
             server_thread.start()
-            namespace = {"__name__": "hermes_tools"}
+            namespace: dict[str, object] = {"__name__": "hermes_tools"}
             try:
                 with patch.dict(
                     os.environ,

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -12,12 +12,16 @@ Run with:  python -m pytest tests/test_code_execution.py -v
    or:     python tests/test_code_execution.py
 """
 
+import base64
+import fnmatch
 import pytest
 # pytestmark removed — tests run fine (61 pass, ~99s)
 
 import json
 import os
+import shlex
 import socket
+import tempfile
 import time
 
 os.environ["TERMINAL_ENV"] = "local"
@@ -59,7 +63,8 @@ from tools.code_execution_tool import (
     _TOOL_DOC_LINES,
     _execute_remote,
     _format_interrupted_output,
-    _resolve_sandbox_tools,
+    _sandbox_tools_for,
+    _sandbox_failure_hint,
 )
 from tools.registry import registry
 
@@ -744,22 +749,287 @@ class TestResolveSandboxTools(unittest.TestCase):
     """Shared helper used by both the local UDS and remote file-RPC paths."""
 
     def test_none_is_legacy_default(self):
-        self.assertEqual(_resolve_sandbox_tools(None), SANDBOX_ALLOWED_TOOLS)
+        self.assertEqual(_sandbox_tools_for(None), SANDBOX_ALLOWED_TOOLS)
 
     def test_empty_list_is_deny_all(self):
-        self.assertEqual(_resolve_sandbox_tools([]), frozenset())
+        self.assertEqual(_sandbox_tools_for([]), frozenset())
 
     def test_nonoverlapping_is_deny_all(self):
         self.assertEqual(
-            _resolve_sandbox_tools(["vision_analyze", "browser_snapshot"]),
+            _sandbox_tools_for(["vision_analyze", "browser_snapshot"]),
             frozenset(),
         )
 
     def test_intersection_keeps_only_sandbox_tools(self):
         self.assertEqual(
-            _resolve_sandbox_tools(["terminal", "vision_analyze"]),
+            _sandbox_tools_for(["terminal", "vision_analyze"]),
             frozenset(["terminal"]),
         )
+
+
+class TestSandboxFailureHints(unittest.TestCase):
+    _IMPORT_ERROR = "ImportError: cannot import name 'terminal' from 'hermes_tools'"
+
+    def test_empty_grant_does_not_advertise_sandbox_tools(self):
+        hint = _sandbox_failure_hint(self._IMPORT_ERROR, enabled_tools=[])
+
+        self.assertIn("Importable tools here: none.", hint)
+
+    def test_partial_grant_advertises_only_the_intersection(self):
+        hint = _sandbox_failure_hint(
+            self._IMPORT_ERROR,
+            enabled_tools=["terminal", "vision_analyze"],
+        )
+
+        self.assertIn("Importable tools here: terminal.", hint)
+        self.assertNotIn("write_file", hint)
+
+
+class _FakeFileRpcEnvironment:
+    """Map the remote poller's shell operations onto a local temp directory."""
+
+    def __init__(self, rpc_dir):
+        self.rpc_dir = rpc_dir
+
+    def execute(self, command, cwd=None, timeout=None):
+        parts = shlex.split(command)
+        if parts[:2] == ["ls", "-1"]:
+            pattern = os.path.normpath(parts[2])
+            directory, filename = os.path.split(pattern)
+            paths = sorted(
+                os.path.join(directory, name)
+                for name in os.listdir(directory)
+                if fnmatch.fnmatch(name, filename)
+            )
+            return {"output": "\n".join(paths)}
+
+        if parts[0] == "cat":
+            with open(parts[1], encoding="utf-8") as request_file:
+                return {"output": request_file.read()}
+
+        if parts[:2] == ["rm", "-f"]:
+            try:
+                os.unlink(parts[2])
+            except FileNotFoundError:
+                pass
+            return {"output": ""}
+
+        if parts[0] == "echo" and "base64" in parts:
+            redirect_index = parts.index(">")
+            move_index = parts.index("mv")
+            temporary_path = parts[redirect_index + 1]
+            response_path = parts[move_index + 2]
+            with open(temporary_path, "wb") as response_file:
+                response_file.write(base64.b64decode(parts[1]))
+            os.replace(temporary_path, response_path)
+            return {"output": ""}
+
+        raise AssertionError(f"Unexpected fake remote command: {command}")
+
+
+class TestSandboxRpcAuthorization(unittest.TestCase):
+    """Exercise the real generated _call() authorization boundaries."""
+
+    _RPC_TOKEN = "test-rpc-token"
+    _REQUESTS = (
+        ("terminal", {"command": "echo denied"}),
+        ("write_file", {"path": "blocked.txt", "content": "blocked"}),
+    )
+
+    @staticmethod
+    def _dispatch_recorder(dispatched):
+        def dispatch(function_name, function_args, task_id=None, user_task=None):
+            dispatched.append((function_name, function_args))
+            return _mock_handle_function_call(
+                function_name,
+                function_args,
+                task_id=task_id,
+                user_task=user_task,
+            )
+
+        return dispatch
+
+    def _run_uds_calls(self, enabled_tools, requests):
+        from tools.code_execution_tool import _rpc_server_loop
+
+        allowed_tools = _sandbox_tools_for(enabled_tools)
+        dispatched = []
+        tool_call_log = []
+        tool_call_counter = [0]
+        stop_event = threading.Event()
+
+        with tempfile.TemporaryDirectory(prefix="hermes-rpc-") as temp_dir:
+            socket_path = os.path.join(temp_dir, "rpc.sock")
+            server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            server_sock.bind(socket_path)
+            server_sock.listen(1)
+
+            def run_server():
+                with patch(
+                    "model_tools.handle_function_call",
+                    side_effect=self._dispatch_recorder(dispatched),
+                ):
+                    _rpc_server_loop(
+                        server_sock,
+                        "test-task",
+                        tool_call_log,
+                        tool_call_counter,
+                        max_tool_calls=10,
+                        allowed_tools=allowed_tools,
+                        stop_event=stop_event,
+                        rpc_token=self._RPC_TOKEN,
+                    )
+
+            server_thread = threading.Thread(target=run_server, daemon=True)
+            server_thread.start()
+            namespace = {"__name__": "hermes_tools"}
+            try:
+                with patch.dict(
+                    os.environ,
+                    {
+                        "HERMES_RPC_SOCKET": socket_path,
+                        "HERMES_RPC_TOKEN": self._RPC_TOKEN,
+                    },
+                ):
+                    exec(
+                        generate_hermes_tools_module(
+                            list(allowed_tools),
+                            transport="uds",
+                        ),
+                        namespace,
+                    )
+                    responses = [
+                        namespace["_call"](tool_name, args)
+                        for tool_name, args in requests
+                    ]
+            finally:
+                client_sock = namespace.get("_sock")
+                if client_sock is not None:
+                    client_sock.close()
+                stop_event.set()
+                server_sock.close()
+                server_thread.join(timeout=5)
+
+        self.assertFalse(server_thread.is_alive())
+        return responses, dispatched
+
+    def _run_file_calls(self, enabled_tools, requests):
+        from tools.code_execution_tool import _rpc_poll_loop
+
+        allowed_tools = _sandbox_tools_for(enabled_tools)
+        dispatched = []
+        tool_call_log = []
+        tool_call_counter = [0]
+        stop_event = threading.Event()
+
+        with tempfile.TemporaryDirectory(prefix="hermes-rpc-") as temp_dir:
+            rpc_dir = os.path.join(temp_dir, "rpc")
+            os.mkdir(rpc_dir)
+            env = _FakeFileRpcEnvironment(rpc_dir)
+
+            def run_poller():
+                with patch(
+                    "model_tools.handle_function_call",
+                    side_effect=self._dispatch_recorder(dispatched),
+                ):
+                    _rpc_poll_loop(
+                        env,
+                        rpc_dir,
+                        "test-task",
+                        tool_call_log,
+                        tool_call_counter,
+                        max_tool_calls=10,
+                        allowed_tools=allowed_tools,
+                        stop_event=stop_event,
+                        rpc_token=self._RPC_TOKEN,
+                    )
+
+            poller_thread = threading.Thread(target=run_poller, daemon=True)
+            poller_thread.start()
+            namespace = {"__name__": "hermes_tools"}
+            try:
+                with patch.dict(
+                    os.environ,
+                    {
+                        "HERMES_RPC_DIR": rpc_dir,
+                        "HERMES_RPC_TOKEN": self._RPC_TOKEN,
+                    },
+                ):
+                    exec(
+                        generate_hermes_tools_module(
+                            list(allowed_tools),
+                            transport="file",
+                        ),
+                        namespace,
+                    )
+                    responses = [
+                        namespace["_call"](tool_name, args)
+                        for tool_name, args in requests
+                    ]
+            finally:
+                stop_event.set()
+                poller_thread.join(timeout=5)
+
+        self.assertFalse(poller_thread.is_alive())
+        return responses, dispatched
+
+    @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
+    def test_uds_empty_and_nonoverlapping_grants_reject_both_tools(self):
+        for enabled_tools in ([], ["vision_analyze"]):
+            with self.subTest(enabled_tools=enabled_tools):
+                responses, dispatched = self._run_uds_calls(
+                    enabled_tools,
+                    self._REQUESTS,
+                )
+
+                for response, (tool_name, _) in zip(responses, self._REQUESTS):
+                    self.assertIn(
+                        f"Tool '{tool_name}' is not available",
+                        response.get("error", ""),
+                    )
+                self.assertEqual(dispatched, [])
+
+    @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
+    def test_uds_partial_grant_dispatches_only_the_intersection(self):
+        responses, dispatched = self._run_uds_calls(
+            ["terminal", "vision_analyze"],
+            (
+                ("terminal", {"command": "echo allowed"}),
+                ("write_file", {"path": "blocked.txt", "content": "blocked"}),
+            ),
+        )
+
+        self.assertIn("mock output for: echo allowed", responses[0].get("output", ""))
+        self.assertIn("Available: terminal", responses[1].get("error", ""))
+        self.assertEqual([name for name, _ in dispatched], ["terminal"])
+
+    def test_file_empty_and_nonoverlapping_grants_reject_both_tools(self):
+        for enabled_tools in ([], ["vision_analyze"]):
+            with self.subTest(enabled_tools=enabled_tools):
+                responses, dispatched = self._run_file_calls(
+                    enabled_tools,
+                    self._REQUESTS,
+                )
+
+                for response, (tool_name, _) in zip(responses, self._REQUESTS):
+                    self.assertIn(
+                        f"Tool '{tool_name}' is not available",
+                        response.get("error", ""),
+                    )
+                self.assertEqual(dispatched, [])
+
+    def test_file_partial_grant_dispatches_only_the_intersection(self):
+        responses, dispatched = self._run_file_calls(
+            ["terminal", "vision_analyze"],
+            (
+                ("terminal", {"command": "echo allowed"}),
+                ("write_file", {"path": "blocked.txt", "content": "blocked"}),
+            ),
+        )
+
+        self.assertIn("mock output for: echo allowed", responses[0].get("output", ""))
+        self.assertIn("Available: terminal", responses[1].get("error", ""))
+        self.assertEqual([name for name, _ in dispatched], ["terminal"])
 
 
 # ---------------------------------------------------------------------------

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -549,8 +549,13 @@ def _finish_remote_kernel_result(kernel_result: Dict[str, Any], *,
 
 
 def _sandbox_tools_for(enabled_tools: Optional[List[str]]) -> frozenset:
-    """Enabled ∩ SANDBOX_ALLOWED_TOOLS, or every sandbox tool when the intersection is empty."""
-    return frozenset(SANDBOX_ALLOWED_TOOLS & set(enabled_tools or ())) or SANDBOX_ALLOWED_TOOLS
+    """Tri-state sandbox tool resolution. None → legacy default (every sandbox tool); an
+    explicit list (possibly empty) → exact intersection with SANDBOX_ALLOWED_TOOLS, so an
+    empty grant denies all rather than broadening to the default
+    (SECURITY-CLASS-faf9d60580300e16 / #84271)."""
+    if enabled_tools is None:
+        return SANDBOX_ALLOWED_TOOLS
+    return frozenset(SANDBOX_ALLOWED_TOOLS & set(enabled_tools))
 
 
 def _run_remote_per_call(env, env_type: str, code: str, effective_task_id: str,

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -41,6 +41,18 @@ SANDBOX_ALLOWED_TOOLS = frozenset([
     "web_search", "web_extract", "read_file", "write_file", "search_files", "patch", "terminal",
 ])
 
+
+def _resolve_sandbox_tools(enabled_tools: Optional[List[str]]) -> frozenset:
+    """Tri-state sandbox capability grant (#84271).
+
+    ``None`` keeps the legacy default (every sandbox tool). An explicit list,
+    including empty, is the exact intersection with ``SANDBOX_ALLOWED_TOOLS``
+    — empty or non-overlapping means deny-all.
+    """
+    if enabled_tools is None:
+        return SANDBOX_ALLOWED_TOOLS
+    return frozenset(SANDBOX_ALLOWED_TOOLS & set(enabled_tools))
+
 # Resource limit defaults (overridable via config.yaml → code_execution.*)
 DEFAULT_TIMEOUT = 300        # 5 minutes
 DEFAULT_MAX_TOOL_CALLS = 50

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -41,18 +41,6 @@ SANDBOX_ALLOWED_TOOLS = frozenset([
     "web_search", "web_extract", "read_file", "write_file", "search_files", "patch", "terminal",
 ])
 
-
-def _resolve_sandbox_tools(enabled_tools: Optional[List[str]]) -> frozenset:
-    """Tri-state sandbox capability grant (#84271).
-
-    ``None`` keeps the legacy default (every sandbox tool). An explicit list,
-    including empty, is the exact intersection with ``SANDBOX_ALLOWED_TOOLS``
-    — empty or non-overlapping means deny-all.
-    """
-    if enabled_tools is None:
-        return SANDBOX_ALLOWED_TOOLS
-    return frozenset(SANDBOX_ALLOWED_TOOLS & set(enabled_tools))
-
 # Resource limit defaults (overridable via config.yaml → code_execution.*)
 DEFAULT_TIMEOUT = 300        # 5 minutes
 DEFAULT_MAX_TOOL_CALLS = 50
@@ -160,9 +148,10 @@ def _missing_hermes_tools_import_hint(m, enabled_tools) -> str:
                 "If that import failed, the generated module may be stale or another "
                 "hermes_tools may be first on sys.path. Check hermes_tools.__file__ "
                 "and retry with reset=true.")
-    available = sorted(SANDBOX_ALLOWED_TOOLS & set(enabled_tools or SANDBOX_ALLOWED_TOOLS))
+    available = sorted(_sandbox_tools_for(enabled_tools))
+    available_text = ", ".join(available) or "none"
     return (f"'{missing}' is not available inside the execute_code sandbox. "
-            f"Importable tools here: {', '.join(available)}. For anything "
+            f"Importable tools here: {available_text}. For anything "
             "else, use the normal tool call instead of execute_code.")
 
 


### PR DESCRIPTION
## What does this PR do?

When `execute_code` had an empty `enabled_tools` capability set, the old code treated it the same as `None` (broaden to all sandbox tools). This PR fixes the tri-state semantics:
- `None` → `SANDBOX_ALLOWED_TOOLS` (legacy default)
- Explicit list (including empty `[]`) → exact intersection (deny-all when empty)

## Related Issue

Fixes #84271

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/code_execution_tool.py`: `_sandbox_tools_for()` tri-state semantics; `_missing_hermes_tools_import_hint()` updated.
- `tests/tools/test_code_execution.py`: Updated import for HEAD's decomposition.

## Non-competing PRs

- #88797: i18n zh keybind strings — completely unrelated to execute_code sandbox security.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_code_execution.py` — code execution tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing