### PR TITLE
fix(doctor): validate model-provider plugins through the providers registry

### DIFF
--- a/hermes_cli/plugin_dev.py
+++ b/hermes_cli/plugin_dev.py
@@ -72,6 +72,19 @@ def _doctor_runtime(plugin_path: Path):
     from hermes_cli.plugins import PluginManager
     from tools.registry import registry
 
+    # Model-provider plugins register into the providers registry at import
+    # time rather than through register(ctx), so Doctor has to snapshot and
+    # restore that registry too, exactly as it does for the tool registry
+    # below. The snapshot reads the module's dicts directly: calling
+    # list_providers() would trigger _discover_providers() and import every
+    # bundled provider, which both pollutes the comparison and defeats the
+    # point of the temporary HERMES_HOME.
+    import providers as providers_module
+
+    providers_registry_before = dict(providers_module._REGISTRY)
+    providers_aliases_before = dict(providers_module._ALIASES)
+    providers_cache_before = providers_module._PROVIDER_LIST_CACHE
+
     entries_before = {entry.name: entry for entry in registry._snapshot_entries()}
     policy_before = dict(registry._plugin_override_policy)
     modules_before = {
@@ -91,6 +104,47 @@ def _doctor_runtime(plugin_path: Path):
                 f"Expected one plugin manifest, discovered {len(manifests)} under {copied}"
             )
         manifest = manifests[0]
+
+        if manifest.kind == "model-provider":
+            # These plugins are never passed to _load_plugin in real discovery
+            # (hermes_cli/plugins.py skips them so providers/ owns their
+            # lifecycle), so validating one that way would fail every correct
+            # plugin on the missing register(ctx) that the contract does not
+            # ask for. Import through the same namespaced loader and assert
+            # the contract that does apply: the module must put at least one
+            # ProviderProfile in the registry.
+            # Observe the register_provider() calls rather than diffing the
+            # registry: the provider being validated may already be present
+            # from the host process's own discovery, in which case a diff
+            # reports nothing and a working plugin looks broken.
+            recorded: list[str] = []
+            real_register_provider = providers_module.register_provider
+
+            def _recording_register_provider(profile, *args, **kwargs):
+                recorded.append(str(getattr(profile, "name", "") or profile))
+                return real_register_provider(profile, *args, **kwargs)
+
+            with patch.object(
+                providers_module, "register_provider", _recording_register_provider
+            ):
+                manager._load_directory_module(
+                    manifest, module_name=manager._policy_module_name(manifest)
+                )
+            registered_providers = tuple(sorted(set(recorded)))
+            if not registered_providers:
+                raise _DoctorLoadError(
+                    "model-provider plugin registered no ProviderProfile; call "
+                    "providers.register_provider(profile) at module level"
+                )
+            yield SimpleNamespace(
+                manifest=manifest,
+                manager=manager,
+                registered_tools=(),
+                registered_hooks=(),
+                registered_providers=registered_providers,
+            )
+            return
+
         manager._load_plugin(manifest)
         loaded = manager._plugins.get(manifest.key or manifest.name)
         if loaded is None:
@@ -104,8 +158,14 @@ def _doctor_runtime(plugin_path: Path):
             manager=manager,
             registered_tools=tuple(sorted(loaded.tools_registered)),
             registered_hooks=tuple(loaded.hooks_registered),
+            registered_providers=(),
         )
     finally:
