### PR TITLE
fix(discord): order free models first in the /model picker so they survive the 25-option cap

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# PR #86175 Discord free-model picker

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -210,6 +210,28 @@ def _truncate_discord_component_text(text: str, limit: int) -> str:
     return _prefix_within_utf16_limit(str(text or ""), max(0, limit))
 
 
+# Discord select menus cap at 25 options (API hard limit). Free models are
+# appended to the END of the curated provider lists (see
+# ``union_with_portal_free_recommendations`` in hermes_cli/models.py), so a
+# naive ``models[:25]`` slice silently drops every ``:free`` model for
+# providers with >25 curated entries (e.g. nous: 36, openrouter: 34). A
+# free-tier user then sees no free options at all. Order free models first
+# within the option budget so they are never hidden behind the cap.
+_DISCORD_SELECT_MAX_OPTIONS = 25
+
+
+def _is_free_model_id(model_id: str) -> bool:
+    """Return True for a model id carrying the conventional ``:free`` marker."""
+    return ":free" in (model_id or "").strip().lower()
+
+
+def _ordered_discord_model_ids(model_ids: list) -> list:
+    """Stable-sort model ids free-first, preserving relative order within each group."""
+    free = [m for m in model_ids if _is_free_model_id(m)]
+    paid = [m for m in model_ids if not _is_free_model_id(m)]
+    return (free + paid)[:_DISCORD_SELECT_MAX_OPTIONS]
+
+
 def _abort_discord_websocket_transport(websocket: Any) -> bool:
     """Abort the active aiohttp transport after a bounded close times out."""
     socket = getattr(websocket, "socket", None)
@@ -9199,7 +9221,7 @@ def _define_discord_view_classes() -> None:
 
             models = provider.get("models", [])
             options = []
