### PR TITLE
feat(feishu): multi-app support with per-app profile routing (#68046)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -178,3 +178,24 @@ jobs:
 
       - name: Run footgun checker
         run: python scripts/check-windows-footguns.py --all
+
+  credential-env-access:
+    # Blocks direct os.getenv()/os.environ reads of credential-shaped env
+    # vars (*_API_KEY, *_TOKEN, *_SECRET, *_PASSWORD) in agent/ and gateway/
+    # — the multiplex-gateway secret scope (agent/secret_scope.py) requires
+    # these go through get_secret() so profiles stay isolated. See
+    # scripts/check_credential_env_access.py for the full rule.
+    name: Credential env access (blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Run credential env-access checker
+        run: python scripts/check_credential_env_access.py --all

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -413,6 +413,23 @@ PARALLEL_TOOL_CALL_GUIDANCE = (
     "in doubt and the calls are independent, batch them."
 )
 
+# Group-chat collaboration vs delegation — guides the bot to @-mention peers
+# (visible, bot-to-bot routed) instead of using delegate_task (invisible
+# subagent) when the goal is getting a colleague's input in a shared chat.
+COLLABORATION_GUIDANCE = (
+    "# Group-chat collaboration: @-mention vs delegation\n"
+    "When you are in a group chat alongside other specialist bots and a task "
+    "needs a colleague's expertise, @-mention that colleague in your reply "
+    "(visible to everyone, routes via the gateway's bot-to-bot mechanism). "
+    "Do NOT use delegate_task for this — delegation spawns an isolated "
+    "subagent with no group context, so the colleague never sees the "
+    "discussion, can't @ others, and the group can't follow the exchange.\n"
+    "Use delegate_task only for independent subtasks you must complete "
+    "yourself (e.g. deep analysis, code generation) where no peer interaction "
+    "is needed. Rule of thumb: @-mention = visible collaboration; delegation "
+    "= solo work handoff."
+)
+
 # OpenAI GPT/Codex-specific execution guidance.  Addresses known failure modes
 # where GPT models abandon work on partial results, skip prerequisite lookups,
 # hallucinate instead of using tools, and declare "done" without verification.

--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -6,7 +6,14 @@ has its own ``.env`` with its own provider keys and platform tokens, so we
 profile A's keys to profile B's turns, and to every subprocess spawned with
 ``env=dict(os.environ)``).
 
-This module provides a fail-closed, context-local secret scope:
+Instead each profile turn gets a fail-closed, context-local secret scope
+(``build_profile_secret_scope``). A profile's scope is **layered**: it starts
+from the global/default home's ``.env`` (a shared credential baseline so a
+deployment-common key like ``OPENROUTER_API_KEY`` doesn't have to be copied
+into every profile), then overlays the profile's own ``.env``. Only this
+context-local dict is affected — nothing is written to ``os.environ`` — so
+sibling profiles stay isolated from each other (each sees the global baseline
+plus its own secrets, never another profile's):
 
 - ``set_secret_scope(mapping)`` installs the active profile's secrets for the
   current task (a contextvar, so it propagates into the agent's worker thread
@@ -119,6 +126,7 @@ _GLOBAL_ENV_PREFIXES = (
     "HERMES_KANBAN_",
     "HERMES_TELEGRAM_",   # tuning knobs (batch delays, fallback toggles) — NOT the token
     "TERMINAL_",          # terminal/sandbox backend settings
+    "GATEWAY_RELAY_",     # per-gateway-process relay auth, shared across all profiles
 )
 
 
@@ -269,25 +277,66 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
     return secrets
 
 
-def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
-    """Build a profile's secret mapping from its ``<home>/.env``.
+def _resolve_global_home(profile_home: Path) -> Optional[Path]:
+    """Return the global/default HERMES_HOME a profile inherits from, or None.
 
-    Returns a fresh dict (safe to install via ``set_secret_scope``). Genuinely
-    global vars are intentionally NOT copied in — ``get_secret`` reads those
-    from ``os.environ`` directly, so the scope holds only profile secrets.
+    Profiles live at ``<hermes_home>/profiles/<name>``; their shared baseline is
+    ``<hermes_home>`` (the ``default`` profile's home). This is resolved by path
+    shape (``parent.name == "profiles"``) rather than via ``get_hermes_home()``,
+    because inside a multiplex turn ``HERMES_HOME`` is overridden to the active
+    profile's home — a lookup there would return the profile, not the global
+    root. Returns ``None`` for the ``default`` profile itself (it IS the global
+    home) and for any non-standard layout, preserving legacy behavior.
+    """
+    home = Path(profile_home).resolve()
+    if home.parent.name == "profiles":
+        return home.parent.parent
+    return None
+
+
+def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
+    """Build a profile's secret mapping, inheriting the global default home.
+
+    The scope is layered (each later layer overrides the previous):
+
+    1. The global/default home's ``.env`` and external-secret snapshot — a
+       shared credential baseline so profiles don't each have to duplicate
+       deployment-common keys (e.g. a shared ``OPENROUTER_API_KEY``).
+    2. The profile's own ``.env`` and external-secret snapshot — profile-specific
+       values override the global baseline.
+
+    Genuinely global vars (``_is_global_env``) are skipped from the external
+    snapshots; ``get_secret`` reads those from ``os.environ`` directly. The
+    result is a fresh dict, safe for ``set_secret_scope``. Only this
+    context-local scope dict is affected — nothing is written to ``os.environ``,
+    and sibling profiles stay isolated (each sees only the global baseline plus
+    its own secrets, never another profile's).
     """
     home = Path(hermes_home)
-    secrets = load_env_file(home / ".env")
+    secrets: Dict[str, str] = {}
 
     try:
         from hermes_cli.env_loader import get_secret_source_values
-        external_secrets = get_secret_source_values(home)
     except Exception:
-        external_secrets = {}
+        get_secret_source_values = None  # type: ignore[assignment]
 
-    for key, value in external_secrets.items():
-        if _is_global_env(key):
-            continue
-        secrets[key] = value
+    def _merge_external(scope_home: Path) -> None:
+        if get_secret_source_values is None:
+            return
+        try:
+            for key, value in get_secret_source_values(scope_home).items():
+                if _is_global_env(key):
+                    continue
+                secrets[key] = value
+        except Exception:
+            pass
+
+    global_home = _resolve_global_home(home)
+    if global_home is not None:
+        secrets.update(load_env_file(global_home / ".env"))
+        _merge_external(global_home)
+
+    secrets.update(load_env_file(home / ".env"))
+    _merge_external(home)
 
     return secrets

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -32,6 +32,7 @@ import re
 from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
+    COLLABORATION_GUIDANCE,
     DEFAULT_AGENT_IDENTITY,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
@@ -361,6 +362,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # agent has tools. Static text → byte-stable prompt (no cache hit).
     if agent.valid_tool_names:
         stable_parts.append(STEER_CHANNEL_NOTE)
+        stable_parts.append(COLLABORATION_GUIDANCE)
 
     # Computer-use — goes in as its own block rather than being merged into
     # tool_guidance because the content is multi-paragraph. The guidance is

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1979,6 +1979,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             pconfig = config.platforms.get(platform)
             runtime_adapter = None
 
+        # Unwrap list-of-configs (multi-instance platforms like multiple Feishu
+        # bots) to the first enabled config. Union[PlatformConfig,
+        # List[PlatformConfig]] allows lists, but the rest of this function
+        # assumes a single PlatformConfig object.
+        if isinstance(pconfig, list):
+            pconfig = next((c for c in pconfig if getattr(c, "enabled", False)), pconfig[0] if pconfig else None)
+
         if transport is not None and transport.is_relay:
             # A relay transport carries the RELAY adapter's config, and
             # resolve_delivery_transport already applied relay's enablement

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -192,6 +192,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -216,6 +217,7 @@ class InProcessCronScheduler(CronScheduler):
                 stop_event,
                 profile_homes=profile_homes,
                 adapters=adapters,
+                profile_adapters=profile_adapters,
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
@@ -276,6 +278,7 @@ class InProcessCronScheduler(CronScheduler):
         *,
         profile_homes,
         adapters=None,
+        profile_adapters=None,
         loop=None,
         interval=60,
         can_dispatch=None,
@@ -287,6 +290,17 @@ class InProcessCronScheduler(CronScheduler):
         agent execution to that profile's home — mirroring how
         ``_profile_runtime_scope`` scopes the multiplexed inbound path and
         ``web_server.py`` scopes per-profile cron API calls.
+
+        ``profile_adapters`` (optional ``{profile_name: {Platform: adapter}}``)
+        lets each profile's tick deliver through ITS OWN live adapters (e.g. a
+        distinct Feishu bot app per profile) instead of every profile reusing
+        the single default-profile ``adapters`` dict — which would either miss
+        the live-adapter path entirely (falling back to the slower standalone
+        HTTP send) or, if the default profile happens to run the same
+        platform, deliver through the wrong bot/credentials. Falls back to
+        ``adapters`` for any profile with no entry (e.g. an older caller that
+        doesn't pass ``profile_adapters``, or a profile with no live adapters
+        of its own yet).
         """
         import logging
         from cron.scheduler import tick as cron_tick
@@ -329,13 +343,17 @@ class InProcessCronScheduler(CronScheduler):
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
                     for entry in profile_homes:
+                        name = entry[0] if isinstance(entry, tuple) else entry
                         home = entry[1] if isinstance(entry, tuple) else entry
+                        entry_adapters = (
+                            (profile_adapters or {}).get(name, adapters)
+                        )
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=entry_adapters,
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -90,10 +90,50 @@ def _coerce_allow_set(raw) -> set[str]:
 class GatewayAuthorizationMixin:
     """User/chat authorization methods for ``GatewayRunner``."""
 
+    def _platform_configs_for_auth(
+        self,
+        platform: Optional[Platform],
+        adapter_id: Optional[str] = None,
+    ) -> list:
+        """Return configs relevant to one inbound source.
+
+        Multi-instance platforms must scope config-driven authorization to the
+        concrete adapter that received the message. Falling back to every
+        config would let app A's allowlist authorize app B if platform IDs
+        collide.
+        """
+        if not platform:
+            return []
+        config = getattr(self, "config", None)
+        if config is None or not hasattr(config, "platforms"):
+            return []
+        platform_cfg = config.platforms.get(platform)
+        configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+        configs = [cfg for cfg in configs if cfg is not None]
+        if not adapter_id or str(adapter_id) == platform.value:
+            return configs
+
+        wanted = str(adapter_id)
+        for cfg in configs:
+            extra = getattr(cfg, "extra", None)
+            if not isinstance(extra, dict):
+                continue
+            configured_id = str(
+                extra.get("adapter_id")
+                or extra.get("app_id")
+                or extra.get("bot_id")
+                or extra.get("client_id")
+                or ""
+            ).strip()
+            if configured_id and wanted == f"{platform.value}:{configured_id}":
+                return [cfg]
+        return []
+
     def _authorization_adapter(
         self,
         platform: Optional[Platform],
         profile: Optional[str] = None,
+        adapter_id: Optional[str] = None,
     ):
         """Resolve the live adapter whose intake policy should gate authorization.
 
@@ -101,12 +141,22 @@ class GatewayAuthorizationMixin:
         ``_profile_adapters[profile]`` while the default/active profile uses
         ``self.adapters``. ``SessionSource.profile`` selects which map to consult.
         When a stamped profile has its own adapter registry entry, the default
-        profile's same-platform adapter must not be consulted as a fallback.
+        profile's same-platform adapter must not be consulted as a fallback. In
+        multi-instance mode, ``adapter_id`` selects the concrete app instance.
         """
         if not platform:
             return None
         profile_name = (profile or "").strip() or None
         if profile_name and profile_name != "default":
+            if adapter_id:
+                profile_adapters_by_id = (
+                    getattr(self, "_profile_adapters_by_id", None) or {}
+                )
+                adapter = profile_adapters_by_id.get(profile_name, {}).get(
+                    str(adapter_id)
+                )
+                if adapter is not None:
+                    return adapter
             active_profile = None
             active_profile_fn = getattr(self, "_active_profile_name", None)
             if callable(active_profile_fn):
@@ -124,6 +174,10 @@ class GatewayAuthorizationMixin:
             # (e.g. its adapter failed to connect) must NOT fall back to the
             # default profile's adapter — that sends replies out the wrong bot.
             return None
+        if adapter_id:
+            adapter = getattr(self, "adapters_by_id", {}).get(str(adapter_id))
+            if adapter is not None:
+                return adapter
         adapters = getattr(self, "adapters", None) or {}
         return adapters.get(platform)
 
@@ -152,6 +206,7 @@ class GatewayAuthorizationMixin:
         return self._authorization_adapter(
             getattr(source, "platform", None),
             getattr(source, "profile", None),
+            getattr(source, "adapter_id", None),
         )
 
     def _registered_transport_adapter(self, source: SessionSource):
@@ -194,6 +249,7 @@ class GatewayAuthorizationMixin:
     def _adapter_authorization_is_upstream(
         self,
         platform: Optional[Platform],
+        adapter_id: Optional[str] = None,
         *,
         profile: Optional[str] = None,
     ) -> bool:
@@ -210,7 +266,7 @@ class GatewayAuthorizationMixin:
         """
         if not platform:
             return False
-        adapter = self._authorization_adapter(platform, profile)
+        adapter = self._authorization_adapter(platform, profile, adapter_id)
         if adapter is None:
             return False
         return bool(getattr(adapter, "authorization_is_upstream", False))
@@ -218,6 +274,7 @@ class GatewayAuthorizationMixin:
     def _adapter_enforces_own_access_policy(
         self,
         platform: Optional[Platform],
+        adapter_id: Optional[str] = None,
         *,
         profile: Optional[str] = None,
     ) -> bool:
@@ -238,7 +295,7 @@ class GatewayAuthorizationMixin:
         # Some test helpers build a bare GatewayRunner via object.__new__ and
         # never set ``adapters``; treat a missing/empty map as "no adapter"
         # rather than raising (see pitfalls.md #17).
-        adapter = self._authorization_adapter(platform, profile)
+        adapter = self._authorization_adapter(platform, profile, adapter_id)
         if adapter is None:
             return False
         return bool(getattr(adapter, "enforces_own_access_policy", False))
@@ -246,6 +303,7 @@ class GatewayAuthorizationMixin:
     def _adapter_dm_policy(
         self,
         platform: Optional[Platform],
+        adapter_id: Optional[str] = None,
         *,
         profile: Optional[str] = None,
     ) -> str:
@@ -266,16 +324,14 @@ class GatewayAuthorizationMixin:
         """
         if not platform:
             return ""
-        adapter = self._authorization_adapter(platform, profile)
+        adapter = self._authorization_adapter(platform, profile, adapter_id)
         policy = getattr(adapter, "_dm_policy", None) if adapter is not None else None
         if policy is None:
-            config = getattr(self, "config", None)
-            platform_cfg = (
-                config.platforms.get(platform)
-                if config is not None and hasattr(config, "platforms")
-                else None
-            )
-            extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
+            extra = None
+            for cfg in self._platform_configs_for_auth(platform, adapter_id):
+                if cfg is not None:
+                    extra = getattr(cfg, "extra", None)
+                    break
             if isinstance(extra, dict):
                 policy = extra.get("dm_policy")
         return str(policy or "").strip().lower()
@@ -283,6 +339,7 @@ class GatewayAuthorizationMixin:
     def _adapter_group_policy(
         self,
         platform: Optional[Platform],
+        adapter_id: Optional[str] = None,
         *,
         profile: Optional[str] = None,
     ) -> str:
@@ -291,8 +348,17 @@ class GatewayAuthorizationMixin:
         Mirror of ``_adapter_dm_policy`` for group / forum / channel traffic:
         returns the lowercased ``group_policy`` (``"open"`` / ``"allowlist"`` /
         ``"disabled"``) for *platform*, or ``""`` when unknown. Prefers the live
-        adapter's resolved ``_group_policy`` and falls back to ``config.extra``
-        for bare runners built without a live adapter.
+        adapter's resolved ``_default_group_policy`` (falling back to
+        ``_group_policy`` when unset) and falls back to ``config.extra`` for
+        bare runners built without a live adapter.
+
+        Note: this must mirror the adapter's own precedence — e.g. Feishu's
+        ``_apply_settings`` sets ``_default_group_policy = default_group_policy
+        or group_policy`` and the adapter's own admission code reads
+        ``_default_group_policy`` first. Reading only ``_group_policy`` here
+        would disagree with the adapter's own decision whenever
+        ``default_group_policy`` is set in config but ``group_policy`` isn't
+        (the adapter forwards the message, the gateway then denies it).
 
         Used by ``_is_user_authorized`` to decide whether an own-policy adapter
         restricted group senders to a configured allowlist (trustworthy) or
@@ -301,24 +367,26 @@ class GatewayAuthorizationMixin:
         """
         if not platform:
             return ""
-        adapter = self._authorization_adapter(platform, profile)
-        policy = getattr(adapter, "_group_policy", None) if adapter is not None else None
-        if policy is None:
-            config = getattr(self, "config", None)
-            platform_cfg = (
-                config.platforms.get(platform)
-                if config is not None and hasattr(config, "platforms")
-                else None
+        adapter = self._authorization_adapter(platform, profile, adapter_id)
+        policy = None
+        if adapter is not None:
+            policy = getattr(adapter, "_default_group_policy", None) or getattr(
+                adapter, "_group_policy", None
             )
-            extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
-            if isinstance(extra, dict):
-                policy = extra.get("group_policy")
+        if not policy:
+            for cfg in self._platform_configs_for_auth(platform, adapter_id):
+                extra = getattr(cfg, "extra", None) if cfg else None
+                if isinstance(extra, dict):
+                    policy = extra.get("default_group_policy") or extra.get("group_policy")
+                    if policy:
+                        break
         return str(policy or "").strip().lower()
 
     def _adapter_group_has_sender_allowlist(
         self,
         platform: Optional[Platform],
         chat_id: Optional[str],
+        adapter_id: Optional[str] = None,
         *,
         profile: Optional[str] = None,
     ) -> bool:
@@ -333,18 +401,14 @@ class GatewayAuthorizationMixin:
         """
         if not platform or not chat_id:
             return False
-        adapter = self._authorization_adapter(platform, profile)
+        adapter = self._authorization_adapter(platform, profile, adapter_id)
         groups = getattr(adapter, "_groups", None) if adapter is not None else None
         if groups is None:
-            config = getattr(self, "config", None)
-            platform_cfg = (
-                config.platforms.get(platform)
-                if config is not None and hasattr(config, "platforms")
-                else None
-            )
-            extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
-            if isinstance(extra, dict):
-                groups = extra.get("groups")
+            for cfg in self._platform_configs_for_auth(platform, adapter_id):
+                extra = getattr(cfg, "extra", None) if cfg else None
+                if isinstance(extra, dict):
+                    groups = extra.get("groups")
+                    break
         if not isinstance(groups, dict):
             return False
 
@@ -437,10 +501,12 @@ class GatewayAuthorizationMixin:
         # SessionSource, and an explicit identity check refuses to authorize a
         # non-bool stand-in (e.g. a MagicMock attribute auto-vivifies truthy in
         # tests) — defensive against accidental fail-open.
+        adapter_id = getattr(source, "adapter_id", None)
         if allow_adapter_delegation and (
             source.delivered_via_upstream_relay is True
             or self._adapter_authorization_is_upstream(
                 source.platform,
+                adapter_id,
                 profile=adapter_profile,
             )
         ):
@@ -574,6 +640,28 @@ class GatewayAuthorizationMixin:
             except Exception:
                 pass
 
+        config_allows_all = False
+        config_allowed_users = set()
+        for cfg in self._platform_configs_for_auth(
+            source.platform,
+            adapter_id,
+        ):
+            extra = getattr(cfg, "extra", None)
+            if not isinstance(extra, dict):
+                continue
+            if str(extra.get("allow_all_users") or "").strip().lower() in {"true", "1", "yes", "on"}:
+                config_allows_all = True
+            allowed = extra.get("allowed_users")
+            if isinstance(allowed, str):
+                config_allowed_users.update(uid.strip() for uid in allowed.split(",") if uid.strip())
+            elif isinstance(allowed, (list, tuple, set)):
+                config_allowed_users.update(str(uid).strip() for uid in allowed if str(uid).strip())
+
+        if config_allows_all:
+            return True
+        if "*" in config_allowed_users:
+            return True
+
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
         if platform_allow_all_var and _auth_env(platform_allow_all_var).lower() in {"true", "1", "yes"}:
@@ -618,7 +706,16 @@ class GatewayAuthorizationMixin:
             group_chat_allowlist = _auth_env(platform_group_chat_env_map.get(source.platform, ""))
         global_allowlist = _auth_env("GATEWAY_ALLOWED_USERS")
 
-        if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:
+        if (
+            not config_allowed_users
+            and not platform_allowlist
+            and not group_user_allowlist
+            and not group_chat_allowlist
+            and not global_allowlist
+        ):
+            # No env allowlists configured. Adapters that own their own
+            # config-driven access policy (dm_policy / group_policy /
+            # allow_from / group_allow_from) already gated this message at
             # No env allowlist configured. Adapters that own their own
             # config-driven access policy (dm_policy / group_policy /
             # allow_from / group_allow_from) gate access at intake, so for those
@@ -644,22 +741,26 @@ class GatewayAuthorizationMixin:
             # fail-open.)
             if allow_adapter_delegation and self._adapter_enforces_own_access_policy(
                 source.platform,
+                adapter_id,
                 profile=adapter_profile,
             ):
                 if source.chat_type in {"group", "forum", "channel"}:
                     effective_policy = self._adapter_group_policy(
                         source.platform,
+                        adapter_id,
                         profile=adapter_profile,
                     )
                     if self._adapter_group_has_sender_allowlist(
                         source.platform,
                         source.chat_id,
+                        adapter_id,
                         profile=adapter_profile,
                     ):
                         return True
                 else:
                     effective_policy = self._adapter_dm_policy(
                         source.platform,
+                        adapter_id,
                         profile=adapter_profile,
                     )
                 if effective_policy == "allowlist":
@@ -747,6 +848,7 @@ class GatewayAuthorizationMixin:
         # imply DM access; TELEGRAM_ALLOWED_USERS remains the platform-wide
         # allowlist and still works everywhere for backward compatibility.
         allowed_ids = set()
+        allowed_ids.update(config_allowed_users)
         if platform_allowlist:
             allowed_ids.update(uid.strip() for uid in platform_allowlist.split(",") if uid.strip())
         if group_user_allowlist:
@@ -797,6 +899,7 @@ class GatewayAuthorizationMixin:
     def _get_unauthorized_dm_behavior(
         self,
         platform: Optional[Platform],
+        adapter_id: Optional[str] = None,
         *,
         profile: Optional[str] = None,
     ) -> str:
@@ -823,9 +926,11 @@ class GatewayAuthorizationMixin:
         # Check for an explicit per-platform override first.
         if config and hasattr(config, "get_unauthorized_dm_behavior") and platform:
             platform_cfg = config.platforms.get(platform) if hasattr(config, "platforms") else None
-            if platform_cfg and "unauthorized_dm_behavior" in getattr(platform_cfg, "extra", {}):
-                # Operator explicitly configured behavior for this platform — respect it.
-                return config.get_unauthorized_dm_behavior(platform)
+            _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+            for cfg in _configs:
+                if cfg and "unauthorized_dm_behavior" in getattr(cfg, "extra", {}):
+                    # Operator explicitly configured behavior for this platform — respect it.
+                    return config.get_unauthorized_dm_behavior(platform)
 
         # Email is inbox-shaped, not chat-shaped: an agent mailbox may contain
         # unrelated unread human email. Require an explicit per-platform
@@ -847,10 +952,17 @@ class GatewayAuthorizationMixin:
         # Prefer the profile-scoped live adapter's resolved policy in multiplex
         # mode; fall back to the default profile's config.extra.
         if platform:
-            dm_policy = self._adapter_dm_policy(platform, profile=profile)
-            if not dm_policy and config and hasattr(config, "platforms"):
-                platform_cfg = config.platforms.get(platform)
-                extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
+            dm_policy = self._adapter_dm_policy(
+                platform,
+                adapter_id,
+                profile=profile,
+            )
+            if not dm_policy:
+                extra = None
+                for cfg in self._platform_configs_for_auth(platform, adapter_id):
+                    extra = getattr(cfg, "extra", None) if cfg else None
+                    if isinstance(extra, dict):
+                        break
                 if isinstance(extra, dict):
                     dm_policy = str(extra.get("dm_policy") or "").strip().lower()
             if dm_policy == "pairing":

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -13,7 +13,7 @@ import os
 import json
 from pathlib import Path
 from dataclasses import asdict, dataclass, field, is_dataclass
-from typing import Dict, List, Optional, Any, Callable
+from typing import Dict, List, Optional, Any, Callable, Union
 from enum import Enum
 
 from hermes_cli.config import get_hermes_home
@@ -718,6 +718,24 @@ class PlatformConfig:
         if _grn is None:
             _grn = extra.get("gateway_restart_notification")
 
+        reserved_keys = {
+            "enabled",
+            "token",
+            "api_key",
+            "home_channel",
+            "reply_to_mode",
+            "gateway_restart_notification",
+            "typing_indicator",
+            "extra",
+        }
+        # ``extra`` may arrive malformed (e.g. a bare string) from hand-edited
+        # YAML; coerce non-mappings to an empty dict so a typo doesn't crash
+        # load — mirrors the home_channel isinstance guard above.
+        extra = dict(_coerce_dict(data.get("extra")))
+        for key, value in data.items():
+            if key not in reserved_keys:
+                extra.setdefault(key, value)
+
         # typing_indicator mirrors gateway_restart_notification: it may arrive
         # top-level or bridged into extra by the shared-key loop in
         # load_gateway_config(), so check both.
@@ -922,7 +940,7 @@ class GatewayConfig:
     Manages all platform connections, session policies, and delivery settings.
     """
     # Platform configurations
-    platforms: Dict[Platform, PlatformConfig] = field(default_factory=dict)
+    platforms: Dict[Platform, Union[PlatformConfig, List[PlatformConfig]]] = field(default_factory=dict)
     
     # Session reset policies by type
     default_reset_policy: SessionResetPolicy = field(default_factory=SessionResetPolicy)
@@ -1022,10 +1040,13 @@ class GatewayConfig:
         """
         connected = []
         for platform, config in self.platforms.items():
-            if not config.enabled:
-                continue
-            if self._is_platform_connected(platform, config):
-                connected.append(platform)
+            configs = config if isinstance(config, list) else [config]
+            for cfg in configs:
+                if not cfg.enabled:
+                    continue
+                if self._is_platform_connected(platform, cfg):
+                    connected.append(platform)
+                    break
         return sorted(connected, key=lambda p: str(p.value))
 
     def _is_platform_connected(self, platform: Platform, config: PlatformConfig) -> bool:
@@ -1073,10 +1094,49 @@ class GatewayConfig:
     def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:
         """Get the home channel for a platform."""
         config = self.platforms.get(platform)
+        if isinstance(config, list):
+            for cfg in config:
+                if cfg.home_channel:
+                    return cfg.home_channel
+            return None
         if config:
             return config.home_channel
         return None
-    
+
+    def iter_platform_configs(self, platform: Platform) -> list[PlatformConfig]:
+        """Return all configs for a platform, preserving multi-app entries."""
+        config = self.platforms.get(platform)
+        if isinstance(config, list):
+            return [cfg for cfg in config if cfg is not None]
+        if config:
+            return [config]
+        return []
+
+    def get_config_for_adapter_id(
+        self,
+        platform: Platform,
+        adapter_id: Optional[str],
+    ) -> Optional[PlatformConfig]:
+        """Find the platform config that produced a concrete adapter id."""
+        configs = self.iter_platform_configs(platform)
+        if not configs:
+            return None
+        if not adapter_id:
+            return configs[0]
+
+        for cfg in configs:
+            extra = cfg.extra if isinstance(cfg.extra, dict) else {}
+            configured_id = str(
+                extra.get("adapter_id")
+                or extra.get("app_id")
+                or extra.get("bot_id")
+                or extra.get("client_id")
+                or ""
+            ).strip()
+            if configured_id and str(adapter_id) == f"{platform.value}:{configured_id}":
+                return cfg
+        return configs[0]
+
     def get_reset_policy(
         self, 
         platform: Optional[Platform] = None,
@@ -1098,9 +1158,14 @@ class GatewayConfig:
         return self.default_reset_policy
     
     def to_dict(self) -> Dict[str, Any]:
+        def _serialize_platform(cfg):
+            if isinstance(cfg, list):
+                return [c.to_dict() for c in cfg]
+            return cfg.to_dict()
+
         return {
             "platforms": {
-                p.value: c.to_dict() for p, c in self.platforms.items()
+                p.value: _serialize_platform(c) for p, c in self.platforms.items()
             },
             "default_reset_policy": self.default_reset_policy.to_dict(),
             "reset_by_type": {
@@ -1139,11 +1204,16 @@ class GatewayConfig:
         platforms = {}
         platforms_data = _coerce_dict(data.get("platforms", {}))
         for platform_name, platform_data in platforms_data.items():
-            if not isinstance(platform_data, dict):
+            if not isinstance(platform_data, (dict, list)):
                 continue
             try:
                 platform = Platform(platform_name)
-                platforms[platform] = PlatformConfig.from_dict(platform_data)
+                if isinstance(platform_data, list):
+                    platforms[platform] = [
+                        PlatformConfig.from_dict(item) for item in platform_data if isinstance(item, dict)
+                    ]
+                elif isinstance(platform_data, dict):
+                    platforms[platform] = PlatformConfig.from_dict(platform_data)
             except ValueError:
                 pass  # Skip unknown platforms
         
@@ -1285,11 +1355,14 @@ class GatewayConfig:
         """
         if platform:
             platform_cfg = self.platforms.get(platform)
-            if platform_cfg and "unauthorized_dm_behavior" in platform_cfg.extra:
-                return _normalize_unauthorized_dm_behavior(
-                    platform_cfg.extra.get("unauthorized_dm_behavior"),
-                    self.unauthorized_dm_behavior,
-                )
+            # Multi-app configs may store a list of PlatformConfig instances.
+            configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+            for cfg in configs:
+                if cfg and "unauthorized_dm_behavior" in cfg.extra:
+                    return _normalize_unauthorized_dm_behavior(
+                        cfg.extra.get("unauthorized_dm_behavior"),
+                        self.unauthorized_dm_behavior,
+                    )
             if platform == Platform.EMAIL:
                 return "ignore"
         return self.unauthorized_dm_behavior
@@ -1298,11 +1371,14 @@ class GatewayConfig:
         """Return the effective notice-delivery mode for a platform."""
         if platform:
             platform_cfg = self.platforms.get(platform)
-            if platform_cfg and "notice_delivery" in platform_cfg.extra:
-                return _normalize_notice_delivery(
-                    platform_cfg.extra.get("notice_delivery"),
-                    "public",
-                )
+            # Multi-app configs may store a list of PlatformConfig instances.
+            configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+            for cfg in configs:
+                if cfg and "notice_delivery" in cfg.extra:
+                    return _normalize_notice_delivery(
+                        cfg.extra.get("notice_delivery"),
+                        "public",
+                    )
         return "public"
 
 
@@ -1504,6 +1580,10 @@ def load_gateway_config() -> GatewayConfig:
                 if not isinstance(source_platforms, dict):
                     return
                 for plat_name, plat_block in source_platforms.items():
+                    # Multi-app configs store a list of PlatformConfig dicts.
+                    if isinstance(plat_block, list):
+                        platforms_data[plat_name] = plat_block
+                        continue
                     if not isinstance(plat_block, dict):
                         continue
                     existing = platforms_data.get(plat_name, {})
@@ -1738,6 +1818,16 @@ def load_gateway_config() -> GatewayConfig:
                         continue
                     try:
                         seeded = entry.apply_yaml_config_fn(yaml_cfg, platform_cfg)
+                    except ValueError as e:
+                        # Validation errors (e.g. duplicate app_id, >10 apps
+                        # limit) must stay visible — the platform would
+                        # otherwise be silently disabled. Log at ERROR so the
+                        # user sees it in gateway logs (#68046).
+                        logger.error(
+                            "Configuration error for %s: %s — platform will be disabled.",
+                            entry.name, e,
+                        )
+                        continue
                     except Exception as e:
                         logger.debug(
                             "apply_yaml_config_fn for %s raised: %s",
@@ -1746,8 +1836,12 @@ def load_gateway_config() -> GatewayConfig:
                         continue
                     if not isinstance(seeded, dict) or not seeded:
                         continue
-                    _, extra = _ensure_platform_extra_dict(platforms_data, entry.name)
-                    extra.update(seeded)
+                    # Multi-app list return: feishu.apps[] → platforms.feishu: [...]
+                    if "platforms_list" in seeded:
+                        platforms_data[entry.name] = seeded["platforms_list"]
+                    else:
+                        _, extra = _ensure_platform_extra_dict(platforms_data, entry.name)
+                        extra.update(seeded)
 
             # Slack settings → env vars: migrated to the slack plugin's
             # ``apply_yaml_config_fn`` hook (see plugins/platforms/slack/
@@ -1847,15 +1941,18 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
     # won't connect and the cause can be confusing without a log line.
     _token_env_names = PLATFORM_TOKEN_ENV_NAMES
     for platform, pconfig in config.platforms.items():
-        if not pconfig.enabled:
-            continue
-        env_name = _token_env_names.get(platform)
-        if env_name and pconfig.token is not None and not pconfig.token.strip():
-            logger.warning(
-                "%s is enabled but %s is empty. "
-                "The adapter will likely fail to connect.",
-                platform.value, env_name,
-            )
+        # Multi-app configs may store a list of PlatformConfig instances.
+        configs = pconfig if isinstance(pconfig, list) else [pconfig]
+        for cfg in configs:
+            if not cfg.enabled:
+                continue
+            env_name = _token_env_names.get(platform)
+            if env_name and cfg.token is not None and not cfg.token.strip():
+                logger.warning(
+                    "%s is enabled but %s is empty. "
+                    "The adapter will likely fail to connect.",
+                    platform.value, env_name,
+                )
 
     # Reject known-weak placeholder tokens.
     # Ported from openclaw/openclaw#64586: users who copy .env.example
@@ -1868,20 +1965,22 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
 
     if has_usable_secret is not None:
         for platform, pconfig in config.platforms.items():
-            if not pconfig.enabled:
-                continue
-            env_name = _token_env_names.get(platform)
-            if not env_name:
-                continue
-            token = pconfig.token
-            if token and token.strip() and not has_usable_secret(token, min_length=4):
-                logger.error(
-                    "%s is enabled but %s is set to a placeholder value ('%s'). "
-                    "Set a real bot token before starting the gateway. "
-                    "The adapter will NOT be started.",
-                    platform.value, env_name, token.strip()[:6] + "...",
-                )
-                pconfig.enabled = False
+            configs = pconfig if isinstance(pconfig, list) else [pconfig]
+            for cfg in configs:
+                if not cfg.enabled:
+                    continue
+                env_name = _token_env_names.get(platform)
+                if not env_name:
+                    continue
+                token = cfg.token
+                if token and token.strip() and not has_usable_secret(token, min_length=4):
+                    logger.error(
+                        "%s is enabled but %s is set to a placeholder value ('%s'). "
+                        "Set a real bot token before starting the gateway. "
+                        "The adapter will NOT be started.",
+                        platform.value, env_name, token.strip()[:6] + "...",
+                    )
+                    cfg.enabled = False
 
 
 def _apply_env_overrides(config: GatewayConfig) -> None:
@@ -1895,6 +1994,19 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             return config.platforms[platform]
 
         platform_config = config.platforms[platform]
+        # Multi-app configs may store a list of PlatformConfig instances.
+        if isinstance(platform_config, list):
+            for cfg in platform_config:
+                # Read (don't pop) the explicit-enable marker: the
+                # registry-driven plugin-enable pass later in this function also
+                # needs it to avoid re-enabling a platform the user explicitly
+                # disabled. The flag is cleared once for all platforms in the
+                # final cleanup at the end of _apply_env_overrides.
+                enabled_was_explicit = bool(cfg.extra.get("_enabled_explicit", False))
+                if not cfg.enabled and not enabled_was_explicit:
+                    cfg.enabled = True
+            return platform_config[0] if platform_config else PlatformConfig(enabled=True)
+
         # Read (don't pop) the explicit-enable marker: the registry-driven
         # plugin-enable pass later in this function also needs it to avoid
         # re-enabling a platform the user explicitly disabled (migrated plugin
@@ -2334,29 +2446,79 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     feishu_app_id = getenv("FEISHU_APP_ID")
     feishu_app_secret = getenv("FEISHU_APP_SECRET")
     if feishu_app_id and feishu_app_secret:
-        if Platform.FEISHU not in config.platforms:
+        feishu_cfg = config.platforms.get(Platform.FEISHU)
+        if feishu_cfg is None:
             config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
-        config.platforms[Platform.FEISHU].extra.update({
-            "app_id": feishu_app_id,
-            "app_secret": feishu_app_secret,
-            "domain": getenv("FEISHU_DOMAIN", "feishu"),
-            "connection_mode": getenv("FEISHU_CONNECTION_MODE", "websocket"),
-        })
-        feishu_encrypt_key = getenv("FEISHU_ENCRYPT_KEY", "")
-        if feishu_encrypt_key:
-            config.platforms[Platform.FEISHU].extra["encrypt_key"] = feishu_encrypt_key
-        feishu_verification_token = getenv("FEISHU_VERIFICATION_TOKEN", "")
-        if feishu_verification_token:
-            config.platforms[Platform.FEISHU].extra["verification_token"] = feishu_verification_token
+            feishu_cfg = config.platforms[Platform.FEISHU]
+        # Multi-app configs may store a list of PlatformConfig instances.
+        if isinstance(feishu_cfg, list):
+            # Legacy FEISHU_* env vars describe one concrete app. Match that
+            # app by id instead of applying singleton credentials/home-channel
+            # state to every list entry. A sole unconfigured entry is also a
+            # safe target; multiple non-matching configured apps are ambiguous.
+            matching_cfgs = [
+                cfg
+                for cfg in feishu_cfg
+                if str((cfg.extra or {}).get("app_id") or "").strip()
+                == str(feishu_app_id).strip()
+            ]
+            unconfigured_cfgs = [
+                cfg
+                for cfg in feishu_cfg
+                if not str((cfg.extra or {}).get("app_id") or "").strip()
+            ]
+            env_target = (
+                matching_cfgs[0]
+                if len(matching_cfgs) == 1
+                else unconfigured_cfgs[0]
+                if len(unconfigured_cfgs) == 1
+                else feishu_cfg[0]
+                if len(feishu_cfg) == 1
+                else None
+            )
+            for cfg in feishu_cfg:
+                cfg.enabled = True
+                cfg.extra.setdefault("domain", getenv("FEISHU_DOMAIN", "feishu"))
+                cfg.extra.setdefault("connection_mode", getenv("FEISHU_CONNECTION_MODE", "websocket"))
+                feishu_encrypt_key = getenv("FEISHU_ENCRYPT_KEY", "")
+                if feishu_encrypt_key and not cfg.extra.get("encrypt_key"):
+                    cfg.extra["encrypt_key"] = feishu_encrypt_key
+                feishu_verification_token = getenv("FEISHU_VERIFICATION_TOKEN", "")
+                if feishu_verification_token and not cfg.extra.get("verification_token"):
+                    cfg.extra["verification_token"] = feishu_verification_token
+            if env_target is not None:
+                env_target.extra.setdefault("app_id", feishu_app_id)
+                env_target.extra.setdefault("app_secret", feishu_app_secret)
+        else:
+            env_target = feishu_cfg
+            feishu_cfg.enabled = True
+            feishu_cfg.extra.update({
+                "app_id": feishu_app_id,
+                "app_secret": feishu_app_secret,
+                "domain": getenv("FEISHU_DOMAIN", "feishu"),
+                "connection_mode": getenv("FEISHU_CONNECTION_MODE", "websocket"),
+            })
+            feishu_encrypt_key = getenv("FEISHU_ENCRYPT_KEY", "")
+            if feishu_encrypt_key:
+                feishu_cfg.extra["encrypt_key"] = feishu_encrypt_key
+            feishu_verification_token = getenv("FEISHU_VERIFICATION_TOKEN", "")
+            if feishu_verification_token:
+                feishu_cfg.extra["verification_token"] = feishu_verification_token
         feishu_home = getenv("FEISHU_HOME_CHANNEL")
         if feishu_home:
-            config.platforms[Platform.FEISHU].home_channel = HomeChannel(
-                platform=Platform.FEISHU,
-                chat_id=feishu_home,
-                name=getenv("FEISHU_HOME_CHANNEL_NAME", "Home"),
-                thread_id=getenv("FEISHU_HOME_CHANNEL_THREAD_ID") or None,
-            )
+            if env_target is None:
+                logger.warning(
+                    "Ignoring FEISHU_HOME_CHANNEL because FEISHU_APP_ID=%s "
+                    "does not identify one entry in the multi-app Feishu config",
+                    feishu_app_id,
+                )
+            else:
+                env_target.home_channel = HomeChannel(
+                    platform=Platform.FEISHU,
+                    chat_id=feishu_home,
+                    name=getenv("FEISHU_HOME_CHANNEL_NAME", "Home"),
+                    thread_id=getenv("FEISHU_HOME_CHANNEL_THREAD_ID") or None,
+                )
 
     # WeCom (Enterprise WeChat)
     wecom_bot_id = getenv("WECOM_BOT_ID")
@@ -2611,7 +2773,16 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             except Exception as e:
                 logger.debug("unknown platform name %r: %s", entry.name, e)
                 continue
-            existing_cfg = config.platforms.get(platform)
+            existing_cfgs = config.iter_platform_configs(platform)
+            explicit_disabled_cfgs = [
+                cfg
+                for cfg in existing_cfgs
+                if not cfg.enabled
+                and bool((cfg.extra or {}).get("_enabled_explicit", False))
+            ]
+            candidate_cfgs = [
+                cfg for cfg in existing_cfgs if cfg not in explicit_disabled_cfgs
+            ]
             # Respect an explicit ``enabled: false`` (YAML / gateway.json /
             # dashboard PUT).  ``_enabled_explicit`` is set in
             # load_gateway_config() (via _merge_platform_map / the shared-key
@@ -2619,11 +2790,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             # explicitly disabled it, never re-enable here just because
             # check_fn() / is_connected() pass (e.g. a token is present but the
             # user set telegram.enabled: false). #41112.
-            if (
-                existing_cfg is not None
-                and not existing_cfg.enabled
-                and bool((existing_cfg.extra or {}).get("_enabled_explicit", False))
-            ):
+            if existing_cfgs and not candidate_cfgs:
                 continue
             # Seed candidate extras from ``env_enablement_fn`` so plugins
             # whose ``is_connected`` reads ``config.extra`` (e.g. Google
@@ -2648,7 +2815,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             # explicitly configured in YAML / env (existing_cfg with
             # enabled=True means the user wrote it themselves or another
             # env-var bridge enabled it — keep that decision).
-            if existing_cfg is None or not existing_cfg.enabled:
+            if not any(cfg.enabled for cfg in candidate_cfgs):
                 if entry.is_connected is not None:
                     try:
                         # Probe with ``enabled=True`` since we're asking
@@ -2658,8 +2825,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                         # ``config.enabled`` being False, which on the
                         # default ``PlatformConfig()`` would fail the
                         # gate even with proper env vars set.
-                        if existing_cfg is not None:
-                            probe_cfg = existing_cfg
+                        if candidate_cfgs:
+                            probe_cfg = candidate_cfgs[0]
                             if not probe_cfg.enabled:
                                 probe_cfg = PlatformConfig(
                                     enabled=True,
@@ -2717,7 +2884,9 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 continue
             if platform not in config.platforms:
                 config.platforms[platform] = PlatformConfig()
-            config.platforms[platform].enabled = True
+                candidate_cfgs = config.iter_platform_configs(platform)
+            for cfg in candidate_cfgs:
+                cfg.enabled = True
             # Commit env-seeded extras onto the now-enabled platform.
             # We've already called ``env_enablement_fn`` above (for the
             # probe); reuse that result instead of calling it twice.
@@ -2727,18 +2896,19 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 # up as a proper HomeChannel dataclass.  Everything else is
                 # merged into ``extra``.
                 home = seed.pop("home_channel", None)
-                config.platforms[platform].extra.update(seed)
-                if isinstance(home, dict) and home.get("chat_id"):
-                    config.platforms[platform].home_channel = HomeChannel(
-                        platform=platform,
-                        chat_id=str(home["chat_id"]),
-                        name=str(home.get("name") or "Home"),
-                        thread_id=(
-                            str(home["thread_id"])
-                            if home.get("thread_id")
-                            else None
-                        ),
-                    )
+                for cfg in candidate_cfgs:
+                    cfg.extra.update(seed)
+                    if isinstance(home, dict) and home.get("chat_id"):
+                        cfg.home_channel = HomeChannel(
+                            platform=platform,
+                            chat_id=str(home["chat_id"]),
+                            name=str(home.get("name") or "Home"),
+                            thread_id=(
+                                str(home["thread_id"])
+                                if home.get("thread_id")
+                                else None
+                            ),
+                        )
     except Exception as e:
         logger.debug("Plugin platform enable pass failed: %s", e)
 
@@ -2762,4 +2932,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         relay_config.extra["relay_url"] = relay_url_val.rstrip("/")
 
     for platform_config in config.platforms.values():
-        platform_config.extra.pop("_enabled_explicit", None)
+        # Multi-app configs may store a list of PlatformConfig instances.
+        configs = platform_config if isinstance(platform_config, list) else [platform_config]
+        for cfg in configs:
+            cfg.extra.pop("_enabled_explicit", None)

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -104,6 +104,14 @@ def resolve_delivery_transport(
     live_adapters = adapters or {}
     native = live_adapters.get(platform)
     native_config = config.platforms.get(platform)
+    # Multi-app configs store a list of PlatformConfig; the live adapter is a
+    # single instance, so unwrap to one enabled entry instead of calling
+    # .enabled on the list (which would raise AttributeError).
+    if isinstance(native_config, list):
+        native_config = next(
+            (c for c in native_config if getattr(c, "enabled", False)),
+            native_config[0] if native_config else None,
+        )
     # Preserve DeliveryRouter's historical support for explicitly supplied live
     # adapters with no config block, but never let an explicitly disabled native
     # adapter shadow an enabled Relay transport.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -164,7 +164,13 @@ def _reply_anchor_for_event(event) -> str | None:
         return None
     if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
         return getattr(event, "reply_to_message_id", None)
-    return getattr(event, "message_id", None)
+    _msg_id = getattr(event, "message_id", None)
+    # Synthetic bot-to-bot events use a "bot2bot-xxx" message_id that Feishu
+    # doesn't recognise — passing it as reply_to makes the API reject the send.
+    # Skip it so the response posts as a standalone message instead.
+    if _msg_id and str(_msg_id).startswith("bot2bot-"):
+        return None
+    return _msg_id
 
 
 def should_send_media_as_audio(platform, ext: str, is_voice: bool = False) -> bool:
@@ -3005,6 +3011,7 @@ class BasePlatformAdapter(ABC):
     def __init__(self, config: PlatformConfig, platform: Platform):
         self.config = config
         self.platform = platform
+        self.adapter_id: Optional[str] = None
         self._message_handler: Optional[MessageHandler] = None
         # Optional gateway-supplied fan-out for platform-native emoji
         # reaction events (see ``set_reaction_handler``).
@@ -5441,6 +5448,17 @@ class BasePlatformAdapter(ABC):
             return self
         return live_adapter
 
+    async def _on_send_dead_letter(
+        self,
+        chat_id: str,
+        content: str,
+        result: "SendResult",
+    ) -> None:
+        """Hook fired when a send permanently fails after all retries and
+        fallbacks. Default is a no-op; platform adapters may override it to
+        forward the lost message to a dead-letter channel. ``result`` is the
+        final failed SendResult (inspect ``.error`` for diagnostics)."""
+
     async def _send_with_retry(
         self,
         chat_id: str,
@@ -5518,6 +5536,7 @@ class BasePlatformAdapter(ABC):
                     await self.send(chat_id=chat_id, content=notice, reply_to=reply_to, metadata=metadata)
                 except Exception as notify_err:
                     logger.debug("[%s] Could not send delivery-failure notice: %s", self.name, notify_err)
+                await self._on_send_dead_letter(chat_id, content, result)
                 return result
 
         # Non-network / post-retry formatting failure: try plain text as fallback
@@ -5530,6 +5549,7 @@ class BasePlatformAdapter(ABC):
         )
         if not fallback_result.success:
             logger.error("[%s] Fallback send also failed: %s", self.name, fallback_result.error)
+            await self._on_send_dead_letter(chat_id, content, fallback_result)
         return fallback_result
 
     @staticmethod
@@ -6471,9 +6491,10 @@ class BasePlatformAdapter(ABC):
                 if text_content and not _tts_caption_delivered:
                     delivery_adapter = self._final_delivery_adapter(event.source)
                     logger.info(
-                        "[%s] Sending response (%d chars) to %s",
+                        "[%s] Sending response (%d chars) via adapter_id=%s to %s",
                         delivery_adapter.name,
                         len(text_content),
+                        getattr(event.source, "adapter_id", None) or getattr(self, "adapter_id", None) or "default",
                         event.source.chat_id,
                     )
                     _reply_anchor = _reply_anchor_for_event(event)
@@ -7025,6 +7046,7 @@ class BasePlatformAdapter(ABC):
         guild_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None,
         message_id: Optional[str] = None,
+        adapter_id: Optional[str] = None,
         role_authorized: bool = False,
         auto_thread_created: bool = False,
         auto_thread_initial_name: Optional[str] = None,
@@ -7092,6 +7114,11 @@ class BasePlatformAdapter(ABC):
             guild_id=str(guild_id) if guild_id else None,
             parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
             message_id=str(message_id) if message_id else None,
+            adapter_id=(
+                str(adapter_id or getattr(self, "adapter_id", None))
+                if (adapter_id or getattr(self, "adapter_id", None))
+                else None
+            ),
             profile=profile,
             role_authorized=role_authorized,
             auto_thread_created=auto_thread_created,

--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -33,6 +33,8 @@ _AMBIENT_TOKEN_SHAPE = re.compile(
     r"|[A-Za-z0-9_-]{32,}"  # long opaque bearer token
 )
 
+from agent.secret_scope import get_secret
+
 
 def relay_url() -> Optional[str]:
     """The connector relay endpoint URL, or None when relay is not configured.
@@ -160,7 +162,7 @@ def relay_connection_auth() -> tuple[Optional[str], Optional[str]]:
     ``gateway.relay_id`` / ``gateway.relay_secret`` in config.yaml.
     """
     gateway_id = os.environ.get("GATEWAY_RELAY_ID", "").strip()
-    secret = os.environ.get("GATEWAY_RELAY_SECRET", "").strip()
+    secret = (get_secret("GATEWAY_RELAY_SECRET") or "").strip()
     if not (gateway_id and secret):
         try:
             from gateway.run import _load_gateway_config  # late import to avoid cycle
@@ -543,7 +545,7 @@ def _resolve_relay_identity_token() -> str:
     """
     token_url = os.environ.get("GATEWAY_RELAY_IDP_TOKEN_URL", "").strip()
     client_id = os.environ.get("GATEWAY_RELAY_IDP_CLIENT_ID", "").strip()
-    client_secret = os.environ.get("GATEWAY_RELAY_IDP_CLIENT_SECRET", "").strip()
+    client_secret = (get_secret("GATEWAY_RELAY_IDP_CLIENT_SECRET") or "").strip()
     scope = os.environ.get("GATEWAY_RELAY_IDP_SCOPE", "").strip()
     if not token_url:
         try:
@@ -750,9 +752,9 @@ def self_provision_relay() -> bool:
         # outbound WS upgrade). Subsequent platforms share the same gatewayId +
         # secret (the connector returns the same record for the same gatewayId).
         # Never logged.
-        if "GATEWAY_RELAY_SECRET" not in os.environ or not os.environ.get("GATEWAY_RELAY_SECRET"):
+        if not (get_secret("GATEWAY_RELAY_SECRET") or ""):
             os.environ["GATEWAY_RELAY_ID"] = str(result.get("gatewayId") or gateway_id)
-            os.environ["GATEWAY_RELAY_SECRET"] = str(result.get("secret") or "")
+            os.environ["GATEWAY_RELAY_SECRET"] = str(result.get("secret") or "")  # credential-lint: ok - process-global (GATEWAY_RELAY_ is in secret_scope._GLOBAL_ENV_PREFIXES)
             os.environ["GATEWAY_RELAY_DELIVERY_KEY"] = str(result.get("deliveryKey") or "")
 
     if not provisioned:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -45,6 +45,7 @@ from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, cast
+from urllib.parse import unquote
 
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_compression import (
@@ -1971,10 +1972,7 @@ from contextlib import contextmanager as _contextmanager
 # profile (SecondaryPortBindingConfigError) so a single bad profile cannot
 # take down the whole multiplexer. The set lives in gateway.config so the
 # dashboard's pre-write validation enforces the same policy.
-from gateway.config import (
-    PORT_BINDING_PLATFORM_VALUES as _PORT_BINDING_PLATFORM_VALUES,
-    platform_binds_port as _platform_binds_port,
-)
+from gateway.config import platform_binds_port as _platform_binds_port
 
 
 class MultiplexConfigError(RuntimeError):
@@ -2452,6 +2450,7 @@ from gateway.session import (
 )
 from gateway.delivery import (
     DeliveryRouter,
+    DeliveryTransport,
     looks_like_telegram_private_chat_id,
     resolve_delivery_transport,
 )
@@ -2521,33 +2520,37 @@ _OWN_POLICY_OPEN_ENV = {
 def _own_policy_open_startup_violation(config) -> Optional[str]:
     """Return a startup-abort reason when open policy lacks allow-all opt-in."""
     for platform, platform_config in getattr(config, "platforms", {}).items():
-        if not getattr(platform_config, "enabled", False):
-            continue
-        open_env = _OWN_POLICY_OPEN_ENV.get(platform)
-        if not open_env:
-            continue
-        dm_env, group_env, allow_all_env = open_env
-        extra = getattr(platform_config, "extra", None) or {}
-        dm_policy = str(
-            extra.get("dm_policy")
-            or (_getenv(dm_env, "pairing") if dm_env else "pairing")
-        ).strip().lower()
-        group_policy = str(
-            extra.get("group_policy")
-            or (_getenv(group_env, "pairing") if group_env else "pairing")
-        ).strip().lower()
-        if dm_policy != "open" and group_policy != "open":
-            continue
-        gateway_allow_all = os.getenv(
-            "GATEWAY_ALLOW_ALL_USERS", ""
-        ).lower() in {"true", "1", "yes"}
-        platform_opted_in = gateway_allow_all or (
-            allow_all_env
-            and _getenv(allow_all_env, "").lower() in {"true", "1", "yes"}
+        platform_configs = (
+            platform_config if isinstance(platform_config, list) else [platform_config]
         )
-        if platform_opted_in:
-            continue
-        return f"{platform.value}: open policy without allow-all opt-in"
+        for concrete_config in platform_configs:
+            if not getattr(concrete_config, "enabled", False):
+                continue
+            open_env = _OWN_POLICY_OPEN_ENV.get(platform)
+            if not open_env:
+                continue
+            dm_env, group_env, allow_all_env = open_env
+            extra = getattr(concrete_config, "extra", None) or {}
+            dm_policy = str(
+                extra.get("dm_policy")
+                or (os.getenv(dm_env, "pairing") if dm_env else "pairing")
+            ).strip().lower()
+            group_policy = str(
+                extra.get("group_policy")
+                or (os.getenv(group_env, "pairing") if group_env else "pairing")
+            ).strip().lower()
+            if dm_policy != "open" and group_policy != "open":
+                continue
+            gateway_allow_all = os.getenv(
+                "GATEWAY_ALLOW_ALL_USERS", ""
+            ).lower() in {"true", "1", "yes"}
+            platform_opted_in = gateway_allow_all or (
+                allow_all_env
+                and os.getenv(allow_all_env, "").lower() in {"true", "1", "yes"}
+            )
+            if platform_opted_in:
+                continue
+            return f"{platform.value}: open policy without allow-all opt-in"
     return None
 
 
@@ -3420,7 +3423,15 @@ def _get_channel_override(
     if not platforms:
         return None
     platform_config = platforms.get(platform)
-    if not platform_config or not platform_config.channel_overrides:
+    if not platform_config:
+        return None
+    # Multi-app platforms (feishu.apps[]) expose a list of per-app configs,
+    # not a single config carrying channel_overrides (#68046). There is no
+    # platform-level override to consult in that shape, so skip cleanly
+    # instead of AttributeError-ing on ``list.channel_overrides``.
+    if isinstance(platform_config, list):
+        return None
+    if not platform_config.channel_overrides:
         return None
     overrides = platform_config.channel_overrides
     for key in _channel_override_lookup_keys(
@@ -3463,7 +3474,7 @@ def _parse_session_key(session_key: str) -> "dict | None":
     """Parse a session key into its component parts.
 
     Session keys follow the format
-    ``agent:main:{platform}:{chat_type}:{chat_id}[:{extra}...]``.
+    ``agent:main:{platform}[:adapter={adapter_id}]:{chat_type}:{chat_id}[:{extra}...]``.
     Returns a dict with ``platform``, ``chat_type``, ``chat_id``, and
     optionally ``thread_id`` keys, or None if the key doesn't match.
 
@@ -3473,6 +3484,10 @@ def _parse_session_key(session_key: str) -> "dict | None":
     thread_id, so we leave ``thread_id`` out to avoid mis-routing.
     """
     parts = session_key.split(":")
+    adapter_id = None
+    if len(parts) >= 6 and parts[3].startswith("adapter="):
+        adapter_id = unquote(parts[3][len("adapter="):]) or None
+        parts = parts[:3] + parts[4:]
     if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
         result = {
             "platform": parts[2],
@@ -3481,6 +3496,8 @@ def _parse_session_key(session_key: str) -> "dict | None":
         }
         if len(parts) > 5 and parts[3] in {"dm", "thread"}:
             result["thread_id"] = parts[5]
+        if adapter_id:
+            result["adapter_id"] = adapter_id
         return result
     return None
 
@@ -6397,12 +6414,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.debug("could not set multiplex-active flag", exc_info=True)
         self.adapters: Dict[Platform, BasePlatformAdapter] = {}
+        self.adapters_by_id: Dict[str, BasePlatformAdapter] = {}
+        self._platform_adapter_ids: Dict[Platform, list[str]] = {}
         # Multi-profile multiplexing: adapters for NON-default profiles live
         # here, keyed by profile name then Platform. self.adapters stays the
         # default/active profile's map so the ~93 existing self.adapters[...]
         # sites are untouched when multiplexing is off (this dict is empty).
         # Populated by _start_secondary_profile_adapters().
         self._profile_adapters: Dict[str, Dict[Platform, BasePlatformAdapter]] = {}
+        self._profile_adapters_by_id: Dict[
+            str, Dict[str, BasePlatformAdapter]
+        ] = {}
+        # Multi-Feishu-app profile routing (#68046): maps adapter_id → profile
+        # name for adapters created from feishu.apps[] entries. Populated in
+        # _register_connected_adapter by reading cfg.extra["profile"].
+        # Unconditionally initialized (empty in single-app mode) so lookups
+        # never hit AttributeError (Fix 7 lifecycle).
+        self._adapter_profile_map: Dict[str, str] = {}
         self._warn_if_docker_media_delivery_is_risky()
         _gateway_runner_ref = _weakref.ref(self)
 
@@ -6808,6 +6836,237 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._teams_pipeline_runtime_error,
             )
 
+    def _adapter_instance_id(self, platform: Platform, adapter: BasePlatformAdapter) -> str:
+        """Return a stable per-config adapter id for multi-instance platforms."""
+        existing = getattr(adapter, "adapter_id", None)
+        if existing:
+            return str(existing)
+        extra = getattr(getattr(adapter, "config", None), "extra", None)
+        configured_id = ""
+        if isinstance(extra, dict):
+            configured_id = str(
+                extra.get("adapter_id")
+                or extra.get("app_id")
+                or extra.get("bot_id")
+                or extra.get("client_id")
+                or ""
+            ).strip()
+        base = f"{platform.value}:{configured_id}" if configured_id else platform.value
+        adapter_id = base
+        suffix = 2
+        # Secondary-profile startup constructs the runner via __new__ (no
+        # __init__) and tracks per-profile collisions via _profile_adapters_by_id,
+        # not the default-profile adapters_by_id — tolerate its absence here so
+        # _adapter_instance_id can still generate the base id for it.
+        _existing_by_id = getattr(self, "adapters_by_id", {})
+        while adapter_id in _existing_by_id and _existing_by_id[adapter_id] is not adapter:
+            adapter_id = f"{base}:{suffix}"
+            suffix += 1
+        setattr(adapter, "adapter_id", adapter_id)
+        return adapter_id
+
+    def _register_connected_adapter(self, platform: Platform, adapter: BasePlatformAdapter) -> None:
+        adapter_id = self._adapter_instance_id(platform, adapter)
+        self.adapters_by_id[adapter_id] = adapter
+        ids = self._platform_adapter_ids.setdefault(platform, [])
+        if adapter_id not in ids:
+            ids.append(adapter_id)
+        self.adapters.setdefault(platform, adapter)
+        # Multi-app profile routing (#68046 Fix 1): extract profile mapping
+        # from the adapter's config.extra and record it so inbound messages
+        # can be stamped with the correct profile before session-key generation.
+        extra = getattr(getattr(adapter, "config", None), "extra", None)
+        if isinstance(extra, dict):
+            profile = extra.get("profile")
+            if isinstance(profile, str) and profile.strip():
+                self._adapter_profile_map[adapter_id] = profile.strip()
+        # Bot-to-bot internal routing: inject the router so feishu adapters'
+        # send hook can dispatch @peer-mentions (Feishu won't deliver bot→bot).
+        if platform == Platform.FEISHU:
+            adapter._bot_to_bot_router = self._route_bot_to_bot
+            adapter._dead_letter_forwarder = self._forward_feishu_dead_letter
+
+    # NOTE: ``_adapter_for_source`` lives on GatewayAuthorizationMixin (the
+    # single source of truth — fail-closed for secondary profiles, relay-aware,
+    # transport-ref-aware, and adapter_id-disambiguated via _authorization_adapter).
+    # An earlier inline copy here shadowed the mixin and regressed routed-profile
+    # and relay-delivery cases; do not reintroduce it.
+
+    def _adapter_for_event(self, event: Optional[MessageEvent]) -> Optional[BasePlatformAdapter]:
+        return self._adapter_for_source(getattr(event, "source", None))
+
+    # Max hops for bot-to-bot internal routing (breaks A→B→C→A rings).
+    _BOT_TO_BOT_HOP_LIMIT = 3
+
+    async def _route_bot_to_bot(
+        self, targets, content: str, chat_id: str, sender_adapter, hop: int = 0, thread_id: Optional[str] = None, anchor_message_id: Optional[str] = None
+    ) -> None:
+        """Inject an outbound @peer-mention directly into the peer adapter.
+
+        Feishu doesn't deliver bot→bot messages, so when bot A's send hook
+        detects it @-mentioned bot B, this builds a synthetic MessageEvent and
+        runs it through B's inbound pipeline. Two loop breakers: (1) skip if
+        target == sender profile (A↔B ping-pong), (2) hop-count cap (rings).
+        """
+        if hop >= self._BOT_TO_BOT_HOP_LIMIT:
+            return
+        import uuid as _uuid
+
+        sender_aid = getattr(sender_adapter, "adapter_id", None)
+        sender_profile = self._adapter_profile_map.get(sender_aid, "")
+        for target_profile, _name in targets:
+            if not target_profile or target_profile == sender_profile:
+                continue
+            target_aid = self.adapter_id_for_profile(target_profile, Platform.FEISHU)
+            target = self.adapters_by_id.get(target_aid) if target_aid else None
+            if target is None or target is sender_adapter:
+                continue
+            sender_name = (
+                getattr(sender_adapter, "_bot_name", None) or sender_profile or "peer-bot"
+            )
+            target_name = getattr(target, "_bot_name", None) or target_profile
+            try:
+                source = target.build_source(
+                    chat_id=chat_id,
+                    chat_name=chat_id,
+                    chat_type="group",
+                    user_id=getattr(sender_adapter, "_bot_open_id", None) or "bot",
+                    user_name=sender_name,
+                    is_bot=True,
+                    adapter_id=getattr(target, "adapter_id", None),
+                    thread_id=thread_id,
+                )
+                logger.debug(
+                    "[Gateway] bot-to-bot source: target=%s target.adapter_id=%s source.adapter_id=%s",
+                    target_profile,
+                    getattr(target, "adapter_id", None),
+                    getattr(source, "adapter_id", None),
+                )
+                # Strip reasoning/thinking blocks so the peer bot only sees the
+                # actual reply, not the sender's internal chain-of-thought.
+                _clean = re.sub(
+                    r"💭\s*\*\*Reasoning:\*\*\s*```.*?```",
+                    "",
+                    content,
+                    flags=re.DOTALL,
+                ).strip()
+                synthetic = MessageEvent(
+                    text=f"[{sender_name} → @{target_name}]: {_clean}",
+                    message_type=MessageType.TEXT,
+                    source=source,
+                    raw_message=None,
+                    message_id=f"bot2bot-{_uuid.uuid4().hex}",
+                    reply_to_message_id=anchor_message_id,
+                    channel_prompt=target._resolve_channel_prompt(chat_id),
+                    timestamp=datetime.now(),
+                    metadata={"hop": hop + 1, "source_profile": sender_profile},
+                )
+                logger.info(
+                    "[Gateway] bot-to-bot route: %s → %s (hop %d, chat %s)",
+                    sender_profile or "?", target_profile, hop + 1, chat_id,
+                )
+                # Bidirectional auto-reply: the target's next send routes back
+                # to the sender (even without @), so the sender "hears" the
+                # reply. hop+1 bounds ping-pong (A↔B↔A rings).
+                target._bot_to_bot_reply_profile = (sender_profile, hop + 1)
+                logger.debug(
+                    "[Gateway] bot-to-bot SET reply_profile: target=%s adapter_id=%s reply_profile=%s",
+                    target_profile, getattr(target, "adapter_id", "?"), (sender_profile, hop + 1),
+                )
+                await target._handle_message_with_guards(synthetic)
+            except Exception:
+                logger.warning(
+                    "[Gateway] bot-to-bot injection to %s failed",
+                    target_profile,
+                    exc_info=True,
+                )
+
+    async def _forward_feishu_dead_letter(
+        self, failed_adapter, chat_id: str, content: str, error: str
+    ) -> None:
+        """Forward a permanently-failed Feishu send to the dead-letter group,
+        emitted by the default (first-registered) Feishu adapter for a stable
+        identity. All colleagues are members of that group, so this send
+        won't itself 230002. Uses ``send`` directly (not ``_send_with_retry``)
+        to avoid recursive dead-lettering; self-failures are logged, never
+        re-raised."""
+        default_adapter = self.adapters.get(Platform.FEISHU)
+        if default_adapter is None:
+            logger.debug("[Gateway] dead-letter: no default feishu adapter; dropping")
+            return
+        _extra = getattr(getattr(default_adapter, "config", None), "extra", None) or {}
+        dead_letter_chat = _extra.get("send_failure_dead_letter_chat", "") or ""
+        if not dead_letter_chat:
+            return
+        sender_profile = (
+            self._adapter_profile_map.get(getattr(failed_adapter, "adapter_id", ""), "")
+            or getattr(failed_adapter, "_bot_name", None)
+            or "unknown"
+        )
+        err_brief = (error or "").strip() or "unknown error"
+        if len(err_brief) > 120:
+            err_brief = err_brief[:120] + "…"
+        summary = (content or "").strip()
+        if len(summary) > 1500:
+            summary = summary[:1500] + "…(truncated)"
+        payload = (
+            "📮 死信投递（发送失败留底）\n"
+            f"来源：{sender_profile}\n"
+            f"目标会话：{chat_id}\n"
+            f"错误：{err_brief}\n"
+            f"--- 原文 ---\n{summary}"
+        )
+        # 死信是留底，绝不能触发 bot-to-bot 路由——否则死信原文摘要里的
+        # @peer 会被 send hook 重新路由给同事（实测过的回环：Tony 从死信
+        # 投递里"看到"了消息）。临时摘掉 default adapter 的 router，让这
+        # 一次发送跳过 send hook 的路由块；finally 恢复，不影响后续协作。
+        _saved_router = getattr(default_adapter, "_bot_to_bot_router", None)
+        default_adapter._bot_to_bot_router = None
+        try:
+            await default_adapter.send(chat_id=dead_letter_chat, content=payload)
+        except Exception:
+            logger.warning(
+                "[Gateway] dead-letter forward to %s failed",
+                dead_letter_chat,
+                exc_info=True,
+            )
+        finally:
+            default_adapter._bot_to_bot_router = _saved_router
+
+    def adapter_id_for_profile(self, profile: str, platform: Optional[Platform] = None) -> Optional[str]:
+        """Reverse lookup: find the adapter_id for a given profile name.
+
+        Used by cron delivery to route messages to the correct multi-app adapter.
+        Returns None if no match (caller falls back to first adapter).
+
+        Format contract: adapter_id is ``"{platform.value}:{configured_id}"``
+        as generated by :meth:`_adapter_instance_id`.  The ``startswith``
+        filter below relies on that format — changing either side without
+        the other will silently break platform-scoped lookups.
+        """
+        for adapter_id, prof in self._adapter_profile_map.items():
+            if prof == profile:
+                if platform is None or adapter_id.startswith(f"{platform.value}:"):
+                    return adapter_id
+        return None
+
+    def _iter_connected_adapters(self) -> list[tuple[Platform, BasePlatformAdapter]]:
+        """Return all connected adapter instances, including multi-app platforms."""
+        seen: set[int] = set()
+        items: list[tuple[Platform, BasePlatformAdapter]] = []
+        for adapter in getattr(self, "adapters_by_id", {}).values():
+            ident = id(adapter)
+            if ident in seen:
+                continue
+            seen.add(ident)
+            items.append((adapter.platform, adapter))
+        for platform, adapter in getattr(self, "adapters", {}).items():
+            ident = id(adapter)
+            if ident in seen:
+                continue
+            seen.add(ident)
+            items.append((platform, adapter))
+        return items
 
     def _warn_if_docker_media_delivery_is_risky(self) -> None:
         """Warn when Docker-backed gateways lack an explicit export mount.
@@ -7770,6 +8029,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not adapter.fatal_error_retryable:
             return False
         platform_config = self.config.platforms.get(adapter.platform)
+        # Multi-app: platforms.get may return a list; unwrap to one enabled
+        # entry so the reconnect watcher doesn't pass a list downstream.
+        # NOTE: still keyed by platform, so a second same-platform failure
+        # overwrites the first — full (platform, adapter_id) keying is a
+        # follow-up.
+        if isinstance(platform_config, list):
+            platform_config = next(
+                (c for c in platform_config if getattr(c, "enabled", False)),
+                platform_config[0] if platform_config else None,
+            )
         if not platform_config or adapter.platform in self._failed_platforms:
             return False
         self._failed_platforms[adapter.platform] = {
@@ -7884,7 +8153,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # incorrectly re-queue it for reconnection, so bail out before any of
         # that happens.
         existing = self.adapters.get(adapter.platform)
-        if existing is not None and existing is not adapter:
+        adapter_id = getattr(adapter, "adapter_id", None)
+        adapter_id_str = str(adapter_id) if adapter_id else ""
+        registered_by_id = (
+            bool(adapter_id_str)
+            and getattr(self, "adapters_by_id", {}).get(adapter_id_str) is adapter
+        )
+        if existing is not adapter and not registered_by_id:
             logger.debug(
                 "Ignoring stale fatal error from a superseded %s adapter instance: %s",
                 adapter.platform.value,
@@ -7915,7 +8190,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             error_message=adapter.fatal_error_message,
         )
 
-        if existing is adapter:
+        claimed_platform_slot = existing is adapter
+        if claimed_platform_slot:
             # Claim this adapter for teardown before awaiting disconnect() —
             # a second fatal-error notification for the same adapter (e.g.
             # from a concurrent recovery path) would otherwise still see
@@ -7923,6 +8199,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # the same object twice.
             self.adapters.pop(adapter.platform, None)
             self.delivery_router.adapters = self.adapters
+        ids = None
+        if registered_by_id:
+            self.adapters_by_id.pop(adapter_id_str, None)
+            ids = self._platform_adapter_ids.get(adapter.platform)
+            if ids and adapter_id_str in ids:
+                ids.remove(adapter_id_str)
 
         # Queue retryable failures BEFORE any disconnect await (#80598).
         # A half-dead transport can wedge native close() (or swallow
@@ -7932,11 +8214,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # reconnect watcher always has work; teardown is best-effort after.
         self._queue_retryable_fatal_platform(adapter)
 
-        if existing is adapter:
-            # A half-closed transport can wedge an adapter's native close()
-            # indefinitely. Reuse the shutdown-path timeout so this runtime
-            # fatal handler always returns to the stay-alive / stranded path.
-            await self._safe_adapter_disconnect(adapter, adapter.platform)
+        # A half-closed transport can wedge an adapter's native close()
+        # indefinitely. Reuse the shutdown-path timeout so this runtime
+        # fatal handler always returns to the stay-alive / stranded path.
+        await self._safe_adapter_disconnect(adapter, adapter.platform)
+
+        if claimed_platform_slot and ids:
+            replacement = self.adapters_by_id.get(ids[0])
+            if replacement is not None:
+                self.adapters[adapter.platform] = replacement
+                self.delivery_router.adapters = self.adapters
 
         if not self.adapters and not self._failed_platforms:
             self._exit_reason = adapter.fatal_error_message or "All messaging adapters disconnected"
@@ -10115,7 +10402,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     continue
 
                 platform_cfg = self.config.platforms.get(platform)
-                if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+                _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+                _grn = any(
+                    getattr(cfg, "gateway_restart_notification", True) for cfg in _configs if cfg is not None
+                )
+                if platform_cfg is not None and not _grn:
                     logger.info(
                         "Shutdown notification suppressed for active session: %s has gateway_restart_notification=false",
                         platform_str,
@@ -10198,16 +10489,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # elsewhere), which would otherwise trigger
         # ``RuntimeError: dictionary changed size during iteration`` —
         # observed in a user report during gateway shutdown.
-        for platform, adapter in list(self.adapters.items()):
-            home = self.config.get_home_channel(platform)
+        for platform, adapter in self._iter_connected_adapters():
+            adapter_id = getattr(adapter, "adapter_id", None)
+            cfg = self.config.get_config_for_adapter_id(platform, adapter_id)
+            home = cfg.home_channel if cfg else self.config.get_home_channel(platform)
             if not home or not home.chat_id:
                 continue
 
-            platform_cfg = self.config.platforms.get(platform)
-            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+            if cfg is not None and not getattr(cfg, "gateway_restart_notification", True):
                 logger.info(
-                    "Shutdown notification suppressed for home channel: %s has gateway_restart_notification=false",
+                    "Shutdown notification suppressed for home channel: %s adapter_id=%s has gateway_restart_notification=false",
                     platform.value,
+                    adapter_id,
                 )
                 continue
 
@@ -11900,118 +12193,149 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         for platform, platform_config in self.config.platforms.items():
             if await self._abort_startup_if_shutdown_requested():
                 return True
-            if not platform_config.enabled:
-                continue
-            # Under multiplexing, a platform may be enabled on the default
-            # profile's config.yaml while its bot token lives only in a
-            # secondary profile's .env. Starting that primary adapter with an
-            # empty token fails immediately and queues an infinite reconnect
-            # loop that can never heal (#64674). Secondary profiles still
-            # start their own adapters under _profile_runtime_scope with the
-            # real token — skip the empty primary instead of failing loudly.
-            if _multiplex_on and not _platform_has_bot_credential(platform, platform_config):
-                logger.info(
-                    "Skipping %s on default profile: no bot credential in this "
-                    "profile's secrets. Secondary multiplexed profiles that "
-                    "provide the token will still connect.",
-                    platform.value,
-                )
-                _multiplex_skipped_platforms.append(platform)
-                continue
-            enabled_platform_count += 1
-            
-            adapter = self._create_adapter(platform, platform_config)
-            if not adapter:
-                # Distinguish between missing builtin deps and missing plugin
-                _pval = platform.value
-                _builtin_names = {m.value for m in Platform.__members__.values()}
-                if _pval not in _builtin_names:
-                    logger.warning(
-                        "No adapter for '%s' — is the plugin installed? "
-                        "(platform is enabled in config.yaml but no plugin registered it)",
-                        _pval,
-                    )
-                else:
-                    logger.warning("No adapter available for %s", _pval)
-                continue
-            
-            # Set up message + fatal error handlers. Under multiplexing the
-            # default profile needs the same whole-handler runtime scope as a
-            # secondary profile: authorization and prompt rendering both run
-            # before the narrower agent-turn scope is installed.
-            adapter.set_message_handler(self._primary_message_handler())
-            adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
-            adapter.set_session_store(self.session_store)
-            adapter.set_busy_session_handler(self._handle_active_session_busy_message)
-            _set_reaction = getattr(adapter, "set_reaction_handler", None)
-            if callable(_set_reaction):
-                _set_reaction(self._handle_reaction_event)
-            adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
-            adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
-            adapter.set_platform_event_handler(self._primary_platform_event_handler())
-            adapter._busy_text_mode = self._busy_text_mode
-            
-            # Try to connect
-            logger.info("Connecting to %s...", platform.value)
-            self._update_platform_runtime_status(
-                platform.value,
-                platform_state="connecting",
-                error_code=None,
-                error_message=None,
-            )
-            try:
-                success = await self._connect_initial_adapter_with_timeout(
-                    adapter, platform
-                )
-                if await self._abort_startup_if_shutdown_requested(adapter, platform):
+            # Multi-app configs may store a list of PlatformConfig instances.
+            configs = platform_config if isinstance(platform_config, list) else [platform_config]
+            for cfg in configs:
+                if not cfg.enabled:
+                    continue
+                if await self._abort_startup_if_shutdown_requested():
                     return True
-                if success:
-                    self.adapters[platform] = adapter
-                    self._sync_voice_mode_state_to_adapter(adapter)
-                    # Wire voice input callback at connect time so voice
-                    # transcription is forwarded without requiring /voice join.
-                    if hasattr(adapter, "_voice_input_callback"):
-                        adapter._voice_input_callback = self._handle_voice_channel_input
-                    connected_count += 1
-                    self._update_platform_runtime_status(
+                # Under multiplexing, a platform may be enabled on the default
+                # profile's config.yaml while its bot token lives only in a
+                # secondary profile's .env. Starting that primary adapter with an
+                # empty token fails immediately and queues an infinite reconnect
+                # loop that can never heal (#64674). Secondary profiles still
+                # start their own adapters under _profile_runtime_scope with the
+                # real token — skip the empty primary instead of failing loudly.
+                if _multiplex_on and not _platform_has_bot_credential(platform, cfg):
+                    logger.info(
+                        "Skipping %s on default profile: no bot credential in this "
+                        "profile's secrets. Secondary multiplexed profiles that "
+                        "provide the token will still connect.",
                         platform.value,
-                        platform_state="connected",
-                        error_code=None,
-                        error_message=None,
-                        needs_attention=False,
-                        retrying_since=None,
                     )
-                    logger.info("✓ %s connected", platform.value)
-                else:
-                    logger.warning("✗ %s failed to connect", platform.value)
-                    # Defensive cleanup: a failed connect() may have
-                    # allocated resources (aiohttp.ClientSession, poll
-                    # tasks, bridge subprocesses) before giving up.
-                    # Without this call, those resources are orphaned
-                    # and Python logs "Unclosed client session" at
-                    # process exit. Adapter disconnect() implementations
-                    # are expected to be idempotent and tolerate
-                    # partial-init state.
-                    await self._safe_adapter_disconnect(adapter, platform)
-                    if adapter.has_fatal_error:
+                    _multiplex_skipped_platforms.append(platform)
+                    continue
+                enabled_platform_count += 1
+            
+                adapter = self._create_adapter(platform, cfg)
+                if not adapter:
+                    # Distinguish between missing builtin deps and missing plugin
+                    _pval = platform.value
+                    _builtin_names = {m.value for m in Platform.__members__.values()}
+                    if _pval not in _builtin_names:
+                        logger.warning(
+                            "No adapter for '%s' — is the plugin installed? "
+                            "(platform is enabled in config.yaml but no plugin registered it)",
+                            _pval,
+                        )
+                    else:
+                        logger.warning("No adapter available for %s", _pval)
+                    continue
+            
+                # Set up message + fatal error handlers. Under multiplexing the
+                # default profile needs the same whole-handler runtime scope as
+                # a secondary profile: authorization and prompt rendering both
+                # run before the narrower agent-turn scope is installed.
+                adapter.set_message_handler(self._primary_message_handler())
+                adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
+                adapter.set_session_store(self.session_store)
+                adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+                _set_reaction = getattr(adapter, "set_reaction_handler", None)
+                if callable(_set_reaction):
+                    _set_reaction(self._handle_reaction_event)
+                adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
+                adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
+                adapter._busy_text_mode = self._busy_text_mode
+                self._adapter_instance_id(platform, adapter)
+            
+                # Try to connect
+                logger.info("Connecting to %s...", platform.value)
+                self._update_platform_runtime_status(
+                    platform.value,
+                    platform_state="connecting",
+                    error_code=None,
+                    error_message=None,
+                )
+                try:
+                    success = await self._connect_initial_adapter_with_timeout(
+                        adapter, platform
+                    )
+                    if await self._abort_startup_if_shutdown_requested(adapter, platform):
+                        return True
+                    if success:
+                        self._register_connected_adapter(platform, adapter)
+                        adapter_id = getattr(adapter, "adapter_id", None)
+                        self._sync_voice_mode_state_to_adapter(adapter)
+                        # Wire voice input callback at connect time so voice
+                        # transcription is forwarded without requiring /voice join.
+                        if hasattr(adapter, "_voice_input_callback"):
+                            adapter._voice_input_callback = self._handle_voice_channel_input
+                        connected_count += 1
                         self._update_platform_runtime_status(
                             platform.value,
-                            platform_state="retrying" if adapter.fatal_error_retryable else "fatal",
-                            error_code=adapter.fatal_error_code,
-                            error_message=adapter.fatal_error_message,
+                            platform_state="connected",
+                            error_code=None,
+                            error_message=None,
+                            needs_attention=False,
+                            retrying_since=None,
                         )
-                        target = (
-                            startup_retryable_errors
-                            if adapter.fatal_error_retryable
-                            else startup_nonretryable_errors
-                        )
-                        target.append(
-                            f"{platform.value}: {adapter.fatal_error_message}"
-                        )
-                        # Queue for reconnection if the error is retryable
-                        if adapter.fatal_error_retryable:
+                        if adapter_id:
+                            logger.info("✓ %s connected (adapter_id=%s)", platform.value, adapter_id)
+                        else:
+                            logger.info("✓ %s connected", platform.value)
+                    else:
+                        logger.warning("✗ %s failed to connect", platform.value)
+                        # Defensive cleanup: a failed connect() may have
+                        # allocated resources (aiohttp.ClientSession, poll
+                        # tasks, bridge subprocesses) before giving up.
+                        # Without this call, those resources are orphaned
+                        # and Python logs "Unclosed client session" at
+                        # process exit. Adapter disconnect() implementations
+                        # are expected to be idempotent and tolerate
+                        # partial-init state.
+                        await self._safe_adapter_disconnect(adapter, platform)
+                        if adapter.has_fatal_error:
+                            self._update_platform_runtime_status(
+                                platform.value,
+                                platform_state="retrying" if adapter.fatal_error_retryable else "fatal",
+                                error_code=adapter.fatal_error_code,
+                                error_message=adapter.fatal_error_message,
+                            )
+                            target = (
+                                startup_retryable_errors
+                                if adapter.fatal_error_retryable
+                                else startup_nonretryable_errors
+                            )
+                            target.append(
+                                f"{platform.value}: {adapter.fatal_error_message}"
+                            )
+                            # Queue for reconnection if the error is retryable
+                            if adapter.fatal_error_retryable:
+                                self._failed_platforms[platform] = {
+                                    "config": cfg,
+                                    "attempts": 1,
+                                    "next_retry": time.monotonic() + 30,
+                                    "credential_claim": self._adapter_credential_claim(
+                                        platform, adapter
+                                    ),
+                                    "listener_claim": self._adapter_listener_claim(
+                                        platform, adapter
+                                    ),
+                                }
+                        else:
+                            self._update_platform_runtime_status(
+                                platform.value,
+                                platform_state="retrying",
+                                error_code=None,
+                                error_message="failed to connect",
+                            )
+                            startup_retryable_errors.append(
+                                f"{platform.value}: failed to connect"
+                            )
+                            # No fatal error info means likely a transient issue — queue for retry
                             self._failed_platforms[platform] = {
-                                "config": platform_config,
+                                "config": cfg,
                                 "attempts": 1,
                                 "next_retry": time.monotonic() + 30,
                                 "queued_at": time.monotonic(),
@@ -12022,57 +12346,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     platform, adapter
                                 ),
                             }
-                    else:
-                        self._update_platform_runtime_status(
-                            platform.value,
-                            platform_state="retrying",
-                            error_code=None,
-                            error_message="failed to connect",
-                        )
-                        startup_retryable_errors.append(
-                            f"{platform.value}: failed to connect"
-                        )
-                        # No fatal error info means likely a transient issue — queue for retry
-                        self._failed_platforms[platform] = {
-                            "config": platform_config,
-                            "attempts": 1,
-                            "next_retry": time.monotonic() + 30,
-                            "queued_at": time.monotonic(),
-                            "credential_claim": self._adapter_credential_claim(
-                                platform, adapter
-                            ),
-                            "listener_claim": self._adapter_listener_claim(
-                                platform, adapter
-                            ),
-                        }
-            except Exception as e:
-                logger.error("✗ %s error: %s", platform.value, e)
-                # Same defensive cleanup path for exceptions — an adapter
-                # that raised mid-connect may still have a live
-                # aiohttp.ClientSession or child subprocess.
-                await self._safe_adapter_disconnect(adapter, platform)
-                self._update_platform_runtime_status(
-                    platform.value,
-                    platform_state="retrying",
-                    error_code=None,
-                    error_message=str(e),
-                )
-                startup_retryable_errors.append(f"{platform.value}: {e}")
-                # Unexpected exceptions are typically transient — queue for retry
-                self._failed_platforms[platform] = {
-                    "config": platform_config,
-                    "attempts": 1,
-                    "next_retry": time.monotonic() + 30,
-                    "queued_at": time.monotonic(),
-                    "credential_claim": self._adapter_credential_claim(
-                        platform, adapter
-                    ),
-                    "listener_claim": self._adapter_listener_claim(
-                        platform, adapter
-                    ),
-                }
-            if await self._abort_startup_if_shutdown_requested():
-                return True
+                except Exception as e:
+                    logger.error("✗ %s error: %s", platform.value, e)
+                    # Same defensive cleanup path for exceptions — an adapter
+                    # that raised mid-connect may still have a live
+                    # aiohttp.ClientSession or child subprocess.
+                    await self._safe_adapter_disconnect(adapter, platform)
+                    self._update_platform_runtime_status(
+                        platform.value,
+                        platform_state="retrying",
+                        error_code=None,
+                        error_message=str(e),
+                    )
+                    startup_retryable_errors.append(f"{platform.value}: {e}")
+                    # Unexpected exceptions are typically transient — queue for retry
+                    self._failed_platforms[platform] = {
+                        "config": cfg,
+                        "attempts": 1,
+                        "next_retry": time.monotonic() + 30,
+                        "queued_at": time.monotonic(),
+                        "credential_claim": self._adapter_credential_claim(
+                            platform, adapter
+                        ),
+                        "listener_claim": self._adapter_listener_claim(
+                            platform, adapter
+                        ),
+                    }
+                if await self._abort_startup_if_shutdown_requested():
+                    return True
 
         # Multi-profile multiplexing: bring up adapters for every OTHER profile
         # this gateway serves. Each profile's adapters connect under that
@@ -12707,11 +13008,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # user_id (thread_sessions_per_user defaults to False) — so the
         # next real user message in the thread shares this same session.
         platform_cfg = self.config.platforms.get(platform)
-        extra = platform_cfg.extra if platform_cfg else {}
+        # Multi-app configs may return a list of PlatformConfig instances.
+        _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+        extra = {}
+        for cfg in _configs:
+            if cfg is not None:
+                extra = cfg.extra
+                break
         session_key = build_session_key(
             dest_source,
             group_sessions_per_user=extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=extra.get("thread_sessions_per_user", False),
+            # Match the profile namespace get_or_create_session derives below
+            # (#4): without this, multi-profile CLI handoff keys collapse to
+            # ``agent:main`` and bind the wrong entry. No-op when multiplex is
+            # off — _resolve_profile_for_key returns None → ``agent:main``.
+            profile=self.session_store._resolve_profile_for_key(dest_source),  # noqa: SLF001
         )
 
         # Make sure there's an entry in the session_store for this key. If
@@ -12723,7 +13035,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # ends the prior session in SQLite and reopens the CLI session under
         # the new key. The CLI's transcript becomes the active one for the
         # gateway from this moment on.
-        switched = await self.async_session_store.switch_session(session_key, cli_session_id)
+        switched = await self.async_session_store.switch_session(
+            session_key, cli_session_id, allow_cross_adapter=True,
+        )
         if switched is None:
             raise RuntimeError(
                 f"could not switch session key {session_key} → {cli_session_id}"
@@ -13380,6 +13694,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
                     adapter.set_platform_event_handler(self._primary_platform_event_handler())
                     adapter._busy_text_mode = self._busy_text_mode
+                    self._adapter_instance_id(platform, adapter)
 
                     # Reconnect after an outage: preserve the platform's
                     # server-side update queue so messages sent while the bot
@@ -13388,7 +13703,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         adapter, platform, is_reconnect=True
                     )
                     if success:
-                        self.adapters[platform] = adapter
+                        self._register_connected_adapter(platform, adapter)
                         self._sync_voice_mode_state_to_adapter(adapter)
                         # Wire voice input callback on reconnect as well (#60623).
                         if hasattr(adapter, "_voice_input_callback"):
@@ -13912,18 +14227,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if cancel_completion_batches is not None:
                 await cancel_completion_batches()
 
-            for platform, adapter in list(self.adapters.items()):
+            for platform, adapter in self._iter_connected_adapters():
                 await self._bounded_adapter_teardown(adapter, platform)
 
             # Disconnect secondary-profile adapters (multiplex mode).
             for _prof, _amap in list(getattr(self, "_profile_adapters", {}).items()):
-                for platform, adapter in list(_amap.items()):
+                _id_map = (
+                    getattr(self, "_profile_adapters_by_id", {}).get(_prof, {})
+                )
+                _seen_profile_adapters: set[int] = set()
+                for adapter in [*_amap.values(), *_id_map.values()]:
+                    if id(adapter) in _seen_profile_adapters:
+                        continue
+                    _seen_profile_adapters.add(id(adapter))
                     await self._bounded_adapter_teardown(
-                        adapter, platform, profile=_prof
+                        adapter, adapter.platform, profile=_prof
                     )
                 _amap.clear()
+                _id_map.clear()
             if hasattr(self, "_profile_adapters"):
                 self._profile_adapters.clear()
+            if hasattr(self, "_profile_adapters_by_id"):
+                self._profile_adapters_by_id.clear()
             logger.info(
                 "Shutdown phase: all adapters disconnected at +%.2fs",
                 _phase_elapsed(),
@@ -13942,6 +14267,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._background_tasks.clear()
 
             self.adapters.clear()
+            getattr(self, "adapters_by_id", {}).clear()
+            getattr(self, "_platform_adapter_ids", {}).clear()
             for _session_key in list(self._running_agents):
                 self._release_running_agent_state(_session_key)
             # Flush pending messages to disk before clearing (#72680).
@@ -14241,12 +14568,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "'open'."
             )
 
-        port_binding_platforms = sorted(
+        # profile_cfg.platforms values are Union[PlatformConfig, List[PlatformConfig]]
+        # — multi-app platforms (e.g. Feishu's apps[]) store a list. Normalize the
+        # same way the adapter-creation loop below does, or list-valued platforms
+        # crash with AttributeError before ever reaching that loop.
+        port_binding_platforms = sorted({
             platform.value
             for platform, platform_config in profile_cfg.platforms.items()
-            if platform_config.enabled
-            and _platform_binds_port(platform.value, platform_config.extra)
-        )
+            for concrete in (
+                platform_config if isinstance(platform_config, list) else [platform_config]
+            )
+            if concrete.enabled
+            and _platform_binds_port(platform.value, concrete.extra)
+        })
         if port_binding_platforms:
             joined = ", ".join(port_binding_platforms)
             raise SecondaryPortBindingConfigError(
@@ -14259,10 +14593,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
         profile_map = self._profile_adapters.setdefault(profile_name, {})
+        profile_adapters_by_id = getattr(self, "_profile_adapters_by_id", None)
+        if profile_adapters_by_id is None:
+            self._profile_adapters_by_id = {}
+            profile_adapters_by_id = self._profile_adapters_by_id
+        profile_id_map = profile_adapters_by_id.setdefault(profile_name, {})
         connected = 0
         for platform, platform_config in profile_cfg.platforms.items():
-            if not platform_config.enabled:
-                continue
             # Relay is shared process-level ingress in multiplex mode. The
             # active profile owns the one connection; connector-stamped
             # source.profile routes inbound turns to secondary profiles.
@@ -14271,87 +14608,95 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 and platform is Platform.RELAY
             ):
                 continue
-            try:
-                with _profile_runtime_scope(profile_home):
-                    adapter = self._create_adapter(platform, platform_config)
-            except Exception as e:
-                logger.error(
-                    "[MULTIPLEX] Profile '%s': _create_adapter('%s') raised %s",
-                    profile_name,
-                    platform.value,
-                    e,
-                    exc_info=True,
-                )
-                continue
-            if not adapter:
-                logger.warning(
-                    "[MULTIPLEX] Profile '%s': skipping platform '%s' - adapter creation returned None",
-                    profile_name,
-                    platform.value,
-                )
-                continue
-
-            # Same-token conflict detection — refuse a duplicate poll.
-            credential_claim = self._adapter_credential_claim(platform, adapter)
-            if credential_claim is not None:
-                owner = claimed.get(credential_claim)
-                if owner is not None:
-                    logger.error(
-                        "Profile '%s' and '%s' both configure %s with the same "
-                        "credential — refusing to start the duplicate (one "
-                        "credential cannot be consumed twice). Give each profile "
-                        "its own %s credential.",
-                        owner, profile_name, platform.value, platform.value,
-                    )
-                    # This adapter has not connected and therefore owns no
-                    # resources to clean up. Calling disconnect here can mutate
-                    # the shared platform state and, for a same-credential Photon
-                    # adapter, shut down the primary profile's live sidecar.
+            platform_configs = (
+                platform_config if isinstance(platform_config, list) else [platform_config]
+            )
+            for concrete_config in platform_configs:
+                if not concrete_config.enabled:
                     continue
-
-            listener_claim = self._adapter_listener_claim(platform, adapter)
-            if listener_claim is not None:
-                owner = claimed.get(listener_claim)
-                if owner is not None:
-                    bind, port = listener_claim[-2:]
+                # Port-binding platforms are already rejected above via the
+                # mode-aware _platform_binds_port() check (over profile_cfg,
+                # before any adapter is created) — that's the single source of
+                # truth so mode-conditional platforms like Feishu (only binds
+                # a port in webhook mode, not its websocket default) aren't
+                # blocked here by a static platform-name check that ignores
+                # `extra`/connection_mode.
+                try:
+                    with _profile_runtime_scope(profile_home):
+                        adapter = self._create_adapter(platform, concrete_config)
+                except Exception as e:
                     logger.error(
-                        "Profile '%s' and '%s' both configure %s sidecars on "
-                        "%s:%s — refusing to start the duplicate listener. "
-                        "Set platforms.%s.extra.sidecar_port to a distinct port "
-                        "for profile '%s'.",
-                        owner,
+                        "[MULTIPLEX] Profile '%s': _create_adapter('%s') raised %s",
                         profile_name,
                         platform.value,
-                        bind,
-                        port,
-                        platform.value,
-                        profile_name,
+                        e,
+                        exc_info=True,
                     )
-                    # Like credential conflicts, this adapter never connected
-                    # and owns no resources that should be disconnected.
+                    continue
+                if not adapter:
+                    logger.warning(
+                        "[MULTIPLEX] Profile '%s': skipping platform '%s' - adapter creation returned None",
+                        profile_name,
+                        platform.value,
+                    )
                     continue
 
-            self._configure_profile_adapter(adapter, profile_name, platform)
+                # Same-token conflict detection — refuse a duplicate poll.
+                fp = self._adapter_credential_fingerprint(adapter)
+                if fp is not None:
+                    owner = claimed.get((platform, fp))
+                    if owner is not None:
+                        logger.error(
+                            "Profile '%s' and '%s' both configure %s with the same "
+                            "credential — refusing to start the duplicate (a single "
+                            "bot token cannot be polled twice). Give each profile its "
+                            "own %s credential.",
+                            owner, profile_name, platform.value, platform.value,
+                        )
+                        await self._safe_adapter_disconnect(adapter, platform)
+                        continue
+                    claimed[(platform, fp)] = profile_name
 
-            try:
-                with _profile_runtime_scope(profile_home):
-                    success = await self._connect_initial_adapter_with_timeout(
-                        adapter, platform
+                self._configure_profile_adapter(adapter, profile_name, platform)
+
+                try:
+                    with _profile_runtime_scope(profile_home):
+                        success = await self._connect_initial_adapter_with_timeout(adapter, platform)
+                    if success:
+                        adapter_id = self._adapter_instance_id(platform, adapter)
+                        base_adapter_id = adapter_id
+                        suffix = 2
+                        while (
+                            adapter_id in profile_id_map
+                            and profile_id_map[adapter_id] is not adapter
+                        ):
+                            adapter_id = f"{base_adapter_id}:{suffix}"
+                            suffix += 1
+                        adapter.adapter_id = adapter_id
+                        profile_map.setdefault(platform, adapter)
+                        profile_id_map[adapter_id] = adapter
+                        connected += 1
+                        logger.info(
+                            "✓ %s connected (profile: %s, adapter_id=%s)",
+                            platform.value,
+                            profile_name,
+                            adapter_id,
+                        )
+                    else:
+                        logger.warning(
+                            "✗ %s failed to connect (profile: %s)",
+                            platform.value,
+                            profile_name,
+                        )
+                        await self._safe_adapter_disconnect(adapter, platform)
+                except Exception as e:
+                    logger.error(
+                        "✗ %s error (profile: %s): %s",
+                        platform.value,
+                        profile_name,
+                        e,
                     )
-                if success:
-                    profile_map[platform] = adapter
-                    if credential_claim is not None:
-                        claimed[credential_claim] = profile_name
-                    if listener_claim is not None:
-                        claimed[listener_claim] = profile_name
-                    connected += 1
-                    logger.info("✓ %s connected (profile: %s)", platform.value, profile_name)
-                else:
-                    logger.warning("✗ %s failed to connect (profile: %s)", platform.value, profile_name)
                     await self._safe_adapter_disconnect(adapter, platform)
-            except Exception as e:
-                logger.error("✗ %s error (profile: %s): %s", platform.value, profile_name, e)
-                await self._safe_adapter_disconnect(adapter, platform)
         return connected
 
     def _configure_profile_adapter(
@@ -14402,6 +14747,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     profile_home = get_profile_dir(profile_name)
                     with _profile_runtime_scope(profile_home):
                         profile_config = load_gateway_config().platforms.get(platform)
+                        # Multi-app: unwrap list to first enabled entry so .enabled
+                        # doesn't raise on a list. TODO: reconnect each app by
+                        # adapter_id rather than only the first enabled one.
+                        if isinstance(profile_config, list):
+                            profile_config = next(
+                                (c for c in profile_config if getattr(c, "enabled", False)),
+                                profile_config[0] if profile_config else None,
+                            )
                         if profile_config is None or not profile_config.enabled:
                             return
                         adapter = self._create_adapter(platform, profile_config)
@@ -14735,6 +15088,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             val = getattr(config, "token", None)
             if isinstance(val, str) and val.strip():
                 token = val.strip()
+        # FeishuAdapter stores its credential as app_id/app_secret rather than
+        # a single token attribute, so none of the lookups above match it.
+        # Without this, duplicate Feishu apps (e.g. an app_id claimed by both
+        # the active profile and a secondary multiplex profile) go undetected,
+        # and the second WebSocket client hangs forever inside lark_oapi's
+        # timeout-less ticket-fetch call instead of being refused. See
+        # _start_one_profile_adapters.
+        if not token:
+            app_id = getattr(adapter, "_app_id", None)
+            app_secret = getattr(adapter, "_app_secret", None)
+            if isinstance(app_id, str) and app_id.strip():
+                token = "feishu:" + app_id.strip() + ":" + (
+                    app_secret.strip() if isinstance(app_secret, str) else ""
+                )
         if not token:
             return None
         import hashlib
@@ -14960,6 +15327,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self,
         session_entry: SessionEntry,
         pinned_session_id: str,
+        *,
+        source_session_key: str = "",
     ) -> Optional[SessionEntry]:
         """Resolve an async completion to its verified owning gateway session.
 
@@ -15096,17 +15465,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if target_session_id == session_entry.session_id:
             return session_entry
 
+        # #64934: a delegation spawned on adapter A must not be sewn onto the
+        # parent session when its completion is delivered through adapter B's
+        # routing key. In multi-app fan-out (Pete→{Tony,Sam}) every target's
+        # completion used to pin back to Pete's session_id, merging Tony and
+        # Sam into one transcript. When the spawning adapter (decoded from
+        # source_session_key) differs from the current route's adapter, drop
+        # the injection fail-closed instead of sewing — the result remains in
+        # the async_delegations table (/tasks). An empty source_session_key
+        # (legacy record, pre-#64934) skips this guard and preserves the pin.
+        _expected_adapter = None
+        if source_session_key:
+            _cur_adapter = (_parse_session_key(session_entry.session_key) or {}).get("adapter_id")
+            _src_adapter = (_parse_session_key(source_session_key) or {}).get("adapter_id")
+            _expected_adapter = _src_adapter
+            if _cur_adapter and _src_adapter and _cur_adapter != _src_adapter:
+                logger.warning(
+                    "Async-delegation completion route adapter %s differs from "
+                    "spawning adapter %s (#64934); dropping injection to avoid "
+                    "cross-adapter session sew (result remains in delegation "
+                    "records). route_key=%s source_key=%s",
+                    _cur_adapter, _src_adapter,
+                    session_entry.session_key, source_session_key,
+                )
+                return None
+
+        _switch_kwargs = {"expected_adapter_id": _expected_adapter} if _expected_adapter else {}
         prior_session_id = session_entry.session_id
         if follows_compression:
             switched = await self.async_session_store.advance_compression_session(
                 session_entry.session_key,
                 prior_session_id,
                 target_session_id,
+                **_switch_kwargs,
             )
         else:
             switched = await self.async_session_store.switch_session(
                 session_entry.session_key,
                 target_session_id,
+                **_switch_kwargs,
             )
         if switched is None:
             logger.warning(
@@ -17815,6 +18212,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             resolved_entry = await self._resolve_async_delegation_session(
                 session_entry,
                 pinned_session_id,
+                source_session_key=str(event_metadata.get("source_session_key") or "").strip(),
             )
             if resolved_entry is None:
                 return
@@ -22875,7 +23273,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return None
 
             platform_cfg = self.config.platforms.get(platform)
-            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+            _configs = platform_cfg if isinstance(platform_cfg, list) else [platform_cfg]
+            _grn = any(
+                getattr(cfg, "gateway_restart_notification", True) for cfg in _configs if cfg is not None
+            )
+            if platform_cfg is not None and not _grn:
                 logger.info(
                     "Restart notification suppressed: %s has gateway_restart_notification=false",
                     platform_str,
@@ -22942,19 +23344,60 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         skipped = skip_targets or set()
         message = "♻️ Gateway online — Hermes is back and ready."
 
-        for platform, platform_cfg in self.config.platforms.items():
-            home = platform_cfg.home_channel
+        # Candidates: (logical platform, home config, transport, adapter_id).
+        # Two sources feed this list:
+        #  1. every physically-connected adapter (multi-app/adapter_id aware,
+        #     so each multiplex instance gets its own notification instead of
+        #     just one per platform);
+        #  2. logical platforms with a configured home channel but no native
+        #     connected adapter (e.g. disabled-but-Relay-fronted platforms),
+        #     resolved the same way normal message delivery does.
+        # Without (2), a platform fronted entirely by Relay never appears in
+        # _iter_connected_adapters() under its own logical Platform key and
+        # its home channel would silently stop getting notified.
+        candidates: list[tuple[Platform, Any, DeliveryTransport, Optional[str]]] = []
+        covered_platforms: set[Platform] = set()
+
+        for platform, adapter in self._iter_connected_adapters():
+            covered_platforms.add(platform)
+            adapter_id = getattr(adapter, "adapter_id", None)
+            cfg = self.config.get_config_for_adapter_id(platform, adapter_id)
+            home = cfg.home_channel if cfg else self.config.get_home_channel(platform)
             if not home or not home.chat_id:
                 continue
 
+            # Build the transport directly from the adapter we're already
+            # iterating rather than re-resolving via resolve_delivery_transport()
+            # (which only consults self.adapters and is not multi-app/adapter_id
+            # aware) — this is what makes home-channel notifications fire for
+            # every connected multiplex adapter instead of just one per platform.
+            transport_platform = (
+                Platform.RELAY if getattr(adapter, "platform", None) == Platform.RELAY else platform
+            )
+            transport = DeliveryTransport(adapter=adapter, config=cfg, transport_platform=transport_platform)
+            candidates.append((platform, cfg, transport, adapter_id))
+
+        for platform, platform_cfg in self.config.platforms.items():
+            if platform in covered_platforms or platform == Platform.RELAY:
+                continue
+            home = platform_cfg.home_channel
+            if not home or not home.chat_id:
+                continue
             transport = resolve_delivery_transport(platform, self.config, self.adapters)
             if transport is None:
                 continue
+            candidates.append((platform, platform_cfg, transport, None))
 
-            if not platform_cfg.gateway_restart_notification:
+        for platform, cfg, transport, adapter_id in candidates:
+            home = cfg.home_channel if cfg else self.config.get_home_channel(platform)
+            if not home or not home.chat_id:
+                continue
+
+            if cfg is not None and not getattr(cfg, "gateway_restart_notification", True):
                 logger.info(
-                    "Home-channel startup notification suppressed: %s has gateway_restart_notification=false",
+                    "Home-channel startup notification suppressed: %s adapter_id=%s has gateway_restart_notification=false",
                     platform.value,
+                    adapter_id,
                 )
                 continue
 
@@ -23527,6 +23970,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         derived_platform = ""
         derived_chat_type = ""
         derived_chat_id = ""
+        derived_adapter_id = ""
 
         if session_key:
             try:
@@ -23550,6 +23994,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 derived_platform = _parsed["platform"]
                 derived_chat_type = _parsed["chat_type"]
                 derived_chat_id = _parsed["chat_id"]
+                derived_adapter_id = _parsed.get("adapter_id", "")
 
         platform_name = str(evt.get("platform") or derived_platform or "").strip().lower()
         chat_type = str(evt.get("chat_type") or derived_chat_type or "").strip().lower()
@@ -23606,6 +24051,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_id=str(evt.get("user_id") or "").strip() or None,
             user_name=str(evt.get("user_name") or "").strip() or None,
             scope_id=scope_id,
+            adapter_id=(
+                str(evt.get("adapter_id") or derived_adapter_id or "").strip()
+                or None
+            ),
         )
 
     async def _drain_watch_notifications(self, completion_queue) -> None:
@@ -23628,6 +24077,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as exc:
                 logger.error("Watch notification injection error: %s", exc)
 
+    def _maybe_reroute_to_parent_adapter(self, evt: dict, current_source):
+        """#64934: reroute a cross-adapter async-delegation completion to its
+        SPAWNING (parent) adapter.
+
+        A delegation spawned on adapter A (Pete) may complete via adapter B's
+        routing key (Tony/Sam in a multi-app fan-out). Delivering through B's
+        source would sew B's routing key onto A's session_id. When the spawning
+        adapter (decoded from ``source_session_key``) differs from the current
+        route's adapter, rebuild the source from ``source_session_key`` so the
+        completion lands in the parent adapter's own session. Same-adapter and
+        unresolvable cases return ``current_source`` unchanged (and the
+        ``_resolve_async_delegation_session`` guard still drops a true
+        cross-adapter sew as a safety net).
+        """
+        source_sk = str(evt.get("source_session_key") or "").strip()
+        if not source_sk or source_sk == str(evt.get("session_key") or "").strip():
+            return current_source
+        cur_aid = str(getattr(current_source, "adapter_id", "") or "").strip()
+        src_aid = str((_parse_session_key(source_sk) or {}).get("adapter_id") or "").strip()
+        if not cur_aid or not src_aid or cur_aid == src_aid:
+            return current_source
+        # Rebuild the source from the parent's session_key. Drop enriched
+        # routing fields so _build_process_event_source re-derives them from
+        # source_session_key (or its session-store origin) instead of reusing
+        # the child adapter's platform/chat_id.
+        parent_evt = {**evt, "session_key": source_sk}
+        for _k in ("platform", "chat_type", "chat_id", "thread_id"):
+            parent_evt.pop(_k, None)
+        parent_source = self._build_process_event_source(parent_evt)
+        if parent_source is None:
+            return current_source
+        logger.info(
+            "Async-delegation completion rerouted to spawning adapter %s "
+            "(was %s) to avoid cross-adapter session sew (#64934)",
+            src_aid, cur_aid,
+        )
+        return parent_source
+
     async def _inject_watch_notification(
         self, synth_text: str, evt: dict,
     ) -> Optional[bool]:
@@ -23641,6 +24128,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         acceptance can still cause durable at-least-once replay.
         """
         source = await asyncio.to_thread(self._build_process_event_source, evt)
+        if source is not None:
+            source = self._maybe_reroute_to_parent_adapter(evt, source)
         if not source:
             # API-server-originated sessions bind a RAW session key (the
             # X-Hermes-Session-Id value — see _bind_api_server_session), not a
@@ -23685,35 +24174,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return None
         platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
-        # Alias-aware resolution (relay-plane): a relay-fronted gateway
-        # registers ONE adapter under Platform.RELAY fronting N logical
-        # platforms, so a literal ``p.value == platform_name`` scan misses
-        # "slack" and silently drops the completion as "no gateway route"
-        # (staging incident 2026-08-09, second occurrence). Resolve through
-        # the shared transport resolver — native adapter wins; relay is
-        # eligible only when it advertises fronting the logical platform.
-        adapter = None
-        try:
-            _platform_enum = Platform(platform_name)
-        except (ValueError, KeyError):
-            _platform_enum = None
-        if _platform_enum is not None:
-            try:
-                _transport = resolve_delivery_transport(
-                    _platform_enum, self.config, self.adapters,
-                )
-            except Exception:
-                _transport = None
-            if _transport is not None:
-                adapter = _transport.adapter
-        if adapter is None:
-            # Legacy literal scan — still correct for native adapters, and
-            # keeps minimal runner stubs (tests) and exotic platform strings
-            # working when the resolver can't run.
-            for p, a in self.adapters.items():
-                if p.value == platform_name:
-                    adapter = a
-                    break
+        adapter = self._adapter_for_source(source)
         if not adapter:
             return None
         from gateway.wake import adapter_supports_push as _wake_push_ok
@@ -23745,6 +24206,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             parent_session_id = str(evt.get("parent_session_id") or "").strip()
             if parent_session_id:
                 metadata["gateway_session_id"] = parent_session_id
+            _delegation_source_sk = str(evt.get("source_session_key") or "").strip()
+            if _delegation_source_sk:
+                metadata["source_session_key"] = _delegation_source_sk
             synth_event = MessageEvent(
                 text=synth_text,
                 message_type=MessageType.TEXT,
@@ -24457,6 +24921,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         message_id = str(watcher.get("message_id") or "").strip() or None
         agent_notify = watcher.get("notify_on_complete", False)
         notify_mode = self._load_background_notifications_mode()
+        watcher_source = self._build_process_event_source({
+            "session_id": session_id,
+            "session_key": session_key,
+            "platform": platform_name,
+            "chat_id": chat_id,
+            "thread_id": thread_id,
+            "user_id": user_id,
+            "user_name": user_name,
+            "adapter_id": watcher.get("adapter_id"),
+        })
+        watcher_adapter = self._adapter_for_source(watcher_source)
+        if watcher_adapter is None and platform_name:
+            try:
+                watcher_adapter = self.adapters.get(Platform(platform_name))
+            except Exception:
+                watcher_adapter = None
 
         logger.debug("Process watcher started: %s (every %ss, notify=%s, agent_notify=%s)",
                       session_id, interval, notify_mode, agent_notify)
@@ -24521,6 +25001,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "user_id": user_id,
                         "user_name": user_name,
                         "message_id": message_id,
+                        "adapter_id": watcher.get("adapter_id"),
                         "started_at": getattr(session, "started_at", None),
                         "command": _command,
                         "exit_code": session.exit_code,
@@ -24604,11 +25085,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             f"[Background process {session_id} finished with exit code {session.exit_code}~ "
                             f"Here's the final output:\n{new_output}]"
                         )
-                    adapter = None
-                    for p, a in self.adapters.items():
-                        if p.value == platform_name:
-                            adapter = a
-                            break
+                    adapter = watcher_adapter
                     if adapter and chat_id:
                         try:
                             send_meta = {"thread_id": thread_id} if thread_id else None
@@ -24635,11 +25112,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"[Background process {session_id} is still running~ "
                     f"New output:\n{new_output}]"
                 )
-                adapter = None
-                for p, a in self.adapters.items():
-                    if p.value == platform_name:
-                        adapter = a
-                        break
+                adapter = watcher_adapter
                 if adapter and chat_id:
                     try:
                         send_meta = {"thread_id": thread_id} if thread_id else None
@@ -29334,8 +29807,24 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     ):
         try:
             profile_homes = _multiplex_profile_homes(runner.config)
+            from hermes_cli.profiles import get_active_profile_name
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                # Secondary profiles have their own adapters in
+                # runner._profile_adapters (e.g. a distinct Feishu bot app per
+                # profile). Without this map, every profile's cron tick reused
+                # the single default-profile `adapters` dict above, so a
+                # secondary profile's live-adapter delivery either silently
+                # fell back to the standalone HTTP path (adapter absent) or —
+                # worse, if the default profile happens to run the same
+                # platform — delivered through the WRONG bot/credentials.
+                # `get_active_profile_name()` keys the default profile's own
+                # entry so the lookup below is uniform for every served profile.
+                active_profile_name = get_active_profile_name() or "default"
+                cron_start_kwargs["profile_adapters"] = {
+                    active_profile_name: runner.adapters,
+                    **runner._profile_adapters,
+                }
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -95,6 +95,7 @@ from .whatsapp_identity import (
     normalize_whatsapp_identifier,  # noqa: F401 - re-exported for gateway.session callers
 )
 from utils import atomic_replace
+from agent.secret_scope import get_secret
 from agent.turn_context import extract_api_content_sidecar
 
 # Session keys/ids flow into filesystem paths downstream (e.g.
@@ -176,6 +177,7 @@ class SessionSource:
     guild_id: Optional[str] = None  # @deprecated legacy alias for scope_id (D-Q2.5)
     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
+    adapter_id: Optional[str] = None  # Concrete adapter instance that received the message
     role_authorized: bool = False  # True when adapter granted access via role (not user ID)
     # Profile this inbound message is routed to in a multiplexing gateway
     # (from the /p/<profile>/ URL prefix or per-credential adapter ownership).
@@ -277,6 +279,8 @@ class SessionSource:
             d["parent_chat_id"] = self.parent_chat_id
         if self.message_id:
             d["message_id"] = self.message_id
+        if self.adapter_id:
+            d["adapter_id"] = self.adapter_id
         if self.profile:
             d["profile"] = self.profile
         if self.auto_thread_created:
@@ -305,6 +309,7 @@ class SessionSource:
             scope_id=data.get("scope_id", data.get("guild_id")),
             parent_chat_id=data.get("parent_chat_id"),
             message_id=data.get("message_id"),
+            adapter_id=data.get("adapter_id"),
             profile=data.get("profile"),
             auto_thread_created=bool(data.get("auto_thread_created", False)),
             auto_thread_initial_name=data.get("auto_thread_initial_name"),
@@ -1067,6 +1072,24 @@ def is_shared_multi_user_session(
     return not group_sessions_per_user
 
 
+def _adapter_id_from_key(session_key: str) -> Optional[str]:
+    """Extract the adapter_id segment from a session key, if present.
+
+    Namespace-agnostic (unlike run.py's ``_parse_session_key``, which requires
+    ``parts[1]=='main'``), so multi-profile keys still resolve. Returns None
+    when the key carries no adapter segment. Used by the #64934 cross-adapter
+    sew guard on ``switch_session``/``advance_compression_session``.
+    """
+    if not session_key:
+        return None
+    from urllib.parse import unquote
+
+    for _part in session_key.split(":"):
+        if _part.startswith("adapter="):
+            return unquote(_part[len("adapter="):]) or None
+    return None
+
+
 def _session_key_namespace(profile: Optional[str]) -> str:
     """Return the ``agent:<ns>`` namespace prefix for a session key.
 
@@ -1132,12 +1155,22 @@ def build_session_key(
         if source.platform == Platform.SLACK and source.scope_id
         else None
     )
+    # Multi-instance adapters, such as multiple Feishu apps, append the
+    # concrete adapter id so colliding app-scoped chat/user ids cannot share
+    # an agent cache or transcript (#68046).
+    adapter_id_part = None
+    _adapter_id = str(getattr(source, "adapter_id", "") or "").strip()
+    if _adapter_id and _adapter_id != platform:
+        adapter_id_part = f"adapter={_adapter_id.replace('%', '%25').replace(':', '%3A')}"
     if source.chat_type == "dm":
         dm_chat_id = source.chat_id
         if source.platform == Platform.WHATSAPP:
             dm_chat_id = canonical_whatsapp_identifier(source.chat_id)
 
-        dm_parts = [ns, platform, "dm"]
+        dm_parts = [ns, platform]
+        if adapter_id_part:
+            dm_parts.append(adapter_id_part)
+        dm_parts.append("dm")
         if slack_scope_id:
             dm_parts.append(slack_scope_id)
         if dm_chat_id:
@@ -1189,7 +1222,10 @@ def build_session_key(
     chat_type_slot = source.chat_type
     if source.prospective_thread_id and not source.thread_id:
         chat_type_slot = "thread"
-    key_parts = [ns, platform, chat_type_slot]
+    key_parts = [ns, platform]
+    if adapter_id_part:
+        key_parts.append(adapter_id_part)
+    key_parts.append(chat_type_slot)
 
     if slack_scope_id:
         key_parts.append(slack_scope_id)
@@ -3322,6 +3358,9 @@ class SessionStore:
         session_key: str,
         expected_session_id: str,
         target_session_id: str,
+        *,
+        allow_cross_adapter: bool = False,
+        expected_adapter_id: Optional[str] = None,
     ) -> Optional[SessionEntry]:
         """CAS-advance one route along an already-verified compression lineage.
 
@@ -3339,6 +3378,16 @@ class SessionStore:
             entry = self._entries.get(session_key)
             if entry is None:
                 return None
+            # #64934 cross-adapter sew guard (mirrors switch_session).
+            if expected_adapter_id and not allow_cross_adapter:
+                _key_adapter = _adapter_id_from_key(session_key)
+                if _key_adapter and _key_adapter != expected_adapter_id:
+                    logger.warning(
+                        "advance_compression_session refused: key adapter %s != "
+                        "expected %s (#64934 cross-adapter sew guard); key=%s",
+                        _key_adapter, expected_adapter_id, session_key,
+                    )
+                    return None
             if entry.session_id == target_session_id:
                 return entry
             if entry.session_id != expected_session_id:
@@ -3353,7 +3402,14 @@ class SessionStore:
             self._save()
             return entry
 
-    def switch_session(self, session_key: str, target_session_id: str) -> Optional[SessionEntry]:
+    def switch_session(
+        self,
+        session_key: str,
+        target_session_id: str,
+        *,
+        allow_cross_adapter: bool = False,
+        expected_adapter_id: Optional[str] = None,
+    ) -> Optional[SessionEntry]:
         """Switch a session key to point at an existing session ID.
 
         Used by ``/resume`` to restore a previously-named session.
@@ -3376,6 +3432,20 @@ class SessionStore:
             # Don't switch if already on that session
             if old_entry.session_id == target_session_id:
                 return old_entry
+            # #64934 cross-adapter sew guard: refuse to re-point a routing key
+            # onto a session owned by a different adapter unless the caller
+            # explicitly opts in (CLI continuity is the one intentional case).
+            # The key→id layer must honor the per-adapter isolation the key
+            # layer already encodes, or #68046's key isolation is bypassed.
+            if expected_adapter_id and not allow_cross_adapter:
+                _key_adapter = _adapter_id_from_key(session_key)
+                if _key_adapter and _key_adapter != expected_adapter_id:
+                    logger.warning(
+                        "switch_session refused: key adapter %s != expected %s "
+                        "(#64934 cross-adapter sew guard); key=%s",
+                        _key_adapter, expected_adapter_id, session_key,
+                    )
+                    return None
 
             db_end_session_id = old_entry.session_id
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -66,7 +66,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Literal, Optional, Sequence
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
@@ -466,6 +466,8 @@ RejectReason = Literal[
     "bots_disabled",
     "bot_not_mentioned",
     "group_policy_rejected",
+    "dm_policy_rejected",
+    "bot_loop_prevented",
 ]
 
 
@@ -1322,16 +1324,86 @@ def _strip_edge_self_mentions(
             return remaining
 
 
+class _ThreadSafeWsLoopProxy:
+    """Race-free stand-in for lark_oapi.ws.client's module-level ``loop``.
+
+    The SDK's Client.start/_connect/_ping_loop/_receive_message_loop all read
+    a single shared ``loop`` module global to call ``.create_task()`` /
+    ``.run_until_complete()``. With multi-profile routing, each profile runs
+    its own WS client in its own thread with its own event loop, and used to
+    overwrite that shared global on every (re)connect (see
+    ``ws_client_module.loop = loop`` below). Two profiles reconnecting close
+    together would stomp on each other's ``loop`` global mid-flight, so
+    ``create_task`` calls would schedule a task onto the wrong profile's
+    event loop and raise ``RuntimeError: ... attached to a different loop``.
+
+    Installed once as a singleton (idempotent even if raced), this proxy
+    carries no mutable state itself — every call resolves the loop that is
+    actually executing right now, which is inherently thread-safe:
+    ``asyncio.get_running_loop()`` for ``create_task`` (always called from
+    within a coroutine already running on the correct loop) and
+    ``asyncio.get_event_loop()`` for the synchronous ``run_until_complete``
+    entrypoint (asyncio keeps that thread-local already).
+    """
+
+    @staticmethod
+    def create_task(coro: Any) -> "asyncio.Task":
+        return asyncio.get_event_loop().create_task(coro)
+
+    @staticmethod
+    def run_until_complete(coro: Any) -> Any:
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+
+_WS_LOOP_PROXY = _ThreadSafeWsLoopProxy()
+
+# Per-thread ping_interval/ping_timeout overrides for the websockets.connect
+# monkeypatch below. Using threading.local() (rather than swapping the
+# shared ws_client_module.websockets.connect attribute per profile thread,
+# as before) avoids the analogous race: concurrent profile threads used to
+# save/restore each other's "original" connect function, so whichever
+# profile connected or reconnected last silently overwrote the ping
+# settings applied to every other profile's subsequent connects.
+_ws_connect_overrides = threading.local()
+_ws_connect_patch_lock = threading.Lock()
+_ws_original_connect: Optional[Callable[..., Any]] = None
+
+
+def _threadsafe_ws_connect(*args: Any, **kwargs: Any) -> Any:
+    ping_interval = getattr(_ws_connect_overrides, "ping_interval", None)
+    ping_timeout = getattr(_ws_connect_overrides, "ping_timeout", None)
+    if ping_interval is not None and "ping_interval" not in kwargs:
+        kwargs["ping_interval"] = ping_interval
+    if ping_timeout is not None and "ping_timeout" not in kwargs:
+        kwargs["ping_timeout"] = ping_timeout
+    assert _ws_original_connect is not None
+    return _ws_original_connect(*args, **kwargs)
+
+
+def _ensure_ws_connect_patched(ws_client_module: Any) -> None:
+    """Idempotently install the thread-safe connect wrapper (once, ever)."""
+    global _ws_original_connect
+    if ws_client_module.websockets.connect is _threadsafe_ws_connect:
+        return
+    with _ws_connect_patch_lock:
+        if ws_client_module.websockets.connect is _threadsafe_ws_connect:
+            return
+        _ws_original_connect = ws_client_module.websockets.connect
+        ws_client_module.websockets.connect = _threadsafe_ws_connect
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     """Run the official Lark WS client in its own thread-local event loop."""
     import lark_oapi.ws.client as ws_client_module
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    ws_client_module.loop = loop
+    # Singleton proxy, not a fresh loop object — safe to assign from every
+    # profile thread without synchronization. See _ThreadSafeWsLoopProxy.
+    ws_client_module.loop = _WS_LOOP_PROXY
+    _ensure_ws_connect_patched(ws_client_module)
     adapter._ws_thread_loop = loop
 
-    original_connect = ws_client_module.websockets.connect
     original_configure = getattr(ws_client, "_configure", None)
 
     def _apply_runtime_ws_overrides() -> None:
@@ -1343,13 +1415,6 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         except Exception:
             logger.debug("[Feishu] Failed to apply websocket runtime overrides", exc_info=True)
 
-    def _connect_with_overrides(*args: Any, **kwargs: Any) -> Any:
-        if adapter._ws_ping_interval is not None and "ping_interval" not in kwargs:
-            kwargs["ping_interval"] = adapter._ws_ping_interval
-        if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
-            kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        return original_connect(*args, **kwargs)
-
     def _configure_with_overrides(conf: Any) -> Any:
         if original_configure is None:
             raise RuntimeError("Feishu _configure_with_overrides called but original_configure is None")
@@ -1357,7 +1422,10 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         _apply_runtime_ws_overrides()
         return result
 
-    ws_client_module.websockets.connect = _connect_with_overrides
+    # Thread-local, not a shared global swap — this profile's ping settings
+    # can never leak into another profile's concurrent (re)connect.
+    _ws_connect_overrides.ping_interval = adapter._ws_ping_interval
+    _ws_connect_overrides.ping_timeout = adapter._ws_ping_timeout
     if original_configure is not None:
         setattr(ws_client, "_configure", _configure_with_overrides)
     _apply_runtime_ws_overrides()
@@ -1366,7 +1434,8 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     except Exception:
         pass
     finally:
-        ws_client_module.websockets.connect = original_connect
+        _ws_connect_overrides.ping_interval = None
+        _ws_connect_overrides.ping_timeout = None
         if original_configure is not None:
             setattr(ws_client, "_configure", original_configure)
         pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
@@ -1524,7 +1593,16 @@ class FeishuAdapter(BasePlatformAdapter):
         self._event_handler: Optional[Any] = None
         self._seen_message_ids: Dict[str, float] = {}  # message_id → seen_at (time.time())
         self._seen_message_order: List[str] = []
-        self._dedup_state_path = get_hermes_home() / "feishu_seen_message_ids.json"
+        # Per-app dedup state. In a multi-app config (feishu.apps[]), each
+        # FeishuAdapter is a separate bot that independently receives the same
+        # group message_id. Sharing one JSON file made concurrent
+        # _persist_seen_message_ids() calls clobber each other (last-writer-
+        # wins) and let one app's seen-set silently suppress another's after a
+        # restart. Namespacing by app_id gives each bot its own file; an empty
+        # app_id (single-app mode / tests) falls back to the legacy path.
+        _app_ns = re.sub(r"[^A-Za-z0-9_-]", "", self._app_id or "")
+        _dedup_name = f"feishu_seen_message_ids_{_app_ns}.json" if _app_ns else "feishu_seen_message_ids.json"
+        self._dedup_state_path = get_hermes_home() / _dedup_name
         self._dedup_lock = threading.Lock()
         self._sender_name_cache: Dict[str, tuple[str, float]] = {}  # sender_id → (name, expire_at)
         self._webhook_rate_counts: Dict[str, tuple[int, float]] = {}  # rate_key → (count, window_start)
@@ -1541,6 +1619,9 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
+        # chat_id → (fetched_at, members list). Group membership changes
+        # infrequently; a TTL avoids refetching on every agent tool call.
+        self._chat_members_cache: Dict[str, tuple] = {}
         self._message_text_cache: "OrderedDict[str, Optional[str]]" = OrderedDict()
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
@@ -1556,10 +1637,89 @@ class FeishuAdapter(BasePlatformAdapter):
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        # Clarify button state (clarify_id → {session_key, message_id, chat_id})
+        self._clarify_state: Dict[str, Dict[str, str]] = {}
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
         self._load_seen_message_ids()
+        # Peer bot registry for bot-to-bot @mention (text-based fallback).
+        # Loaded from feishu_peer_bots.json in HERMES_HOME. Each adapter finds
+        # its own entry by app_id and uses the name+aliases for text @mention
+        # matching in _mentions_self().
+        self._bot_aliases: List[str] = []
+        self._peer_mention_map: Dict[str, str] = {}
+        # peer profile indices for bot-to-bot internal routing (Feishu doesn't
+        # deliver bot→bot messages, so the gateway routes @-mentions itself).
+        self._peer_profile_by_openid: Dict[str, str] = {}
+        self._peer_profile_by_name: Dict[str, str] = {}
+        # profile → canonical display name (for the group-chat colleague hint)
+        self._peer_canonical_by_profile: Dict[str, str] = {}
+        # Runner-injected async router; None = bot-to-bot routing disabled.
+        self._bot_to_bot_router: Optional[Callable] = None
+        # (sender_profile, reply_hop) set when a bot-to-bot synthetic triggers
+        # this adapter's turn; the next send auto-routes the reply back to the
+        # sender (bidirectional). hop increments to bound ping-pong loops.
+        self._bot_to_bot_reply_profile: Optional[tuple] = None
+        self._load_peer_bot_registry()
+        # Bot-to-bot loop prevention: track timestamps of bot-originated
+        # messages per (chat_id, sender_bot) pair. Each individual bot gets
+        # its own budget so normal multi-bot collaboration (6 bots each
+        # replying in the same window) is not penalised, while a single
+        # bot stuck in a self-feeding loop is still caught.
+        self._bot_interaction_history: Dict[tuple[str, str], List[float]] = {}
+        self._BOT_INTERACTION_LIMIT = int(
+            os.getenv("FEISHU_BOT_INTERACTION_LIMIT", "20")
+        )
+        self._BOT_INTERACTION_WINDOW = int(
+            os.getenv("FEISHU_BOT_INTERACTION_WINDOW", "60")
+        )
+
+    def _load_peer_bot_registry(self) -> None:
+        """Load peer bot registry: own aliases for inbound matching, plus the
+        full peer list for outbound @mention construction."""
+        try:
+            registry_path = get_hermes_home() / "feishu_peer_bots.json"
+            if not registry_path.exists():
+                return
+            with open(registry_path) as f:
+                data = json.load(f)
+            for entry in data.get("bots", []):
+                if entry.get("app_id") == self._app_id:
+                    self._bot_aliases = [
+                        a for a in entry.get("aliases", []) if a
+                    ]
+                    canonical = entry.get("name", "")
+                    if canonical and canonical not in self._bot_aliases:
+                        self._bot_aliases.append(canonical)
+                    break
+            # Build peer list (excluding self) for outbound @mention injection.
+            # Map: lowercase alias/name → open_id. On conflict, first entry wins.
+            self._peer_mention_map: Dict[str, str] = {}
+            self._peer_profile_by_openid: Dict[str, str] = {}
+            self._peer_profile_by_name: Dict[str, str] = {}
+            self._peer_canonical_by_profile: Dict[str, str] = {}
+            for entry in data.get("bots", []):
+                if entry.get("app_id") == self._app_id:
+                    continue
+                open_id = entry.get("open_id", "")
+                profile = str(entry.get("profile", "") or "").strip()
+                canonical = str(entry.get("name", "") or "").strip()
+                if not open_id:
+                    continue
+                if profile:
+                    self._peer_profile_by_openid[open_id] = profile
+                    if canonical:
+                        self._peer_canonical_by_profile[profile] = canonical
+                names = [entry.get("name", "")] + entry.get("aliases", [])
+                for name in names:
+                    name = name.strip()
+                    if name and name.lower() not in self._peer_mention_map:
+                        self._peer_mention_map[name.lower()] = open_id
+                        if profile:
+                            self._peer_profile_by_name[name.lower()] = profile
+        except Exception:
+            logger.debug("[Feishu] Failed to load peer bot registry", exc_info=True)
 
     @staticmethod
     def _load_settings(extra: Dict[str, Any]) -> FeishuAdapterSettings:
@@ -1956,6 +2116,12 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        # Synthetic bot-to-bot events use "bot2bot-xxx" message_ids that Feishu
+        # rejects as reply_to (error 99992354) — strip them so the response
+        # posts as a standalone message instead of failing entirely.
+        if reply_to and str(reply_to).startswith("bot2bot-"):
+            reply_to = None
+
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         # When chunking splits a long markdown response, an individual chunk
@@ -2007,10 +2173,85 @@ class FeishuAdapter(BasePlatformAdapter):
                     )
                 last_response = response
 
-            return self._finalize_send_result(last_response, "send failed")
+            result = self._finalize_send_result(last_response, "send failed")
+            # Bot-to-bot internal routing: Feishu doesn't deliver bot→bot
+            # messages, so if this outbound @-mentioned a peer bot, dispatch
+            # to the runner-injected router for direct injection into the peer.
+            if result.success and self._bot_to_bot_router is not None:
+                _targets = self._parse_peer_mention_targets(content)
+                _reply_hop = 0
+                _reply = getattr(self, "_bot_to_bot_reply_profile", None)
+                logger.debug(
+                    "[Feishu] send hook READ reply_profile: adapter_id=%s reply=%s",
+                    getattr(self, "adapter_id", "?"), _reply,
+                )
+                if _reply:
+                    _reply_profile, _reply_hop = _reply
+                    if _reply_profile and _reply_profile not in [t[0] for t in _targets]:
+                        _targets = _targets + [(_reply_profile, _reply_profile)]
+                self._bot_to_bot_reply_profile = None  # one-shot per synthetic turn
+                logger.debug(
+                    "[Feishu] send hook: peer targets=%s reply_hop=%d content=%r",
+                    _targets, _reply_hop, content[:150],
+                )
+                if _targets:
+                    # p2p fallback: a peer @-mentioned in a DM can't be in that
+                    # DM, so the peer's reply would 230002 ("Bot/User can NOT be
+                    # out of the chat"). Reroute the injection to the configured
+                    # fallback group, where all colleagues are members.
+                    _route_chat_id = chat_id
+                    _cfg_extra = getattr(getattr(self, "config", None), "extra", None) or {}
+                    _fallback_chat = _cfg_extra.get("peer_routing_fallback_chat", "") or ""
+                    if _fallback_chat:
+                        # get_chat_info never raises — on lookup failure it
+                        # returns {"type": "dm"}, the safe default for "only
+                        # reroute on DM" (worst case: a misread group gets
+                        # rerouted to a group where peers are still reachable).
+                        _info = await self.get_chat_info(chat_id)
+                        if _info.get("type") == "dm":
+                            _route_chat_id = _fallback_chat
+                            logger.info(
+                                "[Feishu] p2p @peer → rerouting bot-to-bot to fallback chat %s",
+                                _fallback_chat,
+                            )
+                    try:
+                        asyncio.create_task(
+                            self._bot_to_bot_router(
+                                _targets,
+                                content,
+                                _route_chat_id,
+                                self,
+                                hop=_reply_hop,
+                                thread_id=(metadata or {}).get("thread_id"),
+                                anchor_message_id=getattr(result, "message_id", None),
+                            )
+                        )
+                    except Exception:
+                        logger.debug(
+                            "[Feishu] bot-to-bot router dispatch failed", exc_info=True
+                        )
+            return result
         except Exception as exc:
             logger.error("[Feishu] Send error: %s", exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    async def _on_send_dead_letter(self, chat_id, content, result) -> None:
+        """Forward a permanently-failed send to the configured dead-letter
+        group via the runner-injected forwarder (which emits from the default
+        adapter — all colleagues are members of the dead-letter group, so the
+        forward itself won't 230002). No-op when unconfigured or before the
+        runner has injected ``_dead_letter_forwarder``."""
+        _cfg_extra = getattr(getattr(self, "config", None), "extra", None) or {}
+        _dead_letter_chat = _cfg_extra.get("send_failure_dead_letter_chat", "") or ""
+        if not _dead_letter_chat:
+            return
+        _forwarder = getattr(self, "_dead_letter_forwarder", None)
+        if not callable(_forwarder):
+            return
+        try:
+            await _forwarder(self, chat_id, content, getattr(result, "error", "") or "")
+        except Exception:
+            logger.warning("[Feishu] dead-letter forward failed", exc_info=True)
 
     async def edit_message(
         self,
@@ -2236,6 +2477,133 @@ class FeishuAdapter(BasePlatformAdapter):
         tmp_path.write_text(answer, encoding="utf-8")
         tmp_path.replace(response_path)
 
+    # ------------------------------------------------------------------
+    # Clarify — interactive card with one button per choice
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_clarify_card(
+        *,
+        question: str,
+        choices: List[str],
+        clarify_id: str,
+    ) -> Dict[str, Any]:
+        """Build raw card JSON for a multi-choice clarify prompt.
+
+        One button per choice carries ``hermes_clarify_action`` and the
+        ``clarify_id`` so ``_on_card_action_trigger`` can route the callback.
+        A final ``other`` button flips the entry to text-capture mode.
+        """
+        def _btn(label: str, action_value: dict, btn_type: str = "default") -> dict:
+            return {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": label},
+                "type": btn_type,
+                "value": action_value,
+            }
+
+        actions: List[dict] = []
+        for idx, choice in enumerate(choices):
+            actions.append(_btn(
+                str(choice)[:20],  # Feishu button label cap
+                {"hermes_clarify_action": str(idx), "clarify_id": clarify_id},
+            ))
+        actions.append(_btn(
+            "✏️ 其他（手打）",
+            {"hermes_clarify_action": "other", "clarify_id": clarify_id},
+        ))
+
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "❓ " + question[:100], "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": [
+                {"tag": "markdown", "content": question},
+                {"tag": "action", "actions": actions},
+            ],
+        }
+
+    @staticmethod
+    def _build_resolved_clarify_card(
+        *,
+        response: str,
+        user_name: str,
+    ) -> Dict[str, Any]:
+        """Build raw card JSON for a resolved clarify choice."""
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "✅ 已选择", "tag": "plain_text"},
+                "template": "green",
+            },
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": f"**{response}** — by {user_name}",
+                },
+            ],
+        }
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a clarify prompt as a Feishu interactive card.
+
+        Multi-choice mode (``choices`` non-empty): renders one button per
+        option plus a final "Other" button.  Button callbacks resolve via
+        ``tools.clarify_gateway.resolve_gateway_clarify(clarify_id, response)``.
+
+        Open-ended mode (``choices`` empty): renders the question as plain
+        text and enables text-capture so the gateway intercept catches the
+        next user message.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        # Open-ended: fall back to base class text rendering.
+        if not choices:
+            from tools.clarify_gateway import mark_awaiting_text
+            mark_awaiting_text(clarify_id)
+            text = f"❓ {question}"
+            return await self.send(
+                chat_id=chat_id, content=text, metadata=metadata,
+            )
+
+        try:
+            card = self._build_clarify_card(
+                question=question,
+                choices=list(choices),
+                clarify_id=clarify_id,
+            )
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+
+            result = self._finalize_send_result(response, "send_clarify failed")
+            if result.success:
+                self._clarify_state[clarify_id] = {
+                    "session_key": session_key,
+                    "message_id": result.message_id or "",
+                    "chat_id": chat_id,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_clarify failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
     async def send_voice(
         self,
         chat_id: str,
@@ -2457,6 +2825,79 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception:
             logger.warning("[Feishu] Failed to get chat info for %s", chat_id, exc_info=True)
             return fallback
+
+    async def get_chat_members(
+        self, chat_id: str, member_id_type: str = "open_id"
+    ) -> List[Dict[str, str]]:
+        """Return group member list as [{name, member_id, id_type}, ...].
+
+        Lets the agent resolve who is in a chat (with their open_id) so it can
+        @ specific people. The lark SDK exposes this via
+        ``client.im.v1.chat_members.get`` (``GetChatMembersRequest``). Returns
+        ``[]`` on any failure — callers should treat an empty list as "unable
+        to fetch" (commonly a missing ``im:chat.member:read`` scope on the app,
+        which must be granted and the app version published).
+        """
+        # Cache first — a cached hit serves without the client, so a transient
+        # client outage still returns recent membership.
+        now = time.time()
+        cached = self._chat_members_cache.get(chat_id)
+        if cached and now - cached[0] < 300:
+            return list(cached[1])
+
+        if not self._client or not chat_id:
+            return []
+
+        try:
+            from lark_oapi.api.im.v1 import GetChatMembersRequest
+
+            all_members: List[Dict[str, str]] = []
+            page_token: Optional[str] = None
+            while True:
+                builder = (
+                    GetChatMembersRequest.builder()
+                    .chat_id(chat_id)
+                    .member_id_type(member_id_type)
+                    .page_size(100)
+                )
+                if page_token:
+                    builder = builder.page_token(page_token)
+                request = builder.build()
+                response = await self._run_blocking(
+                    self._client.im.v1.chat_members.get, request
+                )
+                if not response or getattr(response, "success", lambda: False)() is False:
+                    code = getattr(response, "code", "unknown")
+                    msg = getattr(response, "msg", "members lookup failed")
+                    logger.warning(
+                        "[Feishu] Failed to get chat members for %s: [%s] %s "
+                        "(empty list returned — if code is a permission error, grant "
+                        "im:chat.member:read and publish a new app version)",
+                        chat_id, code, msg,
+                    )
+                    return all_members
+
+                data = getattr(response, "data", None)
+                items = getattr(data, "items", None) or []
+                for _m in items:
+                    all_members.append({
+                        "name": str(getattr(_m, "name", "") or ""),
+                        "member_id": str(getattr(_m, "member_id", "") or ""),
+                        "id_type": str(getattr(_m, "member_id_type", "") or member_id_type),
+                    })
+                if not getattr(data, "has_more", False):
+                    break
+                page_token = getattr(data, "page_token", None)
+                if not page_token:
+                    break
+
+            self._chat_members_cache[chat_id] = (now, all_members)
+            return list(all_members)
+        except Exception:
+            logger.warning(
+                "[Feishu] Failed to get chat members for %s", chat_id, exc_info=True
+            )
+            return []
 
     def format_message(self, content: str) -> str:
         """Feishu text messages are plain text by default."""
@@ -2734,11 +3175,21 @@ class FeishuAdapter(BasePlatformAdapter):
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
         )
+        clarify_action = (
+            action_value.get("hermes_clarify_action")
+            if isinstance(action_value, dict) else None
+        )
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
+                event=event,
+                action_value=action_value,
+                loop=loop,
+            )
+        if clarify_action is not None:
+            return self._handle_clarify_card_action(
                 event=event,
                 action_value=action_value,
                 loop=loop,
@@ -2985,6 +3436,127 @@ class FeishuAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error("Failed to resolve Feishu update prompt: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Clarify card-action handler + resolver
+    # ------------------------------------------------------------------
+
+    def _handle_clarify_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Schedule clarify resolution and build the synchronous callback response."""
+        clarify_id = action_value.get("clarify_id")
+        if not clarify_id:
+            logger.debug("[Feishu] Card action missing clarify_id, ignoring")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        state = self._clarify_state.get(clarify_id)
+        if not state:
+            logger.debug("[Feishu] Clarify %s already resolved or unknown", clarify_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        action = str(action_value.get("hermes_clarify_action", "") or "")
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
+        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+            logger.warning("[Feishu] Unauthorized clarify click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if callback_chat_id and expected_chat_id and callback_chat_id != expected_chat_id:
+            logger.warning(
+                "[Feishu] Clarify callback chat mismatch for %s (expected=%s, got=%s)",
+                clarify_id, expected_chat_id, callback_chat_id,
+            )
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        # "other" → text-capture mode: flip the entry, don't pop state.
+        if action == "other":
+            if not self._submit_on_loop(
+                loop,
+                self._handle_clarify_other(clarify_id),
+            ):
+                return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+            # Return a toast-like card telling user to type their answer.
+            if P2CardActionTriggerResponse is None:
+                return None
+            response = P2CardActionTriggerResponse()
+            return response
+
+        user_name = self._get_cached_sender_name(open_id) or open_id
+        if not self._submit_on_loop(
+            loop,
+            self._resolve_clarify(
+                clarify_id,
+                action,
+                user_name,
+                open_id=open_id,
+                chat_id=callback_chat_id,
+            ),
+        ):
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        return P2CardActionTriggerResponse()
+
+    async def _handle_clarify_other(self, clarify_id: str) -> None:
+        """Flip a clarify entry into text-capture mode for free-form answers."""
+        from tools.clarify_gateway import mark_awaiting_text
+        mark_awaiting_text(clarify_id)
+
+    async def _resolve_clarify(
+        self,
+        clarify_id: str,
+        action: str,
+        user_name: str,
+        *,
+        open_id: str = "",
+        chat_id: str = "",
+    ) -> None:
+        """Pop clarify state and unblock the waiting agent thread."""
+        state = self._clarify_state.get(clarify_id)
+        if not state:
+            logger.debug("[Feishu] Clarify %s already resolved or unknown", clarify_id)
+            return
+        if not self._is_interactive_operator_authorized(open_id):
+            logger.warning("[Feishu] Unauthorized clarify click by %s for %s", open_id or "<unknown>", clarify_id)
+            return
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if expected_chat_id and chat_id and expected_chat_id != chat_id:
+            logger.warning(
+                "[Feishu] Clarify %s chat mismatch (expected=%s, got=%s)",
+                clarify_id, expected_chat_id, chat_id,
+            )
+            return
+        state = self._clarify_state.pop(clarify_id, None)
+        if not state:
+            logger.debug("[Feishu] Clarify %s already resolved while validating callback", clarify_id)
+            return
+
+        # For choice buttons, the action is the numeric index of the choice.
+        # Look up the entry to resolve with the actual choice text.
+        from tools.clarify_gateway import resolve_gateway_clarify, _entries, _lock
+
+        response_text = action
+        with _lock:
+            entry = _entries.get(clarify_id)
+            if entry and entry.choices:
+                try:
+                    idx = int(action)
+                    if 0 <= idx < len(entry.choices):
+                        response_text = str(entry.choices[idx])
+                except (ValueError, TypeError):
+                    response_text = action
+
+        try:
+            resolved = resolve_gateway_clarify(clarify_id, response_text)
+            logger.info(
+                "Feishu clarify button resolved for session %s (response=%s, user=%s, resolved=%s)",
+                state["session_key"], response_text, user_name, resolved,
+            )
+        except Exception as exc:
+            logger.error("Failed to resolve gateway clarify from Feishu button: %s", exc)
 
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""
@@ -3386,6 +3958,15 @@ class FeishuAdapter(BasePlatformAdapter):
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
         )
+        _channel_prompt = self._resolve_channel_prompt(chat_id, thread_id or None)
+        # Inject peer colleague hint in BOTH group and DM — bots need to know
+        # their colleagues exist even when a user asks in a private chat.
+        _peer_hint = self._build_peer_colleague_hint()
+        if _peer_hint:
+            _channel_prompt = (
+                f"{_channel_prompt}\n{_peer_hint}" if _channel_prompt else _peer_hint
+            )
+            logger.debug("[Feishu] Injected peer colleague hint into %s channel_prompt for %s", chat_type, chat_id)
         normalized = MessageEvent(
             text=text,
             message_type=inbound_type,
@@ -3396,7 +3977,7 @@ class FeishuAdapter(BasePlatformAdapter):
             media_types=media_types,
             reply_to_message_id=reply_to_message_id,
             reply_to_text=reply_to_text,
-            channel_prompt=self._resolve_channel_prompt(chat_id, thread_id or None),
+            channel_prompt=_channel_prompt,
             timestamp=datetime.now(),
         )
         await self._dispatch_inbound_event(normalized)
@@ -4364,6 +4945,30 @@ class FeishuAdapter(BasePlatformAdapter):
             # Defensive: pre-hydration or malformed payloads.
             if not self_ids or not sender_ids:
                 return "self_ids_unknown"
+            # Bot-to-bot loop prevention: track recent messages per
+            # (chat_id, sender_bot) pair. Each bot gets its own budget so
+            # normal multi-bot collaboration is not penalised, while a single
+            # bot stuck in a self-feeding loop is caught.
+            if is_group:
+                now_ts = time.time()
+                # Use the first available sender ID as the bot key.
+                sender_key = next(iter(sender_ids), "") or ""
+                hist_key = (chat_id, sender_key)
+                bot_history = self._bot_interaction_history.get(hist_key, [])
+                # Prune entries outside the window.
+                bot_history = [
+                    t for t in bot_history
+                    if now_ts - t < self._BOT_INTERACTION_WINDOW
+                ]
+                if len(bot_history) >= self._BOT_INTERACTION_LIMIT:
+                    logger.warning(
+                        "[Feishu] Bot interaction limit reached for chat %s "
+                        "sender %s (%d in %ds), dropping bot message to prevent loop.",
+                        chat_id, sender_key, len(bot_history), self._BOT_INTERACTION_WINDOW,
+                    )
+                    return "bot_loop_prevented"
+                bot_history.append(now_ts)
+                self._bot_interaction_history[hist_key] = bot_history
             # Step 4 covers mention enforcement for groups when require_mention
             # is on; check here only on paths step 4 won't reach.
             if mode == "mentions" and not require_mention and not self._mentions_self(message):
@@ -4458,7 +5063,36 @@ class FeishuAdapter(BasePlatformAdapter):
             mentions=getattr(message, "mentions", None),
             bot=self._bot_identity(),
         )
-        return self._post_mentions_bot(normalized.mentions)
+        if self._post_mentions_bot(normalized.mentions):
+            return True
+        # Text-based @mention fallback for bot-to-bot communication.
+        # When a peer bot sends a text message containing "@BotName" or an
+        # alias, the Feishu API does not populate the structured mentions[]
+        # array (only the native client UI does). Match against this bot's
+        # hydrated name and configured aliases so the message passes the
+        # require_mention gate.
+        return self._text_mentions_self(raw_content)
+
+    def _text_mentions_self(self, raw_content: str) -> bool:
+        """Check if raw text content contains @mention of this bot by name/alias."""
+        if not raw_content or not self._bot_aliases:
+            return False
+        # Strip JSON wrapper to get the actual text for plain text messages.
+        text = raw_content
+        try:
+            parsed = json.loads(raw_content)
+            if isinstance(parsed, dict) and "text" in parsed:
+                text = parsed["text"]
+        except (json.JSONDecodeError, TypeError):
+            pass
+        for alias in self._bot_aliases:
+            if not alias:
+                continue
+            # Match "@alias" at word boundary — handles "@Alex", "@架构师", etc.
+            at_alias = f"@{alias}"
+            if at_alias in text:
+                return True
+        return False
 
     def _message_mentions_bot(self, mentions: List[Any]) -> bool:
         # IDs trump names: when both sides have open_id (or both user_id),
@@ -4640,6 +5274,15 @@ class FeishuAdapter(BasePlatformAdapter):
     def _build_outbound_payload(
         self, content: str, *, prefer_post: bool = False,
     ) -> tuple[str, str]:
+        # Peer @mention injection takes priority over plain markdown: agent
+        # output typically contains markdown formatting, so the markdown
+        # branch below would fire first and the <at> injection would never
+        # run. Check for peer mentions first so both structured mentions
+        # (for bot-to-bot communication) and markdown rendering work.
+        if self._peer_mention_map:
+            injected = self._inject_peer_mentions(content)
+            if injected is not None:
+                return "post", injected
         # Empirically (issue #52786), current Feishu clients render markdown
         # tables inside ``post``-type ``md`` elements natively. The previous
         # table-downgrade branch forced any table-containing message to
@@ -4655,6 +5298,166 @@ class FeishuAdapter(BasePlatformAdapter):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
+
+    # Pattern to match @Name at start of content or after whitespace/newline.
+    # Avoids matching emails or code paths. Excludes trailing punctuation
+    # (both ASCII and CJK) so "@Alex, help" matches "Alex" not "Alex,".
+    _PEER_MENTION_RE = re.compile(
+        r"(?:^|(?<=\s))@([^\s@<\[\{\(，。！？；：、）】》]+)"
+    )
+
+    @staticmethod
+    def _code_spans(content: str) -> List[tuple[int, int]]:
+        """Return (start, end) offsets of fenced code blocks in *content*.
+
+        Used to suppress @mention injection inside ```` ``` ```` fenced blocks
+        so that ```` ```python \n @decorator \n ``` ```` is not mistaken for
+        a peer mention.
+        """
+        spans: List[tuple[int, int]] = []
+        in_block = False
+        block_start = 0
+        for m in re.finditer(r"^```", content, re.MULTILINE):
+            if not in_block:
+                in_block = True
+                block_start = m.start()
+            else:
+                in_block = False
+                spans.append((block_start, m.end()))
+        return spans
+
+    def _parse_peer_mention_targets(self, content: str) -> List[tuple]:
+        """Return [(profile, matched_name), ...] for @-mentioned peer bots.
+
+        Mirrors _inject_peer_mentions' scan (_PEER_MENTION_RE + progressive
+        prefix + code-span skip) but resolves to peer profiles for the
+        gateway's internal bot-to-bot router (Feishu doesn't deliver bot→bot
+        messages). De-duplicates by profile.
+        """
+        if not self._peer_mention_map:
+            return []
+        code_spans = self._code_spans(content)
+
+        def _in_code(offset: int) -> bool:
+            return any(s <= offset < e for s, e in code_spans)
+
+        targets: List[tuple] = []
+        seen: set = set()
+        for m in self._PEER_MENTION_RE.finditer(content):
+            if _in_code(m.start()):
+                continue
+            raw_name = m.group(1).strip()
+            open_id = self._peer_mention_map.get(raw_name.lower())
+            resolved = raw_name
+            if not open_id:
+                for end in range(len(raw_name) - 1, 0, -1):
+                    candidate = raw_name[:end]
+                    oid = self._peer_mention_map.get(candidate.lower())
+                    if oid:
+                        open_id = oid
+                        resolved = candidate
+                        break
+            if not open_id:
+                continue
+            profile = (
+                self._peer_profile_by_openid.get(open_id)
+                or self._peer_profile_by_name.get(resolved.lower())
+            )
+            if profile and profile not in seen:
+                seen.add(profile)
+                targets.append((profile, resolved))
+        return targets
+
+    def _build_peer_colleague_hint(self) -> str:
+        """List peer bot colleagues so the agent knows whom it can @.
+
+        Injected into group-chat channel_prompt. Without this the agent has no
+        way to discover its colleagues, so it would never @ them — and the
+        bot-to-bot internal router (send hook) would never fire. The hint is
+        stable (derived from feishu_peer_bots.json), so it doesn't destabilize
+        per-session prompt caching.
+        """
+        peers = getattr(self, "_peer_canonical_by_profile", None) or {}
+        logger.debug(
+            "[Feishu] _build_peer_colleague_hint: peers=%d app_id=%s",
+            len(peers), getattr(self, "_app_id", "?"),
+        )
+        if not peers:
+            return ""
+        names = list(peers.values())
+        return (
+            "[你的同事，可 @ 提及协作（gateway 会把 @同事 的消息内部路由给他们，"
+            "飞书本身不投递 bot→bot 消息）。"
+            "需要同事参与时，在群里 @他们进行可见讨论，不要用 delegation/subagent 委托（对其他人不可见）。"
+            "回复同事时务必 @对方，否则对方收不到你的消息。] "
+            + "、".join(f"@{n}" for n in names)
+        )
+
+    def _inject_peer_mentions(self, content: str) -> Optional[str]:
+        """Scan content for @peer_alias patterns and build a post payload with
+        Feishu <at> elements. Returns None if no peer mentions found.
+
+        Mentions inside fenced code blocks are skipped. Falls back to
+        progressively shorter prefixes if the full match fails, so
+        "@架构师Alex" still resolves when only "架构师" is registered but
+        "架构师Alex" is not.
+        """
+        code_spans = self._code_spans(content)
+
+        def _in_code(offset: int) -> bool:
+            return any(s <= offset < e for s, e in code_spans)
+
+        mentions_found: List[tuple[int, int, str, str]] = []
+        # (match_start, match_end, name, open_id)
+        for m in self._PEER_MENTION_RE.finditer(content):
+            if _in_code(m.start()):
+                continue
+            raw_name = m.group(1).strip()
+            # Try full name first, then progressively shorter prefixes
+            # (e.g. "架构师Alex" -> "架构师" if only the latter is registered)
+            open_id = self._peer_mention_map.get(raw_name.lower())
+            resolved_name = raw_name
+            if not open_id:
+                for end in range(len(raw_name) - 1, 0, -1):
+                    candidate = raw_name[:end]
+                    oid = self._peer_mention_map.get(candidate.lower())
+                    if oid:
+                        open_id = oid
+                        resolved_name = candidate
+                        break
+            if open_id:
+                # match_start/end covers only "@resolved_name" — the rest
+                # of raw_name (e.g. "Alex" after "@架构师") stays in the
+                # following text segment.
+                name_len = len(resolved_name)
+                start = m.start()
+                end = start + 1 + name_len  # +1 for the "@"
+                mentions_found.append((start, end, resolved_name, open_id))
+        if not mentions_found:
+            return None
+        # Build post rows: interleave md elements with <at> elements.
+        # Uses _build_markdown_post_rows for fenced code block isolation,
+        # so markdown rendering (bold, code blocks, tables) is preserved
+        # in the non-mention segments.
+        rows: List[List[Dict[str, str]]] = []
+        pos = 0
+        for start, end, name, open_id in mentions_found:
+            # Text before the mention — use markdown post rows so code blocks
+            # and markdown formatting in surrounding text still render.
+            before = content[pos:start]
+            if before.strip():
+                rows.extend(_build_markdown_post_rows(before))
+            # The <at> element — user_id is the bot's open_id, user_name is
+            # the display name shown in the Feishu client.
+            rows.append([{"tag": "at", "user_id": open_id, "user_name": name}])
+            pos = end
+        # Remaining text after last mention
+        remaining = content[pos:]
+        if remaining.strip():
+            rows.extend(_build_markdown_post_rows(remaining))
+        if not rows:
+            return None
+        return json.dumps({"zh_cn": {"content": rows}}, ensure_ascii=False)
 
     @staticmethod
     def _get_audio_duration_ms(file_path: str) -> int:
@@ -4823,6 +5626,12 @@ class FeishuAdapter(BasePlatformAdapter):
         effective_reply_to = reply_to
         if not effective_reply_to and metadata and metadata.get("thread_id"):
             effective_reply_to = metadata.get("reply_to_message_id")
+        # 最终防御：合成 bot2bot message_id 绝不能作为飞书 reply anchor（飞书以
+        # 99992354 拒绝）。覆盖 reply_to 参数与 metadata.reply_to_message_id 两条
+        # 来源，确保漏过上游 strip（base._reply_anchor_for_event / send / retry）时
+        # 此处兜底。
+        if effective_reply_to and str(effective_reply_to).startswith("bot2bot-"):
+            effective_reply_to = None
         reply_in_thread = bool((metadata or {}).get("thread_id"))
         if effective_reply_to:
             body = self._build_reply_message_body(
@@ -4834,34 +5643,50 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
 
-        # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
+        # 话题消息但无 reply anchor（典型场景：bot-to-bot 合成消息、会话恢复后
+        # anchor 丢失）。飞书 create 不支持 receive_id_type=thread_id，直接发
+        # chat_id 又会在话题群新建话题根。改用 thread_id 查话题内最后一条消息
+        # 作为 reply anchor，以 reply_in_thread 回到原话题。
         _thread_id = (metadata or {}).get("thread_id")
         if _thread_id:
-            body = self._build_create_message_body(
-                receive_id=_thread_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
+            _topic_anchor = await self._fetch_last_message_in_thread(_thread_id)
+            if _topic_anchor:
+                body = self._build_reply_message_body(
+                    content=payload,
+                    msg_type=msg_type,
+                    reply_in_thread=True,
+                    uuid_value=str(uuid.uuid4()),
+                )
+                request = self._build_reply_message_request(_topic_anchor, body)
+                return await self._run_blocking(self._client.im.v1.message.reply, request)
+            logger.warning(
+                "[Feishu] 话题 %s 内无可回复消息；为避免在话题群新建话题根，跳过此次发送",
+                _thread_id,
             )
-            request = self._build_create_message_request("thread_id", body)
-        else:
-            receive_id = chat_id
-            receive_id_type = "chat_id"
-            if chat_id.startswith("feishu_user_id:"):
-                receive_id = chat_id.split(":", 1)[1]
-                receive_id_type = "user_id"
-            elif chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
+            # 返回类飞书 response（success 为 callable），保持 _send_raw_message
+            # 的返回类型契约 —— 上层 _response_succeeded/_finalize_send_result 会
+            # 将其视为发送失败，而非对 bool 调用导致 TypeError 崩溃。
+            return SimpleNamespace(
+                success=lambda: False,
+                code=0,
+                msg=f"thread {_thread_id} has no anchor message; skipped to avoid creating a new topic",
+                data=None,
+            )
 
-            body = self._build_create_message_body(
-                receive_id=receive_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request(receive_id_type, body)
+        receive_id = chat_id
+        receive_id_type = "chat_id"
+        if chat_id.startswith("feishu_user_id:"):
+            receive_id = chat_id.split(":", 1)[1]
+            receive_id_type = "user_id"
+        elif chat_id.startswith("ou_"):
+            receive_id_type = "open_id"
+        body = self._build_create_message_body(
+            receive_id=receive_id,
+            msg_type=msg_type,
+            content=payload,
+            uuid_value=str(uuid.uuid4()),
+        )
+        request = self._build_create_message_request(receive_id_type, body)
         return await self._run_blocking(self._client.im.v1.message.create, request)
 
     @staticmethod
@@ -4997,7 +5822,9 @@ class FeishuAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
         last_error: Optional[Exception] = None
-        active_reply_to = reply_to
+        # Final defense: strip synthetic bot2bot reply_to at the API boundary.
+        # Feishu rejects "bot2bot-xxx" with error 99992354 (invalid message_id).
+        active_reply_to = reply_to if not (reply_to and str(reply_to).startswith("bot2bot-")) else None
         for attempt in range(_FEISHU_SEND_ATTEMPTS):
             try:
                 response = await self._send_raw_message(
@@ -5852,11 +6679,123 @@ def _apply_yaml_config(yaml_cfg: dict, feishu_cfg: dict) -> dict | None:
 
     Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
     feishu_cfg block from gateway/config.py::load_gateway_config() (allow_bots).
-    Env vars take precedence over YAML. Returns None — flows through env.
+
+    Now also supports feishu.apps[] list for multi-app profile routing (#68046).
+    When feishu.apps is configured, each app entry becomes a separate
+    PlatformConfig in the platforms.feishu list, with per-app credentials,
+    home_channel, authorization policies, and profile mapping.
+
+    YAML takes precedence over env vars when feishu.apps[] is configured.
+    Returns bridged config dict for multi-app, or None for single-app mode (flows through env).
     """
+    # Single-app config (legacy): allow_bots
     if "allow_bots" in feishu_cfg and not os.getenv("FEISHU_ALLOW_BOTS"):
         os.environ["FEISHU_ALLOW_BOTS"] = str(feishu_cfg["allow_bots"]).lower()
-    return None
+
+    # Multi-app config: feishu.apps[] list
+    apps_list = feishu_cfg.get("apps")
+    if not isinstance(apps_list, list):
+        return None  # Single-app mode, no bridging needed
+
+    # YAML/env coexistence warning (#68046): if both feishu.apps[] and FEISHU_APP_ID
+    # are present, YAML takes precedence but warn the user of the conflict.
+    if os.getenv("FEISHU_APP_ID"):
+        logger.warning(
+            "Both feishu.apps[] config and FEISHU_APP_ID env var detected; "
+            "using YAML apps config, ignoring env var."
+        )
+
+    # Validate app count (hard limit: 10)
+    if len(apps_list) > 10:
+        raise ValueError(
+            f"feishu.apps contains {len(apps_list)} entries; maximum is 10. "
+            "Multi-app Feishu supports up to 10 concurrent apps per gateway."
+        )
+
+    # Collect app_ids to detect duplicates (#68046)
+    seen_app_ids = set()
+
+    # Build per-app config dicts for platforms.feishu list
+    platform_configs = []
+    for i, app_entry in enumerate(apps_list):
+        if not isinstance(app_entry, dict):
+            continue
+
+        app_id = app_entry.get("app_id")
+        app_secret = app_entry.get("app_secret")
+        if not app_id or not app_secret:
+            continue
+
+        # Duplicate app_id check (#68046)
+        if app_id in seen_app_ids:
+            raise ValueError(f"Duplicate app_id in feishu.apps: {app_id}")
+        seen_app_ids.add(app_id)
+
+        # Base config for this app
+        app_config = {
+            "enabled": True,
+            "extra": {
+                "app_id": app_id,
+                "app_secret": app_secret,
+                # adapter_id is used by _adapter_instance_id() to generate the full
+                # "platform:id" string. Store just the app_id here, not the full prefix.
+                "adapter_id": app_id,
+            }
+        }
+
+        # Optional profile mapping
+        profile = app_entry.get("profile", "").strip()
+        if profile:
+            app_config["extra"]["profile"] = profile
+
+        # Optional home_channel
+        home_channel = app_entry.get("home_channel", "").strip()
+        if home_channel:
+            app_config["extra"]["home_channel"] = home_channel
+
+        # Per-app authorization: allow_all_users
+        if "allow_all_users" in app_entry:
+            app_config["extra"]["allow_all_users"] = app_entry["allow_all_users"]
+
+        # Per-app authorization: allowed_users
+        allowed_users = app_entry.get("allowed_users", "").strip()
+        if allowed_users:
+            app_config["extra"]["allowed_users"] = allowed_users
+
+        # Per-app bot policy (#68046): allow_bots per app entry.
+        # Falls back to the top-level feishu.allow_bots (already bridged to
+        # the env var above), so single-app backward compat is preserved.
+        if "allow_bots" in app_entry:
+            app_config["extra"]["allow_bots"] = str(app_entry["allow_bots"]).lower()
+
+        # Bridge every remaining app_entry field (default_group_policy,
+        # group_policy, require_mention, group_rules, dm_policy, admins, …)
+        # into extra so the adapter's _load_settings sees it. Without this,
+        # per-app YAML policy is silently dropped and the adapter falls back
+        # to env defaults — e.g. FEISHU_GROUP_POLICY=allowlist — which then
+        # rejects all group traffic even though the user wrote
+        # default_group_policy: open (#68046 regression). setdefault keeps
+        # the explicit values assigned above intact.
+        for _field, _value in app_entry.items():
+            app_config["extra"].setdefault(_field, _value)
+
+        # Bridge gateway-level (top-level feishu) routing keys into every
+        # app's extra. Each adapter only reads its own config.extra, so shared
+        # keys must be copied per-app or they vanish. Used by the bot-to-bot
+        # p2p fallback reroute (peer_routing_fallback_chat) and the send-failure
+        # dead-letter sink (send_failure_dead_letter_chat).
+        for _gw_key in ("peer_routing_fallback_chat", "send_failure_dead_letter_chat"):
+            _gw_val = feishu_cfg.get(_gw_key, "")
+            if isinstance(_gw_val, str) and _gw_val.strip():
+                app_config["extra"].setdefault(_gw_key, _gw_val.strip())
+
+        platform_configs.append(app_config)
+
+    if not platform_configs:
+        return None  # No valid apps, fall back to single-app mode
+
+    # Return multi-app config list (will be merged into platforms.feishu)
+    return {"platforms_list": platform_configs}
 
 
 def _is_connected(config) -> bool:

--- a/scripts/check_credential_env_access.py
+++ b/scripts/check_credential_env_access.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Block direct os.getenv()/os.environ access to credential-shaped env vars.
+
+Context: the multiplexing gateway (``gateway.multiplex_profiles``) serves
+many profiles from one process, each with its own ``.env``. Reading a
+credential straight from ``os.environ`` instead of through
+``agent.secret_scope.get_secret()`` bypasses the per-profile secret scope and
+can leak profile A's key into profile B's turn (or crash loud-but-late via
+``UnscopedSecretError`` only in multiplex mode, silently using a stale
+process-env value otherwise). Three real instances of this were found and
+fixed in ``agent/auxiliary_client.py``, ``agent/chat_completion_helpers.py``,
+and ``agent/anthropic_adapter.py`` (OPENROUTER_API_KEY, OPENAI_API_KEY,
+ANTHROPIC_TOKEN, etc., plus dynamic ``key_env``-style lookups) — this script
+exists so the next one is caught before merge instead of by audit.
+
+Two shapes are flagged, both scoped to ``agent/`` and ``gateway/`` (the two
+directories that resolve provider/platform credentials):
+
+1. Literal credential-shaped names: ``os.getenv("FOO_API_KEY")``,
+   ``os.environ.get("FOO_TOKEN")``, ``os.environ["FOO_SECRET"]`` — any name
+   ending in ``_API_KEY`` / ``_TOKEN`` / ``_SECRET`` / ``_PASSWORD``.
+2. Dynamic env-var-name variables following the ``key_env`` convention seen
+   in the fixed call sites: ``os.getenv(key_env)``, ``os.getenv(fb_key_env)``
+   — a variable whose name ends in ``_env`` and contains key/token/secret/
+   password, i.e. it *holds the name* of a credential env var.
+
+See ``agent/secret_scope.py`` for the sanctioned resolution path and
+``docs/design/multiplexing-gateway.md`` (Workstream A) for the design
+rationale.
+
+Exit codes:
+  0 — no violations
+  1 — violations found
+  2 — script error
+
+Usage:
+  python scripts/check_credential_env_access.py            # staged files
+  python scripts/check_credential_env_access.py --all       # full agent/+gateway/
+  python scripts/check_credential_env_access.py --diff main # vs a git ref
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The two directories that resolve provider/platform credentials. Kept
+# tight and explicit rather than repo-wide: cron/ and plugins/platforms/
+# also touch credentials and are worth the same treatment, but that's a
+# follow-up, not bundled into this rule's first cut.
+SCOPE_DIRS = ("agent", "gateway")
+
+# Files inside SCOPE_DIRS that are the sanctioned exception: secret_scope.py
+# IS the get_secret() bridge, and legitimately reads os.environ directly for
+# genuinely-global vars and the multiplex-off fallback path.
+SAFE_FILES = {
+    "agent/secret_scope.py",
+}
+
+# Inline marker that exempts a single line from this check (e.g. a
+# documented, reviewed case where the process-env read is intentional).
+SUPPRESS_MARKER = re.compile(r"#\s*credential-lint\s*:\s*ok\b", re.IGNORECASE)
+
+# Literal env-var name ends with one of these -> credential-shaped.
+_CRED_NAME_SUFFIX = re.compile(r"_(?:API_KEY|TOKEN|SECRET|PASSWORD)$")
+
+_LITERAL_ACCESS = re.compile(
+    r"""\bos\.(?:getenv|environ\.get)\s*\(\s*["']([A-Z0-9_]+)["']"""
+    r"""|\bos\.environ\s*\[\s*["']([A-Z0-9_]+)["']"""
+)
+
+_DYNAMIC_ACCESS = re.compile(
+    r"""\bos\.(?:getenv|environ\.get)\s*\(\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*[,)]"""
+    r"""|\bos\.environ\s*\[\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\]"""
+)
+_CRED_VAR_HINT = re.compile(r"(?i:key|token|secret|password)")
+
+
+def _is_cred_literal(name: str) -> bool:
+    return bool(_CRED_NAME_SUFFIX.search(name))
+
+
+def _is_cred_var_name(name: str) -> bool:
+    return name.lower().endswith("_env") and bool(_CRED_VAR_HINT.search(name))
+
+
+def should_scan_file(path: Path) -> bool:
+    """Return True if the file is a non-test .py file under SCOPE_DIRS."""
+    if path.suffix != ".py":
+        return False
+    try:
+        rel = path.relative_to(REPO_ROOT)
+    except ValueError:
+        return False
+    if not rel.parts or rel.parts[0] not in SCOPE_DIRS:
+        return False
+    if rel.as_posix() in SAFE_FILES:
+        return False
+    return True
+
+
+def iter_files(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for p in paths:
+        if p.is_file():
+            if should_scan_file(p):
+                files.append(p)
+        elif p.is_dir():
+            for f in sorted(p.rglob("*.py")):
+                if should_scan_file(f):
+                    files.append(f)
+    return files
+
+
+def scan_file(path: Path) -> list[tuple[int, str, str]]:
+    """Return (line_number, line, reason) for each unsuppressed violation."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    violations: list[tuple[int, str, str]] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        if SUPPRESS_MARKER.search(line):
+            continue
+
+        for m in _LITERAL_ACCESS.finditer(line):
+            name = m.group(1) or m.group(2)
+            if name and _is_cred_literal(name):
+                violations.append((
+                    i, line.rstrip(),
+                    f'credential-shaped env var "{name}" read directly via '
+                    f"os.getenv/os.environ instead of get_secret({name!r})",
+                ))
+
+        for m in _DYNAMIC_ACCESS.finditer(line):
+            var = m.group(1) or m.group(2)
+            if var and _is_cred_var_name(var):
+                violations.append((
+                    i, line.rstrip(),
+                    f'env-var-name variable "{var}" (looks like it names a '
+                    f"credential) passed to os.getenv/os.environ instead of "
+                    f"get_secret({var})",
+                ))
+
+    return violations
+
+
+def get_staged_files() -> list[Path]:
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+            cwd=REPO_ROOT, stderr=subprocess.DEVNULL,
+            text=True, encoding="utf-8", errors="replace",
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    return [REPO_ROOT / f for f in out.splitlines() if f.strip()]
+
+
+def get_diff_files(ref: str) -> list[Path]:
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", f"{ref}...HEAD", "--name-only", "--diff-filter=ACMR"],
+            cwd=REPO_ROOT, stderr=subprocess.DEVNULL,
+            text=True, encoding="utf-8", errors="replace",
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    return [REPO_ROOT / f for f in out.splitlines() if f.strip()]
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Flag direct os.getenv/os.environ reads of credential-shaped "
+        "env vars in agent/ and gateway/ — use agent.secret_scope.get_secret() instead."
+    )
+    p.add_argument("paths", nargs="*", type=Path,
+                    help="Specific files/dirs to scan (default: staged changes).")
+    p.add_argument("--all", action="store_true",
+                    help="Scan the full agent/ and gateway/ trees.")
+    p.add_argument("--diff", metavar="REF",
+                    help="Scan files changed vs. a git ref (e.g. --diff main).")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+    if hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(encoding="utf-8")
+
+    args = parse_args(argv)
+
+    if args.all:
+        roots = [REPO_ROOT / d for d in SCOPE_DIRS]
+        roots = [r for r in roots if r.exists()]
+    elif args.diff:
+        roots = get_diff_files(args.diff)
+    elif args.paths:
+        roots = [p.resolve() for p in args.paths]
+    else:
+        roots = get_staged_files()
+        if not roots:
+            print(
+                "No staged files to check (use --all for a full scan, "
+                "--diff REF to compare against a ref).",
+                file=sys.stderr,
+            )
+            return 0
+
+    files = iter_files(roots)
+    if not files:
+        print("✓ No agent/ or gateway/ files to scan.")
+        return 0
+
+    total = 0
+    for path in files:
+        for line_no, line, reason in scan_file(path):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            print(f"{rel}:{line_no}: {reason}")
+            print(f"    {line.strip()}")
+            total += 1
+
+    if total:
+        print(
+            f"\n✗ {total} direct credential env-access violation(s) found "
+            f"across {len(files)} file(s) scanned.",
+            file=sys.stderr,
+        )
+        print(
+            "  Fix: from agent.secret_scope import get_secret; use "
+            "get_secret(NAME) instead of os.getenv/os.environ. If the read "
+            "is intentional (reviewed, non-profile-scoped), suppress with "
+            "`# credential-lint: ok` on the same line.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"✓ No credential env-access violations found ({len(files)} file(s) scanned).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_cross_adapter_session_sew.py
+++ b/scripts/check_cross_adapter_session_sew.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Detect cross-adapter session sews (#64934).
+
+Read-only diagnostic for ``state.db.gateway_routing``. The #64934 bug merged
+multiple distinct Feishu-app routing keys (e.g. ``adapter=feishu%3Acli_aad581a8``
+and ``adapter=feishu%3Acli_aad58273d``) onto ONE ``session_id`` during async-
+delegation completion, fusing Tony/Sam into Pete's transcript. After the fix,
+no ``session_id`` should be the target of routing keys from more than one
+adapter (with one documented exception: CLI continuity handoff, which is an
+intentional single cross-adapter rebind, not a multi-adapter fan-out).
+
+Exit codes:
+  0 — no multi-adapter sew detected
+  1 — at least one session_id is shared across adapters (printed with details)
+
+Usage:
+  python scripts/check_cross_adapter_session_sew.py            # $HERMES_HOME/state.db
+  python scripts/check_cross_adapter_session_sew.py --db PATH
+  python scripts/check_cross_adapter_session_sew.py --selftest
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple
+from urllib.parse import unquote
+
+
+def adapter_id_from_key(session_key: str) -> Optional[str]:
+    """Extract the ``adapter=<id>`` segment from a session key.
+
+    Namespace-agnostic (does not assume ``parts[1]=='main'``), so multi-profile
+    keys still resolve. Returns None when the key carries no adapter segment.
+    Mirrors ``gateway.session._adapter_id_from_key``.
+    """
+    if not session_key:
+        return None
+    for part in session_key.split(":"):
+        if part.startswith("adapter="):
+            return unquote(part[len("adapter="):]) or None
+    return None
+
+
+# A row: (session_key, session_id, updated_at_epoch_or_None)
+Row = Tuple[str, Optional[str], Optional[float]]
+
+
+def detect_sews(rows: Iterable[Row]) -> List[dict]:
+    """Group routing rows by session_id and flag any shared across adapters.
+
+    Returns one dict per offending session_id: ``session_id``, ``adapters``
+    (sorted distinct list), ``keys`` (the routing keys), and the max
+    ``updated_at`` among them (so callers can tell a stale historical sew from
+    a fresh post-fix one).
+    """
+    by_sid_adapters: dict = defaultdict(set)
+    by_sid_keys: dict = defaultdict(list)
+    by_sid_ts: dict = defaultdict(list)
+    for session_key, sid, updated_at in rows:
+        aid = adapter_id_from_key(session_key)
+        if not aid or not sid:
+            continue
+        by_sid_adapters[sid].add(aid)
+        by_sid_keys[sid].append(session_key)
+        if updated_at is not None:
+            by_sid_ts[sid].append(updated_at)
+    sews: List[dict] = []
+    for sid, adapters in by_sid_adapters.items():
+        if len(adapters) > 1:
+            sews.append(
+                {
+                    "session_id": sid,
+                    "adapters": sorted(adapters),
+                    "keys": by_sid_keys[sid],
+                    "updated_at": max(by_sid_ts[sid]) if by_sid_ts[sid] else None,
+                }
+            )
+    sews.sort(key=lambda s: (s["updated_at"] or 0.0), reverse=True)
+    return sews
+
+
+def _default_db_path() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / "state.db"
+    except Exception:
+        return Path.home() / ".hermes" / "state.db"
+
+
+def load_rows(db_path: Path) -> List[Row]:
+    """Read all adapter-bearing gateway_routing rows (read-only)."""
+    uri = f"file:{db_path}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    try:
+        # schema: gateway_routing(scope TEXT, session_key TEXT, entry_json TEXT, updated_at REAL)
+        rows = conn.execute(
+            """SELECT session_key,
+                      json_extract(entry_json, '$.session_id'),
+                      updated_at
+               FROM gateway_routing
+               WHERE session_key LIKE '%adapter=%'"""
+        ).fetchall()
+    finally:
+        conn.close()
+    return [(k, s, ts) for k, s, ts in rows]
+
+
+def _fmt_ts(ts: Optional[float]) -> str:
+    if ts is None:
+        return "?"
+    import datetime as _dt
+
+    return _dt.datetime.fromtimestamp(ts, tz=_dt.timezone.utc).isoformat(timespec="seconds")
+
+
+def report(sews: Sequence[dict], total_rows: int) -> str:
+    if not sews:
+        return (
+            f"PASS: scanned {total_rows} adapter-bearing routing rows; "
+            "no session_id is shared across multiple adapters (#64934 clean)."
+        )
+    lines = [
+        f"FAIL: {len(sews)} session_id(s) shared across multiple adapters "
+        f"(of {total_rows} adapter-bearing rows):",
+    ]
+    for s in sews:
+        lines.append("")
+        lines.append(f"  session_id   = {s['session_id']}")
+        lines.append(f"  updated_at   = {_fmt_ts(s['updated_at'])}")
+        lines.append(f"  adapters     = {', '.join(s['adapters'])}  ({len(s['adapters'])})")
+        for k in s["keys"]:
+            lines.append(f"    key = {k}")
+    lines.append("")
+    lines.append(
+        "NOTE: a single historical sew is expected to persist in state.db from "
+        "before the fix. A sew whose updated_at is AFTER the fix deploy indicates "
+        "the bug is still firing — re-run the failing delegation scenario."
+    )
+    return "\n".join(lines)
+
+
+def _selftest() -> int:
+    """Exercise the pure detection logic on synthetic rows."""
+    # 1. No sew — two adapters on two distinct sessions.
+    clean = [
+        ("agent:main:feishu:adapter=feishu%3AappA:group:oc_c:omt_t", "sess_A", 1.0),
+        ("agent:main:feishu:adapter=feishu%3AappB:group:oc_c:omt_t", "sess_B", 2.0),
+    ]
+    assert detect_sews(clean) == [], "distinct sessions must not flag"
+
+    # 2. Sew — two adapters onto one session (the #64934 shape).
+    sewn = [
+        ("agent:main:feishu:adapter=feishu%3AappA:group:oc_c:omt_t", "sess_X", 1.0),
+        ("agent:main:feishu:adapter=feishu%3AappB:group:oc_c:omt_t", "sess_X", 2.0),
+    ]
+    found = detect_sews(sewn)
+    assert len(found) == 1, found
+    assert found[0]["session_id"] == "sess_X"
+    assert sorted(found[0]["adapters"]) == ["feishu:appA", "feishu:appB"]
+    assert found[0]["updated_at"] == 2.0
+
+    # 3. Same adapter, two keys onto one session — NOT a sew (legitimate alias).
+    alias = [
+        ("agent:main:feishu:adapter=feishu%3AappA:dm:oc_c", "sess_Y", 1.0),
+        ("agent:main:feishu:adapter=feishu%3AappA:dm:oc_d", "sess_Y", 2.0),
+    ]
+    assert detect_sews(alias) == [], "same-adapter alias must not flag"
+
+    # 4. namespace-agnostic: profile namespace must not blind the parser.
+    assert adapter_id_from_key("agent:coder:feishu:adapter=feishu%3AappA:group:x") == "feishu:appA"
+    assert adapter_id_from_key("agent:main:feishu:group:x") is None
+
+    print("selftest OK")
+    return 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Detect cross-adapter session sews (#64934).")
+    parser.add_argument("--db", default=None, help="state.db path (default: $HERMES_HOME/state.db)")
+    parser.add_argument("--selftest", action="store_true", help="run built-in detection selftest")
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        return _selftest()
+
+    db_path = Path(args.db) if args.db else _default_db_path()
+    if not db_path.exists():
+        print(f"state.db not found at {db_path}", file=sys.stderr)
+        return 2
+    try:
+        rows = load_rows(db_path)
+    except sqlite3.Error as exc:
+        print(f"failed to read {db_path}: {exc}", file=sys.stderr)
+        return 2
+
+    sews = detect_sews(rows)
+    print(report(sews, total_rows=len(rows)))
+    return 1 if sews else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -425,6 +425,20 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "MATRIX_REQUIRE_MENTION",
 })
 
+# Proxy env vars read by tools/url_safety.py, gateway/platforms/base.py,
+# gateway/platforms/qqbot/adapter.py, and agent/auxiliary_client.py. A
+# developer or CI runner shell with a proxy configured otherwise leaks into
+# DNS-fallback / proxy-detection branches and websocket-proxy selection,
+# making those tests pass or fail depending on the ambient shell instead of
+# the fixture's explicit monkeypatch.setenv calls.
+_PROXY_ENV_VARS = frozenset({
+    "HTTP_PROXY", "http_proxy",
+    "HTTPS_PROXY", "https_proxy",
+    "ALL_PROXY", "all_proxy",
+    "NO_PROXY", "no_proxy",
+    "WSS_PROXY", "wss_proxy",
+})
+
 
 @pytest.fixture(autouse=True)
 def _hermetic_environment(tmp_path, monkeypatch):
@@ -441,6 +455,14 @@ def _hermetic_environment(tmp_path, monkeypatch):
 
     # 2. Blank behavioral HERMES_* vars that could change test semantics.
     for name in _HERMES_BEHAVIORAL_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+    # 2b. Blank proxy env vars. A shell with HTTP_PROXY/HTTPS_PROXY/etc. set
+    # otherwise flips DNS-fallback and proxy-selection branches in
+    # url_safety.py / platforms/base.py / qqbot adapter tests depending on
+    # who runs the suite. Tests exercising proxy behavior set these
+    # explicitly via monkeypatch.setenv.
+    for name in _PROXY_ENV_VARS:
         monkeypatch.delenv(name, raising=False)
 
     # Honcho's fallback host/config resolution legitimately reads the user's

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -414,3 +414,148 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
 
 
+def test_multiplex_ticks_each_profile_with_its_own_adapters(tmp_path, monkeypatch):
+    """Each profile's tick() call gets ITS OWN adapters dict, not the single
+    default-profile dict, so cron delivery for a secondary profile (e.g. a
+    distinct Feishu bot app) resolves the correct live adapter instead of
+    silently falling back to the standalone HTTP path or, worse, delivering
+    through the default profile's (wrong) bot credentials."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    p1 = tmp_path / "default"
+    p2 = tmp_path / "home-ops"
+    for d in (p1, p2):
+        (d / "cron").mkdir(parents=True)
+    profile_homes = [("default", p1), ("home-ops", p2)]
+
+    default_adapters = {"default-marker": object()}
+    secondary_adapters = {"home-ops-marker": object()}
+    profile_adapters = {"default": default_adapters, "home-ops": secondary_adapters}
+
+    # _start_multiplex ticks profile_homes in list order every cycle, so the
+    # call sequence should alternate [default, home-ops, default, home-ops, ...]
+    # with each call carrying that profile's own adapters dict.
+    call_adapters: list = []
+
+    def _tracking_tick(*args, **kwargs):
+        call_adapters.append(kwargs.get("adapters"))
+        return 0
+
+    stop = threading.Event()
+    prov = InProcessCronScheduler()
+
+    with patch("cron.scheduler.tick", side_effect=_tracking_tick), \
+         patch("cron.jobs.record_ticker_heartbeat", lambda **kw: None):
+        t = threading.Thread(
+            target=prov.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "profile_homes": profile_homes,
+                "adapters": default_adapters,
+                "profile_adapters": profile_adapters,
+            },
+            daemon=True,
+        )
+        t.start()
+        deadline = time.monotonic() + 10
+        while len(call_adapters) < len(profile_homes) and time.monotonic() < deadline:
+            time.sleep(0.005)
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive()
+    assert call_adapters[0] is default_adapters
+    assert call_adapters[1] is secondary_adapters
+
+
+def test_multiplex_falls_back_to_default_adapters_when_unmapped(tmp_path, monkeypatch):
+    """A profile absent from profile_adapters (e.g. no live adapters of its
+    own yet, or an older caller that never passes profile_adapters) falls
+    back to the shared `adapters` dict rather than getting None/crashing."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    p1 = tmp_path / "default"
+    p2 = tmp_path / "home-ops"
+    for d in (p1, p2):
+        (d / "cron").mkdir(parents=True)
+    profile_homes = [("default", p1), ("home-ops", p2)]
+
+    default_adapters = {"default-marker": object()}
+    call_adapters: list = []
+
+    def _tracking_tick(*args, **kwargs):
+        call_adapters.append(kwargs.get("adapters"))
+        return 0
+
+    stop = threading.Event()
+    prov = InProcessCronScheduler()
+
+    with patch("cron.scheduler.tick", side_effect=_tracking_tick), \
+         patch("cron.jobs.record_ticker_heartbeat", lambda **kw: None):
+        t = threading.Thread(
+            target=prov.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "profile_homes": profile_homes,
+                "adapters": default_adapters,
+                # No profile_adapters passed at all.
+            },
+            daemon=True,
+        )
+        t.start()
+        deadline = time.monotonic() + 10
+        while len(call_adapters) < len(profile_homes) and time.monotonic() < deadline:
+            time.sleep(0.005)
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive()
+    assert all(a is default_adapters for a in call_adapters)
+
+
+def test_multiplex_heartbeat_scoped_per_profile(tmp_path, monkeypatch):
+    """record_ticker_heartbeat is scoped to each profile's store under
+    multiplex, so 'hermes cron status' can report liveness per profile."""
+    from cron.scheduler_provider import InProcessCronScheduler
+    from cron.jobs import record_ticker_heartbeat as _real_heartbeat
+
+    p_default = tmp_path / "default"
+    p_sec = tmp_path / "home-ops"
+    for d in (p_default, p_sec):
+        (d / "cron").mkdir(parents=True)
+    profile_homes = [("default", p_default), ("home-ops", p_sec)]
+
+    beat_log: list[str] = []
+
+    def _track_beat(*, success=False):
+        beat_log.append(str(success))
+        # Write the real heartbeat files so we can check them after.
+        _real_heartbeat(success=success)
+
+    stop = threading.Event()
+    prov = InProcessCronScheduler()
+
+    with patch("cron.scheduler.tick", return_value=0), \
+         patch("cron.jobs.record_ticker_heartbeat", side_effect=_track_beat):
+        t = threading.Thread(
+            target=prov.start,
+            args=(stop,),
+            kwargs={"interval": 0, "profile_homes": profile_homes},
+            daemon=True,
+        )
+        t.start()
+        deadline = time.monotonic() + 10
+        # Wait for at least 2 tick iterations over all profiles (2 profiles).
+        while len(beat_log) < len(profile_homes) * 2 and time.monotonic() < deadline:
+            time.sleep(0.005)
+        stop.set()
+        t.join(timeout=5)
+
+    assert not t.is_alive()
+    # Every profile should have a heartbeat file.
+    assert (p_default / "cron" / "ticker_heartbeat").exists(), \
+        "default profile heartbeat file missing"
+    assert (p_sec / "cron" / "ticker_heartbeat").exists(), \
+        "secondary profile heartbeat file missing"

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -158,6 +158,18 @@ def make_restart_runner(
     runner.session_store._entries = {}
     runner.delivery_router = MagicMock()
 
+    # Mirrors GatewayRunner.__init__'s multi-instance adapter registry so
+    # code paths that call _adapter_instance_id/_register_connected_adapter
+    # (e.g. during start()) don't hit a missing-attribute error.
+    runner.adapters_by_id = {}
+    runner._platform_adapter_ids = {}
+    runner._adapter_instance_id = GatewayRunner._adapter_instance_id.__get__(
+        runner, GatewayRunner
+    )
+    runner._register_connected_adapter = GatewayRunner._register_connected_adapter.__get__(
+        runner, GatewayRunner
+    )
+
     platform_adapter = adapter or RestartTestAdapter()
     platform_adapter.set_message_handler(AsyncMock(return_value=None))
     platform_adapter.set_busy_session_handler(runner._handle_active_session_busy_message)

--- a/tests/gateway/test_async_delegation_session_binding.py
+++ b/tests/gateway/test_async_delegation_session_binding.py
@@ -217,3 +217,238 @@ class TestResetHandlerInterruptsDelegations:
         src = inspect.getsource(slash_commands.GatewaySlashCommandsMixin._handle_reset_command)
         assert "interrupt_for_session" in src
         assert "session_reset" in src
+
+
+def test_async_delegations_schema_has_cross_adapter_columns():
+    """A (#64934): the durable table carries the cross-adapter routing fields
+    so a completion can be matched back to its spawning adapter."""
+    import tools.async_delegation as ad
+
+    conn = ad._connect()
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(async_delegations)")}
+    finally:
+        conn.close()
+    for col in (
+        "source_adapter_id",
+        "source_profile",
+        "source_session_key",
+        "delegation_type",
+    ):
+        assert col in cols, f"async_delegations missing column {col}"
+
+
+class TestCrossAdapterCompletionIsolation:
+    """#64934: a delegation spawned on adapter A must not be sewn onto the
+    parent session when its completion routes through adapter B (multi-app
+    fan-out). Drop fail-closed; the result remains in async_delegations."""
+
+    @staticmethod
+    def _feishu_entry(session_id, adapter_id):
+        from datetime import datetime
+
+        from gateway.config import Platform
+        from gateway.session import SessionEntry
+
+        aid = adapter_id.replace("%", "%25").replace(":", "%3A")
+        return SessionEntry(
+            session_key=f"agent:main:feishu:adapter={aid}:group:oc_chat:omt_thread",
+            session_id=session_id,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            platform=Platform.FEISHU,
+            chat_type="group",
+        )
+
+    @staticmethod
+    def _source_key(adapter_id):
+        aid = adapter_id.replace("%", "%25").replace(":", "%3A")
+        return f"agent:main:feishu:adapter={aid}:group:oc_chat:omt_thread"
+
+    def _make_runner(self, rows, *, switched_entry=None, compression_tip=None):
+        from gateway.run import GatewayRunner
+        from gateway.session import AsyncSessionStore
+
+        runner = object.__new__(GatewayRunner)
+        db = MagicMock()
+        db.get_session = AsyncMock(side_effect=lambda sid: rows.get(sid))
+        db.get_compression_tip = AsyncMock(return_value=compression_tip)
+        runner._session_db = db
+        runner.session_store = MagicMock()
+        runner.session_store.switch_session = MagicMock(return_value=switched_entry)
+        runner.session_store.advance_compression_session = MagicMock(
+            return_value=switched_entry
+        )
+        runner._async_session_store = AsyncSessionStore(runner.session_store)
+        return runner
+
+    @staticmethod
+    def _assert_no_route_change(runner):
+        runner.session_store.switch_session.assert_not_called()
+        runner.session_store.advance_compression_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cross_adapter_completion_drops_instead_of_sewing(self):
+        # Completion routes through Tony's adapter (cli_aad581a8) but the
+        # delegation was spawned by Pete (cli_aad7c4d).
+        current = self._feishu_entry("sess_tony", "feishu:cli_aad581a8")
+        runner = self._make_runner(
+            {"sess_pete": {"id": "sess_pete", "ended_at": None}},
+            switched_entry=self._feishu_entry("sess_pete", "feishu:cli_aad7c4d"),
+        )
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_pete",
+            source_session_key=self._source_key("feishu:cli_aad7c4d"),
+        )
+
+        assert resolved is None
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
+    async def test_same_adapter_completion_still_pins(self):
+        current = self._feishu_entry("sess_tony", "feishu:cli_aad581a8")
+        target = self._feishu_entry("sess_pete", "feishu:cli_aad581a8")
+        runner = self._make_runner(
+            {"sess_pete": {"id": "sess_pete", "ended_at": None}},
+            switched_entry=target,
+        )
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_pete",
+            source_session_key=self._source_key("feishu:cli_aad581a8"),
+        )
+
+        assert resolved is target
+        runner.session_store.switch_session.assert_called_once_with(
+            current.session_key, "sess_pete", expected_adapter_id="feishu:cli_aad581a8"
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_source_key_falls_back_to_pin(self):
+        # Legacy record (pre-#64934): empty source_session_key → original pin.
+        current = self._feishu_entry("sess_tony", "feishu:cli_aad581a8")
+        target = self._feishu_entry("sess_pete", "feishu:cli_aad7c4d")
+        runner = self._make_runner(
+            {"sess_pete": {"id": "sess_pete", "ended_at": None}},
+            switched_entry=target,
+        )
+
+        resolved = await runner._resolve_async_delegation_session(current, "sess_pete")
+
+        assert resolved is target
+        runner.session_store.switch_session.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cross_adapter_with_compression_still_drops(self):
+        # pinned parent ended via compression; current route owns the lineage
+        # (session_id == pinned) but its KEY belongs to a different adapter.
+        current = self._feishu_entry("sess_pete", "feishu:cli_aad581a8")
+        runner = self._make_runner(
+            {
+                "sess_pete": {
+                    "id": "sess_pete",
+                    "ended_at": "2026-07-08T00:00:00",
+                    "end_reason": "compression",
+                },
+                "sess_child": {"id": "sess_child", "ended_at": None},
+            },
+            switched_entry=self._feishu_entry("sess_child", "feishu:cli_aad7c4d"),
+            compression_tip="sess_child",
+        )
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_pete",
+            source_session_key=self._source_key("feishu:cli_aad7c4d"),
+        )
+
+        assert resolved is None
+        self._assert_no_route_change(runner)
+
+
+class TestParentAdapterReroute:
+    """#64934 (B): a cross-adapter completion is rerouted to the spawning
+    adapter's source so the result lands in the parent's own session."""
+
+    @staticmethod
+    def _feishu_source(adapter_id):
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+
+        return SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_chat",
+            chat_type="group",
+            thread_id="omt_thread",
+            adapter_id=adapter_id,
+        )
+
+    @staticmethod
+    def _key(adapter_id):
+        aid = adapter_id.replace(":", "%3A")
+        return f"agent:main:feishu:adapter={aid}:group:oc_chat:omt_thread"
+
+    def _make_runner(self, parent_source):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._build_process_event_source = lambda evt: parent_source
+        return runner
+
+    def test_cross_adapter_reroutes_to_parent_source(self):
+        parent = self._feishu_source("feishu:cli_aad7c4d")  # Pete
+        runner = self._make_runner(parent)
+        current = self._feishu_source("feishu:cli_aad581a8")  # Tony
+
+        result = runner._maybe_reroute_to_parent_adapter(
+            {
+                "session_key": self._key("feishu:cli_aad581a8"),
+                "source_session_key": self._key("feishu:cli_aad7c4d"),
+            },
+            current,
+        )
+
+        assert result is parent
+
+    def test_same_adapter_no_reroute(self):
+        parent = self._feishu_source("feishu:cli_aad581a8")
+        runner = self._make_runner(parent)
+        current = self._feishu_source("feishu:cli_aad581a8")
+
+        result = runner._maybe_reroute_to_parent_adapter(
+            {
+                "session_key": self._key("feishu:cli_aad581a8"),
+                "source_session_key": self._key("feishu:cli_aad581a8"),
+            },
+            current,
+        )
+
+        assert result is current
+
+    def test_missing_source_key_no_reroute(self):
+        runner = self._make_runner(None)
+        current = self._feishu_source("feishu:cli_aad581a8")
+
+        result = runner._maybe_reroute_to_parent_adapter(
+            {"session_key": self._key("feishu:cli_aad581a8")},
+            current,
+        )
+
+        assert result is current
+
+    def test_parent_source_unresolvable_no_reroute(self):
+        # Cross-adapter but the parent source cannot be rebuilt → stay put;
+        # the resolver guard then drops the sew fail-closed.
+        runner = self._make_runner(None)
+        current = self._feishu_source("feishu:cli_aad581a8")
+
+        result = runner._maybe_reroute_to_parent_adapter(
+            {
+                "session_key": self._key("feishu:cli_aad581a8"),
+                "source_session_key": self._key("feishu:cli_aad7c4d"),
+            },
+            current,
+        )
+
+        assert result is current
+

--- a/tests/gateway/test_cross_adapter_sew_check.py
+++ b/tests/gateway/test_cross_adapter_sew_check.py
@@ -1,0 +1,91 @@
+"""Tests for the #64934 data-layer diagnostic script.
+
+The script lives in ``scripts/`` (not a package), so we load it via importlib
+and exercise its pure detection functions — the same logic the CLI runs
+against ``state.db.gateway_routing`` in production.
+"""
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location(
+        "check_cross_adapter_session_sew",
+        Path(__file__).resolve().parents[2] / "scripts" / "check_cross_adapter_session_sew.py",
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestAdapterIdFromKey:
+    def test_extracts_adapter_segment(self):
+        mod = _load_script()
+        assert mod.adapter_id_from_key(
+            "agent:main:feishu:adapter=feishu%3AappA:group:oc_x:omt_y"
+        ) == "feishu:appA"
+
+    def test_namespace_agnostic(self):
+        # A multi-profile key must still resolve — run.py's _parse_session_key
+        # misses these (it hard-codes parts[1]=='main'), this script must not.
+        mod = _load_script()
+        assert mod.adapter_id_from_key(
+            "agent:coder:feishu:adapter=feishu%3AappB:dm:oc_z"
+        ) == "feishu:appB"
+
+    def test_no_adapter_segment(self):
+        mod = _load_script()
+        assert mod.adapter_id_from_key("agent:main:feishu:group:oc_x") is None
+        assert mod.adapter_id_from_key("") is None
+
+
+class TestDetectSews:
+    def test_flags_cross_adapter_sew(self):
+        mod = _load_script()
+        # The #64934 shape: two distinct adapters onto one session_id.
+        sewn = [
+            ("agent:main:feishu:adapter=feishu%3AappA:group:oc_c:omt_t", "sess_X", 1.0),
+            ("agent:main:feishu:adapter=feishu%3AappB:group:oc_c:omt_t", "sess_X", 2.0),
+        ]
+        found = mod.detect_sews(sewn)
+        assert len(found) == 1
+        assert found[0]["session_id"] == "sess_X"
+        assert sorted(found[0]["adapters"]) == ["feishu:appA", "feishu:appB"]
+        assert found[0]["updated_at"] == 2.0
+
+    def test_ignores_same_adapter_alias(self):
+        mod = _load_script()
+        # Same adapter, two keys on one session is a legitimate alias, not a sew.
+        alias = [
+            ("agent:main:feishu:adapter=feishu%3AappA:dm:oc_c", "sess_Y", 1.0),
+            ("agent:main:feishu:adapter=feishu%3AappA:dm:oc_d", "sess_Y", 2.0),
+        ]
+        assert mod.detect_sews(alias) == []
+
+    def test_clean_distinct_sessions(self):
+        mod = _load_script()
+        clean = [
+            ("agent:main:feishu:adapter=feishu%3AappA:group:oc_c:omt_t", "sess_A", 1.0),
+            ("agent:main:feishu:adapter=feishu%3AappB:group:oc_c:omt_t", "sess_B", 2.0),
+        ]
+        assert mod.detect_sews(clean) == []
+
+    def test_skips_rows_without_adapter_or_sid(self):
+        mod = _load_script()
+        rows = [
+            ("agent:main:feishu:group:oc_c", "sess_Z", 1.0),  # no adapter
+            ("agent:main:feishu:adapter=feishu%3AappA:group:oc_c", None, 2.0),  # no sid
+        ]
+        assert mod.detect_sews(rows) == []
+
+    def test_report_pass_and_fail(self):
+        mod = _load_script()
+        assert "PASS" in mod.report([], 5)
+        fail_report = mod.report(
+            [{"session_id": "s1", "adapters": ["feishu:appA", "feishu:appB"],
+              "keys": ["k1", "k2"], "updated_at": None}],
+            5,
+        )
+        assert "FAIL" in fail_report and "s1" in fail_report

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -241,6 +241,120 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         self.assertEqual(call_kwargs["extra_ua_tags"], ["channel"],
                          "extra_ua_tags must be ['channel'] to enable group event routing")
 
+    def test_ws_loop_proxy_delegates_to_whichever_loop_is_running(self):
+        """Regression test for the multi-profile 'attached to a different
+        loop' crash: the SDK's shared module-level ``loop`` global used to
+        be overwritten by whichever profile thread (re)connected last, so a
+        task created by one profile could get scheduled on another
+        profile's loop. The proxy must always resolve the loop actually
+        driving the current coroutine, never a captured/shared one."""
+        from plugins.platforms.feishu.adapter import _ThreadSafeWsLoopProxy
+
+        proxy = _ThreadSafeWsLoopProxy()
+
+        async def _inner():
+            await proxy.create_task(asyncio.sleep(0))
+            return asyncio.get_running_loop()
+
+        loop_a = asyncio.new_event_loop()
+        loop_b = asyncio.new_event_loop()
+        try:
+            result_a = loop_a.run_until_complete(_inner())
+            result_b = loop_b.run_until_complete(_inner())
+        finally:
+            loop_a.close()
+            loop_b.close()
+
+        self.assertIs(result_a, loop_a)
+        self.assertIs(result_b, loop_b)
+
+    def test_ws_connect_overrides_are_thread_local_across_concurrent_profiles(self):
+        """Regression test: two profiles' WS client threads used to save
+        and restore a shared ``websockets.connect`` reference, so whichever
+        profile (re)connected last would silently leak its
+        ping_interval/ping_timeout onto every other profile's subsequent
+        connects. Per-thread overrides must stay isolated even when both
+        profiles set them and connect at the same instant."""
+        import threading
+
+        from plugins.platforms.feishu import adapter as feishu_module
+
+        captured: Dict[str, Dict[str, object]] = {}
+
+        def _fake_connect(url, **kwargs):
+            captured[threading.current_thread().name] = kwargs
+            return f"conn-for-{url}"
+
+        fake_module = SimpleNamespace(websockets=SimpleNamespace(connect=_fake_connect))
+
+        # Reset singleton patch state so this test doesn't depend on
+        # whichever module happened to be patched by an earlier test.
+        feishu_module._ws_original_connect = None
+        feishu_module._ensure_ws_connect_patched(fake_module)
+
+        barrier = threading.Barrier(2)
+        profiles = {"profile-a": (10, 5), "profile-b": (99, 42)}
+
+        def _worker(name: str, interval: int, timeout: int) -> None:
+            feishu_module._ws_connect_overrides.ping_interval = interval
+            feishu_module._ws_connect_overrides.ping_timeout = timeout
+            barrier.wait()  # force maximum overlap with the other profile
+            fake_module.websockets.connect(f"wss://{name}")
+
+        threads = [
+            threading.Thread(target=_worker, args=(name, interval, timeout), name=name)
+            for name, (interval, timeout) in profiles.items()
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        for name, (interval, timeout) in profiles.items():
+            self.assertEqual(captured[name]["ping_interval"], interval)
+            self.assertEqual(captured[name]["ping_timeout"], timeout)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_edit_message_updates_existing_feishu_message(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def update(self, request):
+                captured["request"] = request
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_progress",
+                    content="📖 read_file: \"/tmp/image.png\"",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_progress")
+        self.assertEqual(captured["request"].message_id, "om_progress")
+        self.assertEqual(captured["request"].request_body.msg_type, "text")
+        self.assertEqual(
+            captured["request"].request_body.content,
+            json.dumps({"text": "📖 read_file: \"/tmp/image.png\""}, ensure_ascii=False),
+        )
 
     @patch.dict(os.environ, {}, clear=True)
     def test_edit_message_falls_back_to_text_when_post_update_is_rejected(self):
@@ -1246,6 +1360,133 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
+    def test_send_with_thread_id_but_no_anchor_replies_into_topic(self):
+        """Regression: 话题消息但无 reply anchor（bot-to-bot 合成消息、会话恢复后
+        anchor 丢失），必须用 thread_id 查话题内最后一条消息作 reply anchor 回到
+        原话题。绝不能走 create（话题群里 create 到 chat_id 会新建话题根），也
+        不能用飞书不支持的 receive_id_type=thread_id。"""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        async def _fetch_last(_thread_id):
+            return "om_topic_last"
+
+        adapter._fetch_last_message_in_thread = _fetch_last
+        captured: dict = {}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["reply"] = request
+                return SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_new"))
+
+            def create(self, request):
+                captured["create"] = request
+                return SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_new"))
+
+        adapter._client = SimpleNamespace(im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI())))
+
+        result = asyncio.run(
+            adapter._send_raw_message(
+                chat_id="oc_chat",
+                msg_type="text",
+                payload='{"text":"hi"}',
+                reply_to=None,
+                metadata={"thread_id": "omt_topic"},
+            )
+        )
+
+        self.assertTrue(result.success())
+        self.assertIn("reply", captured)
+        self.assertNotIn("create", captured, "话题消息不得走 create（会在话题群新建话题根）")
+        self.assertTrue(captured["reply"].request_body.reply_in_thread)
+
+    def test_send_with_thread_id_no_topic_message_skips_not_creates(self):
+        """话题 id 存在但话题内无任何消息（fetch 返回 None）时，必须跳过发送并
+        返回失败，绝不能 fallback 到 create chat_id（会在话题群新建话题根）。"""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        async def _fetch_last(_thread_id):
+            return None
+
+        adapter._fetch_last_message_in_thread = _fetch_last
+        captured: dict = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["create"] = request
+                return SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_new"))
+
+        adapter._client = SimpleNamespace(im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI())))
+
+        result = asyncio.run(
+            adapter._send_raw_message(
+                chat_id="oc_chat",
+                msg_type="text",
+                payload='{"text":"hi"}',
+                reply_to=None,
+                metadata={"thread_id": "omt_topic"},
+            )
+        )
+
+        # 跳过分支返回类飞书 response（success 为 callable，False）；绝不能
+        # 返回 SendResult（其 success 是 bool，会让上层 _response_succeeded 崩溃）。
+        self.assertFalse(result.success())
+        self.assertNotIn("create", captured, "话题空时绝不能 create 新建话题根")
+
+    def test_send_strips_bot2bot_reply_anchor(self):
+        """Regression: 合成 bot2bot message_id 绝不能作为飞书 reply anchor（飞书
+        以 99992354 拒绝）。无论来自 reply_to 参数还是 metadata.reply_to_message_id，
+        都必须在 _send_raw_message 兜底 strip，转而用话题内消息作 anchor。"""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        async def _fetch_last(_thread_id):
+            return "om_topic_last"
+
+        adapter._fetch_last_message_in_thread = _fetch_last
+        captured: dict = {}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured.setdefault("reply_anchors", []).append(request.message_id)
+                return SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_new"))
+
+        adapter._client = SimpleNamespace(im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI())))
+
+        # 场景1: reply_to 参数为 bot2bot
+        asyncio.run(
+            adapter._send_raw_message(
+                chat_id="oc_chat",
+                msg_type="text",
+                payload='{"text":"hi"}',
+                reply_to="bot2bot-aaa",
+                metadata={"thread_id": "omt_topic"},
+            )
+        )
+        # 场景2: metadata.reply_to_message_id 为 bot2bot（绕过 send/retry 的 strip）
+        asyncio.run(
+            adapter._send_raw_message(
+                chat_id="oc_chat",
+                msg_type="text",
+                payload='{"text":"hi"}',
+                reply_to=None,
+                metadata={"thread_id": "omt_topic", "reply_to_message_id": "bot2bot-bbb"},
+            )
+        )
+
+        # 两种来源的 bot2bot 都被 strip；reply anchor 用话题内消息（om_topic_last），
+        # 绝不是 bot2bot-xxx（否则飞书 99992354）。
+        self.assertEqual(len(captured["reply_anchors"]), 2)
+        for anchor in captured["reply_anchors"]:
+            self.assertNotIn("bot2bot", str(anchor))
+
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_post_for_every_chunk_of_multi_chunk_markdown(self):
@@ -1655,6 +1896,70 @@ class TestDedupTTL(unittest.TestCase):
                 assert "om_good" in adapter._seen_message_ids
                 assert "om_bad_str" not in adapter._seen_message_ids
                 assert "om_bad_null" not in adapter._seen_message_ids
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_persist_saves_timestamps_as_dict(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        ts = time.time()
+        adapter._seen_message_ids = {"om_ts1": ts}
+        adapter._seen_message_order = ["om_ts1"]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adapter._dedup_state_path = Path(tmpdir) / "dedup.json"
+            adapter._persist_seen_message_ids()
+            saved = json.loads(adapter._dedup_state_path.read_text())
+        self.assertIsInstance(saved["message_ids"], dict)
+        self.assertAlmostEqual(saved["message_ids"]["om_ts1"], ts, places=1)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_load_backward_compat_list_format(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "dedup.json"
+            path.write_text(json.dumps({"message_ids": ["om_a", "om_b"]}), encoding="utf-8")
+            adapter._dedup_state_path = path
+            adapter._load_seen_message_ids()
+        self.assertIn("om_a", adapter._seen_message_ids)
+        self.assertIn("om_b", adapter._seen_message_ids)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_multi_app_adapters_isolate_dedup_state_by_app_id(self):
+        """Multi-app config (#68046): each FeishuAdapter is a distinct bot
+        that independently receives the same group message_id. Sharing one
+        dedup file let one app's seen-set silently suppress another's after a
+        restart, and concurrent persists clobbered each other. Each app must
+        get its own namespaced file so a message seen by app A is still
+        processed by app B.
+        """
+        import tempfile
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        with tempfile.TemporaryDirectory() as temp_home:
+            with patch.dict(os.environ, {"HERMES_HOME": temp_home}, clear=True):
+                app_a = FeishuAdapter(PlatformConfig(extra={"app_id": "cli_app_a"}))
+                app_b = FeishuAdapter(PlatformConfig(extra={"app_id": "cli_app_b"}))
+
+                # Distinct app_ids → distinct, app_id-namespaced state files.
+                self.assertNotEqual(app_a._dedup_state_path, app_b._dedup_state_path)
+                self.assertIn("cli_app_a", app_a._dedup_state_path.name)
+                self.assertIn("cli_app_b", app_b._dedup_state_path.name)
+
+                # A message seen by app A must NOT suppress the same message_id
+                # in app B — they are different bots in the same group.
+                with patch.object(app_a, "_persist_seen_message_ids"):
+                    self.assertFalse(app_a._is_duplicate("om_shared"))
+                with patch.object(app_b, "_persist_seen_message_ids"):
+                    self.assertFalse(app_b._is_duplicate("om_shared"))
+
+                # Within one app, the same id is still deduplicated.
+                with patch.object(app_a, "_persist_seen_message_ids"):
+                    self.assertTrue(app_a._is_duplicate("om_shared"))
 
 
 class TestGroupMentionAtAll(unittest.TestCase):
@@ -2465,5 +2770,200 @@ class TestChatLockEviction(unittest.TestCase):
 
         adapter = self._make_adapter()
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
+
+
+class TestGetChatMembers(unittest.TestCase):
+    """get_chat_members: parse SDK response, paginate, cache, fail to []."""
+
+    def _build_adapter(self, *, items=None, success=True):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter._chat_members_cache = {}
+
+        def _item(name, mid):
+            return SimpleNamespace(name=name, member_id=mid, member_id_type="open_id")
+
+        resp = SimpleNamespace(
+            success=lambda: success,
+            code=0 if success else 99991672,
+            msg="ok" if success else "permission denied",
+            data=SimpleNamespace(
+                items=[_item(n, m) for n, m in (items or [])],
+                has_more=False,
+                page_token=None,
+            ),
+        )
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    chat_members=SimpleNamespace(get=lambda req: resp)
+                )
+            )
+        )
+
+        async def _run(func, *args):
+            return func(*args)
+
+        adapter._run_blocking = _run
+        return adapter
+
+    def test_returns_members(self):
+        adapter = self._build_adapter(items=[("Alice", "ou_a"), ("Bob", "ou_b")])
+        members = asyncio.run(adapter.get_chat_members("oc_x"))
+        self.assertEqual(members, [
+            {"name": "Alice", "member_id": "ou_a", "id_type": "open_id"},
+            {"name": "Bob", "member_id": "ou_b", "id_type": "open_id"},
+        ])
+
+    def test_failure_returns_empty(self):
+        adapter = self._build_adapter(success=False)
+        self.assertEqual(asyncio.run(adapter.get_chat_members("oc_x")), [])
+
+    def test_no_client_returns_empty(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter._client = None
+        adapter._chat_members_cache = {}
+        self.assertEqual(asyncio.run(adapter.get_chat_members("oc_x")), [])
+
+    def test_cache_hits_without_refetch(self):
+        adapter = self._build_adapter(items=[("Alice", "ou_a")])
+        asyncio.run(adapter.get_chat_members("oc_x"))
+        # Second call must hit cache — sabotaging the client should be harmless.
+        adapter._client = None
+        again = asyncio.run(adapter.get_chat_members("oc_x"))
+        self.assertEqual(again, [{"name": "Alice", "member_id": "ou_a", "id_type": "open_id"}])
+
+
+class TestParsePeerMentionTargets(unittest.TestCase):
+    """_parse_peer_mention_targets: resolve @peer to profile for bot-to-bot routing."""
+
+    def _make_adapter(self, peer_map, by_openid, by_name):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        a = FeishuAdapter.__new__(FeishuAdapter)
+        a._peer_mention_map = peer_map
+        a._peer_profile_by_openid = by_openid
+        a._peer_profile_by_name = by_name
+        return a
+
+    def test_resolves_mention_to_profile(self):
+        a = self._make_adapter(
+            {"架构师": "ou_arch", "alex": "ou_arch"},
+            {"ou_arch": "architect"},
+            {"架构师": "architect", "alex": "architect"},
+        )
+        self.assertEqual(
+            a._parse_peer_mention_targets("@架构师 帮我设计数据库"),
+            [("architect", "架构师")],
+        )
+
+    def test_progressive_prefix_match(self):
+        a = self._make_adapter(
+            {"架构师": "ou_arch"}, {"ou_arch": "architect"}, {"架构师": "architect"}
+        )
+        # "架构师Alex" resolves via progressive prefix to "架构师"
+        self.assertEqual(
+            a._parse_peer_mention_targets("@架构师Alex 你好"),
+            [("architect", "架构师")],
+        )
+
+    def test_no_peer_mention_returns_empty(self):
+        a = self._make_adapter({"架构师": "ou_arch"}, {"ou_arch": "architect"}, {})
+        self.assertEqual(a._parse_peer_mention_targets("没有@任何人"), [])
+
+    def test_skips_mentions_in_code_spans(self):
+        a = self._make_adapter(
+            {"架构师": "ou_arch"}, {"ou_arch": "architect"}, {"架构师": "architect"}
+        )
+        self.assertEqual(a._parse_peer_mention_targets("```\n@架构师\n```"), [])
+
+    def test_dedup_by_profile(self):
+        a = self._make_adapter(
+            {"架构师": "ou_arch", "alex": "ou_arch"},
+            {"ou_arch": "architect"},
+            {},
+        )
+        # two aliases of the same profile collapse to one target
+        self.assertEqual(len(a._parse_peer_mention_targets("@架构师 @Alex")), 1)
+
+    def test_colleague_hint_lists_peers(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        a = FeishuAdapter.__new__(FeishuAdapter)
+        a._peer_canonical_by_profile = {"architect": "架构师Alex", "designer": "设计师Diana"}
+        hint = a._build_peer_colleague_hint()
+        self.assertIn("@架构师Alex", hint)
+        self.assertIn("@设计师Diana", hint)
+
+    def test_colleague_hint_empty_when_no_peers(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        a = FeishuAdapter.__new__(FeishuAdapter)
+        a._peer_canonical_by_profile = {}
+        self.assertEqual(a._build_peer_colleague_hint(), "")
+
+
+class TestRouteBotToBot(unittest.TestCase):
+    """_route_bot_to_bot: inject synthetic inbound to peer + loop breakers."""
+
+    @staticmethod
+    def _make_adapter(adapter_id, bot_open_id, bot_name):
+        return SimpleNamespace(
+            adapter_id=adapter_id,
+            _bot_open_id=bot_open_id,
+            _bot_name=bot_name,
+            build_source=Mock(return_value=SimpleNamespace(profile=None)),
+            _resolve_channel_prompt=Mock(return_value=None),
+            _handle_message_with_guards=AsyncMock(),
+        )
+
+    def _make_runner(self, adapters_by_id, profile_map):
+        from gateway.run import GatewayRunner
+
+        r = GatewayRunner.__new__(GatewayRunner)
+        r.adapters_by_id = adapters_by_id
+        r._adapter_profile_map = profile_map
+        return r
+
+    def test_routes_to_target_adapter(self):
+        from gateway.config import Platform
+
+        sender = self._make_adapter("feishu:pm", "ou_pm", "PM")
+        target = self._make_adapter("feishu:arch", "ou_arch", "Arch")
+        r = self._make_runner(
+            {"feishu:pm": sender, "feishu:arch": target},
+            {"feishu:pm": "product-manager", "feishu:arch": "architect"},
+        )
+        asyncio.run(
+            r._route_bot_to_bot([("architect", "架构师")], "@架构师 设计", "oc_x", sender)
+        )
+        target._handle_message_with_guards.assert_awaited_once()
+
+    def test_skips_when_target_is_sender_profile(self):
+        sender = self._make_adapter("feishu:pm", "ou_pm", "PM")
+        target = self._make_adapter("feishu:arch", "ou_arch", "Arch")
+        r = self._make_runner(
+            {"feishu:pm": sender, "feishu:arch": target},
+            {"feishu:pm": "product-manager", "feishu:arch": "architect"},
+        )
+        # PM @PM → target == sender_profile → skip (A↔B ping-pong breaker)
+        asyncio.run(r._route_bot_to_bot([("product-manager", "PM")], "@PM", "oc_x", sender))
+        target._handle_message_with_guards.assert_not_awaited()
+
+    def test_hop_limit_breaks_loop(self):
+        sender = self._make_adapter("feishu:pm", "ou_pm", "PM")
+        target = self._make_adapter("feishu:arch", "ou_arch", "Arch")
+        r = self._make_runner(
+            {"feishu:pm": sender, "feishu:arch": target},
+            {"feishu:pm": "product-manager", "feishu:arch": "architect"},
+        )
+        # hop >= _BOT_TO_BOT_HOP_LIMIT → no injection (ring breaker)
+        asyncio.run(
+            r._route_bot_to_bot([("architect", "架构师")], "@架构师", "oc_x", sender, hop=99)
+        )
+        target._handle_message_with_guards.assert_not_awaited()
 
 

--- a/tests/gateway/test_feishu_multi_app.py
+++ b/tests/gateway/test_feishu_multi_app.py
@@ -1,0 +1,838 @@
+"""Tests for multi-app Feishu list-config compatibility.
+
+Regression guard: when platforms.feishu is a list, several code paths used to
+raise AttributeError: 'list' object has no attribute 'extra'.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import (
+    GatewayConfig,
+    HomeChannel,
+    Platform,
+    PlatformConfig,
+    _apply_env_overrides,
+)
+from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+from gateway.platforms.base import BasePlatformAdapter
+
+
+class DummyMixin(GatewayAuthorizationMixin):
+    """Minimal mixin instance for testing list-config paths."""
+
+    def __init__(self, config):
+        self.config = config
+        self.adapters = {}
+
+
+class DummyAdapter(BasePlatformAdapter):
+    """Small concrete adapter for runner routing tests."""
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, **kwargs):
+        calls = getattr(self, "send_calls", None)
+        if calls is not None:
+            calls.append((chat_id, content, kwargs))
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"name": chat_id, "type": "dm"}
+
+
+class TestMultiAppListConfig:
+    """Cover the list-config branches introduced in PR #42499."""
+
+    @pytest.fixture
+    def multi_config(self):
+        return GatewayConfig(
+            platforms={
+                Platform.FEISHU: [
+                    PlatformConfig(
+                        enabled=True,
+                        token="app1-token",
+                        extra={
+                            "dm_policy": "open",
+                            "unauthorized_dm_behavior": "ignore",
+                            "notice_delivery": "private",
+                            "app_id": "cli_app1",
+                        },
+                    ),
+                    PlatformConfig(
+                        enabled=True,
+                        token="app2-token",
+                        extra={
+                            "dm_policy": "pairing",
+                            "app_id": "cli_app2",
+                        },
+                    ),
+                ],
+            }
+        )
+
+    @pytest.fixture
+    def single_config(self):
+        return GatewayConfig(
+            platforms={
+                Platform.FEISHU: PlatformConfig(
+                    enabled=True,
+                    token="single-token",
+                    extra={
+                        "dm_policy": "open",
+                        "unauthorized_dm_behavior": "pair",
+                        "notice_delivery": "public",
+                    },
+                ),
+            }
+        )
+
+    # --- GatewayConfig ---
+
+    def test_get_unauthorized_dm_behavior_list_first_wins(self, multi_config):
+        """First config in the list with the key wins."""
+        assert multi_config.get_unauthorized_dm_behavior(Platform.FEISHU) == "ignore"
+
+    def test_get_unauthorized_dm_behavior_single(self, single_config):
+        assert single_config.get_unauthorized_dm_behavior(Platform.FEISHU) == "pair"
+
+    def test_get_unauthorized_dm_behavior_missing_platform(self, single_config):
+        assert single_config.get_unauthorized_dm_behavior(Platform.SLACK) == "pair"
+
+    def test_get_notice_delivery_list_first_wins(self, multi_config):
+        assert multi_config.get_notice_delivery(Platform.FEISHU) == "private"
+
+    def test_get_notice_delivery_single(self, single_config):
+        assert single_config.get_notice_delivery(Platform.FEISHU) == "public"
+
+    def test_get_notice_delivery_missing_platform(self, single_config):
+        assert single_config.get_notice_delivery(Platform.SLACK) == "public"
+
+    # --- GatewayAuthorizationMixin._adapter_dm_policy ---
+
+    def test_adapter_dm_policy_list(self, multi_config):
+        mixin = DummyMixin(multi_config)
+        assert mixin._adapter_dm_policy(Platform.FEISHU) == "open"
+
+    def test_adapter_dm_policy_single(self, single_config):
+        mixin = DummyMixin(single_config)
+        assert mixin._adapter_dm_policy(Platform.FEISHU) == "open"
+
+    def test_adapter_dm_policy_no_config(self):
+        mixin = DummyMixin(GatewayConfig())
+        assert mixin._adapter_dm_policy(Platform.FEISHU) == ""
+
+    # --- GatewayAuthorizationMixin._get_unauthorized_dm_behavior ---
+
+    def test_get_unauthorized_dm_behavior_list_explicit(self, multi_config):
+        mixin = DummyMixin(multi_config)
+        # First list item has explicit unauthorized_dm_behavior
+        assert mixin._get_unauthorized_dm_behavior(Platform.FEISHU) == "ignore"
+
+    def test_get_unauthorized_dm_behavior_single_explicit(self, single_config):
+        mixin = DummyMixin(single_config)
+        assert mixin._get_unauthorized_dm_behavior(Platform.FEISHU) == "pair"
+
+    def test_get_unauthorized_dm_behavior_list_dm_policy_pairing(self):
+        """When no explicit unauthorized_dm_behavior but dm_policy == pairing."""
+        config = GatewayConfig(
+            platforms={
+                Platform.FEISHU: [
+                    PlatformConfig(
+                        enabled=True,
+                        extra={"dm_policy": "pairing"},
+                    ),
+                ],
+            }
+        )
+        mixin = DummyMixin(config)
+        assert mixin._get_unauthorized_dm_behavior(Platform.FEISHU) == "pair"
+
+    def test_get_unauthorized_dm_behavior_list_dm_policy_disabled(self):
+        """When dm_policy is disabled, default to ignore."""
+        config = GatewayConfig(
+            platforms={
+                Platform.FEISHU: [
+                    PlatformConfig(
+                        enabled=True,
+                        extra={"dm_policy": "disabled"},
+                    ),
+                ],
+            }
+        )
+        mixin = DummyMixin(config)
+        assert mixin._get_unauthorized_dm_behavior(Platform.FEISHU) == "ignore"
+
+    def test_get_unauthorized_dm_behavior_no_platform(self):
+        mixin = DummyMixin(GatewayConfig())
+        assert mixin._get_unauthorized_dm_behavior(Platform.FEISHU) == "pair"
+
+    # --- GatewayConfig roundtrip with list ---
+
+    def test_to_dict_from_dict_preserves_list(self, multi_config):
+        d = multi_config.to_dict()
+        restored = GatewayConfig.from_dict(d)
+        feishu_cfgs = restored.platforms[Platform.FEISHU]
+        assert isinstance(feishu_cfgs, list)
+        assert len(feishu_cfgs) == 2
+        assert feishu_cfgs[0].extra["app_id"] == "cli_app1"
+        assert feishu_cfgs[1].extra["app_id"] == "cli_app2"
+
+    def test_from_dict_preserves_top_level_platform_specific_keys_in_extra(self):
+        restored = GatewayConfig.from_dict(
+            {
+                "platforms": {
+                    "feishu": [
+                        {"enabled": True, "app_id": "cli_app1", "app_secret": "secret1"},
+                        {"enabled": True, "app_id": "cli_app2", "app_secret": "secret2"},
+                    ]
+                }
+            }
+        )
+
+        feishu_cfgs = restored.platforms[Platform.FEISHU]
+
+        assert isinstance(feishu_cfgs, list)
+        assert feishu_cfgs[0].extra["app_id"] == "cli_app1"
+        assert feishu_cfgs[0].extra["app_secret"] == "secret1"
+        assert feishu_cfgs[1].extra["app_id"] == "cli_app2"
+        assert feishu_cfgs[1].extra["app_secret"] == "secret2"
+
+    def test_env_overrides_do_not_clobber_explicit_multi_app_credentials(self):
+        config = GatewayConfig.from_dict(
+            {
+                "platforms": {
+                    "feishu": [
+                        {"enabled": True, "app_id": "cli_app1", "app_secret": "secret1"},
+                        {"enabled": True, "app_id": "cli_app2", "app_secret": "secret2"},
+                    ]
+                }
+            }
+        )
+
+        with patch.dict(
+            "os.environ",
+            {
+                "FEISHU_APP_ID": "cli_env",
+                "FEISHU_APP_SECRET": "secret_env",
+                "FEISHU_DOMAIN": "lark",
+                "FEISHU_CONNECTION_MODE": "websocket",
+            },
+            clear=False,
+        ):
+            _apply_env_overrides(config)
+
+        feishu_cfgs = config.platforms[Platform.FEISHU]
+
+        assert isinstance(feishu_cfgs, list)
+        assert feishu_cfgs[0].extra["app_id"] == "cli_app1"
+        assert feishu_cfgs[0].extra["app_secret"] == "secret1"
+        assert feishu_cfgs[1].extra["app_id"] == "cli_app2"
+        assert feishu_cfgs[1].extra["app_secret"] == "secret2"
+        assert feishu_cfgs[0].extra["domain"] == "lark"
+        assert feishu_cfgs[1].extra["domain"] == "lark"
+
+    def test_env_home_channel_targets_matching_feishu_app(self):
+        config = GatewayConfig.from_dict(
+            {
+                "platforms": {
+                    "feishu": [
+                        {"enabled": True, "app_id": "cli_app1", "app_secret": "secret1"},
+                        {"enabled": True, "app_id": "cli_app2", "app_secret": "secret2"},
+                    ]
+                }
+            }
+        )
+
+        with patch.dict(
+            "os.environ",
+            {
+                "FEISHU_APP_ID": "cli_app2",
+                "FEISHU_APP_SECRET": "secret2",
+                "FEISHU_HOME_CHANNEL": "chat-app2",
+                "FEISHU_HOME_CHANNEL_NAME": "App 2 Home",
+            },
+            clear=False,
+        ):
+            _apply_env_overrides(config)
+
+        first, second = config.platforms[Platform.FEISHU]
+        assert first.home_channel is None
+        assert second.home_channel is not None
+        assert second.home_channel.chat_id == "chat-app2"
+        assert second.home_channel.name == "App 2 Home"
+
+    def test_get_home_channel_list(self, multi_config):
+        """get_home_channel should iterate list and return first match."""
+        # Default home_channel is None; test that it doesn't crash
+        assert multi_config.get_home_channel(Platform.FEISHU) is None
+
+    def test_connected_platforms_list(self, multi_config):
+        """connected_platforms should include platform if any list item is connected."""
+        # No real connection, but ensure it doesn't crash on list
+        connected = multi_config.get_connected_platforms()
+        assert isinstance(connected, list)
+
+    def test_is_connected_true_with_app_id(self):
+        """Feishu's plugin-registry connection checker (#68046 item 0)
+        reports connected once app_id is set, regardless of app_secret —
+        mirrors the legacy _PLATFORM_CONNECTED_CHECKERS lambda it replaced."""
+        from plugins.platforms.feishu.adapter import _is_connected
+
+        assert _is_connected(SimpleNamespace(extra={"app_id": "cli_app1"})) is True
+
+    def test_is_connected_false_with_placeholder_app_id(self):
+        """A placeholder profile (empty app_id) must be reported as NOT
+        connected so cron delivery routing skips it instead of attempting a
+        real Feishu API call with empty credentials."""
+        from plugins.platforms.feishu.adapter import _is_connected
+
+        assert _is_connected(SimpleNamespace(extra={"app_id": ""})) is False
+        assert _is_connected(SimpleNamespace(extra={})) is False
+
+    def test_build_source_carries_adapter_id(self):
+        adapter = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_app1"}),
+            Platform.FEISHU,
+        )
+        adapter.adapter_id = "feishu:cli_app1"
+
+        source = adapter.build_source(chat_id="chat-1", user_id="user-1")
+
+        assert source.adapter_id == "feishu:cli_app1"
+
+    def test_build_source_carries_thread_id_for_topic_routing(self):
+        """Regression: bot-to-bot 路由（_route_bot_to_bot）构造合成 source 时
+        必须把原话题 thread_id（omt_）传给 build_source，否则 peer bot 回复会
+        丢失话题上下文，在话题群里每条回复都新建一个话题根。"""
+        adapter = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_app1"}),
+            Platform.FEISHU,
+        )
+        adapter.adapter_id = "feishu:cli_app1"
+
+        source = adapter.build_source(
+            chat_id="chat-1", user_id="user-1", thread_id="omt_topic"
+        )
+
+        assert source.thread_id == "omt_topic"
+
+    @pytest.mark.asyncio
+    async def test_route_bot_to_bot_carries_thread_id_and_anchor(self):
+        """问题1: _route_bot_to_bot 必须把 thread_id 与 sender 的 anchor_message_id
+        透传到合成事件，使 peer bot 回复精确 reply 到 sender 的消息（om_）回到原话题，
+        而非因丢失上下文在话题群里新建话题根。"""
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.adapters = {}
+        runner.adapters_by_id = {}
+        runner._platform_adapter_ids = {}
+        runner._adapter_profile_map = {}
+
+        sender = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_app1"}), Platform.FEISHU
+        )
+        sender.adapter_id = "feishu:cli_app1"
+        sender._bot_name = "Tony"
+        sender._bot_open_id = "ou_sender"
+        target = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_app2"}), Platform.FEISHU
+        )
+        target.adapter_id = "feishu:cli_app2"
+        target._bot_name = "Pete"
+        target._resolve_channel_prompt = lambda chat_id: None
+
+        runner._register_connected_adapter(Platform.FEISHU, sender)
+        runner._register_connected_adapter(Platform.FEISHU, target)
+        runner._adapter_profile_map = {
+            "feishu:cli_app1": "tech-lead",
+            "feishu:cli_app2": "pm",
+        }
+        runner.adapter_id_for_profile = lambda profile, platform=None: {
+            "pm": "feishu:cli_app2"
+        }.get(profile)
+
+        captured: dict = {}
+
+        async def _capture(event):
+            captured["event"] = event
+
+        target._handle_message_with_guards = _capture
+
+        await runner._route_bot_to_bot(
+            [("pm", "Pete")],
+            "hello @Pete",
+            "oc_chat",
+            sender,
+            hop=0,
+            thread_id="omt_topic",
+            anchor_message_id="om_tony_msg",
+        )
+
+        assert captured["event"].source.thread_id == "omt_topic"
+        assert captured["event"].reply_to_message_id == "om_tony_msg"
+
+    def test_session_key_isolates_matching_chat_ids_across_feishu_apps(self):
+        """Different Feishu apps must not share agent/session state."""
+        first = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_same",
+            chat_type="dm",
+            user_id="ou_same",
+            adapter_id="feishu:cli_app1",
+        )
+        second = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_same",
+            chat_type="dm",
+            user_id="ou_same",
+            adapter_id="feishu:cli_app2",
+        )
+
+        first_key = build_session_key(first)
+        second_key = build_session_key(second)
+
+        assert first_key == "agent:main:feishu:adapter=feishu%3Acli_app1:dm:oc_same"
+        assert second_key == "agent:main:feishu:adapter=feishu%3Acli_app2:dm:oc_same"
+        assert first_key != second_key
+
+    def test_runner_routes_source_to_matching_feishu_app_adapter(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.adapters = {}
+        runner.adapters_by_id = {}
+        runner._platform_adapter_ids = {}
+
+        app1 = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_app1"}),
+            Platform.FEISHU,
+        )
+        app2 = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_app2"}),
+            Platform.FEISHU,
+        )
+
+        runner._register_connected_adapter(Platform.FEISHU, app1)
+        runner._register_connected_adapter(Platform.FEISHU, app2)
+
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="chat-from-app2",
+            adapter_id="feishu:cli_app2",
+        )
+
+        assert runner.adapters[Platform.FEISHU] is app1
+        assert runner._adapter_for_source(source) is app2
+
+    @pytest.mark.asyncio
+    async def test_startup_notifications_use_each_feishu_app_home_channel(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.FEISHU: [
+                    PlatformConfig(
+                        enabled=True,
+                        extra={"app_id": "cli_app1"},
+                        home_channel=HomeChannel(
+                            platform=Platform.FEISHU,
+                            chat_id="chat-app1",
+                            name="App 1",
+                        ),
+                    ),
+                    PlatformConfig(
+                        enabled=True,
+                        extra={"app_id": "cli_app2"},
+                        home_channel=HomeChannel(
+                            platform=Platform.FEISHU,
+                            chat_id="chat-app2",
+                            name="App 2",
+                        ),
+                    ),
+                ],
+            }
+        )
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = config
+        runner.adapters = {}
+        runner.adapters_by_id = {}
+        runner._platform_adapter_ids = {}
+
+        app1 = DummyAdapter(config.platforms[Platform.FEISHU][0], Platform.FEISHU)
+        app1.send_calls = []
+        app2 = DummyAdapter(config.platforms[Platform.FEISHU][1], Platform.FEISHU)
+        app2.send_calls = []
+
+        runner._register_connected_adapter(Platform.FEISHU, app1)
+        runner._register_connected_adapter(Platform.FEISHU, app2)
+
+        delivered = await runner._send_home_channel_startup_notifications()
+
+        assert ("feishu", "chat-app1", None) in delivered
+        assert ("feishu", "chat-app2", None) in delivered
+        assert [call[0] for call in app1.send_calls] == ["chat-app1"]
+        assert [call[0] for call in app2.send_calls] == ["chat-app2"]
+
+    @pytest.mark.asyncio
+    async def test_background_completion_uses_source_feishu_app_adapter(
+        self, monkeypatch
+    ):
+        import tools.process_registry as process_registry_module
+
+        config = GatewayConfig(
+            platforms={
+                Platform.FEISHU: [
+                    PlatformConfig(enabled=True, extra={"app_id": "cli_app1"}),
+                    PlatformConfig(enabled=True, extra={"app_id": "cli_app2"}),
+                ]
+            }
+        )
+        runner = GatewayRunner(config)
+        app1 = DummyAdapter(config.platforms[Platform.FEISHU][0], Platform.FEISHU)
+        app2 = DummyAdapter(config.platforms[Platform.FEISHU][1], Platform.FEISHU)
+        app1.handle_message = AsyncMock()
+        app2.handle_message = AsyncMock()
+        runner._register_connected_adapter(Platform.FEISHU, app1)
+        runner._register_connected_adapter(Platform.FEISHU, app2)
+        runner._load_background_notifications_mode = lambda: "all"
+
+        session = SimpleNamespace(
+            output_buffer="done\n",
+            exited=True,
+            exit_code=0,
+            command="echo done",
+        )
+
+        class _Registry:
+            def get(self, _session_id):
+                return session
+
+            def is_completion_consumed(self, _session_id):
+                return False
+
+        monkeypatch.setattr(process_registry_module, "process_registry", _Registry())
+
+        async def _instant_sleep(*_args, **_kwargs):
+            return None
+
+        monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+        await runner._run_process_watcher(
+            {
+                "session_id": "proc-app2",
+                "check_interval": 0,
+                "session_key": (
+                    "agent:main:feishu:adapter=feishu%3Acli_app2:dm:oc_same"
+                ),
+                "platform": "feishu",
+                "chat_id": "oc_same",
+                "notify_on_complete": True,
+            }
+        )
+
+        app1.handle_message.assert_not_awaited()
+        app2.handle_message.assert_awaited_once()
+        event = app2.handle_message.await_args.args[0]
+        assert event.source.adapter_id == "feishu:cli_app2"
+
+
+class TestApplyYamlConfigBridgesPolicy:
+    """Regression: _apply_yaml_config must bridge per-app policy fields
+    (default_group_policy, require_mention, …) into each app's extra, not
+    just the explicit whitelist (app_id/allow_bots/…). Without this, YAML
+    ``default_group_policy: open`` was silently dropped and the adapter fell
+    back to ``FEISHU_GROUP_POLICY=allowlist``, rejecting all group traffic
+    even though the user configured ``open`` (#68046).
+    """
+
+    def test_default_group_policy_bridged_to_each_app_extra(self):
+        from plugins.platforms.feishu.adapter import _apply_yaml_config
+
+        feishu_cfg = {
+            "apps": [
+                {
+                    "app_id": "cli_app1",
+                    "app_secret": "s1",
+                    "default_group_policy": "open",
+                    "require_mention": False,
+                    "profile": "architect",
+                },
+                {
+                    "app_id": "cli_app2",
+                    "app_secret": "s2",
+                    "default_group_policy": "allowlist",
+                },
+            ]
+        }
+        result = _apply_yaml_config({}, feishu_cfg)
+        assert result is not None
+        apps = result["platforms_list"]
+        assert len(apps) == 2
+
+        by_app = {app["extra"]["app_id"]: app["extra"] for app in apps}
+        # Core regression: default_group_policy reaches extra (was dropped →
+        # adapter fell back to env allowlist → group traffic rejected).
+        assert by_app["cli_app1"]["default_group_policy"] == "open"
+        assert by_app["cli_app2"]["default_group_policy"] == "allowlist"
+        # Generic bridge carries other policy fields too.
+        assert by_app["cli_app1"]["require_mention"] is False
+        # Explicit fields assigned upstream stay intact (setdefault).
+        assert by_app["cli_app1"]["app_secret"] == "s1"
+        assert by_app["cli_app1"]["profile"] == "architect"
+
+    def test_gateway_level_routing_keys_bridged_to_each_app(self):
+        """顶层 peer_routing_fallback_chat / send_failure_dead_letter_chat 必须
+        复制进每个 app 的 extra——各 adapter 只读自己的 config.extra，顶层键
+        不桥接就会全部读不到（p2p 重路由、死信转发双双失效）。"""
+        from plugins.platforms.feishu.adapter import _apply_yaml_config
+
+        feishu_cfg = {
+            "peer_routing_fallback_chat": "oc_fallback",
+            "send_failure_dead_letter_chat": "oc_dead",
+            "apps": [
+                {"app_id": "cli_app1", "app_secret": "s1"},
+                {"app_id": "cli_app2", "app_secret": "s2"},
+            ],
+        }
+        result = _apply_yaml_config({}, feishu_cfg)
+        apps = result["platforms_list"]
+        assert len(apps) == 2
+        for app in apps:
+            assert app["extra"]["peer_routing_fallback_chat"] == "oc_fallback"
+            assert app["extra"]["send_failure_dead_letter_chat"] == "oc_dead"
+
+    def test_gateway_level_routing_keys_absent_when_unconfigured(self):
+        """未配置这两个顶层键时，不应写入 extra（空值跳过，setdefault 不写入）。"""
+        from plugins.platforms.feishu.adapter import _apply_yaml_config
+
+        feishu_cfg = {"apps": [{"app_id": "cli_app1", "app_secret": "s1"}]}
+        result = _apply_yaml_config({}, feishu_cfg)
+        extra = result["platforms_list"][0]["extra"]
+        assert "peer_routing_fallback_chat" not in extra
+        assert "send_failure_dead_letter_chat" not in extra
+
+
+class TestP2pFallbackReroute:
+    """规则 A：私聊(dm)里 @ 不在场的 peer，send hook 把 bot-to-bot 注入重路由
+    到配置的 fallback 群，而非原 chat_id（否则 peer 回复 230002 静默丢失）。"""
+
+    def _make_adapter(self, *, fallback_chat="oc_fallback", chat_type="dm"):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import SendResult
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        extra = {"app_id": "cli_app1"}
+        if fallback_chat:
+            extra["peer_routing_fallback_chat"] = fallback_chat
+        # object.__new__ 跳过 __init__（同 feishu_helpers.make_adapter_skeleton），
+        # 只 mock send() 与 send hook 依赖的方法。
+        adapter = object.__new__(FeishuAdapter)
+        adapter.config = PlatformConfig(enabled=True, extra=extra)
+        adapter._client = SimpleNamespace()  # truthy → 绕过 send() 的 not-connected 早退
+        adapter._bot_to_bot_reply_profile = None
+        adapter._parse_peer_mention_targets = lambda content: [("tech-leader", "Tony")]
+        adapter.get_chat_info = AsyncMock(return_value={"type": chat_type})
+        adapter._feishu_send_with_retry = AsyncMock(
+            return_value=SimpleNamespace(success=lambda: True)
+        )
+        adapter._response_succeeded = lambda r: True
+        adapter._finalize_send_result = lambda resp, default: SendResult(
+            success=True, message_id="om_x"
+        )
+        adapter.format_message = lambda c: c
+        adapter.truncate_message = lambda c, m: [c]
+        adapter._build_outbound_payload = lambda chunk, prefer_post=False: ("text", "{}")
+        return adapter
+
+    async def _capture_route_chat(self, adapter):
+        routed = []
+
+        async def _router(targets, content, chat_id, sender_adapter, **kw):
+            routed.append(chat_id)
+
+        adapter._bot_to_bot_router = _router
+        await adapter.send(chat_id="oc_dm", content="hello @Tony")
+        # send hook 用 asyncio.create_task fire-and-forget；让事件循环跑完它。
+        for _ in range(20):
+            if routed:
+                break
+            await asyncio.sleep(0)
+        return routed
+
+    @pytest.mark.asyncio
+    async def test_p2p_mention_reroutes_to_fallback_chat(self):
+        adapter = self._make_adapter(fallback_chat="oc_fallback", chat_type="dm")
+        assert await self._capture_route_chat(adapter) == ["oc_fallback"]
+
+    @pytest.mark.asyncio
+    async def test_group_chat_keeps_original_chat_id(self):
+        adapter = self._make_adapter(fallback_chat="oc_fallback", chat_type="group")
+        assert await self._capture_route_chat(adapter) == ["oc_dm"]
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_fallback_keeps_original_chat_id(self):
+        adapter = self._make_adapter(fallback_chat=None, chat_type="dm")
+        assert await self._capture_route_chat(adapter) == ["oc_dm"]
+
+
+class TestSendDeadLetter:
+    """规则 B：发送永久失败 → _send_with_retry 触发 _on_send_dead_letter；
+    feishu override 把消息转发到死信群（由 default adapter 推送）。"""
+
+    @pytest.mark.asyncio
+    async def test_fallback_failure_triggers_dead_letter_hook(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import SendResult
+
+        adapter = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_app1"}), Platform.FEISHU
+        )
+        adapter.adapter_id = "feishu:cli_app1"
+        # send 始终失败（含 plain-text fallback 重发）→ 走 base.py fallback-fail 死信钩子。
+        adapter.send = AsyncMock(return_value=SendResult(success=False, error="[230002] out of chat"))
+        adapter._is_retryable_error = lambda e: False
+        called = []
+        adapter._on_send_dead_letter = AsyncMock(side_effect=lambda *a, **k: called.append(a))
+        result = await adapter._send_with_retry("oc_chat", "hello")
+        assert result.success is False
+        assert called and called[0][0] == "oc_chat" and called[0][1] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_timeout_failure_skips_dead_letter_hook(self):
+        """timeout 分支（消息可能已投递）不转死信，避免误导性留底。"""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import SendResult
+
+        adapter = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_app1"}), Platform.FEISHU
+        )
+        adapter.adapter_id = "feishu:cli_app1"
+        adapter.send = AsyncMock(return_value=SendResult(success=False, error="timeout"))
+        adapter._is_retryable_error = lambda e: False
+        adapter._is_timeout_error = lambda e: True
+        called = []
+        adapter._on_send_dead_letter = AsyncMock(side_effect=lambda *a, **k: called.append(a))
+        await adapter._send_with_retry("oc_chat", "hello")
+        assert not called
+
+    @pytest.mark.asyncio
+    async def test_feishu_override_forwards_to_injected_forwarder(self):
+        """FeishuAdapter._on_send_dead_letter 读 extra 死信群并调注入的 forwarder。"""
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        ns = SimpleNamespace(
+            config=SimpleNamespace(extra={"send_failure_dead_letter_chat": "oc_dead"}),
+            _dead_letter_forwarder=AsyncMock(),
+        )
+        await FeishuAdapter._on_send_dead_letter(
+            ns, "oc_src", "原内容", SimpleNamespace(error="[230002] x")
+        )
+        ns._dead_letter_forwarder.assert_awaited_once_with(ns, "oc_src", "原内容", "[230002] x")
+
+    @pytest.mark.asyncio
+    async def test_feishu_override_noop_when_dead_letter_unconfigured(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        ns = SimpleNamespace(
+            config=SimpleNamespace(extra={}),
+            _dead_letter_forwarder=AsyncMock(),
+        )
+        await FeishuAdapter._on_send_dead_letter(ns, "oc_src", "x", SimpleNamespace(error="e"))
+        ns._dead_letter_forwarder.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_runner_forwarder_uses_default_adapter(self):
+        """_forward_feishu_dead_letter 用 default adapter 把格式化死信发到死信群。"""
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.adapters = {}
+        runner._adapter_profile_map = {}
+
+        default = DummyAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={"app_id": "cli_default", "send_failure_dead_letter_chat": "oc_dead"},
+            ),
+            Platform.FEISHU,
+        )
+        default.adapter_id = "feishu:cli_default"
+        sent = []
+        default.send = AsyncMock(side_effect=lambda **kw: sent.append(kw))
+        runner.adapters[Platform.FEISHU] = default
+
+        failed = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_x"}), Platform.FEISHU
+        )
+        failed.adapter_id = "feishu:cli_failed"
+        failed._bot_name = "技术总监Tony"
+        runner._adapter_profile_map = {"feishu:cli_failed": "tech-leader"}
+
+        await runner._forward_feishu_dead_letter(failed, "oc_target", "原内容正文", "[230002] out of chat")
+        assert len(sent) == 1
+        assert sent[0]["chat_id"] == "oc_dead"
+        assert "tech-leader" in sent[0]["content"]
+        assert "oc_target" in sent[0]["content"]
+        assert "原内容正文" in sent[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_runner_forwarder_swallows_default_send_error(self):
+        """default adapter 自身发送异常时不递归抛错（避免死信→死信循环）。"""
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.adapters = {}
+        runner._adapter_profile_map = {}
+
+        default = DummyAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={"app_id": "cli_default", "send_failure_dead_letter_chat": "oc_dead"},
+            ),
+            Platform.FEISHU,
+        )
+        default.send = AsyncMock(side_effect=RuntimeError("boom"))
+        runner.adapters[Platform.FEISHU] = default
+
+        failed = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_x"}), Platform.FEISHU
+        )
+        failed._bot_name = "Tony"
+        # 不抛即通过
+        await runner._forward_feishu_dead_letter(failed, "oc_t", "x", "err")
+
+    @pytest.mark.asyncio
+    async def test_runner_forwarder_suppresses_bot_to_bot_router(self):
+        """死信转发期间摘掉 default adapter 的 router，防止死信原文里的 @peer
+        触发 bot-to-bot route 形成回环（实测：Tony 从死信投递里"看到"了消息）。"""
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.adapters = {}
+        runner._adapter_profile_map = {}
+
+        default = DummyAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={"app_id": "cli_default", "send_failure_dead_letter_chat": "oc_dead"},
+            ),
+            Platform.FEISHU,
+        )
+        default._bot_to_bot_router = lambda *a, **k: None  # 模拟注入的 router（非 None）
+        router_during_send = []
+
+        async def _capture_send(**kw):
+            router_during_send.append(getattr(default, "_bot_to_bot_router", None))
+
+        default.send = AsyncMock(side_effect=_capture_send)
+        runner.adapters[Platform.FEISHU] = default
+
+        failed = DummyAdapter(
+            PlatformConfig(enabled=True, extra={"app_id": "cli_x"}), Platform.FEISHU
+        )
+        failed._bot_name = "Tony"
+
+        await runner._forward_feishu_dead_letter(failed, "oc_t", "原文 @技术总监Tony ...", "err")
+        # 发送期间 router 被摘除 → 死信不会触发 bot-to-bot route
+        assert router_during_send == [None]
+        # 发送后 router 恢复，不影响后续正常协作
+        assert callable(default._bot_to_bot_router)

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -132,3 +132,32 @@ def test_secondary_open_policy_fails_startup_guard(monkeypatch):
     assert violation is not None
     assert "wecom" in violation
     assert "open policy" in violation
