### PR TITLE
fix(approval): route check_execute_code_guard through the CLI fall-through too

### DIFF
--- a/tests/tools/test_cli_approval_exec_ask_leak.py
+++ b/tests/tools/test_cli_approval_exec_ask_leak.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 import pytest
 
 import tools.approval as approval_module
-from tools.approval import check_all_command_guards
+from tools.approval import check_all_command_guards, check_execute_code_guard
 from tools.terminal_tool import set_approval_callback
 
 
@@ -82,6 +82,74 @@ class TestCliApprovalSurvivesExecAskLeak:
         set_approval_callback(None)
 
         result = check_all_command_guards("rm -rf /tmp/testdir", "local")
+
+        assert result.get("approved") is False
+        assert result.get("status") == "pending_approval"
+        assert result.get("approval_pending") is True
+
+
+class TestExecuteCodeGuardCliApprovalSurvivesExecAskLeak:
+    """check_execute_code_guard (the whole-script gate) had its own,
+    unfixed copy of the same notify_cb-less short-circuit — sibling of
+    check_all_command_guards, same leak, same missing CLI fall-through."""
+
+    def test_cli_callback_used_when_exec_ask_set_without_notifier(self, monkeypatch):
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        calls = []
+
+        def _cb(command, description, **kwargs):
+            calls.append((command, description))
+            return "once"
+
+        set_approval_callback(_cb)
+        result = check_execute_code_guard("print('hi')", "local")
+
+        assert calls, "CLI approval callback was never invoked"
+        assert result.get("status") != "pending_approval"
+        assert result.get("approval_pending") is not True
+        assert result.get("approved") is True
+        assert result.get("user_approved") is True
+
+    def test_cli_callback_deny_blocks_execution(self, monkeypatch):
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        set_approval_callback(lambda command, description, **kwargs: "deny")
+
+        result = check_execute_code_guard("print('hi')", "local")
+
+        assert result.get("approved") is False
+        assert result.get("outcome") == "denied"
+        assert result.get("status") != "pending_approval"
+
+    def test_cli_callback_timeout_blocks_execution(self, monkeypatch):
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        set_approval_callback(lambda command, description, **kwargs: "timeout")
+
+        result = check_execute_code_guard("print('hi')", "local")
+
+        assert result.get("approved") is False
+        assert result.get("outcome") == "timeout"
+
+    def test_cli_callback_session_choice_persists_approval(self, monkeypatch):
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        set_approval_callback(lambda command, description, **kwargs: "session")
+
+        first = check_execute_code_guard("print('hi')", "local")
+        assert first.get("approved") is True
+
+        # A second call in the same session must short-circuit on the
+        # session-approval cache without prompting again.
+        set_approval_callback(None)
+        second = check_execute_code_guard("print('again')", "local")
+        assert second.get("approved") is True
+        assert second.get("status") != "pending_approval"
+
+    def test_pending_approval_still_used_without_cli_callback(self, monkeypatch):
+        """Headless ask-mode without a CLI callback keeps the pending fallback."""
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        set_approval_callback(None)
+
+        result = check_execute_code_guard("print('hi')", "local")
 
         assert result.get("approved") is False
         assert result.get("status") == "pending_approval"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4621,6 +4621,8 @@ def check_execute_code_guard(code: str, env_type: str,
 
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
+    is_cli = _is_interactive_cli()
+    approval_callback = _resolve_cli_approval_callback()
 
     # Cron: no user is present to approve arbitrary code.
     if _is_cron_approval_context():
@@ -4649,8 +4651,13 @@ def check_execute_code_guard(code: str, env_type: str,
     #   * Local non-interactive non-gateway: documented limitation above.
     # Ask-mode (HERMES_EXEC_ASK) still takes this path even when INTERACTIVE
     # is also set — that combination is how gateway/smart tests and messaging
-    # ask-mode drive whole-script approval. Terminal-command CLI leaks are
-    # handled in check_all_command_guards via the CLI callback fall-through.
+    # ask-mode drive whole-script approval. When that combination leaks into
+    # an interactive CLI with no gateway notify callback registered, the
+    # notify_cb-less branch below falls through to the same CLI Dangerous
+    # Command panel check_all_command_guards uses, instead of a silent
+    # pending_approval. Terminal-command (not whole-script) CLI leaks from
+    # the script's own per-call terminal() guards are handled separately in
+    # check_all_command_guards.
     if not is_gateway and not is_ask:
         return {"approved": True, "message": None}
 
@@ -4778,6 +4785,89 @@ def check_execute_code_guard(code: str, env_type: str,
         notify_cb = _gateway_notify_cbs.get(session_key)
 
     if notify_cb is None:
+        # HERMES_EXEC_ASK (and sometimes a session platform marker) can leak
+        # into an interactive CLI process — most commonly via `import
+        # gateway.run`. Without this, that combination silently queued a
+        # pending approval nobody could see instead of showing the CLI panel
+        # the user can actually answer, even though a callback was
+        # registered (same class as check_all_command_guards / #85865-
+        # adjacent leak this fixes for the whole-script gate specifically).
+        if _should_fall_through_to_cli_approval(
+            is_cli=is_cli,
+            approval_callback=approval_callback,
+            notify_cb=notify_cb,
+        ):
+            _fire_approval_hook(
+                "pre_approval_request",
+                command=display_command,
+                description=display_description,
+                pattern_key=pattern_key,
+                pattern_keys=[pattern_key],
+                session_key=session_key,
+                surface="cli",
+            )
+            choice = prompt_dangerous_approval(
+                display_command,
+                display_description,
+                allow_permanent=not smart_denied_for_owner,
+                approval_callback=approval_callback,
+                smart_denied=smart_denied_for_owner,
+            )
+            _fire_approval_hook(
+                "post_approval_response",
+                command=display_command,
+                description=display_description,
+                pattern_key=pattern_key,
+                pattern_keys=[pattern_key],
+                session_key=session_key,
+                surface="cli",
+                choice=choice,
+            )
+
+            if choice == "timeout":
+                return {
+                    "approved": False,
+                    "message": (
+                        "BLOCKED: Action timed out without user response. The "
+                        "user has NOT consented to this action. Do NOT retry "
+                        "it, do NOT rephrase it, and do NOT attempt the same "
+                        "outcome via a different path. Silence is not consent."
+                    ),
+                    "pattern_key": pattern_key,
+                    "description": description,
+                    "outcome": "timeout",
+                    "user_consent": False,
+                }
+            if choice == "deny":
+                _record_denial(session_key)
+                breaker_addendum = _denial_breaker_addendum(session_key)
+                return {
+                    "approved": False,
+                    "message": (
+                        "BLOCKED: User denied execute_code script execution "
+                        f"(matched '{description}'). Do NOT retry — the user "
+                        f"has explicitly rejected it.{breaker_addendum}"
+                    ),
+                    "pattern_key": pattern_key,
+                    "description": description,
+                    "outcome": "denied",
+                    "user_consent": False,
+                }
+            if not smart_denied_for_owner:
+                if choice == "session":
+                    approve_session(session_key, pattern_key)
+                elif choice == "always":
+                    approve_session(session_key, pattern_key)
+                    approve_permanent(pattern_key)
+                    save_permanent_allowlist(_permanent_approved)
+            _reset_denials(session_key)
+            return {
+                "approved": True,
+                "message": None,
+                "user_approved": True,
+                "description": description,
+            }
+
         # No gateway callback registered (e.g. ask-mode without a notifier):
         # surface a pending approval for backward compatibility.
         pending_data = {


### PR DESCRIPTION
## What does this PR do?

e37a0321eb fixed `_run_approval_gate` and `check_all_command_guards`: when `HERMES_EXEC_ASK` (or a session platform marker) leaks into an interactive CLI process with no gateway notify callback registered, those two functions now prefer the registered CLI Dangerous Command panel over a silent `pending_approval` nobody can see.

`check_execute_code_guard` — the whole-script gate for `execute_code`, a separate function with its own copy of the same `notify_cb is None` short-circuit — never got the same treatment. It doesn't even accept an `approval_callback` parameter. In the same leaked-ask-mode-into-CLI scenario, `execute_code` calls still silently drop into `pending_approval` with the panel never shown, even though a CLI callback is registered.

## The fix

Compute `is_cli`/`approval_callback` the same way the two already-fixed functions do, and when `_should_fall_through_to_cli_approval()` says yes, run the same hook-fire → `prompt_dangerous_approval` → hook-fire → choice-branch sequence `_run_approval_gate`'s tail already uses, adapted to this function's own message/persistence conventions (smart-denied session/permanent suppression, denial-breaker addendum). Falls back to the existing `pending_approval` behavior when no CLI callback is available.

## Testing

- 4 new cases in `tests/tools/test_cli_approval_exec_ask_leak.py` mirroring the existing `check_all_command_guards` pair (approve/deny/timeout/session-persistence).
- Mutation-verified: all 4 fail against the pre-fix code and pass with it restored.
- Neighbor suites green: `tests/tools/*approval*` (291+ tests), `tests/gateway/{test_approval_prompt_redaction,test_tui_approval_redaction,test_plaintext_approval_routing,test_discord_exec_approval_content}`, `tests/cli/test_cli_approval_ui.py`.
- The 7 `test_approval_mode_parity` / `test_nonrecursive_verification_artifact_cleanup` failures seen in one full batch run are pre-existing and independent of this change — confirmed by re-running the identical batch with `tools/approval.py` stashed back to pre-fix: the same 7 fail for the same reasons either way (test-order pollution / `/tmp` symlink resolution, unrelated to this diff).
- `ruff check` clean.

## Adjacent open PR (checked, no semantic overlap)

**#65592** also touches `check_execute_code_guard`, but an earlier, unrelated region of the function (adding an AST dangerous-operation scanner to the `not is_gateway and not is_ask` auto-approve branch). No semantic overlap with this fix's `notify_cb is None` branch; a small rebase may be needed depending on merge order.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)