### PR TITLE
fix(kanban): compute task graph before connection closes in kanban show

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1685,6 +1685,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
         # ``result=``. Surfacing the latest summary here keeps ``show`` from
         # looking like a no-op when the worker actually did real work.
         latest_summary = kb.latest_summary(conn, args.task_id)
+        graph = kb.task_graph_context(conn, args.task_id)
 
     if getattr(args, "json", False):
         payload = {
@@ -1763,7 +1764,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
     # comments / runs.
     from hermes_cli import kanban_diagnostics as kd
     diags = kd.compute_task_diagnostics(
-        task, events, runs, graph=kb.task_graph_context(conn, task.id)
+        task, events, runs, graph=graph
     )
     if diags:
         sev_marker = {"warning": "⚠", "error": "!!", "critical": "!!!"}


### PR DESCRIPTION
## Summary
`hermes kanban show` crashes with `sqlite3.ProgrammingError: Cannot operate on a closed database` on any task.

## Root cause
`_cmd_show` opens the DB via `kb.connect_closing()` — the connection is closed when the `with` block exits — but the diagnostics section then called `kb.task_graph_context(conn, ...)` on the already-closed connection.

## Fix
Compute the task graph inside the `with` block and pass it into `compute_task_diagnostics`.

## Test plan
- [x] `hermes kanban show` now renders a completed task with full diagnostics/events (was: traceback)
- [x] Verified graph path with a real parent/child link
- [x] `pytest tests/tools/test_kanban_tools.py` — 29 passed