### PR TITLE
fix(tui): skip wake checks while wake word is disabled

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1722,14 +1722,16 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
         config["enabled"] = enabled
         return True
 
-    monkeypatch.setattr(server, "_persist_wake_enabled", fake_persist)
-    monkeypatch.setattr(wake_word, "load_wake_word_config", lambda: dict(config))
-    monkeypatch.setattr(wake_word, "check_wake_word_requirements", lambda _cfg: {
+    check_requirements = Mock(return_value={
         "available": True,
         "phrase": "hey hermes",
         "provider": "test",
         "hint": "",
     })
+
+    monkeypatch.setattr(server, "_persist_wake_enabled", fake_persist)
+    monkeypatch.setattr(wake_word, "load_wake_word_config", lambda: dict(config))
+    monkeypatch.setattr(wake_word, "check_wake_word_requirements", check_requirements)
     listener = {"owner": None}
     monkeypatch.setattr(
         wake_word, "start_listening",
@@ -1755,6 +1757,7 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
         }, transport=transport)
         assert passive["result"] == {"started": False, "reason": "disabled"}
         assert persisted == []
+        check_requirements.assert_not_called()
 
         # Explicit gesture: enables in config AND arms.
         clicked = _dispatch_sync({
@@ -1765,6 +1768,7 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
         assert clicked["result"]["started"] is True
         assert clicked["result"]["enabled_persisted"] is True
         assert persisted == [True]
+        check_requirements.assert_called_once()
 
         # Explicit stop: disables in config.
         stopped = server.dispatch({
@@ -1785,9 +1789,36 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
         }, transport=transport)
         assert scoped["result"] == {"started": False, "reason": "disabled_for_surface"}
         assert persisted == [True, False]
+        check_requirements.assert_called_once()
     finally:
         server._wake_owner_transport = None
         server._wake_owner_surface = ""
+
+
+def test_wake_passive_start_reads_disabled_config_before_requirements(monkeypatch):
+    from tools import wake_word
+
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text("wake_word:\n  enabled: false\n", encoding="utf-8")
+    resolve_capture = Mock(return_value="local")
+    check_requirements = Mock(return_value={"available": True})
+    monkeypatch.setattr(wake_word, "resolve_capture_mode", resolve_capture)
+    monkeypatch.setattr(
+        wake_word,
+        "check_wake_word_requirements",
+        check_requirements,
+    )
+
+    response = _dispatch_sync({
+        "id": "wake-passive-config",
+        "method": "wake.start",
+        "params": {"surface": "tui"},
+    })
+
+    assert response["result"] == {"started": False, "reason": "disabled"}
+    resolve_capture.assert_not_called()
+    check_requirements.assert_not_called()
 
 
 def test_wake_status_reports_configured_input_device_and_windows_silence_hint(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1800,7 +1800,13 @@ def test_wake_passive_start_reads_disabled_config_before_requirements(monkeypatc
 
     hermes_home = Path(os.environ["HERMES_HOME"])
     config_path = hermes_home / "config.yaml"
-    config_path.write_text("wake_word:\n  enabled: false\n", encoding="utf-8")
+    config_path.write_text(
+        "wake_word:\n  enabled: false\n  phrase: from-test-config\n",
+        encoding="utf-8",
+    )
+    loaded_config = wake_word.load_wake_word_config()
+    assert loaded_config["enabled"] is False
+    assert loaded_config["phrase"] == "from-test-config"
     resolve_capture = Mock(return_value="local")
     check_requirements = Mock(return_value={"available": True})
     monkeypatch.setattr(wake_word, "resolve_capture_mode", resolve_capture)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13589,6 +13589,14 @@ def _persist_wake_enabled(enabled: bool) -> bool:
         return False
 
 
+def _wake_start_disabled_result(rid, surface: str, cfg: dict) -> dict:
+    """Return ``disabled`` for feature-off, else ``disabled_for_surface``."""
+    reason = "disabled" if not cfg.get("enabled") else "disabled_for_surface"
+    logger.info("wake.start(%s): %s (enabled=%s, surface=%s)",
+                surface, reason, cfg.get("enabled"), cfg.get("surface"))
+    return _ok(rid, {"started": False, "reason": reason})
+
+
 @method("wake.start")
 def _(rid, params: dict) -> dict:
     """Arm the wake-word listener for the calling surface ("tui" | "gui").
@@ -13620,6 +13628,11 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5026, f"wake module unavailable: {e}")
 
     cfg = load_wake_word_config()
+    enable_gesture = persist and not cfg.get("enabled")
+    if not enable_gesture and not wake_surface_enabled(surface, cfg):
+        # Passive auto-arm must stay cheap while wake word is disabled or
+        # scoped to another surface. Requirement checks may install packages.
+        return _wake_start_disabled_result(rid, surface, cfg)
     # Desktop remote (gui) prefers client capture: Mac mic → wake.feed PCM,
     # while the engine still runs on the backend. CLI/TUI stay local.
     prefer_client = surface in ("gui", "desktop") or bool(params.get("client_capture"))
@@ -13641,20 +13654,13 @@ def _(rid, params: dict) -> dict:
             "capture": capture_mode,
         })
     enabled_persisted = False
-    if persist and not cfg.get("enabled"):
+    if enable_gesture:
         enabled_persisted = _persist_wake_enabled(True)
         if enabled_persisted:
             cfg = dict(cfg)
             cfg["enabled"] = True
     if not wake_surface_enabled(surface, cfg):
-        # Distinguish "feature off in config" (reason: disabled — a persist:true
-        # retry can turn it on) from "scoped to a different surface" (reason:
-        # disabled_for_surface — respects an explicit wake_word.surface choice,
-        # which persist does NOT override).
-        reason = "disabled" if not cfg.get("enabled") else "disabled_for_surface"
-        logger.info("wake.start(%s): %s (enabled=%s, surface=%s)",
-                    surface, reason, cfg.get("enabled"), cfg.get("surface"))
-        return _ok(rid, {"started": False, "reason": reason})
+        return _wake_start_disabled_result(rid, surface, cfg)
 
     existing_owner, existing_surface = _wake_owner_snapshot()
     if existing_owner is not None and (


### PR DESCRIPTION
## Related Issue

Fixes #86131

## What does this PR do?

The TUI passively calls `wake.start` when the gateway becomes ready. When wake word was disabled, the handler still resolved the capture mode and checked optional voice dependencies before returning `disabled`. Those checks can start a lazy STT install even though no listener should be armed.

This change applies the config and surface gate first for passive requests. An explicit `persist: true` enable action still checks requirements before saving `wake_word.enabled`, so a setup that cannot arm is not recorded as enabled.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Return the existing `disabled` or `disabled_for_surface` result before capture and dependency checks when the request is not enabling wake word.
- Keep the requirements-first behavior for an explicit enable action.
- Extend the existing toggle test and add a temporary-`HERMES_HOME` config-path regression test.

## How to Test

1. Run `./venv/bin/python -m pytest tests/test_tui_gateway_server.py -k wake -q` (`4 passed`).
2. Run `./venv/bin/python -m pytest tests/test_tui_gateway_server.py -q` (`553 passed`).
3. Run `uvx --from ruff==0.15.10 ruff check tui_gateway/server.py tests/test_tui_gateway_server.py` (`All checks passed`).
4. Run `git diff --check origin/main...HEAD` (no errors).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, behavior and configuration are unchanged
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change only reorders a platform-neutral config gate
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tool or schema changed

## Screenshots / Logs

N/A — covered by the gateway regression tests above.