+
+
+def test_handoff_process_passes_profile_to_session_key():
+    """#4: _process_handoff must wire profile into build_session_key so a
+    multi-profile CLI handoff keys under ``agent:<profile>`` instead of
+    collapsing to the default ``agent:main`` namespace (which would bind the
+    wrong session_store entry)."""
+    import inspect
+
+    from gateway.run import GatewayRunner
+
+    src = inspect.getsource(GatewayRunner._process_handoff)
+    assert "_resolve_profile_for_key" in src
+    assert "profile=" in src
+
+
+def test_build_session_key_profile_namespace_isolates_handoff_target():
+    """#4 semantic: with a resolved profile, build_session_key namespaces the
+    handoff key under ``agent:<profile>``, distinct from ``agent:main``."""
+    from gateway.session import SessionSource, build_session_key
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id="c1", chat_type="dm", user_id="u1",
+    )
+    default_key = build_session_key(source)  # no profile → agent:main
+    profiled_key = build_session_key(source, profile="coder")
+    assert default_key.startswith("agent:main:")
+    assert profiled_key.startswith("agent:coder:")
+    assert default_key != profiled_key

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -63,6 +63,9 @@ def _make_runner():
     runner._exit_cleanly = False
     runner._failed_platforms = {}
     runner.adapters = {}
