### PR TITLE
fix(agent): preserve active Codex streams past stale timeout

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3850,8 +3850,12 @@ def _connection_candidates(conn: Any):
             stack.append(inner)
 
 
-def _iter_pool_sockets(client: Any):
+def _iter_pool_sockets(client: Any, *, active_only: bool = False):
     """Yield raw sockets reachable from an OpenAI/httpx client pool.
+
+    When ``active_only`` is true, skip connections that explicitly report
+    themselves idle. Connections without a reliable ``is_idle`` signal remain
+    eligible so older/private httpcore layouts keep working.
 
     httpcore 1.x stores the concrete HTTP11/HTTP2 connection under
     ``conn._connection``; older versions exposed stream attributes directly
@@ -3883,6 +3887,14 @@ def _iter_pool_sockets(client: Any):
             or []
         )
         for conn in list(connections):
+            if active_only:
+                is_idle = getattr(conn, "is_idle", None)
+                if callable(is_idle):
+                    try:
+                        if is_idle():
+                            continue
+                    except Exception:
+                        pass
             for candidate in _connection_candidates(conn):
                 stream = (
                     getattr(candidate, "_network_stream", None)
@@ -4115,7 +4127,7 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
 
 
 
-def force_close_tcp_sockets(client: Any) -> int:
+def force_close_tcp_sockets(client: Any, *, active_only: bool = False) -> int:
     """Abort in-flight TCP I/O by shutting down sockets WITHOUT closing FDs.
 
     When a provider drops a connection mid-stream — or the user issues an
@@ -4155,12 +4167,12 @@ def force_close_tcp_sockets(client: Any) -> int:
 
     shutdown_count = 0
     try:
-        for sock in _iter_pool_sockets(client):
+        for sock in _iter_pool_sockets(client, active_only=active_only):
             try:
                 sock.shutdown(_socket.SHUT_RDWR)
             except OSError:
                 # Already shut down / not connected / FD invalid — all benign.
-                pass
+                continue
             # IMPORTANT (#29507): do NOT call sock.close() here. See docstring.
             shutdown_count += 1
     except Exception as exc:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -27,6 +27,8 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
+import httpx
+
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
@@ -871,7 +873,11 @@ def interruptible_api_call(agent, api_kwargs: dict):
     if should_use_direct_api_call(agent):
         return direct_api_call(agent, api_kwargs)
 
-    result = {"response": None, "error": None}
+    result = {
+        "response": None,
+        "error": None,
+        "error_monotonic": None,
+    }
 
     # Cross-turn stale-call circuit breaker (#58962) — non-streaming sibling
     # of the guard in interruptible_streaming_api_call.  Quiet-mode /
@@ -880,6 +886,13 @@ def interruptible_api_call(agent, api_kwargs: dict):
     _check_stale_giveup(agent)
 
     request_client_holder = {"client": None, "owner_tid": None}
+    # Request-local terminal marker. Watchdog/interrupt sets this under the
+    # same lock used by client registration, before attempting socket abort.
+    request_state: dict[str, Any] = {
+        "terminal_reason": None,
+        "confirmed_abort_reason": None,
+        "confirmed_abort_started_monotonic": None,
+    }
     # Transport kind of the registered request client ("openai" or
     # "anthropic_messages") so _close_request_client_once routes to the right
     # abort/close helpers (#67142).
@@ -896,6 +909,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
     _request_cancelled = {"value": False}
 
     def _set_request_client(client, *, kind: str = "openai"):
+        late_reason = None
         with request_client_lock:
             request_client_holder["client"] = client
             request_client_kind["value"] = kind
@@ -903,9 +917,39 @@ def interruptible_api_call(agent, api_kwargs: dict):
             # only shuts the connection down rather than racing the worker
             # for FD ownership during ``client.close()``.
             request_client_holder["owner_tid"] = threading.get_ident()
+            late_reason = request_state["terminal_reason"]
+            if late_reason is not None:
+                # The deadline/cancel transition won while client creation was
+                # in flight. Abort under the registration lock so this client
+                # can never be handed to dispatch as an unguarded late request.
+                try:
+                    if kind == "anthropic_messages":
+                        agent._abort_request_anthropic_client(
+                            client, reason=late_reason
+                        )
+                    else:
+                        agent._abort_request_openai_client(
+                            client, reason=late_reason
+                        )
+                except Exception:
+                    logger.debug(
+                        "Abort after late request-client registration failed",
+                        exc_info=True,
+                    )
+        if late_reason is not None:
+            if late_reason == "interrupt_abort":
+                raise InterruptedError(
+                    "Agent interrupted before request dispatch"
+                )
+            raise TimeoutError(
+                "API call timed out before request dispatch "
+                f"[watchdog_abort_reason={late_reason}]"
+            )
         return client
 
-    def _close_request_client_once(reason: str) -> None:
+    def _close_request_client_once(
+        reason: str, *, terminal: bool = False
+    ) -> int:
         # #29507: dispatch on the calling thread.
         #
         # When ``_call`` (the worker) reaches its ``finally`` it owns the
@@ -919,6 +963,10 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # BIO on the worker thread then wrote a 24-byte TLS application-data
         # record into the SQLite header (#29507).
         with request_client_lock:
