### PR TITLE
feat(telegram): honor config.yaml extra for inbound text batch delay

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -762,7 +762,15 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
-        self._media_batch_delay_seconds = env_float("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", 0.8)
+        # Prefer config.yaml extra (WhatsApp-style); env remains a fallback.
+        if self._extra_has("media_batch_delay_seconds"):
+            self._media_batch_delay_seconds = self._coerce_float_extra(
+                "media_batch_delay_seconds", 0.8, min_value=0.0, max_value=30.0,
+            )
+        else:
+            self._media_batch_delay_seconds = env_float(
+                "HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", 0.8,
+            )
         self._pending_photo_batches: Dict[str, MessageEvent] = {}
         self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
         self._media_group_events: Dict[str, MessageEvent] = {}
@@ -771,21 +779,41 @@ class TelegramAdapter(BasePlatformAdapter):
         # messages are aggregated into a single MessageEvent.  Lower defaults
         # (0.3s / 1.0s instead of 0.6s / 2.0s) let short replies stream
         # without a noticeable wait — combined with the adaptive fast-path
-        # in ``_calc_text_batch_delay`` below, ≤320-codepoint replies settle
+        # in ``_text_batch_quiet_seconds`` below, ≤320-codepoint replies settle
         # in ~180ms.  All bounds are conservative for Telegram's
         # ~1 edit/s flood envelope.
-        self._text_batch_delay_seconds = self._env_float_clamped(
-            "HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS",
-            0.3,
-            min_value=0.08,
-            max_value=2.0,
-        )
-        self._text_batch_split_delay_seconds = self._env_float_clamped(
-            "HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS",
-            1.0,
-            min_value=self._text_batch_delay_seconds,
-            max_value=4.0,
-        )
+        #
+        # ``platforms.telegram.extra.text_batch_delay_seconds`` is the
+        # operator quiet period (same key as WhatsApp). When that extra is
+        # set, adaptive 0.18s/0.24s caps are skipped so a 3s setting actually
+        # waits 3s on short bubbles. Unset extra keeps the latency-tuned
+        # default (PR #10388).
+        self._text_batch_delay_from_config = self._extra_has("text_batch_delay_seconds")
+        if self._text_batch_delay_from_config:
+            self._text_batch_delay_seconds = self._coerce_float_extra(
+                "text_batch_delay_seconds", 0.3, min_value=0.0, max_value=30.0,
+            )
+        else:
+            self._text_batch_delay_seconds = self._env_float_clamped(
+                "HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS",
+                0.3,
+                min_value=0.08,
+                max_value=2.0,
+            )
+        if self._extra_has("text_batch_split_delay_seconds"):
+            self._text_batch_split_delay_seconds = self._coerce_float_extra(
+                "text_batch_split_delay_seconds",
+                max(self._text_batch_delay_seconds, 1.0),
+                min_value=self._text_batch_delay_seconds,
+                max_value=30.0,
+            )
+        else:
+            self._text_batch_split_delay_seconds = self._env_float_clamped(
+                "HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS",
+                1.0,
+                min_value=self._text_batch_delay_seconds,
+                max_value=4.0,
+            )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._drop_delayed_deliveries = False
@@ -1636,6 +1664,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 return False
             return default
         return bool(value)
+
+    def _extra_has(self, key: str) -> bool:
+        extra = getattr(getattr(self, "config", None), "extra", None)
+        return isinstance(extra, dict) and key in extra
 
     def _coerce_float_extra(
         self,
@@ -9344,6 +9376,25 @@ class TelegramAdapter(BasePlatformAdapter):
             self._flush_text_batch(key)
         )
 
