### PR TITLE
fix(mcp): keep embedded resource downloads discoverable

### DIFF
--- a/tests/tools/test_mcp_resource_content.py
+++ b/tests/tools/test_mcp_resource_content.py
@@ -41,6 +41,32 @@ def doc_cache(tmp_path, monkeypatch):
 
 
 class TestRenderResourceBlock:
+    def test_empty_embedded_text_surfaces_resource_uri(self):
+        from tools.mcp_tool import _render_mcp_resource_block
+
+        resource = SimpleNamespace(
+            uri="paperless://documents/105/download",
+            mimeType="application/octet-stream",
+            text="",
+            blob=None,
+        )
+
+        out = _render_mcp_resource_block(_embedded(resource), "paperless")
+
+        assert "paperless://documents/105/download" in out
+        assert "mcp__paperless__read_resource" in out
+
+    def test_empty_embedded_text_does_not_hide_blob(self, doc_cache):
+        from tools.mcp_tool import _render_mcp_resource_block
+
+        resource = _blob_resource(PDF_BYTES)
+        resource.text = ""
+
+        out = _render_mcp_resource_block(_embedded(resource), "slack")
+
+        assert "saved to" in out
+        assert "application/pdf" in out
+
     def test_embedded_pdf_blob_is_materialized(self, doc_cache):
         from tools.mcp_tool import _render_mcp_resource_block
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1027,10 +1027,12 @@ def _cache_mcp_audio_block(block) -> str:
 def _render_mcp_resource_block(block, server_name: str = "") -> str:
     """Render an MCP ``ResourceLink`` or ``EmbeddedResource`` block as text.
 
-    - ``EmbeddedResource`` with text contents → the text itself.
+    - ``EmbeddedResource`` with non-empty text contents → the text itself.
     - ``EmbeddedResource`` with blob contents → bytes are decoded (size-capped)
       and materialized into the Hermes document cache; returns a marker with
       the local path so file/terminal tools can consume it.
+    - ``EmbeddedResource`` with neither text nor blob → its URI plus a pointer
+      at the server's read_resource tool.
     - ``ResourceLink`` → the URI plus a pointer at the server's read_resource
       tool. No network fetch happens here; the link is only readable through
       the originating MCP session.
@@ -1065,17 +1067,28 @@ def _render_mcp_resource_block(block, server_name: str = "") -> str:
         return ""
 
     text = getattr(resource, "text", None)
-    if text is not None:
-        return str(text)
+    text_value = str(text) if text is not None else ""
+    if text_value:
+        return text_value
 
     blob = getattr(resource, "blob", None)
+    uri = str(getattr(resource, "uri", "") or "")
+    mime = str(getattr(resource, "mimeType", "") or "")
     if blob is None:
-        return ""
+        if not uri:
+            return ""
+        details = f"uri={uri}"
+        if mime:
+            details += f", mimeType={mime}"
+        reader = (
+            mcp_prefixed_tool_name(server_name, "read_resource")
+            if server_name
+            else "the MCP server's read_resource tool"
+        )
+        return f"[MCP embedded resource: {details} — fetch it with {reader}]"
 
     import base64
 
-    uri = str(getattr(resource, "uri", "") or "")
-    mime = str(getattr(resource, "mimeType", "") or "")
     if len(blob) > _MCP_RESOURCE_MAX_B64_CHARS:
         return f"[MCP embedded resource too large to cache: ~{len(blob) * 3 // 4} bytes, uri={uri}]"
     try:


### PR DESCRIPTION
## What does this PR do?

MCP tools that return an embedded resource with an empty `text` field no longer produce an empty result and hide the download target. Hermes now preserves a present blob, or surfaces the resource URI and the server-specific `read_resource` tool when no blob exists, so the agent can discover and retrieve the resource.

### Symptom

An MCP server can return an `EmbeddedResource` such as `paperless://documents/105/download` with `text: ""` and no blob. Hermes renders that block as an empty string, so the tool result contains neither the resource URI nor a follow-up action.

### Impact

Agents using MCP servers that represent lazily fetched binary downloads this way cannot discover the returned resource target. They must reconstruct or hardcode the URI before calling `read_resource`.

### Bug Cause

**Trigger:** `tools/mcp_tool.py` / `_render_mcp_resource_block()` / an embedded resource whose `text` value is an empty string.

**Causal chain:**
1. An MCP tool returns an `EmbeddedResource` with an empty `text` field and a valid URI, optionally alongside a blob.
2. `_render_mcp_resource_block()` treats every non-`None` text value as authoritative and returns the empty string before checking the blob or URI.
3. The caller drops the falsey rendered block, leaving the agent with an empty result and no resource target.

**Why it is wrong:** Empty text contains no resource content and must not suppress a blob or the URI needed to fetch the resource.

**Working sibling / contrast:** `ResourceLink` blocks already retain their URI and identify the originating server's `read_resource` tool.

**Ruled out:** The MCP server payload is not missing the target; the reported payload includes a valid `resource.uri`. Non-empty embedded text and normal blob-only resources already render through separate working paths.

### Fix

Treat only non-empty embedded text as rendered content. If a blob is present, materialize it even when `text` is empty. If neither text nor blob provides content, render the embedded resource URI, MIME type, and server-specific `read_resource` hint. Focused regression tests cover both empty-text paths.

## Related Issue

Closes #86178

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py` - fall through empty embedded text to blob handling or an actionable URI marker.
- `tests/tools/test_mcp_resource_content.py` - cover URI fallback and blob preservation when embedded text is empty.

## How to Test

1. Return an embedded MCP resource with `text: ""`, no blob, and a valid URI.
2. Confirm the rendered result contains the URI and the server-specific `read_resource` tool name.
3. Run the focused resource-content tests:

```bash
scripts/run_tests.sh tests/tools/test_mcp_resource_content.py
```

Result: 16 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior and regression coverage are self-contained
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the formatter logic is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool schema changes
