### PR TITLE
fix(doctor): bound large-store and provider probes

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -37,16 +37,11 @@ from typing import Any, Dict, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Ensure boto3/botocore are installed before any code in this module runs.
-# Upstream removed boto3 from [all] extras (PRs #24220, #24515); lazy_deps
-# handles on-demand installation so the Bedrock provider still works in the
-# EKS deployment without baking boto3 into the base image.
+# Upstream removed boto3 from [all] extras (PRs #24220, #24515). Keep the
+# dependency lazy: importing this module for diagnostics or provider discovery
+# must not start a network install. _require_boto3() installs on first actual
+# Bedrock use, preserving the EKS path without baking boto3 into the base image.
 # ---------------------------------------------------------------------------
-try:
-    from tools.lazy_deps import ensure
-    ensure("provider.bedrock", prompt=False)
-except Exception:
-    pass  # lazy_deps unavailable or install failed — let downstream imports surface the real error
 
 
 # ---------------------------------------------------------------------------
@@ -66,11 +61,17 @@ def _require_boto3():
     try:
         import boto3
     except ImportError:
-        raise ImportError(
-            "The 'boto3' package is required for the AWS Bedrock provider. "
-            "Install it with: pip install boto3\n"
-            "Or install Hermes with Bedrock support: pip install -e '.[bedrock]'"
-        )
+        try:
+            from tools.lazy_deps import ensure
+
+            ensure("provider.bedrock", prompt=False)
+            import boto3
+        except Exception as exc:
+            raise ImportError(
+                "The 'boto3' package is required for the AWS Bedrock provider. "
+                "Install it with: pip install boto3\n"
+                "Or install Hermes with Bedrock support: pip install -e '.[bedrock]'"
+            ) from exc
     # converse() / converse_stream() were added in boto3 1.34.59.
     # When Hermes is installed editable into system Python, the system boto3
     # (e.g. Ubuntu 24.04 ships 1.34.46) may take precedence over the venv

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -320,6 +320,11 @@ def check_info(text: str):
 STATE_DB_SIZE_WARN_BYTES = 1 * 1024 * 1024 * 1024   # 1 GiB logical size
 
 
+def _should_run_full_state_db_integrity_check(db_path: Path) -> bool:
+    """Keep doctor's synchronous full scan away from already-large stores."""
+    return db_path.stat().st_size < STATE_DB_SIZE_WARN_BYTES
+
+
 # Shared byte formatter, aliased to the name this module's three rendering
 # call sites already use.
 from hermes_cli.sizefmt import format_bytes as _human_bytes
@@ -1704,7 +1709,24 @@ def run_doctor(args):
             # repaired in place with --fix).
             from hermes_state import _db_opens_cleanly, repair_state_db_schema
 
