### PR TITLE
fix(telegram): rebind TypeHandler after lazy install

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -415,7 +415,7 @@ def check_telegram_requirements() -> bool:
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
-    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global CommandHandler, CallbackQueryHandler, TypeHandler, TelegramMessageHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -434,6 +434,7 @@ def check_telegram_requirements() -> bool:
         from telegram.ext import (
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
+            TypeHandler as _TH,
             MessageHandler as _MH,
             ContextTypes as _CT, filters as _filters,
         )
@@ -450,6 +451,7 @@ def check_telegram_requirements() -> bool:
     Application = _App
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
+    TypeHandler = _TH
     TelegramMessageHandler = _MH
     ContextTypes = _CT
     filters = _filters

--- a/tests/gateway/test_telegram_connect.py
+++ b/tests/gateway/test_telegram_connect.py
@@ -6,6 +6,7 @@ background reconnection (#31049).
 """
 
 import sys
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -40,6 +41,19 @@ import plugins.platforms.telegram.adapter as telegram_mod  # noqa: E402
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 
 
+def test_lazy_install_rebinds_type_handler(monkeypatch):
+    """A same-process lazy install must replace every Any placeholder."""
+    import tools.lazy_deps
+
+    expected_type_handler = sys.modules["telegram.ext"].TypeHandler
+    monkeypatch.setattr(telegram_mod, "TELEGRAM_AVAILABLE", False)
+    monkeypatch.setattr(telegram_mod, "TypeHandler", Any)
+    monkeypatch.setattr(tools.lazy_deps, "ensure", lambda *_args, **_kwargs: True)
+
+    assert telegram_mod.check_telegram_requirements() is True
+    assert telegram_mod.TypeHandler is expected_type_handler
+
+
 class TestTelegramUnconfiguredNonRetryable:
     """Verify that missing dependency/token sets a non-retryable fatal error."""
 
@@ -53,4 +67,3 @@ class TestTelegramUnconfiguredNonRetryable:
         assert adapter.has_fatal_error is True
         assert adapter.fatal_error_retryable is False
         assert adapter.fatal_error_code == "missing_dependency"
-


### PR DESCRIPTION
## Summary
- rebind `TypeHandler` alongside the other python-telegram-bot symbols after a same-process lazy install
- prevent `typing.Any` from surviving dependency installation and crashing Telegram startup
- add a focused regression test for the lazy-install path

## Incident
After an in-gateway update, the replacement process imported the Telegram adapter before `python-telegram-bot` was available. Lazy installation succeeded, but `TypeHandler` remained the `typing.Any` placeholder. Registering the platform observer then raised `TypeError: Any cannot be instantiated`, leaving the gateway running without Telegram until a second restart.

## Verification
- `uv run --extra dev pytest -q tests/gateway/test_telegram_connect.py` — 2 passed
- `uv run --extra dev --with python-telegram-bot==22.8 pytest -q tests/test_telegram_polling_progress_ptb.py` — 6 passed
- Ruff passed for both changed files
- Independent review passed with no security or logic findings