### PR TITLE
fix(gateway): stop the fallback-provider sync shadowing explicit /model choices

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7745,6 +7745,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         lists, desktop/dashboard details, and follow-up session tooling report the
         backend that actually answered the latest turn.
 
+        Writes through the SAME flat ``model_config`` keys (``provider``/
+        ``base_url``/``api_mode``) the explicit ``/model`` persist path
+        (``update_session_model``) writes — previously this wrote a separate
+        nested ``gateway_runtime`` dict that ``session_gateway_runtime()``'s
+        reader preferred unconditionally over those flat keys, so an
+        automatic fallback sync here could permanently shadow a user's
+        later, explicit ``/model`` choice on resume.
+
         Called from the ``run_sync`` closure, which executes off the event loop
         in the executor thread — so the synchronous ``SessionDB`` (``_db``) is
         used directly rather than awaiting the AsyncSessionDB forwarder.
@@ -7758,7 +7766,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "provider": getattr(agent, "provider", None),
             "base_url": getattr(agent, "base_url", None),
             "api_mode": getattr(agent, "api_mode", None),
-            "fallback_active": bool(getattr(agent, "_fallback_activated", False)),
         }
         runtime = {k: v for k, v in runtime.items() if v not in (None, "")}
 
@@ -7775,13 +7782,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 config = {}
             if not isinstance(config, dict):
                 config = {}
-            gateway_runtime = dict(config.get("gateway_runtime") or {})
+            current_flat = {
+                k: config.get(k) for k in ("provider", "base_url", "api_mode")
+            }
             if current_model == model and all(
-                gateway_runtime.get(k) == v for k, v in runtime.items()
+                current_flat.get(k) == v for k, v in runtime.items()
             ):
                 return
-            config["gateway_runtime"] = runtime
-            db.update_session_meta(session_id, json.dumps(config), model=model)
+            db.update_session_gateway_runtime(session_id, model, **runtime)
         except Exception:
             logger.debug("Failed to sync gateway session model metadata", exc_info=True)
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5953,6 +5953,56 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._delete_unreferenced_system_prompts(conn)
         self._execute_write(_do)
 