+            if terminal and request_state["terminal_reason"] is None:
+                # Commit terminal ownership before inspecting/aborting client.
+                # A concurrent late registration must observe this marker.
+                request_state["terminal_reason"] = reason
             request_client = request_client_holder.get("client")
             owner_tid = request_client_holder.get("owner_tid")
             stranger_thread = (
@@ -935,21 +983,55 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 # (socket shutdown + slot poison), so holding the lock across
                 # it only delays the racing pop, never the data path.
                 if request_client_kind.get("value", "openai") == "anthropic_messages":
-                    agent._abort_request_anthropic_client(
+                    shutdown_count = agent._abort_request_anthropic_client(
                         request_client, reason=reason
                     )
                 else:
-                    agent._abort_request_openai_client(request_client, reason=reason)
-                return
+                    shutdown_count = agent._abort_request_openai_client(
+                        request_client, reason=reason
+                    )
+                return max(0, int(shutdown_count or 0))
             # Owning thread (or no recorded owner) → pop and fully close.
             request_client_holder["client"] = None
             request_client_holder["owner_tid"] = None
         if request_client is None:
-            return
+            return 0
         if request_client_kind.get("value", "openai") == "anthropic_messages":
             agent._close_request_anthropic_client(request_client, reason=reason)
         else:
             agent._close_request_openai_client(request_client, reason=reason)
+        return 0
+
+    def _record_confirmed_abort(reason: str) -> None:
+        """Record a bounded abort window only after shutdown is confirmed.
+
+        ``socket.shutdown()`` can wake the worker before the abort helper
+        returns.  Capture the start before entering the helper, then publish it
+        only when the helper confirms that at least one shutdown succeeded.
+        This preserves spontaneous errors that predate the abort attempt while
+        still recognizing the transport error produced during shutdown.
+        """
+        abort_started_monotonic = time.monotonic()
+        shutdown_count = _close_request_client_once(reason, terminal=True)
+        if shutdown_count > 0:
+            request_state["confirmed_abort_reason"] = reason
+            request_state["confirmed_abort_started_monotonic"] = (
+                abort_started_monotonic
+            )
+
+    def _raise_if_interrupted() -> None:
+        """Give a request-local user interrupt priority over other outcomes."""
+        if not agent._interrupt_requested:
+            return
+        _request_cancelled["value"] = True
+        logger.debug(
+            "Force-closing httpx client due to interrupt (not a network error)."
+        )
+        try:
+            _close_request_client_once("interrupt_abort", terminal=True)
+        except Exception:
+            pass
+        raise InterruptedError("Agent interrupted during API call")
 
     def _call():
         try:
@@ -971,6 +1053,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 ),
             )
         except Exception as e:
+            result["error_monotonic"] = time.monotonic()
             # If the request was cancelled by the main thread's interrupt
             # handler, the transport error is the expected consequence of our
             # own force-close, NOT a network bug. Swallow it instead of
@@ -1156,6 +1239,10 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
         _elapsed = time.time() - _call_start
 
+        # Interrupt wins if it becomes eligible on the same polling iteration
+        # as any watchdog. This preserves user intent at timeout boundaries.
+        _raise_if_interrupted()
+
         # TTFB detector: the Codex stream has produced no event at all and
         # we're past the first-byte cutoff → the backend opened the
         # connection but isn't responding. Kill it so the retry loop can
@@ -1193,7 +1280,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     f"Reconnecting."
                 )
             try:
-                _close_request_client_once("codex_ttfb_kill")
+                _record_confirmed_abort("codex_ttfb_kill")
             except Exception:
                 pass
             agent._emit_wait_notice(
@@ -1243,7 +1330,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 f"Reconnecting."
             )
             try:
-                _close_request_client_once("codex_stream_idle_kill")
+                _record_confirmed_abort("codex_stream_idle_kill")
             except Exception:
                 pass
             agent._touch_activity(
@@ -1274,7 +1361,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 # #67142: routes by client kind — anthropic now aborts the
                 # request-local client's sockets from this poll (stranger)
                 # thread instead of closing the shared _anthropic_client.
-                _close_request_client_once("stale_call_kill")
+                _record_confirmed_abort("stale_call_kill")
             except Exception:
                 pass
             # Circuit breaker (#58962): count the stale kill.  See the
@@ -1297,28 +1384,31 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     )
             break
 
-        if agent._interrupt_requested:
-            # Mark THIS request cancelled before force-closing so the worker's
-            # exception handler recognizes the forced transport error as a
-            # cancel and exits cleanly instead of surfacing a network error or
-            # (in the streaming path) burning full retry cycles. (#6600)
-            _request_cancelled["value"] = True
-            logger.debug(
-                "Force-closing httpx client due to interrupt (not a network error)."
-            )
-            # Force-close the in-flight worker-local HTTP connection to stop
-            # token generation without poisoning the shared client used to
-            # seed future retries. #67142: for anthropic this aborts the
-            # request-local client's sockets from this poll (stranger) thread
-            # rather than closing the shared _anthropic_client, which could
-            # release a TLS FD mid-SSL-BIO and corrupt an unrelated SQLite DB.
-            try:
-                _close_request_client_once("interrupt_abort")
-            except Exception:
-                pass
-            raise InterruptedError("Agent interrupted during API call")
+    # The worker can finish between the final in-loop interrupt check and the
+    # next ``is_alive()`` condition. Preserve the original post-worker guard so
+    # a /stop arriving in that boundary window still owns the outcome.
+    _raise_if_interrupted()
+
     if result["error"] is not None:
-        raise result["error"]
+        worker_error = result["error"]
+        error_monotonic = result["error_monotonic"]
+        confirmed_abort_reason = request_state["confirmed_abort_reason"]
+        confirmed_abort_started_monotonic = request_state[
+            "confirmed_abort_started_monotonic"
+        ]
+        if (
+            confirmed_abort_reason is not None
+            and confirmed_abort_started_monotonic is not None
+            and error_monotonic is not None
+            and confirmed_abort_started_monotonic <= error_monotonic
+            and type(worker_error) is httpx.ReadError
+            and str(worker_error) == "[Errno 32] Broken pipe"
+        ):
+            raise TimeoutError(
+                "API call was aborted by the local watchdog "
+                f"[watchdog_abort_reason={confirmed_abort_reason}]"
+            ) from worker_error
+        raise worker_error
     # Success — clear the circuit breaker (#58962): the provider proved
     # responsive.  See the canonical comment block above ``_stale_streak()``.
     if result["response"] is not None:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1196,6 +1196,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
     if _codex_watchdog_enabled:
         # Reset before the worker starts so a marker left over from a previous
         # call on this agent can't be misread as first-byte for this one.
+        agent._codex_stream_event_lock = threading.RLock()
         agent._codex_stream_last_event_ts = None
         agent._codex_stream_last_progress_ts = None
 
@@ -1344,9 +1345,29 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 )
             break
 
-        # Stale-call detector: kill the connection if no response
-        # arrives within the configured timeout.
+        # After an OpenAI Codex request receives its first SSE event, activity
+        # is governed by the stream-idle watchdog instead. Serialize the final
+        # marker check with event publication so first-SSE cannot race a
+        # generic stale abort at the deadline. The Codex hard ceiling remains
+        # an absolute backstop and intentionally bypasses this suppression.
+        _codex_hard_ceiling_reached = (
+            _codex_hard_timeout > 0 and _elapsed > _codex_hard_timeout
+        )
         if _elapsed > _stale_timeout:
