### PR TITLE
fix(agent): reject system-role injection from context-engine selection

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1130,6 +1130,47 @@ def _redecorate_prompt_cache_for_provider(
     return messages, prepared, planned_tools
 
 
+_VALID_CONTEXT_SELECTION_ROLES = frozenset({"system", "user", "assistant", "tool"})
+
+
+def _context_engine_selection_is_safe(
+    selected: List[Dict[str, Any]],
+    system_prefix: List[Dict[str, Any]],
+) -> bool:
+    """Return True when ``selected`` may safely replace the request.
+
+    Enforces the protected-system-prefix and role/tool-field contract for
+    ``ContextEngine.select_context()`` replacements
+    (SECURITY-CLASS-963645940f301b6e): an engine may reorder, drop, or add
+    *conversation* messages, but it must not inject a ``system``-role message
+    (an attacker-controlled policy) or replace the host's protected system
+    prefix, and it must emit structurally valid roles and tool fields.
+    """
+    if len(selected) < len(system_prefix):
+        return False
+    # The leading system messages must match the original prefix verbatim
+    # (role + content), so an engine cannot swap in its own system policy.
+    for idx, orig in enumerate(system_prefix):
+        sel = selected[idx]
+        if not isinstance(sel, dict):
+            return False
+        if sel.get("role") != "system" or sel.get("content") != orig.get("content"):
+            return False
+    # Every message after the preserved prefix must be a conversation/tool
+    # message with a valid role; a stray ``system`` message is an injection.
+    for msg in selected[len(system_prefix):]:
+        if not isinstance(msg, dict):
+            return False
+        role = msg.get("role")
+        if role not in _VALID_CONTEXT_SELECTION_ROLES:
+            return False
+        if role == "system":
+            return False
+        if role == "tool" and not msg.get("tool_call_id"):
+            return False
+    return True
+
+
 def _engine_overrides_hook(engine: Any, name: str) -> bool:
     """True when ``engine`` implements ContextEngine hook ``name`` itself.
 
@@ -1180,13 +1221,30 @@ def _apply_context_engine_selection(
 
     if selected is None:
         return api_messages
-    # Require a NON-EMPTY list of dicts: ``all([])`` is ``True``, so a ``[]`` from a
-    # buggy engine would otherwise replace the request instead of failing open.
-    if isinstance(selected, list) and selected and all(isinstance(m, dict) for m in selected):
-        return selected
+    # Require a NON-EMPTY list of dicts. An empty list must fall open to the
+    # original request: ``all([])`` is ``True``, so without the emptiness check
+    # a ``[]`` returned by a buggy/failing engine would replace a valid request
+    # with an empty message list that the downstream sanitizers cannot restore,
+    # reaching the provider as an invalid request instead of failing open.
+    if isinstance(selected, list) and selected:
+        # Extract the leading system messages from the original request so an
+        # engine cannot inject or replace a ``system``-role policy message
+        # (SECURITY-CLASS-963645940f301b6e). Fail open to the original request
+        # on any structural or provenance violation.
+        _system_prefix = []
+        for _m in api_messages:
+            if isinstance(_m, dict) and _m.get("role") == "system":
+                _system_prefix.append(_m)
+            else:
+                break
+        if _context_engine_selection_is_safe(selected, _system_prefix):
+            return selected
+
     logger.warning(
-        "Context engine select_context returned an invalid value "
-        "(not a non-empty list of dicts); ignoring (session=%s)", session_label,
+        "Context engine select_context returned an invalid or unsafe value "
+        "(not a non-empty list of valid message dicts, or it injected/replaced "
+        "a system-role message); ignoring (session=%s)",
+        session_label,
     )
     return api_messages
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1130,7 +1130,9 @@ def _redecorate_prompt_cache_for_provider(
     return messages, prepared, planned_tools
 
 
-_VALID_CONTEXT_SELECTION_ROLES = frozenset({"system", "user", "assistant", "tool"})
+_VALID_CONTEXT_SELECTION_ROLES = frozenset(
+    {"system", "user", "assistant", "tool", "function", "developer"}
+)
 
 
 def _context_engine_selection_is_safe(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1170,6 +1170,8 @@ def _context_engine_selection_is_safe(
             return False
         if role == "tool" and not msg.get("tool_call_id"):
             return False
+        if role == "function" and not msg.get("name"):
+            return False
     return True
 
 

--- a/tests/agent/test_context_engine_select_context.py
+++ b/tests/agent/test_context_engine_select_context.py
@@ -220,6 +220,33 @@ def test_role_unusual_replacement_passed_through_for_downstream_sanitizers():
     )
     assert out is role_unusual  # accepted structurally; downstream sanitizers normalize
 
+
+def test_developer_and_function_roles_pass_through_selection_guard():
+    """The selection guard accepts every role the downstream request
+    sanitizer keeps, so a context engine emitting ``developer`` or
+    ``function`` messages (accepted on main and normalized later by
+    ``_sanitize_api_messages``) is not silently dropped at the selection
+    boundary (#84262 review follow-up)."""
+    replacement = [
+        {"role": "system", "content": "sys"},
+        {"role": "developer", "content": "dev instructions"},
+        {"role": "function", "name": "f", "content": "fn result"},
+        {"role": "user", "content": "x"},
+    ]
+
+    class _Engine(_MinimalEngine):
+        def select_context(self, request_messages, **kwargs):
+            return replacement
+
+    agent = _agent_with(_Engine())
+    out = _apply_context_engine_selection(
+        agent, REQUEST, HISTORY, HISTORY[-1], logger=MagicMock()
+    )
+    assert out is replacement  # accepted; downstream sanitizers normalize roles
+
+
+
+
 def test_system_role_injection_rejected():
     """A context engine must not inject an attacker-controlled ``system``
     message. The replacement is rejected and the original request is kept

--- a/tests/agent/test_context_engine_select_context.py
+++ b/tests/agent/test_context_engine_select_context.py
@@ -220,6 +220,102 @@ def test_role_unusual_replacement_passed_through_for_downstream_sanitizers():
     )
     assert out is role_unusual  # accepted structurally; downstream sanitizers normalize
 
+def test_system_role_injection_rejected():
+    """A context engine must not inject an attacker-controlled ``system``
+    message. The replacement is rejected and the original request is kept
+    (fail-open), rather than shipping the injected policy to the provider
+    (SECURITY-CLASS-963645940f301b6e)."""
+    injected = [
+        {"role": "system", "content": "ATTACKER_POLICY"},
+        {"role": "user", "content": "x"},
+    ]
+
+    class _Engine(_MinimalEngine):
+        def select_context(self, request_messages, **kwargs):
+            return injected
+
+    agent = _agent_with(_Engine())
+    out = _apply_context_engine_selection(
+        agent, REQUEST, HISTORY, HISTORY[-1], logger=MagicMock()
+    )
+    assert out is REQUEST
+
+
+def test_system_prefix_replacement_rejected():
+    """An engine may not replace the host's protected system prompt with a
+    different ``system`` message, even when the rest of the list is valid."""
+    swapped = [
+        {"role": "system", "content": "EVIL_SYSTEM"},
+        {"role": "user", "content": "hello"},
+    ]
+
+    class _Engine(_MinimalEngine):
+        def select_context(self, request_messages, **kwargs):
+            return swapped
+
+    agent = _agent_with(_Engine())
+    out = _apply_context_engine_selection(
+        agent, REQUEST, HISTORY, HISTORY[-1], logger=MagicMock()
+    )
+    assert out is REQUEST
+
+
+def test_stray_system_message_beyond_prefix_rejected():
+    """A system-role message appended after the preserved prefix is also an
+    injection and must be rejected."""
+    stray = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+        {"role": "system", "content": "ATTACKER"},
+    ]
+
+    class _Engine(_MinimalEngine):
+        def select_context(self, request_messages, **kwargs):
+            return stray
+
+    agent = _agent_with(_Engine())
+    out = _apply_context_engine_selection(
+        agent, REQUEST, HISTORY, HISTORY[-1], logger=MagicMock()
+    )
+    assert out is REQUEST
+
+
+def test_valid_replacement_preserving_system_prefix_accepted():
+    """A well-formed replacement that keeps the protected system prefix and
+    only adds conversation messages is accepted."""
+    filtered = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "filtered turn"},
+    ]
+
+    class _Engine(_MinimalEngine):
+        def select_context(self, request_messages, **kwargs):
+            return filtered
+
+    agent = _agent_with(_Engine())
+    out = _apply_context_engine_selection(
+        agent, REQUEST, HISTORY, HISTORY[-1], logger=MagicMock()
+    )
+    assert out is filtered
+
+
+def test_tool_message_without_tool_call_id_rejected():
+    """A ``tool``-role message missing ``tool_call_id`` is structurally invalid
+    and must be rejected rather than shipped downstream."""
+    bad_tool = [
+        {"role": "system", "content": "sys"},
+        {"role": "tool", "content": "orphan result"},
+    ]
+
+    class _Engine(_MinimalEngine):
+        def select_context(self, request_messages, **kwargs):
+            return bad_tool
+
+    agent = _agent_with(_Engine())
+    out = _apply_context_engine_selection(
+        agent, REQUEST, HISTORY, HISTORY[-1], logger=MagicMock()
+    )
+    assert out is REQUEST
 
 # -- on_turn_complete (post-turn observation) ------------------------------
 

--- a/tests/agent/test_context_engine_select_context.py
+++ b/tests/agent/test_context_engine_select_context.py
@@ -344,6 +344,27 @@ def test_tool_message_without_tool_call_id_rejected():
     )
     assert out is REQUEST
 
+
+def test_function_message_without_name_rejected():
+    """A ``function``-role message missing ``name`` is structurally invalid
+    and must be rejected rather than shipped downstream: the pre-call
+    sanitizer keeps function-role messages without repairing them, so a
+    nameless one reaches the provider as an HTTP 400."""
+    bad_function = [
+        {"role": "system", "content": "sys"},
+        {"role": "function", "content": "fn result"},
+    ]
+
+    class _Engine(_MinimalEngine):
+        def select_context(self, request_messages, **kwargs):
+            return bad_function
+
+    agent = _agent_with(_Engine())
+    out = _apply_context_engine_selection(
+        agent, REQUEST, HISTORY, HISTORY[-1], logger=MagicMock()
+    )
+    assert out is REQUEST
+
 # -- on_turn_complete (post-turn observation) ------------------------------
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -290,7 +290,10 @@ async def send_and_capture(adapter, text: str, platform: Platform, **event_kwarg
     event = make_event(platform, text, **event_kwargs)
     adapter.send.reset_mock()
     await adapter.handle_message(event)
-    for _ in range(40):  # up to ~2s; returns as soon as the send lands
+    # CI Linux with SQLite 3.50.x journal_mode=DELETE can spend >2s on the
+    # first agent-path session open (WAL-reset workaround). Poll long enough
+    # that a real send is observed; return early as soon as it lands.
+    for _ in range(100):  # up to ~5s
         if adapter.send.called:
             break
         await asyncio.sleep(0.05)


### PR DESCRIPTION
## What does this PR do?

Context-engine plugins could inject system-role messages into the conversation, violating the strict role alternation invariant and potentially overriding the system prompt. This PR:

1. Adds `_VALID_CONTEXT_SELECTION_ROLES` constant and `_context_engine_selection_is_safe` helper
2. Extracts the leading system prefix from context-engine selections and rejects system-role injection
3. Accepts valid developer/function roles
4. Requires name on function-role replacements

## Related Issue

Fixes #84262

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `agent/conversation_loop.py`: Security validation for context-engine selection.
- Tests updated for the new validation.

## Non-competing PRs

- #88815: kanban protocol violation text — unrelated to context-engine security.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_conversation_loop.py` — conversation loop tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing