### PR TITLE
[Talos] Add authoritative session-turn lifecycle hooks (or7-platform#191)

### DIFF
--- a/agent/lifecycle_hooks.py
+++ b/agent/lifecycle_hooks.py
@@ -1,0 +1,237 @@
+"""Versioned, privacy-bounded lifecycle hook payloads.
+
+These helpers are the provider boundary for delegated children and managed
+background processes.  Payloads intentionally contain only stable identities,
+small integers, and allowlisted enum values.  Runtime text (prompts, commands,
+paths, output, exceptions, model/tool metadata) must never cross this seam.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_sequence_lock = threading.Lock()
+_sequences: dict[tuple[str, str], int] = {}
+
+SUBAGENT_LIFECYCLE_VERSION = 2
+DELEGATION_WRAPPER_LIFECYCLE_VERSION = 1
+MANAGED_PROCESS_LIFECYCLE_VERSION = 2
+
+_LIFECYCLE_VERSIONS = {
+    "subagent": SUBAGENT_LIFECYCLE_VERSION,
+    "delegation_wrapper": DELEGATION_WRAPPER_LIFECYCLE_VERSION,
+    "managed_process": MANAGED_PROCESS_LIFECYCLE_VERSION,
+}
+
+SUBAGENT_EVENTS = frozenset(
+    {"registered", "queued", "started", "heartbeat", "cancel_requested", "terminal"}
+)
+SUBAGENT_ROLES = frozenset({"leaf", "orchestrator"})
+SUBAGENT_TERMINAL_STATUSES = frozenset({"succeeded", "failed", "cancelled"})
+SUBAGENT_CANCEL_REASONS = frozenset({"waiter_timeout", "parent_interrupt", "explicit_cancel"})
+DELEGATION_WRAPPER_EVENTS = frozenset({"registered", "started", "timed_out", "terminal"})
+DELEGATION_WRAPPER_TERMINAL_STATUSES = frozenset({"succeeded", "failed", "cancelled"})
+
+MANAGED_PROCESS_EVENTS = frozenset(
+    {"started", "heartbeat", "probe_unavailable", "terminal", "adopted"}
+)
+PROCESS_PID_SCOPES = frozenset({"host", "sandbox"})
+PROCESS_BACKENDS = frozenset(
+    {"local", "docker", "singularity", "modal", "managed_modal", "daytona", "ssh", "unknown"}
+)
+PROCESS_TERMINAL_STATUSES = frozenset(
+    {"exited", "killed", "lost", "failed_start", "already_exited"}
+)
+PROCESS_TERMINATION_SOURCES = frozenset(
+    {"process.kill", "kill_all", "backend_lost", "failed_start", "reader", "reconciler", "unknown"}
+)
+
+
+def _identity(value: Any) -> Optional[str]:
+    return value if isinstance(value, str) and value else None
+
+
+def _integer(value: Any) -> Optional[int]:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _envelope(kind: str, source_id: Optional[str], event: str) -> dict[str, Any]:
+    """Build the versioned ordering envelope for one opaque source identity."""
+    if source_id is None:
+        raise ValueError(f"{kind} lifecycle event requires a stable source identity")
+    key = (kind, source_id)
+    with _sequence_lock:
+        sequence = _sequences.get(key, 0) + 1
+        _sequences[key] = sequence
+    occurred_at = datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace(
+        "+00:00", "Z"
+    )
+    return {
+        "contract_version": _LIFECYCLE_VERSIONS[kind],
+        "event": event,
+        "occurred_at": occurred_at,
+        "sequence": sequence,
+    }
+
+
+def _emit(hook_name: str, payload: dict[str, Any]) -> None:
+    try:
+        from hermes_cli.plugins import invoke_hook
+
+        # A single DTO keyword makes the privacy boundary explicit and prevents
+        # future helper locals from accidentally becoming hook kwargs.
+        invoke_hook(hook_name, dto=payload)
+    except Exception:
+        logger.debug("lifecycle_hook_failed hook=%s reason=callback_error", hook_name)
+
+
+def emit_subagent_lifecycle(
+    event: str,
+    *,
+    child_session_id: Any,
+    child_subagent_id: Any,
+    parent_session_id: Any = None,
+    parent_turn_id: Any = None,
+    parent_subagent_id: Any = None,
+    delegation_wrapper_id: Any = None,
+    child_role: Any = None,
+    terminal_status: Any = None,
+    cancel_reason: Any = None,
+) -> None:
+    """Emit one versioned delegated-child lifecycle observation."""
+    if event not in SUBAGENT_EVENTS:
+        raise ValueError(f"invalid subagent lifecycle event: {event}")
+    role = child_role if child_role in SUBAGENT_ROLES else None
+    terminal = terminal_status if terminal_status in SUBAGENT_TERMINAL_STATUSES else None
+    reason = cancel_reason if cancel_reason in SUBAGENT_CANCEL_REASONS else None
+    child_session = _identity(child_session_id)
+    child_subagent = _identity(child_subagent_id)
+    if child_session is None or child_subagent is None:
+        raise ValueError("subagent lifecycle event requires stable child identities")
+    payload = {
+        **_envelope("subagent", child_subagent, event),
+        "child_session_id": child_session,
+        "child_subagent_id": child_subagent,
+        "parent_session_id": _identity(parent_session_id),
+        "parent_turn_id": _identity(parent_turn_id),
+        "parent_subagent_id": _identity(parent_subagent_id),
+        "delegation_wrapper_id": _identity(delegation_wrapper_id),
+        "child_role": role,
+    }
+    if event == "terminal":
+        if terminal is None:
+            raise ValueError("terminal subagent lifecycle event requires terminal_status")
+        payload["terminal_status"] = terminal
+    if event == "cancel_requested":
+        if reason is None:
+            raise ValueError("cancel_requested requires an allowlisted cancel_reason")
+        payload["cancel_reason"] = reason
+    _emit("subagent_lifecycle", payload)
+
+
+def emit_delegation_wrapper_lifecycle(
+    event: str,
+    *,
+    wrapper_id: Any,
+    child_subagent_id: Any,
+    parent_session_id: Any = None,
+    parent_turn_id: Any = None,
+    parent_subagent_id: Any = None,
+    terminal_status: Any = None,
+) -> None:
+    """Emit one privacy-bounded lifecycle fact for a delegation waiter."""
+    if event not in DELEGATION_WRAPPER_EVENTS:
+        raise ValueError(f"invalid delegation-wrapper lifecycle event: {event}")
+    wrapper = _identity(wrapper_id)
+    child = _identity(child_subagent_id)
+    if wrapper is None or child is None:
+        raise ValueError("delegation-wrapper lifecycle requires stable wrapper and child identities")
+    payload = {
+        **_envelope("delegation_wrapper", wrapper, event),
+        "wrapper_id": wrapper,
+        "child_subagent_id": child,
+        "parent_session_id": _identity(parent_session_id),
+        "parent_turn_id": _identity(parent_turn_id),
+        "parent_subagent_id": _identity(parent_subagent_id),
+    }
+    if event == "terminal":
+        status = terminal_status if terminal_status in DELEGATION_WRAPPER_TERMINAL_STATUSES else None
+        if status is None:
+            raise ValueError("terminal delegation-wrapper event requires terminal_status")
+        payload["terminal_status"] = status
+    _emit("delegation_wrapper_lifecycle", payload)
+
+
+def managed_process_backend(env: Any) -> str:
+    if env is None:
+        return "local"
+    module_name = type(env).__module__.rsplit(".", 1)[-1]
+    return module_name if module_name in PROCESS_BACKENDS else "unknown"
+
+
+def managed_process_backend_id(env: Any) -> Optional[str]:
+    """Return an opaque stable backend identity, never a path or command."""
+    if env is None:
+        return None
+    for attr in ("_sandbox_id", "_container_id", "sandbox_id", "container_id", "instance_id"):
+        value = getattr(env, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def emit_managed_process_lifecycle(
+    event: str,
+    *,
+    process_id: Any,
+    task_id: Any = None,
+    session_key: Any = None,
+    pid: Any = None,
+    host_start_time: Any = None,
+    host_boot_id: Any = None,
+    pid_scope: Any = None,
+    backend: Any = None,
+    backend_id: Any = None,
+    backend_process_id: Any = None,
+    terminal_status: Any = None,
+    termination_source: Any = None,
+    exit_code: Any = None,
+) -> None:
+    """Emit one versioned managed-process lifecycle observation."""
+    if event not in MANAGED_PROCESS_EVENTS:
+        raise ValueError(f"invalid managed process lifecycle event: {event}")
+    scope = pid_scope if pid_scope in PROCESS_PID_SCOPES else None
+    backend_name = backend if backend in PROCESS_BACKENDS else "unknown"
+    process_identity = _identity(process_id)
+    if process_identity is None:
+        raise ValueError("managed-process lifecycle event requires a stable process identity")
+    payload = {
+        **_envelope("managed_process", process_identity, event),
+        "process_id": process_identity,
+        "task_id": _identity(task_id),
+        "session_key": _identity(session_key),
+        "pid": _integer(pid),
+        "host_start_time": _integer(host_start_time),
+        "host_boot_id": _identity(host_boot_id),
+        "pid_scope": scope,
+        "backend": backend_name,
+        "backend_id": _identity(backend_id),
+        "backend_process_id": _identity(backend_process_id),
+    }
+    if event == "terminal":
+        status = terminal_status if terminal_status in PROCESS_TERMINAL_STATUSES else None
+        if status is None:
+            raise ValueError("terminal managed-process event requires terminal_status")
+        payload["terminal_status"] = status
+        payload["termination_source"] = (
+            termination_source
+            if termination_source in PROCESS_TERMINATION_SOURCES
+            else "unknown"
+        )
+        payload["exit_code"] = _integer(exit_code)
+    _emit("managed_process_lifecycle", payload)

--- a/agent/lifecycle_hooks.py
+++ b/agent/lifecycle_hooks.py
@@ -1,7 +1,8 @@
 """Versioned, privacy-bounded lifecycle hook payloads.
 
-These helpers are the provider boundary for delegated children and managed
-background processes.  Payloads intentionally contain only stable identities,
+These helpers are the provider boundary for session turns, delegated children,
+and managed background processes. Payloads intentionally contain only stable
+identities,
 small integers, and allowlisted enum values.  Runtime text (prompts, commands,
 paths, output, exceptions, model/tool metadata) must never cross this seam.
 """
@@ -21,12 +22,17 @@ _sequences: dict[tuple[str, str], int] = {}
 SUBAGENT_LIFECYCLE_VERSION = 2
 DELEGATION_WRAPPER_LIFECYCLE_VERSION = 1
 MANAGED_PROCESS_LIFECYCLE_VERSION = 2
+SESSION_TURN_LIFECYCLE_VERSION = 1
 
 _LIFECYCLE_VERSIONS = {
     "subagent": SUBAGENT_LIFECYCLE_VERSION,
     "delegation_wrapper": DELEGATION_WRAPPER_LIFECYCLE_VERSION,
     "managed_process": MANAGED_PROCESS_LIFECYCLE_VERSION,
+    "session_turn": SESSION_TURN_LIFECYCLE_VERSION,
 }
+
+SESSION_TURN_EVENTS = frozenset({"registered", "started", "heartbeat", "terminal"})
+SESSION_TURN_TERMINAL_OUTCOMES = frozenset({"succeeded", "failed", "cancelled"})
 
 SUBAGENT_EVENTS = frozenset(
     {"registered", "queued", "started", "heartbeat", "cancel_requested", "terminal"}
@@ -88,6 +94,43 @@ def _emit(hook_name: str, payload: dict[str, Any]) -> None:
         invoke_hook(hook_name, dto=payload)
     except Exception:
         logger.debug("lifecycle_hook_failed hook=%s reason=callback_error", hook_name)
+
+
+def emit_session_turn_lifecycle(
+    event: str,
+    *,
+    session_id: Any,
+    turn_id: Any,
+    terminal_outcome: Any = None,
+) -> None:
+    """Emit one versioned, turn-scoped gateway execution observation."""
+    if event not in SESSION_TURN_EVENTS:
+        raise ValueError(f"invalid session turn lifecycle event: {event}")
+    session = _identity(session_id)
+    turn = _identity(turn_id)
+    if session is None or turn is None:
+        raise ValueError(
+            "session-turn lifecycle event requires stable session and turn identities"
+        )
+    payload = {
+        **_envelope("session_turn", turn, event),
+        "session_id": session,
+        "turn_id": turn,
+    }
+    if event == "terminal":
+        outcome = (
+            terminal_outcome
+            if terminal_outcome in SESSION_TURN_TERMINAL_OUTCOMES
+            else None
+        )
+        if outcome is None:
+            raise ValueError("terminal session-turn event requires terminal_outcome")
+        payload["terminal_outcome"] = outcome
+    elif terminal_outcome is not None:
+        raise ValueError(
+            "terminal_outcome is only valid for terminal session-turn events"
+        )
+    _emit("session_turn_lifecycle", payload)
 
 
 def emit_subagent_lifecycle(

--- a/agent/lifecycle_hooks.py
+++ b/agent/lifecycle_hooks.py
@@ -85,15 +85,17 @@ def _envelope(kind: str, source_id: Optional[str], event: str) -> dict[str, Any]
     }
 
 
-def _emit(hook_name: str, payload: dict[str, Any]) -> None:
+def _emit(hook_name: str, payload: dict[str, Any]) -> bool:
     try:
         from hermes_cli.plugins import invoke_hook
 
         # A single DTO keyword makes the privacy boundary explicit and prevents
         # future helper locals from accidentally becoming hook kwargs.
         invoke_hook(hook_name, dto=payload)
+        return True
     except Exception:
-        logger.debug("lifecycle_hook_failed hook=%s reason=callback_error", hook_name)
+        logger.warning("lifecycle_hook_failed hook=%s reason=callback_error", hook_name)
+        return False
 
 
 def emit_session_turn_lifecycle(
@@ -102,7 +104,7 @@ def emit_session_turn_lifecycle(
     session_id: Any,
     turn_id: Any,
     terminal_outcome: Any = None,
-) -> None:
+) -> bool:
     """Emit one versioned, turn-scoped gateway execution observation."""
     if event not in SESSION_TURN_EVENTS:
         raise ValueError(f"invalid session turn lifecycle event: {event}")
@@ -130,7 +132,7 @@ def emit_session_turn_lifecycle(
         raise ValueError(
             "terminal_outcome is only valid for terminal session-turn events"
         )
-    _emit("session_turn_lifecycle", payload)
+    return _emit("session_turn_lifecycle", payload)
 
 
 def emit_subagent_lifecycle(

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -428,7 +428,15 @@ def build_turn_context(
     # Generate unique task_id if not provided to isolate VMs between tasks.
     effective_task_id = task_id or str(uuid.uuid4())
     agent._current_task_id = effective_task_id
-    turn_id = f"{agent.session_id or 'session'}:{effective_task_id}:{uuid.uuid4().hex[:8]}"
+    authoritative_turn_id = getattr(agent, "_authoritative_turn_id", None)
+    turn_id = (
+        authoritative_turn_id
+        if isinstance(authoritative_turn_id, str) and authoritative_turn_id
+        else f"{agent.session_id or 'session'}:{effective_task_id}:{uuid.uuid4().hex[:8]}"
+    )
+    # The API edge injects this once for a durable session turn. Do not let a
+    # reused agent accidentally apply the same provider identity to a later turn.
+    agent._authoritative_turn_id = None
     agent._current_turn_id = turn_id
     agent._current_api_request_id = ""
     # Tripwire: warn (with both turn ids) when this turn starts before the

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -240,6 +240,17 @@ coordination; `terminal` maps the durable coordinator result. The same native
 turn ID is installed on the root agent, so delegated children created during
 that turn report the same `parent_turn_id`.
 
+Callbacks run on a per-turn ordered daemon dispatcher, never on aiohttp or the
+execution coordinator. Its queue is bounded: observer backpressure may drop
+heartbeats, but cannot reorder or displace registered, started, or terminal.
+Drops, callback failures, and callbacks exceeding the latency threshold produce
+privacy-safe warning logs and process-local counters. Close queues terminal
+exactly once; bounded flush occurs only after the execution lease is released,
+so a slow or hung observer cannot delay requests, heartbeats, or lease release.
+Coordinator cancellation is cooperative: it requests child interruption but
+retains lease and heartbeat ownership until the executor actually exits, then
+maps the durable terminal result.
+
 Startup adoption is intentionally not emitted. Although the durable lease can
 prove that another process still owns a turn, this provider process cannot
 observe that owner's eventual completion or continue its per-turn sequence.

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -222,6 +222,31 @@ and `child_goal`.
 Observers can use these hooks to model nested trajectories while keeping child
 agent execution linked to the parent turn that spawned it.
 
+### Native Session-Turn Lifecycle
+
+The versioned `session_turn_lifecycle` hook observes durable API session turns
+at the gateway coordinator's authoritative boundaries. Its single `dto`
+keyword has contract version 1 and contains only `contract_version`, `event`,
+`occurred_at`, `sequence`, `session_id`, and `turn_id`. A `terminal` DTO also
+contains `terminal_outcome`, one of `succeeded`, `failed`, or `cancelled`.
+Events are `registered`, `started`, periodic `heartbeat`, and exactly one
+`terminal` for a coordinator execution that reaches durable terminal state.
+Sequence is strictly increasing within each turn. Runtime input, output, tool
+data, and error text never cross this hook.
+
+`registered` follows durable turn reservation; `started` follows the durable
+transition to running; heartbeats cover agent execution and delivery
+coordination; `terminal` maps the durable coordinator result. The same native
+turn ID is installed on the root agent, so delegated children created during
+that turn report the same `parent_turn_id`.
+
+Startup adoption is intentionally not emitted. Although the durable lease can
+prove that another process still owns a turn, this provider process cannot
+observe that owner's eventual completion or continue its per-turn sequence.
+Treating that proof as local adoption would therefore invent ownership and
+could produce conflicting sequences. Startup reconciliation preserves a live
+owner or interrupts work whose owner is not mechanically live.
+
 ## Payload Safety
 
 Observer payloads are designed for telemetry consumers, not raw object access.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5458,6 +5458,7 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        authoritative_turn_id: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -5502,6 +5503,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                     if agent_ref is not None:
                         agent_ref[0] = agent
+                    if isinstance(authoritative_turn_id, str) and authoritative_turn_id:
+                        agent._authoritative_turn_id = authoritative_turn_id
                     effective_task_id = session_id or str(uuid.uuid4())
                     result = agent.run_conversation(
                         user_message=user_message,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -9,6 +9,7 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/models                  — lists hermes-agent and any configured model_routes aliases
 - GET  /v1/capabilities            — machine-readable API capabilities for external UIs
 - GET  /api/sessions               — list client-visible Hermes sessions
+- GET  /api/sessions/search        — owner-scoped full-text message search
 - POST /api/sessions               — create an empty Hermes session
 - GET/PATCH/DELETE /api/sessions/{session_id} — read/update/delete a session
 - GET  /api/sessions/{session_id}/messages — read session message history
@@ -40,10 +41,14 @@ Requires:
 """
 
 import asyncio
+import base64
+import binascii
 import errno
 import hashlib
 import hmac
+import html
 import json
+import unicodedata
 from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar
 from functools import wraps
@@ -51,11 +56,12 @@ import logging
 import os
 import re
 import sqlite3
+import subprocess
 import sys
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
@@ -91,8 +97,47 @@ from gateway.platforms.base import (
 )
 from agent.redact import redact_sensitive_text
 from gateway.readiness import collect_runtime_readiness
+from hermes_state import SessionSearchUnavailable
+from gateway.session_execution_lease import (
+    SessionExecutionConflict,
+    SessionExecutionLease,
+)
+from gateway.platforms.session_turns import (
+    MAX_INLINE_IMAGE_TOTAL_BYTES,
+    MAX_INPUT_TEXT_LENGTH,
+    SESSION_TURN_CAPABILITIES,
+    SessionTurnService,
+)
 
 logger = logging.getLogger(__name__)
+
+OCC_CAPABILITY_REVISION = "occ.conversation_gateway.h1-h2-h3.v2"
+
+
+def _capability_build_id() -> str:
+    """Return the immutable source/image revision advertised to OCC."""
+    try:
+        from hermes_cli.build_info import get_build_sha
+
+        baked = get_build_sha(short=40)
+        if baked:
+            return baked
+    except Exception:
+        pass
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parents[2],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        ).strip()
+    except Exception:
+        return "unknown"
+
+
+class SessionHistoryReadError(RuntimeError):
+    """Canonical persisted history could not be read safely."""
 
 
 def _hermes_version() -> str:
@@ -123,7 +168,18 @@ def _hermes_version() -> str:
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
-MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversations with tool calls
+# The transport cap must truthfully carry the advertised durable-turn payload:
+# the 10 MiB decoded inline-image budget grows by 4/3 as base64 on the wire,
+# plus the 64 KiB text cap at up to 6 bytes per JSON-escaped character, plus
+# JSON framing. 16 MiB bounds that envelope with headroom and still keeps a
+# hard, safe ceiling; long agent conversations with tool calls also fit.
+_TURN_WIRE_ENVELOPE_BYTES = (
+    ((MAX_INLINE_IMAGE_TOTAL_BYTES + 2) // 3) * 4  # base64 of decoded budget
+    + 6 * MAX_INPUT_TEXT_LENGTH                    # worst-case escaped text
+    + 64 * 1024                                    # JSON framing / headers slack
+)
+MAX_REQUEST_BYTES = 16 * 1024 * 1024
+assert _TURN_WIRE_ENVELOPE_BYTES <= MAX_REQUEST_BYTES
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
@@ -1078,6 +1134,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # Shutdown counts this reservation so the request cannot slip through
         # the drain between its first await and _run_agent()/task registration.
         self._pending_agent_requests: int = 0
+        # Durable OCC/browser turns live in a focused edge service. Keeping
+        # orchestration out of this already-large adapter also ensures no new
+        # model tool/schema is introduced.
+        self._session_turn_service = SessionTurnService(self)
 
     def active_agent_work_count(self) -> int:
         """Return all live agent work owned by this API adapter.
@@ -1563,6 +1623,8 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/toolsets", self._handle_toolsets),
             ("GET", "/api/sessions", self._handle_list_sessions),
             ("POST", "/api/sessions", self._handle_create_session),
+            # Static route must precede /api/sessions/{session_id}.
+            ("GET", "/api/sessions/search", self._handle_session_search),
             ("GET", "/api/sessions/{session_id}", self._handle_get_session),
             ("PATCH", "/api/sessions/{session_id}", self._handle_patch_session),
             ("DELETE", "/api/sessions/{session_id}", self._handle_delete_session),
@@ -1570,6 +1632,11 @@ class APIServerAdapter(BasePlatformAdapter):
             ("POST", "/api/sessions/{session_id}/fork", self._handle_fork_session),
             ("POST", "/api/sessions/{session_id}/chat", self._handle_session_chat),
             ("POST", "/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream),
+            ("POST", "/api/sessions/{session_id}/turns", self._handle_session_turn_submit),
+            ("GET", "/api/sessions/{session_id}/turns/{turn_id}", self._handle_session_turn_status),
+            ("GET", "/api/sessions/{session_id}/turns/{turn_id}/events", self._handle_session_turn_events),
+            ("POST", "/api/sessions/{session_id}/turns/{turn_id}/stop", self._handle_session_turn_stop),
+            ("POST", "/api/sessions/{session_id}/turns/{turn_id}/deliver", self._handle_session_turn_deliver),
             ("POST", "/v1/chat/completions", self._handle_chat_completions),
             ("POST", "/v1/responses", self._handle_responses),
             ("GET", "/v1/responses/{response_id}", self._handle_get_response),
@@ -1610,6 +1677,7 @@ class APIServerAdapter(BasePlatformAdapter):
     # (e.g. ``agent:main:webui:dm:user-42``) while staying small enough
     # that the sanitized form is safe to pass into Honcho / state.db.
     _MAX_SESSION_HEADER_LEN = 256
+    _MAX_OWNER_USER_ID_LEN = 256
 
     def _parse_session_key_header(
         self, request: "web.Request"
@@ -2081,9 +2149,30 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
+        session_db = await self._ensure_session_db_async()
+        session_search_available = bool(
+            self._search_cursor_signing_key()
+            and session_db
+            and await asyncio.to_thread(session_db.session_search_available)
+        )
+        session_search_endpoint = {
+            "method": "GET",
+            "path": "/api/sessions/search",
+            "owner_scope": ["user_id", "source"],
+            "pagination": {
+                "type": "cursor",
+                "parameter": "cursor",
+                "ordering": ["timestamp_desc", "message_id_desc"],
+                "snapshot": "message_id_high_water",
+                "cursor": "hmac_authenticated_v2",
+            },
+        }
+
         return web.json_response({
             "object": "hermes.api_server.capabilities",
             "platform": "hermes-agent",
+            "revision": OCC_CAPABILITY_REVISION,
+            "build_id": _capability_build_id(),
             "model": self._model_name,
             "auth": {
                 "type": "bearer",
@@ -2112,9 +2201,23 @@ class APIServerAdapter(BasePlatformAdapter):
                 "tool_progress_events": True,
                 "approval_events": True,
                 "session_resources": True,
+                "session_create_owner_bound": True,
+                "session_search": session_search_available,
                 "session_chat": True,
                 "session_chat_streaming": True,
                 "session_fork": True,
+                "session_fork_anchored_preserve_source": True,
+                "session_fork_anchor_field": "anchor_message_id",
+                "session_fork_user_message_anchor": True,
+                "durable_session_turns": True,
+                "conversation_turn_contract": "h1",
+                "durable_turn_idempotency": True,
+                "durable_turn_status": True,
+                "durable_turn_resumable_events": True,
+                "durable_turn_stop": True,
+                "durable_turn_manual_delivery": True,
+                "conversation_turn_slack_delivery": True,
+                "conversation_turn_image_input": True,
                 "admin_config_rw": False,
                 "jobs_admin": False,
                 "memory_write_api": False,
@@ -2139,7 +2242,18 @@ class APIServerAdapter(BasePlatformAdapter):
                 "skills": {"method": "GET", "path": "/v1/skills"},
                 "toolsets": {"method": "GET", "path": "/v1/toolsets"},
                 "sessions": {"method": "GET", "path": "/api/sessions"},
-                "session_create": {"method": "POST", "path": "/api/sessions"},
+                **(
+                    {"session_search": session_search_endpoint}
+                    if session_search_available
+                    else {}
+                ),
+                "session_create": {
+                    "method": "POST",
+                    "path": "/api/sessions",
+                    "owner_field": "user_id",
+                    "owner_max_chars": self._MAX_OWNER_USER_ID_LEN,
+                    "source": "api_server",
+                },
                 "session": {"method": "GET", "path": "/api/sessions/{session_id}"},
                 "session_update": {"method": "PATCH", "path": "/api/sessions/{session_id}"},
                 "session_delete": {"method": "DELETE", "path": "/api/sessions/{session_id}"},
@@ -2147,6 +2261,20 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork"},
                 "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
+                "session_turn_submit": {"method": "POST", "path": "/api/sessions/{session_id}/turns"},
+                "session_turn_status": {"method": "GET", "path": "/api/sessions/{session_id}/turns/{turn_id}"},
+                "session_turn_events": {"method": "GET", "path": "/api/sessions/{session_id}/turns/{turn_id}/events"},
+                "session_turn_stop": {"method": "POST", "path": "/api/sessions/{session_id}/turns/{turn_id}/stop"},
+                "session_turn_deliver": {"method": "POST", "path": "/api/sessions/{session_id}/turns/{turn_id}/deliver"},
+                "conversation_turn_create": {"method": "POST", "path": "/api/sessions/{session_id}/turns"},
+                "conversation_turn_status": {"method": "GET", "path": "/api/sessions/{session_id}/turns/{turn_id}"},
+                "conversation_turn_events": {"method": "GET", "path": "/api/sessions/{session_id}/turns/{turn_id}/events"},
+                "conversation_turn_stop": {"method": "POST", "path": "/api/sessions/{session_id}/turns/{turn_id}/stop"},
+                "conversation_turn_deliver": {"method": "POST", "path": "/api/sessions/{session_id}/turns/{turn_id}/deliver"},
+            },
+            "session_turns": {
+                **SESSION_TURN_CAPABILITIES,
+                "transport": {"max_request_bytes": MAX_REQUEST_BYTES},
             },
         })
 
@@ -2260,9 +2388,23 @@ class APIServerAdapter(BasePlatformAdapter):
             "output_tokens", "cache_read_tokens", "cache_write_tokens",
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
             "api_call_count", "parent_session_id", "last_active", "preview",
-            "_lineage_root_id",
+            "_lineage_root_id", "branch_point_message_id",
         )
         payload = {key: session.get(key) for key in safe_keys if key in session}
+        if "branch_point_message_id" not in payload:
+            raw_config = session.get("model_config")
+            try:
+                model_config = (
+                    json.loads(raw_config)
+                    if isinstance(raw_config, str)
+                    else raw_config
+                )
+            except (json.JSONDecodeError, TypeError):
+                model_config = None
+            if isinstance(model_config, dict):
+                branch_point = model_config.get("_branch_point_message_id")
+                if isinstance(branch_point, int) and not isinstance(branch_point, bool):
+                    payload["branch_point_message_id"] = branch_point
         # Avoid exposing full system prompts/model_config through the client API;
         # callers only need to know whether those snapshots exist.
         payload["has_system_prompt"] = bool(session.get("system_prompt"))
@@ -2303,12 +2445,30 @@ class APIServerAdapter(BasePlatformAdapter):
     async def _conversation_history_for_session(self, session_id: str) -> List[Dict[str, Any]]:
         db = await self._ensure_session_db_async()
         if db is None:
-            return []
+            raise SessionHistoryReadError("session database unavailable")
         try:
             return await asyncio.to_thread(db.get_messages_as_conversation, session_id)
         except Exception as exc:
-            logger.warning("Failed to load session history for %s: %s", session_id, exc)
-            return []
+            logger.warning("Failed to load session history for %s", session_id)
+            raise SessionHistoryReadError("session history unavailable") from exc
+
+    async def _acquire_session_execution_lease(
+        self,
+        session_id: str,
+        *,
+        owner_prefix: str,
+        on_lost: Optional[Callable[[], None]] = None,
+    ) -> SessionExecutionLease:
+        db = await self._ensure_session_db_async()
+        if db is None:
+            raise SessionHistoryReadError("session database unavailable")
+        return await SessionExecutionLease.acquire(
+            db,
+            session_id,
+            owner_prefix=owner_prefix,
+            wait_timeout=0.0,
+            on_lost=on_lost,
+        )
 
     async def _handle_list_sessions(self, request: "web.Request") -> "web.Response":
         """GET /api/sessions — list persisted Hermes sessions."""
@@ -2339,6 +2499,340 @@ class APIServerAdapter(BasePlatformAdapter):
             "has_more": len(sessions) == limit,
         })
 
+    _SEARCH_CREDENTIAL_ASSIGNMENT_RE = re.compile(
+        r"(?i)(?<![A-Za-z0-9_.-])"
+        r"(?P<key>[A-Za-z0-9_.-]{0,64}"
+        r"(?:api[_. -]?key|access[_. -]?token|refresh[_. -]?token|token|secret|"
+        r"password|passwd|credential|authorization|auth)"
+        r"[A-Za-z0-9_.-]{0,64})"
+        r"(?P<sep>\s*(?:=|:)\s*)"
+        r"(?P<value>\"[^\"\r\n]*\"|'[^'\r\n]*'|[^\s,;&]+)"
+    )
+    _SEARCH_AUTHORIZATION_RE = re.compile(
+        r"(?i)((?:proxy-)?authorization\s*:\s*)"
+        r"(?:(?:bearer|basic|token|digest)\s+)?[^\s,;]+"
+    )
+    _SEARCH_BEARER_RE = re.compile(
+        r"(?i)(?<![A-Za-z0-9_-])(bearer\s+)[A-Za-z0-9._~+/=-]{8,}"
+    )
+    _SEARCH_JWT_RE = re.compile(
+        r"eyJ[A-Za-z0-9_-]{10,}(?:\.[A-Za-z0-9_=-]{4,}){0,2}"
+    )
+    _SEARCH_REDACTED_SENTINEL_RE = re.compile(r"«redacted(?::[^»]*)?»")
+    _SEARCH_CURSOR_VERSION = 2
+    _SEARCH_CURSOR_TTL_SECONDS = 900
+
+    @classmethod
+    def _redact_search_content(cls, value: Any) -> str:
+        """Completely remove credential values before any snippet slicing."""
+        text = str(value or "")
+        text = cls._SEARCH_AUTHORIZATION_RE.sub(r"\1[REDACTED]", text)
+        text = cls._SEARCH_BEARER_RE.sub(r"\1[REDACTED]", text)
+        text = cls._SEARCH_JWT_RE.sub("[REDACTED]", text)
+        text = cls._SEARCH_CREDENTIAL_ASSIGNMENT_RE.sub(
+            lambda match: f"{match.group('key')}{match.group('sep')}[REDACTED]",
+            text,
+        )
+        redacted = redact_sensitive_text(
+            text,
+            force=True,
+            file_read=True,
+            redact_url_credentials=True,
+        )
+        return cls._SEARCH_REDACTED_SENTINEL_RE.sub("[REDACTED]", redacted)
+
+    @classmethod
+    def _bounded_search_snippet(cls, value: Any, maximum: int = 480) -> str:
+        """Return one globally redacted, query-independent prefix per message."""
+        redacted = " ".join(cls._redact_search_content(value).split())
+        if not redacted or maximum < 2:
+            return "…"
+
+        # Never return a complete body, even when it is shorter than the bound.
+        excerpt = redacted[:192]
+        if len(excerpt) == len(redacted):
+            excerpt = excerpt[:-1]
+        if not excerpt:
+            return "…"
+
+        output: List[str] = []
+        used = 0
+        for character in excerpt:
+            escaped = html.escape(character, quote=True)
+            if used + len(escaped) > maximum - 1:
+                break
+            output.append(escaped)
+            used += len(escaped)
+        return "".join(output) + "…"
+
+    @staticmethod
+    def _search_cursor_scope_hash(value: str) -> str:
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _normalize_search_query(value: str) -> str:
+        return " ".join(unicodedata.normalize("NFKC", value).split())
+
+    def _search_cursor_signing_key(self) -> Optional[bytes]:
+        if not self._api_key:
+            return None
+        return hmac.new(
+            self._api_key.encode("utf-8"),
+            b"hermes-session-search-cursor:v2",
+            hashlib.sha256,
+        ).digest()
+
+    def _encode_search_cursor(
+        self,
+        *,
+        query: str,
+        user_id: str,
+        source: str,
+        snapshot_message_id: int,
+        boundary: Dict[str, Any],
+    ) -> str:
+        signing_key = self._search_cursor_signing_key()
+        if signing_key is None:
+            raise SessionSearchUnavailable("Session search cursor signing unavailable")
+        now = int(time.time())
+        payload = {
+            "v": self._SEARCH_CURSOR_VERSION,
+            "q": self._search_cursor_scope_hash(self._normalize_search_query(query)),
+            "u": self._search_cursor_scope_hash(user_id),
+            "s": self._search_cursor_scope_hash(source),
+            "h": snapshot_message_id,
+            "t": boundary["timestamp"],
+            "i": int(boundary["message_id"]),
+            "e": now + self._SEARCH_CURSOR_TTL_SECONDS,
+        }
+        encoded_payload = base64.urlsafe_b64encode(
+            json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        ).rstrip(b"=")
+        signature = base64.urlsafe_b64encode(
+            hmac.new(signing_key, encoded_payload, hashlib.sha256).digest()
+        ).rstrip(b"=")
+        return f"{encoded_payload.decode('ascii')}.{signature.decode('ascii')}"
+
+    def _decode_search_cursor(
+        self,
+        value: str,
+        *,
+        query: str,
+        user_id: str,
+        source: str,
+    ) -> Optional[Dict[str, Any]]:
+        signing_key = self._search_cursor_signing_key()
+        if (
+            signing_key is None
+            or not value
+            or len(value) > 2_048
+            or not re.fullmatch(r"[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+", value)
+        ):
+            return None
+        try:
+            encoded_payload, encoded_signature = value.split(".", 1)
+            signature = base64.b64decode(
+                encoded_signature + "=" * (-len(encoded_signature) % 4),
+                altchars=b"-_",
+                validate=True,
+            )
+            expected_signature = hmac.new(
+                signing_key, encoded_payload.encode("ascii"), hashlib.sha256
+            ).digest()
+            if not hmac.compare_digest(signature, expected_signature):
+                return None
+            payload_bytes = base64.b64decode(
+                encoded_payload + "=" * (-len(encoded_payload) % 4),
+                altchars=b"-_",
+                validate=True,
+            )
+            payload = json.loads(payload_bytes)
+            if (
+                not isinstance(payload, dict)
+                or set(payload) != {"v", "q", "u", "s", "h", "t", "i", "e"}
+                or payload.get("v") != self._SEARCH_CURSOR_VERSION
+            ):
+                return None
+            expected = (
+                self._search_cursor_scope_hash(self._normalize_search_query(query)),
+                self._search_cursor_scope_hash(user_id),
+                self._search_cursor_scope_hash(source),
+            )
+            actual = (payload.get("q"), payload.get("u"), payload.get("s"))
+            if any(
+                not isinstance(left, str)
+                or not isinstance(right, str)
+                or not hmac.compare_digest(left, right)
+                for left, right in zip(actual, expected)
+            ):
+                return None
+            high_water = int(payload["h"])
+            message_id = int(payload["i"])
+            timestamp = payload["t"]
+            expires_at = int(payload["e"])
+            if (
+                high_water < 0
+                or message_id <= 0
+                or not isinstance(timestamp, (int, float))
+                or timestamp < 0
+                or expires_at < int(time.time())
+            ):
+                return None
+            return {
+                "snapshot_message_id": high_water,
+                "after": (timestamp, message_id),
+            }
+        except (
+            binascii.Error,
+            KeyError,
+            TypeError,
+            UnicodeDecodeError,
+            ValueError,
+            json.JSONDecodeError,
+        ):
+            return None
+
+    async def _handle_session_search(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/search — safe exact-owner FTS search."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        query = request.rel_url.query
+        allowed = {"q", "user_id", "source", "limit", "cursor"}
+        if any(key not in allowed for key in query):
+            return web.json_response(
+                _openai_error("Invalid search query parameters", code="invalid_query"),
+                status=400,
+            )
+        for key in allowed:
+            if len(query.getall(key, [])) > 1:
+                return web.json_response(
+                    _openai_error("Duplicate search query parameter", code="invalid_query"),
+                    status=400,
+                )
+
+        q = (query.get("q") or "").strip()
+        user_id = (query.get("user_id") or "").strip()
+        source = (query.get("source") or "").strip()
+        if (
+            not q
+            or not user_id
+            or not source
+            or len(q) > 256
+            or len(user_id) > 256
+            or len(source) > 64
+            or any(
+                "\x00" in value or "\r" in value or "\n" in value
+                for value in (q, user_id, source)
+            )
+        ):
+            return web.json_response(
+                _openai_error(
+                    "Invalid or missing owner-scoped search query",
+                    code="invalid_query",
+                ),
+                status=400,
+            )
+
+        raw_limit = query.get("limit")
+        if raw_limit is None:
+            limit = 20
+        elif re.fullmatch(r"[0-9]+", raw_limit):
+            limit = int(raw_limit)
+        else:
+            limit = 0
+        if not 1 <= limit <= 50:
+            return web.json_response(
+                _openai_error("Invalid search pagination", code="invalid_query"),
+                status=400,
+            )
+
+        cursor_value = query.get("cursor")
+        cursor = None
+        if cursor_value is not None:
+            cursor = self._decode_search_cursor(
+                cursor_value,
+                query=q,
+                user_id=user_id,
+                source=source,
+            )
+            if cursor is None:
+                return web.json_response(
+                    _openai_error("Invalid search cursor", code="invalid_query"),
+                    status=400,
+                )
+
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return web.json_response(
+                _openai_error(
+                    "Session search unavailable", code="session_search_unavailable"
+                ),
+                status=503,
+            )
+        try:
+            if self._search_cursor_signing_key() is None:
+                raise SessionSearchUnavailable(
+                    "Session search cursor signing unavailable"
+                )
+            if not await asyncio.to_thread(db.session_search_available):
+                raise SessionSearchUnavailable("Session full-text search is unavailable")
+            rows, snapshot_message_id = await asyncio.to_thread(
+                db.search_messages_scoped,
+                q,
+                user_id=user_id,
+                source=source,
+                limit=limit + 1,
+                snapshot_message_id=(
+                    cursor["snapshot_message_id"] if cursor is not None else None
+                ),
+                after=cursor["after"] if cursor is not None else None,
+            )
+        except SessionSearchUnavailable:
+            logger.warning("Owner-scoped session search unavailable", exc_info=True)
+            return web.json_response(
+                _openai_error(
+                    "Session search unavailable", code="session_search_unavailable"
+                ),
+                status=503,
+            )
+        except Exception:
+            logger.exception("Owner-scoped session search failed")
+            return web.json_response(
+                _openai_error("Session search failed", err_type="server_error"),
+                status=500,
+            )
+
+        has_more = len(rows) > limit
+        page_rows = rows[:limit]
+        data = [
+            {
+                "session_id": row["session_id"],
+                "message_id": row["message_id"],
+                "role": row["role"],
+                "timestamp": row["timestamp"],
+                "snippet": self._bounded_search_snippet(row.get("content")),
+            }
+            for row in page_rows
+        ]
+        next_cursor = None
+        if has_more and page_rows:
+            next_cursor = self._encode_search_cursor(
+                query=q,
+                user_id=user_id,
+                source=source,
+                snapshot_message_id=snapshot_message_id,
+                boundary=page_rows[-1],
+            )
+        return web.json_response({
+            "object": "list",
+            "data": data,
+            "limit": limit,
+            "has_more": has_more,
+            "next_cursor": next_cursor,
+        })
+
     async def _handle_create_session(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions -- create an empty Hermes session row.
 
@@ -2367,6 +2861,24 @@ class APIServerAdapter(BasePlatformAdapter):
         if len(session_id) > self._MAX_SESSION_HEADER_LEN:
             return web.json_response(_openai_error("Session ID too long", code="invalid_session_id"), status=400)
 
+        user_id = body.get("user_id")
+        if user_id is not None:
+            if not isinstance(user_id, str):
+                return web.json_response(
+                    _openai_error("user_id must be a string", code="invalid_user_id"),
+                    status=400,
+                )
+            user_id = user_id.strip()
+            if (
+                not user_id
+                or len(user_id) > self._MAX_OWNER_USER_ID_LEN
+                or re.search(r'[\x00-\x1f\x7f]', user_id)
+            ):
+                return web.json_response(
+                    _openai_error("Invalid user_id", code="invalid_user_id"),
+                    status=400,
+                )
+
         model = body.get("model") or self._model_name
         system_prompt = body.get("system_prompt")
         if system_prompt is not None and not isinstance(system_prompt, str):
@@ -2388,11 +2900,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 import time as _time
                 conn.execute(
                     """INSERT INTO sessions (
-                       id, source, model, system_prompt, started_at
-                    ) VALUES (?, ?, ?, ?, ?)""",
+                       id, source, user_id, model, system_prompt, started_at
+                    ) VALUES (?, ?, ?, ?, ?, ?)""",
                     (
                         session_id,
                         "api_server",
+                        user_id,
                         str(model) if model else None,
                         system_prompt,
                         _time.time(),
@@ -2419,7 +2932,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ).fetchone()
                 return (dict(session_row) if session_row else {
                     "id": session_id, "source": "api_server",
-                    "model": model, "title": title,
+                    "user_id": user_id, "model": model, "title": title,
                 }), None
             return db._execute_write(_atomic)
 
@@ -2500,51 +3013,193 @@ class APIServerAdapter(BasePlatformAdapter):
         })
 
     async def _handle_fork_session(self, request: "web.Request") -> "web.Response":
-        """POST /api/sessions/{session_id}/fork — branch via current SessionDB primitives."""
+        """POST /api/sessions/{session_id}/fork — exact, non-mutating branch."""
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
         source_id = request.match_info["session_id"]
-        source, err = await self._get_existing_session_or_404(source_id)
+        _, err = await self._get_existing_session_or_404(source_id)
         if err:
             return err
         body, err = await self._read_json_body(request)
         if err:
             return err
-        db = await self._ensure_session_db_async()
-        fork_id = str(body.get("id") or body.get("session_id") or f"api_{int(time.time())}_{uuid.uuid4().hex[:8]}").strip()
-        if not fork_id or re.search(r'[\r\n\x00]', fork_id):
-            return web.json_response(_openai_error("Invalid session ID", code="invalid_session_id"), status=400)
-        if await asyncio.to_thread(db.get_session, fork_id):
-            return web.json_response(_openai_error(f"Session already exists: {fork_id}", code="session_exists"), status=409)
 
-        # Match the CLI /branch semantics: mark the original as branched, then
-        # create a child session that carries the transcript forward. This uses
-        # SessionDB's native parent_session_id/end_reason visibility model rather
-        # than inventing a parallel fork store.
-        await asyncio.to_thread(db.end_session, source_id, "branched")
-        await asyncio.to_thread(db.create_session,
-            fork_id,
-            "api_server",
-            model=source.get("model"),
-            system_prompt=source.get("system_prompt"),
-            parent_session_id=source_id,
-        )
-        messages = await asyncio.to_thread(db.get_messages, source_id)
-        await asyncio.to_thread(db.replace_messages, fork_id, messages)
+        if body.get("preserve_source") is not True:
+            return web.json_response(
+                _openai_error(
+                    "preserve_source must be true for an anchored fork",
+                    code="preserve_source_required",
+                ),
+                status=400,
+            )
+
+        has_canonical_anchor = "anchor_message_id" in body
+        has_legacy_anchor = "from_message_id" in body
+        canonical_anchor = body.get("anchor_message_id")
+        legacy_anchor = body.get("from_message_id")
+        if (
+            not has_canonical_anchor
+            and not has_legacy_anchor
+            or has_canonical_anchor
+            and has_legacy_anchor
+            and canonical_anchor != legacy_anchor
+        ):
+            return web.json_response(
+                _openai_error(
+                    "Supply anchor_message_id, or compatible from_message_id, but not conflicting values",
+                    code="invalid_anchor",
+                ),
+                status=400,
+            )
+        anchor_message_id = canonical_anchor if has_canonical_anchor else legacy_anchor
+        if (
+            not isinstance(anchor_message_id, int)
+            or isinstance(anchor_message_id, bool)
+            or anchor_message_id <= 0
+        ):
+            return web.json_response(
+                _openai_error(
+                    "anchor_message_id must be a positive integer",
+                    code="invalid_anchor",
+                ),
+                status=400,
+            )
+
+        idempotency_key = body.get("idempotency_key")
+        if not isinstance(idempotency_key, str) or not idempotency_key.strip():
+            return web.json_response(
+                _openai_error(
+                    "idempotency_key must be a non-empty string",
+                    code="invalid_idempotency_key",
+                ),
+                status=400,
+            )
+        idempotency_key = idempotency_key.strip()
+        if len(idempotency_key) > 255:
+            return web.json_response(
+                _openai_error(
+                    "idempotency_key is too long (max 255 characters)",
+                    code="invalid_idempotency_key",
+                ),
+                status=400,
+            )
+
         title = body.get("title")
-        if title is None:
-            base = source.get("title") or "fork"
-            try:
-                title = await asyncio.to_thread(db.get_next_title_in_lineage, base)
-            except Exception:
-                title = f"{base} fork"
+        if title is not None and not isinstance(title, str):
+            return web.json_response(
+                _openai_error("title must be a string", code="invalid_title"),
+                status=400,
+            )
+
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return web.json_response(
+                _openai_error(
+                    "Session database unavailable", code="session_db_unavailable"
+                ),
+                status=503,
+            )
         try:
-            await asyncio.to_thread(db.set_session_title, fork_id, str(title))
+            clean_title = db.sanitize_title(title)
         except ValueError as exc:
-            return web.json_response(_openai_error(str(exc), code="invalid_title"), status=400)
-        fork = await asyncio.to_thread(db.get_session, fork_id) or {"id": fork_id, "parent_session_id": source_id}
-        return web.json_response({"object": "hermes.session", "session": self._session_response(fork)}, status=201)
+            return web.json_response(
+                _openai_error(str(exc), code="invalid_title"), status=400
+            )
+
+        raw_fork_id = body.get("id") or body.get("session_id")
+        requested_fork_id = str(raw_fork_id).strip() if raw_fork_id else None
+        fork_id = requested_fork_id or f"api_{int(time.time())}_{uuid.uuid4().hex[:8]}"
+        from gateway.session import _is_path_unsafe
+        if (
+            not fork_id
+            or re.search(r'[\r\n\x00]', fork_id)
+            or _is_path_unsafe(fork_id)
+            or len(fork_id) > self._MAX_SESSION_HEADER_LEN
+        ):
+            return web.json_response(
+                _openai_error("Invalid session ID", code="invalid_session_id"),
+                status=400,
+            )
+
+        try:
+            result, fork = await asyncio.to_thread(
+                db.fork_session_at_message,
+                source_id,
+                fork_id,
+                anchor_message_id,
+                idempotency_key,
+                title=clean_title,
+                requested_child_session_id=requested_fork_id,
+            )
+        except Exception:
+            logger.exception("Atomic anchored fork failed for source %s", source_id)
+            return web.json_response(
+                _openai_error("Failed to fork session", code="session_fork_failed"),
+                status=500,
+            )
+
+        if result == "source_missing":
+            return web.json_response(
+                _openai_error(
+                    f"Session not found: {source_id}", code="session_not_found"
+                ),
+                status=404,
+            )
+        if result == "invalid_anchor":
+            return web.json_response(
+                _openai_error(
+                    "anchor_message_id does not belong to the source session",
+                    code="invalid_anchor",
+                ),
+                status=400,
+            )
+        if result == "unsafe_anchor":
+            return web.json_response(
+                _openai_error(
+                    "anchor_message_id is not a canonical user message or "
+                    "completed assistant response safe for continuation",
+                    code="unsafe_anchor",
+                ),
+                status=400,
+            )
+        if result == "session_exists":
+            return web.json_response(
+                _openai_error(
+                    f"Session already exists: {fork_id}", code="session_exists"
+                ),
+                status=409,
+            )
+        if result == "invalid_title":
+            return web.json_response(
+                _openai_error("Title already in use", code="invalid_title"),
+                status=400,
+            )
+        if result == "idempotency_stale":
+            return web.json_response(
+                _openai_error(
+                    "idempotency_key refers to a fork whose child no longer exists",
+                    code="idempotency_stale",
+                ),
+                status=409,
+            )
+        if result == "idempotency_conflict":
+            return web.json_response(
+                _openai_error(
+                    "idempotency_key was already used for a different fork request",
+                    code="idempotency_conflict",
+                ),
+                status=409,
+            )
+
+        return web.json_response(
+            {
+                "object": "hermes.session",
+                "session": self._session_response(fork),
+                "idempotent_replay": result == "replayed",
+            },
+            status=200 if result == "replayed" else 201,
+        )
 
     @_admit_api_agent_request
     async def _handle_session_chat(self, request: "web.Request") -> "web.Response":
@@ -2565,14 +3220,35 @@ class APIServerAdapter(BasePlatformAdapter):
         system_prompt = body.get("system_message") or body.get("instructions")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
-        history = await self._conversation_history_for_session(session_id)
-        result, usage = await self._run_agent(
-            user_message=user_message,
-            conversation_history=history,
-            ephemeral_system_prompt=system_prompt,
-            session_id=session_id,
-            gateway_session_key=gateway_session_key,
-        )
+        try:
+            lease = await self._acquire_session_execution_lease(
+                session_id, owner_prefix="api:session-chat"
+            )
+        except SessionExecutionConflict:
+            return web.json_response(
+                _openai_error("Session already has an active execution", code="active_session_execution"),
+                status=409,
+            )
+        except SessionHistoryReadError:
+            return web.json_response(
+                _openai_error("Session history unavailable", code="session_history_unavailable"),
+                status=503,
+            )
+        async with lease:
+            try:
+                history = await self._conversation_history_for_session(session_id)
+            except SessionHistoryReadError:
+                return web.json_response(
+                    _openai_error("Session history unavailable", code="session_history_unavailable"),
+                    status=503,
+                )
+            result, usage = await self._run_agent(
+                user_message=user_message,
+                conversation_history=history,
+                ephemeral_system_prompt=system_prompt,
+                session_id=session_id,
+                gateway_session_key=gateway_session_key,
+            )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
         final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
         headers = {"X-Hermes-Session-Id": effective_session_id or session_id}
@@ -2649,10 +3325,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 _enqueue(event_name, {"message_id": message_id, "tool_name": tool_name, "preview": preview, "args": args})
 
         async def _run_and_signal() -> None:
+            lease = None
             try:
+                lease = await self._acquire_session_execution_lease(
+                    session_id, owner_prefix="api:session-chat-stream"
+                )
+                history = await self._conversation_history_for_session(session_id)
                 await queue.put(_event_payload("run.started", {"user_message": {"role": "user", "content": user_message}}))
                 await queue.put(_event_payload("message.started", {"message": {"id": message_id, "role": "assistant"}}))
-                history = await self._conversation_history_for_session(session_id)
                 result, usage = await self._run_agent(
                     user_message=user_message,
                     conversation_history=history,
@@ -2680,10 +3360,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     "messages": turn_messages,
                     "usage": usage,
                 }))
+            except SessionExecutionConflict:
+                await queue.put(_event_payload("error", {"message": "Session already has an active execution", "code": "active_session_execution"}))
+            except SessionHistoryReadError:
+                await queue.put(_event_payload("error", {"message": "Session history unavailable", "code": "session_history_unavailable"}))
             except Exception as exc:
                 logger.exception("[api_server] session chat stream failed")
                 await queue.put(_event_payload("error", {"message": _redact_api_error_text(exc)}))
             finally:
+                if lease is not None:
+                    await lease.release()
                 await queue.put(_event_payload("done", {}))
                 await queue.put(None)
 
@@ -2726,6 +3412,24 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[api_server] session SSE stream error: %s", exc)
         return response
+
+    # Durable/replayable session-turn API. All behavior and persistence live
+    # in session_turns.py; these methods intentionally stay as thin route seams.
+    @_admit_api_agent_request
+    async def _handle_session_turn_submit(self, request: "web.Request") -> "web.Response":
+        return await self._session_turn_service.submit(request)
+
+    async def _handle_session_turn_status(self, request: "web.Request") -> "web.Response":
+        return await self._session_turn_service.status(request)
+
+    async def _handle_session_turn_events(self, request: "web.Request") -> "web.StreamResponse":
+        return await self._session_turn_service.events(request)
+
+    async def _handle_session_turn_stop(self, request: "web.Request") -> "web.Response":
+        return await self._session_turn_service.stop(request)
+
+    async def _handle_session_turn_deliver(self, request: "web.Request") -> "web.Response":
+        return await self._session_turn_service.deliver(request)
 
     @_admit_api_agent_request
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
@@ -2837,9 +3541,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 db = await self._ensure_session_db_async()
                 if db is not None:
                     history = await asyncio.to_thread(db.get_messages_as_conversation, session_id)
-            except Exception as e:
-                logger.warning("Failed to load session history for %s: %s", session_id, e)
-                history = []
+            except Exception:
+                logger.warning("Failed to load canonical session history for %s", session_id)
+                return web.json_response(
+                    _openai_error(
+                        "Session history unavailable",
+                        code="session_history_unavailable",
+                    ),
+                    status=503,
+                )
         else:
             # Derive a stable session ID from the conversation fingerprint so
             # that consecutive messages from the same Open WebUI (or similar)
@@ -5559,6 +6269,9 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         try:
+            # Reconcile crash-uncertain durable turns before accepting traffic.
+            # This never resumes work; it terminalizes it as interrupted.
+            await self._session_turn_service.reconcile_startup()
             mws = [
                 mw
                 for mw in (

--- a/gateway/platforms/session_turns.py
+++ b/gateway/platforms/session_turns.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 
 SESSION_TURN_HEARTBEAT_INTERVAL_SECONDS = 15.0
 SESSION_TURN_LIFECYCLE_QUEUE_SIZE = 32
+SESSION_TURN_LIFECYCLE_WORKERS = 4
+SESSION_TURN_LIFECYCLE_PENDING_DISPATCHERS = 32
 SESSION_TURN_LIFECYCLE_SLOW_SECONDS = 0.1
 SESSION_TURN_LIFECYCLE_FLUSH_SECONDS = 0.05
 
@@ -61,6 +63,7 @@ _lifecycle_metrics = {
     "heartbeat_dropped": 0,
     "observer_failed": 0,
     "observer_slow": 0,
+    "observer_capacity_exhausted": 0,
     "terminal_enqueue_failed": 0,
 }
 
@@ -83,10 +86,124 @@ def session_turn_lifecycle_metrics() -> Dict[str, int]:
         return dict(_lifecycle_metrics)
 
 
+class _SessionTurnLifecycleExecutor:
+    """Process-wide fixed observer capacity with a bounded pending queue.
+
+    Python cannot forcibly stop a plugin callback. A hung callback therefore
+    occupies one of a fixed number of daemon workers, while the bounded queue
+    prevents completed turns from accumulating behind it forever. Once both
+    bounds are exhausted, new lifecycle streams explicitly degrade fail-open.
+    """
+
+    def __init__(self, workers: int, pending: int):
+        self.worker_count = max(1, workers)
+        self.pending_capacity = max(1, pending)
+        self._queue: queue.Queue[SessionTurnLifecycleDispatcher] = queue.Queue(
+            maxsize=self.pending_capacity
+        )
+        self._start_lock = threading.Lock()
+        self._stats_lock = threading.Lock()
+        self._started = False
+        self._active = 0
+        self._next_observation = 0
+        self._observations: Dict[int, tuple[str, float, bool]] = {}
+        # Pay the fixed worker startup cost at module initialization, never on
+        # a latency-sensitive turn-admission path.
+        self._start_workers()
+        threading.Thread(
+            target=self._watch_slow_callbacks,
+            name="session-lifecycle-watchdog",
+            daemon=True,
+        ).start()
+
+    def submit(self, dispatcher: "SessionTurnLifecycleDispatcher") -> bool:
+        try:
+            self._queue.put_nowait(dispatcher)
+            return True
+        except queue.Full:
+            return False
+
+    def stats(self) -> Dict[str, int]:
+        with self._stats_lock:
+            active = self._active
+        return {
+            "workers": self.worker_count,
+            "active": active,
+            "pending": self._queue.qsize(),
+            "pending_capacity": self.pending_capacity,
+        }
+
+    def observe_callback_started(self, event: str) -> int:
+        with self._stats_lock:
+            self._next_observation += 1
+            token = self._next_observation
+            self._observations[token] = (event, time.monotonic(), False)
+            return token
+
+    def observe_callback_finished(self, token: int) -> None:
+        with self._stats_lock:
+            self._observations.pop(token, None)
+
+    def _start_workers(self) -> None:
+        if self._started:
+            return
+        with self._start_lock:
+            if self._started:
+                return
+            for index in range(self.worker_count):
+                threading.Thread(
+                    target=self._worker,
+                    name=f"session-turn-lifecycle-{index}",
+                    daemon=True,
+                ).start()
+            self._started = True
+
+    def _worker(self) -> None:
+        while True:
+            dispatcher = self._queue.get()
+            with self._stats_lock:
+                self._active += 1
+            try:
+                dispatcher._run()
+            finally:
+                with self._stats_lock:
+                    self._active -= 1
+                self._queue.task_done()
+
+    def _watch_slow_callbacks(self) -> None:
+        """Report hung callbacks from one fixed watchdog, never per-turn timers."""
+        while True:
+            time.sleep(max(0.01, SESSION_TURN_LIFECYCLE_SLOW_SECONDS / 2))
+            now = time.monotonic()
+            slow_events = []
+            with self._stats_lock:
+                for token, (event, started_at, reported) in list(
+                    self._observations.items()
+                ):
+                    if not reported and now - started_at >= SESSION_TURN_LIFECYCLE_SLOW_SECONDS:
+                        self._observations[token] = (event, started_at, True)
+                        slow_events.append(event)
+            for event in slow_events:
+                _note_lifecycle_degradation(
+                    "observer_slow", event, "callback_slow"
+                )
+
+
+_lifecycle_executor = _SessionTurnLifecycleExecutor(
+    SESSION_TURN_LIFECYCLE_WORKERS,
+    SESSION_TURN_LIFECYCLE_PENDING_DISPATCHERS,
+)
+
+
+def session_turn_lifecycle_executor_stats() -> Dict[str, int]:
+    """Return privacy-safe fixed-capacity observer executor diagnostics."""
+    return _lifecycle_executor.stats()
+
+
 class SessionTurnLifecycleDispatcher:
     """Ordered, bounded, non-blocking observer delivery for one durable turn.
 
-    Plugin code runs only on this dispatcher's daemon thread. Heartbeats are
+    Plugin code runs only on the process-wide fixed daemon pool. Heartbeats are
     lossy under backpressure, while the structural registered/started/terminal
     facts are retained. A slow or permanently hung plugin therefore cannot
     hold aiohttp, the coordinator, or the persistent execution lease.
@@ -100,14 +217,15 @@ class SessionTurnLifecycleDispatcher:
         )
         self._closed = False
         self._drained = threading.Event()
-        self._thread = threading.Thread(
-            target=self._run,
-            name="session-turn-lifecycle",
-            daemon=True,
-        )
         # Registered is admitted before the worker can observe later events.
         self._queue.put_nowait(("registered", {}))
-        self._thread.start()
+        self._admitted = _lifecycle_executor.submit(self)
+        if not self._admitted:
+            self._closed = True
+            self._drained.set()
+            _note_lifecycle_degradation(
+                "observer_capacity_exhausted", "registered", "executor_saturated"
+            )
 
     def emit(self, event: str, **extra: Any) -> bool:
         """Queue an event without waiting; return whether it was retained."""
@@ -155,15 +273,7 @@ class SessionTurnLifecycleDispatcher:
     def _run(self) -> None:
         while True:
             event, extra = self._queue.get()
-            slow = threading.Event()
-
-            def report_slow() -> None:
-                if not slow.is_set():
-                    _note_lifecycle_degradation("observer_slow", event, "callback_slow")
-
-            watchdog = threading.Timer(SESSION_TURN_LIFECYCLE_SLOW_SECONDS, report_slow)
-            watchdog.daemon = True
-            watchdog.start()
+            observation = _lifecycle_executor.observe_callback_started(event)
             try:
                 delivered = _emit_turn_lifecycle(
                     event,
@@ -179,8 +289,7 @@ class SessionTurnLifecycleDispatcher:
                 # Defensive: _emit_turn_lifecycle is already fail-open.
                 _note_lifecycle_degradation("observer_failed", event, "callback_error")
             finally:
-                slow.set()
-                watchdog.cancel()
+                _lifecycle_executor.observe_callback_finished(observation)
             if event == "terminal":
                 self._drained.set()
                 return
@@ -1346,15 +1455,35 @@ class SessionTurnService:
             if outcome is not None:
                 if dispatcher is not None:
                     dispatcher.close(outcome)
-            if execution_lease is not None:
-                await execution_lease.release()
-            # Observer completion is bounded and happens only after lease
-            # release. to_thread keeps even this small grace off aiohttp.
-            if dispatcher is not None and outcome is not None:
-                await asyncio.to_thread(
-                    dispatcher.flush, SESSION_TURN_LIFECYCLE_FLUSH_SECONDS
-                )
-            self._agent_refs.pop(turn_id, None)
+            try:
+                if execution_lease is not None:
+                    # A caller may cancel this coordinator repeatedly during
+                    # unwind. Keep re-awaiting the lease's one shielded release
+                    # operation until durable ownership and heartbeat are gone.
+                    while True:
+                        try:
+                            await execution_lease.release()
+                            break
+                        except asyncio.CancelledError:
+                            continue
+                # Observer completion is bounded and happens only after lease
+                # release. Shield one to_thread call so repeated cancellation
+                # cannot spawn abandoned flush workers.
+                if dispatcher is not None and outcome is not None:
+                    flush_task = asyncio.create_task(
+                        asyncio.to_thread(
+                            dispatcher.flush, SESSION_TURN_LIFECYCLE_FLUSH_SECONDS
+                        )
+                    )
+                    while True:
+                        try:
+                            await asyncio.shield(flush_task)
+                            break
+                        except asyncio.CancelledError:
+                            continue
+            finally:
+                self._agent_refs.pop(turn_id, None)
+                self._lifecycle_dispatchers.pop(turn_id, None)
 
     async def _deliver_slack(self, store: SessionTurnStore, turn_id: str, binding: SlackBinding,
                              slack_adapter: Any, content: str) -> None:

--- a/gateway/platforms/session_turns.py
+++ b/gateway/platforms/session_turns.py
@@ -22,6 +22,7 @@ import time
 import uuid
 import warnings
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Callable, Dict, Optional, TypeVar
 
 from aiohttp import web
@@ -38,6 +39,144 @@ SESSION_TURN_LIFECYCLE_WORKERS = 4
 SESSION_TURN_LIFECYCLE_PENDING_DISPATCHERS = 32
 SESSION_TURN_LIFECYCLE_SLOW_SECONDS = 0.1
 SESSION_TURN_LIFECYCLE_FLUSH_SECONDS = 0.05
+SESSION_TURN_CALLBACK_QUEUE_SIZE = 32
+
+
+class _CallbackEventClass(Enum):
+    """Persistence guarantees for events emitted by synchronous agent callbacks."""
+
+    STRUCTURAL = "structural"
+    VOLATILE = "volatile"
+
+
+@dataclass(frozen=True)
+class _CallbackPersistenceEvent:
+    event_class: _CallbackEventClass
+    event_type: str
+    data: Dict[str, Any]
+
+
+class _CallbackPersistenceOverloaded(RuntimeError):
+    """Stop an on-loop producer rather than lose a structural event."""
+
+
+class _CallbackPersistenceIngress:
+    """Bounded sync-callback ingress to one loop-owned persistence pump.
+
+    Structural callbacks from the agent worker apply backpressure to that worker.
+    A callback unexpectedly invoked on the aiohttp loop cannot wait without
+    deadlocking, so saturation raises and safely stops its producer. Volatile
+    deltas use one coalescing loop notification and explicitly request canonical
+    resync when one cannot be retained.
+    """
+
+    def __init__(self, loop: asyncio.AbstractEventLoop, maxsize: int):
+        self.loop = loop
+        self.queue: asyncio.Queue[_CallbackPersistenceEvent] = asyncio.Queue(
+            maxsize=max(1, maxsize)
+        )
+        self.done = asyncio.Event()
+        self.pump_task: Optional[asyncio.Task[Any]] = None
+        self.max_observed = 0
+        self.resync_required = False
+        self._loop_thread_id = threading.get_ident()
+        self._volatile_lock = threading.Lock()
+        self._pending_volatile: Optional[_CallbackPersistenceEvent] = None
+        self._volatile_notification_pending = False
+        self._accepting = True
+
+    def bind_pump(self, pump_task: asyncio.Task[Any]) -> None:
+        self.pump_task = pump_task
+
+    def append_structural(self, event_type: str, data: Dict[str, Any]) -> None:
+        event = _CallbackPersistenceEvent(
+            _CallbackEventClass.STRUCTURAL, event_type, dict(data)
+        )
+        if threading.get_ident() == self._loop_thread_id:
+            if not self._accepting:
+                raise _CallbackPersistenceOverloaded("callback persistence closed")
+            try:
+                self.queue.put_nowait(event)
+            except asyncio.QueueFull as exc:
+                raise _CallbackPersistenceOverloaded(
+                    "structural callback persistence saturated"
+                ) from exc
+            self._observe_size()
+            return
+        future = asyncio.run_coroutine_threadsafe(self._put_structural(event), self.loop)
+        # Backpressure only the agent callback thread, never the aiohttp loop.
+        future.result()
+
+    async def _put_structural(self, event: _CallbackPersistenceEvent) -> None:
+        while self._accepting:
+            if self.pump_task is not None and self.pump_task.done():
+                raise _CallbackPersistenceOverloaded("callback persistence unavailable")
+            try:
+                await asyncio.wait_for(self.queue.put(event), timeout=0.05)
+                self._observe_size()
+                return
+            except asyncio.TimeoutError:
+                continue
+        raise _CallbackPersistenceOverloaded("callback persistence closed")
+
+    def append_volatile(self, event_type: str, data: Dict[str, Any]) -> None:
+        event = _CallbackPersistenceEvent(
+            _CallbackEventClass.VOLATILE, event_type, dict(data)
+        )
+        if threading.get_ident() == self._loop_thread_id:
+            if not self._accepting:
+                return
+            try:
+                self.queue.put_nowait(event)
+                self._observe_size()
+            except asyncio.QueueFull:
+                self.resync_required = True
+            return
+        with self._volatile_lock:
+            if not self._accepting:
+                return
+            if self._pending_volatile is not None:
+                # Do not concatenate bodies: retained callback memory stays fixed.
+                self.resync_required = True
+                return
+            self._pending_volatile = event
+            if self._volatile_notification_pending:
+                return
+            self._volatile_notification_pending = True
+        self.loop.call_soon_threadsafe(self._flush_volatile)
+
+    def _flush_volatile(self) -> None:
+        with self._volatile_lock:
+            event = self._pending_volatile
+            self._pending_volatile = None
+            self._volatile_notification_pending = False
+        if event is None:
+            return
+        if not self._accepting:
+            self.resync_required = True
+            return
+        try:
+            self.queue.put_nowait(event)
+            self._observe_size()
+        except asyncio.QueueFull:
+            self.resync_required = True
+
+    def close(self) -> None:
+        """Run on the loop after the agent exits; retain or mark the last delta."""
+        with self._volatile_lock:
+            self._accepting = False
+            pending = self._pending_volatile
+            self._pending_volatile = None
+        if pending is not None:
+            try:
+                self.queue.put_nowait(pending)
+                self._observe_size()
+            except asyncio.QueueFull:
+                self.resync_required = True
+        self.done.set()
+
+    def _observe_size(self) -> None:
+        self.max_observed = max(self.max_observed, self.queue.qsize())
 
 
 @dataclass
@@ -1211,6 +1350,17 @@ class SessionTurnService:
             finish_and_append, propagate_cancellation=False
         )
 
+    async def _finish_after_callback_store_failure(
+        self, store: SessionTurnStore, turn_id: str
+    ) -> None:
+        """Terminate without appending behind structural events the pump lost."""
+        await self._store_operation(
+            lambda: store.finish(
+                turn_id, "failed", safe_error_code="event_store_failed"
+            ),
+            propagate_cancellation=False,
+        )
+
     @staticmethod
     def _turn_id(request: web.Request, body: Dict[str, Any]) -> str:
         header_id = request.headers.get("Idempotency-Key", "").strip()
@@ -1401,7 +1551,9 @@ class SessionTurnService:
         heartbeat_task: Optional[asyncio.Task[Any]] = None
         agent_task: Optional[asyncio.Task[Any]] = None
         callback_event_task: Optional[asyncio.Task[Any]] = None
-        callback_events_done = threading.Event()
+        callback_ingress: Optional[_CallbackPersistenceIngress] = None
+        callback_events_drained = False
+        drain_callback_events: Optional[Callable[[], Any]] = None
         dispatcher = self._lifecycle_dispatchers.get(turn_id)
         self._agent_refs[turn_id] = agent_ref
         try:
@@ -1463,39 +1615,67 @@ class SessionTurnService:
                 return
             message_high_water = await self._store_operation(store.message_high_water)
 
-            callback_events: queue.Queue[tuple[str, Dict[str, Any]]] = queue.Queue()
+            callback_ingress = _CallbackPersistenceIngress(
+                asyncio.get_running_loop(), SESSION_TURN_CALLBACK_QUEUE_SIZE
+            )
 
             async def persist_callback_events() -> None:
+                assert callback_ingress is not None
                 while True:
+                    if callback_ingress.done.is_set() and callback_ingress.queue.empty():
+                        break
                     try:
-                        event_type, data = callback_events.get_nowait()
-                    except queue.Empty:
-                        if callback_events_done.is_set():
-                            return
-                        await asyncio.sleep(0.01)
+                        event = await asyncio.wait_for(
+                            callback_ingress.queue.get(), timeout=0.05
+                        )
+                    except asyncio.TimeoutError:
                         continue
                     durable = await self._store_operation(
-                        lambda event_type=event_type, data=data: store.append_event(
-                            turn_id, event_type, data
+                        lambda event=event: store.append_event(
+                            turn_id, event.event_type, event.data
                         )
                     )
                     if (
-                        event_type == "assistant.delta"
+                        event.event_class is _CallbackEventClass.VOLATILE
                         and payload["delivery_mode"] != "slack_only"
                     ):
                         self._volatile_events.setdefault(turn_id, {})[
                             durable["seq"]
-                        ] = {**durable, "data": dict(data)}
+                        ] = {**durable, "data": dict(event.data)}
+                if callback_ingress.resync_required:
+                    # A durable body-free delta marker drives all replay paths
+                    # through the canonical-transcript resync contract.
+                    await self._store_operation(
+                        lambda: store.append_event(
+                            turn_id, "assistant.delta", {"volatile": True}
+                        )
+                    )
 
             callback_event_task = asyncio.create_task(persist_callback_events())
+            callback_ingress.bind_pump(callback_event_task)
 
-            async def drain_callback_events() -> bool:
-                callback_events_done.set()
+            async def _drain_callback_events() -> bool:
+                nonlocal callback_events_drained
+                if not callback_events_drained:
+                    assert callback_ingress is not None
+                    callback_ingress.close()
+                    callback_events_drained = True
                 assert callback_event_task is not None
-                results = await asyncio.gather(
-                    callback_event_task, return_exceptions=True
-                )
-                if isinstance(results[0], BaseException):
+                # Shield the single owned pump and re-await through repeated
+                # cancellation. No retained structural event may be overtaken by
+                # terminal persistence, and the pump exception is consumed here.
+                while not callback_event_task.done():
+                    try:
+                        await asyncio.shield(callback_event_task)
+                    except asyncio.CancelledError:
+                        continue
+                    except Exception:
+                        break
+                if callback_event_task.cancelled():
+                    error: Optional[BaseException] = asyncio.CancelledError()
+                else:
+                    error = callback_event_task.exception()
+                if error is not None:
                     logger.error(
                         "session_turn_background_task_failed "
                         "reason=callback_event_store_error"
@@ -1503,12 +1683,7 @@ class SessionTurnService:
                     return False
                 return True
 
-            def append(event_type: str, data: Dict[str, Any]) -> None:
-                # Agent callbacks may originate on the aiohttp loop or on an
-                # executor thread. Queue only safe projections here; the one
-                # loop-owned pump routes every SQLite call through the ordered
-                # off-loop helper without blocking either caller.
-                callback_events.put_nowait((event_type, dict(data)))
+            drain_callback_events = _drain_callback_events
 
             def on_delta(delta: Any) -> None:
                 if (
@@ -1516,13 +1691,19 @@ class SessionTurnService:
                     and isinstance(delta, str)
                     and delta
                 ):
-                    append("assistant.delta", {"delta": delta})
+                    assert callback_ingress is not None
+                    callback_ingress.append_volatile(
+                        "assistant.delta", {"delta": delta}
+                    )
 
             def on_tool_start(tool_call_id: Any, function_name: Any, function_args: Any) -> None:
                 projected = project_safe_tool_event(
                     "tool.started", tool_call_id=tool_call_id, tool_name=function_name, args=function_args
                 )
-                append(projected["event"], projected["data"])
+                assert callback_ingress is not None
+                callback_ingress.append_structural(
+                    projected["event"], projected["data"]
+                )
 
             def on_tool_complete(tool_call_id: Any, function_name: Any, function_args: Any, function_result: Any) -> None:
                 try:
@@ -1538,7 +1719,10 @@ class SessionTurnService:
                     event_type, tool_call_id=tool_call_id, tool_name=function_name,
                     args=function_args, output=function_result,
                 )
-                append(projected["event"], projected["data"])
+                assert callback_ingress is not None
+                callback_ingress.append_structural(
+                    projected["event"], projected["data"]
+                )
 
             agent_task = asyncio.create_task(
                 self.adapter._run_agent(
@@ -1581,10 +1765,9 @@ class SessionTurnService:
                     # Continue heartbeat and lease ownership until the executor
                     # future itself resolves. Repeated cancellation is handled
                     # by the same bounded, non-abandoning loop.
+            assert drain_callback_events is not None
             if not await drain_callback_events():
-                await self._finish_turn(
-                    store, turn_id, "failed", "turn.failed", "event_store_failed"
-                )
+                await self._finish_after_callback_store_failure(store, turn_id)
                 return
             effective_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
             if execution_lease is None or not await execution_lease.still_owned():
@@ -1646,17 +1829,21 @@ class SessionTurnService:
             # so cancellation can never contradict a persisted turn.started.
             if agent_task is not None and agent_task.done():
                 phase.execution_done = True
-            if callback_event_task is not None and not callback_events_done.is_set():
-                callback_events_done.set()
-                await asyncio.gather(callback_event_task, return_exceptions=True)
+            if callback_event_task is not None:
+                assert drain_callback_events is not None
+                if not await drain_callback_events():
+                    await self._finish_after_callback_store_failure(store, turn_id)
+                    return
             await self._finish_turn(
                 store, turn_id, "interrupted", "turn.interrupted",
                 phase.cancellation_code,
             )
         except Exception:
-            if callback_event_task is not None and not callback_events_done.is_set():
-                callback_events_done.set()
-                await asyncio.gather(callback_event_task, return_exceptions=True)
+            if callback_event_task is not None:
+                assert drain_callback_events is not None
+                if not await drain_callback_events():
+                    await self._finish_after_callback_store_failure(store, turn_id)
+                    return
             await self._finish_turn(
                 store, turn_id, "failed", "turn.failed", "run_failed"
             )
@@ -1760,16 +1947,13 @@ class SessionTurnService:
                 return None
             return store.get_delivery(turn_id, "slack") or {}
 
-        delivery = await self._store_operation(begin_and_read_delivery)
-        if delivery is None:
-            return
-
         async def record_outcome(
             state: str,
             event_type: str,
             error_code: Optional[str] = None,
             *,
             provider_message_id: Optional[str] = None,
+            cancellation_resistant: bool = False,
         ) -> None:
             def finish_and_append() -> None:
                 store.finish_delivery(
@@ -1784,7 +1968,48 @@ class SessionTurnService:
                     data["error_code"] = error_code
                 store.append_event(turn_id, event_type, data)
 
-            await self._store_operation(finish_and_append)
+            await self._store_operation(
+                finish_and_append,
+                propagate_cancellation=not cancellation_resistant,
+            )
+
+        async def record_cancelled_sending() -> None:
+            # Own exactly one ordered transition task and retrieve every error.
+            transition = asyncio.create_task(
+                record_outcome(
+                    "needs_manual_retry",
+                    "delivery.failed",
+                    "delivery_outcome_unknown",
+                    cancellation_resistant=True,
+                )
+            )
+            while not transition.done():
+                try:
+                    await asyncio.shield(transition)
+                except asyncio.CancelledError:
+                    continue
+                except Exception:
+                    break
+            if not transition.cancelled() and transition.exception() is not None:
+                logger.error(
+                    "session_turn_delivery_transition_failed "
+                    "destination=slack reason=store_error"
+                )
+
+        try:
+            delivery = await self._store_operation(begin_and_read_delivery)
+        except asyncio.CancelledError:
+            # _store_operation finishes its worker before propagating, so inspect
+            # the resulting durable state rather than guessing whether begin ran.
+            current = await self._store_operation(
+                lambda: store.get_delivery(turn_id, "slack"),
+                propagate_cancellation=False,
+            )
+            if current is not None and current.get("state") == "sending":
+                await record_cancelled_sending()
+            raise
+        if delivery is None:
+            return
 
         if len(content) > MAX_SLACK_ROUTED_CHARS:
             await record_outcome(
@@ -1799,6 +2024,12 @@ class SessionTurnService:
             result = await slack_adapter.send(
                 binding.chat_id, content, reply_to=binding.thread_id, metadata=metadata
             )
+        except asyncio.CancelledError:
+            # chat.postMessage may already have reached Slack. Own one shielded,
+            # ordered write through repeated cancellation before propagating;
+            # neither provider text nor message content enters the ledger/log.
+            await record_cancelled_sending()
+            raise
         except Exception:
             await record_outcome(
                 "needs_manual_retry",

--- a/gateway/platforms/session_turns.py
+++ b/gateway/platforms/session_turns.py
@@ -1380,6 +1380,7 @@ class SessionTurnService:
             tuple[str, str], asyncio.Task[tuple[Optional[Dict[str, Any]], bool]]
         ] = {}
         self._interruption_owners: Dict[str, asyncio.Task[Any]] = {}
+        self._interruption_watcher_owners: Dict[str, asyncio.Task[Any]] = {}
         self._lifecycle_dispatchers: Dict[str, SessionTurnLifecycleDispatcher] = {}
         self._lifecycle_cleanup_owners: set[str] = set()
         # Assistant text deltas are intentionally process-local. Canonical
@@ -1897,7 +1898,13 @@ class SessionTurnService:
                                 self._interrupt_when_available(turn_id)
                             )
                             self._interruption_owners[turn_id] = watcher
+                            self._interruption_watcher_owners[turn_id] = watcher
                             self._track_background_task(watcher)
+                            watcher.add_done_callback(
+                                lambda done: self._interruption_watcher_done(
+                                    turn_id, done
+                                )
+                            )
                     # Continue heartbeat and lease ownership until the executor
                     # future itself resolves. Repeated cancellation is handled
                     # by the same bounded, non-abandoning loop.
@@ -2078,6 +2085,7 @@ class SessionTurnService:
             # another interrupt.  This also covers never-entered coordinators,
             # and ``finally`` prevents a cleanup failure from leaking ownership.
             self._interruption_owners.pop(turn_id, None)
+            self._interruption_watcher_owners.pop(turn_id, None)
             self._agent_refs.pop(turn_id, None)
             self._lifecycle_dispatchers.pop(turn_id, None)
             self._lifecycle_cleanup_owners.discard(turn_id)
@@ -2406,6 +2414,13 @@ class SessionTurnService:
 
         key = (session_id, turn_id)
         handoff = self._stop_handoffs.get(key)
+        if handoff is not None and handoff.done():
+            # A retry may arrive before the completed handoff's done callback.
+            # Retire that exact generation synchronously so one caller creates
+            # the recovery handoff below and concurrent callers join it.
+            if self._stop_handoffs.get(key) is handoff:
+                self._stop_handoffs.pop(key, None)
+            handoff = None
         if handoff is None:
             handoff = asyncio.create_task(
                 self._perform_stop_handoff(store, session_id, turn_id)
@@ -2457,6 +2472,13 @@ class SessionTurnService:
         if public is not None and (
             transitioned or public["status"] == "stopping"
         ):
+            owner = self._interruption_owners.get(turn_id)
+            if owner is not None:
+                # A retry can enter after the watcher task has completed but
+                # before its call_soon() done callback has run.  Inspect and
+                # conditionally release the exact failed generation here, with
+                # no await before a replacement owner is installed below.
+                self._release_failed_interruption_watcher(turn_id, owner)
             if self._interruption_owners.get(turn_id) is not None:
                 return public, transitioned
 
@@ -2473,21 +2495,59 @@ class SessionTurnService:
             else:
                 watcher = asyncio.create_task(self._interrupt_when_available(turn_id))
                 self._interruption_owners[turn_id] = watcher
+                self._interruption_watcher_owners[turn_id] = watcher
                 self._track_background_task(watcher)
-
-                def watcher_done(done: asyncio.Task[Any]) -> None:
-                    # Normally _finalize_execution owns removal.  A durable
-                    # queued row can also be stopped without ever being admitted
-                    # in this process; no execution finalizer exists in that
-                    # case, so the completed watcher must release its marker.
-                    if (
-                        turn_id not in self._tasks
-                        and self._interruption_owners.get(turn_id) is done
-                    ):
-                        self._interruption_owners.pop(turn_id, None)
-
-                watcher.add_done_callback(watcher_done)
+                watcher.add_done_callback(
+                    lambda done: self._interruption_watcher_done(turn_id, done)
+                )
         return public, transitioned
+
+    def _interruption_watcher_done(
+        self, turn_id: str, watcher: asyncio.Task[Any]
+    ) -> None:
+        """Preserve successful ownership; release failed watcher generations."""
+        # A successful interrupt request remains owned until the worker
+        # finalizer. Failure/cancellation did not deliver that request, so
+        # release the exact generation even while a local execution exists.
+        if self._release_failed_interruption_watcher(turn_id, watcher):
+            return
+        # A durable queued row can be stopped without ever being admitted in
+        # this process; no execution finalizer exists in that case.
+        if (
+            turn_id not in self._tasks
+            and self._interruption_owners.get(turn_id) is watcher
+        ):
+            self._interruption_owners.pop(turn_id, None)
+            self._interruption_watcher_owners.pop(turn_id, None)
+
+    def _release_failed_interruption_watcher(
+        self, turn_id: str, watcher: asyncio.Task[Any]
+    ) -> bool:
+        """Release only the current failed watcher generation, if completed."""
+        if self._interruption_watcher_owners.get(turn_id) is not watcher:
+            return False
+        if not watcher.done():
+            return False
+        if watcher.cancelled():
+            reason = "cancelled"
+        else:
+            try:
+                failure = watcher.exception()
+            except asyncio.CancelledError:
+                reason = "cancelled"
+            else:
+                if failure is None:
+                    return False
+                reason = "internal_error"
+        if self._interruption_owners.get(turn_id) is not watcher:
+            return False
+        self._interruption_owners.pop(turn_id, None)
+        self._interruption_watcher_owners.pop(turn_id, None)
+        # Never log turn identity or exception text: either can contain
+        # tenant/provider data.  The stable classification is operationally
+        # sufficient and safe for shared logs.
+        logger.error("session_turn_interrupt_watcher_failed reason=%s", reason)
+        return True
 
     async def _interrupt_when_available(self, turn_id: str) -> None:
         """Close the small race between stop admission and agent construction."""

--- a/gateway/platforms/session_turns.py
+++ b/gateway/platforms/session_turns.py
@@ -266,6 +266,14 @@ class SessionTurnLifecycleDispatcher:
         self._closed = True
         return accepted
 
+    def abort(self) -> bool:
+        """Stop delivery without inventing a non-durable terminal fact."""
+        if self._closed:
+            return False
+        accepted = self.emit("_close")
+        self._closed = True
+        return accepted
+
     def flush(self, timeout: Optional[float] = None) -> bool:
         """Wait for terminal delivery. Never call directly on the event loop."""
         return self._drained.wait(timeout)
@@ -273,6 +281,9 @@ class SessionTurnLifecycleDispatcher:
     def _run(self) -> None:
         while True:
             event, extra = self._queue.get()
+            if event == "_close":
+                self._drained.set()
+                return
             observation = _lifecycle_executor.observe_callback_started(event)
             try:
                 delivered = _emit_turn_lifecycle(
@@ -1096,6 +1107,7 @@ class SessionTurnService:
         self._tasks: Dict[str, asyncio.Task[Any]] = {}
         self._agent_refs: Dict[str, list[Any]] = {}
         self._lifecycle_dispatchers: Dict[str, SessionTurnLifecycleDispatcher] = {}
+        self._lifecycle_cleanup_owners: set[str] = set()
         # Assistant text deltas are intentionally process-local. Canonical
         # SessionDB messages are the only durable transcript authority.
         self._volatile_events: Dict[str, Dict[int, Dict[str, Any]]] = {}
@@ -1198,29 +1210,86 @@ class SessionTurnService:
 
         if created:
             # reserve() committed the runnable identity before this observation.
-            # Construct before scheduling: its bounded FIFO already contains
-            # registered, so started can never overtake it.
-            self._lifecycle_dispatchers[turn_id] = SessionTurnLifecycleDispatcher(
-                session_id, turn_id
+            self._admit_execution(
+                store, turn_id, session_id, payload, binding, slack_adapter
             )
-            task = asyncio.create_task(
-                self._execute(store, turn_id, session_id, payload, binding, slack_adapter)
-            )
-            self._tasks[turn_id] = task
-            try:
-                self.adapter._background_tasks.add(task)
-                task.add_done_callback(self.adapter._background_tasks.discard)
-            except (AttributeError, TypeError):
-                pass
-            task.add_done_callback(lambda _task, tid=turn_id: self._tasks.pop(tid, None))
         public = store.public_turn(turn_id)
         return web.json_response(
             {"object": "hermes.session.turn.accepted" if created else "hermes.session.turn.reused", "turn": public},
             status=202 if created else 200,
         )
 
+    def _track_background_task(self, task: asyncio.Task[Any]) -> None:
+        try:
+            self.adapter._background_tasks.add(task)
+            task.add_done_callback(self.adapter._background_tasks.discard)
+        except (AttributeError, TypeError):
+            pass
+
+    def _admit_execution(
+        self,
+        store: SessionTurnStore,
+        turn_id: str,
+        session_id: str,
+        payload: Dict[str, Any],
+        binding: Optional[SlackBinding],
+        slack_adapter: Any,
+    ) -> asyncio.Task[Any]:
+        """Own task admission and its never-entered cancellation seam."""
+        # Construct before scheduling: registered is already first in its FIFO.
+        dispatcher = SessionTurnLifecycleDispatcher(session_id, turn_id)
+        self._lifecycle_dispatchers[turn_id] = dispatcher
+        entered = [False]
+        task = asyncio.create_task(
+            self._execute(
+                store,
+                turn_id,
+                session_id,
+                payload,
+                binding,
+                slack_adapter,
+                entered,
+            )
+        )
+        self._tasks[turn_id] = task
+        self._track_background_task(task)
+
+        def execution_done(done: asyncio.Task[Any]) -> None:
+            if done.cancelled() and not entered[0]:
+                # A coroutine cancelled before its first instruction cannot run
+                # _execute's try/finally. Transfer all ownership to the same
+                # cleanup seam used by the normal execution epilogue.
+                cleanup = asyncio.create_task(
+                    self._finalize_execution(
+                        store,
+                        turn_id,
+                        cancelled_before_entry=True,
+                    )
+                )
+                self._tasks[turn_id] = cleanup
+                self._track_background_task(cleanup)
+                cleanup.add_done_callback(
+                    lambda finished, tid=turn_id: self._remove_task_if_current(
+                        tid, finished
+                    )
+                )
+            else:
+                self._remove_task_if_current(turn_id, done)
+
+        task.add_done_callback(execution_done)
+        return task
+
+    def _remove_task_if_current(
+        self, turn_id: str, task: asyncio.Task[Any]
+    ) -> None:
+        if self._tasks.get(turn_id) is task:
+            self._tasks.pop(turn_id, None)
+
     async def _execute(self, store: SessionTurnStore, turn_id: str, session_id: str,
-                       payload: Dict[str, Any], binding: Optional[SlackBinding], slack_adapter: Any) -> None:
+                       payload: Dict[str, Any], binding: Optional[SlackBinding], slack_adapter: Any,
+                       entered: Optional[list[bool]] = None) -> None:
+        if entered is not None:
+            entered[0] = True
         agent_ref: list[Any] = [None]
         execution_lease = None
         heartbeat_task: Optional[asyncio.Task[Any]] = None
@@ -1432,15 +1501,54 @@ class SessionTurnService:
             store.finish(turn_id, "failed", safe_error_code="run_failed")
             store.append_event(turn_id, "turn.failed", {"status": "failed", "error_code": "run_failed"})
         finally:
+            await self._finalize_execution(
+                store,
+                turn_id,
+                execution_lease=execution_lease,
+                heartbeat_task=heartbeat_task,
+            )
+
+    async def _finalize_execution(
+        self,
+        store: SessionTurnStore,
+        turn_id: str,
+        *,
+        cancelled_before_entry: bool = False,
+        execution_lease: Any = None,
+        heartbeat_task: Optional[asyncio.Task[Any]] = None,
+    ) -> None:
+        """Idempotently clean up either admission or normal execution exit."""
+        if turn_id in self._lifecycle_cleanup_owners:
+            return
+        self._lifecycle_cleanup_owners.add(turn_id)
+        dispatcher = self._lifecycle_dispatchers.get(turn_id)
+        try:
+            if cancelled_before_entry:
+                changed = store.finish(
+                    turn_id,
+                    "interrupted",
+                    safe_error_code="cancelled_before_execution",
+                )
+                if changed:
+                    store.append_event(
+                        turn_id,
+                        "turn.interrupted",
+                        {
+                            "status": "interrupted",
+                            "error_code": "cancelled_before_execution",
+                        },
+                    )
+
             if heartbeat_task is not None:
                 heartbeat_task.cancel()
                 try:
                     await heartbeat_task
                 except asyncio.CancelledError:
                     pass
-            # The durable ledger is the outcome authority. This single epilogue
-            # maps every coordinator exit without leaking safe_error_code or raw
-            # exception text, and emits nothing while execution remains live.
+
+            # The durable ledger alone authorizes public terminal truth. If it
+            # cannot supply a terminal row, stop the private dispatcher without
+            # synthesizing a lifecycle terminal.
             row = store.get(turn_id)
             status = row.get("status") if row else None
             outcome = (
@@ -1452,38 +1560,38 @@ class SessionTurnService:
                 if isinstance(status, str)
                 else None
             )
-            if outcome is not None:
-                if dispatcher is not None:
+            if dispatcher is not None:
+                if outcome is None:
+                    dispatcher.abort()
+                else:
                     dispatcher.close(outcome)
-            try:
-                if execution_lease is not None:
-                    # A caller may cancel this coordinator repeatedly during
-                    # unwind. Keep re-awaiting the lease's one shielded release
-                    # operation until durable ownership and heartbeat are gone.
-                    while True:
-                        try:
-                            await execution_lease.release()
-                            break
-                        except asyncio.CancelledError:
-                            continue
-                # Observer completion is bounded and happens only after lease
-                # release. Shield one to_thread call so repeated cancellation
-                # cannot spawn abandoned flush workers.
-                if dispatcher is not None and outcome is not None:
-                    flush_task = asyncio.create_task(
-                        asyncio.to_thread(
-                            dispatcher.flush, SESSION_TURN_LIFECYCLE_FLUSH_SECONDS
-                        )
+
+            if execution_lease is not None:
+                # Re-await the lease's single shielded release operation through
+                # repeated coordinator cancellation.
+                while True:
+                    try:
+                        await execution_lease.release()
+                        break
+                    except asyncio.CancelledError:
+                        continue
+
+            if dispatcher is not None:
+                flush_task = asyncio.create_task(
+                    asyncio.to_thread(
+                        dispatcher.flush, SESSION_TURN_LIFECYCLE_FLUSH_SECONDS
                     )
-                    while True:
-                        try:
-                            await asyncio.shield(flush_task)
-                            break
-                        except asyncio.CancelledError:
-                            continue
-            finally:
-                self._agent_refs.pop(turn_id, None)
-                self._lifecycle_dispatchers.pop(turn_id, None)
+                )
+                while True:
+                    try:
+                        await asyncio.shield(flush_task)
+                        break
+                    except asyncio.CancelledError:
+                        continue
+        finally:
+            self._agent_refs.pop(turn_id, None)
+            self._lifecycle_dispatchers.pop(turn_id, None)
+            self._lifecycle_cleanup_owners.discard(turn_id)
 
     async def _deliver_slack(self, store: SessionTurnStore, turn_id: str, binding: SlackBinding,
                              slack_adapter: Any, content: str) -> None:

--- a/gateway/platforms/session_turns.py
+++ b/gateway/platforms/session_turns.py
@@ -1373,7 +1373,9 @@ class SessionTurnService:
         # Stop requests have two distinct pieces of process-local ownership.
         # The handoff survives its HTTP waiter, while an interruption owner
         # prevents concurrent/recovery handoffs from spawning duplicate
-        # watchers for the same durable stopping edge.
+        # interrupts for the same durable stopping edge.  The interruption
+        # owner is a per-turn lifetime marker: completing the synchronous
+        # interrupt call (or its watcher) does not mean the worker has exited.
         self._stop_handoffs: Dict[
             tuple[str, str], asyncio.Task[tuple[Optional[Dict[str, Any]], bool]]
         ] = {}
@@ -1878,15 +1880,24 @@ class SessionTurnService:
                         lambda: store.request_stop(turn_id),
                         propagate_cancellation=False,
                     )
-                    agent = agent_ref[0]
-                    if agent is not None:
-                        try:
-                            agent.interrupt("Session turn coordinator cancellation requested")
-                        except Exception:
-                            pass
-                    else:
-                        watcher = asyncio.create_task(self._interrupt_when_available(turn_id))
-                        self._track_background_task(watcher)
+                    if self._interruption_owners.get(turn_id) is None:
+                        agent = agent_ref[0]
+                        if agent is not None:
+                            current = asyncio.current_task()
+                            assert current is not None
+                            self._interruption_owners[turn_id] = current
+                            try:
+                                agent.interrupt(
+                                    "Session turn coordinator cancellation requested"
+                                )
+                            except Exception:
+                                pass
+                        else:
+                            watcher = asyncio.create_task(
+                                self._interrupt_when_available(turn_id)
+                            )
+                            self._interruption_owners[turn_id] = watcher
+                            self._track_background_task(watcher)
                     # Continue heartbeat and lease ownership until the executor
                     # future itself resolves. Repeated cancellation is handled
                     # by the same bounded, non-abandoning loop.
@@ -2061,6 +2072,12 @@ class SessionTurnService:
                     except asyncio.CancelledError:
                         continue
         finally:
+            # A successful interrupt call is only a request.  Retain its owner
+            # until this authoritative execution/worker cleanup seam so a
+            # repeated stop while the turn is still ``stopping`` cannot issue
+            # another interrupt.  This also covers never-entered coordinators,
+            # and ``finally`` prevents a cleanup failure from leaking ownership.
+            self._interruption_owners.pop(turn_id, None)
             self._agent_refs.pop(turn_id, None)
             self._lifecycle_dispatchers.pop(turn_id, None)
             self._lifecycle_cleanup_owners.discard(turn_id)
@@ -2440,11 +2457,7 @@ class SessionTurnService:
         if public is not None and (
             transitioned or public["status"] == "stopping"
         ):
-            owner = self._interruption_owners.get(turn_id)
-            if owner is not None and owner.done():
-                self._interruption_owners.pop(turn_id, None)
-                owner = None
-            if owner is not None:
+            if self._interruption_owners.get(turn_id) is not None:
                 return public, transitioned
 
             ref = self._agent_refs.get(turn_id)
@@ -2457,16 +2470,20 @@ class SessionTurnService:
                     agent.interrupt("Stop requested via session turn API")
                 except Exception:
                     pass
-                finally:
-                    if self._interruption_owners.get(turn_id) is current:
-                        self._interruption_owners.pop(turn_id, None)
             else:
                 watcher = asyncio.create_task(self._interrupt_when_available(turn_id))
                 self._interruption_owners[turn_id] = watcher
                 self._track_background_task(watcher)
 
                 def watcher_done(done: asyncio.Task[Any]) -> None:
-                    if self._interruption_owners.get(turn_id) is done:
+                    # Normally _finalize_execution owns removal.  A durable
+                    # queued row can also be stopped without ever being admitted
+                    # in this process; no execution finalizer exists in that
+                    # case, so the completed watcher must release its marker.
+                    if (
+                        turn_id not in self._tasks
+                        and self._interruption_owners.get(turn_id) is done
+                    ):
                         self._interruption_owners.pop(turn_id, None)
 
                 watcher.add_done_callback(watcher_done)

--- a/gateway/platforms/session_turns.py
+++ b/gateway/platforms/session_turns.py
@@ -1370,6 +1370,14 @@ class SessionTurnService:
         self._store_operation_lock = asyncio.Lock()
         self._tasks: Dict[str, asyncio.Task[Any]] = {}
         self._agent_refs: Dict[str, list[Any]] = {}
+        # Stop requests have two distinct pieces of process-local ownership.
+        # The handoff survives its HTTP waiter, while an interruption owner
+        # prevents concurrent/recovery handoffs from spawning duplicate
+        # watchers for the same durable stopping edge.
+        self._stop_handoffs: Dict[
+            tuple[str, str], asyncio.Task[tuple[Optional[Dict[str, Any]], bool]]
+        ] = {}
+        self._interruption_owners: Dict[str, asyncio.Task[Any]] = {}
         self._lifecycle_dispatchers: Dict[str, SessionTurnLifecycleDispatcher] = {}
         self._lifecycle_cleanup_owners: set[str] = set()
         # Assistant text deltas are intentionally process-local. Canonical
@@ -2360,16 +2368,49 @@ class SessionTurnService:
         if store is None:
             return _error("Session database unavailable", "session_db_unavailable", 503)
         turn_id = request.match_info["turn_id"]
-        turn = await self._store_operation(lambda: store.get(turn_id))
-        if not turn or turn["session_id"] != request.match_info["session_id"]:
+        session_id = request.match_info["session_id"]
+        public, _transitioned = await self._join_stop_handoff(
+            store, session_id, turn_id
+        )
+        if public is None:
             return _error("Turn not found", "turn_not_found", 404)
-        if turn["status"] in TERMINAL_STATUSES:
-            public = await self._store_operation(
-                lambda: store.public_turn(turn_id)
-            )
+        if public["status"] in TERMINAL_STATUSES:
             return web.json_response(
                 {"object": "hermes.session.turn.stop", "turn": public}
             )
+        return web.json_response(
+            {"object": "hermes.session.turn.stop", "turn": public}, status=202
+        )
+
+    async def _join_stop_handoff(
+        self, store: SessionTurnStore, session_id: str, turn_id: str
+    ) -> tuple[Optional[Dict[str, Any]], bool]:
+        """Join one cancellation-resistant durable-stop/interruption handoff."""
+
+        key = (session_id, turn_id)
+        handoff = self._stop_handoffs.get(key)
+        if handoff is None:
+            handoff = asyncio.create_task(
+                self._perform_stop_handoff(store, session_id, turn_id)
+            )
+            self._stop_handoffs[key] = handoff
+            self._track_background_task(handoff)
+
+            def handoff_done(done: asyncio.Task[Any]) -> None:
+                if self._stop_handoffs.get(key) is done:
+                    self._stop_handoffs.pop(key, None)
+
+            handoff.add_done_callback(handoff_done)
+
+        # Client disconnect/request cancellation only abandons this waiter. The
+        # tracked handoff keeps ownership through durable commit and interrupt.
+        return await asyncio.shield(handoff)
+
+    async def _perform_stop_handoff(
+        self, store: SessionTurnStore, session_id: str, turn_id: str
+    ) -> tuple[Optional[Dict[str, Any]], bool]:
+        """Commit/read stop truth, then recover or claim interruption ownership."""
+
         # Let a just-admitted task finish durable lease/history admission so a
         # stop does not race it into a false "stopped before start" result.
         # Bounded and event-loop friendly; genuinely queued work still stops.
@@ -2379,27 +2420,57 @@ class SessionTurnService:
                 break
             await asyncio.sleep(0.01)
         def stop_and_read() -> tuple[Optional[Dict[str, Any]], bool]:
+            existing = store.get(turn_id)
+            if existing is None or existing["session_id"] != session_id:
+                return None, False
+            if existing["status"] in TERMINAL_STATUSES:
+                return store.public_turn(turn_id), False
             result = store.request_stop(turn_id)
             if result is None:
                 return None, False
             _row, transitioned = result
             return store.public_turn(turn_id), transitioned
 
-        public, transitioned = await self._store_operation(stop_and_read)
-        if transitioned:
+        # This task, rather than an HTTP request task, owns the ordered store
+        # operation. shield() in the caller ensures a disconnected request can
+        # neither cancel the commit nor strand its interruption handoff.
+        public, transitioned = await self._store_operation(
+            stop_and_read, propagate_cancellation=False
+        )
+        if public is not None and (
+            transitioned or public["status"] == "stopping"
+        ):
+            owner = self._interruption_owners.get(turn_id)
+            if owner is not None and owner.done():
+                self._interruption_owners.pop(turn_id, None)
+                owner = None
+            if owner is not None:
+                return public, transitioned
+
             ref = self._agent_refs.get(turn_id)
             agent = ref[0] if ref else None
             if agent is not None:
+                current = asyncio.current_task()
+                assert current is not None
+                self._interruption_owners[turn_id] = current
                 try:
                     agent.interrupt("Stop requested via session turn API")
                 except Exception:
                     pass
+                finally:
+                    if self._interruption_owners.get(turn_id) is current:
+                        self._interruption_owners.pop(turn_id, None)
             else:
                 watcher = asyncio.create_task(self._interrupt_when_available(turn_id))
+                self._interruption_owners[turn_id] = watcher
                 self._track_background_task(watcher)
-        return web.json_response(
-            {"object": "hermes.session.turn.stop", "turn": public}, status=202
-        )
+
+                def watcher_done(done: asyncio.Task[Any]) -> None:
+                    if self._interruption_owners.get(turn_id) is done:
+                        self._interruption_owners.pop(turn_id, None)
+
+                watcher.add_done_callback(watcher_done)
+        return public, transitioned
 
     async def _interrupt_when_available(self, turn_id: str) -> None:
         """Close the small race between stop admission and agent construction."""

--- a/gateway/platforms/session_turns.py
+++ b/gateway/platforms/session_turns.py
@@ -22,7 +22,7 @@ import time
 import uuid
 import warnings
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional, TypeVar
 
 from aiohttp import web
 
@@ -30,6 +30,7 @@ from gateway.session_execution_lease import SessionExecutionConflict
 
 
 logger = logging.getLogger(__name__)
+_StoreResult = TypeVar("_StoreResult")
 
 SESSION_TURN_HEARTBEAT_INTERVAL_SECONDS = 15.0
 SESSION_TURN_LIFECYCLE_QUEUE_SIZE = 32
@@ -37,6 +38,23 @@ SESSION_TURN_LIFECYCLE_WORKERS = 4
 SESSION_TURN_LIFECYCLE_PENDING_DISPATCHERS = 32
 SESSION_TURN_LIFECYCLE_SLOW_SECONDS = 0.1
 SESSION_TURN_LIFECYCLE_FLUSH_SECONDS = 0.05
+
+
+@dataclass
+class _TurnExecutionState:
+    """Authoritative phase reached only after the corresponding durable write."""
+
+    entered: bool = False
+    started: bool = False
+    execution_done: bool = False
+
+    @property
+    def cancellation_code(self) -> str:
+        if not self.started:
+            return "cancelled_before_execution"
+        if self.execution_done:
+            return "cancelled_after_execution"
+        return "cancelled_during_execution"
 
 
 def _emit_turn_lifecycle(event: str, session_id: str, turn_id: str, **extra: Any) -> bool:
@@ -1104,6 +1122,10 @@ class SessionTurnService:
         self.adapter = adapter
         self._stores: Dict[int, SessionTurnStore] = {}
         self._store_lock = asyncio.Lock()
+        # SessionDB serializes SQLite with its own lock. This lock additionally
+        # preserves submission order for all loop-originated store operations;
+        # the operation itself always runs off the aiohttp loop.
+        self._store_operation_lock = asyncio.Lock()
         self._tasks: Dict[str, asyncio.Task[Any]] = {}
         self._agent_refs: Dict[str, list[Any]] = {}
         self._lifecycle_dispatchers: Dict[str, SessionTurnLifecycleDispatcher] = {}
@@ -1129,6 +1151,61 @@ class SessionTurnService:
     async def reconcile_startup(self) -> None:
         """Initialize the ledger and interrupt crash-uncertain prior work."""
         await self._store()
+
+    async def _store_operation(
+        self,
+        operation: Callable[[], _StoreResult],
+        *,
+        propagate_cancellation: bool = True,
+    ) -> _StoreResult:
+        """Run one ordered store operation off-loop and never abandon its thread."""
+
+        async def run_ordered() -> _StoreResult:
+            async with self._store_operation_lock:
+                return await asyncio.to_thread(operation)
+
+        operation_task = asyncio.create_task(run_ordered())
+        cancelled = False
+        while True:
+            try:
+                result = await asyncio.shield(operation_task)
+                break
+            except asyncio.CancelledError:
+                cancelled = True
+                continue
+        if cancelled and propagate_cancellation:
+            raise asyncio.CancelledError
+        return result
+
+    async def _finish_turn(
+        self,
+        store: SessionTurnStore,
+        turn_id: str,
+        status: str,
+        event_type: str,
+        error_code: Optional[str] = None,
+        effective_session_id: Optional[str] = None,
+    ) -> bool:
+        """Persist terminal row and matching ledger event as one ordered unit."""
+
+        def finish_and_append() -> bool:
+            changed = store.finish(
+                turn_id,
+                status,
+                safe_error_code=error_code,
+                effective_session_id=effective_session_id,
+            )
+            if changed:
+                data = {"status": status}
+                if error_code is not None:
+                    data["error_code"] = error_code
+                store.append_event(turn_id, event_type, data)
+            return changed
+
+        # Terminal ownership must survive cancellation through both writes.
+        return await self._store_operation(
+            finish_and_append, propagate_cancellation=False
+        )
 
     @staticmethod
     def _turn_id(request: web.Request, body: Dict[str, Any]) -> str:
@@ -1181,7 +1258,9 @@ class SessionTurnService:
             return web.json_response(
                 {
                     "object": "hermes.session.turn.reused",
-                    "turn": store.public_turn(turn_id),
+                    "turn": await self._store_operation(
+                        lambda: store.public_turn(turn_id)
+                    ),
                 },
                 status=200,
             )
@@ -1213,13 +1292,30 @@ class SessionTurnService:
             self._admit_execution(
                 store, turn_id, session_id, payload, binding, slack_adapter
             )
-        public = store.public_turn(turn_id)
+        public = await self._store_operation(lambda: store.public_turn(turn_id))
         return web.json_response(
             {"object": "hermes.session.turn.accepted" if created else "hermes.session.turn.reused", "turn": public},
             status=202 if created else 200,
         )
 
+    @staticmethod
+    def _consume_background_task_exception(task: asyncio.Task[Any]) -> None:
+        """Retrieve failures and log only a stable, privacy-safe classification."""
+        if task.cancelled():
+            return
+        try:
+            failure = task.exception()
+        except asyncio.CancelledError:
+            return
+        if failure is not None:
+            logger.error(
+                "session_turn_background_task_failed reason=internal_task_error"
+            )
+
     def _track_background_task(self, task: asyncio.Task[Any]) -> None:
+        # Exception retrieval is unconditional even when an adapter does not
+        # expose the optional ownership set.
+        task.add_done_callback(self._consume_background_task_exception)
         try:
             self.adapter._background_tasks.add(task)
             task.add_done_callback(self.adapter._background_tasks.discard)
@@ -1239,7 +1335,7 @@ class SessionTurnService:
         # Construct before scheduling: registered is already first in its FIFO.
         dispatcher = SessionTurnLifecycleDispatcher(session_id, turn_id)
         self._lifecycle_dispatchers[turn_id] = dispatcher
-        entered = [False]
+        phase = _TurnExecutionState()
         task = asyncio.create_task(
             self._execute(
                 store,
@@ -1248,14 +1344,17 @@ class SessionTurnService:
                 payload,
                 binding,
                 slack_adapter,
-                entered,
+                phase,
             )
         )
         self._tasks[turn_id] = task
         self._track_background_task(task)
 
         def execution_done(done: asyncio.Task[Any]) -> None:
-            if done.cancelled() and not entered[0]:
+            # Explicitly consume the execution exception here as well as in the
+            # generic tracker. Reading it does not alter cleanup ownership.
+            self._consume_background_task_exception(done)
+            if done.cancelled() and not phase.entered:
                 # A coroutine cancelled before its first instruction cannot run
                 # _execute's try/finally. Transfer all ownership to the same
                 # cleanup seam used by the normal execution epilogue.
@@ -1269,8 +1368,9 @@ class SessionTurnService:
                 self._tasks[turn_id] = cleanup
                 self._track_background_task(cleanup)
                 cleanup.add_done_callback(
-                    lambda finished, tid=turn_id: self._remove_task_if_current(
-                        tid, finished
+                    lambda finished, tid=turn_id: (
+                        self._consume_background_task_exception(finished),
+                        self._remove_task_if_current(tid, finished),
                     )
                 )
             else:
@@ -1287,9 +1387,9 @@ class SessionTurnService:
 
     async def _execute(self, store: SessionTurnStore, turn_id: str, session_id: str,
                        payload: Dict[str, Any], binding: Optional[SlackBinding], slack_adapter: Any,
-                       entered: Optional[list[bool]] = None) -> None:
-        if entered is not None:
-            entered[0] = True
+                       phase: Optional[_TurnExecutionState] = None) -> None:
+        phase = phase or _TurnExecutionState()
+        phase.entered = True
         agent_ref: list[Any] = [None]
         execution_lease = None
         heartbeat_task: Optional[asyncio.Task[Any]] = None
@@ -1309,16 +1409,27 @@ class SessionTurnService:
                     on_lost=interrupt_on_lease_loss,
                 )
             except SessionExecutionConflict:
-                store.finish(turn_id, "failed", safe_error_code="active_session_execution")
-                store.append_event(turn_id, "turn.failed", {"status": "failed", "error_code": "active_session_execution"})
+                await self._finish_turn(
+                    store, turn_id, "failed", "turn.failed", "active_session_execution"
+                )
                 return
-            if store.stop_requested(turn_id):
-                store.finish(turn_id, "interrupted", safe_error_code="stopped_before_start")
-                store.append_event(turn_id, "turn.interrupted", {"status": "interrupted", "error_code": "stopped_before_start"})
+            if await self._store_operation(lambda: store.stop_requested(turn_id)):
+                await self._finish_turn(
+                    store, turn_id, "interrupted", "turn.interrupted", "stopped_before_start"
+                )
                 return
-            if not store.set_running(turn_id):
+            def start_turn() -> bool:
+                if not store.set_running(turn_id):
+                    return False
+                store.append_event(turn_id, "turn.started", {"status": "running"})
+                # Set in the same off-loop ownership unit as the durable write.
+                # If the coordinator is cancelled while awaiting this worker,
+                # _store_operation waits for it and the catch below sees truth.
+                phase.started = True
+                return True
+
+            if not await self._store_operation(start_turn):
                 return
-            store.append_event(turn_id, "turn.started", {"status": "running"})
             if dispatcher is not None:
                 dispatcher.emit("started")
 
@@ -1332,18 +1443,17 @@ class SessionTurnService:
             try:
                 history = await self.adapter._conversation_history_for_session(session_id)
             except Exception:
-                store.finish(turn_id, "failed", safe_error_code="history_read_failed")
-                store.append_event(turn_id, "turn.failed", {"status": "failed", "error_code": "history_read_failed"})
-                return
-            if store.stop_requested(turn_id):
-                store.finish(turn_id, "interrupted", safe_error_code="stopped_before_execution")
-                store.append_event(
-                    turn_id,
-                    "turn.interrupted",
-                    {"status": "interrupted", "error_code": "stopped_before_execution"},
+                await self._finish_turn(
+                    store, turn_id, "failed", "turn.failed", "history_read_failed"
                 )
                 return
-            message_high_water = await asyncio.to_thread(store.message_high_water)
+            if await self._store_operation(lambda: store.stop_requested(turn_id)):
+                await self._finish_turn(
+                    store, turn_id, "interrupted", "turn.interrupted",
+                    "stopped_before_execution",
+                )
+                return
+            message_high_water = await self._store_operation(store.message_high_water)
 
             def append(event_type: str, data: Dict[str, Any]) -> None:
                 durable = store.append_event(turn_id, event_type, data)
@@ -1401,6 +1511,7 @@ class SessionTurnService:
                     # abandons the still-live thread. Shield the child and keep
                     # this coordinator as monitoring owner until real exit.
                     result, _usage = await asyncio.shield(agent_task)
+                    phase.execution_done = True
                     break
                 except asyncio.CancelledError:
                     if agent_task.done():
@@ -1416,45 +1527,36 @@ class SessionTurnService:
                             pass
                     else:
                         watcher = asyncio.create_task(self._interrupt_when_available(turn_id))
-                        try:
-                            self.adapter._background_tasks.add(watcher)
-                            watcher.add_done_callback(self.adapter._background_tasks.discard)
-                        except (AttributeError, TypeError):
-                            pass
+                        self._track_background_task(watcher)
                     # Continue heartbeat and lease ownership until the executor
                     # future itself resolves. Repeated cancellation is handled
                     # by the same bounded, non-abandoning loop.
             effective_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
             if execution_lease is None or not await execution_lease.still_owned():
-                store.finish(
-                    turn_id,
-                    "interrupted",
-                    safe_error_code="execution_lease_lost",
-                    effective_session_id=effective_id,
-                )
-                store.append_event(
-                    turn_id,
-                    "turn.interrupted",
-                    {"status": "interrupted", "error_code": "execution_lease_lost"},
+                await self._finish_turn(
+                    store, turn_id, "interrupted", "turn.interrupted",
+                    "execution_lease_lost", effective_id,
                 )
                 return
-            if store.stop_requested(turn_id):
-                store.finish(turn_id, "interrupted", safe_error_code="stop_requested", effective_session_id=effective_id)
-                store.append_event(turn_id, "turn.interrupted", {"status": "interrupted", "error_code": "stop_requested"})
+            if await self._store_operation(lambda: store.stop_requested(turn_id)):
+                await self._finish_turn(
+                    store, turn_id, "interrupted", "turn.interrupted",
+                    "stop_requested", effective_id,
+                )
                 return
             if not isinstance(result, dict) or result.get("failed"):
-                store.finish(turn_id, "failed", safe_error_code="run_failed", effective_session_id=effective_id)
-                store.append_event(turn_id, "turn.failed", {"status": "failed", "error_code": "run_failed"})
+                await self._finish_turn(
+                    store, turn_id, "failed", "turn.failed", "run_failed", effective_id
+                )
                 return
 
-            assistant_message_id = await asyncio.to_thread(
-                store.anchor_completed_assistant,
-                turn_id,
-                effective_id,
-                after_message_id=message_high_water,
+            assistant_message_id = await self._store_operation(
+                lambda: store.anchor_completed_assistant(
+                    turn_id, effective_id, after_message_id=message_high_water
+                )
             )
-            anchored_content = await asyncio.to_thread(
-                store.anchored_assistant_content, turn_id
+            anchored_content = await self._store_operation(
+                lambda: store.anchored_assistant_content(turn_id)
             )
             final_response = result.get("final_response")
             if (
@@ -1463,43 +1565,40 @@ class SessionTurnService:
                 or not isinstance(final_response, str)
                 or anchored_content != final_response
             ):
-                store.finish(
-                    turn_id,
-                    "failed",
-                    safe_error_code="assistant_anchor_mismatch",
-                    effective_session_id=effective_id,
-                )
-                store.append_event(
-                    turn_id,
-                    "turn.failed",
-                    {"status": "failed", "error_code": "assistant_anchor_mismatch"},
+                await self._finish_turn(
+                    store, turn_id, "failed", "turn.failed",
+                    "assistant_anchor_mismatch", effective_id,
                 )
                 return
-            store.append_event(
-                turn_id,
-                "assistant.completed",
-                {"completed": True, "assistant_message_id": assistant_message_id},
+            await self._store_operation(
+                lambda: store.append_event(
+                    turn_id,
+                    "assistant.completed",
+                    {"completed": True, "assistant_message_id": assistant_message_id},
+                )
             )
             if payload["delivery_mode"] in {"slack_only", "both"}:
                 assert binding is not None and slack_adapter is not None
                 await self._deliver_slack(
                     store, turn_id, binding, slack_adapter, anchored_content
                 )
-            store.finish(turn_id, "completed", effective_session_id=effective_id)
-            store.append_event(turn_id, "turn.completed", {"status": "completed"})
+            await self._finish_turn(
+                store, turn_id, "completed", "turn.completed",
+                effective_session_id=effective_id,
+            )
         except asyncio.CancelledError:
-            # Cancellation before an executor exists is mechanically terminal.
-            # Once agent_task exists, the shielded loop above retains ownership
-            # and this branch is unreachable until that worker has really quit.
-            store.finish(turn_id, "interrupted", safe_error_code="cancelled_before_execution")
-            store.append_event(
-                turn_id,
-                "turn.interrupted",
-                {"status": "interrupted", "error_code": "cancelled_before_execution"},
+            # Phase changes only after its corresponding durable truth exists,
+            # so cancellation can never contradict a persisted turn.started.
+            if agent_task is not None and agent_task.done():
+                phase.execution_done = True
+            await self._finish_turn(
+                store, turn_id, "interrupted", "turn.interrupted",
+                phase.cancellation_code,
             )
         except Exception:
-            store.finish(turn_id, "failed", safe_error_code="run_failed")
-            store.append_event(turn_id, "turn.failed", {"status": "failed", "error_code": "run_failed"})
+            await self._finish_turn(
+                store, turn_id, "failed", "turn.failed", "run_failed"
+            )
         finally:
             await self._finalize_execution(
                 store,
@@ -1524,20 +1623,13 @@ class SessionTurnService:
         dispatcher = self._lifecycle_dispatchers.get(turn_id)
         try:
             if cancelled_before_entry:
-                changed = store.finish(
+                await self._finish_turn(
+                    store,
                     turn_id,
                     "interrupted",
-                    safe_error_code="cancelled_before_execution",
+                    "turn.interrupted",
+                    "cancelled_before_execution",
                 )
-                if changed:
-                    store.append_event(
-                        turn_id,
-                        "turn.interrupted",
-                        {
-                            "status": "interrupted",
-                            "error_code": "cancelled_before_execution",
-                        },
-                    )
 
             if heartbeat_task is not None:
                 heartbeat_task.cancel()
@@ -1545,11 +1637,18 @@ class SessionTurnService:
                     await heartbeat_task
                 except asyncio.CancelledError:
                     pass
+                except Exception:
+                    # Awaiting retrieves the exception; never expose its text.
+                    logger.error(
+                        "session_turn_background_task_failed reason=heartbeat_error"
+                    )
 
             # The durable ledger alone authorizes public terminal truth. If it
             # cannot supply a terminal row, stop the private dispatcher without
             # synthesizing a lifecycle terminal.
-            row = store.get(turn_id)
+            row = await self._store_operation(
+                lambda: store.get(turn_id), propagate_cancellation=False
+            )
             status = row.get("status") if row else None
             outcome = (
                 {

--- a/gateway/platforms/session_turns.py
+++ b/gateway/platforms/session_turns.py
@@ -14,6 +14,7 @@ import binascii
 import hashlib
 import io
 import json
+import logging
 import re
 import time
 import uuid
@@ -24,6 +25,29 @@ from typing import Any, Dict, Optional
 from aiohttp import web
 
 from gateway.session_execution_lease import SessionExecutionConflict
+
+
+logger = logging.getLogger(__name__)
+
+SESSION_TURN_HEARTBEAT_INTERVAL_SECONDS = 15.0
+
+
+def _emit_turn_lifecycle(event: str, session_id: str, turn_id: str, **extra: Any) -> None:
+    """Emit an observer-only fact without allowing observers to affect execution."""
+    try:
+        from agent.lifecycle_hooks import emit_session_turn_lifecycle
+
+        emit_session_turn_lifecycle(
+            event,
+            session_id=session_id,
+            turn_id=turn_id,
+            **extra,
+        )
+    except Exception:
+        logger.debug(
+            "session_turn_lifecycle_failed event=%s reason=invalid_or_callback_error",
+            event,
+        )
 
 
 DELIVERY_MODES = frozenset({"occ_only", "slack_only", "both"})
@@ -927,6 +951,9 @@ class SessionTurnService:
             return _error(str(exc), "invalid_turn", 400)
 
         if created:
+            # reserve() committed the runnable identity before this observation.
+            # Emit before scheduling so registered always precedes started.
+            _emit_turn_lifecycle("registered", session_id, turn_id)
             task = asyncio.create_task(
                 self._execute(store, turn_id, session_id, payload, binding, slack_adapter)
             )
@@ -947,6 +974,7 @@ class SessionTurnService:
                        payload: Dict[str, Any], binding: Optional[SlackBinding], slack_adapter: Any) -> None:
         agent_ref: list[Any] = [None]
         execution_lease = None
+        heartbeat_task: Optional[asyncio.Task[Any]] = None
         self._agent_refs[turn_id] = agent_ref
         try:
             def interrupt_on_lease_loss() -> None:
@@ -971,6 +999,14 @@ class SessionTurnService:
             if not store.set_running(turn_id):
                 return
             store.append_event(turn_id, "turn.started", {"status": "running"})
+            _emit_turn_lifecycle("started", session_id, turn_id)
+
+            async def emit_heartbeats() -> None:
+                while True:
+                    await asyncio.sleep(SESSION_TURN_HEARTBEAT_INTERVAL_SECONDS)
+                    _emit_turn_lifecycle("heartbeat", session_id, turn_id)
+
+            heartbeat_task = asyncio.create_task(emit_heartbeats())
             try:
                 history = await self.adapter._conversation_history_for_session(session_id)
             except Exception:
@@ -1033,6 +1069,7 @@ class SessionTurnService:
                 tool_start_callback=on_tool_start,
                 tool_complete_callback=on_tool_complete,
                 agent_ref=agent_ref,
+                authoritative_turn_id=turn_id,
             )
             effective_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
             if execution_lease is None or not await execution_lease.still_owned():
@@ -1108,6 +1145,33 @@ class SessionTurnService:
             store.finish(turn_id, "failed", safe_error_code="run_failed")
             store.append_event(turn_id, "turn.failed", {"status": "failed", "error_code": "run_failed"})
         finally:
+            if heartbeat_task is not None:
+                heartbeat_task.cancel()
+                try:
+                    await heartbeat_task
+                except asyncio.CancelledError:
+                    pass
+            # The durable ledger is the outcome authority. This single epilogue
+            # maps every coordinator exit without leaking safe_error_code or raw
+            # exception text, and emits nothing while execution remains live.
+            row = store.get(turn_id)
+            status = row.get("status") if row else None
+            outcome = (
+                {
+                    "completed": "succeeded",
+                    "failed": "failed",
+                    "interrupted": "cancelled",
+                }.get(status)
+                if isinstance(status, str)
+                else None
+            )
+            if outcome is not None:
+                _emit_turn_lifecycle(
+                    "terminal",
+                    session_id,
+                    turn_id,
+                    terminal_outcome=outcome,
+                )
             if execution_lease is not None:
                 await execution_lease.release()
             self._agent_refs.pop(turn_id, None)

--- a/gateway/platforms/session_turns.py
+++ b/gateway/platforms/session_turns.py
@@ -73,6 +73,10 @@ class _CallbackPersistenceOverloaded(RuntimeError):
     """Stop a producer after retaining an exact structural resync range."""
 
 
+class _InterruptDeliveryFailed(RuntimeError):
+    """Privacy-safe internal signal that an agent rejected an interrupt call."""
+
+
 class _CallbackPersistenceIngress:
     """Bounded sync-callback ingress to one loop-owned persistence pump.
 
@@ -1888,11 +1892,14 @@ class SessionTurnService:
                             assert current is not None
                             self._interruption_owners[turn_id] = current
                             try:
-                                agent.interrupt(
+                                self._deliver_interrupt(
+                                    agent,
                                     "Session turn coordinator cancellation requested"
                                 )
-                            except Exception:
-                                pass
+                            except _InterruptDeliveryFailed:
+                                self._release_direct_interruption_owner(
+                                    turn_id, current
+                                )
                         else:
                             watcher = asyncio.create_task(
                                 self._interrupt_when_available(turn_id)
@@ -2489,9 +2496,14 @@ class SessionTurnService:
                 assert current is not None
                 self._interruption_owners[turn_id] = current
                 try:
-                    agent.interrupt("Stop requested via session turn API")
-                except Exception:
-                    pass
+                    self._deliver_interrupt(
+                        agent, "Stop requested via session turn API"
+                    )
+                except _InterruptDeliveryFailed:
+                    # The durable row remains truthfully stopping.  This exact
+                    # handoff did not deliver the request, so relinquish only
+                    # its generation and let a later stop retry safely.
+                    self._release_direct_interruption_owner(turn_id, current)
             else:
                 watcher = asyncio.create_task(self._interrupt_when_available(turn_id))
                 self._interruption_owners[turn_id] = watcher
@@ -2549,6 +2561,26 @@ class SessionTurnService:
         logger.error("session_turn_interrupt_watcher_failed reason=%s", reason)
         return True
 
+    def _release_direct_interruption_owner(
+        self, turn_id: str, owner: asyncio.Task[Any]
+    ) -> bool:
+        """Conditionally release one failed synchronous interruption handoff."""
+        if self._interruption_owners.get(turn_id) is not owner:
+            return False
+        self._interruption_owners.pop(turn_id, None)
+        logger.error(
+            "session_turn_interrupt_delivery_failed reason=internal_error"
+        )
+        return True
+
+    @staticmethod
+    def _deliver_interrupt(agent: Any, reason: str) -> None:
+        """Deliver an interrupt or raise a typed signal with no provider detail."""
+        try:
+            agent.interrupt(reason)
+        except Exception:
+            raise _InterruptDeliveryFailed from None
+
     async def _interrupt_when_available(self, turn_id: str) -> None:
         """Close the small race between stop admission and agent construction."""
         while True:
@@ -2558,10 +2590,7 @@ class SessionTurnService:
             ref = self._agent_refs.get(turn_id)
             agent = ref[0] if ref else None
             if agent is not None:
-                try:
-                    agent.interrupt("Stop requested via session turn API")
-                except Exception:
-                    pass
+                self._deliver_interrupt(agent, "Stop requested via session turn API")
                 return
             await asyncio.sleep(0.01)
 

--- a/gateway/platforms/session_turns.py
+++ b/gateway/platforms/session_turns.py
@@ -1143,8 +1143,12 @@ class SessionTurnService:
             return self._stores[key]
         async with self._store_lock:
             if key not in self._stores:
-                store = await asyncio.to_thread(SessionTurnStore, db)
-                await asyncio.to_thread(store.reconcile_uncertain)
+                def initialize_store() -> SessionTurnStore:
+                    store = SessionTurnStore(db)
+                    store.reconcile_uncertain()
+                    return store
+
+                store = await self._store_operation(initialize_store)
                 self._stores[key] = store
         return self._stores[key]
 
@@ -1241,11 +1245,11 @@ class SessionTurnService:
 
         # An accepted idempotency key is durable truth. Browser retries must
         # reuse it even if the Slack adapter's current connectivity changed.
-        existing = await asyncio.to_thread(store.get, turn_id)
+        existing = await self._store_operation(lambda: store.get(turn_id))
         if existing is not None:
             try:
-                _turn, _created = await asyncio.to_thread(
-                    store.reserve, session_id, turn_id, payload
+                _turn, _created = await self._store_operation(
+                    lambda: store.reserve(session_id, turn_id, payload)
                 )
             except ConflictingTurn:
                 return _error(
@@ -1269,8 +1273,8 @@ class SessionTurnService:
         slack_adapter = None
         if payload["delivery_mode"] in {"slack_only", "both"}:
             try:
-                binding = await asyncio.to_thread(
-                    resolve_slack_binding, store.db, session_id
+                binding = await self._store_operation(
+                    lambda: resolve_slack_binding(store.db, session_id)
                 )
             except SlackBindingError as exc:
                 return _error("Session has no unique Slack binding", exc.code, 409)
@@ -1279,7 +1283,9 @@ class SessionTurnService:
                 return _error("Slack adapter is not connected", "slack_unavailable", 503)
 
         try:
-            turn, created = await asyncio.to_thread(store.reserve, session_id, turn_id, payload)
+            turn, created = await self._store_operation(
+                lambda: store.reserve(session_id, turn_id, payload)
+            )
         except ConflictingTurn:
             return _error("turn_id was already used for a different request", "idempotency_conflict", 409)
         except TurnConflict:
@@ -1394,6 +1400,8 @@ class SessionTurnService:
         execution_lease = None
         heartbeat_task: Optional[asyncio.Task[Any]] = None
         agent_task: Optional[asyncio.Task[Any]] = None
+        callback_event_task: Optional[asyncio.Task[Any]] = None
+        callback_events_done = threading.Event()
         dispatcher = self._lifecycle_dispatchers.get(turn_id)
         self._agent_refs[turn_id] = agent_ref
         try:
@@ -1455,13 +1463,52 @@ class SessionTurnService:
                 return
             message_high_water = await self._store_operation(store.message_high_water)
 
+            callback_events: queue.Queue[tuple[str, Dict[str, Any]]] = queue.Queue()
+
+            async def persist_callback_events() -> None:
+                while True:
+                    try:
+                        event_type, data = callback_events.get_nowait()
+                    except queue.Empty:
+                        if callback_events_done.is_set():
+                            return
+                        await asyncio.sleep(0.01)
+                        continue
+                    durable = await self._store_operation(
+                        lambda event_type=event_type, data=data: store.append_event(
+                            turn_id, event_type, data
+                        )
+                    )
+                    if (
+                        event_type == "assistant.delta"
+                        and payload["delivery_mode"] != "slack_only"
+                    ):
+                        self._volatile_events.setdefault(turn_id, {})[
+                            durable["seq"]
+                        ] = {**durable, "data": dict(data)}
+
+            callback_event_task = asyncio.create_task(persist_callback_events())
+
+            async def drain_callback_events() -> bool:
+                callback_events_done.set()
+                assert callback_event_task is not None
+                results = await asyncio.gather(
+                    callback_event_task, return_exceptions=True
+                )
+                if isinstance(results[0], BaseException):
+                    logger.error(
+                        "session_turn_background_task_failed "
+                        "reason=callback_event_store_error"
+                    )
+                    return False
+                return True
+
             def append(event_type: str, data: Dict[str, Any]) -> None:
-                durable = store.append_event(turn_id, event_type, data)
-                if event_type == "assistant.delta" and payload["delivery_mode"] != "slack_only":
-                    self._volatile_events.setdefault(turn_id, {})[durable["seq"]] = {
-                        **durable,
-                        "data": dict(data),
-                    }
+                # Agent callbacks may originate on the aiohttp loop or on an
+                # executor thread. Queue only safe projections here; the one
+                # loop-owned pump routes every SQLite call through the ordered
+                # off-loop helper without blocking either caller.
+                callback_events.put_nowait((event_type, dict(data)))
 
             def on_delta(delta: Any) -> None:
                 if (
@@ -1518,7 +1565,10 @@ class SessionTurnService:
                         # A child cancellation is a real execution outcome, not
                         # a request to abandon coordinator ownership.
                         await agent_task
-                    await asyncio.to_thread(store.request_stop, turn_id)
+                    await self._store_operation(
+                        lambda: store.request_stop(turn_id),
+                        propagate_cancellation=False,
+                    )
                     agent = agent_ref[0]
                     if agent is not None:
                         try:
@@ -1531,6 +1581,11 @@ class SessionTurnService:
                     # Continue heartbeat and lease ownership until the executor
                     # future itself resolves. Repeated cancellation is handled
                     # by the same bounded, non-abandoning loop.
+            if not await drain_callback_events():
+                await self._finish_turn(
+                    store, turn_id, "failed", "turn.failed", "event_store_failed"
+                )
+                return
             effective_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
             if execution_lease is None or not await execution_lease.still_owned():
                 await self._finish_turn(
@@ -1591,11 +1646,17 @@ class SessionTurnService:
             # so cancellation can never contradict a persisted turn.started.
             if agent_task is not None and agent_task.done():
                 phase.execution_done = True
+            if callback_event_task is not None and not callback_events_done.is_set():
+                callback_events_done.set()
+                await asyncio.gather(callback_event_task, return_exceptions=True)
             await self._finish_turn(
                 store, turn_id, "interrupted", "turn.interrupted",
                 phase.cancellation_code,
             )
         except Exception:
+            if callback_event_task is not None and not callback_events_done.is_set():
+                callback_events_done.set()
+                await asyncio.gather(callback_event_task, return_exceptions=True)
             await self._finish_turn(
                 store, turn_id, "failed", "turn.failed", "run_failed"
             )
@@ -1694,12 +1755,41 @@ class SessionTurnService:
 
     async def _deliver_slack(self, store: SessionTurnStore, turn_id: str, binding: SlackBinding,
                              slack_adapter: Any, content: str) -> None:
-        if not store.begin_delivery(turn_id, "slack"):
+        def begin_and_read_delivery() -> Optional[Dict[str, Any]]:
+            if not store.begin_delivery(turn_id, "slack"):
+                return None
+            return store.get_delivery(turn_id, "slack") or {}
+
+        delivery = await self._store_operation(begin_and_read_delivery)
+        if delivery is None:
             return
-        delivery = store.get_delivery(turn_id, "slack") or {}
+
+        async def record_outcome(
+            state: str,
+            event_type: str,
+            error_code: Optional[str] = None,
+            *,
+            provider_message_id: Optional[str] = None,
+        ) -> None:
+            def finish_and_append() -> None:
+                store.finish_delivery(
+                    turn_id,
+                    "slack",
+                    state,
+                    error_code,
+                    provider_message_id=provider_message_id,
+                )
+                data = {"destination": "slack", "status": state}
+                if error_code is not None:
+                    data["error_code"] = error_code
+                store.append_event(turn_id, event_type, data)
+
+            await self._store_operation(finish_and_append)
+
         if len(content) > MAX_SLACK_ROUTED_CHARS:
-            store.finish_delivery(turn_id, "slack", "rejected", "delivery_too_large")
-            store.append_event(turn_id, "delivery.failed", {"destination": "slack", "status": "rejected", "error_code": "delivery_too_large"})
+            await record_outcome(
+                "rejected", "delivery.failed", "delivery_too_large"
+            )
             return
         metadata = dict(binding.metadata)
         # The durable delivery id is also Slack's idempotency key. The bounded
@@ -1710,40 +1800,34 @@ class SessionTurnService:
                 binding.chat_id, content, reply_to=binding.thread_id, metadata=metadata
             )
         except Exception:
-            store.finish_delivery(turn_id, "slack", "needs_manual_retry", "delivery_outcome_unknown")
-            store.append_event(turn_id, "delivery.failed", {"destination": "slack", "status": "needs_manual_retry", "error_code": "delivery_outcome_unknown"})
+            await record_outcome(
+                "needs_manual_retry",
+                "delivery.failed",
+                "delivery_outcome_unknown",
+            )
             return
         if getattr(result, "success", False):
             provider_message_id = getattr(result, "message_id", None)
             if not isinstance(provider_message_id, str) or not provider_message_id:
-                store.finish_delivery(
-                    turn_id,
-                    "slack",
+                await record_outcome(
                     "needs_manual_retry",
+                    "delivery.failed",
                     "provider_receipt_missing",
                 )
-                store.append_event(
-                    turn_id,
-                    "delivery.failed",
-                    {
-                        "destination": "slack",
-                        "status": "needs_manual_retry",
-                        "error_code": "provider_receipt_missing",
-                    },
-                )
                 return
-            store.finish_delivery(
-                turn_id,
-                "slack",
+            await record_outcome(
                 "delivered",
+                "delivery.completed",
                 provider_message_id=provider_message_id,
             )
-            store.append_event(turn_id, "delivery.completed", {"destination": "slack", "status": "delivered"})
         else:
             # Once chat.postMessage was attempted, a timeout/error can be
             # ambiguous.  Never retry automatically.
-            store.finish_delivery(turn_id, "slack", "needs_manual_retry", "delivery_outcome_unknown")
-            store.append_event(turn_id, "delivery.failed", {"destination": "slack", "status": "needs_manual_retry", "error_code": "delivery_outcome_unknown"})
+            await record_outcome(
+                "needs_manual_retry",
+                "delivery.failed",
+                "delivery_outcome_unknown",
+            )
 
     async def status(self, request: web.Request) -> web.Response:
         auth_err = self.adapter._check_auth(request)
@@ -1752,7 +1836,9 @@ class SessionTurnService:
         store = await self._store()
         if store is None:
             return _error("Session database unavailable", "session_db_unavailable", 503)
-        turn = await asyncio.to_thread(store.public_turn, request.match_info["turn_id"])
+        turn = await self._store_operation(
+            lambda: store.public_turn(request.match_info["turn_id"])
+        )
         if not turn or turn["session_id"] != request.match_info["session_id"]:
             return _error("Turn not found", "turn_not_found", 404)
         return web.json_response({"object": "hermes.session.turn.status", "turn": turn})
@@ -1765,7 +1851,7 @@ class SessionTurnService:
         if store is None:
             return _error("Session database unavailable", "session_db_unavailable", 503)
         turn_id = request.match_info["turn_id"]
-        turn = await asyncio.to_thread(store.get, turn_id)
+        turn = await self._store_operation(lambda: store.get(turn_id))
         if not turn or turn["session_id"] != request.match_info["session_id"]:
             return _error("Turn not found", "turn_not_found", 404)
         raw_sequence = request.headers.get("Last-Event-ID") or request.query.get("after") or "0"
@@ -1775,7 +1861,9 @@ class SessionTurnService:
                 raise ValueError
         except (TypeError, ValueError):
             return _error("Last-Event-ID must be a non-negative integer", "invalid_last_event_id", 400)
-        low_water, high_water, event_count = await asyncio.to_thread(store.event_bounds, turn_id)
+        low_water, high_water, event_count = await self._store_operation(
+            lambda: store.event_bounds(turn_id)
+        )
         if sequence > high_water:
             return _resync_error(
                 "Last-Event-ID is ahead of the durable event high-water mark",
@@ -1788,7 +1876,9 @@ class SessionTurnService:
                 "event_gap",
                 high_water=high_water,
             )
-        initial_rows = await asyncio.to_thread(store.events_after, turn_id, sequence)
+        initial_rows = await self._store_operation(
+            lambda: store.events_after(turn_id, sequence)
+        )
         volatile = self._volatile_events.get(turn_id, {})
         missing_volatile = any(
             row["event"] == "assistant.delta" and row["seq"] not in volatile
@@ -1808,8 +1898,12 @@ class SessionTurnService:
         await response.prepare(request)
         try:
             while True:
-                rows = await asyncio.to_thread(store.events_after, turn_id, sequence)
-                current = await asyncio.to_thread(store.get, turn_id)
+                def read_stream_state() -> tuple[
+                    list[Dict[str, Any]], Optional[Dict[str, Any]]
+                ]:
+                    return store.events_after(turn_id, sequence), store.get(turn_id)
+
+                rows, current = await self._store_operation(read_stream_state)
                 missing_volatile = any(
                     row["event"] == "assistant.delta"
                     and row["seq"] not in self._volatile_events.get(turn_id, {})
@@ -1862,12 +1956,14 @@ class SessionTurnService:
             return _error("Session database unavailable", "session_db_unavailable", 503)
         session_id = request.match_info["session_id"]
         turn_id = request.match_info["turn_id"]
-        turn = await asyncio.to_thread(store.get, turn_id)
+        turn = await self._store_operation(lambda: store.get(turn_id))
         if not turn or turn["session_id"] != session_id:
             return _error("Turn not found", "turn_not_found", 404)
         if turn["status"] != "completed":
             return _error("Turn is not completed", "turn_not_completed", 409)
-        existing = await asyncio.to_thread(store.get_delivery, turn_id, "slack")
+        existing = await self._store_operation(
+            lambda: store.get_delivery(turn_id, "slack")
+        )
         if existing:
             if existing["state"] == "delivered":
                 return web.json_response({"object": "hermes.session.turn.delivery", "delivery": existing})
@@ -1877,14 +1973,18 @@ class SessionTurnService:
                 409,
             )
         try:
-            binding = await asyncio.to_thread(resolve_slack_binding, store.db, session_id)
+            binding = await self._store_operation(
+                lambda: resolve_slack_binding(store.db, session_id)
+            )
         except SlackBindingError as exc:
             return _error("Session has no unique Slack binding", exc.code, 409)
         slack_adapter = self.adapter._get_platform_callback_adapter(request, "slack")
         if slack_adapter is None:
             return _error("Slack adapter is not connected", "slack_unavailable", 503)
         try:
-            content = await asyncio.to_thread(store.anchored_assistant_content, turn_id)
+            content = await self._store_operation(
+                lambda: store.anchored_assistant_content(turn_id)
+            )
         except Exception:
             return _error("Session history unavailable", "session_history_unavailable", 503)
         if not isinstance(content, str):
@@ -1896,7 +1996,9 @@ class SessionTurnService:
         await self._deliver_slack(
             store, turn_id, binding, slack_adapter, content
         )
-        delivery = await asyncio.to_thread(store.get_delivery, turn_id, "slack")
+        delivery = await self._store_operation(
+            lambda: store.get_delivery(turn_id, "slack")
+        )
         status = 200 if delivery and delivery["state"] == "delivered" else 409
         return web.json_response(
             {"object": "hermes.session.turn.delivery", "delivery": delivery}, status=status
@@ -1910,11 +2012,16 @@ class SessionTurnService:
         if store is None:
             return _error("Session database unavailable", "session_db_unavailable", 503)
         turn_id = request.match_info["turn_id"]
-        turn = await asyncio.to_thread(store.get, turn_id)
+        turn = await self._store_operation(lambda: store.get(turn_id))
         if not turn or turn["session_id"] != request.match_info["session_id"]:
             return _error("Turn not found", "turn_not_found", 404)
         if turn["status"] in TERMINAL_STATUSES:
-            return web.json_response({"object": "hermes.session.turn.stop", "turn": store.public_turn(turn_id)})
+            public = await self._store_operation(
+                lambda: store.public_turn(turn_id)
+            )
+            return web.json_response(
+                {"object": "hermes.session.turn.stop", "turn": public}
+            )
         # Let a just-admitted task finish durable lease/history admission so a
         # stop does not race it into a false "stopped before start" result.
         # Bounded and event-loop friendly; genuinely queued work still stops.
@@ -1923,7 +2030,15 @@ class SessionTurnService:
             if (ref and ref[0] is not None) or turn_id not in self._tasks:
                 break
             await asyncio.sleep(0.01)
-        stopped = await asyncio.to_thread(store.request_stop, turn_id)
+        def stop_and_record() -> Optional[Dict[str, Any]]:
+            stopped = store.request_stop(turn_id)
+            if stopped is not None and stopped["status"] == "stopping":
+                store.append_event(
+                    turn_id, "turn.stopping", {"status": "stopping"}
+                )
+            return store.public_turn(turn_id)
+
+        public = await self._store_operation(stop_and_record)
         ref = self._agent_refs.get(turn_id)
         agent = ref[0] if ref else None
         if agent is not None:
@@ -1933,14 +2048,9 @@ class SessionTurnService:
                 pass
         else:
             watcher = asyncio.create_task(self._interrupt_when_available(turn_id))
-            try:
-                self.adapter._background_tasks.add(watcher)
-                watcher.add_done_callback(self.adapter._background_tasks.discard)
-            except (AttributeError, TypeError):
-                pass
-        store.append_event(turn_id, "turn.stopping", {"status": "stopping"})
+            self._track_background_task(watcher)
         return web.json_response(
-            {"object": "hermes.session.turn.stop", "turn": store.public_turn(turn_id)}, status=202
+            {"object": "hermes.session.turn.stop", "turn": public}, status=202
         )
 
     async def _interrupt_when_available(self, turn_id: str) -> None:

--- a/gateway/platforms/session_turns.py
+++ b/gateway/platforms/session_turns.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
+import concurrent.futures
 import hashlib
 import io
 import json
@@ -40,6 +41,7 @@ SESSION_TURN_LIFECYCLE_PENDING_DISPATCHERS = 32
 SESSION_TURN_LIFECYCLE_SLOW_SECONDS = 0.1
 SESSION_TURN_LIFECYCLE_FLUSH_SECONDS = 0.05
 SESSION_TURN_CALLBACK_QUEUE_SIZE = 32
+SESSION_TURN_CALLBACK_ENQUEUE_TIMEOUT_SECONDS = 1.0
 
 
 class _CallbackEventClass(Enum):
@@ -54,20 +56,30 @@ class _CallbackPersistenceEvent:
     event_class: _CallbackEventClass
     event_type: str
     data: Dict[str, Any]
+    structural_sequence: Optional[int] = None
+
+
+@dataclass
+class _StructuralSubmission:
+    """Handshake that makes timeout cancellation and enqueue mutually exclusive."""
+
+    event: _CallbackPersistenceEvent
+    lock: threading.Lock
+    cancelled: bool = False
+    enqueued: bool = False
 
 
 class _CallbackPersistenceOverloaded(RuntimeError):
-    """Stop an on-loop producer rather than lose a structural event."""
+    """Stop a producer after retaining an exact structural resync range."""
 
 
 class _CallbackPersistenceIngress:
     """Bounded sync-callback ingress to one loop-owned persistence pump.
 
-    Structural callbacks from the agent worker apply backpressure to that worker.
-    A callback unexpectedly invoked on the aiohttp loop cannot wait without
-    deadlocking, so saturation raises and safely stops its producer. Volatile
-    deltas use one coalescing loop notification and explicitly request canonical
-    resync when one cannot be retained.
+    Structural callbacks apply bounded backpressure. If a callback cannot be
+    retained, one out-of-band resync range records every rejected structural
+    ordinal; the pump persists that marker after all retained events and before
+    terminal truth. Volatile deltas use one coalescing loop notification.
     """
 
     def __init__(self, loop: asyncio.AbstractEventLoop, maxsize: int):
@@ -84,40 +96,117 @@ class _CallbackPersistenceIngress:
         self._pending_volatile: Optional[_CallbackPersistenceEvent] = None
         self._volatile_notification_pending = False
         self._accepting = True
+        self._structural_lock = threading.Lock()
+        self._next_structural_sequence = 1
+        self._structural_resync_range: Optional[tuple[int, int]] = None
+        self._producer_stopped = False
 
     def bind_pump(self, pump_task: asyncio.Task[Any]) -> None:
         self.pump_task = pump_task
 
     def append_structural(self, event_type: str, data: Dict[str, Any]) -> None:
-        event = _CallbackPersistenceEvent(
-            _CallbackEventClass.STRUCTURAL, event_type, dict(data)
-        )
-        if threading.get_ident() == self._loop_thread_id:
-            if not self._accepting:
+        # Serialize producers so the first rejected ordinal closes ingress and
+        # every later rejected fact extends one exact contiguous range.
+        with self._structural_lock:
+            sequence = self._next_structural_sequence
+            self._next_structural_sequence += 1
+            event = _CallbackPersistenceEvent(
+                _CallbackEventClass.STRUCTURAL,
+                event_type,
+                dict(data),
+                structural_sequence=sequence,
+            )
+            if self._producer_stopped or not self._accepting:
+                self._mark_structural_resync(sequence)
                 raise _CallbackPersistenceOverloaded("callback persistence closed")
-            try:
-                self.queue.put_nowait(event)
-            except asyncio.QueueFull as exc:
-                raise _CallbackPersistenceOverloaded(
-                    "structural callback persistence saturated"
-                ) from exc
-            self._observe_size()
-            return
-        future = asyncio.run_coroutine_threadsafe(self._put_structural(event), self.loop)
-        # Backpressure only the agent callback thread, never the aiohttp loop.
-        future.result()
+            if threading.get_ident() == self._loop_thread_id:
+                try:
+                    self.queue.put_nowait(event)
+                except asyncio.QueueFull as exc:
+                    self._mark_structural_resync(sequence)
+                    raise _CallbackPersistenceOverloaded(
+                        "structural callback persistence saturated"
+                    ) from exc
+                self._observe_size()
+                return
+            self._append_structural_from_callback_thread(event, sequence)
 
-    async def _put_structural(self, event: _CallbackPersistenceEvent) -> None:
+    def _append_structural_from_callback_thread(
+        self, event: _CallbackPersistenceEvent, sequence: int
+    ) -> None:
+        if self.loop.is_closed() or not self.loop.is_running():
+            self._mark_structural_resync(sequence)
+            raise _CallbackPersistenceOverloaded("callback persistence loop unavailable")
+        submission = _StructuralSubmission(event=event, lock=threading.Lock())
+        try:
+            future = asyncio.run_coroutine_threadsafe(
+                self._put_structural(submission), self.loop
+            )
+        except RuntimeError as exc:
+            self._mark_structural_resync(sequence)
+            raise _CallbackPersistenceOverloaded(
+                "callback persistence loop unavailable"
+            ) from exc
+        deadline = time.monotonic() + SESSION_TURN_CALLBACK_ENQUEUE_TIMEOUT_SECONDS
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or self.loop.is_closed() or not self.loop.is_running():
+                with submission.lock:
+                    if submission.enqueued:
+                        return
+                    submission.cancelled = True
+                future.cancel()
+                self._mark_structural_resync(sequence)
+                raise _CallbackPersistenceOverloaded(
+                    "structural callback persistence unavailable"
+                )
+            try:
+                future.result(timeout=min(0.05, remaining))
+                return
+            except concurrent.futures.TimeoutError:
+                continue
+            except Exception as exc:
+                with submission.lock:
+                    enqueued = submission.enqueued
+                if enqueued:
+                    return
+                self._mark_structural_resync(sequence)
+                raise _CallbackPersistenceOverloaded(
+                    "callback persistence unavailable"
+                ) from exc
+
+    async def _put_structural(self, submission: _StructuralSubmission) -> None:
         while self._accepting:
             if self.pump_task is not None and self.pump_task.done():
                 raise _CallbackPersistenceOverloaded("callback persistence unavailable")
-            try:
-                await asyncio.wait_for(self.queue.put(event), timeout=0.05)
-                self._observe_size()
-                return
-            except asyncio.TimeoutError:
-                continue
+            with submission.lock:
+                if submission.cancelled:
+                    raise _CallbackPersistenceOverloaded(
+                        "callback persistence enqueue cancelled"
+                    )
+                try:
+                    self.queue.put_nowait(submission.event)
+                except asyncio.QueueFull:
+                    pass
+                else:
+                    submission.enqueued = True
+                    self._observe_size()
+                    return
+            await asyncio.sleep(0.01)
         raise _CallbackPersistenceOverloaded("callback persistence closed")
+
+    def _mark_structural_resync(self, sequence: int) -> None:
+        self._producer_stopped = True
+        if self._structural_resync_range is None:
+            self._structural_resync_range = (sequence, sequence)
+        else:
+            first, last = self._structural_resync_range
+            self._structural_resync_range = (min(first, sequence), max(last, sequence))
+
+    @property
+    def structural_resync_range(self) -> Optional[tuple[int, int]]:
+        with self._structural_lock:
+            return self._structural_resync_range
 
     def append_volatile(self, event_type: str, data: Dict[str, Any]) -> None:
         event = _CallbackPersistenceEvent(
@@ -924,7 +1013,10 @@ class SessionTurnStore:
         content = self.db._decode_content(row["content"])
         return content if isinstance(content, str) else None
 
-    def request_stop(self, turn_id: str) -> Optional[Dict[str, Any]]:
+    def request_stop(
+        self, turn_id: str
+    ) -> Optional[tuple[Dict[str, Any], bool]]:
+        """Atomically request stop, record its edge once, and report ownership."""
         now = time.time()
 
         def stop(conn):
@@ -933,15 +1025,26 @@ class SessionTurnStore:
             ).fetchone()
             if row is None:
                 return None
-            if row["status"] not in TERMINAL_STATUSES:
+            transitioned = row["status"] in {"queued", "running"}
+            if transitioned:
                 conn.execute(
                     "UPDATE api_session_turns SET stop_requested = 1, status = 'stopping', "
                     "updated_at = ? WHERE turn_id = ?", (now, turn_id)
                 )
+                seq_row = conn.execute(
+                    "SELECT COALESCE(MAX(seq), 0) + 1 AS seq "
+                    "FROM api_session_turn_events WHERE turn_id = ?", (turn_id,)
+                ).fetchone()
+                conn.execute(
+                    "INSERT INTO api_session_turn_events "
+                    "(turn_id, seq, event_type, data_json, created_at) "
+                    "VALUES (?, ?, 'turn.stopping', ?, ?)",
+                    (turn_id, int(seq_row["seq"]), '{\"status\": \"stopping\"}', now),
+                )
             result = conn.execute(
                 "SELECT * FROM api_session_turns WHERE turn_id = ?", (turn_id,)
             ).fetchone()
-            return dict(result)
+            return dict(result), transitioned
         return self.db._execute_write(stop)
 
     def stop_requested(self, turn_id: str) -> bool:
@@ -1650,6 +1753,20 @@ class SessionTurnService:
                             turn_id, "assistant.delta", {"volatile": True}
                         )
                     )
+                structural_range = callback_ingress.structural_resync_range
+                if structural_range is not None:
+                    missing_from, missing_through = structural_range
+                    await self._store_operation(
+                        lambda: store.append_event(
+                            turn_id,
+                            "session.resync_required",
+                            {
+                                "reason": "structural_events_lost",
+                                "missing_from": missing_from,
+                                "missing_through": missing_through,
+                            },
+                        )
+                    )
 
             callback_event_task = asyncio.create_task(persist_callback_events())
             callback_ingress.bind_pump(callback_event_task)
@@ -2261,25 +2378,25 @@ class SessionTurnService:
             if (ref and ref[0] is not None) or turn_id not in self._tasks:
                 break
             await asyncio.sleep(0.01)
-        def stop_and_record() -> Optional[Dict[str, Any]]:
-            stopped = store.request_stop(turn_id)
-            if stopped is not None and stopped["status"] == "stopping":
-                store.append_event(
-                    turn_id, "turn.stopping", {"status": "stopping"}
-                )
-            return store.public_turn(turn_id)
+        def stop_and_read() -> tuple[Optional[Dict[str, Any]], bool]:
+            result = store.request_stop(turn_id)
+            if result is None:
+                return None, False
+            _row, transitioned = result
+            return store.public_turn(turn_id), transitioned
 
-        public = await self._store_operation(stop_and_record)
-        ref = self._agent_refs.get(turn_id)
-        agent = ref[0] if ref else None
-        if agent is not None:
-            try:
-                agent.interrupt("Stop requested via session turn API")
-            except Exception:
-                pass
-        else:
-            watcher = asyncio.create_task(self._interrupt_when_available(turn_id))
-            self._track_background_task(watcher)
+        public, transitioned = await self._store_operation(stop_and_read)
+        if transitioned:
+            ref = self._agent_refs.get(turn_id)
+            agent = ref[0] if ref else None
+            if agent is not None:
+                try:
+                    agent.interrupt("Stop requested via session turn API")
+                except Exception:
+                    pass
+            else:
+                watcher = asyncio.create_task(self._interrupt_when_available(turn_id))
+                self._track_background_task(watcher)
         return web.json_response(
             {"object": "hermes.session.turn.stop", "turn": public}, status=202
         )

--- a/gateway/platforms/session_turns.py
+++ b/gateway/platforms/session_turns.py
@@ -15,7 +15,9 @@ import hashlib
 import io
 import json
 import logging
+import queue
 import re
+import threading
 import time
 import uuid
 import warnings
@@ -30,24 +32,158 @@ from gateway.session_execution_lease import SessionExecutionConflict
 logger = logging.getLogger(__name__)
 
 SESSION_TURN_HEARTBEAT_INTERVAL_SECONDS = 15.0
+SESSION_TURN_LIFECYCLE_QUEUE_SIZE = 32
+SESSION_TURN_LIFECYCLE_SLOW_SECONDS = 0.1
+SESSION_TURN_LIFECYCLE_FLUSH_SECONDS = 0.05
 
 
-def _emit_turn_lifecycle(event: str, session_id: str, turn_id: str, **extra: Any) -> None:
-    """Emit an observer-only fact without allowing observers to affect execution."""
+def _emit_turn_lifecycle(event: str, session_id: str, turn_id: str, **extra: Any) -> bool:
+    """Invoke the provider boundary. Call only from an observer worker thread."""
     try:
         from agent.lifecycle_hooks import emit_session_turn_lifecycle
 
-        emit_session_turn_lifecycle(
+        return emit_session_turn_lifecycle(
             event,
             session_id=session_id,
             turn_id=turn_id,
             **extra,
         )
     except Exception:
-        logger.debug(
+        logger.warning(
             "session_turn_lifecycle_failed event=%s reason=invalid_or_callback_error",
             event,
         )
+        return False
+
+
+_lifecycle_metric_lock = threading.Lock()
+_lifecycle_metrics = {
+    "heartbeat_dropped": 0,
+    "observer_failed": 0,
+    "observer_slow": 0,
+    "terminal_enqueue_failed": 0,
+}
+
+
+def _note_lifecycle_degradation(metric: str, event: str, reason: str) -> None:
+    """Record a privacy-safe provider degradation without touching execution."""
+    with _lifecycle_metric_lock:
+        _lifecycle_metrics[metric] = _lifecycle_metrics.get(metric, 0) + 1
+    logger.warning(
+        "session_turn_lifecycle_degraded event=%s reason=%s metric=%s",
+        event,
+        reason,
+        metric,
+    )
+
+
+def session_turn_lifecycle_metrics() -> Dict[str, int]:
+    """Return process-local safe counters for monitoring/tests."""
+    with _lifecycle_metric_lock:
+        return dict(_lifecycle_metrics)
+
+
+class SessionTurnLifecycleDispatcher:
+    """Ordered, bounded, non-blocking observer delivery for one durable turn.
+
+    Plugin code runs only on this dispatcher's daemon thread. Heartbeats are
+    lossy under backpressure, while the structural registered/started/terminal
+    facts are retained. A slow or permanently hung plugin therefore cannot
+    hold aiohttp, the coordinator, or the persistent execution lease.
+    """
+
+    def __init__(self, session_id: str, turn_id: str):
+        self.session_id = session_id
+        self.turn_id = turn_id
+        self._queue: queue.Queue[tuple[str, Dict[str, Any]]] = queue.Queue(
+            maxsize=max(4, SESSION_TURN_LIFECYCLE_QUEUE_SIZE)
+        )
+        self._closed = False
+        self._drained = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="session-turn-lifecycle",
+            daemon=True,
+        )
+        # Registered is admitted before the worker can observe later events.
+        self._queue.put_nowait(("registered", {}))
+        self._thread.start()
+
+    def emit(self, event: str, **extra: Any) -> bool:
+        """Queue an event without waiting; return whether it was retained."""
+        if self._closed:
+            _note_lifecycle_degradation("observer_failed", event, "dispatcher_closed")
+            return False
+        try:
+            self._queue.put_nowait((event, dict(extra)))
+            return True
+        except queue.Full:
+            if event == "heartbeat":
+                _note_lifecycle_degradation("heartbeat_dropped", event, "queue_full")
+                return False
+            # Structural events must not be displaced by observer latency.
+            # At capacity after registered/started, at least one queued item is
+            # a heartbeat; evict the oldest heartbeat without blocking.
+            with self._queue.mutex:
+                for index, item in enumerate(self._queue.queue):
+                    if item[0] == "heartbeat":
+                        del self._queue.queue[index]
+                        self._queue.not_full.notify()
+                        break
+                else:
+                    _note_lifecycle_degradation(
+                        "terminal_enqueue_failed" if event == "terminal" else "observer_failed",
+                        event,
+                        "structural_queue_full",
+                    )
+                    return False
+            self._queue.put_nowait((event, dict(extra)))
+            return True
+
+    def close(self, terminal_outcome: str) -> bool:
+        """Queue exactly one terminal and reject all later events."""
+        if self._closed:
+            return False
+        accepted = self.emit("terminal", terminal_outcome=terminal_outcome)
+        self._closed = True
+        return accepted
+
+    def flush(self, timeout: Optional[float] = None) -> bool:
+        """Wait for terminal delivery. Never call directly on the event loop."""
+        return self._drained.wait(timeout)
+
+    def _run(self) -> None:
+        while True:
+            event, extra = self._queue.get()
+            slow = threading.Event()
+
+            def report_slow() -> None:
+                if not slow.is_set():
+                    _note_lifecycle_degradation("observer_slow", event, "callback_slow")
+
+            watchdog = threading.Timer(SESSION_TURN_LIFECYCLE_SLOW_SECONDS, report_slow)
+            watchdog.daemon = True
+            watchdog.start()
+            try:
+                delivered = _emit_turn_lifecycle(
+                    event,
+                    self.session_id,
+                    self.turn_id,
+                    **extra,
+                )
+                if not delivered:
+                    _note_lifecycle_degradation(
+                        "observer_failed", event, "callback_error"
+                    )
+            except Exception:
+                # Defensive: _emit_turn_lifecycle is already fail-open.
+                _note_lifecycle_degradation("observer_failed", event, "callback_error")
+            finally:
+                slow.set()
+                watchdog.cancel()
+            if event == "terminal":
+                self._drained.set()
+                return
 
 
 DELIVERY_MODES = frozenset({"occ_only", "slack_only", "both"})
@@ -850,6 +986,7 @@ class SessionTurnService:
         self._store_lock = asyncio.Lock()
         self._tasks: Dict[str, asyncio.Task[Any]] = {}
         self._agent_refs: Dict[str, list[Any]] = {}
+        self._lifecycle_dispatchers: Dict[str, SessionTurnLifecycleDispatcher] = {}
         # Assistant text deltas are intentionally process-local. Canonical
         # SessionDB messages are the only durable transcript authority.
         self._volatile_events: Dict[str, Dict[int, Dict[str, Any]]] = {}
@@ -952,8 +1089,11 @@ class SessionTurnService:
 
         if created:
             # reserve() committed the runnable identity before this observation.
-            # Emit before scheduling so registered always precedes started.
-            _emit_turn_lifecycle("registered", session_id, turn_id)
+            # Construct before scheduling: its bounded FIFO already contains
+            # registered, so started can never overtake it.
+            self._lifecycle_dispatchers[turn_id] = SessionTurnLifecycleDispatcher(
+                session_id, turn_id
+            )
             task = asyncio.create_task(
                 self._execute(store, turn_id, session_id, payload, binding, slack_adapter)
             )
@@ -975,6 +1115,8 @@ class SessionTurnService:
         agent_ref: list[Any] = [None]
         execution_lease = None
         heartbeat_task: Optional[asyncio.Task[Any]] = None
+        agent_task: Optional[asyncio.Task[Any]] = None
+        dispatcher = self._lifecycle_dispatchers.get(turn_id)
         self._agent_refs[turn_id] = agent_ref
         try:
             def interrupt_on_lease_loss() -> None:
@@ -999,12 +1141,14 @@ class SessionTurnService:
             if not store.set_running(turn_id):
                 return
             store.append_event(turn_id, "turn.started", {"status": "running"})
-            _emit_turn_lifecycle("started", session_id, turn_id)
+            if dispatcher is not None:
+                dispatcher.emit("started")
 
             async def emit_heartbeats() -> None:
                 while True:
                     await asyncio.sleep(SESSION_TURN_HEARTBEAT_INTERVAL_SECONDS)
-                    _emit_turn_lifecycle("heartbeat", session_id, turn_id)
+                    if dispatcher is not None:
+                        dispatcher.emit("heartbeat")
 
             heartbeat_task = asyncio.create_task(emit_heartbeats())
             try:
@@ -1061,16 +1205,47 @@ class SessionTurnService:
                 )
                 append(projected["event"], projected["data"])
 
-            result, _usage = await self.adapter._run_agent(
-                user_message=_agent_input(payload),
-                conversation_history=history,
-                session_id=session_id,
-                stream_delta_callback=on_delta,
-                tool_start_callback=on_tool_start,
-                tool_complete_callback=on_tool_complete,
-                agent_ref=agent_ref,
-                authoritative_turn_id=turn_id,
+            agent_task = asyncio.create_task(
+                self.adapter._run_agent(
+                    user_message=_agent_input(payload),
+                    conversation_history=history,
+                    session_id=session_id,
+                    stream_delta_callback=on_delta,
+                    tool_start_callback=on_tool_start,
+                    tool_complete_callback=on_tool_complete,
+                    agent_ref=agent_ref,
+                    authoritative_turn_id=turn_id,
+                )
             )
+            while True:
+                try:
+                    # Cancelling a Task waiting directly on run_in_executor
+                    # abandons the still-live thread. Shield the child and keep
+                    # this coordinator as monitoring owner until real exit.
+                    result, _usage = await asyncio.shield(agent_task)
+                    break
+                except asyncio.CancelledError:
+                    if agent_task.done():
+                        # A child cancellation is a real execution outcome, not
+                        # a request to abandon coordinator ownership.
+                        await agent_task
+                    await asyncio.to_thread(store.request_stop, turn_id)
+                    agent = agent_ref[0]
+                    if agent is not None:
+                        try:
+                            agent.interrupt("Session turn coordinator cancellation requested")
+                        except Exception:
+                            pass
+                    else:
+                        watcher = asyncio.create_task(self._interrupt_when_available(turn_id))
+                        try:
+                            self.adapter._background_tasks.add(watcher)
+                            watcher.add_done_callback(self.adapter._background_tasks.discard)
+                        except (AttributeError, TypeError):
+                            pass
+                    # Continue heartbeat and lease ownership until the executor
+                    # future itself resolves. Repeated cancellation is handled
+                    # by the same bounded, non-abandoning loop.
             effective_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
             if execution_lease is None or not await execution_lease.still_owned():
                 store.finish(
@@ -1135,12 +1310,15 @@ class SessionTurnService:
             store.finish(turn_id, "completed", effective_session_id=effective_id)
             store.append_event(turn_id, "turn.completed", {"status": "completed"})
         except asyncio.CancelledError:
-            # An asyncio cancellation does not kill run_in_executor work.  Only
-            # mark interrupted here when no agent was ever created; otherwise a
-            # still-running worker must remain truthfully stopping.
-            if agent_ref[0] is None:
-                store.finish(turn_id, "interrupted", safe_error_code="cancelled_before_execution")
-            raise
+            # Cancellation before an executor exists is mechanically terminal.
+            # Once agent_task exists, the shielded loop above retains ownership
+            # and this branch is unreachable until that worker has really quit.
+            store.finish(turn_id, "interrupted", safe_error_code="cancelled_before_execution")
+            store.append_event(
+                turn_id,
+                "turn.interrupted",
+                {"status": "interrupted", "error_code": "cancelled_before_execution"},
+            )
         except Exception:
             store.finish(turn_id, "failed", safe_error_code="run_failed")
             store.append_event(turn_id, "turn.failed", {"status": "failed", "error_code": "run_failed"})
@@ -1166,14 +1344,16 @@ class SessionTurnService:
                 else None
             )
             if outcome is not None:
-                _emit_turn_lifecycle(
-                    "terminal",
-                    session_id,
-                    turn_id,
-                    terminal_outcome=outcome,
-                )
+                if dispatcher is not None:
+                    dispatcher.close(outcome)
             if execution_lease is not None:
                 await execution_lease.release()
+            # Observer completion is bounded and happens only after lease
+            # release. to_thread keeps even this small grace off aiohttp.
+            if dispatcher is not None and outcome is not None:
+                await asyncio.to_thread(
+                    dispatcher.flush, SESSION_TURN_LIFECYCLE_FLUSH_SECONDS
+                )
             self._agent_refs.pop(turn_id, None)
 
     async def _deliver_slack(self, store: SessionTurnStore, turn_id: str, binding: SlackBinding,

--- a/gateway/platforms/session_turns.py
+++ b/gateway/platforms/session_turns.py
@@ -1,0 +1,1415 @@
+"""Durable, resumable session-turn API support.
+
+This is an API-edge contract, not a model tool.  Turn/outbox metadata and safe
+SSE frames share ``state.db`` with SessionDB, while SessionDB messages remain
+the only transcript.  No input or final-response columns exist in the turn
+ledger.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import hashlib
+import io
+import json
+import re
+import time
+import uuid
+import warnings
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from aiohttp import web
+
+from gateway.session_execution_lease import SessionExecutionConflict
+
+
+DELIVERY_MODES = frozenset({"occ_only", "slack_only", "both"})
+ACTIVE_STATUSES = frozenset({"queued", "running", "stopping"})
+TERMINAL_STATUSES = frozenset({"completed", "failed", "interrupted"})
+MAX_TURN_ID_LENGTH = 128
+MAX_INPUT_TEXT_LENGTH = 65_536
+MAX_INLINE_IMAGES = 4
+MAX_INLINE_IMAGE_BYTES = 5 * 1024 * 1024
+MAX_INLINE_IMAGE_TOTAL_BYTES = 10 * 1024 * 1024
+MAX_IMAGE_DIMENSION = 16_384
+MAX_IMAGE_PIXELS = 40_000_000
+MAX_IMAGE_FRAMES = 256
+MAX_SLACK_ROUTED_CHARS = 3_000
+INLINE_IMAGE_MIME_TYPES = frozenset({"image/png", "image/jpeg", "image/webp", "image/gif"})
+_TURN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_DATA_IMAGE_RE = re.compile(
+    r"^data:(image/(?:png|jpeg|webp|gif));base64,([A-Za-z0-9+/=\r\n]+)$",
+    re.IGNORECASE,
+)
+
+
+class TurnInputError(ValueError):
+    """The submitted turn body is invalid."""
+
+
+class ConflictingTurn(RuntimeError):
+    """A turn id was reused with a different request fingerprint."""
+
+
+class TurnConflict(RuntimeError):
+    """A session already has an active turn."""
+
+
+class SlackBindingError(RuntimeError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class SlackBinding:
+    chat_id: str
+    thread_id: Optional[str]
+    metadata: Dict[str, Any]
+
+
+def _safe_tool_label(tool_name: Any) -> str:
+    name = str(tool_name or "tool")
+    name = re.sub(r"[^A-Za-z0-9 _.-]", "", name)[:64].strip() or "tool"
+    return name.replace("_", " ").replace("-", " ").title()
+
+
+def project_safe_tool_event(event_type: str, **event: Any) -> Dict[str, Any]:
+    """Project an internal callback to the deliberately tiny public schema."""
+    statuses = {
+        "tool.started": "running",
+        "tool.completed": "completed",
+        "tool.failed": "failed",
+    }
+    data: Dict[str, Any] = {
+        "tool_call_id": str(event.get("tool_call_id") or "")[:128],
+        "label": _safe_tool_label(event.get("tool_name")),
+        "status": statuses.get(event_type, "failed"),
+    }
+    if event_type == "tool.failed":
+        data["error_code"] = "tool_failed"
+    return {"event": event_type, "data": data}
+
+
+def _validated_image_dimensions(decoded: bytes, declared_mime: str) -> tuple[int, int]:
+    """Verify the container and fully decode pixels with Pillow."""
+    try:
+        from PIL import Image, UnidentifiedImageError
+    except ImportError as exc:
+        raise TurnInputError("Inline image decoder is unavailable") from exc
+
+    expected_format = {
+        "image/png": "PNG",
+        "image/jpeg": "JPEG",
+        "image/gif": "GIF",
+        "image/webp": "WEBP",
+    }[declared_mime]
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", Image.DecompressionBombWarning)
+            with Image.open(io.BytesIO(decoded)) as image:
+                if image.format != expected_format:
+                    raise TurnInputError("Image magic/MIME mismatch")
+                width, height = image.size
+                if (
+                    width <= 0
+                    or height <= 0
+                    or width > MAX_IMAGE_DIMENSION
+                    or height > MAX_IMAGE_DIMENSION
+                ):
+                    raise TurnInputError("Image dimensions exceed the safe limit")
+                if width * height > MAX_IMAGE_PIXELS:
+                    raise TurnInputError("Image dimensions exceed the safe pixel limit")
+                image.verify()
+            # ``verify`` checks container integrity but deliberately does not
+            # decode image data. Re-open and load every frame/pixel so corrupt,
+            # truncated, and invalid compressed payloads fail before admission.
+            with Image.open(io.BytesIO(decoded)) as image:
+                if image.format != expected_format or image.size != (width, height):
+                    raise TurnInputError("Image payload changed during verification")
+                frame_count = int(getattr(image, "n_frames", 1) or 1)
+                if frame_count > MAX_IMAGE_FRAMES:
+                    raise TurnInputError("Image frame count exceeds the safe limit")
+                for frame in range(frame_count):
+                    image.seek(frame)
+                    image.load()
+    except TurnInputError:
+        raise
+    except (Image.DecompressionBombError, Image.DecompressionBombWarning) as exc:
+        # Pillow rejects extreme pixel counts while opening the container,
+        # before our explicit width/height checks can run.  Keep that bounded
+        # input failure deterministic instead of misclassifying it as corrupt
+        # image data.
+        raise TurnInputError("Image dimensions exceed the safe pixel limit") from exc
+    except (
+        UnidentifiedImageError,
+        OSError,
+        SyntaxError,
+        ValueError,
+    ) as exc:
+        raise TurnInputError("Image payload is malformed, truncated, or unsafe") from exc
+    return width, height
+
+
+def _image_decoder_readiness_probe() -> bool:
+    try:
+        from PIL import Image
+
+        probe = io.BytesIO()
+        Image.new("RGB", (1, 1), "black").save(probe, format="PNG")
+        return _validated_image_dimensions(probe.getvalue(), "image/png") == (1, 1)
+    except Exception:
+        return False
+
+
+IMAGE_DECODER_READY = _image_decoder_readiness_probe()
+
+
+def _normalize_inline_image(value: Any) -> tuple[str, int]:
+    if not IMAGE_DECODER_READY:
+        raise TurnInputError("Inline image decoder is unavailable")
+    if isinstance(value, dict):
+        value = value.get("data_url") or value.get("url") or value.get("image_url")
+    if not isinstance(value, str) or not value.lower().startswith("data:image/"):
+        raise TurnInputError("Images must be bounded inline data:image/...;base64 payloads")
+    match = _DATA_IMAGE_RE.fullmatch(value.strip())
+    if not match:
+        raise TurnInputError("Invalid inline image encoding or unsupported image MIME type")
+    mime = match.group(1).lower()
+    if mime not in INLINE_IMAGE_MIME_TYPES:
+        raise TurnInputError("Unsupported inline image MIME type")
+    try:
+        decoded = base64.b64decode(match.group(2), validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise TurnInputError("Invalid inline image base64") from exc
+    size = len(decoded)
+    if size <= 0 or size > MAX_INLINE_IMAGE_BYTES:
+        raise TurnInputError("Inline image exceeds the per-image size limit")
+    _validated_image_dimensions(decoded, mime)
+    canonical = f"data:{mime};base64,{base64.b64encode(decoded).decode('ascii')}"
+    return canonical, size
+
+
+def normalize_turn_payload(body: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(body, dict):
+        raise TurnInputError("Request body must be an object")
+    allowed = {"turn_id", "input", "images", "delivery_mode"}
+    unknown = set(body) - allowed
+    if unknown:
+        raise TurnInputError(f"Unsupported turn field: {sorted(unknown)[0]}")
+    mode = str(body.get("delivery_mode") or "occ_only").strip().lower()
+    if mode not in DELIVERY_MODES:
+        raise TurnInputError("delivery_mode must be occ_only, slack_only, or both")
+
+    raw_input = body.get("input")
+    if isinstance(raw_input, str):
+        text = raw_input
+        raw_images = body.get("images") or []
+    elif isinstance(raw_input, dict):
+        unknown_input = set(raw_input) - {"text", "images"}
+        if unknown_input:
+            raise TurnInputError(f"Unsupported input field: {sorted(unknown_input)[0]}")
+        text = raw_input.get("text") or ""
+        raw_images = raw_input.get("images") or []
+    else:
+        raise TurnInputError("input must be text or an object with text and images")
+    if not isinstance(text, str):
+        raise TurnInputError("input.text must be a string")
+    if len(text) > MAX_INPUT_TEXT_LENGTH:
+        raise TurnInputError("input.text exceeds the length limit")
+    if not isinstance(raw_images, list):
+        raise TurnInputError("input.images must be an array")
+    if len(raw_images) > MAX_INLINE_IMAGES:
+        raise TurnInputError("Too many inline images")
+
+    images = []
+    total = 0
+    for image in raw_images:
+        normalized, size = _normalize_inline_image(image)
+        total += size
+        if total > MAX_INLINE_IMAGE_TOTAL_BYTES:
+            raise TurnInputError("Inline images exceed the total size limit")
+        images.append(normalized)
+    if not text.strip() and not images:
+        raise TurnInputError("Turn input cannot be empty")
+    return {"input": {"text": text, "images": images}, "delivery_mode": mode}
+
+
+def _fingerprint(payload: Dict[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _agent_input(payload: Dict[str, Any]) -> Any:
+    text = payload["input"]["text"]
+    images = payload["input"]["images"]
+    if not images:
+        return text
+    parts = []
+    if text:
+        parts.append({"type": "text", "text": text})
+    parts.extend({"type": "image_url", "image_url": {"url": image}} for image in images)
+    return parts
+
+
+class SessionTurnStore:
+    """Transactional turn/event/outbox ledger stored inside SessionDB.state.db."""
+
+    def __init__(self, session_db: Any):
+        self.db = session_db
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        def create(conn):
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS api_session_turns (
+                    turn_id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    fingerprint TEXT NOT NULL,
+                    delivery_mode TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    safe_error_code TEXT,
+                    stop_requested INTEGER NOT NULL DEFAULT 0,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    started_at REAL,
+                    finished_at REAL,
+                    effective_session_id TEXT,
+                    assistant_message_id TEXT,
+                    FOREIGN KEY(session_id) REFERENCES sessions(id) ON DELETE CASCADE
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_api_session_turns_one_active
+                    ON api_session_turns(session_id)
+                    WHERE status IN ('queued', 'running', 'stopping');
+                CREATE INDEX IF NOT EXISTS idx_api_session_turns_session_created
+                    ON api_session_turns(session_id, created_at DESC);
+                CREATE TABLE IF NOT EXISTS api_session_turn_events (
+                    turn_id TEXT NOT NULL,
+                    seq INTEGER NOT NULL,
+                    event_type TEXT NOT NULL,
+                    data_json TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    PRIMARY KEY(turn_id, seq),
+                    FOREIGN KEY(turn_id) REFERENCES api_session_turns(turn_id) ON DELETE CASCADE
+                );
+                CREATE TABLE IF NOT EXISTS api_session_turn_outbox (
+                    turn_id TEXT NOT NULL,
+                    destination TEXT NOT NULL,
+                    delivery_id TEXT,
+                    provider_message_id TEXT,
+                    state TEXT NOT NULL,
+                    safe_error_code TEXT,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY(turn_id, destination),
+                    FOREIGN KEY(turn_id) REFERENCES api_session_turns(turn_id) ON DELETE CASCADE
+                );
+                """
+            )
+            outbox_columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(api_session_turn_outbox)").fetchall()
+            }
+            if "delivery_id" not in outbox_columns:
+                conn.execute("ALTER TABLE api_session_turn_outbox ADD COLUMN delivery_id TEXT")
+            if "provider_message_id" not in outbox_columns:
+                conn.execute(
+                    "ALTER TABLE api_session_turn_outbox ADD COLUMN provider_message_id TEXT"
+                )
+            turn_columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(api_session_turns)").fetchall()
+            }
+            if "assistant_message_id" not in turn_columns:
+                conn.execute(
+                    "ALTER TABLE api_session_turns ADD COLUMN assistant_message_id TEXT"
+                )
+        self.db._execute_write(create)
+
+    @staticmethod
+    def validate_turn_id(turn_id: Any) -> str:
+        value = str(turn_id or "").strip()
+        if len(value) > MAX_TURN_ID_LENGTH or not _TURN_ID_RE.fullmatch(value):
+            raise TurnInputError("Invalid turn_id / Idempotency-Key")
+        return value
+
+    def reserve(self, session_id: str, turn_id: str, body: Dict[str, Any]) -> tuple[Dict[str, Any], bool]:
+        turn_id = self.validate_turn_id(turn_id)
+        payload = normalize_turn_payload(body)
+        fingerprint = _fingerprint(payload)
+        now = time.time()
+
+        def reserve_tx(conn):
+            existing = conn.execute(
+                "SELECT * FROM api_session_turns WHERE turn_id = ?", (turn_id,)
+            ).fetchone()
+            if existing:
+                row = dict(existing)
+                if row["session_id"] != session_id or row["fingerprint"] != fingerprint:
+                    raise ConflictingTurn(turn_id)
+                return row, False
+            session = conn.execute("SELECT id FROM sessions WHERE id = ?", (session_id,)).fetchone()
+            if session is None:
+                raise KeyError(session_id)
+            active = conn.execute(
+                "SELECT turn_id FROM api_session_turns WHERE session_id = ? "
+                "AND status IN ('queued','running','stopping') LIMIT 1",
+                (session_id,),
+            ).fetchone()
+            if active:
+                raise TurnConflict(str(active["turn_id"]))
+            try:
+                conn.execute(
+                    "INSERT INTO api_session_turns "
+                    "(turn_id, session_id, fingerprint, delivery_mode, status, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, 'queued', ?, ?)",
+                    (turn_id, session_id, fingerprint, payload["delivery_mode"], now, now),
+                )
+            except Exception as exc:
+                if "idx_api_session_turns_one_active" in str(exc) or "UNIQUE constraint" in str(exc):
+                    raise TurnConflict(session_id) from exc
+                raise
+            row = conn.execute(
+                "SELECT * FROM api_session_turns WHERE turn_id = ?", (turn_id,)
+            ).fetchone()
+            return dict(row), True
+
+        return self.db._execute_write(reserve_tx)
+
+    def get(self, turn_id: str) -> Optional[Dict[str, Any]]:
+        with self.db._lock:
+            row = self.db._conn.execute(
+                "SELECT * FROM api_session_turns WHERE turn_id = ?", (turn_id,)
+            ).fetchone()
+        return dict(row) if row else None
+
+    def public_turn(self, turn_id: str) -> Optional[Dict[str, Any]]:
+        row = self.get(turn_id)
+        if not row:
+            return None
+        keys = (
+            "turn_id", "session_id", "delivery_mode", "status", "safe_error_code",
+            "created_at", "updated_at", "started_at", "finished_at", "effective_session_id",
+            "assistant_message_id",
+        )
+        result = {key: row.get(key) for key in keys}
+        with self.db._lock:
+            deliveries = self.db._conn.execute(
+                "SELECT destination, delivery_id, provider_message_id, state, safe_error_code, "
+                "created_at, updated_at "
+                "FROM api_session_turn_outbox WHERE turn_id = ? ORDER BY destination",
+                (turn_id,),
+            ).fetchall()
+        result["deliveries"] = [dict(item) for item in deliveries]
+        result["provenance"] = {
+            "runtime": "hermes",
+            "edge": "api_server",
+            "execution": "single_run",
+            "transcript": "session_db",
+        }
+        result["object"] = "hermes.session.turn"
+        return result
+
+    def _set_status(self, turn_id: str, status: str, safe_error_code: Optional[str] = None,
+                    effective_session_id: Optional[str] = None) -> bool:
+        now = time.time()
+        terminal = status in TERMINAL_STATUSES
+
+        def update(conn):
+            row = conn.execute(
+                "SELECT status FROM api_session_turns WHERE turn_id = ?", (turn_id,)
+            ).fetchone()
+            if row is None or row["status"] in TERMINAL_STATUSES:
+                return False
+            conn.execute(
+                "UPDATE api_session_turns SET status = ?, safe_error_code = ?, updated_at = ?, "
+                "started_at = CASE WHEN ? = 'running' THEN COALESCE(started_at, ?) ELSE started_at END, "
+                "finished_at = CASE WHEN ? THEN ? ELSE finished_at END, "
+                "effective_session_id = COALESCE(?, effective_session_id) WHERE turn_id = ?",
+                (status, safe_error_code, now, status, now, int(terminal), now,
+                 effective_session_id, turn_id),
+            )
+            return True
+        return bool(self.db._execute_write(update))
+
+    def set_running(self, turn_id: str) -> bool:
+        return self._set_status(turn_id, "running")
+
+    def finish(self, turn_id: str, status: str, *, safe_error_code: Optional[str] = None,
+               effective_session_id: Optional[str] = None) -> bool:
+        if status not in TERMINAL_STATUSES:
+            raise ValueError("finish requires a terminal status")
+        return self._set_status(turn_id, status, safe_error_code, effective_session_id)
+
+    def message_high_water(self) -> int:
+        with self.db._lock:
+            row = self.db._conn.execute(
+                "SELECT COALESCE(MAX(id), 0) AS high FROM messages"
+            ).fetchone()
+        return int(row["high"])
+
+    def anchor_completed_assistant(
+        self, turn_id: str, effective_session_id: str, *, after_message_id: int
+    ) -> Optional[str]:
+        """Persist the exact final assistant row created after turn admission."""
+        def anchor(conn):
+            tail = conn.execute(
+                "SELECT id, role FROM messages WHERE session_id = ? AND active = 1 "
+                "AND id > ? ORDER BY id DESC LIMIT 1",
+                (effective_session_id, after_message_id),
+            ).fetchone()
+            if tail is None or tail["role"] != "assistant":
+                return None
+            message_id = str(tail["id"])
+            cursor = conn.execute(
+                "UPDATE api_session_turns SET assistant_message_id = ?, "
+                "effective_session_id = ?, updated_at = ? WHERE turn_id = ? "
+                "AND status IN ('running','stopping') AND assistant_message_id IS NULL",
+                (message_id, effective_session_id, time.time(), turn_id),
+            )
+            return message_id if cursor.rowcount == 1 else None
+        return self.db._execute_write(anchor)
+
+    def anchored_assistant_content(self, turn_id: str) -> Optional[str]:
+        """Fetch only the assistant row durably anchored to this turn."""
+        with self.db._lock:
+            row = self.db._conn.execute(
+                "SELECT m.content FROM api_session_turns t JOIN messages m "
+                "ON CAST(m.id AS TEXT) = t.assistant_message_id "
+                "AND m.session_id = t.effective_session_id "
+                "WHERE t.turn_id = ? AND m.role = 'assistant' AND m.active = 1",
+                (turn_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        content = self.db._decode_content(row["content"])
+        return content if isinstance(content, str) else None
+
+    def request_stop(self, turn_id: str) -> Optional[Dict[str, Any]]:
+        now = time.time()
+
+        def stop(conn):
+            row = conn.execute(
+                "SELECT * FROM api_session_turns WHERE turn_id = ?", (turn_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            if row["status"] not in TERMINAL_STATUSES:
+                conn.execute(
+                    "UPDATE api_session_turns SET stop_requested = 1, status = 'stopping', "
+                    "updated_at = ? WHERE turn_id = ?", (now, turn_id)
+                )
+            result = conn.execute(
+                "SELECT * FROM api_session_turns WHERE turn_id = ?", (turn_id,)
+            ).fetchone()
+            return dict(result)
+        return self.db._execute_write(stop)
+
+    def stop_requested(self, turn_id: str) -> bool:
+        row = self.get(turn_id)
+        return bool(row and row.get("stop_requested"))
+
+    def append_event(self, turn_id: str, event_type: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        now = time.time()
+        if event_type == "assistant.delta":
+            clean_data = {"volatile": True}
+        else:
+            forbidden = {
+                "content", "delta", "text", "input", "prompt", "response",
+                "reasoning", "output", "preview", "args", "messages",
+            }
+            clean_data = {key: value for key, value in data.items() if key not in forbidden}
+
+        def append(conn):
+            row = conn.execute(
+                "SELECT COALESCE(MAX(seq), 0) + 1 AS seq FROM api_session_turn_events WHERE turn_id = ?",
+                (turn_id,),
+            ).fetchone()
+            seq = int(row["seq"])
+            conn.execute(
+                "INSERT INTO api_session_turn_events (turn_id, seq, event_type, data_json, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (turn_id, seq, event_type, json.dumps(clean_data, ensure_ascii=False), now),
+            )
+            return {"seq": seq, "event": event_type, "data": clean_data, "created_at": now}
+        return self.db._execute_write(append)
+
+    def event_bounds(self, turn_id: str) -> tuple[int, int, int]:
+        with self.db._lock:
+            row = self.db._conn.execute(
+                "SELECT COALESCE(MIN(seq), 0) AS low, COALESCE(MAX(seq), 0) AS high, "
+                "COUNT(*) AS count FROM api_session_turn_events WHERE turn_id = ?",
+                (turn_id,),
+            ).fetchone()
+        return int(row["low"]), int(row["high"]), int(row["count"])
+
+    def events_after(self, turn_id: str, sequence: int) -> list[Dict[str, Any]]:
+        with self.db._lock:
+            rows = self.db._conn.execute(
+                "SELECT seq, event_type, data_json, created_at FROM api_session_turn_events "
+                "WHERE turn_id = ? AND seq > ? ORDER BY seq", (turn_id, sequence)
+            ).fetchall()
+        return [
+            {"seq": int(row["seq"]), "event": row["event_type"],
+             "data": json.loads(row["data_json"]), "created_at": row["created_at"]}
+            for row in rows
+        ]
+
+    def begin_delivery(self, turn_id: str, destination: str) -> bool:
+        now = time.time()
+
+        def begin(conn):
+            existing = conn.execute(
+                "SELECT state FROM api_session_turn_outbox WHERE turn_id = ? AND destination = ?",
+                (turn_id, destination),
+            ).fetchone()
+            if existing:
+                return False
+            delivery_id = str(uuid.uuid5(
+                uuid.NAMESPACE_URL, f"hermes-session-turn-delivery:{turn_id}:{destination}"
+            ))
+            conn.execute(
+                "INSERT INTO api_session_turn_outbox "
+                "(turn_id, destination, delivery_id, state, created_at, updated_at) "
+                "VALUES (?, ?, ?, 'sending', ?, ?)",
+                (turn_id, destination, delivery_id, now, now),
+            )
+            return True
+        return bool(self.db._execute_write(begin))
+
+    def finish_delivery(
+        self,
+        turn_id: str,
+        destination: str,
+        state: str,
+        safe_error_code: Optional[str] = None,
+        *,
+        provider_message_id: Optional[str] = None,
+    ) -> None:
+        now = time.time()
+        self.db._execute_write(lambda conn: conn.execute(
+            "UPDATE api_session_turn_outbox SET state = ?, safe_error_code = ?, "
+            "provider_message_id = COALESCE(?, provider_message_id), updated_at = ? "
+            "WHERE turn_id = ? AND destination = ?",
+            (
+                state,
+                safe_error_code,
+                provider_message_id,
+                now,
+                turn_id,
+                destination,
+            ),
+        ))
+
+    def get_delivery(self, turn_id: str, destination: str) -> Optional[Dict[str, Any]]:
+        with self.db._lock:
+            row = self.db._conn.execute(
+                "SELECT * FROM api_session_turn_outbox WHERE turn_id = ? AND destination = ?",
+                (turn_id, destination),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def reconcile_uncertain(self) -> int:
+        """Interrupt only work whose persistent execution owner is not live."""
+        now = time.time()
+
+        def reconcile(conn):
+            turns = conn.execute(
+                "SELECT turn_id, session_id FROM api_session_turns "
+                "WHERE status IN ('queued','running','stopping')"
+            ).fetchall()
+            interrupted = 0
+            for row in turns:
+                turn_id = row["turn_id"]
+                lease = conn.execute(
+                    "SELECT * FROM session_execution_leases WHERE session_id = ?",
+                    (row["session_id"],),
+                ).fetchone()
+                if lease is not None:
+                    owner_state = self.db.session_execution_lease_owner_state(
+                        lease, now=now
+                    )
+                    if owner_state == "live":
+                        continue
+                    conn.execute(
+                        "DELETE FROM session_execution_leases "
+                        "WHERE session_id = ? AND owner_id = ?",
+                        (row["session_id"], lease["owner_id"]),
+                    )
+                conn.execute(
+                    "UPDATE api_session_turns SET status='interrupted', "
+                    "safe_error_code='process_restarted', updated_at=?, finished_at=? "
+                    "WHERE turn_id=? AND status IN ('queued','running','stopping')",
+                    (now, now, turn_id),
+                )
+                seq_row = conn.execute(
+                    "SELECT COALESCE(MAX(seq), 0) + 1 AS seq "
+                    "FROM api_session_turn_events WHERE turn_id=?",
+                    (turn_id,),
+                ).fetchone()
+                conn.execute(
+                    "INSERT INTO api_session_turn_events "
+                    "(turn_id, seq, event_type, data_json, created_at) "
+                    "VALUES (?, ?, 'turn.interrupted', ?, ?)",
+                    (
+                        turn_id,
+                        int(seq_row["seq"]),
+                        json.dumps({
+                            "status": "interrupted",
+                            "error_code": "process_restarted",
+                        }),
+                        now,
+                    ),
+                )
+                interrupted += 1
+            conn.execute(
+                "UPDATE api_session_turn_outbox SET state='needs_manual_retry', "
+                "safe_error_code='delivery_outcome_unknown', updated_at=? "
+                "WHERE state='sending'",
+                (now,),
+            )
+            return interrupted
+        return int(self.db._execute_write(reconcile) or 0)
+
+
+
+def _json_object(value: Any) -> Optional[Dict[str, Any]]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    return None
+
+
+def _add_slack_evidence(
+    evidence: Dict[str, set[str]], value: Dict[str, Any], *, session_key: str = ""
+) -> None:
+    source = value.get("source")
+    if isinstance(source, dict):
+        _add_slack_evidence(evidence, source, session_key=session_key)
+    elif source:
+        evidence["platform"].add(str(source).strip().lower())
+    platform = value.get("platform")
+    if platform:
+        evidence["platform"].add(str(platform).strip().lower())
+    for key in ("chat_id", "channel_id"):
+        if value.get(key):
+            evidence["chat"].add(str(value[key]).strip())
+    for key in ("thread_id", "thread_ts"):
+        if value.get(key):
+            evidence["thread"].add(str(value[key]).strip())
+    for key in ("scope_id", "team_id", "workspace_id", "slack_team_id"):
+        if value.get(key):
+            evidence["workspace"].add(str(value[key]).strip())
+    key = str(value.get("session_key") or session_key or "")
+    match = re.search(r":slack:([^:]+):(?:channel|chat):([^:]+)(?::thread:([^:]+))?", key)
+    if match:
+        evidence["platform"].add("slack")
+        evidence["workspace"].add(match.group(1))
+        evidence["chat"].add(match.group(2))
+        if match.group(3):
+            evidence["thread"].add(match.group(3))
+
+
+def resolve_slack_binding(session_db: Any, session_id: Optional[str] = None) -> SlackBinding:
+    """Resolve the nearest unique Slack-bound lineage row, checking all durable metadata."""
+    if session_id is None and isinstance(session_db, dict):
+        rows = [session_db]
+        routing: list[Dict[str, Any]] = []
+    else:
+        with session_db._lock:
+            rows = [dict(row) for row in session_db._conn.execute(
+                """WITH RECURSIVE lineage(id, depth) AS (
+                     SELECT ?, 0 UNION ALL
+                     SELECT s.parent_session_id, lineage.depth + 1
+                     FROM lineage JOIN sessions s ON s.id = lineage.id
+                     WHERE s.parent_session_id IS NOT NULL
+                   )
+                   SELECT s.*, lineage.depth FROM lineage JOIN sessions s ON s.id=lineage.id
+                   ORDER BY lineage.depth""",
+                (session_id,),
+            ).fetchall()]
+            routing_rows = session_db._conn.execute(
+                "SELECT session_key, entry_json FROM gateway_routing"
+            ).fetchall()
+        routing = []
+        lineage_ids = {row["id"] for row in rows}
+        for route_row in routing_rows:
+            entry = _json_object(route_row["entry_json"])
+            if entry and str(entry.get("session_id") or "") in lineage_ids:
+                entry = dict(entry)
+                entry.setdefault("session_key", route_row["session_key"])
+                routing.append(entry)
+
+    for row in rows:
+        evidence = {
+            key: set() for key in ("platform", "chat", "thread", "workspace")
+        }
+        _add_slack_evidence(evidence, row)
+        origin = _json_object(row.get("origin_json"))
+        if origin:
+            _add_slack_evidence(
+                evidence,
+                origin,
+                session_key=str(row.get("session_key") or ""),
+            )
+        for entry in routing:
+            if str(entry.get("session_id") or "") == str(row.get("id") or ""):
+                _add_slack_evidence(evidence, entry)
+
+        # A continuation row may retain source='slack' while intentionally
+        # inheriting routing from its parent. It becomes the nearest *bound*
+        # row only when durable target evidence exists on that row.
+        if not any(evidence[key] for key in ("chat", "thread", "workspace")):
+            continue
+        if evidence["platform"] != {"slack"}:
+            code = (
+                "ambiguous_slack_binding"
+                if len(evidence["platform"]) > 1
+                else "no_slack_binding"
+            )
+            raise SlackBindingError(code)
+        if len(evidence["chat"]) != 1 or len(evidence["workspace"]) != 1:
+            code = (
+                "ambiguous_slack_binding"
+                if len(evidence["chat"]) > 1 or len(evidence["workspace"]) > 1
+                else "no_slack_binding"
+            )
+            raise SlackBindingError(code)
+        if len(evidence["thread"]) > 1:
+            raise SlackBindingError("ambiguous_slack_binding")
+
+        chat_id = next(iter(evidence["chat"]))
+        thread_id = next(iter(evidence["thread"]), None)
+        workspace = next(iter(evidence["workspace"]))
+        metadata: Dict[str, Any] = {"scope_id": workspace}
+        if thread_id:
+            metadata["thread_id"] = thread_id
+        return SlackBinding(chat_id, thread_id, metadata)
+
+    raise SlackBindingError("no_slack_binding")
+
+
+
+def _resync_error(message: str, code: str, *, high_water: int) -> web.Response:
+    return web.json_response(
+        {"error": {
+            "message": message,
+            "type": "event_cursor_error",
+            "code": code,
+            "resync_required": True,
+            "high_water": high_water,
+        }},
+        status=409,
+    )
+
+
+def _error(message: str, code: str, status: int) -> web.Response:
+    return web.json_response(
+        {"error": {"message": message, "type": "invalid_request_error", "code": code}},
+        status=status,
+    )
+
+
+class SessionTurnService:
+    """aiohttp-facing coordinator; APIServerAdapter delegates thinly here."""
+
+    def __init__(self, adapter: Any):
+        self.adapter = adapter
+        self._stores: Dict[int, SessionTurnStore] = {}
+        self._store_lock = asyncio.Lock()
+        self._tasks: Dict[str, asyncio.Task[Any]] = {}
+        self._agent_refs: Dict[str, list[Any]] = {}
+        # Assistant text deltas are intentionally process-local. Canonical
+        # SessionDB messages are the only durable transcript authority.
+        self._volatile_events: Dict[str, Dict[int, Dict[str, Any]]] = {}
+
+    async def _store(self) -> Optional[SessionTurnStore]:
+        db = await self.adapter._ensure_session_db_async()
+        if db is None:
+            return None
+        key = id(db)
+        if key in self._stores:
+            return self._stores[key]
+        async with self._store_lock:
+            if key not in self._stores:
+                store = await asyncio.to_thread(SessionTurnStore, db)
+                await asyncio.to_thread(store.reconcile_uncertain)
+                self._stores[key] = store
+        return self._stores[key]
+
+    async def reconcile_startup(self) -> None:
+        """Initialize the ledger and interrupt crash-uncertain prior work."""
+        await self._store()
+
+    @staticmethod
+    def _turn_id(request: web.Request, body: Dict[str, Any]) -> str:
+        header_id = request.headers.get("Idempotency-Key", "").strip()
+        body_id = str(body.get("turn_id") or "").strip()
+        if header_id and body_id and header_id != body_id:
+            raise TurnInputError("Idempotency-Key and turn_id must match")
+        return SessionTurnStore.validate_turn_id(header_id or body_id)
+
+    async def submit(self, request: web.Request) -> web.Response:
+        auth_err = self.adapter._check_auth(request)
+        if auth_err:
+            return auth_err
+        body, body_err = await self.adapter._read_json_body(request)
+        if body_err:
+            return body_err
+        session_id = request.match_info["session_id"]
+        session, session_err = await self.adapter._get_existing_session_or_404(session_id)
+        if session_err:
+            return session_err
+        try:
+            turn_id = self._turn_id(request, body)
+            # Full payload validation decodes every inline image with Pillow.
+            # That CPU-heavy work must never run on the aiohttp event loop —
+            # a single large submit would freeze every in-flight request.
+            payload = await asyncio.to_thread(normalize_turn_payload, body)
+        except TurnInputError as exc:
+            return _error(str(exc), "invalid_turn", 400)
+
+        store = await self._store()
+        if store is None:
+            return _error("Session database unavailable", "session_db_unavailable", 503)
+
+        # An accepted idempotency key is durable truth. Browser retries must
+        # reuse it even if the Slack adapter's current connectivity changed.
+        existing = await asyncio.to_thread(store.get, turn_id)
+        if existing is not None:
+            try:
+                _turn, _created = await asyncio.to_thread(
+                    store.reserve, session_id, turn_id, payload
+                )
+            except ConflictingTurn:
+                return _error(
+                    "turn_id was already used for a different request",
+                    "idempotency_conflict",
+                    409,
+                )
+            except TurnInputError as exc:
+                return _error(str(exc), "invalid_turn", 400)
+            return web.json_response(
+                {
+                    "object": "hermes.session.turn.reused",
+                    "turn": store.public_turn(turn_id),
+                },
+                status=200,
+            )
+
+        binding = None
+        slack_adapter = None
+        if payload["delivery_mode"] in {"slack_only", "both"}:
+            try:
+                binding = await asyncio.to_thread(
+                    resolve_slack_binding, store.db, session_id
+                )
+            except SlackBindingError as exc:
+                return _error("Session has no unique Slack binding", exc.code, 409)
+            slack_adapter = self.adapter._get_platform_callback_adapter(request, "slack")
+            if slack_adapter is None:
+                return _error("Slack adapter is not connected", "slack_unavailable", 503)
+
+        try:
+            turn, created = await asyncio.to_thread(store.reserve, session_id, turn_id, payload)
+        except ConflictingTurn:
+            return _error("turn_id was already used for a different request", "idempotency_conflict", 409)
+        except TurnConflict:
+            return _error("Session already has an active turn", "active_turn_conflict", 409)
+        except TurnInputError as exc:
+            return _error(str(exc), "invalid_turn", 400)
+
+        if created:
+            task = asyncio.create_task(
+                self._execute(store, turn_id, session_id, payload, binding, slack_adapter)
+            )
+            self._tasks[turn_id] = task
+            try:
+                self.adapter._background_tasks.add(task)
+                task.add_done_callback(self.adapter._background_tasks.discard)
+            except (AttributeError, TypeError):
+                pass
+            task.add_done_callback(lambda _task, tid=turn_id: self._tasks.pop(tid, None))
+        public = store.public_turn(turn_id)
+        return web.json_response(
+            {"object": "hermes.session.turn.accepted" if created else "hermes.session.turn.reused", "turn": public},
+            status=202 if created else 200,
+        )
+
+    async def _execute(self, store: SessionTurnStore, turn_id: str, session_id: str,
+                       payload: Dict[str, Any], binding: Optional[SlackBinding], slack_adapter: Any) -> None:
+        agent_ref: list[Any] = [None]
+        execution_lease = None
+        self._agent_refs[turn_id] = agent_ref
+        try:
+            def interrupt_on_lease_loss() -> None:
+                agent = agent_ref[0]
+                if agent is not None:
+                    agent.interrupt("Persistent session execution lease lost")
+
+            try:
+                execution_lease = await self.adapter._acquire_session_execution_lease(
+                    session_id,
+                    owner_prefix=f"api:durable-turn:{turn_id}",
+                    on_lost=interrupt_on_lease_loss,
+                )
+            except SessionExecutionConflict:
+                store.finish(turn_id, "failed", safe_error_code="active_session_execution")
+                store.append_event(turn_id, "turn.failed", {"status": "failed", "error_code": "active_session_execution"})
+                return
+            if store.stop_requested(turn_id):
+                store.finish(turn_id, "interrupted", safe_error_code="stopped_before_start")
+                store.append_event(turn_id, "turn.interrupted", {"status": "interrupted", "error_code": "stopped_before_start"})
+                return
+            if not store.set_running(turn_id):
+                return
+            store.append_event(turn_id, "turn.started", {"status": "running"})
+            try:
+                history = await self.adapter._conversation_history_for_session(session_id)
+            except Exception:
+                store.finish(turn_id, "failed", safe_error_code="history_read_failed")
+                store.append_event(turn_id, "turn.failed", {"status": "failed", "error_code": "history_read_failed"})
+                return
+            if store.stop_requested(turn_id):
+                store.finish(turn_id, "interrupted", safe_error_code="stopped_before_execution")
+                store.append_event(
+                    turn_id,
+                    "turn.interrupted",
+                    {"status": "interrupted", "error_code": "stopped_before_execution"},
+                )
+                return
+            message_high_water = await asyncio.to_thread(store.message_high_water)
+
+            def append(event_type: str, data: Dict[str, Any]) -> None:
+                durable = store.append_event(turn_id, event_type, data)
+                if event_type == "assistant.delta" and payload["delivery_mode"] != "slack_only":
+                    self._volatile_events.setdefault(turn_id, {})[durable["seq"]] = {
+                        **durable,
+                        "data": dict(data),
+                    }
+
+            def on_delta(delta: Any) -> None:
+                if (
+                    payload["delivery_mode"] != "slack_only"
+                    and isinstance(delta, str)
+                    and delta
+                ):
+                    append("assistant.delta", {"delta": delta})
+
+            def on_tool_start(tool_call_id: Any, function_name: Any, function_args: Any) -> None:
+                projected = project_safe_tool_event(
+                    "tool.started", tool_call_id=tool_call_id, tool_name=function_name, args=function_args
+                )
+                append(projected["event"], projected["data"])
+
+            def on_tool_complete(tool_call_id: Any, function_name: Any, function_args: Any, function_result: Any) -> None:
+                try:
+                    from agent.display import _detect_tool_failure
+
+                    failed, _safe_internal_detail = _detect_tool_failure(
+                        str(function_name or ""), function_result
+                    )
+                except Exception:
+                    failed = False
+                event_type = "tool.failed" if failed else "tool.completed"
+                projected = project_safe_tool_event(
+                    event_type, tool_call_id=tool_call_id, tool_name=function_name,
+                    args=function_args, output=function_result,
+                )
+                append(projected["event"], projected["data"])
+
+            result, _usage = await self.adapter._run_agent(
+                user_message=_agent_input(payload),
+                conversation_history=history,
+                session_id=session_id,
+                stream_delta_callback=on_delta,
+                tool_start_callback=on_tool_start,
+                tool_complete_callback=on_tool_complete,
+                agent_ref=agent_ref,
+            )
+            effective_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
+            if execution_lease is None or not await execution_lease.still_owned():
+                store.finish(
+                    turn_id,
+                    "interrupted",
+                    safe_error_code="execution_lease_lost",
+                    effective_session_id=effective_id,
+                )
+                store.append_event(
+                    turn_id,
+                    "turn.interrupted",
+                    {"status": "interrupted", "error_code": "execution_lease_lost"},
+                )
+                return
+            if store.stop_requested(turn_id):
+                store.finish(turn_id, "interrupted", safe_error_code="stop_requested", effective_session_id=effective_id)
+                store.append_event(turn_id, "turn.interrupted", {"status": "interrupted", "error_code": "stop_requested"})
+                return
+            if not isinstance(result, dict) or result.get("failed"):
+                store.finish(turn_id, "failed", safe_error_code="run_failed", effective_session_id=effective_id)
+                store.append_event(turn_id, "turn.failed", {"status": "failed", "error_code": "run_failed"})
+                return
+
+            assistant_message_id = await asyncio.to_thread(
+                store.anchor_completed_assistant,
+                turn_id,
+                effective_id,
+                after_message_id=message_high_water,
+            )
+            anchored_content = await asyncio.to_thread(
+                store.anchored_assistant_content, turn_id
+            )
+            final_response = result.get("final_response")
+            if (
+                assistant_message_id is None
+                or not isinstance(anchored_content, str)
+                or not isinstance(final_response, str)
+                or anchored_content != final_response
+            ):
+                store.finish(
+                    turn_id,
+                    "failed",
+                    safe_error_code="assistant_anchor_mismatch",
+                    effective_session_id=effective_id,
+                )
+                store.append_event(
+                    turn_id,
+                    "turn.failed",
+                    {"status": "failed", "error_code": "assistant_anchor_mismatch"},
+                )
+                return
+            store.append_event(
+                turn_id,
+                "assistant.completed",
+                {"completed": True, "assistant_message_id": assistant_message_id},
+            )
+            if payload["delivery_mode"] in {"slack_only", "both"}:
+                assert binding is not None and slack_adapter is not None
+                await self._deliver_slack(
+                    store, turn_id, binding, slack_adapter, anchored_content
+                )
+            store.finish(turn_id, "completed", effective_session_id=effective_id)
+            store.append_event(turn_id, "turn.completed", {"status": "completed"})
+        except asyncio.CancelledError:
+            # An asyncio cancellation does not kill run_in_executor work.  Only
+            # mark interrupted here when no agent was ever created; otherwise a
+            # still-running worker must remain truthfully stopping.
+            if agent_ref[0] is None:
+                store.finish(turn_id, "interrupted", safe_error_code="cancelled_before_execution")
+            raise
+        except Exception:
+            store.finish(turn_id, "failed", safe_error_code="run_failed")
+            store.append_event(turn_id, "turn.failed", {"status": "failed", "error_code": "run_failed"})
+        finally:
+            if execution_lease is not None:
+                await execution_lease.release()
+            self._agent_refs.pop(turn_id, None)
+
+    async def _deliver_slack(self, store: SessionTurnStore, turn_id: str, binding: SlackBinding,
+                             slack_adapter: Any, content: str) -> None:
+        if not store.begin_delivery(turn_id, "slack"):
+            return
+        delivery = store.get_delivery(turn_id, "slack") or {}
+        if len(content) > MAX_SLACK_ROUTED_CHARS:
+            store.finish_delivery(turn_id, "slack", "rejected", "delivery_too_large")
+            store.append_event(turn_id, "delivery.failed", {"destination": "slack", "status": "rejected", "error_code": "delivery_too_large"})
+            return
+        metadata = dict(binding.metadata)
+        # The durable delivery id is also Slack's idempotency key. The bounded
+        # content contract guarantees the adapter performs exactly one call.
+        metadata["client_msg_id"] = str(delivery["delivery_id"])
+        try:
+            result = await slack_adapter.send(
+                binding.chat_id, content, reply_to=binding.thread_id, metadata=metadata
+            )
+        except Exception:
+            store.finish_delivery(turn_id, "slack", "needs_manual_retry", "delivery_outcome_unknown")
+            store.append_event(turn_id, "delivery.failed", {"destination": "slack", "status": "needs_manual_retry", "error_code": "delivery_outcome_unknown"})
+            return
+        if getattr(result, "success", False):
+            provider_message_id = getattr(result, "message_id", None)
+            if not isinstance(provider_message_id, str) or not provider_message_id:
+                store.finish_delivery(
+                    turn_id,
+                    "slack",
+                    "needs_manual_retry",
+                    "provider_receipt_missing",
+                )
+                store.append_event(
+                    turn_id,
+                    "delivery.failed",
+                    {
+                        "destination": "slack",
+                        "status": "needs_manual_retry",
+                        "error_code": "provider_receipt_missing",
+                    },
+                )
+                return
+            store.finish_delivery(
+                turn_id,
+                "slack",
+                "delivered",
+                provider_message_id=provider_message_id,
+            )
+            store.append_event(turn_id, "delivery.completed", {"destination": "slack", "status": "delivered"})
+        else:
+            # Once chat.postMessage was attempted, a timeout/error can be
+            # ambiguous.  Never retry automatically.
+            store.finish_delivery(turn_id, "slack", "needs_manual_retry", "delivery_outcome_unknown")
+            store.append_event(turn_id, "delivery.failed", {"destination": "slack", "status": "needs_manual_retry", "error_code": "delivery_outcome_unknown"})
+
+    async def status(self, request: web.Request) -> web.Response:
+        auth_err = self.adapter._check_auth(request)
+        if auth_err:
+            return auth_err
+        store = await self._store()
+        if store is None:
+            return _error("Session database unavailable", "session_db_unavailable", 503)
+        turn = await asyncio.to_thread(store.public_turn, request.match_info["turn_id"])
+        if not turn or turn["session_id"] != request.match_info["session_id"]:
+            return _error("Turn not found", "turn_not_found", 404)
+        return web.json_response({"object": "hermes.session.turn.status", "turn": turn})
+
+    async def events(self, request: web.Request) -> web.StreamResponse:
+        auth_err = self.adapter._check_auth(request)
+        if auth_err:
+            return auth_err
+        store = await self._store()
+        if store is None:
+            return _error("Session database unavailable", "session_db_unavailable", 503)
+        turn_id = request.match_info["turn_id"]
+        turn = await asyncio.to_thread(store.get, turn_id)
+        if not turn or turn["session_id"] != request.match_info["session_id"]:
+            return _error("Turn not found", "turn_not_found", 404)
+        raw_sequence = request.headers.get("Last-Event-ID") or request.query.get("after") or "0"
+        try:
+            sequence = int(raw_sequence)
+            if sequence < 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            return _error("Last-Event-ID must be a non-negative integer", "invalid_last_event_id", 400)
+        low_water, high_water, event_count = await asyncio.to_thread(store.event_bounds, turn_id)
+        if sequence > high_water:
+            return _resync_error(
+                "Last-Event-ID is ahead of the durable event high-water mark",
+                "event_cursor_ahead",
+                high_water=high_water,
+            )
+        if event_count and (low_water != 1 or event_count != high_water):
+            return _resync_error(
+                "Durable event history contains a gap; canonical resync is required",
+                "event_gap",
+                high_water=high_water,
+            )
+        initial_rows = await asyncio.to_thread(store.events_after, turn_id, sequence)
+        volatile = self._volatile_events.get(turn_id, {})
+        missing_volatile = any(
+            row["event"] == "assistant.delta" and row["seq"] not in volatile
+            for row in initial_rows
+        )
+        if missing_volatile and turn["status"] in TERMINAL_STATUSES:
+            return _resync_error(
+                "Volatile assistant deltas were missed; reload the canonical transcript",
+                "volatile_events_lost",
+                high_water=high_water,
+            )
+        response = web.StreamResponse(status=200, headers={
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        })
+        await response.prepare(request)
+        try:
+            while True:
+                rows = await asyncio.to_thread(store.events_after, turn_id, sequence)
+                current = await asyncio.to_thread(store.get, turn_id)
+                missing_volatile = any(
+                    row["event"] == "assistant.delta"
+                    and row["seq"] not in self._volatile_events.get(turn_id, {})
+                    for row in rows
+                )
+                if missing_volatile:
+                    if current and current["status"] not in TERMINAL_STATUSES:
+                        await asyncio.sleep(0.01)
+                        continue
+                    wire = json.dumps(
+                        {
+                            "error_code": "volatile_events_lost",
+                            "resync_required": True,
+                        }
+                    )
+                    await response.write(
+                        f"event: session.resync_required\ndata: {wire}\n\n".encode("utf-8")
+                    )
+                    break
+                for row in rows:
+                    if row["event"] == "assistant.delta":
+                        row = self._volatile_events[turn_id][row["seq"]]
+                    sequence = row["seq"]
+                    wire = json.dumps(row["data"], ensure_ascii=False)
+                    await response.write(
+                        f"id: {sequence}\nevent: {row['event']}\ndata: {wire}\n\n".encode("utf-8")
+                    )
+                if current and current["status"] in TERMINAL_STATUSES and not rows:
+                    break
+                try:
+                    await asyncio.sleep(0.05)
+                except asyncio.CancelledError:
+                    raise
+        except (ConnectionResetError, BrokenPipeError):
+            pass
+        return response
+
+    async def deliver(self, request: web.Request) -> web.Response:
+        """Idempotently perform an explicit Slack delivery when no attempt exists."""
+        auth_err = self.adapter._check_auth(request)
+        if auth_err:
+            return auth_err
+        body, body_err = await self.adapter._read_json_body(request)
+        if body_err:
+            return body_err
+        if set(body) - {"destination"} or body.get("destination") != "slack":
+            return _error("destination must be slack", "invalid_delivery", 400)
+        store = await self._store()
+        if store is None:
+            return _error("Session database unavailable", "session_db_unavailable", 503)
+        session_id = request.match_info["session_id"]
+        turn_id = request.match_info["turn_id"]
+        turn = await asyncio.to_thread(store.get, turn_id)
+        if not turn or turn["session_id"] != session_id:
+            return _error("Turn not found", "turn_not_found", 404)
+        if turn["status"] != "completed":
+            return _error("Turn is not completed", "turn_not_completed", 409)
+        existing = await asyncio.to_thread(store.get_delivery, turn_id, "slack")
+        if existing:
+            if existing["state"] == "delivered":
+                return web.json_response({"object": "hermes.session.turn.delivery", "delivery": existing})
+            return _error(
+                "Slack delivery was already attempted; outcome cannot be safely retried",
+                "delivery_not_retryable",
+                409,
+            )
+        try:
+            binding = await asyncio.to_thread(resolve_slack_binding, store.db, session_id)
+        except SlackBindingError as exc:
+            return _error("Session has no unique Slack binding", exc.code, 409)
+        slack_adapter = self.adapter._get_platform_callback_adapter(request, "slack")
+        if slack_adapter is None:
+            return _error("Slack adapter is not connected", "slack_unavailable", 503)
+        try:
+            content = await asyncio.to_thread(store.anchored_assistant_content, turn_id)
+        except Exception:
+            return _error("Session history unavailable", "session_history_unavailable", 503)
+        if not isinstance(content, str):
+            return _error(
+                "Completed assistant anchor is missing or mismatched",
+                "assistant_anchor_unavailable",
+                409,
+            )
+        await self._deliver_slack(
+            store, turn_id, binding, slack_adapter, content
+        )
+        delivery = await asyncio.to_thread(store.get_delivery, turn_id, "slack")
+        status = 200 if delivery and delivery["state"] == "delivered" else 409
+        return web.json_response(
+            {"object": "hermes.session.turn.delivery", "delivery": delivery}, status=status
+        )
+
+    async def stop(self, request: web.Request) -> web.Response:
+        auth_err = self.adapter._check_auth(request)
+        if auth_err:
+            return auth_err
+        store = await self._store()
+        if store is None:
+            return _error("Session database unavailable", "session_db_unavailable", 503)
+        turn_id = request.match_info["turn_id"]
+        turn = await asyncio.to_thread(store.get, turn_id)
+        if not turn or turn["session_id"] != request.match_info["session_id"]:
+            return _error("Turn not found", "turn_not_found", 404)
+        if turn["status"] in TERMINAL_STATUSES:
+            return web.json_response({"object": "hermes.session.turn.stop", "turn": store.public_turn(turn_id)})
+        # Let a just-admitted task finish durable lease/history admission so a
+        # stop does not race it into a false "stopped before start" result.
+        # Bounded and event-loop friendly; genuinely queued work still stops.
+        for _ in range(10):
+            ref = self._agent_refs.get(turn_id)
+            if (ref and ref[0] is not None) or turn_id not in self._tasks:
+                break
+            await asyncio.sleep(0.01)
+        stopped = await asyncio.to_thread(store.request_stop, turn_id)
+        ref = self._agent_refs.get(turn_id)
+        agent = ref[0] if ref else None
+        if agent is not None:
+            try:
+                agent.interrupt("Stop requested via session turn API")
+            except Exception:
+                pass
+        else:
+            watcher = asyncio.create_task(self._interrupt_when_available(turn_id))
+            try:
+                self.adapter._background_tasks.add(watcher)
+                watcher.add_done_callback(self.adapter._background_tasks.discard)
+            except (AttributeError, TypeError):
+                pass
+        store.append_event(turn_id, "turn.stopping", {"status": "stopping"})
+        return web.json_response(
+            {"object": "hermes.session.turn.stop", "turn": store.public_turn(turn_id)}, status=202
+        )
+
+    async def _interrupt_when_available(self, turn_id: str) -> None:
+        """Close the small race between stop admission and agent construction."""
+        while True:
+            task = self._tasks.get(turn_id)
+            if task is None or task.done():
+                return
+            ref = self._agent_refs.get(turn_id)
+            agent = ref[0] if ref else None
+            if agent is not None:
+                try:
+                    agent.interrupt("Stop requested via session turn API")
+                except Exception:
+                    pass
+                return
+            await asyncio.sleep(0.01)
+
+    async def wait_for_turn(self, turn_id: str) -> None:
+        task = self._tasks.get(turn_id)
+        if task is not None:
+            await task
+
+
+SESSION_TURN_CAPABILITIES = {
+    "durable": True,
+    "idempotency": {"header": "Idempotency-Key", "body_field": "turn_id"},
+    "delivery_modes": ["occ_only", "slack_only", "both"],
+    "routing": "session_origin_only",
+    "events": {"transport": "sse", "resumable": True, "last_event_id": True, "sequence": True},
+    "safe_progress": True,
+    "input_text": {"max_chars": MAX_INPUT_TEXT_LENGTH},
+    "inline_images": {
+        "remote_urls": False,
+        "max_count": MAX_INLINE_IMAGES,
+        "max_bytes_each": MAX_INLINE_IMAGE_BYTES,
+        "max_bytes_total": MAX_INLINE_IMAGE_TOTAL_BYTES,
+        "max_dimension": MAX_IMAGE_DIMENSION,
+        "max_pixels": MAX_IMAGE_PIXELS,
+        "max_frames": MAX_IMAGE_FRAMES,
+        "mime_types": sorted(INLINE_IMAGE_MIME_TYPES),
+    },
+    "cancellation": "cooperative_truthful",
+    "delivery": {
+        "manual_operation": "POST /api/sessions/{session_id}/turns/{turn_id}/deliver",
+        "delivery_id": True,
+        "automatic_retry": False,
+        "ambiguous_retry": False,
+        "slack_atomic_max_chars": MAX_SLACK_ROUTED_CHARS,
+    },
+    "restart_reconciliation": "interrupt_uncertain_no_auto_execute",
+}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2097,6 +2097,7 @@ from gateway.config import (
 )
 from gateway.session import (
     AsyncSessionStore,
+    CanonicalSessionHistoryError,
     SessionEntry,
     SessionStore,
     SessionSource,
@@ -2110,6 +2111,7 @@ from gateway.session import (
 )
 from gateway.delivery import DeliveryRouter, looks_like_telegram_private_chat_id
 from gateway.turn_lease import SessionTurnLeaseRegistry
+from gateway.session_execution_lease import SessionExecutionLease
 from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
@@ -3420,6 +3422,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # so release is granted per-turn and a stale unwind can never free a
         # newer turn's lease (#28686 ownership lesson).
         self._turn_lease_tokens: Dict[tuple, Any] = {}
+        # Canonical SessionDB-backed lease shared with API/OCC execution paths.
+        self._durable_turn_lease_tokens: Dict[tuple, SessionExecutionLease] = {}
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
         # Last successfully-resolved (non-empty) model, keyed by session. Used
         # as a fallback when a fresh config read transiently returns an empty
@@ -12100,6 +12104,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as _goal_exc:
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
             return _agent_result
+        except CanonicalSessionHistoryError:
+            logger.error(
+                "Canonical session history unavailable for gateway session %s",
+                _quick_key,
+            )
+            return (
+                "I couldn't safely load this conversation's history, so the turn "
+                "was not run. Please retry after the session database is available."
+            )
         finally:
             # MoA one-shot restore must run on EVERY exit path, not just
             # success. The restore data lives on the per-turn event object
@@ -12122,6 +12135,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Turn lease (#64934): release THIS turn's lease token — keyed by
             # (routing key, run generation) so this unwind can only ever free
             # the lease its own turn acquired, never a newer turn's.
+            # Canonical SessionDB lease must be released before the local
+            # registry token so another process cannot enter during unwind.
+            await self._release_durable_turn_lease(_quick_key, _run_generation)
             self._release_turn_lease(_quick_key, _run_generation)
 
     def _restore_moa_one_shot(self, event: "MessageEvent", quick_key: str) -> None:
@@ -12960,6 +12976,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     self._turn_lease_tokens = {}
                 self._turn_lease_tokens[(_quick_key, run_generation)] = _lease_token
 
+        # Cross-process canonical lease closes API/OCC versus gateway/Slack
+        # overlap. It is acquired before history read and released by the
+        # dispatch finally on every success/error/interrupt path.
+        _durable_lease = None
+        _canonical_db = getattr(getattr(self, "_session_db", None), "_db", getattr(self, "_session_db", None))
+        # Require the concrete SessionDB lease interface.  Generic mocks and
+        # legacy transcript shims synthesize arbitrary attributes and must not
+        # be mistaken for a durable ownership backend.
+        _lease_backend = all(
+            callable(getattr(type(_canonical_db), method, None))
+            for method in (
+                "acquire_session_execution_lease",
+                "get_session_execution_lease",
+                "heartbeat_session_execution_lease",
+                "release_session_execution_lease",
+            )
+        )
+        if _lease_backend:
+            def _interrupt_on_durable_lease_loss() -> None:
+                active = self._running_agents.get(_quick_key)
+                if callable(getattr(active, "interrupt", None)):
+                    active.interrupt("Persistent session execution lease lost")
+
+            _durable_lease = await SessionExecutionLease.acquire(
+                _canonical_db,
+                session_entry.session_id,
+                owner_prefix=f"gateway:{_quick_key}:{run_generation}",
+                wait_timeout=_float_env("HERMES_AGENT_TIMEOUT", 1800),
+                on_lost=_interrupt_on_durable_lease_loss,
+            )
+            if not hasattr(self, "_durable_turn_lease_tokens"):
+                self._durable_turn_lease_tokens = {}
+            self._durable_turn_lease_tokens[(_quick_key, run_generation)] = _durable_lease
+
         # Load conversation history from transcript
         history = await self.async_session_store.load_transcript(session_entry.session_id)
         
@@ -13719,6 +13769,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
             )
+            if _durable_lease is not None and not await _durable_lease.still_owned():
+                logger.error(
+                    "Discarding gateway result for %s after persistent lease loss",
+                    _quick_key,
+                )
+                return None
 
             # Stop persistent typing indicator now that the agent is done.
             # Slack AI status is scoped to a thread/workspace, so preserve the
@@ -18588,6 +18644,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # _persist_active_agents).
         self._persist_active_agents()
         return True
+
+    async def _release_durable_turn_lease(self, session_key: str, run_generation: int) -> bool:
+        tokens = getattr(self, "_durable_turn_lease_tokens", None)
+        if not tokens:
+            return False
+        token = tokens.pop((session_key, run_generation), None)
+        if token is None:
+            return False
+        try:
+            return await token.release()
+        except Exception:
+            logger.debug("Failed to release durable session execution lease", exc_info=True)
+            return False
 
     def _release_turn_lease(self, session_key: str, run_generation: int) -> bool:
         """Release the turn lease acquired by (``session_key``, ``run_generation``).

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1157,6 +1157,10 @@ class AsyncSessionStore:
         return _offloaded
 
 
+class CanonicalSessionHistoryError(RuntimeError):
+    """The canonical SessionDB transcript could not be read safely."""
+
+
 class SessionStore:
     """
     Manages session storage and retrieval.
@@ -3112,7 +3116,7 @@ class SessionStore:
         migrated (their DB row holds the full message history).
         """
         if not self._db:
-            return []
+            raise CanonicalSessionHistoryError("session database unavailable")
         try:
             # repair_alternation: this load feeds LIVE REPLAY. A durable
             # user;user wedge (e.g. a turn that persisted no assistant row)
@@ -3121,9 +3125,9 @@ class SessionStore:
             return self._db.get_messages_as_conversation(
                 session_id, repair_alternation=True
             )
-        except Exception as e:
-            logger.debug("Could not load messages from DB: %s", e)
-            return []
+        except Exception as exc:
+            logger.warning("Could not load canonical SessionDB history for %s", session_id)
+            raise CanonicalSessionHistoryError("session history unavailable") from exc
 
     def rewind_session(self, session_id: str, n: int = 1) -> Optional[Dict[str, Any]]:
         """Back up ``n`` user turns via soft-delete, keeping rows for audit.

--- a/gateway/session_execution_lease.py
+++ b/gateway/session_execution_lease.py
@@ -23,6 +23,7 @@ class SessionExecutionLease:
     session_id: str
     owner_id: str
     _heartbeat_task: Optional[asyncio.Task[Any]] = None
+    _release_task: Optional[asyncio.Task[bool]] = None
     _released: bool = False
     _lost: bool = False
     _on_lost: Optional[Callable[[], None]] = None
@@ -90,16 +91,28 @@ class SessionExecutionLease:
         return owned
 
     async def release(self) -> bool:
-        if self._released:
-            return False
-        self._released = True
+        """Release exactly once; cancellation never abandons the operation.
+
+        ``_released`` means either the release completed or ``_release_task``
+        is the shielded in-flight operation that every caller can re-await.
+        """
+        if self._release_task is None:
+            self._release_task = asyncio.create_task(self._release())
+            self._released = True
+        return await asyncio.shield(self._release_task)
+
+    async def _release(self) -> bool:
         if self._heartbeat_task is not None:
             self._heartbeat_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await self._heartbeat_task
-        return bool(await asyncio.to_thread(
-            self.db.release_session_execution_lease, self.session_id, self.owner_id
-        ))
+        return bool(
+            await asyncio.to_thread(
+                self.db.release_session_execution_lease,
+                self.session_id,
+                self.owner_id,
+            )
+        )
 
     async def __aenter__(self) -> "SessionExecutionLease":
         return self

--- a/gateway/session_execution_lease.py
+++ b/gateway/session_execution_lease.py
@@ -1,0 +1,108 @@
+"""Canonical persistent execution lease for SessionDB-backed agent turns."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+
+LEASE_TTL_SECONDS = 60.0
+LEASE_HEARTBEAT_SECONDS = 20.0
+
+
+class SessionExecutionConflict(RuntimeError):
+    """Another owner already executes against this canonical session."""
+
+
+@dataclass
+class SessionExecutionLease:
+    db: Any
+    session_id: str
+    owner_id: str
+    _heartbeat_task: Optional[asyncio.Task[Any]] = None
+    _released: bool = False
+    _lost: bool = False
+    _on_lost: Optional[Callable[[], None]] = None
+
+    @classmethod
+    async def acquire(
+        cls,
+        db: Any,
+        session_id: str,
+        *,
+        owner_prefix: str,
+        wait_timeout: float = 0.0,
+        on_lost: Optional[Callable[[], None]] = None,
+    ) -> "SessionExecutionLease":
+        owner_id = f"{owner_prefix}:{uuid.uuid4().hex}"
+        deadline = asyncio.get_running_loop().time() + max(0.0, wait_timeout)
+        while True:
+            acquired = await asyncio.to_thread(
+                db.acquire_session_execution_lease,
+                session_id,
+                owner_id,
+                ttl_seconds=LEASE_TTL_SECONDS,
+            )
+            if acquired:
+                lease = cls(
+                    db=db,
+                    session_id=session_id,
+                    owner_id=owner_id,
+                    _on_lost=on_lost,
+                )
+                lease._heartbeat_task = asyncio.create_task(lease._heartbeat())
+                return lease
+            if asyncio.get_running_loop().time() >= deadline:
+                raise SessionExecutionConflict(session_id)
+            await asyncio.sleep(0.05)
+
+    async def _heartbeat(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(LEASE_HEARTBEAT_SECONDS)
+                alive = await asyncio.to_thread(
+                    self.db.heartbeat_session_execution_lease,
+                    self.session_id,
+                    self.owner_id,
+                    ttl_seconds=LEASE_TTL_SECONDS,
+                )
+                if not alive:
+                    self._lost = True
+                    if self._on_lost is not None:
+                        with contextlib.suppress(Exception):
+                            self._on_lost()
+                    return
+        except asyncio.CancelledError:
+            return
+
+    async def still_owned(self) -> bool:
+        if self._released or self._lost:
+            return False
+        row = await asyncio.to_thread(
+            self.db.get_session_execution_lease, self.session_id
+        )
+        owned = bool(row and row.get("owner_id") == self.owner_id)
+        if not owned:
+            self._lost = True
+        return owned
+
+    async def release(self) -> bool:
+        if self._released:
+            return False
+        self._released = True
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._heartbeat_task
+        return bool(await asyncio.to_thread(
+            self.db.release_session_execution_lease, self.session_id, self.owner_id
+        ))
+
+    async def __aenter__(self) -> "SessionExecutionLease":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.release()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -163,6 +163,11 @@ VALID_HOOKS: Set[str] = {
     "on_session_reset",
     "subagent_start",
     "subagent_stop",
+    # Versioned provider lifecycle contracts. These observer-only hooks carry
+    # identity/enums-only DTOs; see agent.lifecycle_hooks.
+    "subagent_lifecycle",
+    "delegation_wrapper_lifecycle",
+    "managed_process_lifecycle",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent
     # after the internal-event guard but BEFORE auth/pairing and agent
     # dispatch. Plugins may return a dict to influence flow:
@@ -212,6 +217,14 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+}
+
+# Explicit per-hook payload contract versions. Hooks omitted here retain their
+# historical unversioned callback kwargs; adding the two entries is additive.
+HOOK_CONTRACT_VERSIONS: Dict[str, int] = {
+    "subagent_lifecycle": 2,
+    "delegation_wrapper_lifecycle": 1,
+    "managed_process_lifecycle": 2,
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -168,6 +168,7 @@ VALID_HOOKS: Set[str] = {
     "subagent_lifecycle",
     "delegation_wrapper_lifecycle",
     "managed_process_lifecycle",
+    "session_turn_lifecycle",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent
     # after the internal-event guard but BEFORE auth/pairing and agent
     # dispatch. Plugins may return a dict to influence flow:
@@ -220,11 +221,12 @@ VALID_HOOKS: Set[str] = {
 }
 
 # Explicit per-hook payload contract versions. Hooks omitted here retain their
-# historical unversioned callback kwargs; adding the two entries is additive.
+# historical unversioned callback kwargs; adding entries here is additive.
 HOOK_CONTRACT_VERSIONS: Dict[str, int] = {
     "subagent_lifecycle": 2,
     "delegation_wrapper_lifecycle": 1,
     "managed_process_lifecycle": 2,
+    "session_turn_lifecycle": 1,
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -38,6 +38,11 @@ except ImportError:  # pragma: no cover - stripped/scaffold installs only
 
 logger = logging.getLogger(__name__)
 
+
+class SessionSearchUnavailable(RuntimeError):
+    """The authoritative FTS index cannot safely serve session search."""
+
+
 _COMPRESSION_LOCK_HOLDER_PID_RE = re.compile(r"(?:^|:)pid=(\d+)(?::|$)")
 
 
@@ -210,7 +215,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 23
+SCHEMA_VERSION = 24
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
 # state_meta key ``fts_storage_version``. The main schema version advances
@@ -1171,6 +1176,30 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     acquired_at REAL NOT NULL,
     expires_at REAL NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS session_fork_requests (
+    idempotency_key TEXT PRIMARY KEY,
+    source_session_id TEXT NOT NULL,
+    anchor_message_id INTEGER NOT NULL,
+    preserve_source INTEGER NOT NULL,
+    requested_title TEXT,
+    requested_session_id TEXT,
+    child_session_id TEXT NOT NULL,
+    created_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_execution_leases (
+    session_id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    owner_pid INTEGER NOT NULL,
+    owner_host TEXT NOT NULL,
+    owner_boot_id TEXT NOT NULL,
+    acquired_at REAL NOT NULL,
+    heartbeat_at REAL NOT NULL,
+    expires_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_session_execution_leases_expires
+    ON session_execution_leases(expires_at);
 
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
@@ -2929,6 +2958,71 @@ class SessionDB:
 
         cursor.executescript(SCHEMA_SQL)
 
+        # v24 fork reservations are durable tombstones, not child-owned rows.
+        # Early review builds declared child_session_id with ON DELETE CASCADE,
+        # which silently made a consumed key reusable after child cleanup. Heal
+        # that pre-release shape by rebuilding the table without the foreign key
+        # while preserving every reservation. This is intentionally structural,
+        # not version-gated: an early build may already have stamped v24.
+        fork_request_fks = cursor.execute(
+            "PRAGMA foreign_key_list(session_fork_requests)"
+        ).fetchall()
+        if any(row["from"] == "child_session_id" for row in fork_request_fks):
+            cursor.executescript(
+                """
+                ALTER TABLE session_fork_requests
+                    RENAME TO session_fork_requests_child_owned;
+                CREATE TABLE session_fork_requests (
+                    idempotency_key TEXT PRIMARY KEY,
+                    source_session_id TEXT NOT NULL,
+                    anchor_message_id INTEGER NOT NULL,
+                    preserve_source INTEGER NOT NULL,
+                    requested_title TEXT,
+                    requested_session_id TEXT,
+                    child_session_id TEXT NOT NULL,
+                    created_at REAL NOT NULL
+                );
+                INSERT INTO session_fork_requests (
+                    idempotency_key, source_session_id, anchor_message_id,
+                    preserve_source, requested_title, requested_session_id,
+                    child_session_id, created_at
+                )
+                SELECT idempotency_key, source_session_id, anchor_message_id,
+                       preserve_source, requested_title, requested_session_id,
+                       child_session_id, created_at
+                FROM session_fork_requests_child_owned;
+                DROP TABLE session_fork_requests_child_owned;
+                """
+            )
+
+        # Early H1 builds tied execution leases to sessions with a foreign key.
+        # Gateway admission and synthetic recovery can legitimately acquire the
+        # exclusivity fence before a session row is materialized, so rebuild
+        # that metadata-only table once without weakening its PRIMARY KEY.
+        if cursor.execute(
+            "PRAGMA foreign_key_list(session_execution_leases)"
+        ).fetchall():
+            cursor.executescript(
+                """
+                ALTER TABLE session_execution_leases RENAME TO session_execution_leases_with_fk;
+                CREATE TABLE session_execution_leases (
+                    session_id TEXT PRIMARY KEY,
+                    owner_id TEXT NOT NULL,
+                    owner_pid INTEGER NOT NULL,
+                    owner_host TEXT NOT NULL,
+                    owner_boot_id TEXT NOT NULL,
+                    acquired_at REAL NOT NULL,
+                    heartbeat_at REAL NOT NULL,
+                    expires_at REAL NOT NULL
+                );
+                INSERT INTO session_execution_leases
+                    SELECT * FROM session_execution_leases_with_fk;
+                DROP TABLE session_execution_leases_with_fk;
+                CREATE INDEX IF NOT EXISTS idx_session_execution_leases_expires
+                    ON session_execution_leases(expires_at);
+                """
+            )
+
         # ── Declarative column reconciliation ──────────────────────────
         # Diff live tables against SCHEMA_SQL and ADD any missing columns.
         # This is idempotent and self-healing: even if a version-gated
@@ -3501,6 +3595,495 @@ class SessionDB:
         """Create a new session record. Returns the session_id."""
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
+
+    def fork_session_at_message(
+        self,
+        source_session_id: str,
+        child_session_id: str,
+        anchor_message_id: int,
+        idempotency_key: str,
+        *,
+        title: Optional[str] = None,
+        requested_child_session_id: Optional[str] = None,
+    ) -> Tuple[str, Optional[Dict[str, Any]]]:
+        """Atomically create a non-mutating child through an exact message.
+
+        The source row and all of its messages are read-only in this transaction.
+        The child row, copied transcript, lineage markers, title, and idempotency
+        record commit together or are all rolled back. The return status is one
+        of ``created``, ``replayed``, ``source_missing``, ``invalid_anchor``,
+        ``unsafe_anchor``, ``session_exists``, ``invalid_title``,
+        ``idempotency_stale``, or ``idempotency_conflict``.
+
+        Idempotency reservations intentionally outlive their child session. A
+        consumed key can therefore never create a second child after cleanup;
+        replay against a deleted child returns ``idempotency_stale``.
+
+        Gateway peer identifiers are intentionally not copied. Reusing the
+        source's ``session_key``/chat/thread tuple would make the newer child the
+        gateway's active head. The stable owner and execution routing snapshots
+        (source, user, model/model_config, billing route, prompt, cwd/profile)
+        are safe to inherit; delivery can resolve messaging targets through the
+        parent lineage without stealing the live source lane.
+        """
+
+        def _do(conn):
+            prior = conn.execute(
+                "SELECT * FROM session_fork_requests WHERE idempotency_key = ?",
+                (idempotency_key,),
+            ).fetchone()
+            if prior is not None:
+                same_request = (
+                    prior["source_session_id"] == source_session_id
+                    and int(prior["anchor_message_id"]) == anchor_message_id
+                    and int(prior["preserve_source"]) == 1
+                    and prior["requested_title"] == title
+                    and prior["requested_session_id"] == requested_child_session_id
+                )
+                if not same_request:
+                    return "idempotency_conflict", None
+                child = conn.execute(
+                    "SELECT * FROM sessions WHERE id = ?",
+                    (prior["child_session_id"],),
+                ).fetchone()
+                if child is None:
+                    # The durable reservation is a tombstone: a consumed key
+                    # never becomes reusable merely because cleanup removed the
+                    # child session.
+                    return "idempotency_stale", None
+                result = dict(child)
+                result["branch_point_message_id"] = int(prior["anchor_message_id"])
+                return "replayed", result
+
+            source = conn.execute(
+                "SELECT * FROM sessions WHERE id = ?", (source_session_id,)
+            ).fetchone()
+            if source is None:
+                return "source_missing", None
+
+            prefix = conn.execute(
+                "SELECT id, role, content, api_content, tool_call_id, tool_calls, "
+                "finish_reason, reasoning, reasoning_content, reasoning_details, "
+                "codex_reasoning_items FROM messages "
+                "WHERE session_id = ? AND active = 1 AND id <= ? ORDER BY id",
+                (source_session_id, anchor_message_id),
+            ).fetchall()
+            if not prefix or int(prefix[-1]["id"]) != anchor_message_id:
+                return "invalid_anchor", None
+
+            def _contains_tool_block(value: Any) -> bool:
+                if isinstance(value, list):
+                    return any(_contains_tool_block(item) for item in value)
+                if not isinstance(value, dict):
+                    return False
+                if value.get("type") in {
+                    "tool_use",
+                    "tool_result",
+                    "function_call",
+                    "function_call_output",
+                }:
+                    return True
+                return any(_contains_tool_block(item) for item in value.values())
+
+            def _contains_reasoning_block(value: Any) -> bool:
+                if isinstance(value, list):
+                    return any(_contains_reasoning_block(item) for item in value)
+                if not isinstance(value, dict):
+                    return False
+                if value.get("type") in {"reasoning", "thinking", "redacted_thinking"}:
+                    return True
+                return any(
+                    (
+                        key in {"reasoning", "reasoning_content", "thinking"}
+                        and item not in (None, "", [], {})
+                    )
+                    or _contains_reasoning_block(item)
+                    for key, item in value.items()
+                )
+
+            def _normalized_finish_reason(value: Any) -> Optional[str]:
+                if not isinstance(value, str) or not value.strip():
+                    return None
+                return value.strip().lower().replace("-", "_")
+
+            complete_finish_reasons = {
+                "stop",
+                "completed",
+                "complete",
+                "end_turn",
+                "endturn",
+            }
+            tool_finish_reasons = {
+                "tool_calls",
+                "tool_call",
+                "tool_use",
+                "tooluse",
+                "function_call",
+                "function_calls",
+            }
+            def _parse_arguments(value: Any) -> bool:
+                if isinstance(value, dict):
+                    return True
+                if not isinstance(value, str) or not value.strip():
+                    return False
+                try:
+                    return isinstance(json.loads(value), dict)
+                except (json.JSONDecodeError, TypeError):
+                    return False
+
+            def _validated_tool_call(call: Any) -> Optional[str]:
+                if not isinstance(call, dict):
+                    return None
+                call_type = call.get("type")
+                if call_type == "function":
+                    call_id = call.get("id")
+                    function = call.get("function")
+                    if not isinstance(function, dict):
+                        return None
+                    name = function.get("name")
+                    arguments = function.get("arguments")
+                elif call_type == "function_call":
+                    call_id = call.get("call_id")
+                    name = call.get("name")
+                    arguments = call.get("arguments")
+                elif call_type == "tool_use":
+                    call_id = call.get("id")
+                    name = call.get("name")
+                    arguments = call.get("input")
+                else:
+                    return None
+                if not isinstance(call_id, str) or not call_id.strip():
+                    return None
+                if not isinstance(name, str) or not name.strip():
+                    return None
+                if not _parse_arguments(arguments):
+                    return None
+                return call_id
+
+            expected = "user"
+            pending_call_ids: set[str] = set()
+            for row in prefix:
+                role = row["role"]
+                try:
+                    tool_calls = json.loads(row["tool_calls"]) if row["tool_calls"] else []
+                except (json.JSONDecodeError, TypeError):
+                    return "unsafe_anchor", None
+                content = self._decode_content(row["content"])
+                if _contains_tool_block(content) or _contains_tool_block(row["api_content"]):
+                    return "unsafe_anchor", None
+
+                if expected == "user":
+                    if role != "user" or tool_calls or row["tool_call_id"]:
+                        return "unsafe_anchor", None
+                    expected = "assistant"
+                    continue
+
+                if expected == "assistant":
+                    if role != "assistant" or row["tool_call_id"]:
+                        return "unsafe_anchor", None
+                    finish_reason = _normalized_finish_reason(row["finish_reason"])
+                    if not isinstance(tool_calls, list):
+                        return "unsafe_anchor", None
+                    if not tool_calls:
+                        if finish_reason not in complete_finish_reasons:
+                            return "unsafe_anchor", None
+                        expected = "user"
+                        continue
+                    if finish_reason not in tool_finish_reasons:
+                        return "unsafe_anchor", None
+                    validated_ids = [_validated_tool_call(call) for call in tool_calls]
+                    if any(call_id is None for call_id in validated_ids):
+                        return "unsafe_anchor", None
+                    pending_call_ids = {call_id for call_id in validated_ids if call_id}
+                    if len(pending_call_ids) != len(validated_ids):
+                        return "unsafe_anchor", None
+                    expected = "tool"
+                    continue
+
+                if role != "tool" or tool_calls:
+                    return "unsafe_anchor", None
+                call_id = row["tool_call_id"]
+                if (
+                    not isinstance(call_id, str)
+                    or not call_id
+                    or call_id not in pending_call_ids
+                ):
+                    return "unsafe_anchor", None
+                pending_call_ids.remove(call_id)
+                if not pending_call_ids:
+                    expected = "assistant"
+
+            # Two anchor shapes are continuation-safe: a fully completed final
+            # assistant response (the walk expects a new user turn next), or a
+            # canonical user message the child will answer next (the walk
+            # expects an assistant turn and the anchor row itself is that user
+            # message). A tool row, partial/truncated assistant, or unresolved
+            # tool group can never be repaired after the fork — when the walk
+            # ends expecting "assistant" after a resolved tool group, the
+            # anchor row is a tool result, so the role check rejects it.
+            if pending_call_ids:
+                return "unsafe_anchor", None
+            anchor_is_completed_assistant = expected == "user"
+            anchor_is_canonical_user = (
+                expected == "assistant" and prefix[-1]["role"] == "user"
+            )
+            anchor = prefix[-1]
+            if anchor_is_canonical_user:
+                anchor_content = self._decode_content(anchor["content"])
+                if anchor_content in (None, "", [], {}):
+                    return "unsafe_anchor", None
+            reasoning_values = (
+                anchor["reasoning"],
+                anchor["reasoning_content"],
+                anchor["reasoning_details"],
+                anchor["codex_reasoning_items"],
+            )
+            if (
+                any(
+                    value not in (None, "", "[]", "{}")
+                    for value in reasoning_values
+                )
+                or _contains_reasoning_block(
+                    self._decode_content(anchor["content"])
+                )
+            ):
+                return "unsafe_anchor", None
+            if not (anchor_is_completed_assistant or anchor_is_canonical_user):
+                return "unsafe_anchor", None
+
+            if conn.execute(
+                "SELECT 1 FROM sessions WHERE id = ?", (child_session_id,)
+            ).fetchone():
+                return "session_exists", None
+            if title and conn.execute(
+                "SELECT 1 FROM sessions WHERE title = ?", (title,)
+            ).fetchone():
+                return "invalid_title", None
+
+            source_config = source["model_config"]
+            try:
+                model_config = json.loads(source_config) if source_config else {}
+            except (json.JSONDecodeError, TypeError):
+                model_config = {}
+            if not isinstance(model_config, dict):
+                model_config = {}
+            model_config = dict(model_config)
+            model_config["_branched_from"] = source_session_id
+            model_config["_branch_point_message_id"] = anchor_message_id
+
+            conn.execute(
+                """INSERT INTO sessions (
+                   id, source, user_id, model, model_config, system_prompt,
+                   parent_session_id, started_at, cwd, git_branch, git_repo_root,
+                   billing_provider, billing_base_url, billing_mode, profile_name,
+                   pricing_version, title
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    child_session_id,
+                    source["source"],
+                    source["user_id"],
+                    source["model"],
+                    json.dumps(model_config),
+                    source["system_prompt"],
+                    source_session_id,
+                    time.time(),
+                    source["cwd"],
+                    source["git_branch"],
+                    source["git_repo_root"],
+                    source["billing_provider"],
+                    source["billing_base_url"],
+                    source["billing_mode"],
+                    source["profile_name"],
+                    source["pricing_version"],
+                    title,
+                ),
+            )
+
+            message_columns = (
+                "role, content, tool_call_id, tool_calls, tool_name, "
+                "effect_disposition, timestamp, token_count, finish_reason, "
+                "reasoning, reasoning_content, reasoning_details, "
+                "codex_reasoning_items, codex_message_items, "
+                "platform_message_id, observed, active, compacted, api_content, "
+                "display_kind, display_metadata"
+            )
+            conn.execute(
+                f"INSERT INTO messages (session_id, {message_columns}) "
+                f"SELECT ?, {message_columns} FROM messages "
+                "WHERE session_id = ? AND active = 1 AND id <= ? ORDER BY id",
+                (child_session_id, source_session_id, anchor_message_id),
+            )
+
+            copied = conn.execute(
+                "SELECT tool_calls FROM messages WHERE session_id = ? ORDER BY id",
+                (child_session_id,),
+            ).fetchall()
+            tool_call_count = 0
+            for row in copied:
+                raw_tool_calls = row["tool_calls"]
+                if not raw_tool_calls:
+                    continue
+                try:
+                    parsed = json.loads(raw_tool_calls)
+                except (json.JSONDecodeError, TypeError):
+                    parsed = raw_tool_calls
+                tool_call_count += len(parsed) if isinstance(parsed, list) else 1
+            conn.execute(
+                "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
+                (len(copied), tool_call_count, child_session_id),
+            )
+            conn.execute(
+                """INSERT INTO session_fork_requests (
+                   idempotency_key, source_session_id, anchor_message_id,
+                   preserve_source, requested_title, requested_session_id,
+                   child_session_id, created_at
+                ) VALUES (?, ?, ?, 1, ?, ?, ?, ?)""",
+                (
+                    idempotency_key,
+                    source_session_id,
+                    anchor_message_id,
+                    title,
+                    requested_child_session_id,
+                    child_session_id,
+                    time.time(),
+                ),
+            )
+            child = conn.execute(
+                "SELECT * FROM sessions WHERE id = ?", (child_session_id,)
+            ).fetchone()
+            result = dict(child)
+            result["branch_point_message_id"] = anchor_message_id
+            return "created", result
+
+        return self._execute_write(_do)
+
+    @staticmethod
+    def _execution_lease_process_identity() -> tuple[int, str, str]:
+        """Return PID, host and Linux boot id used for safe stale-owner checks."""
+        pid = os.getpid()
+        try:
+            host = os.uname().nodename
+        except AttributeError:  # pragma: no cover - Windows
+            import socket
+            host = socket.gethostname()
+        try:
+            boot_id = Path("/proc/sys/kernel/random/boot_id").read_text(encoding="ascii").strip()
+        except OSError:
+            boot_id = "unavailable"
+        return pid, host, boot_id
+
+    @classmethod
+    def _execution_lease_owner_is_alive(cls, row: Any) -> bool:
+        """Return whether a same-host/same-boot owner PID is still alive."""
+        pid, host, boot_id = cls._execution_lease_process_identity()
+        if str(row["owner_host"]) != host or str(row["owner_boot_id"]) != boot_id:
+            return False
+        owner_pid = int(row["owner_pid"])
+        if owner_pid == pid:
+            return True
+        try:
+            os.kill(owner_pid, 0)
+        except ProcessLookupError:
+            return False
+        except (PermissionError, OSError):
+            return True
+        return True
+
+    @classmethod
+    def session_execution_lease_owner_state(cls, row: Any, *, now: Optional[float] = None) -> str:
+        """Classify durable ownership as ``live``, ``dead``, or ``stale``.
+
+        A local PID is directly verifiable. Remote-host or prior-boot owners are
+        preserved only through their unexpired heartbeat window; once expired,
+        they are deterministically stale and may be fenced.
+        """
+        current_pid, host, boot_id = cls._execution_lease_process_identity()
+        same_host_boot = (
+            str(row["owner_host"]) == host
+            and str(row["owner_boot_id"]) == boot_id
+        )
+        if same_host_boot:
+            if int(row["owner_pid"]) == current_pid:
+                return "live"
+            return "live" if cls._execution_lease_owner_is_alive(row) else "dead"
+        current_time = time.time() if now is None else float(now)
+        return "live" if float(row["expires_at"]) > current_time else "stale"
+
+    def get_session_execution_lease(self, session_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            assert self._conn is not None
+            row = self._conn.execute(
+                "SELECT * FROM session_execution_leases WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def acquire_session_execution_lease(
+        self, session_id: str, owner_id: str, *, ttl_seconds: float = 60.0
+    ) -> bool:
+        """Atomically acquire/renew the canonical cross-process session lease.
+
+        A same-host/same-boot lease is never stolen from a live PID and may be
+        reconciled as soon as that PID is provably dead. A remote-host or
+        prior-boot owner is preserved through its heartbeat expiry, then
+        classified stale so a crashed process cannot wedge the session.
+        """
+        if not session_id or not owner_id:
+            return False
+        now = time.time()
+        ttl = max(5.0, float(ttl_seconds))
+        pid, host, boot_id = self._execution_lease_process_identity()
+
+        def _acquire(conn):
+            row = conn.execute(
+                "SELECT * FROM session_execution_leases WHERE session_id = ?", (session_id,)
+            ).fetchone()
+            if row is not None and row["owner_id"] != owner_id:
+                if self.session_execution_lease_owner_state(row, now=now) == "live":
+                    return False
+            conn.execute(
+                """INSERT INTO session_execution_leases
+                   (session_id, owner_id, owner_pid, owner_host, owner_boot_id,
+                    acquired_at, heartbeat_at, expires_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(session_id) DO UPDATE SET
+                     owner_id=excluded.owner_id, owner_pid=excluded.owner_pid,
+                     owner_host=excluded.owner_host, owner_boot_id=excluded.owner_boot_id,
+                     acquired_at=CASE WHEN session_execution_leases.owner_id=excluded.owner_id
+                                      THEN session_execution_leases.acquired_at
+                                      ELSE excluded.acquired_at END,
+                     heartbeat_at=excluded.heartbeat_at, expires_at=excluded.expires_at""",
+                (session_id, owner_id, pid, host, boot_id, now, now, now + ttl),
+            )
+            return True
+
+        return bool(self._execute_write(_acquire))
+
+    def heartbeat_session_execution_lease(
+        self, session_id: str, owner_id: str, *, ttl_seconds: float = 60.0
+    ) -> bool:
+        now = time.time()
+
+        def _heartbeat(conn):
+            cursor = conn.execute(
+                "UPDATE session_execution_leases SET heartbeat_at=?, expires_at=? "
+                "WHERE session_id=? AND owner_id=?",
+                (now, now + max(5.0, float(ttl_seconds)), session_id, owner_id),
+            )
+            return cursor.rowcount == 1
+
+        return bool(self._execute_write(_heartbeat))
+
+    def release_session_execution_lease(self, session_id: str, owner_id: str) -> bool:
+        """Release only the caller's exact owner token; idempotent and fenced."""
+        def _release(conn):
+            cursor = conn.execute(
+                "DELETE FROM session_execution_leases WHERE session_id=? AND owner_id=?",
+                (session_id, owner_id),
+            )
+            return cursor.rowcount == 1
+
+        return bool(self._execute_write(_release))
 
     def record_gateway_session_peer(
         self,
@@ -7228,6 +7811,135 @@ class SessionDB:
                     len(rows) if rows is not None else "err",
                     query[:200],
                 )
+
+    def session_search_available(self) -> bool:
+        """Execute a harmless scoped MATCH probe against the production query shape."""
+        if not self._fts_enabled or self._conn is None:
+            return False
+        try:
+            with self._lock:
+                self._conn.execute(
+                    """
+                    SELECT m.id, m.timestamp, s.user_id, s.source
+                    FROM messages_fts
+                    JOIN messages m ON m.id = messages_fts.rowid
+                    JOIN sessions s ON s.id = m.session_id
+                    WHERE messages_fts MATCH ?
+                      AND s.user_id = ?
+                      AND s.source = ?
+                      AND m.role IN ('user', 'assistant')
+                    ORDER BY m.timestamp DESC, m.id DESC
+                    LIMIT 1
+                    """,
+                    (
+                        '"__hermes_session_search_readiness_probe_7f31c9__"',
+                        "__readiness_owner__",
+                        "__readiness_source__",
+                    ),
+                ).fetchall()
+            return True
+        except (sqlite3.DatabaseError, TypeError, ValueError):
+            return False
+
+    def search_messages_scoped(
+        self,
+        query: str,
+        *,
+        user_id: str,
+        source: str,
+        limit: int = 20,
+        snapshot_message_id: Optional[int] = None,
+        after: Optional[Tuple[Any, int]] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """Return a minimal exact-owner FTS page using immutable keyset order.
+
+        Results are ordered only by message timestamp and id. BM25 rank is mutable
+        when the FTS corpus changes and therefore must never participate in a
+        cross-request cursor boundary. ``snapshot_message_id`` excludes later
+        inserts while ``after`` advances over the fixed immutable sort tuple.
+        """
+        if not self.session_search_available():
+            raise SessionSearchUnavailable("Session full-text search is unavailable")
+        if not user_id or not source:
+            return [], 0
+        if not query or not query.strip() or limit <= 0:
+            return [], 0
+
+        fts_query = self._sanitize_fts5_query(query)
+        if not fts_query:
+            return [], 0
+
+        assert self._conn is not None
+        try:
+            with self._lock:
+                if snapshot_message_id is None:
+                    snapshot_row = self._conn.execute(
+                        """
+                        SELECT COALESCE(MAX(m.id), 0)
+                        FROM messages m
+                        JOIN sessions s ON s.id = m.session_id
+                        WHERE (m.active = 1 OR m.compacted = 1)
+                          AND s.user_id = ?
+                          AND s.source = ?
+                          AND m.role IN ('user', 'assistant')
+                        """,
+                        (user_id, source),
+                    ).fetchone()
+                    snapshot_message_id = int(snapshot_row[0] or 0)
+
+                params: List[Any] = [
+                    fts_query,
+                    user_id,
+                    source,
+                    snapshot_message_id,
+                ]
+                keyset_clause = ""
+                if after is not None:
+                    after_timestamp, after_message_id = after
+                    keyset_clause = """
+                      AND (
+                            m.timestamp < ?
+                         OR (m.timestamp = ? AND m.id < ?)
+                      )
+                    """
+                    params.extend([after_timestamp, after_timestamp, after_message_id])
+
+                params.append(limit)
+                sql = f"""
+                    SELECT
+                        m.id AS message_id,
+                        m.session_id,
+                        m.role,
+                        m.timestamp,
+                        m.content
+                    FROM messages_fts
+                    JOIN messages m ON m.id = messages_fts.rowid
+                    JOIN sessions s ON s.id = m.session_id
+                    WHERE messages_fts MATCH ?
+                      AND (m.active = 1 OR m.compacted = 1)
+                      AND s.user_id = ?
+                      AND s.source = ?
+                      AND m.role IN ('user', 'assistant')
+                      AND m.id <= ?
+                    {keyset_clause}
+                    ORDER BY m.timestamp DESC, m.id DESC
+                    LIMIT ?
+                """
+                rows = [dict(row) for row in self._conn.execute(sql, params).fetchall()]
+                return rows, snapshot_message_id
+        except sqlite3.DatabaseError as exc:
+            if self._try_runtime_fts_rebuild(exc):
+                return self.search_messages_scoped(
+                    query,
+                    user_id=user_id,
+                    source=source,
+                    limit=limit,
+                    snapshot_message_id=snapshot_message_id,
+                    after=after,
+                )
+            raise SessionSearchUnavailable(
+                "Session full-text search is operationally unavailable"
+            ) from exc
 
     def _describe_search_path(self, query: str) -> str:
         """Best-effort name of the routing path a query takes (log-only)."""

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2327,6 +2327,24 @@ class SlackAdapter(BasePlatformAdapter):
         return ""
 
     @staticmethod
+    def _metadata_client_msg_id(metadata: Optional[Dict[str, Any]]) -> str:
+        """Return a validated Slack client_msg_id for transport deduplication.
+
+        Slack accepts UUID-shaped client ids on chat.postMessage. Keep this an
+        adapter-only routing field: invalid/browser-controlled values are
+        dropped rather than forwarded to Slack.
+        """
+        if not metadata:
+            return ""
+        value = str(metadata.get("client_msg_id") or "").strip().lower()
+        if re.fullmatch(
+            r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+            value,
+        ):
+            return value
+        return ""
+
+    @staticmethod
     def _workspace_event_id(team_id: str, event_id: str) -> str:
         """Scope Slack's workspace-local event/message ids for deduplication."""
         return f"{team_id}:{event_id}" if team_id else str(event_id)
@@ -2537,15 +2555,18 @@ class SlackAdapter(BasePlatformAdapter):
             # 3000-char limits, so those fall back to plain text. The ``text``
             # field is always kept as the notification/accessibility fallback.
             blocks = self._maybe_blocks(content) if len(chunks) == 1 else None
+            client_msg_id = self._metadata_client_msg_id(metadata)
 
             for i, chunk in enumerate(chunks):
-                kwargs = {
+                kwargs: Dict[str, Any] = {
                     "channel": chat_id,
                     "text": chunk,
                     "mrkdwn": True,
                 }
                 if blocks and i == 0:
                     kwargs["blocks"] = blocks
+                if client_msg_id and i == 0:
+                    kwargs["client_msg_id"] = client_msg_id
                 if thread_ts:
                     kwargs["thread_ts"] = thread_ts
                     # Only broadcast the first chunk of the first reply

--- a/tests/agent/test_subagent_lifecycle_hooks.py
+++ b/tests/agent/test_subagent_lifecycle_hooks.py
@@ -5,6 +5,8 @@ import time
 from concurrent.futures import Future
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from agent import lifecycle_hooks as lh
 from tools import delegate_tool as dt
 
@@ -114,6 +116,51 @@ def test_identity_enum_dtos_drop_runtime_text(monkeypatch):
     assert emitted[2][1]["exit_code"] is None
 
 
+def test_session_turn_lifecycle_v1_exact_shape_sequence_and_validation(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(lh, "_emit", lambda hook, payload: emitted.append((hook, payload)))
+
+    lh.emit_session_turn_lifecycle(
+        "registered", session_id="session-native", turn_id="turn-native"
+    )
+    lh.emit_session_turn_lifecycle(
+        "terminal",
+        session_id="session-native",
+        turn_id="turn-native",
+        terminal_outcome="failed",
+    )
+
+    assert [hook for hook, _dto in emitted] == [
+        "session_turn_lifecycle",
+        "session_turn_lifecycle",
+    ]
+    registered, terminal = [dto for _hook, dto in emitted]
+    assert set(registered) == {
+        "contract_version",
+        "event",
+        "occurred_at",
+        "sequence",
+        "session_id",
+        "turn_id",
+    }
+    assert set(terminal) == set(registered) | {"terminal_outcome"}
+    assert registered["contract_version"] == terminal["contract_version"] == 1
+    assert registered["session_id"] == terminal["session_id"] == "session-native"
+    assert registered["turn_id"] == terminal["turn_id"] == "turn-native"
+    assert registered["sequence"] < terminal["sequence"]
+    assert terminal["terminal_outcome"] == "failed"
+    assert registered["occurred_at"].endswith("Z")
+
+    with pytest.raises(ValueError):
+        lh.emit_session_turn_lifecycle("adopted", session_id="s", turn_id="t")
+    with pytest.raises(ValueError):
+        lh.emit_session_turn_lifecycle("started", session_id="s", turn_id="t", terminal_outcome="failed")
+    with pytest.raises(ValueError):
+        lh.emit_session_turn_lifecycle(
+            "terminal", session_id="s", turn_id="t", terminal_outcome="raw exception"
+        )
+
+
 def test_emitted_dto_versions_match_advertised_hook_contracts(monkeypatch):
     from hermes_cli.plugins import HOOK_CONTRACT_VERSIONS
 
@@ -142,6 +189,9 @@ def test_emitted_dto_versions_match_advertised_hook_contracts(monkeypatch):
         pid_scope="host",
         backend="local",
     )
+    lh.emit_session_turn_lifecycle(
+        "started", session_id="session-version", turn_id="turn-version"
+    )
 
     assert set(emitted) == set(HOOK_CONTRACT_VERSIONS)
     assert {
@@ -164,8 +214,9 @@ def test_registered_after_stable_ids_and_legacy_start_is_preserved(monkeypatch):
     parent._fallback_chain = []
     parent.request_overrides = {}
     parent.openrouter_min_coding_score = None
-    child = MagicMock()
-    child.session_id = "stable-child-session"
+    children = [MagicMock(), MagicMock()]
+    children[0].session_id = "stable-child-session-0"
+    children[1].session_id = "stable-child-session-1"
     calls = []
 
     monkeypatch.setattr(
@@ -173,31 +224,41 @@ def test_registered_after_stable_ids_and_legacy_start_is_preserved(monkeypatch):
         lambda hook, **payload: calls.append((hook, dict(payload))),
     )
     monkeypatch.setattr(dt, "_resolve_child_credential_pool", lambda *_args: None)
-    with patch("run_agent.AIAgent", return_value=child):
-        built = dt._build_child_agent(
-            task_index=0,
-            goal="goal prompt must not leak from v1",
-            context=None,
-            toolsets=None,
-            model=None,
-            max_iterations=5,
-            parent_agent=parent,
-            task_count=1,
-        )
+    with patch("run_agent.AIAgent", side_effect=children):
+        built = [
+            dt._build_child_agent(
+                task_index=index,
+                goal="goal prompt must not leak from v1",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=5,
+                parent_agent=parent,
+                task_count=2,
+            )
+            for index in range(2)
+        ]
 
-    assert built is child
+    assert built == children
     lifecycle = [
         payload["dto"] for hook, payload in calls if hook == "subagent_lifecycle"
     ]
-    assert len(lifecycle) == 1
-    assert lifecycle[0]["event"] == "registered"
-    assert lifecycle[0]["child_session_id"] == "stable-child-session"
-    assert lifecycle[0]["child_subagent_id"]
+    assert len(lifecycle) == 2
+    assert all(dto["event"] == "registered" for dto in lifecycle)
+    assert {dto["child_session_id"] for dto in lifecycle} == {
+        "stable-child-session-0",
+        "stable-child-session-1",
+    }
+    assert len({dto["child_subagent_id"] for dto in lifecycle}) == 2
+    assert {dto["parent_turn_id"] for dto in lifecycle} == {"turn-1"}
     assert "goal prompt must not leak" not in repr(lifecycle)
     # Existing plugins retain their historical callback and payload.
     legacy = [payload for hook, payload in calls if hook == "subagent_start"]
-    assert len(legacy) == 1
-    assert legacy[0]["child_goal"] == "goal prompt must not leak from v1"
+    assert len(legacy) == 2
+    assert all(
+        payload["child_goal"] == "goal prompt must not leak from v1"
+        for payload in legacy
+    )
 
 
 def test_provider_invokes_native_hook_with_one_bounded_dto(monkeypatch):

--- a/tests/agent/test_subagent_lifecycle_hooks.py
+++ b/tests/agent/test_subagent_lifecycle_hooks.py
@@ -1,0 +1,575 @@
+"""Contract tests for versioned delegated-child lifecycle hooks."""
+
+import threading
+import time
+from concurrent.futures import Future
+from unittest.mock import MagicMock, patch
+
+from agent import lifecycle_hooks as lh
+from tools import delegate_tool as dt
+
+
+_CANARIES = {
+    "SECRET-CANARY",
+    "goal prompt must not leak",
+    "model response must not leak",
+    "terminal --danger",
+    "/private/worktree/path",
+    "RuntimeError: raw exception",
+}
+
+
+def _parent():
+    parent = MagicMock()
+    parent.session_id = "parent-session"
+    parent._current_turn_id = "turn-1"
+    parent._current_task_id = "parent-task"
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._touch_activity = MagicMock()
+    return parent
+
+
+def _child(release: threading.Event, started: threading.Event):
+    child = MagicMock()
+    child.session_id = "child-session"
+    child._subagent_id = "subagent-1"
+    child._delegation_wrapper_id = "wrapper-1"
+    child._parent_subagent_id = None
+    child._parent_turn_id = "turn-1"
+    child._delegate_role = "leaf"
+    child._delegate_depth = 1
+    child._credential_pool = MagicMock()
+    child._credential_pool.acquire_lease.return_value = "lease-1"
+    child.get_activity_summary.return_value = {
+        "current_tool": "terminal",
+        "api_call_count": 1,
+        "max_iterations": 50,
+        "last_activity_desc": "working",
+    }
+
+    def run_conversation(**_kwargs):
+        started.set()
+        release.wait(timeout=5)
+        return {"final_response": "model response must not leak", "completed": True}
+
+    child.run_conversation.side_effect = run_conversation
+    return child
+
+
+def test_identity_enum_dtos_drop_runtime_text(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(lh, "_emit", lambda hook, payload: emitted.append((hook, payload)))
+
+    lh.emit_subagent_lifecycle(
+        "terminal",
+        child_session_id="child-session",
+        child_subagent_id="subagent-1",
+        parent_session_id="parent-session",
+        child_role="leaf",
+        terminal_status="succeeded",
+    )
+    lh.emit_delegation_wrapper_lifecycle(
+        "terminal",
+        wrapper_id="wrapper-1",
+        child_subagent_id="subagent-1",
+        terminal_status="cancelled",
+    )
+    lh.emit_managed_process_lifecycle(
+        "terminal",
+        process_id="proc-1",
+        task_id="task-1",
+        pid=123,
+        host_start_time=456,
+        host_boot_id="boot-identity",
+        pid_scope="host",
+        backend="local",
+        terminal_status="exited",
+        termination_source="reader",
+    )
+
+    assert {hook for hook, _ in emitted} == {
+        "subagent_lifecycle",
+        "delegation_wrapper_lifecycle",
+        "managed_process_lifecycle",
+    }
+    serialized = repr(emitted)
+    assert not any(canary in serialized for canary in _CANARIES)
+    assert set(emitted[0][1]) == {
+        "contract_version",
+        "event",
+        "occurred_at",
+        "sequence",
+        "child_session_id",
+        "child_subagent_id",
+        "parent_session_id",
+        "parent_turn_id",
+        "parent_subagent_id",
+        "delegation_wrapper_id",
+        "child_role",
+        "terminal_status",
+    }
+    assert emitted[0][1]["occurred_at"].endswith("Z")
+    assert type(emitted[0][1]["sequence"]) is int
+    assert emitted[2][1]["exit_code"] is None
+
+
+def test_emitted_dto_versions_match_advertised_hook_contracts(monkeypatch):
+    from hermes_cli.plugins import HOOK_CONTRACT_VERSIONS
+
+    emitted = {}
+    monkeypatch.setattr(
+        lh, "_emit", lambda hook, payload: emitted.setdefault(hook, dict(payload))
+    )
+
+    lh.emit_subagent_lifecycle(
+        "started",
+        child_session_id="child-session-version",
+        child_subagent_id="subagent-version",
+        child_role="leaf",
+    )
+    lh.emit_delegation_wrapper_lifecycle(
+        "started",
+        wrapper_id="wrapper-version",
+        child_subagent_id="subagent-version",
+    )
+    lh.emit_managed_process_lifecycle(
+        "started",
+        process_id="process-version",
+        pid=123,
+        host_start_time=456,
+        host_boot_id="boot-version",
+        pid_scope="host",
+        backend="local",
+    )
+
+    assert set(emitted) == set(HOOK_CONTRACT_VERSIONS)
+    assert {
+        hook: dto["contract_version"] for hook, dto in emitted.items()
+    } == HOOK_CONTRACT_VERSIONS
+
+
+def test_registered_after_stable_ids_and_legacy_start_is_preserved(monkeypatch):
+    parent = _parent()
+    parent._delegate_depth = 0
+    parent.base_url = "https://example.invalid/v1"
+    parent.api_key = "key"
+    parent.model = "model"
+    parent.provider = "openai"
+    parent.api_mode = "chat_completions"
+    parent.reasoning_config = {"enabled": False}
+    parent.enabled_toolsets = []
+    parent.disabled_toolsets = []
+    parent.prefill_messages = None
+    parent._fallback_chain = []
+    parent.request_overrides = {}
+    parent.openrouter_min_coding_score = None
+    child = MagicMock()
+    child.session_id = "stable-child-session"
+    calls = []
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda hook, **payload: calls.append((hook, dict(payload))),
+    )
+    monkeypatch.setattr(dt, "_resolve_child_credential_pool", lambda *_args: None)
+    with patch("run_agent.AIAgent", return_value=child):
+        built = dt._build_child_agent(
+            task_index=0,
+            goal="goal prompt must not leak from v1",
+            context=None,
+            toolsets=None,
+            model=None,
+            max_iterations=5,
+            parent_agent=parent,
+            task_count=1,
+        )
+
+    assert built is child
+    lifecycle = [
+        payload["dto"] for hook, payload in calls if hook == "subagent_lifecycle"
+    ]
+    assert len(lifecycle) == 1
+    assert lifecycle[0]["event"] == "registered"
+    assert lifecycle[0]["child_session_id"] == "stable-child-session"
+    assert lifecycle[0]["child_subagent_id"]
+    assert "goal prompt must not leak" not in repr(lifecycle)
+    # Existing plugins retain their historical callback and payload.
+    legacy = [payload for hook, payload in calls if hook == "subagent_start"]
+    assert len(legacy) == 1
+    assert legacy[0]["child_goal"] == "goal prompt must not leak from v1"
+
+
+def test_provider_invokes_native_hook_with_one_bounded_dto(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda hook, **kwargs: calls.append((hook, kwargs)),
+    )
+
+    lh.emit_subagent_lifecycle(
+        "started",
+        child_session_id="child-session",
+        child_subagent_id="subagent-dto",
+        child_role="leaf",
+    )
+
+    assert len(calls) == 1
+    hook, kwargs = calls[0]
+    assert hook == "subagent_lifecycle"
+    assert set(kwargs) == {"dto"}
+    assert kwargs["dto"]["event"] == "started"
+    assert kwargs["dto"]["sequence"] == 1
+    assert "SECRET-CANARY" not in repr(kwargs)
+
+
+def test_child_owned_start_timeout_heartbeat_terminal_and_cleanup(monkeypatch):
+    release = threading.Event()
+    started = threading.Event()
+    parent = _parent()
+    child = _child(release, started)
+    parent._active_children.append(child)
+    events = []
+    wrapper_events = []
+    events_lock = threading.Lock()
+
+    def capture(hook, payload):
+        with events_lock:
+            target = wrapper_events if hook == "delegation_wrapper_lifecycle" else events
+            target.append(dict(payload))
+
+    monkeypatch.setattr(lh, "_emit", capture)
+    monkeypatch.setattr(dt, "_HEARTBEAT_INTERVAL", 0.01)
+    monkeypatch.setattr(dt, "_HEARTBEAT_STALE_CYCLES_IN_TOOL", 1000)
+    monkeypatch.setattr(dt, "_get_child_timeout", lambda: 0.08)
+    monkeypatch.setattr(dt, "_dump_subagent_timeout_diagnostic", lambda **_kw: None)
+
+    result = dt._run_single_child(
+        task_index=0,
+        goal="goal prompt must not leak",
+        child=child,
+        parent_agent=parent,
+    )
+
+    assert started.is_set()
+    assert result["status"] == "timeout"
+    with events_lock:
+        timeout_events = list(events)
+    names = [event["event"] for event in timeout_events]
+    assert names[:2] == ["queued", "started"]
+    assert "heartbeat" in names
+    assert names[-1] == "cancel_requested"
+    assert "terminal" not in names
+    assert [event["event"] for event in wrapper_events] == [
+        "started", "timed_out", "terminal"
+    ]
+    assert wrapper_events[-1]["terminal_status"] == "cancelled"
+    # Waiter timeout owns none of the live-child cleanup.
+    assert child in parent._active_children
+    assert child._credential_pool.release_lease.call_count == 0
+    assert child.close.call_count == 0
+    assert child._subagent_id in dt._active_subagents
+
+    heartbeat_count = names.count("heartbeat")
+    deadline = time.monotonic() + 1
+    while time.monotonic() < deadline:
+        with events_lock:
+            if sum(e["event"] == "heartbeat" for e in events) > heartbeat_count:
+                break
+        time.sleep(0.01)
+    else:
+        raise AssertionError("child-owned heartbeat stopped at waiter timeout")
+
+    release.set()
+    deadline = time.monotonic() + 2
+    terminal = []
+    while time.monotonic() < deadline:
+        with events_lock:
+            terminal = [e for e in events if e["event"] == "terminal"]
+        if terminal and child.close.call_count:
+            break
+        time.sleep(0.01)
+
+    assert len(terminal) == 1
+    assert terminal[0]["terminal_status"] == "succeeded"
+    assert child not in parent._active_children
+    child._credential_pool.release_lease.assert_called_once_with("lease-1")
+    child.close.assert_called_once()
+    assert child._subagent_id not in dt._active_subagents
+    assert not any(canary in repr(events) for canary in _CANARIES)
+
+
+def test_terminal_failure_is_emitted_once_under_exception(monkeypatch):
+    child = MagicMock()
+    child.session_id = "child-session"
+    child._subagent_id = "subagent-fail"
+    child._delegation_wrapper_id = "wrapper-fail"
+    child._delegate_role = "leaf"
+    child._delegate_depth = 1
+    child._credential_pool = None
+    child.get_activity_summary.return_value = {}
+    child.run_conversation.side_effect = RuntimeError("RuntimeError: raw exception")
+    parent = _parent()
+    parent._active_children.append(child)
+    emitted = []
+    monkeypatch.setattr(lh, "_emit", lambda _hook, payload: emitted.append(dict(payload)))
+    monkeypatch.setattr(dt, "_get_child_timeout", lambda: None)
+
+    result = dt._run_single_child(0, "SECRET-CANARY", child, parent)
+
+    terminal = [
+        event for event in emitted
+        if event["event"] == "terminal" and "child_session_id" in event
+    ]
+    assert result["status"] == "error"
+    assert len(terminal) == 1
+    assert terminal[0]["terminal_status"] == "failed"
+    assert "RuntimeError: raw exception" not in repr(emitted)
+
+
+def test_post_registration_setup_failures_terminalize_child_and_wrapper_once(monkeypatch):
+    for failure in ("lease", "registry"):
+        child = MagicMock()
+        child.session_id = f"child-session-{failure}"
+        child._subagent_id = f"subagent-{failure}"
+        child._delegation_wrapper_id = f"wrapper-{failure}"
+        child._delegate_role = "leaf"
+        child._delegate_depth = 1
+        child.get_activity_summary.return_value = {}
+        child._credential_pool = MagicMock()
+        child._credential_pool.acquire_lease.return_value = None
+        parent = _parent()
+        parent._active_children.append(child)
+        emitted = []
+        monkeypatch.setattr(
+            lh, "_emit", lambda hook, payload: emitted.append((hook, dict(payload)))
+        )
+        if failure == "lease":
+            child._credential_pool.acquire_lease.side_effect = RuntimeError("SECRET-CANARY")
+            register = patch.object(dt, "_register_subagent")
+        else:
+            register = patch.object(dt, "_register_subagent", side_effect=RuntimeError("SECRET-CANARY"))
+
+        with register:
+            try:
+                dt._run_single_child(0, "goal prompt must not leak", child, parent)
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError("setup failure must propagate")
+
+        terminal = [(hook, dto) for hook, dto in emitted if dto["event"] == "terminal"]
+        assert len(terminal) == 2
+        assert {hook for hook, _ in terminal} == {
+            "subagent_lifecycle",
+            "delegation_wrapper_lifecycle",
+        }
+        assert all(dto["terminal_status"] == "failed" for _, dto in terminal)
+        assert child not in parent._active_children
+        child.close.assert_called_once()
+        assert "SECRET-CANARY" not in repr(emitted)
+
+
+def test_later_batch_build_failure_closes_every_registered_unstarted_child(monkeypatch):
+    parent = _parent()
+    parent._delegate_depth = 0
+    first = MagicMock()
+    first.session_id = "child-built-before-failure"
+    emitted = []
+
+    monkeypatch.setattr(
+        lh, "_emit", lambda hook, payload: emitted.append((hook, dict(payload)))
+    )
+    monkeypatch.setattr(dt, "_resolve_child_credential_pool", lambda *_args: None)
+
+    with patch(
+        "run_agent.AIAgent",
+        side_effect=[first, RuntimeError("SECRET-CANARY later build failure")],
+    ):
+        try:
+            dt.delegate_task(
+                tasks=[{"goal": "first private goal"}, {"goal": "second private goal"}],
+                parent_agent=parent,
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("later child build failure must propagate")
+
+    child_events = [
+        dto for hook, dto in emitted
+        if hook == "subagent_lifecycle"
+        and dto.get("child_session_id") == "child-built-before-failure"
+    ]
+    wrapper_events = [
+        dto for hook, dto in emitted
+        if hook == "delegation_wrapper_lifecycle"
+        and dto.get("child_subagent_id") == child_events[0]["child_subagent_id"]
+    ]
+    assert [dto["event"] for dto in child_events] == ["registered", "terminal"]
+    assert [dto["event"] for dto in wrapper_events] == ["registered", "terminal"]
+    assert child_events[-1]["terminal_status"] == "failed"
+    assert wrapper_events[-1]["terminal_status"] == "failed"
+    assert parent._active_children == []
+    first.close.assert_called_once()
+    assert not any(canary in repr(emitted) for canary in _CANARIES)
+
+
+def test_partial_batch_submit_failure_closes_failed_and_unsubmitted_children(monkeypatch):
+    parent = _parent()
+    parent._delegate_depth = 0
+    children = []
+    for index in range(3):
+        child = MagicMock()
+        child.session_id = f"child-submit-{index}"
+        child._credential_pool = None
+        child.get_activity_summary.return_value = {}
+        child.run_conversation.return_value = {
+            "final_response": "safe summary",
+            "completed": True,
+            "api_calls": 1,
+        }
+        children.append(child)
+    emitted = []
+
+    class FailSecondSubmitExecutor:
+        def __init__(self, **_kwargs):
+            self.submit_count = 0
+            self.threads = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            self.shutdown(wait=True)
+            return False
+
+        def shutdown(self, wait=True, **_kwargs):
+            if wait:
+                for thread in self.threads:
+                    thread.join(timeout=2)
+
+        def submit(self, fn, **kwargs):
+            self.submit_count += 1
+            if self.submit_count == 2:
+                raise RuntimeError("SECRET-CANARY submit failure")
+            future = Future()
+
+            def run():
+                try:
+                    future.set_result(fn(**kwargs))
+                except BaseException as exc:
+                    future.set_exception(exc)
+
+            thread = threading.Thread(target=run)
+            self.threads.append(thread)
+            thread.start()
+            return future
+
+    monkeypatch.setattr(
+        lh, "_emit", lambda hook, payload: emitted.append((hook, dict(payload)))
+    )
+    monkeypatch.setattr(dt, "_resolve_child_credential_pool", lambda *_args: None)
+    monkeypatch.setattr(dt, "_get_child_timeout", lambda: None)
+    monkeypatch.setattr(
+        "tools.daemon_pool.DaemonThreadPoolExecutor", FailSecondSubmitExecutor
+    )
+
+    with patch("run_agent.AIAgent", side_effect=children):
+        try:
+            dt.delegate_task(
+                tasks=[{"goal": f"private goal {i}"} for i in range(3)],
+                parent_agent=parent,
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("executor submit failure must propagate")
+
+    for index, child in enumerate(children):
+        child_events = [
+            dto for hook, dto in emitted
+            if hook == "subagent_lifecycle"
+            and dto.get("child_session_id") == f"child-submit-{index}"
+        ]
+        wrapper_events = [
+            dto for hook, dto in emitted
+            if hook == "delegation_wrapper_lifecycle"
+            and dto.get("child_subagent_id") == child_events[0]["child_subagent_id"]
+        ]
+        terminals = [dto for dto in child_events if dto["event"] == "terminal"]
+        wrapper_terminals = [dto for dto in wrapper_events if dto["event"] == "terminal"]
+        assert len(terminals) == 1
+        assert len(wrapper_terminals) == 1
+        expected = "succeeded" if index == 0 else "failed"
+        assert terminals[0]["terminal_status"] == expected
+        assert wrapper_terminals[0]["terminal_status"] == expected
+        if index > 0:
+            assert "started" not in [dto["event"] for dto in child_events]
+        child.close.assert_called_once()
+
+    assert parent._active_children == []
+    assert not any(canary in repr(emitted) for canary in _CANARIES)
+
+
+def test_nonempty_failed_and_incomplete_results_never_emit_success(monkeypatch):
+    result_shapes = [
+        {
+            "final_response": "Invalid API response after retries",
+            "completed": False,
+            "failed": True,
+            "error": "provider failure",
+        },
+        {
+            "final_response": "Content policy blocked this request",
+            "completed": False,
+            "failed": True,
+            "error": "content_policy_violation",
+        },
+        {
+            "final_response": "Partial answer at the iteration limit",
+            "completed": False,
+            "failed": False,
+            "exit_reason": "max_iterations",
+        },
+        {"final_response": "", "completed": True, "failed": False},
+        {"final_response": "(empty)", "completed": True, "failed": False},
+        {
+            "final_response": "Contradictory provider result",
+            "completed": True,
+            "failed": True,
+        },
+    ]
+
+    monkeypatch.setattr(dt, "_get_child_timeout", lambda: None)
+    for index, run_result in enumerate(result_shapes):
+        child = MagicMock()
+        child.session_id = f"child-session-failed-{index}"
+        child._subagent_id = f"subagent-result-failed-{index}"
+        child._delegation_wrapper_id = f"wrapper-result-failed-{index}"
+        child._delegate_role = "leaf"
+        child._delegate_depth = 1
+        child._credential_pool = None
+        child.get_activity_summary.return_value = {}
+        child.run_conversation.return_value = run_result
+        parent = _parent()
+        parent._active_children.append(child)
+        emitted = []
+        monkeypatch.setattr(
+            lh, "_emit", lambda _hook, payload: emitted.append(dict(payload))
+        )
+
+        parent_result = dt._run_single_child(
+            index, "SECRET-CANARY", child, parent
+        )
+
+        terminal = [
+            event for event in emitted
+            if event["event"] == "terminal" and "child_session_id" in event
+        ]
+        assert parent_result["status"] == "failed"
+        assert parent_result["exit_reason"] != "completed"
+        assert len(terminal) == 1
+        assert terminal[0]["terminal_status"] == "failed"
+        if run_result["final_response"]:
+            assert run_result["final_response"] not in repr(emitted)

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -90,6 +90,8 @@ class _FakeAgent:
         self._persist_calls = 0
         self._session_messages = []
         self._pending_cli_user_message = None
+        self._authoritative_turn_id: str | None = None
+        self._current_turn_id = ""
         self._session_persist_lock = threading.RLock()
         # Records _cached_system_prompt at the moment _ensure_db_session()
         # is called (regression guard for #45499 turn-setup ordering).
@@ -228,6 +230,20 @@ def test_task_id_passthrough():
     ctx = _build(agent, task_id="fixed-task")
     assert ctx.effective_task_id == "fixed-task"
     assert agent._current_task_id == "fixed-task"
+
+
+def test_authoritative_provider_turn_id_is_shared_and_consumed_once():
+    agent = _FakeAgent()
+    agent._authoritative_turn_id = "native-turn-1"
+
+    first = _build(agent, task_id="first-task")
+    child_parent_ids = [agent._current_turn_id, agent._current_turn_id]
+    second = _build(agent, task_id="second-task")
+
+    assert first.turn_id == "native-turn-1"
+    assert child_parent_ids == ["native-turn-1", "native-turn-1"]
+    assert second.turn_id != first.turn_id
+    assert second.turn_id.startswith("sess-1:second-task:")
 
 
 def test_persist_user_message_becomes_original():

--- a/tests/gateway/test_api_server_session_search.py
+++ b/tests/gateway/test_api_server_session_search.py
@@ -1,0 +1,530 @@
+"""Behavior contract and real SQLite E2E for owner-scoped session search."""
+
+import base64
+import hashlib
+import html
+import hmac
+import json
+import time
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from hermes_state import SessionDB
+
+
+AUTH = {"Authorization": "Bearer test-search-key"}
+
+
+def _make_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    for method, path, handler in adapter._http_route_table():
+        app.router.add_route(method, path, handler)
+    return app
+
+
+@pytest.fixture
+def search_runtime(tmp_path, monkeypatch):
+    """Run the actual HTTP handler over a real temp-HERMES_HOME state.db."""
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    db = SessionDB(db_path=hermes_home / "state.db")
+    if not db._fts_enabled:
+        db.close()
+        pytest.skip("SQLite FTS5 unavailable")
+
+    fixtures = (
+        ("owned-slack-a", "slack", "owner-1"),
+        ("owned-slack-b", "slack", "owner-1"),
+        ("other-owner", "slack", "owner-2"),
+        ("other-source", "cli", "owner-1"),
+    )
+    for session_id, source, user_id in fixtures:
+        db.create_session(session_id, source=source, user_id=user_id)
+
+    secret = "sk-" + "testcredential1234567890"
+    db.append_message(
+        "owned-slack-a",
+        "user",
+        f"or7needle <script>alert(1)</script> API_KEY={secret} "
+        + "private-tail " * 100
+        + "DO_NOT_LEAK_FULL_BODY",
+    )
+    db.append_message(
+        "owned-slack-a",
+        "assistant",
+        "or7needle assistant safe match",
+        reasoning="REASONING_DO_NOT_LEAK",
+    )
+    db.append_message(
+        "owned-slack-a", "tool", "or7needle raw tool output must not appear"
+    )
+    db.append_message(
+        "owned-slack-a", "system", "or7needle system prompt must not appear"
+    )
+    db.append_message(
+        "owned-slack-a", "developer", "or7needle developer prompt must not appear"
+    )
+    db.append_message("owned-slack-b", "user", "or7needle second owned match")
+    db.append_message("owned-slack-b", "assistant", "unrelated body")
+    db.append_message(
+        "owned-slack-b",
+        "user",
+        "or7marker [[[user-authored-marker]]] useful surrounding context",
+    )
+    db.append_message("other-owner", "user", "or7needle foreign owner body")
+    db.append_message("other-source", "user", "or7needle foreign source body")
+
+    adapter = APIServerAdapter(
+        PlatformConfig(enabled=True, extra={"key": "test-search-key"})
+    )
+    adapter._session_db = db
+    try:
+        yield adapter, db, secret
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_search_requires_auth_and_exact_nonempty_owner_scope(search_runtime):
+    adapter, _, _ = search_runtime
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        unauthenticated = await client.get(
+            "/api/sessions/search?q=or7needle&user_id=owner-1&source=slack"
+        )
+        assert unauthenticated.status == 401
+
+        for query in (
+            "user_id=owner-1&source=slack",
+            "q=&user_id=owner-1&source=slack",
+            "q=or7needle&source=slack",
+            "q=or7needle&user_id=owner-1",
+            "q=or7needle&user_id=&source=slack",
+            "q=or7needle&user_id=owner-1&source=",
+        ):
+            response = await client.get(f"/api/sessions/search?{query}", headers=AUTH)
+            assert response.status == 400
+            assert (await response.json())["error"]["code"] == "invalid_query"
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_malformed_duplicate_unknown_and_unbounded_params(
+    search_runtime,
+):
+    adapter, _, _ = search_runtime
+    base = "/api/sessions/search?user_id=owner-1&source=slack"
+    cases = (
+        f"{base}&q=or7needle&q=second",
+        f"{base}&q=or7needle&user_id=owner-1",
+        f"{base}&q=or7needle&limit=0",
+        f"{base}&q=or7needle&limit=51",
+        f"{base}&q=or7needle&limit=abc",
+        f"{base}&q=or7needle&offset=0",
+        f"{base}&q=or7needle&cursor=not-base64",
+        f"{base}&q=or7needle&extra=true",
+        f"{base}&q={'x' * 257}",
+        f"/api/sessions/search?q=or7needle&user_id={'x' * 257}&source=slack",
+        f"/api/sessions/search?q=or7needle&user_id=owner-1&source={'x' * 65}",
+    )
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        for url in cases:
+            response = await client.get(url, headers=AUTH)
+            assert response.status == 400, url
+            assert (await response.json())["error"]["code"] == "invalid_query"
+
+
+@pytest.mark.asyncio
+async def test_search_is_owner_source_and_role_scoped_with_safe_bounded_fields(
+    search_runtime,
+):
+    adapter, _, secret = search_runtime
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        response = await client.get(
+            "/api/sessions/search?q=or7needle&user_id=owner-1&source=slack&limit=20",
+            headers=AUTH,
+        )
+        assert response.status == 200
+        payload = await response.json()
+
+    assert payload["object"] == "list"
+    assert payload["limit"] == 20
+    assert payload["has_more"] is False
+    assert payload["next_cursor"] is None
+    assert {row["session_id"] for row in payload["data"]} == {
+        "owned-slack-a",
+        "owned-slack-b",
+    }
+    assert {row["role"] for row in payload["data"]} <= {"user", "assistant"}
+
+    allowed = {"session_id", "message_id", "role", "timestamp", "snippet"}
+    assert payload["data"]
+    for row in payload["data"]:
+        assert set(row) == allowed
+        assert len(row["snippet"]) <= 512
+        assert "<script>" not in row["snippet"]
+
+    serialized = json.dumps(payload)
+    assert secret not in serialized
+    assert "raw tool output" not in serialized
+    assert "system prompt" not in serialized
+    assert "developer prompt" not in serialized
+    assert "REASONING_DO_NOT_LEAK" not in serialized
+    assert "foreign owner" not in serialized
+    assert "foreign source" not in serialized
+    assert "DO_NOT_LEAK_FULL_BODY" not in serialized
+    assert "content" not in serialized
+    assert "context" not in serialized
+    assert any("or7needle" in row["snippet"] for row in payload["data"])
+    assert any("&lt;script&gt;" in row["snippet"] for row in payload["data"])
+
+
+@pytest.mark.asyncio
+async def test_search_redacts_complete_credential_without_head_or_tail_fragments(search_runtime):
+    adapter, _, secret = search_runtime
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        response = await client.get(
+            "/api/sessions/search?q=sk&user_id=owner-1&source=slack",
+            headers=AUTH,
+        )
+        assert response.status == 200
+        payload = await response.json()
+
+    serialized = html.unescape(json.dumps(payload))
+    assert payload["data"]
+    assert secret not in serialized
+    assert "testcredential1234567890" not in serialized
+    assert "credential1234567890" not in serialized
+    assert "sk-" not in serialized
+    assert "sk-test" not in serialized
+    assert "7890" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_search_never_trusts_user_authored_highlight_markers(search_runtime):
+    adapter, _, _ = search_runtime
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        response = await client.get(
+            "/api/sessions/search?q=or7marker&user_id=owner-1&source=slack",
+            headers=AUTH,
+        )
+        assert response.status == 200
+        payload = await response.json()
+
+    snippet = payload["data"][0]["snippet"]
+    assert "or7marker" in snippet
+    assert "<mark>user-authored-marker</mark>" not in snippet
+    assert "[[[user-authored-marker]]]" in html.unescape(snippet)
+
+
+@pytest.mark.asyncio
+async def test_search_short_match_is_useful_but_never_returns_complete_body(
+    search_runtime,
+):
+    adapter, _, _ = search_runtime
+    original = "or7needle assistant safe match"
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        response = await client.get(
+            "/api/sessions/search?q=or7needle&user_id=owner-1&source=slack&limit=20",
+            headers=AUTH,
+        )
+        assert response.status == 200
+        payload = await response.json()
+
+    snippets = [html.unescape(row["snippet"]) for row in payload["data"]]
+    assert any("assistant safe" in snippet for snippet in snippets)
+    assert all(
+        original not in snippet.replace("<mark>", "").replace("</mark>", "")
+        for snippet in snippets
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_snippet_is_query_independent_and_blocks_reconstruction(search_runtime):
+    adapter, db, _ = search_runtime
+    message_id = db.append_message(
+        "owned-slack-a",
+        "user",
+        "firstprobe " + "alpha-private " * 30 + "secondprobe " + "omega-private " * 30,
+    )
+
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        first = await client.get(
+            "/api/sessions/search?q=firstprobe&user_id=owner-1&source=slack",
+            headers=AUTH,
+        )
+        second = await client.get(
+            "/api/sessions/search?q=secondprobe&user_id=owner-1&source=slack",
+            headers=AUTH,
+        )
+        first_payload = await first.json()
+        second_payload = await second.json()
+
+    assert first.status == second.status == 200
+    first_row = next(row for row in first_payload["data"] if row["message_id"] == message_id)
+    second_row = next(row for row in second_payload["data"] if row["message_id"] == message_id)
+    assert first_row["snippet"] == second_row["snippet"]
+    assert "secondprobe" not in html.unescape(first_row["snippet"])
+
+
+@pytest.mark.parametrize(
+    "content, forbidden",
+    (
+        (
+            'credprobe MiXeD_ApI_KeY = "AbCdEfGhIjKlMnOpQrStUvWxYz012345" boundary',
+            ("AbCdEf", "012345", "QrStUv"),
+        ),
+        (
+            "credprobe Authorization: Bearer abcDEF0123456789xyzXYZ9876543210 boundary",
+            ("abcDEF", "6543210", "xyzXYZ"),
+        ),
+        (
+            "credprobe " + "x" * 150 + " api-token=tok_HEAD_middle_SECRET_tail999 boundary",
+            ("tok_HEAD", "tail999", "SECRET"),
+        ),
+        (
+            "credprobe eyJabcdefghijklmno.abcdefghijklmnop.signaturetail boundary",
+            ("eyJabc", "signaturetail", "hijklmno"),
+        ),
+    ),
+)
+def test_search_snippet_redacts_assignments_before_boundary_truncation(content, forbidden):
+    snippet = html.unescape(APIServerAdapter._bounded_search_snippet(content))
+    assert "[REDACTED]" in snippet or all(value not in snippet for value in forbidden)
+    for value in forbidden:
+        assert value not in snippet
+
+
+@pytest.mark.asyncio
+async def test_search_sanitizes_natural_language_fts_and_returns_nonmatches(
+    search_runtime,
+):
+    adapter, _, _ = search_runtime
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        malformed = await client.get(
+            "/api/sessions/search?q=%28or7needle%20OR%20%22unterminated&user_id=owner-1&source=slack",
+            headers=AUTH,
+        )
+        assert malformed.status == 200
+        assert isinstance((await malformed.json())["data"], list)
+
+        nonmatch = await client.get(
+            "/api/sessions/search?q=definitelyabsent&user_id=owner-1&source=slack",
+            headers=AUTH,
+        )
+        assert nonmatch.status == 200
+        assert (await nonmatch.json())["data"] == []
+
+
+@pytest.mark.asyncio
+async def test_search_cursor_is_authenticated_scope_bound_and_expires(
+    search_runtime,
+    monkeypatch,
+):
+    adapter, db, _ = search_runtime
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        for index in range(4):
+            db.append_message(
+                "owned-slack-a", "user", f"or7needle cursor fixture {index}"
+            )
+        first_response = await client.get(
+            "/api/sessions/search?q=or7needle&user_id=owner-1&source=slack&limit=2",
+            headers=AUTH,
+        )
+        first = await first_response.json()
+        cursor = first["next_cursor"]
+        assert cursor
+
+        replacement = "A" if cursor[-1] != "A" else "B"
+        tampered = cursor[:-1] + replacement
+        encoded_payload, _signature = cursor.split(".", 1)
+        decoded_payload = json.loads(
+            base64.urlsafe_b64decode(
+                encoded_payload + "=" * (-len(encoded_payload) % 4)
+            )
+        )
+        decoded_payload["v"] = 999
+        unsupported_payload = base64.urlsafe_b64encode(
+            json.dumps(decoded_payload, separators=(",", ":")).encode()
+        ).rstrip(b"=")
+        unsupported_signature = base64.urlsafe_b64encode(
+            hmac.new(
+                adapter._search_cursor_signing_key(),
+                unsupported_payload,
+                hashlib.sha256,
+            ).digest()
+        ).rstrip(b"=")
+        unsupported = (
+            unsupported_payload.decode() + "." + unsupported_signature.decode()
+        )
+        cases = (
+            "/api/sessions/search?q=or7needle&user_id=owner-1&source=slack"
+            f"&limit=2&cursor={tampered}",
+            "/api/sessions/search?q=different&user_id=owner-1&source=slack"
+            f"&limit=2&cursor={cursor}",
+            "/api/sessions/search?q=or7needle&user_id=owner-2&source=slack"
+            f"&limit=2&cursor={cursor}",
+            "/api/sessions/search?q=or7needle&user_id=owner-1&source=cli"
+            f"&limit=2&cursor={cursor}",
+            "/api/sessions/search?q=or7needle&user_id=owner-1&source=slack"
+            "&limit=2&cursor=malformed.cursor",
+            "/api/sessions/search?q=or7needle&user_id=owner-1&source=slack"
+            f"&limit=2&cursor={unsupported}",
+        )
+        for url in cases:
+            response = await client.get(url, headers=AUTH)
+            assert response.status == 400
+            assert (await response.json())["error"]["code"] == "invalid_query"
+
+        monkeypatch.setattr(time, "time", lambda: 4_000_000_000)
+        expired = await client.get(
+            "/api/sessions/search?q=or7needle&user_id=owner-1&source=slack"
+            f"&limit=2&cursor={cursor}",
+            headers=AUTH,
+        )
+        expired_payload = await expired.json()
+
+    assert expired.status == 400
+    assert expired_payload["error"]["code"] == "invalid_query"
+
+
+@pytest.mark.asyncio
+async def test_search_stable_multi_page_snapshot_has_no_overlap_or_omission_on_insert_and_rank_update(
+    search_runtime,
+):
+    adapter, db, _ = search_runtime
+    initial_ids = []
+    for index in range(9):
+        initial_ids.append(
+            db.append_message(
+                "owned-slack-a", "user", f"pageprobe stable fixture {index}"
+            )
+        )
+
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        async def page(cursor: str | None = None):
+            cursor_query = f"&cursor={cursor}" if cursor else ""
+            response = await client.get(
+                "/api/sessions/search?q=pageprobe&user_id=owner-1&source=slack"
+                f"&limit=3{cursor_query}",
+                headers=AUTH,
+            )
+            assert response.status == 200
+            return await response.json()
+
+        first = await page()
+        inserted_id = db.append_message(
+            "owned-slack-a", "user", "pageprobe inserted after snapshot"
+        )
+        # Change BM25 term frequency for a row already returned. Immutable
+        # timestamp/id keyset ordering must make this irrelevant to pagination.
+        updated_id = first["data"][0]["message_id"]
+        db._conn.execute(
+            "UPDATE messages SET content = ? WHERE id = ?",
+            ("pageprobe " * 100, updated_id),
+        )
+        db._conn.commit()
+
+        pages = [first]
+        while pages[-1]["has_more"]:
+            pages.append(await page(pages[-1]["next_cursor"]))
+
+    returned = [row["message_id"] for payload in pages for row in payload["data"]]
+    assert len(returned) == len(set(returned))
+    assert set(returned) == set(initial_ids)
+    assert inserted_id not in returned
+
+@pytest.mark.asyncio
+async def test_capabilities_advertise_owner_scoped_search(search_runtime):
+    adapter, _, _ = search_runtime
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        response = await client.get("/v1/capabilities", headers=AUTH)
+        assert response.status == 200
+        payload = await response.json()
+
+    assert payload["features"]["session_search"] is True
+    assert payload["endpoints"]["session_search"] == {
+        "method": "GET",
+        "path": "/api/sessions/search",
+        "owner_scope": ["user_id", "source"],
+        "pagination": {
+            "type": "cursor",
+            "parameter": "cursor",
+            "ordering": ["timestamp_desc", "message_id_desc"],
+            "snapshot": "message_id_high_water",
+            "cursor": "hmac_authenticated_v2",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_search_without_cursor_signing_credential_fails_closed(search_runtime):
+    adapter, _, _ = search_runtime
+    adapter._api_key = ""
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        capabilities = await client.get("/v1/capabilities")
+        response = await client.get(
+            "/api/sessions/search?q=or7needle&user_id=owner-1&source=slack"
+        )
+        advertised = await capabilities.json()
+        failure = await response.json()
+
+    assert advertised["features"]["session_search"] is False
+    assert "session_search" not in advertised["endpoints"]
+    assert response.status == 503
+    assert failure["error"]["code"] == "session_search_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_search_disabled_is_not_advertised_and_returns_safe_503(search_runtime):
+    adapter, db, _ = search_runtime
+    db._fts_enabled = False
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        capabilities = await client.get("/v1/capabilities", headers=AUTH)
+        assert capabilities.status == 200
+        advertised = await capabilities.json()
+        assert advertised["features"]["session_search"] is False
+        assert "session_search" not in advertised["endpoints"]
+
+        response = await client.get(
+            "/api/sessions/search?q=or7needle&user_id=owner-1&source=slack",
+            headers=AUTH,
+        )
+        assert response.status == 503
+        payload = await response.json()
+        assert payload["error"]["code"] == "session_search_unavailable"
+        serialized = json.dumps(payload).lower()
+        assert "messages_fts" not in serialized
+        assert "sqlite" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_search_operational_fts_failure_is_503_not_empty_success(
+    search_runtime, monkeypatch
+):
+    adapter, db, _ = search_runtime
+    db._conn.execute("DROP TABLE messages_fts")
+    # A metadata-only readiness check would still claim success here. The
+    # capability probe must execute a harmless scoped MATCH and fail closed.
+    monkeypatch.setattr(db, "_fts_table_exists", lambda _name: True)
+    async with TestClient(TestServer(_make_app(adapter))) as client:
+        capabilities = await client.get("/v1/capabilities", headers=AUTH)
+        assert capabilities.status == 200
+        advertised = await capabilities.json()
+        assert advertised["features"]["session_search"] is False
+        assert "session_search" not in advertised["endpoints"]
+
+        response = await client.get(
+            "/api/sessions/search?q=or7needle&user_id=owner-1&source=slack",
+            headers=AUTH,
+        )
+        assert response.status == 503
+        payload = await response.json()
+        assert payload["error"]["code"] == "session_search_unavailable"
+        serialized = json.dumps(payload).lower()
+        assert "messages_fts" not in serialized
+        assert "sqlite" not in serialized

--- a/tests/gateway/test_gateway_silence_tokens.py
+++ b/tests/gateway/test_gateway_silence_tokens.py
@@ -42,7 +42,9 @@ def _runner(monkeypatch, tmp_path):
     runner._is_user_authorized = lambda _source: True
     runner._set_session_env = lambda _context: None
     runner._handle_active_session_busy_message = AsyncMock(return_value=False)
-    runner._session_db = MagicMock()
+    # These focused response-filter tests use the mocked SessionStore below;
+    # they do not provide a canonical SessionDB execution-lease backend.
+    runner._session_db = None
     runner._recover_telegram_topic_thread_id = lambda _source: None
     runner._cache_session_source = lambda _key, _source: None
     runner._is_session_run_current = lambda _key, _gen: True
@@ -163,3 +165,21 @@ async def test_prose_mentioning_silence_token_is_delivered(monkeypatch, tmp_path
     )
 
     assert response == text
+
+
+@pytest.mark.asyncio
+async def test_real_gateway_history_failure_stops_before_agent_execution(monkeypatch, tmp_path):
+    from gateway.session import CanonicalSessionHistoryError
+
+    runner = _runner(monkeypatch, tmp_path)
+    runner.session_store.load_transcript.side_effect = CanonicalSessionHistoryError(
+        "sensitive sqlite detail"
+    )
+    runner._run_agent = AsyncMock()
+
+    with pytest.raises(CanonicalSessionHistoryError):
+        await runner._handle_message_with_agent(
+            _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+        )
+
+    runner._run_agent.assert_not_awaited()

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,5 +1,7 @@
 """Focused tests for API server session-control endpoints."""
 
+import json
+import sqlite3
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -7,8 +9,81 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import PlatformConfig
-from gateway.platforms.api_server import APIServerAdapter
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    MAX_REQUEST_BYTES,
+    _TURN_WIRE_ENVELOPE_BYTES,
+    body_limit_middleware,
+)
 from hermes_state import SessionDB
+
+
+def _append_completed_turn(
+    session_db,
+    session_id,
+    user="question",
+    assistant="answer",
+    *,
+    finish_reason="stop",
+):
+    session_db.append_message(session_id, "user", user)
+    return session_db.append_message(
+        session_id, "assistant", assistant, finish_reason=finish_reason
+    )
+
+
+def _tool_call(call_id, name="test_tool"):
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": "{}"},
+    }
+
+
+def _responses_tool_call(call_id, name="test_tool"):
+    return {
+        "call_id": call_id,
+        "type": "function_call",
+        "name": name,
+        "arguments": {},
+    }
+
+
+def _anthropic_tool_call(call_id, name="test_tool"):
+    return {
+        "id": call_id,
+        "type": "tool_use",
+        "name": name,
+        "input": {},
+    }
+
+
+def _assert_valid_for_next_user_turn(messages):
+    """Strict provider-neutral role/tool shape accepted before a new user turn."""
+    expect = "user"
+    pending_tool_calls = set()
+    for message in messages:
+        role = message["role"]
+        if expect == "user":
+            assert role == "user"
+            expect = "assistant"
+        elif expect == "assistant":
+            assert role == "assistant"
+            tool_calls = message.get("tool_calls") or []
+            if tool_calls:
+                pending_tool_calls = {call["id"] for call in tool_calls}
+                assert len(pending_tool_calls) == len(tool_calls)
+                expect = "tool"
+            else:
+                expect = "user"
+        else:
+            assert role == "tool"
+            assert message.get("tool_call_id") in pending_tool_calls
+            pending_tool_calls.remove(message["tool_call_id"])
+            if not pending_tool_calls:
+                expect = "assistant"
+    assert expect == "user"
+    assert not pending_tool_calls
 
 
 @pytest.fixture
@@ -59,11 +134,20 @@ async def test_capabilities_advertises_session_control_surface(adapter):
         assert resp.status == 200
         data = await resp.json()
 
+    assert data["object"] == "hermes.api_server.capabilities"
+    assert data["platform"] == "hermes-agent"
+    assert data["revision"] == "occ.conversation_gateway.h1-h2-h3.v2"
+    assert len(data["build_id"]) == 40
+    assert int(data["build_id"], 16) >= 0
     features = data["features"]
     assert features["session_resources"] is True
+    assert features["session_create_owner_bound"] is True
     assert features["session_chat"] is True
     assert features["session_chat_streaming"] is True
     assert features["session_fork"] is True
+    assert features["session_fork_anchored_preserve_source"] is True
+    assert features["session_fork_anchor_field"] == "anchor_message_id"
+    assert features["session_fork_user_message_anchor"] is True
     assert features["admin_config_rw"] is False
     assert features["memory_write_api"] is False
     assert features["skills_api"] is True
@@ -73,6 +157,50 @@ async def test_capabilities_advertises_session_control_surface(adapter):
         "method": "POST",
         "path": "/api/sessions/{session_id}/chat/stream",
     }
+    assert data["endpoints"]["session_create"] == {
+        "method": "POST",
+        "path": "/api/sessions",
+        "owner_field": "user_id",
+        "owner_max_chars": 256,
+        "source": "api_server",
+    }
+    assert data["session_turns"]["input_text"]["max_chars"] == 65_536
+    assert data["session_turns"]["inline_images"]["max_frames"] == 256
+    assert data["session_turns"]["transport"]["max_request_bytes"] == 16 * 1024 * 1024
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_transport_accepts_near_limit_and_rejects_over_limit():
+    assert MAX_REQUEST_BYTES == 16 * 1024 * 1024
+    assert _TURN_WIRE_ENVELOPE_BYTES <= MAX_REQUEST_BYTES
+
+    async def consume(request):
+        payload = await request.read()
+        return web.json_response({"size": len(payload)})
+
+    app = web.Application(
+        middlewares=[body_limit_middleware],
+        client_max_size=MAX_REQUEST_BYTES,
+    )
+    app.router.add_post("/consume", consume)
+    async with TestClient(TestServer(app)) as cli:
+        near = await cli.post(
+            "/consume",
+            data=b"x" * (MAX_REQUEST_BYTES - 1),
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        assert near.status == 200, await near.text()
+        assert (await near.json())["size"] == MAX_REQUEST_BYTES - 1
+
+        over = await cli.post(
+            "/consume",
+            data=b"x" * (MAX_REQUEST_BYTES + 1),
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        over_payload = await over.json()
+
+    assert over.status == 413
+    assert over_payload["error"]["code"] == "body_too_large"
 
 
 @pytest.mark.asyncio
@@ -170,6 +298,75 @@ async def test_session_crud_and_message_history(adapter, session_db):
 
 
 @pytest.mark.asyncio
+async def test_authenticated_session_create_persists_owner_atomically_and_fixes_source(
+    auth_adapter, session_db
+):
+    app = _create_session_app(auth_adapter)
+    headers = {"Authorization": "Bearer sk-test"}
+    owner = "owner-" + "x" * 250
+    assert len(owner) == auth_adapter._MAX_OWNER_USER_ID_LEN
+    async with TestClient(TestServer(app)) as cli:
+        unauthenticated = await cli.post(
+            "/api/sessions",
+            json={"id": "owner-session", "user_id": owner},
+        )
+        assert unauthenticated.status == 401
+
+        created = await cli.post(
+            "/api/sessions",
+            json={
+                "id": "owner-session",
+                "user_id": f"  {owner}  ",
+                "source": "slack",
+                "title": "Owned API session",
+            },
+            headers=headers,
+        )
+        assert created.status == 201, await created.text()
+        payload = await created.json()
+
+        compatible = await cli.post(
+            "/api/sessions",
+            json={"id": "legacy-owner-omitted"},
+            headers=headers,
+        )
+        assert compatible.status == 201
+        compatible_payload = await compatible.json()
+
+    stored = session_db.get_session("owner-session")
+    assert payload["session"]["user_id"] == owner
+    assert payload["session"]["source"] == "api_server"
+    assert stored["user_id"] == owner
+    assert stored["source"] == "api_server"
+    assert stored["title"] == "Owned API session"
+    assert compatible_payload["session"]["user_id"] is None
+    assert session_db.get_session("legacy-owner-omitted")["user_id"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "user_id",
+    ["", "   ", 42, "bad\nowner", "x" * 257],
+)
+async def test_session_create_rejects_invalid_owner_without_partial_row(
+    auth_adapter, session_db, user_id
+):
+    session_id = f"invalid-owner-{abs(hash(str(user_id)))}"
+    app = _create_session_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            "/api/sessions",
+            json={"id": session_id, "user_id": user_id, "title": "must rollback"},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        payload = await response.json()
+
+    assert response.status == 400
+    assert payload["error"]["code"] == "invalid_user_id"
+    assert session_db.get_session(session_id) is None
+
+
+@pytest.mark.asyncio
 async def test_session_messages_follow_compression_tip(adapter, session_db):
     source_id = session_db.create_session("source-session", "api_server")
     session_db.append_message(source_id, "user", "before compression")
@@ -190,25 +387,1027 @@ async def test_session_messages_follow_compression_tip(adapter, session_db):
 
 
 @pytest.mark.asyncio
-async def test_session_fork_uses_current_sessiondb_branch_primitives(adapter, session_db):
-    source_id = session_db.create_session("source-session", "api_server", model="test-model")
+async def test_session_fork_is_authenticated_anchored_and_source_exactly_immutable(
+    auth_adapter, session_db
+):
+    source_id = session_db.create_session(
+        "source-session",
+        "slack",
+        model="test-model",
+        model_config={"provider": "openrouter", "route": "safe-route"},
+        system_prompt="stable prompt",
+        user_id="owner-42",
+        cwd="/tmp/project",
+    )
+    session_db._conn.execute(
+        """UPDATE sessions
+           SET git_branch = ?, git_repo_root = ?, billing_provider = ?,
+               billing_base_url = ?, billing_mode = ?, profile_name = ?,
+               pricing_version = ?
+           WHERE id = ?""",
+        (
+            "talos/issue-159",
+            "/tmp/project",
+            "openrouter",
+            "https://provider.invalid/v1",
+            "api",
+            "talos",
+            "2026-07",
+            source_id,
+        ),
+    )
+    session_db.record_gateway_session_peer(
+        source_id,
+        source="slack",
+        user_id="owner-42",
+        session_key="slack:owner-42:C1:T1",
+        chat_id="C1",
+        chat_type="channel",
+        thread_id="T1",
+        display_name="Owner thread",
+        origin_json='{"platform":"slack","chat_id":"C1"}',
+    )
     session_db.set_session_title(source_id, "Original")
     session_db.append_message(source_id, "user", "first path")
-    session_db.append_message(source_id, "assistant", "answer")
+    session_db.append_message(
+        source_id, "assistant", "answer", finish_reason="stop"
+    )
+    session_db.append_message(source_id, "user", "later turn")
+    anchor_id = session_db.get_messages(source_id)[1]["id"]
 
-    app = _create_session_app(adapter)
+    source_row_before = session_db.get_session(source_id)
+    source_messages_before = session_db.get_messages(source_id, include_inactive=True)
+    active_head_before = session_db.find_latest_gateway_session_for_peer(
+        source="slack",
+        user_id="owner-42",
+        session_key="slack:owner-42:C1:T1",
+        chat_id="C1",
+        chat_type="channel",
+        thread_id="T1",
+    )
+
+    app = _create_session_app(auth_adapter)
+    request_body = {
+        "id": "anchored-child",
+        "title": "Alternative",
+        "anchor_message_id": anchor_id,
+        "preserve_source": True,
+        "idempotency_key": "fork-request-1",
+    }
     async with TestClient(TestServer(app)) as cli:
-        resp = await cli.post(f"/api/sessions/{source_id}/fork", json={"title": "Alternative"})
-        assert resp.status == 201
+        unauthenticated = await cli.post(
+            f"/api/sessions/{source_id}/fork", json=request_body
+        )
+        assert unauthenticated.status == 401
+
+        resp = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json=request_body,
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert resp.status == 201, await resp.text()
         payload = await resp.json()
+
+        get_resp = await cli.get(
+            "/api/sessions/anchored-child",
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert get_resp.status == 200
+        fetched = await get_resp.json()
 
     fork = payload["session"]
     assert payload["object"] == "hermes.session"
-    assert fork["id"] != source_id
+    assert payload["idempotent_replay"] is False
+    assert fork["id"] == "anchored-child"
     assert fork["parent_session_id"] == source_id
+    assert fork["branch_point_message_id"] == anchor_id
     assert fork["title"] == "Alternative"
-    assert [m["content"] for m in session_db.get_messages(fork["id"])] == ["first path", "answer"]
-    assert session_db.get_session(source_id)["end_reason"] == "branched"
+    assert fork["source"] == "slack"
+    assert fork["user_id"] == "owner-42"
+    assert fork["model"] == "test-model"
+    assert fetched["session"]["branch_point_message_id"] == anchor_id
+    assert "model_config" not in fork
+    assert "system_prompt" not in fork
+    assert "idempotency_key" not in json.dumps(payload)
+
+    child_row = session_db.get_session(fork["id"])
+    child_config = json.loads(child_row["model_config"])
+    assert child_config["provider"] == "openrouter"
+    assert child_config["route"] == "safe-route"
+    assert child_config["_branched_from"] == source_id
+    assert child_config["_branch_point_message_id"] == anchor_id
+    assert child_row["system_prompt"] == "stable prompt"
+    assert child_row["cwd"] == "/tmp/project"
+    assert child_row["git_branch"] == "talos/issue-159"
+    assert child_row["git_repo_root"] == "/tmp/project"
+    assert child_row["billing_provider"] == "openrouter"
+    assert child_row["billing_base_url"] == "https://provider.invalid/v1"
+    assert child_row["billing_mode"] == "api"
+    assert child_row["profile_name"] == "talos"
+    assert child_row["pricing_version"] == "2026-07"
+    assert child_row["session_key"] is None
+    assert child_row["chat_id"] is None
+    assert child_row["thread_id"] is None
+    assert child_row["display_name"] is None
+    assert child_row["origin_json"] is None
+    assert child_row["ended_at"] is None
+    assert child_row["end_reason"] is None
+    assert [m["content"] for m in session_db.get_messages(fork["id"])] == [
+        "first path",
+        "answer",
+    ]
+
+    assert session_db.get_session(source_id) == source_row_before
+    assert (
+        session_db.get_messages(source_id, include_inactive=True)
+        == source_messages_before
+    )
+    active_head_after = session_db.find_latest_gateway_session_for_peer(
+        source="slack",
+        user_id="owner-42",
+        session_key="slack:owner-42:C1:T1",
+        chat_id="C1",
+        chat_type="channel",
+        thread_id="T1",
+    )
+    assert active_head_before["id"] == source_id
+    assert active_head_after["id"] == source_id
+
+
+@pytest.mark.asyncio
+async def test_session_fork_slices_only_active_rows_through_exact_anchor(
+    auth_adapter, session_db
+):
+    source_id = session_db.create_session("active-only-source", "api_server")
+    inactive_user = session_db.append_message(source_id, "user", "abandoned")
+    inactive_assistant = session_db.append_message(
+        source_id, "assistant", "abandoned answer", finish_reason="stop"
+    )
+    session_db._conn.execute(
+        "UPDATE messages SET active = 0 WHERE id IN (?, ?)",
+        (inactive_user, inactive_assistant),
+    )
+    session_db.append_message(source_id, "user", "canonical")
+    anchor_id = session_db.append_message(
+        source_id, "assistant", "canonical answer", finish_reason="stop"
+    )
+    source_before = session_db.get_messages(source_id, include_inactive=True)
+
+    app = _create_session_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": "active-only-child",
+                "anchor_message_id": anchor_id,
+                "preserve_source": True,
+                "idempotency_key": "active-only-key",
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        response_text = await response.text()
+
+    assert response.status == 201, response_text
+    child = session_db.get_messages("active-only-child", include_inactive=True)
+    assert [message["content"] for message in child] == [
+        "canonical",
+        "canonical answer",
+    ]
+    assert all(message["active"] for message in child)
+    assert session_db.get_messages(source_id, include_inactive=True) == source_before
+
+
+@pytest.mark.asyncio
+async def test_session_fork_idempotent_replay_and_conflicting_reuse(
+    auth_adapter, session_db
+):
+    source_id = session_db.create_session("source-session", "api_server")
+    anchor_id = _append_completed_turn(session_db, source_id)
+    app = _create_session_app(auth_adapter)
+    body = {
+        "anchor_message_id": anchor_id,
+        "preserve_source": True,
+        "idempotency_key": "stable-key",
+    }
+    headers = {"Authorization": "Bearer sk-test"}
+
+    async with TestClient(TestServer(app)) as cli:
+        created = await cli.post(
+            f"/api/sessions/{source_id}/fork", json=body, headers=headers
+        )
+        assert created.status == 201
+        first = await created.json()
+
+        replay = await cli.post(
+            f"/api/sessions/{source_id}/fork", json=body, headers=headers
+        )
+        assert replay.status == 200
+        second = await replay.json()
+
+        conflict = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={**body, "title": "different request"},
+            headers=headers,
+        )
+        assert conflict.status == 409
+        conflict_payload = await conflict.json()
+
+    assert second["idempotent_replay"] is True
+    assert second["session"]["id"] == first["session"]["id"]
+    assert conflict_payload["error"]["code"] == "idempotency_conflict"
+    children = session_db._conn.execute(
+        "SELECT id FROM sessions WHERE parent_session_id = ?", (source_id,)
+    ).fetchall()
+    assert [row["id"] for row in children] == [first["session"]["id"]]
+
+
+@pytest.mark.asyncio
+async def test_session_fork_rejects_foreign_anchor_without_creating_child(
+    auth_adapter, session_db
+):
+    source_id = session_db.create_session("source-session", "api_server")
+    session_db.append_message(source_id, "user", "source message")
+    other_id = session_db.create_session("other-session", "api_server")
+    session_db.append_message(other_id, "user", "foreign message")
+    foreign_anchor = session_db.get_messages(other_id)[0]["id"]
+    source_before = session_db.get_session(source_id)
+    messages_before = session_db.get_messages(source_id, include_inactive=True)
+
+    app = _create_session_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": "must-not-exist",
+                "from_message_id": foreign_anchor,
+                "preserve_source": True,
+                "idempotency_key": "invalid-anchor-key",
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert resp.status == 400
+        payload = await resp.json()
+
+    assert payload["error"]["code"] == "invalid_anchor"
+    assert session_db.get_session("must-not-exist") is None
+    assert session_db.get_session(source_id) == source_before
+    assert session_db.get_messages(source_id, include_inactive=True) == messages_before
+    assert session_db._conn.execute(
+        "SELECT 1 FROM session_fork_requests WHERE idempotency_key = ?",
+        ("invalid-anchor-key",),
+    ).fetchone() is None
+
+
+@pytest.mark.asyncio
+async def test_session_fork_failure_rolls_back_child_messages_and_idempotency(
+    auth_adapter, session_db
+):
+    source_id = session_db.create_session("source-session", "api_server")
+    anchor_id = _append_completed_turn(session_db, source_id)
+    source_before = session_db.get_session(source_id)
+    messages_before = session_db.get_messages(source_id, include_inactive=True)
+    session_db._conn.executescript(
+        """
+        CREATE TRIGGER fail_anchored_child_copy
+        BEFORE INSERT ON messages
+        WHEN NEW.session_id = 'rollback-child'
+        BEGIN
+            SELECT RAISE(ABORT, 'injected child copy failure');
+        END;
+        """
+    )
+
+    app = _create_session_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": "rollback-child",
+                "anchor_message_id": anchor_id,
+                "preserve_source": True,
+                "idempotency_key": "rollback-key",
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert resp.status == 500
+        payload = await resp.json()
+
+    assert payload["error"]["code"] == "session_fork_failed"
+    assert session_db.get_session("rollback-child") is None
+    assert session_db._conn.execute(
+        "SELECT 1 FROM messages WHERE session_id = 'rollback-child'"
+    ).fetchone() is None
+    assert session_db._conn.execute(
+        "SELECT 1 FROM session_fork_requests WHERE idempotency_key = 'rollback-key'"
+    ).fetchone() is None
+    assert session_db.get_session(source_id) == source_before
+    assert session_db.get_messages(source_id, include_inactive=True) == messages_before
+
+
+@pytest.mark.asyncio
+async def test_session_fork_requires_preserve_source_and_bounded_fields(
+    auth_adapter, session_db
+):
+    source_id = session_db.create_session("source-session", "api_server")
+    anchor_id = _append_completed_turn(session_db, source_id)
+    headers = {"Authorization": "Bearer sk-test"}
+    app = _create_session_app(auth_adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        missing_preserve = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "anchor_message_id": anchor_id,
+                "idempotency_key": "missing-preserve",
+            },
+            headers=headers,
+        )
+        assert missing_preserve.status == 400
+        assert (await missing_preserve.json())["error"]["code"] == "preserve_source_required"
+
+        long_title = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "anchor_message_id": anchor_id,
+                "preserve_source": True,
+                "idempotency_key": "long-title",
+                "title": "x" * (SessionDB.MAX_TITLE_LENGTH + 1),
+            },
+            headers=headers,
+        )
+        assert long_title.status == 400
+        assert (await long_title.json())["error"]["code"] == "invalid_title"
+
+        long_key = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "anchor_message_id": anchor_id,
+                "preserve_source": True,
+                "idempotency_key": "k" * 256,
+            },
+            headers=headers,
+        )
+        assert long_key.status == 400
+        assert (await long_key.json())["error"]["code"] == "invalid_idempotency_key"
+
+    assert session_db._conn.execute(
+        "SELECT COUNT(*) AS n FROM sessions WHERE parent_session_id = ?", (source_id,)
+    ).fetchone()["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_session_fork_anchor_contract_accepts_canonical_and_compatible_alias(
+    auth_adapter, session_db
+):
+    source_id = session_db.create_session("source-session", "api_server")
+    anchor_id = _append_completed_turn(session_db, source_id)
+    headers = {"Authorization": "Bearer sk-test"}
+    app = _create_session_app(auth_adapter)
+
+    requests = [
+        ({"anchor_message_id": anchor_id}, "canonical-child", "canonical-key"),
+        ({"from_message_id": anchor_id}, "legacy-child", "legacy-key"),
+        (
+            {"anchor_message_id": anchor_id, "from_message_id": anchor_id},
+            "equal-fields-child",
+            "equal-fields-key",
+        ),
+    ]
+    async with TestClient(TestServer(app)) as cli:
+        for anchor_fields, child_id, key in requests:
+            response = await cli.post(
+                f"/api/sessions/{source_id}/fork",
+                json={
+                    **anchor_fields,
+                    "id": child_id,
+                    "preserve_source": True,
+                    "idempotency_key": key,
+                },
+                headers=headers,
+            )
+            assert response.status == 201, await response.text()
+            assert (await response.json())["session"]["branch_point_message_id"] == anchor_id
+
+        mismatched = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "anchor_message_id": anchor_id,
+                "from_message_id": anchor_id + 1,
+                "id": "mismatch-child",
+                "preserve_source": True,
+                "idempotency_key": "mismatch-key",
+            },
+            headers=headers,
+        )
+        missing = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": "missing-child",
+                "preserve_source": True,
+                "idempotency_key": "missing-key",
+            },
+            headers=headers,
+        )
+        mismatched_payload = await mismatched.json()
+        missing_payload = await missing.json()
+
+    assert mismatched.status == 400
+    assert mismatched_payload["error"]["code"] == "invalid_anchor"
+    assert missing.status == 400
+    assert missing_payload["error"]["code"] == "invalid_anchor"
+    assert session_db.get_session("mismatch-child") is None
+    assert session_db.get_session("missing-child") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "prefix_kind",
+    [
+        "assistant-tool-request-anchor",
+        "partial-multi-tool-results",
+        "complete-multi-tool-results-tool-anchor",
+        "assistant-native-tool-use-block",
+        "system-anchor",
+        "developer-anchor",
+        "consecutive-users-before-final",
+        "orphan-tool-result",
+    ],
+)
+async def test_session_fork_rejects_prefixes_unsafe_for_a_new_user_turn(
+    auth_adapter, session_db, prefix_kind
+):
+    source_id = session_db.create_session("source-session", "api_server")
+    if prefix_kind in {"system-anchor", "developer-anchor"}:
+        anchor_id = session_db.append_message(source_id, prefix_kind.split("-")[0], "policy")
+    else:
+        anchor_id = session_db.append_message(source_id, "user", "first")
+        if prefix_kind == "assistant-tool-request-anchor":
+            anchor_id = session_db.append_message(
+                source_id, "assistant", "calling", tool_calls=[_tool_call("call-1")]
+            )
+        elif prefix_kind in {
+            "partial-multi-tool-results",
+            "complete-multi-tool-results-tool-anchor",
+        }:
+            session_db.append_message(
+                source_id,
+                "assistant",
+                "calling",
+                tool_calls=[_tool_call("call-1"), _tool_call("call-2")],
+            )
+            anchor_id = session_db.append_message(
+                source_id, "tool", "one", tool_call_id="call-1", tool_name="test_tool"
+            )
+            if prefix_kind == "complete-multi-tool-results-tool-anchor":
+                anchor_id = session_db.append_message(
+                    source_id, "tool", "two", tool_call_id="call-2", tool_name="test_tool"
+                )
+        elif prefix_kind == "assistant-native-tool-use-block":
+            anchor_id = session_db.append_message(
+                source_id,
+                "assistant",
+                [{"type": "tool_use", "id": "native-1", "name": "test_tool"}],
+            )
+        elif prefix_kind == "consecutive-users-before-final":
+            session_db.append_message(source_id, "user", "second")
+            anchor_id = session_db.append_message(source_id, "assistant", "answer")
+        elif prefix_kind == "orphan-tool-result":
+            anchor_id = session_db.append_message(
+                source_id, "tool", "orphan", tool_call_id="unknown", tool_name="test_tool"
+            )
+    source_before = session_db.get_session(source_id)
+    messages_before = session_db.get_messages(source_id, include_inactive=True)
+    app = _create_session_app(auth_adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": "unsafe-child",
+                "anchor_message_id": anchor_id,
+                "preserve_source": True,
+                "idempotency_key": f"unsafe-{prefix_kind}",
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        response_payload = await response.json()
+
+    assert response.status == 400
+    assert response_payload["error"]["code"] == "unsafe_anchor"
+    assert session_db.get_session("unsafe-child") is None
+    assert session_db.get_session(source_id) == source_before
+    assert session_db.get_messages(source_id, include_inactive=True) == messages_before
+
+
+@pytest.mark.asyncio
+async def test_session_fork_accepts_canonical_user_anchor_and_still_rejects_truncated_assistant(
+    auth_adapter, session_db
+):
+    """Or7 #159: a canonical user message is a valid exact-message fork anchor.
+
+    The child transcript ends with that user message (the next agent run
+    answers it); assistant anchors remain restricted to fully completed
+    terminal boundaries.
+    """
+    source_id = session_db.create_session("user-anchor-source", "api_server")
+    first_user = session_db.append_message(source_id, "user", "first question")
+    session_db.append_message(
+        source_id, "assistant", "first answer", finish_reason="stop"
+    )
+    tail_user = session_db.append_message(source_id, "user", "edited question")
+    truncated_assistant = session_db.append_message(
+        source_id, "assistant", "cut off", finish_reason="length"
+    )
+    source_before = session_db.get_session(source_id)
+    messages_before = session_db.get_messages(source_id, include_inactive=True)
+    headers = {"Authorization": "Bearer sk-test"}
+    app = _create_session_app(auth_adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        tail_fork = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": "user-tail-child",
+                "anchor_message_id": tail_user,
+                "preserve_source": True,
+                "idempotency_key": "user-tail-key",
+            },
+            headers=headers,
+        )
+        assert tail_fork.status == 201, await tail_fork.text()
+        tail_payload = await tail_fork.json()
+
+        replay = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": "user-tail-child",
+                "anchor_message_id": tail_user,
+                "preserve_source": True,
+                "idempotency_key": "user-tail-key",
+            },
+            headers=headers,
+        )
+        assert replay.status == 200
+        assert (await replay.json())["idempotent_replay"] is True
+
+        mid_fork = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": "user-mid-child",
+                "anchor_message_id": first_user,
+                "preserve_source": True,
+                "idempotency_key": "user-mid-key",
+            },
+            headers=headers,
+        )
+        assert mid_fork.status == 201, await mid_fork.text()
+
+        truncated = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": "truncated-child",
+                "anchor_message_id": truncated_assistant,
+                "preserve_source": True,
+                "idempotency_key": "truncated-key",
+            },
+            headers=headers,
+        )
+        truncated_payload = await truncated.json()
+
+    assert tail_payload["session"]["branch_point_message_id"] == tail_user
+    assert [m["content"] for m in session_db.get_messages("user-tail-child")] == [
+        "first question",
+        "first answer",
+        "edited question",
+    ]
+    assert [m["role"] for m in session_db.get_messages("user-tail-child")] == [
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert [m["content"] for m in session_db.get_messages("user-mid-child")] == [
+        "first question"
+    ]
+    assert truncated.status == 400
+    assert truncated_payload["error"]["code"] == "unsafe_anchor"
+    assert session_db.get_session("truncated-child") is None
+    assert session_db.get_session(source_id) == source_before
+    assert session_db.get_messages(source_id, include_inactive=True) == messages_before
+
+
+@pytest.mark.asyncio
+async def test_session_fork_accepts_first_completed_response_and_exact_multi_tool_prefix(
+    auth_adapter, session_db
+):
+    source_id = session_db.create_session("source-session", "api_server")
+    first_anchor = _append_completed_turn(
+        session_db,
+        source_id,
+        "first",
+        "first answer",
+        finish_reason="stop",
+    )
+    session_db.append_message(source_id, "user", "use tools")
+    session_db.append_message(
+        source_id,
+        "assistant",
+        "working",
+        tool_calls=[_tool_call("call-1", "alpha"), _tool_call("call-2", "beta")],
+        finish_reason="tool_calls",
+        api_content="working exactly",
+    )
+    session_db.append_message(
+        source_id, "tool", "alpha result", tool_call_id="call-1", tool_name="alpha"
+    )
+    session_db.append_message(
+        source_id, "tool", "beta result", tool_call_id="call-2", tool_name="beta"
+    )
+    final_anchor = session_db.append_message(
+        source_id, "assistant", "complete", finish_reason="stop"
+    )
+    source_before = session_db.get_session(source_id)
+    source_messages_before = session_db.get_messages(source_id, include_inactive=True)
+    app = _create_session_app(auth_adapter)
+    headers = {"Authorization": "Bearer sk-test"}
+
+    async with TestClient(TestServer(app)) as cli:
+        first = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": "first-valid-child",
+                "anchor_message_id": first_anchor,
+                "preserve_source": True,
+                "idempotency_key": "first-valid",
+            },
+            headers=headers,
+        )
+        assert first.status == 201, await first.text()
+
+        complete = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": "complete-tool-child",
+                "anchor_message_id": final_anchor,
+                "preserve_source": True,
+                "idempotency_key": "complete-tool",
+            },
+            headers=headers,
+        )
+        assert complete.status == 201, await complete.text()
+
+    child_messages = session_db.get_messages("complete-tool-child", include_inactive=True)
+    source_prefix = [m for m in source_messages_before if m["id"] <= final_anchor]
+    immutable_columns = [
+        "role",
+        "content",
+        "tool_call_id",
+        "tool_calls",
+        "tool_name",
+        "finish_reason",
+        "api_content",
+        "reasoning",
+        "reasoning_content",
+        "active",
+    ]
+    assert [
+        {key: message.get(key) for key in immutable_columns} for message in child_messages
+    ] == [
+        {key: message.get(key) for key in immutable_columns} for message in source_prefix
+    ]
+    assert len(child_messages) == len(source_prefix)
+    assert session_db.get_session(source_id) == source_before
+    assert session_db.get_messages(source_id, include_inactive=True) == source_messages_before
+
+    provider_history = session_db.get_messages_as_conversation("complete-tool-child")
+    _assert_valid_for_next_user_turn(provider_history)
+    assert [message["role"] for message in provider_history] == [
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+        "tool",
+        "tool",
+        "assistant",
+    ]
+
+    mock_run = AsyncMock(
+        return_value=(
+            {"final_response": "continued", "session_id": "complete-tool-child"},
+            {"total_tokens": 1},
+        )
+    )
+    with (
+        patch.object(auth_adapter, "_run_agent", mock_run),
+        patch("agent.agent_runtime_helpers.repair_message_sequence") as repair_sequence,
+    ):
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                "/api/sessions/complete-tool-child/chat",
+                json={"message": "continue"},
+                headers=headers,
+            )
+            assert response.status == 200, await response.text()
+
+    repair_sequence.assert_not_called()
+    assert mock_run.await_args is not None
+    first_post_fork_history = mock_run.await_args.kwargs["conversation_history"]
+    assert first_post_fork_history == provider_history
+    _assert_valid_for_next_user_turn(first_post_fork_history)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "finish_reason",
+    [
+        "length",
+        "max_tokens",
+        "content_filter",
+        "interrupted",
+        "cancelled",
+        "tool_calls",
+        "unknown_nonterminal_reason",
+        None,
+    ],
+)
+async def test_session_fork_rejects_modern_anchor_without_recognized_completion(
+    auth_adapter, session_db, finish_reason
+):
+    source_id = session_db.create_session(
+        f"finish-source-{finish_reason}", "api_server"
+    )
+    session_db.append_message(source_id, "user", "known completed turn")
+    session_db.append_message(
+        source_id, "assistant", "complete", finish_reason="stop"
+    )
+    session_db.append_message(source_id, "user", "candidate turn")
+    anchor_id = session_db.append_message(
+        source_id,
+        "assistant",
+        "possibly partial",
+        finish_reason=finish_reason,
+    )
+
+    app = _create_session_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": f"finish-child-{anchor_id}",
+                "anchor_message_id": anchor_id,
+                "preserve_source": True,
+                "idempotency_key": f"finish-key-{anchor_id}",
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        payload = await response.json()
+
+    assert response.status == 400
+    assert payload["error"]["code"] == "unsafe_anchor"
+    assert session_db.get_session(f"finish-child-{anchor_id}") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", ["user", "assistant"])
+async def test_session_fork_rejects_reasoning_boundary_anchor(
+    auth_adapter, session_db, role
+):
+    source_id = session_db.create_session(f"reasoning-{role}-source", "api_server")
+    if role == "assistant":
+        session_db.append_message(source_id, "user", "question")
+        anchor_id = session_db.append_message(
+            source_id,
+            "assistant",
+            "final-looking answer",
+            finish_reason="stop",
+            reasoning="private reasoning boundary",
+        )
+    else:
+        anchor_id = session_db.append_message(
+            source_id,
+            "user",
+            "question",
+            reasoning_content="private reasoning boundary",
+        )
+
+    app = _create_session_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": f"reasoning-{role}-child",
+                "anchor_message_id": anchor_id,
+                "preserve_source": True,
+                "idempotency_key": f"reasoning-{role}-key",
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        payload = await response.json()
+
+    assert response.status == 400
+    assert payload["error"]["code"] == "unsafe_anchor"
+    assert session_db.get_session(f"reasoning-{role}-child") is None
+
+
+@pytest.mark.asyncio
+async def test_session_fork_accepts_terminal_reason_and_rejects_missing_finish_reason(
+    auth_adapter, session_db
+):
+    modern_id = session_db.create_session("modern-finish-source", "api_server")
+    session_db.append_message(modern_id, "user", "modern")
+    modern_anchor = session_db.append_message(
+        modern_id, "assistant", "done", finish_reason="stop"
+    )
+    legacy_id = session_db.create_session("legacy-finish-source", "api_server")
+    session_db.append_message(legacy_id, "user", "legacy")
+    legacy_anchor = session_db.append_message(legacy_id, "assistant", "done")
+
+    app = _create_session_app(auth_adapter)
+    headers = {"Authorization": "Bearer sk-test"}
+    async with TestClient(TestServer(app)) as cli:
+        modern = await cli.post(
+            f"/api/sessions/{modern_id}/fork",
+            json={
+                "id": "modern-finish-child",
+                "anchor_message_id": modern_anchor,
+                "preserve_source": True,
+                "idempotency_key": "modern-finish-key",
+            },
+            headers=headers,
+        )
+        modern_text = await modern.text()
+        legacy = await cli.post(
+            f"/api/sessions/{legacy_id}/fork",
+            json={
+                "id": "legacy-finish-child",
+                "anchor_message_id": legacy_anchor,
+                "preserve_source": True,
+                "idempotency_key": "legacy-finish-key",
+            },
+            headers=headers,
+        )
+        legacy_payload = await legacy.json()
+
+    assert modern.status == 201, modern_text
+    assert legacy.status == 400
+    assert legacy_payload["error"]["code"] == "unsafe_anchor"
+    assert session_db.get_session("legacy-finish-child") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool_calls,tool_result_ids",
+    [
+        ([{"id": "id-only"}], ["id-only"]),
+        ([_tool_call("empty-name", "")], ["empty-name"]),
+        (
+            [{
+                "id": "bad-args",
+                "type": "function",
+                "function": {"name": "test_tool", "arguments": "{not-json"},
+            }],
+            ["bad-args"],
+        ),
+        ([_tool_call("duplicate"), _tool_call("duplicate")], ["duplicate"]),
+        ([_tool_call("expected")], ["orphan"]),
+        ([_tool_call("twice")], ["twice", "twice"]),
+    ],
+)
+async def test_session_fork_rejects_malformed_or_unmatched_tool_call_groups(
+    auth_adapter, session_db, tool_calls, tool_result_ids
+):
+    first_call_id = (
+        tool_calls[0].get("id")
+        or tool_calls[0].get("call_id")
+        or "missing"
+    )
+    source_id = session_db.create_session(
+        f"malformed-tool-source-{first_call_id}-{len(tool_result_ids)}",
+        "api_server",
+    )
+    session_db.append_message(source_id, "user", "use a tool")
+    session_db.append_message(
+        source_id,
+        "assistant",
+        "calling",
+        tool_calls=tool_calls,
+        finish_reason="tool_calls",
+    )
+    for result_id in tool_result_ids:
+        session_db.append_message(
+            source_id,
+            "tool",
+            "result",
+            tool_call_id=result_id,
+            tool_name="test_tool",
+        )
+    anchor_id = session_db.append_message(
+        source_id, "assistant", "final", finish_reason="stop"
+    )
+
+    app = _create_session_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": f"malformed-tool-child-{anchor_id}",
+                "anchor_message_id": anchor_id,
+                "preserve_source": True,
+                "idempotency_key": f"malformed-tool-key-{anchor_id}",
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        payload = await response.json()
+
+    assert response.status == 400
+    assert payload["error"]["code"] == "unsafe_anchor"
+
+
+@pytest.mark.asyncio
+async def test_session_fork_accepts_complete_provider_neutral_tool_call_shapes(
+    auth_adapter, session_db
+):
+    source_id = session_db.create_session("provider-neutral-tools", "api_server")
+    shapes = [
+        _tool_call("openai-call", "openai_tool"),
+        _responses_tool_call("responses-call", "responses_tool"),
+        _anthropic_tool_call("anthropic-call", "anthropic_tool"),
+    ]
+    for index, call in enumerate(shapes):
+        session_db.append_message(source_id, "user", f"turn {index}")
+        session_db.append_message(
+            source_id,
+            "assistant",
+            "calling",
+            tool_calls=[call],
+            finish_reason="tool_calls",
+        )
+        call_id = call.get("call_id") or call["id"]
+        session_db.append_message(
+            source_id,
+            "tool",
+            "result",
+            tool_call_id=call_id,
+            tool_name=(call.get("function") or {}).get("name") or call.get("name"),
+        )
+        anchor_id = session_db.append_message(
+            source_id, "assistant", "done", finish_reason="stop"
+        )
+
+    app = _create_session_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            f"/api/sessions/{source_id}/fork",
+            json={
+                "id": "provider-neutral-child",
+                "anchor_message_id": anchor_id,
+                "preserve_source": True,
+                "idempotency_key": "provider-neutral-key",
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        response_text = await response.text()
+
+    assert response.status == 201, response_text
+    assert len(session_db.get_messages("provider-neutral-child")) == 12
+
+
+@pytest.mark.asyncio
+async def test_consumed_fork_key_survives_child_delete_and_cannot_create_again(
+    auth_adapter, session_db
+):
+    source_id = session_db.create_session("delete-reuse-source", "api_server")
+    session_db.append_message(source_id, "user", "branch")
+    anchor_id = session_db.append_message(
+        source_id, "assistant", "done", finish_reason="stop"
+    )
+    body = {
+        "id": "delete-reuse-child",
+        "anchor_message_id": anchor_id,
+        "preserve_source": True,
+        "idempotency_key": "delete-reuse-key",
+    }
+    headers = {"Authorization": "Bearer sk-test"}
+    app = _create_session_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        created = await cli.post(
+            f"/api/sessions/{source_id}/fork", json=body, headers=headers
+        )
+        assert created.status == 201, await created.text()
+        assert session_db.delete_session("delete-reuse-child") is True
+        reservation = session_db._conn.execute(
+            "SELECT child_session_id FROM session_fork_requests WHERE idempotency_key = ?",
+            ("delete-reuse-key",),
+        ).fetchone()
+        assert reservation["child_session_id"] == "delete-reuse-child"
+
+        stale = await cli.post(
+            f"/api/sessions/{source_id}/fork", json=body, headers=headers
+        )
+        stale_payload = await stale.json()
+
+    assert stale.status == 409
+    assert stale_payload["error"]["code"] == "idempotency_stale"
+    assert session_db.get_session("delete-reuse-child") is None
 
 
 @pytest.mark.asyncio
@@ -249,6 +1448,70 @@ async def test_session_chat_loads_history_and_preserves_session_headers(auth_ada
         {"role": "user", "content": "earlier"},
         {"role": "assistant", "content": "prior answer"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_session_chat_fails_closed_on_history_error_before_model(auth_adapter, session_db):
+    session_id = session_db.create_session("chat-history-fail", "api_server")
+    mock_run = AsyncMock()
+    app = _create_session_app(auth_adapter)
+    with patch.object(auth_adapter, "_run_agent", mock_run), patch.object(
+        session_db, "get_messages_as_conversation", side_effect=sqlite3.DatabaseError("secret db path")
+    ):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={"message": "next"},
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            payload = await resp.json()
+    assert resp.status == 503
+    assert payload["error"]["code"] == "session_history_unavailable"
+    assert "secret" not in json.dumps(payload)
+    mock_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_fails_closed_on_history_error_before_model(adapter, session_db):
+    session_id = session_db.create_session("stream-history-fail", "api_server")
+    mock_run = AsyncMock()
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", mock_run), patch.object(
+        session_db, "get_messages_as_conversation", side_effect=sqlite3.DatabaseError("secret db path")
+    ):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream", json={"message": "next"}
+            )
+            body = await resp.text()
+
+    assert resp.status == 200
+    assert "session_history_unavailable" in body
+    assert "secret db path" not in body
+    assert "event: run.started" not in body
+    mock_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_session_chat_conflicts_with_canonical_durable_owner(auth_adapter, session_db):
+    session_id = session_db.create_session("chat-lease-conflict", "api_server")
+    assert session_db.acquire_session_execution_lease(session_id, "gateway-owner") is True
+    mock_run = AsyncMock()
+    app = _create_session_app(auth_adapter)
+    with patch.object(auth_adapter, "_run_agent", mock_run):
+        async with TestClient(TestServer(app)) as cli:
+            unauthorized = await cli.post(
+                f"/api/sessions/{session_id}/chat", json={"message": "next"}
+            )
+            conflict = await cli.post(
+                f"/api/sessions/{session_id}/chat", json={"message": "next"},
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            conflict_payload = await conflict.json()
+    assert unauthorized.status == 401
+    assert conflict.status == 409
+    assert conflict_payload["error"]["code"] == "active_session_execution"
+    mock_run.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_turns.py
+++ b/tests/gateway/test_session_turns.py
@@ -1140,6 +1140,144 @@ async def test_stop_reports_stopping_until_worker_actually_exits(session_db):
 
 
 @pytest.mark.asyncio
+async def test_sequential_repeated_stop_interrupts_once_through_worker_exit(session_db):
+    worker_ready = asyncio.Event()
+    worker_release = asyncio.Event()
+
+    class Agent:
+        interrupts = 0
+
+        def interrupt(self, _reason):
+            self.interrupts += 1
+
+    agent = Agent()
+
+    async def run_agent(**kwargs):
+        kwargs["agent_ref"][0] = agent
+        worker_ready.set()
+        await worker_release.wait()
+        return {"final_response": "discarded", "messages": []}, {}
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._run_agent = run_agent
+    service = adapter._session_turn_service
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        submitted = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-stop-sequential"},
+            json=_payload(),
+        )
+        assert submitted.status == 202
+        await asyncio.wait_for(worker_ready.wait(), 1)
+
+        first = await client.post(
+            "/api/sessions/s1/turns/turn-stop-sequential/stop"
+        )
+        second = await client.post(
+            "/api/sessions/s1/turns/turn-stop-sequential/stop"
+        )
+        assert first.status == second.status == 202
+        assert (await first.json())["turn"]["status"] == "stopping"
+        assert (await second.json())["turn"]["status"] == "stopping"
+        assert agent.interrupts == 1
+        assert "turn-stop-sequential" in service._interruption_owners
+
+        worker_release.set()
+        await service.wait_for_turn("turn-stop-sequential")
+        assert "turn-stop-sequential" not in service._interruption_owners
+
+        later = await client.post(
+            "/api/sessions/s1/turns/turn-stop-sequential/stop"
+        )
+        assert later.status == 200
+        assert (await later.json())["turn"]["status"] == "interrupted"
+        assert agent.interrupts == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_repeated_stop_joins_watcher_through_worker_exit(session_db):
+    runner_entered = asyncio.Event()
+    publish_agent = asyncio.Event()
+    worker_release = asyncio.Event()
+    interrupted = asyncio.Event()
+
+    class Agent:
+        interrupts = 0
+
+        def interrupt(self, _reason):
+            self.interrupts += 1
+            interrupted.set()
+
+    agent = Agent()
+
+    async def run_agent(**kwargs):
+        runner_entered.set()
+        await publish_agent.wait()
+        kwargs["agent_ref"][0] = agent
+        await worker_release.wait()
+        return {"final_response": "discarded", "messages": []}, {}
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._run_agent = run_agent
+    service = adapter._session_turn_service
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        submitted = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-stop-watcher-lifetime"},
+            json=_payload(),
+        )
+        assert submitted.status == 202
+        await asyncio.wait_for(runner_entered.wait(), 1)
+
+        first = await client.post(
+            "/api/sessions/s1/turns/turn-stop-watcher-lifetime/stop"
+        )
+        assert first.status == 202
+        publish_agent.set()
+        await asyncio.wait_for(interrupted.wait(), 1)
+
+        # The watcher has synchronously returned, but its per-turn owner must
+        # remain until the still-live worker and central finalizer both exit.
+        repeated = await asyncio.gather(
+            *[
+                client.post(
+                    "/api/sessions/s1/turns/turn-stop-watcher-lifetime/stop"
+                )
+                for _ in range(8)
+            ]
+        )
+        assert all(response.status == 202 for response in repeated)
+        assert agent.interrupts == 1
+        assert "turn-stop-watcher-lifetime" in service._interruption_owners
+
+        worker_release.set()
+        await service.wait_for_turn("turn-stop-watcher-lifetime")
+        assert "turn-stop-watcher-lifetime" not in service._interruption_owners
+
+        later = await asyncio.gather(
+            *[
+                client.post(
+                    "/api/sessions/s1/turns/turn-stop-watcher-lifetime/stop"
+                )
+                for _ in range(3)
+            ]
+        )
+        assert all(response.status == 200 for response in later)
+        later_payloads = await asyncio.gather(
+            *[response.json() for response in later]
+        )
+        assert all(
+            payload["turn"]["status"] == "interrupted"
+            for payload in later_payloads
+        )
+        assert agent.interrupts == 1
+
+
+@pytest.mark.asyncio
 async def test_concurrent_repeated_stop_records_and_watches_once(session_db, monkeypatch):
     gate = asyncio.Event()
 
@@ -1828,6 +1966,32 @@ async def test_forced_cleanup_failure_is_retrieved_and_privacy_safe(
 
 
 @pytest.mark.asyncio
+async def test_central_finalizer_releases_interrupt_owner_on_cleanup_failure(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    service = adapter._session_turn_service
+    store = SessionTurnStore(session_db)
+    turn_id = "interrupt-owner-cleanup-failure"
+    owner = asyncio.current_task()
+    assert owner is not None
+    service._interruption_owners[turn_id] = owner
+    service._agent_refs[turn_id] = [MagicMock()]
+
+    async def fail_cleanup_store(*_args, **_kwargs):
+        raise RuntimeError("cleanup failed")
+
+    monkeypatch.setattr(service, "_store_operation", fail_cleanup_store)
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        await service._finalize_execution(store, turn_id)
+
+    assert turn_id not in service._interruption_owners
+    assert turn_id not in service._agent_refs
+    assert turn_id not in service._lifecycle_cleanup_owners
+
+
+@pytest.mark.asyncio
 async def test_blocking_finalize_store_does_not_block_event_loop(
     session_db, monkeypatch: pytest.MonkeyPatch
 ):
@@ -2017,6 +2181,7 @@ async def test_stop_watcher_failure_is_retrieved_and_privacy_safe(
     ]
     assert "session_turn_background_task_failed" in caplog.text
     assert "private watcher secret" not in caplog.text
+    assert service._interruption_owners == {}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_turns.py
+++ b/tests/gateway/test_session_turns.py
@@ -1228,6 +1228,140 @@ async def test_coordinator_cancellation_retains_worker_heartbeat_lease_and_termi
 
 
 @pytest.mark.asyncio
+async def test_post_agent_cancellation_preserves_started_ledger_truth(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    """Cancellation after agent exit must not claim execution never started."""
+    still_owned_entered = asyncio.Event()
+    fake_lease = MagicMock()
+
+    async def blocked_still_owned():
+        still_owned_entered.set()
+        await asyncio.Event().wait()
+
+    fake_lease.still_owned = AsyncMock(side_effect=blocked_still_owned)
+    fake_lease.release = AsyncMock(return_value=True)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._acquire_session_execution_lease = AsyncMock(return_value=fake_lease)
+
+    async def run_agent(**_kwargs):
+        session_db.append_message("s1", "user", "hello")
+        session_db.append_message("s1", "assistant", "finished agent result")
+        return {"final_response": "finished agent result"}, {}
+
+    adapter._run_agent = run_agent
+    store = SessionTurnStore(session_db)
+    turn_id = "cancel-after-agent"
+    store.reserve("s1", turn_id, _payload())
+    coordinator = adapter._session_turn_service._admit_execution(
+        store, turn_id, "s1", _payload(), None, None
+    )
+    await asyncio.wait_for(still_owned_entered.wait(), 1)
+    coordinator.cancel()
+    await adapter._session_turn_service.wait_for_turn(turn_id)
+
+    row = store.get(turn_id)
+    events = store.events_after(turn_id, 0)
+    assert row["status"] == "interrupted"
+    assert row["started_at"] is not None
+    assert row["safe_error_code"] == "cancelled_after_execution"
+    assert [event["event"] for event in events] == [
+        "turn.started", "turn.interrupted"
+    ]
+    assert events[-1]["data"]["error_code"] == "cancelled_after_execution"
+    fake_lease.release.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_forced_cleanup_failure_is_retrieved_and_privacy_safe(
+    session_db, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """Cleanup ownership reports failure without asyncio's unretrieved warning."""
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    service = adapter._session_turn_service
+    store = SessionTurnStore(session_db)
+    turn_id = "forced-cleanup-failure"
+    store.reserve("s1", turn_id, _payload())
+    monkeypatch.setattr(
+        service,
+        "_finalize_execution",
+        AsyncMock(side_effect=RuntimeError("private cleanup secret")),
+    )
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    loop_contexts = []
+    loop = asyncio.get_running_loop()
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: loop_contexts.append(context))
+    try:
+        execution = service._admit_execution(
+            store, turn_id, "s1", _payload(), None, None
+        )
+        execution.cancel()
+        await asyncio.gather(execution, return_exceptions=True)
+        deadline = time.monotonic() + 1
+        while turn_id in service._tasks and time.monotonic() < deadline:
+            await asyncio.sleep(0)
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert turn_id not in service._tasks
+    assert not [
+        context for context in loop_contexts
+        if context.get("message") == "Task exception was never retrieved"
+    ]
+    assert "session_turn_background_task_failed" in caplog.text
+    assert "private cleanup secret" not in caplog.text
+    # The forced replacement intentionally prevented the real cleanup body;
+    # explicitly drain its test-only observer after proving task ownership.
+    dispatcher = service._lifecycle_dispatchers.pop(turn_id)
+    dispatcher.abort()
+    assert await asyncio.to_thread(dispatcher.flush, 1)
+
+
+@pytest.mark.asyncio
+async def test_blocking_finalize_store_does_not_block_event_loop(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    """Synchronous SQLite finalization remains ordered but runs off-loop."""
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    service = adapter._session_turn_service
+    store = SessionTurnStore(session_db)
+    turn_id = "blocking-finalize-store"
+    store.reserve("s1", turn_id, _payload())
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_args, **_kwargs: [])
+    finish_entered = threading.Event()
+    finish_release = threading.Event()
+    original_finish = store.finish
+
+    def blocking_finish(*args, **kwargs):
+        finish_entered.set()
+        finish_release.wait(timeout=2)
+        return original_finish(*args, **kwargs)
+
+    monkeypatch.setattr(store, "finish", blocking_finish)
+    execution = service._admit_execution(
+        store, turn_id, "s1", _payload(), None, None
+    )
+    execution.cancel()
+    await asyncio.gather(execution, return_exceptions=True)
+    assert await asyncio.to_thread(finish_entered.wait, 1)
+
+    # This timer must fire while finish() is blocked in the store worker.
+    ticked = asyncio.Event()
+    asyncio.get_running_loop().call_later(0.02, ticked.set)
+    await asyncio.wait_for(ticked.wait(), 0.1)
+    finish_release.set()
+    await service.wait_for_turn(turn_id)
+
+    assert store.get(turn_id)["status"] == "interrupted"
+
+
+@pytest.mark.asyncio
 async def test_immediate_prestart_cancellation_reclaims_all_lifecycle_capacity(
     session_db, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/gateway/test_session_turns.py
+++ b/tests/gateway/test_session_turns.py
@@ -1383,6 +1383,115 @@ async def test_failed_stop_watcher_releases_owner_and_concurrent_retry_runs_once
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("delivery_path", ["direct", "watcher"])
+async def test_interrupt_exception_releases_owner_and_concurrent_retry_terminalizes_once(
+    session_db,
+    caplog: pytest.LogCaptureFixture,
+    delivery_path: str,
+):
+    """A real Agent.interrupt exception is retryable on both delivery paths."""
+    runner_entered = asyncio.Event()
+    publish_agent = asyncio.Event()
+    agent_ready = asyncio.Event()
+    interrupt_delivered = asyncio.Event()
+    worker_release = asyncio.Event()
+
+    class Agent:
+        attempts = 0
+        delivered = 0
+
+        def interrupt(self, _reason):
+            self.attempts += 1
+            if self.attempts == 1:
+                raise RuntimeError("private direct provider interrupt secret")
+            self.delivered += 1
+            interrupt_delivered.set()
+
+    agent = Agent()
+
+    async def run_agent(**kwargs):
+        runner_entered.set()
+        if delivery_path == "watcher":
+            await publish_agent.wait()
+        kwargs["agent_ref"][0] = agent
+        agent_ready.set()
+        await worker_release.wait()
+        return {"final_response": "discarded", "messages": []}, {}
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._run_agent = run_agent
+    service = adapter._session_turn_service
+    turn_id = f"interrupt-exception-{delivery_path}"
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        submitted = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": turn_id},
+            json=_payload(),
+        )
+        assert submitted.status == 202
+        await asyncio.wait_for(runner_entered.wait(), 1)
+        if delivery_path == "direct":
+            await asyncio.wait_for(agent_ready.wait(), 1)
+
+        first = await client.post(f"/api/sessions/s1/turns/{turn_id}/stop")
+        assert first.status == 202
+        first_body = await first.json()
+        assert first_body["turn"]["status"] == "stopping"
+        assert "private direct provider interrupt secret" not in await first.text()
+
+        if delivery_path == "watcher":
+            publish_agent.set()
+            await asyncio.wait_for(agent_ready.wait(), 1)
+
+        deadline = time.monotonic() + 1
+        while turn_id in service._interruption_owners and time.monotonic() < deadline:
+            await asyncio.sleep(0)
+        assert agent.attempts == 1
+        assert agent.delivered == 0
+        assert turn_id not in service._interruption_owners
+
+        # All retries race for one handoff generation.  One interrupt is
+        # delivered; its owner then survives through authoritative worker exit.
+        retries = await asyncio.gather(
+            *[
+                client.post(f"/api/sessions/s1/turns/{turn_id}/stop")
+                for _ in range(12)
+            ]
+        )
+        assert all(response.status == 202 for response in retries)
+        await asyncio.wait_for(interrupt_delivered.wait(), 1)
+        assert agent.attempts == 2
+        assert agent.delivered == 1
+        assert turn_id in service._interruption_owners
+
+        worker_release.set()
+        await service.wait_for_turn(turn_id)
+        terminal = await client.get(f"/api/sessions/s1/turns/{turn_id}")
+        assert terminal.status == 200
+        assert (await terminal.json())["turn"]["status"] == "interrupted"
+
+        later = await asyncio.gather(
+            *[
+                client.post(f"/api/sessions/s1/turns/{turn_id}/stop")
+                for _ in range(3)
+            ]
+        )
+        assert all(response.status == 200 for response in later)
+
+    assert agent.attempts == 2
+    assert agent.delivered == 1
+    assert turn_id not in service._interruption_owners
+    assert turn_id not in service._interruption_watcher_owners
+    assert "private direct provider interrupt secret" not in caplog.text
+    if delivery_path == "watcher":
+        assert "session_turn_interrupt_watcher_failed reason=internal_error" in caplog.text
+    else:
+        assert "session_turn_interrupt_delivery_failed reason=internal_error" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_concurrent_repeated_stop_records_and_watches_once(session_db, monkeypatch):
     gate = asyncio.Event()
 

--- a/tests/gateway/test_session_turns.py
+++ b/tests/gateway/test_session_turns.py
@@ -56,6 +56,239 @@ def _png(width: int = 1, height: int = 1) -> str:
 
 
 @pytest.mark.asyncio
+async def test_callback_drain_survives_cancellation_without_terminal_overtake(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    service = adapter._session_turn_service
+    store = SessionTurnStore(session_db)
+    turn_id = "cancel-during-callback-drain"
+    store.reserve("s1", turn_id, _payload())
+    persistence_entered = threading.Event()
+    persistence_release = threading.Event()
+    original_append = store.append_event
+
+    def blocked_append(tid, event_type, data):
+        if event_type == "tool.started":
+            persistence_entered.set()
+            persistence_release.wait(timeout=2)
+        return original_append(tid, event_type, data)
+
+    monkeypatch.setattr(store, "append_event", blocked_append)
+
+    async def run_agent(**kwargs):
+        kwargs["tool_start_callback"]("call-1", "terminal", {})
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", "done")
+        return {"final_response": "done"}, {}
+
+    adapter._run_agent = run_agent
+    execution = service._admit_execution(
+        store, turn_id, "s1", _payload(), None, None
+    )
+    assert await asyncio.to_thread(persistence_entered.wait, 1)
+    execution.cancel()
+    await asyncio.sleep(0)
+    assert not execution.done()
+    persistence_release.set()
+    await service.wait_for_turn(turn_id)
+
+    events = store.events_after(turn_id, 0)
+    names = [event["event"] for event in events]
+    assert store.get(turn_id)["status"] == "completed"
+    assert names.index("tool.started") < names.index("assistant.completed")
+    assert names.index("tool.started") < names.index("turn.completed")
+
+
+@pytest.mark.asyncio
+async def test_slack_send_cancellation_durably_marks_manual_retry_privacy_safe(
+    session_db,
+):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    service = adapter._session_turn_service
+    store = SessionTurnStore(session_db)
+    turn_id = "cancel-slack-send"
+    store.reserve("s1", turn_id, _payload(mode="both"))
+    send_entered = asyncio.Event()
+
+    async def cancelled_send(*_args, **_kwargs):
+        send_entered.set()
+        await asyncio.Future()
+
+    slack = MagicMock()
+    slack.send = cancelled_send
+    task = asyncio.create_task(
+        service._deliver_slack(
+            store,
+            turn_id,
+            SlackBinding(chat_id="safe", thread_id=None, metadata={}),
+            slack,
+            "private assistant body",
+        )
+    )
+    await asyncio.wait_for(send_entered.wait(), 1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    delivery = store.get_delivery(turn_id, "slack")
+    events = store.events_after(turn_id, 0)
+    assert delivery is not None
+    assert delivery["state"] == "needs_manual_retry"
+    assert delivery["safe_error_code"] == "delivery_outcome_unknown"
+    assert [event["event"] for event in events] == ["delivery.failed"]
+    assert "private assistant body" not in repr(events)
+
+
+@pytest.mark.asyncio
+async def test_slow_callback_store_applies_bounded_worker_backpressure_and_recovers(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    import gateway.platforms.session_turns as session_turns
+
+    monkeypatch.setattr(session_turns, "SESSION_TURN_CALLBACK_QUEUE_SIZE", 2)
+    created_ingress = []
+    ingress_type = session_turns._CallbackPersistenceIngress
+
+    def capture_ingress(loop, maxsize):
+        ingress = ingress_type(loop, maxsize)
+        created_ingress.append(ingress)
+        return ingress
+
+    monkeypatch.setattr(session_turns, "_CallbackPersistenceIngress", capture_ingress)
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    service = adapter._session_turn_service
+    store = SessionTurnStore(session_db)
+    turn_id = "bounded-callback-backpressure"
+    store.reserve("s1", turn_id, _payload())
+    first_write_entered = threading.Event()
+    release_store = threading.Event()
+    producer_done = threading.Event()
+    original_append = store.append_event
+
+    def slow_append(tid, event_type, data):
+        if event_type == "tool.started" and not first_write_entered.is_set():
+            first_write_entered.set()
+            release_store.wait(timeout=2)
+        return original_append(tid, event_type, data)
+
+    monkeypatch.setattr(store, "append_event", slow_append)
+
+    async def run_agent(**kwargs):
+        def worker():
+            for index in range(8):
+                call_id = f"call-{index}"
+                kwargs["tool_start_callback"](call_id, "terminal", {})
+                kwargs["tool_complete_callback"](
+                    call_id, "terminal", {}, "success"
+                )
+            producer_done.set()
+
+        await asyncio.to_thread(worker)
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", "done")
+        return {"final_response": "done"}, {}
+
+    adapter._run_agent = run_agent
+    execution = service._admit_execution(
+        store, turn_id, "s1", _payload(), None, None
+    )
+    assert await asyncio.to_thread(first_write_entered.wait, 1)
+    await asyncio.sleep(0.03)
+    assert not producer_done.is_set()
+    ticked = asyncio.Event()
+    asyncio.get_running_loop().call_soon(ticked.set)
+    await asyncio.wait_for(ticked.wait(), 0.1)
+    assert created_ingress[0].queue.qsize() <= 2
+    assert created_ingress[0].max_observed <= 2
+
+    release_store.set()
+    await service.wait_for_turn(turn_id)
+    assert execution.done()
+    structural = [
+        event["event"]
+        for event in store.events_after(turn_id, 0)
+        if event["event"].startswith("tool.")
+    ]
+    assert structural == ["tool.started", "tool.completed"] * 8
+    assert store.get(turn_id)["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_failing_callback_store_never_overtakes_retained_structure_and_recovers(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    service = adapter._session_turn_service
+    store = SessionTurnStore(session_db)
+    producer_queued_following_event = threading.Event()
+    original_append = store.append_event
+    fail_callbacks = True
+
+    def failing_append(tid, event_type, data):
+        if fail_callbacks and event_type == "tool.started":
+            # Ensure tool.completed is retained behind the failing current event.
+            producer_queued_following_event.wait(timeout=1)
+            raise sqlite3.OperationalError("private callback store failure")
+        return original_append(tid, event_type, data)
+
+    monkeypatch.setattr(store, "append_event", failing_append)
+
+    async def run_agent(**kwargs):
+        def worker():
+            kwargs["tool_start_callback"]("call-1", "terminal", {})
+            kwargs["tool_complete_callback"](
+                "call-1", "terminal", {}, "success"
+            )
+            producer_queued_following_event.set()
+
+        await asyncio.to_thread(worker)
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message(
+            "s1", "assistant", kwargs["authoritative_turn_id"]
+        )
+        return {"final_response": kwargs["authoritative_turn_id"]}, {}
+
+    adapter._run_agent = run_agent
+    failed_turn = "callback-store-failure"
+    store.reserve("s1", failed_turn, _payload())
+    service._admit_execution(
+        store, failed_turn, "s1", _payload(), None, None
+    )
+    await service.wait_for_turn(failed_turn)
+
+    assert store.get(failed_turn)["status"] == "failed"
+    assert store.get(failed_turn)["safe_error_code"] == "event_store_failed"
+    # A terminal event must not jump ahead of the retained tool.completed event.
+    assert [event["event"] for event in store.events_after(failed_turn, 0)] == [
+        "turn.started"
+    ]
+
+    fail_callbacks = False
+    recovered_turn = "callback-store-recovered"
+    store.reserve("s1", recovered_turn, _payload())
+    service._admit_execution(
+        store, recovered_turn, "s1", _payload(), None, None
+    )
+    await service.wait_for_turn(recovered_turn)
+
+    recovered_events = [
+        event["event"] for event in store.events_after(recovered_turn, 0)
+    ]
+    assert store.get(recovered_turn)["status"] == "completed"
+    assert recovered_events == [
+        "turn.started",
+        "tool.started",
+        "tool.completed",
+        "assistant.completed",
+        "turn.completed",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_execution_lease_release_survives_repeated_cancellation(
     session_db, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/gateway/test_session_turns.py
+++ b/tests/gateway/test_session_turns.py
@@ -1278,6 +1278,111 @@ async def test_concurrent_repeated_stop_joins_watcher_through_worker_exit(sessio
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("failure_kind", "expected_reason"),
+    [("exception", "internal_error"), ("cancelled", "cancelled")],
+)
+async def test_failed_stop_watcher_releases_owner_and_concurrent_retry_runs_once(
+    session_db,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    failure_kind: str,
+    expected_reason: str,
+):
+    runner_entered = asyncio.Event()
+    publish_agent = asyncio.Event()
+    worker_release = asyncio.Event()
+    interrupted = asyncio.Event()
+    first_watcher_finished = asyncio.Event()
+    retry_watcher_started = asyncio.Event()
+
+    class Agent:
+        interrupts = 0
+
+        def interrupt(self, _reason):
+            self.interrupts += 1
+            interrupted.set()
+
+    agent = Agent()
+
+    async def run_agent(**kwargs):
+        runner_entered.set()
+        await publish_agent.wait()
+        kwargs["agent_ref"][0] = agent
+        await worker_release.wait()
+        return {"final_response": "discarded", "messages": []}, {}
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._run_agent = run_agent
+    service = adapter._session_turn_service
+    original_watcher = service._interrupt_when_available
+    watcher_calls = 0
+
+    async def fail_once_then_interrupt(turn_id):
+        nonlocal watcher_calls
+        watcher_calls += 1
+        if watcher_calls == 1:
+            first_watcher_finished.set()
+            if failure_kind == "exception":
+                raise RuntimeError("private watcher retry secret")
+            raise asyncio.CancelledError
+        retry_watcher_started.set()
+        await original_watcher(turn_id)
+
+    monkeypatch.setattr(service, "_interrupt_when_available", fail_once_then_interrupt)
+    turn_id = f"turn-stop-watcher-{failure_kind}-retry"
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        submitted = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": turn_id},
+            json=_payload(),
+        )
+        assert submitted.status == 202
+        await asyncio.wait_for(runner_entered.wait(), 1)
+
+        first = await client.post(f"/api/sessions/s1/turns/{turn_id}/stop")
+        assert first.status == 202
+        await asyncio.wait_for(first_watcher_finished.wait(), 1)
+        for _ in range(10):
+            if turn_id not in service._interruption_owners:
+                break
+            await asyncio.sleep(0)
+        assert turn_id not in service._interruption_owners
+        assert turn_id not in service._interruption_watcher_owners
+
+        retries = await asyncio.gather(
+            *[
+                client.post(f"/api/sessions/s1/turns/{turn_id}/stop")
+                for _ in range(8)
+            ]
+        )
+        assert all(response.status == 202 for response in retries)
+        await asyncio.wait_for(retry_watcher_started.wait(), 1)
+        assert watcher_calls == 2
+
+        publish_agent.set()
+        await asyncio.wait_for(interrupted.wait(), 1)
+        assert agent.interrupts == 1
+        assert turn_id in service._interruption_owners
+
+        worker_release.set()
+        await service.wait_for_turn(turn_id)
+        terminal = await client.get(f"/api/sessions/s1/turns/{turn_id}")
+        assert terminal.status == 200
+        assert (await terminal.json())["turn"]["status"] == "interrupted"
+
+    assert watcher_calls == 2
+    assert agent.interrupts == 1
+    assert turn_id not in service._interruption_owners
+    assert turn_id not in service._interruption_watcher_owners
+    assert "session_turn_interrupt_watcher_failed" in caplog.text
+    assert f"reason={expected_reason}" in caplog.text
+    assert "private watcher retry secret" not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_concurrent_repeated_stop_records_and_watches_once(session_db, monkeypatch):
     gate = asyncio.Event()
 

--- a/tests/gateway/test_session_turns.py
+++ b/tests/gateway/test_session_turns.py
@@ -27,6 +27,7 @@ from gateway.platforms.session_turns import (
     project_safe_tool_event,
     resolve_slack_binding,
 )
+from gateway.session_execution_lease import SessionExecutionLease
 from hermes_state import SessionDB
 
 
@@ -51,6 +52,48 @@ def _png(width: int = 1, height: int = 1) -> str:
     raw += chunk(b"IDAT", zlib.compress(b"\x00\x00\x00\x00\x00"))
     raw += chunk(b"IEND", b"")
     return "data:image/png;base64," + base64.b64encode(raw).decode()
+
+
+@pytest.mark.asyncio
+async def test_execution_lease_release_survives_repeated_cancellation(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    entered = threading.Event()
+    unblock = threading.Event()
+    original_release = session_db.release_session_execution_lease
+    release_calls = 0
+
+    def blocked_release(session_id, owner_id):
+        nonlocal release_calls
+        release_calls += 1
+        entered.set()
+        unblock.wait(timeout=2)
+        return original_release(session_id, owner_id)
+
+    monkeypatch.setattr(session_db, "release_session_execution_lease", blocked_release)
+    lease = await SessionExecutionLease.acquire(
+        session_db, "s1", owner_prefix="repeated-cancel"
+    )
+
+    try:
+        for _ in range(3):
+            waiter = asyncio.create_task(lease.release())
+            assert await asyncio.to_thread(entered.wait, 1)
+            waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+            assert lease._released is True
+            assert lease._release_task is not None
+            assert not lease._release_task.cancelled()
+            assert session_db.get_session_execution_lease("s1") is not None
+    finally:
+        unblock.set()
+
+    assert await lease.release() is True
+    assert release_calls == 1
+    assert lease._release_task is not None and lease._release_task.done()
+    assert lease._heartbeat_task is not None and lease._heartbeat_task.done()
+    assert session_db.get_session_execution_lease("s1") is None
 
 
 def test_duplicate_submit_reuses_same_turn_without_second_reservation(session_db):
@@ -1207,6 +1250,9 @@ async def test_slow_observer_never_blocks_post_worker_or_lease_release(
         return {"final_response": "done"}, {}
 
     adapter._run_agent = run_agent
+    # Exclude one-time ledger/SQLite initialization from the observer latency
+    # assertion; this test measures only turn admission with a hung callback.
+    await adapter._session_turn_service.reconcile_startup()
     async with TestClient(TestServer(_app(adapter))) as client:
         started_at = time.perf_counter()
         response = await client.post(
@@ -1216,15 +1262,100 @@ async def test_slow_observer_never_blocks_post_worker_or_lease_release(
         )
         elapsed = time.perf_counter() - started_at
         assert response.status == 202
-        assert elapsed < 0.1
+        assert elapsed < 0.5  # Far below the callback's two-second block.
         assert await asyncio.to_thread(entered.wait, 1)
         await adapter._session_turn_service.wait_for_turn("slow-observer")
 
     assert SessionTurnStore(session_db).get("slow-observer")["status"] == "completed"
     assert session_db.get_session_execution_lease("s1") is None
+    assert "slow-observer" not in adapter._session_turn_service._lifecycle_dispatchers
     release.set()
-    dispatcher = adapter._session_turn_service._lifecycle_dispatchers["slow-observer"]
-    assert await asyncio.to_thread(dispatcher.flush, 1)
+
+
+@pytest.mark.asyncio
+async def test_hung_observer_many_turns_has_fixed_capacity_and_no_dispatcher_leaks(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    import gateway.platforms.session_turns as session_turns
+
+    release = threading.Event()
+    entered = 0
+    entered_lock = threading.Lock()
+    baseline = session_turns.session_turn_lifecycle_metrics()
+    stats = session_turns.session_turn_lifecycle_executor_stats()
+    turn_count = stats["workers"] + stats["pending_capacity"] + 12
+
+    def hung_observer(hook, **_kwargs):
+        nonlocal entered
+        if hook == "session_turn_lifecycle":
+            with entered_lock:
+                entered += 1
+            release.wait(timeout=5)
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", hung_observer)
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    for index in range(1, turn_count):
+        session_db.create_session(f"bounded-{index}", "api_server")
+
+    async def run_agent(**kwargs):
+        session_id = kwargs["session_id"]
+        session_db.append_message(session_id, "user", kwargs["user_message"])
+        session_db.append_message(session_id, "assistant", "done")
+        return {"final_response": "done"}, {}
+
+    adapter._run_agent = run_agent
+    try:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            responses = await asyncio.gather(
+                *[
+                    client.post(
+                        f"/api/sessions/{'s1' if index == 0 else f'bounded-{index}'}/turns",
+                        headers={"Idempotency-Key": f"bounded-turn-{index}"},
+                        json=_payload(),
+                    )
+                    for index in range(turn_count)
+                ]
+            )
+            assert {response.status for response in responses} == {202}
+            await asyncio.gather(
+                *[
+                    adapter._session_turn_service.wait_for_turn(f"bounded-turn-{index}")
+                    for index in range(turn_count)
+                ]
+            )
+
+        executor = session_turns.session_turn_lifecycle_executor_stats()
+        assert executor["active"] <= executor["workers"]
+        assert executor["pending"] <= executor["pending_capacity"]
+        assert len(
+            [
+                thread
+                for thread in threading.enumerate()
+                if thread.name.startswith("session-turn-lifecycle-")
+            ]
+        ) == executor["workers"]
+        assert entered <= executor["workers"]
+        assert (
+            session_turns.session_turn_lifecycle_metrics()[
+                "observer_capacity_exhausted"
+            ]
+            > baseline["observer_capacity_exhausted"]
+        )
+        assert adapter._session_turn_service._lifecycle_dispatchers == {}
+    finally:
+        release.set()
+
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        executor = session_turns.session_turn_lifecycle_executor_stats()
+        if executor["active"] == 0 and executor["pending"] == 0:
+            break
+        await asyncio.sleep(0.01)
+    assert session_turns.session_turn_lifecycle_executor_stats()["active"] == 0
+    assert session_turns.session_turn_lifecycle_executor_stats()["pending"] == 0
 
 
 def test_lifecycle_dispatcher_backpressure_drops_only_heartbeats_and_logs_metric(

--- a/tests/gateway/test_session_turns.py
+++ b/tests/gateway/test_session_turns.py
@@ -1108,3 +1108,371 @@ async def test_native_lifecycle_maps_terminal_outcome_without_error_text(
         "terminal_outcome",
     }
     assert "secret" not in repr(terminal)
+
+
+@pytest.mark.asyncio
+async def test_coordinator_cancellation_retains_worker_heartbeat_lease_and_terminal_truth(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    """Cancelling asyncio ownership must not abandon a live executor worker."""
+    import gateway.platforms.session_turns as session_turns
+
+    lifecycle = []
+    worker_started = threading.Event()
+    worker_release = threading.Event()
+    worker_exited = threading.Event()
+    agent = MagicMock()
+
+    def capture(hook, **kwargs):
+        if hook == "session_turn_lifecycle":
+            lifecycle.append(dict(kwargs["dto"]))
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", capture)
+    monkeypatch.setattr(session_turns, "SESSION_TURN_HEARTBEAT_INTERVAL_SECONDS", 0.01)
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    async def run_agent(**kwargs):
+        def worker():
+            kwargs["agent_ref"][0] = agent
+            worker_started.set()
+            worker_release.wait(timeout=2)
+            session_db.append_message("s1", "user", kwargs["user_message"])
+            session_db.append_message("s1", "assistant", "late result")
+            worker_exited.set()
+            return {
+                "final_response": "late result",
+                "messages": session_db.get_messages_as_conversation("s1"),
+            }, {}
+
+        return await asyncio.to_thread(worker)
+
+    adapter._run_agent = run_agent
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "cancel-live-worker"},
+            json=_payload(),
+        )
+        assert response.status == 202
+        assert await asyncio.to_thread(worker_started.wait, 1)
+        coordinator = adapter._session_turn_service._tasks["cancel-live-worker"]
+        coordinator.cancel()
+        await asyncio.sleep(0.04)
+
+        row = SessionTurnStore(session_db).get("cancel-live-worker")
+        assert row["status"] == "stopping"
+        assert not worker_exited.is_set()
+        assert session_db.get_session_execution_lease("s1") is not None
+        before = sum(item["event"] == "heartbeat" for item in lifecycle)
+        await asyncio.sleep(0.03)
+        after = sum(item["event"] == "heartbeat" for item in lifecycle)
+        assert after > before
+        assert not [item for item in lifecycle if item["event"] == "terminal"]
+
+        worker_release.set()
+        await adapter._session_turn_service.wait_for_turn("cancel-live-worker")
+
+    assert worker_exited.is_set()
+    assert session_db.get_session_execution_lease("s1") is None
+    row = SessionTurnStore(session_db).get("cancel-live-worker")
+    assert row["status"] == "interrupted"
+    terminal = [item for item in lifecycle if item["event"] == "terminal"]
+    assert len(terminal) == 1
+    assert terminal[0]["terminal_outcome"] == "cancelled"
+    assert agent.interrupt.call_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_slow_observer_never_blocks_post_worker_or_lease_release(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    entered = threading.Event()
+    release = threading.Event()
+
+    def slow_observer(hook, **_kwargs):
+        if hook == "session_turn_lifecycle" and not entered.is_set():
+            entered.set()
+            release.wait(timeout=2)
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", slow_observer)
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    async def run_agent(**kwargs):
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", "done")
+        return {"final_response": "done"}, {}
+
+    adapter._run_agent = run_agent
+    async with TestClient(TestServer(_app(adapter))) as client:
+        started_at = time.perf_counter()
+        response = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "slow-observer"},
+            json=_payload(),
+        )
+        elapsed = time.perf_counter() - started_at
+        assert response.status == 202
+        assert elapsed < 0.1
+        assert await asyncio.to_thread(entered.wait, 1)
+        await adapter._session_turn_service.wait_for_turn("slow-observer")
+
+    assert SessionTurnStore(session_db).get("slow-observer")["status"] == "completed"
+    assert session_db.get_session_execution_lease("s1") is None
+    release.set()
+    dispatcher = adapter._session_turn_service._lifecycle_dispatchers["slow-observer"]
+    assert await asyncio.to_thread(dispatcher.flush, 1)
+
+
+def test_lifecycle_dispatcher_backpressure_drops_only_heartbeats_and_logs_metric(
+    monkeypatch: pytest.MonkeyPatch
+):
+    import gateway.platforms.session_turns as session_turns
+
+    entered = threading.Event()
+    release = threading.Event()
+    lifecycle = []
+    baseline = session_turns.session_turn_lifecycle_metrics()
+
+    def blocked(hook, **kwargs):
+        if hook == "session_turn_lifecycle":
+            lifecycle.append(dict(kwargs["dto"]))
+            if kwargs["dto"]["event"] == "registered":
+                entered.set()
+                release.wait(timeout=2)
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", blocked)
+    monkeypatch.setattr(session_turns, "SESSION_TURN_LIFECYCLE_QUEUE_SIZE", 4)
+    dispatcher = session_turns.SessionTurnLifecycleDispatcher("safe-session", "safe-turn")
+    assert entered.wait(timeout=1)
+    assert dispatcher.emit("started")
+    for _ in range(20):
+        dispatcher.emit("heartbeat")
+    assert dispatcher.close("succeeded")
+
+    metrics = session_turns.session_turn_lifecycle_metrics()
+    assert metrics["heartbeat_dropped"] > baseline["heartbeat_dropped"]
+    release.set()
+    assert dispatcher.flush(timeout=1)
+    names = [item["event"] for item in lifecycle]
+    assert names[0:2] == ["registered", "started"]
+    assert names[-1] == "terminal"
+    assert names.count("terminal") == 1
+
+
+@pytest.mark.asyncio
+async def test_lease_loss_emits_one_cancelled_terminal_after_worker_exit(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    lifecycle = []
+    fake_lease = MagicMock()
+    fake_lease.still_owned = AsyncMock(return_value=False)
+    fake_lease.release = AsyncMock(return_value=False)
+
+    def capture(hook, **kwargs):
+        if hook == "session_turn_lifecycle":
+            lifecycle.append(dict(kwargs["dto"]))
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", capture)
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._acquire_session_execution_lease = AsyncMock(return_value=fake_lease)
+
+    async def run_agent(**kwargs):
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", "untrusted after lease loss")
+        return {"final_response": "untrusted after lease loss"}, {}
+
+    adapter._run_agent = run_agent
+    async with TestClient(TestServer(_app(adapter))) as client:
+        await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "lease-loss-once"},
+            json=_payload(),
+        )
+        await adapter._session_turn_service.wait_for_turn("lease-loss-once")
+
+    row = SessionTurnStore(session_db).get("lease-loss-once")
+    assert row["status"] == "interrupted"
+    assert row["safe_error_code"] == "execution_lease_lost"
+    terminal = [item for item in lifecycle if item["event"] == "terminal"]
+    assert len(terminal) == 1
+    assert terminal[0]["terminal_outcome"] == "cancelled"
+    fake_lease.release.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_history_read_failure_lifecycle_is_registered_started_terminal(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    lifecycle = []
+
+    def capture(hook, **kwargs):
+        if hook == "session_turn_lifecycle":
+            lifecycle.append(dict(kwargs["dto"]))
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", capture)
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._conversation_history_for_session = AsyncMock(
+        side_effect=RuntimeError("private history failure")
+    )
+    async with TestClient(TestServer(_app(adapter))) as client:
+        await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "history-lifecycle"},
+            json=_payload(),
+        )
+        await adapter._session_turn_service.wait_for_turn("history-lifecycle")
+
+    assert [item["event"] for item in lifecycle] == ["registered", "started", "terminal"]
+    assert lifecycle[-1]["terminal_outcome"] == "failed"
+    assert "private" not in repr(lifecycle)
+
+
+@pytest.mark.asyncio
+async def test_simultaneous_duplicate_posts_register_and_execute_once(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    lifecycle = []
+    calls = 0
+    release = asyncio.Event()
+
+    def capture(hook, **kwargs):
+        if hook == "session_turn_lifecycle":
+            lifecycle.append(dict(kwargs["dto"]))
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", capture)
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    async def run_agent(**kwargs):
+        nonlocal calls
+        calls += 1
+        await release.wait()
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", "once")
+        return {"final_response": "once"}, {}
+
+    adapter._run_agent = run_agent
+    async with TestClient(TestServer(_app(adapter))) as client:
+        responses = await asyncio.gather(*[
+            client.post(
+                "/api/sessions/s1/turns",
+                headers={"Idempotency-Key": "duplicate-race"},
+                json=_payload(),
+            )
+            for _ in range(2)
+        ])
+        release.set()
+        await adapter._session_turn_service.wait_for_turn("duplicate-race")
+
+    assert sorted(response.status for response in responses) == [200, 202]
+    assert calls == 1
+    assert sum(item["event"] == "registered" for item in lifecycle) == 1
+    assert sum(item["event"] == "terminal" for item in lifecycle) == 1
+
+
+@pytest.mark.asyncio
+async def test_startup_preserves_live_owner_without_adoption_or_lifecycle(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    store = SessionTurnStore(session_db)
+    store.reserve("s1", "foreign-live", _payload())
+    store.set_running("foreign-live")
+    assert session_db.acquire_session_execution_lease("s1", "foreign-owner", ttl_seconds=30)
+    lifecycle = []
+    monkeypatch.setattr(
+        "hermes_cli.plugins.invoke_hook",
+        lambda hook, **kwargs: lifecycle.append((hook, kwargs)),
+    )
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    await adapter._session_turn_service.reconcile_startup()
+
+    assert store.get("foreign-live")["status"] == "running"
+    assert adapter._session_turn_service._tasks == {}
+    assert lifecycle == []
+
+
+@pytest.mark.asyncio
+async def test_api_root_turn_identity_reaches_child_parent_turn_id_end_to_end(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    """The admitted API identity, not a synthesized task id, parents children."""
+    from tools import delegate_tool
+
+    lifecycle = []
+    parent = MagicMock()
+    parent.session_id = "s1"
+    parent._delegate_depth = 0
+    parent.base_url = "https://example.invalid/v1"
+    parent.api_key = "key"
+    parent.model = "model"
+    parent.provider = "openai"
+    parent.api_mode = "chat_completions"
+    parent.reasoning_config = {"enabled": False}
+    parent.enabled_toolsets = []
+    parent.disabled_toolsets = []
+    parent.prefill_messages = None
+    parent._fallback_chain = []
+    parent.request_overrides = {}
+    parent.openrouter_min_coding_score = None
+    child = MagicMock()
+    child.session_id = "child-session"
+
+    def capture(hook, **kwargs):
+        if hook in {"session_turn_lifecycle", "subagent_lifecycle"}:
+            lifecycle.append((hook, dict(kwargs["dto"])))
+        return []
+
+    def run_conversation(*, user_message, **_kwargs):
+        # This assignment is the real turn-prologue contract in
+        # build_turn_context; its focused test covers consumption/reset.
+        parent._current_turn_id = parent._authoritative_turn_id
+        delegate_tool._build_child_agent(
+            task_index=0,
+            goal="private child goal",
+            context=None,
+            toolsets=None,
+            model=None,
+            max_iterations=2,
+            parent_agent=parent,
+            task_count=1,
+        )
+        session_db.append_message("s1", "user", user_message)
+        session_db.append_message("s1", "assistant", "done")
+        return {"final_response": "done"}
+
+    parent.run_conversation.side_effect = run_conversation
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", capture)
+    monkeypatch.setattr("run_agent.AIAgent", MagicMock(return_value=child))
+    monkeypatch.setattr(delegate_tool, "_resolve_child_credential_pool", lambda *_args: None)
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    monkeypatch.setattr(adapter, "_create_agent", MagicMock(return_value=parent))
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "root-authoritative-turn"},
+            json=_payload(),
+        )
+        assert response.status == 202
+        await adapter._session_turn_service.wait_for_turn("root-authoritative-turn")
+
+    registered_children = [
+        dto for hook, dto in lifecycle
+        if hook == "subagent_lifecycle" and dto["event"] == "registered"
+    ]
+    assert len(registered_children) == 1
+    assert registered_children[0]["parent_turn_id"] == "root-authoritative-turn"
+    assert "private child goal" not in repr(registered_children)

--- a/tests/gateway/test_session_turns.py
+++ b/tests/gateway/test_session_turns.py
@@ -217,6 +217,131 @@ async def test_slow_callback_store_applies_bounded_worker_backpressure_and_recov
 
 
 @pytest.mark.asyncio
+async def test_loop_thread_full_persists_exact_resync_before_terminal(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    import gateway.platforms.session_turns as session_turns
+
+    monkeypatch.setattr(session_turns, "SESSION_TURN_CALLBACK_QUEUE_SIZE", 1)
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    service = adapter._session_turn_service
+    store = SessionTurnStore(session_db)
+    turn_id = "loop-thread-structural-full"
+    store.reserve("s1", turn_id, _payload())
+    first_write_entered = threading.Event()
+    release_store = threading.Event()
+    original_append = store.append_event
+
+    def blocked_append(tid, event_type, data):
+        if event_type == "tool.started" and data.get("tool_call_id") == "call-1":
+            first_write_entered.set()
+            release_store.wait(timeout=2)
+        return original_append(tid, event_type, data)
+
+    monkeypatch.setattr(store, "append_event", blocked_append)
+
+    async def run_agent(**kwargs):
+        # These callbacks deliberately run on the owner loop. The pump consumes
+        # the first event and blocks in its store thread; the second fills the
+        # sole queue slot, so the third must become the durable missing range.
+        kwargs["tool_start_callback"]("call-1", "terminal", {})
+        assert await asyncio.to_thread(first_write_entered.wait, 1)
+        kwargs["tool_complete_callback"]("call-1", "terminal", {}, "ok")
+        try:
+            kwargs["tool_start_callback"]("call-2", "terminal", {})
+        finally:
+            release_store.set()
+
+    adapter._run_agent = run_agent
+    service._admit_execution(store, turn_id, "s1", _payload(), None, None)
+    await service.wait_for_turn(turn_id)
+
+    events = store.events_after(turn_id, 0)
+    names = [event["event"] for event in events]
+    marker = next(event for event in events if event["event"] == "session.resync_required")
+    assert marker["data"] == {
+        "reason": "structural_events_lost",
+        "missing_from": 3,
+        "missing_through": 3,
+    }
+    assert names.index("tool.completed") < names.index("session.resync_required")
+    assert names.index("session.resync_required") < names.index("turn.failed")
+    assert store.get(turn_id)["status"] == "failed"
+
+
+def test_callback_thread_on_stopped_loop_fails_bounded_and_marks_resync():
+    import gateway.platforms.session_turns as session_turns
+
+    loop = asyncio.new_event_loop()
+    ingress_holder = []
+    started = threading.Event()
+
+    def own_loop():
+        asyncio.set_event_loop(loop)
+        ingress_holder.append(session_turns._CallbackPersistenceIngress(loop, 1))
+        started.set()
+        loop.run_forever()
+
+    owner = threading.Thread(target=own_loop)
+    owner.start()
+    assert started.wait(timeout=1)
+    ingress = ingress_holder[0]
+    loop.call_soon_threadsafe(loop.stop)
+    owner.join(timeout=1)
+    assert not owner.is_alive()
+
+    before = time.monotonic()
+    with pytest.raises(session_turns._CallbackPersistenceOverloaded):
+        ingress.append_structural("tool.started", {"tool_call_id": "call-1"})
+    assert time.monotonic() - before < 0.5
+    assert ingress.structural_resync_range == (1, 1)
+    assert ingress.queue.empty()
+    loop.close()
+
+
+def test_callback_thread_timeout_cancels_pending_enqueue_without_late_insert(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import gateway.platforms.session_turns as session_turns
+
+    monkeypatch.setattr(
+        session_turns, "SESSION_TURN_CALLBACK_ENQUEUE_TIMEOUT_SECONDS", 0.05
+    )
+    loop = asyncio.new_event_loop()
+    ingress_holder = []
+    blocked = threading.Event()
+    release = threading.Event()
+    processed = threading.Event()
+
+    def own_loop():
+        asyncio.set_event_loop(loop)
+        ingress = session_turns._CallbackPersistenceIngress(loop, 1)
+        ingress.append_structural("tool.started", {"tool_call_id": "retained"})
+        ingress_holder.append(ingress)
+        loop.call_soon(lambda: (blocked.set(), release.wait(timeout=1)))
+        loop.run_forever()
+
+    owner = threading.Thread(target=own_loop)
+    owner.start()
+    assert blocked.wait(timeout=1)
+    ingress = ingress_holder[0]
+
+    with pytest.raises(session_turns._CallbackPersistenceOverloaded):
+        ingress.append_structural("tool.completed", {"tool_call_id": "rejected"})
+    assert ingress.structural_resync_range == (2, 2)
+    release.set()
+    loop.call_soon_threadsafe(processed.set)
+    assert processed.wait(timeout=1)
+    assert ingress.queue.qsize() == 1
+    assert ingress.queue.get_nowait().data["tool_call_id"] == "retained"
+    loop.call_soon_threadsafe(loop.stop)
+    owner.join(timeout=1)
+    assert not owner.is_alive()
+    loop.close()
+
+
+@pytest.mark.asyncio
 async def test_failing_callback_store_never_overtakes_retained_structure_and_recovers(
     session_db, monkeypatch: pytest.MonkeyPatch
 ):
@@ -1012,6 +1137,49 @@ async def test_stop_reports_stopping_until_worker_actually_exits(session_db):
         await adapter._session_turn_service.wait_for_turn("turn-stop")
         final = await client.get("/api/sessions/s1/turns/turn-stop")
         assert (await final.json())["turn"]["status"] == "interrupted"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_repeated_stop_records_and_watches_once(session_db, monkeypatch):
+    gate = asyncio.Event()
+
+    async def run_agent(**_kwargs):
+        await gate.wait()
+        return {"failed": True}, {}
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._run_agent = run_agent
+    service = adapter._session_turn_service
+    watcher_started = 0
+
+    async def counted_watcher(_turn_id):
+        nonlocal watcher_started
+        watcher_started += 1
+        await gate.wait()
+
+    monkeypatch.setattr(service, "_interrupt_when_available", counted_watcher)
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        submitted = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-stop-concurrent"},
+            json=_payload(),
+        )
+        assert submitted.status == 202
+        await asyncio.sleep(0)
+        responses = await asyncio.gather(*[
+            client.post("/api/sessions/s1/turns/turn-stop-concurrent/stop")
+            for _ in range(8)
+        ])
+        assert all(response.status == 202 for response in responses)
+        public = [(await response.json())["turn"] for response in responses]
+        assert all(turn["status"] == "stopping" for turn in public)
+        assert watcher_started == 1
+        events = SessionTurnStore(session_db).events_after("turn-stop-concurrent", 0)
+        assert [event["event"] for event in events].count("turn.stopping") == 1
+        gate.set()
+        await service.wait_for_turn("turn-stop-concurrent")
 
 
 def test_no_transcript_duplication_store_has_no_content_columns(session_db):

--- a/tests/gateway/test_session_turns.py
+++ b/tests/gateway/test_session_turns.py
@@ -1228,6 +1228,97 @@ async def test_coordinator_cancellation_retains_worker_heartbeat_lease_and_termi
 
 
 @pytest.mark.asyncio
+async def test_immediate_prestart_cancellation_reclaims_all_lifecycle_capacity(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    """Never-entered coordinators still durably terminate and drain observers."""
+    import gateway.platforms.session_turns as session_turns
+
+    lifecycle = []
+
+    def capture(hook, **kwargs):
+        if hook == "session_turn_lifecycle":
+            lifecycle.append(dict(kwargs["dto"]))
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", capture)
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    service = adapter._session_turn_service
+    store = SessionTurnStore(session_db)
+    admitted: dict[str, bool] = {}
+    tasks = []
+
+    # No await occurs between create_task and cancel: all 80 coordinators are
+    # deterministically cancelled before their coroutine's first instruction.
+    for index in range(80):
+        session_id = "s1" if index == 0 else f"prestart-session-{index}"
+        if index:
+            session_db.create_session(session_id, "api_server")
+        turn_id = f"prestart-turn-{index}"
+        store.reserve(session_id, turn_id, _payload(turn_id))
+        task = service._admit_execution(
+            store, turn_id, session_id, _payload(turn_id), None, None
+        )
+        admitted[turn_id] = service._lifecycle_dispatchers[turn_id]._admitted
+        task.cancel()
+        tasks.append(task)
+
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        stats = session_turns.session_turn_lifecycle_executor_stats()
+        if (
+            not service._tasks
+            and not service._lifecycle_dispatchers
+            and stats["active"] == 0
+            and stats["pending"] == 0
+        ):
+            break
+        await asyncio.sleep(0.01)
+
+    assert service._tasks == {}
+    assert service._lifecycle_dispatchers == {}
+    stats = session_turns.session_turn_lifecycle_executor_stats()
+    assert stats["active"] == stats["pending"] == 0
+
+    by_turn = {
+        turn_id: [item for item in lifecycle if item["turn_id"] == turn_id]
+        for turn_id in admitted
+    }
+    for turn_id, was_admitted in admitted.items():
+        row = store.get(turn_id)
+        assert row["status"] == "interrupted"
+        assert row["safe_error_code"] == "cancelled_before_execution"
+        events = by_turn[turn_id]
+        if was_admitted:
+            assert [item["event"] for item in events] == ["registered", "terminal"]
+            assert events[-1]["terminal_outcome"] == "cancelled"
+        else:
+            # Executor saturation is the contract's explicit observer fail-open.
+            assert events == []
+
+    # Recovered observer/executor capacity must support a complete later turn.
+    async def run_agent(**kwargs):
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", "recovered")
+        return {"final_response": "recovered"}, {}
+
+    adapter._run_agent = run_agent
+    normal_id = "post-prestart-normal"
+    store.reserve("s1", normal_id, _payload("normal"))
+    service._admit_execution(store, normal_id, "s1", _payload("normal"), None, None)
+    await service.wait_for_turn(normal_id)
+    normal = [item for item in lifecycle if item["turn_id"] == normal_id]
+    assert store.get(normal_id)["status"] == "completed"
+    assert [item["event"] for item in normal] == ["registered", "started", "terminal"]
+    assert normal[-1]["terminal_outcome"] == "succeeded"
+    assert service._tasks == {}
+    assert service._lifecycle_dispatchers == {}
+
+
+@pytest.mark.asyncio
 async def test_slow_observer_never_blocks_post_worker_or_lease_release(
     session_db, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/gateway/test_session_turns.py
+++ b/tests/gateway/test_session_turns.py
@@ -955,3 +955,156 @@ async def test_slack_only_turn_never_exposes_assistant_deltas_to_occ(session_db)
 
     assert "assistant.delta" not in wire
     assert "must not reach OCC" not in wire
+
+
+@pytest.mark.asyncio
+async def test_native_lifecycle_orders_heartbeats_and_distinguishes_sequential_turns(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    import gateway.platforms.session_turns as session_turns
+
+    lifecycle = []
+
+    def capture(hook, **kwargs):
+        if hook == "session_turn_lifecycle":
+            lifecycle.append(dict(kwargs["dto"]))
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", capture)
+    monkeypatch.setattr(session_turns, "SESSION_TURN_HEARTBEAT_INTERVAL_SECONDS", 0.01)
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    async def run_agent(**kwargs):
+        native_id = kwargs["authoritative_turn_id"]
+        await asyncio.sleep(0.035)
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", native_id)
+        return {
+            "final_response": native_id,
+            "messages": session_db.get_messages_as_conversation("s1"),
+        }, {}
+
+    adapter._run_agent = run_agent
+    async with TestClient(TestServer(_app(adapter))) as client:
+        for turn_id in ("native-turn-a", "native-turn-b"):
+            response = await client.post(
+                "/api/sessions/s1/turns",
+                headers={"Idempotency-Key": turn_id},
+                json=_payload(turn_id),
+            )
+            assert response.status == 202
+            await adapter._session_turn_service.wait_for_turn(turn_id)
+
+    assert {dto["turn_id"] for dto in lifecycle} == {
+        "native-turn-a",
+        "native-turn-b",
+    }
+    for turn_id in ("native-turn-a", "native-turn-b"):
+        events = [dto for dto in lifecycle if dto["turn_id"] == turn_id]
+        assert events[0]["event"] == "registered"
+        assert events[1]["event"] == "started"
+        assert "heartbeat" in [dto["event"] for dto in events[2:-1]]
+        assert events[-1]["event"] == "terminal"
+        assert events[-1]["terminal_outcome"] == "succeeded"
+        assert sum(dto["event"] == "terminal" for dto in events) == 1
+        assert [dto["sequence"] for dto in events] == sorted(
+            dto["sequence"] for dto in events
+        )
+        assert len({dto["sequence"] for dto in events}) == len(events)
+        assert {dto["session_id"] for dto in events} == {"s1"}
+
+
+@pytest.mark.asyncio
+async def test_native_lifecycle_observer_failure_is_fail_open(session_db, monkeypatch):
+    def broken_observer(hook, **kwargs):
+        if hook == "session_turn_lifecycle":
+            raise RuntimeError("observer secret must not affect the turn")
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", broken_observer)
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    async def run_agent(**kwargs):
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", "done")
+        return {
+            "final_response": "done",
+            "messages": session_db.get_messages_as_conversation("s1"),
+        }, {}
+
+    adapter._run_agent = run_agent
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "observer-fail-open"},
+            json=_payload(),
+        )
+        await adapter._session_turn_service.wait_for_turn("observer-fail-open")
+        status = await client.get("/api/sessions/s1/turns/observer-fail-open")
+        turn = (await status.json())["turn"]
+
+    assert response.status == 202
+    assert turn["status"] == "completed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stop", "expected_outcome"),
+    [(False, "failed"), (True, "cancelled")],
+)
+async def test_native_lifecycle_maps_terminal_outcome_without_error_text(
+    session_db, monkeypatch: pytest.MonkeyPatch, stop, expected_outcome
+):
+    lifecycle = []
+
+    def capture(hook, **kwargs):
+        if hook == "session_turn_lifecycle":
+            lifecycle.append(dict(kwargs["dto"]))
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", capture)
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    lease_gate = asyncio.Event()
+    if stop:
+        adapter._run_agent = AsyncMock()
+        acquire_lease = adapter._acquire_session_execution_lease
+
+        async def delayed_acquire(*args, **kwargs):
+            await lease_gate.wait()
+            return await acquire_lease(*args, **kwargs)
+
+        monkeypatch.setattr(adapter, "_acquire_session_execution_lease", delayed_acquire)
+    else:
+        adapter._run_agent = AsyncMock(side_effect=RuntimeError("raw provider secret"))
+
+    turn_id = f"terminal-{expected_outcome}"
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": turn_id},
+            json=_payload(),
+        )
+        assert response.status == 202
+        if stop:
+            # request_stop before the scheduled worker starts is an authoritative
+            # cancelled-before-start result.
+            await client.post(f"/api/sessions/s1/turns/{turn_id}/stop")
+            lease_gate.set()
+        await adapter._session_turn_service.wait_for_turn(turn_id)
+
+    terminal = [dto for dto in lifecycle if dto["event"] == "terminal"]
+    assert len(terminal) == 1
+    assert terminal[0]["terminal_outcome"] == expected_outcome
+    assert set(terminal[0]) == {
+        "contract_version",
+        "event",
+        "occurred_at",
+        "sequence",
+        "session_id",
+        "turn_id",
+        "terminal_outcome",
+    }
+    assert "secret" not in repr(terminal)

--- a/tests/gateway/test_session_turns.py
+++ b/tests/gateway/test_session_turns.py
@@ -21,6 +21,7 @@ from gateway.platforms.api_server import APIServerAdapter
 from gateway.platforms.base import SendResult
 from gateway.platforms.session_turns import (
     ConflictingTurn,
+    SlackBinding,
     SessionTurnStore,
     TurnConflict,
     TurnInputError,
@@ -1359,6 +1360,159 @@ async def test_blocking_finalize_store_does_not_block_event_loop(
     await service.wait_for_turn(turn_id)
 
     assert store.get(turn_id)["status"] == "interrupted"
+
+
+@pytest.mark.asyncio
+async def test_blocking_delivery_store_does_not_block_loop_and_keeps_state_event_order(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    service = adapter._session_turn_service
+    store = SessionTurnStore(session_db)
+    store.reserve("s1", "blocking-delivery", _payload(mode="both"))
+    entered = threading.Event()
+    release = threading.Event()
+    original_begin = store.begin_delivery
+
+    def blocking_begin(*args, **kwargs):
+        entered.set()
+        release.wait(timeout=2)
+        return original_begin(*args, **kwargs)
+
+    monkeypatch.setattr(store, "begin_delivery", blocking_begin)
+    binding = SlackBinding(chat_id="safe", thread_id=None, metadata={})
+    delivery = asyncio.create_task(
+        service._deliver_slack(
+            store,
+            "blocking-delivery",
+            binding,
+            AsyncMock(),
+            "x" * 3_001,
+        )
+    )
+    assert await asyncio.to_thread(entered.wait, 1)
+
+    ticked = asyncio.Event()
+    asyncio.get_running_loop().call_later(0.02, ticked.set)
+    await asyncio.wait_for(ticked.wait(), 0.1)
+    release.set()
+    await delivery
+
+    persisted = store.get_delivery("blocking-delivery", "slack")
+    events = store.events_after("blocking-delivery", 0)
+    assert persisted is not None and persisted["state"] == "rejected"
+    assert [event["event"] for event in events] == ["delivery.failed"]
+    assert events[0]["data"]["status"] == persisted["state"]
+
+
+@pytest.mark.asyncio
+async def test_blocking_stop_store_does_not_block_aiohttp_loop(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    service = adapter._session_turn_service
+    await service.reconcile_startup()
+    store = await service._store()
+    assert store is not None
+    store.reserve("s1", "blocking-stop", _payload())
+    entered = threading.Event()
+    release = threading.Event()
+    original_stop = store.request_stop
+
+    def blocking_stop(*args, **kwargs):
+        entered.set()
+        release.wait(timeout=2)
+        return original_stop(*args, **kwargs)
+
+    monkeypatch.setattr(store, "request_stop", blocking_stop)
+    async with TestClient(TestServer(_app(adapter))) as client:
+        stop_task = asyncio.create_task(
+            client.post("/api/sessions/s1/turns/blocking-stop/stop")
+        )
+        assert await asyncio.to_thread(entered.wait, 1)
+        capability = await asyncio.wait_for(client.get("/v1/capabilities"), 0.2)
+        assert capability.status == 200
+        release.set()
+        response = await stop_task
+        body = await response.json()
+
+    assert response.status == 202
+    assert body["turn"]["status"] == "stopping"
+    assert [event["event"] for event in store.events_after("blocking-stop", 0)] == [
+        "turn.stopping"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_store_operations_preserve_submission_order(session_db):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    service = adapter._session_turn_service
+    first_entered = threading.Event()
+    first_release = threading.Event()
+    observed = []
+
+    def first():
+        observed.append("first-start")
+        first_entered.set()
+        first_release.wait(timeout=2)
+        observed.append("first-end")
+
+    def second():
+        observed.append("second")
+
+    first_task = asyncio.create_task(service._store_operation(first))
+    assert await asyncio.to_thread(first_entered.wait, 1)
+    second_task = asyncio.create_task(service._store_operation(second))
+    await asyncio.sleep(0.02)
+    assert observed == ["first-start"]
+    first_release.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert observed == ["first-start", "first-end", "second"]
+
+
+@pytest.mark.asyncio
+async def test_stop_watcher_failure_is_retrieved_and_privacy_safe(
+    session_db,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    service = adapter._session_turn_service
+    await service.reconcile_startup()
+    store = await service._store()
+    assert store is not None
+    store.reserve("s1", "broken-stop-watcher", _payload())
+    monkeypatch.setattr(
+        service,
+        "_interrupt_when_available",
+        AsyncMock(side_effect=RuntimeError("private watcher secret")),
+    )
+    loop_contexts = []
+    loop = asyncio.get_running_loop()
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: loop_contexts.append(context))
+    try:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.post(
+                "/api/sessions/s1/turns/broken-stop-watcher/stop"
+            )
+            assert response.status == 202
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert not [
+        context
+        for context in loop_contexts
+        if context.get("message") == "Task exception was never retrieved"
+    ]
+    assert "session_turn_background_task_failed" in caplog.text
+    assert "private watcher secret" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_turns.py
+++ b/tests/gateway/test_session_turns.py
@@ -1182,6 +1182,109 @@ async def test_concurrent_repeated_stop_records_and_watches_once(session_db, mon
         await service.wait_for_turn("turn-stop-concurrent")
 
 
+@pytest.mark.asyncio
+async def test_cancelled_http_stops_finish_commit_handoff_and_interrupt_once(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    """Cancellation after the stopping commit cannot orphan interruption."""
+
+    worker_released = asyncio.Event()
+    agent_ready = asyncio.Event()
+
+    class Agent:
+        interrupts = 0
+
+        def interrupt(self, _reason):
+            self.interrupts += 1
+            worker_released.set()
+
+    agent = Agent()
+
+    async def run_agent(**kwargs):
+        kwargs["agent_ref"][0] = agent
+        agent_ready.set()
+        await worker_released.wait()
+        return {"final_response": "must be discarded", "messages": []}, {}
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._run_agent = run_agent
+    service = adapter._session_turn_service
+    await service.reconcile_startup()
+    store = await service._store()
+    assert store is not None
+    turn_id = "cancel-stop-after-commit"
+    store.reserve("s1", turn_id, _payload())
+    service._admit_execution(store, turn_id, "s1", _payload(), None, None)
+    await asyncio.wait_for(agent_ready.wait(), 1)
+
+    commit_finished = threading.Event()
+    return_from_store = threading.Event()
+    original_stop = store.request_stop
+
+    def commit_then_block(*args, **kwargs):
+        result = original_stop(*args, **kwargs)
+        commit_finished.set()
+        return_from_store.wait(timeout=2)
+        return result
+
+    monkeypatch.setattr(store, "request_stop", commit_then_block)
+    watcher_calls = 0
+    original_watcher = service._interrupt_when_available
+
+    async def counted_watcher(requested_turn_id):
+        nonlocal watcher_calls
+        watcher_calls += 1
+        await original_watcher(requested_turn_id)
+
+    monkeypatch.setattr(service, "_interrupt_when_available", counted_watcher)
+
+    def stop_request():
+        request = MagicMock()
+        request.match_info = {"session_id": "s1", "turn_id": turn_id}
+        return request
+
+    # Every HTTP handler joins the same tracked handoff. Cancel all waiters at
+    # the exact seam where SQLite has committed stopping but the worker thread
+    # has not returned the transition result to the event loop.
+    requests = [asyncio.create_task(service.stop(stop_request())) for _ in range(12)]
+    assert await asyncio.to_thread(commit_finished.wait, 1)
+    assert store.get(turn_id)["status"] == "stopping"
+    for request in requests:
+        request.cancel()
+    cancelled = await asyncio.gather(*requests, return_exceptions=True)
+    assert all(isinstance(result, asyncio.CancelledError) for result in cancelled)
+
+    return_from_store.set()
+    await asyncio.wait_for(worker_released.wait(), 1)
+    await service.wait_for_turn(turn_id)
+    for _ in range(20):
+        if not service._stop_handoffs and not service._interruption_owners:
+            break
+        await asyncio.sleep(0)
+
+    events = store.events_after(turn_id, 0)
+    assert store.get(turn_id)["status"] == "interrupted"
+    assert agent.interrupts == 1
+    assert watcher_calls == 0
+    assert [event["event"] for event in events].count("turn.stopping") == 1
+    assert service._stop_handoffs == {}
+    assert service._interruption_owners == {}
+
+    # A later idempotent stop observes terminal truth and cannot create a
+    # second edge, interruption, watcher, or leaked owner.
+    later = await service.stop(stop_request())
+    assert later.status == 200
+    assert json.loads(later.text)["turn"]["status"] == "interrupted"
+    assert agent.interrupts == 1
+    assert watcher_calls == 0
+    assert [
+        event["event"] for event in store.events_after(turn_id, 0)
+    ].count("turn.stopping") == 1
+    assert service._stop_handoffs == {}
+    assert service._interruption_owners == {}
+
+
 def test_no_transcript_duplication_store_has_no_content_columns(session_db):
     store = SessionTurnStore(session_db)
     store.reserve("s1", "turn-1", _payload("body must not be here"))

--- a/tests/gateway/test_session_turns.py
+++ b/tests/gateway/test_session_turns.py
@@ -1,0 +1,957 @@
+"""Behavior contract for durable API session turns (Or7 #159)."""
+
+import asyncio
+import base64
+import io
+import json
+import sqlite3
+import struct
+import threading
+import time
+import zlib
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from gateway.platforms.base import SendResult
+from gateway.platforms.session_turns import (
+    ConflictingTurn,
+    SessionTurnStore,
+    TurnConflict,
+    TurnInputError,
+    project_safe_tool_event,
+    resolve_slack_binding,
+)
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def session_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SessionDB:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("s1", "api_server")
+    return db
+
+
+def _payload(text: str = "hello", mode: str = "occ_only") -> dict:
+    return {"input": {"text": text, "images": []}, "delivery_mode": mode}
+
+
+def _png(width: int = 1, height: int = 1) -> str:
+    def chunk(kind: bytes, data: bytes) -> bytes:
+        return struct.pack(">I", len(data)) + kind + data + struct.pack(">I", zlib.crc32(kind + data))
+
+    raw = b"\x89PNG\r\n\x1a\n"
+    raw += chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0))
+    raw += chunk(b"IDAT", zlib.compress(b"\x00\x00\x00\x00\x00"))
+    raw += chunk(b"IEND", b"")
+    return "data:image/png;base64," + base64.b64encode(raw).decode()
+
+
+def test_duplicate_submit_reuses_same_turn_without_second_reservation(session_db):
+    store = SessionTurnStore(session_db)
+    first, created = store.reserve("s1", "turn-1", _payload())
+    second, reused = store.reserve("s1", "turn-1", _payload())
+
+    assert created is True
+    assert reused is False
+    assert second["turn_id"] == first["turn_id"]
+    assert second["fingerprint"] == first["fingerprint"]
+
+
+def test_conflicting_fingerprint_reuse_is_rejected(session_db):
+    store = SessionTurnStore(session_db)
+    store.reserve("s1", "turn-1", _payload("first"))
+
+    with pytest.raises(ConflictingTurn):
+        store.reserve("s1", "turn-1", _payload("different"))
+
+
+def test_one_active_turn_per_session_is_enforced(session_db):
+    store = SessionTurnStore(session_db)
+    store.reserve("s1", "turn-1", _payload())
+
+    with pytest.raises(TurnConflict):
+        store.reserve("s1", "turn-2", _payload("second"))
+
+
+def test_restart_reconciliation_interrupts_uncertain_work_without_execution(session_db):
+    store = SessionTurnStore(session_db)
+    store.reserve("s1", "queued", _payload())
+    store.set_running("queued")
+
+    assert store.reconcile_uncertain() == 1
+    turn = store.get("queued")
+    assert turn["status"] == "interrupted"
+    assert turn["safe_error_code"] == "process_restarted"
+    events = store.events_after("queued", 0)
+    assert events[-1]["event"] == "turn.interrupted"
+    assert events[-1]["data"]["error_code"] == "process_restarted"
+
+
+def test_restart_reconciliation_preserves_live_unexpired_lease(session_db):
+    store = SessionTurnStore(session_db)
+    store.reserve("s1", "live", _payload())
+    store.set_running("live")
+    assert session_db.acquire_session_execution_lease("s1", "live-owner", ttl_seconds=30)
+
+    assert store.reconcile_uncertain() == 0
+    assert store.get("live")["status"] == "running"
+    assert session_db.get_session_execution_lease("s1")["owner_id"] == "live-owner"
+
+
+def test_restart_reconciliation_interrupts_dead_owner_and_removes_lease(session_db):
+    store = SessionTurnStore(session_db)
+    store.reserve("s1", "dead", _payload())
+    store.set_running("dead")
+    assert session_db.acquire_session_execution_lease("s1", "dead-owner", ttl_seconds=30)
+    session_db._execute_write(lambda conn: conn.execute(
+        "UPDATE session_execution_leases SET owner_pid = ? WHERE session_id = ?",
+        (999_999_999, "s1"),
+    ))
+
+    assert store.reconcile_uncertain() == 1
+    assert store.get("dead")["status"] == "interrupted"
+    assert session_db.get_session_execution_lease("s1") is None
+
+
+def test_reconnect_replays_events_after_last_sequence(session_db):
+    store = SessionTurnStore(session_db)
+    store.reserve("s1", "turn-1", _payload())
+    one = store.append_event("turn-1", "turn.started", {"status": "running"})
+    two = store.append_event("turn-1", "assistant.delta", {"delta": "Hi"})
+
+    assert one["seq"] < two["seq"]
+    assert store.events_after("turn-1", one["seq"]) == [two]
+
+
+def test_durable_event_rows_never_store_assistant_delta_bodies(session_db):
+    store = SessionTurnStore(session_db)
+    store.reserve("s1", "turn-body-free", _payload("user body sentinel"))
+    store.append_event("turn-body-free", "assistant.delta", {"delta": "assistant body sentinel"})
+
+    persisted = session_db._conn.execute(
+        "SELECT data_json FROM api_session_turn_events WHERE turn_id = ?",
+        ("turn-body-free",),
+    ).fetchone()[0]
+    ledger = repr(session_db._conn.execute(
+        "SELECT * FROM api_session_turns WHERE turn_id = ?", ("turn-body-free",)
+    ).fetchone())
+    assert "assistant body sentinel" not in persisted
+    assert "user body sentinel" not in ledger
+
+
+def test_safe_tool_projection_never_contains_sensitive_fields():
+    projected = project_safe_tool_event(
+        "tool.started",
+        tool_call_id="call-1",
+        tool_name="terminal",
+        args={"command": "print secret"},
+        preview="token=secret",
+        output="credential",
+        reasoning="hidden",
+        stack_trace="trace",
+    )
+
+    assert projected == {
+        "event": "tool.started",
+        "data": {
+            "tool_call_id": "call-1",
+            "label": "Terminal",
+            "status": "running",
+        },
+    }
+    wire = json.dumps(projected)
+    for forbidden in ("command", "preview", "output", "reasoning", "trace", "token"):
+        assert forbidden not in wire
+
+
+def test_inline_images_are_bounded_and_remote_images_rejected(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    import gateway.platforms.session_turns as session_turns
+
+    store = SessionTurnStore(session_db)
+    inline = _png()
+    turn, created = store.reserve(
+        "s1",
+        "turn-inline",
+        {"input": {"text": "look", "images": [inline]}, "delivery_mode": "occ_only"},
+    )
+    assert created is True
+    assert turn["status"] == "queued"
+    store.finish("turn-inline", "interrupted")
+
+    with pytest.raises(TurnInputError, match="inline"):
+        store.reserve(
+            "s1",
+            "turn-image",
+            {"input": {"text": "look", "images": ["https://example.test/x.png"]}, "delivery_mode": "occ_only"},
+        )
+    with pytest.raises(TurnInputError, match="Too many"):
+        store.reserve(
+            "s1",
+            "turn-count",
+            {"input": {"text": "look", "images": [inline] * 5}, "delivery_mode": "occ_only"},
+        )
+    monkeypatch.setattr(session_turns, "MAX_INLINE_IMAGE_BYTES", 1)
+    with pytest.raises(TurnInputError, match="per-image"):
+        store.reserve(
+            "s1",
+            "turn-size",
+            {"input": {"text": "look", "images": [inline]}, "delivery_mode": "occ_only"},
+        )
+
+
+@pytest.mark.parametrize(
+    "image,match",
+    [
+        ("data:image/jpeg;base64," + _png().split(",", 1)[1], "MIME"),
+        ("data:image/png;base64,iVBORw0KGgo=", "truncated"),
+        (_png(100_000, 100_000), "dimensions"),
+    ],
+)
+def test_inline_images_reject_spoofed_truncated_and_bomb_dimensions(session_db, image, match):
+    store = SessionTurnStore(session_db)
+    with pytest.raises(TurnInputError, match=match):
+        store.reserve(
+            "s1",
+            f"turn-image-{match.lower()}",
+            {"input": {"text": "look", "images": [image]}, "delivery_mode": "occ_only"},
+        )
+
+
+def test_inline_image_decoder_rejects_corrupt_compressed_pixels(session_db):
+    from PIL import Image
+
+    output = io.BytesIO()
+    Image.new("RGB", (2, 2), "red").save(output, format="PNG")
+    corrupt = bytearray(output.getvalue())
+    idat = corrupt.index(b"IDAT")
+    corrupt[idat + 8] ^= 0xFF
+    image = "data:image/png;base64," + base64.b64encode(corrupt).decode()
+
+    with pytest.raises(TurnInputError):
+        SessionTurnStore(session_db).reserve(
+            "s1", "turn-corrupt-pixels",
+            {"input": {"text": "look", "images": [image]}, "delivery_mode": "occ_only"},
+        )
+
+
+def test_session_execution_lease_is_persistent_owner_checked_and_reconciles_dead_owner(tmp_path):
+    first = SessionDB(db_path=tmp_path / "lease.db")
+    first.create_session("shared", "api_server")
+    second = SessionDB(db_path=tmp_path / "lease.db")
+
+    assert first.acquire_session_execution_lease("shared", "owner-a", ttl_seconds=30)
+    assert not second.acquire_session_execution_lease("shared", "owner-b", ttl_seconds=30)
+    assert not second.release_session_execution_lease("shared", "owner-b")
+    assert first.release_session_execution_lease("shared", "owner-a")
+    assert second.acquire_session_execution_lease("shared", "owner-b", ttl_seconds=30)
+    second._execute_write(lambda conn: conn.execute(
+        "UPDATE session_execution_leases SET owner_pid = ?, expires_at = ? WHERE session_id = ?",
+        (999_999_999, 0, "shared"),
+    ))
+    assert first.acquire_session_execution_lease("shared", "owner-c", ttl_seconds=30)
+
+
+def test_execution_lease_can_serialize_admitted_session_before_session_row_exists(tmp_path):
+    db = SessionDB(db_path=tmp_path / "lease-without-session.db")
+
+    assert db.acquire_session_execution_lease("admitted-not-yet-persisted", "owner-a")
+    assert not db.acquire_session_execution_lease("admitted-not-yet-persisted", "owner-b")
+
+
+def test_browser_supplied_routing_fields_are_rejected(session_db):
+    store = SessionTurnStore(session_db)
+    with pytest.raises(TurnInputError, match="Unsupported turn field"):
+        store.reserve(
+            "s1",
+            "turn-route",
+            {**_payload(mode="slack_only"), "channel_id": "C_ATTACKER"},
+        )
+
+
+def test_destination_outbox_is_unique_and_pending_is_ambiguous_on_restart(session_db):
+    store = SessionTurnStore(session_db)
+    store.reserve("s1", "turn-1", _payload(mode="both"))
+    assert store.begin_delivery("turn-1", "slack") is True
+    assert store.begin_delivery("turn-1", "slack") is False
+
+    store.reconcile_uncertain()
+    delivery = store.get_delivery("turn-1", "slack")
+    assert delivery["state"] == "needs_manual_retry"
+    assert delivery["safe_error_code"] == "delivery_outcome_unknown"
+
+
+def _app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    for method, path, handler in adapter._http_route_table():
+        if "/api/sessions/{session_id}/turns" in path or path == "/v1/capabilities":
+            app.router.add_route(method, path, handler)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_image_normalization_never_blocks_aiohttp_event_loop(
+    session_db, monkeypatch: pytest.MonkeyPatch
+):
+    import gateway.platforms.session_turns as session_turns
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._run_agent = AsyncMock(
+        return_value=({"final_response": "done", "messages": []}, {})
+    )
+    original = session_turns.normalize_turn_payload
+    started = threading.Event()
+    release = threading.Event()
+    worker_threads: list[int] = []
+
+    def deliberately_slow_normalize(body):
+        worker_threads.append(threading.get_ident())
+        started.set()
+        release.wait(timeout=1.0)
+        return original(body)
+
+    monkeypatch.setattr(
+        session_turns, "normalize_turn_payload", deliberately_slow_normalize
+    )
+    fallback = threading.Timer(1.0, release.set)
+    fallback.start()
+    loop_thread = threading.get_ident()
+    started_at = time.perf_counter()
+    try:
+        async with TestClient(TestServer(_app(adapter))) as client:
+            submit_task = asyncio.create_task(
+                client.post(
+                    "/api/sessions/s1/turns",
+                    headers={"Idempotency-Key": "turn-responsive"},
+                    json=_payload(),
+                )
+            )
+            while not started.is_set():
+                await asyncio.sleep(0)
+            capability = await asyncio.wait_for(
+                client.get("/v1/capabilities"), timeout=0.4
+            )
+            assert capability.status == 200
+            assert time.perf_counter() - started_at < 0.5
+            release.set()
+            submitted = await asyncio.wait_for(submit_task, timeout=1.0)
+            assert submitted.status == 202
+            await adapter._session_turn_service.wait_for_turn("turn-responsive")
+    finally:
+        release.set()
+        fallback.cancel()
+
+    assert len(worker_threads) >= 2
+    assert all(thread_id != loop_thread for thread_id in worker_threads)
+
+
+@pytest.mark.asyncio
+async def test_history_read_failure_fails_durable_turn_before_agent_execution(session_db):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._run_agent = AsyncMock()
+    original_history = session_db.get_messages_as_conversation
+    session_db.get_messages_as_conversation = MagicMock(side_effect=sqlite3.DatabaseError("secret"))
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        submitted = await client.post(
+            "/api/sessions/s1/turns", headers={"Idempotency-Key": "turn-history-fail"}, json=_payload(),
+        )
+        assert submitted.status == 202
+        await adapter._session_turn_service.wait_for_turn("turn-history-fail")
+        status = await client.get("/api/sessions/s1/turns/turn-history-fail")
+        turn = (await status.json())["turn"]
+
+    assert turn["status"] == "failed"
+    assert turn["safe_error_code"] == "history_read_failed"
+    adapter._run_agent.assert_not_awaited()
+
+    # The failed history read must not strand the canonical lease.
+    session_db.get_messages_as_conversation = original_history
+    adapter._run_agent = AsyncMock(return_value=({"final_response": "ok", "messages": []}, {}))
+    async with TestClient(TestServer(_app(adapter))) as client:
+        retry = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-history-retry"},
+            json=_payload("retry"),
+        )
+        await adapter._session_turn_service.wait_for_turn("turn-history-retry")
+    assert retry.status == 202
+    adapter._run_agent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_legacy_chat_history_read_failure_returns_safe_503_without_agent_execution(session_db):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._run_agent = AsyncMock()
+    session_db.get_messages_as_conversation = MagicMock(side_effect=sqlite3.DatabaseError("/secret/state.db"))
+    app = web.Application()
+    app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post("/api/sessions/s1/chat", json={"message": "hello"})
+        data = await response.json()
+
+    assert response.status == 503
+    assert data["error"]["code"] == "session_history_unavailable"
+    assert "/secret" not in json.dumps(data)
+    adapter._run_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_durable_and_legacy_session_paths_share_one_persistent_execution_lease(session_db):
+    gate = asyncio.Event()
+    started = asyncio.Event()
+    calls = 0
+
+    async def run_agent(**kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            started.set()
+            await gate.wait()
+        return {"final_response": "done", "messages": []}, {}
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._run_agent = run_agent
+    app = _app(adapter)
+    app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
+
+    async with TestClient(TestServer(app)) as client:
+        submitted = await client.post(
+            "/api/sessions/s1/turns", headers={"Idempotency-Key": "turn-held"}, json=_payload(),
+        )
+        assert submitted.status == 202
+        await started.wait()
+        conflict = await client.post("/api/sessions/s1/chat", json={"message": "second"})
+        assert conflict.status == 409
+        assert (await conflict.json())["error"]["code"] == "active_session_execution"
+        gate.set()
+        await adapter._session_turn_service.wait_for_turn("turn-held")
+        after = await client.post("/api/sessions/s1/chat", json={"message": "third"})
+        assert after.status == 200
+
+
+@pytest.mark.asyncio
+async def test_occ_only_executes_once_attempts_zero_slack_sends_and_does_not_duplicate_transcript(session_db):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    async def canonical_run(**kwargs):
+        # The edge must not pre-append a user message; AIAgent/SessionDB owns
+        # the complete turn atomically through the existing run machinery.
+        assert session_db.get_messages("s1") == []
+        session_db.replace_messages(
+            "s1",
+            [
+                {"role": "user", "content": kwargs["user_message"]},
+                {"role": "assistant", "content": "done"},
+            ],
+        )
+        return {"final_response": "done", "messages": session_db.get_messages_as_conversation("s1")}, {}
+
+    adapter._run_agent = AsyncMock(side_effect=canonical_run)
+    slack = AsyncMock()
+    adapter.gateway_runner = type("Runner", (), {"adapters": {}})()
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        first = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-1"},
+            json=_payload(),
+        )
+        assert first.status == 202
+        await adapter._session_turn_service.wait_for_turn("turn-1")
+        retry = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-1"},
+            json=_payload(),
+        )
+        assert retry.status == 200
+
+    assert adapter._run_agent.await_count == 1
+    assert [message["role"] for message in session_db.get_messages("s1")] == ["user", "assistant"]
+    slack.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_slack_mode_sends_exactly_once_via_connected_adapter(session_db):
+    origin = {
+        "platform": "slack",
+        "chat_id": "C123",
+        "thread_id": "171.2",
+        "scope_id": "T123",
+    }
+    session_db.record_gateway_session_peer(
+        "s1",
+        source="slack",
+        session_key="agent:main:slack:T123:channel:C123:thread:171.2",
+        chat_id="C123",
+        thread_id="171.2",
+        origin_json=json.dumps(origin),
+    )
+    slack = AsyncMock()
+    slack.send.return_value = SendResult(success=True, message_id="171.3")
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    def canonical_run(**kwargs):
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", "done")
+        return {"final_response": "done", "messages": session_db.get_messages("s1")}, {}
+
+    adapter._run_agent = AsyncMock(side_effect=canonical_run)
+    adapter._get_platform_callback_adapter = lambda _request, name: slack if name == "slack" else None
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-slack"},
+            json=_payload(mode="both"),
+        )
+        assert response.status == 202
+        await adapter._session_turn_service.wait_for_turn("turn-slack")
+        events = await client.get("/api/sessions/s1/turns/turn-slack/events")
+        safe_wire = await events.text()
+
+    slack.send.assert_awaited_once()
+    args, kwargs = slack.send.await_args
+    assert args[:2] == ("C123", "done")
+    assert kwargs["reply_to"] == "171.2"
+    assert kwargs["metadata"]["client_msg_id"]
+    assert adapter._run_agent.await_count == 1
+    assert "C123" not in safe_wire
+    assert "171.2" not in safe_wire
+    assert "T123" not in safe_wire
+    assert kwargs["metadata"]["client_msg_id"] not in safe_wire
+    persisted = SessionTurnStore(session_db)
+    delivery = persisted.get_delivery("turn-slack", "slack")
+    turn = persisted.get("turn-slack")
+    assert turn is not None and turn["assistant_message_id"]
+    assert delivery is not None and delivery["provider_message_id"] == "171.3"
+    assert delivery["provider_message_id"] != delivery["delivery_id"]
+
+
+def test_slack_binding_walks_to_nearest_bound_ancestor_and_checks_all_metadata(session_db):
+    origin = {"platform": "slack", "chat_id": "C123", "thread_id": "171.2", "scope_id": "T123"}
+    session_db.record_gateway_session_peer(
+        "s1", source="slack", session_key="agent:main:slack:T123:channel:C123:thread:171.2",
+        chat_id="C123", thread_id="171.2", origin_json=json.dumps(origin),
+    )
+    session_db.end_session("s1", "compression")
+    session_db.create_session("child", "slack", parent_session_id="s1")
+    session_db.save_gateway_routing_entry(
+        "agent:main:slack:T123:channel:C123:thread:171.2",
+        json.dumps({"session_id": "s1", "source": {"platform": "slack", "chat_id": "C123", "thread_id": "171.2", "scope_id": "T123"}}),
+    )
+    binding = resolve_slack_binding(session_db, "child")
+    assert (binding.chat_id, binding.thread_id) == ("C123", "171.2")
+
+    session_db.save_gateway_routing_entry(
+        "conflict",
+        json.dumps({"session_id": "child", "source": {"platform": "slack", "chat_id": "C999", "thread_id": "171.2", "scope_id": "T123"}}),
+    )
+    with pytest.raises(Exception, match="ambiguous_slack_binding"):
+        resolve_slack_binding(session_db, "child")
+
+
+def test_slack_binding_uses_nearest_bound_row_without_aggregating_valid_ancestor(session_db):
+    parent = {"platform": "slack", "chat_id": "C_PARENT", "thread_id": "1", "scope_id": "T1"}
+    child = {"platform": "slack", "chat_id": "C_CHILD", "thread_id": "2", "scope_id": "T1"}
+    session_db.record_gateway_session_peer(
+        "s1", source="slack", session_key="parent", origin_json=json.dumps(parent)
+    )
+    session_db.create_session("child-nearest", "slack", parent_session_id="s1")
+    session_db.record_gateway_session_peer(
+        "child-nearest", source="slack", session_key="child", origin_json=json.dumps(child)
+    )
+
+    binding = resolve_slack_binding(session_db, "child-nearest")
+    assert (binding.chat_id, binding.thread_id) == ("C_CHILD", "2")
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_slack_send_failure_is_not_automatically_retried(session_db):
+    origin = {
+        "platform": "slack",
+        "chat_id": "C123",
+        "thread_id": "171.2",
+        "scope_id": "T123",
+    }
+    session_db.record_gateway_session_peer(
+        "s1", source="slack", session_key="binding", origin_json=json.dumps(origin)
+    )
+    slack = AsyncMock()
+    slack.send.side_effect = TimeoutError("ambiguous transport outcome")
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    def canonical_run(**kwargs):
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", "done")
+        return {
+            "final_response": "done",
+            "messages": session_db.get_messages_as_conversation("s1"),
+        }, {}
+
+    adapter._run_agent = AsyncMock(side_effect=canonical_run)
+    adapter._get_platform_callback_adapter = (
+        lambda _request, name: slack if name == "slack" else None
+    )
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        first = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-ambiguous"},
+            json=_payload(mode="slack_only"),
+        )
+        assert first.status == 202
+        await adapter._session_turn_service.wait_for_turn("turn-ambiguous")
+        # Durable reuse must not depend on the adapter still being connected.
+        adapter._get_platform_callback_adapter = lambda request, name: None
+        retry = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-ambiguous"},
+            json=_payload(mode="slack_only"),
+        )
+        assert retry.status == 200
+        status = await client.get("/api/sessions/s1/turns/turn-ambiguous")
+        delivery = (await status.json())["turn"]["deliveries"][0]
+
+    slack.send.assert_awaited_once()
+    assert delivery["state"] == "needs_manual_retry"
+    assert delivery["safe_error_code"] == "delivery_outcome_unknown"
+
+
+@pytest.mark.asyncio
+async def test_explicit_deliver_is_idempotent_and_never_retries_unknown_send(session_db):
+    origin = {"platform": "slack", "chat_id": "C123", "thread_id": "171.2", "scope_id": "T123"}
+    session_db.record_gateway_session_peer(
+        "s1", source="slack", session_key="binding", chat_id="C123", thread_id="171.2",
+        origin_json=json.dumps(origin),
+    )
+    slack = AsyncMock()
+    slack.send.side_effect = TimeoutError("ambiguous")
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    def canonical_run(**kwargs):
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", "done")
+        return {
+            "final_response": "done",
+            "messages": session_db.get_messages_as_conversation("s1"),
+        }, {}
+
+    adapter._run_agent = AsyncMock(side_effect=canonical_run)
+    adapter._get_platform_callback_adapter = lambda _request, name: slack if name == "slack" else None
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        submitted = await client.post(
+            "/api/sessions/s1/turns", headers={"Idempotency-Key": "turn-deliver"}, json=_payload(mode="both"),
+        )
+        await adapter._session_turn_service.wait_for_turn("turn-deliver")
+        first = await client.post("/api/sessions/s1/turns/turn-deliver/deliver", json={"destination": "slack"})
+        second = await client.post("/api/sessions/s1/turns/turn-deliver/deliver", json={"destination": "slack"})
+        status = await client.get("/api/sessions/s1/turns/turn-deliver")
+        delivery = (await status.json())["turn"]["deliveries"][0]
+
+    assert submitted.status == 202
+    assert first.status == second.status == 409
+    assert slack.send.await_count == 1
+    assert delivery["delivery_id"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "origin,code",
+    [
+        ({"platform": "api_server"}, "no_slack_binding"),
+        (
+            {"platform": "slack", "chat_id": "C1", "channel_id": "C2", "thread_id": "1"},
+            "ambiguous_slack_binding",
+        ),
+    ],
+)
+async def test_slack_binding_missing_or_ambiguous_fails_closed_before_run(session_db, origin, code):
+    session_db.record_gateway_session_peer(
+        "s1", source=origin["platform"], session_key="binding", origin_json=json.dumps(origin)
+    )
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._run_agent = AsyncMock()
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-slack"},
+            json=_payload(mode="slack_only"),
+        )
+        assert response.status == 409
+        assert (await response.json())["error"]["code"] == code
+
+    adapter._run_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stop_reports_stopping_until_worker_actually_exits(session_db):
+    gate = asyncio.Event()
+    agent = type("Agent", (), {"interrupt": lambda self, reason: None})()
+
+    async def run_agent(**kwargs):
+        kwargs["agent_ref"][0] = agent
+        await gate.wait()
+        return {"final_response": "late", "messages": []}, {}
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._run_agent = run_agent
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        submit = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-stop"},
+            json=_payload(),
+        )
+        assert submit.status == 202
+        await asyncio.sleep(0)
+        stop = await client.post("/api/sessions/s1/turns/turn-stop/stop")
+        assert stop.status == 202
+        assert (await stop.json())["turn"]["status"] == "stopping"
+        status = await client.get("/api/sessions/s1/turns/turn-stop")
+        assert (await status.json())["turn"]["status"] == "stopping"
+        gate.set()
+        await adapter._session_turn_service.wait_for_turn("turn-stop")
+        final = await client.get("/api/sessions/s1/turns/turn-stop")
+        assert (await final.json())["turn"]["status"] == "interrupted"
+
+
+def test_no_transcript_duplication_store_has_no_content_columns(session_db):
+    store = SessionTurnStore(session_db)
+    store.reserve("s1", "turn-1", _payload("body must not be here"))
+    columns = {
+        row[1]
+        for row in session_db._conn.execute("PRAGMA table_info(api_session_turns)").fetchall()
+    }
+    assert not ({"input", "text", "prompt", "assistant_content", "output", "reasoning"} & columns)
+
+
+def test_capabilities_advertise_durable_turn_contract():
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+
+    async def check():
+        async with TestClient(TestServer(_app(adapter))) as client:
+            response = await client.get("/v1/capabilities")
+            data = await response.json()
+            assert data["features"]["conversation_turn_contract"] == "h1"
+            assert data["features"]["durable_turn_idempotency"] is True
+            assert data["features"]["durable_turn_status"] is True
+            assert data["features"]["durable_turn_resumable_events"] is True
+            assert data["features"]["durable_turn_stop"] is True
+            assert data["endpoints"]["conversation_turn_create"]["path"].endswith("/turns")
+            turns = data["session_turns"]
+            assert turns["durable"] is True
+            assert turns["routing"] == "session_origin_only"
+            assert turns["events"]["resumable"] is True
+            assert turns["events"]["last_event_id"] is True
+            assert turns["safe_progress"] is True
+            assert turns["input_text"] == {"max_chars": 65_536}
+            from gateway.platforms.api_server import MAX_REQUEST_BYTES
+
+            assert turns["transport"] == {"max_request_bytes": MAX_REQUEST_BYTES}
+            assert turns["inline_images"]["remote_urls"] is False
+            assert turns["inline_images"]["max_dimension"] == 16_384
+            assert turns["inline_images"]["max_pixels"] == 40_000_000
+            assert turns["cancellation"] == "cooperative_truthful"
+            assert data["endpoints"]["session_turn_deliver"] == {
+                "method": "POST",
+                "path": "/api/sessions/{session_id}/turns/{turn_id}/deliver",
+            }
+            assert turns["delivery"] == {
+                "manual_operation": "POST /api/sessions/{session_id}/turns/{turn_id}/deliver",
+                "delivery_id": True,
+                "automatic_retry": False,
+                "ambiguous_retry": False,
+                "slack_atomic_max_chars": 3_000,
+            }
+
+    asyncio.run(check())
+
+
+def test_slack_client_msg_id_validation_is_uuid_only():
+    from plugins.platforms.slack.adapter import SlackAdapter
+
+    valid = "3f60c8d8-4dd8-5dd2-9bf4-f66db1c600f8"
+    assert SlackAdapter._metadata_client_msg_id({"client_msg_id": valid}) == valid
+    assert SlackAdapter._metadata_client_msg_id({"client_msg_id": "browser-controlled"}) == ""
+
+
+@pytest.mark.asyncio
+async def test_slack_send_forwards_valid_client_msg_id_once():
+    from plugins.platforms.slack.adapter import SlackAdapter
+
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="test"))
+    adapter._app = MagicMock()
+    adapter._app.client = AsyncMock()
+    adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "1.0"})
+    adapter._running = True
+    client_msg_id = "3f60c8d8-4dd8-5dd2-9bf4-f66db1c600f8"
+
+    result = await adapter.send(
+        "C123",
+        "done",
+        metadata={"client_msg_id": client_msg_id},
+    )
+
+    assert result.success is True
+    adapter._app.client.chat_postMessage.assert_awaited_once_with(
+        channel="C123",
+        text="done",
+        mrkdwn=True,
+        client_msg_id=client_msg_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sse_last_event_id_replays_only_later_durable_frames(session_db):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    async def streamed_run(**kwargs):
+        kwargs["stream_delta_callback"]("one")
+        kwargs["stream_delta_callback"]("two")
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", "onetwo")
+        return {
+            "final_response": "onetwo",
+            "messages": session_db.get_messages_as_conversation("s1"),
+        }, {}
+
+    adapter._run_agent = streamed_run
+    async with TestClient(TestServer(_app(adapter))) as client:
+        submitted = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-events"},
+            json=_payload(),
+        )
+        assert submitted.status == 202
+        await adapter._session_turn_service.wait_for_turn("turn-events")
+        replay = await client.get(
+            "/api/sessions/s1/turns/turn-events/events",
+            headers={"Last-Event-ID": "1"},
+        )
+        wire = await replay.text()
+
+    assert replay.status == 200
+    assert "id: 1\n" not in wire
+    assert "event: assistant.delta" in wire
+    assert 'data: {"delta": "one"}' in wire
+    assert "event: turn.completed" in wire
+
+
+@pytest.mark.asyncio
+async def test_sse_impossible_high_water_and_durable_gap_require_canonical_resync(session_db):
+    store = SessionTurnStore(session_db)
+    store.reserve("s1", "turn-gap", _payload())
+    store.append_event("turn-gap", "turn.started", {"status": "running"})
+    store.append_event("turn-gap", "assistant.delta", {"delta": "safe"})
+    store.finish("turn-gap", "completed")
+    session_db._execute_write(lambda conn: conn.execute(
+        "DELETE FROM api_session_turn_events WHERE turn_id = ? AND seq = 1", ("turn-gap",)
+    ))
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        high = await client.get(
+            "/api/sessions/s1/turns/turn-gap/events", headers={"Last-Event-ID": "99"}
+        )
+        gap = await client.get(
+            "/api/sessions/s1/turns/turn-gap/events", headers={"Last-Event-ID": "0"}
+        )
+        high_data = await high.json()
+        gap_data = await gap.json()
+
+    assert high.status == gap.status == 409
+    assert high_data["error"]["code"] == "event_cursor_ahead"
+    assert gap_data["error"]["code"] == "event_gap"
+    assert high_data["error"]["resync_required"] is True
+
+
+@pytest.mark.asyncio
+async def test_sse_after_volatile_delta_loss_requires_canonical_resync(session_db):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+
+    async def streamed_run(**kwargs):
+        kwargs["stream_delta_callback"]("volatile body")
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", "volatile body")
+        return {"final_response": "volatile body", "messages": session_db.get_messages("s1")}, {}
+
+    adapter._run_agent = streamed_run
+    async with TestClient(TestServer(_app(adapter))) as client:
+        submitted = await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-volatile-loss"},
+            json=_payload(),
+        )
+        assert submitted.status == 202
+        await adapter._session_turn_service.wait_for_turn("turn-volatile-loss")
+
+    adapter._session_turn_service = type(adapter._session_turn_service)(adapter)
+    # Avoid startup reconciliation changing the already-completed turn.
+    async with TestClient(TestServer(_app(adapter))) as client:
+        replay = await client.get(
+            "/api/sessions/s1/turns/turn-volatile-loss/events",
+            headers={"Last-Event-ID": "0"},
+        )
+        data = await replay.json()
+
+    assert replay.status == 409
+    assert data["error"]["code"] == "volatile_events_lost"
+    assert data["error"]["resync_required"] is True
+
+
+@pytest.mark.asyncio
+async def test_slack_only_turn_never_exposes_assistant_deltas_to_occ(session_db):
+    origin = {"platform": "slack", "chat_id": "C123", "thread_id": "1", "scope_id": "T1"}
+    session_db.record_gateway_session_peer(
+        "s1", source="slack", session_key="bound", origin_json=json.dumps(origin)
+    )
+    slack = AsyncMock()
+    slack.send.return_value = SendResult(success=True, message_id="provider-receipt")
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._session_db = session_db
+    adapter._get_platform_callback_adapter = lambda _request, name: slack if name == "slack" else None
+
+    async def streamed_run(**kwargs):
+        kwargs["stream_delta_callback"]("must not reach OCC")
+        session_db.append_message("s1", "user", kwargs["user_message"])
+        session_db.append_message("s1", "assistant", "must not reach OCC")
+        return {"final_response": "must not reach OCC", "messages": session_db.get_messages("s1")}, {}
+
+    adapter._run_agent = streamed_run
+    async with TestClient(TestServer(_app(adapter))) as client:
+        await client.post(
+            "/api/sessions/s1/turns",
+            headers={"Idempotency-Key": "turn-slack-only"},
+            json=_payload(mode="slack_only"),
+        )
+        await adapter._session_turn_service.wait_for_turn("turn-slack-only")
+        events = await client.get("/api/sessions/s1/turns/turn-slack-only/events")
+        wire = await events.text()
+
+    assert "assistant.delta" not in wire
+    assert "must not reach OCC" not in wire

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -11,6 +11,7 @@ import yaml
 
 from hermes_cli.plugins import (
     ENTRY_POINTS_GROUP,
+    HOOK_CONTRACT_VERSIONS,
     VALID_HOOKS,
     PluginContext,
     PluginManager,
@@ -628,6 +629,12 @@ class TestPluginHooks:
         assert "post_api_request" in VALID_HOOKS
         assert "api_request_error" in VALID_HOOKS
         assert "subagent_start" in VALID_HOOKS
+        assert "subagent_lifecycle" in VALID_HOOKS
+        assert "delegation_wrapper_lifecycle" in VALID_HOOKS
+        assert "managed_process_lifecycle" in VALID_HOOKS
+        assert HOOK_CONTRACT_VERSIONS["subagent_lifecycle"] == 2
+        assert HOOK_CONTRACT_VERSIONS["delegation_wrapper_lifecycle"] == 1
+        assert HOOK_CONTRACT_VERSIONS["managed_process_lifecycle"] == 2
         assert "transform_terminal_output" in VALID_HOOKS
         assert "transform_tool_result" in VALID_HOOKS
         assert "transform_llm_output" in VALID_HOOKS

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -632,9 +632,11 @@ class TestPluginHooks:
         assert "subagent_lifecycle" in VALID_HOOKS
         assert "delegation_wrapper_lifecycle" in VALID_HOOKS
         assert "managed_process_lifecycle" in VALID_HOOKS
+        assert "session_turn_lifecycle" in VALID_HOOKS
         assert HOOK_CONTRACT_VERSIONS["subagent_lifecycle"] == 2
         assert HOOK_CONTRACT_VERSIONS["delegation_wrapper_lifecycle"] == 1
         assert HOOK_CONTRACT_VERSIONS["managed_process_lifecycle"] == 2
+        assert HOOK_CONTRACT_VERSIONS["session_turn_lifecycle"] == 1
         assert "transform_terminal_output" in VALID_HOOKS
         assert "transform_tool_result" in VALID_HOOKS
         assert "transform_llm_output" in VALID_HOOKS

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -77,6 +77,106 @@ def db(tmp_path):
     session_db.close()
 
 
+def test_session_fork_request_schema_uses_canonical_anchor(db):
+    columns = {
+        row["name"]
+        for row in db._conn.execute("PRAGMA table_info(session_fork_requests)").fetchall()
+    }
+    assert "anchor_message_id" in columns
+    assert "from_message_id" not in columns
+    assert not any(
+        row["from"] == "child_session_id"
+        for row in db._conn.execute(
+            "PRAGMA foreign_key_list(session_fork_requests)"
+        ).fetchall()
+    )
+    assert db._conn.execute("SELECT version FROM schema_version").fetchone()["version"] == SCHEMA_VERSION
+
+
+def test_session_fork_same_key_race_replays_one_durable_child(tmp_path):
+    from concurrent.futures import ThreadPoolExecutor
+
+    path = tmp_path / "fork-race.db"
+    setup = SessionDB(path)
+    setup.create_session("source", "api_server")
+    setup.append_message("source", "user", "question")
+    anchor = setup.append_message(
+        "source", "assistant", "answer", finish_reason="stop"
+    )
+    setup.close()
+
+    def fork_once():
+        worker = SessionDB(path)
+        try:
+            return worker.fork_session_at_message(
+                "source",
+                "same-child",
+                anchor,
+                "same-key",
+                requested_child_session_id="same-child",
+            )[0]
+        finally:
+            worker.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = sorted(pool.map(lambda _: fork_once(), range(2)))
+
+    verify = SessionDB(path)
+    try:
+        assert outcomes == ["created", "replayed"]
+        assert verify._conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE parent_session_id = 'source'"
+        ).fetchone()[0] == 1
+        assert verify._conn.execute(
+            "SELECT COUNT(*) FROM session_fork_requests WHERE idempotency_key = 'same-key'"
+        ).fetchone()[0] == 1
+    finally:
+        verify.close()
+
+
+def test_session_fork_conflicting_key_race_creates_only_winner(tmp_path):
+    from concurrent.futures import ThreadPoolExecutor
+
+    path = tmp_path / "fork-conflict-race.db"
+    setup = SessionDB(path)
+    setup.create_session("source", "api_server")
+    setup.append_message("source", "user", "question")
+    anchor = setup.append_message(
+        "source", "assistant", "answer", finish_reason="stop"
+    )
+    setup.close()
+
+    def fork_once(index):
+        worker = SessionDB(path)
+        try:
+            child = f"child-{index}"
+            return worker.fork_session_at_message(
+                "source",
+                child,
+                anchor,
+                "conflicting-key",
+                title=f"title-{index}",
+                requested_child_session_id=child,
+            )[0]
+        finally:
+            worker.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = sorted(pool.map(fork_once, range(2)))
+
+    verify = SessionDB(path)
+    try:
+        assert outcomes == ["created", "idempotency_conflict"]
+        assert verify._conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE parent_session_id = 'source'"
+        ).fetchone()[0] == 1
+        assert verify._conn.execute(
+            "SELECT COUNT(*) FROM session_fork_requests WHERE idempotency_key = 'conflicting-key'"
+        ).fetchone()[0] == 1
+    finally:
+        verify.close()
+
+
 # =========================================================================
 # Session lifecycle
 # =========================================================================

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1,7 +1,9 @@
 """Tests for tools/process_registry.py — ProcessRegistry query methods, pruning, checkpoint."""
 
 import json
+import logging
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -703,13 +705,17 @@ class TestSpawnEnvSanitization:
         class FakeEnv:
             def __init__(self):
                 self.commands = []
+                self.process_token = None
 
             def get_temp_dir(self):
                 return "/data/data/com.termux/files/usr/tmp"
 
             def execute(self, command, **kwargs):
                 self.commands.append((command, kwargs))
-                return {"output": "4321\n"}
+                if len(self.commands) == 1:
+                    self.process_token = re.findall(r"\b[0-9a-f]{32}\b", command)[-1]
+                    return {"output": "4321\n"}
+                return {"output": f"4321 98765 {self.process_token}\n"}
 
         env = FakeEnv()
         fake_thread = MagicMock()
@@ -720,6 +726,7 @@ class TestSpawnEnvSanitization:
 
         bg_command = env.commands[0][0]
         assert session.pid == 4321
+        assert session.backend_process_id.endswith(":98765")
         assert "/data/data/com.termux/files/usr/tmp/hermes_bg_" in bg_command
         assert ".exit" in bg_command
         assert "rc=$?;" in bg_command
@@ -776,13 +783,15 @@ class TestSpawnEnvSanitization:
     def test_env_poller_quotes_temp_paths_with_spaces(self, registry):
         session = _make_session(sid="proc_space")
         session.exited = False
+        session.pid = 4321
+        session.backend_process_id = "token:98765"
 
         class FakeEnv:
             def __init__(self):
                 self.commands = []
                 self._responses = iter([
                     {"output": "hello\n"},
-                    {"output": "1\n"},
+                    {"output": "exited\n"},
                     {"output": "0\n"},
                 ])
 
@@ -800,10 +809,11 @@ class TestSpawnEnvSanitization:
                 "/path with spaces/hermes_bg.log",
                 "/path with spaces/hermes_bg.pid",
                 "/path with spaces/hermes_bg.exit",
+                "/path with spaces/hermes_bg.identity",
             )
 
         assert env.commands[0][0] == "cat '/path with spaces/hermes_bg.log' 2>/dev/null"
-        assert env.commands[1][0] == "kill -0 \"$(cat '/path with spaces/hermes_bg.pid' 2>/dev/null)\" 2>/dev/null; echo $?"
+        assert "cat '/path with spaces/hermes_bg.identity'" in env.commands[1][0]
         assert env.commands[2][0] == "cat '/path with spaces/hermes_bg.exit' 2>/dev/null"
 
 
@@ -845,6 +855,7 @@ class TestPopenLeakOnSetupFailure:
              patch("subprocess.Popen", return_value=proc), \
              patch("threading.Thread", side_effect=boom), \
              patch("os.getpgid", side_effect=ProcessLookupError), \
+             patch.object(registry, "_terminate_host_pid", side_effect=lambda *_args: killed.append(True)), \
              patch.object(registry, "_write_checkpoint"):
             with pytest.raises(RuntimeError, match="Thread creation failed"):
                 registry.spawn_local("echo hello", cwd="/tmp")
@@ -877,6 +888,7 @@ class TestPopenLeakOnSetupFailure:
              patch("subprocess.Popen", return_value=proc), \
              patch("threading.Thread", return_value=fake_thread), \
              patch("os.getpgid", side_effect=ProcessLookupError), \
+             patch.object(registry, "_terminate_host_pid", side_effect=lambda *_args: killed.append(True)), \
              patch.object(registry, "_write_checkpoint", side_effect=OSError("disk full")):
             with pytest.raises(OSError, match="disk full"):
                 registry.spawn_local("echo hello", cwd="/tmp")
@@ -969,6 +981,8 @@ class TestCheckpoint:
             "session_id": "proc_live",
             "command": "sleep 999",
             "pid": os.getpid(),  # current process — guaranteed alive
+            "host_start_time": ProcessRegistry._safe_host_start_time(os.getpid()),
+            "host_boot_id": ProcessRegistry._safe_host_boot_id(),
             "task_id": "t1",
             "session_key": "sk1",
             "watcher_platform": "telegram",
@@ -997,6 +1011,8 @@ class TestCheckpoint:
             "session_id": "proc_live",
             "command": "sleep 999",
             "pid": os.getpid(),
+            "host_start_time": ProcessRegistry._safe_host_start_time(os.getpid()),
+            "host_boot_id": ProcessRegistry._safe_host_boot_id(),
             "task_id": "t1",
             "watcher_interval": 0,
         }]))
@@ -1011,6 +1027,8 @@ class TestCheckpoint:
             "session_id": "proc_live",
             "command": "sleep 999",
             "pid": os.getpid(),
+            "host_start_time": ProcessRegistry._safe_host_start_time(os.getpid()),
+            "host_boot_id": ProcessRegistry._safe_host_boot_id(),
             "task_id": "t1",
             "session_key": "sk1",
         }]))
@@ -1052,6 +1070,8 @@ class TestCheckpoint:
             "session_id": "proc_live",
             "command": "python -c 'import time; time.sleep(0.4)'",
             "pid": proc.pid,
+            "host_start_time": ProcessRegistry._safe_host_start_time(proc.pid),
+            "host_boot_id": ProcessRegistry._safe_host_boot_id(),
             "task_id": "t1",
             "session_key": "sk1",
         }]))
@@ -1108,22 +1128,26 @@ class TestKillProcess:
         s.process = MagicMock()
         s.process.pid = 12345
         s.host_start_time = 67890
+        s.host_boot_id = "boot"
         registry._running[s.id] = s
         terminate_calls = []
 
         monkeypatch.setattr(
             registry,
             "_terminate_host_pid",
-            lambda pid, expected_start=None: terminate_calls.append((pid, expected_start)),
+            lambda pid, expected_start=None, expected_boot=None: terminate_calls.append(
+                (pid, expected_start, expected_boot)
+            ),
         )
+        monkeypatch.setattr(registry, "_host_pid_identity_status", lambda *_args: "ours")
         monkeypatch.setattr(registry, "_write_checkpoint", lambda: None)
 
         result = registry.kill_process(s.id)
 
         assert result["status"] == "killed"
-        assert terminate_calls == [(12345, 67890)]
+        assert terminate_calls == [(12345, 67890, "boot")]
 
-    def test_kill_detached_session_uses_host_pid(self, registry):
+    def test_kill_detached_session_without_full_tuple_refuses_pid(self, registry):
         s = _make_session(sid="proc_detached", command="sleep 999")
         s.pid = 424242
         s.detached = True
@@ -1155,8 +1179,9 @@ class TestKillProcess:
                  patch.object(_psutil, "Process", side_effect=lambda pid: FakeProcess(pid)):
                 result = registry.kill_process(s.id)
 
-            assert result["status"] == "killed"
-            assert ("terminate", 424242) in terminate_calls
+            assert result["status"] == "error"
+            assert terminate_calls == []
+            assert s.exited is False
         finally:
             registry._running.pop(s.id, None)
 
@@ -1732,6 +1757,10 @@ def test_drain_notifications_owns_event_callback_fails_closed():
 
 
 class TestTerminateHostPidWindows:
+    @pytest.fixture(autouse=True)
+    def _verified_identity(self, monkeypatch):
+        monkeypatch.setattr(ProcessRegistry, "_host_pid_is_ours", lambda *_args: True)
+
     """Windows branch uses ``taskkill /T /F`` — the documented MS tree-kill
     primitive. We can't use psutil's ``children(recursive=True)`` /
     ``.terminate()`` path on Windows because (1) Windows doesn't maintain
@@ -1817,6 +1846,10 @@ class TestTerminateHostPidWindows:
 
 
 class TestTerminateHostPidPosix:
+    @pytest.fixture(autouse=True)
+    def _verified_identity(self, monkeypatch):
+        monkeypatch.setattr(ProcessRegistry, "_host_pid_is_ours", lambda *_args: True)
+
     """POSIX branch walks the tree via psutil and SIGTERMs children first."""
 
     def test_posix_walks_tree_and_terminates_children_then_parent(self, monkeypatch):
@@ -1909,7 +1942,11 @@ class TestPidReuseGuard:
             real_start = ProcessRegistry._safe_host_start_time(proc.pid)
             assert real_start is not None, "no /proc start time on this platform?"
             # Simulate recycling: the recorded baseline no longer matches.
-            registry._terminate_host_pid(proc.pid, expected_start=real_start + 1)
+            registry._terminate_host_pid(
+                proc.pid,
+                expected_start=real_start + 1,
+                expected_boot=ProcessRegistry._safe_host_boot_id(),
+            )
             # The process must still be alive — the guard refused to signal it.
             assert not _wait_until(lambda: proc.poll() is not None, timeout=1.0)
             assert proc.poll() is None
@@ -1922,19 +1959,23 @@ class TestPidReuseGuard:
         proc = _spawn_python_sleep(30)
         try:
             real_start = ProcessRegistry._safe_host_start_time(proc.pid)
-            registry._terminate_host_pid(proc.pid, expected_start=real_start)
+            registry._terminate_host_pid(
+                proc.pid,
+                expected_start=real_start,
+                expected_boot=ProcessRegistry._safe_host_boot_id(),
+            )
             assert _wait_until(lambda: proc.poll() is not None, timeout=5.0)
         finally:
             if proc.poll() is None:
                 proc.kill()
                 proc.wait()
 
-    def test_terminate_without_baseline_is_best_effort(self, registry):
-        """No baseline (legacy) → degrade to prior unconditional behaviour."""
+    def test_terminate_without_full_tuple_refuses_bare_pid(self, registry):
+        """No baseline means no signal: a bare PID is not identity."""
         proc = _spawn_python_sleep(30)
         try:
-            registry._terminate_host_pid(proc.pid)  # expected_start=None
-            assert _wait_until(lambda: proc.poll() is not None, timeout=5.0)
+            registry._terminate_host_pid(proc.pid)
+            assert not _wait_until(lambda: proc.poll() is not None, timeout=1.0)
         finally:
             if proc.poll() is None:
                 proc.kill()
@@ -1950,6 +1991,7 @@ class TestPidReuseGuard:
             "pid": os.getpid(),            # alive...
             "pid_scope": "host",
             "host_start_time": wrong_start,  # ...but a different process now
+            "host_boot_id": ProcessRegistry._safe_host_boot_id(),
             "task_id": "t1",
         }]))
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
@@ -1966,13 +2008,14 @@ class TestPidReuseGuard:
             "pid": os.getpid(),
             "pid_scope": "host",
             "host_start_time": real_start,
+            "host_boot_id": ProcessRegistry._safe_host_boot_id(),
             "task_id": "t1",
         }]))
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
             assert registry.recover_from_checkpoint() == 1
 
-    def test_legacy_checkpoint_without_start_time_still_recovers(self, registry, tmp_path):
-        """Entries written before host_start_time existed degrade to liveness."""
+    def test_legacy_checkpoint_without_tuple_is_not_recovered(self, registry, tmp_path):
+        """Legacy bare-PID entries fail closed rather than being adopted."""
         checkpoint = tmp_path / "procs.json"
         checkpoint.write_text(json.dumps([{
             "session_id": "proc_legacy",
@@ -1982,7 +2025,7 @@ class TestPidReuseGuard:
             "task_id": "t1",
         }]))
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
-            assert registry.recover_from_checkpoint() == 1
+            assert registry.recover_from_checkpoint() == 0
 
     def test_write_checkpoint_backfills_host_start_time(self, registry, tmp_path):
         """A host session is checkpointed with a kernel start time recorded."""
@@ -1994,24 +2037,31 @@ class TestPidReuseGuard:
             registry._write_checkpoint()
             data = json.loads((tmp_path / "procs.json").read_text())
             assert data[0]["host_start_time"] is not None
+            assert data[0]["host_boot_id"] is not None
 
-    def test_refresh_detached_marks_recycled_pid_exited(self, registry):
-        """A detached session whose PID got recycled is moved to finished."""
+    def test_refresh_detached_mismatch_stays_unknown_for_sentinel(self, registry):
+        """A detached mismatch is probe uncertainty, never terminal evidence."""
         wrong_start = (ProcessRegistry._safe_host_start_time(os.getpid()) or 0) + 999
         s = _make_session(sid="proc_detached")
-        s.pid = os.getpid()          # alive, but...
+        s.pid = os.getpid()
         s.pid_scope = "host"
         s.detached = True
-        s.host_start_time = wrong_start  # ...identity no longer matches
+        s.host_start_time = wrong_start
+        s.host_boot_id = ProcessRegistry._safe_host_boot_id()
         registry._running[s.id] = s
         refreshed = registry._refresh_detached_session(s)
-        assert refreshed.exited is True
-        assert s.id in registry._finished
+        assert refreshed.exited is False
+        assert s.id in registry._running
+        assert s.id not in registry._finished
 
 
 @pytest.mark.skipif(sys.platform == "win32",
                     reason="POSIX SIGTERM→SIGKILL escalation; Windows uses taskkill /F")
 class TestSigkillEscalation:
+    @pytest.fixture(autouse=True)
+    def _verified_identity(self, monkeypatch):
+        monkeypatch.setattr(ProcessRegistry, "_host_pid_is_ours", lambda *_args: True)
+
     """Bounded SIGTERM→SIGKILL escalation in _terminate_host_pid.
 
     A daemon that ignores/stalls on SIGTERM must be force-killed after the
@@ -2082,11 +2132,23 @@ class TestSigkillEscalation:
         """A start-time mismatch must still spare the PID — no SIGTERM, no SIGKILL."""
         monkeypatch.setattr(ProcessRegistry, "_daemon_term_grace_seconds",
                             staticmethod(lambda: 1.0))
+        # This test exercises the real tuple guard rather than the class fixture's
+        # signalling-path bypass used by the escalation-only tests above.
+        monkeypatch.setattr(
+            ProcessRegistry,
+            "_host_pid_is_ours",
+            lambda pid, start, boot: ProcessRegistry._host_pid_identity_status(
+                pid, start, boot
+            ) == "ours",
+        )
         proc = self._spawn_trap()
         try:
             real_start = ProcessRegistry._safe_host_start_time(proc.pid)
             ProcessRegistry._terminate_host_pid(
-                proc.pid, expected_start=(real_start or 0) + 1)
+                proc.pid,
+                expected_start=(real_start or 0) + 1,
+                expected_boot=ProcessRegistry._safe_host_boot_id(),
+            )
             assert not _wait_until(lambda: proc.poll() is not None, timeout=1.5)
             assert proc.poll() is None
         finally:
@@ -2229,3 +2291,278 @@ class TestHandleProcessRedaction:
         monkeypatch.setattr(pr, "process_registry", reg)
         out = json.loads(pr._handle_process({"action": "log", "session_id": sess.id}))
         assert "zzzopaque1234567890abcdef" in out["output"]
+
+
+class TestManagedProcessLifecycleHooks:
+    def test_local_started_uses_exact_identity_after_registry_insert(self, registry, monkeypatch):
+        from agent import lifecycle_hooks as lh
+        emitted = []
+        proc = MagicMock(pid=4242, stdout=MagicMock(), returncode=None)
+        reader = MagicMock()
+
+        def capture(hook, payload):
+            assert payload["process_id"] in registry._running
+            emitted.append((hook, dict(payload)))
+
+        monkeypatch.setattr(lh, "_emit", capture)
+        monkeypatch.setattr(registry, "_safe_host_start_time", lambda _pid: 98765)
+        monkeypatch.setattr(registry, "_start_local_lifecycle_monitor", lambda _s: None)
+        with patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+             patch("tools.process_registry.subprocess.Popen", return_value=proc), \
+             patch("tools.process_registry.threading.Thread", return_value=reader), \
+             patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_local("SECRET-CANARY command", cwd="/private/cwd", task_id="task-1")
+
+        payload = emitted[0][1]
+        assert session.pid == payload["pid"] == 4242
+        assert payload["host_start_time"] == 98765
+        assert payload["host_boot_id"] == session.host_boot_id
+        assert payload["event"] == "started"
+        assert "SECRET-CANARY" not in repr(payload)
+        assert "/private/cwd" not in repr(payload)
+
+    def test_remote_started_carries_stable_backend_identity(self, registry, monkeypatch):
+        from agent import lifecycle_hooks as lh
+        emitted = []
+
+        class DockerEnv:
+            __module__ = "tools.environments.docker"
+            _container_id = "container-identity-1"
+            process_token = ""
+
+            def execute(self, command, **_kwargs):
+                if ".identity" in command and command.lstrip().startswith("cat "):
+                    return {
+                        "output": f"31337 424242 {self.process_token}\n",
+                        "returncode": 0,
+                    }
+                tokens = re.findall(r"[0-9a-f]{32}", command)
+                self.process_token = tokens[-1]
+                return {"output": "31337\n", "returncode": 0}
+
+        monkeypatch.setattr(lh, "_emit", lambda hook, payload: emitted.append((hook, dict(payload))))
+        with patch("tools.process_registry.threading.Thread", return_value=MagicMock()), \
+             patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_via_env(DockerEnv(), "raw command canary")
+
+        payload = emitted[0][1]
+        assert session.id in registry._running
+        assert payload["backend"] == "docker"
+        assert payload["backend_id"] == "container-identity-1"
+        assert session.pid == 31337
+        assert payload["pid"] is None
+        assert payload["host_start_time"] is None
+        assert payload["host_boot_id"] is None
+        assert "raw command canary" not in repr(payload)
+
+    def test_remote_kill_refuses_unverified_namespace_pid(self, registry):
+        class DockerEnv:
+            __module__ = "tools.environments.docker"
+            _container_id = "container-kill-refusal"
+
+            def __init__(self):
+                self.calls = []
+
+            def execute(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+                raise AssertionError("bare sandbox PID must never be signalled")
+
+        env = DockerEnv()
+        session = _make_session(sid="proc_remote_kill")
+        session.pid = 31337
+        session.pid_scope = "sandbox"
+        session.env_ref = env
+        registry._running[session.id] = session
+
+        result = registry.kill_process(session.id)
+
+        assert result["status"] == "error"
+        assert "identity cannot be verified" in result["error"]
+        assert env.calls == []
+
+    def test_remote_failed_start_emits_exactly_one_terminal_dto(self, registry, monkeypatch):
+        from agent import lifecycle_hooks as lh
+        emitted = []
+
+        class DockerEnv:
+            __module__ = "tools.environments.docker"
+            _container_id = "container-failed-start"
+
+            def execute(self, *_args, **_kwargs):
+                return {"output": "launch failed", "returncode": 2}
+
+        monkeypatch.setattr(
+            lh, "_emit", lambda _hook, payload: emitted.append(dict(payload))
+        )
+        with patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_via_env(DockerEnv(), "raw command canary")
+
+        terminal = [event for event in emitted if event["event"] == "terminal"]
+        assert session.exited is True
+        assert len(terminal) == 1
+        assert terminal[0]["terminal_status"] == "failed_start"
+        assert terminal[0]["termination_source"] == "failed_start"
+        assert "raw command canary" not in repr(terminal)
+
+    def test_remote_without_stable_backend_identity_emits_no_lifecycle(self, registry, monkeypatch):
+        from agent import lifecycle_hooks as lh
+        emitted = []
+
+        class UnknownEnv:
+            __module__ = "tools.environments.ssh"
+            process_token = ""
+
+            def execute(self, command, **_kwargs):
+                if ".identity" in command and command.lstrip().startswith("cat "):
+                    return {
+                        "output": f"31337 424242 {self.process_token}\n",
+                        "returncode": 0,
+                    }
+                tokens = re.findall(r"[0-9a-f]{32}", command)
+                self.process_token = tokens[-1]
+                return {"output": "31337\n", "returncode": 0}
+
+        monkeypatch.setattr(
+            lh, "_emit", lambda hook, payload: emitted.append((hook, dict(payload)))
+        )
+        with patch("tools.process_registry.threading.Thread", return_value=MagicMock()), \
+             patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_via_env(UnknownEnv(), "raw command canary")
+
+        assert session.id in registry._running
+        assert emitted == []
+
+    def test_backend_outage_is_probe_unavailable_not_terminal(self, registry, monkeypatch, caplog):
+        from agent import lifecycle_hooks as lh
+        session = _make_session(sid="proc_remote")
+        session.pid, session.pid_scope = 99, "sandbox"
+        registry._running[session.id] = session
+        probe_seen, emitted = threading.Event(), []
+
+        class BrokenEnv:
+            __module__ = "tools.environments.ssh"
+            instance_id = "remote-instance-1"
+
+            def execute(self, *_args, **_kwargs):
+                raise RuntimeError("raw backend exception canary")
+
+        def capture(_hook, payload):
+            emitted.append(dict(payload))
+            probe_seen.set()
+
+        broken_env = BrokenEnv()
+        session.env_ref = broken_env
+        caplog.set_level(logging.DEBUG, logger="tools.process_registry")
+        monkeypatch.setattr(lh, "_emit", capture)
+        monkeypatch.setattr("tools.process_registry.time.sleep", lambda _seconds: None)
+        thread = threading.Thread(target=registry._env_poller_loop,
+                                  args=(session, broken_env, "/log", "/pid", "/exit"), daemon=True)
+        thread.start()
+        assert probe_seen.wait(timeout=1)
+        assert session.exited is False
+        assert session.id in registry._running
+        assert not any(event["event"] == "terminal" for event in emitted)
+        assert "raw backend exception canary" not in repr(emitted)
+        session.exited = True
+        thread.join(timeout=1)
+        assert "raw backend exception canary" not in caplog.text
+
+    def test_empty_remote_probe_is_probe_unavailable_not_silent(self, registry, monkeypatch):
+        from agent import lifecycle_hooks as lh
+        session = _make_session(sid="proc_remote_empty")
+        session.pid, session.pid_scope = 99, "sandbox"
+        registry._running[session.id] = session
+        seen, emitted = threading.Event(), []
+
+        class EmptyEnv:
+            __module__ = "tools.environments.docker"
+            _container_id = "container-empty-probe"
+
+            def execute(self, *_args, **_kwargs):
+                return {"output": "", "returncode": 0}
+
+        def capture(_hook, payload):
+            emitted.append(dict(payload))
+            session.exited = True
+            seen.set()
+
+        env = EmptyEnv()
+        session.env_ref = env
+        monkeypatch.setattr(lh, "_emit", capture)
+        monkeypatch.setattr("tools.process_registry.time.sleep", lambda _seconds: None)
+        thread = threading.Thread(
+            target=registry._env_poller_loop,
+            args=(session, env, "/log", "/pid", "/exit"),
+            daemon=True,
+        )
+        thread.start()
+        assert seen.wait(timeout=1)
+        thread.join(timeout=1)
+        assert [event["event"] for event in emitted] == ["probe_unavailable"]
+
+    def test_move_to_finished_emits_terminal_exactly_once_under_race(self, registry, monkeypatch):
+        from agent import lifecycle_hooks as lh
+        session = _make_session(sid="proc_race", exited=True, exit_code=0)
+        session.pid = 123
+        session.host_start_time = 456
+        session.host_boot_id = "boot"
+        registry._running[session.id] = session
+        emitted, lock = [], threading.Lock()
+
+        def capture(_hook, payload):
+            with lock:
+                emitted.append(dict(payload))
+
+        monkeypatch.setattr(lh, "_emit", capture)
+        monkeypatch.setattr(registry, "_write_checkpoint", lambda: None)
+        racers = [threading.Thread(target=registry._move_to_finished, args=(session,)) for _ in range(12)]
+        for racer in racers:
+            racer.start()
+        for racer in racers:
+            racer.join()
+
+        terminal = [event for event in emitted if event["event"] == "terminal"]
+        assert len(terminal) == 1
+        assert terminal[0]["terminal_status"] == "exited"
+        assert terminal[0]["exit_code"] == 0
+
+    def test_pid_reuse_mismatch_never_heartbeats_recycled_identity(self, registry, monkeypatch):
+        from agent import lifecycle_hooks as lh
+        session = _make_session(sid="proc_reused")
+        session.pid, session.host_start_time, session.process = 123, 456, MagicMock()
+        session.host_boot_id = "boot"
+        session.process.poll.return_value = None
+        emitted = []
+        waits = iter([False])
+        monkeypatch.setattr(session._completion_event, "wait", lambda _timeout: next(waits))
+        monkeypatch.setattr(registry, "_host_pid_is_ours", lambda *_args: False)
+        monkeypatch.setattr(lh, "_emit", lambda _hook, payload: emitted.append(dict(payload)))
+
+        registry._local_lifecycle_monitor(session)
+        assert [event["event"] for event in emitted] == ["probe_unavailable"]
+
+    def test_verified_checkpoint_recovery_emits_adopted(self, registry, monkeypatch, tmp_path):
+        from agent import lifecycle_hooks as lh
+        start_time = ProcessRegistry._safe_host_start_time(os.getpid())
+        checkpoint = tmp_path / "processes.json"
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_adopted",
+            "command": "SECRET-CANARY",
+            "pid": os.getpid(),
+            "pid_scope": "host",
+            "host_start_time": start_time,
+            "host_boot_id": ProcessRegistry._safe_host_boot_id(),
+            "task_id": "task-adopted",
+        }]))
+        emitted = []
+        monkeypatch.setattr(lh, "_emit", lambda _hook, payload: emitted.append(dict(payload)))
+        monkeypatch.setattr(registry, "_start_local_lifecycle_monitor", lambda _s: None)
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint), \
+             patch.object(registry, "_write_checkpoint"):
+            assert registry.recover_from_checkpoint() == 1
+
+        adopted = [event for event in emitted if event["event"] == "adopted"]
+        assert len(adopted) == 1
+        assert adopted[0]["process_id"] == "proc_adopted"
+        assert adopted[0]["host_start_time"] == start_time
+        assert "SECRET-CANARY" not in repr(adopted)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1116,6 +1116,7 @@ def _build_child_agent(
     # one key.  parent_id is non-None when THIS parent is itself a subagent
     # (nested orchestrator -> worker chain).
     subagent_id = f"sa-{task_index}-{_uuid.uuid4().hex[:8]}"
+    wrapper_id = f"dw-{task_index}-{_uuid.uuid4().hex[:12]}"
     parent_subagent_id = getattr(parent_agent, "_subagent_id", None)
     tui_depth = max(0, child_depth - 1)  # 0 = first-level child for the UI
 
@@ -1417,9 +1418,15 @@ def _build_child_agent(
     # Stash subagent identity for nested-delegation event propagation and
     # for _run_single_child / interrupt_subagent to look up by id.
     child._subagent_id = subagent_id
+    setattr(child, "_delegation_wrapper_id", wrapper_id)
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
     child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
+    # A built child is provider-registered before it is submitted for
+    # execution.  Keep an object-local guard so batch construction/dispatch
+    # failures can close that pre-start lifecycle exactly once.
+    child._delegation_prestart_cleanup_lock = threading.Lock()
+    child._delegation_prestart_cleanup_done = False
     # Stable sidebar marker: delegate subagent sessions must stay out of
     # session pickers even when a parent delete orphans them (parent_session_id
     # → NULL). Mirrors /branch's ``_branched_from`` pattern — see
@@ -1455,6 +1462,33 @@ def _build_child_agent(
             logger.debug("spawn_requested relay failed: %s", exc)
 
     try:
+        from agent.lifecycle_hooks import emit_subagent_lifecycle
+
+        emit_subagent_lifecycle(
+            "registered",
+            parent_session_id=getattr(parent_agent, "session_id", None),
+            parent_turn_id=getattr(parent_agent, "_current_turn_id", "") or "",
+            parent_subagent_id=parent_subagent_id,
+            delegation_wrapper_id=wrapper_id,
+            child_session_id=getattr(child, "session_id", None),
+            child_subagent_id=subagent_id,
+            child_role=effective_role,
+        )
+        from agent.lifecycle_hooks import emit_delegation_wrapper_lifecycle
+        emit_delegation_wrapper_lifecycle(
+            "registered",
+            wrapper_id=wrapper_id,
+            child_subagent_id=subagent_id,
+            parent_session_id=getattr(parent_agent, "session_id", None),
+            parent_turn_id=getattr(parent_agent, "_current_turn_id", "") or "",
+            parent_subagent_id=parent_subagent_id,
+        )
+    except Exception:
+        logger.debug(
+            "subagent_lifecycle_failed event=registered reason=callback_error"
+        )
+
+    try:
         from hermes_cli.plugins import invoke_hook as _invoke_hook
         _invoke_hook(
             "subagent_start",
@@ -1470,6 +1504,75 @@ def _build_child_agent(
         logger.debug("subagent_start hook invocation failed", exc_info=True)
 
     return child
+
+
+def _fail_registered_unstarted_child(child: Any, parent_agent: Any) -> None:
+    """Terminalize and release a provider-registered child that never started.
+
+    Batch construction and executor submission are both fallible after
+    ``_build_child_agent`` has emitted the child and wrapper ``registered``
+    events.  Such children never enter ``_run_single_child``, so its normal
+    terminal and cleanup authority cannot run.  This function is the narrow
+    pre-start owner for those failure paths.
+    """
+    lock = getattr(child, "_delegation_prestart_cleanup_lock", None)
+    if lock is None:
+        lock = threading.Lock()
+        setattr(child, "_delegation_prestart_cleanup_lock", lock)
+    with lock:
+        if getattr(child, "_delegation_prestart_cleanup_done", False) is True:
+            return
+        child._delegation_prestart_cleanup_done = True
+
+    lifecycle_args = {
+        "parent_session_id": getattr(parent_agent, "session_id", None),
+        "parent_turn_id": getattr(child, "_parent_turn_id", "") or "",
+        "parent_subagent_id": getattr(child, "_parent_subagent_id", None),
+    }
+    try:
+        from agent.lifecycle_hooks import emit_subagent_lifecycle
+
+        emit_subagent_lifecycle(
+            "terminal",
+            delegation_wrapper_id=getattr(child, "_delegation_wrapper_id", None),
+            child_session_id=getattr(child, "session_id", None),
+            child_subagent_id=getattr(child, "_subagent_id", None),
+            child_role=getattr(child, "_delegate_role", None),
+            terminal_status="failed",
+            **lifecycle_args,
+        )
+    except Exception:
+        logger.debug("subagent_lifecycle_failed event=terminal reason=prestart_cleanup")
+    try:
+        from agent.lifecycle_hooks import emit_delegation_wrapper_lifecycle
+
+        emit_delegation_wrapper_lifecycle(
+            "terminal",
+            wrapper_id=getattr(child, "_delegation_wrapper_id", None),
+            child_subagent_id=getattr(child, "_subagent_id", None),
+            terminal_status="failed",
+            **lifecycle_args,
+        )
+    except Exception:
+        logger.debug(
+            "delegation_wrapper_lifecycle_failed event=terminal reason=prestart_cleanup"
+        )
+
+    if parent_agent is not None and hasattr(parent_agent, "_active_children"):
+        try:
+            active_lock = getattr(parent_agent, "_active_children_lock", None)
+            if active_lock:
+                with active_lock:
+                    parent_agent._active_children.remove(child)
+            else:
+                parent_agent._active_children.remove(child)
+        except (ValueError, AttributeError):
+            pass
+    try:
+        if child is not None and hasattr(child, "close"):
+            child.close()
+    except Exception:
+        logger.debug("Failed to close unstarted delegated child", exc_info=True)
 
 
 def _dump_subagent_timeout_diagnostic(
@@ -1804,28 +1907,13 @@ def _run_single_child(
     """
     child_start = time.monotonic()
 
-    # Get the progress callback from the child agent
     child_progress_cb = getattr(child, "tool_progress_callback", None)
-
-    # Restore parent tool names using the value saved before child construction
-    # mutated the global. This is the correct parent toolset, not the child's.
-    import model_tools
-
-    _saved_tool_names = getattr(
-        child, "_delegate_saved_tool_names", list(model_tools._last_resolved_tool_names)
-    )
-
     child_pool = getattr(child, "_credential_pool", None)
     leased_cred_id = None
-    if child_pool is not None:
-        leased_cred_id = child_pool.acquire_lease()
-        if leased_cred_id is not None:
-            try:
-                leased_entry = child_pool.current()
-                if leased_entry is not None and hasattr(child, "_swap_credential"):
-                    child._swap_credential(leased_entry)
-            except Exception as exc:
-                logger.debug("Failed to bind child to leased credential: %s", exc)
+    _saved_tool_names = []
+    _raw_sid = getattr(child, "_subagent_id", None)
+    _subagent_id = _raw_sid if isinstance(_raw_sid, str) else None
+    _live_registered = False
 
     # Heartbeat: periodically propagate child activity to the parent so the
     # gateway inactivity timeout doesn't fire while the subagent is working.
@@ -1838,10 +1926,67 @@ def _run_single_child(
     _last_seen_iter = [0]
     _last_seen_tool = [None]  # type: list
     _stale_count = [0]
+    _legacy_touch_suppressed = [False]
+
+    def _emit_child_lifecycle(event: str, **extra: Any) -> None:
+        try:
+            from agent.lifecycle_hooks import emit_subagent_lifecycle
+
+            emit_subagent_lifecycle(
+                event,
+                parent_session_id=getattr(parent_agent, "session_id", None),
+                parent_turn_id=getattr(child, "_parent_turn_id", "") or "",
+                parent_subagent_id=getattr(child, "_parent_subagent_id", None),
+                delegation_wrapper_id=getattr(child, "_delegation_wrapper_id", None),
+                child_session_id=getattr(child, "session_id", None),
+                child_subagent_id=_subagent_id,
+                child_role=getattr(child, "_delegate_role", None),
+                **extra,
+            )
+        except Exception:
+            logger.debug(
+                "subagent_lifecycle_failed event=%s reason=invalid_or_callback_error",
+                event,
+            )
+
+    def _emit_wrapper_lifecycle(event: str, **extra: Any) -> None:
+        try:
+            from agent.lifecycle_hooks import emit_delegation_wrapper_lifecycle
+            emit_delegation_wrapper_lifecycle(
+                event,
+                wrapper_id=getattr(child, "_delegation_wrapper_id", None),
+                child_subagent_id=getattr(child, "_subagent_id", None),
+                parent_session_id=getattr(parent_agent, "session_id", None),
+                parent_turn_id=getattr(child, "_parent_turn_id", "") or "",
+                parent_subagent_id=getattr(child, "_parent_subagent_id", None),
+                **extra,
+            )
+        except Exception:
+            logger.debug("delegation_wrapper_lifecycle_failed event=%s", event)
+
+    _child_terminal_lock = threading.Lock()
+    _child_terminal_done = [False]
+
+    def _emit_child_terminal_once(status: str) -> None:
+        with _child_terminal_lock:
+            if _child_terminal_done[0]:
+                return
+            _child_terminal_done[0] = True
+        _emit_child_lifecycle("terminal", terminal_status=status)
 
     def _heartbeat_loop():
         while not _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+            # Contract heartbeat is independent of the waiting wrapper and is
+            # owned by the live child execution context.
+            try:
+                _emit_child_lifecycle("heartbeat")
+            except Exception:
+                logger.debug(
+                    "subagent_lifecycle_failed event=heartbeat reason=callback_error"
+                )
             if parent_agent is None:
+                continue
+            if _legacy_touch_suppressed[0]:
                 continue
             touch = getattr(parent_agent, "_touch_activity", None)
             if not touch:
@@ -1887,7 +2032,10 @@ def _run_single_child(
                         _stale_count[0],
                         child_tool or "<none>",
                     )
-                    break  # stop touching parent, let gateway timeout fire
+                    # Suppress only the legacy parent-activity touch. The v1
+                    # lifecycle heartbeat remains owned by the live child.
+                    _legacy_touch_suppressed[0] = True
+                    continue
 
                 if child_tool:
                     desc = (
@@ -1910,42 +2058,113 @@ def _run_single_child(
 
     _heartbeat_thread = threading.Thread(target=_heartbeat_loop, daemon=True)
 
-    # Register the live agent in the module-level registry so the TUI can
-    # target it by subagent_id (kill, pause, status queries).  Unregistered
-    # in the finally block, even when the child raises.  Test doubles that
-    # hand us a MagicMock don't carry stable ids; skip registration then.
-    _raw_sid = getattr(child, "_subagent_id", None)
-    _subagent_id = _raw_sid if isinstance(_raw_sid, str) else None
-    if _subagent_id:
-        _raw_depth = getattr(child, "_delegate_depth", 1)
-        _tui_depth = max(0, _raw_depth - 1) if isinstance(_raw_depth, int) else 0
-        _parent_sid = getattr(child, "_parent_subagent_id", None)
-        _register_subagent(
-            {
-                "subagent_id": _subagent_id,
-                "parent_id": _parent_sid if isinstance(_parent_sid, str) else None,
-                "depth": _tui_depth,
-                "goal": goal,
-                "model": (
-                    getattr(child, "model", None)
-                    if isinstance(getattr(child, "model", None), str)
-                    else None
-                ),
-                "started_at": time.time(),
-                "status": "running",
-                "tool_count": 0,
-                "agent": child,
-            }
+    # Every operation after provider registration is under terminal authority.
+    # A setup failure happens before actual child start, so close both records
+    # from their registered state and release any partially acquired resource.
+    try:
+        import model_tools
+
+        _saved_tool_names = getattr(
+            child,
+            "_delegate_saved_tool_names",
+            list(model_tools._last_resolved_tool_names),
         )
+        if child_pool is not None:
+            leased_cred_id = child_pool.acquire_lease()
+            if leased_cred_id is not None:
+                try:
+                    leased_entry = child_pool.current()
+                    if leased_entry is not None and hasattr(child, "_swap_credential"):
+                        child._swap_credential(leased_entry)
+                except Exception as exc:
+                    logger.debug("Failed to bind child to leased credential: %s", exc)
+
+        if _subagent_id:
+            _raw_depth = getattr(child, "_delegate_depth", 1)
+            _tui_depth = max(0, _raw_depth - 1) if isinstance(_raw_depth, int) else 0
+            _parent_sid = getattr(child, "_parent_subagent_id", None)
+            _register_subagent(
+                {
+                    "subagent_id": _subagent_id,
+                    "parent_id": _parent_sid if isinstance(_parent_sid, str) else None,
+                    "depth": _tui_depth,
+                    "goal": goal,
+                    "model": (
+                        getattr(child, "model", None)
+                        if isinstance(getattr(child, "model", None), str)
+                        else None
+                    ),
+                    "started_at": time.time(),
+                    "status": "running",
+                    "tool_count": 0,
+                    "agent": child,
+                }
+            )
+            _live_registered = True
+    except BaseException:
+        _emit_child_terminal_once("failed")
+        _emit_wrapper_lifecycle("terminal", terminal_status="failed")
+        if _live_registered and _subagent_id:
+            _unregister_subagent(_subagent_id)
+        if child_pool is not None and leased_cred_id is not None:
+            try:
+                child_pool.release_lease(leased_cred_id)
+            except Exception:
+                pass
+        if parent_agent is not None and hasattr(parent_agent, "_active_children"):
+            try:
+                parent_agent._active_children.remove(child)
+            except (ValueError, AttributeError):
+                pass
+        try:
+            if child is not None and hasattr(child, "close"):
+                child.close()
+        except Exception:
+            pass
+        raise
+
+    _owner_cleanup_lock = threading.Lock()
+    _owner_cleanup_done = [False]
+    _child_future = None
+
+    def _cleanup_after_actual_child() -> None:
+        """Release child-owned resources exactly once after real completion."""
+        with _owner_cleanup_lock:
+            if _owner_cleanup_done[0]:
+                return
+            _owner_cleanup_done[0] = True
+
+        _heartbeat_stop.set()
+        if (
+            _heartbeat_thread.ident is not None
+            and _heartbeat_thread is not threading.current_thread()
+        ):
+            _heartbeat_thread.join(timeout=5)
+        if _subagent_id:
+            _unregister_subagent(_subagent_id)
+        if child_pool is not None and leased_cred_id is not None:
+            try:
+                child_pool.release_lease(leased_cred_id)
+            except Exception as exc:
+                logger.debug("Failed to release credential lease: %s", exc)
+        if parent_agent is not None and hasattr(parent_agent, "_active_children"):
+            try:
+                lock = getattr(parent_agent, "_active_children_lock", None)
+                if lock:
+                    with lock:
+                        parent_agent._active_children.remove(child)
+                else:
+                    parent_agent._active_children.remove(child)
+            except (ValueError, UnboundLocalError) as exc:
+                logger.debug("Could not remove child from active_children: %s", exc)
+        try:
+            if child is not None and hasattr(child, "close"):
+                child.close()
+        except Exception:
+            logger.debug("Failed to close child agent after delegation")
 
     try:
-        _heartbeat_thread.start()
-        if child_progress_cb:
-            try:
-                child_progress_cb("subagent.start", preview=goal)
-            except Exception as e:
-                logger.debug("Progress callback start failed: %s", e)
-
+        _emit_wrapper_lifecycle("started")
         # File-state coordination: reuse the stable subagent_id as the child's
         # task_id so file_state writes, active-subagents registry, and TUI
         # events all share one key.  Falls back to a fresh uuid only if the
@@ -2003,22 +2222,89 @@ def _run_single_child(
             except Exception as e:
                 logger.debug("Child text relay failed: %s", e)
 
+        _queue_announced = threading.Event()
+
+        def _terminal_status(run_result: Any) -> str:
+            """Classify only explicit conversation outcomes; ambiguity fails closed."""
+            if not isinstance(run_result, dict):
+                return "failed"
+            if run_result.get("interrupted") is True:
+                return "cancelled"
+            if run_result.get("failed") is True:
+                return "failed"
+            summary_value = run_result.get("final_response")
+            if (
+                run_result.get("completed") is True
+                and isinstance(summary_value, str)
+                and summary_value.strip()
+                and summary_value.strip() != "(empty)"
+            ):
+                return "succeeded"
+            # Partial, max-iteration, provider-exhaustion, and legacy/unknown
+            # result shapes are not authoritative success signals even when they
+            # carry non-empty user-facing text.
+            return "failed"
+
         def _run_with_thread_capture():
             _worker_thread_holder["t"] = threading.current_thread()
+            # A successful submit does not itself prove execution. The gate lets
+            # the submitter publish queued before this owner publishes started.
+            _queue_announced.wait()
             from agent.delegation_context import delegated_child_context
 
             with delegated_child_context():
-                return child.run_conversation(
-                    user_message=goal,
-                    task_id=child_task_id,
-                    stream_callback=_relay_child_text,
-                )
+                try:
+                    _heartbeat_thread.start()
+                    if child_progress_cb:
+                        try:
+                            child_progress_cb("subagent.start", preview=goal)
+                        except Exception as exc:
+                            logger.debug("Progress callback start failed: %s", exc)
+                    _emit_child_lifecycle("started")
+                    run_result = child.run_conversation(
+                        user_message=goal,
+                        task_id=child_task_id,
+                        stream_callback=_relay_child_text,
+                    )
+                    _emit_child_terminal_once(_terminal_status(run_result))
+                    return run_result
+                except BaseException:
+                    _emit_child_terminal_once("failed")
+                    raise
+                finally:
+                    _cleanup_after_actual_child()
 
-        _child_future = _timeout_executor.submit(_run_with_thread_capture)
+        try:
+            _child_future = _timeout_executor.submit(_run_with_thread_capture)
+            _emit_child_lifecycle("queued")
+        except Exception:
+            # Registration already happened during child construction. Close the
+            # pre-start attempt authoritatively so observers cannot strand it.
+            _emit_child_terminal_once("failed")
+            _emit_wrapper_lifecycle("terminal", terminal_status="failed")
+            _cleanup_after_actual_child()
+            raise
+        finally:
+            _queue_announced.set()
         try:
             result = _child_future.result(timeout=child_timeout)
         except Exception as _timeout_exc:
-            # Signal the child to stop so its thread can exit cleanly.
+            is_timeout = isinstance(_timeout_exc, (FuturesTimeoutError, TimeoutError))
+            if is_timeout:
+                _emit_wrapper_lifecycle("timed_out")
+                # The waiter is complete even though the child future remains
+                # authoritative for its own lifecycle and cleanup.
+                _emit_wrapper_lifecycle("terminal", terminal_status="cancelled")
+                try:
+                    _emit_child_lifecycle(
+                        "cancel_requested", cancel_reason="waiter_timeout"
+                    )
+                except Exception:
+                    logger.debug(
+                        "subagent_lifecycle_failed event=cancel_requested reason=callback_error"
+                    )
+            # Signal the child to stop so its thread can exit cleanly. This is a
+            # request only; terminal and cleanup remain owned by the live future.
             try:
                 if hasattr(child, "interrupt"):
                     child.interrupt()
@@ -2027,7 +2313,6 @@ def _run_single_child(
             except Exception:
                 pass
 
-            is_timeout = isinstance(_timeout_exc, (FuturesTimeoutError, TimeoutError))
             duration = round(time.monotonic() - child_start, 2)
             logger.warning(
                 "Subagent %d %s after %.1fs",
@@ -2097,6 +2382,7 @@ def _run_single_child(
                         f"stuck on a slow API call or unresponsive network request."
                     )
             else:
+                _emit_wrapper_lifecycle("terminal", terminal_status="failed")
                 _err = str(_timeout_exc)
 
             return {
@@ -2126,22 +2412,20 @@ def _run_single_child(
 
         summary = result.get("final_response") or ""
         completed = result.get("completed", False)
+        failed = result.get("failed", False)
         interrupted = result.get("interrupted", False)
         api_calls = result.get("api_calls", 0)
 
-        # The child emits the literal "(empty)" sentinel (see run_agent.py) when
-        # it gives up after repeated empty-LLM-response retries — typically a
-        # transport bug (misrouted provider, adapter returning empty
-        # ChatCompletion, etc.). Treat it as a failure so the parent surfaces
-        # it instead of silently accepting zero-content "success".
-        _empty_sentinel = summary.strip() == "(empty)"
-
+        # Parent-visible status is derived from the same authoritative classifier
+        # used by the lifecycle terminal event, including the literal ``(empty)``
+        # transport-failure sentinel.
+        authoritative_terminal = _terminal_status(result)
+        _emit_wrapper_lifecycle("terminal", terminal_status=authoritative_terminal)
         if interrupted:
             status = "interrupted"
-        elif summary and not _empty_sentinel:
-            # A summary means the subagent produced usable output.
-            # exit_reason ("completed" vs "max_iterations") already
-            # tells the parent *how* the task ended.
+        elif authoritative_terminal == "succeeded":
+            # Parent-facing status must agree with authoritative lifecycle truth:
+            # usable text alone cannot turn an explicit/partial failure into success.
             status = "completed"
         else:
             status = "failed"
@@ -2185,8 +2469,10 @@ def _run_single_child(
         # Determine exit reason
         if interrupted:
             exit_reason = "interrupted"
-        elif completed:
+        elif authoritative_terminal == "succeeded":
             exit_reason = "completed"
+        elif failed or completed:
+            exit_reason = "error"
         else:
             exit_reason = "max_iterations"
 
@@ -2354,56 +2640,18 @@ def _run_single_child(
         }
 
     finally:
-        # Stop the heartbeat thread so it doesn't keep touching parent activity
-        # after the child has finished (or failed).  Guard the join: .start()
-        # now lives inside the try block, so if it raised (OS thread
-        # exhaustion) the thread was never started and Thread.join() would
-        # raise RuntimeError.  ident is None until start() succeeds.
-        _heartbeat_stop.set()
-        if _heartbeat_thread.ident is not None:
-            _heartbeat_thread.join(timeout=5)
-
-        # Drop the TUI-facing registry entry.  Safe to call even if the
-        # child was never registered (e.g. ID missing on test doubles).
-        if _subagent_id:
-            _unregister_subagent(_subagent_id)
-
-        if child_pool is not None and leased_cred_id is not None:
-            try:
-                child_pool.release_lease(leased_cred_id)
-            except Exception as exc:
-                logger.debug("Failed to release credential lease: %s", exc)
-
-        # Restore the parent's tool names so the process-global is correct
-        # for any subsequent execute_code calls or other consumers.
+        # Before a future exists (or after it is done), this wrapper owns
+        # cleanup. A timed-out live future remains the sole cleanup owner.
+        if _child_future is None or _child_future.done():
+            _cleanup_after_actual_child()
+        # Process-global tool-name restoration is wrapper-owned and safe on a
+        # waiter timeout. Child liveness resources are released only by
+        # _cleanup_after_actual_child inside the actual future.
         import model_tools
 
         saved_tool_names = getattr(child, "_delegate_saved_tool_names", None)
         if isinstance(saved_tool_names, list):
             model_tools._last_resolved_tool_names = list(saved_tool_names)
-
-        # Remove child from active tracking
-
-        # Unregister child from interrupt propagation
-        if hasattr(parent_agent, "_active_children"):
-            try:
-                lock = getattr(parent_agent, "_active_children_lock", None)
-                if lock:
-                    with lock:
-                        parent_agent._active_children.remove(child)
-                else:
-                    parent_agent._active_children.remove(child)
-            except (ValueError, UnboundLocalError) as e:
-                logger.debug("Could not remove child from active_children: %s", e)
-
-        # Close tool resources (terminal sandboxes, browser daemons,
-        # background processes, httpx clients) so subagent subprocesses
-        # don't outlive the delegation.
-        try:
-            if hasattr(child, "close"):
-                child.close()
-        except Exception:
-            logger.debug("Failed to close child agent after delegation")
 
 
 def _recover_tasks_from_json_string(
@@ -2600,48 +2848,58 @@ def delegate_task(
     # child build raises (otherwise _last_resolved_tool_names stays corrupted).
     children = []
     try:
-        for i, t in enumerate(task_list):
-            # Per-task role beats top-level; normalise again so unknown
-            # per-task values warn and degrade to leaf uniformly.
-            effective_role = _normalize_role(t.get("role") or top_role)
-            child = _build_child_agent(
-                task_index=i,
-                goal=t["goal"],
-                context=t.get("context"),
-                # Subagents always inherit the parent's toolsets; the model
-                # cannot choose or narrow them (no model-facing toolsets arg).
-                toolsets=None,
-                model=creds["model"],
-                max_iterations=effective_max_iter,
-                task_count=n_tasks,
-                parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_request_overrides=creds.get("request_overrides"),
-                override_max_tokens=creds.get("max_output_tokens"),
-                override_acp_command=creds.get("command"),
-                override_acp_args=creds.get("args"),
-                role=effective_role,
-            )
-            # Override with correct parent tool names (before child construction mutated global)
-            child._delegate_saved_tool_names = _parent_tool_names
-            # Tee the child's progress events into its live transcript log.
-            # wrap_progress_callback preserves the inner callback contract
-            # (including the _flush attribute) and never lets writer failures
-            # reach the agent loop. When no parent display exists the inner
-            # callback is None and the wrapper still records events.
-            _writer = live_writers[i] if i < len(live_writers) else None
-            if _writer is not None:
-                child.tool_progress_callback = wrap_progress_callback(
-                    getattr(child, "tool_progress_callback", None), _writer
+        try:
+            for i, t in enumerate(task_list):
+                # Per-task role beats top-level; normalise again so unknown
+                # per-task values warn and degrade to leaf uniformly.
+                effective_role = _normalize_role(t.get("role") or top_role)
+                child = _build_child_agent(
+                    task_index=i,
+                    goal=t["goal"],
+                    context=t.get("context"),
+                    # Subagents always inherit the parent's toolsets; the model
+                    # cannot choose or narrow them (no model-facing toolsets arg).
+                    toolsets=None,
+                    model=creds["model"],
+                    max_iterations=effective_max_iter,
+                    task_count=n_tasks,
+                    parent_agent=parent_agent,
+                    override_provider=creds["provider"],
+                    override_base_url=creds["base_url"],
+                    override_api_key=creds["api_key"],
+                    override_api_mode=creds["api_mode"],
+                    override_request_overrides=creds.get("request_overrides"),
+                    override_max_tokens=creds.get("max_output_tokens"),
+                    override_acp_command=creds.get("command"),
+                    override_acp_args=creds.get("args"),
+                    role=effective_role,
                 )
-                child._live_transcript_path = str(_writer.path)
-            children.append((i, t, child))
-    finally:
-        # Authoritative restore: reset global to parent's tool names after all children built
-        _model_tools._last_resolved_tool_names = _parent_tool_names
+                # From this point the provider lifecycle is registered; bind
+                # it to the batch cleanup owner before any further setup.
+                children.append((i, t, child))
+                # Override with correct parent tool names (before child construction mutated global)
+                child._delegate_saved_tool_names = _parent_tool_names
+                # Tee the child's progress events into its live transcript log.
+                # wrap_progress_callback preserves the inner callback contract
+                # (including the _flush attribute) and never lets writer failures
+                # reach the agent loop. When no parent display exists the inner
+                # callback is None and the wrapper still records events.
+                _writer = live_writers[i] if i < len(live_writers) else None
+                if _writer is not None:
+                    child.tool_progress_callback = wrap_progress_callback(
+                        getattr(child, "tool_progress_callback", None), _writer
+                    )
+                    child._live_transcript_path = str(_writer.path)
+        finally:
+            # Authoritative restore: reset global to parent's tool names after all children built
+            _model_tools._last_resolved_tool_names = _parent_tool_names
+    except BaseException:
+        # A later build failed after earlier children were provider-registered.
+        # They will never reach _run_single_child, so close their lifecycle and
+        # resources here before preserving the original build failure.
+        for _i, _t, built_child in children:
+            _fail_registered_unstarted_child(built_child, parent_agent)
+        raise
 
     def _execute_and_aggregate() -> dict:
         """Run all built children (1 or N), join on them, aggregate results,
@@ -2669,15 +2927,28 @@ def delegate_task(
             from tools.daemon_pool import DaemonThreadPoolExecutor
             with DaemonThreadPoolExecutor(max_workers=max_children) as executor:
                 futures = {}
-                for i, t, child in children:
-                    future = executor.submit(
-                        _run_single_child,
-                        task_index=i,
-                        goal=t["goal"],
-                        child=child,
-                        parent_agent=parent_agent,
-                    )
-                    futures[future] = i
+                submitted_count = 0
+                try:
+                    for i, t, child in children:
+                        future = executor.submit(
+                            _run_single_child,
+                            task_index=i,
+                            goal=t["goal"],
+                            child=child,
+                            parent_agent=parent_agent,
+                        )
+                        futures[future] = i
+                        submitted_count += 1
+                except BaseException:
+                    # The failing submit and every later child remain in their
+                    # provider-registered state and have no execution owner.
+                    # Already-submitted children retain _run_single_child as
+                    # their sole terminal/cleanup authority.
+                    for _i, _t, unstarted_child in children[submitted_count:]:
+                        _fail_registered_unstarted_child(
+                            unstarted_child, parent_agent
+                        )
+                    raise
 
                 # Poll futures with interrupt checking.  as_completed() blocks
                 # until ALL futures finish — if a child agent gets stuck,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -100,6 +100,7 @@ class ProcessSession:
     cwd: Optional[str] = None                   # Working directory
     started_at: float = 0.0                     # time.time() of spawn (wall clock)
     host_start_time: Optional[int] = None       # kernel start ticks (/proc/<pid>/stat f22) — PID-reuse guard
+    host_boot_id: Optional[str] = None          # kernel boot UUID — reboot/PID-reuse guard
     exited: bool = False                        # Whether the process has finished
     exit_code: Optional[int] = None             # Exit code (None if still running)
     completion_reason: str = "exited"           # exited|killed|lost|failed_start|already_exited
@@ -108,6 +109,7 @@ class ProcessSession:
     max_output_chars: int = MAX_OUTPUT_CHARS
     detached: bool = False                      # True if recovered from crash (no pipe)
     pid_scope: str = "host"                     # "host" for local/PTY PIDs, "sandbox" for env-local PIDs
+    backend_process_id: Optional[str] = None      # backend-scoped token + process start identity
     # Watcher/notification metadata (persisted for crash recovery)
     watcher_platform: str = ""
     watcher_chat_id: str = ""
@@ -136,6 +138,9 @@ class ProcessSession:
     _completion_event: threading.Event = field(default_factory=threading.Event, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
+    _lifecycle_thread: Optional[threading.Thread] = field(default=None, repr=False)
+    _lifecycle_last_heartbeat_at: float = field(default=0.0, repr=False)
+    _lifecycle_last_probe_unavailable_at: float = field(default=0.0, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
 
 
@@ -212,6 +217,90 @@ class ProcessRegistry:
         # terminal tab. Distinct from kill — the process keeps running; only the
         # UI view is dropped (the user can reopen it from the status stack).
         self.on_close = None
+
+    @staticmethod
+    def _emit_process_lifecycle(
+        session: ProcessSession, event: str, **extra: Any
+    ) -> None:
+        from agent.lifecycle_hooks import (
+            emit_managed_process_lifecycle,
+            managed_process_backend,
+            managed_process_backend_id,
+        )
+
+        backend = managed_process_backend(session.env_ref)
+        backend_id = managed_process_backend_id(session.env_ref)
+        # Remote lifecycle is authoritative only with a stable backend identity.
+        # Missing identity degrades telemetry without affecting the process.
+        if session.pid_scope == "sandbox" and backend_id is None:
+            return
+        if session.pid_scope == "host" and (
+            not session.pid
+            or session.host_start_time is None
+            or not session.host_boot_id
+        ):
+            return
+        if event == "heartbeat":
+            now = time.monotonic()
+            if now - session._lifecycle_last_heartbeat_at < 15:
+                return
+            session._lifecycle_last_heartbeat_at = now
+        elif event == "probe_unavailable":
+            now = time.monotonic()
+            if now - session._lifecycle_last_probe_unavailable_at < 15:
+                return
+            session._lifecycle_last_probe_unavailable_at = now
+        emit_managed_process_lifecycle(
+            event,
+            process_id=session.id,
+            task_id=session.task_id,
+            session_key=session.session_key,
+            # Sandbox PIDs are namespace-local observations, not canonical
+            # host identities. Keep them private to the process registry.
+            pid=session.pid if session.pid_scope == "host" else None,
+            host_start_time=(
+                session.host_start_time if session.pid_scope == "host" else None
+            ),
+            host_boot_id=(
+                session.host_boot_id if session.pid_scope == "host" else None
+            ),
+            pid_scope=session.pid_scope,
+            backend=backend,
+            backend_id=backend_id,
+            backend_process_id=session.backend_process_id,
+            exit_code=session.exit_code,
+            **extra,
+        )
+
+    def _local_lifecycle_monitor(self, session: ProcessSession) -> None:
+        """Heartbeat only while the exact local PID identity remains ours."""
+        while not session._completion_event.wait(15):
+            try:
+                if session.exited:
+                    return
+                if session.process is not None and session.process.poll() is not None:
+                    return
+                identity = self._host_pid_identity_status(
+                    session.pid, session.host_start_time, session.host_boot_id
+                )
+                if identity != "ours":
+                    self._emit_process_lifecycle(session, "probe_unavailable")
+                    return
+                self._emit_process_lifecycle(session, "heartbeat")
+            except Exception:
+                logger.debug(
+                    "managed_process_lifecycle_failed event=heartbeat reason=callback_error"
+                )
+
+    def _start_local_lifecycle_monitor(self, session: ProcessSession) -> None:
+        monitor = threading.Thread(
+            target=self._local_lifecycle_monitor,
+            args=(session,),
+            daemon=True,
+            name=f"proc-lifecycle-{session.id}",
+        )
+        session._lifecycle_thread = monitor
+        monitor.start()
 
     @staticmethod
     def _clean_shell_noise(text: str) -> str:
@@ -468,36 +557,69 @@ class ProcessRegistry:
         except Exception:
             return None
 
+    @staticmethod
+    def _safe_host_boot_id() -> Optional[str]:
+        """Authoritative kernel boot UUID, or None when unavailable."""
+        try:
+            with open("/proc/sys/kernel/random/boot_id", encoding="utf-8") as handle:
+                value = handle.read().strip()
+        except Exception:
+            return None
+        return value or None
+
     @classmethod
-    def _host_pid_is_ours(cls, pid: Optional[int], expected_start: Optional[int]) -> bool:
-        """True only if ``pid`` is alive AND still the process we spawned.
-
-        The kernel recycles PID/PGID numbers once a process exits and is reaped,
-        so a stored PID can later name an *unrelated* process — observed in the
-        wild as a recycled number landing on a desktop browser's session leader,
-        which our tree-kill then SIGTERMs (Firefox dying at irregular intervals).
-        We compare the kernel start time captured at spawn against the live one;
-        a mismatch means the number was recycled and must never be signalled.
-
-        When no baseline was captured (legacy checkpoints, or platforms without
-        ``/proc``) we degrade to a bare liveness check rather than refusing to
-        act, preserving prior best-effort behaviour.
-        """
+    def _host_pid_identity_status(
+        cls,
+        pid: Optional[int],
+        expected_start: Optional[int],
+        expected_boot: Optional[str],
+    ) -> str:
+        """Return ours, dead, mismatch, or unavailable for a full host tuple."""
+        if not pid or expected_start is None or not expected_boot:
+            return "unavailable"
+        live_boot = cls._safe_host_boot_id()
+        if live_boot is None:
+            return "unavailable"
+        if live_boot != expected_boot:
+            return "mismatch"
         if not cls._is_host_pid_alive(pid):
-            return False
-        if expected_start is None:
-            return True
-        return cls._safe_host_start_time(pid) == expected_start
+            return "dead"
+        live_start = cls._safe_host_start_time(pid)
+        if live_start is None:
+            return "unavailable"
+        return "ours" if live_start == expected_start else "mismatch"
+
+    @classmethod
+    def _host_pid_is_ours(
+        cls,
+        pid: Optional[int],
+        expected_start: Optional[int],
+        expected_boot: Optional[str],
+    ) -> bool:
+        """True only for a complete, currently matching PID/start/boot tuple.
+
+        Missing tuple members fail closed. A bare PID is never sufficient for
+        liveness, adoption, or signalling because PID values are recycled.
+        """
+        return cls._host_pid_identity_status(
+            pid, expected_start, expected_boot
+        ) == "ours"
 
     def _refresh_detached_session(self, session: Optional[ProcessSession]) -> Optional[ProcessSession]:
         """Update recovered host-PID sessions when the underlying process has exited."""
         if session is None or session.exited or not session.detached or session.pid_scope != "host":
             return session
 
-        # Identity-aware liveness: a recycled PID (alive but a different process
-        # than we spawned) must be treated as "our process exited", so it is
-        # moved to finished and can never be tree-killed by a later kill().
-        if self._host_pid_is_ours(session.pid, session.host_start_time):
+        identity = self._host_pid_identity_status(
+            session.pid, session.host_start_time, session.host_boot_id
+        )
+        if identity == "ours":
+            return session
+
+        # Mismatch/unavailable is uncertainty, not terminal evidence. Keep the
+        # record running for Sentinel reconciliation and never touch that PID.
+        if identity != "dead":
+            self._emit_process_lifecycle(session, "probe_unavailable")
             return session
 
         with session._lock:
@@ -544,7 +666,12 @@ class ProcessRegistry:
             return 2.0
 
     @classmethod
-    def _terminate_host_pid(cls, pid: int, expected_start: Optional[int] = None) -> None:
+    def _terminate_host_pid(
+        cls,
+        pid: Optional[int],
+        expected_start: Optional[int] = None,
+        expected_boot: Optional[str] = None,
+    ) -> None:
         """Terminate a host-visible PID and its descendants.
 
         ``expected_start`` is the kernel start time captured when we spawned the
@@ -586,13 +713,13 @@ class ProcessRegistry:
         POSIX and a missing ``taskkill.exe`` on Windows (effectively
         unreachable on real Windows installs, but cheap insurance).
         """
-        if expected_start is not None and not cls._host_pid_is_ours(pid, expected_start):
+        if not pid or not cls._host_pid_is_ours(pid, expected_start, expected_boot):
             # PID was recycled (start time changed) or is gone — never signal a
             # stranger. A leaked orphan is strictly preferable to killing e.g.
             # a browser whose session leader reused this dead session's PID.
             logger.warning(
-                "Refusing to terminate host pid %d: start-time mismatch — "
-                "PID was recycled onto an unrelated process.", pid,
+                "Refusing to terminate host pid %s: identity tuple unavailable or mismatched.",
+                pid,
             )
             return
         if _IS_WINDOWS:
@@ -732,6 +859,7 @@ class ProcessRegistry:
                 )
                 session.pid = pty_proc.pid
                 session.host_start_time = self._safe_host_start_time(session.pid)
+                session.host_boot_id = self._safe_host_boot_id()
                 # Store the pty handle on the session for read/write
                 session._pty = pty_proc
 
@@ -743,18 +871,34 @@ class ProcessRegistry:
                     name=f"proc-pty-reader-{session.id}",
                 )
                 session._reader_thread = reader
-                reader.start()
 
                 with self._lock:
                     self._prune_if_needed()
                     self._running[session.id] = session
 
+                self._emit_process_lifecycle(session, "started")
+                reader.start()
+                self._start_local_lifecycle_monitor(session)
                 self._write_checkpoint()
                 return session
 
             except ImportError:
                 logger.warning("ptyprocess not installed, falling back to pipe mode")
             except Exception as e:
+                with self._lock:
+                    was_registered = session.id in self._running
+                if was_registered:
+                    try:
+                        if session._pty is not None:
+                            session._pty.terminate(force=True)
+                    except Exception:
+                        pass
+                    session.exited = True
+                    session.exit_code = -1
+                    session.completion_reason = "failed_start"
+                    session.termination_source = "failed_start"
+                    self._move_to_finished(session)
+                    raise
                 logger.warning("PTY spawn failed (%s), falling back to pipe mode", e)
 
         # Standard Popen path (non-PTY or PTY fallback)
@@ -785,6 +929,7 @@ class ProcessRegistry:
         session.process = proc
         session.pid = proc.pid
         session.host_start_time = self._safe_host_start_time(session.pid)
+        session.host_boot_id = self._safe_host_boot_id()
 
         try:
             # Start output reader thread
@@ -795,32 +940,32 @@ class ProcessRegistry:
                 name=f"proc-reader-{session.id}",
             )
             session._reader_thread = reader
-            reader.start()
 
             with self._lock:
                 self._prune_if_needed()
                 self._running[session.id] = session
 
+            self._emit_process_lifecycle(session, "started")
+            reader.start()
+            self._start_local_lifecycle_monitor(session)
             self._write_checkpoint()
         except Exception:
             # Post-Popen setup failed — kill the orphaned subprocess (and any
             # descendants spawned via setsid) before re-raising so they do not
             # leak as untracked background processes.
-            try:
-                if not _IS_WINDOWS:
-                    try:
-                        kill_signal = getattr(signal, "SIGKILL", signal.SIGTERM)
-                        os.killpg(os.getpgid(proc.pid), kill_signal)  # windows-footgun: ok - guarded by _IS_WINDOWS above
-                    except (ProcessLookupError, PermissionError, OSError):
-                        proc.kill()
-                else:
-                    proc.kill()
-            except Exception:
-                pass
+            self._terminate_host_pid(
+                proc.pid, session.host_start_time, session.host_boot_id
+            )
             try:
                 proc.wait(timeout=5)
             except Exception:
                 pass
+            with session._lock:
+                session.exited = True
+                session.exit_code = getattr(proc, "returncode", None)
+                session.completion_reason = "failed_start"
+                session.termination_source = "failed_start"
+            self._move_to_finished(session)
             raise
 
         return session
@@ -861,16 +1006,22 @@ class ProcessRegistry:
         log_path = f"{temp_dir}/hermes_bg_{session.id}.log"
         pid_path = f"{temp_dir}/hermes_bg_{session.id}.pid"
         exit_path = f"{temp_dir}/hermes_bg_{session.id}.exit"
+        identity_path = f"{temp_dir}/hermes_bg_{session.id}.identity"
+        process_token = uuid.uuid4().hex
         quoted_command = shlex.quote(command)
         quoted_temp_dir = shlex.quote(temp_dir)
         quoted_log_path = shlex.quote(log_path)
         quoted_pid_path = shlex.quote(pid_path)
         quoted_exit_path = shlex.quote(exit_path)
+        quoted_identity_path = shlex.quote(identity_path)
         bg_command = (
             f"mkdir -p {quoted_temp_dir} && "
             f"( nohup bash -lc {quoted_command} > {quoted_log_path} 2>&1; "
             f"rc=$?; printf '%s\\n' \"$rc\" > {quoted_exit_path} ) & "
-            f"echo $! > {quoted_pid_path} && cat {quoted_pid_path}"
+            f"pid=$!; echo $pid > {quoted_pid_path}; "
+            f"start=$(awk '{{print $22}}' /proc/$pid/stat 2>/dev/null) || exit 1; "
+            f"printf '%s %s %s\\n' \"$pid\" \"$start\" {shlex.quote(process_token)} > {quoted_identity_path}; "
+            f"cat {quoted_pid_path}"
         )
 
         try:
@@ -886,6 +1037,18 @@ class ProcessRegistry:
                 if line.isdigit():
                     session.pid = int(line)
                     break
+            if session.pid is not None:
+                identity_result = env.execute(f"cat {quoted_identity_path}", timeout=timeout)
+                identity_parts = identity_result.get("output", "").strip().split()
+                if (
+                    len(identity_parts) == 3
+                    and identity_parts[0] == str(session.pid)
+                    and identity_parts[1].isdigit()
+                    and identity_parts[2] == process_token
+                ):
+                    session.backend_process_id = f"{process_token}:{identity_parts[1]}"
+                else:
+                    session.pid = None
             # If the wrapper couldn't produce a PID (for example, syntax
             # error or broken redirect), treat it as a failed launch instead
             # of exposing a fake running session.
@@ -904,24 +1067,37 @@ class ProcessRegistry:
             session.termination_source = "failed_start"
             session.output_buffer = f"Failed to start: {e}"
 
+        reader: Optional[threading.Thread] = None
         if not session.exited:
-            # Start a poller thread that periodically reads the log file
+            # Build the identity-aware poller before registry insertion, but do
+            # not start it until the stable remote PID and registry row exist.
             reader = threading.Thread(
                 target=self._env_poller_loop,
-                args=(session, env, log_path, pid_path, exit_path),
+                args=(session, env, log_path, pid_path, exit_path, identity_path),
                 daemon=True,
                 name=f"proc-poller-{session.id}",
             )
             session._reader_thread = reader
-            reader.start()
+
+        from agent.lifecycle_hooks import managed_process_backend_id
 
         with self._lock:
             self._prune_if_needed()
             if not session.exited:
                 self._running[session.id] = session
+            elif managed_process_backend_id(env) is not None:
+                # The backend identity plus provider process id is stable even
+                # when launch produced no sandbox PID. Register only long enough
+                # for the terminal authority to publish failed_start.
+                self._running[session.id] = session
 
         if not session.exited:
+            assert reader is not None
+            self._emit_process_lifecycle(session, "started")
+            reader.start()
             self._write_checkpoint()
+        elif session.id in self._running:
+            self._move_to_finished(session)
 
         return session
 
@@ -979,12 +1155,14 @@ class ProcessRegistry:
             self._move_to_finished(session)
 
     def _env_poller_loop(
-        self, session: ProcessSession, env: Any, log_path: str, pid_path: str, exit_path: str
+        self, session: ProcessSession, env: Any, log_path: str, pid_path: str,
+        exit_path: str, identity_path: Optional[str] = None,
     ):
         """Background thread: poll a sandbox log file for non-local backends."""
         quoted_log_path = shlex.quote(log_path)
         quoted_pid_path = shlex.quote(pid_path)
         quoted_exit_path = shlex.quote(exit_path)
+        quoted_identity_path = shlex.quote(identity_path or "")
         prev_output_len = 0  # track delta for watch pattern scanning
         while not session.exited:
             time.sleep(2)  # Poll every 2 seconds
@@ -1004,37 +1182,60 @@ class ProcessRegistry:
                         self._check_watch_patterns(session, delta)
                         self._emit_output(session, delta)
 
-                # Check if process is still running
+                # Check the exact backend process identity, not a namespace-local PID.
+                if not session.backend_process_id or not identity_path:
+                    self._emit_process_lifecycle(session, "probe_unavailable")
+                    continue
+                expected_token, expected_start = session.backend_process_id.split(":", 1)
                 check = env.execute(
-                    f"kill -0 \"$(cat {quoted_pid_path} 2>/dev/null)\" 2>/dev/null; echo $?",
+                    f"set -- $(cat {quoted_identity_path} 2>/dev/null); "
+                    f"if [ \"$1\" != {shlex.quote(str(session.pid))} ] || "
+                    f"[ \"$2\" != {shlex.quote(expected_start)} ] || "
+                    f"[ \"$3\" != {shlex.quote(expected_token)} ]; then echo mismatch; "
+                    f"else current=$(awk '{{print $22}}' /proc/$1/stat 2>/dev/null); "
+                    f"if [ -z \"$current\" ]; then echo exited; "
+                    f"elif [ \"$current\" = \"$2\" ]; then echo alive; "
+                    f"else echo mismatch; fi; fi",
                     timeout=5,
                 )
                 check_output = check.get("output", "").strip()
-                if check_output and check_output.splitlines()[-1].strip() != "0":
-                    # Process has exited -- get exit code captured by the wrapper shell.
-                    exit_result = env.execute(
-                        f"cat {quoted_exit_path} 2>/dev/null",
-                        timeout=5,
-                    )
-                    exit_str = exit_result.get("output", "").strip()
-                    try:
-                        session.exit_code = int(exit_str.splitlines()[-1].strip())
-                    except (ValueError, IndexError):
-                        session.exit_code = -1
-                    session.exited = True
-                    if session.completion_reason != "killed":
-                        session.completion_reason = "exited"
-                    self._move_to_finished(session)
-                    return
 
-            except Exception:
-                # Environment might be gone (sandbox reaped, etc.)
+                if check_output.endswith("alive"):
+                    self._emit_process_lifecycle(session, "heartbeat")
+                    continue
+                if not check_output.endswith("exited"):
+                    # A changed token/start identity is PID reuse or an
+                    # unverifiable probe, never evidence about our process.
+                    self._emit_process_lifecycle(session, "probe_unavailable")
+                    continue
+
+                # The exact identity disappeared. Only the wrapper's exit marker
+                # can now provide terminal evidence.
+                exit_result = env.execute(
+                    f"cat {quoted_exit_path} 2>/dev/null",
+                    timeout=5,
+                )
+                exit_str = exit_result.get("output", "").strip()
+                try:
+                    session.exit_code = int(exit_str.splitlines()[-1].strip())
+                except (ValueError, IndexError):
+                    self._emit_process_lifecycle(session, "probe_unavailable")
+                    continue
                 session.exited = True
-                session.exit_code = -1
-                session.completion_reason = "lost"
-                session.termination_source = "backend_lost"
+                if session.completion_reason != "killed":
+                    session.completion_reason = "exited"
                 self._move_to_finished(session)
                 return
+
+            except Exception:
+                # A backend outage says only that the probe is unavailable. It
+                # must never be promoted to false "lost"/terminal evidence.
+                self._emit_process_lifecycle(session, "probe_unavailable")
+                logger.debug(
+                    "managed_process_probe_unavailable process=%s reason=backend_error",
+                    session.id,
+                )
+                continue
 
     def _pty_reader_loop(self, session: ProcessSession):
         """Background thread: read output from a PTY process."""
@@ -1082,6 +1283,23 @@ class ProcessRegistry:
             self._finished[session.id] = session
         session._completion_event.set()
         self._write_checkpoint()
+
+        # This was_running guard is the single terminal authority. Reader,
+        # waiter, kill, and reconciliation races may all call this method, but
+        # only the first removal from _running publishes terminal.
+        if was_running:
+            terminal_status = (
+                session.completion_reason
+                if session.completion_reason
+                in {"exited", "killed", "lost", "failed_start", "already_exited"}
+                else "exited"
+            )
+            self._emit_process_lifecycle(
+                session,
+                "terminal",
+                terminal_status=terminal_status,
+                termination_source=session.termination_source or "unknown",
+            )
 
         # Only enqueue completion notification on the FIRST move.  Without
         # this guard, kill_process() and the reader thread can both call
@@ -1537,37 +1755,62 @@ class ProcessRegistry:
         try:
             if session._pty:
                 # PTY process -- terminate via ptyprocess
+                identity = self._host_pid_identity_status(
+                    session.pid, session.host_start_time, session.host_boot_id
+                )
+                if identity != "ours":
+                    self._emit_process_lifecycle(session, "probe_unavailable")
+                    return {
+                        "status": "error",
+                        "error": "Process identity is unavailable or no longer matches; refusing to signal PID",
+                    }
                 try:
                     session._pty.terminate(force=True)
                 except Exception:
-                    if session.pid:
-                        os.kill(session.pid, signal.SIGTERM)
+                    self._terminate_host_pid(
+                        session.pid, session.host_start_time, session.host_boot_id
+                    )
             elif session.process:
                 # Local process -- kill the process tree. On Windows this
                 # must be taskkill /T /F; Popen.terminate() only kills the
                 # shell wrapper and leaves Git Bash descendants behind.
-                self._terminate_host_pid(session.process.pid, session.host_start_time)
+                identity = self._host_pid_identity_status(
+                    session.process.pid, session.host_start_time, session.host_boot_id
+                )
+                if identity != "ours":
+                    self._emit_process_lifecycle(session, "probe_unavailable")
+                    return {
+                        "status": "error",
+                        "error": "Process identity is unavailable or no longer matches; refusing to signal PID",
+                    }
+                self._terminate_host_pid(
+                    session.process.pid, session.host_start_time, session.host_boot_id
+                )
             elif session.env_ref and session.pid:
-                # Non-local -- kill inside sandbox
-                session.env_ref.execute(f"kill {session.pid} 2>/dev/null", timeout=5)
+                # A namespace-local PID alone is not an authoritative process
+                # identity and may have been recycled. Refuse bare-PID signalling
+                # until the backend provides an identity-aware kill primitive.
+                self._emit_process_lifecycle(session, "probe_unavailable")
+                return {
+                    "status": "error",
+                    "error": "Sandbox process identity cannot be verified; refusing to signal PID",
+                }
             elif session.detached and session.pid_scope == "host" and session.pid:
                 # Identity check, not bare liveness: if the PID is gone OR was
                 # recycled onto an unrelated process, treat our process as
                 # exited and never tree-kill the stranger.
-                if not self._host_pid_is_ours(session.pid, session.host_start_time):
-                    with session._lock:
-                        session.exited = True
-                        session.exit_code = None
-                        output = strip_ansi(session.output_buffer[-2000:])
-                    if consume_output:
-                        self._completion_consumed.add(session_id)
-                    self._move_to_finished(session)
+                identity = self._host_pid_identity_status(
+                    session.pid, session.host_start_time, session.host_boot_id
+                )
+                if identity != "ours":
+                    self._emit_process_lifecycle(session, "probe_unavailable")
                     return {
-                        "status": "already_exited",
-                        "exit_code": session.exit_code,
-                        "output": output,
+                        "status": "error",
+                        "error": "Recovered process identity is unavailable or no longer matches; refusing to signal PID",
                     }
-                self._terminate_host_pid(session.pid, session.host_start_time)
+                self._terminate_host_pid(
+                    session.pid, session.host_start_time, session.host_boot_id
+                )
             else:
                 return {
                     "status": "error",
@@ -1889,12 +2132,15 @@ class ProcessRegistry:
                         # for sessions spawned before this field existed.
                         if s.host_start_time is None and s.pid_scope == "host" and s.pid:
                             s.host_start_time = self._safe_host_start_time(s.pid)
+                        if s.host_boot_id is None and s.pid_scope == "host" and s.pid:
+                            s.host_boot_id = self._safe_host_boot_id()
                         entries.append({
                             "session_id": s.id,
                             "command": s.command,
                             "pid": s.pid,
                             "pid_scope": s.pid_scope,
                             "host_start_time": s.host_start_time,
+                            "host_boot_id": s.host_boot_id,
                             "cwd": s.cwd,
                             "started_at": s.started_at,
                             "task_id": s.task_id,
@@ -1956,7 +2202,8 @@ class ProcessRegistry:
             # watcher tree-kill a stranger (e.g. a browser). Re-validate the
             # kernel start time recorded in the checkpoint.
             recorded_start = entry.get("host_start_time")
-            if not self._host_pid_is_ours(pid, recorded_start):
+            recorded_boot = entry.get("host_boot_id")
+            if not self._host_pid_is_ours(pid, recorded_start, recorded_boot):
                 if self._is_host_pid_alive(pid):
                     logger.info(
                         "Not recovering session %s: pid %d is alive but its "
@@ -1973,6 +2220,7 @@ class ProcessRegistry:
                 session_key=entry.get("session_key", ""),
                 pid=pid,
                 host_start_time=recorded_start,
+                host_boot_id=recorded_boot,
                 pid_scope=pid_scope,
                 cwd=entry.get("cwd"),
                 started_at=entry.get("started_at", time.time()),
@@ -1989,6 +2237,8 @@ class ProcessRegistry:
             )
             with self._lock:
                 self._running[session.id] = session
+            self._emit_process_lifecycle(session, "adopted")
+            self._start_local_lifecycle_monitor(session)
             recovered += 1
             logger.info("Recovered detached process: %s (pid=%d)", session.command[:60], pid)
 


### PR DESCRIPTION
## Purpose
Provide the authoritative gateway turn lifecycle required by dagyrox/or7-platform#191 so Active Work can project a real root turn before wrapper/child rows and preserve PostgreSQL parent truth.

## Provenance
- Acting lane: Talos
- Lifecycle owner: Hermes
- Architecture authority: Athena — READY_FOR_CONSUMER at exact head b206af73eb99a35ac98877d9597b22d6cbd8a1dc
- Related issue: https://github.com/dagyrox/or7-platform/issues/191
- Governed run: 530149e8-b8a3-4fcc-b21e-0fd8360c1445
- Work packet: docs/agentic-operations/work-packets/2026-08-10-issue-191-canonical-active-work-lifecycle.md (or7-platform)
- Hermes Kanban card: not available

## Scope
- Versioned privacy-bounded session_turn_lifecycle v1 at durable registered/started/heartbeat/terminal boundaries
- Root provider turn identity propagated to delegated children
- Bounded ordered fail-open observer dispatch
- Cancellation/lease/stop/delivery/store ordering and recovery hardening
- Extensive deterministic race/path coverage

## Evidence
- Athena: READY_FOR_CONSUMER on exact head
- Related review suite: 223 passed
- Lease/API integration: 46 passed
- Ruff and diff check: green

No secrets or runtime content cross the lifecycle DTO.