### PR TITLE
fix: pass resolved path in search_tool (wrong-worktree search)

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -388,6 +388,24 @@ class TestSearchHandler:
         mock_ops.search.assert_called_once()
 
     @patch("tools.file_tools._get_file_ops")
+    @patch("tools.file_tools._resolve_path_for_task", return_value="/worktree/repo")
+    def test_search_dispatches_resolved_path_not_raw(self, mock_resolve, mock_get):
+        """search_tool must pass the RESOLVED path to file_ops.search, not the
+        raw argument. A raw "." would otherwise resolve against file_ops' live
+        cwd (which can point at a different checkout) instead of the
+        authoritative workspace base — the wrong-worktree search bug."""
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"matches": []}
+        mock_ops.search.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import search_tool
+        search_tool(pattern="needle", target="content", path=".")
+        mock_ops.search.assert_called_once()
+        assert mock_ops.search.call_args.kwargs["path"] == "/worktree/repo"
+
+    @patch("tools.file_tools._get_file_ops")
     def test_search_passes_all_params(self, mock_get):
         mock_ops = MagicMock()
         result_obj = MagicMock()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1807,8 +1807,15 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             return json.dumps({"error": block_error}, ensure_ascii=False)
 
         file_ops = _get_file_ops(task_id)
+        # Pass the RESOLVED path (the authoritative worktree base used by
+        # read_file/patch/write_file), not the raw argument. The raw "." would
+        # otherwise fall through to file_ops' live-cwd resolution, which can
+        # point at a different checkout than the one the agent is working in
+        # (the wrong-worktree search bug). resolved_path is absolute, or None
+        # if resolution raised — fall back to the raw path only in that case.
+        search_path = str(resolved_path) if resolved_path is not None else path
         result = file_ops.search(
-            pattern=pattern, path=path, target=target, file_glob=file_glob,
+            pattern=pattern, path=search_path, target=target, file_glob=file_glob,
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
         omitted = _filter_read_blocked_search_results(result, task_id)


### PR DESCRIPTION
## Problem

`search_tool` resolves the path for the block-check via `_resolve_path_for_task` — the same authoritative workspace-root resolution used by `read_file` / `patch` / `write_file` — but then passes the **raw** path argument to `file_ops.search()`, discarding the resolution.

So a relative path like `.` falls through to `FileOperations._exec`'s live-cwd resolution (`self.env.cwd`), which can point at a different checkout than the agent is actually working in. In a git-worktree session (or any multi-session desktop/TUI setup sharing a terminal env), `search_files(path=".")` silently searches the wrong tree — returning zero results for content that clearly exists in the active worktree — while `read_file` / `patch` / `write_file` on the same relative paths land in the correct tree.

## Fix

Pass the resolved path (`str(resolved_path)`) to `file_ops.search()` instead of the raw argument, falling back to the raw path only when resolution failed (`resolved_path is None`). This aligns `search_tool` with the other file tools.

## Test

Adds `TestSearchHandler::test_search_dispatches_resolved_path_not_raw`, asserting `search_tool` dispatches the resolved absolute path rather than the raw `.`. Confirmed to fail on `main` and pass with the fix.

## Notes

- This is the search-side counterpart of the existing wrong-worktree discipline already applied to `read_file` / `patch` / `write_file` (see `references/worktree-cwd-discipline.md`).
- Search result paths now surface as absolute, matching the other file tools' behavior.
