### PR TITLE
fix(delegation): stop subagents inheriting reasoning their model can't honor

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3533,6 +3533,24 @@ def _format_concise_process_notification(
     return text
 
 
+def _has_api_server_wake_fallback(session_key: str, evt: dict) -> bool:
+    """Is an unresolvable synthetic source recoverable by the caller?
+
+    Mirrors the raw-session-id recovery in ``_process_synthetic_event``: the
+    api_server binds a RAW ``X-Hermes-Session-Id`` as the session key rather
+    than a structured ``agent:main:...`` one, so routing metadata cannot be
+    derived from it — but the caller then wakes that session by self-post
+    instead of dropping the event.
+
+    Used only to pick a log level, so a recoverable delivery is not reported
+    with wording that reads as lost work.
+    """
+    if str((evt or {}).get("origin_session_id") or "").strip():
+        return True
+    sk = str(session_key or "").strip()
+    return bool(sk) and _parse_session_key(sk) is None
+
+
 def _format_gateway_process_notification(evt: dict) -> "str | None":
     """Format a watch pattern event from completion_queue into a [IMPORTANT:] message."""
     evt_type = evt.get("type", "completion")
@@ -23555,13 +23573,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         chat_type = str(evt.get("chat_type") or derived_chat_type or "").strip().lower()
         chat_id = str(evt.get("chat_id") or derived_chat_id or "").strip()
         if not platform_name or not chat_type or not chat_id:
-            logger.warning(
-                "Synthetic event source unresolvable: "
-                "session_key=%r platform=%r chat_type=%r chat_id=%r "
-                "evt_type=%s",
-                session_key, platform_name, chat_type, chat_id,
-                evt.get("type", "?"),
-            )
+            if _has_api_server_wake_fallback(session_key, evt):
+                # Expected for api_server-bound sessions: the caller recovers the
+                # raw session id and wakes the session by self-post. Warning here
+                # reads as dropped work and has been misdiagnosed as exactly that.
+                logger.debug(
+                    "Synthetic event source not derivable from raw api_server "
+                    "session key %r; caller falls back to a self-post wake "
+                    "(evt_type=%s)",
+                    session_key, evt.get("type", "?"),
+                )
+            else:
+                logger.warning(
+                    "Synthetic event source unresolvable, event will be dropped: "
+                    "session_key=%r platform=%r chat_type=%r chat_id=%r "
+                    "evt_type=%s",
+                    session_key, platform_name, chat_type, chat_id,
+                    evt.get("type", "?"),
+                )
             return None
 
         try:

--- a/tests/gateway/test_synthetic_source_log_level.py
+++ b/tests/gateway/test_synthetic_source_log_level.py
@@ -1,0 +1,59 @@
+"""A recoverable delivery must not be logged as if the work were lost.
+
+``_build_process_event_source`` returns None for a raw (non-``agent:main:``)
+session key because it cannot derive routing metadata from one. Its caller
+then recovers: it pulls the raw session id back out and wakes the api_server
+session via self-post. That path works — production logs show the wake firing
+6 ms after the warning, followed by a full agent run.
+
+The warning text ("Synthetic event source unresolvable") nevertheless reads as
+dropped work, and was misread exactly that way during an audit. Raw api_server
+keys have a documented fallback and belong at debug level; a structured key
+that still fails to resolve has no fallback and must keep warning.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from gateway.run import _has_api_server_wake_fallback
+
+
+def test_raw_session_key_has_a_fallback():
+    """The api_server binds the raw X-Hermes-Session-Id as the session key."""
+    assert _has_api_server_wake_fallback("20260812_002915_c9118f", {}) is True
+
+
+def test_origin_session_id_has_a_fallback():
+    """The caller prefers origin_session_id when the event carries one."""
+    assert _has_api_server_wake_fallback("", {"origin_session_id": "20260812_002915_c9118f"}) is True
+
+
+def test_structured_key_has_no_fallback():
+    """A platform-qualified key that fails to resolve is genuinely unroutable."""
+    assert _has_api_server_wake_fallback("agent:main:telegram:dm:12345", {}) is False
+
+
+def test_empty_key_without_origin_has_no_fallback():
+    """A CLI-origin event carries neither — nothing to wake."""
+    assert _has_api_server_wake_fallback("", {}) is False
+
+
+if __name__ == "__main__":  # pytest is not installed in the Hermes venv
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        try:
+            fn()
+            print(f"PASS  {name}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"FAIL  {name}: {exc}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"ERROR {name}: {type(exc).__name__}: {exc}")
+    print(f"\n{failures} failing" if failures else "\nall green")
+    sys.exit(1 if failures else 0)

--- a/tests/tools/test_delegate_reasoning_inheritance.py
+++ b/tests/tools/test_delegate_reasoning_inheritance.py
@@ -1,0 +1,127 @@
+"""Subagents must not inherit a reasoning config their model cannot honor.
+
+Regression: with ``delegation.reasoning_effort`` unset or empty, the override
+gate in delegate_tool was skipped entirely and the child inherited the parent's
+reasoning config. A frontier parent with thinking enabled then handed
+``thinking`` to a local worker model that does not support it, and Ollama
+answered ``HTTP 400: "qwen3-coder-next" does not support thinking`` — a
+non-retryable client error that killed the whole delegation batch.
+
+Inheriting only makes sense when the child runs the parent's model. When
+delegation routes to a different model (the normal case — a cheap local
+worker), the parent's reasoning settings say nothing about what the child
+supports, so they must not be carried over silently.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.delegate_tool import _resolve_child_reasoning
+
+PARENT = {"enabled": True, "effort": "high"}
+
+
+def test_unset_effort_does_not_inherit_thinking_for_a_different_child_model():
+    """The bug: empty string skipped the gate and inherited the parent."""
+    child = _resolve_child_reasoning(
+        delegation_cfg={"reasoning_effort": ""},
+        parent_reasoning=PARENT,
+        parent_model="gpt-5.6-terra",
+        child_model="qwen3-coder-next",
+    )
+    assert child == {"enabled": False}
+
+
+def test_missing_effort_key_does_not_inherit_thinking_for_a_different_child_model():
+    child = _resolve_child_reasoning(
+        delegation_cfg={},
+        parent_reasoning=PARENT,
+        parent_model="gpt-5.6-terra",
+        child_model="qwen3-coder-next",
+    )
+    assert child == {"enabled": False}
+
+
+def test_unset_effort_still_inherits_when_child_runs_the_parent_model():
+    """Same model = the parent's settings are known-good for the child."""
+    child = _resolve_child_reasoning(
+        delegation_cfg={"reasoning_effort": ""},
+        parent_reasoning=PARENT,
+        parent_model="gpt-5.6-terra",
+        child_model="gpt-5.6-terra",
+    )
+    assert child == PARENT
+
+
+def test_explicit_effort_is_honored_even_for_a_different_child_model():
+    """An operator who asks for thinking on a capable worker still gets it."""
+    child = _resolve_child_reasoning(
+        delegation_cfg={"reasoning_effort": "medium"},
+        parent_reasoning=PARENT,
+        parent_model="gpt-5.6-terra",
+        child_model="gpt-oss:120b",
+    )
+    assert child == {"enabled": True, "effort": "medium"}
+
+
+def test_explicit_none_disables_thinking():
+    child = _resolve_child_reasoning(
+        delegation_cfg={"reasoning_effort": "none"},
+        parent_reasoning=PARENT,
+        parent_model="gpt-5.6-terra",
+        child_model="gpt-oss:120b",
+    )
+    assert child == {"enabled": False}
+
+
+def test_yaml_boolean_false_disables_thinking():
+    """``reasoning_effort: false`` in YAML arrives as a bool, not a string."""
+    child = _resolve_child_reasoning(
+        delegation_cfg={"reasoning_effort": False},
+        parent_reasoning=PARENT,
+        parent_model="gpt-5.6-terra",
+        child_model="gpt-oss:120b",
+    )
+    assert child == {"enabled": False}
+
+
+def test_unrecognized_effort_falls_back_to_not_inheriting():
+    """A typo must not silently re-enable the failure mode."""
+    child = _resolve_child_reasoning(
+        delegation_cfg={"reasoning_effort": "sky-high"},
+        parent_reasoning=PARENT,
+        parent_model="gpt-5.6-terra",
+        child_model="qwen3-coder-next",
+    )
+    assert child == {"enabled": False}
+
+
+def test_parent_without_reasoning_stays_without_reasoning():
+    child = _resolve_child_reasoning(
+        delegation_cfg={},
+        parent_reasoning=None,
+        parent_model="gpt-5.6-terra",
+        child_model="gpt-5.6-terra",
+    )
+    assert child is None
+
+
+if __name__ == "__main__":  # pytest is not installed in the Hermes venv
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        try:
+            fn()
+            print(f"PASS  {name}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"FAIL  {name}: {exc}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"ERROR {name}: {type(exc).__name__}: {exc}")
+    print(f"\n{failures} failing" if failures else "\nall green")
+    sys.exit(1 if failures else 0)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1463,6 +1463,52 @@ def _inherit_parent_base_url(parent_agent, fallback_base_url: Optional[str]) -> 
     return fallback_base_url or None
 
 
+def _resolve_child_reasoning(
+    delegation_cfg: Optional[Dict[str, Any]],
+    parent_reasoning,
+    parent_model: Optional[str],
+    child_model: Optional[str],
+):
+    """Decide which reasoning config a subagent should run with.
+
+    An explicit ``delegation.reasoning_effort`` always wins.  With no explicit
+    setting the parent's config is inherited **only when the child runs the
+    parent's model** — a different model says nothing about whether it supports
+    thinking, and handing ``thinking`` to a model that lacks it is answered with
+    a non-retryable ``HTTP 400 ... does not support thinking`` that kills the
+    entire delegation batch.
+
+    The previous gate skipped the override for an empty string or a missing key
+    and inherited unconditionally, which made the failure mode the default for
+    the common setup: a frontier parent delegating to a cheap local worker.
+    """
+    cfg = delegation_cfg or {}
+    effort = cfg.get("reasoning_effort")
+    # Keep the raw value — ``str(x or "")`` would coerce a YAML boolean False
+    # (``reasoning_effort: false``) to "" and lose the "disabled" intent.
+    if effort or effort is False:
+        try:
+            from hermes_constants import parse_reasoning_effort
+
+            parsed = parse_reasoning_effort(effort)
+        except Exception as exc:
+            logger.debug("Could not load delegation reasoning_effort: %s", exc)
+            parsed = None
+        if parsed is not None:
+            return parsed
+        logger.warning(
+            "Unknown delegation.reasoning_effort %r; not inheriting the parent's "
+            "reasoning config for child model %r",
+            effort,
+            child_model,
+        )
+
+    # ``model=None`` means "run the parent's model", which is safe to inherit.
+    if (child_model or parent_model) == parent_model:
+        return parent_reasoning
+    return {"enabled": False}
+
+
 def _build_child_agent(
     task_index: int,
     goal: str,
@@ -1706,27 +1752,14 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
+    # Resolve reasoning config: delegation override > inherit only on same model
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
-    child_reasoning = parent_reasoning
-    try:
-        # Keep the raw value — ``str(x or "")`` would coerce a YAML boolean
-        # False (``reasoning_effort: false``) to "" and inherit the parent
-        # instead of disabling thinking for children.
-        delegation_effort = delegation_cfg.get("reasoning_effort")
-        if delegation_effort or delegation_effort is False:
-            from hermes_constants import parse_reasoning_effort
-
-            parsed = parse_reasoning_effort(delegation_effort)
-            if parsed is not None:
-                child_reasoning = parsed
-            else:
-                logger.warning(
-                    "Unknown delegation.reasoning_effort '%s', inheriting parent level",
-                    delegation_effort,
-                )
-    except Exception as exc:
-        logger.debug("Could not load delegation reasoning_effort: %s", exc)
+    child_reasoning = _resolve_child_reasoning(
+        delegation_cfg,
+        parent_reasoning,
+        getattr(parent_agent, "model", None),
+        model,
+    )
 
     # Inherit the parent's fallback provider chain so subagents can recover
     # from rate-limits and credential exhaustion exactly like the top-level


### PR DESCRIPTION
## Problem

With `delegation.reasoning_effort` unset or empty, the override gate in
`_build_child_agent` is skipped entirely and the child inherits the parent's
reasoning config:

```python
delegation_effort = delegation_cfg.get("reasoning_effort")
if delegation_effort or delegation_effort is False:   # "" and None fall through
    ...
```

A frontier parent with thinking enabled then hands `thinking` to a local worker
model that does not support it, and the provider answers:

```
HTTP 400: "qwen3-coder-next" does not support thinking
```

That is a non-retryable client error, so the subagent dies immediately and the
whole delegation batch is lost. Observed in production on 2026-08-12: both
tasks in one batch failed this way, ~40 s after dispatch.

This is the default shape of the failure for the most common delegation setup —
a capable parent fanning out to a cheap local worker — because "unset" is a
perfectly normal state for that config key.

## Root cause

The gate treats "no explicit setting" as "inherit the parent". Inheriting is
only sound when the child runs the parent's *model*: a different model says
nothing about whether it supports thinking, so carrying the parent's reasoning
config across a model boundary is unfounded.

## Fix

Extract the decision into `_resolve_child_reasoning(...)` and inherit only on a
model match.

- An explicit `delegation.reasoning_effort` still wins in every case, so an
  operator who wants thinking on a capable worker (e.g. `gpt-oss:120b`) keeps it.
- `model=None` means "run the parent's model", which is still safe to inherit.
- An unrecognized value now falls back to no-thinking instead of logging a
  warning and silently restoring the failure mode.

Deliberately *not* fail-closed-for-everyone: unconditionally disabling thinking
for children would regress workers that do support it.

8 regression tests in `tests/tools/test_delegate_reasoning_inheritance.py`
covering empty string, missing key, YAML boolean `false`, explicit level,
same-model inheritance, and the unknown-value path. Verified end-to-end with a
live delegation batch after the change (completed in 10 s, zero thinking errors).

## Second commit — misleading gateway warning

`_build_process_event_source` cannot derive routing metadata from a raw
(non-`agent:main:`) session key and returns `None`, logging:

```
WARNING Synthetic event source unresolvable: session_key=... evt_type=async_delegation
```

The caller then recovers the raw session id and wakes the api_server session by
self-post — production logs show that wake firing 6 ms later, followed by a full
agent run. Nothing is dropped, but the wording reads as lost work and was
misdiagnosed as exactly that during an audit of delegation reliability.

Routes the known-recoverable case to `debug` via a small predicate that mirrors
the caller's recovery, and keeps the warning for a structured key that genuinely
has no fallback — now saying plainly that the event will be dropped.

Happy to split this into a separate PR if you'd prefer to keep the two concerns
apart.

## Notes

`pytest` is not installed in the standard Hermes runtime venv, so both test
files also carry a small `__main__` runner for local verification. They are
ordinary pytest test functions and need no special handling in CI.
