### PR TITLE
fix(state): verify and self-repair FTS5 indexes on engine change

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -65,6 +65,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     escape_like as _escape_like,
     DEFERRED_INDEX_SQL,
     FTS_CJK_STALE_KEY,
+    FTS_INTEGRITY_ENGINE_KEY,
     FTS_SQL,
     FTS_STALE_KEY,
     FTS_STORAGE_VERSION,

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -624,6 +624,16 @@ FTS_CJK_STALE_KEY = "fts_cjk_stale"
 FTS_STALE_KEY = "fts_stale"
 
 
+# state_meta key holding the sqlite3.sqlite_version that last passed the
+# FTS5 'integrity-check' sweep at open. An index written by one SQLite
+# engine can be unreadable by another (the trigram tokenizer's handling of
+# embedded NUL changed across engines, so MATCH and trigger writes succeed
+# while DELETE fails with "malformed inverted index", #86027). The open-time
+# gate therefore re-verifies — and 'rebuild'-repairs — the FTS tables once
+# per ENGINE VERSION instead of on every open.
+FTS_INTEGRITY_ENGINE_KEY = "fts_integrity_engine"
+
+
 # ── Legacy (v22 / inline-content) FTS DDL ──────────────────────────────
 # Used ONLY to keep an existing pre-v23 install's search working and its
 # triggers repairable UNTIL the user opts into `hermes db optimize`. This is

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -17,6 +17,7 @@ from hermes_constants import get_hermes_home
 from hermes_state_common import (
     DEFERRED_INDEX_SQL,
     FTS_CJK_STALE_KEY,
+    FTS_INTEGRITY_ENGINE_KEY,
     FTS_STALE_KEY,
     FTS_SQL,
     FTS_STORAGE_VERSION,
@@ -37,6 +38,26 @@ logger = logging.getLogger("hermes_state")
 # Cache for schema_read_probe_statements() — parsing SCHEMA_SQL spins up an
 # in-memory SQLite database, so derive the statements once per process.
 _READ_PROBE_STATEMENTS: Optional[tuple] = None
+
+# Per-table legacy DDL + trigger group for the drop-recreate fallback in
+# _rebuild_legacy_fts_indexes: a malformed inverted index can fail even the
+# plain ``DELETE FROM <table>`` the backfill starts with (#86027). Dropping
+# a virtual table leaves its sync triggers on ``messages`` dangling, so the
+# triggers go first; the DDL re-creates table AND triggers (IF NOT EXISTS).
+_LEGACY_FTS_TABLES = {
+    "messages_fts": (
+        ("messages_fts_insert", "messages_fts_delete", "messages_fts_update"),
+        LEGACY_FTS_SQL,
+    ),
+    "messages_fts_trigram": (
+        (
+            "messages_fts_trigram_insert",
+            "messages_fts_trigram_delete",
+            "messages_fts_trigram_update",
+        ),
+        LEGACY_FTS_TRIGRAM_SQL,
+    ),
+}
 
 
 def schema_read_probe_statements() -> tuple:
@@ -307,27 +328,69 @@ class SessionSchemaMixin:
         earlier no-FTS5 runtime. Inline tables have no external-content
         'rebuild' source, so we DELETE + reinsert the concatenated content
         the legacy triggers produced. Never touches the v23 shape.
+
+        A DELETE that fails with DatabaseError (the #86027 malformed-index
+        class: the index was written by a different SQLite engine) falls
+        back to dropping and recreating the virtual table from its legacy
+        DDL before backfilling, so the repair never fails the open. A
+        fallback that cannot complete leaves the ``fts_stale`` breadcrumb
+        so the next open performs the full recovery instead of trusting a
+        possibly-empty index.
         """
-        cursor.execute("DELETE FROM messages_fts")
-        cursor.execute(
-            "INSERT INTO messages_fts(rowid, content) "
+        backfill_sql = (
+            "INSERT INTO {table}(rowid, content) "
             "SELECT id, "
             "COALESCE(content, '') || ' ' || "
             "COALESCE(tool_name, '') || ' ' || "
             "COALESCE(tool_calls, '') "
             "FROM messages"
         )
-        if not include_trigram:
-            return
-        cursor.execute("DELETE FROM messages_fts_trigram")
-        cursor.execute(
-            "INSERT INTO messages_fts_trigram(rowid, content) "
-            "SELECT id, "
-            "COALESCE(content, '') || ' ' || "
-            "COALESCE(tool_name, '') || ' ' || "
-            "COALESCE(tool_calls, '') "
-            "FROM messages"
-        )
+        tables = ("messages_fts",)
+        if include_trigram:
+            tables += ("messages_fts_trigram",)
+        for table in tables:
+            triggers, ddl = _LEGACY_FTS_TABLES[table]
+            try:
+                cursor.execute(f"DELETE FROM {table}")
+            except sqlite3.DatabaseError as exc:
+                logger.warning(
+                    "Cannot clear legacy FTS index %s with DELETE (%s); "
+                    "dropping and recreating it instead",
+                    table,
+                    exc,
+                )
+                try:
+                    for trigger in triggers:
+                        cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+                    cursor.execute(f"DROP TABLE IF EXISTS {table}")
+                    cursor.executescript(ddl)
+                    # Backfill inside the same guard: a failure here (e.g.
+                    # messages itself unreadable) must not escape and fail
+                    # the open — this method is a best-effort repair path.
+                    cursor.execute(backfill_sql.format(table=table))
+                except sqlite3.Error as fallback_exc:
+                    # The recreated table may be empty but structurally
+                    # valid, so the engine-integrity gate later in the open
+                    # would pass it and stamp the marker — freezing a
+                    # silently-dead index. Drop the existing fts_stale
+                    # breadcrumb instead: the next open routes through
+                    # _recover_stale_fts (full drop/recreate/backfill), and
+                    # if that still cannot complete, FTS degrades visibly
+                    # instead of staying empty forever.
+                    cursor.execute(
+                        "INSERT INTO state_meta (key, value) VALUES (?, '1') "
+                        "ON CONFLICT(key) DO UPDATE SET value = '1'",
+                        (FTS_STALE_KEY,),
+                    )
+                    logger.error(
+                        "Could not recreate legacy FTS index %s (%s); marked "
+                        "FTS stale for full recovery on next open — run "
+                        "`hermes sessions repair` to rebuild it now",
+                        table,
+                        fallback_exc,
+                    )
+                continue
+            cursor.execute(backfill_sql.format(table=table))
 
     def _fts_table_probe(self, cursor: sqlite3.Cursor, table_name: str) -> Optional[bool]:
         try:
@@ -345,6 +408,99 @@ class SessionSchemaMixin:
             if "no such table" in str(exc).lower():
                 return False
             raise
+
+    def _verify_fts_engine_integrity(self, cursor: sqlite3.Cursor) -> None:
+        """Re-verify FTS5 index integrity once per SQLite engine version.
+
+        An index written by one SQLite engine can be silently unreadable by
+        another (#86027: the trigram tokenizer changed how content with an
+        embedded NUL is tokenized, so MATCH and the sync triggers keep
+        working while ``DELETE FROM`` and the FTS5 'integrity-check' command
+        fail with "malformed inverted index"). With triggers intact nothing
+        else on the open path notices, so the DB silently carries a broken
+        derived index across the upgrade.
+
+        Gated by the state_meta key ``fts_integrity_engine``: when it holds
+        the running ``sqlite3.sqlite_version`` the sweep already passed on
+        this engine and costs a single meta read. Otherwise every EXISTING
+        FTS table gets one 'integrity-check'; a failure is repaired in place
+        with the 'rebuild' command (full re-tokenization from the stored
+        content) and re-verified. A repair that cannot be verified logs the
+        manual escape hatch and leaves the marker unstamped so the next open
+        retries. Never raises: this hardens derived indexes only and must
+        not fail opening the canonical store.
+        """
+        if self.read_only:
+            return
+        try:
+            row = cursor.execute(
+                "SELECT value FROM state_meta WHERE key = ? LIMIT 1",
+                (FTS_INTEGRITY_ENGINE_KEY,),
+            ).fetchone()
+            if row is not None:
+                stamped = row["value"] if isinstance(row, sqlite3.Row) else row[0]
+                if stamped == sqlite3.sqlite_version:
+                    return
+
+            capability_missing = False
+            verified = True
+            for table in ("messages_fts", "messages_fts_trigram", "messages_fts_cjk"):
+                status = self._fts_table_probe(cursor, table)
+                if status is not True:
+                    if status is None:
+                        # An incapable host (e.g. no trigram tokenizer) must
+                        # not stamp the engine marker on behalf of the
+                        # capable host that may have written these indexes.
+                        capability_missing = True
+                    continue
+                try:
+                    cursor.execute(
+                        f"INSERT INTO {table}({table}) VALUES('integrity-check')"
+                    )
+                except sqlite3.DatabaseError as exc:
+                    try:
+                        cursor.execute(
+                            f"INSERT INTO {table}({table}) VALUES('rebuild')"
+                        )
+                        cursor.execute(
+                            f"INSERT INTO {table}({table}) VALUES('integrity-check')"
+                        )
+                    except sqlite3.DatabaseError as repair_exc:
+                        verified = False
+                        logger.error(
+                            "FTS index %s in %s failed integrity verification "
+                            "under SQLite %s and could not be repaired "
+                            "automatically (%s); run `hermes sessions repair` "
+                            "to rebuild it",
+                            table,
+                            self.db_path,
+                            sqlite3.sqlite_version,
+                            repair_exc,
+                        )
+                        continue
+                    logger.warning(
+                        "Rebuilt FTS index %s in %s: the stored inverted "
+                        "index was not verifiable under SQLite %s (%s)",
+                        table,
+                        self.db_path,
+                        sqlite3.sqlite_version,
+                        exc,
+                    )
+            if capability_missing or not verified:
+                return
+            self.set_meta(
+                FTS_INTEGRITY_ENGINE_KEY,
+                sqlite3.sqlite_version,
+                cursor=cursor,
+            )
+        except sqlite3.Error as exc:
+            # The gate is best-effort hardening: an unexpected engine error
+            # degrades to "unchecked this open", never to a failed open.
+            logger.warning(
+                "FTS engine integrity gate skipped for %s: %s",
+                self.db_path,
+                exc,
+            )
 
     def _recover_stale_fts(self, cursor: sqlite3.Cursor, *, legacy: bool) -> bool:
         """Atomically rebuild stale base/trigram indexes and resume syncing."""
@@ -1267,6 +1423,11 @@ class SessionSchemaMixin:
             # AFTER UPDATE OF variants. IF NOT EXISTS cannot rewrite them.
             if getattr(self, "_fts_enabled", False):
                 self._migrate_broad_fts_update_triggers(cursor)
+
+            # One FTS integrity sweep per SQLite engine version (#86027):
+            # verify every existing index, 'rebuild'-repair any another
+            # engine left unreadable, then stamp the engine marker.
+            self._verify_fts_engine_integrity(cursor)
 
         self._conn.commit()
 

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -329,13 +329,15 @@ class SessionSchemaMixin:
         'rebuild' source, so we DELETE + reinsert the concatenated content
         the legacy triggers produced. Never touches the v23 shape.
 
-        A DELETE that fails with DatabaseError (the #86027 malformed-index
-        class: the index was written by a different SQLite engine) falls
-        back to dropping and recreating the virtual table from its legacy
-        DDL before backfilling, so the repair never fails the open. A
-        fallback that cannot complete leaves the ``fts_stale`` breadcrumb
-        so the next open performs the full recovery instead of trusting a
-        possibly-empty index.
+        A DELETE that fails with the malformed-index error class (the
+        #86027 corruption: the index was written by a different SQLite
+        engine) falls back to atomically dropping and recreating the
+        virtual table from its legacy DDL before backfilling, so the
+        repair never fails the open. Transient lock/busy/IO errors are
+        re-raised for the outer open-retry path instead (adopted from the
+        #86062 review round). A fallback that cannot complete leaves the
+        ``fts_stale`` breadcrumb so the next open performs the full
+        recovery instead of trusting a possibly-empty index.
         """
         backfill_sql = (
             "INSERT INTO {table}(rowid, content) "
@@ -343,7 +345,7 @@ class SessionSchemaMixin:
             "COALESCE(content, '') || ' ' || "
             "COALESCE(tool_name, '') || ' ' || "
             "COALESCE(tool_calls, '') "
-            "FROM messages"
+            "FROM messages;"
         )
         tables = ("messages_fts",)
         if include_trigram:
@@ -353,30 +355,44 @@ class SessionSchemaMixin:
             try:
                 cursor.execute(f"DELETE FROM {table}")
             except sqlite3.DatabaseError as exc:
+                if not SessionSchemaMixin._is_malformed_fts_index_error(exc):
+                    raise
                 logger.warning(
                     "Cannot clear legacy FTS index %s with DELETE (%s); "
                     "dropping and recreating it instead",
                     table,
                     exc,
                 )
+                recovery_sql = (
+                    "BEGIN IMMEDIATE;"
+                    + "".join(
+                        f"DROP TRIGGER IF EXISTS {trigger};" for trigger in triggers
+                    )
+                    + f"DROP TABLE IF EXISTS {table};"
+                    + ddl
+                    + backfill_sql.format(table=table)
+                    + "COMMIT;"
+                )
                 try:
-                    for trigger in triggers:
-                        cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
-                    cursor.execute(f"DROP TABLE IF EXISTS {table}")
-                    cursor.executescript(ddl)
-                    # Backfill inside the same guard: a failure here (e.g.
-                    # messages itself unreadable) must not escape and fail
-                    # the open — this method is a best-effort repair path.
-                    cursor.execute(backfill_sql.format(table=table))
-                except sqlite3.Error as fallback_exc:
-                    # The recreated table may be empty but structurally
-                    # valid, so the engine-integrity gate later in the open
-                    # would pass it and stamp the marker — freezing a
-                    # silently-dead index. Drop the existing fts_stale
-                    # breadcrumb instead: the next open routes through
-                    # _recover_stale_fts (full drop/recreate/backfill), and
-                    # if that still cannot complete, FTS degrades visibly
-                    # instead of staying empty forever.
+                    # One executescript wrapped in BEGIN IMMEDIATE/COMMIT —
+                    # the _recover_stale_fts house pattern — so drop +
+                    # recreate + backfill commit atomically and a concurrent
+                    # writer can never observe a half-dropped index.
+                    cursor.executescript(recovery_sql)
+                except sqlite3.DatabaseError as fallback_exc:
+                    try:
+                        cursor.connection.rollback()
+                    except sqlite3.Error:
+                        pass
+                    # A rolled-back recovery leaves the original malformed
+                    # table intact, but if the script died after CREATE the
+                    # table may exist empty-but-valid: the engine-integrity
+                    # gate later in the open would pass it and stamp the
+                    # marker, freezing a silently-dead index. Drop the
+                    # fts_stale breadcrumb instead: the next open routes
+                    # through _recover_stale_fts (full drop/recreate/
+                    # backfill), and if that still cannot complete, FTS
+                    # degrades visibly instead of staying empty forever.
                     cursor.execute(
                         "INSERT INTO state_meta (key, value) VALUES (?, '1') "
                         "ON CONFLICT(key) DO UPDATE SET value = '1'",
@@ -391,6 +407,30 @@ class SessionSchemaMixin:
                     )
                 continue
             cursor.execute(backfill_sql.format(table=table))
+
+    @staticmethod
+    def _is_malformed_fts_index_error(exc: BaseException) -> bool:
+        """True when *exc* is the corrupt-index class that justifies a
+        drop-and-recreate rebuild, rather than a transient lock/busy/IO
+        error that the open-retry path should handle instead.
+
+        Message-based classification adopted from the #86062 review round
+        (credit @StanleyStetson / @Christopher-Schulze): treating every
+        ``DatabaseError`` as corruption makes a ``database is locked``
+        trigger a redundant rebuild (and, pre-atomicity, an autocommitted
+        DROP TABLE).
+        """
+        if not isinstance(exc, sqlite3.DatabaseError):
+            return False
+        message = str(exc).lower()
+        return any(
+            marker in message
+            for marker in (
+                "malformed inverted index",
+                "database disk image is malformed",
+                "malformed database schema",
+            )
+        )
 
     def _fts_table_probe(self, cursor: sqlite3.Cursor, table_name: str) -> Optional[bool]:
         try:
@@ -458,6 +498,23 @@ class SessionSchemaMixin:
                         f"INSERT INTO {table}({table}) VALUES('integrity-check')"
                     )
                 except sqlite3.DatabaseError as exc:
