### PR TITLE
fix: resolve glm-5.3 context window to 1M like glm-5.2

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -481,13 +481,16 @@ DEFAULT_CONTEXT_LENGTHS = {
     # https://platform.minimax.io/docs/api-reference/text-chat-openai
     "minimax-m3": 1000000,
     "minimax": 204800,
-    # GLM — GLM-5.2 ships with a 1M context window (verified empirically:
-    # needle-in-a-haystack retrieval at 789K prompt tokens succeeded with
-    # zero errors on api.z.ai/api/coding/paas/v4).  Older GLM models
+    # GLM — GLM-5.2 and GLM-5.3 ship with a 1M context window (5.2 verified
+    # empirically: needle-in-a-haystack retrieval at 789K prompt tokens
+    # succeeded with zero errors on api.z.ai/api/coding/paas/v4; 5.3 is the
+    # same base model as 5.2 per the Z.ai launch post, and Z.ai's own
+    # evaluations ran it with 400K-1M context windows).  Older GLM models
     # (5, 5.1, 5-turbo) are ~202K.  Longest-key-first substring matching
-    # ensures "glm-5.2" resolves to 1M while older variants still hit the
-    # generic 202K fallback.
+    # ensures "glm-5.2"/"glm-5.3" resolve to 1M while older variants still
+    # hit the generic 202K fallback.
     "glm-5.2": 1_048_576,
+    "glm-5.3": 1_048_576,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -353,8 +353,43 @@ class TestDefaultContextLengths:
                     f"{model_id}: expected {expected_ctx}, got {actual}"
                 )
 
+    def test_glm_53_resolves_to_1m_like_glm_52(self):
+        """GLM-5.3 is the same base model as GLM-5.2 (Z.ai launch post,
+        2026-08-14) and runs 400K-1M contexts in Z.ai's own evaluations.
+        Without an explicit entry it falls into the generic 202K ``glm``
+        fallback, triggering context compression ~5x too early — which
+        destroys the cached prefix on every compression boundary.
+        """
+        from agent.model_metadata import get_model_context_length
+        from unittest.mock import patch as mock_patch
 
+        expected_keys = {
+            "glm-5.2": 1_048_576,
+            "glm-5.3": 1_048_576,
+        }
+        for key, value in expected_keys.items():
+            assert key in DEFAULT_CONTEXT_LENGTHS, f"{key} missing"
+            assert DEFAULT_CONTEXT_LENGTHS[key] == value, (
+                f"{key} should be {value}, got {DEFAULT_CONTEXT_LENGTHS[key]}"
+            )
 
+        # Longest-first substring matching must resolve 5.2/5.3 to 1M
+        # (native Z.ai, bare slugs) while older variants still fall back
+        # to the ~202K ``glm`` entry.
+        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            cases = [
+                ("glm-5.3", 1_048_576),
+                ("glm-5.2", 1_048_576),
+                ("glm-5.1", 202752),
+                ("glm-5", 202752),
+            ]
+            for model_id, expected_ctx in cases:
+                actual = get_model_context_length(model_id, provider="zai")
+                assert actual == expected_ctx, (
+                    f"{model_id}: expected {expected_ctx}, got {actual}"
+                )
 
 
 


### PR DESCRIPTION
## Problem

GLM-5.3 shares its base model with GLM-5.2 (per Z.ai's launch post, 2026-08-14) and Z.ai's own evaluations run it at 400K–1M context. Without an explicit entry, longest-first substring matching dropped `glm-5.3` into the generic ~202K `glm` fallback.

Consequence: context compression triggered ~5x too early. Compression rewrites the message history and destroys the cached prefix — cratering the cache hit rate on long sessions, the exact opposite of what GLM-5.3's cached-input pricing rewards.

## Fix

- Add `glm-5.3: 1_048_576` to `DEFAULT_CONTEXT_LENGTHS` alongside `glm-5.2`, with updated comment
- Regression test `test_glm_53_resolves_to_1m_like_glm_52` asserting table entries + resolver behavior for 5.3/5.2 (1M) vs 5.1/5 (202K)

## Testing

- `pytest tests/agent/test_model_metadata.py tests/agent/test_model_metadata_local_ctx.py` — 105 passed (incl. new test), rebased on current main (`de0abc061`)