-            _write_reason = _db_opens_cleanly(state_db_path)
+            # A full SQLite integrity check is O(database size) and can make
+            # doctor appear hung for minutes on a healthy multi-GB store. The
+            # normal repair/recovery paths still run it; doctor keeps its
+            # journal/schema/read and rolled-back FTS read/write probes, but
+            # defers the full scan for stores already classified as large.
+            _run_full_integrity = _should_run_full_state_db_integrity_check(
+                state_db_path
+            )
+            _write_reason = _db_opens_cleanly(
+                state_db_path,
+                check_integrity=_run_full_integrity,
+            )
+            if not _run_full_integrity:
+                check_info(
+                    "Skipped full state.db integrity scan in doctor "
+                    f"({_human_bytes(state_db_path.stat().st_size)} database); "
+                    "run 'hermes sessions repair --check-only' offline for the full scan"
+                )
             if _write_reason is not None:
                 check_warn(
                     f"{_DHH}/state.db fails a write-health probe (FTS index may be corrupt)",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1814,13 +1814,17 @@ def preflight_db_writability(
             _ensure_writable(p)
 
 
-def _db_opens_cleanly(db_path: Path) -> Optional[str]:
+def _db_opens_cleanly(
+    db_path: Path,
+    *,
+    check_integrity: bool = True,
+) -> Optional[str]:
     """Probe a DB on a fresh connection. Returns None if healthy, else a reason.
 
     Runs the same first-statement (``PRAGMA journal_mode``) that trips the
-    malformed-schema parse, then ``PRAGMA integrity_check`` and a canonical
-    ``sessions`` read, and finally a rolled-back ``messages`` write so that
-    FTS5 index corruption — which leaves base-table reads and
+    malformed-schema parse, optionally runs ``PRAGMA integrity_check``, then
+    performs a canonical ``sessions`` read and a rolled-back ``messages``
+    write so that FTS5 index corruption — which leaves base-table reads and
     ``integrity_check`` passing while every ``INSERT INTO messages`` fails
     through the FTS triggers — is reported as unhealthy rather than slipping
     past as a false "ok" (#50502).
@@ -1835,10 +1839,11 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         # working), so tokenizer absence must never classify as corruption.
         load_fts5_cjk_extension(conn)
         conn.execute("PRAGMA journal_mode").fetchone()
-        rows = conn.execute("PRAGMA integrity_check").fetchall()
-        problems = [str(r[0]) for r in rows if r and str(r[0]).lower() != "ok"]
-        if problems:
-            return "; ".join(problems[:3])
+        if check_integrity:
+            rows = conn.execute("PRAGMA integrity_check").fetchall()
+            problems = [str(r[0]) for r in rows if r and str(r[0]).lower() != "ok"]
+            if problems:
+                return "; ".join(problems[:3])
         conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
 
         # FTS5 read probe: run a representative MATCH query against the

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1054,6 +1054,34 @@ class TestCallConverseStreamIamFallback:
 class TestRequireBoto3VersionCheck:
     """Test that _require_boto3() rejects boto3 versions older than 1.34.59."""
 
+    def test_import_does_not_trigger_lazy_install(self):
+        """Provider discovery and doctor may import the adapter read-only."""
+        import importlib
+        import agent.bedrock_adapter as adapter
+
+        with patch("tools.lazy_deps.ensure") as ensure:
+            importlib.reload(adapter)
+
+        ensure.assert_not_called()
+
+    def test_first_real_use_triggers_lazy_install_when_boto3_is_missing(self):
+        import sys
+
+        from agent.bedrock_adapter import _require_boto3
+
+        fake_boto3 = MagicMock()
+        fake_boto3.__version__ = "1.34.59"
+
+        def install_boto3(*_args, **_kwargs):
+            sys.modules["boto3"] = fake_boto3
+
+        with patch.dict("sys.modules", {"boto3": None}):
+            with patch("tools.lazy_deps.ensure", side_effect=install_boto3) as ensure:
+                result = _require_boto3()
+
+        ensure.assert_called_once_with("provider.bedrock", prompt=False)
+        assert result is fake_boto3
+
     def test_raises_runtime_error_when_boto3_too_old(self):
         """boto3 < 1.34.59 should raise RuntimeError with upgrade instructions."""
         from agent.bedrock_adapter import _require_boto3

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -16,6 +16,21 @@ from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
 
 
+class TestStateDbIntegrityPolicy:
+    def test_full_scan_runs_below_large_db_threshold(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        db_path.write_bytes(b"sqlite")
+
+        assert doctor._should_run_full_state_db_integrity_check(db_path) is True
+
+    def test_full_scan_is_deferred_at_large_db_threshold(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        with db_path.open("wb") as handle:
+            handle.truncate(doctor.STATE_DB_SIZE_WARN_BYTES)
+
+        assert doctor._should_run_full_state_db_integrity_check(db_path) is False
+
+
 class TestDoctorPlatformHints:
     def test_termux_package_hint(self, monkeypatch):
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -273,6 +273,18 @@ def test_fts_write_corruption_detected_by_write_probe(tmp_path):
     assert reason is not None
 
 
+def test_fts_write_probe_still_runs_when_integrity_check_is_skipped(tmp_path):
+    """Doctor's large-DB path keeps the targeted FTS write-health probe."""
+    from hermes_state import _db_opens_cleanly
+
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    _corrupt_fts_index_data(db_path)
+
+    reason = _db_opens_cleanly(db_path, check_integrity=False)
+    assert reason is not None
+
+
 def test_fts_write_corruption_repaired_in_place(tmp_path):
     """repair_state_db_schema rebuilds the FTS index; reads + writes resume."""
     from hermes_state import _db_opens_cleanly


### PR DESCRIPTION
## Summary

- defer `PRAGMA integrity_check` during `hermes doctor` when `state.db` is already at the existing 1 GiB large-store threshold
- keep journal/schema/session and rolled-back FTS read/write health probes active for large stores
- preserve full integrity checks for repair and recovery callers
- stop `agent.bedrock_adapter` imports from triggering a lazy boto3 network install; install only on first actual Bedrock use

## Root cause

`hermes doctor` had two independent unbounded/very slow paths:

1. `_db_opens_cleanly()` always ran a full SQLite integrity scan. On a healthy 15.2 GiB state store this exceeded 300 seconds.
2. The API-connectivity section imported `agent.bedrock_adapter` before checking AWS credentials. That module called `lazy_deps.ensure()` at import time, so a read-only diagnostic could block on pip/network even for users who do not use Bedrock.

## Behavior

For stores below 1 GiB, Doctor keeps the existing full integrity check. At or above the threshold it reports that the full scan was deferred and points to the explicit offline `hermes sessions repair --check-only` command. Repair/recovery behavior is unchanged.

Bedrock still auto-installs boto3 when `_require_boto3()` is reached by real provider use; module import and provider discovery are now side-effect free.

## Verification

- `uv run pytest -q tests/agent/test_bedrock_adapter.py` — 59 passed, 5 skipped
- `uv run pytest -q tests/test_state_db_malformed_repair.py` — 17 passed
- `uv run pytest -q tests/hermes_cli/test_doctor.py -k 'not test_doctor_reports_vercel_backend_diagnostics'` — 53 passed
- `uv run ruff check ...` — passed
- live acceptance against a healthy 15.2 GiB / 2,006-session store, with boto3 absent from the venv: `hermes doctor` completed in 4 seconds with exit 0 (previously timed out at 120–300 seconds)

The excluded Vercel diagnostic test fails unchanged on the unmodified upstream baseline in this local environment; it is unrelated to this diff.