+    def update_session_gateway_runtime(
+        self,
+        session_id: str,
+        model: str,
+        *,
+        provider: Optional[str] = None,
+        base_url: Optional[str] = None,
+        api_mode: Optional[str] = None,
+    ) -> None:
+        """Persist the model/provider a gateway turn actually ran with.
+
+        Sibling of ``update_session_model`` for the automatic case: provider
+        fallback can switch ``agent.model``/``agent.provider``/``base_url``/
+        ``api_mode`` mid-turn, after the session row was created. Writes the
+        SAME flat ``model_config`` keys (``provider``/``base_url``/
+        ``api_mode``) ``update_session_model``'s explicit ``/model`` persist
+        writes, through the shared merge discipline (lineage markers
+        survive), so ``session_gateway_runtime()``'s reader sees whichever
+        wrote most recently. Previously this wrote a separate nested
+        ``gateway_runtime`` dict that ``session_gateway_runtime()`` read with
+        unconditional priority over the flat keys — an automatic fallback
+        sync could permanently shadow the user's later, explicit ``/model``
+        choice on resume, routing it back to a stale fallback provider.
+
+        Unlike ``update_session_model``, this is a best-effort background
+        sync (not a user action): does not touch ``browser_model_lock`` or
+        ``system_prompt``, since a flaky provider can trigger this on every
+        turn and neither should be disturbed by an automatic resync.
+        """
+        if not session_id or not model:
+            return
+        self.flush_token_counts()
+
+        def _do(conn):
+            patch: Dict[str, Any] = {}
+            if provider:
+                patch["provider"] = provider
+            if base_url:
+                patch["base_url"] = base_url
+            if api_mode:
+                patch["api_mode"] = api_mode
+            merged = self._merge_model_config_json(conn, session_id, patch)
+            if merged is _MODEL_CONFIG_ROW_MISSING:
+                return
+            conn.execute(
+                "UPDATE sessions SET model = ?, model_config = ? WHERE id = ?",
+                (model, merged, session_id),
+            )
+        self._execute_write(_do)
+
     def _merge_model_config_json(
         self,
         conn,
@@ -6137,16 +6187,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Read the persisted runtime route off a session row dict.
 
         Accepts the dict returned by ``get_session`` (``model_config`` is a
-        JSON string) or an already-parsed dict. Prefers the nested
-        ``gateway_runtime`` key (written by the gateway's
-        ``_sync_session_model_from_agent`` and the CLI ``/model`` persist),
-        falling back to the top-level ``provider``/``base_url``/``api_mode``
-        keys the TUI gateway's ``_runtime_model_config`` writes. As a last
-        resort, falls back to the ``billing_provider`` column (written on
-        every session's first accounted API call) so sessions that never ran
-        ``/model`` still restore the provider that actually served them.
-        Returns an empty dict on any parse failure — resume falls back to
-        ambient config resolution.
+        JSON string) or an already-parsed dict. Prefers a nested
+        ``gateway_runtime`` key when present — legacy data only:
+        ``_sync_session_model_from_agent`` wrote this shape before it was
+        switched to the flat keys below (an automatic fallback sync could
+        otherwise permanently shadow a later, explicit ``/model`` choice,
+        since this nested blob was read with unconditional priority). New
+        writes never create it, but old rows can still carry one. Falls
+        back to the top-level ``provider``/``base_url``/``api_mode`` keys —
+        written by both ``update_session_model`` (explicit ``/model``
+        persist) and ``update_session_gateway_runtime`` (automatic fallback
+        sync) through the same merge discipline, so whichever wrote most
+        recently wins naturally. As a last resort, falls back to the
+        ``billing_provider`` column (written on every session's first
+        accounted API call) so sessions that never ran ``/model`` still
+        restore the provider that actually served them. Returns an empty
+        dict on any parse failure — resume falls back to ambient config
+        resolution.
         """
         raw = (session_meta or {}).get("model_config")
         if isinstance(raw, str):

--- a/tests/gateway/test_sync_session_model_from_agent.py
+++ b/tests/gateway/test_sync_session_model_from_agent.py
@@ -1,0 +1,122 @@
+"""Regression: gateway fallback sync must not shadow an explicit /model choice.
+
+``_sync_session_model_from_agent`` runs after every gateway turn to persist
+whatever provider a fallback chain actually used. ``update_session_model``
+runs when the user explicitly switches models with ``/model``. Both used to
+write to different shapes of ``model_config`` (a nested ``gateway_runtime``
+dict vs. flat top-level keys), and ``session_gateway_runtime()`` — the single
+reader both CLI resume and the TUI gateway use — preferred the nested shape
+unconditionally. A fallback sync landing after an explicit /model switch
+would permanently shadow the user's choice on the next resume, silently
+routing back to the stale fallback provider.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _make_runner(db):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = SimpleNamespace(_db=db)
+    return runner
+
+
+def _agent(model, provider=None, base_url=None, api_mode=None):
+    return SimpleNamespace(
+        model=model, provider=provider, base_url=base_url, api_mode=api_mode,
+    )
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    database = SessionDB(db_path=tmp_path / "state.db")
+    database.create_session(session_id="s1", source="telegram", model="m0")
+    return database
+
+
+def test_fallback_sync_writes_flat_keys_not_nested(db):
+    """The automatic sync must use the SAME shape as the explicit /model
+    persist — no more separate nested gateway_runtime dict."""
+    runner = _make_runner(db)
+    runner._sync_session_model_from_agent(
+        "s1", _agent("claude-x", provider="anthropic", base_url="https://api.anthropic.com"),
+    )
+
+    meta = db.get_session("s1")
+    assert meta["model"] == "claude-x"
+    runtime = SessionDB.session_gateway_runtime(meta)
+    assert runtime["provider"] == "anthropic"
+    assert runtime["base_url"] == "https://api.anthropic.com"
+
+    import json
+    config = json.loads(meta["model_config"])
+    assert "gateway_runtime" not in config
+    assert config["provider"] == "anthropic"
+
+
+def test_explicit_model_switch_after_fallback_sync_wins_on_resume(db):
+    """The exact bug scenario: a background fallback sync writes first, then
+    the user explicitly switches models. Resume must see the user's choice,
+    not the earlier fallback."""
+    runner = _make_runner(db)
+
+    # Provider fallback happens mid-turn; the gateway syncs it automatically.
+    runner._sync_session_model_from_agent(
+        "s1", _agent("gpt-5-mini", provider="openai", base_url="https://api.openai.com/v1"),
+    )
+
+    # The user then explicitly switches models via /model.
+    db.update_session_model("s1", "claude-opus", provider="anthropic")
+
+    meta = db.get_session("s1")
+    runtime = SessionDB.session_gateway_runtime(meta)
+    assert runtime["provider"] == "anthropic", (
+        "explicit /model choice was shadowed by the earlier automatic "
+        "fallback sync"
+    )
+
+
+def test_fallback_sync_after_explicit_switch_updates_runtime(db):
+    """The reverse order: an explicit switch, then a later fallback event
+    (e.g. that provider goes down) must also be visible on resume."""
+    runner = _make_runner(db)
+
+    db.update_session_model("s1", "claude-opus", provider="anthropic")
+    runner._sync_session_model_from_agent(
+        "s1", _agent("gpt-5-mini", provider="openai", base_url="https://api.openai.com/v1"),
+    )
+
+    meta = db.get_session("s1")
+    runtime = SessionDB.session_gateway_runtime(meta)
+    assert runtime["provider"] == "openai"
+    assert meta["model"] == "gpt-5-mini"
+
+
+def test_unchanged_state_is_a_noop(db, monkeypatch):
+    """No write when model/provider/base_url/api_mode already match."""
+    runner = _make_runner(db)
+    runner._sync_session_model_from_agent(
+        "s1", _agent("claude-x", provider="anthropic", base_url="https://a"),
+    )
+
+    calls = []
+    monkeypatch.setattr(
+        db, "update_session_gateway_runtime",
+        lambda *a, **k: calls.append((a, k)),
+    )
+    runner._sync_session_model_from_agent(
+        "s1", _agent("claude-x", provider="anthropic", base_url="https://a"),
+    )
+    assert calls == []
+
+
+def test_missing_session_row_is_silent_noop(db):
+    runner = _make_runner(db)
+    # Must not raise for a session that doesn't exist.
+    runner._sync_session_model_from_agent("nonexistent", _agent("claude-x", provider="anthropic"))


### PR DESCRIPTION
## What does this PR do?

56a41715dc (billing_provider fallback + provider persist on `/model`, this week) made `update_session_model()` write the switched provider into `model_config` as a flat top-level key (`$.provider`), read back by `session_gateway_runtime()`'s second tier.

`_sync_session_model_from_agent()` — the gateway's automatic sync that runs after every turn to track provider-fallback switches (`agent.provider` can change after the session row exists) — writes to a **different** shape: a nested `model_config["gateway_runtime"]` dict, built via a raw dict assignment instead of the shared `_merge_model_config_json` discipline every other `model_config` writer uses. `session_gateway_runtime()`'s reader treats that nested key as first-tier, **unconditional priority** over the flat keys.

**Net effect:** if a fallback event ever synced after a session was created, and the user later made an explicit `/model` switch, resume would still restore the earlier fallback's provider — the user's explicit, later choice was silently shadowed by an automatic background write. Verified end-to-end against a real `SessionDB`: sync openai's fallback, then explicit `/model` to anthropic, and `session_gateway_runtime()` still returned `"openai"`.

## The fix

Adds `SessionDB.update_session_gateway_runtime()`, a sibling of `update_session_model()` using the **same** flat-key merge discipline — so lineage markers survive and both writers land in the same place, with the last write naturally winning (no separate priority tier needed). `_sync_session_model_from_agent` now calls it instead of hand-rolling a nested-dict `UPDATE`. Drops the write-only, never-read `fallback_active` field this path used to persist (confirmed unused: grepped for every reader).

`session_gateway_runtime()`'s nested-key read path is left in place (now read-only) for backward compatibility with sessions that already have an old nested `gateway_runtime` blob from before this fix; new writes never create one.

## Testing

- 5 new cases in `tests/gateway/test_sync_session_model_from_agent.py`, including the exact shadowing scenario end-to-end against a real `SessionDB` (both write orders).
- Mutation-verified: 3 fail against the pre-fix code (including the shadowing scenario, which asserts `"openai" != "anthropic"` on the pre-fix path) and pass with it restored.
- Neighbor suites: `tests/cli/test_resume_model_restore.py` (27 total, unchanged reader logic), `tests/test_hermes_state.py` + `tests/hermes_state/` (332 passed — the 1 FTS5 projection-query-count failure is pre-existing and unrelated, confirmed by re-running it with `hermes_state.py`/`gateway/run.py` stashed back to pre-fix — same failure either way), `tests/gateway/{test_session_model_override_persistence,test_48031_model_switch_after_auto_reset,test_model_switch_persistence,test_model_picker_persist,test_session_model_override_routing,test_session_model_reset}` all green.
- `ruff check` clean.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)