### PR TITLE
fix(discord): neutralize undeliverable MEDIA directives in outbound text

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2110,6 +2110,76 @@ def _strip_media_tag_directives(text: str) -> str:
     return cleaned
 
 
+# ---------------------------------------------------------------------------
+# Undeliverable-MEDIA neutralisation
+# ---------------------------------------------------------------------------
+# A ``MEDIA:<path>`` directive that fails delivery (placeholder, hallucinated
+# path, missing file, denied prefix) must never reach the user as raw text —
+# an absolute filesystem path is a leak (issue #86122).  ``_strip_media_tag_directives``
+# deliberately leaves undeliverable tags visible so the bare-path detector
+# (``extract_local_files``) can still pick them up downstream (#34517).  This
+# neutralizer is the display/adapter backstop: it strips deliverable tags
+# exactly as before, then replaces any remaining ``MEDIA:`` directive outside
+# a protected span with ``<attachment unavailable>`` so the path never leaks.
+_UNDELIVERED_MEDIA_TOKEN = "<attachment unavailable>"
+
+# Matches a leftover ``MEDIA:`` keyword plus the placeholder/path token that
+# follows it.  Runs only AFTER ``_strip_media_tag_directives`` has removed
+# deliverable tags, so anything this pattern matches is undeliverable:
+#   - angle/squared placeholders (``<local-file-path>``, ``[placeholder]``)
+#   - quoted / backticked paths
+#   - anchored bare paths (``~/``, ``/``, ``X:\\``) with an unknown/no
+#     extension that failed on-disk validation
+# Optional leading/trailing emphasis markers (``**``, ``*``, ``_``, backticks)
+# are consumed so emphasis-wrapped directives are fully replaced.
+_MEDIA_LEFTOVER_RE = re.compile(
+    r'''[`"'*_]{0,3}MEDIA:\s*'''
+    r'''(?:'''
+    r'''<[^>\n]+>|'''
+    r'''\[[^\]\n]+\]|'''
+    r'''`[^`\n]+`|'''
+    r'''"[^"\n]+"|'''
+    r''''[^'\n]+'|'''
+    r'''(?:~/|/|[A-Za-z]:[/\\])[^\s\n`"']+'''
+    r''')'''
+    r'''[`"'*_]{0,3}''',
+    re.IGNORECASE,
+)
+
+
+def neutralize_undeliverable_media_tags(text: str) -> str:
+    """Strip deliverable MEDIA: tags and replace undeliverable ones with a token.
+
+    Deliverable tags (known-extension, or extension-less paths that validate on
+    disk) are removed exactly as ``_strip_media_tag_directives`` does.  Any
+    remaining ``MEDIA:`` directive outside a protected span (code block,
+    inline code, blockquote, JSON string value) is replaced with
+    ``<attachment unavailable>`` so an absolute filesystem path can never reach
+    the user.  Used by the display path and the Discord adapter backstop.
+    """
+    if (
+        "MEDIA:" not in text
+        and "[[audio_as_voice]]" not in text
+        and "[[as_document]]" not in text
+    ):
+        return text
+    cleaned = _strip_media_tag_directives(text)
+    if "MEDIA:" not in cleaned:
+        return cleaned
+    # Locate leftover MEDIA: spans on a masked copy (offset-preserving), then
+    # replace those spans in the unmasked text — same pattern as
+    # _strip_media_tag_directives, so protected spans survive verbatim.
+    masked = BasePlatformAdapter._mask_protected_spans(cleaned)
+    masked = BasePlatformAdapter._mask_json_string_media(masked)
+    spans = [m.span() for m in _MEDIA_LEFTOVER_RE.finditer(masked)]
+    if not spans:
+        return cleaned
+    chars = list(cleaned)
+    for start, end in reversed(_merge_spans(spans)):
+        chars[start:end] = list(_UNDELIVERED_MEDIA_TOKEN)
+    return "".join(chars)
+
+
 def get_document_cache_dir() -> Path:
     """Return the document cache directory, creating it if it doesn't exist."""
     d = _resolve_cache_dir("DOCUMENT_CACHE_DIR", "cache/documents", "document_cache")
