### PR TITLE
fix(gateway): honest capability surfaces — filtered toolsets, profile-scoped skills, MCP catalog

### DIFF
--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -446,7 +446,20 @@ def _(rid, params: dict) -> dict:
                         {"name": skill_name, "enabled": skill_name.lower() not in disabled}
                     )
 
-            from toolsets import get_all_toolsets, get_toolset_info
+            # Toolsets: the same filtered universe the `hermes tools`
+            # checklist offers — configurable toolsets (built-in + plugin),
+            # minus platform-restricted ones that don't apply here — with
+            # enablement resolved the way the runtime actually resolves it.
+            # The raw registry (get_all_toolsets) leaks internal platform
+            # composites (hermes-discord, feishu_drive, ...) and reports
+            # everything "enabled" whenever the profile has no pin, which a
+            # capabilities UI then faithfully mis-renders (tester report).
+            from hermes_cli.tools_config import (
+                _get_effective_configurable_toolsets,
+                _get_platform_tools,
+                _toolset_allowed_for_platform,
+            )
+            from toolsets import resolve_toolset
 
             tools_cfg = cfg.get("tools") if isinstance(cfg.get("tools"), dict) else {}
             pinned = tools_cfg.get("enabled_toolsets")
@@ -455,15 +468,32 @@ def _(rid, params: dict) -> dict:
                 if isinstance(pinned, list)
                 else None
             )
+            try:
+                platform_enabled = set(
+                    _get_platform_tools(cfg, "cli", include_default_mcp_servers=False)
+                )
+            except Exception:
+                platform_enabled = set()
             toolsets_out = []
-            for ts_name in sorted(get_all_toolsets().keys()):
-                info = get_toolset_info(ts_name) or {}
+            for ts_name, ts_label, ts_desc in _get_effective_configurable_toolsets():
+                if not _toolset_allowed_for_platform(ts_name, "cli"):
+                    continue
+                try:
+                    tool_count = len(set(resolve_toolset(ts_name)))
+                except Exception:
+                    tool_count = 0
+                enabled = (
+                    ts_name in pinned_set
+                    if pinned_set is not None
+                    else ts_name in platform_enabled
+                )
                 toolsets_out.append(
                     {
                         "name": ts_name,
-                        "description": info.get("description") or "",
-                        "tool_count": len(info.get("tools") or []),
-                        "enabled": True if pinned_set is None else ts_name in pinned_set,
+                        "label": ts_label,
+                        "description": ts_desc or "",
+                        "tool_count": tool_count,
+                        "enabled": enabled,
                     }
                 )
 

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1731,6 +1731,23 @@ def _(rid, params: dict) -> dict:
 @method("skills.manage")
 def _(rid, params: dict) -> dict:
     action, query = params.get("action", "list"), params.get("query", "")
+    # Optional profile scoping: list/install operate on that profile's
+    # skills dir (capabilities UIs manage a bot's skills from the main
+    # window). Search/browse/inspect hit the shared hub catalog — the
+    # override is harmless there and keeps the semantics uniform.
+    profile = str(params.get("profile") or "").strip()
+    token = None
+    if profile:
+        try:
+            from hermes_cli.profiles import get_profile_dir
+            from hermes_constants import set_hermes_home_override
+
+            profile_dir = get_profile_dir(profile)
+            if not profile_dir or not profile_dir.is_dir():
+                return _err(rid, 4064, f"profile '{profile}' not found")
+            token = set_hermes_home_override(str(profile_dir))
+        except Exception as e:
+            return _err(rid, 5024, str(e))
     try:
         if action == "list":
             from hermes_cli.banner import get_available_skills
@@ -1785,6 +1802,72 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4017, f"unknown skills action: {action}")
     except Exception as e:
         return _err(rid, 5024, str(e))
+    finally:
+        if token is not None:
+            try:
+                from hermes_constants import reset_hermes_home_override
+
+                reset_hermes_home_override(token)
+            except Exception:
+                pass
+
+
+@method("mcp.catalog")
+def _(rid, params: dict) -> dict:
+    """Bundled MCP catalog with per-profile install/enable state.
+
+    Params: optional ``profile`` (defaults to the launch profile). Result:
+    ``{servers: [{name, description, installed, enabled, requires: [env
+    keys], transport}]}`` — the same catalog `hermes mcp` offers, so
+    capability UIs can present the full menu and know which entries need
+    setup (missing requires) before they'll work.
+    """
+    profile = str(params.get("profile") or "").strip()
+    token = None
+    try:
+        if profile:
+            from hermes_cli.profiles import get_profile_dir
+            from hermes_constants import set_hermes_home_override
+
+            profile_dir = get_profile_dir(profile)
+            if not profile_dir or not profile_dir.is_dir():
+                return _err(rid, 4064, f"profile '{profile}' not found")
+            token = set_hermes_home_override(str(profile_dir))
+
+        from hermes_cli import mcp_catalog
+
+        out = []
+        for entry in mcp_catalog.list_catalog():
+            try:
+                requires = [str(k) for k in (getattr(entry, "env_keys", None) or [])]
+            except Exception:
+                requires = []
+            out.append(
+                {
+                    "name": entry.name,
+                    "description": getattr(entry, "description", "") or "",
+                    "installed": bool(mcp_catalog.is_installed(entry.name)),
+                    "enabled": bool(mcp_catalog.is_enabled(entry.name)),
+                    "requires": requires,
+                    # TransportSpec object — reduce to its kind string.
+                    "transport": str(
+                        getattr(getattr(entry, "transport", None), "kind", "")
+                        or getattr(entry, "transport", "")
+                        or "stdio"
+                    ),
+                }
+            )
+        return _ok(rid, {"servers": out})
+    except Exception as e:
+        return _err(rid, 5024, str(e))
+    finally:
+        if token is not None:
+            try:
+                from hermes_constants import reset_hermes_home_override
+
+                reset_hermes_home_override(token)
+            except Exception:
+                pass
 
 
 @method("skills.reload")


### PR DESCRIPTION
Bot Mode tester screenshot: the profile editor's Tools list shows `desktop_ui`, `discord_admin`, `feishu_drive`, `hermes-bluebubbles`, `hermes-cron`… all checked. Two real bugs in `profiles.describe` and two gaps:

**1. Toolsets: raw registry leak + dishonest enablement.** `describe` iterated `get_all_toolsets()` — the internal registry, including platform composites and gated/hidden toolsets that `hermes tools` deliberately never offers — and reported `enabled: true` for everything whenever the profile had no `enabled_toolsets` pin. A capabilities UI faithfully renders that as 'this bot has feishu_drive enabled'. Now it serves the same filtered universe the `hermes tools` checklist offers (`_get_effective_configurable_toolsets` + platform restriction filter), with enablement resolved through `_get_platform_tools` — the same path the runtime uses. Response rows gain a `label` field.

**2. `skills.manage` gains optional `profile`** — list/install run under that profile's home override, so an editor can show a bot's installed skills and install hub skills INTO the bot. Hub search/browse/inspect (shared catalog) unchanged.

**3. New `mcp.catalog`** — the bundled catalog (`hermes_cli.mcp_catalog`) with per-profile `installed`/`enabled` + `requires` (env keys), so UIs can present the full menu and route entries that need setup through setup instead of listing dead servers. TransportSpec reduced to its kind string (JSON-safe).

E2E on a live HERMES_HOME: describe returns only user-facing toolsets (`web`, `browser`, `terminal`, …) with honest enabled flags and zero `hermes-*`/platform leaks; `mcp.catalog` returns the 5-entry catalog with state; `skills.manage(profile=...)` scopes correctly.