+                    if not SessionSchemaMixin._is_malformed_fts_index_error(exc):
+                        # Transient (lock/busy/IO) — not the corruption
+                        # class. Leave the marker unstamped so the next
+                        # open re-runs the sweep instead of freezing an
+                        # unverified state (classification adopted from
+                        # the #86062 review round).
+                        verified = False
+                        logger.warning(
+                            "FTS integrity check for %s in %s hit a transient "
+                            "error under SQLite %s (%s); marker left unstamped "
+                            "to retry on next open",
+                            table,
+                            self.db_path,
+                            sqlite3.sqlite_version,
+                            exc,
+                        )
+                        continue
                     try:
                         cursor.execute(
                             f"INSERT INTO {table}({table}) VALUES('rebuild')"

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -355,7 +355,7 @@ class SessionSchemaMixin:
             try:
                 cursor.execute(f"DELETE FROM {table}")
             except sqlite3.DatabaseError as exc:
-                if not SessionSchemaMixin._is_malformed_fts_index_error(exc):
+                if SessionSchemaMixin._is_transient_sqlite_error(exc):
                     raise
                 logger.warning(
                     "Cannot clear legacy FTS index %s with DELETE (%s); "
@@ -409,28 +409,21 @@ class SessionSchemaMixin:
             cursor.execute(backfill_sql.format(table=table))
 
     @staticmethod
-    def _is_malformed_fts_index_error(exc: BaseException) -> bool:
-        """True when *exc* is the corrupt-index class that justifies a
-        drop-and-recreate rebuild, rather than a transient lock/busy/IO
-        error that the open-retry path should handle instead.
+    def _is_transient_sqlite_error(exc: BaseException) -> bool:
+        """True for lock/busy/IO/readonly errors the open-retry path handles.
 
-        Message-based classification adopted from the #86062 review round
-        (credit @StanleyStetson / @Christopher-Schulze): treating every
-        ``DatabaseError`` as corruption makes a ``database is locked``
-        trigger a redundant rebuild (and, pre-atomicity, an autocommitted
-        DROP TABLE).
+        Class-based split (replaces the message-string classifier from the
+        #86062 review round, which the #86183 review flagged as fragile):
+        corruption — ``SQLITE_CORRUPT`` and the FTS5 corrupt-structure
+        class — surfaces as plain ``sqlite3.DatabaseError``, never
+        ``OperationalError``, while ``database is locked`` / disk-IO /
+        readonly are ``OperationalError``. An isinstance check therefore
+        classifies both directions with no dependence on SQLite's error
+        wording; verified against a really-corrupt index (which also
+        showed a ``fts5: corrupt structure record`` DELETE failure the
+        string list missed) and a real ``database is locked``.
         """
-        if not isinstance(exc, sqlite3.DatabaseError):
-            return False
-        message = str(exc).lower()
-        return any(
-            marker in message
-            for marker in (
-                "malformed inverted index",
-                "database disk image is malformed",
-                "malformed database schema",
-            )
-        )
+        return isinstance(exc, sqlite3.OperationalError)
 
     def _fts_table_probe(self, cursor: sqlite3.Cursor, table_name: str) -> Optional[bool]:
         try:
@@ -461,49 +454,64 @@ class SessionSchemaMixin:
         derived index across the upgrade.
 
         Gated by the state_meta key ``fts_integrity_engine``: when it holds
-        the running ``sqlite3.sqlite_version`` the sweep already passed on
-        this engine and costs a single meta read. Otherwise every EXISTING
-        FTS table gets one 'integrity-check'; a failure is repaired in place
-        with the 'rebuild' command (full re-tokenization from the stored
-        content) and re-verified. A repair that cannot be verified logs the
-        manual escape hatch and leaves the marker unstamped so the next open
+        the running ``sqlite3.sqlite_version`` plus this host's capability
+        signature the sweep already passed here and costs a few cheap
+        metadata reads. Otherwise every EXISTING FTS table gets one
+        'integrity-check'; a failure is repaired in place with the
+        'rebuild' command (full re-tokenization from the stored content)
+        and re-verified. A repair that cannot be verified logs the manual
+        escape hatch and leaves the marker unstamped so the next open
         retries. Never raises: this hardens derived indexes only and must
         not fail opening the canonical store.
+
+        The capability signature (``|missing=<tables>`` appended when a
+        probe returns None, e.g. a host without the cjk tokenizer
+        extension) lets an incapable host also sweep at most once per
+        engine+capability pair instead of on every open, while a capable
+        host reading an incapable host's stamp sees a signature mismatch
+        and re-verifies — an incapable host still never vouches, on behalf
+        of a capable one, for indexes it could not check.
         """
         if self.read_only:
             return
         try:
+            probes = {
+                table: self._fts_table_probe(cursor, table)
+                for table in (
+                    "messages_fts",
+                    "messages_fts_trigram",
+                    "messages_fts_cjk",
+                )
+            }
+            missing = sorted(
+                table for table, status in probes.items() if status is None
+            )
+            stamp = sqlite3.sqlite_version
+            if missing:
+                stamp = f"{stamp}|missing={','.join(missing)}"
+
             row = cursor.execute(
                 "SELECT value FROM state_meta WHERE key = ? LIMIT 1",
                 (FTS_INTEGRITY_ENGINE_KEY,),
             ).fetchone()
             if row is not None:
                 stamped = row["value"] if isinstance(row, sqlite3.Row) else row[0]
-                if stamped == sqlite3.sqlite_version:
+                if stamped == stamp:
                     return
 
-            capability_missing = False
             verified = True
-            for table in ("messages_fts", "messages_fts_trigram", "messages_fts_cjk"):
-                status = self._fts_table_probe(cursor, table)
+            for table, status in probes.items():
                 if status is not True:
-                    if status is None:
-                        # An incapable host (e.g. no trigram tokenizer) must
-                        # not stamp the engine marker on behalf of the
-                        # capable host that may have written these indexes.
-                        capability_missing = True
                     continue
                 try:
                     cursor.execute(
                         f"INSERT INTO {table}({table}) VALUES('integrity-check')"
                     )
                 except sqlite3.DatabaseError as exc:
-                    if not SessionSchemaMixin._is_malformed_fts_index_error(exc):
-                        # Transient (lock/busy/IO) — not the corruption
-                        # class. Leave the marker unstamped so the next
-                        # open re-runs the sweep instead of freezing an
-                        # unverified state (classification adopted from
-                        # the #86062 review round).
+                    if self._is_transient_sqlite_error(exc):
+                        # Lock/busy/IO — not corruption. Leave the marker
+                        # unstamped so the next open re-runs the sweep
+                        # instead of freezing an unverified state.
                         verified = False
                         logger.warning(
                             "FTS integrity check for %s in %s hit a transient "
@@ -543,11 +551,11 @@ class SessionSchemaMixin:
                         sqlite3.sqlite_version,
                         exc,
                     )
-            if capability_missing or not verified:
+            if not verified:
                 return
             self.set_meta(
                 FTS_INTEGRITY_ENGINE_KEY,
-                sqlite3.sqlite_version,
+                stamp,
                 cursor=cursor,
             )
         except sqlite3.Error as exc:

--- a/tests/state/test_fts_engine_integrity_gate.py
+++ b/tests/state/test_fts_engine_integrity_gate.py
@@ -1,0 +1,356 @@
+"""Engine-version-gated FTS5 integrity verification at SessionDB open (#86027).
+
+Upgrading the SQLite engine underneath an existing state.db (v0.18.2 →
+v0.20.1 class) can leave a legacy inline ``messages_fts_trigram`` index that
+only the writing engine can read: MATCH keeps answering, trigger writes keep
+succeeding, and the damage surfaces only on ``DELETE FROM`` / the FTS5
+``'integrity-check'`` command as ``malformed inverted index``. With the sync
+triggers intact nothing on the open path ever noticed — the DB silently
+carried a broken derived index.
+
+The fix: ``_init_schema`` runs the FTS5 ``'integrity-check'`` special
+command on every existing FTS table once per engine version (the passing
+version is stamped into state_meta under ``fts_integrity_engine``), repairs
+failures in place via ``'rebuild'``, and only then stamps the marker.
+
+CI cannot install the old engine, so the corruption is fabricated by
+overwriting the inverted-index blocks (``%_data``) with garbage: the stored
+content (``%_content``) stays intact, which is exactly the shape the
+'rebuild' repair recovers from, while 'integrity-check' — and, for the
+trigram table, a plain ``DELETE FROM`` — raise DatabaseError.
+"""
+
+import logging
+import sqlite3
+
+import pytest
+
+from hermes_state import (
+    FTS_INTEGRITY_ENGINE_KEY,
+    LEGACY_FTS_SQL,
+    LEGACY_FTS_TRIGRAM_SQL,
+    SCHEMA_SQL,
+    SessionDB,
+    _FTS_TRIGGERS,
+)
+
+
+def _make_legacy_db(db_path, texts=("alpha needle one", "beta needle two")):
+    """Legacy v22-shape store: inline FTS tables, live triggers, indexed rows."""
+    raw = sqlite3.connect(str(db_path))
+    raw.executescript(SCHEMA_SQL)
+    try:
+        raw.executescript(LEGACY_FTS_SQL + LEGACY_FTS_TRIGRAM_SQL)
+    except sqlite3.OperationalError as exc:
+        raw.close()
+        pytest.skip(f"required FTS tokenizer unavailable: {exc}")
+    raw.execute(
+        "INSERT INTO sessions (id, source, started_at) VALUES ('s1', 'test', 1.0)"
+    )
+    for i, text in enumerate(texts):
+        raw.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES ('s1', 'user', ?, ?)",
+            (text, 1.0 + i),
+        )
+    # Commit the trigger-driven FTS writes BEFORE any corruption: rewriting
+    # %_data blocks in the same transaction as pending FTS inserts makes the
+    # commit itself fail inside fts5's consistency checks.
+    raw.commit()
+    raw.close()
+
+
+def _corrupt_fts_index(db_path, table):
+    """Overwrite the inverted-index blocks so 'integrity-check' (and, for the
+    trigram table, plain DELETE) raise DatabaseError while %_content stays
+    intact — i.e. a shape the 'rebuild' repair fully recovers from."""
+    raw = sqlite3.connect(str(db_path))
+    raw.execute(
+        f"UPDATE {table}_data SET block = X'DEADBEEFDEADBEEFDEADBEEFDEADBEEF'"
+    )
+    raw.commit()
+    raw.close()
+
+
+def _integrity_check_ok(db_path, table):
+    raw = sqlite3.connect(str(db_path))
+    try:
+        raw.execute(f"INSERT INTO {table}({table}) VALUES('integrity-check')")
+        return True
+    except sqlite3.DatabaseError:
+        return False
+    finally:
+        try:
+            raw.rollback()
+        except sqlite3.Error:
+            pass
+        raw.close()
+
+
+def _match_count(db_path, table, term):
+    raw = sqlite3.connect(str(db_path))
+    try:
+        return raw.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE {table} MATCH ?", (term,)
+        ).fetchone()[0]
+    finally:
+        raw.close()
+
+
+def _meta_value(db_path, key):
+    raw = sqlite3.connect(str(db_path))
+    try:
+        row = raw.execute(
+            "SELECT value FROM state_meta WHERE key = ?", (key,)
+        ).fetchone()
+        return None if row is None else row[0]
+    finally:
+        raw.close()
+
+
+def _set_meta(db_path, key, value):
+    raw = sqlite3.connect(str(db_path))
+    raw.execute(
+        "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, value),
+    )
+    raw.commit()
+    raw.close()
+
+
+def _live_fts_triggers(db_path):
+    raw = sqlite3.connect(str(db_path))
+    try:
+        rows = raw.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'trigger' "
+            f"AND name IN ({','.join('?' for _ in _FTS_TRIGGERS)})",
+            _FTS_TRIGGERS,
+        ).fetchall()
+        return {row[0] for row in rows}
+    finally:
+        raw.close()
+
+
+class TestFtsEngineIntegrityGate:
+    def test_open_detects_and_repairs_engine_left_corruption(self, tmp_path, caplog):
+        """T1: a legacy DB whose trigram index the current engine cannot read
+        is repaired at open via 'rebuild' and stamped with the engine marker."""
+        db_path = tmp_path / "legacy-state.db"
+        _make_legacy_db(db_path)
+        assert _match_count(db_path, "messages_fts_trigram", "needle") == 2
+        _corrupt_fts_index(db_path, "messages_fts_trigram")
+
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            db = SessionDB(db_path=db_path)
+        try:
+            assert _integrity_check_ok(db_path, "messages_fts")
+            assert _integrity_check_ok(db_path, "messages_fts_trigram")
+            assert _match_count(db_path, "messages_fts", "needle") == 2
+            assert _match_count(db_path, "messages_fts_trigram", "needle") == 2
+            assert (
+                _meta_value(db_path, FTS_INTEGRITY_ENGINE_KEY)
+                == sqlite3.sqlite_version
+            )
+            assert any(
+                "messages_fts_trigram" in record.message
+                for record in caplog.records
+                if record.levelno == logging.WARNING
+            )
+        finally:
+            db.close()
+
+    def test_matching_engine_marker_skips_the_gate(self, tmp_path):
+        """T2: the marker equals the running engine → no re-verification, so a
+        (re-introduced) inconsistency survives the open untouched."""
+        db_path = tmp_path / "legacy-state.db"
+        _make_legacy_db(db_path)
+        _corrupt_fts_index(db_path, "messages_fts_trigram")
+        _set_meta(db_path, FTS_INTEGRITY_ENGINE_KEY, sqlite3.sqlite_version)
+
+        db = SessionDB(db_path=db_path)
+        try:
+            assert not _integrity_check_ok(db_path, "messages_fts_trigram")
+            assert (
+                _meta_value(db_path, FTS_INTEGRITY_ENGINE_KEY)
+                == sqlite3.sqlite_version
+            )
+        finally:
+            db.close()
+
+    def test_engine_change_reverifies_and_repairs(self, tmp_path):
+        """T3: a marker from a different engine version does not satisfy the
+        gate — the sweep runs, repairs, and re-stamps the current version."""
+        db_path = tmp_path / "legacy-state.db"
+        _make_legacy_db(db_path)
+        _corrupt_fts_index(db_path, "messages_fts_trigram")
+        _set_meta(db_path, FTS_INTEGRITY_ENGINE_KEY, "3.0.0")
+
+        db = SessionDB(db_path=db_path)
+        try:
+            assert _integrity_check_ok(db_path, "messages_fts_trigram")
+            assert _match_count(db_path, "messages_fts_trigram", "needle") == 2
+            assert (
+                _meta_value(db_path, FTS_INTEGRITY_ENGINE_KEY)
+                == sqlite3.sqlite_version
+            )
+        finally:
+            db.close()
+
+    def test_legacy_trigger_repair_survives_delete_failure(self, tmp_path):
+        """T4: the triggers-need-repair backfill starts with ``DELETE FROM``
+        the inline tables; on the malformed-index class that DELETE itself
+        raises, so the rebuild must fall back to drop-recreate-backfill
+        instead of failing the open."""
+        db_path = tmp_path / "legacy-state.db"
+        _make_legacy_db(db_path)
+        raw = sqlite3.connect(str(db_path))
+        raw.execute("DROP TRIGGER messages_fts_trigram_delete")
+        raw.commit()
+        raw.close()
+        _corrupt_fts_index(db_path, "messages_fts_trigram")
+
+        db = SessionDB(db_path=db_path)  # must not raise
+        try:
+            assert _integrity_check_ok(db_path, "messages_fts")
+            assert _integrity_check_ok(db_path, "messages_fts_trigram")
+            assert _match_count(db_path, "messages_fts", "needle") == 2
+            assert _match_count(db_path, "messages_fts_trigram", "needle") == 2
+            assert _live_fts_triggers(db_path) == set(_FTS_TRIGGERS)
+        finally:
+            db.close()
+
+    def test_read_only_open_never_touches_the_index(self, tmp_path):
+        """T5: a read-only open neither repairs nor stamps the marker."""
+        db_path = tmp_path / "legacy-state.db"
+        _make_legacy_db(db_path)
+        _corrupt_fts_index(db_path, "messages_fts_trigram")
+
+        ro = SessionDB(db_path=db_path, read_only=True)
+        try:
+            assert not _integrity_check_ok(db_path, "messages_fts_trigram")
+            assert _meta_value(db_path, FTS_INTEGRITY_ENGINE_KEY) is None
+        finally:
+            ro.close()
+
+    def test_v23_external_content_layout_repaired(self, tmp_path):
+        """T6: the same gate covers the v23 external-content layout (the
+        'rebuild' command re-reads the canonical messages table). The DB is
+        born on the current engine — which stamps the marker at creation —
+        so the engine change is simulated by stamping an older version, as
+        an upgraded install would carry."""
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        if not db._fts_enabled:
+            db.close()
+            pytest.skip("FTS5 unavailable in this build")
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "alpha needle one")
+        db.append_message("s1", "user", "beta needle two")
+        db.close()
+
+        _corrupt_fts_index(db_path, "messages_fts")
+        _set_meta(db_path, FTS_INTEGRITY_ENGINE_KEY, "3.0.0")
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert _integrity_check_ok(db_path, "messages_fts")
+            assert _integrity_check_ok(db_path, "messages_fts_trigram")
+            assert _match_count(db_path, "messages_fts", "needle") == 2
+            assert (
+                _meta_value(db_path, FTS_INTEGRITY_ENGINE_KEY)
+                == sqlite3.sqlite_version
+            )
+        finally:
+            reopened.close()
+
+
+class _FailingCursor:
+    """Cursor double for _rebuild_legacy_fts_indexes failure paths: SQL
+    matching a configured prefix raises; everything else succeeds."""
+
+    def __init__(self, failures):
+        self.failures = failures
+        self.executed = []
+        self.params = []
+
+    def _maybe_raise(self, sql):
+        for prefix, exc in self.failures.items():
+            if sql.startswith(prefix):
+                raise exc
+
+    def execute(self, sql, params=()):
+        self.executed.append(sql)
+        self.params.append(params)
+        self._maybe_raise(sql)
+        return self
+
+    def executescript(self, sql):
+        self.executed.append(sql)
+        self.params.append(())
+        self._maybe_raise(sql)
+
+
+def _stale_breadcrumb_dropped(cursor):
+    """True if the fts_stale breadcrumb write was attempted (any params
+    recorded alongside a state_meta upsert)."""
+    from hermes_state import FTS_STALE_KEY
+
+    return any(
+        sql.startswith("INSERT INTO state_meta") and p and p[0] == FTS_STALE_KEY
+        for sql, p in zip(cursor.executed, cursor.params)
+    )
+
+
+class TestLegacyRebuildFallbackFailures:
+    def test_fallback_own_failure_logs_and_continues(self, caplog):
+        """T7: DELETE fails and the drop-recreate fallback ALSO fails →
+        logger.error with the `hermes sessions repair` hint, the fts_stale
+        breadcrumb is dropped (a possibly-half-recreated table must not be
+        trusted by the next open), and no exception escapes."""
+        cursor = _FailingCursor(
+            {
+                "DELETE FROM": sqlite3.DatabaseError(
+                    "database disk image is malformed"
+                ),
+                "DROP TABLE": sqlite3.OperationalError("database is locked"),
+            }
+        )
+        with caplog.at_level(logging.ERROR, logger="hermes_state"):
+            SessionDB._rebuild_legacy_fts_indexes(cursor, include_trigram=False)
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert "messages_fts" in errors[0].message
+        assert "hermes sessions repair" in errors[0].message
+        assert _stale_breadcrumb_dropped(cursor)
+        # the failure happened at the DROP step, before any backfill attempt
+        assert not any(sql.startswith("INSERT INTO messages") for sql in cursor.executed)
+
+    def test_post_fallback_backfill_failure_does_not_raise(self, caplog):
+        """T8: DELETE fails, drop-recreate succeeds, but the backfill INSERT
+        fails → the failure is contained (error log + repair hint + fts_stale
+        breadcrumb so the next open runs the full recovery — an empty
+        recreated table would otherwise pass 'integrity-check' and freeze a
+        silently-dead index under the stamped marker), and it must NOT
+        escape and fail the open."""
+        cursor = _FailingCursor(
+            {
+                "DELETE FROM": sqlite3.DatabaseError(
+                    "database disk image is malformed"
+                ),
+                "INSERT INTO messages_fts(": sqlite3.DatabaseError(
+                    "database disk image is malformed"
+                ),
+            }
+        )
+        with caplog.at_level(logging.ERROR, logger="hermes_state"):
+            SessionDB._rebuild_legacy_fts_indexes(cursor, include_trigram=False)
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert "hermes sessions repair" in errors[0].message
+        assert _stale_breadcrumb_dropped(cursor)
+        # the fallback ran its full shape: triggers dropped, table dropped,
+        # legacy DDL re-applied, backfill attempted
+        assert any(sql.startswith("DROP TRIGGER IF EXISTS") for sql in cursor.executed)
+        assert any(sql.startswith("DROP TABLE IF EXISTS") for sql in cursor.executed)
+        assert any("CREATE VIRTUAL TABLE" in sql for sql in cursor.executed)

