### PR TITLE
fix(constants): repair mode-stripped managed Node entrypoints

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -334,6 +334,124 @@ _managed_node_heal_attempted = False
 _NODE_BOOTSTRAP_SCRIPT = Path(__file__).resolve().parent / "scripts" / "lib" / "node-bootstrap.sh"
 
 
+def _managed_node_roots(home: Path | None = None) -> list[Path]:
+    """Return unique managed Node tree roots (``$HERMES_HOME/node``), resolved."""
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    for directory in iter_hermes_node_dirs(home):
+        root = directory if directory.name != "bin" else directory.parent
+        try:
+            resolved = root.resolve()
+        except OSError:
+            continue
+        if resolved in seen or resolved.name != "node":
+            continue
+        seen.add(resolved)
+        roots.append(resolved)
+    return roots
+
+
+def _is_within_managed_node_root(path: Path, root: Path) -> bool:
+    """True if *path* resolves inside *root*; never follows a symlink escape."""
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _managed_node_entrypoint_names() -> set[str]:
+    names: set[str] = set()
+    for command in ("node", "npm", "npx"):
+        names.update(_candidate_node_command_names(command))
+    return names
+
+
+def _iter_managed_node_entrypoints(home: Path | None = None):
+    """Yield ``(root, candidate)`` for each managed node/npm/npx name."""
+    names = _managed_node_entrypoint_names()
+    for root in _managed_node_roots(home):
+        for directory in (root, root / "bin"):
+            if not directory.is_dir():
+                continue
+            for name in names:
+                yield root, directory / name
+
+
+def _managed_node_has_nonexecutable_entrypoints(home: Path | None = None) -> bool:
+    """True when a managed node/npm/npx file exists but lacks owner execute."""
+    if sys.platform == "win32":
+        return False
+    for root, candidate in _iter_managed_node_entrypoints(home):
+        try:
+            st = candidate.lstat()
+        except OSError:
+            continue
+        if stat.S_ISLNK(st.st_mode):
+            if not _is_within_managed_node_root(candidate, root):
+                continue
+            try:
+                mode = candidate.resolve().stat().st_mode
+            except OSError:
+                continue
+        elif stat.S_ISREG(st.st_mode):
+            if not _is_within_managed_node_root(candidate, root):
+                continue
+            mode = st.st_mode
+        else:
+            continue
+        if not (mode & stat.S_IXUSR):
+            return True
+    return False
+
+
+def repair_managed_node_executable_modes(home: Path | None = None) -> bool:
+    """POSIX: restore execute bits on managed node/npm/npx entrypoints.
+
+    Only touches regular files that resolve inside a managed node root.
+    Never chmods a symlink whose target is outside the managed root.
+    Returns True if any mode was repaired.
+    """
+    if sys.platform == "win32":
+        return False
+
+    repaired = False
+    for root, candidate in _iter_managed_node_entrypoints(home):
+        try:
+            st = candidate.lstat()
+        except OSError:
+            continue
+
+        if stat.S_ISLNK(st.st_mode):
+            if not _is_within_managed_node_root(candidate, root):
+                continue
+            try:
+                path_to_chmod = candidate.resolve()
+            except OSError:
+                continue
+            if not _is_within_managed_node_root(path_to_chmod, root):
+                continue
+        elif stat.S_ISREG(st.st_mode):
+            if not _is_within_managed_node_root(candidate, root):
+                continue
+            path_to_chmod = candidate
+        else:
+            continue
+
+        try:
+            mode = path_to_chmod.stat().st_mode
+        except OSError:
+            continue
+        if mode & stat.S_IXUSR:
+            continue
+        try:
+            os.chmod(path_to_chmod, (mode & 0o777) | 0o111)
+        except OSError:
+            continue
+        repaired = True
+    return repaired
+
+
 def node_tool_runnable(path: str | None) -> bool:
     """Return True only when *path* is a Node/npm/npx binary that actually runs.
 
@@ -374,16 +492,27 @@ def node_tool_runnable(path: str | None) -> bool:
 
 
 def hermes_managed_node_tree_present(home: Path | None = None) -> bool:
-    """Return True when any Hermes-managed node/npm/npx shim exists on disk."""
-    names = set()
-    for command in ("node", "npm", "npx"):
-        names.update(_candidate_node_command_names(command))
+    """Return True when any Hermes-managed node/npm/npx shim exists on disk.
+
+    Presence does not require the execute bit: a mode-stripped (0644) tree is
+    still a managed tree so mode-repair or heal can run. Matches the shell
+    ``[ -f ]`` check in ``_nb_managed_tool_broken``.
+    """
+    names = _managed_node_entrypoint_names()
     for directory in iter_hermes_node_dirs(home):
         for name in names:
             candidate = directory / name
-            if candidate.is_file() and (
-                sys.platform == "win32" or os.access(candidate, os.X_OK)
-            ):
+            if sys.platform == "win32":
+                if candidate.is_file():
+                    return True
+                continue
+            try:
+                st = candidate.lstat()
+            except OSError:
+                continue
+            if stat.S_ISREG(st.st_mode):
+                return True
+            if stat.S_ISLNK(st.st_mode) and candidate.exists():
                 return True
     return False
 
@@ -512,6 +641,8 @@ def bootstrap_hermes_managed_node() -> str | None:
     if not ok:
         return None
 
+    repair_managed_node_executable_modes()
+
     for directory in iter_hermes_node_dirs():
         for name in _candidate_node_command_names("npm"):
             candidate = directory / name
@@ -534,6 +665,7 @@ def heal_hermes_managed_node() -> bool:
     global _managed_node_heal_attempted
     if _managed_node_heal_attempted:
         return False
+    repair_managed_node_executable_modes()
     if not hermes_managed_node_tree_present():
         return False
     _managed_node_heal_attempted = True
@@ -623,7 +755,14 @@ def find_hermes_node_executable(command: str) -> str | None:
                     broken = True
         return None, broken
 
+    repair_managed_node_executable_modes()
     resolved, broken_present = _first_runnable()
+    if resolved is None and not broken_present:
+        if _managed_node_has_nonexecutable_entrypoints():
+            broken_present = True
+            repair_managed_node_executable_modes()
+            resolved, broken2 = _first_runnable()
+            broken_present = broken_present or broken2
     needs_heal = broken_present or (
         resolved is not None and _managed_node_tree_outdated()
     )

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -278,6 +278,78 @@ class TestNodeToolRunnable:
 
         assert hermes_constants.find_hermes_node_executable("node") == str(node)
 
+    def test_mode_only_damage_repairs_without_full_heal(self, tmp_path, monkeypatch):
+        """0644 managed shims get +x restored; heal must not redownload."""
+        target = hermes_constants._HERMES_NODE_TARGET_MAJOR
+        profile_home = tmp_path / "profiles" / "assistant"
+        managed_bin = profile_home / "node" / "bin"
+        managed_bin.mkdir(parents=True)
+        node = self._stub(
+            managed_bin, "node", f"#!/bin/sh\necho 'v{target}.5.1'\nexit 0\n", mode=0o644
+        )
+        self._stub(managed_bin, "npm", "#!/bin/sh\necho '10.9.0'\nexit 0\n", mode=0o644)
+        self._stub(managed_bin, "npx", "#!/bin/sh\necho '10.9.0'\nexit 0\n", mode=0o644)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setenv("PATH", "")
+        monkeypatch.setattr(hermes_constants, "_managed_node_heal_attempted", False)
+
+        def _heal():
+            raise AssertionError("heal must not run for mode-only damage")
+
+        monkeypatch.setattr(hermes_constants, "heal_hermes_managed_node", _heal)
+
+        resolved = hermes_constants.find_hermes_node_executable("node")
+        assert resolved == str(node)
+        assert os.access(node, os.X_OK)
+
+    def test_symlink_escape_not_chmodded(self, tmp_path, monkeypatch):
+        """Repair must not chmod a managed shim that points outside the tree."""
+        profile_home = tmp_path / "profiles" / "assistant"
+        managed_bin = profile_home / "node" / "bin"
+        managed_bin.mkdir(parents=True)
+        outside = tmp_path / "outside-node"
+        outside.write_text("#!/bin/sh\necho 'v22.0.0'\nexit 0\n")
+        outside.chmod(0o644)
+        (managed_bin / "node").symlink_to(outside)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setenv("PATH", "")
+        monkeypatch.setattr(hermes_constants, "_managed_node_heal_attempted", False)
+        monkeypatch.setattr(hermes_constants, "heal_hermes_managed_node", lambda: False)
+
+        assert hermes_constants.repair_managed_node_executable_modes() is False
+        assert not os.access(outside, os.X_OK)
+
+        hermes_constants.find_hermes_node_executable("node")
+        assert not os.access(outside, os.X_OK)
+        assert outside.stat().st_mode & 0o111 == 0
+
+    def test_tree_present_with_nonexecutable_files(self, tmp_path, monkeypatch):
+        """A 0644 managed node file still counts as a present tree."""
+        profile_home = tmp_path / "profiles" / "assistant"
+        managed_bin = profile_home / "node" / "bin"
+        managed_bin.mkdir(parents=True)
+        self._stub(managed_bin, "node", "#!/bin/sh\necho 'v22.0.0'\nexit 0\n", mode=0o644)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        assert hermes_managed_node_tree_present() is True
+
+    def test_repair_managed_node_executable_modes_restores_execute_bit(
+        self, tmp_path, monkeypatch
+    ):
+        profile_home = tmp_path / "hermes"
+        managed_bin = profile_home / "node" / "bin"
+        managed_bin.mkdir(parents=True)
+        node = self._stub(managed_bin, "node", "#!/bin/sh\nexit 0\n", mode=0o644)
+        npm = self._stub(managed_bin, "npm", "#!/bin/sh\nexit 0\n", mode=0o644)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        assert not os.access(node, os.X_OK)
+        assert hermes_constants.repair_managed_node_executable_modes() is True
+        assert os.access(node, os.X_OK)
+        assert os.access(npm, os.X_OK)
+        assert hermes_constants.repair_managed_node_executable_modes() is False
 
 
 class TestIsContainer:


### PR DESCRIPTION
## Summary

Managed Node under `$HERMES_HOME/node` can land with `0644` entrypoints (no `+x`). Python then treated the tree as absent, never healed, and left operators needing a host-side `chmod`.

## Root cause

In `hermes_constants.py`:

- `hermes_managed_node_tree_present()` required `os.access(..., X_OK)` on POSIX
- `find_hermes_node_executable()` only considered X_OK candidates, so `broken` stayed false and heal never ran
- `heal_hermes_managed_node()` early-returned when the tree looked absent
- Shell heal (`_nb_managed_tool_broken`) already treated plain `-f` + failed `--version` as broken — Python did not

## Fix

- `repair_managed_node_executable_modes()` restores execute bits on `node`/`npm`/`npx` only when the path resolves inside a managed `$HERMES_HOME/node` root (symlink escapes refused)
- Call repair from `find_hermes_node_executable`, `bootstrap_hermes_managed_node`, and `heal_hermes_managed_node`
- Tree presence no longer requires X_OK so mode-stripped trees remain visible to heal if chmod is insufficient

## Why it matters

Without this, TUI/browser tooling that depends on managed Node stays dead after a mode-stripping extract/FS, and `maybe_repair_npm_engine` (EBADENGINE-only) cannot help.

## Test plan

```bash
python -m pytest tests/test_hermes_constants.py -q
# 49 passed, 5 skipped @ 3b4390b28
```

Named coverage:

- `test_mode_only_damage_repairs_without_full_heal`
- `test_symlink_escape_not_chmodded`
- `test_tree_present_with_nonexecutable_files`
- `test_repair_managed_node_executable_modes_restores_execute_bit`

## Risk

POSIX-only mode repair; Windows paths unchanged. Symlink targets outside the managed root are never chmod'd. Full redownload heal still available if bits cannot be restored.

## Closest work

none found for #86118 (mode-only class). Related managed-Node heal PRs target different roots (gutted trees, PATH preference, Windows shims).

Fixes #86118
