### PR TITLE
fix(desktop): lone tile header beats persisted headerHidden (unclosable dead zone)

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { forceLoneHeaderForPanes } from './lone-header'
+import { forceLoneHeaderForPanes, resolveZoneHeaderHidden } from './lone-header'
 
 describe('forceLoneHeaderForPanes', () => {
   const chrome =
@@ -33,5 +33,30 @@ describe('forceLoneHeaderForPanes', () => {
 
   it('leaves standing side chrome (files / sessions) headerless', () => {
     expect(forceLoneHeaderForPanes(['files'], chrome('right'), noCollapse)).toBe(false)
+  })
+})
+
+describe('resolveZoneHeaderHidden', () => {
+  it('a lone closeable tile keeps its strip even over a persisted hide (dead-zone regression)', () => {
+    expect(resolveZoneHeaderHidden({ persisted: true, shownCount: 1, forceLoneHeader: true })).toBe(false)
+    expect(resolveZoneHeaderHidden({ persisted: undefined, shownCount: 1, forceLoneHeader: true })).toBe(false)
+  })
+
+  it('headerVeto always suppresses the strip', () => {
+    expect(resolveZoneHeaderHidden({ headerVeto: true, shownCount: 1, forceLoneHeader: true })).toBe(true)
+  })
+
+  it('preserves the persisted choice where no force applies', () => {
+    // Lone side chrome the user deliberately hid stays hidden.
+    expect(resolveZoneHeaderHidden({ persisted: true, shownCount: 1, forceLoneHeader: false })).toBe(true)
+    // A stacked zone (the chat strip) keeps the user's hide too.
+    expect(resolveZoneHeaderHidden({ persisted: true, shownCount: 3, forceLoneHeader: true })).toBe(true)
+    // An explicitly shown lone zone keeps its bar.
+    expect(resolveZoneHeaderHidden({ persisted: false, shownCount: 1, forceLoneHeader: false })).toBe(false)
+  })
+
+  it('defaults lone non-tile panes to headerless', () => {
+    expect(resolveZoneHeaderHidden({ shownCount: 1, forceLoneHeader: false })).toBe(true)
+    expect(resolveZoneHeaderHidden({ shownCount: 2, forceLoneHeader: false })).toBe(false)
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.ts
@@ -33,3 +33,29 @@ export function forceLoneHeaderForPanes(
 
   return shown.length === 1 && isCollapsePane(shown[0])
 }
+
+/** Header visibility for a zone, in precedence order:
+ *  1. a full-page view (headerVeto) always suppresses the strip;
+ *  2. a LONE closeable tile always keeps its strip — even over a persisted
+ *     `headerHidden: true` (a double-tap hide or an older build's leftover).
+ *     Without the strip the tile has no tab to grab and no close gesture
+ *     reachable over a webview/iframe body: an unclosable dead zone whose
+ *     only escape was a layout reset;
+ *  3. otherwise the user's persisted choice stands (normalize deliberately
+ *     keeps it), defaulting to headerless for lone side chrome. */
+export function resolveZoneHeaderHidden(input: {
+  headerVeto?: boolean
+  persisted?: boolean
+  shownCount: number
+  forceLoneHeader: boolean
+}): boolean {
+  if (input.headerVeto) {
+    return true
+  }
+
+  if (input.shownCount <= 1 && input.forceLoneHeader) {
+    return false
+  }
+
+  return input.persisted ?? input.shownCount <= 1
+}

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -70,7 +70,10 @@ import {
 } from '../tab-selection'
 
 import { type DoubleTapContext, startPaneDrag } from './drag-session'
-import { forceLoneHeaderForPanes } from './lone-header'
+import {
+  forceLoneHeaderForPanes,
+  resolveZoneHeaderHidden
+} from './lone-header'
 import { useActiveTabVisible } from './tab-strip-scroll'
 import { paneChrome } from './track-model'
 
@@ -252,7 +255,14 @@ export function TreeGroup({
 
   // A full-page view (headerVeto) suppresses the strip while it's the active
   // pane — a page is not a tab-able surface; the bar returns with the chat.
-  const headerHidden = paneChrome(active).headerVeto || (node.headerHidden ?? (shown.length <= 1 && !forceLoneHeader))
+  // resolveZoneHeaderHidden also makes a lone closeable tile's strip beat a
+  // persisted headerHidden — that state was an unclosable dead zone.
+  const headerHidden = resolveZoneHeaderHidden({
+    headerVeto: paneChrome(active).headerVeto,
+    persisted: node.headerHidden,
+    shownCount: shown.length,
+    forceLoneHeader
+  })
 
   // A group collapses ALONG its parent split's axis. In a row that means the
   // WIDTH collapses — a full-width horizontal header would strand a tall


### PR DESCRIPTION
## Problem

A lone preview/session tile in a zone with a persisted `headerHidden: true` (set by the double-tap-on-strip gesture, or left over from an older build) renders with **no tab strip**: no tab to grab and no close gesture. Because preview bodies are webview/iframe guests, right-click (zone menu) and keyboard focus never reach the host, so the zone menu's Close and ⌘W are both unreachable. The zone becomes an unclosable dead zone; `normalize` deliberately preserves the persisted flag across restarts, so the only escape was a full layout reset.

Repro: open a URL preview (it docks as its own lone zone, `placement: 'main'`) → double-click its tab strip to hide the header → restart the app (flag persists) → the preview has no strip and cannot be closed from the visible UI.

## Fix

`forceLoneHeaderForPanes` already encodes the invariant "a closeable surface never becomes an unclosable dead zone", but `TreeGroup` evaluated `node.headerHidden ??` **before** it, so the persisted flag silently won. This extracts the decision into `resolveZoneHeaderHidden()` with explicit precedence:

1. `headerVeto` (full-page views) still suppresses the strip;
2. a lone closeable tile (`forceLoneHeader`) **keeps its strip even over a persisted hide** — the fix;
3. every other zone keeps the user's persisted choice exactly as before (stacked chat strips, side chrome, etc. are untouched).

## Tests

- New `resolveZoneHeaderHidden` cases in `lone-header.test.ts`: the dead-zone regression (persisted hide + lone tile → strip), veto, preserved choices, defaults.
- `npx vitest run src/components/pane-shell`: 20 files / 109 tests pass. `tsc --build` clean.