+        providers_module._REGISTRY.clear()
+        providers_module._REGISTRY.update(providers_registry_before)
+        providers_module._ALIASES.clear()
+        providers_module._ALIASES.update(providers_aliases_before)
+        providers_module._PROVIDER_LIST_CACHE = providers_cache_before
         entries_after = {entry.name: entry for entry in registry._snapshot_entries()}
         changed_names = {
             name
@@ -146,6 +206,7 @@ class DoctorReport:
     findings: list[DoctorFinding] = field(default_factory=list)
     registered_tools: tuple[str, ...] = ()
     registered_hooks: tuple[str, ...] = ()
+    registered_providers: tuple[str, ...] = ()
 
     @property
     def ok(self) -> bool:
@@ -171,10 +232,13 @@ class DoctorReport:
             lines.append(
                 "  OK: runtime discovery, manifest parsing, import, and registration passed"
             )
-        lines.append(
+        registrations = (
             f"  registrations: {len(self.registered_tools)} tool(s), "
             f"{len(self.registered_hooks)} hook(s)"
         )
+        if self.registered_providers:
+            registrations += f", {len(self.registered_providers)} provider(s)"
+        lines.append(registrations)
         return "\n".join(lines)
 
 
@@ -306,6 +370,21 @@ def doctor_plugin(target: str | os.PathLike[str] | None = None) -> DoctorReport:
             report.manifest = host.manifest
             report.registered_tools = host.registered_tools
             report.registered_hooks = host.registered_hooks
+            report.registered_providers = host.registered_providers
+
+            if host.manifest.kind == "model-provider":
+                # No register(ctx) runs, so there are no hooks or tools to
+                # check for drift. Declaring either is a manifest mistake
+                # rather than a load failure.
+                for field_name in ("provides_hooks", "provides_tools"):
+                    if getattr(host.manifest, field_name, None):
+                        report.warning(
+                            f"model-provider plugin declares {field_name}, which is "
+                            "never registered; providers/ discovery imports the module "
+                            "without calling register(ctx)"
+                        )
+                _check_manifest_v2(report, host.manifest)
+                return report
 
             from hermes_cli.plugins import VALID_HOOKS
 

--- a/tests/hermes_cli/test_plugin_dev.py
+++ b/tests/hermes_cli/test_plugin_dev.py
@@ -134,3 +134,88 @@ def test_doctor_blocks_live_network(tmp_path: Path) -> None:
     report = doctor_plugin(plugin)
     assert report.ok is False
     assert "network access is disabled while Plugin Doctor runs" in report.format_text()
+
+
+_PROVIDER_PLUGIN = (
+    "from providers import register_provider\n"
+    "from providers.base import ProviderProfile\n\n"
+    "register_provider(\n"
+    "    ProviderProfile(\n"
+    "        name='{name}',\n"
+    "        display_name='Demo Provider',\n"
+    "        env_vars=('DEMO_API_KEY',),\n"
+    "        base_url='https://api.demo.example.com/v1',\n"
+    "        auth_type='api_key',\n"
+    "    )\n"
+    ")\n"
+)
+
+
+def _write_provider_plugin(root: Path, name: str, *, manifest_extra: str = "", body: str | None = None) -> Path:
+    plugin = root / name
+    plugin.mkdir()
+    (plugin / "plugin.yaml").write_text(
+        f"name: {name}\nkind: model-provider\nversion: 0.1.0\n{manifest_extra}",
+        encoding="utf-8",
+    )
+    (plugin / "__init__.py").write_text(
+        _PROVIDER_PLUGIN.format(name=name) if body is None else body,
+        encoding="utf-8",
+    )
+    return plugin
+
+
+def test_doctor_accepts_model_provider_plugin(tmp_path: Path) -> None:
+    """A model-provider plugin registers at import and has no register(ctx).
+
+    Validating one through the standalone path fails it on a function the
+    contract never asks for, which is what happens to every bundled provider.
+    """
+    from hermes_cli.plugin_dev import doctor_plugin
+
+    plugin = _write_provider_plugin(tmp_path, "demo-provider")
+
+    report = doctor_plugin(plugin)
+    assert report.ok, report.format_text()
+    assert report.manifest is not None
+    assert report.manifest.kind == "model-provider"
+    assert report.registered_providers == ("demo-provider",)
+    assert "1 provider(s)" in report.format_text()
+
+
+def test_doctor_rejects_model_provider_that_registers_nothing(tmp_path: Path) -> None:
+    from hermes_cli.plugin_dev import doctor_plugin
+
+    plugin = _write_provider_plugin(
+        tmp_path, "empty-provider", body="# registers nothing\n"
+    )
+
+    report = doctor_plugin(plugin)
+    assert report.ok is False
+    messages = "\n".join(f.message for f in report.findings)
+    assert "registered no ProviderProfile" in messages
+
+
+def test_doctor_warns_when_model_provider_declares_tools(tmp_path: Path) -> None:
+    from hermes_cli.plugin_dev import doctor_plugin
+
+    plugin = _write_provider_plugin(
+        tmp_path, "declares-tools", manifest_extra="provides_tools:\n  - something\n"
+    )
+
+    report = doctor_plugin(plugin)
+    assert report.ok, report.format_text()
+    warnings = [f.message for f in report.findings if f.level == "warning"]
+    assert any("provides_tools" in message for message in warnings)
+
+
+def test_doctor_restores_provider_registry(tmp_path: Path) -> None:
+    import providers
+
+    from hermes_cli.plugin_dev import doctor_plugin
+
+    plugin = _write_provider_plugin(tmp_path, "restore-provider")
+
+    report = doctor_plugin(plugin)
+    assert report.ok, report.format_text()
+    assert "restore-provider" not in providers._REGISTRY


### PR DESCRIPTION
## What does this PR do?

Makes `hermes plugins doctor` validate `kind: model-provider` plugins correctly. Today it fails all of them, including all 34 bundled ones:

```
$ hermes plugins doctor gmi --ci
  ERROR: Plugin registration failed: no register() function
EXIT=1
```

`doctor_plugin` calls `PluginManager._load_plugin` directly. That is the inner import-and-register step; the `kind` dispatch lives in the outer discovery loop (`hermes_cli/plugins.py:3925-3931`), where model-provider plugins are deliberately skipped so `providers/` discovery owns their lifecycle. Doctor never enters that loop, so it validated them as standalone plugins and required a `register(ctx)` their contract does not define. The docs say the opposite: `developer-guide/model-provider-plugin.md` states "The only required file is `__init__.py`" and its minimal example is module-level `register_provider(profile)`.

This branches on `manifest.kind` and validates the contract that actually applies: the module must register at least one `ProviderProfile`. That turns a false failure into a real check, since a provider plugin that registers nothing was previously indistinguishable from one that works.

Two details worth calling out, both learned the hard way while writing it:

- **The call is observed, not diffed.** Wrapping `providers.register_provider` catches the registration even when the provider is already in `_REGISTRY` from the host process's own lazy discovery. My first attempt diffed the registry and still failed `hermes plugins doctor gmi`, because `gmi` was already registered before Doctor ran.
- **Doctor was leaking into the live process.** It restored the tool registry and `sys.modules` but not the provider registry, so validating a plugin left its profiles registered. This adds that restoration to the same `finally` block.

## Related Issue

Fixes #86153

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugin_dev.py`, `_doctor_runtime`: snapshot `providers._REGISTRY` / `_ALIASES` / `_PROVIDER_LIST_CACHE` (read directly, not via `list_providers()`, which would trigger `_discover_providers()` and import every bundled provider); for `kind: model-provider`, import through `_load_directory_module` with `register_provider` wrapped to record calls, and raise a `_DoctorLoadError` if nothing registers; restore the three provider globals in `finally`.
- `hermes_cli/plugin_dev.py`, `doctor_plugin`: for that kind, skip the hook/tool drift checks (no `register(ctx)` runs, so there is nothing to drift), warn if the manifest declares `provides_tools` or `provides_hooks`, and keep `_check_manifest_v2` running for every kind.
- `hermes_cli/plugin_dev.py`, `DoctorReport`: new `registered_providers` field, appended to the `registrations:` line only when non-empty, so existing output is unchanged for other kinds.
- `tests/hermes_cli/test_plugin_dev.py`: four tests, following the existing fixture shape, covering a valid model-provider plugin, one that registers nothing, one that wrongly declares tools, and registry restoration.

No behaviour changes for `standalone`, `backend`, `platform` or `exclusive` plugins.

## How to Test

1. Before the change, on a stock install: `hermes plugins doctor gmi --ci` fails with `no register() function`, exit 1. Same for `nous` and for any third-party model-provider plugin.
2. After: it passes and reports `registrations: 0 tool(s), 0 hook(s), 1 provider(s)`.
3. A model-provider plugin whose `__init__.py` registers nothing now fails with `model-provider plugin registered no ProviderProfile; call providers.register_provider(profile) at module level`.
4. `pytest tests/hermes_cli/test_plugin_dev.py -q`.
5. Regression check on the other kinds: `hermes plugins doctor telegram --ci` and a standalone plugin both still pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64), Python 3.11

On the full suite: I ran `tests/hermes_cli/test_plugin_dev.py` (9 passed, the 5 existing plus my 4) and exercised the four scenarios above end to end, but I did not run the whole `tests/` tree to completion on this box, so I have left that box unticked rather than claim it. CI covers it.

Worth being precise about how I verified, since `plugin_dev.py` is the file under test: I loaded the patched module in-process rather than editing my Hermes checkout, so the runtime the results came from is otherwise stock v0.20.1 (2026.8.13). The three relevant files are byte-identical to `main` at `c896c09c4`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A. The docs already describe the behaviour this restores: `developer-guide/plugins/index.md` tells authors to run `hermes plugins doctor . --ci` with no kind exclusion, and `developer-guide/model-provider-plugin.md` documents the no-`register()` contract. Nothing needs rewording; the code now matches.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — dict snapshots and an import; no paths, processes or encodings involved
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool behaviour changed

## Screenshots / Logs

Before:

```
$ hermes plugins doctor gmi --ci
Plugin Doctor: .../plugins/model-providers/gmi
  ERROR: Plugin registration failed: no register() function
  registrations: 0 tool(s), 0 hook(s)
EXIT=1
```

After, on the four scenarios:

```
--- model-provider that registers a profile
  manifest: demo-provider 0.1.0 (model-provider)
  OK: runtime discovery, manifest parsing, import, and registration passed
  registrations: 0 tool(s), 0 hook(s), 1 provider(s)

--- model-provider that registers nothing
  ERROR: model-provider plugin registered no ProviderProfile; call providers.register_provider(profile) at module level

--- standalone plugin (regression check)
  manifest: plain 0.1.0 (standalone)
  OK: runtime discovery, manifest parsing, import, and registration passed

--- model-provider declaring provides_tools
  WARN: model-provider plugin declares provides_tools, which is never registered; providers/ discovery imports the module without calling register(ctx)
  OK: runtime discovery, manifest parsing, import, and registration passed
  registrations: 0 tool(s), 0 hook(s), 1 provider(s)
```

One related case I could not confirm and am not claiming to fix: a third-party memory provider written against `register_memory_provider()` alone would probably hit the same failure, since Doctor also bypasses the `exclusive` branch at `plugins.py:3907`. All 8 bundled memory plugins happen to define `register()`, so they pass today. Happy to extend this to that kind in the same shape if you would like it in one pass.

---

🤖 Generated with Claude Code (Claude Opus 5)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee
