### PR TITLE
fix(desktop): stabilize nested workspace deduplication

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -492,6 +492,18 @@ describe('liveSessionProjectId', () => {
     expect(id).toBe('p_app')
   })
 
+  it('prefers an equally specific cwd project over the git repo root project regardless of catalog order', () => {
+    const session = makeSession('C:\\tmp\\suvp', {
+      git_branch: 'feature/container',
+      git_repo_root: 'C:\\Users\\operator\\Documents\\suvp-mvp'
+    })
+    const cwdProject = makeProject('p_suvp', ['C:\\tmp\\suvp'])
+    const repoProject = makeProject('p_home', ['C:\\Users\\operator'])
+
+    expect(liveSessionProjectId(session, [repoProject, cwdProject])).toBe('p_suvp')
+    expect(liveSessionProjectId(session, [cwdProject, repoProject])).toBe('p_suvp')
+  })
+
   it('anchors a cwd-less session on its git_repo_root (backend groups it there too)', () => {
     // Older/imported rows carry only a repo root; the sidebar files them under
     // the repo's project, so membership (and color) must resolve from the root.
@@ -542,6 +554,13 @@ describe('liveSessionProjectId', () => {
         makeProject('p_www', ['/www/elsewhere'])
       ])
     ).toBe('p_www')
+    // A strictly deeper repo-root match still overrides a broader cwd match.
+    expect(
+      liveSessionProjectId(makeSession('/www/elsewhere', { git_repo_root: '/home/u/proj/nested' }), [
+        makeProject('p_www', ['/www']),
+        makeProject('p_nested', ['/home/u/proj'])
+      ])
+    ).toBe('p_nested')
   })
 
   it('matches a mixed-case/separator Windows cwd to its explicit project in the live overlay', () => {

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -396,21 +396,36 @@ export function liveSessionProjectId(session: SessionInfo, explicitProjects: Pro
   let projectId = ''
   let bestLen = -1
 
-  for (const project of explicitProjects) {
-    if (project.archived) {
-      continue
+  const matchExplicitProject = (target: string) => {
+    if (!target) {
+      return
     }
 
-    for (const folder of project.folders) {
-      if (isPathUnder(folder.path, cwd) || isPathUnder(folder.path, repoRoot)) {
-        const len = segments(folder.path).length
+    for (const project of explicitProjects) {
+      if (project.archived) {
+        continue
+      }
 
-        if (len > bestLen) {
-          bestLen = len
-          projectId = project.id
+      for (const folder of project.folders) {
+        if (isPathUnder(folder.path, target)) {
+          const len = segments(folder.path).length
+
+          if (len > bestLen) {
+            bestLen = len
+            projectId = project.id
+          }
         }
       }
     }
+  }
+
+  // Match the same ordered candidate ladder as the backend: cwd first, then
+  // the persisted git root. A root may win only when its project folder is
+  // strictly deeper; equal-depth matches retain the cwd project.
+  matchExplicitProject(cwd)
+
+  if (repoRoot !== cwd) {
+    matchExplicitProject(repoRoot)
   }
 
   if (projectId) {


### PR DESCRIPTION
## What does this PR do?

Fixes unstable workspace deduplication in Hermes Desktop when a cwd belongs equally specifically to both a nested project and a Git-repository-root project.

Previously, equal-depth candidates were resolved by catalog order, so the repo-root project could win and visually duplicate or misclassify the nested workspace. The resolver now uses a deterministic tie-breaker that prefers the more specific cwd project over the repo-root fallback, regardless of input order.

No matching open or closed issue/PR was found for this symptom.

## Related Issue

N/A — no matching issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts`
  - make equal-depth workspace selection deterministic;
  - prefer the equally specific cwd project over a repository-root fallback.
- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts`
  - add regression coverage for both catalog ordering directions.

## How to Test

From `apps/desktop`:

1. `npx vitest run --project ui src/app/chat/sidebar/projects/workspace-groups.test.ts`
2. `npx vitest run --project ui src/app/chat/sidebar/projects`
3. `npm run check:lint`

Verified on exact upstream base `c896c09c42910c584c4c7d2325b58c14713ea42c`:

- focused suite: 57/57 passed;
- neighboring sidebar-project suites: 75/75 passed;
- Desktop typecheck + lint: exit 0;
- scoped ESLint: 0 errors (one existing-style warning in the new regression block);
- independent fresh-clone RED→GREEN reproduction completed;
- reviewed binary patch SHA-256: `2333cc58df027a8c41cf2b33c078398d5adb8cefa0755c7e6150ee918a1bc8c9`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched open and closed PRs/issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (not run; this patch is Desktop TypeScript only)
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update — N/A; behavior-only bug fix with regression tests
- [x] `cli-config.yaml.example` update — N/A; no config change
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture/workflow change
- [x] Cross-platform impact considered; implementation uses normalized workspace paths and no platform-specific API
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

No visual asset changed. The regression is covered at the workspace-group resolver boundary and was independently reproduced RED on the unchanged base, then GREEN with this patch.
