### PR TITLE
fix(desktop): refresh sessions on profile switch

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
@@ -1,0 +1,61 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $changeEventsAvailable, $cronChangeTick, $sessionsChangeTick } from '@/store/live-sync'
+import { $activeSessionId } from '@/store/session'
+
+import { useBackgroundSync } from './use-background-sync'
+
+const noop = () => undefined
+const requestGateway = async () => ({ sessions: [] })
+
+function render(activeGatewayProfile: string, refreshSessions: () => Promise<void>) {
+  return renderHook(
+    ({ profile }: { profile: string }) => {
+      useBackgroundSync({
+        activeGatewayProfile: profile,
+        activeIsMessaging: false,
+        activeSessionId: null,
+        freshDraftReady: false,
+        gatewayState: 'open',
+        refreshActiveMessagingTranscript: noop,
+        refreshCronJobs: noop,
+        refreshCurrentModel: noop,
+        refreshHermesConfig: noop,
+        refreshMessagingSessions: noop,
+        refreshSessions,
+        requestGateway
+      })
+    },
+    { initialProps: { profile: activeGatewayProfile } }
+  )
+}
+
+describe('useBackgroundSync profile-scoped session refresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    $activeSessionId.set(null)
+    $changeEventsAvailable.set(false)
+    $cronChangeTick.set(0)
+    $sessionsChangeTick.set(0)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('refreshes the session list after the active gateway profile changes', async () => {
+    const refreshSessions = vi.fn(async () => undefined)
+    const hook = render('default', refreshSessions)
+
+    await act(async () => undefined)
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+    refreshSessions.mockClear()
+
+    hook.rerender({ profile: 'nova' })
+
+    await act(async () => undefined)
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -264,7 +264,7 @@ export function useBackgroundSync({
         })
         .catch(() => undefined)
     }
-  }, [gatewayState, refreshCurrentModel, refreshSessions, requestGateway])
+  }, [activeGatewayProfile, gatewayState, refreshCurrentModel, refreshSessions, requestGateway])
 
   // A reconnect loses renderer-only working/attention atoms while the backend
   // keeps the actual turns alive. Re-seed from the gateway's in-memory session


### PR DESCRIPTION
## Summary
- re-run the foreground sidebar session refresh when the active gateway profile changes
- prevent previous-profile sessions from remaining in the sidebar after a profile switch
- add a regression test for `default → nova` profile switching

## Validation
- `npm exec vitest -- run --project ui src/app/contrib/hooks/use-background-sync.test.tsx src/app/session/hooks/use-session-list-actions.test.tsx src/store/profile.test.ts`
- `npm exec eslint -- src/app/contrib/hooks/use-background-sync.ts src/app/contrib/hooks/use-background-sync.test.tsx`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run test:desktop:platforms` (1055 passed, 2 skipped)