### PR TITLE
fix(tui): keep disabled wake word from stalling startup

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1724,12 +1724,13 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
 
     monkeypatch.setattr(server, "_persist_wake_enabled", fake_persist)
     monkeypatch.setattr(wake_word, "load_wake_word_config", lambda: dict(config))
-    monkeypatch.setattr(wake_word, "check_wake_word_requirements", lambda _cfg: {
+    check_requirements = Mock(return_value={
         "available": True,
         "phrase": "hey hermes",
         "provider": "test",
         "hint": "",
     })
+    monkeypatch.setattr(wake_word, "check_wake_word_requirements", check_requirements)
     listener = {"owner": None}
     monkeypatch.setattr(
         wake_word, "start_listening",
@@ -1755,6 +1756,7 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
         }, transport=transport)
         assert passive["result"] == {"started": False, "reason": "disabled"}
         assert persisted == []
+        check_requirements.assert_not_called()
 
         # Explicit gesture: enables in config AND arms.
         clicked = _dispatch_sync({
@@ -1765,6 +1767,7 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
         assert clicked["result"]["started"] is True
         assert clicked["result"]["enabled_persisted"] is True
         assert persisted == [True]
+        check_requirements.assert_called_once()
 
         # Explicit stop: disables in config.
         stopped = server.dispatch({
@@ -1785,6 +1788,7 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
         }, transport=transport)
         assert scoped["result"] == {"started": False, "reason": "disabled_for_surface"}
         assert persisted == [True, False]
+        assert check_requirements.call_count == 2
     finally:
         server._wake_owner_transport = None
         server._wake_owner_surface = ""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13620,6 +13620,14 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5026, f"wake module unavailable: {e}")
 
     cfg = load_wake_word_config()
+    if not persist and not wake_surface_enabled(surface, cfg):
+        # Passive auto-arm is a startup convenience, so a disabled surface
+        # must return before capture/device and dependency probes.  Explicit
+        # gestures still probe first so an unusable setup is never persisted.
+        reason = "disabled" if not cfg.get("enabled") else "disabled_for_surface"
+        logger.info("wake.start(%s): %s (enabled=%s, surface=%s)",
+                    surface, reason, cfg.get("enabled"), cfg.get("surface"))
+        return _ok(rid, {"started": False, "reason": reason})
     # Desktop remote (gui) prefers client capture: Mac mic → wake.feed PCM,
     # while the engine still runs on the backend. CLI/TUI stay local.
     prefer_client = surface in ("gui", "desktop") or bool(params.get("client_capture"))


### PR DESCRIPTION
## What does this PR do?

When wake word is disabled, the TUI passively sends `wake.start` during startup. That request currently probes capture and optional speech dependencies before honoring the disabled configuration, which can occupy the serialized stdio request loop while a dependency is installed and delay session startup RPCs. This change returns immediately for disabled passive auto-arm requests while preserving requirement probing for explicit enable gestures.

### Symptom

Starting `hermes --tui` with local STT configured, optional local STT packages missing, and wake word disabled can remain at `forging session...` while `faster-whisper` installation is triggered.

### Impact

TUI startup RPCs such as `commands.catalog`, `setup.status`, and `session.create` can time out even though the disabled wake-word feature should not be initialized.

### Bug Cause

**Trigger:** `tui_gateway/server.py` / `wake.start` / passive request with `persist` false

**Causal chain:**
1. The TUI sends a passive `wake.start` request when the gateway becomes ready.
2. The handler resolves capture mode and calls `check_wake_word_requirements()` before checking `wake_surface_enabled()`.
3. Optional local STT detection can start a lazy dependency installation on the serialized stdio request loop, delaying unrelated startup RPCs.

**Why it is wrong:** A disabled passive startup convenience should not perform capture, device, or dependency probes.

**Working sibling / contrast:** Explicit `persist: true` enable gestures must still probe requirements before persisting an unusable configuration, and the classic CLI checks whether the surface is enabled before starting.

**Ruled out:** The renderer does not fail to send startup requests; the blocking work occurs inside the earlier passive `wake.start` dispatch before the disabled guard is reached.

### Fix

Check `wake_surface_enabled()` before capture and dependency probes for passive auto-arm requests. Keep the existing requirements-first ordering for explicit enable gestures and preserve explicit surface scoping. The regression assertions verify that passive disabled auto-arm performs no requirement probe, while explicit enable and scoped gestures still do.

## Related Issue

Closes #86131

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` - short-circuit disabled passive wake startup before capture and dependency probes.
- `tests/test_tui_gateway_server.py` - verify passive, explicit-enable, and scoped wake probe behavior.

## How to Test

1. Run the focused wake gateway tests:

```bash
HERMES_PYTHON=C:/workspace/hermes-agent/.venv/Scripts/python.exe scripts/run_tests.sh tests/test_tui_gateway_server.py tests/tui_gateway/test_protocol.py -k wake -q
```

2. Confirm all 8 focused tests pass.
3. Confirm the passive disabled request does not call the requirement probe, while explicit enable and scoped requests still do.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all 8 focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the in-process gateway behavior on Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A because this restores existing disabled-feature behavior
- [x] `cli-config.yaml.example` update is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the handler ordering is platform-independent
- [x] Tool description and schema updates are N/A because no model tool behavior changed

## Screenshots / Logs

Focused test result: 8 passed.
