### PR TITLE
fix(cli): resolve the duplicated prompt/status chrome class (interrupt, resize, focus regain, tmux attach)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3614,6 +3614,58 @@ def _strip_leaked_bracketed_paste_wrappers(text: str) -> str:
     return strip_leaked_bracketed_paste_wrappers(text)
 
 
+def _hermes_call_output_screen_diff(
+    orig_osd,
+    app,
+    output,
+    screen,
+    current_pos,
+    color_depth,
+    previous_screen,
+    last_style,
+    is_done,
+    full_screen,
+    attrs_for_style_string,
+    style_string_has_style,
+    size,
+    previous_width,
+):
+    """Call prompt_toolkit ``_output_screen_diff`` with Hermes resize guards.
+
+    1. Inflate ``previous_screen.height`` when the new screen is taller so pt
+       skips the reserve-vertical-space cursor move that stamps chrome into
+       scrollback (pt #29 / Hermes #26137).
+    2. On AttributeError/TypeError from a corrupt previous paint buffer
+       (classic after tmux attach with same width), retry once with
+       ``previous_screen=None`` so pt first-paints cleanly instead of crashing
+       the event loop with ``'cell' object has no attribute 'char'``.
+    """
+    try:
+        if previous_screen is not None and hasattr(previous_screen, "height"):
+            if previous_screen.height < screen.height:
+                previous_screen.height = screen.height
+    except Exception:
+        pass
+
+    try:
+        return orig_osd(
+            app, output, screen, current_pos, color_depth,
+            previous_screen, last_style, is_done, full_screen,
+            attrs_for_style_string, style_string_has_style,
+            size, previous_width,
+        )
+    except (AttributeError, TypeError):
+        # Corrupt previous_screen / row cells after client reattach.
+        return orig_osd(
+            app, output, screen, current_pos, color_depth,
+            None,  # previous_screen → first-paint erase path
+            None,  # last_style
+            is_done, full_screen,
+            attrs_for_style_string, style_string_has_style,
+            size, 0,  # previous_width → treat as changed
+        )
+
+
 def _apply_bracketed_paste_timeout_patch() -> None:
     """Patch prompt_toolkit to recover from torn bracketed-paste sequences.
 
@@ -5162,9 +5214,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # reach, leaving a duplicated status bar stranded above the live origin.
         # Ctrl+L / /redraw clears it cleanly, so route the resize path through
         # the SAME recovery: wipe the visible viewport (banner-safe — CSI 2J
-        # only, never CSI 3J) and replay the transcript so nothing is lost.
-        # Row-count-only changes skip this (no reflow → no ghost) to avoid an
-        # unnecessary full repaint.
+        # by default; CSI 3J only when display.cli_rebuild_scrollback_on_redraw
+        # is enabled) and replay the transcript so nothing is lost.
+        # Same-width SIGWINCH (tmux attach, benign focus/tab signals) is left
+        # untouched — no clear, no replay — because a 2J without replay erases
+        # the visible transcript and a replay against preserved scrollback
+        # duplicates it (#65293). The stale-previous_screen crash tmux attach
+        # used to trigger is handled by _hermes_call_output_screen_diff's
+        # retry-with-first-paint instead (#83874).
         try:
             new_width = self._get_tui_terminal_width()
         except Exception:
@@ -18110,20 +18167,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     other code path's behavior.
 
                     Critical: do NOT replace a None previous_screen with
-                    a fresh Screen() — that would skip the proper
-                    reset_attributes()+erase_down() at L178-185 which
-                    fires when previous_screen is None (first-paint /
+                    a fresh Screen() on the happy path — that would skip
+                    the proper reset_attributes()+erase_down() at L178-185
+                    which fires when previous_screen is None (first-paint /
                     width-change).  Without that reset, ANSI styles
                     leak between renders.
-                    """
-                    try:
-                        if previous_screen is not None and hasattr(previous_screen, "height"):
-                            if previous_screen.height < screen.height:
-                                previous_screen.height = screen.height
-                    except Exception:
-                        pass
 
