### PR TITLE
feat(voice): stream Gemini 3.1 TTS into Discord voice channels

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1330,6 +1330,37 @@ platform_toolsets:
 #     optimize_streaming_latency: 0  # 0-2, trades quality for lower latency
 #     sample_rate: 24000    # 22050 / 24000 / 44100 / 48000
 #     bit_rate: 128000      # MP3 bitrate (codec=mp3 only)
+#
+#   # Streaming TTS (chunked PCM, starts speaking before the full clip is
+#   # synthesized). Only some providers/models support it; the resolver never
+#   # silently swaps your voice — set `provider` to pin a streamer or `auto`
+#   # to take the first usable one (elevenlabs → gemini → openai → xai).
+#   # Gemini TTS note: gemini-3.6-flash is a text/multimodal model, NOT a TTS
+#   # model. The Gemini TTS model with incremental audio streaming is
+#   # gemini-3.1-flash-tts-preview (streamGenerateContent SSE).
+#   streaming:
+#     provider: ""           # "" (default) = stream with tts.provider when it has a chunked API; name pins a streamer; "auto" walks the priority list
+#
+# =============================================================================
+# Discord voice channel extras (voice_fx)
+# =============================================================================
+# Live voice-channel mixer: ambient "thinking" bed, ducked speech clips, and
+# incremental streaming TTS. All OFF by default; opt in per setting.
+#
+# discord:
+#   voice_fx:
+#     enabled: false            # master switch for ambient/ack effects
+#     streaming_tts: false      # incremental PCM TTS in live VC (begin speaking
+#                               # on the first Gemini 3.1 chunk instead of after
+#                               # the full clip). Independent of `enabled`; set
+#                               # tts.gemini.model = gemini-3.1-flash-tts-preview
+#     ambient_enabled: true     # idle "thinking" bed while tools run
+#     ambient_path: ""          # optional custom loop file; "" = synthesised
+#     ambient_gain: 0.18
+#     duck_gain: 0.06
+#     speech_gain: 1.0
+#     lead_silence_ms: 200      # warm-up silence before each clip
+#     ack_enabled: true         # short phrase before tool calls
 
 # =============================================================================
 # Voice Transcription (Speech-to-Text)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -611,13 +611,24 @@ class StreamingTTSHandle:
     """
     chat_id: str = ""
     audio_format: AudioFormat = field(default_factory=AudioFormat)
-    # Set to True after the first PCM chunk has been written (audible output
-    # has started).  The consumer uses this to decide whether a failure
-    # should fall back to whole-file TTS (not yet audible) or just end
+    # Set by the adapter only after Discord requests the frame following the
+    # first non-silent PCM frame, which confirms the preceding packet send
+    # returned successfully. The consumer uses this to decide whether a
+    # failure should fall back to whole-file TTS (not yet audible) or end
     # cleanly (already audible — don't replay from the beginning).
     audible: bool = False
+    # Set for intentional user interruption (for example voice barge-in). Such
+    # turns never fall back to whole-file TTS, even before the first frame.
+    interrupted: bool = False
     # Set to True by abort_streaming_tts; late chunks are dropped.
     aborted: bool = False
+    # Unexpected platform sink termination; finish must not report success.
+    platform_failed: bool = False
+    # Adapter-to-consumer lifecycle callbacks. ``on_interrupt`` is reserved for
+    # intentional user/lifecycle stops; ``on_abort`` reports an unexpected
+    # platform sink failure while preserving pre-audio fallback semantics.
+    on_interrupt: Optional[Callable[[str], None]] = field(default=None, repr=False)
+    on_abort: Optional[Callable[[str], None]] = field(default=None, repr=False)
 
 
 def streaming_tts_turn_key(session_key: str | None, turn_marker: Any = None, *, event: Any = None) -> str | None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -66,6 +66,7 @@ from agent.turn_context import (
 )
 from hermes_cli.config import _is_ssh_remote_tilde_cwd, cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from gateway.streaming_tts_consumer import interrupt_streaming_tts_consumer
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -28654,9 +28655,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             agent.interrupt(pending_text)
                             _interrupt_detected.set()
                             # Abort streaming TTS on barge-in (#60671).
-                            _stts = streaming_tts_consumer_holder[0]
-                            if _stts is not None:
-                                _stts.abort("barge-in")
+                            interrupt_streaming_tts_consumer(
+                                streaming_tts_consumer_holder, "barge-in"
+                            )
                             break
                 except asyncio.CancelledError:
                     raise
@@ -28941,9 +28942,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _backup_agent.interrupt(_bp_text)
                             _interrupt_detected.set()
                             # Abort streaming TTS on barge-in (#60671).
-                            _stts = streaming_tts_consumer_holder[0]
-                            if _stts is not None:
-                                _stts.abort("barge-in")
+                            interrupt_streaming_tts_consumer(
+                                streaming_tts_consumer_holder, "barge-in"
+                            )
 
             else:
                 # Poll loop: check the agent's built-in activity tracker
@@ -29043,9 +29044,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _backup_agent.interrupt(_bp_text)
                             _interrupt_detected.set()
                             # Abort streaming TTS on barge-in (#60671).
-                            _stts = streaming_tts_consumer_holder[0]
-                            if _stts is not None:
-                                _stts.abort("barge-in")
+                            interrupt_streaming_tts_consumer(
+                                streaming_tts_consumer_holder, "barge-in"
+                            )
 
             if _inactivity_timeout:
                 # Build a diagnostic summary from the agent's activity tracker.

--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -52,6 +52,17 @@ _ABORT = object()
 _DONE = object()
 
 
+def interrupt_streaming_tts_consumer(
+    holder: list[Any], reason: str = "barge-in"
+) -> bool:
+    """Interrupt the active per-turn consumer, if any, with fallback suppression."""
+    consumer = holder[0] if holder else None
+    if consumer is None:
+        return False
+    consumer.interrupt(reason)
+    return True
+
+
 class StreamingTTSConsumer:
     """Consumes LLM text deltas and produces streaming PCM audio for an adapter."""
 
@@ -75,7 +86,9 @@ class StreamingTTSConsumer:
 
         # Resolve the streaming provider once. If unavailable, the consumer is
         # inactive and the gateway falls back to whole-file TTS.
-        self._streamer = resolve_streaming_provider(tts_config)
+        self._streamer = resolve_streaming_provider(
+            tts_config, require_transport_cancellation=True
+        )
         self._chunker = SentenceChunker()
 
         if self._streamer is not None:
@@ -96,6 +109,8 @@ class StreamingTTSConsumer:
         self._completed = False
         self._partial = False
         self._aborted = False
+        self._interrupted = False
+        self._abort_reason = "cancelled"
         self._finished = False
         self._dropped = False
         self._suppress_whole_file = False
@@ -131,7 +146,7 @@ class StreamingTTSConsumer:
 
     @property
     def audible(self) -> bool:
-        """True once the first PCM chunk has been written."""
+        """True once the platform has emitted its first non-silent PCM frame."""
         return bool(self._handle and self._handle.audible)
 
     @property
@@ -141,8 +156,11 @@ class StreamingTTSConsumer:
 
     @property
     def suppress_whole_file(self) -> bool:
-        """True when the gateway should skip the legacy whole-file TTS fallback."""
-        return self._suppress_whole_file
+        """True when the gateway should skip legacy whole-file TTS fallback."""
+        return bool(
+            self._suppress_whole_file
+            or (self._handle and (self._handle.audible or self._handle.interrupted))
+        )
 
     @property
     def done(self) -> bool:
@@ -217,7 +235,7 @@ class StreamingTTSConsumer:
 
     async def _run(self) -> None:
         """Drain clauses from the queue, synthesise, and write to the adapter."""
-        if not self.active:
+        if not self.active or self._aborted:
             return
 
         if not self._adapter.supports_streaming_tts(self._chat_id, self._audio_format):
@@ -238,8 +256,17 @@ class StreamingTTSConsumer:
         if self._handle is None:
             return
 
+        # Surfaces can notify the owner about intentional interruptions or an
+        # unexpected sink failure so provider transport is cancelled promptly.
+        self._handle.on_interrupt = self.interrupt
+        self._handle.on_abort = self.abort
         self._started = True
-        self._suppress_whole_file = False
+        if self._aborted:
+            if self._interrupted:
+                self._handle.interrupted = True
+                self._suppress_whole_file = True
+            await self._safe_abort(self._abort_reason)
+            return
 
         try:
             while True:
@@ -263,8 +290,10 @@ class StreamingTTSConsumer:
                     await self._synthesise_and_write(item)
                 except Exception as exc:
                     logger.warning("streaming TTS clause failed: %s", exc)
-                    if self._handle and self._handle.audible:
-                        self._partial = True
+                    if self._handle and (
+                        self._handle.audible or self._handle.interrupted
+                    ):
+                        self._partial = self._handle.audible
                         self._suppress_whole_file = True
                     else:
                         self._suppress_whole_file = False
@@ -273,6 +302,13 @@ class StreamingTTSConsumer:
                     return
 
             if not self._aborted and self._handle is not None:
+                if self._handle.interrupted:
+                    # Intentional barge-in must never replay from the start,
+                    # even when it arrived before Discord emitted frame one.
+                    self._partial = self._handle.audible
+                    self._completed = False
+                    self._suppress_whole_file = True
+                    return
                 _finish_failed = False
                 try:
                     await self._adapter.finish_streaming_tts(self._handle, interrupted=self._aborted)
@@ -331,15 +367,18 @@ class StreamingTTSConsumer:
                 return
             if not chunk:
                 continue
-            was_audible = self._handle.audible
             await self._adapter.write_streaming_tts(self._handle, chunk)
-            if not was_audible:
-                self._handle.audible = True
-                self._suppress_whole_file = True
+            # The adapter owns ``handle.audible`` and sets it only after the
+            # platform has actually emitted non-silent PCM.
 
     async def _iter_stream_chunks(self, text: str):
         """Yield provider PCM chunks one at a time without blocking the loop."""
         if self._streamer is None:
+            return
+        async_stream = getattr(self._streamer, "astream", None)
+        if callable(async_stream):
+            async for chunk in async_stream(text):
+                yield chunk
             return
         iterator = iter(self._streamer.stream(text))
         while True:
@@ -381,12 +420,30 @@ class StreamingTTSConsumer:
     # Cancellation and completion
     # ------------------------------------------------------------------
 
+    def interrupt(self, reason: str = "user interrupted speech") -> None:
+        """Cancel an intentional barge-in and permanently suppress replay."""
+        with self._lock:
+            self._interrupted = True
+            self._abort_reason = reason
+            self._suppress_whole_file = True
+        if self._handle is not None:
+            self._handle.interrupted = True
+        self.abort(reason)
+
     def abort(self, reason: str = "cancelled") -> None:
         """Idempotent cancellation from any thread."""
         with self._lock:
+            self._abort_reason = reason
             if self._aborted:
                 return
             self._aborted = True
+        # Close provider transport immediately so a blocked ``to_thread(next)``
+        # does not occupy the shared executor until its socket timeout.
+        try:
+            if self._streamer is not None:
+                self._streamer.cancel()
+        except Exception:
+            pass
         # Guarantee the _ABORT sentinel reaches the queue.  If the bounded
         # queue is full, drain one item to make room — the sentinel must
         # not be lost (#60671 hardening).

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2255,7 +2255,8 @@ DEFAULT_CONFIG = {
         # stop-and-swap — the Grok-voice-mode feel. discord.py ships no mixer;
         # this is implemented in plugins/platforms/discord/voice_mixer.py.
         "voice_fx": {
-            "enabled": False,         # master switch for the mixer subsystem
+            "enabled": False,         # master switch for ambient / ack effects
+            "streaming_tts": False,   # incremental PCM TTS in live VC (independent opt-in)
             "ambient_enabled": True,  # play the idle "thinking" bed while tools run
             "ambient_path": "",       # custom loop audio file; "" = synthesised pad
             "ambient_gain": 0.18,     # idle bed loudness, 0.0–1.0

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -576,9 +576,16 @@ class VoiceReceiver:
     SAMPLE_RATE = 48000        # Discord native rate
     CHANNELS = 2               # Discord sends stereo
 
-    def __init__(self, voice_client, allowed_user_ids: set = None):
+    def __init__(
+        self,
+        voice_client,
+        allowed_user_ids: set = None,
+        on_speech_start=None,
+    ):
         self._vc = voice_client
         self._allowed_user_ids = allowed_user_ids or set()
+        self._on_speech_start = on_speech_start
+        self._speech_notified_ssrc: set[int] = set()
         self._running = False
 
         # Decryption
@@ -631,7 +638,13 @@ class VoiceReceiver:
             self._last_packet_time.clear()
             self._decoders.clear()
             self._ssrc_to_user.clear()
+            self._speech_notified_ssrc.clear()
         logger.info("VoiceReceiver stopped")
+
+    @property
+    def paused(self) -> bool:
+        """Whether inbound packet handling is currently suspended."""
+        return self._paused
 
     def pause(self):
         self._paused = True
@@ -811,9 +824,19 @@ class VoiceReceiver:
             if ssrc not in self._decoders:
                 self._decoders[ssrc] = discord.opus.Decoder()
             pcm = self._decoders[ssrc].decode(decrypted)
+            notify_user = 0
             with self._lock:
                 self._buffers[ssrc].extend(pcm)
                 self._last_packet_time[ssrc] = time.monotonic()
+                if ssrc not in self._speech_notified_ssrc:
+                    notify_user = int(self._ssrc_to_user.get(ssrc, 0) or 0)
+                    if notify_user:
+                        self._speech_notified_ssrc.add(ssrc)
+            if notify_user and self._on_speech_start is not None:
+                try:
+                    self._on_speech_start(notify_user)
+                except Exception:
+                    logger.debug("Voice speech-start callback failed", exc_info=True)
         except Exception as e:
             with self._lock:
                 self._decoders.pop(ssrc, None)
@@ -880,10 +903,12 @@ class VoiceReceiver:
                         completed.append((user_id, bytes(buf)))
                     self._buffers[ssrc] = bytearray()
                     self._last_packet_time.pop(ssrc, None)
+                    self._speech_notified_ssrc.discard(ssrc)
                 elif silence_duration >= self.SILENCE_THRESHOLD * 2:
                     # Stale buffer with no valid user — discard
                     self._buffers.pop(ssrc, None)
                     self._last_packet_time.pop(ssrc, None)
+                    self._speech_notified_ssrc.discard(ssrc)
 
         return completed
 
@@ -904,6 +929,7 @@ class VoiceReceiver:
                         completed.append((user_id, bytes(buf)))
                 self._buffers.pop(ssrc, None)
                 self._last_packet_time.pop(ssrc, None)
+                self._speech_notified_ssrc.discard(ssrc)
 
         return completed
 
@@ -1058,6 +1084,7 @@ class DiscordAdapter(BasePlatformAdapter):
     # a hard two-minute ceiling.
     PLAYBACK_TIMEOUT = 120
     PLAYBACK_TIMEOUT_PADDING = 30
+    STREAMING_TTS_TERMINAL_TIMEOUT = 2.0
 
     def format_tool_preview(self, preview: ToolPreview) -> str:
         """Keep a truncated URL preview clickable in Discord markdown."""
@@ -1080,6 +1107,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
+        self._voice_leaving: set[int] = set()  # guilds whose teardown has begun
         # Text batching: merge rapid successive messages (Telegram-style)
         self._text_batch_delay_seconds = env_float("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", 0.6)
         self._text_batch_split_delay_seconds = env_float("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", 2.0)
@@ -1104,6 +1132,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # Installed once per guild on join; lets acks / TTS / the "thinking"
         # loop overlap in one outgoing stream instead of stop-and-swap.
         self._voice_mixers: Dict[int, Any] = {}  # guild_id -> VoiceMixer
+        # Exactly one live incremental TTS handle per guild. New streams
+        # supersede the previous handle before any audio is accepted.
+        self._streaming_tts_handles: Dict[int, Any] = {}
         self._ambient_pcm_cache: Optional[bytes] = None  # decoded ambient bed
         self._voice_fx_cfg: Dict[str, Any] = self._load_voice_fx_config()
         # Track threads where the bot has participated so follow-up messages
@@ -4298,7 +4329,8 @@ class DiscordAdapter(BasePlatformAdapter):
         Returns a dict with safe defaults so callers never KeyError.
         """
         defaults: Dict[str, Any] = {
-            "enabled": False,        # master switch for the mixer subsystem
+            "enabled": False,        # master switch for ambient / ack effects
+            "streaming_tts": False,  # incremental PCM TTS in live VC (independent opt-in)
             "ambient_enabled": True, # idle "thinking" bed while tools run
             "ambient_path": "",      # optional custom loop file; "" = synthesised
             "ambient_gain": 0.18,    # idle bed loudness (0..1)
@@ -4413,6 +4445,8 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         if self._ambient_pcm_cache is not None:
             return self._ambient_pcm_cache
+        if not self._voice_fx_cfg.get("enabled"):
+            return None
         if not self._voice_fx_cfg.get("ambient_enabled"):
             return None
         try:
@@ -4451,15 +4485,30 @@ class DiscordAdapter(BasePlatformAdapter):
         if ambient:
             mixer.set_ambient(ambient)
 
+        loop = asyncio.get_running_loop()
+
         def _after(error):
             if error:
                 logger.error("Voice mixer stream error (guild=%d): %s", guild_id, error)
+            loop.call_soon_threadsafe(self._voice_mixer_stopped, guild_id, mixer)
 
         if vc.is_playing():
             vc.stop()
         vc.play(mixer, after=_after)
         self._voice_mixers[guild_id] = mixer
         logger.info("Voice mixer installed (guild=%d, ambient=%s)", guild_id, bool(ambient))
+
+    def _voice_mixer_stopped(self, guild_id: int, mixer) -> None:
+        """Forget a stopped mixer without deleting a newer replacement."""
+        if self._voice_mixers.get(guild_id) is mixer:
+            self._voice_mixers.pop(guild_id, None)
+        handle = self._streaming_tts_handles.get(guild_id)
+        if handle is not None and getattr(handle, "child", None) is not None:
+            # cleanup() normally notified the child's drained callback. This is
+            # a defensive fallback for sender failures that bypass cleanup.
+            child = handle.child
+            if getattr(child, "finished", False):
+                self._streaming_tts_drained(handle)
 
     def _lead_silence_bytes(self) -> bytes:
         """PCM silence prepended to speech clips on the mixer path.
@@ -4489,7 +4538,10 @@ class DiscordAdapter(BasePlatformAdapter):
         a turn, so the user hears "let me look into that" before the bot goes
         quiet to work.  No-op unless the mixer is installed and acks enabled.
         """
-        if not self._voice_fx_cfg.get("ack_enabled"):
+        if (
+            not self._voice_fx_cfg.get("enabled")
+            or not self._voice_fx_cfg.get("ack_enabled")
+        ):
             return False
         mixer = self._voice_mixers.get(guild_id)
         if mixer is None:
@@ -4540,9 +4592,284 @@ class DiscordAdapter(BasePlatformAdapter):
                         pass
 
     def voice_mixer_active(self, guild_id: int) -> bool:
-        """True when a continuous mixer is installed for this guild."""
+        """True when an open continuous mixer is installed for this guild."""
         mixers = getattr(self, "_voice_mixers", None)
-        return bool(mixers) and mixers.get(guild_id) is not None
+        mixer = mixers.get(guild_id) if mixers else None
+        return mixer is not None and getattr(mixer, "closed", False) is not True
+
+    def _voice_mixer_requested(self) -> bool:
+        """Whether either effects or streaming needs the continuous mixer."""
+        cfg = getattr(self, "_voice_fx_cfg", {})
+        return bool(cfg.get("enabled") or cfg.get("streaming_tts"))
+
+    # ------------------------------------------------------------------
+    # Streaming TTS adapter contract (#60671) — Discord live-VC path
+    # ------------------------------------------------------------------
+
+    def _guild_for_text_chat(self, chat_id: str) -> Optional[int]:
+        """Return the guild whose bound text channel matches *chat_id*."""
+        for gid, text_ch_id in (self._voice_text_channels or {}).items():
+            if str(text_ch_id) == str(chat_id):
+                return gid
+        return None
+
+    def supports_streaming_tts(self, chat_id: str, audio_format) -> bool:
+        """True when this guild can accept incremental PCM in the VC right now."""
+        if not getattr(self, "_voice_fx_cfg", {}).get("streaming_tts"):
+            return False
+        if not (getattr(audio_format, "sample_rate", 0) == 24000
+                and getattr(audio_format, "channels", 0) == 1
+                and getattr(audio_format, "sample_width", 0) == 2):
+            return False
+        gid = self._guild_for_text_chat(chat_id)
+        if (
+            gid is None
+            or gid in getattr(self, "_voice_leaving", set())
+            or not self.is_in_voice_channel(gid)
+        ):
+            return False
+        return self.voice_mixer_active(gid)
+
+    async def begin_streaming_tts(self, chat_id: str, audio_format, metadata=None):
+        from gateway.platforms.base import StreamingTTSHandle
+
+        gid = self._guild_for_text_chat(chat_id)
+        if gid is None or gid in getattr(self, "_voice_leaving", set()):
+            return None
+        mixer = self._voice_mixers.get(gid)
+        if mixer is None or getattr(mixer, "closed", False) is True:
+            return None
+
+        handle = StreamingTTSHandle(chat_id=chat_id, audio_format=audio_format)
+        handle.guild_id = gid  # type: ignore[attr-defined]
+        handle.loop = asyncio.get_running_loop()  # type: ignore[attr-defined]
+        handle.terminal_event = asyncio.Event()  # type: ignore[attr-defined]
+        child = None
+
+        # One live stream per guild. Remove ownership before aborting the old
+        # child so its drained callback cannot re-arm the timeout underneath
+        # the replacement stream.
+        handles = getattr(self, "_streaming_tts_handles", None)
+        if handles is None:
+            handles = self._streaming_tts_handles = {}
+        previous = handles.pop(gid, None)
+        if previous is not None:
+            self._terminate_streaming_tts_handle(
+                previous,
+                reason="stream replaced",
+                interrupted=True,
+                release_ownership=False,
+            )
+
+        self._cancel_voice_timeout(gid)
+        try:
+            child = mixer.begin_streaming_speech(
+                on_drained=self._make_streaming_drained_cb(handle),
+                on_audible=self._make_streaming_audible_cb(handle),
+            )
+            handle.child = child  # type: ignore[attr-defined]
+            # Pre-roll lead silence INSIDE the streaming child (24 kHz mono) so
+            # the voice socket is warm before the first provider sample.
+            lead = self._lead_silence_24k_mono_bytes()
+            if lead and child.write(lead) is False:
+                raise RuntimeError("voice mixer closed before streaming began")
+            handles[gid] = handle
+            logger.info(
+                "[%s] Streaming TTS session started (guild=%d, fmt=%s)",
+                self.name, gid, audio_format,
+            )
+            return handle
+        except Exception as e:
+            if child is not None:
+                try:
+                    child.abort()
+                except Exception:
+                    pass
+            if handles.get(gid) is handle:
+                handles.pop(gid, None)
+            self._reset_voice_timeout(gid)
+            logger.warning("[%s] begin_streaming_tts failed: %s", self.name, e)
+            return None
+
+    def _lead_silence_24k_mono_bytes(self) -> bytes:
+        """Lead silence at the streaming child's native format (24k mono).
+
+        24 000 Hz * 2 bytes/sample / 1000 ms == 48 bytes per ms.
+        """
+        cfg = getattr(self, "_voice_fx_cfg", None) or {}
+        try:
+            lead_ms = int(cfg.get("lead_silence_ms", 0) or 0)
+        except (TypeError, ValueError):
+            return b""
+        if lead_ms <= 0:
+            return b""
+        return b"\x00" * (lead_ms * 48)
+
+    def _make_streaming_audible_cb(self, handle):
+        def _on_audible(_child) -> None:
+            loop = getattr(handle, "loop", None)
+            if loop is not None and not loop.is_closed():
+                loop.call_soon_threadsafe(self._streaming_tts_audible, handle)
+        return _on_audible
+
+    @staticmethod
+    def _signal_streaming_tts_terminal(handle) -> None:
+        event = getattr(handle, "terminal_event", None)
+        if event is not None:
+            event.set()
+
+    def _streaming_tts_audible(self, handle) -> None:
+        handle.audible = True
+        self._signal_streaming_tts_terminal(handle)
+
+    def _make_streaming_drained_cb(self, handle):
+        def _on_drained(_child) -> None:
+            # Natural drain runs on discord.py's sender thread. Marshal adapter
+            # bookkeeping back onto the gateway loop.
+            loop = getattr(handle, "loop", None)
+            if loop is not None and not loop.is_closed():
+                loop.call_soon_threadsafe(self._streaming_tts_drained, handle)
+        return _on_drained
+
+    def _streaming_tts_drained(self, handle) -> None:
+        """Release guild ownership and re-arm inactivity after final audio."""
+        gid = getattr(handle, "guild_id", None)
+        self._signal_streaming_tts_terminal(handle)
+        if gid is None:
+            return
+        handles = getattr(self, "_streaming_tts_handles", {})
+        if handles.get(gid) is not handle:
+            return  # superseded handle; its replacement owns the timeout
+        child = getattr(handle, "child", None)
+        if (
+            child is not None
+            and getattr(child, "aborted", False)
+            and not getattr(handle, "aborted", False)
+        ):
+            # The sender/mixer vanished without an adapter-owned termination.
+            # Cancel the consumer/provider before releasing ownership so an
+            # active HTTP stream cannot outlive its Discord sink.
+            handle.platform_failed = True
+            handle.aborted = True
+            on_abort = getattr(handle, "on_abort", None)
+            if callable(on_abort):
+                try:
+                    on_abort("Discord voice mixer stopped unexpectedly")
+                except Exception:
+                    logger.debug(
+                        "streaming TTS abort callback failed",
+                        exc_info=True,
+                    )
+        handles.pop(gid, None)
+        self._reset_voice_timeout(gid)
+
+    def _terminate_streaming_tts_handle(
+        self,
+        handle,
+        *,
+        reason: str,
+        interrupted: bool,
+        release_ownership: bool,
+    ) -> None:
+        """Terminate one handle and, for intentional stops, cancel its producer."""
+        if getattr(handle, "aborted", False):
+            return
+        if interrupted:
+            handle.interrupted = True
+            on_interrupt = getattr(handle, "on_interrupt", None)
+            if callable(on_interrupt):
+                try:
+                    on_interrupt(reason)
+                except Exception:
+                    logger.debug(
+                        "streaming TTS interruption callback failed",
+                        exc_info=True,
+                    )
+        handle.aborted = True
+        child = getattr(handle, "child", None)
+        if child is not None:
+            try:
+                child.abort()
+            except Exception:
+                pass
+        self._signal_streaming_tts_terminal(handle)
+        if release_ownership:
+            self._streaming_tts_drained(handle)
+
+    def _handle_voice_barge_in(self, guild_id: int, user_id: int) -> None:
+        """Stop current streamed speech when an authorized user starts talking."""
+        guild = self._client.get_guild(guild_id) if self._client is not None else None
+        if not self._is_allowed_user(str(user_id), guild=guild, is_dm=False):
+            return
+        handle = getattr(self, "_streaming_tts_handles", {}).get(guild_id)
+        if handle is None or getattr(handle, "aborted", False):
+            return
+        self._terminate_streaming_tts_handle(
+            handle,
+            reason="voice barge-in",
+            interrupted=True,
+            release_ownership=True,
+        )
+        logger.info(
+            "[%s] Streaming TTS interrupted by voice barge-in (guild=%d, user=%d)",
+            self.name, guild_id, user_id,
+        )
+
+    async def write_streaming_tts(self, handle, chunk: bytes) -> None:
+        child = getattr(handle, "child", None)
+        if child is None or getattr(handle, "aborted", False):
+            return  # late chunk after abort: drop silently
+        accepted = child.write(chunk)
+        if accepted is False:
+            raise RuntimeError("Discord voice mixer stopped during streaming TTS")
+
+    async def finish_streaming_tts(self, handle, *, interrupted: bool = False) -> None:
+        if getattr(handle, "platform_failed", False):
+            raise RuntimeError("Discord voice mixer stopped unexpectedly")
+        if getattr(handle, "aborted", False):
+            return  # finish-after-adapter-abort is a no-op
+        child = getattr(handle, "child", None)
+        if child is not None:
+            child.finish()  # propagate errors: the consumer decides fallback
+            if getattr(child, "drained", False):
+                self._streaming_tts_drained(handle)
+
+        # Do not decide whole-file fallback while a final streaming frame is
+        # still buffered between sender pulls. The terminal event is set by
+        # either post-send audibility acknowledgement or terminal drain/failure.
+        terminal = getattr(handle, "terminal_event", None)
+        if terminal is not None and not terminal.is_set():
+            try:
+                await asyncio.wait_for(
+                    terminal.wait(),
+                    timeout=self.STREAMING_TTS_TERMINAL_TIMEOUT,
+                )
+            except asyncio.TimeoutError as exc:
+                # Sender stopped pulling. Remove buffered PCM before permitting
+                # whole-file fallback, otherwise both paths could later play.
+                self._terminate_streaming_tts_handle(
+                    handle,
+                    reason="timed out waiting for Discord sender acknowledgement",
+                    interrupted=False,
+                    release_ownership=True,
+                )
+                raise RuntimeError(
+                    "Discord voice sender did not acknowledge streaming audio"
+                ) from exc
+        if getattr(handle, "platform_failed", False):
+            raise RuntimeError("Discord voice mixer stopped unexpectedly")
+        # A zero-chunk provider response drains without becoming audible and
+        # therefore remains eligible for whole-file fallback.
+
+    async def abort_streaming_tts(self, handle, error: Optional[str] = None) -> None:
+        self._terminate_streaming_tts_handle(
+            handle,
+            reason=error or "stream aborted",
+            interrupted=False,
+            release_ownership=True,
+        )
+        if error:
+            logger.warning("[%s] Streaming TTS aborted: %s", self.name, error)
 
     async def join_voice_channel(self, channel, *, text_channel_id: int = None, source: dict = None) -> bool:
         """Join a Discord voice channel. Returns True on success.
@@ -4558,6 +4885,8 @@ class DiscordAdapter(BasePlatformAdapter):
         guild_id = channel.guild.id
 
         async with self._voice_locks.setdefault(guild_id, asyncio.Lock()):
+            if guild_id in getattr(self, "_voice_leaving", set()):
+                return False
             # Already connected in this guild?
             existing = self._voice_clients.get(guild_id)
             if existing and existing.is_connected():
@@ -4579,9 +4908,22 @@ class DiscordAdapter(BasePlatformAdapter):
             if source is not None:
                 self._voice_sources[guild_id] = source
 
-            # Start voice receiver (Phase 2: listen to users)
+            # Start voice receiver (Phase 2: listen to users). Keep capture
+            # active during streaming TTS: outbound bot RTP is filtered by SSRC,
+            # and speech-start events provide immediate barge-in.
             try:
-                receiver = VoiceReceiver(vc, allowed_user_ids=self._allowed_user_ids)
+                loop = asyncio.get_running_loop()
+
+                def _speech_started(user_id: int) -> None:
+                    loop.call_soon_threadsafe(
+                        self._handle_voice_barge_in, guild_id, user_id
+                    )
+
+                receiver = VoiceReceiver(
+                    vc,
+                    allowed_user_ids=self._allowed_user_ids,
+                    on_speech_start=_speech_started,
+                )
                 receiver.start()
                 self._voice_receivers[guild_id] = receiver
                 self._voice_listen_tasks[guild_id] = asyncio.ensure_future(
@@ -4590,10 +4932,11 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("Voice receiver failed to start: %s", e)
 
-            # Phase 3: install the continuous mixer (ambient bed + ducked
-            # speech).  Best-effort — if it fails we fall back to the legacy
-            # one-shot FFmpegPCMAudio playback path in play_in_voice_channel.
-            if getattr(self, "_voice_fx_cfg", {}).get("enabled"):
+            # Install the continuous mixer when either the optional effects
+            # subsystem or live streaming TTS is enabled. Streaming must work
+            # independently of ambient/ack effects; _get_ambient_pcm() returns
+            # no bed when the effects master switch is off.
+            if self._voice_mixer_requested():
                 try:
                     await self._install_voice_mixer(guild_id, vc)
                 except Exception as e:
@@ -4602,40 +4945,68 @@ class DiscordAdapter(BasePlatformAdapter):
             return True
 
     async def leave_voice_channel(self, guild_id: int) -> None:
-        """Disconnect from the voice channel in a guild."""
-        async with self._voice_locks.setdefault(guild_id, asyncio.Lock()):
-            # Stop voice receiver first
-            receiver = self._voice_receivers.pop(guild_id, None)
-            pending_inputs = []
-            if receiver:
-                pending_inputs = receiver.flush_pending()
-                receiver.stop()
-            listen_task = self._voice_listen_tasks.pop(guild_id, None)
-            if listen_task:
-                listen_task.cancel()
+        """Disconnect promptly, then preserve any already-buffered user speech."""
+        leaving = getattr(self, "_voice_leaving", None)
+        if leaving is None:
+            leaving = self._voice_leaving = set()
+        if guild_id in leaving:
+            return
+        pending_inputs = []
+        leaving.add(guild_id)
+        try:
+            async with self._voice_locks.setdefault(guild_id, asyncio.Lock()):
+                # Freeze incoming audio without running transcription/agent work
+                # while the voice client and active provider are still alive.
+                receiver = self._voice_receivers.pop(guild_id, None)
+                if receiver:
+                    pending_inputs = receiver.flush_pending()
+                    receiver.stop()
+                listen_task = self._voice_listen_tasks.pop(guild_id, None)
+                if listen_task:
+                    listen_task.cancel()
 
+                # Cancel streamed speech and its provider before the first await.
+                handle = getattr(self, "_streaming_tts_handles", {}).pop(guild_id, None)
+                if handle is not None:
+                    self._terminate_streaming_tts_handle(
+                        handle,
+                        reason="voice channel left",
+                        interrupted=True,
+                        release_ownership=False,
+                    )
+                mixer = None
+                if getattr(self, "_voice_mixers", None) is not None:
+                    mixer = self._voice_mixers.pop(guild_id, None)
+                if mixer is not None:
+                    try:
+                        mixer.cleanup()
+                    except Exception:
+                        logger.debug("voice mixer cleanup failed", exc_info=True)
+
+                # Remove/cancel inactivity ownership before disconnect. If this
+                # leave was invoked by the timeout task itself, do not self-cancel.
+                self._cancel_voice_timeout(guild_id)
+                vc = self._voice_clients.pop(guild_id, None)
+                if vc and vc.is_connected():
+                    try:
+                        if vc.is_playing():
+                            vc.stop()
+                    except Exception:
+                        pass
+                    await vc.disconnect()
+
+            # Preserve speech captured immediately before /voice leave, but only
+            # after releasing the lifecycle lock and removing the voice sink.
+            # Replies use the normal non-voice fallback; a re-entrant command
+            # cannot deadlock against this guild's join/leave lock.
             guild = self._client.get_guild(guild_id) if self._client is not None else None
             for user_id, pcm_data in pending_inputs:
                 if self._is_allowed_user(str(user_id), guild=guild, is_dm=False):
                     await self._process_voice_input(guild_id, user_id, pcm_data)
-
-            # Tear down the mixer (stops the continuous outgoing stream).
-            if getattr(self, "_voice_mixers", None) is not None:
-                self._voice_mixers.pop(guild_id, None)
-
-            vc = self._voice_clients.pop(guild_id, None)
-            if vc and vc.is_connected():
-                try:
-                    if vc.is_playing():
-                        vc.stop()
-                except Exception:
-                    pass
-                await vc.disconnect()
-            task = self._voice_timeout_tasks.pop(guild_id, None)
-            if task:
-                task.cancel()
+        finally:
             self._voice_text_channels.pop(guild_id, None)
             self._voice_sources.pop(guild_id, None)
+            leaving.discard(guild_id)
 
     async def play_in_voice_channel(self, guild_id: int, audio_path: str) -> bool:
         """Play an audio file in the connected voice channel.
@@ -4666,15 +5037,19 @@ class DiscordAdapter(BasePlatformAdapter):
                 pcm = await asyncio.to_thread(decode_to_pcm, audio_path)
                 if pcm:
                     speech_gain = float(self._voice_fx_cfg.get("speech_gain", 1.0))
-                    mixer.play_speech(self._lead_silence_bytes() + pcm, gain=speech_gain)
-                    # Block until the speech child drains so callers serialise
-                    # replies (mirrors legacy semantics) but the ambient keeps
-                    # playing underneath the whole time.
+                    speech_child = mixer.play_speech(
+                        self._lead_silence_bytes() + pcm,
+                        gain=speech_gain,
+                    )
+                    if speech_child is None:
+                        return False
+                    # Serialise only this clip. Other speech (notably an active
+                    # incremental reply) has independent lifetime/ownership.
                     wait_start = time.monotonic()
-                    while mixer.speech_active:
+                    while not speech_child.finished:
                         if time.monotonic() - wait_start > playback_timeout:
                             logger.warning("Mixer speech playback timed out after %.1fs", playback_timeout)
-                            mixer.stop_speech()
+                            mixer.stop_speech_child(speech_child)
                             break
                         await asyncio.sleep(0.05)
                     return True
@@ -4747,12 +5122,18 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _cancel_voice_timeout(self, guild_id: int) -> None:
         task = self._voice_timeout_tasks.pop(guild_id, None)
-        if task:
+        try:
+            current = asyncio.current_task()
+        except RuntimeError:  # synchronous config/tests: no running loop
+            current = None
+        if task and task is not current:
             task.cancel()
 
     def _reset_voice_timeout(self, guild_id: int) -> None:
         """Reset the auto-disconnect inactivity timer."""
         self._cancel_voice_timeout(guild_id)
+        if guild_id in getattr(self, "_voice_leaving", set()):
+            return
         timeout = self._voice_timeout_limit()
         if timeout <= 0:
             logger.debug("Voice inactivity timeout disabled (guild=%d)", guild_id)

--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -44,7 +44,7 @@ the mixer's output cannot echo back into transcription.
 
 import logging
 import threading
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import discord
 
@@ -153,6 +153,181 @@ class MixerChild:
         return samples
 
 
+class StreamingMixerChild:
+    """Incremental 24 kHz mono s16le speech source for :class:`VoiceMixer`.
+
+    Provider chunks may split int16 samples arbitrarily.  Complete samples are
+    converted immediately to Discord-native 48 kHz stereo s16le (an exact 2x
+    rate expansion) and retained in a bounded buffer until the audio thread
+    drains 20 ms frames.  An empty-but-open stream returns silence rather than
+    EOF so discord.py keeps polling while the provider is between chunks.
+
+    Lifecycle: ``write`` while open, then ``finish`` (producer done; buffered
+    audio still drains on the sender thread) or ``abort`` (drop everything).
+    The one-shot ``on_drained`` callback fires exactly once, when the child
+    reaches its terminal state — either after the buffer drains naturally or
+    immediately on abort — so owners can release resources (e.g. the voice
+    receiver echo guard) only when no more audio can be emitted.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        gain: float = 1.0,
+        max_buffer_bytes: int = 16 * 1024 * 1024,
+        on_drained: "Optional[Callable[['StreamingMixerChild'], None]]" = None,
+        on_audible: "Optional[Callable[['StreamingMixerChild'], None]]" = None,
+    ) -> None:
+        self.name = name
+        self.gain = float(gain)
+        self.is_speech = True
+        self._max_buffer_bytes = max(FRAME_SIZE, int(max_buffer_bytes))
+        self._buffer = bytearray()
+        self._input_carry = bytearray()
+        self._lock = threading.Lock()
+        self._input_finished = False
+        self._aborted = False
+        self._finished = False
+        self._drained_notified = False
+        self._audible_notified = False
+        self._audible_pending = False
+        self._on_drained = on_drained
+        self._on_audible = on_audible
+
+    @property
+    def finished(self) -> bool:
+        with self._lock:
+            return self._finished
+
+    @property
+    def aborted(self) -> bool:
+        """True when playback ended by abort rather than a natural drain."""
+        with self._lock:
+            return self._aborted
+
+    @property
+    def audible_pending(self) -> bool:
+        """True after a non-silent frame was pulled but not yet send-acked."""
+        with self._lock:
+            return self._audible_pending
+
+    @property
+    def drained(self) -> bool:
+        """True when no more frames will ever be emitted and the one-shot
+        ``on_drained`` callback has not yet fired (owner may act on it)."""
+        with self._lock:
+            return self._finished and not self._drained_notified
+
+    def write(self, pcm_24k_mono: bytes) -> bool:
+        """Append provider PCM, returning False when this child is terminal."""
+        if not pcm_24k_mono:
+            return True
+        np = _require_numpy()
+        with self._lock:
+            if self._aborted:
+                return False
+            if self._input_finished:
+                raise RuntimeError("streaming speech is already finished")
+            data = bytes(self._input_carry) + bytes(pcm_24k_mono)
+            even = len(data) & ~1
+            self._input_carry[:] = data[even:]
+            if not even:
+                return True
+            mono = np.frombuffer(data[:even], dtype=np.int16)
+            # 24k mono -> 48k stereo: duplicate each sample once in time and
+            # duplicate both rate-expanded samples across the two channels.
+            converted = np.repeat(np.repeat(mono, 2), 2).astype(np.int16).tobytes()
+            if len(self._buffer) + len(converted) > self._max_buffer_bytes:
+                raise BufferError("streaming speech buffer limit exceeded")
+            self._buffer.extend(converted)
+            return True
+
+    def finish(self) -> None:
+        with self._lock:
+            self._input_carry.clear()  # incomplete int16 sample is not audio
+            self._input_finished = True
+
+    def abort(self) -> None:
+        self._abort_silent()
+        self._notify_drained()
+
+    def _abort_silent(self) -> None:
+        """Abort without firing ``on_drained``.
+
+        Used by the mixer itself (``stop_speech`` / ``cleanup``), which
+        already owns the aggregate state and must not re-enter it through the
+        callback.
+        """
+        with self._lock:
+            self._aborted = True
+            self._input_finished = True
+            self._input_carry.clear()
+            self._buffer.clear()
+            self._finished = True
+
+    def _notify_drained(self) -> None:
+        with self._lock:
+            if self._drained_notified:
+                return
+            self._drained_notified = True
+            cb = self._on_drained
+        if cb is not None:
+            cb(self)
+
+    def fire_drained_cb(self) -> None:
+        """Fire the one-shot drained callback if the child is terminal.
+
+        Called by the mixer AFTER releasing its own lock, so the callback can
+        safely re-enter the mixer or run sender-thread side effects.
+        """
+        with self._lock:
+            if not self._finished or self._drained_notified:
+                return
+            self._drained_notified = True
+            cb = self._on_drained
+        if cb is not None:
+            cb(self)
+
+    def fire_audible_cb(self) -> None:
+        """Fire sender-confirmed audibility after the mixer lock is released."""
+        with self._lock:
+            if not self._audible_pending:
+                return
+            self._audible_pending = False
+            cb = self._on_audible
+        if cb is not None:
+            cb(self)
+
+    def read_frame(self) -> "Optional[np.ndarray]":
+        np = _require_numpy()
+        with self._lock:
+            if self._finished or self._aborted:
+                return None
+            if len(self._buffer) >= FRAME_SIZE:
+                chunk = bytes(self._buffer[:FRAME_SIZE])
+                del self._buffer[:FRAME_SIZE]
+            elif self._input_finished:
+                if not self._buffer:
+                    # Natural drain: terminal state.  The callback fires via
+                    # fire_drained_cb() (called by the mixer after releasing
+                    # its lock) — never inline, to avoid lock re-entrancy.
+                    self._finished = True
+                    return None
+                chunk = bytes(self._buffer)
+                self._buffer.clear()
+                chunk += b"\x00" * (FRAME_SIZE - len(chunk))
+            else:
+                chunk = SILENCE_FRAME
+            if not self._audible_notified and any(chunk):
+                self._audible_notified = True
+                self._audible_pending = True
+        samples = np.frombuffer(chunk, dtype=np.int16).astype(np.float32)
+        if self.gain != 1.0:
+            samples *= self.gain
+        return samples
+
+
 class VoiceMixer(discord.AudioSource):
     """A continuous ``discord.AudioSource`` that mixes N child streams.
 
@@ -176,7 +351,7 @@ class VoiceMixer(discord.AudioSource):
     ):
         self._lock = threading.Lock()
         self._ambient: Optional[MixerChild] = None