-            for model_id in models[:25]:
+            for model_id in _ordered_discord_model_ids(models):
                 short = model_id.split("/")[-1] if "/" in model_id else model_id
                 options.append(
                     discord.SelectOption(
@@ -9288,7 +9310,7 @@ def _define_discord_view_classes() -> None:
             self._build_model_select(provider_slug)
 
             total = provider.get("total_models", 0) if provider else 0
-            shown = min(len(provider.get("models", [])), 25) if provider else 0
+            shown = len(_ordered_discord_model_ids(provider.get("models", []))) if provider else 0
             extra = f"\n*{total - shown} more available — type `/model <name>` directly*" if total > shown else ""
 
             await interaction.response.edit_message(

--- a/tests/plugins/platforms/test_discord_model_picker_free.py
+++ b/tests/plugins/platforms/test_discord_model_picker_free.py
@@ -1,0 +1,66 @@
+"""Unit tests for the Discord model-picker free-model ordering.
+
+Regression: free models are appended to the END of curated provider lists
+(union_with_portal_free_recommendations in hermes_cli/models.py), so a naive
+``models[:25]`` slice in the Discord model dropdown silently dropped every
+``:free`` model for providers with more than 25 curated entries (nous: 36,
+openrouter: 34). Free-first ordering keeps them visible within Discord's
+25-option select cap.
+"""
+
+from plugins.platforms.discord.adapter import (
+    _DISCORD_SELECT_MAX_OPTIONS,
+    _is_free_model_id,
+    _ordered_discord_model_ids,
+)
+
+
+def test_free_models_ordered_first_within_cap():
+    # Simulate nous: 30 paid + 6 free appended at the end.
+    paid = [f"vendor/model-{i}" for i in range(30)]
+    free = [
+        "upstage/solar-pro4:free",
+        "meituan/longcat-2.0:free",
+        "poolside/laguna-s-2.1:free",
+        "stepfun/step-3.7-flash:free",
+        "tencent/hy3:free",
+        "poolside/laguna-xs-2.1:free",
+    ]
+    ordered = _ordered_discord_model_ids(paid + free)
+
+    # Every free model survives and lands at the front.
+    assert ordered[: len(free)] == free
+    # Within the 25-option Discord cap.
+    assert len(ordered) <= _DISCORD_SELECT_MAX_OPTIONS
+    # Paid tail is truncated but leading paid models still present, order kept.
+    assert ordered[0].endswith(":free")
+    assert "vendor/model-0" in ordered
+
+
+def test_fewer_than_cap_returns_all_free_first_preserving_order():
+    models = ["a/one", "b/two:free", "c/three", "d/four:free"]
+    ordered = _ordered_discord_model_ids(models)
+    assert ordered == ["b/two:free", "d/four:free", "a/one", "c/three"]
+
+
+def test_empty_list_returns_empty():
+    assert _ordered_discord_model_ids([]) == []
+
+
+def test_no_free_models_unchanged_within_cap():
+    many = [f"vendor/m{i}" for i in range(40)]
+    ordered = _ordered_discord_model_ids(many)
+    assert len(ordered) == _DISCORD_SELECT_MAX_OPTIONS
+    assert ordered == many[:_DISCORD_SELECT_MAX_OPTIONS]
+
+
+def test_discord_select_max_options_is_25():
+    assert _DISCORD_SELECT_MAX_OPTIONS == 25
+
+
+def test_is_free_model_id():
+    assert _is_free_model_id("upstage/solar-pro4:free")
+    assert _is_free_model_id("nvidia/nemotron-3-ultra-550b-a55b:free")
+    assert not _is_free_model_id("openai/gpt-5.5")
+    assert not _is_free_model_id("")
+    assert not _is_free_model_id("vendor/model:paid-tier")


### PR DESCRIPTION
## Prior work / credit

This fix was first identified and proposed by **@Deepdelver** in **#75577** ("fix(discord): keep free models visible in /model picker"). They got there first and hold the credit for the fix.

This PR supersedes #75577's implementation with a refactored equivalent (factored `_is_free_model_id` / `_ordered_discord_model_ids` helpers, broader `":free"` substring detection, and dedicated unit coverage) while preserving the same free-first ordering. The original fix's authorship is credited via the `Co-authored-by` trailer on the fix commit.

## Summary

Fixes **#86174** — the Discord `/model` picker silently dropped **every free (`:free`) model** for providers with more than 25 curated models.

**Root cause:** Discord select menus cap at **25 options** (API hard limit). The model dropdown used a naive `models[:25]` slice (`plugins/platforms/discord/adapter.py`). Free models are **appended to the end** of curated provider lists by `union_with_portal_free_recommendations` (`hermes_cli/models.py`), so for providers exceeding 25 curated entries every `:free` model fell past the slice and never appeared.

Verified with live picker data:
- **nous**: 36 total, 6 free (positions 31–36) → **0 shown**
- **openrouter**: 34 total, 2 free (positions 33–34) → **0 shown**

A free-tier user saw zero free options, and the "type `/model <name>` directly" hint required already knowing the exact free model name.

## Change

Order free models **first** within the 25-option budget so they are never hidden behind the cap:

- `_is_free_model_id(model_id)` — detects the conventional `:free` marker
- `_ordered_discord_model_ids(model_ids)` — stable free-first ordering, truncated to the Discord cap
- `_build_model_select` now uses `_ordered_discord_model_ids` instead of `models[:25]`
- the "shown" count uses the same ordering so the "N more available" hint stays accurate

Preserves relative order within each group (paid models keep curated order after the free tier).

## Cross-platform check (Discord vs Telegram)

We double-checked both surfaces for the same issue:

- **Discord — broken, fixed here.** Hard `models[:25]` select-option slice dropped end-appended free models.
- **Telegram — already correct, no change needed.** The Telegram picker uses a **paginated inline keyboard** (`_MODEL_PAGE_SIZE = 8`) over the *full* model list stored in picker state. `_build_model_keyboard` pages through all models via `_format_choice_page`, so free models at the end of a long list are reachable with Next ▶ pagination — never truncated. Verified end-to-end: `state["model_list"]` holds the complete provider list and page navigation re-pages over it.

The fix is deliberately Discord-scoped; Telegram needs no change.

## Tests

New `tests/plugins/platforms/test_discord_model_picker_free.py` — 6 unit tests covering:
- free models ordered first and surviving the 25-option cap
- fewer-than-cap returns all models free-first, order preserved
- empty list and no-free lists unchanged
- the 25-option constant and the `:free` detector

## Files
- `plugins/platforms/discord/adapter.py` (+24/−2)
- `tests/plugins/platforms/test_discord_model_picker_free.py` (new)