--- a/tests/state/test_fts_engine_integrity_gate.py
+++ b/tests/state/test_fts_engine_integrity_gate.py
@@ -233,6 +233,39 @@ class TestFtsEngineIntegrityGate:
         finally:
             ro.close()
 
+    def test_capability_signature_stamped_and_skips_resweep(self, tmp_path, monkeypatch):
+        """T10: a host whose probe cannot see a table (e.g. no cjk
+        tokenizer) sweeps at most once per engine+capability pair — the
+        stamp encodes the missing-capability signature, so a same-shape
+        reopen skips, while the bare-version stamp semantics are unchanged
+        on fully capable hosts."""
+        db_path = tmp_path / "legacy-state.db"
+        _make_legacy_db(db_path)
+
+        real_probe = SessionDB._fts_table_probe
+
+        def incapable_probe(self, cursor, table_name):
+            if table_name == "messages_fts_cjk":
+                return None  # capability missing, table unverifiable here
+            return real_probe(self, cursor, table_name)
+
+        monkeypatch.setattr(SessionDB, "_fts_table_probe", incapable_probe)
+        db = SessionDB(db_path=db_path)
+        db.close()
+        expected_stamp = f"{sqlite3.sqlite_version}|missing=messages_fts_cjk"
+        assert _meta_value(db_path, FTS_INTEGRITY_ENGINE_KEY) == expected_stamp
+
+        # A same-capability reopen skips the sweep entirely: corruption
+        # introduced after the stamp survives untouched (matching-marker
+        # semantics, now signature-scoped).
+        _corrupt_fts_index(db_path, "messages_fts_trigram")
+        db = SessionDB(db_path=db_path)
+        db.close()
+        assert not _integrity_check_ok(db_path, "messages_fts_trigram")
+        assert (
+            _meta_value(db_path, FTS_INTEGRITY_ENGINE_KEY) == expected_stamp
+        )
+
     def test_v23_external_content_layout_repaired(self, tmp_path):
         """T6: the same gate covers the v23 external-content layout (the
         'rebuild' command re-reads the canonical messages table). The DB is

--- a/tests/state/test_fts_engine_integrity_gate.py
+++ b/tests/state/test_fts_engine_integrity_gate.py
@@ -265,18 +265,29 @@ class TestFtsEngineIntegrityGate:
             reopened.close()
 
 
+class _FakeConnection:
+    def __init__(self):
+        self.rollbacks = 0
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
 class _FailingCursor:
     """Cursor double for _rebuild_legacy_fts_indexes failure paths: SQL