+    def _text_batch_quiet_seconds(self, *, total_len: int, last_chunk_len: int) -> float:
+        """Quiet period before flushing a pending text batch.
+
+        Default (no ``text_batch_delay_seconds`` extra): adaptive tiers from
+        PR #10388 so short bubbles stay near-instant. Explicit
+        ``platforms.telegram.extra.text_batch_delay_seconds`` is the quiet
+        period for every non-split batch — operators can wait 2–5s for
+        multi-bubble input (file caption / follow-up text).
+        """
+        if last_chunk_len >= self._SPLIT_THRESHOLD:
+            return self._text_batch_split_delay_seconds
+        if getattr(self, "_text_batch_delay_from_config", False):
+            return self._text_batch_delay_seconds
+        if total_len <= self._TEXT_BATCH_FAST_LEN:
+            return min(self._text_batch_delay_seconds, self._TEXT_BATCH_FAST_DELAY_S)
+        if total_len <= self._TEXT_BATCH_SHORT_LEN:
+            return min(self._text_batch_delay_seconds, self._TEXT_BATCH_SHORT_DELAY_S)
+        return self._text_batch_delay_seconds
+
     async def _flush_text_batch(self, key: str) -> None:
         """Wait for the quiet period then dispatch the aggregated text.
 
@@ -9352,29 +9403,12 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         current_task = asyncio.current_task()
         try:
-            # Adaptive delay tiers:
-            #  - last chunk ≥ _SPLIT_THRESHOLD: a continuation is almost
-            #    certain → wait the longer split delay.
-            #  - total accumulated text ≤ _TEXT_BATCH_FAST_LEN (~320 cp):
-            #    short message → cap delay at _TEXT_BATCH_FAST_DELAY_S
-            #    so the agent sees the text near-instantly.
-            #  - total ≤ _TEXT_BATCH_SHORT_LEN (~1024 cp):
-            #    medium → cap at _TEXT_BATCH_SHORT_DELAY_S.
-            #  - otherwise: use the configured cap.
-            # Tiers compose with operator overrides via the env-var-driven
-            # ``_text_batch_delay_seconds`` (e.g. an operator who sets the
-            # cap below 0.18s gets that lower number on every tier).
             pending = self._pending_text_batches.get(key)
             last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
             total_len = len(getattr(pending, "text", "") or "") if pending else 0
-            if last_len >= self._SPLIT_THRESHOLD:
-                delay = self._text_batch_split_delay_seconds
-            elif total_len <= self._TEXT_BATCH_FAST_LEN:
-                delay = min(self._text_batch_delay_seconds, self._TEXT_BATCH_FAST_DELAY_S)
-            elif total_len <= self._TEXT_BATCH_SHORT_LEN:
-                delay = min(self._text_batch_delay_seconds, self._TEXT_BATCH_SHORT_DELAY_S)
-            else:
-                delay = self._text_batch_delay_seconds
+            delay = self._text_batch_quiet_seconds(
+                total_len=total_len, last_chunk_len=last_len,
+            )
             await asyncio.sleep(delay)
             event = self._pending_text_batches.pop(key, None)
             if not event:

--- a/tests/gateway/test_telegram_text_batch_perf.py
+++ b/tests/gateway/test_telegram_text_batch_perf.py
@@ -31,13 +31,11 @@ class TestEnvFloatClamped:
     """_env_float_clamped is the fence around every float env var the
     adapter reads — must reject NaN/Inf and honor min/max bounds."""
 
-
     def test_rejects_nan(self, monkeypatch):
         monkeypatch.setenv("HERMES_TEST_VAR", "nan")
         result = TelegramAdapter._env_float_clamped("HERMES_TEST_VAR", 0.5)
         assert math.isfinite(result)
         assert result == 0.5
-
 
     def test_clamps_below_min(self, monkeypatch):
         monkeypatch.setenv("HERMES_TEST_VAR", "0.01")
@@ -61,21 +59,41 @@ class TestAdaptiveTextBatchTiers:
 
     def test_fast_tier_uses_min_with_configured_cap(self, adapter):
         """A short message picks the lower of the fast-tier delay and
-        the operator's configured cap."""
-        # Operator set a generous cap (0.6s); fast tier should win.
+        the operator's configured cap when extra is unset."""
+        adapter._text_batch_delay_from_config = False
         adapter._text_batch_delay_seconds = 0.6
-        delay = min(
-            adapter._text_batch_delay_seconds,
-            TelegramAdapter._TEXT_BATCH_FAST_DELAY_S,
-        )
+        adapter._text_batch_split_delay_seconds = 1.0
+        delay = adapter._text_batch_quiet_seconds(total_len=10, last_chunk_len=10)
         assert delay == TelegramAdapter._TEXT_BATCH_FAST_DELAY_S
 
-        # Operator tightened the cap below the fast-tier delay; cap wins.
         adapter._text_batch_delay_seconds = 0.10
-        delay = min(
-            adapter._text_batch_delay_seconds,
-            TelegramAdapter._TEXT_BATCH_FAST_DELAY_S,
-        )
+        delay = adapter._text_batch_quiet_seconds(total_len=10, last_chunk_len=10)
         assert delay == 0.10
 
+    def test_explicit_config_extra_skips_adaptive_caps(self, adapter):
+        """platforms.telegram.extra.text_batch_delay_seconds is the quiet
+        period even for short bubbles (file + follow-up text)."""
+        adapter._text_batch_delay_from_config = True
+        adapter._text_batch_delay_seconds = 3.0
+        adapter._text_batch_split_delay_seconds = 6.0
+        delay = adapter._text_batch_quiet_seconds(total_len=20, last_chunk_len=20)
+        assert delay == 3.0
 
