### PR TITLE
fix(desktop): compare pinned/archived in the session list signature

### DIFF
--- a/apps/desktop/src/lib/session-signatures.test.ts
+++ b/apps/desktop/src/lib/session-signatures.test.ts
@@ -4,7 +4,8 @@ import type { SessionInfo } from '@/hermes'
 
 import { sameCronSignature, sessionMessagesSignature } from './session-signatures'
 
-const session = (id: string, title: string | null): SessionInfo => ({ id, title }) as SessionInfo
+const session = (id: string, title: string | null, extra: Partial<SessionInfo> = {}): SessionInfo =>
+  ({ id, title, ...extra }) as SessionInfo
 
 describe('sameCronSignature', () => {
   it('is false when the lengths differ', () => {
@@ -27,6 +28,28 @@ describe('sameCronSignature', () => {
     const a = [session('a', 't'), session('b', 't')]
     const b = [session('b', 't'), session('a', 't')]
     expect(sameCronSignature(a, b)).toBe(false)
+  })
+
+  // A pin-only page must reach $sessions: session-pin-sync treats the row as
+  // authoritative and releases its write guard when a page confirms the value
+  // it wrote. Gating that page out froze the row and re-pinned what the user
+  // had just unpinned (#76919).
+  it('is false when only the pinned flag changed', () => {
+    const a = [session('a', 't', { pinned: true })]
+    const b = [session('a', 't', { pinned: false })]
+    expect(sameCronSignature(a, b)).toBe(false)
+  })
+
+  it('is false when only the archived flag changed', () => {
+    const a = [session('a', 't', { archived: false })]
+    const b = [session('a', 't', { archived: true })]
+    expect(sameCronSignature(a, b)).toBe(false)
+  })
+
+  it('is true when both flags match', () => {
+    const a = [session('a', 't', { archived: false, pinned: true })]
+    const b = [session('a', 't', { archived: false, pinned: true })]
+    expect(sameCronSignature(a, b)).toBe(true)
   })
 })
 

--- a/apps/desktop/src/lib/session-signatures.ts
+++ b/apps/desktop/src/lib/session-signatures.ts
@@ -23,7 +23,14 @@ export function sameCronSignature(a: SessionInfo[], b: SessionInfo[]): boolean {
       session.preview === other.preview &&
       session.message_count === other.message_count &&
       session.last_active === other.last_active &&
-      session.ended_at === other.ended_at
+      session.ended_at === other.ended_at &&
+      // Row STATE, not just row content: session-pin-sync reconciles the
+      // sidebar's pins against `pinned` on the rows in this atom, so a page
+      // whose only delta is a flag has to swap in or the reconciler reads a
+      // frozen copy forever. An idle conversation never moves any of the
+      // fields above again, which is exactly when a pin gets toggled (#76919).
+      session.pinned === other.pinned &&
+      session.archived === other.archived
     )
   })
 }


### PR DESCRIPTION
## What does this PR do?

Unpinning a conversation in the Desktop sidebar re-pins it a few seconds later, and the backend row and the sidebar end up permanently disagreeing. This fixes the last link in that loop: `sameCronSignature` compared row *content* but not row *state*, so a session page whose only delta was `pinned` never reached `$sessions`.

**The chain**

`refreshSessions()` swaps the session atom only when the signature says the page changed:

```ts
setSessions(prev => {
  const next = mergeSessionPage(prev, incoming, sessionsToKeep())

  return sameCronSignature(prev, next) ? prev : next   // ← next discarded
})
```

`sameCronSignature` compared `id, _lineage_root_id, title, source, profile, preview, message_count, last_active, ended_at`. A page whose only difference was the pin flag was judged identical, so `prev` was kept and the cached row's `pinned` froze at whatever it was the last time some *other* field moved. For an idle conversation — exactly the stale ones a user goes and unpins — none of those fields ever move again, so it froze permanently.

