### PR TITLE
fix(tui_gateway): reject non string text in paste.collapse

### DIFF
--- a/tests/tui_gateway/test_paste_collapse_guard.py
+++ b/tests/tui_gateway/test_paste_collapse_guard.py
@@ -1,0 +1,50 @@
+"""Regression tests: paste.collapse must reject non-string ``text``.
+
+``paste.collapse`` stored ``params.get("text", "")`` and passed it straight
+to ``Path.write_text``. A list or dict for ``text`` passes the truthiness
+check and then makes ``write_text`` raise ``TypeError`` (and
+``text.count("\\n")`` would raise first for types without ``.count``). The
+handler runs inline on the gateway's stdin reader thread, where no
+exception is caught, so one malformed frame kills the gateway process.
+
+The fix returns a 4000 JSON-RPC error for non-string ``text`` before any
+disk write.
+"""
+
+import pytest
+
+import tui_gateway.server as server
+
+
+BAD_TEXT_VALUES = [
+    ["line"],
+    {"a": 1},
+    123,
+    1.5,
+    True,   # bool passes truthiness, write_text(True) would TypeError
+    None,   # not a string, so the guard returns 4000 before the empty check
+]
+
+
+def _request(params):
+    return {"jsonrpc": "2.0", "id": "r1", "method": "paste.collapse", "params": params}
+
+
+@pytest.mark.parametrize("bad", BAD_TEXT_VALUES)
+def test_non_string_text_returns_error_not_crash(bad):
+    resp = server.handle_request(_request({"text": bad}))
+    assert isinstance(resp, dict)
+    assert "error" in resp
+    assert resp["error"]["code"] == 4000
+
+
+def test_empty_text_still_returns_4004():
+    resp = server.handle_request(_request({"text": ""}))
+    assert "error" in resp
+    assert resp["error"]["code"] == 4004
+
+
+def test_valid_text_still_writes_paste():
+    resp = server.handle_request(_request({"text": "hello\nworld"}))
+    assert "error" not in resp
+    assert resp["result"]["lines"] == 2

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -15,6 +15,8 @@ _profile_scoped = _registry.profile_scoped
 def _(rid, params: dict) -> dict:
     global _paste_counter
     text = params.get("text", "")
+    if not isinstance(text, str):
+        return _err(rid, 4000, "text must be a string")
     if not text:
         return _err(rid, 4004, "empty paste")
 


### PR DESCRIPTION
## What does this PR do?

Stops the TUI gateway process from dying when a client sends a non string value for the `text` parameter of `paste.collapse`.

The handler took `params.get("text", "")` and only checked that it was not empty. It then called `text.count("\n")` and `Path.write_text(text)`. A list, dict, number, or bool that passed the empty check made those calls raise `TypeError` or `AttributeError`. The handler runs inline on the stdin reader thread and the entry loop does not catch handler exceptions, so one malformed frame killed the whole gateway process.

The fix adds a type check before any disk write and answers a 4000 error, the same style of error the handler already uses for bad input.

## Related Issue

Fixes #86165

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/methods_complete.py`: `paste.collapse` now returns a 4000 error when `text` is not a string, before any disk write
- `tests/tui_gateway/test_paste_collapse_guard.py`: regression tests with list, dict, number, bool, and None values, plus tests that the empty case still gives 4004 and a valid paste still works

## How to Test

Before the fix, this single frame kills the gateway:

1. `python -m tui_gateway.entry`
2. Send on stdin: `{"jsonrpc": "2.0", "id": 1, "method": "paste.collapse", "params": {"text": [1]}}`
3. Without the fix the process exits with `TypeError`. With the fix you get a 4000 JSON-RPC error and the process keeps running.

Or run the tests:

```
scripts/run_tests.sh tests/tui_gateway/test_paste_collapse_guard.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (`scripts/run_tests.sh tests/tui_gateway/` in full plus the new regression file. The only failures are pre existing on this Windows machine and byte identical on plain upstream main. Full suite left to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) (N/A)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys (N/A)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (no OS specific code, pure Python type handling)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior (N/A)