+    runner.adapters_by_id = {}
+    runner._platform_adapter_ids = {}
+    runner._adapter_profile_map = {}
     runner.delivery_router = MagicMock()
     runner._running_agents = {}
     runner._pending_messages = {}

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -265,6 +265,8 @@ def _stub_adapter(platform: Platform, runner) -> "_StubAdapter":
     a = _StubAdapter.__new__(_StubAdapter)
     a.platform = platform
     a.gateway_runner = runner
+    # __new__ bypasses BasePlatformAdapter.__init__, which normally sets this.
+    a.adapter_id = None
     return a
 
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -543,6 +543,88 @@ class TestSessionStoreSwitchSession:
         db.close()
 
 
+class TestSwitchSessionCrossAdapterGuard:
+    """#64934: switch_session/advance_compression_session refuse to sew a
+    routing key onto a session owned by a different adapter unless the caller
+    explicitly opts in. The key→id layer honors the per-adapter isolation the
+    key layer encodes."""
+
+    @staticmethod
+    def _store(tmp_path):
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+        store._db = SessionDB(db_path=tmp_path / "state.db")
+        store._loaded = True
+        return store
+
+    @staticmethod
+    def _feishu_group_entry(store, adapter_id):
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_chat",
+            chat_type="group",
+            user_id="user-1",
+            adapter_id=adapter_id,
+        )
+        return store.get_or_create_session(source)
+
+    def test_refuses_cross_adapter_sew(self, tmp_path):
+        store = self._store(tmp_path)
+        entry = self._feishu_group_entry(store, "feishu:app1")
+        # target owned by app2; key is app1 → refused, entry unchanged
+        result = store.switch_session(
+            entry.session_key, "target_sid",
+            expected_adapter_id="feishu:app2",
+        )
+        assert result is None
+        assert store._entries[entry.session_key].session_id == entry.session_id
+        store._db.close()
+
+    def test_allows_same_adapter(self, tmp_path):
+        store = self._store(tmp_path)
+        entry = self._feishu_group_entry(store, "feishu:app1")
+        store._db.create_session("target_sid", "feishu")
+        result = store.switch_session(
+            entry.session_key, "target_sid",
+            expected_adapter_id="feishu:app1",
+        )
+        assert result is not None
+        assert result.session_id == "target_sid"
+        store._db.close()
+
+    def test_skips_check_when_no_expected_adapter(self, tmp_path):
+        store = self._store(tmp_path)
+        entry = self._feishu_group_entry(store, "feishu:app1")
+        store._db.create_session("target_sid", "feishu")
+        # no expected_adapter_id → guard skipped, legacy behavior preserved
+        result = store.switch_session(entry.session_key, "target_sid")
+        assert result is not None
+        store._db.close()
+
+    def test_allows_cross_when_explicit(self, tmp_path):
+        store = self._store(tmp_path)
+        entry = self._feishu_group_entry(store, "feishu:app1")
+        store._db.create_session("target_sid", "feishu")
+        result = store.switch_session(
+            entry.session_key, "target_sid",
+            allow_cross_adapter=True,
+            expected_adapter_id="feishu:app2",
+        )
+        assert result is not None
+        store._db.close()
+
+    def test_advance_compression_refuses_cross_adapter(self, tmp_path):
+        store = self._store(tmp_path)
+        entry = self._feishu_group_entry(store, "feishu:app1")
+        result = store.advance_compression_session(
+            entry.session_key, entry.session_id, "target_sid",
+            expected_adapter_id="feishu:app2",
+        )
+        assert result is None
+        store._db.close()
+
+
 class TestSessionStoreLookup:
     @pytest.fixture()
     def store(self, tmp_path):

