### PR TITLE
fix(cli): scan payloads during recovery inspection

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -277,6 +277,8 @@ def _table_columns(conn: sqlite3.Connection, table: str) -> list[str]:
 def _table_inventory(
     conn: sqlite3.Connection,
     table: str,
+    *,
+    scan_payload: bool = False,
 ) -> dict[str, Any]:
     result: dict[str, Any] = {"available": False, "columns": [], "rows": None}
     try:
@@ -285,15 +287,35 @@ def _table_inventory(
             return result
         result["available"] = True
         result["columns"] = columns
-        result["rows"] = int(
-            conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
-        )
+        if scan_payload:
+            # COUNT(*) may be answered entirely from a healthy covering index,
+            # masking malformed table leaves or overflow pages. Inspect-only
+            # promises readability, so force the table b-tree and materialize
+            # every payload column one row at a time (bounded to one row of
+            # memory). Derived indexes are rebuilt in the destination and must
+            # not decide whether canonical payload data is recoverable.
+            quoted = ", ".join(f'"{column}"' for column in columns)
+            rows = 0
+            for _row in conn.execute(f'SELECT {quoted} FROM "{table}" NOT INDEXED'):
+                rows += 1
+            result["rows"] = rows
+            result["payload_readable"] = True
+        else:
+            result["rows"] = int(
+                conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+            )
     except sqlite3.DatabaseError as exc:
+        if scan_payload and result["available"]:
+            result["payload_readable"] = False
         result["error"] = str(exc)
     return result
 
 
-def _inspect_connection(conn: sqlite3.Connection) -> dict[str, Any]:
+def _inspect_connection(
+    conn: sqlite3.Connection,
+    *,
+    scan_payload: bool = False,
+) -> dict[str, Any]:
     conn.execute("PRAGMA writable_schema=ON")
     report: dict[str, Any] = {"tables": {}, "errors": [], "warnings": []}
     try:
@@ -306,7 +328,11 @@ def _inspect_connection(conn: sqlite3.Connection) -> dict[str, Any]:
         report["warnings"].append(f"journal mode: {exc}")
 
     for table in (*_CANONICAL_TABLES, "state_meta", *_TOPIC_TABLES):
-        report["tables"][table] = _table_inventory(conn, table)
+        report["tables"][table] = _table_inventory(
+            conn,
+            table,
+            scan_payload=scan_payload,
+        )
 
     for required in ("sessions", "messages"):
         table_report = report["tables"][required]
@@ -321,6 +347,8 @@ def _inspect_connection(conn: sqlite3.Connection) -> dict[str, Any]:
 def _snapshot_and_inspect(
     source: Path,
     work_root: Path,
+    *,
+    scan_payload: bool = False,
 ) -> tuple[tempfile.TemporaryDirectory[str], Path, dict[str, Any]]:
     before = _source_fingerprint(source)
     temp_dir = tempfile.TemporaryDirectory(
@@ -351,7 +379,7 @@ def _snapshot_and_inspect(
             timeout=1.0,
         )
         try:
-            inspection = _inspect_connection(conn)
+            inspection = _inspect_connection(conn, scan_payload=scan_payload)
         finally:
             conn.close()
         inspection["source_bundle"] = copied
@@ -371,7 +399,11 @@ def inspect_session_database(
 
     source, _, work_root = _validate_paths(source_path, work_dir=work_dir)
     disk_space = _disk_space_preflight(source, work_root, None)
-    temp_dir, _, inspection = _snapshot_and_inspect(source, work_root)
+    temp_dir, _, inspection = _snapshot_and_inspect(
+        source,
+        work_root,
+        scan_payload=True,
+    )
     try:
         return {
             "operation": "inspect",

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -479,12 +479,87 @@ def test_partial_recovery_keeps_messages_when_sessions_are_unsalvageable(
     assert report["installed"] is False
 
 
+def test_inspection_reads_payload_not_only_covering_count_index(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "count-readable-payload-corrupt.db"
+    message_count = 320
+    messages_root, count_index_root = _make_page_spanning_source(
+        source,
+        message_count,
+    )
+    assert count_index_root is not None, (
+        "fixture requires SQLite to satisfy COUNT(*) from a covering index"
+    )
+    _corrupt_middle_table_leaf(source, messages_root)
+
+    conn = sqlite3.connect(str(source), isolation_level=None)
+    try:
+        plan = " ".join(
+            str(row[3])
+            for row in conn.execute(
+                "EXPLAIN QUERY PLAN SELECT COUNT(*) FROM messages"
+            ).fetchall()
+        )
+        assert "COVERING INDEX" in plan
+        assert (
+            conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+            == message_count
+        )
+        with pytest.raises(sqlite3.DatabaseError, match="malformed"):
+            conn.execute("SELECT * FROM messages").fetchall()
+    finally:
+        conn.close()
+
+    inspection = inspect_session_database(source, work_dir=tmp_path)
+
+    messages = inspection["tables"]["messages"]
+    assert messages["available"] is True
+    assert messages["rows"] is None
+    assert messages["payload_readable"] is False
+    assert "malformed" in messages["error"]
+    assert inspection["recoverable"] is False
 
 
+def test_inspection_ignores_corrupt_covering_index_when_payload_is_readable(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "count-index-corrupt-payload-readable.db"
+    message_count = 320
+    _messages_root, count_index_root = _make_page_spanning_source(
+        source,
+        message_count,
+    )
+    assert count_index_root is not None, (
+        "fixture requires SQLite to satisfy COUNT(*) from a covering index"
+    )
+    _corrupt_middle_table_leaf(
+        source,
+        count_index_root,
+        require_interior=False,
+    )
 
+    conn = sqlite3.connect(str(source), isolation_level=None)
+    try:
+        with pytest.raises(sqlite3.DatabaseError, match="malformed"):
+            conn.execute("SELECT COUNT(*) FROM messages").fetchone()
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM messages NOT INDEXED"
+            ).fetchone()[0]
+            == message_count
+        )
+    finally:
+        conn.close()
 
+    inspection = inspect_session_database(source, work_dir=tmp_path)
 
-
+    messages = inspection["tables"]["messages"]
+    assert messages["available"] is True
+    assert messages["rows"] == message_count
+    assert messages["payload_readable"] is True
+    assert "error" not in messages
+    assert inspection["recoverable"] is True
 
 
 def test_cli_allow_partial_salvages_rows_across_a_corrupt_leaf(


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive `hermes sessions recover --inspect-only` result when SQLite can answer `COUNT(*)` from a healthy covering index while canonical table payload pages are malformed.

`inspect_session_database()` now performs a bounded-memory, full-column table scan with `NOT INDEXED`. Normal recovery keeps its lightweight pre-copy inventory because the copy phase already traverses every payload, avoiding a redundant full-database read.

## Related Issue

Fixes #86224

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add an opt-in payload scan to `hermes_cli/session_recovery.py` inspection internals.
- Force inspection scans through the canonical table B-tree with `NOT INDEXED` and materialize one full row at a time.
- Add `payload_readable` to deep per-table inspection results and preserve existing lightweight inventory behavior for normal recovery.
- Add physical SQLite regressions for both directions: a malformed `messages` table leaf with a readable covering count index, and a malformed covering index with readable table payloads.

## How to Test

1. Run `HERMES_PYTHON=/path/to/python scripts/run_tests.sh -j 1 tests/hermes_cli/test_session_recovery.py -q`.
2. Run `HERMES_PYTHON=/path/to/python scripts/run_tests.sh -j 2 tests/hermes_cli -q`.
3. Run `ruff check hermes_cli/session_recovery.py tests/hermes_cli/test_session_recovery.py`.
4. Run `python scripts/check-windows-footguns.py hermes_cli/session_recovery.py tests/hermes_cli/test_session_recovery.py`.
5. Run `ty check hermes_cli/session_recovery.py`.

The regressions prove both sides of the inspection boundary before checking Hermes behavior:

- `SELECT COUNT(*) FROM messages` still returns all 320 rows through a covering index;
- `SELECT * FROM messages` raises `database disk image is malformed`;
- deep inspection sets `payload_readable: false` and `recoverable: false` for that malformed table payload;
- after corrupting only the covering index, ordinary `COUNT(*)` fails while `COUNT(*) ... NOT INDEXED` and deep payload inspection still read all 320 rows;
- deep inspection then sets `payload_readable: true` and `recoverable: true`, so a rebuildable secondary index cannot create an inspection false negative.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.8.0-63-generic, Python 3.11.14 (uv standalone runtime)

The full repository suite was not run locally. The complete `tests/hermes_cli` run finished with **5,330 passed, 3 failed, and 59 skipped**. All three failures reproduce unchanged in a detached, unmodified `origin/main@0a8765a236` worktree under the same hermetic runner:

- `test_early_recovery.py::test_early_recovery_module_is_stdlib_only`
- `test_doctor.py::test_doctor_reports_vercel_backend_diagnostics`
- `test_update_import_guard.py::test_import_guard_flags_missing_first_party_module`

The focused session-recovery file passed in both its standalone run and the broader suite. GitHub Actions will run the full platform matrix.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; this corrects existing inspect semantics and adds an inline rationale
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the Windows footgun check passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused recovery tests after rebasing onto current `main`:

```text
6 tests passed, 0 failed
```

Broader CLI suite:

```text
5330 passed, 3 baseline-reproducible failures, 59 skipped
```

Static checks:

```text
All checks passed!
ty: All checks passed!
No Windows footguns found (2 file(s) scanned).
```