### PR TITLE
fix(plugins): point community plugin index and seed entry at live endpoints

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -1,19 +1,7 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-08-12T00:00:00Z",
+  "generated_at": "2026-08-14T00:00:00Z",
   "plugins": [
-    {
-      "name": "hermes-media-studio",
-      "description": "Media Studio — generative media workspace plugin for Hermes Desktop (fal + Krea, durable job queue, library).",
-      "author": "NousResearch",
-      "tags": ["media", "image-gen", "video-gen", "dashboard", "desktop"],
-      "repo": "NousResearch/hermes-media-studio",
-      "ref": "e8d59971d2b7901405b39dac7b03bdd616272d0d",
-      "homepage": "https://github.com/NousResearch/hermes-media-studio",
-      "capabilities": ["tools", "dashboard"],
-      "api_version": 1,
-      "added_at": "2026-08-12"
-    },
     {
       "name": "hermes-telegram-business",
       "description": "Observe-with-approval Telegram Business Mode (secretary bot) plugin — every drafted reply requires owner approval before it reaches the customer.",

--- a/hermes_cli/plugin_index.py
+++ b/hermes_cli/plugin_index.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -27,8 +28,13 @@ from hermes_constants import get_hermes_home
 logger = logging.getLogger(__name__)
 
 # Canonical index location. Override via config key ``plugins.index_url``.
+# The index is maintained in this repository — ``hermes_cli/data/plugin_index.json``
+# is the single source of truth: the raw GitHub URL below is the canonical fetch
+# endpoint and the bundled copy is the offline fallback, so the two stay in sync
+# by construction. Plugin authors submit entries via a PR to hermes-agent
+# (see website/docs/user-guide/features/plugins.md).
 DEFAULT_INDEX_URL = (
-    "https://raw.githubusercontent.com/NousResearch/hermes-plugin-index/main/index.json"
+    "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/hermes_cli/data/plugin_index.json"
 )
 
 # Cache the fetched index for 24 hours; a stale cache is still preferred over
@@ -200,6 +206,11 @@ def _fetch_remote() -> Optional[List[PluginIndexEntry]]:
         return entries
     except Exception as exc:
         logger.debug("plugin index: remote fetch failed (%s): %s", url, exc)
+        print(
+            f"Warning: could not reach the plugin index at {url} "
+            f"({exc.__class__.__name__}: {exc}); showing the cached or bundled index",
+            file=sys.stderr,
+        )
         return None
 
 

--- a/hermes_cli/plugin_packs.py
+++ b/hermes_cli/plugin_packs.py
@@ -13,14 +13,14 @@ Format (canonical)::
     author: hyper
     version: 1.0.0
     plugins:
-      - name: hermes-media-studio          # bare community-index name…
-        ref: e8d59971d2b7901405b39dac7b03bdd616272d0d
+      - name: hermes-telegram-business     # bare community-index name…
+        ref: e905f3bc5eeaa5a9dab9bc5155601b3ebec75757
       - repo: owner/approval-relay         # …or explicit owner/repo / git URL
         ref: 8f3c2d1a9b4e5f6071829304a5b6c7d8e9f00112
-        subdir: plugins/relay              # optional path within the repo
-    config:                                # optional plugins.entries seeds
-      hermes-media-studio:
-        default_model: flux-3
+        subdir: plugins/relay            # optional path within the repo
+    config:                              # optional plugins.entries seeds
+      hermes-telegram-business:
+        require_approval: true
     skills: []                             # declared seam — NOT auto-installed
 
 Supply-chain posture:

--- a/tests/hermes_cli/test_plugin_index_search.py
+++ b/tests/hermes_cli/test_plugin_index_search.py
@@ -496,3 +496,65 @@ class TestCmdSearch:
             "capability": None,
             "refresh": False,
         }
+
+
+# ---------------------------------------------------------------------------
+# Index endpoint (issue #86154)
+# ---------------------------------------------------------------------------
+
+
+class TestIndexEndpoint:
+    def test_default_index_url_serves_repo_catalog(self):
+        """The canonical index URL must point at a live file in this repository.
+
+        Regression guard for #86154: the URL previously pointed at
+        NousResearch/hermes-plugin-index, which does not exist (404), so every
+        user silently searched the bundled seed forever.
+        """
+        assert plugin_index.DEFAULT_INDEX_URL == (
+            "https://raw.githubusercontent.com/NousResearch/hermes-agent/"
+            "main/hermes_cli/data/plugin_index.json"
+        )
+
+    def test_remote_fetch_failure_warns_on_stderr(self, monkeypatch, capsys):
+        """A failed remote fetch must be visible on stderr, not just debug logs.
+
+        Regression guard for #86154: the failure used to be swallowed at debug
+        level, so the permanent seed fallback was invisible.
+        """
+        import httpx
+
+        def boom(url, **kwargs):
+            raise httpx.ConnectError("connection refused")
+
+        monkeypatch.setattr(httpx, "get", boom)
+        assert plugin_index._fetch_remote() is None
+        err = capsys.readouterr().err
+        assert "Warning: could not reach the plugin index" in err
+        assert "connection refused" in err
+
+    def test_remote_fetch_http_404_warns_on_stderr(self, monkeypatch, capsys):
+        """The exact #86154 scenario (HTTP 404) also surfaces on stderr."""
+        import httpx
+
+        req = httpx.Request("GET", plugin_index.DEFAULT_INDEX_URL)
+
+        class NotFoundResponse:
+            text = ""
+
+            def raise_for_status(self):
+                raise httpx.HTTPStatusError(
+                    "Not Found", request=req, response=httpx.Response(404, request=req)
+                )
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **k: NotFoundResponse())
+        assert plugin_index._fetch_remote() is None
+        assert "Warning: could not reach the plugin index" in capsys.readouterr().err
+
+    def test_bundled_seed_has_no_dead_media_studio_entry(self):
+        """The unclonable seed entry (NousResearch/hermes-media-studio, 404)
+        must not be part of the bundled seed."""
+        raw = json.loads(plugin_index.SEED_INDEX_PATH.read_text(encoding="utf-8"))
+        repos = [e["repo"] for e in raw["plugins"]]
+        assert "NousResearch/hermes-media-studio" not in repos
+        assert "NousResearch/hermes-telegram-business" in repos

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -469,7 +469,7 @@ Once you've found a plugin, install it by bare name — the name is resolved
 through the index to its `owner/repo` plus the index-pinned commit:
 
 ```bash
-hermes plugins install hermes-media-studio
+hermes plugins install hermes-telegram-business
 ```
 
 If a name matches more than one entry, the candidates are listed and nothing
