### PR TITLE
test: mock optional Anthropic client in interrupt test

### DIFF
--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5777,15 +5777,19 @@ class TestAnthropicInterruptHandler:
         from run_agent import AIAgent
         from agent.chat_completion_helpers import interruptible_api_call
 
-        agent = AIAgent(
-            api_key="test-key",
-            base_url="https://api.anthropic.com",
-            provider="anthropic",
-            model="claude-test",
-            quiet_mode=True,
-            skip_context_files=True,
-            skip_memory=True,
-        )
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=MagicMock(),
+        ):
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://api.anthropic.com",
+                provider="anthropic",
+                model="claude-test",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
         agent.api_mode = "anthropic_messages"
         agent._interrupt_requested = False
         agent._anthropic_client = MagicMock()


### PR DESCRIPTION
## Summary
- mock `build_anthropic_client` while constructing the Anthropic-mode agent in the interrupt behavior test
- keep the test focused on request-local abort behavior instead of requiring the optional Anthropic SDK

## Root cause
`anthropic` is intentionally an optional/lazy dependency and is excluded from the default `[all]` development environment. The new interrupt test constructed a native Anthropic `AIAgent` without mocking the client factory, so it failed during setup with `ImportError` before exercising `interruptible_api_call`.

## Verification
- `pytest tests/run_agent/test_run_agent.py::TestAnthropicInterruptHandler -q` → 1 passed
- `pytest tests/run_agent/test_run_agent.py -q` → 244 passed, 1 pre-existing thread warning
- `python -m py_compile tests/run_agent/test_run_agent.py`
- `git diff --check`
