### PR TITLE
feat(telegram): use forum topic names as session titles

### DIFF
--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1176,6 +1176,36 @@ class GatewayInboundMixin:
             logger.debug("FIFO orphan rescue pre-claim failed for %s", _quick_key, exc_info=True)
             return event, source, is_internal
 
+    async def _handle_telegram_forum_topic_name(self, event: MessageEvent) -> bool:
+        """Persist an authorized Telegram topic create/rename as the canonical session title."""
+        metadata = getattr(event, "metadata", None) or {}
+        name = metadata.get("telegram_forum_topic_name")
+        source = getattr(event, "source", None)
+        if (
+            not isinstance(name, str)
+            or not name.strip()
+            or source is None
+            or source.platform != Platform.TELEGRAM
+            or not source.thread_id
+        ):
+            return False
+
+        try:
+            session_entry = await self.async_session_store.get_or_create_session(
+                source, touch_activity=False
+            )
+            if self._session_db is None:
+                logger.warning(
+                    "Could not store Telegram forum topic name: session database unavailable"
+                )
+            else:
+                await self._session_db.set_session_title(session_entry.session_id, name)
+        except ValueError as exc:
+            logger.warning("Could not store Telegram forum topic name: %s", exc)
+        except Exception:
+            logger.warning("Could not store Telegram forum topic name", exc_info=True)
+        return True
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """Handle an incoming message from any platform: auth → command check → running-agent
         interrupt → get/create session → build context → run agent → return response."""
@@ -1192,6 +1222,11 @@ class GatewayInboundMixin:
         # — Discord interaction passthrough builds its own MessageEvent and
         # calls handle_message directly, so a teardown on the relay's inbound
         # handler left those turns muted.
+
+        # Topic service updates carry user metadata, not agent input. Persist
+        # after authorization, then consume without starting an empty turn.
+        if await self._handle_telegram_forum_topic_name(event):
+            return None
 
         _paused_notice = self._hm_estop_gate(event, source, is_internal)
         if _paused_notice is not None:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2690,6 +2690,11 @@ class TelegramAdapter(BasePlatformAdapter):
         app.add_handler(TelegramMessageHandler(
             filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
             self._handle_media_message))
+        app.add_handler(TelegramMessageHandler(
+            filters.StatusUpdate.FORUM_TOPIC_CREATED
+            | filters.StatusUpdate.FORUM_TOPIC_EDITED,
+            self._handle_forum_topic_name_update,
+        ))
         app.add_handler(CallbackQueryHandler(self._handle_callback_query))
         # Inline command picker; inert until the owner enables inline mode via BotFather /setinline.
         app.add_handler(InlineQueryHandler(self._handle_inline_query))