-        self._speech: List[MixerChild] = []
+        self._speech: List[Union[MixerChild, StreamingMixerChild]] = []
         self._ambient_gain = float(ambient_gain)
         self._duck_gain = float(duck_gain)
         self._speech_gain = float(speech_gain)
@@ -214,10 +389,10 @@ class VoiceMixer(discord.AudioSource):
     # ------------------------------------------------------------------
 
     def play_speech(self, pcm: bytes, *, gain: Optional[float] = None,
-                    fade_in_ms: int = 40) -> None:
-        """Layer a one-shot speech clip over the ambient bed (ducks ambient)."""
+                    fade_in_ms: int = 40) -> Optional[MixerChild]:
+        """Layer a one-shot clip and return its independently trackable child."""
         if not pcm:
-            return
+            return None
         with self._lock:
             child = MixerChild(
                 "speech", pcm, loop=False,
@@ -229,17 +404,102 @@ class VoiceMixer(discord.AudioSource):
             self._duck_release_left = 0
             if self._ambient is not None:
                 self._ambient.gain = self._duck_gain
+            return child
+
+    @property
+    def closed(self) -> bool:
+        with self._lock:
+            return self._closed
+
+    def begin_streaming_speech(
+        self,
+        *,
+        gain: Optional[float] = None,
+        max_buffer_bytes: int = 16 * 1024 * 1024,
+        on_drained: "Optional[Callable[[StreamingMixerChild], None]]" = None,
+        on_audible: "Optional[Callable[[StreamingMixerChild], None]]" = None,
+    ) -> StreamingMixerChild:
+        """Attach and return an open incremental speech child.
+
+        ``on_drained`` fires once when the child reaches its terminal state
+        (natural drain or abort), after the mixer has removed the child and
+        released the duck if it was the last speech source.
+        """
+        def _child_drained(child: StreamingMixerChild) -> None:
+            self._streaming_child_drained(child)
+            if on_drained is not None:
+                on_drained(child)
+
+        child = StreamingMixerChild(
+            "streaming-speech",
+            gain=self._speech_gain if gain is None else float(gain),
+            max_buffer_bytes=max_buffer_bytes,
+            on_drained=_child_drained,
+            on_audible=on_audible,
+        )
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("voice mixer is closed")
+            self._speech.append(child)
+            self._speech_active = True
+            self._duck_release_left = 0
+            if self._ambient is not None:
+                self._ambient.gain = self._duck_gain
+        return child
+
+    def _streaming_child_drained(self, child: StreamingMixerChild) -> None:
+        """Remove *child* and release the duck when no speech children remain.
+
+        Runs from the sender thread (natural drain) or the producer thread
+        (abort); always under the mixer lock, never re-entrant.
+        """
+        with self._lock:
+            try:
+                self._speech.remove(child)
+            except ValueError:
+                pass
+            if not self._speech and self._speech_active:
+                self._begin_duck_release_locked()
 
     @property
     def speech_active(self) -> bool:
         with self._lock:
             return self._speech_active
 
-    def stop_speech(self) -> None:
-        """Drop any in-flight speech immediately and release the duck."""
+    def stop_speech_child(
+        self, child: Union[MixerChild, StreamingMixerChild]
+    ) -> None:
+        """Stop only *child*, preserving unrelated speech in the same guild."""
+        drained: Optional[StreamingMixerChild] = None
         with self._lock:
+            try:
+                self._speech.remove(child)
+            except ValueError:
+                return
+            if isinstance(child, StreamingMixerChild):
+                child._abort_silent()
+                drained = child
+            else:
+                child._finished = True
+            if not self._speech and self._speech_active:
+                self._begin_duck_release_locked()
+        if drained is not None:
+            drained.fire_drained_cb()
+
+    def stop_speech(self) -> None:
+        """Drop every in-flight speech source and notify streaming owners."""
+        drained: List[StreamingMixerChild] = []
+        with self._lock:
+            for child in self._speech:
+                if isinstance(child, StreamingMixerChild):
+                    child._abort_silent()
+                    drained.append(child)
+                else:
+                    child._finished = True
             self._speech.clear()
             self._begin_duck_release_locked()
+        for child in drained:
+            child.fire_drained_cb()
 
     def _begin_duck_release_locked(self) -> None:
         self._speech_active = False
@@ -262,13 +522,29 @@ class VoiceMixer(discord.AudioSource):
 
             np = _require_numpy()
             acc: "Optional[np.ndarray]" = None
+            drained: List[StreamingMixerChild] = []
+            # A second source.read() proves discord.py successfully returned
+            # from send_audio_packet() for the preceding frame. A pending child
+            # is acknowledged now, before this call produces the next frame.
+            audible: List[StreamingMixerChild] = [
+                child
+                for child in self._speech
+                if (
+                    isinstance(child, StreamingMixerChild)
+                    and child.audible_pending
+                )
+            ]
 
             # Speech children (drop exhausted ones; release duck when last ends)
             if self._speech:
-                still_live: List[MixerChild] = []
+                still_live: List[Union[MixerChild, StreamingMixerChild]] = []
                 for child in self._speech:
                     frame = child.read_frame()
                     if frame is None:
+                        # Terminal streaming children fire their drained
+                        # callback AFTER this lock is released.
+                        if isinstance(child, StreamingMixerChild) and child.drained:
+                            drained.append(child)
                         continue
                     acc = frame if acc is None else acc + frame
                     still_live.append(child)
@@ -292,16 +568,34 @@ class VoiceMixer(discord.AudioSource):
                     acc = amb if acc is None else acc + amb
 
             if acc is None:
-                return SILENCE_FRAME
+                frame_out = SILENCE_FRAME
+            else:
+                np.clip(acc, -32768, 32767, out=acc)
+                frame_out = acc.astype(np.int16).tobytes()
 
-            np.clip(acc, -32768, 32767, out=acc)
-            return acc.astype(np.int16).tobytes()
+        # Post-send audible acknowledgement and drained callbacks run outside
+        # lock because adapter callbacks may re-enter mixer lifecycle methods.
+        for child in audible:
+            child.fire_audible_cb()
+        for child in drained:
+            child.fire_drained_cb()
+        return frame_out
 
     def cleanup(self) -> None:  # called by discord.py when playback stops
+        drained: List[StreamingMixerChild] = []
         with self._lock:
             self._closed = True
             self._ambient = None
+            for child in self._speech:
+                if isinstance(child, StreamingMixerChild):
+                    child._abort_silent()
+                    drained.append(child)
             self._speech.clear()
+            self._speech_active = False
+        # Notify owners outside the mixer lock so adapter callbacks may safely
+        # schedule cleanup/fallback work.
+        for child in drained:
+            child.fire_drained_cb()
 
 
 # ----------------------------------------------------------------------

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -7,6 +7,7 @@ integration (install on join, play routing, ack) is tested with the standard
 ``object.__new__(DiscordAdapter)`` helper used elsewhere in the voice suite.
 """
 
+import asyncio
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -32,6 +33,55 @@ import voice_mixer as vm  # noqa: E402
 # =====================================================================
 # Pure mixer unit tests
 # =====================================================================
+
+class TestStreamingMixerChild:
+    def test_split_24k_mono_input_converts_to_discord_frame(self):
+        child = vm.StreamingMixerChild("stream", max_buffer_bytes=vm.FRAME_SIZE * 2)
+        mono = np.arange(480, dtype=np.int16).tobytes()
+        child.write(mono[:101])
+        child.write(mono[101:])
+        child.finish()
+
+        frame = child.read_frame()
+        assert frame is not None
+        expected = np.repeat(np.repeat(np.arange(480, dtype=np.int16), 2), 2)
+        np.testing.assert_array_equal(frame.astype(np.int16), expected)
+        assert child.read_frame() is None
+
+    def test_underrun_returns_silence_until_finished(self):
+        child = vm.StreamingMixerChild("stream")
+        frame = child.read_frame()
+        assert frame is not None
+        assert np.count_nonzero(frame) == 0
+        assert not child.finished
+
+        child.finish()
+        assert child.read_frame() is None
+        assert child.finished
+
+    def test_finish_drains_partial_frame_with_padding(self):
+        child = vm.StreamingMixerChild("stream")
+        child.write(np.array([123], dtype=np.int16).tobytes())
+        child.finish()
+        frame = child.read_frame()
+        assert frame is not None
+        assert frame[0] == frame[1] == frame[2] == frame[3] == 123
+        assert np.count_nonzero(frame[4:]) == 0
+        assert child.read_frame() is None
+
+    def test_abort_drops_buffered_audio(self):
+        child = vm.StreamingMixerChild("stream")
+        child.write(np.arange(480, dtype=np.int16).tobytes())
+        child.abort()
+        assert child.read_frame() is None
+        assert child.finished
+
+    def test_buffer_is_bounded(self):
+        child = vm.StreamingMixerChild("stream", max_buffer_bytes=vm.FRAME_SIZE)
+        child.write(np.arange(480, dtype=np.int16).tobytes())
+        with pytest.raises(BufferError):
+            child.write(np.array([1], dtype=np.int16).tobytes())
+
 
 class TestVoiceMixerCore:
     def test_frame_geometry_matches_discord(self):
@@ -78,12 +128,15 @@ def _make_adapter(fx_cfg=None):
     adapter._client = MagicMock()
     adapter._voice_clients = {}
     adapter._voice_locks = {}
-    adapter._voice_text_channels = {}
+    adapter._voice_text_channels = {111: 111}
     adapter._voice_sources = {}
     adapter._voice_timeout_tasks = {}
     adapter._voice_receivers = {}
     adapter._voice_listen_tasks = {}
     adapter._voice_mixers = {}
+    adapter._streaming_tts_handles = {}
+    adapter._cancel_voice_timeout = MagicMock()
+    adapter._reset_voice_timeout = MagicMock()
     adapter._ambient_pcm_cache = None
     adapter._voice_fx_cfg = fx_cfg if fx_cfg is not None else {
         "enabled": True, "ambient_enabled": True, "ambient_path": "",
@@ -93,8 +146,132 @@ def _make_adapter(fx_cfg=None):
     return adapter
 
 
-class TestVoiceMixerActive:
+class TestStreamingMixerLifecycle:
+    def test_drained_callback_fires_once_on_natural_drain(self):
+        events = []
+        mx = vm.VoiceMixer()
+        child = mx.begin_streaming_speech(on_drained=lambda c: events.append("drained"))
+        child.write(np.arange(480, dtype=np.int16).tobytes())
+        child.finish()
+        for _ in range(100):
+            mx.read()
+            if not mx.speech_active:
+                break
+        assert events == ["drained"]
 
+    def test_drained_callback_fires_on_abort(self):
+        events = []
+        mx = vm.VoiceMixer()
+        child = mx.begin_streaming_speech(on_drained=lambda c: events.append("drained"))
+        child.write(np.arange(480, dtype=np.int16).tobytes())
+        child.abort()
+        assert events == ["drained"]
+
+    def test_abort_one_streaming_child_keeps_sibling_speech_active(self):
+        mx = vm.VoiceMixer()
+        a = mx.begin_streaming_speech()
+        b = mx.begin_streaming_speech()
+        b.write(np.arange(960, dtype=np.int16).tobytes())
+        a.abort()
+        assert mx.speech_active is True, "sibling speech must stay active"
+        assert mx.read() != vm.SILENCE_FRAME, "sibling audio must still play"
+        b.abort()
+        assert mx.speech_active is False
+
+    def test_stop_speech_aborts_streaming_children_and_notifies_owner(self):
+        events = []
+        mx = vm.VoiceMixer()
+        child = mx.begin_streaming_speech(
+            on_drained=lambda _child: events.append("drained")
+        )
+        child.write(np.arange(960, dtype=np.int16).tobytes())
+        mx.stop_speech()
+        assert mx.speech_active is False
+        assert events == ["drained"]
+        # A late producer write must not resurrect audio into the mixer.
+        assert child.write(np.arange(480, dtype=np.int16).tobytes()) is False
+        assert mx.read() == vm.SILENCE_FRAME
+
+    def test_stopping_one_shot_clip_does_not_abort_streaming_sibling(self):
+        mx = vm.VoiceMixer()
+        stream = mx.begin_streaming_speech()
+        stream.write(np.arange(960, dtype=np.int16).tobytes())
+        clip = mx.play_speech(b"\x01\x00" * (vm.FRAME_SIZE // 2))
+
+        mx.stop_speech_child(clip)
+
+        assert clip.finished is True
+        assert stream.write(np.arange(480, dtype=np.int16).tobytes()) is True
+        assert mx.speech_active is True
+        assert mx.read() != vm.SILENCE_FRAME
+        stream.abort()
+
+    def test_audible_callback_runs_outside_mixer_lock(self):
+        callback_ran = asyncio.Event()
+        mx = vm.VoiceMixer()
+
+        def on_audible(_child):
+            assert mx.speech_active is True
+            callback_ran.set()
+
+        child = mx.begin_streaming_speech(on_audible=on_audible)
+        child.write(np.arange(480, dtype=np.int16).tobytes())
+        mx.read()  # first pull; callback is deferred until post-send acknowledgement
+        thread = __import__("threading").Thread(target=mx.read, daemon=True)
+        thread.start()
+        thread.join(timeout=1.0)
+
+        assert not thread.is_alive(), "on_audible re-entered the mixer lock"
+        assert callback_ran.is_set()
+
+    def test_cleanup_notifies_stream_owner_and_rejects_new_children(self):
+        events = []
+        mx = vm.VoiceMixer()
+        child = mx.begin_streaming_speech(on_drained=lambda _c: events.append("drained"))
+        child.write(np.arange(480, dtype=np.int16).tobytes())
+        mx.cleanup()
+        assert events == ["drained"]
+        assert child.write(b"\x00\x00") is False
+        with pytest.raises(RuntimeError, match="closed"):
+            mx.begin_streaming_speech()
+
+
+class TestVoiceMixerActive:
+    def test_streaming_child_plays_before_finish(self):
+        mx = vm.VoiceMixer()
+        child = mx.begin_streaming_speech()
+        child.write(np.arange(480, dtype=np.int16).tobytes())
+        frame = mx.read()
+        assert frame != vm.SILENCE_FRAME
+        assert mx.speech_active
+
+    def test_streaming_child_underrun_keeps_mixer_alive(self):
+        mx = vm.VoiceMixer()
+        child = mx.begin_streaming_speech()
+        # Empty but open: silence frames, mixer must not stop the stream.
+        assert mx.read() == vm.SILENCE_FRAME
+        # One full 20ms-worth of input (480 mono samples) converts to a full
+        # Discord frame, so the next read emits audio.
+        child.write(np.arange(480, dtype=np.int16).tobytes())
+        assert mx.read() != vm.SILENCE_FRAME
+
+    def test_streaming_child_finish_releases_duck(self):
+        mx = vm.VoiceMixer()
+        child = mx.begin_streaming_speech()
+        child.write(np.arange(480, dtype=np.int16).tobytes())
+        child.finish()
+        drained = 0
+        while mx.speech_active and drained < 100:
+            mx.read()
+            drained += 1
+        assert not mx.speech_active
+
+    def test_abort_streaming_child_stops_speech_immediately(self):
+        mx = vm.VoiceMixer()
+        child = mx.begin_streaming_speech()
+        child.write(np.arange(960, dtype=np.int16).tobytes())
+        child.abort()
+        assert not mx.speech_active
 
     def test_false_when_attr_missing(self):
         # Defensive getattr path (object.__new__ helper that forgot the attr).
@@ -105,6 +282,24 @@ class TestVoiceMixerActive:
         assert bare.voice_mixer_active(111) is False
 
 
+class TestVoiceMixerActivation:
+    def test_streaming_requests_mixer_without_effects(self):
+        adapter = _make_adapter({"enabled": False, "streaming_tts": True})
+        assert adapter._voice_mixer_requested() is True
+
+    def test_no_mixer_when_effects_and_streaming_are_off(self):
+        adapter = _make_adapter({"enabled": False, "streaming_tts": False})
+        assert adapter._voice_mixer_requested() is False
+
+    def test_streaming_only_does_not_create_ambient_audio(self):
+        adapter = _make_adapter({
+            "enabled": False,
+            "streaming_tts": True,
+            "ambient_enabled": True,
+        })
+        assert adapter._get_ambient_pcm() is None
+
+
 class TestPlayInVoiceChannelMixerPath:
     @pytest.mark.asyncio
     async def test_routes_through_mixer_when_present(self):
@@ -113,17 +308,14 @@ class TestPlayInVoiceChannelMixerPath:
         vc.is_connected.return_value = True
         adapter._voice_clients[111] = vc
 
-        # speech_active returns True once (so play_speech is observed) then
-        # False so the wait loop exits promptly.
+        # The returned one-shot child is already finished, so the wait loop
+        # exits without consulting unrelated streaming siblings.
         class _Mixer:
             def __init__(self):
-                self._polls = 0
-                self.play_speech = MagicMock()
-
-            @property
-            def speech_active(self):
-                self._polls += 1
-                return self._polls <= 1
+                child = MagicMock()
+                child.finished = True
+                self.play_speech = MagicMock(return_value=child)
+                self.stop_speech_child = MagicMock()
 
         mixer = _Mixer()
         adapter._voice_mixers[111] = mixer
@@ -137,6 +329,26 @@ class TestPlayInVoiceChannelMixerPath:
         adapter._reset_voice_timeout.assert_called_once_with(111)
         # Legacy path must NOT have been used.
         vc.play.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_clip_timeout_stops_only_its_returned_child(self):
+        adapter = _make_adapter()
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        adapter._voice_clients[111] = vc
+        adapter._playback_timeout_for_audio = AsyncMock(return_value=-1.0)
+        clip = MagicMock()
+        clip.finished = False
+        mixer = MagicMock()
+        mixer.play_speech.return_value = clip
+        adapter._voice_mixers[111] = mixer
+
+        fake_pcm = b"\x00" * vm.FRAME_SIZE
+        with patch.object(vm, "decode_to_pcm", return_value=fake_pcm):
+            assert await adapter.play_in_voice_channel(111, "/tmp/x.mp3") is True
+
+        mixer.stop_speech_child.assert_called_once_with(clip)
+        mixer.stop_speech.assert_not_called()
 
 
 class TestLeadSilence:
@@ -158,8 +370,400 @@ class TestLeadSilence:
 class TestPlayAckInVoice:
     @pytest.mark.asyncio
     async def test_noop_when_ack_disabled(self):
-        adapter = _make_adapter({"ack_enabled": False})
+        adapter = _make_adapter({"enabled": True, "ack_enabled": False})
         adapter._voice_mixers[111] = MagicMock()
         assert await adapter.play_ack_in_voice(111) is False
+
+    @pytest.mark.asyncio
+    async def test_noop_when_effects_disabled_but_streaming_enabled(self):
+        adapter = _make_adapter({
+            "enabled": False,
+            "ack_enabled": True,
+            "streaming_tts": True,
+        })
+        adapter._voice_mixers[111] = MagicMock()
+        assert await adapter.play_ack_in_voice(111) is False
+
+
+class TestVoiceReceiverPauseState:
+    def test_pause_state_is_observable(self):
+        from plugins.platforms.discord.adapter import VoiceReceiver
+
+        receiver = object.__new__(VoiceReceiver)
+        receiver._paused = False
+        assert receiver.paused is False
+        receiver.pause()
+        assert receiver.paused is True
+        receiver.resume()
+        assert receiver.paused is False
+
+
+class TestStreamingTTSContract:
+    @pytest.mark.asyncio
+    async def test_supports_false_without_mixer(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter()
+        assert adapter.supports_streaming_tts("111", AudioFormat()) is False
+
+    @pytest.mark.asyncio
+    async def test_supports_true_when_connected_flag_on(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter({"streaming_tts": True})
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        adapter._voice_clients[111] = vc
+        adapter._voice_mixers[111] = MagicMock()
+        assert adapter.supports_streaming_tts("111", AudioFormat()) is True
+
+    @pytest.mark.asyncio
+    async def test_supports_false_on_wrong_format(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter({"streaming_tts": True})
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        adapter._voice_clients[111] = vc
+        adapter._voice_mixers[111] = MagicMock()
+        assert adapter.supports_streaming_tts(
+            "111", AudioFormat(sample_rate=44100, channels=2, sample_width=2)
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_begin_returns_handle_and_warms_child_with_lead_silence(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter({"lead_silence_ms": 200})
+        mixer = MagicMock()
+        child = MagicMock()
+        mixer.begin_streaming_speech.return_value = child
+        adapter._voice_mixers[111] = mixer
+        receiver = MagicMock()
+        adapter._voice_receivers[111] = receiver
+        fmt = AudioFormat(sample_rate=24000, channels=1, sample_width=2)
+        handle = await adapter.begin_streaming_tts("111", fmt)
+        assert handle is not None
+        assert handle.audio_format == fmt
+        mixer.begin_streaming_speech.assert_called_once()
+        # 200 ms of 24 kHz mono s16le lead silence == 200 * 48 bytes.
+        written = child.write.call_args[0][0]
+        assert len(written) == 200 * 48
+        assert written == b"\x00" * (200 * 48)
+        receiver.pause.assert_not_called()
+        adapter._cancel_voice_timeout.assert_called_once_with(111)
+
+    @pytest.mark.asyncio
+    async def test_write_becomes_audible_only_after_next_sender_pull_acknowledges_send(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        adapter._voice_mixers[111] = mixer
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        assert handle is not None
+        await adapter.write_streaming_tts(
+            handle, np.arange(480, dtype=np.int16).tobytes()
+        )
+        assert handle.audible is False
+        assert mixer.read() != vm.SILENCE_FRAME
+        assert handle.audible is False  # frame was pulled but not yet send-acked
+        mixer.read()  # AudioPlayer only pulls again after send_audio_packet succeeds
+        await asyncio.sleep(0)
+        assert handle.audible is True
+
+    @pytest.mark.asyncio
+    async def test_first_frame_send_failure_cleanup_never_marks_audible(self):
+        from gateway.platforms.base import AudioFormat
+
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        adapter._voice_mixers[111] = mixer
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        await adapter.write_streaming_tts(
+            handle, np.arange(480, dtype=np.int16).tobytes()
+        )
+
+        assert mixer.read() != vm.SILENCE_FRAME
+        # Model discord.py AudioPlayer failing in send_audio_packet(): cleanup is
+        # called and there is no subsequent source.read() acknowledgement.
+        mixer.cleanup()
+        await asyncio.sleep(0)
+
+        assert handle.audible is False
+        assert handle.platform_failed is True
+
+    @pytest.mark.asyncio
+    async def test_finish_waits_for_final_frame_send_ack_before_fallback_decision(self):
+        from gateway.platforms.base import AudioFormat
+
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        adapter._voice_mixers[111] = mixer
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        await adapter.write_streaming_tts(
+            handle, np.arange(480, dtype=np.int16).tobytes()
+        )
+
+        finishing = asyncio.create_task(adapter.finish_streaming_tts(handle))
+        await asyncio.sleep(0)
+        assert finishing.done() is False
+        assert mixer.read() != vm.SILENCE_FRAME
+        await asyncio.sleep(0)
+        assert finishing.done() is False
+
+        mixer.read()  # acknowledges the preceding non-silent sender frame
+        await finishing
+
+        assert handle.audible is True
+        assert handle.aborted is False
+
+    @pytest.mark.asyncio
+    async def test_finish_sender_ack_timeout_aborts_buffer_before_fallback(self):
+        from gateway.platforms.base import AudioFormat
+
+        adapter = _make_adapter()
+        adapter.STREAMING_TTS_TERMINAL_TIMEOUT = 0.01
+        mixer = vm.VoiceMixer()
+        adapter._voice_mixers[111] = mixer
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        await adapter.write_streaming_tts(
+            handle, np.arange(480, dtype=np.int16).tobytes()
+        )
+
+        with pytest.raises(RuntimeError, match="did not acknowledge"):
+            await adapter.finish_streaming_tts(handle)
+
+        assert handle.audible is False
+        assert handle.aborted is True
+        assert handle.child.aborted is True
+        assert mixer.read() == vm.SILENCE_FRAME
+
+    @pytest.mark.asyncio
+    async def test_finish_without_audio_keeps_handle_not_audible(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter()
+        mixer = MagicMock()
+        child = MagicMock()
+        child.drained = True
+        child.aborted = False
+        mixer.begin_streaming_speech.return_value = child
+        adapter._voice_mixers[111] = mixer
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        assert handle is not None
+        await adapter.finish_streaming_tts(handle)
+        assert handle.audible is False, (
+            "never-audible stream must stay not-audible so whole-file fallback "
+            "is not suppressed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_finish_rearms_timeout_only_after_drain(self):
+        from gateway.platforms.base import AudioFormat
+
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        adapter._voice_mixers[111] = mixer
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        assert handle is not None
+        await adapter.write_streaming_tts(
+            handle, np.arange(1440, dtype=np.int16).tobytes()
+        )
+        finishing = asyncio.create_task(adapter.finish_streaming_tts(handle))
+        await asyncio.sleep(0)
+        mixer.read()
+        mixer.read()  # post-send acknowledgement while more PCM is buffered
+        await finishing
+        adapter._reset_voice_timeout.assert_not_called()
+        for _ in range(200):
+            mixer.read()
+            if not mixer.speech_active:
+                break
+        await asyncio.sleep(0)
+        adapter._reset_voice_timeout.assert_called_once_with(111)
+
+    @pytest.mark.asyncio
+    async def test_streaming_never_touches_receiver_pause_state(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter()
+        mixer = MagicMock()
+        child = MagicMock()
+        mixer.begin_streaming_speech.return_value = child
+        receiver = MagicMock()
+        receiver.paused = True
+        adapter._voice_mixers[111] = mixer
+        adapter._voice_receivers[111] = receiver
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        assert handle is not None
+        await adapter.abort_streaming_tts(handle)
+        receiver.pause.assert_not_called()
+        receiver.resume.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_begin_rolls_back_child_and_timeout_on_failure(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter({"lead_silence_ms": 10})
+        mixer = MagicMock()
+        child = MagicMock()
+        child.write.side_effect = RuntimeError("boom")
+        mixer.begin_streaming_speech.return_value = child
+        adapter._voice_mixers[111] = mixer
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        assert handle is None
+        child.abort.assert_called_once()
+        adapter._reset_voice_timeout.assert_called_once_with(111)
+
+    @pytest.mark.asyncio
+    async def test_finish_after_abort_is_noop(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter()
+        mixer = MagicMock()
+        child = MagicMock()
+        mixer.begin_streaming_speech.return_value = child
+        adapter._voice_mixers[111] = mixer
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        assert handle is not None
+        await adapter.abort_streaming_tts(handle)
+        await adapter.finish_streaming_tts(handle)
+        assert child.finish.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_abort_aborts_child_and_rearms_timeout(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter()
+        mixer = MagicMock()
+        child = MagicMock()
+        mixer.begin_streaming_speech.return_value = child
+        adapter._voice_mixers[111] = mixer
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        assert handle is not None
+        await adapter.abort_streaming_tts(handle, "boom")
+        child.abort.assert_called_once()
+        adapter._reset_voice_timeout.assert_called_once_with(111)
+        assert handle.aborted is True
+
+    @pytest.mark.asyncio
+    async def test_new_stream_supersedes_old_without_rearming_timeout(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter()
+        mixer = MagicMock()
+        first_child = MagicMock()
+        second_child = MagicMock()
+        mixer.begin_streaming_speech.side_effect = [first_child, second_child]
+        adapter._voice_mixers[111] = mixer
+        first = await adapter.begin_streaming_tts("111", AudioFormat())
+        on_interrupt = MagicMock()
+        first.on_interrupt = on_interrupt
+        second = await adapter.begin_streaming_tts("111", AudioFormat())
+        assert first.interrupted is True
+        assert first.aborted is True
+        on_interrupt.assert_called_once_with("stream replaced")
+        first_child.abort.assert_called_once()
+        assert adapter._streaming_tts_handles[111] is second
+        adapter._reset_voice_timeout.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_leave_interrupts_stream_and_cancels_producer(self):
+        from gateway.platforms.base import AudioFormat
+
+        adapter = _make_adapter()
+        mixer = MagicMock()
+        child = MagicMock()
+        mixer.begin_streaming_speech.return_value = child
+        adapter._voice_mixers[111] = mixer
+        voice_client = MagicMock()
+        voice_client.disconnect = AsyncMock()
+        adapter._voice_clients[111] = voice_client
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        on_interrupt = MagicMock()
+        handle.on_interrupt = on_interrupt
+
+        await adapter.leave_voice_channel(111)
+
+        assert handle.interrupted is True
+        assert handle.aborted is True
+        on_interrupt.assert_called_once_with("voice channel left")
+        child.abort.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unexpected_mixer_cleanup_aborts_provider_owner(self):
+        from gateway.platforms.base import AudioFormat
+
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        adapter._voice_mixers[111] = mixer
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        on_abort = MagicMock()
+        handle.on_abort = on_abort
+
+        mixer.cleanup()
+        await asyncio.sleep(0)
+
+        assert handle.child.aborted is True
+        assert handle.aborted is True
+        on_abort.assert_called_once_with("Discord voice mixer stopped unexpectedly")
+        with pytest.raises(RuntimeError, match="mixer stopped unexpectedly"):
+            await adapter.finish_streaming_tts(handle)
+        assert 111 not in adapter._streaming_tts_handles
+
+    @pytest.mark.asyncio
+    async def test_closed_mixer_rejects_stream(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        mixer.cleanup()
+        adapter._voice_mixers[111] = mixer
+        assert await adapter.begin_streaming_tts("111", AudioFormat()) is None
+        assert adapter.voice_mixer_active(111) is False
+
+    @pytest.mark.asyncio
+    async def test_authorized_voice_barge_in_aborts_current_stream(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter()
+        adapter._is_allowed_user = MagicMock(return_value=True)
+        mixer = MagicMock()
+        child = MagicMock()
+        mixer.begin_streaming_speech.return_value = child
+        adapter._voice_mixers[111] = mixer
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        on_interrupt = MagicMock()
+        handle.on_interrupt = on_interrupt
+        adapter._handle_voice_barge_in(111, 42)
+        assert handle.interrupted is True
+        assert handle.aborted is True
+        on_interrupt.assert_called_once_with("voice barge-in")
+        child.abort.assert_called_once()
+        assert 111 not in adapter._streaming_tts_handles
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_voice_does_not_interrupt_stream(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter()
+        adapter._is_allowed_user = MagicMock(return_value=False)
+        mixer = MagicMock()
+        child = MagicMock()
+        mixer.begin_streaming_speech.return_value = child
+        adapter._voice_mixers[111] = mixer
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        adapter._handle_voice_barge_in(111, 99)
+        assert handle.aborted is False
+        child.abort.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_abort_is_idempotent(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter()
+        mixer = MagicMock()
+        child = MagicMock()
+        mixer.begin_streaming_speech.return_value = child
+        adapter._voice_mixers[111] = mixer
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        assert handle is not None
+        await adapter.abort_streaming_tts(handle)
+        await adapter.abort_streaming_tts(handle)
+        assert child.abort.call_count == 1
+        assert handle.aborted is True
+
+    @pytest.mark.asyncio
+    async def test_no_streaming_when_mixer_absent(self):
+        from gateway.platforms.base import AudioFormat
+        adapter = _make_adapter()
+        handle = await adapter.begin_streaming_tts("111", AudioFormat())
+        assert handle is None
 
 

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -16,7 +16,10 @@ import time
 import pytest
 
 from gateway.platforms.base import AudioFormat, StreamingTTSHandle
-from gateway.streaming_tts_consumer import StreamingTTSConsumer
+from gateway.streaming_tts_consumer import (
+    StreamingTTSConsumer,
+    interrupt_streaming_tts_consumer,
+)
 from tools.tts_streaming import SentenceChunker
 
 
@@ -105,6 +108,28 @@ class SlowStreamer(FakeStreamer):
             self.finished.set()
 
 
+class CancellableFirstChunkStreamer(FakeStreamer):
+    """Blocks before frame one until consumer cancellation closes the stream."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.started = threading.Event()
+        self.cancelled = threading.Event()
+        self.finished = threading.Event()
+
+    def stream(self, text: str):
+        self.started.set()
+        try:
+            self.cancelled.wait(timeout=5.0)
+            return
+            yield b"unreachable"  # pragma: no cover
+        finally:
+            self.finished.set()
+
+    def cancel(self):
+        self.cancelled.set()
+
+
 class SlowFirstChunkStreamer(FakeStreamer):
     """Blocks before the first chunk so timeout happens before audio starts."""
 
@@ -121,6 +146,10 @@ class SlowFirstChunkStreamer(FakeStreamer):
             yield b"chunk-1-0"
         finally:
             self.finished.set()
+
+
+    def cancel(self):
+        self.allow_first_chunk.set()
 
 
 class BlockingSecondChunkStreamer(FakeStreamer):
@@ -142,6 +171,23 @@ class BlockingSecondChunkStreamer(FakeStreamer):
             yield b"chunk-1-1"
         finally:
             self.finished.set()
+
+    def cancel(self):
+        self.allow_remaining_chunks.set()
+
+
+class AsyncOnlyStreamer(FakeStreamer):
+    def __init__(self):
+        super().__init__()
+        self.stream_calls = []
+
+    def stream(self, _text):
+        raise AssertionError("sync stream path must not run")
+
+    async def astream(self, text):
+        self.stream_calls.append(text)
+        yield b"\x01\x02"
+        yield b"\x03\x04"
 
 
 class UnsupportedAdapter:
@@ -290,6 +336,104 @@ class TestConsumerLifecycle:
 
         _run_test(run)
 
+    def test_immediate_barge_in_before_task_runs_never_opens_platform_stream(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = CancellableFirstChunkStreamer()
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            interrupt_streaming_tts_consumer([consumer], "voice barge-in")
+
+            assert await consumer.wait_complete(timeout=2.0) is False
+            assert adapter.begin_count == 0
+            assert adapter.abort_count == 0
+            assert adapter.handle is None
+            assert consumer.suppress_whole_file is True
+
+        _run_test(run)
+
+    def test_barge_in_racing_platform_begin_aborts_new_handle(self):
+        async def run(loop):
+            class BlockingBeginAdapter(FakeVoiceAdapter):
+                def __init__(self):
+                    super().__init__()
+                    self.begin_entered = asyncio.Event()
+                    self.release_begin = asyncio.Event()
+
+                async def begin_streaming_tts(self, chat_id, audio_format, metadata=None):
+                    self.begin_count += 1
+                    self.begin_entered.set()
+                    await self.release_begin.wait()
+                    self.handle = StreamingTTSHandle(
+                        chat_id=chat_id, audio_format=audio_format
+                    )
+                    return self.handle
+
+            adapter = BlockingBeginAdapter()
+            consumer = _make_consumer(adapter, "chat1", loop, FakeStreamer())
+            consumer.start()
+            await adapter.begin_entered.wait()
+
+            interrupt_streaming_tts_consumer([consumer], "voice barge-in")
+            adapter.release_begin.set()
+
+            assert await consumer.wait_complete(timeout=2.0) is False
+            assert adapter.begin_count == 1
+            assert adapter.abort_count == 1
+            assert adapter.handle.aborted is True
+            assert adapter.handle.interrupted is True
+            assert consumer.suppress_whole_file is True
+
+        _run_test(run)
+
+    def test_barge_in_before_first_frame_cancels_provider_and_suppresses_fallback(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = CancellableFirstChunkStreamer()
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("This sentence is interrupted before frame one. ")
+            consumer.finish()
+            assert await asyncio.to_thread(streamer.started.wait, 1.0)
+            assert adapter.handle is not None
+
+            interrupt_streaming_tts_consumer([consumer], "voice barge-in")
+
+            assert await consumer.wait_complete(timeout=2.0) is False
+            assert streamer.cancelled.is_set()
+            assert streamer.finished.is_set()
+            assert adapter.handle.interrupted is True
+            assert adapter.handle.audible is False
+            assert consumer.suppress_whole_file is True
+            assert adapter.written_chunks == []
+
+        _run_test(run)
+
+    def test_unexpected_platform_sink_abort_cancels_provider_before_first_frame(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = CancellableFirstChunkStreamer()
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("This sentence loses its Discord mixer sink. ")
+            consumer.finish()
+            assert await asyncio.to_thread(streamer.started.wait, 1.0)
+            assert adapter.handle is not None
+
+            adapter.handle.platform_failed = True
+            adapter.handle.aborted = True
+            adapter.handle.on_abort("Discord voice mixer stopped unexpectedly")
+
+            assert await consumer.wait_complete(timeout=2.0) is False
+            assert streamer.cancelled.is_set()
+            assert streamer.finished.is_set()
+            assert consumer.suppress_whole_file is False
+            assert adapter.written_chunks == []
+
+        _run_test(run)
 
     def test_post_audio_timeout_keeps_suppression_then_aborts(self):
         """After audible audio, a finalisation timeout aborts the consumer.
@@ -335,6 +479,17 @@ class TestConsumerLifecycle:
 
 class TestStreamerFormatAndLooping:
     """Constructor wiring should derive format and keep provider I/O off-loop."""
+
+    def test_prefers_native_async_stream_without_executor_bridge(self):
+        async def run(loop):
+            adapter = FakeVoiceAdapter()
+            streamer = AsyncOnlyStreamer()
+            consumer = _make_consumer(adapter, "chat", loop, streamer)
+            chunks = [chunk async for chunk in consumer._iter_stream_chunks("hello")]
+            assert chunks == [b"\x01\x02", b"\x03\x04"]
+            assert streamer.stream_calls == ["hello"]
+
+        _run_test(run)
 
     def test_audio_format_tracks_resolved_streamer(self):
         streamer = FakeStreamer(chunks_per_clause=1, sample_rate=48000, channels=2, sample_width=4)
@@ -640,36 +795,3 @@ class TestPostAudioTimeoutAbort:
             assert consumer._aborted is True
 
         _run_test(run)
-
-
-# ---------------------------------------------------------------------------
-# Real gateway regression: no _streaming_tts_consumer NameError (#60671)
-# ---------------------------------------------------------------------------
-
-
-class TestGatewayOuterFinalisationNoNameError:
-    """Exercise the real outer finalisation path to prove no NameError.
-
-    This test does NOT use the StreamingTTSConsumer helper tests alone —
-    it verifies that ``gateway/run.py``'s outer finalisation code can
-    reference ``streaming_tts_consumer_holder[0]`` without hitting a
-    NameError on a normal gateway turn.  We do this by importing the
-    symbol and exercising the code path that would have failed.
-    """
-
-    def test_streaming_tts_consumer_holder_is_list_not_name(self):
-        """The outer scope uses a holder list, not a bare local name.
-
-        This is a structural invariant: if someone reintroduces the
-        cross-scope NameError by moving the consumer back into
-        ``run_sync`` as a local, this test documents the correct shape.
-        """
-        # The holder pattern is the fix.  Verify it is a mutable container.
-        holder: list = [None]
-        assert holder[0] is None
-        holder[0] = "sentinel"
-        assert holder[0] == "sentinel"
-        # The outer scope must be able to read it without a NameError.
-        # This is trivially true with a holder, but was NOT true when
-        # the consumer was a run_sync local.
-        _ = holder[0]

--- a/tests/gateway/test_streaming_tts_gateway_regression.py
+++ b/tests/gateway/test_streaming_tts_gateway_regression.py
@@ -26,6 +26,7 @@ import gateway.run as gateway_run
 from gateway.config import Platform
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
+from tests.gateway.test_run_cleanup_progress import CleanupCaptureAdapter
 
 
 class _NoopAgent:
@@ -153,5 +154,126 @@ def test_run_agent_voice_turn_no_name_error(monkeypatch, tmp_path):
 
     result = asyncio.new_event_loop().run_until_complete(_run())
     assert result["final_response"] == "Hello from the agent."
+
+
+@pytest.mark.parametrize("route", ["direct", "unlimited-backup", "timed-backup"])
+def test_all_gateway_barge_in_routes_interrupt_active_streaming_consumer(
+    monkeypatch, tmp_path, route
+):
+    """Exercise the direct monitor and both real backup poll branches."""
+    _setup_monkeypatches(monkeypatch, tmp_path)
+    session_key = "agent:main:telegram:dm:12345"
+
+    class InterruptibleAgent(_NoopAgent):
+        runs = 0
+        interrupted = threading.Event()
+
+        def run_conversation(self, *args, **kwargs):
+            type(self).runs += 1
+            if type(self).runs == 1:
+                assert type(self).interrupted.wait(timeout=2.0)
+            return super().run_conversation(*args, **kwargs)
+
+        def interrupt(self, text=None):
+            self.is_interrupted = True
+            self.interrupt_message = text
+            type(self).interrupted.set()
+
+        def get_activity_summary(self):
+            return {"seconds_since_activity": 0.0}
+
+    class FakeStreamingConsumer:
+        instances = []
+
+        def __init__(self, **kwargs):
+            self.active = True
+            self.done = False
+            self.suppress_whole_file = False
+            self.interrupt_reasons = []
+            type(self).instances.append(self)
+
+        def start(self):
+            return None
+
+        def on_delta(self, text):
+            return None
+
+        def interrupt(self, reason):
+            self.interrupt_reasons.append(reason)
+            self.suppress_whole_file = True
+            self.done = True
+
+        def finish(self):
+            self.done = True
+
+        async def wait_complete(self, timeout=10.0):
+            return False
+
+        def abort(self, reason="cancelled"):
+            self.done = True
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = InterruptibleAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import gateway.streaming_tts_consumer as stts_module
+
+    monkeypatch.setattr(stts_module, "StreamingTTSConsumer", FakeStreamingConsumer)
+    adapter = CleanupCaptureAdapter()
+    adapter._auto_tts_default = True
+    source = _make_voice_source()
+    pending = MessageEvent(text="stop talking", source=source)
+    adapter._pending_messages[session_key] = pending
+    adapter._active_sessions[session_key] = threading.Event()
+    adapter._active_sessions[session_key].set()
+
+    original_has_pending = adapter.has_pending_interrupt
+
+    def routed_has_pending(key):
+        if route != "direct":
+            task = asyncio.current_task()
+            qualname = getattr(task.get_coro(), "__qualname__", "") if task else ""
+            if "monitor_for_interrupt" in qualname:
+                return False
+        return original_has_pending(key)
+
+    adapter.has_pending_interrupt = routed_has_pending
+    runner = _make_runner()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    monkeypatch.setattr(
+        gateway_run.GatewayRunner,
+        "_adapter_for_source",
+        lambda self, event_source: adapter,
+    )
+    monkeypatch.setenv(
+        "HERMES_AGENT_TIMEOUT", "0" if route == "unlimited-backup" else "60"
+    )
+    monkeypatch.setenv("HERMES_AGENT_TIMEOUT_WARNING", "0")
+
+    if route != "direct":
+        original_wait = asyncio.wait
+
+        async def fast_poll(awaitables, *, timeout=None, **kwargs):
+            if timeout == 5.0:
+                timeout = 0.01
+            return await original_wait(awaitables, timeout=timeout, **kwargs)
+
+        monkeypatch.setattr(asyncio, "wait", fast_poll)
+
+    async def run_turn():
+        runner._gateway_loop = asyncio.get_running_loop()
+        return await runner._run_agent(
+            message="Hello Jarvis",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-1",
+            session_key=session_key,
+            message_type=MessageType.VOICE,
+        )
+
+    asyncio.run(run_turn())
+
+    assert FakeStreamingConsumer.instances
+    assert FakeStreamingConsumer.instances[0].interrupt_reasons == ["barge-in"]
 
 

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -722,6 +722,9 @@ class TestDiscordVoiceChannelMethods:
         adapter._voice_timeout_tasks = {}
         adapter._voice_receivers = {}
         adapter._voice_listen_tasks = {}
+        adapter._voice_mixers = {}
+        adapter._streaming_tts_handles = {}
+        adapter._voice_leaving = set()
         adapter._voice_input_callback = None
         adapter._allowed_user_ids = set()
         adapter._running = True
@@ -736,8 +739,8 @@ class TestDiscordVoiceChannelMethods:
 
 
     @pytest.mark.asyncio
-    async def test_leave_voice_channel_processes_pending_audio_before_disconnect(self):
-        """Recent speech is transcribed before the voice connection is torn down."""
+    async def test_leave_voice_channel_terminates_stream_and_disconnects_before_pending_audio(self):
+        """Leave cancels speech promptly, then preserves pending input as text work."""
         adapter = self._make_adapter()
         events = []
         mock_vc = MagicMock()
@@ -748,6 +751,15 @@ class TestDiscordVoiceChannelMethods:
 
         mock_vc.disconnect = disconnect
         adapter._voice_clients[111] = mock_vc
+        child = MagicMock()
+        handle = SimpleNamespace(
+            guild_id=111,
+            child=child,
+            aborted=False,
+            interrupted=False,
+            on_interrupt=lambda _reason: events.append("terminate"),
+        )
+        adapter._streaming_tts_handles[111] = handle
 
         mock_receiver = MagicMock()
         mock_receiver.flush_pending.side_effect = lambda: events.append("flush") or [(42, b"pcm")]
@@ -757,13 +769,19 @@ class TestDiscordVoiceChannelMethods:
         adapter._is_allowed_user = MagicMock(return_value=True)
 
         async def process(guild_id, user_id, pcm_data):
+            assert guild_id not in adapter._voice_clients
+            assert adapter._voice_locks[guild_id].locked() is False
             events.append("process")
 
         adapter._process_voice_input = process
+        adapter._voice_timeout_tasks[111] = asyncio.current_task()
 
         await adapter.leave_voice_channel(111)
 
-        assert events == ["flush", "stop", "process", "disconnect"]
+        assert events == ["flush", "stop", "terminate", "disconnect", "process"]
+        assert handle.aborted is True
+        child.abort.assert_called_once()
+        assert adapter._voice_leaving == set()
         adapter._is_allowed_user.assert_called_once_with("42", guild=adapter._client.get_guild(111), is_dm=False)
 
 
@@ -1266,6 +1284,9 @@ class TestVoiceTimeoutCleansRunnerState:
         adapter._voice_timeout_tasks = {}
         adapter._voice_receivers = {}
         adapter._voice_listen_tasks = {}
+        adapter._voice_mixers = {}
+        adapter._streaming_tts_handles = {}
+        adapter._voice_leaving = set()
         adapter._voice_input_callback = None
         adapter._on_voice_disconnect = None
         adapter._client = None
@@ -1329,6 +1350,9 @@ class TestPlaybackTimeout:
         adapter._voice_timeout_tasks = {}
         adapter._voice_receivers = {}
         adapter._voice_listen_tasks = {}
+        adapter._voice_mixers = {}
+        adapter._streaming_tts_handles = {}
+        adapter._voice_leaving = set()
         adapter._voice_input_callback = None
         adapter._on_voice_disconnect = None
         adapter._client = None

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -6,6 +6,7 @@ synth path are all mocked. Covers the registry/resolver, provider availability,
 the chunked-streamer playback path, and the universal per-sentence sync fallback.
 """
 
+import asyncio
 import os
 import queue
 import sys
@@ -65,7 +66,13 @@ class TestSpeechInterruptedLatch:
 # ── Registry + resolver ──────────────────────────────────────────────────
 
 
-def _register_fake(monkeypatch, name, available=True, chunks=(b"\x00\x00",)):
+def _register_fake(
+    monkeypatch,
+    name,
+    available=True,
+    chunks=(b"\x00\x00",),
+    async_transport_cancellable=False,
+):
     class _Fake(ts.StreamingTTSProvider):
         sample_rate = 24000
 
@@ -76,6 +83,12 @@ def _register_fake(monkeypatch, name, available=True, chunks=(b"\x00\x00",)):
         def stream(self, text):
             yield from chunks
 
+    _Fake.async_transport_cancellable = async_transport_cancellable
+    if async_transport_cancellable:
+        async def _astream(self, text):
+            for chunk in chunks:
+                yield chunk
+        _Fake.astream = _astream
     monkeypatch.setitem(ts._REGISTRY, name, _Fake)
     return _Fake
 
@@ -91,6 +104,48 @@ def test_never_swaps_provider_for_streaming(monkeypatch):
     # (non-streaming) provider — that would silently change their voice.
     _register_fake(monkeypatch, "elevenlabs")
     assert ts.resolve_streaming_provider({"provider": "edge"}) is None
+
+
+def test_cancellable_resolution_rejects_pinned_legacy_transport(monkeypatch):
+    _register_fake(monkeypatch, "openai", async_transport_cancellable=False)
+    assert ts.resolve_streaming_provider(
+        {"streaming": {"provider": "openai"}},
+        require_transport_cancellation=True,
+    ) is None
+
+
+def test_async_cancellable_resolution_rejects_claim_without_astream(monkeypatch):
+    class FalseClaim(ts.StreamingTTSProvider):
+        async_transport_cancellable = True
+
+        @staticmethod
+        def available():
+            return True
+
+        def stream(self, text):
+            yield b"legacy"
+
+    monkeypatch.setitem(ts._REGISTRY, "false-claim", FalseClaim)
+    assert ts.resolve_streaming_provider(
+        {"streaming": {"provider": "false-claim"}},
+        require_transport_cancellation=True,
+    ) is None
+
+
+def test_cancellable_auto_skips_legacy_provider_for_gemini(monkeypatch):
+    legacy = _register_fake(monkeypatch, "elevenlabs")
+    cancellable = _register_fake(
+        monkeypatch, "gemini", async_transport_cancellable=True
+    )
+    monkeypatch.setattr(ts, "_PROVIDER_PRIORITY", ["elevenlabs", "gemini"])
+
+    provider = ts.resolve_streaming_provider(
+        {"streaming": {"provider": "auto"}},
+        require_transport_cancellation=True,
+    )
+
+    assert not isinstance(provider, legacy)
+    assert isinstance(provider, cancellable)
 
 
 # ── Built-in provider availability ───────────────────────────────────────
@@ -215,16 +270,17 @@ def test_xai_available_uses_oauth_credential_resolver(monkeypatch):
 # ── 16 MiB per-sentence stream cap ───────────────────────────────────────
 
 
-def test_stream_cap_truncates_runaway_upstream(monkeypatch):
+def test_stream_cap_raises_instead_of_silently_truncating(monkeypatch):
     monkeypatch.setattr(ts, "_STREAM_SENTENCE_BYTE_CAP", 100)
 
     def _endless():
         while True:
             yield b"\x00" * 64
 
-    out = list(ts._capped(_endless(), "test"))
-    assert len(out) == 1  # 64 ok, 128 > cap → stop
-    assert sum(len(c) for c in out) <= 100
+    iterator = ts._capped(_endless(), "test")
+    assert next(iterator) == b"\x00" * 64
+    with pytest.raises(ts.StreamingTTSLimitError, match="decoded audio cap"):
+        next(iterator)
 
 
 # ── Dispatch: chunked streamer path (regression tests) ───────────────────
@@ -958,3 +1014,398 @@ def test_sync_pipeline_cleans_temp_files(monkeypatch):
     assert created, "expected temp files to be created via mkstemp"
     leftovers = [p for p in created if os.path.exists(p)]
     assert not leftovers, f"temp files not cleaned: {leftovers}"
+
+
+# ── Gemini 3.1 streamGenerateContent transport ───────────────────────────
+#
+# Gemini 3.1 Flash TTS Preview emits incremental PCM through the existing
+# streamGenerateContent SSE API. Credentials stay in the x-goog-api-key header
+# and redirects are disabled so requests cannot forward the key cross-origin.
+
+import base64 as _b64
+import json as _json
+
+
+def _sse_context(events):
+    resp = MagicMock()
+    body = b"".join(
+        b"data: "
+        + (_json.dumps(ev) if not isinstance(ev, str) else ev).encode()
+        + b"\n\n"
+        for ev in events
+    )
+    resp.headers = {"content-type": "text/event-stream; charset=utf-8"}
+    # Split arbitrarily to prove the bounded parser handles network chunking.
+    resp.iter_content.return_value = iter(
+        body[i:i + 17] for i in range(0, len(body), 17)
+    )
+    resp.__enter__.return_value = resp
+    return resp
+
+
+def _gemini_audio_event(b64_data: str) -> dict:
+    return {
+        "candidates": [{
+            "content": {"parts": [{
+                "inlineData": {"mimeType": "audio/L16;rate=24000", "data": b64_data},
+            }]},
+        }],
+    }
+
+
+class TestGeminiStreamingTransport:
+    def _streamer(self):
+        return ts.GeminiStreamer(
+            {"gemini": {"model": "gemini-3.1-flash-tts-preview"}},
+            {"model": "gemini-3.1-flash-tts-preview"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_transport_streams_pcm_without_sync_thread(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+        event = _gemini_audio_event(_b64.b64encode(b"\x09\x0a").decode())
+        wire = b"data: " + _json.dumps(event).encode() + b"\n\n"
+        captured = {}
+
+        class Response:
+            headers = {"content-type": "text/event-stream"}
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_bytes(self, chunk_size):
+                assert chunk_size == 8192
+                yield wire[:7]
+                yield wire[7:]
+
+        class StreamContext:
+            async def __aenter__(self):
+                return Response()
+
+            async def __aexit__(self, *_args):
+                return None
+
+        class Client:
+            def __init__(self, **kwargs):
+                captured["client"] = kwargs
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def stream(self, method, url, **kwargs):
+                captured.update(method=method, url=url, request=kwargs)
+                return StreamContext()
+
+        monkeypatch.setattr(httpx, "AsyncClient", Client)
+        chunks = [chunk async for chunk in self._streamer().astream("Async")]
+        assert chunks == [b"\x09\x0a"]
+        assert captured["method"] == "POST"
+        assert captured["client"]["follow_redirects"] is False
+        assert captured["request"]["headers"] == {"x-goog-api-key": "g-key"}
+
+    @pytest.mark.asyncio
+    async def test_async_cancel_interrupts_pre_header_wait(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        class StreamContext:
+            async def __aenter__(self):
+                started.set()
+                try:
+                    await asyncio.Event().wait()
+                finally:
+                    cancelled.set()
+
+            async def __aexit__(self, *_args):
+                return None
+
+        class Client:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def stream(self, *_args, **_kwargs):
+                return StreamContext()
+
+        monkeypatch.setattr(httpx, "AsyncClient", Client)
+        streamer = self._streamer()
+
+        async def consume():
+            return [chunk async for chunk in streamer.astream("Cancel headers")]
+
+        task = asyncio.create_task(consume())
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        streamer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=1.0)
+        assert cancelled.is_set()
+
+    @pytest.mark.asyncio
+    async def test_async_deadline_covers_pre_header_wait(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+        monkeypatch.setattr(ts, "_GEMINI_STREAM_DEADLINE_S", 0.05)
+
+        class StreamContext:
+            async def __aenter__(self):
+                await asyncio.Event().wait()
+
+            async def __aexit__(self, *_args):
+                return None
+
+        class Client:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def stream(self, *_args, **_kwargs):
+                return StreamContext()
+
+        monkeypatch.setattr(httpx, "AsyncClient", Client)
+        start = time.monotonic()
+        with pytest.raises(TimeoutError):
+            _ = [chunk async for chunk in self._streamer().astream("Deadline")]
+        assert time.monotonic() - start < 0.5
+
+    def test_31_uses_stream_generate_content_with_header_auth(self, monkeypatch):
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured["url"] = url
+            captured["kwargs"] = kwargs
+            return _sse_context([
+                _gemini_audio_event(_b64.b64encode(b"\x01\x02").decode()),
+            ])
+
+        monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+        with patch("requests.post", side_effect=fake_post):
+            assert list(self._streamer().stream("Hello")) == [b"\x01\x02"]
+
+        assert captured["url"].endswith(
+            "/models/gemini-3.1-flash-tts-preview:streamGenerateContent"
+        )
+        assert captured["kwargs"]["params"] == {"alt": "sse"}
+        assert captured["kwargs"]["headers"]["x-goog-api-key"] == "g-key"
+        assert captured["kwargs"]["allow_redirects"] is False
+        body = captured["kwargs"]["json"]
+        assert body["generationConfig"]["responseModalities"] == ["AUDIO"]
+        voice = body["generationConfig"]["speechConfig"]["voiceConfig"]
+        assert voice["prebuiltVoiceConfig"]["voiceName"] == "Kore"
+
+    def test_yields_pcm_from_multiple_audio_events(self, monkeypatch):
+        chunks = [b"\x01\x02\x03\x04", b"\x05\x06"]
+        events = [_gemini_audio_event(_b64.b64encode(c).decode()) for c in chunks]
+        with patch("requests.post", return_value=_sse_context(events)):
+            assert list(self._streamer().stream("Speak")) == chunks
+
+    def test_ignores_non_audio_and_malformed_events(self, monkeypatch):
+        good = _gemini_audio_event(_b64.b64encode(b"\x0a\x0b").decode())
+        events = [
+            [],
+            "not json",
+            {"candidates": []},
+            {"candidates": [{"content": {"parts": [None, "text"]}}]},
+            {"candidates": [{"content": {"parts": [{"text": "hello"}]}}]},
+            good,
+        ]
+        with patch("requests.post", return_value=_sse_context(events)):
+            assert list(self._streamer().stream("Robust")) == [b"\x0a\x0b"]
+
+    def test_invalid_base64_is_ignored(self, monkeypatch):
+        bad = _gemini_audio_event("not-valid-base64!!!")
+        good = _gemini_audio_event(_b64.b64encode(b"\x0c\x0d").decode())
+        with patch("requests.post", return_value=_sse_context([bad, good])):
+            assert list(self._streamer().stream("Robust")) == [b"\x0c\x0d"]
+
+    def test_uses_provider_secret_resolver(self, monkeypatch):
+        captured = {}
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.setattr(
+            ts,
+            "_resolve_key",
+            lambda env_name, provider: "secret-source-key" if env_name == "GEMINI_API_KEY" else "",
+        )
+
+        def fake_post(_url, **kwargs):
+            captured["headers"] = kwargs["headers"]
+            return _sse_context([])
+
+        with patch("requests.post", side_effect=fake_post):
+            list(self._streamer().stream("Secret"))
+        assert captured["headers"]["x-goog-api-key"] == "secret-source-key"
+
+    def test_rejects_non_sse_or_missing_content_type(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+        for headers in ({"content-type": "application/json"}, {}):
+            response = _sse_context([])
+            response.headers = headers
+            with patch("requests.post", return_value=response):
+                with pytest.raises(RuntimeError, match="unexpected content type"):
+                    list(self._streamer().stream("Wrong response"))
+
+    def test_rejects_oversized_unterminated_sse_event(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+        response = _sse_context([])
+        response.iter_content.return_value = iter([b"data: " + b"x" * (4 * 1024 * 1024 + 1)])
+        with patch("requests.post", return_value=response):
+            with pytest.raises(RuntimeError, match="SSE event exceeds"):
+                list(self._streamer().stream("Oversized"))
+
+    def test_ignores_inline_data_with_wrong_or_missing_audio_mime(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+        encoded = _b64.b64encode(b"\x01\x02").decode()
+        invalid_mimes = [
+            "image/png",
+            "audio/L16evil;rate=24000",
+            "audio/L16;rate=24000;channels=2",
+            "audio/L16;rate=16000",
+            "audio/L16;rate=not-a-number",
+        ]
+        invalid_events = []
+        for mime in invalid_mimes:
+            event = _gemini_audio_event(encoded)
+            event["candidates"][0]["content"]["parts"][0]["inlineData"][
+                "mimeType"
+            ] = mime
+            invalid_events.append(event)
+        missing = _gemini_audio_event(encoded)
+        del missing["candidates"][0]["content"]["parts"][0]["inlineData"][
+            "mimeType"
+        ]
+        good = _gemini_audio_event(_b64.b64encode(b"\x03\x04").decode())
+        with patch(
+            "requests.post",
+            return_value=_sse_context([*invalid_events, missing, good]),
+        ):
+            assert list(self._streamer().stream("Formats")) == [b"\x03\x04"]
+
+    def test_raw_sse_cap_is_cumulative_before_json_decode(self):
+        response = _sse_context([])
+        response.iter_content.return_value = iter([b": keepalive\n", b": keepalive\n"])
+        with pytest.raises(RuntimeError, match="raw SSE bytes"):
+            list(
+                ts._iter_bounded_sse_data(
+                    response,
+                    label="test SSE",
+                    deadline=time.monotonic() + 1,
+                    raw_byte_cap=15,
+                )
+            )
+
+    def test_absolute_deadline_rejects_trickled_sse(self):
+        response = _sse_context([])
+        response.iter_content.return_value = iter([b": keepalive\n"])
+        with pytest.raises(TimeoutError, match="absolute deadline"):
+            list(
+                ts._iter_bounded_sse_data(
+                    response,
+                    label="test SSE",
+                    deadline=time.monotonic() - 1,
+                )
+            )
+
+    def test_deadline_closes_blocked_body_read(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+        monkeypatch.setattr(ts, "_GEMINI_STREAM_DEADLINE_S", 0.05)
+        closed = threading.Event()
+
+        class BlockingResponse:
+            headers = {"content-type": "text/event-stream; charset=utf-8"}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                self.close()
+
+            def raise_for_status(self):
+                return None
+
+            def iter_content(self, chunk_size):
+                assert chunk_size == 8192
+                closed.wait(timeout=1.0)
+                return iter(())
+
+            def close(self):
+                closed.set()
+
+        started = time.monotonic()
+        with patch("requests.post", return_value=BlockingResponse()):
+            with pytest.raises(TimeoutError, match="absolute deadline"):
+                list(self._streamer().stream("Deadline"))
+        assert time.monotonic() - started < 0.5
+        assert closed.is_set()
+
+    def test_cancel_before_request_prevents_network_start(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+        streamer = self._streamer()
+        streamer.cancel()
+        with patch("requests.post") as post:
+            assert list(streamer.stream("Already cancelled")) == []
+        post.assert_not_called()
+
+    def test_cancel_closes_blocked_response_promptly(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+        started = threading.Event()
+        closed = threading.Event()
+
+        class BlockingResponse:
+            headers = {"content-type": "text/event-stream"}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                self.close()
+
+            def raise_for_status(self):
+                return None
+
+            def iter_content(self, chunk_size):
+                assert chunk_size == 8192
+                started.set()
+                closed.wait(timeout=2.0)
+                return iter(())
+
+            def close(self):
+                closed.set()
+
+        streamer = self._streamer()
+        errors = []
+
+        def consume():
+            try:
+                list(streamer.stream("Cancel"))
+            except Exception as exc:  # pragma: no cover - surfaced below
+                errors.append(exc)
+
+        thread = threading.Thread(target=consume)
+        with patch("requests.post", return_value=BlockingResponse()):
+            thread.start()
+            assert started.wait(timeout=1.0)
+            streamer.cancel()
+            thread.join(timeout=1.0)
+
+        assert closed.is_set()
+        assert not thread.is_alive()
+        assert errors == []

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 import re
+import threading
 import time
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, Iterator, List, Optional
@@ -37,6 +38,13 @@ logger = logging.getLogger(__name__)
 # providers (``_read_tts_response_bytes`` in tools.tts_tool): a buggy or
 # hostile endpoint must not be able to feed us unbounded audio.
 _STREAM_SENTENCE_BYTE_CAP = 16 * 1024 * 1024
+_GEMINI_STREAM_DEADLINE_S = 60.0
+_GEMINI_RAW_SSE_BYTE_CAP = 24 * 1024 * 1024
+_GEMINI_SSE_EVENT_BYTE_CAP = 4 * 1024 * 1024
+
+
+class StreamingTTSLimitError(RuntimeError):
+    """A bounded streaming transport exceeded an integrity/resource limit."""
 
 
 def _resolve_key(env_var: str, provider_id: str) -> str:
@@ -134,6 +142,10 @@ class StreamingTTSProvider(ABC):
     sample_rate: int = 24000
     channels: int = 1
     sample_width: int = 2  # bytes/sample (int16)
+    # Gateway streaming requires native async cancellation that can stop DNS,
+    # connect, and header waits. Legacy synchronous stream() implementations
+    # may keep best-effort cancel() without qualifying for gateway use.
+    async_transport_cancellable: bool = False
 
     def __init__(self, tts_config: Dict, section: Dict):
         self.tts_config = tts_config
@@ -147,6 +159,9 @@ class StreamingTTSProvider(ABC):
     @abstractmethod
     def stream(self, text: str) -> Iterator[bytes]:
         """Yield PCM chunks for ``text``. Raise on failure (caller logs)."""
+
+    def cancel(self) -> None:
+        """Best-effort cancellation of an active provider request."""
 
 
 _REGISTRY: Dict[str, type[StreamingTTSProvider]] = {}
@@ -182,6 +197,8 @@ _PROVIDER_PRIORITY: List[str] = ["elevenlabs", "gemini", "openai", "xai"]
 def resolve_streaming_provider(
     tts_config: Dict,
     preferred: Optional[str] = None,
+    *,
+    require_transport_cancellation: bool = False,
 ) -> Optional[StreamingTTSProvider]:
     """Return a ready streamer for the *configured* provider, else ``None``.
 
@@ -198,19 +215,31 @@ def resolve_streaming_provider(
        chosen voice. We never silently swap to a different provider just
        to get streaming.
     """
+    def _acceptable(
+        instance: Optional[StreamingTTSProvider],
+    ) -> Optional[StreamingTTSProvider]:
+        if instance is None:
+            return None
+        if require_transport_cancellation and (
+            not getattr(instance, "async_transport_cancellable", False)
+            or not callable(getattr(instance, "astream", None))
+        ):
+            return None
+        return instance
+
     streaming_cfg = tts_config.get("streaming") or {}
     pinned = str(streaming_cfg.get("provider") or "").lower().strip()
     if pinned == "auto":
         for name in _PROVIDER_PRIORITY:
-            inst = _try_instantiate(name, tts_config)
+            inst = _acceptable(_try_instantiate(name, tts_config))
             if inst is not None:
                 return inst
         return None
     if pinned:
-        return _try_instantiate(pinned, tts_config)
+        return _acceptable(_try_instantiate(pinned, tts_config))
 
     name = (preferred or _get_provider(tts_config)).lower().strip()
-    return _try_instantiate(name, tts_config)
+    return _acceptable(_try_instantiate(name, tts_config))
 
 
 # ---------------------------------------------------------------------------
@@ -304,22 +333,164 @@ def _capped(chunks: Iterator[bytes], label: str) -> Iterator[bytes]:
     for chunk in chunks:
         total += len(chunk)
         if total > _STREAM_SENTENCE_BYTE_CAP:
-            logger.warning("%s exceeded %d bytes for one sentence; truncating",
-                           label, _STREAM_SENTENCE_BYTE_CAP)
-            return
+            raise StreamingTTSLimitError(
+                f"{label} exceeded its decoded audio cap of "
+                f"{_STREAM_SENTENCE_BYTE_CAP} bytes"
+            )
         yield chunk
+
+
+def _safe_close_streaming_response(response) -> None:
+    try:
+        response.close()
+    except Exception:
+        pass
+
+
+def _iter_bounded_sse_data(
+    response,
+    *,
+    label: str,
+    deadline: float,
+    raw_byte_cap: int = _GEMINI_RAW_SSE_BYTE_CAP,
+) -> Iterator[bytes]:
+    """Yield bounded SSE data and close blocked reads at the absolute deadline."""
+    content_type = str(response.headers.get("content-type", ""))
+    media_type = content_type.split(";", 1)[0].strip().lower()
+    if media_type != "text/event-stream":
+        raise RuntimeError(f"{label} returned unexpected content type {content_type!r}")
+
+    deadline_timer = threading.Timer(
+        max(0.0, deadline - time.monotonic()),
+        _safe_close_streaming_response,
+        args=(response,),
+    )
+    deadline_timer.daemon = True
+    deadline_timer.start()
+    event_cap = _GEMINI_SSE_EVENT_BYTE_CAP
+    raw_total = 0
+    pending = bytearray()
+    try:
+        for chunk in response.iter_content(chunk_size=8192):
+            if time.monotonic() > deadline:
+                raise TimeoutError(f"{label} exceeded its absolute deadline")
+            if not chunk:
+                continue
+            raw_total += len(chunk)
+            if raw_total > raw_byte_cap:
+                raise RuntimeError(f"{label} exceeded {raw_byte_cap} raw SSE bytes")
+            pending.extend(chunk)
+            while True:
+                newline = pending.find(b"\n")
+                if newline < 0:
+                    if len(pending) > event_cap:
+                        raise RuntimeError(f"{label} SSE event exceeds {event_cap} bytes")
+                    break
+                line = bytes(pending[:newline]).rstrip(b"\r")
+                del pending[:newline + 1]
+                if len(line) > event_cap:
+                    raise RuntimeError(f"{label} SSE event exceeds {event_cap} bytes")
+                if line.startswith(b"data:"):
+                    yield line[len(b"data:"):].lstrip()
+        if time.monotonic() > deadline:
+            raise TimeoutError(f"{label} exceeded its absolute deadline")
+        if len(pending) > event_cap:
+            raise RuntimeError(f"{label} SSE event exceeds {event_cap} bytes")
+        line = bytes(pending).rstrip(b"\r")
+        if line.startswith(b"data:"):
+            yield line[len(b"data:"):].lstrip()
+    finally:
+        deadline_timer.cancel()
+
+
+def _decode_gemini_sse_audio(raw: bytes) -> List[bytes]:
+    """Decode supported mono 24 kHz L16 parts from one Gemini SSE event."""
+    import base64
+    import json
+
+    try:
+        event = json.loads(raw)
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(event, dict):
+        return []
+    try:
+        parts = event["candidates"][0]["content"]["parts"]
+    except (KeyError, IndexError, TypeError):
+        return []
+
+    chunks: List[bytes] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        inline = part.get("inlineData") or part.get("inline_data") or {}
+        if not isinstance(inline, dict):
+            continue
+        mime = str(inline.get("mimeType") or inline.get("mime_type") or "")
+        mime_parts = [item.strip().lower() for item in mime.split(";")]
+        media_type = mime_parts[0] if mime_parts else ""
+        params: Dict[str, str] = {}
+        malformed = False
+        for item in mime_parts[1:]:
+            if "=" not in item:
+                malformed = True
+                break
+            key, value = item.split("=", 1)
+            if not key or key in params:
+                malformed = True
+                break
+            params[key] = value
+        if (
+            malformed
+            or media_type != "audio/l16"
+            or params.get("rate") != "24000"
+            or params.get("channels", "1") != "1"
+        ):
+            logger.warning(
+                "Gemini SSE: ignoring unsupported audio format %r",
+                mime,
+            )
+            continue
+        b64 = inline.get("data", "")
+        if not b64:
+            continue
+        try:
+            chunks.append(base64.b64decode(b64, validate=True))
+        except (ValueError, TypeError) as exc:
+            logger.warning("Gemini SSE: bad base64 audio: %s", exc)
+    return chunks
 
 
 @register("gemini")
 class GeminiStreamer(StreamingTTSProvider):
-    """Gemini ``streamGenerateContent?alt=sse`` → base64 PCM chunks (24 kHz).
+    """Gemini ``streamGenerateContent?alt=sse`` → PCM chunks (24 kHz mono).
 
-    Salvaged from PR #47588 (@Cdddo) and rebased onto the post-campaign
-    infrastructure: credentials via the provider-secret resolver, requests
-    (not httpx) with a bounded streamed body, and main's provider ABC.
+    ``gemini-3.1-flash-tts-preview`` is currently the only Gemini TTS model
+    that emits audio incrementally. Credentials are resolved through the
+    provider-secret chain and sent in ``x-goog-api-key``, never the URL.
     """
 
     sample_rate = 24000
+    async_transport_cancellable = True
+
+    def __init__(self, tts_config: Dict, section: Dict):
+        super().__init__(tts_config, section)
+        self._response_lock = threading.Lock()
+        self._active_response = None
+        self._active_async_loop = None
+        self._active_async_task = None
+        self._cancelled = threading.Event()
+
+    def cancel(self) -> None:
+        self._cancelled.set()
+        with self._response_lock:
+            response = self._active_response
+            loop = self._active_async_loop
+            task = self._active_async_task
+        if response is not None:
+            _safe_close_streaming_response(response)
+        if loop is not None and task is not None and not loop.is_closed():
+            loop.call_soon_threadsafe(task.cancel)
 
     @staticmethod
     def available() -> bool:
@@ -328,10 +499,154 @@ class GeminiStreamer(StreamingTTSProvider):
             or _resolve_key("GOOGLE_API_KEY", "gemini")
         )
 
-    def stream(self, text: str) -> Iterator[bytes]:
-        import base64
-        import json as _json
+    async def astream(self, text: str):
+        """Async Gemini transport used by gateway voice for prompt cancellation."""
+        import asyncio
 
+        import httpx
+
+        from tools.tts_tool import (
+            DEFAULT_GEMINI_TTS_BASE_URL,
+            DEFAULT_GEMINI_TTS_MODEL,
+            DEFAULT_GEMINI_TTS_VOICE,
+        )
+
+        if self._cancelled.is_set():
+            return
+        api_key = (
+            _resolve_key("GEMINI_API_KEY", "gemini")
+            or _resolve_key("GOOGLE_API_KEY", "gemini")
+        )
+        model = str(
+            self.section.get("model", DEFAULT_GEMINI_TTS_MODEL)
+        ).strip() or DEFAULT_GEMINI_TTS_MODEL
+        voice = str(
+            self.section.get("voice", DEFAULT_GEMINI_TTS_VOICE)
+        ).strip() or DEFAULT_GEMINI_TTS_VOICE
+        base_url = str(
+            self.section.get("base_url")
+            or get_env_value("GEMINI_BASE_URL")
+            or DEFAULT_GEMINI_TTS_BASE_URL
+        ).strip().rstrip("/")
+        payload = {
+            "contents": [{"parts": [{"text": text}]}],
+            "generationConfig": {
+                "responseModalities": ["AUDIO"],
+                "speechConfig": {
+                    "voiceConfig": {
+                        "prebuiltVoiceConfig": {"voiceName": voice},
+                    },
+                },
+            },
+        }
+        url = f"{base_url}/models/{model}:streamGenerateContent"
+        loop = asyncio.get_running_loop()
+        task = asyncio.current_task()
+        with self._response_lock:
+            self._active_async_loop = loop
+            self._active_async_task = task
+
+        raw_byte_cap = _GEMINI_RAW_SSE_BYTE_CAP
+        event_cap = _GEMINI_SSE_EVENT_BYTE_CAP
+        raw_total = 0
+        decoded_total = 0
+        pending = bytearray()
+        try:
+            timeout = httpx.Timeout(
+                _GEMINI_STREAM_DEADLINE_S,
+                connect=min(10.0, _GEMINI_STREAM_DEADLINE_S),
+            )
+            async with asyncio.timeout(_GEMINI_STREAM_DEADLINE_S):
+                async with httpx.AsyncClient(
+                    follow_redirects=False,
+                    timeout=timeout,
+                ) as client:
+                    async with client.stream(
+                        "POST",
+                        url,
+                        params={"alt": "sse"},
+                        headers={"x-goog-api-key": api_key},
+                        json=payload,
+                    ) as response:
+                        response.raise_for_status()
+                        content_type = str(response.headers.get("content-type", ""))
+                        media_type = content_type.split(";", 1)[0].strip().lower()
+                        if media_type != "text/event-stream":
+                            raise RuntimeError(
+                                "Gemini streaming TTS returned unexpected "
+                                f"content type {content_type!r}"
+                            )
+                        async for chunk in response.aiter_bytes(chunk_size=8192):
+                            if not chunk:
+                                continue
+                            raw_total += len(chunk)
+                            if raw_total > raw_byte_cap:
+                                raise RuntimeError(
+                                    "Gemini streaming TTS exceeded "
+                                    f"{raw_byte_cap} raw SSE bytes"
+                                )
+                            pending.extend(chunk)
+                            while True:
+                                newline = pending.find(b"\n")
+                                if newline < 0:
+                                    if len(pending) > event_cap:
+                                        raise RuntimeError(
+                                            "Gemini streaming TTS SSE event "
+                                            f"exceeds {event_cap} bytes"
+                                        )
+                                    break
+                                line = bytes(pending[:newline]).rstrip(b"\r")
+                                del pending[:newline + 1]
+                                if len(line) > event_cap:
+                                    raise RuntimeError(
+                                        "Gemini streaming TTS SSE event "
+                                        f"exceeds {event_cap} bytes"
+                                    )
+                                if not line.startswith(b"data:"):
+                                    continue
+                                for pcm in _decode_gemini_sse_audio(
+                                    line[len(b"data:"):].lstrip()
+                                ):
+                                    decoded_total += len(pcm)
+                                    if decoded_total > _STREAM_SENTENCE_BYTE_CAP:
+                                        raise StreamingTTSLimitError(
+                                            "Gemini streaming TTS exceeded its "
+                                            "decoded audio cap of "
+                                            f"{_STREAM_SENTENCE_BYTE_CAP} bytes"
+                                        )
+                                    yield pcm
+                        if len(pending) > event_cap:
+                            raise RuntimeError(
+                                "Gemini streaming TTS SSE event "
+                                f"exceeds {event_cap} bytes"
+                            )
+                        line = bytes(pending).rstrip(b"\r")
+                        if line.startswith(b"data:"):
+                            for pcm in _decode_gemini_sse_audio(
+                                line[len(b"data:"):].lstrip()
+                            ):
+                                decoded_total += len(pcm)
+                                if decoded_total > _STREAM_SENTENCE_BYTE_CAP:
+                                    raise StreamingTTSLimitError(
+                                        "Gemini streaming TTS exceeded its "
+                                        "decoded audio cap of "
+                                        f"{_STREAM_SENTENCE_BYTE_CAP} bytes"
+                                    )
+                                yield pcm
+        finally:
+            with self._response_lock:
+                if self._active_async_task is task:
+                    self._active_async_loop = None
+                    self._active_async_task = None
+
+    def stream(self, text: str) -> Iterator[bytes]:
+        """Legacy synchronous compatibility path.
+
+        Gateway playback never selects this path: only ``astream()`` advertises
+        cancellation across DNS/connect/header/body. Here cancel() is best-effort
+        once ``requests`` has returned a response, with phase timeouts providing
+        the pre-header bound.
+        """
         import requests
 
         from tools.tts_tool import (
@@ -363,36 +678,45 @@ class GeminiStreamer(StreamingTTSProvider):
                 },
             },
         }
-        # ``?alt=sse`` flips the response from a single JSON blob to an SSE
-        # feed of base64 PCM chunks — the whole point of this provider.
         url = f"{base_url}/models/{model}:streamGenerateContent"
 
         def _sse_chunks() -> Iterator[bytes]:
+            deadline = time.monotonic() + _GEMINI_STREAM_DEADLINE_S
+            if self._cancelled.is_set():
+                return
+            remaining = max(0.001, deadline - time.monotonic())
             with requests.post(
                 url,
-                params={"alt": "sse", "key": api_key},
+                params={"alt": "sse"},
+                headers={"x-goog-api-key": api_key},
                 json=payload,
-                timeout=60,
+                timeout=(min(10.0, remaining), min(15.0, remaining)),
                 stream=True,
+                # requests may preserve custom headers across redirects. Do
+                # not risk forwarding the API key to a different origin.
+                allow_redirects=False,
             ) as response:
-                response.raise_for_status()
-                for line in response.iter_lines(decode_unicode=True):
-                    if not line or not line.startswith("data: "):
-                        continue
-                    try:
-                        event = _json.loads(line[len("data: "):])
-                        parts = event["candidates"][0]["content"]["parts"]
-                    except (ValueError, KeyError, IndexError, TypeError):
-                        continue
-                    for part in parts:
-                        inline = part.get("inlineData") or part.get("inline_data") or {}
-                        b64 = inline.get("data", "")
-                        if not b64:
-                            continue
-                        try:
-                            yield base64.b64decode(b64)
-                        except (ValueError, TypeError) as exc:
-                            logger.warning("Gemini SSE: bad base64 audio: %s", exc)
+                with self._response_lock:
+                    self._active_response = response
+                try:
+                    if self._cancelled.is_set():
+                        _safe_close_streaming_response(response)
+                        return
+                    response.raise_for_status()
+                    for raw in _iter_bounded_sse_data(
+                        response,
+                        label="Gemini streaming TTS",
+                        deadline=deadline,
+                    ):
+                        yield from _decode_gemini_sse_audio(raw)
+                    if not self._cancelled.is_set() and time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            "Gemini streaming TTS exceeded its absolute deadline"
+                        )
+                finally:
+                    with self._response_lock:
+                        if self._active_response is response:
+                            self._active_response = None
 
         yield from _capped(_sse_chunks(), "Gemini streaming TTS")
 


### PR DESCRIPTION
## Summary

- stream Gemini 3.1 Flash TTS Preview through `streamGenerateContent?alt=sse`
- feed incremental 24 kHz mono PCM into Discord as 48 kHz stereo 20 ms frames
- bound raw SSE events, cumulative response bytes, decoded PCM, and mixer buffering
- support absolute connect/header/body deadlines, prompt async task cancellation, underrun silence, voice barge-in, and duplicate-free fallback
- cancel provider transport on replacement, leave, or unexpected mixer teardown; disconnect before processing pending STT
- track audibility only after Discord's sender confirms the preceding non-silent frame
- keep streaming opt-in via `discord.voice_fx.streaming_tts` (default: `false`) and independent from ambient/ack effects
- keep API credentials in `x-goog-api-key`, never the URL, and disable redirects

## Validation

- 124 canonical Gemini/Discord/gateway streaming tests passed
- 212 expanded voice and integration tests passed (34 deselected)
- Ruff passed on every changed Python module and test
- `git diff --check origin/main...HEAD` passed
- concurrent mixer stress passed for 30 cycles with eight producers, three readers, and concurrent finish/abort/cleanup

## Configuration

```yaml
tts:
  gemini:
    model: gemini-3.1-flash-tts-preview
discord:
  voice_fx:
    enabled: false
    streaming_tts: true
```

`voice_fx.enabled` controls ambient/ack effects. Streaming TTS is an independent opt-in and remains disabled by default. The conversation model is unchanged.