--- a/tests/gateway/test_shutdown_cache_cleanup.py
+++ b/tests/gateway/test_shutdown_cache_cleanup.py
@@ -108,6 +108,12 @@ class _FakeGateway:
         except Exception:
             pass
 
+    def _iter_connected_adapters(self):
+        # Mirrors GatewayRunner._iter_connected_adapters's simple case: this
+        # fake has no multi-instance adapters_by_id registry, just the
+        # single-profile `adapters` map.
+        return list(self.adapters.items())
+
     def _evict_cached_agent(self, key):
         pass
 

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -62,6 +62,10 @@ def make_startup_runner(tmp_path):
         sessions_dir=tmp_path / "sessions",
     )
     runner.adapters = {}
+    # Mirrors GatewayRunner.__init__'s multi-instance adapter registry, used
+    # by _adapter_instance_id/_register_connected_adapter during start().
+    runner.adapters_by_id = {}
+    runner._platform_adapter_ids = {}
     runner._running = False
     runner._shutdown_event = asyncio.Event()
     runner._exit_reason = None

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -163,7 +163,11 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
             task_json TEXT,
             delivery_claim TEXT,
             delivery_claimed_at REAL,
-            origin_session_id TEXT NOT NULL DEFAULT ''
+            origin_session_id TEXT NOT NULL DEFAULT '',
+            source_adapter_id TEXT NOT NULL DEFAULT '',
+            source_profile TEXT NOT NULL DEFAULT '',
+            source_session_key TEXT NOT NULL DEFAULT '',
+            delegation_type TEXT NOT NULL DEFAULT 'same_adapter'
         )"""
     )
     columns = {row[1] for row in conn.execute("PRAGMA table_info(async_delegations)")}
@@ -178,6 +182,14 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         # completions recovered after a process restart are unroutable on
         # api_server (the in-memory record that carried it is gone).
         ("origin_session_id", "TEXT"),
+        # #64934: the spawning (parent) adapter/profile/session_key, so a
+        # completion arriving on a DIFFERENT adapter (multi-app fan-out) can
+        # be detected and rerouted instead of sewn onto the parent session_id.
+        # Empty for legacy records → resolver falls back to the original pin.
+        ("source_adapter_id", "TEXT"),
+        ("source_profile", "TEXT"),
+        ("source_session_key", "TEXT"),
+        ("delegation_type", "TEXT"),
     ):
         if name not in columns:
             conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
@@ -257,13 +269,19 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
                (delegation_id, origin_session, origin_ui_session_id,
                 parent_session_id, state, dispatched_at, updated_at,
                 delivery_state, delivery_attempts, owner_pid,
-                owner_started_at, task_json, origin_session_id)
-               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?)""",
+                owner_started_at, task_json, origin_session_id,
+                source_adapter_id, source_profile, source_session_key,
+                delegation_type)
+               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?,
+                       ?, ?, ?, ?)""",
             (record["delegation_id"], record.get("session_key", ""),
              record.get("origin_ui_session_id", ""), record.get("parent_session_id"),
              record["dispatched_at"], now, __import__("os").getpid(),
              owner_started_at, json.dumps(task_payload),
-             record.get("origin_session_id", "")),
+             record.get("origin_session_id", ""),
+             record.get("source_adapter_id", ""), record.get("source_profile", ""),
+             record.get("source_session_key", ""),
+             record.get("delegation_type", "same_adapter")),
         )
     _prune_durable_records()
 
@@ -344,12 +362,13 @@ def recover_abandoned_delegations() -> int:
         rows = conn.execute(
             """SELECT delegation_id, origin_session, origin_ui_session_id,
                       parent_session_id, dispatched_at, owner_pid,
