### PR TITLE
fix(security): pin nanoid and postcss versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -37,7 +37,7 @@ min-release-age-exclude[]=brace-expansion
 # js-yaml 4.3.1 includes fixes for GHSA-5p4m-2wfm-xmqj. remove when > 2wks old (rel 2026-07-31)
 min-release-age-exclude[]=js-yaml
 
-# nanoid 3.3.17 includes fixes for GHSA-2v37-7h3g-55p8. remove when > 2wks old (rel 2026-08-03)
+# nanoid 3.3.18 includes fixes for GHSA-2v37-7h3g-55p8. remove when > 2wks old (rel 2026-08-07)
 min-release-age-exclude[]=nanoid
 
 # mermaid 11.16.1 includes fixes for 5 GHSAs. remove when > 2wks old (rel 2026-08-04)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16482,9 +16482,9 @@
       }
     },
     "node_modules/sanitize-html/node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -16500,9 +16500,9 @@
       }
     },
     "node_modules/sanitize-html/node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -16519,7 +16519,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -18322,9 +18322,9 @@
       }
     },
     "node_modules/vite/node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -18340,9 +18340,9 @@
       }
     },
     "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -18359,7 +18359,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "mermaid": "11.16.1",
     "dompurify": "3.4.13",
     "ip-address": "10.3.1",
-    "nanoid@^3": "3.3.17",
+    "nanoid@^3": "3.3.18",
     "nanoid@^6": "6.0.0",
     "js-yaml@^4": "4.3.1",
     "undici@^6": "6.28.0",
     "undici@^7": "7.29.0",
-    "postcss": "8.5.23",
+    "postcss": "8.5.26",
     "tar": "7.5.22"
   },
   "engines": {


### PR DESCRIPTION
## Summary

This is a standalone dependency-security PR, intentionally separate from PR #85800. It carries the exact nanoid/postcss security pin that was present as a reviewed, pre-existing local patch in the Hermes runtime checkout.

## Exact changes

Only these three files changed:

- `.npmrc` — refreshes the nanoid security-pin comment/date for nanoid 3.3.18.
- `package.json` — changes the overrides to:
  - `nanoid@^3`: `3.3.18`
  - `postcss`: `8.5.26`
- `package-lock.json` — updates the corresponding nested nanoid/postcss package versions, registry URLs, integrity hashes, and dependency ranges.

The branch is based on `main` at `c896c09c42910c584c4c7d2325b58c14713ea42c` and contains no cron guardrail or local Hermes operations-script changes.

## Validation

- Parsed `package.json` and `package-lock.json` as JSON.
- Verified the override values exactly match nanoid 3.3.18 and postcss 8.5.26.
- Verified the affected lockfile entries use the expected resolved versions and integrity values.
- `git diff --check`
- `npm ci --ignore-scripts --dry-run --no-audit --no-fund` (completed successfully; 1362 packages resolved in dry-run mode).

No OSV/npm audit or other security scan is claimed here; CI should perform the repository's normal scans.

## Scope exclusions

- Does not modify or merge PR #85800.
- Does not include the cron scheduler hotfix.
- Does not include the local auto-update wrapper, restart post-check, or runtime checkout changes.
- Does not run or alter the live Hermes gateway.
