### PR TITLE
fix(gateway): reject legacy V1 webhook HMAC by default

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -657,8 +657,20 @@ class WebhookAdapter(BasePlatformAdapter):
                 return False
             return _hmac_str_equal(v2_sig, _hex_hmac(secret, v2_timestamp.encode() + b"." + body))
         # Generic V1 (legacy, deprecated): body-only HMAC → replays indefinitely.
+        # V1 is rejected by default (security fail-closed). A route may explicitly
+        # opt in with ``allow_legacy_v1: true`` to preserve backward compatibility
+        # during migration to V2; the warning is still emitted once per route so
+        # the operator is reminded to migrate.
         generic_sig = headers.get("X-Webhook-Signature", "")
         if generic_sig:
+            route_config = self._routes.get(route_name, {})
+            if not route_config.get("allow_legacy_v1", False):
+                logger.warning(
+                    "[webhook] Route '%s' sent legacy V1 signature (X-Webhook-Signature) which is replayable "
+                    "(no timestamp binding). V1 is rejected by default; set 'allow_legacy_v1: true' on the "
+                    "route to accept during migration, or switch to X-Webhook-Signature-V2 with "
+                    "X-Webhook-Timestamp.", route_name)
+                return False
             if route_name not in self._v1_signature_warned:
                 self._v1_signature_warned.add(route_name)
                 logger.warning("[webhook] Route '%s' uses legacy body-only HMAC (no timestamp), which is vulnerable "

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -664,7 +664,9 @@ class WebhookAdapter(BasePlatformAdapter):
         generic_sig = headers.get("X-Webhook-Signature", "")
         if generic_sig:
             route_config = self._routes.get(route_name, {})
-            if not route_config.get("allow_legacy_v1", False):
+            # Identity check only: YAML "false", 1, and non-empty objects
+            # are all truthy and must not re-enable replayable V1 HMAC.
+            if route_config.get("allow_legacy_v1") is not True:
                 logger.warning(
                     "[webhook] Route '%s' sent legacy V1 signature (X-Webhook-Signature) which is replayable "
                     "(no timestamp binding). V1 is rejected by default; set 'allow_legacy_v1: true' on the "

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -301,6 +301,33 @@ class TestValidateSignature:
         )
         assert adapter._validate_signature(req, body, secret) is True
 
+    @pytest.mark.parametrize(
+        "malformed_flag",
+        ("false", "true", 1, 0, {"enabled": True}),
+    )
+    def test_v1_signature_rejected_for_non_boolean_allow_legacy_v1(
+        self, malformed_flag
+    ):
+        """Only the boolean True opts in. Truthy strings, numbers, and
+        objects must not re-enable replayable body-only HMAC."""
+        adapter = _make_adapter(
+            routes={
+                "legacy-route": {
+                    "prompt": "test",
+                    "allow_legacy_v1": malformed_flag,
+                }
+            },
+            secret="generic-secret",
+        )
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        sig = _generic_signature(body, secret)
+        req = _mock_request(
+            headers={"X-Webhook-Signature": sig},
+            match_info={"route_name": "legacy-route"},
+        )
+        assert adapter._validate_signature(req, body, secret) is False
+
     def test_v1_signature_wrong_secret_rejected_even_with_allow_legacy_v1(self):
         """Even with ``allow_legacy_v1: true``, a wrong signature is rejected."""
         adapter = _make_adapter(

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -263,24 +263,73 @@ class TestValidateSignature:
         })
         assert adapter._validate_signature(req, body, secret) is False
 
-    def test_v1_replay_attack_succeeds_demonstrating_the_hole_v2_closes(self):
-        """Regression/documentation test: a captured (body, signature) V1
-        pair replays successfully no matter how much time has passed,
-        because the V1 signature has no timestamp binding at all. This is
-        the exact vulnerability V2 fixes — it is not asserting desired
-        behavior, it is pinning the known, accepted-with-warning legacy
-        gap so a future change to V1's semantics doesn't silently alter it
-        without a deliberate decision."""
+    def test_v1_signature_rejected_by_default(self):
+        """V1 (body-only HMAC) is rejected by default because it has no
+        timestamp binding and is therefore replayable. A captured
+        (body, signature) pair must not validate, regardless of how much
+        time has passed (SECURITY-CLASS-a93a9b33ab551b86)."""
         adapter = _make_adapter()
         body = b'{"event": "push"}'
         secret = "generic-secret"
         sig = _generic_signature(body, secret)
