### PR TITLE
fix(desktop): quiesce owned backend before Windows update handoff

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -221,6 +221,8 @@ import {
   wrapHandoffForDetachedConsole
 } from './updater-process'
 import { formatBlockerMessage, formatProbeFailedMessage, scanVenvBlockers } from './venv-blocker-scan'
+import { runWindowsUpdatePreflight } from './windows-update-state'
+import { runWindowsUpdateTransaction } from './windows-update-transaction'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
 import { readWindowBelow } from './window-below'
@@ -2895,7 +2897,6 @@ async function applyUpdates(opts = {}) {
   }
 
   updateInFlight = true
-
   try {
     const updater = resolveUpdaterBinary()
 
@@ -2994,29 +2995,12 @@ async function applyUpdates(opts = {}) {
     // anything.  Runs while the backend is still alive.
     preflightStateDb(HERMES_HOME, rememberLog)
 
-    // Stop our own backend(s) and wait for the venv shim to unlock BEFORE we
-    // spawn the updater. Without this the updater races a still-locked
-    // hermes.exe (held by the backend child / its grandchildren) and the update
-    // bricks. See releaseBackendLockForUpdate for the full failure analysis.
-    const lock = await releaseBackendLockForUpdate(updateRoot)
-
-    if (!lock.unlocked) {
-      // Something OUTSIDE this app holds the venv (a second window, a user
-      // terminal running hermes, an unkillable child). Handing off anyway
-      // guarantees a half-updated venv — abort loudly instead and let the
-      // user close the holder and retry. Restart our own backend so the app
-      // keeps working after the failed attempt.
-      const message =
-        'Update aborted: another process is holding the Hermes install open ' +
-        '(a second Hermes window or a terminal running hermes?). Close it and retry.'
-
-      emitUpdateProgress({ stage: 'error', message, percent: null })
-      startHermes().catch(() => {})
-
-      return { ok: false, error: message }
-    }
-
-    // Preflight: after releasing our own backends, check for remaining
+    // Windows preflight runs before any owned process is stopped. No scanner
+    // class currently documents a graceful stop + active-work safety contract,
+    // so blocked scans remain blocked rather than force-killing work or an
+    // unknown holder. A clear scan is the only authorization to hand off.
+    //
+    // Preflight checks for remaining
     // Hermes processes running from this venv.  The updater normally refuses
     // when it detects a holder, but because the updater is spawned detached
     // with stdio:ignore, the user never sees that refusal and the update
@@ -3025,30 +3009,8 @@ async function applyUpdates(opts = {}) {
     // Windows phenomenon.  ALL failures (blocked, missing python, timeout,
     // malformed output, missing psutil) abort the handoff — never proceed
     // to the detached updater when the venv state is unknown.
-    if (IS_WINDOWS) {
-      const scanOutcome = await scanVenvBlockers(updateRoot)
 
-      if (scanOutcome.kind === 'blocked') {
-        const message = formatBlockerMessage(scanOutcome.result)
-
-        rememberLog(`[updates] venv-blocked: ${scanOutcome.result.processes.length} process(es) hold the install`)
-        emitUpdateProgress({ stage: 'error', message, percent: null })
-        startHermes().catch(() => {})
-
-        return { ok: false, error: 'venv-blocked', message }
-      }
-
-      if (scanOutcome.kind === 'probe-failure') {
-        const message = formatProbeFailedMessage()
-
-        rememberLog(`[updates] venv-blocker probe failed: ${scanOutcome.error}`)
-        emitUpdateProgress({ stage: 'error', message, percent: null })
-        startHermes().catch(() => {})
-
-        return { ok: false, error: 'venv-probe-failed', message }
-      }
-    }
-
+    const launchDetachedUpdater = async () => {
     // Detached so the updater outlives this process — it needs us GONE before
     // `hermes update` will run (the venv shim is locked while we live).
     //
@@ -3157,7 +3119,80 @@ async function applyUpdates(opts = {}) {
       app.quit()
     }, UPDATE_HANDOFF_DWELL_MS)
 
-    return { ok: true, handedOff: true, updater }
+      return { ok: true, handedOff: true, updater }
+    }
+
+    if (!IS_WINDOWS) {
+      return launchDetachedUpdater()
+    }
+
+    const transaction = await runWindowsUpdateTransaction({
+      preflight: () => runWindowsUpdatePreflight({
+        scan: () => scanVenvBlockers(updateRoot),
+        // Scanner metadata is diagnostic only and cannot grant permission to
+        // stop a process. Only the directly-owned local primary backend, with
+        // a matching PID, has a documented cooperative shutdown contract.
+        canQuiesceOwned: process => {
+          const owned = backendConnectionState.getProcess()
+          return process.blockerClass === 'desktop-backend'
+            && process.sameInstall
+            && Number.isInteger(owned?.pid)
+            && owned?.pid === process.pid
+            && owned.exitCode === null
+            && !owned.killed
+        },
+        quiesceOwned: async processes => {
+          const owned = backendConnectionState.getProcess()
+          if (processes.length !== 1 || !owned || !Number.isInteger(owned.pid)
+            || processes[0].blockerClass !== 'desktop-backend' || processes[0].pid !== owned.pid) {
+            return false
+          }
+          // Invalidate first so no connection path can reuse this process as it
+          // drains. SIGTERM is cooperative here; unlike stopBackendChild it
+          // never escalates to a tree kill.
+          backendConnectionState.invalidate()
+          try {
+            owned.kill('SIGTERM')
+          } catch {
+            return false
+          }
+          return waitForBackendExitGracefully(owned)
+        },
+        onTransition: state => rememberLog(`[updates] windows preflight: ${state.phase}`)
+      }),
+      // This is the production detached updater-spawn seam; transaction tests
+      // exercise the same callback boundary and assert it is unreachable while
+      // preflight is blocked.
+      spawnUpdater: launchDetachedUpdater,
+      releaseUpdateGateBeforeReconnect: () => { updateInFlight = false },
+      reconnect: () => startHermes(),
+      onPhase: phase => {
+        rememberLog(`[updates] windows preflight: ${phase}`)
+        if (phase === 'reconnect') {
+          emitUpdateProgress({ stage: 'restart', message: 'Reconnecting Hermes after the aborted update.', percent: null })
+        }
+      }
+    })
+
+    if (transaction.kind === 'handed-off') {
+      return transaction.value
+    }
+
+    const message = transaction.preflight.blockers
+      ? formatBlockerMessage(transaction.preflight.blockers)
+      : formatProbeFailedMessage()
+    const error = transaction.preflight.blockers ? 'venv-blocked' : 'venv-probe-failed'
+    rememberLog(`[updates] ${error}: ${transaction.preflight.error || 'preflight aborted'}`)
+    emitUpdateProgress({ stage: 'error', message, percent: null })
+
+    if (transaction.kind === 'reconnect-failed') {
+      const reconnectMessage = `Update aborted and Hermes could not reconnect: ${(transaction.error as any)?.message || String(transaction.error)}`
+      rememberLog(`[updates] windows preflight: reconnect failed: ${(transaction.error as any)?.message || String(transaction.error)}`)
+      emitUpdateProgress({ stage: 'error', message: reconnectMessage, percent: null })
+      return { ok: false, error: 'reconnect-failed', message: reconnectMessage }
+    }
+
+    return { ok: false, error, message }
   } finally {
     updateInFlight = false
   }
@@ -7989,6 +8024,29 @@ async function waitForBackendExit(child, timeoutMs = 5000) {
       clearTimeout(timer)
       resolve()
     })
