### PR TITLE
fix(buzz): reply in-thread instead of flat channel posts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -840,7 +840,7 @@ def _resolve_progress_thread_id(
         return str(source_thread_id) if source_thread_id else None
     if source_thread_id:
         return str(source_thread_id)
-    if platform_key in {"slack", "mattermost"} and event_message_id:
+    if platform_key in {"slack", "mattermost", "buzz"} and event_message_id:
         return str(event_message_id)
     return None
 
@@ -27068,6 +27068,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if (
                 source.platform in (Platform.FEISHU, Platform.MATTERMOST)
                 and source.thread_id
+                and event_message_id
+            )
+            or (
+                # Buzz has no native thread_id; threading is always via reply-to
+                # the triggering event id (channel clutter otherwise).
+                str(getattr(source.platform, "value", source.platform) or "").lower() == "buzz"
                 and event_message_id
             )
             or _relay_prospective_thread_id

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1839,7 +1839,8 @@ class GatewayStreamConsumer:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                metadata=self.metadata,
+                reply_to=self._initial_reply_to_id,
+                metadata=self._metadata_for_send(final=False),
             )
             # Note: do NOT set _already_sent = True here.
             # Commentary messages are interim status updates (e.g. "Using browser

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -609,7 +609,11 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
-        reply_target = reply_to or (metadata or {}).get("thread_id")
+        # Prefer explicit reply_to, then metadata.thread_id (Slack-style), then
+        # metadata.reply_to_message_id (gateway stream consumer / progress).
+        # Without the last, interim commentary posts flat in the channel.
+        meta = metadata or {}
+        reply_target = reply_to or meta.get("thread_id") or meta.get("reply_to_message_id")
         if reply_target:
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=content)

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -407,6 +407,29 @@ class TestBuzzAdapterSend:
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
+    @pytest.mark.asyncio
+    async def test_send_uses_metadata_reply_to_message_id(self):
+        """Gateway stream/progress pass reply anchors via metadata.
+
+        Without honoring reply_to_message_id, mid-turn commentary posts as
+        new top-level channel messages instead of thread replies.
+        """
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-reply", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "threaded reply",
+            metadata={"reply_to_message_id": "root-event-abc"},
+        )
+        assert result.success is True
+        args, _stdin = cli.calls[0]
+        assert "--reply-to" in args
+        assert args[args.index("--reply-to") + 1] == "root-event-abc"
+
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1925,3 +1925,14 @@ class TestSlackReplyInThreadProgressRouting:
             event_message_id="1700000000.000100",
             reply_in_thread=False,
         ) is None
+
+    def test_buzz_uses_event_message_id_as_progress_thread(self):
+        """Buzz has no native thread_id; progress must reply-to the trigger."""
+        from gateway.run import _resolve_progress_thread_id
+
+        assert _resolve_progress_thread_id(
+            "buzz",
+            source_thread_id=None,
+            event_message_id="evt-trigger-001",
+            reply_in_thread=True,
+        ) == "evt-trigger-001"


### PR DESCRIPTION
## Summary
Buzz channel threading depends on `buzz messages send --reply-to <event-id>`. Hermes was dropping the reply anchor for most mid-turn and progress sends, so agents (e.g. Kathy) flooded channels with top-level posts instead of nesting under the triggering message.

## Changes
1. **`plugins/platforms/buzz/adapter.py`** — honor `metadata.reply_to_message_id` (gateway stream/progress path), not only `thread_id`.
2. **`gateway/stream_consumer.py`** — pass `reply_to=self._initial_reply_to_id` on interim commentary sends.
3. **`gateway/run.py`** — treat `buzz` like slack/mattermost for progress thread resolution; set `_progress_reply_to` to the trigger event id for buzz.

## Tests
- `test_send_uses_metadata_reply_to_message_id` (buzz adapter)
- `test_buzz_uses_event_message_id_as_progress_thread` (progress routing)

## Config note (optional hygiene)
For Buzz, official docs still recommend:
```yaml
display:
  platforms:
    buzz:
      interim_assistant_messages: false
      tool_progress: "off"
```
This PR fixes threading even if those remain on; suppressing interim traffic further reduces noise.

## Motivation
Live deploy: one agent produced ~65 channel posts with only ~8 threaded. After these fixes + display hygiene, new replies nest under the user message.