### PR TITLE
fix(cli): report omitted session recovery state

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -45,6 +45,23 @@ _TOPIC_TABLES = (
     "telegram_dm_topic_bindings",
 )
 
+_OMITTED_DURABLE_TABLES = ("delivery_obligations",)
+_KNOWN_DELIVERY_STATES = frozenset({
+    "pending",
+    "attempting",
+    "failed",
+    "delivered",
+    "abandoned",
+})
+_TERMINAL_DELIVERY_STATES = frozenset({"delivered", "abandoned"})
+_UNKNOWN_DEFAULT = object()
+# The async-delegation migration adds origin_session_id without a SQL default,
+# so legacy rows remain NULL. The durable writer stores "" when no origin is
+# available. Both values mean "no origin" for omission reporting.
+_SEMANTIC_COLUMN_EMPTY_VALUES: dict[tuple[str, str], tuple[object, ...]] = {
+    ("async_delegations", "origin_session_id"): (None, ""),
+}
+
 # These values describe derived indexes or the schema that owns an optional
 # table. A fresh destination must generate them from its own current schema.
 _GENERATED_META_KEYS = frozenset({
@@ -272,6 +289,49 @@ def _copy_source_bundle(source: Path, snapshot_dir: Path) -> tuple[Path, list[st
 
 def _table_columns(conn: sqlite3.Connection, table: str) -> list[str]:
     return [str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table}")')]
+
+
+def _table_column_defaults(
+    conn: sqlite3.Connection,
+    table: str,
+) -> dict[str, Optional[str]]:
+    return {
+        str(row[1]): None if row[4] is None else str(row[4])
+        for row in conn.execute(f'PRAGMA table_info("{table}")')
+    }
+
+
+def _quote_identifier(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _schema_object_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
+def _source_table_columns_with_error(
+    source: sqlite3.Connection,
+    table: str,
+) -> tuple[list[str], Optional[str]]:
+    try:
+        columns = _table_columns(source, table)
+    except sqlite3.DatabaseError as exc:
+        return [], str(exc)
+    if columns:
+        return columns, None
+    try:
+        if _schema_object_exists(source, table):
+            # PRAGMA writable_schema=ON deliberately hides malformed schema
+            # objects from table_info so readable canonical tables can still
+            # be salvaged. sqlite_master remains the source-of-truth inventory.
+            return [], "source table schema is unreadable"
+    except sqlite3.DatabaseError as exc:
+        return [], str(exc)
+    return [], None
 
 
 def _table_inventory(
@@ -792,6 +852,236 @@ def _copy_table_salvage(
     return result
 
 
+def _sqlite_literal_default(default_sql: Optional[str]) -> object:
+    if default_sql is None:
+        return None
+    value = default_sql.strip()
+    while len(value) >= 2 and value.startswith("(") and value.endswith(")"):
+        value = value[1:-1].strip()
+    upper = value.upper()
+    if upper == "NULL":
+        return None
+    if upper == "TRUE":
+        return 1
+    if upper == "FALSE":
+        return 0
+    if len(value) >= 2 and value[0] == value[-1] == "'":
+        return value[1:-1].replace("''", "'")
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        return value[1:-1].replace('""', '"')
+    if len(value) >= 3 and upper.startswith("X'") and value.endswith("'"):
+        try:
+            return bytes.fromhex(value[2:-1])
+        except ValueError:
+            return _UNKNOWN_DEFAULT
+    try:
+        return int(value, 10)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return _UNKNOWN_DEFAULT
+
+
+def _source_column_has_non_default_value(
+    source: sqlite3.Connection,
+    table: str,
+    column: str,
+    default_sql: Optional[str],
+) -> bool:
+    quoted_table = _quote_identifier(table)
+    quoted_column = _quote_identifier(column)
+    semantic_empty_values = _SEMANTIC_COLUMN_EMPTY_VALUES.get((table, column))
+    if semantic_empty_values is not None:
+        predicate = " AND ".join(
+            f"{quoted_column} IS NOT ?" for _value in semantic_empty_values
+        )
+        parameters = semantic_empty_values
+    else:
+        default_value = _sqlite_literal_default(default_sql)
+        if default_value is _UNKNOWN_DEFAULT:
+            predicate = f"{quoted_column} IS NOT NULL"
+            parameters = ()
+        else:
+            predicate = f"{quoted_column} IS NOT ?"
+            parameters = (default_value,)
+    row = source.execute(
+        f"SELECT 1 FROM {quoted_table} NOT INDEXED WHERE {predicate} LIMIT 1",
+        parameters,
+    ).fetchone()
+    return row is not None
+
+
+def _record_unreadable_table_omission(
+    report: dict[str, Any],
+    table: str,
+    error: str,
+    *,
+    copy_status: Optional[str] = None,
+) -> None:
+    table_report: dict[str, Any] = {
+        "omitted": True,
+        "copied_rows": 0,
+        "inspection_error": error,
+    }
+    if copy_status is not None:
+        table_report["copy_status"] = copy_status
+    report["tables"][table] = table_report
+    report["loss_detected"] = True
+    report["warnings"].append(
+        f"{table}: recovery omitted a source table whose schema could not be read"
+    )
+
+
+def _build_omission_report(
+    source: sqlite3.Connection,
+    destination: sqlite3.Connection,
+    copy_report: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Describe durable source state that the current recovery omits.
+
+    This is deliberately reporting-only. Delivery obligations carry
+    at-least-once replay semantics and must not be copied or re-owned by an
+    offline recovery tool without an explicit policy decision.
+    """
+
+    report: dict[str, Any] = {
+        "tables": {},
+        "columns": {},
+        "warnings": [],
+        "loss_detected": False,
+    }
+
+    for table, table_copy in copy_report.items():
+        source_columns, schema_error = _source_table_columns_with_error(source, table)
+        if schema_error is not None:
+            _record_unreadable_table_omission(
+                report,
+                table,
+                schema_error,
+                copy_status=table_copy.get("status"),
+            )
+            continue
+        if not source_columns:
+            continue
+        source_defaults = _table_column_defaults(source, table)
+        destination_columns = _table_columns(destination, table)
+        omitted_columns = [
+            column for column in source_columns if column not in destination_columns
+        ]
+        if not omitted_columns:
+            continue
+
+        material_columns: list[str] = []
+        inspection_errors: dict[str, str] = {}
+        for column in omitted_columns:
+            try:
+                if _source_column_has_non_default_value(
+                    source,
+                    table,
+                    column,
+                    source_defaults.get(column),
+                ):
+                    material_columns.append(column)
+            except sqlite3.DatabaseError as exc:
+                inspection_errors[column] = str(exc)
+
+        column_report: dict[str, Any] = {
+            "copy_status": table_copy.get("status"),
+            "omitted_source_columns": omitted_columns,
+            "columns_with_non_default_values": material_columns,
+        }
+        if inspection_errors:
+            column_report["inspection_errors"] = inspection_errors
+        report["columns"][table] = column_report
+
+        if material_columns:
+            report["loss_detected"] = True
+            report["warnings"].append(
+                f"{table}: recovery omitted source-only column(s) with "
+                f"non-default values: {', '.join(material_columns)}"
+            )
+        if inspection_errors:
+            report["loss_detected"] = True
+            report["warnings"].append(
+                f"{table}: recovery could not determine whether omitted "
+                "source-only column(s) contain data: "
+                + ", ".join(sorted(inspection_errors))
+            )
+
+    for table in _OMITTED_DURABLE_TABLES:
+        source_columns, schema_error = _source_table_columns_with_error(source, table)
+        if schema_error is not None:
+            _record_unreadable_table_omission(report, table, schema_error)
+            continue
+        if not source_columns:
+            continue
+
+        table_report: dict[str, Any] = {
+            "omitted": True,
+            "copied_rows": 0,
+        }
+        report["tables"][table] = table_report
+        if "state" not in source_columns:
+            table_report["inspection_error"] = "source table has no state column"
+            report["loss_detected"] = True
+            report["warnings"].append(
+                f"{table}: recovery omitted the table and its states could not "
+                "be inspected"
+            )
+            continue
+
+        state_counts: dict[str, int] = {}
+        try:
+            quoted_table = _quote_identifier(table)
+            for row in source.execute(
+                f'SELECT "state" FROM {quoted_table} NOT INDEXED'
+            ):
+                if row[0] is None:
+                    state = "<NULL>"
+                else:
+                    raw_state = str(row[0])
+                    state = (
+                        raw_state
+                        if raw_state in _KNOWN_DELIVERY_STATES
+                        else "<UNKNOWN>"
+                    )
+                state_counts[state] = state_counts.get(state, 0) + 1
+        except sqlite3.DatabaseError as exc:
+            table_report["inspection_error"] = str(exc)
+            report["loss_detected"] = True
+            report["warnings"].append(
+                f"{table}: recovery omitted the table and its states could not "
+                f"be read: {exc}"
+            )
+            continue
+
+        source_rows = sum(state_counts.values())
+        non_terminal_rows = sum(
+            count
+            for state, count in state_counts.items()
+            if state not in _TERMINAL_DELIVERY_STATES
+        )
+        table_report.update({
+            "source_rows": source_rows,
+            "state_counts": state_counts,
+            "non_terminal_rows": non_terminal_rows,
+        })
+        if non_terminal_rows:
+            report["loss_detected"] = True
+            report["warnings"].append(
+                f"{table}: recovery omitted {non_terminal_rows} non-terminal "
+                "delivery obligation(s); pending final replies may be lost"
+            )
+        elif source_rows:
+            report["warnings"].append(
+                f"{table}: recovery omitted {source_rows} terminal delivery "
+                "obligation(s) under the current recovery policy"
+            )
+
+    return report
+
+
 def _copy_state_meta(
     source: sqlite3.Connection,
     destination: sqlite3.Connection,
@@ -1168,6 +1458,7 @@ def _verify_recovered_database(
     copy_report: dict[str, dict[str, Any]],
     allow_partial: bool = False,
     orphan_cleanup: Optional[dict[str, Any]] = None,
+    omissions: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     verification: dict[str, Any] = {
         "errors": [],
@@ -1295,6 +1586,12 @@ def _verify_recovered_database(
                 verification["loss_detected"] = True
             else:
                 verification["errors"].append(message)
+
+        if omissions is not None:
+            verification["omissions"] = omissions
+            verification["warnings"].extend(omissions.get("warnings") or [])
+            if omissions.get("loss_detected"):
+                verification["loss_detected"] = True
 
         if orphan_cleanup:
             orphan_count = int(
@@ -1483,6 +1780,17 @@ def _recover_via_lost_and_found(
     )
     verification["complete"] = False
 
+    omissions = {
+        "tables": {},
+        "columns": {},
+        "warnings": [
+            "Omission inventory is unavailable because the source table "
+            "schemas were unreadable."
+        ],
+        "loss_detected": True,
+        "inspection_unavailable": True,
+    }
+
     source_unchanged = (
         _source_fingerprint(source) == inspection["source_fingerprint"]
     )
@@ -1515,6 +1823,7 @@ def _recover_via_lost_and_found(
         "session_stubs": stubbing,
         "fts_rebuild": fts,
         "copy": copy_report,
+        "omissions": omissions,
         "orphan_cleanup": {
             "sessions_reconstructed": stubbing["sessions_stubbed"],
             "messages_retained": stubbing["messages_retained"],
@@ -1662,6 +1971,11 @@ def recover_session_database(
                     progress_cb=progress_cb,
                     source_rows=table_inspection.get("rows"),
                 )
+            omissions = _build_omission_report(
+                source_conn,
+                destination_conn,
+                copy_report,
+            )
             orphan_cleanup = (
                 _cleanup_partial_orphans(destination_conn)
                 if allow_partial
@@ -1684,6 +1998,7 @@ def recover_session_database(
             copy_report=copy_report,
             allow_partial=allow_partial,
             orphan_cleanup=orphan_cleanup,
+            omissions=omissions,
         )
         source_unchanged = (
             _source_fingerprint(source) == inspection["source_fingerprint"]
@@ -1710,6 +2025,7 @@ def recover_session_database(
                 "warnings": inspection["warnings"],
             },
             "copy": copy_report,
+            "omissions": omissions,
             "orphan_cleanup": orphan_cleanup,
             "derived_metadata": derived_metadata,
             "verification": verification,

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -228,6 +228,21 @@ def cmd_sessions(args, sessions_parser=None):
                 "and orphan count in the JSON report before installing it."
             )
             return 0
+        omissions = report.get("omissions") or {}
+        if report.get("verified") and omissions.get("loss_detected"):
+            print(f"✓ Recovery output verified with known omissions at: {output}")
+            print("  The output passed integrity and foreign-key checks.")
+            print("  The active session database was not changed.")
+            omission_warnings = omissions.get("warnings") or []
+            if omission_warnings:
+                print("  Known omissions:")
+                for warning in omission_warnings:
+                    print(f"    - {warning}")
+            print(
+                "  This output is incomplete. Review the JSON report "
+                "before installing it."
+            )
+            return 0
         print("✗ Recovery output did not pass every verification check.")
         print("  Do not install it. Review the JSON report for partial data or errors.")
         return 1

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -19,6 +19,7 @@ from hermes_cli.session_recovery import (
     SessionRecoverySourceError,
     inspect_session_database,
     recover_session_database,
+    write_recovery_report,
 )
 
 
@@ -28,6 +29,10 @@ def _sha256(path: Path) -> str:
         for chunk in iter(lambda: handle.read(64 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _table_column_names(conn: sqlite3.Connection, table: str) -> list[str]:
+    return [str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table}")')]
 
 
 def _make_source(path: Path) -> dict[str, int]:
@@ -300,6 +305,84 @@ def _corrupt_table_root(path: Path, root_page: int) -> None:
     path.write_bytes(data)
 
 
+def _make_auxiliary_omission_source(
+    path: Path,
+    *,
+    delivery_states: tuple[str, ...],
+    origin_session_id: str | None = None,
+) -> None:
+    db = SessionDB(db_path=path)
+    try:
+        db.create_session("omission-session", "cli", cwd="/tmp/omission")
+        db.append_message("omission-session", "user", "synthetic fixture")
+    finally:
+        db.close()
+
+    from gateway.delivery_ledger import _initialize_schema as init_delivery_schema
+    from tools.async_delegation import _initialize_schema as init_delegation_schema
+
+    conn = sqlite3.connect(str(path), isolation_level=None)
+    try:
+        init_delivery_schema(conn)
+        init_delegation_schema(conn)
+        for index, state in enumerate(delivery_states):
+            conn.execute(
+                """INSERT INTO delivery_obligations (
+                    obligation_id, session_key, platform, chat_id, thread_id,
+                    content, state, attempts, created_at, updated_at,
+                    owner_pid, owner_started_at, last_error
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    f"obligation-{index}",
+                    "telegram:chat-1",
+                    "telegram",
+                    "chat-1",
+                    None,
+                    "synthetic final response",
+                    state,
+                    0,
+                    1.0,
+                    1.0,
+                    999_999,
+                    1,
+                    None,
+                ),
+            )
+        if origin_session_id is not None:
+            conn.execute(
+                """INSERT INTO async_delegations (
+                    delegation_id, origin_session, state, dispatched_at,
+                    updated_at, origin_session_id
+                ) VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    "delegation-omission",
+                    "omission-session",
+                    "completed",
+                    1.0,
+                    1.0,
+                    origin_session_id,
+                ),
+            )
+    finally:
+        conn.close()
+
+
+def _malform_table_schema(path: Path, table: str) -> None:
+    conn = sqlite3.connect(str(path), isolation_level=None)
+    try:
+        schema_version = int(conn.execute("PRAGMA schema_version").fetchone()[0])
+        conn.execute("PRAGMA writable_schema=ON")
+        cursor = conn.execute(
+            "UPDATE sqlite_master SET sql = ? "
+            "WHERE type = 'table' AND name = ?",
+            (f"CREATE TABLE {table}(", table),
+        )
+        assert cursor.rowcount == 1
+        conn.execute(f"PRAGMA schema_version = {schema_version + 1}")
+    finally:
+        conn.close()
+
+
 def test_snapshot_blocks_connections_opened_during_the_copy(
     tmp_path: Path,
 ) -> None:
@@ -479,12 +562,203 @@ def test_partial_recovery_keeps_messages_when_sessions_are_unsalvageable(
     assert report["installed"] is False
 
 
+def test_recovery_reports_non_terminal_and_lazy_schema_omissions(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "auxiliary-source.db"
+    output = tmp_path / "auxiliary-recovered.db"
+    _make_auxiliary_omission_source(
+        source,
+        delivery_states=("pending", "delivered", "unexpected-private-state"),
+        origin_session_id="raw-origin-session-id",
+    )
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+    report_path = tmp_path / "auxiliary-recovery.json"
+    write_recovery_report(report_path, report)
+    persisted_report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert "delivery_obligations" in persisted_report["omissions"]["tables"]
+
+    omissions = report["omissions"]
+    delivery = omissions["tables"]["delivery_obligations"]
+    assert delivery["state_counts"] == {
+        "pending": 1,
+        "delivered": 1,
+        "<UNKNOWN>": 1,
+    }
+    assert delivery["non_terminal_rows"] == 2
+    delegation = omissions["columns"]["async_delegations"]
+    assert delegation["omitted_source_columns"] == ["origin_session_id"]
+    assert delegation["columns_with_non_default_values"] == ["origin_session_id"]
+    assert omissions["loss_detected"] is True
+    assert report["verification"]["loss_detected"] is True
+    assert report["complete"] is False
+    assert report["partial"] is True
+    assert report["verified"] is True
+    assert any(
+        "pending final replies may be lost" in warning
+        for warning in report["verification"]["warnings"]
+    )
+
+    conn = sqlite3.connect(str(output), isolation_level=None)
+    try:
+        assert _table_column_names(conn, "delivery_obligations") == []
+        assert "origin_session_id" not in _table_column_names(
+            conn,
+            "async_delegations",
+        )
+    finally:
+        conn.close()
 
 
+def test_terminal_delivery_omission_is_reported_without_claiming_data_loss(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "terminal-delivery-source.db"
+    output = tmp_path / "terminal-delivery-recovered.db"
+    _make_auxiliary_omission_source(
+        source,
+        delivery_states=("delivered", "abandoned"),
+        origin_session_id="",
+    )
+    conn = sqlite3.connect(str(source), isolation_level=None)
+    try:
+        conn.execute(
+            """INSERT INTO async_delegations (
+                delegation_id, origin_session, state, dispatched_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?)""",
+            ("delegation-null-origin", "omission-session", "completed", 1.0, 1.0),
+        )
+    finally:
+        conn.close()
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    delivery = report["omissions"]["tables"]["delivery_obligations"]
+    assert delivery["state_counts"] == {"delivered": 1, "abandoned": 1}
+    assert delivery["non_terminal_rows"] == 0
+    delegation = report["omissions"]["columns"]["async_delegations"]
+    assert delegation["columns_with_non_default_values"] == []
+    assert report["omissions"]["loss_detected"] is False
+    assert report["verification"]["loss_detected"] is False
+    assert report["complete"] is True
+    assert report["partial"] is False
+    assert any(
+        "terminal delivery obligation" in warning
+        for warning in report["verification"]["warnings"]
+    )
 
 
+def test_unreadable_omitted_table_schema_is_reported_as_loss(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "malformed-auxiliary-schema.db"
+    output = tmp_path / "malformed-auxiliary-recovered.db"
+    _make_auxiliary_omission_source(
+        source,
+        delivery_states=("pending",),
+    )
+    _malform_table_schema(source, "delivery_obligations")
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    delivery = report["omissions"]["tables"]["delivery_obligations"]
+    assert delivery["omitted"] is True
+    assert delivery["inspection_error"] == "source table schema is unreadable"
+    assert report["omissions"]["loss_detected"] is True
+    assert report["verification"]["loss_detected"] is True
+    assert report["complete"] is False
+    assert report["partial"] is True
+    assert report["verified"] is True
 
 
+def test_source_only_literal_default_is_reported_without_claiming_data_loss(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "defaulted-column-source.db"
+    output = tmp_path / "defaulted-column-recovered.db"
+    _make_source(source)
+    conn = sqlite3.connect(str(source), isolation_level=None)
+    try:
+        conn.execute(
+            "ALTER TABLE async_delegations "
+            "ADD COLUMN future_marker TEXT DEFAULT 'unset'"
+        )
+    finally:
+        conn.close()
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    delegation = report["omissions"]["columns"]["async_delegations"]
+    assert delegation["omitted_source_columns"] == ["future_marker"]
+    assert delegation["columns_with_non_default_values"] == []
+    assert report["omissions"]["loss_detected"] is False
+    assert report["complete"] is True
+    assert report["partial"] is False
+
+
+@pytest.mark.parametrize(
+    ("delivery_states", "expected_complete", "expected_loss", "expected_message"),
+    [
+        (("delivered",), True, False, "Recovered database verified at"),
+        (
+            ("pending",),
+            False,
+            True,
+            "Recovery output verified with known omissions at",
+        ),
+    ],
+)
+def test_cli_distinguishes_verified_auxiliary_omissions(
+    tmp_path: Path,
+    delivery_states: tuple[str, ...],
+    expected_complete: bool,
+    expected_loss: bool,
+    expected_message: str,
+) -> None:
+    state_label = delivery_states[0]
+    source = tmp_path / f"cli-{state_label}-source.db"
+    output = tmp_path / f"cli-{state_label}-recovered.db"
+    _make_auxiliary_omission_source(
+        source,
+        delivery_states=delivery_states,
+        origin_session_id="",
+    )
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(tmp_path / f"cli-{state_label}-home")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "sessions",
+            "recover",
+            "--source",
+            str(source),
+            "--output",
+            str(output),
+            "--work-dir",
+            str(tmp_path),
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert expected_message in result.stdout
+    assert "did not pass every verification check" not in result.stdout
+    report_path = output.with_name(output.name + ".recovery.json")
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["complete"] is expected_complete
+    assert report["verified"] is True
+    assert report["omissions"]["loss_detected"] is expected_loss
+    if expected_loss:
+        assert "pending final replies may be lost" in result.stdout
 
 
 def test_cli_allow_partial_salvages_rows_across_a_corrupt_leaf(

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -266,6 +266,8 @@ def test_lost_and_found_lane_recovers_schema_unreadable_source(
     assert report["complete"] is False
     assert report["installed"] is False
     assert report["unreadable_schemas"] == ["sessions", "messages"]
+    assert report["omissions"]["loss_detected"] is True
+    assert report["omissions"]["inspection_unavailable"] is True
     assert any(
         "BEST-EFFORT" in warning
         for warning in report["verification"]["warnings"]


### PR DESCRIPTION
## What does this PR do?

Makes offline session-recovery reports account for durable source state that the current recovery contract does not copy.

This PR is deliberately reporting-only. It does **not** copy or replay delivery obligations, change ownership fields, or initialize plugin/gateway schemas in the destination. Those behaviors need a separate maintainer-approved recovery policy because replaying already delivered work can duplicate user-visible messages.

## Related Issue

Addresses the reporting portion of #86236. It intentionally leaves replay, retention, and schema-ownership policy open for maintainer discussion.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Inventory omitted `delivery_obligations` rows by state without copying or re-owning them.
- Treat `pending`, `attempting`, `failed`, unknown, and NULL states as non-terminal; mark the recovery lossy when any such obligations are omitted.
- Report omitted terminal obligations without declaring them data loss, preserving the current anti-duplicate-delivery policy boundary.
- Compare source and destination schemas for copied tables, list source-only columns, and detect values that differ from declared literal defaults or known application-level empty sentinels (`NULL` / `''` for `origin_session_id`).
- Cross-check `sqlite_master` so `PRAGMA writable_schema=ON` cannot silently hide a malformed source table schema from omission reporting.
- Propagate material omissions into `verification.loss_detected`, `partial`, and `complete` while leaving structural `verified` semantics unchanged.
- Add a distinct CLI result for structurally verified output with known omissions: exit 0, keep `complete: false`, print the omission warnings, and require report review before installation instead of claiming verification failed.
- Keep the report shape additive in page-level lost-and-found mode by marking omission inventory as unavailable rather than omitting the section.
- Add synthetic tests for lossy non-terminal/lazy-column state, terminal-only state with both semantic empty sentinels, malformed auxiliary schema, a source-only literal-default column, lost-and-found report shape, and both CLI exit/message paths.

## How to Test

1. Run `HERMES_PYTHON=/path/to/python scripts/run_tests.sh -j 1 tests/hermes_cli/test_session_recovery.py tests/hermes_cli/test_session_recovery_lost_and_found.py -q`.
2. Run the unchanged delivery-ledger and async-delegation suites listed in the test log below.
3. Run `ruff check hermes_cli/sessions_cmd.py hermes_cli/session_recovery.py tests/hermes_cli/test_session_recovery.py tests/hermes_cli/test_session_recovery_lost_and_found.py`.
4. Run `python scripts/check-windows-footguns.py` against those same four changed files.
5. Run `ty check hermes_cli/session_recovery.py`.

The synthetic fixtures contain placeholder strings only. No user database, credentials, internal address, platform token, or session content is included.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.8.0-63-generic, Python 3.11.14 (uv standalone runtime)

The full repository and complete `tests/hermes_cli` suites were not run on this branch. The focused recovery, lost-and-found, delivery-ledger, and async-delegation matrix completed with **66 passed, 1 skipped, and 0 failed** through the repository's hermetic `scripts/run_tests.sh` wrapper; GitHub Actions will run the full matrix.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the new report fields and policy boundary are documented in code and the related issue
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the Windows footgun check passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused recovery/delivery/async matrix (9 files):

```text
66 tests passed, 1 skipped, 0 failed
```

Static checks:

```text
All checks passed!
ty: All checks passed!
No Windows footguns found (4 file(s) scanned).
```