+  })
+}
+
+/**
+ * Observe a cooperative Desktop-owned backend shutdown without escalating to
+ * taskkill. For update preflight, an uncooperative process blocks the update.
+ */
+async function waitForBackendExitGracefully(child, timeoutMs = 5000) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return true
+  }
+
+  return await new Promise<boolean>(resolve => {
+    let settled = false
+    const finish = value => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(value)
+    }
+    const timer = setTimeout(() => finish(false), timeoutMs)
+    child.once('exit', () => finish(true))
+    child.once('error', () => finish(false))
   })
 }
 

--- a/apps/desktop/electron/venv-blocker-scan.test.ts
+++ b/apps/desktop/electron/venv-blocker-scan.test.ts
@@ -22,6 +22,14 @@ import {
   scanVenvBlockers
 } from './venv-blocker-scan'
 
+const blocker = (over: any = {}) => ({
+  pid: 1,
+  name: 'python.exe',
+  blocker_class: 'hermes-cli',
+  same_install: true,
+  ...over
+})
+
 // ---------------------------------------------------------------------------
 // resolveVenvPython
 // ---------------------------------------------------------------------------
@@ -53,15 +61,15 @@ describe('resolveVenvPython', () => {
 // ---------------------------------------------------------------------------
 
 describe('formatBlockerMessage', () => {
-  it('includes PID, name, cmdline, remote-client warning, and retry suggestion', () => {
+  it('includes PID, name, category, remote-client warning, and retry suggestion without a command line', () => {
     const msg = formatBlockerMessage({
       blocked: true,
-      processes: [{ pid: 101, name: 'python.exe', cmdline: 'serve --host 10.0.0.1' }]
+      processes: [{ pid: 101, name: 'python.exe', blockerClass: 'desktop-backend', sameInstall: true }]
     })
 
     assert.ok(msg.includes('PID 101'))
     assert.ok(msg.includes('python.exe'))
-    assert.ok(msg.includes('serve'))
+    assert.ok(msg.includes('desktop-backend'))
     assert.ok(msg.includes('remote backend'))
     assert.ok(msg.includes('retry'))
     assert.ok(!msg.includes('force-venv'))
@@ -92,7 +100,7 @@ describe('parseVenvBlockerScanOutput', () => {
     const o = parseVenvBlockerScanOutput(
       ok({
         blocked: true,
-        processes: [{ pid: 1, name: 'p', cmdline: 'c' }]
+        processes: [blocker()]
       })
     )
 
@@ -119,27 +127,24 @@ describe('parseVenvBlockerScanOutput', () => {
   })
 
   it('blocked=false with non-empty processes rejected', () => {
-    assert.equal(
-      parseVenvBlockerScanOutput(ok({ processes: [{ pid: 1, name: 'p', cmdline: 'c' }] })).kind,
-      'probe-failure'
-    )
+    assert.equal(parseVenvBlockerScanOutput(ok({ processes: [blocker()] })).kind, 'probe-failure')
   })
 
   it('process pid must be positive integer', () => {
     assert.equal(
-      parseVenvBlockerScanOutput(ok({ blocked: true, processes: [{ pid: 0, name: 'p', cmdline: 'c' }] })).kind,
+      parseVenvBlockerScanOutput(ok({ blocked: true, processes: [blocker({ pid: 0 })] })).kind,
       'probe-failure'
     )
   })
 
   it('process name must be non-empty string', () => {
     assert.equal(
-      parseVenvBlockerScanOutput(ok({ blocked: true, processes: [{ pid: 1, name: '', cmdline: 'c' }] })).kind,
+      parseVenvBlockerScanOutput(ok({ blocked: true, processes: [blocker({ name: '' })] })).kind,
       'probe-failure'
     )
   })
 
-  it('process missing cmdline is rejected', () => {
+  it('process missing blocker metadata is rejected', () => {
     assert.equal(
       parseVenvBlockerScanOutput(ok({ blocked: true, processes: [{ pid: 1, name: 'p' }] })).kind,
       'probe-failure'
@@ -158,7 +163,7 @@ describe('scanVenvBlockers', () => {
   const blockedJson = JSON.stringify({
     ok: true,
     blocked: true,
-    processes: [{ pid: 1, name: 'p', cmdline: 'c' }]
+    processes: [blocker()]
   })
 
   function execReturn(json: string): any {

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -21,7 +21,8 @@ const execFileAsync = promisify(execFile)
 export interface VenvBlockerProcess {
   pid: number
   name: string
-  cmdline: string
+  blockerClass: string
+  sameInstall: boolean
 }
 
 export interface VenvBlockerScanResult {
@@ -77,7 +78,7 @@ export function parseVenvBlockerScanOutput(raw: string): ScanOutcome {
       return { kind: 'probe-failure', error: 'process entry must be an object' }
     }
 
-    const { pid, name, cmdline } = entry
+    const { pid, name, blocker_class, same_install } = entry
 
     if (!Number.isInteger(pid) || pid <= 0) {
       return { kind: 'probe-failure', error: 'process pid must be a positive integer' }
@@ -87,11 +88,20 @@ export function parseVenvBlockerScanOutput(raw: string): ScanOutcome {
       return { kind: 'probe-failure', error: 'process name must be a non-empty string' }
     }
 
-    if (typeof cmdline !== 'string') {
-      return { kind: 'probe-failure', error: 'process cmdline must be a string' }
+    if (typeof blocker_class !== 'string' || blocker_class.length === 0) {
+      return { kind: 'probe-failure', error: 'process blocker_class must be a non-empty string' }
     }
 
-    processes.push({ pid, name, cmdline })
+    if (typeof same_install !== 'boolean') {
+      return { kind: 'probe-failure', error: 'process same_install must be a boolean' }
+    }
+
+    processes.push({
+      pid,
+      name,
+      blockerClass: blocker_class,
+      sameInstall: same_install
+    })
   }
 
   // Reject inconsistent combinations
@@ -172,7 +182,8 @@ export function resolveVenvPython(updateRoot: string): string | null {
 }
 
 /**
- * Build a human-readable error message from blocker scan results.
+ * Build a human-readable error message from blocker scan results. The scan
+ * deliberately never supplies raw command lines, which can include secrets.
  * Does NOT recommend --force-venv.
  */
 export function formatBlockerMessage(result: VenvBlockerScanResult): string {
@@ -184,7 +195,7 @@ export function formatBlockerMessage(result: VenvBlockerScanResult): string {
   ]
 
   for (const proc of result.processes.slice(0, 10)) {
-    lines.push(`  PID ${proc.pid}  ${proc.name}  ${proc.cmdline}`)
+    lines.push(`  PID ${proc.pid}  ${proc.name}  (${proc.blockerClass})`)
   }
 
   if (result.processes.length > 10) {

--- a/apps/desktop/electron/windows-update-state.test.ts
+++ b/apps/desktop/electron/windows-update-state.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+import { runWindowsUpdatePreflight } from './windows-update-state'
+
+const clear = { kind: 'clear' as const, result: { blocked: false, processes: [] } }
+const blocker = { pid: 7, name: 'python.exe', blockerClass: 'desktop-backend', sameInstall: true, }
+
+test('blocked unknown holders abort and reconnect without quiescing them', async () => {
+  const phases: string[] = []
+  let quiesced = false
+  const result = await runWindowsUpdatePreflight({
+    scan: async () => ({ kind: 'blocked', result: { blocked: true, processes: [blocker] } }),
+    quiesceOwned: async () => { quiesced = true; return true },
+    canQuiesceOwned: () => false,
+    onTransition: state => phases.push(state.phase)
+  })
+  assert.equal(result.phase, 'abort')
+  assert.equal(result.decision, 'reconnect')
+  assert.equal(quiesced, false)
+  assert.deepEqual(phases, ['blocked', 'abort'])
+})
+
+test('only documented owned holders are gracefully quiesced then rescanned before handoff', async () => {
+  const phases: string[] = []
+  let calls = 0
+  const result = await runWindowsUpdatePreflight({
+    scan: async () => ++calls === 1
+      ? { kind: 'blocked', result: { blocked: true, processes: [blocker] } }
+      : clear,
+    quiesceOwned: async processes => { assert.equal(processes.length, 1); return true },
+    canQuiesceOwned: process => process.pid === blocker.pid && process.blockerClass === 'desktop-backend',
+    onTransition: state => phases.push(state.phase)
+  })
+  assert.equal(result.decision, 'handoff')
+  assert.equal(calls, 2)
+  assert.deepEqual(phases, ['blocked', 'quiescing', 'rescan', 'handoff'])
+})
+
+test('probe failure aborts rather than allowing handoff', async () => {
+  const result = await runWindowsUpdatePreflight({
+    scan: async () => ({ kind: 'probe-failure', error: 'scanner unavailable' }),
+    quiesceOwned: async () => true,
+    canQuiesceOwned: () => false
+  })
+  assert.deepEqual(result, { phase: 'abort', decision: 'reconnect', error: 'scanner unavailable' })
+})
+
+test('a holder that remains after documented quiescence aborts and reconnects', async () => {
+  const phases: string[] = []
+  let calls = 0
+  const result = await runWindowsUpdatePreflight({
+    scan: async () => {
+      calls += 1
+      return {
+        kind: 'blocked' as const,
+        result: {
+          blocked: true,
+          processes: [blocker]
+        }
+      }
+    },
+    quiesceOwned: async () => true,
+    canQuiesceOwned: () => true,
+    onTransition: state => phases.push(state.phase)
+  })
+
+  assert.equal(calls, 2, 'a clear second scan is required before handoff')
+  assert.equal(result.phase, 'abort')
+  assert.equal(result.decision, 'reconnect')
+  assert.match(result.error || '', /holders remain/i)
+  assert.deepEqual(phases, ['blocked', 'quiescing', 'rescan', 'abort'])
+})

--- a/apps/desktop/electron/windows-update-state.ts
+++ b/apps/desktop/electron/windows-update-state.ts
@@ -1,0 +1,62 @@
+import type { ScanOutcome, VenvBlockerScanResult } from './venv-blocker-scan'
+
+export type WindowsUpdatePhase = 'blocked' | 'quiescing' | 'rescan' | 'handoff' | 'result' | 'reconnect' | 'abort'
+export type WindowsUpdateDecision = 'handoff' | 'reconnect' | 'abort'
+
+export interface WindowsUpdateState {
+  phase: WindowsUpdatePhase
+  decision?: WindowsUpdateDecision
+  blockers?: VenvBlockerScanResult
+  error?: string
+}
+
+export interface WindowsUpdateStateDeps {
+  scan: () => Promise<ScanOutcome>
+  /** Graceful stop for documented, Desktop-owned process roots only. */
+  quiesceOwned: (processes: VenvBlockerScanResult['processes']) => Promise<boolean>
+  /**
+   * Local ownership proof for a graceful-stop contract. Scanner metadata is
+   * diagnostic only: it must never grant permission to stop a process.
+   */
+  canQuiesceOwned: (process: VenvBlockerScanResult['processes'][number]) => boolean
+  onTransition?: (state: WindowsUpdateState) => void
+}
+
+function transition(deps: WindowsUpdateStateDeps, state: WindowsUpdateState): WindowsUpdateState {
+  deps.onTransition?.(state)
+  return state
+}
+
+/**
+ * Fail-closed preflight transition machine. It never kills a process. A
+ * blocked scan can enter quiescing only when every holder is explicitly marked
+ * as supporting a documented graceful protocol; otherwise it aborts/reconnects.
+ */
+export async function runWindowsUpdatePreflight(deps: WindowsUpdateStateDeps): Promise<WindowsUpdateState> {
+  const first = await deps.scan()
+  if (first.kind === 'probe-failure') {
+    return transition(deps, { phase: 'abort', decision: 'reconnect', error: first.error })
+  }
+  if (first.kind === 'clear') {
+    return transition(deps, { phase: 'handoff', decision: 'handoff' })
+  }
+
+  transition(deps, { phase: 'blocked', blockers: first.result })
+  if (!first.result.processes.every(process => process.sameInstall && deps.canQuiesceOwned(process))) {
+    return transition(deps, { phase: 'abort', decision: 'reconnect', blockers: first.result, error: 'holders require user action' })
+  }
+
+  transition(deps, { phase: 'quiescing', blockers: first.result })
+  if (!(await deps.quiesceOwned(first.result.processes))) {
+    return transition(deps, { phase: 'abort', decision: 'reconnect', blockers: first.result, error: 'graceful quiescence failed' })
+  }
+
+  transition(deps, { phase: 'rescan' })
+  const second = await deps.scan()
+  if (second.kind === 'clear') return transition(deps, { phase: 'handoff', decision: 'handoff' })
+  return transition(deps, {
+    phase: 'abort', decision: 'reconnect',
+    blockers: second.kind === 'blocked' ? second.result : undefined,
+    error: second.kind === 'blocked' ? 'holders remain after graceful quiescence' : second.error
+  })
+}

--- a/apps/desktop/electron/windows-update-transaction.test.ts
+++ b/apps/desktop/electron/windows-update-transaction.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+
+import { runWindowsUpdateTransaction } from './windows-update-transaction'
+
+const blocked = {
+  phase: 'abort' as const,
+  decision: 'reconnect' as const,
+  blockers: {
+    blocked: true,
+    processes: [{ pid: 7, name: 'python.exe', blockerClass: 'desktop-backend', sameInstall: true }]
+  },
+  error: 'holders require user action'
+}
+
+const clear = { phase: 'handoff' as const, decision: 'handoff' as const }
+
+test('caller-level Windows transaction never invokes the updater across two aborted reconnects, then invokes it once after a clean rescan', async () => {
+  const preflights = [blocked, blocked, clear]
+  const phases: string[] = []
+  let updaterSpawns = 0
+  let reconnects = 0
+
+  const applyWindowsUpdate = () => runWindowsUpdateTransaction({
+    preflight: async () => preflights.shift() || clear,
+    spawnUpdater: async () => {
+      updaterSpawns += 1
+      return { pid: 42 }
+    },
+    reconnect: async () => { reconnects += 1 },
+    onPhase: phase => phases.push(phase)
+  })
+
+  assert.equal((await applyWindowsUpdate()).kind, 'aborted')
+  assert.equal((await applyWindowsUpdate()).kind, 'aborted')
+  assert.equal(updaterSpawns, 0, 'aborted preflights must never reach spawnUpdaterProcess')
+  assert.equal(reconnects, 2, 'each aborted preflight reconnects deterministically')
+  assert.deepEqual(phases, ['abort', 'result', 'reconnect', 'complete', 'abort', 'result', 'reconnect', 'complete'])
+
+  const clean = await applyWindowsUpdate()
+  assert.equal(clean.kind, 'handed-off')
+  assert.equal(updaterSpawns, 1, 'exactly one updater spawn follows a clean rescan')
+  assert.equal(reconnects, 2)
+})
+
+test('caller-level Windows transaction returns a reconnect failure and never spawns the updater', async () => {
+  let updaterSpawns = 0
+  const result = await runWindowsUpdateTransaction({
+    preflight: async () => blocked,
+    spawnUpdater: async () => { updaterSpawns += 1 },
+    reconnect: async () => { throw new Error('backend socket refused') }
+  })
+
+  assert.equal(result.kind, 'reconnect-failed')
+  assert.equal(updaterSpawns, 0)
+  if (result.kind === 'reconnect-failed') {
+    assert.match(String((result.error as Error).message), /socket refused/)
+  }
+})

--- a/apps/desktop/electron/windows-update-transaction.ts
+++ b/apps/desktop/electron/windows-update-transaction.ts
@@ -1,0 +1,43 @@
+import type { WindowsUpdateState } from './windows-update-state'
+
+export type WindowsUpdateTransactionResult<T> =
+  | { kind: 'handed-off'; value: T; preflight: WindowsUpdateState }
+  | { kind: 'aborted'; preflight: WindowsUpdateState }
+  | { kind: 'reconnect-failed'; preflight: WindowsUpdateState; error: unknown }
+
+export interface WindowsUpdateTransactionDeps<T> {
+  preflight: () => Promise<WindowsUpdateState>
+  /** The real detached-updater spawn seam. It runs only after a clean handoff decision. */
+  spawnUpdater: () => Promise<T>
+  /** Re-establish the Desktop backend after a failed/aborted preflight. */
+  reconnect: () => Promise<void>
+  /** Opens the in-process update gate before reconnecting the backend. */
+  releaseUpdateGateBeforeReconnect?: () => void
+  onPhase?: (phase: 'result' | 'reconnect' | 'complete' | 'abort') => void
+}
+
+/**
+ * Execute the caller-level Windows update decision: an aborted preflight never
+ * reaches the detached updater, and reconnect is awaited so failure is returned
+ * to the update IPC caller instead of becoming an unobserved log side effect.
+ */
+export async function runWindowsUpdateTransaction<T>(
+  deps: WindowsUpdateTransactionDeps<T>
+): Promise<WindowsUpdateTransactionResult<T>> {
+  const preflight = await deps.preflight()
+  if (preflight.decision === 'handoff') {
+    return { kind: 'handed-off', value: await deps.spawnUpdater(), preflight }
+  }
+
+  deps.onPhase?.('abort')
+  deps.onPhase?.('result')
+  deps.onPhase?.('reconnect')
+  deps.releaseUpdateGateBeforeReconnect?.()
+  try {
+    await deps.reconnect()
+    deps.onPhase?.('complete')
+    return { kind: 'aborted', preflight }
+  } catch (error) {
+    return { kind: 'reconnect-failed', preflight, error }
+  }
+}

--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -126,6 +126,42 @@ def _is_pausable_gateway(cmdline: str) -> bool:
     return looks_like_gateway_command_line(cmdline)
 
 
+def _classify_blocker(cmdline: str) -> str:
+    """Return a stable, command-line-free ownership class for a holder.
+
+    The Desktop must be able to explain *why* an update is stopped without
+    echoing a command line (which can carry URLs or credentials).  This is
+    diagnostic metadata only: all non-exempt matches remain blockers until a
+    future class has a documented graceful-stop contract.
+    """
+    normalized = cmdline.lower()
+    if "-m hermes_cli.main" in normalized and " serve" in normalized:
+        return "desktop-backend"
+    if "kanban" in normalized:
+        return "kanban-worker"
+    if ".hermes-runtime" in normalized or "managed-runtime" in normalized:
+        return "managed-runtime-helper"
+    if "-m hermes_cli.main" in normalized:
+        return "hermes-cli"
+    return "unknown"
+
+
+def _blocker_record(pid: int, name: str, cmdline: str) -> dict[str, object]:
+    """Build the privacy-safe scan record consumed by Desktop.
+
+    ``_detect_venv_python_processes`` only returns processes resolved under
+    the active installation, so ``same_install`` is true by construction.
+    No currently reported class is automatically quiesced: callers must keep
+    the fail-closed preflight until it has an explicit stop/health contract.
+    """
+    return {
+        "pid": pid,
+        "name": name.rsplit("\\", 1)[-1].rsplit("/", 1)[-1],
+        "blocker_class": _classify_blocker(cmdline),
+        "same_install": True,
+    }
+
+
 def main() -> None:
     """Entry point.  Prints one JSON doc to stdout.  Exits 0 for valid scan."""
     try:
@@ -141,14 +177,7 @@ def main() -> None:
         _emit_probe_fail(f"scan aborted: {exc}")
 
     processes = [
-        {
-            "pid": pid,
-            "name": name,
-            # Truncate for display AFTER the gateway exemption has seen the
-            # full cmdline (long managed-runtime interpreter paths would
-            # otherwise swallow the `gateway run` argv).
-            "cmdline": _redact_sensitive_cmdline(cmdline)[:120],
-        }
+        _blocker_record(pid, name, cmdline)
         for pid, name, cmdline in matches
         if not _is_pausable_gateway(cmdline)
     ]

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -17,6 +17,7 @@ import pytest
 
 import agent.redact as redact_module
 from hermes_cli._scan_venv_blockers import (
+    _classify_blocker,
     _is_pausable_gateway,
     _redact_sensitive_cmdline,
     main,
@@ -35,6 +36,25 @@ def _psutil_fake() -> dict:
 
 
 
+
+
+# ---------------------------------------------------------------------------
+# _classify_blocker — no command line is exposed to the Desktop policy layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("cmdline", "expected"),
+    [
+        ("python.exe -m hermes_cli.main serve --token should-not-matter", "desktop-backend"),
+        ("python.exe -m hermes_cli.main --profile work gateway run", "hermes-cli"),
+        ("python.exe -m hermes_cli.main kanban worker", "kanban-worker"),
+        ("C:\\x\\.hermes-runtime\\python.exe helper.py", "managed-runtime-helper"),
+        ("python.exe custom.py", "unknown"),
+    ],
+)
+def test_classify_blocker(cmdline: str, expected: str) -> None:
+    assert _classify_blocker(cmdline) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -196,6 +216,8 @@ def test_main_exempts_gateway_chain_but_keeps_other_holders(monkeypatch, capsys)
     assert code == 0
     assert data["blocked"] is True
     assert [p["pid"] for p in data["processes"]] == [56]
+    assert data["processes"][0]["blocker_class"] == "unknown"
+    assert data["processes"][0]["same_install"] is True
     assert data["pausable_gateways"] == 2
 
 
@@ -211,6 +233,7 @@ def test_main_desktop_serve_backend_still_blocks(monkeypatch, capsys):
     assert code == 0
     assert data["blocked"] is True
     assert [p["pid"] for p in data["processes"]] == [78]
+    assert data["processes"][0]["blocker_class"] == "desktop-backend"
     assert data["pausable_gateways"] == 0
 
 def test_main_gateway_with_long_managed_runtime_path_is_exempt(monkeypatch, capsys):
@@ -237,9 +260,10 @@ def test_main_gateway_with_long_managed_runtime_path_is_exempt(monkeypatch, caps
     assert data["processes"] == []
     assert data["pausable_gateways"] == 1
 
-    # A long-path NON-gateway holder still blocks, with cmdline truncated for display.
+    # A long-path NON-gateway holder still blocks without leaking command lines.
     stray = (92, "python.exe", long_exe + "  -m some_other_module --serve-forever")
     code, data = _run_main_with_detector(monkeypatch, capsys, [gateway, stray])
     assert data["blocked"] is True
     assert [p["pid"] for p in data["processes"]] == [92]
-    assert len(data["processes"][0]["cmdline"]) <= 120
+    assert data["processes"][0]["name"] == "python.exe"
+    assert "cmdline" not in data["processes"][0]


### PR DESCRIPTION
## Problem

On Windows, a Desktop-initiated update must replace packages inside the managed Hermes virtual environment. The Desktop-owned `python -m hermes_cli.main serve` backend can itself hold those files open. The previous flow released that backend before it established an authoritative process snapshot, leaving a timing window: the updater could observe a stale/self holder or begin the handoff while the backend was still unwinding. That presents as an aborted update followed by a Retry/relaunch loop.

A separate historical false positive—truncated long gateway command lines preventing the scheduled gateway exemption—was fixed independently in `0b33ee88e`. This PR does **not** duplicate that fix.

## Fix

Make the Windows update apply path an explicit preflight transaction:

1. scan managed-runtime holders before changing process state;
2. refuse to touch unknown, ACP, gateway, or external holders;
3. quiesce only the Desktop backend owned by this Electron process when it is the sole recognized holder;
4. rescan and proceed to the existing Windows handoff only after the installation is clear;
5. restore the backend connection if the update cannot safely proceed.

The scanner emits a deliberately small, privacy-preserving classification (`desktop-backend`, `gateway`, `acp`, `hermes-cli`, or `unknown`) rather than exposing raw command lines to the Desktop process.

## Safety properties

- No broad `taskkill`, runtime-wide kill, or mutation of third-party processes.
- Unknown or ACP-owned holders remain a clear, actionable block rather than being terminated.
- The existing updater/handoff mechanism is unchanged after preflight succeeds.

## Validation

- `npm run typecheck --workspace apps/desktop`
- `npm run test:desktop:platforms --workspace apps/desktop -- --run electron/windows-update-state.test.ts electron/windows-update-transaction.test.ts electron/venv-blocker-scan.test.ts` — 26 passed
- `uv run --with pytest --with pytest-xdist python -m pytest tests/hermes_cli/test_scan_venv_blockers.py -q -o 'addopts=' -n 0` — 29 passed
- Manual Windows Desktop update: the app closed cleanly, the updater completed with exit code 0, and Desktop relaunched.

## Related work

- #74326
- #78089
- #78188
- #84778

This is intentionally narrower than #84778: it resolves the Desktop self-holder coordination gap without force-terminating every managed-runtime process.