+            _stale_abort_serialized = False
+            if (
+                _codex_watchdog_enabled
+                and _openai_codex_backend
+                and not _codex_hard_ceiling_reached
+            ):
+                with agent._codex_stream_event_lock:
+                    if getattr(agent, "_codex_stream_last_event_ts", None) is not None:
+                        continue
+                    try:
+                        _record_confirmed_abort("stale_call_kill")
+                    except Exception:
+                        pass
+                    _stale_abort_serialized = True
             _silent_hint: Optional[str] = None
             _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
             if callable(_hint_fn):
@@ -1357,13 +1378,14 @@ def interruptible_api_call(agent, api_kwargs: dict):
             _report_stale_nonstream_kill(
                 agent, api_kwargs, _elapsed, _stale_timeout, hint=_silent_hint
             )
-            try:
-                # #67142: routes by client kind — anthropic now aborts the
-                # request-local client's sockets from this poll (stranger)
-                # thread instead of closing the shared _anthropic_client.
-                _record_confirmed_abort("stale_call_kill")
-            except Exception:
-                pass
+            if not _stale_abort_serialized:
+                try:
+                    # #67142: routes by client kind — anthropic now aborts the
+                    # request-local client's sockets from this poll (stranger)
+                    # thread instead of closing the shared _anthropic_client.
+                    _record_confirmed_abort("stale_call_kill")
+                except Exception:
+                    pass
             # Circuit breaker (#58962): count the stale kill.  See the
             # canonical comment block above ``_stale_streak()``.
             _bump_stale_streak(agent)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1302,6 +1302,16 @@ def _consume_codex_event_stream(
     return final
 
 
+def _publish_codex_stream_event(agent) -> None:
+    """Publish SSE activity under the watchdog's first-event decision lock."""
+    event_lock = getattr(agent, "_codex_stream_event_lock", None)
+    if event_lock is None:
+        agent._codex_stream_last_event_ts = time.time()
+    else:
+        with event_lock:
+            agent._codex_stream_last_event_ts = time.time()
+
+
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
     """Execute one streaming Responses API request and return the final response.
 
@@ -1333,7 +1343,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
     def _on_event(event: Any) -> None:
         # TTFB watchdog and activity touch — runs once per SSE event.
-        agent._codex_stream_last_event_ts = time.time()
+        _publish_codex_stream_event(agent)
         agent._touch_activity("receiving stream response")
 
     for attempt in range(max_stream_retries + 1):

--- a/run_agent.py
+++ b/run_agent.py
@@ -4919,10 +4919,12 @@ class AIAgent:
         return create_openai_client(self, client_kwargs, reason=reason, shared=shared)
 
     @staticmethod
-    def _force_close_tcp_sockets(client: Any) -> int:
+    def _force_close_tcp_sockets(
+        client: Any, *, active_only: bool = False
+    ) -> int:
         """Forwarder — see ``agent.agent_runtime_helpers.force_close_tcp_sockets``."""
         from agent.agent_runtime_helpers import force_close_tcp_sockets
-        return force_close_tcp_sockets(client)
+        return force_close_tcp_sockets(client, active_only=active_only)
 
     def _close_openai_client(self, client: Any, *, reason: str, shared: bool) -> None:
         if client is None:
@@ -5216,7 +5218,7 @@ class AIAgent:
             return
         self._close_openai_client(client, reason=reason, shared=False)
 
-    def _abort_request_openai_client(self, client: Any, *, reason: str) -> None:
+    def _abort_request_openai_client(self, client: Any, *, reason: str) -> int:
         """Cross-thread abort: shut sockets down without releasing FDs.
 
         Companion to :meth:`_close_request_openai_client` for stranger-thread
@@ -5231,7 +5233,7 @@ class AIAgent:
         — which is where the FD release belongs.
         """
         if client is None:
-            return
+            return 0
         # A pool whose sockets were shut down from a stranger thread must
         # never be reused: poison the cache slot so the owner-thread close
         # discards it and the next create builds a fresh client.
@@ -5240,7 +5242,9 @@ class AIAgent:
             if cache["client"] is client:
                 cache["poisoned"] = True
         try:
-            shutdown_count = self._force_close_tcp_sockets(client)
+            shutdown_count = self._force_close_tcp_sockets(
+                client, active_only=True
+            )
             # tcp_force_closed=0 means the stranger-thread abort found no
             # sockets to shut down — the worker stays blocked in recv and the
             # provider keeps the slot (#72975). Surface that as WARNING so it
@@ -5259,6 +5263,7 @@ class AIAgent:
                     else ""
                 ),
             )
+            return shutdown_count
         except Exception as exc:
             logger.debug(
                 "OpenAI client abort failed (%s, shared=False) %s error=%s",
@@ -5266,6 +5271,7 @@ class AIAgent:
                 self._client_log_context(),
                 exc,
             )
+            return 0
 
     def _create_request_anthropic_client(self, *, reason: str) -> Any:
         """Build a request-local Anthropic client for one in-flight call.
@@ -5334,7 +5340,7 @@ class AIAgent:
                 exc,
             )
 
-    def _abort_request_anthropic_client(self, client: Any, *, reason: str) -> None:
+    def _abort_request_anthropic_client(self, client: Any, *, reason: str) -> int:
         """Cross-thread abort for request-local Anthropic clients.
 
         Stranger threads (the interrupt-check / stale-stream detector loop)
@@ -5344,9 +5350,11 @@ class AIAgent:
         unblocks and releases the FD from its own thread.
         """
         if client is None:
-            return
+            return 0
         try:
-            shutdown_count = self._force_close_tcp_sockets(client)
+            shutdown_count = self._force_close_tcp_sockets(
+                client, active_only=True
+            )
             # Same visibility contract as the OpenAI abort path (#72975):
             # zero sockets shut down means the abort did not unblock the
             # worker — log WARNING, not a success-shaped INFO.
@@ -5365,6 +5373,7 @@ class AIAgent:
                     else ""
                 ),
             )