@@ -478,25 +478,27 @@ index and keep working exactly as before. An explicit `--ref <sha>` always
 overrides the index pin.
 
 **How the index is fetched.** The index lives at a canonical URL
-(`https://raw.githubusercontent.com/NousResearch/hermes-plugin-index/main/index.json`,
+(`https://raw.githubusercontent.com/NousResearch/hermes-agent/main/hermes_cli/data/plugin_index.json`,
 overridable via `hermes config set plugins.index_url <url>`). Fetches are
 cached under `~/.hermes/cache/plugin_index.json` for 24 hours; when the
 remote is unreachable the stale cache is used, and when there is no cache at
 all a bundled seed copy ships with Hermes — so search works fully offline.
+If the remote fetch fails you will see a warning on stderr before the cached
+or bundled index is shown.
 
 **Index entry format.** Each entry is a JSON object:
 
 ```json
 {
-  "name": "hermes-media-studio",
-  "description": "Generative media workspace plugin.",
+  "name": "hermes-telegram-business",
+  "description": "Telegram secretary bot with owner approval.",
   "author": "NousResearch",
-  "tags": ["media", "image-gen"],
-  "repo": "NousResearch/hermes-media-studio",
-  "ref": "<40-char commit SHA>",
+  "tags": ["telegram", "gateway", "approvals", "messaging"],
+  "repo": "NousResearch/hermes-telegram-business",
+  "ref": "e905f3bc5eeaa5a9dab9bc5155601b3ebec75757",
   "subdir": null,
-  "homepage": "https://github.com/NousResearch/hermes-media-studio",
-  "capabilities": ["tools", "dashboard"],
+  "homepage": "https://github.com/NousResearch/hermes-telegram-business",
+  "capabilities": ["platform"],
   "api_version": 1,
   "added_at": "2026-08-12"
 }
@@ -506,11 +508,12 @@ all a bundled seed copy ships with Hermes — so search works fully offline.
 SHA, and optional `subdir` supports monorepos. The bundled seed file
 (`hermes_cli/data/plugin_index.json` in the repo) is the format reference.
 
-**Submitting a plugin.** The index is maintained as a plain JSON file —
-submit a pull request to the
-[hermes-plugin-index](https://github.com/NousResearch/hermes-plugin-index)
-repository adding your entry (name, description, author, tags, `owner/repo`,
-and a pinned commit SHA). Review covers the entry's *metadata* only.
+**Submitting a plugin.** The index is maintained as a plain JSON file in this
+repository — submit a pull request to
+[hermes-agent](https://github.com/NousResearch/hermes-agent) updating
+[`hermes_cli/data/plugin_index.json`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/data/plugin_index.json)
+with your entry (name, description, author, tags, `owner/repo`, and a pinned
+commit SHA). Review covers the entry's *metadata* only.
 
 :::warning Indexed ≠ audited
 Inclusion in the community index means the entry's metadata was reviewed —
@@ -532,14 +535,14 @@ description: STT + streaming TTS + approval relay
 author: hyper
 version: 1.0.0
 plugins:
-  - name: hermes-media-studio            # bare community-index name…
-    ref: e8d59971d2b7901405b39dac7b03bdd616272d0d
+  - name: hermes-telegram-business        # bare community-index name…
+    ref: e905f3bc5eeaa5a9dab9bc5155601b3ebec75757
   - repo: owner/approval-relay           # …or explicit owner/repo (or git URL)
     ref: 8f3c2d1a9b4e5f6071829304a5b6c7d8e9f00112
     subdir: plugins/relay                # optional monorepo path
 config:                                  # optional, non-secret seeds only
-  hermes-media-studio:
-    default_model: flux-3
+  hermes-telegram-business:
+    require_approval: true
 skills: []                               # declared list only (not auto-installed yet)
 ```
 


### PR DESCRIPTION
## Summary

Fixes #86154: two dead endpoints shipped by #84919.

1. **Canonical index URL 404s.** `DEFAULT_INDEX_URL` pointed at
   `https://raw.githubusercontent.com/NousResearch/hermes-plugin-index/main/index.json`,
   a repository that does not exist. Every `hermes plugins search`/`install`
   attempt failed the remote fetch, silently fell back to the bundled seed
   (`except Exception` → `logger.debug` → `return None`), and no cache was
   ever written — so every user searched the same frozen 5-entry seed forever.

2. **First seed entry unclonable.** `hermes-media-studio` pointed at
   `NousResearch/hermes-media-studio`, which returns 404. The pinned SHA
   `e8d59971d2b7…` is not present in any public repository, and the only
   public repo with that name (`yimisunrise/hermes-media-studio`) is a
   different plugin entirely.

## Changes

- `hermes_cli/plugin_index.py`: `DEFAULT_INDEX_URL` now serves
  `hermes_cli/data/plugin_index.json` from this repository
  (`https://raw.githubusercontent.com/NousResearch/hermes-agent/main/hermes_cli/data/plugin_index.json`)
  — the bundled seed is the single source of truth, so remote and seed stay
  in sync by construction. This mirrors how the model catalog is already
  hosted (`hermes_cli/model_catalog.py` → `website/static/api/model-catalog.json`).
- `hermes_cli/plugin_index.py`: a failed remote fetch now prints
  `Warning: could not reach the plugin index at <url> …; showing the cached
  or bundled index` on stderr (still logged at debug), so a dead URL can no
  longer degrade silently.
- `hermes_cli/data/plugin_index.json`: dropped the unclonable
  `hermes-media-studio` entry (the 18 open "Community plugin: …" issues now
  have a destination: a PR to this repo updating this file).
- Docs (`website/docs/user-guide/features/plugins.md`): canonical URL,
  submission instructions ("submit a PR to hermes-agent updating
  `hermes_cli/data/plugin_index.json`"), install/JSON/pack examples moved to
  live entries; matching example in `hermes_cli/plugin_packs.py` docstring.

## Validation

- `tests/hermes_cli/test_plugin_index_search.py` +4 regression tests:
  URL guard, stderr warning on connect error, stderr warning on HTTP 404,
  seed no longer contains the dead repo.
- pytest: test_plugin_index_search (100), test_plugins_cmd* (70) — all pass.
- ruff clean.
- Live smoke test: `load_index(refresh=True)` against the new URL returns
  `source="remote"`.

Closes #86154