### PR TITLE
feat(website): Skills Hub picker embed mode (?embed=picker)

### DIFF
--- a/website/src/pages/skills/index.tsx
+++ b/website/src/pages/skills/index.tsx
@@ -285,6 +285,7 @@ function SkillCard({
   onCategoryClick,
   onTagClick,
   style,
+  onPick,
 }: {
   skill: Skill;
   query: string;
@@ -293,6 +294,8 @@ function SkillCard({
   onCategoryClick: (cat: string) => void;
   onTagClick: (tag: string) => void;
   style?: React.CSSProperties;
+  /** Picker embed mode: render "+ Add to this Agent" and call this. */
+  onPick?: (skill: Skill) => void;
 }) {
   const src = SOURCE_CONFIG[skill.source] || SOURCE_CONFIG["optional"];
   const icon = CATEGORY_ICONS[skill.category] || "\u{1F4E6}";
@@ -420,6 +423,17 @@ function SkillCard({
                 text={skill.installCmd || `hermes skills install ${skill.name}`}
               />
             </div>
+            {onPick ? (
+              <button
+                className={styles.pickBtn}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onPick(skill);
+                }}
+              >
+                + Add to this Agent
+              </button>
+            ) : null}
             <div className={styles.cardLinks}>
               {skill.docsPath ? (
                 <a
@@ -486,6 +500,36 @@ function buildSearchHaystack(s: Skill): string {
 }
 
 export default function SkillsDashboard() {
+  // Picker embed mode (?embed=picker): the page is being iframed by a host
+  // app (Hermes desktop's Bot Mode agent editor) as a skill PICKER. Site
+  // chrome is hidden via a CSS class and every card gains an
+  // "+ Add to this Agent" button that posts
+  //   { type: 'hermes-skill-pick', name, identifier, installCmd, source }
+  // to the parent window. The HOST performs the actual install through its
+  // own gateway (skills.manage) — the page never installs anything, so
+  // there is no origin to trust in this direction; parents must validate
+  // event.origin themselves before acting on the message.
+  const pickerMode =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("embed") === "picker";
+
+  const pickSkill = useCallback(
+    (skill: Skill) => {
+      if (typeof window === "undefined" || window.parent === window) return;
+      window.parent.postMessage(
+        {
+          type: "hermes-skill-pick",
+          name: skill.name,
+          identifier: skill.identifier || skill.name,
+          installCmd: skill.installCmd || `hermes skills install ${skill.name}`,
+          source: skill.source,
+        },
+        "*"
+      );
+    },
+    []
+  );
+
   // Lazy-loaded data. Was bundled into the JS chunk (~22 MB at 50k skills,
   // which made the initial page load unusable on mobile). Now fetched on
   // mount from the same CDN that serves the docs.
@@ -636,7 +680,7 @@ export default function SkillsDashboard() {
       title="Skills Hub"
       description="Browse all skills and plugins available for Hermes Agent"
     >
-      <div className={styles.page}>
+      <div className={`${styles.page} ${pickerMode ? styles.pickerMode : ""}`}>
         <header className={styles.hero}>
           <div className={styles.heroGlow} />
           <div className={styles.heroContent}>
@@ -869,6 +913,7 @@ export default function SkillsDashboard() {
                         onCategoryClick={handleCategoryClick}
                         onTagClick={handleTagClick}
                         style={{ animationDelay: `${Math.min(i, 20) * 25}ms` }}
+                        onPick={pickerMode ? pickSkill : undefined}
                       />
                     );
                   })}

--- a/website/src/pages/skills/styles.module.css
+++ b/website/src/pages/skills/styles.module.css
@@ -969,3 +969,40 @@
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   }
 }
+
+/* ── Picker embed mode (?embed=picker) ──────────────────────────────────────
+   The page is iframed by a host app as a skill picker: hide the docs site
+   chrome (navbar/footer render outside .page, so target them via :global)
+   and the hero, tighten spacing, and style the "+ Add to this Agent" CTA. */
+.pickerMode .hero {
+  display: none;
+}
+
+.pickerMode {
+  padding-top: 0.5rem;
+}
+
+:global(html):has(.pickerMode) :global(.navbar),
+:global(html):has(.pickerMode) :global(footer) {
+  display: none;
+}
+
+.pickBtn {
+  display: block;
+  width: 100%;
+  margin-top: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  border: 1px solid var(--ifm-color-primary);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--ifm-color-primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.pickBtn:hover {
+  background: var(--ifm-color-primary);
+  color: var(--ifm-background-color, #0b0b0e);
+}


### PR DESCRIPTION
Bot Mode's agent editor wants the REAL Skills Hub page as its skill browser — the full catalog UI at /docs/skills, embedded, with a '+ Add to this Agent' action per skill (maintainer request). Cross-origin scripting into the docs site is impossible from an iframe host, so the page itself gains a first-class picker mode:

- `?embed=picker`: hides docs chrome (navbar/footer/hero via CSS, including a :global(html):has() rule so the chrome outside the page root is caught), tightens spacing
- Every skill card renders **+ Add to this Agent**, posting `{type: 'hermes-skill-pick', name, identifier, installCmd, source}` to `window.parent`
- The page never installs anything and receives nothing — one-way notification; hosts must validate `event.origin` (docs origin) before acting, and perform installs through their own gateway (`skills.manage`)

No query param → byte-identical behavior to today. First consumer is the Bot Mode plugin's Skills tab; the mode is generic for any Hermes surface that wants a skills picker.