`session-pin-sync` then treats that frozen row as authoritative. Its write guard (`daeedf67c`, from #77170) is designed to be released by a page that **confirms** the value it wrote, with `WRITE_GUARD_MS` as a fallback for when no page ever does:

```ts
if (guard.value === row.pinned) {
  unconfirmed.delete(guardKey)          // confirmed — never reached in production
} else if (Date.now() - guard.at < WRITE_GUARD_MS) {
  continue                              // page predates the write — skip
} else {
  unconfirmed.delete(guardKey)          // "no page ever confirmed us, let the server win"
}
```

Because the confirming page was filtered out one layer up, the third branch was the only one that ever ran. Roughly ten seconds after an unpin, the next `reconcile()` — and it is wired to `$pinnedSessionIds.listen`, so *unpinning the next conversation fires it* — read the frozen `pinned: true` row and called `pinSession()` again.

Adoption marks the id `mirrored`, so the push pass never re-`PATCH`ed either: the local set said pinned, `sessions.pinned` said `0`, and they stayed that way. That asymmetry is the tell — of the five pins my sidebar was rendering, **four were `pinned = 0` in `state.db`**.

**The fix** is to compare both flags, so a pin-only page swaps in. That restores the guard's confirm path and turns `WRITE_GUARD_MS` back into a backstop instead of the load-bearing branch. `archived` is included for the same reason — it is row state a consumer reads, and leaving it out is the same latent trap.

The churn the gate exists to prevent is unaffected: these two flags only move when a user pins or archives something, so this adds one atom swap per deliberate user action, not per turn or per broadcast.

Deliberately scoped to the signature. The `session-pin-sync` guard is correct once it can actually be confirmed; I have not touched it.

## Related Issue

Fixes #76919

The guard added for that issue is sound, but the symptom it describes still reproduces on `main` because the page that was meant to release the guard never arrives. Likely the same root cause, though I have not verified them directly: #74914 (pin/unpin silently fails, cache reset does not help) and #85969 (sidebar and backend pin state disagreeing).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/session-signatures.ts` — compare `pinned` and `archived` in `sameCronSignature`, with a comment on why row state belongs in a signature a reconciler depends on.
- `apps/desktop/src/lib/session-signatures.test.ts` — regression coverage for a pin-only delta, an archive-only delta, and the unchanged-flags case. The helper now takes an `extra` partial.

## How to Test

**Reproduce on `main`** (two profiles make it obvious, one is enough):

1. Pin a conversation that has been idle for a while, so nothing else about the row is changing.
2. Unpin it in the sidebar. Confirm the write landed: `sqlite3 ~/.hermes/profiles/<p>/state.db "select id, pinned from sessions where id='<id>'"` → `0`.
3. Unpin a second pinned conversation more than ten seconds later.
4. The first one reappears in **Pinned**, and its `state.db` row still reads `0` — the sidebar and the backend now disagree, and the disagreement is stable.

**With this patch**, step 4 does not happen: the page carrying `pinned: false` reaches `$sessions`, confirms the guard, and the row stays unpinned.

**Automated:**

```bash
cd apps/desktop
npx vitest run --project ui src/lib/session-signatures.test.ts   # 10 passed
npx vitest run --project ui src/store/session-pin-sync.test.ts   # unchanged, still green
npx vitest run --project ui                                      # full renderer suite
npx tsc -p . --noEmit && npx eslint src/                         # clean
```

The two new flag tests fail on `main` (`2 failed | 8 passed`) and pass with the patch, so they pin the actual regression rather than restating the fix.

Worth noting: `session-pin-sync.test.ts` already has `releases the guard once a page confirms the written value`, and it passes on `main` — because the test hands `$sessions` the confirming page directly. That is precisely why this went unnoticed; the gap is one layer up, in the pipeline that decides whether such a page is ever delivered.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #77170 fixed the guard's lifetime; nothing open touches `sameCronSignature`
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run**: this is a renderer-only TypeScript change with no Python surface. I ran the desktop `ui` vitest project, `tsc --noEmit`, and `eslint` instead.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Hermes Desktop 0.17.0 on Windows 11 against a gateway on Ubuntu 24.04 (remote mode, multi-profile); test suite run on Ubuntu 24.04.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A, renderer-side pure function
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

The Desktop's localStorage write-ahead log (`Local Storage/leveldb/*.log`, append-only) caught the loop in the act — three consecutive commits of `hermes.desktop.pinnedSessions`:

| commit | pins | live ids |
|---|---|---|
| v1 | 15 | `269416`, `bf8758`, `b306c7`, `917767`, `91e65a` |
| v2 | 13 | `b306c7`, `269416`, `91e65a` — user unpinned `bf8758` and `917767` |
| v3 | 15 | `b306c7`, `269416`, `c97d86`, `917767`, `bf8758` — **both back**, plus a third |

Every resurrected id read `pinned = 0` in its profile's `state.db` at that moment, and `pullRemotePins()` is the only non-interactive caller of `pinSession()` — so the row it acted on had to be a stale cached copy. (Ten of the fifteen stored ids resolved to no session at all, long-deleted conversations; they were inert.)