-                      owner_started_at, task_json, origin_session_id
+                      owner_started_at, task_json, origin_session_id,
+                      source_session_key
                FROM async_delegations WHERE state IN ('running','finalizing')"""
         ).fetchall()
         for row in rows:
             (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
-             pid, started, task_json, origin_session_id) = row
+             pid, started, task_json, origin_session_id, source_sk) = row
             live = False
             if pid:
                 live = _pid_exists(int(pid))
@@ -365,6 +384,7 @@ def recover_abandoned_delegations() -> int:
                 # after a restart remain routable to api_server sessions.
                 "origin_session_id": origin_session_id or "",
                 "parent_session_id": parent_id, "goal": task.get("goal", ""),
+                "source_session_key": source_sk or "",
                 "goals": task.get("goals"), "context": task.get("context"),
                 "toolsets": task.get("toolsets"), "role": task.get("role"),
                 "model": task.get("model"), "is_batch": bool(task.get("is_batch")),
@@ -969,6 +989,7 @@ def _push_completion_event(
         "origin_ui_session_id": record.get("origin_ui_session_id", ""),
         "origin_session_id": record.get("origin_session_id", ""),
         "parent_session_id": record.get("parent_session_id"),
+        "source_session_key": record.get("source_session_key", ""),
         "goal": record.get("goal", ""),
         "context": record.get("context"),
         "toolsets": record.get("toolsets"),
@@ -1028,6 +1049,7 @@ def dispatch_async_delegation_batch(
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     delegation_id: Optional[str] = None,
     progress_fn: Optional[Callable[[], tuple]] = None,
+    source_session_key: str = "",
 ) -> Dict[str, Any]:
     """Dispatch a WHOLE fan-out batch as ONE background unit.
 