-    matching a configured prefix raises; everything else succeeds."""
+    containing a configured marker raises; everything else succeeds. The
+    atomic fallback runs as one executescript, so markers match by
+    containment (the fallback script contains no fast-path DELETE)."""
 
     def __init__(self, failures):
         self.failures = failures
         self.executed = []
         self.params = []
+        self.connection = _FakeConnection()
 
     def _maybe_raise(self, sql):
-        for prefix, exc in self.failures.items():
-            if sql.startswith(prefix):
+        for marker, exc in self.failures.items():
+            if marker in sql:
                 raise exc
 
     def execute(self, sql, params=()):
@@ -304,16 +315,19 @@ def _stale_breadcrumb_dropped(cursor):
 
 class TestLegacyRebuildFallbackFailures:
     def test_fallback_own_failure_logs_and_continues(self, caplog):
-        """T7: DELETE fails and the drop-recreate fallback ALSO fails →
-        logger.error with the `hermes sessions repair` hint, the fts_stale
-        breadcrumb is dropped (a possibly-half-recreated table must not be
-        trusted by the next open), and no exception escapes."""
+        """T7: DELETE fails with the malformed class and the atomic recovery
+        script ALSO fails → rollback attempted, logger.error with the
+        `hermes sessions repair` hint, the fts_stale breadcrumb is dropped
+        (a possibly-half-recreated table must not be trusted by the next
+        open), and no exception escapes."""
         cursor = _FailingCursor(
             {
-                "DELETE FROM": sqlite3.DatabaseError(
+                "DELETE FROM messages_fts": sqlite3.DatabaseError(
                     "database disk image is malformed"
                 ),
-                "DROP TABLE": sqlite3.OperationalError("database is locked"),
+                "DROP TABLE IF EXISTS messages_fts;": sqlite3.DatabaseError(
+                    "malformed inverted index for FTS5 table"
+                ),
             }
         )
         with caplog.at_level(logging.ERROR, logger="hermes_state"):
@@ -323,22 +337,26 @@ class TestLegacyRebuildFallbackFailures:
         assert "messages_fts" in errors[0].message
         assert "hermes sessions repair" in errors[0].message
         assert _stale_breadcrumb_dropped(cursor)
-        # the failure happened at the DROP step, before any backfill attempt
-        assert not any(sql.startswith("INSERT INTO messages") for sql in cursor.executed)
+        assert cursor.connection.rollbacks >= 1
+        # the atomic recovery script ran (single BEGIN IMMEDIATE-wrapped
+        # executescript) and failed before any separate backfill execute
+        assert any(sql.startswith("BEGIN IMMEDIATE;") for sql in cursor.executed)
+        assert not any(
+            sql.startswith("INSERT INTO messages_fts(") for sql in cursor.executed
+        )
 
     def test_post_fallback_backfill_failure_does_not_raise(self, caplog):
-        """T8: DELETE fails, drop-recreate succeeds, but the backfill INSERT
-        fails → the failure is contained (error log + repair hint + fts_stale
-        breadcrumb so the next open runs the full recovery — an empty
-        recreated table would otherwise pass 'integrity-check' and freeze a
-        silently-dead index under the stamped marker), and it must NOT
-        escape and fail the open."""
+        """T8: DELETE fails, but the failure inside the atomic recovery
+        script is at the backfill INSERT → rollback + error log + repair
+        hint + fts_stale breadcrumb (an empty recreated table would
+        otherwise pass 'integrity-check' and freeze a silently-dead index
+        under the stamped marker), and nothing escapes to fail the open."""
         cursor = _FailingCursor(
             {
-                "DELETE FROM": sqlite3.DatabaseError(
+                "DELETE FROM messages_fts": sqlite3.DatabaseError(
                     "database disk image is malformed"
                 ),
-                "INSERT INTO messages_fts(": sqlite3.DatabaseError(
+                "INSERT INTO messages_fts(rowid, content)": sqlite3.DatabaseError(
                     "database disk image is malformed"
                 ),
             }
@@ -349,8 +367,32 @@ class TestLegacyRebuildFallbackFailures:
         assert len(errors) == 1
         assert "hermes sessions repair" in errors[0].message
         assert _stale_breadcrumb_dropped(cursor)
-        # the fallback ran its full shape: triggers dropped, table dropped,
-        # legacy DDL re-applied, backfill attempted
-        assert any(sql.startswith("DROP TRIGGER IF EXISTS") for sql in cursor.executed)
-        assert any(sql.startswith("DROP TABLE IF EXISTS") for sql in cursor.executed)
-        assert any("CREATE VIRTUAL TABLE" in sql for sql in cursor.executed)
+        assert cursor.connection.rollbacks >= 1
+        # the recovery ran its full shape inside one atomic script
+        scripts = [s for s in cursor.executed if s.startswith("BEGIN IMMEDIATE;")]
+        assert len(scripts) == 1
+        assert "DROP TRIGGER IF EXISTS messages_fts_insert" in scripts[0]
+        assert "DROP TABLE IF EXISTS messages_fts;" in scripts[0]
+        assert "CREATE VIRTUAL TABLE" in scripts[0]
+        assert "INSERT INTO messages_fts(rowid, content)" in scripts[0]
+        assert scripts[0].rstrip().endswith("COMMIT;")
+
+    def test_transient_delete_error_reraises_without_fallback(self, caplog):
+        """T9: a lock/busy-style DELETE failure is NOT the corruption class
+        — it must re-raise for the open-retry path (pre-fallback behavior)
+        and must not run the drop-recreate script or drop the fts_stale
+        breadcrumb (classification adopted from the #86062 review round)."""
+        cursor = _FailingCursor(
+            {
+                "DELETE FROM messages_fts": sqlite3.OperationalError(
+                    "database is locked"
+                )
+            }
+        )
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            SessionDB._rebuild_legacy_fts_indexes(cursor, include_trigram=False)
+        assert not any(
+            sql.startswith("BEGIN IMMEDIATE;") for sql in cursor.executed
+        )
+        assert not _stale_breadcrumb_dropped(cursor)
+        assert cursor.connection.rollbacks == 0

--- a/tests/state/test_fts_engine_integrity_gate_acceptance.py
+++ b/tests/state/test_fts_engine_integrity_gate_acceptance.py
@@ -1,0 +1,785 @@
+"""Acceptance tests: engine-version-gated FTS5 integrity self-repair (#86027).
+
+Red-team acceptance suite, written ONLY from the behavior spec (design doc),
+never from the implementation. Final landing directory: ``tests/state/``
+(same repo-root-relative import depth as the existing state tests).
+
+Run (from the repo root)::
+
+    PYTHONPATH=. python -m pytest <this file> -q --import-mode=importlib
+
+``--import-mode=importlib`` is required because the mandated staging filename
+``<name>.acceptance.test.py`` is not importable under pytest's default
+prepend mode; when landing in ``tests/state/`` either keep the flag or strip
+the ``.acceptance`` infix from the filename.
+
+Spec under test (summary):
+  1. state_meta ``fts_integrity_engine`` == sqlite3.sqlite_version → zero
+     'integrity-check' executions on open; marker missing or different →
+     exactly one 'integrity-check' per EXISTING fts table
+     (messages_fts / messages_fts_trigram / messages_fts_cjk).
+  2. A table whose 'integrity-check' raises sqlite3.DatabaseError gets
+     exactly one 'rebuild' plus exactly one re-check; on success the marker
+     is stamped with the current engine and MATCH hit counts are identical
+     to pre-corruption.
+  3. If the re-check still fails: logger.error containing the guidance
+     string ``hermes sessions repair``, marker NOT stamped, open survives.
+  4. read_only=True → no integrity-check, no marker write, open succeeds.
+  5. Legacy inline DB (malformed index + one missing fts trigger) → open
+     succeeds, indexes backfilled from ``messages``, all 6 legacy fts
+     triggers present.
+  6. The v23 external-content layout (ordinary SessionDB-created DB) is
+     covered by the same gate.
+  7. No fts tables → marker still written.
+  8. No sqlite error raised inside the gate may fail the open.
+
+Fabrication notes (verified against raw SQLite 3.50.4 by a one-off script;
+see the red-team report):
+  * CI has one SQLite engine, so a genuine "index written by an older
+    engine" state cannot be produced. We corrupt the FTS5 shadow segment
+    store directly — ``UPDATE <fts>_data SET block = X'DEADBEEF...'`` —
+    which makes ``INSERT INTO <fts>(<fts>) VALUES('integrity-check')``
+    raise sqlite3.DatabaseError("database disk image is malformed") on BOTH
+    layouts, while 'rebuild' afterwards restores the exact pre-corruption
+    MATCH hits.
+  * The other candidate (DELETE a ``%_content`` shadow row, leaving orphan
+    postings) also trips integrity-check, but its repair legitimately loses
+    that row (4/5 hits), so it is unusable for the MATCH-preservation
+    assertions and is not used.
+  * "Engine changed" is fabricated by writing a stale marker value directly
+    into state_meta (the gate keys on marker != sqlite3.sqlite_version).
+
+Observability notes:
+  * Counts of special commands come from a connection trace callback
+    (``set_trace_callback``), which is independent of how the gate executes
+    statements.
+  * The behavioral stubs (re-corrupt after 'rebuild'; raise on
+    'integrity-check') intercept ``cursor.execute`` via a connection
+    factory. On Python 3.11 ``Connection.execute()`` bypasses a Python-level
+    ``cursor()`` override, so the stubs rely on the contract signature
+    ``_verify_fts_engine_integrity(self, cursor)`` — i.e. the special
+    commands run through a cursor obtained from ``self._conn.cursor()``
+    (which ``_init_schema`` demonstrably uses).
+"""
+
+import logging
+import re
+import sqlite3
+
+import pytest
+
+from hermes_state import (
+    FTS_SQL,
+    FTS_TRIGRAM_SQL,
+    LEGACY_FTS_SQL,
+    LEGACY_FTS_TRIGRAM_SQL,
+    SCHEMA_SQL,
+    SessionDB,
+    _FTS_TRIGGERS,
+)
+
+# ── Contract literals (must match the design doc verbatim) ──────────────────
+GATE_MARKER_KEY = "fts_integrity_engine"
+REPAIR_HINT = "hermes sessions repair"
+FTS_TABLES = ("messages_fts", "messages_fts_trigram", "messages_fts_cjk")
+
+# A plausible OLD engine version; tests assert it differs from the current
+# one before relying on it to fabricate an engine change.
+STALE_ENGINE = "3.31.1"
+
+DEADBEEF_BLOCK = "X'DEADBEEFDEADBEEFDEADBEEFDEADBEEF'"
+
+_INTEGRITY_CHECK_RE = re.compile(r"values\s*\(\s*'integrity-check'\s*\)", re.I)
+_REBUILD_RE = re.compile(r"values\s*\(\s*'rebuild'\s*\)", re.I)
+_SPECIAL_TABLE_RE = re.compile(
+    r"insert\s+into\s+(messages_fts_cjk|messages_fts_trigram|messages_fts)\s*\(",
+    re.I,
+)
+
+
+def _fts5_available() -> bool:
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute("CREATE VIRTUAL TABLE _probe USING fts5(x)")
+        return True
+    except sqlite3.OperationalError:
+        return False
+    finally:
+        conn.close()
+
+
+if not _fts5_available():
+    pytest.skip(
+        "FTS5 unavailable in this build — engine-integrity gate not testable",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_hermes_home(tmp_path, monkeypatch):
+    """Keep schema-parse caches and any home-relative writes off ~/.hermes."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+
+
+# ── Spy plumbing ─────────────────────────────────────────────────────────────
+
+
+class _GateSpyCursor(sqlite3.Cursor):
+    """Cursor double for the engine-integrity gate.
+
+    Counting is done by the trace callback (see _traced_open); this cursor
+    only provides the two BEHAVIORAL stubs the trace callback cannot:
+
+    * ``raise_on_integrity_check`` — raise sqlite3.OperationalError from
+      every 'integrity-check' execution (spec 8: the open must survive).
+    * ``recorrupt_table`` — after the real 'rebuild' for that table runs,
+      re-apply the shadow-store corruption so the post-repair re-check
+      fails (spec 3: repair-failure path).
+
+    Relies on the contract that the gate executes through a cursor
+    (``_verify_fts_engine_integrity(self, cursor)``).
+    """
+
+    raise_on_integrity_check = False
+    recorrupt_table = None
+    integrity_attempts = 0
+
+    def execute(self, sql, params=()):
+        if _INTEGRITY_CHECK_RE.search(sql or ""):
+            type(self).integrity_attempts += 1
+            if type(self).raise_on_integrity_check:
+                raise sqlite3.OperationalError(
+                    "disk I/O error (fabricated by the acceptance test)"
+                )
+        result = super().execute(sql, params)
+        if type(self).recorrupt_table is not None:
+            match = _SPECIAL_TABLE_RE.search(sql or "")
+            if (
+                match is not None
+                and match.group(1) == type(self).recorrupt_table
+                and _REBUILD_RE.search(sql or "")
+            ):
+                super().execute(
+                    f"UPDATE {match.group(1)}_data SET block = {DEADBEEF_BLOCK}"
+                )
+        return result
+
+    def executescript(self, script):
+        result = super().executescript(script)
+        if type(self).recorrupt_table is not None:
+            match = _SPECIAL_TABLE_RE.search(script or "")
+            if (
+                match is not None
+                and match.group(1) == type(self).recorrupt_table
+                and _REBUILD_RE.search(script or "")
+            ):
+                super().execute(
+                    f"UPDATE {match.group(1)}_data SET block = {DEADBEEF_BLOCK}"
+                )
+        return result
+
+
+class _GateSpyConnection(sqlite3.Connection):
+    def cursor(self, *args, **kwargs):
+        kwargs.setdefault("factory", _GateSpyCursor)
+        return super().cursor(*args, **kwargs)
+
+
+def _traced_open(
+    db_path,
+    monkeypatch,
+    statements,
+    *,
+    read_only=False,
+    raise_on_integrity_check=False,
+    recorrupt_table=None,
+):
+    """Open a SessionDB with connection-level statement tracing enabled.
+
+    Every SQL statement executed on any connection opened during the
+    constructor is appended to *statements* (scoped: the sqlite3.connect
+    patch is undone as soon as the constructor returns).
+    """
+    real_connect = sqlite3.connect
+
+    def spy_connect(*args, **kwargs):
+        kwargs["factory"] = _GateSpyConnection
+        conn = real_connect(*args, **kwargs)
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    _GateSpyCursor.raise_on_integrity_check = raise_on_integrity_check
+    _GateSpyCursor.recorrupt_table = recorrupt_table
+    _GateSpyCursor.integrity_attempts = 0
+    try:
+        with monkeypatch.context() as mp:
+            mp.setattr(sqlite3, "connect", spy_connect)
+            return SessionDB(db_path=db_path, read_only=read_only)
+    finally:
+        _GateSpyCursor.raise_on_integrity_check = False
+        _GateSpyCursor.recorrupt_table = None
+
+
+def _count_integrity_checks(statements):
+    return sum(1 for s in statements if _INTEGRITY_CHECK_RE.search(s))
+
+
+def _count_rebuilds(statements):
+    return sum(1 for s in statements if _REBUILD_RE.search(s))
+
+
+# ── Raw-database helpers ─────────────────────────────────────────────────────
+
+
+def _seed_raw_messages(conn, session_id="s1", *, count, start=0, prefix="needle message"):
+    conn.execute(
+        "INSERT OR IGNORE INTO sessions (id, source, started_at) "
+        "VALUES (?, 'test', 1.0)",
+        (session_id,),
+    )
+    for i in range(start, start + count):
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES (?, 'user', ?, ?)",
+            (session_id, f"{prefix} {i}", float(i)),
+        )
+
+
+def _build_raw_v23_db(db_path, *, messages=4):
+    """A v23-layout DB (external-content FTS) with no gate marker yet."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(SCHEMA_SQL + FTS_SQL + FTS_TRIGRAM_SQL)
+        _seed_raw_messages(conn, count=messages)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _build_raw_legacy_db(db_path, *, messages=4):
+    """A v22-style legacy inline-FTS DB with no gate marker yet."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        try:
+            conn.executescript(SCHEMA_SQL + LEGACY_FTS_SQL + LEGACY_FTS_TRIGRAM_SQL)
+        except sqlite3.OperationalError as exc:
+            pytest.skip(f"required FTS tokenizer unavailable: {exc}")
+        _seed_raw_messages(conn, count=messages)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _marker_value(db_path):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT value FROM state_meta WHERE key = ?", (GATE_MARKER_KEY,)
+        ).fetchone()
+        return None if row is None else row[0]
+    finally:
+        conn.close()
+
+
+def _set_marker(db_path, value):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        if value is None:
+            conn.execute("DELETE FROM state_meta WHERE key = ?", (GATE_MARKER_KEY,))
+        else:
+            conn.execute(
+                "INSERT OR REPLACE INTO state_meta (key, value) VALUES (?, ?)",
+                (GATE_MARKER_KEY, value),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _corrupt_fts_index(db_path, table):
+    """Fabricate the 'engine-upgrade malformed FTS index' state.
+
+    Overwrites every shadow segment block with DEADBEEF. Verified by a
+    one-off script: this makes the FTS5 special command 'integrity-check'
+    raise sqlite3.DatabaseError on both layouts, while 'rebuild' repairs it
+    and restores the exact pre-corruption MATCH hits.
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(f"UPDATE {table}_data SET block = {DEADBEEF_BLOCK}")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _match_count(db_path, table, term):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE {table} MATCH ?", (term,)
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _existing_fts_tables(db_path):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ).fetchall()
+        names = {row[0] for row in rows}
+        return {t for t in FTS_TABLES if t in names}
+    finally:
+        conn.close()
+
+
+def _legacy_fts_trigger_names(db_path):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        placeholders = ",".join("?" for _ in _FTS_TRIGGERS)
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master "
+            f"WHERE type = 'trigger' AND name IN ({placeholders})",
+            _FTS_TRIGGERS,
+        ).fetchall()
+        return {row[0] for row in rows}
+    finally:
+        conn.close()
+
+
+def _open_and_close(db_path, monkeypatch, statements, **kwargs):
+    """Open + immediately close; statements accumulate from the open only."""
+    db = None
+    try:
+        db = _traced_open(db_path, monkeypatch, statements, **kwargs)
+    finally:
+        if db is not None:
+            db.close()
+
+
+class TestFtsEngineIntegrityGate:
+    # ── Contract interface ────────────────────────────────────────────────
+
+    def test_contract_method_exists_with_cursor_signature(self):
+        """The spec pins SessionSchemaMixin._verify_fts_engine_integrity(cursor)."""
+        import inspect
+
+        from hermes_state_schema import SessionSchemaMixin
+
+        assert hasattr(SessionSchemaMixin, "_verify_fts_engine_integrity"), (
+            "SessionSchemaMixin._verify_fts_engine_integrity is missing — "
+            "the engine-version FTS integrity gate is not implemented"
+        )
+        signature = inspect.signature(
+            SessionSchemaMixin._verify_fts_engine_integrity
+        )
+        positional = [
+            p
+            for p in signature.parameters.values()
+            if p.kind
+            in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+        ]
+        assert len(positional) == 2  # (self, cursor)
+
+    # ── Spec 1: gating ────────────────────────────────────────────────────
+
+    def test_missing_marker_verifies_each_fts_table_exactly_once(
+        self, tmp_path, monkeypatch
+    ):
+        """Marker absent → exactly one integrity-check per existing fts table,
+        no rebuilds, marker stamped with the current engine."""
+        db_path = tmp_path / "state.db"
+        _build_raw_v23_db(db_path, messages=4)
+        assert _marker_value(db_path) is None
+        pre_tables = _existing_fts_tables(db_path)
+        assert len(pre_tables) >= 2  # messages_fts + messages_fts_trigram
+
+        statements = []
+        _open_and_close(db_path, monkeypatch, statements)
+
+        post_tables = _existing_fts_tables(db_path)
+        # CONTRACT_AMBIGUOUS: whether the gate runs before or after the
+        # same-open FTS DDL (e.g. messages_fts_cjk creation) decides which
+        # existence snapshot applies; both orderings are contract-conformant,
+        # so accept either — but exactly once per table in that snapshot.
+        assert _count_integrity_checks(statements) in {
+            len(pre_tables),
+            len(post_tables),
+        }
+        assert _count_rebuilds(statements) == 0
+        assert _marker_value(db_path) == sqlite3.sqlite_version
+
+    def test_stale_marker_triggers_reverification_and_restamp(
+        self, tmp_path, monkeypatch
+    ):
+        """Marker != current engine → verification runs again and the marker
+        is re-stamped with the current engine."""
+        assert STALE_ENGINE != sqlite3.sqlite_version
+        db_path = tmp_path / "state.db"
+        _build_raw_v23_db(db_path, messages=3)
+        _set_marker(db_path, STALE_ENGINE)
+        pre_tables = _existing_fts_tables(db_path)
+
+        statements = []
+        _open_and_close(db_path, monkeypatch, statements)
+
+        assert _count_integrity_checks(statements) in {
+            len(pre_tables),
+            len(_existing_fts_tables(db_path)),
+        }
+        assert _count_rebuilds(statements) == 0
+        assert _marker_value(db_path) == sqlite3.sqlite_version
+
+    def test_matching_marker_runs_zero_integrity_checks_on_reopen(
+        self, tmp_path, monkeypatch
+    ):
+        """Marker == current engine → open performs zero 'integrity-check'
+        executions (zero index cost) and leaves the marker intact."""
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session("s1", source="test")
+            db.append_message("s1", "user", "needle first")
+            db.append_message("s1", "user", "needle second")
+        finally:
+            db.close()
+        # First open must have stamped the marker (spec 1/7).
+        assert _marker_value(db_path) == sqlite3.sqlite_version
+
+        statements = []
+        _open_and_close(db_path, monkeypatch, statements)
+
+        assert _count_integrity_checks(statements) == 0
+        assert _count_rebuilds(statements) == 0
+        assert _marker_value(db_path) == sqlite3.sqlite_version
+
+    # ── Spec 2 + 6: detection, repair, v23 external-content coverage ──────
+
+    def test_engine_change_detects_and_repairs_external_content_index(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Spec 6: an ordinary SessionDB-created (v23 external-content) DB is
+        covered by the gate. Spec 2: corrupted table → exactly one 'rebuild'
+        + exactly one re-check; warning names the table; marker stamped;
+        MATCH hits identical to pre-corruption."""
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session("s1", source="test")
+            for i in range(4):
+                db.append_message("s1", "user", f"needle payload {i}")
+        finally:
+            db.close()
+        baseline_base = _match_count(db_path, "messages_fts", "needle")
+        baseline_trigram = _match_count(db_path, "messages_fts_trigram", "needle")
+        assert baseline_base == 4
+        assert baseline_trigram == 4
+
+        # Fabricate the engine change + the carried-over malformed index.
+        _set_marker(db_path, STALE_ENGINE)
+        _corrupt_fts_index(db_path, "messages_fts")
+        pre_tables = _existing_fts_tables(db_path)
+        assert len(pre_tables) >= 2
+
+        caplog.set_level(logging.DEBUG)
+        statements = []
+        _open_and_close(db_path, monkeypatch, statements)
+
+        # Spec 2: exactly one rebuild for the corrupted table.
+        assert _count_rebuilds(statements) == 1
+        # Every existing table checked once + exactly one post-repair re-check
+        # (CONTRACT_AMBIGUOUS: gate-vs-DDL ordering, see the marker test above).
+        assert _count_integrity_checks(statements) in {
+            len(pre_tables) + 1,
+            len(_existing_fts_tables(db_path)) + 1,
+        }
+        # Spec 2: repair is logged as a warning naming the corrupted table
+        # (word-bounded so messages_fts_trigram does not satisfy it).
+        assert any(
+            record.levelno == logging.WARNING
+            and re.search(r"\bmessages_fts\b", record.getMessage())
+            for record in caplog.records
+        )
+        assert _marker_value(db_path) == sqlite3.sqlite_version
+        # Spec 2: MATCH hit counts identical to pre-corruption.
+        assert _match_count(db_path, "messages_fts", "needle") == baseline_base
+        assert (
+            _match_count(db_path, "messages_fts_trigram", "needle")
+            == baseline_trigram
+        )
+
+    def test_engine_change_repairs_legacy_inline_trigram_index(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Legacy inline (v11–v22) messages_fts_trigram: same gate, same
+        repair contract, MATCH hits restored."""
+        db_path = tmp_path / "legacy-state.db"
+        _build_raw_legacy_db(db_path, messages=4)
+        baseline_trigram = _match_count(db_path, "messages_fts_trigram", "needle")
+        baseline_base = _match_count(db_path, "messages_fts", "needle")
+        assert baseline_trigram == 4
+
+        _set_marker(db_path, STALE_ENGINE)
+        _corrupt_fts_index(db_path, "messages_fts_trigram")
+        pre_tables = _existing_fts_tables(db_path)
+        assert pre_tables == {"messages_fts", "messages_fts_trigram"}
+
+        caplog.set_level(logging.DEBUG)
+        statements = []
+        _open_and_close(db_path, monkeypatch, statements)
+
+        assert _count_rebuilds(statements) == 1
+        # 2 tables verified once + 1 post-repair re-check (legacy has no cjk).
+        assert _count_integrity_checks(statements) == len(pre_tables) + 1
+        assert any(
+            record.levelno == logging.WARNING
+            and re.search(r"\bmessages_fts_trigram\b", record.getMessage())
+            for record in caplog.records
+        )
+        assert _marker_value(db_path) == sqlite3.sqlite_version
+        assert _match_count(db_path, "messages_fts_trigram", "needle") == (
+            baseline_trigram
+        )
+        assert _match_count(db_path, "messages_fts", "needle") == baseline_base
+
+    # ── Spec 3: repair-failure fallback ───────────────────────────────────
+
+    def test_failed_repair_verification_logs_hint_and_keeps_db_open(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """'rebuild' succeeds but the re-check still fails (re-corrupted by
+        the cursor stub) → logger.error with 'hermes sessions repair', no
+        marker stamp, exactly one repair attempt, open survives."""
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session("s1", source="test")
+            for i in range(3):
+                db.append_message("s1", "user", f"needle payload {i}")
+        finally:
+            db.close()
+
+        _set_marker(db_path, STALE_ENGINE)
+        _corrupt_fts_index(db_path, "messages_fts")
+
+        caplog.set_level(logging.DEBUG)
+        statements = []
+        db = None
+        try:
+            db = _traced_open(
+                db_path, monkeypatch, statements, recorrupt_table="messages_fts"
+            )
+            # Spec 3: the open must NOT fail, and the DB stays usable.
+            db.create_session("survivor", source="test")
+        finally:
+            if db is not None:
+                db.close()
+
+        assert _count_rebuilds(statements) == 1  # one attempt, no repair loop
+        assert _GateSpyCursor.integrity_attempts >= 2  # detect + re-check
+        assert any(
+            record.levelno == logging.ERROR
+            and REPAIR_HINT in record.getMessage()
+            for record in caplog.records
+        ), "repair-verification failure must log an error guiding the user " \
+           "to 'hermes sessions repair'"
+        # Spec 3: marker must NOT be stamped as verified for this engine.
+        assert _marker_value(db_path) != sqlite3.sqlite_version
+
+    # ── Spec 4: read-only opens ───────────────────────────────────────────
+
+    def test_read_only_open_runs_no_gate_and_writes_no_marker(
+        self, tmp_path, monkeypatch
+    ):
+        db_path = tmp_path / "state.db"
+        _build_raw_v23_db(db_path, messages=3)
+        assert _marker_value(db_path) is None
+
+        statements = []
+        ro = None
+        try:
+            ro = _traced_open(db_path, monkeypatch, statements, read_only=True)
+            # Open succeeded and the FTS surfaces are genuinely present.
+            assert ro._fts_enabled is True
+        finally:
+            if ro is not None:
+                ro.close()
+
+        assert _count_integrity_checks(statements) == 0
+        assert _count_rebuilds(statements) == 0
+        assert _marker_value(db_path) is None  # no marker write on ro open
+
+        # Control: the SAME database opened writable DOES run the gate and
+        # stamp the marker — proving the skip is the read-only gate policy,
+        # not the gate being absent.
+        writable_pre_tables = _existing_fts_tables(db_path)
+        writable_statements = []
+        _open_and_close(db_path, monkeypatch, writable_statements)
+        assert _count_integrity_checks(writable_statements) in {
+            len(writable_pre_tables),
+            len(_existing_fts_tables(db_path)),
+        }
+        assert _marker_value(db_path) == sqlite3.sqlite_version
+
+    # ── Spec 5: legacy DELETE-fallback (trigger-degraded) path ────────────
+
+    def test_legacy_trigger_degraded_corruption_backfills_from_messages(
+        self, tmp_path, monkeypatch
+    ):
+        """Legacy DB: malformed trigram index + one missing fts trigger →
+        open succeeds, index content backfilled from ``messages`` (gap rows
+        included), all 6 legacy fts triggers present."""
+        db_path = tmp_path / "legacy-degraded.db"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            try:
+                conn.executescript(
+                    SCHEMA_SQL + LEGACY_FTS_SQL + LEGACY_FTS_TRIGRAM_SQL
+                )
+            except sqlite3.OperationalError as exc:
+                pytest.skip(f"required FTS tokenizer unavailable: {exc}")
+            _seed_raw_messages(conn, count=3)
+            conn.commit()
+            # Degrade one trigger, then write rows the missing trigger let
+            # slip past the trigram index (the index-gap this path repairs).
+            conn.execute("DROP TRIGGER messages_fts_trigram_insert")
+            _seed_raw_messages(conn, count=2, start=100)
+            conn.commit()
+            conn.execute(
+                f"UPDATE messages_fts_trigram_data SET block = {DEADBEEF_BLOCK}"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        total_messages = 5
+        assert _marker_value(db_path) is None
+
+        statements = []
+        db = None
+        try:
+            db = _traced_open(db_path, monkeypatch, statements)
+        finally:
+            if db is not None:
+                db.close()
+
+        # Spec 5: open succeeded (we got here) and all 6 triggers are back.
+        assert _legacy_fts_trigger_names(db_path) == set(_FTS_TRIGGERS)
+        # Spec 5: index content backfilled from messages — the 2 gap rows
+        # written while the trigger was missing are searchable too.
+        assert (
+            _match_count(db_path, "messages_fts_trigram", "needle")
+            == total_messages
+        )
+        assert _match_count(db_path, "messages_fts", "needle") == total_messages
+        # CONTRACT_AMBIGUOUS: the spec pins the OUTCOME of this path, not the
+        # mechanism (gate 'rebuild' vs _rebuild_legacy_fts_indexes DELETE
+        # fallback), so require: every existing table verified at least once
+        # and no repair loop.
+        assert _count_integrity_checks(statements) >= 2
+        assert _count_rebuilds(statements) <= 1
+        # CONTRACT_AMBIGUOUS: assumes the gate stamps the marker once the
+        # post-repair state verifies (strict spec-2 reading).
+        assert _marker_value(db_path) == sqlite3.sqlite_version
+
+    # ── Spec 7: no fts tables ─────────────────────────────────────────────
+
+    def test_marker_stamped_when_db_transiently_has_no_fts_tables(
+        self, tmp_path, monkeypatch
+    ):
+        """Spec 7 on an FTS5-capable runtime: a DB that (transiently) has no
+        fts tables — e.g. an interrupted optimize-storage — still gets the
+        marker stamped."""
+        db_path = tmp_path / "no-fts.db"
+        _build_raw_v23_db(db_path, messages=2)
+        conn = sqlite3.connect(str(db_path))
+        try:
+            for trigger in _FTS_TRIGGERS:
+                conn.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+            conn.execute("DROP VIEW IF EXISTS messages_fts_trigram_src")
+            conn.execute("DROP TABLE IF EXISTS messages_fts_trigram")
+            conn.execute("DROP TABLE IF EXISTS messages_fts")
+            conn.commit()
+        finally:
+            conn.close()
+        assert _existing_fts_tables(db_path) == set()
+        assert _marker_value(db_path) is None
+
+        statements = []
+        _open_and_close(db_path, monkeypatch, statements)
+
+        # The DDL recreates the fts tables during this same open, so the
+        # gate-time table set is order-dependent; the marker write is not.
+        assert _marker_value(db_path) == sqlite3.sqlite_version
+        assert _count_integrity_checks(statements) in {
+            0,  # gate ran before the DDL recreated the tables
+            len(_existing_fts_tables(db_path)),  # gate ran after
+        }
+
+    def test_marker_not_stamped_on_fts5less_runtime(
+        self, tmp_path, monkeypatch
+    ):
+        """Spec 7 (AMENDED 2026-08-14, adjudicated): an FTS5-less runtime
+        must NOT stamp the engine marker. A host with no verification
+        capability must not vouch for the indexes on behalf of a capable
+        host running the same engine version (same conservative principle
+        as the probe-None skip), and skipping the gate entirely keeps
+        FTS5-less opens zero-cost — the next capable host re-verifies.
+
+        Original pin (strict pre-amendment reading: marker still written)
+        was adjudicated against the conservative reading; this test now
+        guards the amended contract."""
+        db_path = tmp_path / "no-fts5.db"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.executescript(SCHEMA_SQL)
+            _seed_raw_messages(conn, count=2)
+            conn.commit()
+        finally:
+            conn.close()
+
+        monkeypatch.setattr(
+            SessionDB, "_sqlite_supports_fts5", lambda self, cursor: False
+        )
+
+        statements = []
+        _open_and_close(db_path, monkeypatch, statements)
+
+        assert _existing_fts_tables(db_path) == set()
+        assert _count_integrity_checks(statements) == 0
+        assert _marker_value(db_path) is None
+
+    # ── Spec 8: the gate never fails the open ─────────────────────────────
+
+    def test_gate_sqlite_errors_never_fail_the_open(self, tmp_path, monkeypatch):
+        """Every 'integrity-check' execution raises sqlite3.OperationalError
+        (a sqlite3.DatabaseError subclass) — the open must still succeed and
+        the DB stay usable."""
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session("s1", source="test")
+            db.append_message("s1", "user", "needle payload")
+        finally:
+            db.close()
+
+        _set_marker(db_path, STALE_ENGINE)
+
+        statements = []
+        db = None
+        try:
+            db = _traced_open(
+                db_path, monkeypatch, statements, raise_on_integrity_check=True
+            )
+            # The open survived; the store is still usable for writes.
+            db.create_session("survivor", source="test")
+        finally:
+            if db is not None:
+                db.close()
+
+        # The gate really did attempt integrity checks (and hit the raised
+        # error) rather than being skipped entirely.
+        assert _GateSpyCursor.integrity_attempts >= 1
+        # CONTRACT_AMBIGUITY: marker semantics for this path (probe raised
+        # OperationalError — repair-vs-swallow is not pinned by the spec)
+        # are deliberately left unasserted; only open survival is spec 8.

--- a/tests/state/test_fts_engine_integrity_gate_acceptance.py
+++ b/tests/state/test_fts_engine_integrity_gate_acceptance.py
@@ -1,17 +1,11 @@
 """Acceptance tests: engine-version-gated FTS5 integrity self-repair (#86027).
 
 Red-team acceptance suite, written ONLY from the behavior spec (design doc),
-never from the implementation. Final landing directory: ``tests/state/``
-(same repo-root-relative import depth as the existing state tests).
+never from the implementation.
 
 Run (from the repo root)::
 
-    PYTHONPATH=. python -m pytest <this file> -q --import-mode=importlib
-
-``--import-mode=importlib`` is required because the mandated staging filename
-``<name>.acceptance.test.py`` is not importable under pytest's default
-prepend mode; when landing in ``tests/state/`` either keep the flag or strip
-the ``.acceptance`` infix from the filename.
+    PYTHONPATH=. python -m pytest tests/state/test_fts_engine_integrity_gate_acceptance.py -q
 
 Spec under test (summary):
   1. state_meta ``fts_integrity_engine`` == sqlite3.sqlite_version → zero


### PR DESCRIPTION
Fixes #86027

## Problem

An existing v0.18.2 `state.db` upgraded to a newer bundled SQLite can carry a legacy inline `messages_fts_trigram` index that only the **writing** engine accepts: MATCH queries and the sync triggers keep succeeding, while `DELETE FROM messages_fts_trigram` and the FTS5 `'integrity-check'` command fail with `malformed inverted index`. Root cause (confirmed on the reporter's affected DB — 1 message with an embedded NUL): the trigram tokenizer changed how NUL-containing content is tokenized between 3.46.1 and 3.5x, and each engine's integrity check accepts only its own writer's output (verified mutually — 3.46.1 also rejects an index written by 3.53.0 for the same content).

With triggers intact, *nothing errors at open*, so the malformed state is carried silently and indefinitely — the reporter only found it via `PRAGMA quick_check`. `hermes sessions repair` / `doctor --fix` already detect and fix this class (strategy `rebuild_fts`), but only when the user happens to run them.

## Fix

**Open-time engine gate** — `_init_schema` runs the FTS5 `'integrity-check'` special command on every existing FTS table (`messages_fts`, `messages_fts_trigram`, `messages_fts_cjk`) **once per SQLite engine version**. The passing version is stamped into `state_meta` under `fts_integrity_engine`; a matching stamp costs a single meta read per open. A failing check is repaired in place with `'rebuild'` (works on ordinary inline tables too — it re-tokenizes the stored `%_content` shadow) and re-verified. Design constraints:

- read-only opens skip the gate entirely
- a runtime without the verification capability (no FTS5 / probe returns `None` for a tokenizer) never stamps the marker on behalf of a capable host running the same engine version
- no `sqlite3` error inside the gate can fail the open; an unverifiable repair logs the `hermes sessions repair` escape hatch and leaves the marker unstamped so the next open retries

**Hardened legacy rebuild** — `_rebuild_legacy_fts_indexes`' `DELETE`-based repair (the trigger-degradation path) now falls back to drop-recreate when a malformed index rejects even the plain `DELETE`: drop the sync triggers, drop the virtual table, re-create both from the legacy DDL, backfill from `messages`. The fallback is self-contained — a backfill failure logs instead of escaping, so the repair can never fail the open.

## Tests

CI cannot install the old engine, so the corruption is fabricated by overwriting the inverted-index shadow blocks (`%_data`) with garbage — the shape `'rebuild'` fully recovers from (deleting `%_content` shadow rows was rejected: `'rebuild'` re-tokenizes from there, so the row would be lost permanently).

- 8 unit + 12 acceptance tests in `tests/state/` covering: detect+repair (legacy inline and v23 external-content), marker skip on matching engine, re-verify on engine change, read-only skip, DELETE fallback, fallback/backfill failure containment, no-tables marker stamp, gate never failing the open
- state suites: 378 passed, 2 skipped
- real-world check: a malformed DB written under SQLite 3.46.1 (NUL-containing content, exact #86027 scenario) opens and repairs in one pass under 3.53.0, preserving MATCH counts; the second open is zero-cost

## Accepted trade-offs (from review)

- a runtime whose probe returns `None` (e.g. missing tokenizer extension) never gets a stamp → it re-runs the sweep on every writable open; cheap against absent tables, deliberate conservatism against stamping blind
- the first open after an engine change pays a synchronous full-index `'integrity-check'` — the same order as a rebuild, once per bundled-SQLite upgrade
- a transient `SQLITE_BUSY` during the check is treated as corruption-class and triggers a redundant rebuild; self-limiting and logged


## References

- Root cause / canonical issue: #69672 (this PR was cut against #86027, since triaged as its duplicate). Addresses the **malformed-index recovery** consequence; the prevention layer (keeping the `\x00json:` sentinel out of indexed text) and the DB-bloat consequence are tracked in #69798.
- Related recovery PR: #86062 — its review round produced two refinements this PR adopts with credit (narrow malformed-index error classification; atomic `BEGIN IMMEDIATE` recovery). Remaining deltas here: the engine-version marker gate (once per engine change vs. a full-index probe on every legacy open), v23/cjk layout coverage, and the `fts_stale` breadcrumb containment on failed recovery.
- Independent field confirmations: @MrRosc (Docker, `NUL_MESSAGES=1`), @prudkov (native install, 28 sentinel rows / 2 GB, mutual-rejection table; plus the reverse-direction hazard of repairing with a mismatched external SQLite build).
- Known limitation (verified locally): the gate keys on the engine version of the running process — an external rebuild with a different SQLite build re-flips the index while the marker still matches, so the next open skips verification. The durable fix for that is prevention (#69798).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved full-text search index integrity checks and recovery for existing databases.
  * Automatically rebuilds damaged search indexes and restores required triggers when possible.
  * Preserves database usability when repair attempts cannot be completed.
  * Avoids unnecessary integrity checks when the recorded SQLite engine version is still valid.
  * Handles read-only databases and environments without FTS5 support more safely.

* **Tests**
  * Added comprehensive coverage for index corruption, repair, engine-version changes, read-only behavior, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