@@ -4976,10 +5046,10 @@ class BasePlatformAdapter(ABC):
     def strip_media_directives_for_display(text: str) -> str:
         """Strip MEDIA: directives from streamed/display text.
 
-        Known-extension tags are removed unconditionally (same as
-        ``MEDIA_TAG_CLEANUP_RE``). Extension-less tags are removed only when
-        ``validate_media_delivery_path`` accepts the path so undeliverable
-        paths stay visible for debugging.
+        Deliverable tags (known-extension, or extension-less paths that validate
+        on disk) are removed.  Undeliverable tags are replaced with
+        ``<attachment unavailable>`` so an absolute path never leaks into
+        user-visible text (issue #86122).
         """
         if (
             "MEDIA:" not in text
@@ -4987,7 +5057,7 @@ class BasePlatformAdapter(ABC):
             and "[[as_document]]" not in text
         ):
             return text
-        cleaned = _strip_media_tag_directives(text)
+        cleaned = neutralize_undeliverable_media_tags(text)
         cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
         return cleaned.rstrip()
 
@@ -6342,6 +6412,13 @@ class BasePlatformAdapter(ABC):
                     if local_files:
                         logger.info("[%s] extract_local_files found %d file(s) in response", self.name, len(local_files))
 
+                # Neutralize any undeliverable MEDIA: directive that survived
+                # extraction (placeholder, hallucinated path, missing file) so an
+                # absolute filesystem path never reaches the user (issue #86122).
+                # Deliverable tags were already stripped by extract_media /
+                # _strip_media_directives above.
+                text_content = neutralize_undeliverable_media_tags(text_content)
+
                 # A2 (#29346): extraction can reduce a non-empty response to
                 # empty text with no attachment, and the `if text_content` guard
                 # below then drops it silently. Recover on every platform (#33842
@@ -6350,7 +6427,7 @@ class BasePlatformAdapter(ABC):
                     # Recover from the post-extract_media `response`, not the raw
                     # snapshot: extract_media already stripped MEDIA (incl. spaced
                     # paths) with its full grammar, so no fragment can leak.
-                    _recovered = _strip_media_directives(response).strip()
+                    _recovered = neutralize_undeliverable_media_tags(response).strip()
                     if _recovered:
                         logger.warning(
                             "[%s] response_delivery_recovered: extract pipeline "

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -164,6 +164,7 @@ from gateway.platforms.base import (
     _prefix_within_utf16_limit,
     utf16_len,
     validate_inbound_media_size,
+    neutralize_undeliverable_media_tags,
 )
 from tools.url_safety import is_safe_url
 
@@ -3439,6 +3440,12 @@ class DiscordAdapter(BasePlatformAdapter):
             return result
 
         try:
+            # Backstop: a MEDIA: directive must never reach Discord as raw
+            # text (issue #86122). Deliverable tags are handled upstream; any
+            # undeliverable leftover is replaced with a sanitized token so an
+            # absolute filesystem path never leaks into the chat.
+            content = neutralize_undeliverable_media_tags(content)
+
             # Determine target channel: thread_id in metadata takes precedence.
             thread_id = None
             if metadata and metadata.get("thread_id"):
@@ -3563,6 +3570,11 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         # _derive_forum_thread_name is defined further down in this same
         # module — no cross-module import needed.
+
+        # Backstop: neutralize undeliverable MEDIA: directives before deriving
+        # the thread title so a leading ``MEDIA:/path`` line never becomes the
+        # forum thread name (issue #86122).
+        content = neutralize_undeliverable_media_tags(content)
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)

