### PR TITLE
fix(tools): keep Kanban results compact for non-ASCII tasks

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -80,6 +80,57 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert "runs" in d
 
 
+def test_show_only_includes_worker_context_for_own_task(monkeypatch, worker_env):
+    from agent.delegation_context import non_dispatcher_owned_context
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        other_tid = kb.create_task(conn, title="other-task", assignee="peer")
+    finally:
+        conn.close()
+
+    foreign = json.loads(kt._handle_show({"task_id": other_tid}))
+    assert "worker_context" not in foreign
+
+    with non_dispatcher_owned_context():
+        nested_cron = json.loads(kt._handle_show({"task_id": worker_env}))
+    assert "worker_context" not in nested_cron
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
+    orchestrator = json.loads(kt._handle_show({"task_id": worker_env}))
+    assert "worker_context" not in orchestrator
+
+
+def test_kanban_tool_outputs_preserve_unicode(monkeypatch, worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        conn.execute(
+            "UPDATE tasks SET title = ?, body = ? WHERE id = ?",
+            ("日本語の作業", "説明", worker_env),
+        )
+        kb.add_attachment(
+            conn,
+            worker_env,
+            filename="資料.txt",
+            stored_path="unused",
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert "成功" in kt._ok(message="成功")
+    assert "日本語の作業" in kt._handle_show({})
+    assert "資料.txt" in kt._handle_attachments({})
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
+    assert "日本語の作業" in kt._handle_list({})
+
+
 def test_list_filters_tasks(monkeypatch, worker_env):
     """kanban_list gives orchestrators filtered board discovery."""
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1700,9 +1700,11 @@ KANBAN_SHOW_SCHEMA = {
         "Read a task's full state — title, body, assignee, parent task "
         "handoffs, your prior attempts on this task if any, comments, "
         "and recent events. Use this to (re)orient yourself before "
-        "starting work, especially on retries. The response includes a "
+        "starting work, especially on retries. When a dispatcher-owned "
+        "worker reads its own task, the response also includes a "
         "pre-formatted ``worker_context`` string suitable for inclusion "
-        "verbatim in your reasoning."
+        "verbatim in its reasoning; other callers receive only the "
+        "structured task fields."
     ),
     "parameters": {
         "type": "object",

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -437,7 +437,7 @@ def inject_new_comments_from_env(agent: Any) -> bool:
 
 
 def _ok(**fields: Any) -> str:
-    return json.dumps({"ok": True, **fields})
+    return json.dumps({"ok": True, **fields}, ensure_ascii=False)
 
 
 def _normalize_profile(value: Any) -> Optional[str]:
@@ -560,7 +560,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "started_at": r.started_at, "ended_at": r.ended_at,
                 }
 
-            return json.dumps({
+            result = {
                 "task": _task_dict(task),
                 "parents": parents,
                 "children": children,
@@ -575,12 +575,13 @@ def _handle_show(args: dict, **kw) -> str:
                     for e in events[-50:]   # cap; full log via CLI
                 ],
                 "runs": [_run_dict(r) for r in runs],
-                # Also surface the worker's own context block so the
-                # agent can include it directly if it wants. This is
-                # the same string build_worker_context returns to the
-                # dispatcher at spawn time.
-                "worker_context": kb.build_worker_context(conn, tid),
-            })
+            }
+            if (
+                os.environ.get("HERMES_KANBAN_TASK") == tid
+                and _is_dispatcher_owned_worker()
+            ):
+                result["worker_context"] = kb.build_worker_context(conn, tid)
+            return json.dumps(result, ensure_ascii=False)
         finally:
             conn.close()
     except ValueError as e:
@@ -642,7 +643,7 @@ def _handle_list(args: dict, **kw) -> str:
                     if truncated and limit < KANBAN_LIST_MAX_LIMIT else None
                 ),
                 "promoted": promoted,
-            })
+            }, ensure_ascii=False)
         finally:
             conn.close()
     except ValueError as e:
@@ -1330,7 +1331,7 @@ def _handle_attachments(args: dict, **kw) -> str:
                     }
                     for a in atts
                 ],
-            })
+            }, ensure_ascii=False)
         finally:
             conn.close()
     except ValueError as e:


### PR DESCRIPTION
## What does this PR do?

Kanban tool results now preserve non-ASCII text instead of expanding it into JSON escape sequences, and `kanban_show` only includes the duplicated worker orientation block for the dispatcher-owned worker reading its own task. This reduces model-facing payload size without removing the context workers need to execute their assigned card.

### Symptom

Kanban results containing non-ASCII task content serialize each code point as a `\uXXXX` escape. In addition, `kanban_show` returns a full `worker_context` copy to orchestrators and callers reading another task, even though the same task, history, parent, and comment data is already present in structured fields.

### Impact

The measured issue sample grew from 1,149,517 source characters to 1,995,547 serialized characters because of ASCII escaping. A sampled foreign-task `kanban_show` response also duplicated about 48.6% of its content in `worker_context`, increasing context-window and model-input costs for Kanban workflows.

### Bug Cause

**Trigger:** `tools/kanban_tools.py` model-facing JSON serializers and `_handle_show`

**Causal chain:**
1. A Kanban handler builds a result containing non-ASCII task content or a caller requests task details.
2. The output paths use `json.dumps` with its ASCII-escaping default, while `_handle_show` unconditionally builds `worker_context` regardless of caller identity.
3. The model receives expanded Unicode escapes and, for non-target callers, a redundant formatted copy of data already present in the structured result.

**Why it is wrong:** JSON does not require non-ASCII text to be escaped, and only the dispatcher-owned worker reading its assigned task needs the preformatted orientation context.

**Working sibling / contrast:** Other model-facing tool outputs already serialize with `ensure_ascii=False`. The dispatcher environment provides both ownership and exact task identity signals for safely retaining worker context on the intended path.

**Ruled out:** Internal metadata serialization used for redact-and-parse round trips does not produce model-facing output, so it is not part of the inflation path and remains unchanged.

### Fix

Use `ensure_ascii=False` on all four model-facing Kanban output paths. Gate `worker_context` on both dispatcher ownership and exact `HERMES_KANBAN_TASK` identity, document that conditional contract in the tool schema, and add regression coverage for own-task retention, foreign/orchestrator omission, nested cron behavior, and Unicode preservation.

## Related Issue

Closes #86242

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/kanban_tools.py` - preserve Unicode in model-facing results, conditionally include worker context, and align the show schema with that behavior.
- `tests/tools/test_kanban_tools.py` - cover caller-specific context inclusion and Unicode output across all affected handlers.

## How to Test

1. Run the focused regression tests for context gating and Unicode serialization.
2. Run the complete Kanban tool test file.

```bash
scripts/run_tests.sh tests/tools/test_kanban_tools.py -k 'show_only_includes_worker_context_for_own_task or kanban_tool_outputs_preserve_unicode' -v
scripts/run_tests.sh tests/tools/test_kanban_tools.py
```

Verified locally: 2 focused tests passed and the full file passed 34 tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing workflow changed
- [x] Config example update: N/A - no configuration changed
- [x] Architecture guide update: N/A - no architecture changed
- [x] Cross-platform impact considered: JSON serialization and environment identity checks are platform-independent
- [x] Tool descriptions/schemas updated to document conditional `worker_context` behavior

## Screenshots / Logs

N/A - regression behavior is covered by automated handler tests.