@@ -5692,6 +5697,36 @@ class TelegramAdapter(BasePlatformAdapter):
     def _effective_update_message(self, update: Update) -> Optional[Message]:
         """Message-like payload for normal messages and channel posts (``update.channel_post``)."""
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
+
+    async def _handle_forum_topic_name_update(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        """Forward an authorized human's forum topic create/rename metadata."""
+        msg = self._effective_update_message(update)
+        actor = getattr(msg, "from_user", None) if msg is not None else None
+        if (
+            msg is None
+            or actor is None
+            or bool(getattr(actor, "is_bot", False))
+            or not self._is_user_authorized_from_message(msg)
+        ):
+            return
+
+        topic = getattr(msg, "forum_topic_edited", None) or getattr(
+            msg, "forum_topic_created", None
+        )
+        name = getattr(topic, "name", None)
+        if not isinstance(name, str) or not name.strip():
+            return
+
+        event = self._build_message_event(
+            msg, MessageType.TEXT, update_id=getattr(update, "update_id", None)
+        )
+        event.text = ""
+        event.allow_gateway_control = False
+        event.source.chat_topic = name
+        event.metadata["telegram_forum_topic_name"] = name
+        await self.handle_message(event)
 
     def _log_blocked_user(self, msg, *, level=logging.WARNING, what: str = "unauthorized user") -> None:
         logger.log(

--- a/tests/gateway/test_gateway_platform_event_hook.py
+++ b/tests/gateway/test_gateway_platform_event_hook.py
@@ -672,14 +672,14 @@ class TestRegisterHandlers:
         app = MagicMock()
         a._register_handlers(app)
 
-        # Six core handlers (default group, no group kwarg — incl. the
+        # Seven core handlers (default group, no group kwarg — incl. the
         # inline command picker) plus the gateway_platform_event observer
         # alone in group 99, so it observes alongside rather than
         # displacing the core handlers.
         calls = app.add_handler.call_args_list
-        assert len(calls) == 7
+        assert len(calls) == 8
         assert len([c for c in calls if c.kwargs.get("group") == 99]) == 1
-        assert len([c for c in calls if not c.kwargs]) == 6
+        assert len([c for c in calls if not c.kwargs]) == 7
 
     def test_rebuild_re_registers_observer(self):
         """A second call on a fresh app (e.g. a future rebuild) re-registers
@@ -691,7 +691,7 @@ class TestRegisterHandlers:
         a._register_handlers(first_app)
         a._register_handlers(rebuilt_app)  # the rebuild path
 
-        assert rebuilt_app.add_handler.call_count == 7
+        assert rebuilt_app.add_handler.call_count == 8
         assert len(self._observer_calls(rebuilt_app)) == 1
 
     def test_transient_init_rebuild_uses_shared_registration(self, monkeypatch):

--- a/tests/gateway/test_telegram_forum_topic_titles.py
+++ b/tests/gateway/test_telegram_forum_topic_titles.py
@@ -1,0 +1,122 @@
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100123",
+        chat_name="Dev",
+        chat_type="group",
+        user_id="7",
+        user_name="tester",
+        thread_id="42",
+    )
+
+
+def _update(*, created_name=None, edited_name=None, is_bot=False):
+    return SimpleNamespace(
+        update_id=99,
+        effective_message=SimpleNamespace(
+            from_user=SimpleNamespace(id=7, is_bot=is_bot),
+            forum_topic_created=(
+                SimpleNamespace(name=created_name) if created_name is not None else None
+            ),
+            forum_topic_edited=(
+                SimpleNamespace(name=edited_name) if edited_name is not None else None
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_authorized_topic_create_and_edit_update_one_canonical_session_title():
+    from gateway.run import GatewayRunner
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    source = _source()
+    event = MessageEvent(text="", source=source, message_id="1")
+    adapter: Any = object.__new__(TelegramAdapter)
+    adapter._build_message_event = MagicMock(return_value=event)
+    adapter._is_user_authorized_from_message = MagicMock(return_value=True)
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_forum_topic_name_update(
+        _update(created_name="Hermes: updates"), SimpleNamespace()
+    )
+
+    adapter.handle_message.assert_awaited_once_with(event)
+    assert event.text == ""
+    assert event.allow_gateway_control is False
+    assert event.source.chat_topic == "Hermes: updates"
+    assert event.metadata == {"telegram_forum_topic_name": "Hermes: updates"}
+
+    entry = SessionEntry(
+        session_key="agent:main:telegram:group:-100123:42",
+        session_id="session-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+        origin=source,
+    )
+    runner: Any = object.__new__(GatewayRunner)
+    store = object()
+    get_or_create = AsyncMock(return_value=entry)
+    runner.session_store = store
+    runner._async_session_store = SimpleNamespace(
+        _store=store,
+        get_or_create_session=get_or_create,
+    )
+    set_title = AsyncMock(return_value=True)
+    runner._session_db = SimpleNamespace(set_session_title=set_title)
+
+    assert await runner._handle_telegram_forum_topic_name(event) is True
+    event.metadata["telegram_forum_topic_name"] = "Hermes: releases"
+    assert await runner._handle_telegram_forum_topic_name(event) is True
+
+    assert [call.args for call in set_title.await_args_list] == [
+        ("session-1", "Hermes: updates"),
+        ("session-1", "Hermes: releases"),
+    ]
+    assert all(
+        call.kwargs == {"touch_activity": False}
+        for call in get_or_create.await_args_list
+    )
+
+    adapter.handle_message.reset_mock()
+    await adapter._handle_forum_topic_name_update(
+        _update(edited_name="Automatic title", is_bot=True), SimpleNamespace()
+    )
+    await adapter._handle_forum_topic_name_update(
+        _update(edited_name=""), SimpleNamespace()
+    )
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_topic_service_update_is_consumed_after_authorization_before_turn_start():
+    from gateway.run import GatewayRunner
+
+    event = MessageEvent(
+        text="",
+        source=_source(),
+        metadata={"telegram_forum_topic_name": "Hermes: updates"},
+    )
+    runner: Any = object.__new__(GatewayRunner)
+    runner._hm_admit_event = AsyncMock(return_value=(event, event.source, False))
+    runner._handle_telegram_forum_topic_name = AsyncMock(return_value=True)
+    runner._hm_estop_gate = MagicMock(side_effect=AssertionError("turn path reached"))
+
+    assert await runner._handle_message(event) is None
+    runner._hm_admit_event.assert_awaited_once_with(event)
+    runner._handle_telegram_forum_topic_name.assert_awaited_once_with(event)
+    runner._hm_estop_gate.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Consumes authorized Telegram `forum_topic_created` and `forum_topic_edited` service updates and stores the human-selected topic name as the canonical Hermes session title.

The adapter forwards only authorized human events with a non-empty name. The current inbound pipeline persists that metadata immediately after authorization, resolves the existing chat/thread session without touching user-activity time, and consumes the service event before pause, busy-session, command, or agent-turn handling. Routing remains based on immutable chat/thread IDs.

## Related work

- #5488 identifies the same service-message gap but persists a broader topic registry in `config.yaml`.
- #21458 routes broader lifecycle events through an older adapter.
- #46644 handles the opposite direction: Hermes title to Telegram topic name.
- #51839 stores topic names in a separate source-metadata cache.

None supplies this current-adapter Telegram-name to canonical `sessions.title` contract; this PR remains the narrow implementation for session naming.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Register focused Telegram create/edit forum-topic service handlers.
- Ignore bot-authored, unauthorized, and nameless events.
- Forward the selected name as metadata with gateway control disabled.
- Persist through the existing canonical session title setter without counting user activity.
- Consume metadata after authorization and before any turn-start path.
- Port gateway behavior to the current `run_inbound` owner instead of the `run.py` facade.
- Add two current-main invariants and update the handler-registry fixture.

## Review feedback disposition

All four prior review observations remain explicitly resolved:

1. Telegram topic edits intentionally update the canonical session title. They are direct user-selected conversation renames; no reliable title-provenance field exists to preserve another title source without divergence.
2. The service event remains consumed when persistence is unavailable. It is metadata rather than agent input, and starting an empty turn or adding a lossy in-memory retry queue would be incorrect.
3. Each explicit Telegram rename produces one small canonical title write. A debounce would add shutdown-loss state without protecting a realistic hot path.
4. The current inbound call site states and verifies that topic metadata is handled after authorization and before turn start.

No maintainer review or inline findings are pending.

## How to Test

`./scripts/run_tests.sh tests/gateway/test_telegram_forum_topic_titles.py tests/gateway/test_telegram_topic_mode.py tests/gateway/test_session_title_rename_lane.py tests/gateway/test_telegram_topic_profile_routing_76423.py tests/gateway/test_telegram_topic_profile_isolation_76423.py tests/gateway/test_gateway_platform_event_hook.py`

Both new invariants fail against current upstream `main` and pass on this head.

## Verification

- 62 focused Telegram/topic/session-title/handler tests passed.
- Focused Ruff passed.
- Plugin-compat pointer audit passed.
- Contributor attribution audit passed.
- `git diff --check` passed.

## Checklist

### Code

- [x] I've read the current contributing guide and area instructions.
- [x] My commit message follows Conventional Commits.
- [x] I inspected the full PR/comment/review history and all related topic-name work.
- [x] The patch contains only the Telegram-name to canonical-session-title contract.
- [x] I added two current-main invariants and proved they fail without the feature.
- [x] Tested on macOS 26.6.1 with Python 3.11.

### Documentation & Housekeeping

- [x] User documentation: N/A — no command or configuration surface changed.
- [x] Config documentation: N/A — no keys changed.
- [x] Architecture documentation: N/A — code follows the current inbound-pipeline split.
- [x] Cross-platform behavior considered — the feature is Telegram transport and SQLite session metadata.
- [x] Tool schema documentation: N/A — no tool schema changed.