--- a/tests/gateway/test_media_directive_leak.py
+++ b/tests/gateway/test_media_directive_leak.py
@@ -1,0 +1,209 @@
+"""Regression tests for issue #86122: undeliverable ``MEDIA:`` directives must
+never leak as raw text to Discord (or any platform).
+
+A ``MEDIA:<path>`` directive that cannot be delivered — placeholder, hallucinated
+path, missing file, or denied prefix — must be replaced with a sanitized
+``<attachment unavailable>`` token instead of surfacing an absolute filesystem
+path to the user.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    neutralize_undeliverable_media_tags,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sync unit tests — neutralize_undeliverable_media_tags
+# ---------------------------------------------------------------------------
+
+def test_placeholder_tag_neutralized():
+    assert (
+        neutralize_undeliverable_media_tags("MEDIA:<local-file-path>")
+        == "<attachment unavailable>"
+    )
+
+
+def test_system_prompt_example_neutralized():
+    # The system prompt teaches ``MEDIA:/absolute/path/to/file`` — a model that
+    # echoes it verbatim must not leak the literal text.
+    out = neutralize_undeliverable_media_tags("MEDIA:/absolute/path/to/file")
+    assert out == "<attachment unavailable>"
+
+
+def test_denied_prefix_neutralized():
+    assert neutralize_undeliverable_media_tags("MEDIA:/etc/passwd") == "<attachment unavailable>"
+    assert neutralize_undeliverable_media_tags("MEDIA:~/.ssh/id_rsa") == "<attachment unavailable>"
+
+
+def test_missing_known_extension_stripped():
+    # A known-extension tag whose file is missing is stripped (no token, no leak).
+    out = neutralize_undeliverable_media_tags("See MEDIA:/tmp/definitely/missing.png here")
+    assert "MEDIA:" not in out
+    assert "/tmp/definitely/missing.png" not in out
+
+
+def test_text_only_unchanged():
+    assert neutralize_undeliverable_media_tags("Hello, world!") == "Hello, world!"
+
+
+def test_prose_mention_of_media_keyword_preserved():
+    # A bare ``MEDIA:`` keyword not followed by a path/placeholder is ordinary
+    # prose and must be left untouched.
+    text = "use the MEDIA: syntax to attach files"
+    assert neutralize_undeliverable_media_tags(text) == text
+
+
+def test_split_tag_prefix_neutralized():
+    # A MEDIA: tag split across stream chunks: the prefix chunk's MEDIA: keyword
+    # and its partial anchored path are neutralized, so no absolute path leaks.
+    prefix = "Here is your file: MEDIA:/tmp/a/very/long/path/fi"
+    out = neutralize_undeliverable_media_tags(prefix)
+    assert "MEDIA:" not in out
+    assert "/tmp/a/very/long/path/fi" not in out
+
+
+def test_emphasis_wrapped_neutralized():
+    assert (
+        neutralize_undeliverable_media_tags("**MEDIA:<local-file-path>**")
+        == "<attachment unavailable>"
+    )
+    assert neutralize_undeliverable_media_tags("*MEDIA:/etc/passwd*") == "<attachment unavailable>"
+
+
+def test_protected_code_block_preserved():
+    text = "```\nMEDIA:/etc/passwd\n```"
+    assert neutralize_undeliverable_media_tags(text) == text
+
+
+def test_protected_inline_code_preserved():
+    text = "see `MEDIA:/etc/passwd` in docs"
+    assert neutralize_undeliverable_media_tags(text) == text
+
+
+def test_protected_json_string_preserved():
+    text = '{"result": "MEDIA:/tmp/stale.png"}'
+    assert neutralize_undeliverable_media_tags(text) == text
+
+
+def test_absolute_path_never_leaks():
+    for path in ("/etc/passwd", "~/.ssh/id_rsa", "/etc/shadow", "~/.aws/credentials"):
+        out = neutralize_undeliverable_media_tags(f"MEDIA:{path}")
+        assert path not in out
+        assert "MEDIA:" not in out
+
+
+def test_display_path_neutralizes():
+    out = BasePlatformAdapter.strip_media_directives_for_display("got MEDIA:<local-file-path>")
+    assert "MEDIA:" not in out
+    assert "<attachment unavailable>" in out
+
+
+def test_existing_extensionless_file_stripped(tmp_path):
+    # An existing, non-denied extension-less file validates and is stripped
+    # (delivered upstream), not tokenized.
+    f = tmp_path / "Caddyfile"
+    f.write_text("x")
+    out = neutralize_undeliverable_media_tags(f"MEDIA:{f}")
+    assert "MEDIA:" not in out
+    assert str(f) not in out
+    assert "<attachment unavailable>" not in out
+
+
+# ---------------------------------------------------------------------------
+# Discord adapter backstop (async)
+# ---------------------------------------------------------------------------
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+def _make_adapter():
+    return DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+
+@pytest.mark.asyncio
+async def test_discord_send_neutralizes_undeliverable_media(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _make_adapter()
+    captured = {}
+
+    async def fake_send(*, content, reference=None):
+        captured["content"] = content
+        return SimpleNamespace(id=888)
+
+    channel = SimpleNamespace(send=fake_send)
+    adapter._client = SimpleNamespace(
+        get_channel=MagicMock(return_value=channel),
+        fetch_channel=AsyncMock(),
+    )
+
+    await adapter.send("555", "Here MEDIA:<local-file-path> is your file.")
+
+    assert "local-file-path" not in captured["content"]
+    assert "<attachment unavailable>" in captured["content"]
+
+
+@pytest.mark.asyncio
+async def test_discord_forum_thread_name_neutralized(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _make_adapter()
+    captured = {}
+
+    async def fake_create_thread(*, name, content, **kw):
+        captured["name"] = name
+        captured["content"] = content
+        thread = SimpleNamespace(id=999)
+        thread.message = SimpleNamespace(id=999)
+        return thread
+
+    forum = SimpleNamespace(type=15, create_thread=fake_create_thread, send=AsyncMock())
+    adapter._client = SimpleNamespace(
+        get_channel=MagicMock(return_value=forum),
+        fetch_channel=AsyncMock(),
+    )
+
+    await adapter.send("555", "MEDIA:<local-file-path>\nbody text")
+
+    assert "local-file-path" not in captured["name"]
+    assert "<attachment unavailable>" in captured["name"]


### PR DESCRIPTION
## Summary

Outbound `MEDIA:<path>` directives that cannot be delivered — placeholder, hallucinated path, missing file, or denied prefix — leaked as raw chat text in Discord instead of being uploaded or sanitized. This exposed absolute filesystem paths to the user.

## Root cause

The cleanup regex (`MEDIA_TAG_CLEANUP_RE`) only strips tags whose path has a known deliverable extension; the secondary `MEDIA_EXTENSIONLESS_TAG_RE` only strips a tag whose path validates on disk. Any other `MEDIA:` directive (placeholder, missing file, denied prefix) was deliberately left visible so the bare-path detector could pick it up — but that path leaks to the user. The Discord adapter also had no backstop: `send()` shipped content verbatim, and `_send_to_forum()` could promote a leading `MEDIA:` line into the forum thread title.

## Fix (defense-in-depth)

- `neutralize_undeliverable_media_tags()` — strips deliverable tags and replaces undeliverable leftovers with `<attachment unavailable>` (never the raw path).
- Display path (`strip_media_directives_for_display`) neutralizes for streaming and shared platforms (Telegram included).
- Non-streaming dispatch (`_process_message_background`) and the #29346 recovery branch.
- Discord `send()` and `_send_to_forum()` backstop, including the derived forum thread title.

## Tests

`tests/gateway/test_media_directive_leak.py` (16 tests): placeholders, system-prompt example, denylist paths, missing-file known extension, emphasis-wrapped tags, protected spans (code blocks / inline code / JSON strings) preserved verbatim, prose `MEDIA:` mentions untouched, and the Discord `send()` / forum backstop.

## Notes

- Absolute filesystem paths are never exposed in user-visible text.
- Text-only messages are unchanged; existing safety/allowlist/size/type checks are untouched.
- The fix lives in the shared `BasePlatformAdapter` path, so Telegram and other platforms inherit it.

Fixes #86122
