### PR TITLE
fix(cli): preload skills in oneshot mode

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -180,6 +180,7 @@ def _run_and_exit_oneshot(
     provider: object = None,
     toolsets: object = None,
     usage_file: object = None,
+    skills: object = None,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -189,6 +190,7 @@ def _run_and_exit_oneshot(
             model=model,
             provider=provider,
             toolsets=toolsets,
+            skills=skills,
             usage_file=usage_file,
         )
     except KeyboardInterrupt:
@@ -11241,6 +11243,7 @@ def _try_fast_chat_launch() -> bool:
             model=getattr(args, "model", None),
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
+            skills=getattr(args, "skills", None),
             usage_file=getattr(args, "usage_file", None),
         )
 
@@ -11298,6 +11301,7 @@ def _try_termux_fast_cli_launch() -> bool:
             model=getattr(args, "model", None),
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
+            skills=getattr(args, "skills", None),
             usage_file=getattr(args, "usage_file", None),
         )
 
@@ -12993,6 +12997,7 @@ def main():
             model=getattr(args, "model", None),
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
+            skills=getattr(args, "skills", None),
             usage_file=getattr(args, "usage_file", None),
         )
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -173,6 +173,7 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    skills: object = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -187,6 +188,8 @@ def run_oneshot(
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
             spend per invocation.
+        skills: Optional comma-separated string or iterable of skills to
+            preload for this run.
 
     Returns the exit code.  The caller owns process termination.
     """
@@ -247,6 +250,7 @@ def run_oneshot(
                     model=model,
                     provider=provider,
                     toolsets=explicit_toolsets,
+                    skills=skills,
                     use_config_toolsets=use_config_toolsets,
                 )
             except BaseException as exc:  # noqa: BLE001
@@ -325,6 +329,7 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    skills: object = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -457,6 +462,8 @@ def _run_agent(
             clarify_callback=_oneshot_clarify_callback,
         )
 
+        _apply_preloaded_skills(agent, skills)
+
         # Belt-and-braces: make sure AIAgent doesn't invoke any streaming
         # display callbacks that would bypass our stdout capture.
         agent.suppress_status_output = True
@@ -490,6 +497,46 @@ def _run_agent(
                 session_db.close()
             except Exception:
                 logging.debug("oneshot session store cleanup failed", exc_info=True)
+
+
+def _apply_preloaded_skills(agent, skills: object = None) -> list[str]:
+    """Load explicit ``-s/--skills`` values into a one-shot agent.
+
+    One-shot bypasses ``cli.py``, so it must perform the same explicit skill
+    preload before the first (and only) model call.  The agent already owns a
+    stable session id at this point, which keeps skill template rendering
+    consistent with normal chat sessions.
+    """
+    parsed = _normalize_toolsets(skills) or []
+    parsed = list(dict.fromkeys(parsed))
+    if not parsed:
+        return []
+
+    from agent.skill_commands import build_preloaded_skills_prompt
+
+    skills_prompt, loaded_skills, missing_skills = build_preloaded_skills_prompt(
+        parsed,
+        task_id=getattr(agent, "session_id", None),
+    )
+    if missing_skills:
+        missing_display = ", ".join(missing_skills)
+        if loaded_skills:
+            logging.getLogger(__name__).warning(
+                "Unknown skill(s) requested, skipping: %s. Continuing with: %s.",
+                missing_display,
+                ", ".join(loaded_skills),
+            )
+        else:
+            raise ValueError(f"Unknown skill(s): {missing_display}")
+
+    if skills_prompt:
+        current = getattr(agent, "ephemeral_system_prompt", None)
+        agent.ephemeral_system_prompt = "\n\n".join(
+            part for part in (current, skills_prompt) if part
+        ).strip()
+        agent.preloaded_skills = loaded_skills
+
+    return loaded_skills
 
 
 def _oneshot_clarify_callback(question: str, choices=None, multi_select=False) -> str:

--- a/tests/hermes_cli/test_oneshot_skills.py
+++ b/tests/hermes_cli/test_oneshot_skills.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_apply_preloaded_skills_uses_session_and_preserves_existing_prompt(monkeypatch):
+    from agent import skill_commands
+    from hermes_cli.oneshot import _apply_preloaded_skills
+
+    captured = {}
+
+    def fake_build(skills, task_id=None):
+        captured["skills"] = skills
+        captured["task_id"] = task_id
+        return "loaded skill prompt", ["alpha", "beta"], []
+
+    monkeypatch.setattr(skill_commands, "build_preloaded_skills_prompt", fake_build)
+    agent = SimpleNamespace(
+        session_id="session-123",
+        ephemeral_system_prompt="existing prompt",
+    )
+
+    loaded = _apply_preloaded_skills(agent, ["alpha,beta", "alpha"])
+
+    assert loaded == ["alpha", "beta"]
+    assert captured == {
+        "skills": ["alpha", "beta"],
+        "task_id": "session-123",
+    }
+    assert agent.ephemeral_system_prompt == "existing prompt\n\nloaded skill prompt"
+    assert agent.preloaded_skills == ["alpha", "beta"]
+
+
+def test_apply_preloaded_skills_rejects_fully_unknown_request(monkeypatch):
+    from agent import skill_commands
+    from hermes_cli.oneshot import _apply_preloaded_skills
+
+    monkeypatch.setattr(
+        skill_commands,
+        "build_preloaded_skills_prompt",
+        lambda skills, task_id=None: ("", [], skills),
+    )
+    agent = SimpleNamespace(
+        session_id="session-123",
+        ephemeral_system_prompt=None,
+    )
+
+    with pytest.raises(ValueError, match=r"Unknown skill\(s\): missing-skill"):
+        _apply_preloaded_skills(agent, "missing-skill")
+
+    assert agent.ephemeral_system_prompt is None
+
+
+def test_run_oneshot_forwards_skills_to_agent(monkeypatch, capsys):
+    import hermes_cli.oneshot as oneshot
+
+    captured = {}
+
+    def fake_run_agent(prompt, **kwargs):
+        captured["prompt"] = prompt
+        captured.update(kwargs)
+        return "ok", {"final_response": "ok", "failed": False, "partial": False}
+
+    monkeypatch.setattr(oneshot, "_run_agent", fake_run_agent)
+
+    assert oneshot.run_oneshot("hello", skills=["alpha,beta"]) == 0
+    assert captured["prompt"] == "hello"
+    assert captured["skills"] == ["alpha,beta"]
+    assert capsys.readouterr().out == "ok\n"
+
+
+def test_main_oneshot_wrapper_forwards_skills(monkeypatch):
+    import hermes_cli.main as main
+    import hermes_cli.oneshot as oneshot
+
+    captured = {}
+
+    def fake_run_oneshot(prompt, **kwargs):
+        captured["prompt"] = prompt
+        captured.update(kwargs)
+        return 0
+
+    class ExitCalled(Exception):
+        pass
+
+    monkeypatch.setattr(oneshot, "run_oneshot", fake_run_oneshot)
+    monkeypatch.setattr(main, "_cleanup_oneshot_runtime", lambda: None)
+    monkeypatch.setattr(
+        main,
+        "_exit_after_oneshot",
+        lambda rc: (_ for _ in ()).throw(ExitCalled(rc)),
+    )
+
+    with pytest.raises(ExitCalled):
+        main._run_and_exit_oneshot("hello", skills=["alpha"])
+
+    assert captured["prompt"] == "hello"
+    assert captured["skills"] == ["alpha"]


### PR DESCRIPTION
## Summary

- forward `-s` / `--skills` through every one-shot CLI dispatch path
- load requested skills into the one-shot agent before its only model call
- preserve existing ephemeral prompt content and match chat behavior for missing skills

## Scope

- no gateway, provider, model, or container changes
- no migrations
- no deployment changes

## Verification

- `pytest -q -p no:cacheprovider tests/hermes_cli/test_oneshot_skills.py tests/hermes_cli/test_tui_resume_flow.py tests/hermes_cli/test_argparse_flag_propagation.py tests/cli/test_cli_preloaded_skills.py` — 19 passed
- `ruff check --no-cache hermes_cli/main.py hermes_cli/oneshot.py tests/hermes_cli/test_oneshot_skills.py` — passed
- offline integration against a real nested skill: loaded `theclamai-content-intelligence`, injected 7,721 prompt characters, no network or model call