@@ -1069,6 +1091,7 @@ def dispatch_async_delegation_batch(
         "origin_session_id": origin_session_id,
         "parent_session_id": parent_session_id,
         **_capture_routing_origin(),
+        "source_session_key": source_session_key,
         "status": "running",
         "dispatched_at": dispatched_at,
         "completed_at": None,
@@ -1181,6 +1204,7 @@ def _push_batch_completion_event(
         "origin_ui_session_id": event_record.get("origin_ui_session_id", ""),
         "origin_session_id": event_record.get("origin_session_id", ""),
         "parent_session_id": event_record.get("parent_session_id"),
+        "source_session_key": event_record.get("source_session_key", ""),
         "goal": event_record.get("goal", ""),
         "goals": event_record.get("goals"),
         "context": event_record.get("context"),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4019,6 +4019,7 @@ def delegate_task(
             origin_ui_session_id=_origin_ui_session_id,
             origin_session_id=_wake_sid,
             parent_session_id=_parent_session_id,
+            source_session_key=_session_key,
             runner=_batch_runner,
             interrupt_fn=_batch_interrupt,
             max_async_children=_get_max_async_children(),

--- a/tools/feishu_chat_tool.py
+++ b/tools/feishu_chat_tool.py
@@ -1,0 +1,92 @@
+"""Feishu Chat Tool -- get group chat members.
+
+Provides ``get_chat_members`` so the agent can list the people in a Feishu
+group chat (with their open_id) before @-mentioning specific members. Resolves
+the live adapter via ``_gateway_runner_ref`` (gateway mode only).
+"""
+
+import importlib.util
+import json
+import logging
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+
+GET_CHAT_MEMBERS_SCHEMA = {
+    "name": "get_chat_members",
+    "description": (
+        "Get the member list of the current Feishu/Lark group chat — returns "
+        "each member's name and open_id. Call this before @-mentioning specific "
+        "people in a group so you know their open_id. Only works in Feishu group "
+        "chats under the gateway."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "chat_id": {
+                "type": "string",
+                "description": "Optional chat_id; defaults to the current group chat from session context.",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def _check_feishu() -> bool:
+    # Mirrors feishu_doc_tool: cheap importability probe (avoids the ~5s cost
+    # of executing lark_oapi's __init__ at every tool-availability check). The
+    # real import + adapter resolution happens in the handler.
+    try:
+        return importlib.util.find_spec("lark_oapi") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+async def _handle_get_chat_members(args: dict, **kwargs) -> str:
+    from gateway.session_context import get_session_env
+
+    chat_id = (args.get("chat_id") or "").strip() or get_session_env(
+        "HERMES_SESSION_CHAT_ID", ""
+    )
+    if not chat_id:
+        return tool_error("No chat_id available (not in a Feishu group chat context)")
+
+    from gateway.config import Platform
+    from gateway.run import _gateway_runner_ref
+
+    runner = _gateway_runner_ref()
+    adapter = runner.adapters.get(Platform.FEISHU) if runner is not None else None
+    if adapter is None or not hasattr(adapter, "get_chat_members"):
+        return tool_error(
+            "Feishu adapter unavailable — this tool only works in gateway mode on the Feishu platform"
+        )
+
+    members = await adapter.get_chat_members(chat_id)
+    if not members:
+        return tool_error(
+            "No members returned — the app likely lacks the im:chat.member:read "
+            "scope (grant it in the Feishu developer console and publish a new "
+            "app version), or the chat has no members"
+        )
+    return tool_result(
+        success=True,
+        content=json.dumps(
+            {"members": members, "count": len(members)}, ensure_ascii=False
+        ),
+    )
+
+
+registry.register(
+    name="get_chat_members",
+    toolset="feishu_chat",
+    schema=GET_CHAT_MEMBERS_SCHEMA,
+    handler=_handle_get_chat_members,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=True,
+    description="Get Feishu group chat members",
+    emoji="\U0001f465",
+)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -402,6 +402,11 @@ def _handle_send(args):
         return tool_error(f"Unknown platform: {platform_name}")
 
     pconfig = config.platforms.get(platform)
+    # Handle List[PlatformConfig] (feishu multi-app config)
+    if isinstance(pconfig, list):
+        if not pconfig:
+            return tool_error(f"Platform '{platform_name}' has no active configurations.")
+        pconfig = pconfig[0]
     if not pconfig or not pconfig.enabled:
         # Weixin can be configured purely via .env; synthesize a pconfig so
         # send_message and cron delivery work without a gateway.yaml entry.

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -196,9 +196,14 @@ _ALWAYS_BLOCKED_NETWORKS = (
 
 # Exact HTTPS hostnames allowed to resolve to private/benchmark-space IPs.
 # This is intentionally narrow: QQ media downloads can legitimately resolve
-# to 198.18.0.0/15 behind local proxy/benchmark infrastructure.
+# to 198.18.0.0/15 behind local proxy/benchmark infrastructure. Same story
+# for github.com/raw.githubusercontent.com on dev boxes running a local
+# proxy (e.g. Surge) with fake-ip DNS enabled — do NOT flip the global
+# security.allow_private_urls toggle for this, add the specific host here.
 _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
     "multimedia.nt.qq.com.cn",
+    "github.com",
+    "raw.githubusercontent.com",
 })
 
 _MAX_SSRF_CONNECT_IPS = 8

--- a/toolsets.py
+++ b/toolsets.py
@@ -372,6 +372,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "feishu_chat": {
+        "description": "Feishu/Lark group chat operations (list members for @-mention)",
+        "tools": ["get_chat_members"],
+        "includes": []
+    },
+
     "spotify": {
         "description": "Native Spotify playback, search, playlist, album, and library tools",
         "tools": [


### PR DESCRIPTION
## Summary

- `platforms.feishu.apps[]` list config: up to 10 concurrent Feishu apps per gateway, each with own credentials, `home_channel`, authorization policies, and profile mapping; YAML takes precedence over `FEISHU_APP_ID` env
- Session keys isolate agent/session state across Feishu apps (cross-adapter session-sew guard on `switch_session`/`advance_compression_session`, with companion tests)
- Credential env access guard: block direct `os.getenv()` reads of credential-shaped vars in the multiplex gateway (`agent/secret_scope.py` + enforcement script)
- Per-app websocket reconnect, fatal-error by-id bookkeeping (`adapters_by_id`), and multiplex authz wiring
- Rebased onto current main: preserves #80598 queue-before-disconnect ordering, strict-session routing guards, relay alias-aware adapter resolution, concise process notifications

## Testing

- `tests/gateway/test_feishu_multi_app.py` — 42 tests
- `tests/gateway/test_cross_adapter_sew_check.py` — 8 tests
- Full regression across touched areas (test_session, test_feishu, test_platform_reconnect, test_startup_restart_race, test_multiplex_profile_authz, test_profile_resolution, test_async_delegation_session_binding, test_shutdown_cache_cleanup, test_scheduler_provider) — 300/300 passed
- `ruff check .` clean