-                    return _orig_osd(
+                    Safety net: if the diff crashes with AttributeError /
+                    TypeError (corrupt previous_screen after tmux attach —
+                    "'cell' object has no attribute 'char'"), retry once
+                    with previous_screen=None so pt takes the first-paint
+                    erase path instead of wedging the event loop.
+                    """
+                    return _hermes_call_output_screen_diff(
+                        _orig_osd,
                         app, output, screen, current_pos, color_depth,
                         previous_screen, last_style, is_done, full_screen,
                         attrs_for_style_string, style_string_has_style,

--- a/cli.py
+++ b/cli.py
@@ -5022,6 +5022,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             flush_stdin()
         except Exception:
             pass
+        # #60920: The interruption marker is now printed with
+        # _suspend_output_history in chat(), so _OUTPUT_HISTORY only
+        # contains the normal response text (no marker text). Do NOT
+        # clear history here — _force_full_redraw → _replay_output_history
+        # replays the response correctly without duplicating the marker.
+        # The /redraw + Ctrl+L paths also preserve replay for scrollback
+        # recovery as intended.
         self._force_full_redraw()
 
     def _clear_prompt_toolkit_screen(self, app, *, rebuild_scrollback: bool = False) -> None:
@@ -14980,15 +14987,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             # Handle interrupt - check if we were interrupted
             pending_message = None
+            _show_interrupt_marker = False
             _interrupted_this_turn = bool(result and result.get("interrupted"))
             # Expose the flag for post-turn hooks (e.g. goal continuation)
             # so they can skip themselves when the turn was user-cancelled.
             self._last_turn_interrupted = _interrupted_this_turn
             if _interrupted_this_turn:
                 pending_message = result.get("interrupt_message") or interrupt_msg
-                # Add indicator that we were interrupted
-                if response and pending_message:
-                    response = response + "\n\n---\n_[Interrupted - processing new message]_"
+                # #60920: Don't append the interruption marker to response so it
+                # is never recorded in _OUTPUT_HISTORY by the Panel rendering
+                # below. The marker is printed separately with _suspend_output_history
+                # after the response Panel to preserve the visual while avoiding
+                # duplicates on terminal redraw (_recover_terminal_after_interrupt).
+                _show_interrupt_marker = bool(response and pending_message)
             elif interrupt_msg:
                 # We fired agent.interrupt(interrupt_msg) but the turn result
                 # doesn't acknowledge it. Two ways this happens, both racy:
@@ -15118,6 +15129,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         ))
                     except Exception:
                         pass
+
+            # #60920: Print interruption marker with history suppressed so it
+            # is never recorded in _OUTPUT_HISTORY. The marker was previously
+            # appended to `response` which caused a duplicate on terminal redraw
+            # when _replay_output_history replayed it. Printing it here with
+            # _suspend_output_history preserves the user-visible indicator while
+            # keeping _OUTPUT_HISTORY clean for replay.
+            if _show_interrupt_marker:
+                with _suspend_output_history():
+                    _cprint(f"\n{_DIM}── [Interrupted — processing new message] ──{_RST}")
 
 
             # Focus view: dim recovery line reporting what was hidden this turn

--- a/cli.py
+++ b/cli.py
@@ -501,6 +501,12 @@ def load_cli_config() -> Dict[str, Any]:
             "busy_input_mode": "interrupt",
             "persistent_output": True,
             "persistent_output_max_lines": 200,
+            # Clear terminal scrollback as well as the visible viewport when the
+            # classic CLI performs a full redraw/resize recovery. Disabled by
+            # default because some users prefer preserving terminal history;
+            # enable when a terminal/tmux stack stamps stale prompt chrome into
+            # scrollback during fullscreen/restore resizes.
+            "cli_rebuild_scrollback_on_redraw": False,
             # Print a one-line summary of resolved modal prompts (approval /
             # clarify) into scrollback so the decision survives the repaint.
             "persist_prompts": True,
@@ -5013,12 +5019,33 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         app = getattr(self, "_app", None)
         if not app:
             return
-        self._clear_prompt_toolkit_screen(app)
+        self._clear_prompt_toolkit_screen(
+            app,
+            rebuild_scrollback=self._redraw_rebuilds_scrollback(),
+        )
         _replay_output_history()
         try:
             app.invalidate()
         except Exception:
             pass
+
+    @staticmethod
+    def _redraw_rebuilds_scrollback() -> bool:
+        """Return whether CLI redraw/resize recovery should clear scrollback.
+
+        Some terminal/tmux stacks move prompt_toolkit's non-fullscreen bottom
+        chrome into scrollback when the window is maximized/restored. A normal
+        CSI 2J viewport clear cannot remove those stale prompt/input-rule rows,
+        so users who hit that class of bug need CSI 3J as well, followed by the
+        existing bounded output-history replay.
+        """
+        display_config = CLI_CONFIG.get("display") if isinstance(CLI_CONFIG, dict) else {}
+        if not isinstance(display_config, dict):
+            display_config = {}
+        raw = display_config.get("cli_rebuild_scrollback_on_redraw", False)
+        if isinstance(raw, str):
+            return raw.strip().lower() in {"1", "true", "yes", "on", "always"}
+        return bool(raw)
 
     def _recover_terminal_after_interrupt(self) -> None:
         """Recover the terminal after an interrupted agent turn (#33271).
@@ -5160,7 +5187,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         )
         if width_changed:
             try:
-                self._clear_prompt_toolkit_screen(app, rebuild_scrollback=False)
+                self._clear_prompt_toolkit_screen(
+                    app,
+                    rebuild_scrollback=self._redraw_rebuilds_scrollback(),
+                )
                 _replay_output_history()
             except Exception:
                 pass

--- a/cli.py
+++ b/cli.py
@@ -5121,9 +5121,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             new_width = None
         prev_width = getattr(self, "_last_resize_width", None)
-        # First resize of the session has no prior width to compare against;
-        # treat it as a change so an initial maximize/restore is covered too.
-        width_changed = new_width is not None and new_width != prev_width
+        # Replay only on an OBSERVED width change.  The first signal of a
+        # session must not count as one (#65293): GNOME Terminal and friends
+        # deliver benign SIGWINCHes (tab bar appearing, monitor-scale change,
+        # focus events), and a 2J+replay against preserved scrollback
+        # duplicates everything ``_OUTPUT_HISTORY`` holds — after a resume
+        # that is the entire "Previous Conversation" recap plus the first
+        # live exchange.  ``_install_resize_recovery`` seeds the baseline at
+        # startup, so an initial maximize/restore still differs from it and
+        # is still recovered; with no baseline (width probe failed) this
+        # signal just records one for the next comparison.
+        width_changed = (
+            new_width is not None
+            and prev_width is not None
+            and new_width != prev_width
+        )
         if width_changed:
             try:
                 self._clear_prompt_toolkit_screen(app, rebuild_scrollback=False)
@@ -5221,6 +5233,45 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             self._resize_recovery_pending = False
             self._recover_after_resize(app, original_on_resize)
+
+    def _install_resize_recovery(self, app) -> None:
+        """Route prompt_toolkit's ``_on_resize`` through the debounced
+        ghost-clearing recovery (#5474/#49120) and record the current terminal
+        width as the baseline for width-change detection.
+
+        Seeding the baseline here is what keeps the session's FIRST SIGWINCH
+        honest (#65293): ``_recover_after_resize`` replays the transcript only
+        on an observed width change, and without a startup baseline it could
+        not tell a benign signal (GNOME Terminal tab bar, monitor-scale
+        change) from a real one.  An initial maximize/restore still differs
+        from the seeded width, so it is still recovered.
+
+        The probe reads ``app.output`` directly — NOT
+        ``_get_tui_terminal_width`` — because this runs before ``app.run()``,
+        when ``get_app()`` still returns prompt_toolkit's DummyApplication
+        whose DummyOutput reports a hardcoded 80 columns; seeding that fake
+        width would make the first real signal look like a width change and
+        resurrect the duplicate-replay bug this exists to fix.
+        ``app.output`` is the same object the running app's resize handler
+        measures, so install-time and signal-time widths are comparable.
+        """
+        width = None
+        try:
+            width = app.output.get_size().columns
+        except Exception:
+            width = None
+        if not width or width <= 0:
+            try:
+                width = shutil.get_terminal_size((80, 24)).columns
+            except Exception:
+                width = None
+        self._last_resize_width = width
+        original_on_resize = app._on_resize
+
+        def _resize_clear_ghosts():
+            self._schedule_resize_recovery(app, original_on_resize)
+
+        app._on_resize = _resize_clear_ghosts
 
     def _status_bar_context_style(self, percent_used: Optional[int]) -> str:
         if percent_used is None:
@@ -18036,12 +18087,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # don't permanently freeze the input (issue #16263). Idempotent.
         _apply_bracketed_paste_timeout_patch()
 
-        _original_on_resize = app._on_resize
-
-        def _resize_clear_ghosts():
-            self._schedule_resize_recovery(app, _original_on_resize)
-
-        app._on_resize = _resize_clear_ghosts
+        self._install_resize_recovery(app)
 
         def spinner_loop():
             while not self._should_exit:

--- a/cli.py
+++ b/cli.py
@@ -5081,6 +5081,32 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             pass
 
+    def _schedule_focus_regain_redraw(self, min_interval: float = 1.0) -> None:
+        """Repaint after a terminal focus-in report (``CSI I``), rate-limited.
+
+        Terminals with focus tracking active (Ghostty, iTerm2, xterm builds,
+        multiplexers that toggle DECSET 1004 upstream) emit ``\\x1b[I`` when
+        the Hermes tab/window becomes visible again. Emulators can coalesce
+        or drop hidden-tab output and repaint the surface while we're
+        invisible, so on regain prompt_toolkit's incremental diff stacks on
+        stale content — a second copy of the composer/prompt chrome next to
+        the ghost of the old one (#60920 focus-regain variant, #25337).
+
+        The stock handling maps ``CSI I``/``CSI O`` to ``Keys.Ignore`` so the
+        bytes never pollute the input buffer; this hook additionally routes
+        focus-in through the same recovery as Ctrl+L / ``/redraw``. It is
+        self-gating: terminals that never enable focus tracking never emit
+        the sequence, so nothing changes for them. Rate-limited so a burst of
+        focus reports (rapid Alt+Tab, mux pane hops) repaints at most once
+        per ``min_interval`` seconds.
+        """
+        now = time.monotonic()
+        last = getattr(self, "_last_focus_regain_redraw", 0.0)
+        if now - last < min_interval:
+            return
+        self._last_focus_regain_redraw = now
+        self._force_full_redraw()
+
     @staticmethod
     def _redraw_rebuilds_scrollback() -> bool:
         """Return whether CLI redraw/resize recovery should clear scrollback.
@@ -16100,7 +16126,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             VT100 parser level. Without this no-op binding the default
             self-insert path would still fire and the bytes would land in
             the buffer.
+
+            Focus-in (CSI I) additionally schedules a rate-limited full
+            repaint: while the tab/window was hidden the emulator may have
+            coalesced output or repainted the surface, so prompt_toolkit's
+            incremental diff would stack a fresh copy of the prompt chrome
+            on top of the stale one (#60920 focus-regain variant, #25337).
             """
+            try:
+                for press in getattr(event, "key_sequence", None) or ():
+                    if getattr(press, "data", None) == "\x1b[I":
+                        self._schedule_focus_regain_redraw()
+                        break
+            except Exception:
+                pass
             return None
 
         def handle_enter(event):

--- a/cli.py
+++ b/cli.py
@@ -3954,6 +3954,26 @@ def _estimate_tui_input_height(
     return min(max(visual_lines, 1), max(1, int(max_height or 1)))
 
 
+def _status_bar_visible_from_display_config(display_config: object) -> bool:
+    """Return the initial classic-CLI status-bar visibility from display config.
+
+    ``display.tui_statusbar`` is the persisted user-facing setting toggled by
+    the TUI/statusbar controls. YAML parses bare ``off`` as ``False``, while
+    older config snapshots or hand edits may use strings such as ``"off"`` or
+    ``"hidden"``. Treat those values consistently so a new CLI process does not
+    re-enable a status bar that the user deliberately disabled.
+    """
+    if not isinstance(display_config, dict):
+        display_config = {}
+    statusbar_config = display_config.get(
+        "statusbar",
+        display_config.get("tui_statusbar", "top"),
+    )
+    if isinstance(statusbar_config, str):
+        return statusbar_config.strip().lower() not in {"0", "false", "hidden", "no", "off"}
+    return statusbar_config is not False
+
+
 def _collect_query_images(query: str | None, image_arg: str | None = None) -> tuple[str, list[Path]]:
     """Collect local image attachments for single-query CLI flows."""
     message = query or ""
@@ -4865,7 +4885,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._voice_barge_phase = None  # "generation" or "playback" phase of the last barge trip
 
         # Status bar visibility (toggled via /statusbar)
-        self._status_bar_visible = True
+        self._status_bar_visible = _status_bar_visible_from_display_config(
+            CLI_CONFIG.get("display") if isinstance(CLI_CONFIG, dict) else None
+        )
         # Battery read-out in the status bar (toggled via /battery, off by
         # default). Persisted to display.battery so it survives restarts.
         self._battery_visible = bool(CLI_CONFIG["display"].get("battery", False))

--- a/contributors/emails/angeon922@gmail.com
+++ b/contributors/emails/angeon922@gmail.com
@@ -1,0 +1,1 @@
+angeon922-collab

--- a/contributors/emails/halaprix@users.noreply.github.com
+++ b/contributors/emails/halaprix@users.noreply.github.com
@@ -1,0 +1,1 @@
+halaprix

--- a/contributors/emails/hunter@mail.com
+++ b/contributors/emails/hunter@mail.com
@@ -1,0 +1,1 @@
+zoidypuh

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1211,6 +1211,12 @@ DEFAULT_CONFIG = {
         # behaves badly with replayed scrollback.
         "persistent_output": True,
         "persistent_output_max_lines": 200,
+        # Clear terminal scrollback as well as the visible viewport when the
+        # classic CLI performs a full redraw/resize recovery. Disabled by
+        # default because some users prefer preserving terminal history;
+        # enable when a terminal/tmux stack stamps stale prompt chrome into
+        # scrollback during fullscreen/restore window transitions.
+        "cli_rebuild_scrollback_on_redraw": False,
         # Print a one-line summary of resolved modal prompts (approval /
         # clarify) into scrollback so the question and decision survive the
         # panel repaint. Set false to keep scrollback untouched.

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -142,3 +142,119 @@ class TestForceFullRedraw:
         bare_cli._app = app
 
         bare_cli._force_full_redraw()  # must not raise
+
+
+class TestFirstSigwinchBaseline:
+    """Bug #65293: the session's FIRST SIGWINCH used to be force-treated as a
+    width change (no prior width to compare against), so a benign resize
+    signal — GNOME Terminal tab bar appearing, monitor-scale change, focus
+    events — cleared the viewport and replayed ``_OUTPUT_HISTORY``.  After a
+    resume that deque holds the whole "Previous Conversation" recap plus the
+    first live exchange, so everything reprinted as a duplicate.  A replay
+    must require an OBSERVED width change against a recorded baseline.
+    """
+
+    def test_first_sigwinch_with_unchanged_width_does_not_replay(
+        self, bare_cli, monkeypatch
+    ):
+        app = MagicMock()
+        events = []
+        app.renderer.output.erase_screen.side_effect = lambda: events.append("erase")
+        original_on_resize = lambda: events.append("original_resize")
+
+        bare_cli._status_bar_suppressed_after_resize = False
+        # No baseline recorded yet — the pre-fix code forced width_changed=True.
+        assert getattr(bare_cli, "_last_resize_width", None) is None
+        monkeypatch.setattr(bare_cli, "_get_tui_terminal_width", lambda: 120)
+        monkeypatch.setattr(bare_cli, "_schedule_status_bar_unsuppress", lambda *_: None)
+        monkeypatch.setattr(
+            cli_mod, "_replay_output_history", lambda: events.append("replay")
+        )
+
+        bare_cli._recover_after_resize(app, original_on_resize)
+
+        # Width did not change — no clear, no replay, straight to prompt_toolkit.
+        assert events == ["original_resize"]
+        app.renderer.output.erase_screen.assert_not_called()
+        # The signal still records the baseline for the next comparison.
+        assert bare_cli._last_resize_width == 120
+
+    def test_real_width_change_after_baseline_still_replays(
+        self, bare_cli, monkeypatch
+    ):
+        """The #49120 recovery (2J + replay) must still fire on a real change."""
+        app = MagicMock()
+        events = []
+        app.renderer.output.erase_screen.side_effect = lambda: events.append("erase")
+        original_on_resize = lambda: events.append("original_resize")
+
+        bare_cli._status_bar_suppressed_after_resize = False
+        bare_cli._last_resize_width = 120
+        monkeypatch.setattr(bare_cli, "_get_tui_terminal_width", lambda: 90)
+        monkeypatch.setattr(bare_cli, "_schedule_status_bar_unsuppress", lambda *_: None)
+        monkeypatch.setattr(
+            cli_mod, "_replay_output_history", lambda: events.append("replay")
+        )
+
+        bare_cli._recover_after_resize(app, original_on_resize)
+
+        assert "erase" in events and "replay" in events
+        assert bare_cli._last_resize_width == 90
+
+    def test_install_resize_recovery_seeds_width_baseline(self, bare_cli):
+        """Hook installation records the CURRENT width as the baseline, so an
+        initial maximize/restore (a real change vs that baseline) is still
+        recovered while a same-size first signal is not.
+
+        The baseline must come from ``app.output`` — the same object the
+        running app measures on SIGWINCH — not from ``get_app()``, which
+        before ``app.run()`` is a DummyApplication reporting a fake 80 cols.
+        """
+        app = MagicMock()
+        app.output.get_size.return_value.columns = 132
+        scheduled = []
+        bare_cli._schedule_resize_recovery = lambda *a, **k: scheduled.append(a)
+
+        original = app._on_resize
+        bare_cli._install_resize_recovery(app)
+
+        assert bare_cli._last_resize_width == 132
+        assert app._on_resize is not original  # hook installed
+        app._on_resize()  # simulated SIGWINCH → routes to the debouncer
+        assert len(scheduled) == 1
+        assert scheduled[0][0] is app
+        assert scheduled[0][1] is original
+
+    def test_install_resize_recovery_falls_back_to_shutil(
+        self, bare_cli, monkeypatch
+    ):
+        """A dead app.output probe falls back to shutil, never to the
+        DummyApplication's fake width."""
+        import os as os_mod
+
+        app = MagicMock()
+        app.output.get_size.side_effect = RuntimeError("not attached")
+        monkeypatch.setattr(
+            cli_mod.shutil,
+            "get_terminal_size",
+            lambda _default: os_mod.terminal_size((97, 40)),
+        )
+
+        bare_cli._install_resize_recovery(app)
+
+        assert bare_cli._last_resize_width == 97
+
+    def test_install_resize_recovery_survives_width_probe_failure(
+        self, bare_cli, monkeypatch
+    ):
+        app = MagicMock()
+        app.output.get_size.side_effect = RuntimeError("not attached")
+
+        def _boom(_default):
+            raise RuntimeError("no tty")
+
+        monkeypatch.setattr(cli_mod.shutil, "get_terminal_size", _boom)
+
+        bare_cli._install_resize_recovery(app)  # must not raise
+
+        assert getattr(bare_cli, "_last_resize_width", None) is None

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -389,3 +389,40 @@ class TestFirstSigwinchBaseline:
         bare_cli._install_resize_recovery(app)  # must not raise
 
         assert getattr(bare_cli, "_last_resize_width", None) is None
+
+
+class TestFocusRegainRedraw:
+    """Focus-in (CSI I) routes through the same recovery as Ctrl+L, rate-limited.
+
+    While the tab/window is hidden the emulator may coalesce output or repaint
+    the surface; on regain prompt_toolkit's incremental diff stacks a fresh
+    copy of the prompt chrome on top of the stale one (#60920 focus-regain
+    variant, #25337).
+    """
+
+    def test_focus_regain_triggers_full_redraw(self, bare_cli):
+        calls = []
+        bare_cli._force_full_redraw = lambda: calls.append("redraw")
+
+        bare_cli._schedule_focus_regain_redraw()
+
+        assert calls == ["redraw"]
+
+    def test_focus_regain_redraw_is_rate_limited(self, bare_cli):
+        calls = []
+        bare_cli._force_full_redraw = lambda: calls.append("redraw")
+
+        bare_cli._schedule_focus_regain_redraw(min_interval=60.0)
+        bare_cli._schedule_focus_regain_redraw(min_interval=60.0)
+        bare_cli._schedule_focus_regain_redraw(min_interval=60.0)
+
+        assert calls == ["redraw"]
+
+    def test_focus_regain_redraw_fires_again_after_interval(self, bare_cli):
+        calls = []
+        bare_cli._force_full_redraw = lambda: calls.append("redraw")
+
+        bare_cli._schedule_focus_regain_redraw(min_interval=0.0)
+        bare_cli._schedule_focus_regain_redraw(min_interval=0.0)
+
+        assert calls == ["redraw", "redraw"]

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -123,6 +123,81 @@ class TestForceFullRedraw:
         assert events[:3] == ["erase", "scrollback_wipe", "replay"]
         assert events.index("scrollback_wipe") < events.index("original_resize")
 
+    def test_same_width_sigwinch_is_left_untouched(self, bare_cli, monkeypatch):
+        """Same-width SIGWINCH (tmux attach, benign focus/tab signals) must not
+        clear the viewport or replay: a 2J without replay erases the visible
+        transcript, and a replay duplicates it (#65293). The tmux-attach
+        stale-paint crash is handled by _hermes_call_output_screen_diff's
+        retry instead (#83874)."""
+        app = MagicMock()
+        events = []
+        app.renderer.output.erase_screen.side_effect = lambda: events.append("erase")
+        app.renderer.output.write_raw.side_effect = lambda *_: events.append("scrollback_wipe")
+        original_on_resize = lambda: events.append("original_resize")
+
+        bare_cli._status_bar_suppressed_after_resize = False
+        bare_cli._last_resize_width = 120
+        monkeypatch.setattr(bare_cli, "_get_tui_terminal_width", lambda: 120)
+        monkeypatch.setattr(bare_cli, "_schedule_status_bar_unsuppress", lambda *_: None)
+        monkeypatch.setattr(cli_mod, "_replay_output_history", lambda: events.append("replay"))
+
+        bare_cli._recover_after_resize(app, original_on_resize)
+
+        assert "erase" not in events
+        assert "replay" not in events
+        assert "scrollback_wipe" not in events
+        assert events == ["original_resize"]
+        assert bare_cli._last_resize_width == 120
+        assert bare_cli._status_bar_suppressed_after_resize is True
+
+    def test_output_screen_diff_retries_on_corrupt_previous_screen(self, bare_cli):
+        """Corrupt previous_screen must not wedge the paint loop.
+
+        After tmux attach, _output_screen_diff can raise AttributeError
+        ('cell' object has no attribute 'char'). Retry with previous_screen=None.
+        """
+        calls = []
+
+        def fake_osd(
+            app, output, screen, current_pos, color_depth,
+            previous_screen, last_style, is_done, full_screen,
+            attrs_for_style_string, style_string_has_style,
+            size, previous_width,
+        ):
+            calls.append((previous_screen, previous_width, last_style))
+            if previous_screen is not None:
+                # Exact failure mode from the classic CLI event loop.
+                raise AttributeError("'cell' object has no attribute 'char'")
+            return ("ok", current_pos, last_style)
+
+        screen = MagicMock()
+        screen.height = 10
+        previous = MagicMock()
+        previous.height = 8
+
+        result = cli_mod._hermes_call_output_screen_diff(
+            fake_osd,
+            app=None,
+            output=None,
+            screen=screen,
+            current_pos=None,
+            color_depth=None,
+            previous_screen=previous,
+            last_style="style",
+            is_done=False,
+            full_screen=False,
+            attrs_for_style_string=None,
+            style_string_has_style=None,
+            size=None,
+            previous_width=80,
+        )
+
+        assert result[0] == "ok"
+        assert len(calls) == 2
+        assert calls[0][0] is previous
+        assert previous.height == 10  # height inflate still applied first
+        assert calls[1] == (None, 0, None)
+
     def test_resize_recovery_is_debounced(self, bare_cli, monkeypatch):
         timers = []
         calls = []

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -53,6 +53,11 @@ class TestForceFullRedraw:
         monkeypatch.setattr(bare_cli, "_get_tui_terminal_width", lambda: 90)
         monkeypatch.setattr(bare_cli, "_schedule_status_bar_unsuppress", lambda *_: None)
         monkeypatch.setattr(cli_mod, "_replay_output_history", lambda: events.append("replay"))
+        monkeypatch.setattr(
+            cli_mod,
+            "CLI_CONFIG",
+            {"display": {"cli_rebuild_scrollback_on_redraw": False}},
+        )
 
         bare_cli._recover_after_resize(app, original_on_resize)
 
@@ -66,6 +71,57 @@ class TestForceFullRedraw:
         assert bare_cli._last_resize_width == 90
         assert bare_cli._status_bar_suppressed_after_resize is True
 
+    def test_force_redraw_uses_full_screen_clear_without_scrollback_clear(self, bare_cli, monkeypatch):
+        app = MagicMock()
+        bare_cli._app = app
+        monkeypatch.setattr(
+            cli_mod,
+            "CLI_CONFIG",
+            {"display": {"cli_rebuild_scrollback_on_redraw": False}},
+        )
+
+        bare_cli._force_full_redraw()
+
+        app.renderer.output.erase_screen.assert_called_once()
+        app.renderer.output.cursor_goto.assert_called_once_with(0, 0)
+        app.renderer.output.write_raw.assert_not_called()
+
+    def test_force_redraw_can_clear_scrollback_when_configured(self, bare_cli, monkeypatch):
+        app = MagicMock()
+        bare_cli._app = app
+        monkeypatch.setattr(
+            cli_mod,
+            "CLI_CONFIG",
+            {"display": {"cli_rebuild_scrollback_on_redraw": True}},
+        )
+
+        bare_cli._force_full_redraw()
+
+        app.renderer.output.erase_screen.assert_called_once()
+        app.renderer.output.write_raw.assert_called_once_with("\x1b[3J")
+
+    def test_resize_recovery_can_clear_scrollback_when_configured(self, bare_cli, monkeypatch):
+        app = MagicMock()
+        events = []
+        app.renderer.output.erase_screen.side_effect = lambda: events.append("erase")
+        app.renderer.output.write_raw.side_effect = lambda *_: events.append("scrollback_wipe")
+        original_on_resize = lambda: events.append("original_resize")
+
+        bare_cli._status_bar_suppressed_after_resize = False
+        bare_cli._last_resize_width = 200
+        monkeypatch.setattr(bare_cli, "_get_tui_terminal_width", lambda: 90)
+        monkeypatch.setattr(bare_cli, "_schedule_status_bar_unsuppress", lambda *_: None)
+        monkeypatch.setattr(cli_mod, "_replay_output_history", lambda: events.append("replay"))
+        monkeypatch.setattr(
+            cli_mod,
+            "CLI_CONFIG",
+            {"display": {"cli_rebuild_scrollback_on_redraw": "true"}},
+        )
+
+        bare_cli._recover_after_resize(app, original_on_resize)
+
+        assert events[:3] == ["erase", "scrollback_wipe", "replay"]
+        assert events.index("scrollback_wipe") < events.index("original_resize")
 
     def test_resize_recovery_is_debounced(self, bare_cli, monkeypatch):
         timers = []

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -1,4 +1,5 @@
 import time
+from copy import deepcopy
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -73,6 +74,23 @@ class TestCLIStatusBar:
         snapshot = cli_obj._get_status_bar_snapshot()
 
         assert snapshot["session_title"] == "user-profiles"
+
+    def test_status_bar_config_helper_treats_persisted_off_as_hidden(self):
+        for value in (False, "off", "false", "hidden", "no", "0"):
+            assert cli_mod._status_bar_visible_from_display_config({"tui_statusbar": value}) is False
+
+        for value in (True, "top", "bottom", "on", None):
+            assert cli_mod._status_bar_visible_from_display_config({"tui_statusbar": value}) is True
+
+    def test_status_bar_initial_visibility_honors_tui_statusbar_config(self, monkeypatch):
+        config = deepcopy(cli_mod.CLI_CONFIG)
+        config.setdefault("display", {})["tui_statusbar"] = False
+        config["display"].pop("statusbar", None)
+        monkeypatch.setattr(cli_mod, "CLI_CONFIG", config)
+
+        cli_obj = HermesCLI(model="test-model", toolsets=[], provider="auto")
+
+        assert cli_obj._status_bar_visible is False
 
     def test_context_style_thresholds(self):
         cli_obj = _make_cli()

--- a/tests/cli/test_interrupt_output_history_regression.py
+++ b/tests/cli/test_interrupt_output_history_regression.py
@@ -1,0 +1,326 @@
+"""Regression tests for #60920/#60941: interrupt marker duplication on redraw.
+
+The root cause: The interrupt marker ("_[Interrupted - processing new message]_")
+was being appended to the response string, which got recorded in _OUTPUT_HISTORY
+by the Panel rendering via _cprint → _record_output_history. When
+_recover_terminal_after_interrupt called _force_full_redraw → _replay_output_history,
+the marker was replayed on top of the already-visible message, causing duplicates
+that accumulated on every SIGWINCH.
+
+The fix:
+1. A flag ``_show_interrupt_marker`` is set instead of mutating ``response``.
+2. After the Panel rendering, the marker is printed via ``_cprint`` inside a
+   ``_suspend_output_history()`` context so it never enters ``_OUTPUT_HISTORY``.
+3. ``_recover_terminal_after_interrupt`` no longer clears ``_OUTPUT_HISTORY`` —
+   it doesn't need to, because the marker was never recorded.
+
+These tests verify the contract at the module level without hitting the full
+prompt_toolkit input loop.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import cli as cli_mod
+from cli import HermesCLI, _suspend_output_history
+
+
+@pytest.fixture(autouse=True)
+def reset_output_history():
+    """Reset _OUTPUT_HISTORY before and after every test."""
+    cli_mod._configure_output_history(True, 200)
+    yield
+    cli_mod._configure_output_history(True, 200)
+
+
+# ── Recovery path: _OUTPUT_HISTORY must NOT be cleared ──────────────
+
+
+class TestRecoverTerminalPreservesHistory:
+    """_recover_terminal_after_interrupt must NOT clear output history.
+
+    The old fix cleared _OUTPUT_HISTORY before the redraw to prevent the
+    interrupt marker from being replayed. The new fix avoids recording the
+    marker in the first place, so the clear is unnecessary *and* harmful —
+    it would discard legitimate scrollback content.
+    """
+
+    def test_history_preserved_after_recovery(self, monkeypatch):
+        """After recovery, _OUTPUT_HISTORY still contains earlier output."""
+        cli_mod._configure_output_history(True, 10)
+        cli_mod._record_output_history("normal response text")
+
+        cli = object.__new__(HermesCLI)
+        cli._force_full_redraw = MagicMock()
+
+        with patch("hermes_cli.curses_ui.flush_stdin"):
+            cli._recover_terminal_after_interrupt()
+
+        assert list(cli_mod._OUTPUT_HISTORY) == ["normal response text"], (
+            "_recover_terminal_after_interrupt must NOT clear _OUTPUT_HISTORY"
+        )
+
+    def test_recovery_still_calls_force_full_redraw(self, monkeypatch):
+        """The recovery path still forces a redraw (original behavior preserved)."""
+        cli = object.__new__(HermesCLI)
+        cli._force_full_redraw = MagicMock()
+
+        with patch("hermes_cli.curses_ui.flush_stdin"):
+            cli._recover_terminal_after_interrupt()
+
+        cli._force_full_redraw.assert_called_once()
+
+    def test_normal_scrollback_survives_interrupt_cycle(self, monkeypatch):
+        """Multiple lines of scrollback survive a full interrupt → recovery cycle."""
+        cli_mod._configure_output_history(True, 50)
+        for i in range(5):
+            cli_mod._record_output_history(f"visible line {i}")
+
+        cli = object.__new__(HermesCLI)
+        cli._force_full_redraw = MagicMock()
+
+        with patch("hermes_cli.curses_ui.flush_stdin"):
+            cli._recover_terminal_after_interrupt()
+
+        assert len(cli_mod._OUTPUT_HISTORY) == 5
+        assert list(cli_mod._OUTPUT_HISTORY) == [
+            f"visible line {i}" for i in range(5)
+        ]
+
+
+# ── Marker suppression: _suspend_output_history blocks recording ────
+
+
+class TestInterruptMarkerNotRecorded:
+    """The interrupt marker must never enter _OUTPUT_HISTORY.
+
+    Because it's printed inside a ``with _suspend_output_history():`` block,
+    the marker text stays out of the replay buffer and _replay_output_history
+    cannot duplicate it on redraw or resize.
+    """
+
+    def test_suspend_blocks_recording_during_cprint(self, monkeypatch):
+        """Text printed via _cprint while supressed is not recorded in history."""
+        cli_mod._configure_output_history(True, 10)
+        monkeypatch.setattr(cli_mod, "_pt_print", lambda x: None)
+        monkeypatch.setattr(cli_mod, "_PT_ANSI", lambda t: t)
+
+        # Record something before so we can distinguish "empty" from "never configured"
+        cli_mod._record_output_history("before marker")
+
+        with _suspend_output_history():
+            cli_mod._cprint("── [Interrupted — processing new message] ──")
+
+        assert list(cli_mod._OUTPUT_HISTORY) == ["before marker"], (
+            "_OUTPUT_HISTORY must not contain the marker text printed "
+            "under _suspend_output_history"
+        )
+
+    def test_normal_cprint_still_records(self, monkeypatch):
+        """Normal _cprint calls (outside the suspend context) are still recorded.
+
+        Regression: the fix must not accidentally suppress ALL output history,
+        only the interrupt marker.
+        """
+        cli_mod._configure_output_history(True, 10)
+        printed = []
+        monkeypatch.setattr(cli_mod, "_pt_print", lambda x: printed.append(x))
+        monkeypatch.setattr(cli_mod, "_PT_ANSI", lambda t: t)
+
+        cli_mod._cprint("normal response text")
+
+        assert "normal response text" in list(cli_mod._OUTPUT_HISTORY)
+        assert printed == ["normal response text"]
+
+    def test_suspend_is_idempotent_nested(self):
+        """Nested _suspend_output_history() calls restore correctly."""
+        cli_mod._configure_output_history(True, 10)
+        cli_mod._record_output_history("before")
+
+        with _suspend_output_history():
+            cli_mod._record_output_history("inside outer")
+            with _suspend_output_history():
+                cli_mod._record_output_history("inside inner")
+
+        cli_mod._record_output_history("after")
+
+        assert list(cli_mod._OUTPUT_HISTORY) == [
+            "before",
+            "after",
+        ]
+
+
+# ── _show_interrupt_marker flag logic ──────────────────────────────
+
+
+class TestShowInterruptMarkerLogic:
+    """The _show_interrupt_marker flag must be set correctly.
+
+    The flag is True only when: the turn was interrupted (result.interrupted),
+    AND there is both a response AND a pending_message (interrupt_msg).
+    """
+
+    def test_marker_shown_when_interrupted_with_response_and_message(self):
+        """Happy path: interrupted turn with response and pending_message."""
+        result = {"interrupted": True}
+        response = "Some partial response"
+        pending_message = "interrupt message"
+
+        _show_interrupt_marker = False
+        _interrupted_this_turn = bool(result and result.get("interrupted"))
+
+        if _interrupted_this_turn:
+            pending_message = result.get("interrupt_message") or pending_message
+            _show_interrupt_marker = bool(response and pending_message)
+
+        assert _show_interrupt_marker is True
+
+    def test_marker_suppressed_when_no_response(self):
+        """No marker when there is no response text to interrupt."""
+        result = {"interrupted": True}
+        response = ""
+        pending_message = "interrupt message"
+
+        _show_interrupt_marker = False
+        _interrupted_this_turn = bool(result and result.get("interrupted"))
+
+        if _interrupted_this_turn:
+            pending_message = result.get("interrupt_message") or pending_message
+            _show_interrupt_marker = bool(response and pending_message)
+
+        assert _show_interrupt_marker is False
+
+    def test_marker_suppressed_when_no_pending_message(self):
+        """No marker when there's no interrupt message text."""
+        result = {"interrupted": True}
+        response = "Some partial response"
+        pending_message = None
+
+        _show_interrupt_marker = False
+        _interrupted_this_turn = bool(result and result.get("interrupted"))
+
+        if _interrupted_this_turn:
+            pending_message = result.get("interrupt_message") or pending_message
+            _show_interrupt_marker = bool(response and pending_message)
+
+        assert _show_interrupt_marker is False
+
+    def test_marker_suppressed_when_not_interrupted(self):
+        """No marker when the turn was not interrupted."""
+        result = {"completed": True}
+        response = "Full response text"
+        pending_message = "interrupt message"
+
+        _show_interrupt_marker = False
+        _interrupted_this_turn = bool(result and result.get("interrupted"))
+
+        if _interrupted_this_turn:
+            pending_message = result.get("interrupt_message") or pending_message
+            _show_interrupt_marker = bool(response and pending_message)
+
+        assert _show_interrupt_marker is False
+
+    def test_marker_shown_with_explicit_interrupt_message(self):
+        """Marker shown when result provides interrupt_message."""
+        result = {"interrupted": True, "interrupt_message": "User cancelled"}
+        response = "Partial output"
+        pending_message = "default interrupt msg"
+
+        _show_interrupt_marker = False
+        _interrupted_this_turn = bool(result and result.get("interrupted"))
+
+        if _interrupted_this_turn:
+            pending_message = result.get("interrupt_message") or pending_message
+            _show_interrupt_marker = bool(response and pending_message)
+
+        assert _show_interrupt_marker is True
+        assert pending_message == "User cancelled"
+
+
+# ── End-to-end: _show_interrupt_marker → _cprint flow ──────────────
+
+
+class TestInterruptMarkerPrintFlow:
+    """End-to-end: the flag leads to a supressed _cprint of the marker."""
+
+    def test_marker_printed_via_suspend_after_panel(self, monkeypatch):
+        """When _show_interrupt_marker is True, the marker is cprinted.
+
+        The marker text is printed inside _suspend_output_history so it
+        bypasses _OUTPUT_HISTORY.
+        """
+        cli_mod._configure_output_history(True, 10)
+        printed_lines = []
+
+        monkeypatch.setattr(cli_mod, "_pt_print", lambda x: printed_lines.append(x))
+        monkeypatch.setattr(cli_mod, "_PT_ANSI", lambda t: t)
+
+        # Simulate the production flow
+        _show_interrupt_marker = True
+        if _show_interrupt_marker:
+            with _suspend_output_history():
+                cli_mod._cprint(
+                    "\n── [Interrupted — processing new message] ──"
+                )
+
+        # Marker was printed but NOT recorded in history
+        assert printed_lines, "Marker must have been printed"
+        assert "Interrupted" in printed_lines[0]
+        assert list(cli_mod._OUTPUT_HISTORY) == []
+
+    def test_no_marker_printed_when_flag_false(self, monkeypatch):
+        """When _show_interrupt_marker is False, nothing is printed."""
+        printed_lines = []
+        monkeypatch.setattr(cli_mod, "_pt_print", lambda x: printed_lines.append(x))
+        monkeypatch.setattr(cli_mod, "_PT_ANSI", lambda t: t)
+
+        _show_interrupt_marker = False
+        if _show_interrupt_marker:
+            with _suspend_output_history():
+                cli_mod._cprint("── [Interrupted] ──")
+
+        assert printed_lines == []
+
+
+# ── _replay does not replay the marker (E2E) ───────────────────────
+
+
+class TestReplayDoesNotDuplicateMarker:
+    """_replay_output_history must not contain the interrupt marker.
+
+    After an interrupted turn, only the normal response is in the history.
+    Redrawing replays only the response — no marker duplication.
+    """
+
+    def test_replay_clean_after_interrupted_turn(self, monkeypatch):
+        """Simulate: normal response recorded, marker supressed → replay is clean."""
+        cli_mod._configure_output_history(True, 10)
+
+        # Normal response gets recorded
+        cli_mod._record_output_history("Assistant response text")
+
+        printed = []
+        monkeypatch.setattr(cli_mod, "_pt_print", lambda x: printed.append(x))
+        monkeypatch.setattr(cli_mod, "_PT_ANSI", lambda t: t)
+
+        # Marker gets printed with supressed history (does NOT enter _OUTPUT_HISTORY)
+        with _suspend_output_history():
+            cli_mod._cprint("── [Interrupted — processing new message] ──")
+
+        # History must contain only the normal response
+        assert list(cli_mod._OUTPUT_HISTORY) == ["Assistant response text"], (
+            "Interrupt marker must not appear in _OUTPUT_HISTORY"
+        )
+
+        # Replay the history — this emits the normal response via _pt_print
+        cli_mod._replay_output_history()
+
+        # The replayed output must contain only the response, NOT the marker
+        # (marker was printed once by _cprint, but replay must not repeat it)
+        marker_count = sum(1 for p in printed if "Interrupted" in str(p))
+        assert marker_count == 1, (
+            f"Marker must appear exactly once (from _cprint), not {marker_count} "
+            "(duplicated by _replay_output_history)"
+        )
+        assert "Assistant response text" in "".join(printed)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1749,6 +1749,7 @@ display:
     fields: ["model", "context_pct", "cwd"]
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
+  cli_rebuild_scrollback_on_redraw: false  # Classic CLI: also wipe terminal scrollback (CSI 3J) on /redraw / Ctrl+L / width-change resize recovery. Enable when a terminal/tmux stack stamps stale prompt chrome into scrollback on maximize/restore.
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
 ```
 


### PR DESCRIPTION
## Summary
Fixes the whole "prompt/status chrome duplicates in the classic CLI" bug class in one pass: interrupt markers no longer replay as duplicates, benign first SIGWINCHes no longer duplicate the resumed transcript, focus regain (Alt+Tab back) no longer leaves a ghost composer copy, the status bar honors its persisted off setting at startup, and stubborn tmux/fullscreen stacks get an opt-in scrollback rebuild.

Root cause across the cluster: `_replay_output_history()` and prompt_toolkit's incremental diff both repaint against terminal state that still contains a copy of the chrome — after interrupts, resizes, focus regain, and maximize/restore — so a second copy stacks on the first.

## Changes (salvages 4 contributor PRs + one follow-up of ours)
- **#60941 (@AIalliAI)** — interrupt marker is printed under `_suspend_output_history()` so it never enters `_OUTPUT_HISTORY` and can never be replayed as a duplicate (fixes #60920); + 326-line regression suite
- **#65444 (@halaprix)** — resize recovery replays only on an OBSERVED width change against a startup-seeded baseline; the session's first benign SIGWINCH (GNOME tab bar, monitor scale, focus events) no longer duplicates the whole resumed conversation (fixes #65293)
- **#59729 (@angeon922-collab)** — classic CLI startup honors persisted `display.tui_statusbar: off`; new opt-in `display.cli_rebuild_scrollback_on_redraw` sends CSI 3J on /redraw / width-change recovery for terminal stacks that stamp stale prompt chrome into scrollback
- **#83874 (@zoidypuh)** — `_output_screen_diff` retries with `previous_screen=None` when a corrupt post-tmux-attach paint buffer raises (`'cell' object has no attribute 'char'`), instead of wedging the event loop. The same-width force-clear half of that PR was intentionally NOT taken (it would erase the visible transcript on benign signals — exactly the #65293 class); the crash it targeted is fully covered by the retry
- **Ours** — focus-in (`CSI I`) now routes through the same rate-limited full-redraw recovery as Ctrl+L//redraw, clearing ghost composer/prompt copies after tab/window switches (focus-regain variant on #60920, #25337); self-gating (only terminals that emit focus reports are affected), max one repaint/second
- Docs: `display.cli_rebuild_scrollback_on_redraw` documented in configuration.md; default registered in `config_defaults.py` (moved from the pre-refactor `config.py` location the salvaged commit targeted)

## Validation
| Scenario | Before | After |
|---|---|---|
| Interrupt + resize | marker duplicated 7-8x | marker never recorded, never replayed |
| Resume + benign first SIGWINCH | whole recap duplicated | no clear, no replay; baseline recorded |
| Real width change | replay (correct) | replay exactly once (unchanged) |
| Alt+Tab back (focus-in) | ghost composer copy persists | rate-limited full repaint |
| tmux attach corrupt paint | event loop wedged with AttributeError | retried as clean first paint |
| `display.tui_statusbar: off` | bar re-enabled every start | stays hidden |
| `/redraw` default / opt-in | — | CSI 2J only / CSI 2J+3J |

58 targeted tests pass (`test_cli_force_redraw`, `test_cli_status_bar`, `test_interrupt_output_history_regression`, `test_cli_terminal_shortcuts`); 13-scenario E2E with real `cli.py` imports and a real VT100 parser feed: ALL PASS. Contributor authorship preserved per-commit; attribution audit green.

## Infographic

![CLI chrome recovery mission patches](https://files.catbox.moe/d99p2f.png)
