### PR TITLE
fix(gateway): profile model inheritance broke when voice mirroring created config.yaml first

### DIFF
--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -357,20 +357,36 @@ def _(rid, params: dict) -> dict:
             model_set = True
         except Exception:
             pass
-    elif is_truthy_value(params.get("mirror_credentials", True)) and not (path / "config.yaml").exists():
-        # No explicit pin and no cloned config: inherit the launch profile's
-        # provider+model so the first turn resolves. Same writer as the pin.
+    elif is_truthy_value(params.get("mirror_credentials", True)):
+        # No explicit pin: inherit the launch profile's provider+model so the
+        # first turn resolves. Gate on the MODEL SECTION being absent, not on
+        # config.yaml existing — earlier mirroring steps (voice sections,
+        # #85755) legitimately create the file first, and a file-existence
+        # gate silently skipped inheritance for every non-clone bot
+        # ("No inference provider configured" on first message, tester
+        # report). Clones bring their own model section and stay untouched.
         try:
-            from hermes_cli.config import load_config_readonly
+            from hermes_cli.config import load_config_readonly, read_user_config_raw
             from hermes_cli.web_routers.profiles import _write_profile_model
+            from hermes_constants import (
+                reset_hermes_home_override,
+                set_hermes_home_override,
+            )
 
-            cfg = load_config_readonly() or {}
-            model_cfg = cfg.get("model") or {}
-            inherited_provider = str(model_cfg.get("provider") or "")
-            inherited_model = str(model_cfg.get("default") or "")
-            if inherited_provider and inherited_model:
-                _write_profile_model(path, inherited_provider, inherited_model)
-                mirrored["model_inherited"] = True
+            token = set_hermes_home_override(str(path))
+            try:
+                dst_model = (read_user_config_raw() or {}).get("model") or {}
+            finally:
+                reset_hermes_home_override(token)
+
+            if not (dst_model.get("provider") and dst_model.get("default")):
+                cfg = load_config_readonly() or {}
+                model_cfg = cfg.get("model") or {}
+                inherited_provider = str(model_cfg.get("provider") or "")
+                inherited_model = str(model_cfg.get("default") or "")
+                if inherited_provider and inherited_model:
+                    _write_profile_model(path, inherited_provider, inherited_model)
+                    mirrored["model_inherited"] = True
         except Exception:
             pass
 


### PR DESCRIPTION
Bot Mode tester report with screenshots: a fresh bot shows **'Inherit (launch profile)'** in its editor, but its first message dies with **'No inference provider configured'** — while the main agent is authenticated and working.

Root cause: `profiles.create`'s model-inheritance branch was gated on `config.yaml` **not existing** in the new profile. Voice-section mirroring (#85755) runs earlier in the same handler and legitimately creates `config.yaml` (stt/tts sections) — so since that merge, inheritance has silently skipped for every non-clone, non-pinned profile. The editor's 'Inherit' display was honest about the *intent*; the profile genuinely had no `model` section, and agent init failed exactly as screenshotted. (The regression was visible in our own E2E receipts as `model_inherited: false` — recorded, never chased.)

Fix: gate on the actual condition — the profile's raw config lacking a complete `model` section (`provider`+`default`), read via the canonical raw loader under the profile-scoped home override (config-read-guard clean). Clones bring their own model section and stay untouched; explicit `model`+`provider` pins take the same path as before.

E2E on a live HERMES_HOME: create receipt `model_inherited: true`; fresh profile's config.yaml carries the launch profile's provider/model; a bot created this way initializes its first turn.