### PR TITLE
fix(desktop): pin active-profile.json when creating a new profile

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1218,7 +1218,31 @@ def create_profile(
     # unit-generation paths handle gateway lifecycle.
     _maybe_register_gateway_service(canon)
 
+    # Pin the desktop app's active-profile.json to the newly created profile.
+    # Without this, CLI-spawned profiles leave the desktop silently pinned to
+    # `default` — the new profile's tools/config are unreachable from the
+    # desktop surface until the user manually picks it in the UI.
+    _pin_active_profile(canon)
+
     return profile_dir
+
+
+def _pin_active_profile(name: str) -> None:
+    """Tell the desktop app which profile is active.
+
+    Writes ``{"profile": <name>}`` to the desktop's ``active-profile.json``
+    (``%APPDATA%\\Hermes\\active-profile.json`` on Windows). Best-effort —
+    never fails profile creation if the desktop dir is unwritable or absent
+    (headless installs).
+    """
+    try:
+        from hermes_cli.gui_uninstall import desktop_userdata_dir
+
+        user_data = desktop_userdata_dir()
+        active_file = user_data / "active-profile.json"
+        active_file.write_text(json.dumps({"profile": name}), encoding="utf-8")
+    except Exception:
+        pass  # headless / no desktop — non-fatal
 
 
 def seed_profile_skills(profile_dir: Path, quiet: bool = False) -> Optional[dict]:


### PR DESCRIPTION
## Problem

When a profile is created via the CLI (e.g. `hermes profile create mr_john --clone`),
the desktop app's `active-profile.json` is never written. The file is only created
when the user picks a profile in the desktop UI picker — CLI spawns bypass the UI
entirely.

Missing file → `primaryProfileKey()` falls back to `default` → the desktop
silently launches the `default` backend instead of the new profile's backend.
The new profile's tools and config are unreachable from the desktop surface — no
error, no warning, just a quiet fail-open to `default`.

This is a real footgun: a perfectly healthy CLI-spawned profile looks broken in
the desktop because the backend is pinned to the wrong profile.

## Fix

Call `_pin_active_profile()` at the very end of `create_profile()` — writes
`{"profile": <name>}` to the desktop's `active-profile.json` (e.g.
`%APPDATA%\Hermes\active-profile.json` on Windows). Uses the existing
`desktop_userdata_dir()` helper from `gui_uninstall.py`, so the path resolution
is already platform-correct.

Best-effort and fully non-failing: if the desktop directory doesn't exist
(headless installs) or is unwritable, the write is skipped silently. Profile
creation always succeeds.

## Files

- `hermes_cli/profiles.py` — new `_pin_active_profile()` helper (18 lines) +
  call site at the end of `create_profile()`. 24 insertions, 0 deletions.

## Testing

- [x] `create_profile()` writes `active-profile.json` to the desktop userData dir
- [x] Headless installs (no desktop dir) — no failure, profile created normally
- [ ] Manual: CLI profile create → desktop relaunch → session lands on new
  profile with its tools visible