+            return shutdown_count
         except Exception as exc:
             logger.debug(
                 "Anthropic client abort failed (%s, shared=False) provider=%s model=%s error=%s",
@@ -5373,6 +5382,7 @@ class AIAgent:
                 getattr(self, "model", None),
                 exc,
             )
+            return 0
 
     def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
         """Forwarder — see ``agent.codex_runtime.run_codex_stream``."""

--- a/tests/agent/test_codex_post_first_event_watchdogs.py
+++ b/tests/agent/test_codex_post_first_event_watchdogs.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import os
+import threading
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from agent import chat_completion_helpers as cch
+from agent import codex_runtime
+
+
+def _agent(*, codex: bool, stale_timeout: float) -> MagicMock:
+    agent = MagicMock()
+    agent.api_mode = "codex_responses" if codex else "chat_completions"
+    agent.provider = "openai-codex" if codex else "openai"
+    agent.platform = "cli"
+    agent.is_subagent = False
+    agent._interrupt_requested = False
+    agent._base_url_hostname = "chatgpt.com" if codex else "api.openai.com"
+    agent._base_url_lower = (
+        "https://chatgpt.com/backend-api/codex"
+        if codex
+        else "https://api.openai.com/v1"
+    )
+    agent._compute_non_stream_stale_timeout.return_value = stale_timeout
+    agent._codex_silent_hang_hint.return_value = None
+    agent._create_request_openai_client.return_value = MagicMock(name="client")
+    agent._close_request_openai_client = MagicMock()
+    return agent
+
+
+def _env(*, ttfb: float, idle: float, hard: float = 2.0) -> dict[str, str]:
+    return {
+        "HERMES_CODEX_TTFB_TIMEOUT_SECONDS": str(ttfb),
+        "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS": str(idle),
+        "HERMES_CODEX_HARD_TIMEOUT_SECONDS": str(hard),
+    }
+
+
+class CodexPostFirstEventWatchdogs(unittest.TestCase):
+    def test_active_codex_sse_can_run_past_generic_stale_timeout(self) -> None:
+        agent = _agent(codex=True, stale_timeout=0.05)
+        aborted = threading.Event()
+        expected = SimpleNamespace(id="completed")
+
+        def abort(_client, *, reason):
+            aborted.set()
+            return 1
+
+        def active_stream(*_args, **_kwargs):
+            # Hold the event/stale decision lock across the first generic stale
+            # polling deadline, then publish the first SSE before releasing it.
+            # The watchdog must re-check the marker under this same lock.
+            with agent._codex_stream_event_lock:
+                time.sleep(0.35)
+                codex_runtime._publish_codex_stream_event(agent)
+            deadline = time.monotonic() + 0.35
+            while time.monotonic() < deadline:
+                codex_runtime._publish_codex_stream_event(agent)
+                if aborted.wait(0.02):
+                    raise httpx.ReadError("[Errno 32] Broken pipe")
+            return expected
+
+        agent._abort_request_openai_client.side_effect = abort
+        agent._run_codex_stream.side_effect = active_stream
+
+        with patch.dict(os.environ, _env(ttfb=0, idle=0.1), clear=False):
+            response = cch.interruptible_api_call(
+                agent, {"model": "gpt-test", "input": "x"}
+            )
+
+        self.assertIs(response, expected)
+        self.assertFalse(aborted.is_set())
+
+    def test_codex_sse_idle_still_uses_specialized_idle_kill(self) -> None:
+        agent = _agent(codex=True, stale_timeout=10.0)
+        aborted = threading.Event()
+
+        def abort(_client, *, reason):
+            aborted.set()
+            return 1
+
+        def idle_stream(*_args, **_kwargs):
+            agent._codex_stream_last_event_ts = time.time()
+            self.assertTrue(aborted.wait(3.0))
+            raise httpx.ReadError("[Errno 32] Broken pipe")
+
+        agent._abort_request_openai_client.side_effect = abort
+        agent._run_codex_stream.side_effect = idle_stream
+
+        with patch.dict(os.environ, _env(ttfb=0, idle=0.05), clear=False):
+            with self.assertRaises(TimeoutError) as caught:
+                cch.interruptible_api_call(
+                    agent, {"model": "gpt-test", "input": "x"}
+                )
+        self.assertIn("codex_stream_idle_kill", str(caught.exception))
+
+    def test_non_codex_without_response_still_uses_generic_stale_kill(self) -> None:
+        agent = _agent(codex=False, stale_timeout=0.05)
+        aborted = threading.Event()
+        request_client = agent._create_request_openai_client.return_value
+
+        def abort(_client, *, reason):
+            aborted.set()
+            return 1
+
+        def blocked_create(**_kwargs):
+            self.assertTrue(aborted.wait(3.0))
+            raise httpx.ReadError("[Errno 32] Broken pipe")
+
+        agent._abort_request_openai_client.side_effect = abort
+        request_client.chat.completions.create.side_effect = blocked_create
+
+        with patch.dict(os.environ, _env(ttfb=0, idle=0), clear=False):
+            with self.assertRaises(TimeoutError) as caught:
+                cch.interruptible_api_call(
+                    agent, {"model": "gpt-test", "messages": []}
+                )
+        self.assertIn("stale_call_kill", str(caught.exception))
+
+    def test_codex_without_any_sse_still_uses_ttfb_recovery(self) -> None:
+        agent = _agent(codex=True, stale_timeout=10.0)
+        aborted = threading.Event()
+
+        def abort(_client, *, reason):
+            aborted.set()
+            return 1
+
+        def silent_stream(*_args, **_kwargs):
+            self.assertTrue(aborted.wait(3.0))
+            raise httpx.ReadError("[Errno 32] Broken pipe")
+
+        agent._abort_request_openai_client.side_effect = abort
+        agent._run_codex_stream.side_effect = silent_stream
+
+        with patch.dict(os.environ, _env(ttfb=0.05, idle=0), clear=False):
+            with self.assertRaises(TimeoutError) as caught:
+                cch.interruptible_api_call(
+                    agent, {"model": "gpt-test", "input": "x"}
+                )
+        self.assertIn("codex_ttfb_kill", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/test_nonstream_late_registration_guard.py
+++ b/tests/agent/test_nonstream_late_registration_guard.py
@@ -1,0 +1,200 @@
+"""Regression tests for request-client registration racing terminal watchdogs.
+
+A watchdog or interrupt may win while the worker is still constructing its
+request-local client. Once that terminal transition wins, a subsequently
+registered client must be aborted before provider dispatch, and owner-thread
+cleanup must still run.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agent import chat_completion_helpers as cch
+
+
+class NonstreamLateRegistrationGuardTests(unittest.TestCase):
+    def _make_codex_agent(self) -> MagicMock:
+        agent = MagicMock()
+        agent.api_mode = "codex_responses"
+        agent.provider = "openai-codex"
+        agent.platform = "cli"
+        agent.is_subagent = False
+        agent._interrupt_requested = False
+        agent._base_url_hostname = "chatgpt.com"
+        agent._base_url_lower = "https://chatgpt.com/backend-api/codex"
+        agent._compute_non_stream_stale_timeout.return_value = 30.0
+        agent._codex_silent_hang_hint.return_value = None
+        agent._create_request_openai_client = MagicMock()
+        agent._abort_request_openai_client = MagicMock()
+        agent._close_request_openai_client = MagicMock()
+        agent._run_codex_stream = MagicMock(return_value=object())
+        return agent
+
+    @staticmethod
+    def _wait_for(predicate, timeout: float = 3.0) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            time.sleep(0.01)
+        raise AssertionError("condition was not reached before timeout")
+
+    def _run_registration_blocked_until_after_watchdog(
+        self,
+        *,
+        watchdog: str,
+    ) -> tuple[MagicMock, MagicMock]:
+        agent = self._make_codex_agent()
+        client = MagicMock(name=f"{watchdog}_request_client")
+        release_registration = threading.Event()
+        creation_started = threading.Event()
+
+        def create_client(**_kwargs):
+            creation_started.set()
+            if watchdog == "sse_idle":
+                agent._codex_stream_last_event_ts = time.time()
+            self.assertTrue(release_registration.wait(3.0))
+            return client
+
+        agent._create_request_openai_client.side_effect = create_client
+
+        def release_after_terminal_transition(message):
+            # Both watchdog branches touch activity only after committing the
+            # terminal marker under request_client_lock.
+            if "killed after" in str(message):
+                release_registration.set()
+
+        agent._touch_activity.side_effect = release_after_terminal_transition
+        env = {
+            "HERMES_CODEX_TTFB_TIMEOUT_SECONDS": "0.001",
+            "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS": "0.001",
+        }
+
+        try:
+            with patch.dict(os.environ, env, clear=False):
+                with self.assertRaises(TimeoutError):
+                    cch.interruptible_api_call(
+                        agent, {"model": "gpt-test", "input": "hi"}
+                    )
+        finally:
+            release_registration.set()
+
+        self.assertTrue(creation_started.is_set())
+        self._wait_for(lambda: agent._close_request_openai_client.called)
+        return agent, client
+
+    def test_ttfb_watchdog_before_registration_blocks_late_dispatch_and_cleans_up(self):
+        agent, client = self._run_registration_blocked_until_after_watchdog(
+            watchdog="ttfb"
+        )
+
+        agent._run_codex_stream.assert_not_called()
+        agent._abort_request_openai_client.assert_called_once_with(
+            client, reason="codex_ttfb_kill"
+        )
+        agent._close_request_openai_client.assert_called_once_with(
+            client, reason="request_error_cleanup"
+        )
+
+    def test_sse_idle_watchdog_before_registration_blocks_late_dispatch(self):
+        agent, client = self._run_registration_blocked_until_after_watchdog(
+            watchdog="sse_idle"
+        )
+
+        agent._run_codex_stream.assert_not_called()
+        agent._abort_request_openai_client.assert_called_once_with(
+            client, reason="codex_stream_idle_kill"
+        )
+
+    def test_interrupt_before_registration_blocks_late_dispatch_and_cleans_up(self):
+        agent = self._make_codex_agent()
+        client = MagicMock(name="interrupted_request_client")
+        release_registration = threading.Event()
+        creation_started = threading.Event()
+
+        def create_client(**_kwargs):
+            creation_started.set()
+            self.assertTrue(release_registration.wait(3.0))
+            return client
+
+        agent._create_request_openai_client.side_effect = create_client
+        # The worker blocks in client creation. The first poll commits the
+        # interrupt terminal marker; the caller then raises and releases the
+        # worker in the finally below.
+        agent._interrupt_requested = True
+        try:
+            with patch.dict(
+                os.environ,
+                {
+                    "HERMES_CODEX_TTFB_TIMEOUT_SECONDS": "0",
+                    "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS": "0",
+                },
+                clear=False,
+            ):
+                with self.assertRaises(InterruptedError):
+                    cch.interruptible_api_call(
+                        agent, {"model": "gpt-test", "input": "hi"}
+                    )
+        finally:
+            release_registration.set()
+
+        self.assertTrue(creation_started.is_set())
+        self._wait_for(lambda: agent._close_request_openai_client.called)
+        agent._run_codex_stream.assert_not_called()
+        agent._abort_request_openai_client.assert_called_once_with(
+            client, reason="interrupt_abort"
+        )
+        agent._close_request_openai_client.assert_called_once_with(
+            client, reason="request_error_cleanup"
+        )
+
+    def test_registration_before_ttfb_watchdog_aborts_registered_client(self):
+        agent = self._make_codex_agent()
+        client = MagicMock(name="registered_request_client")
+        request_entered = threading.Event()
+        abort_observed = threading.Event()
+
+        agent._create_request_openai_client.return_value = client
+
+        def run_stream(*_args, **_kwargs):
+            request_entered.set()
+            self.assertTrue(abort_observed.wait(3.0))
+            raise RuntimeError("aborted")
+
+        def abort_client(actual_client, *, reason):
+            self.assertIs(actual_client, client)
+            self.assertEqual(reason, "codex_ttfb_kill")
+            abort_observed.set()
+
+        agent._run_codex_stream.side_effect = run_stream
+        agent._abort_request_openai_client.side_effect = abort_client
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_CODEX_TTFB_TIMEOUT_SECONDS": "0.05",
+                "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS": "0",
+            },
+            clear=False,
+        ):
+            with self.assertRaises(RuntimeError):
+                cch.interruptible_api_call(
+                    agent, {"model": "gpt-test", "input": "hi"}
+                )
+
+        self.assertTrue(request_entered.is_set())
+        agent._abort_request_openai_client.assert_called_once_with(
+            client, reason="codex_ttfb_kill"
+        )
+        agent._close_request_openai_client.assert_called_once_with(
+            client, reason="request_error_cleanup"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/test_watchdog_broken_pipe_matrix.py
+++ b/tests/agent/test_watchdog_broken_pipe_matrix.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import os
+import threading
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from agent import agent_runtime_helpers as runtime_helpers
+from agent import chat_completion_helpers as cch
+
+
+class BrokenPipeCausalityMatrix(unittest.TestCase):
+    def agent(self):
+        a = MagicMock()
+        a.api_mode = "codex_responses"
+        a.provider = "openai-codex"
+        a.platform = "cli"
+        a.is_subagent = False
+        a._interrupt_requested = False
+        a._base_url_hostname = "chatgpt.com"
+        a._base_url_lower = "https://chatgpt.com/backend-api/codex"
+        a._compute_non_stream_stale_timeout.return_value = 30.0
+        a._codex_silent_hang_hint.return_value = None
+        a._create_request_openai_client.return_value = MagicMock(name="client")
+        a._close_request_openai_client = MagicMock()
+        return a
+
+    def run_watchdog_error(self, error, *, watchdog="ttfb"):
+        a = self.agent()
+        aborted = threading.Event()
+        if watchdog == "stale":
+            a._compute_non_stream_stale_timeout.return_value = 0.05
+        def abort(_client, *, reason):
+            aborted.set()
+            return 1
+        def stream(*_args, **_kwargs):
+            if watchdog == "idle":
+                a._codex_stream_last_event_ts = time.time()
+            self.assertTrue(aborted.wait(3.0))
+            raise error
+        a._abort_request_openai_client.side_effect = abort
+        a._run_codex_stream.side_effect = stream
+        env = {
+            "HERMES_CODEX_TTFB_TIMEOUT_SECONDS": "0.05" if watchdog == "ttfb" else "0",
+            "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS": "0.05" if watchdog == "idle" else "0",
+        }
+        return a, env, lambda: cch.interruptible_api_call(a, {"model":"gpt-test","input":"x"})
+
+    def test_ttfb_post_abort_readerror_broken_pipe_translates(self):
+        original = httpx.ReadError("[Errno 32] Broken pipe")
+        _a, env, call = self.run_watchdog_error(original)
+        with patch.dict(os.environ, env, clear=False):
+            with self.assertRaises(TimeoutError) as caught:
+                call()
+        self.assertIs(caught.exception.__cause__, original)
+        self.assertIn("codex_ttfb_kill", str(caught.exception))
+
+    def test_idle_post_abort_readerror_broken_pipe_translates(self):
+        original = httpx.ReadError("[Errno 32] Broken pipe")
+        _a, env, call = self.run_watchdog_error(original, watchdog="idle")
+        with patch.dict(os.environ, env, clear=False):
+            with self.assertRaises(TimeoutError) as caught:
+                call()
+        self.assertIs(caught.exception.__cause__, original)
+        self.assertIn("codex_stream_idle_kill", str(caught.exception))
+
+    def test_stale_post_abort_readerror_broken_pipe_translates(self):
+        original = httpx.ReadError("[Errno 32] Broken pipe")
+        _a, env, call = self.run_watchdog_error(original, watchdog="stale")
+        with patch.dict(os.environ, env, clear=False):
+            with self.assertRaises(TimeoutError) as caught:
+                call()
+        self.assertIs(caught.exception.__cause__, original)
+        self.assertIn("stale_call_kill", str(caught.exception))
+
+    def test_broken_pipe_recorded_before_abort_helper_returns_translates(self):
+        """shutdown may wake the worker before the abort helper returns."""
+        a = self.agent()
+        original = httpx.ReadError("[Errno 32] Broken pipe")
+        shutdown_effect_seen = threading.Event()
+        worker_error_timestamped = threading.Event()
+        main_tid = threading.get_ident()
+        real_monotonic = time.monotonic
+
+        def monotonic():
+            value = real_monotonic()
+            if threading.get_ident() != main_tid:
+                worker_error_timestamped.set()
+            return value
+
+        def abort(_client, *, reason):
+            shutdown_effect_seen.set()
+            self.assertTrue(worker_error_timestamped.wait(3.0))
+            return 1
+
+        def stream(*_args, **_kwargs):
+            self.assertTrue(shutdown_effect_seen.wait(3.0))
+            raise original
+
+        a._abort_request_openai_client.side_effect = abort
+        a._run_codex_stream.side_effect = stream
+        with patch.object(cch.time, "monotonic", side_effect=monotonic), patch.dict(
+            os.environ,
+            {
+                "HERMES_CODEX_TTFB_TIMEOUT_SECONDS": "0.05",
+                "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS": "0",
+            },
+            clear=False,
+        ):
+            with self.assertRaises(TimeoutError) as caught:
+                cch.interruptible_api_call(
+                    a, {"model": "gpt-test", "input": "x"}
+                )
+        self.assertIs(caught.exception.__cause__, original)
+        self.assertIn("codex_ttfb_kill", str(caught.exception))
+
+    def test_force_close_counts_only_successful_shutdowns(self):
+        failed = MagicMock()
+        failed.shutdown.side_effect = OSError("already closed")
+        succeeded = MagicMock()
+        with patch.object(
+            runtime_helpers,
+            "_iter_pool_sockets",
+            return_value=[failed, succeeded],
+        ):
+            count = runtime_helpers.force_close_tcp_sockets(object())
+        self.assertEqual(count, 1)
+        failed.shutdown.assert_called_once()
+        succeeded.shutdown.assert_called_once()
+
+    def test_active_only_shutdown_skips_idle_pool_socket(self):
+        idle_socket = MagicMock()
+        active_socket = MagicMock()
+        idle_stream = SimpleNamespace(_sock=idle_socket)
+        active_stream = SimpleNamespace(_sock=active_socket)
+        idle_inner = SimpleNamespace(
+            _connection=None,
+            _network_stream=idle_stream,
+            _stream=None,
+        )
+        active_inner = SimpleNamespace(
+            _connection=None,
+            _network_stream=active_stream,
+            _stream=None,
+        )
+        idle_connection = SimpleNamespace(
+            is_idle=lambda: True,
+            _connection=idle_inner,
+        )
+        active_connection = SimpleNamespace(
+            is_idle=lambda: False,
+            _connection=active_inner,
+        )
+        pool = SimpleNamespace(
+            _connections=[idle_connection, active_connection]
+        )
+        with patch.object(
+            runtime_helpers,
+            "_iter_httpx_pool_objects",
+            return_value=[pool],
+        ):
+            count = runtime_helpers.force_close_tcp_sockets(
+                object(), active_only=True
+            )
+        self.assertEqual(count, 1)
+        idle_socket.shutdown.assert_not_called()
+        active_socket.shutdown.assert_called_once()
+
+    def test_openai_and_anthropic_abort_entrypoints_skip_idle_pool_socket(self):
+        from run_agent import AIAgent
+
+        def client_with_pool():
+            idle_socket = MagicMock()
+            active_socket = MagicMock()
+            idle_connection = SimpleNamespace(
+                is_idle=lambda: True,
+                _connection=SimpleNamespace(
+                    _connection=None,
+                    _network_stream=SimpleNamespace(_sock=idle_socket),
+                    _stream=None,
+                ),
+            )
+            active_connection = SimpleNamespace(
+                is_idle=lambda: False,
+                _connection=SimpleNamespace(
+                    _connection=None,
+                    _network_stream=SimpleNamespace(_sock=active_socket),
+                    _stream=None,
+                ),
+            )
+            pool = SimpleNamespace(
+                _connections=[idle_connection, active_connection]
+            )
+            http_client = SimpleNamespace(
+                _transport=SimpleNamespace(_pool=pool),
+                _mounts={},
+            )
+            return SimpleNamespace(_client=http_client), idle_socket, active_socket
+
+        agent = AIAgent.__new__(AIAgent)
+        setattr(agent, "provider", "test")
+        setattr(agent, "base_url", "https://example.test/v1")
+        setattr(agent, "model", "test-model")
+
+        for transport in ("openai", "anthropic"):
+            with self.subTest(transport=transport):
+                client, idle_socket, active_socket = client_with_pool()
+                if transport == "openai":
+                    count = agent._abort_request_openai_client(
+                        client, reason="test_abort"
+                    )
+                else:
+                    count = agent._abort_request_anthropic_client(
+                        client, reason="test_abort"
+                    )
+                self.assertEqual(count, 1)
+                idle_socket.shutdown.assert_not_called()
+                active_socket.shutdown.assert_called_once()
+
+    def test_force_close_all_oserrors_reports_zero(self):
+        failed = MagicMock()
+        failed.shutdown.side_effect = OSError("already closed")
+        with patch.object(
+            runtime_helpers,
+            "_iter_pool_sockets",
+            return_value=[failed],
+        ):
+            count = runtime_helpers.force_close_tcp_sockets(object())
+        self.assertEqual(count, 0)
+        failed.shutdown.assert_called_once()
+
+    def test_abort_without_socket_shutdown_preserves_readerror(self):
+        a = self.agent()
+        original = httpx.ReadError("[Errno 32] Broken pipe")
+        aborted = threading.Event()
+
+        def abort(_client, *, reason):
+            aborted.set()
+            return 0
+
+        def stream(*_args, **_kwargs):
+            self.assertTrue(aborted.wait(3.0))
+            raise original
+
+        a._abort_request_openai_client.side_effect = abort
+        a._run_codex_stream.side_effect = stream
+        with patch.dict(os.environ, {
+            "HERMES_CODEX_TTFB_TIMEOUT_SECONDS":"0.05",
+            "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS":"0",
+        }, clear=False):
+            with self.assertRaises(httpx.ReadError) as caught:
+                cch.interruptible_api_call(a,{"model":"gpt-test","input":"x"})
+        self.assertIs(caught.exception, original)
+
+    def test_custom_readerror_with_broken_pipe_text_is_preserved(self):
+        class ReadError(Exception):
+            pass
+
+        a = self.agent()
+        original = ReadError("[Errno 32] Broken pipe")
+        _a, env, call = self.run_watchdog_error(original)
+        with patch.dict(os.environ, env, clear=False):
+            with self.assertRaises(ReadError) as caught:
+                call()
+        self.assertIs(caught.exception, original)
+
+    def test_custom_httpx_prefixed_readerror_is_preserved(self):
+        ReadError = type("ReadError", (Exception,), {"__module__": "httpx_fake"})
+        original = ReadError("[Errno 32] Broken pipe")
+        _a, env, call = self.run_watchdog_error(original)
+        with patch.dict(os.environ, env, clear=False):
+            with self.assertRaises(ReadError) as caught:
+                call()
+        self.assertIs(caught.exception, original)
+
+    def test_nonexact_case_or_whitespace_messages_are_preserved(self):
+        for message in (
+            "[errno 32] broken pipe",
+            " [Errno 32] Broken pipe",
+            "[Errno 32] Broken pipe ",
+        ):
+            with self.subTest(message=message):
+                original = httpx.ReadError(message)
+                _a, env, call = self.run_watchdog_error(original)
+                with patch.dict(os.environ, env, clear=False):
+                    with self.assertRaises(httpx.ReadError) as caught:
+                        call()
+                self.assertIs(caught.exception, original)
+
+    def test_misleading_broken_pipe_text_is_preserved(self):
+        a = self.agent()
+        original = httpx.ReadError("proxy said broken pipe while validating")
+        _a, env, call = self.run_watchdog_error(original)
+        with patch.dict(os.environ, env, clear=False):
+            with self.assertRaises(httpx.ReadError) as caught:
+                call()
+        self.assertIs(caught.exception, original)
+
+    def test_post_abort_other_readerror_is_preserved(self):
+        original = httpx.ReadError("connection reset")
+        _a, env, call = self.run_watchdog_error(original)
+        with patch.dict(os.environ, env, clear=False):
+            with self.assertRaises(httpx.ReadError) as caught:
+                call()
+        self.assertIs(caught.exception, original)
+
+    def test_post_abort_bare_brokenpipe_is_preserved(self):
+        original = BrokenPipeError(32, "Broken pipe")
+        _a, env, call = self.run_watchdog_error(original)
+        with patch.dict(os.environ, env, clear=False):
+            with self.assertRaises(BrokenPipeError) as caught:
+                call()
+        self.assertIs(caught.exception, original)
+
+    def test_interrupt_has_priority_when_watchdog_also_eligible(self):
+        a = self.agent()
+        dispatch_started = threading.Event()
+
+        abort_seen = threading.Event()
+
+        def stream(*_args, **_kwargs):
+            dispatch_started.set()
+            self.assertTrue(abort_seen.wait(3.0))
+            raise httpx.ReadError("[Errno 32] Broken pipe")
+
+        def abort(_client, *, reason):
+            abort_seen.set()
+            return 1
+
+        a._run_codex_stream.side_effect = stream
+        a._abort_request_openai_client.side_effect = abort
+        timer = threading.Timer(
+            0.02, setattr, args=(a, "_interrupt_requested", True)
+        )
+        timer.start()
+        try:
+            with patch.dict(os.environ, {
+                "HERMES_CODEX_TTFB_TIMEOUT_SECONDS":"0.001",
+                "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS":"0",
+            }, clear=False):
+                with self.assertRaises(InterruptedError):
+                    cch.interruptible_api_call(a,{"model":"gpt-test","input":"x"})
+        finally:
+            timer.cancel()
+        self.assertTrue(dispatch_started.is_set())
+        a._abort_request_openai_client.assert_called_once()
+        self.assertEqual(
+            a._abort_request_openai_client.call_args.kwargs["reason"],
+            "interrupt_abort",
+        )
+
+    def test_interrupt_after_worker_completion_still_has_priority(self):
+        a = self.agent()
+        response = object()
+        a._run_codex_stream.return_value = response
+
+        class CompletedThenInterruptedThread:
+            def __init__(self, *, target, daemon):
+                self._target = target
+                self.daemon = daemon
+
+            def start(self):
+                self._target()
+                a._interrupt_requested = True
+
+            def is_alive(self):
+                return False
+
+        with patch.object(cch.threading, "Thread", CompletedThenInterruptedThread):
+            with self.assertRaises(InterruptedError):
+                cch.interruptible_api_call(
+                    a, {"model": "gpt-test", "input": "x"}
+                )
+        a._run_codex_stream.assert_called_once()
+
+    def test_response_completed_during_watchdog_join_is_returned(self):
+        a = self.agent()
+        aborted = threading.Event()
+        response = object()
+
+        def abort(_client, *, reason):
+            aborted.set()
+            return 1
+
+        def stream(*_args, **_kwargs):
+            self.assertTrue(aborted.wait(3.0))
+            return response
+
+        a._abort_request_openai_client.side_effect = abort
+        a._run_codex_stream.side_effect = stream
+        with patch.dict(os.environ, {
+            "HERMES_CODEX_TTFB_TIMEOUT_SECONDS":"0.05",
+            "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS":"0",
+        }, clear=False):
+            actual = cch.interruptible_api_call(
+                a, {"model":"gpt-test","input":"x"}
+            )
+        self.assertIs(actual, response)
+
+    def test_spontaneous_readerror_racing_later_watchdog_is_preserved(self):
+        a = self.agent()
+        original = httpx.ReadError("[Errno 32] Broken pipe")
+        def stream(*_args, **_kwargs):
+            raise original
+
+        def slow_close(_client, *, reason):
+            time.sleep(0.5)
+
+        a._run_codex_stream.side_effect = stream
+        a._close_request_openai_client.side_effect = slow_close
+        with patch.dict(os.environ, {
+            "HERMES_CODEX_TTFB_TIMEOUT_SECONDS":"0.05",
+            "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS":"0",
+        }, clear=False):
+            with self.assertRaises(httpx.ReadError) as caught:
+                cch.interruptible_api_call(a,{"model":"gpt-test","input":"x"})
+        self.assertIs(caught.exception, original)
+
+    def test_spontaneous_readerror_broken_pipe_is_preserved(self):
+        a = self.agent()
+        original = httpx.ReadError("[Errno 32] Broken pipe")
+        a._run_codex_stream.side_effect = original
+        with patch.dict(os.environ, {
+            "HERMES_CODEX_TTFB_TIMEOUT_SECONDS":"30",
+            "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS":"30",
+        }, clear=False):
+            with self.assertRaises(httpx.ReadError) as caught:
+                cch.interruptible_api_call(a,{"model":"gpt-test","input":"x"})
+        self.assertIs(caught.exception, original)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/cron/test_cron_direct_api_call_watchdog.py
+++ b/tests/cron/test_cron_direct_api_call_watchdog.py
@@ -246,10 +246,16 @@ def test_e2e_cron_turn_is_bounded_through_the_real_agent_routing(monkeypatch):
     agent = _build_cron_agent(monkeypatch)
     agent.client = wire
     monkeypatch.setattr(run_agent, "OpenAI", lambda **_kwargs: wire)
+
+    def force_close_active_socket(self, client, *, active_only=False):
+        assert active_only is True
+        client.sockets_shut_down.set()
+        return 1
+
     monkeypatch.setattr(
         run_agent.AIAgent,
         "_force_close_tcp_sockets",
-        lambda self, client: (client.sockets_shut_down.set(), 1)[1],
+        force_close_active_socket,
     )
 
     started = time.time()


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the generic stale watchdog could terminate an active Codex SSE stream after the stale timeout, even though the stream was still producing events.

The change:
- protects first-event registration and stale-call abort with a per-request lock;
- re-checks the first-event marker when the stale deadline is reached;
- preserves the existing Codex hard ceiling and specialized watchdogs;
- adds regression tests for the race and related watchdog lifecycle behavior.

## Testing

- 28/28 relevant unittest tests passed
- py_compile passed
- git diff --check passed
- Performance smoke test passed:
  - TTFB: 0.530 s
  - first SSE: 0.594 s
  - stream completed normally after ~161 s
  - response.completed received
  - 0 aborts
  - generic stale watchdog did not terminate the active stream

## Type of Change

- [x] Bug fix
- [x] Tests