+    def test_split_chunk_still_uses_split_delay_when_extra_set(self, adapter):
+        adapter._text_batch_delay_from_config = True
+        adapter._text_batch_delay_seconds = 3.0
+        adapter._text_batch_split_delay_seconds = 6.0
+        delay = adapter._text_batch_quiet_seconds(
+            total_len=4100, last_chunk_len=TelegramAdapter._SPLIT_THRESHOLD,
+        )
+        assert delay == 6.0
+
+    def test_extra_has_reads_platform_config(self, adapter):
+        from gateway.config import PlatformConfig
+
+        adapter.config = PlatformConfig(
+            enabled=True, token="x", extra={"text_batch_delay_seconds": 3.0},
+        )
+        assert adapter._extra_has("text_batch_delay_seconds") is True
+        assert adapter._extra_has("media_batch_delay_seconds") is False
+        assert adapter._coerce_float_extra("text_batch_delay_seconds", 0.3) == 3.0

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -104,6 +104,25 @@ platforms:
 
 Telegram allows up to 100 BotCommands, but large command payloads can fail. Hermes defaults to 60 for reliability and clamps configured values to `1..100`; use `/commands` for the full command list.
 
+### Message batching (debounce)
+
+Telegram already coalesces rapid text (client-side splits) and albums. The **default** quiet period for short bubbles is ~180ms so a single reply still feels instant.
+
+If users send context as several bubbles (file, then instruction, then a follow-up), that window is too short and the agent starts on the first fragment. Raise it in `config.yaml` — same keys as WhatsApp. **Setting the extra skips the 180ms/240ms caps** so the value you type is the value you get:
+
+```yaml
+# ~/.hermes/config.yaml
+gateway:
+  platforms:
+    telegram:
+      extra:
+        text_batch_delay_seconds: 3.0         # quiet period (0 = flush immediately)
+        text_batch_split_delay_seconds: 6.0   # longer wait near Telegram's 4096 split
+        media_batch_delay_seconds: 1.5        # photo/album quiet period
+```
+
+Leave the keys unset to keep the stock low-latency defaults. Env vars (`HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS`, …) still work as a fallback and do **not** lift the short-message caps — use `config.yaml` extra when you want a longer wait.
+
 ## Step 3: Privacy Mode (Critical for Groups)
 
 Telegram bots have a **privacy mode** that is **enabled by default**. This is the single most common source of confusion when using bots in groups.


### PR DESCRIPTION
## Problem

Telegram already batches inbound text, but short bubbles are hard-capped at **180ms / 240ms** (`_TEXT_BATCH_FAST_DELAY_S` / `_TEXT_BATCH_SHORT_DELAY_S`, PR #10388). Raising `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` cannot lift that cap (`min(configured, 0.18)`).

Real users send context as several bubbles (file, then instruction, then a follow-up). The agent starts on the first fragment.

WhatsApp already exposes `platforms.whatsapp.extra.text_batch_delay_seconds` and honors it. Telegram did not.

## Approach

- Read `platforms.telegram.extra.text_batch_delay_seconds` / `text_batch_split_delay_seconds` / `media_batch_delay_seconds` (same keys as WhatsApp).
- **When `text_batch_delay_seconds` extra is set**, skip the 180ms/240ms adaptive caps so the configured quiet period is the quiet period.
- **When extra is unset**, keep the PR #10388 default (short replies still feel instant). No default-latency change.
- Env vars remain a fallback and still do **not** lift the short-message caps (behavior stays in `config.yaml`, not `.env`).
- Extract `_text_batch_quiet_seconds` so tests hit production logic.

## Tests

- Existing adaptive-tier tests now call `_text_batch_quiet_seconds`.
- New: extra set → 3s delay on a 20-char bubble; split-threshold still uses split delay; `_extra_has` reads `PlatformConfig.extra`.
- Sabotage: disabling the extra branch makes the new test fail (`0.18 == 3.0`).
- `uv run --extra dev pytest tests/gateway/test_telegram_text_batch_perf.py tests/gateway/test_telegram_text_batching.py` → 12 passed.

## Docs

`website/docs/user-guide/messaging/telegram.md` — Message batching section, mirrored on WhatsApp.

## Risk

- Defaults unchanged if extra is unset.
- File-then-separate-text still use different queues (media vs text). Out of scope; caption-on-file remains the workaround for that mix.

Closes nothing (no open issue for this exact gap; #2434 already shipped the original batcher).