-        original_request = _mock_request(headers={"X-Webhook-Signature": sig})
-        assert adapter._validate_signature(original_request, body, secret) is True
-        # "Time passes" — nothing about a V1 signature depends on time, so
-        # a captured pair replayed much later still validates.
-        replayed_request = _mock_request(headers={"X-Webhook-Signature": sig})
-        assert adapter._validate_signature(replayed_request, body, secret) is True
+        req = _mock_request(
+            headers={"X-Webhook-Signature": sig},
+            match_info={"route_name": "test-route"},
+        )
+        assert adapter._validate_signature(req, body, secret) is False
+        # A replay of the same pair is also rejected (no time dependency).
+        replayed = _mock_request(
+            headers={"X-Webhook-Signature": sig},
+            match_info={"route_name": "test-route"},
+        )
+        assert adapter._validate_signature(replayed, body, secret) is False
+
+    def test_v1_signature_accepted_with_explicit_allow_legacy_v1(self):
+        """A route that explicitly sets ``allow_legacy_v1: true`` opts in to
+        the legacy body-only HMAC during migration. The signature is still
+        validated, and the operator is warned once per route."""
+        adapter = _make_adapter(
+            routes={"legacy-route": {"prompt": "test", "allow_legacy_v1": True}},
+            secret="generic-secret",
+        )
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        sig = _generic_signature(body, secret)
+        req = _mock_request(
+            headers={"X-Webhook-Signature": sig},
+            match_info={"route_name": "legacy-route"},
+        )
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_v1_signature_wrong_secret_rejected_even_with_allow_legacy_v1(self):
+        """Even with ``allow_legacy_v1: true``, a wrong signature is rejected."""
+        adapter = _make_adapter(
+            routes={"legacy-route": {"prompt": "test", "allow_legacy_v1": True}},
+            secret="generic-secret",
+        )
+        body = b'{"event": "push"}'
+        sig = _generic_signature(body, "wrong-secret")
+        req = _mock_request(
+            headers={"X-Webhook-Signature": sig},
+            match_info={"route_name": "legacy-route"},
+        )
+        assert adapter._validate_signature(req, body, "generic-secret") is False
+
+    def test_v2_signature_still_accepted(self):
+        """V2 signatures (with timestamp) are unaffected by the V1 default
+        rejection — they were never replayable."""
+        adapter = _make_adapter()
+        body = b'{"event": "push"}'
+        secret = "generic-secret"
+        timestamp = str(int(time.time()))
+        sig = _generic_v2_signature(body, secret, timestamp)
+        req = _mock_request(
+            headers={
+                "X-Webhook-Signature-V2": sig,
+                "X-Webhook-Timestamp": timestamp,
+            },
+        )
+        assert adapter._validate_signature(req, body, secret) is True
 
 
     def test_validate_svix_signature_raw_secret_valid(self):


### PR DESCRIPTION
## What does this PR do?

Legacy V1 webhook HMAC validation was accepted by default, leaving webhook endpoints vulnerable to replay attacks. This PR:

1. Rejects V1 webhook HMAC by default (fail-closed)
2. Requires explicit per-route opt-in via `allow_legacy_v1: true`
3. The opt-in requires boolean `True` (identity check), not just truthy
4. Emits a deprecation warning when V1 is opted in

## Related Issue

Fixes #84265

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `gateway/platforms/webhook.py`: V1 HMAC reject-by-default with `allow_legacy_v1` opt-in gate.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_webhook.py` — webhook tests pass.
2. Full project checker passes.

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-review completed
- [x] Tests added/updated and passing