### PR TITLE
fix(agent): keep credential rotation working after custom provider switches

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -923,6 +923,37 @@ def sync_credential_pool_entry_id(agent) -> None:
         agent._credential_pool_entry_id = None
 
 
+def _credential_pool_provider_key(provider: str, base_url: str = "") -> str:
+    """Return the pool identity for a live runtime provider.
+
+    New-style ``providers.<name>`` entries intentionally keep their bare config
+    key as the runtime provider, while credential pools use ``custom:<name>``.
+    Canonicalize only configured custom providers so built-in provider pools
+    retain their exact identities.
+    """
+    provider_norm = str(provider or "").strip().lower()
+    if not provider_norm or provider_norm.startswith("custom:"):
+        return provider_norm
+
+    try:
+        from hermes_cli.runtime_provider import (
+            find_custom_provider_identity,
+            has_named_custom_provider,
+        )
+        from hermes_cli.providers import custom_provider_slug
+
+        if provider_norm == "custom":
+            return find_custom_provider_identity(base_url) or provider_norm
+        if has_named_custom_provider(provider_norm):
+            expected_identity = custom_provider_slug(provider_norm, provider_norm)
+            endpoint_identity = find_custom_provider_identity(base_url)
+            if endpoint_identity == expected_identity:
+                return expected_identity
+    except Exception:
+        pass
+    return provider_norm
+
+
 def recover_with_credential_pool(
     agent,
     *,
@@ -966,34 +997,17 @@ def recover_with_credential_pool(
     # because swapping the pool's credentials would set base_url/api_key
     # without fixing the empty provider field, leaving the agent in a
     # corrupted state (provider="" model="").
-    if pool_provider and current_provider != pool_provider:
-        # Custom endpoints use two naming conventions for the SAME provider:
-        # the agent carries the generic ``custom`` label while the pool is
-        # keyed ``custom:<name>`` (see CUSTOM_POOL_PREFIX). A literal string
-        # compare treats them as a mismatch and skips recovery for every
-        # custom-provider user — 401s/429s then burn the full retry cycle
-        # with no rotation or refresh. Accept the pair as matching only when
-        # the agent's CURRENT base_url actually resolves to this pool key,
-        # so a fallback provider (or a different custom endpoint) still
-        # triggers the guard.
-        _custom_match = False
-        if current_provider == "custom" and pool_provider.startswith("custom:"):
-            try:
-                from agent.credential_pool import get_custom_provider_pool_key
-                _agent_base = (getattr(agent, "base_url", "") or "").strip()
-                _custom_match = bool(_agent_base) and (
-                    (get_custom_provider_pool_key(_agent_base) or "").strip().lower()
-                    == pool_provider
-                )
-            except Exception:
-                _custom_match = False
-        if not _custom_match:
-            _ra().logger.warning(
-                "Credential pool provider mismatch: pool=%s, agent=%s — "
-                "skipping pool mutation to avoid cross-provider contamination",
-                pool_provider, current_provider,
-            )
-            return False, has_retried_429
+    current_pool_provider = _credential_pool_provider_key(
+        current_provider,
+        str(getattr(agent, "base_url", "") or ""),
+    )
+    if pool_provider and current_pool_provider != pool_provider:
+        _ra().logger.warning(
+            "Credential pool provider mismatch: pool=%s, agent=%s — "
+            "skipping pool mutation to avoid cross-provider contamination",
+            pool_provider, current_provider,
+        )
+        return False, has_retried_429
 
     # Attribute the failure to the API key the agent actually dispatched the
     # request with, not to pool.current(). The current() pointer is shared,
@@ -2602,19 +2616,28 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # logged + swallowed: the switch itself must still complete.
         old_norm = (old_provider or "").strip().lower()
         new_norm = (new_provider or "").strip().lower()
-        if old_norm != new_norm or getattr(agent, "_credential_pool", None) is None:
+        pool_provider = _credential_pool_provider_key(new_provider, agent.base_url)
+        current_pool = getattr(agent, "_credential_pool", None)
+        current_pool_provider = str(
+            getattr(current_pool, "provider", "") or ""
+        ).strip().lower()
+        if (
+            old_norm != new_norm
+            or current_pool is None
+            or current_pool_provider != pool_provider
+        ):
             # A pool bound to the old provider is worse than no pool: the
             # recovery guard rejects it and every later 401/429 skips rotation.
             agent._credential_pool = None
             agent._credential_pool_entry_id = None
             try:
                 from agent.credential_pool import load_pool
-                agent._credential_pool = load_pool(new_provider)
+                agent._credential_pool = load_pool(pool_provider)
             except Exception as _pool_exc:  # noqa: BLE001
                 logger.warning(
                     "switch_model: credential pool reload failed for %s (%s); "
                     "continuing without pool rotation this turn",
-                    new_provider, _pool_exc,
+                    pool_provider, _pool_exc,
                 )
         # ── Build new client ──
         if (new_provider or "").strip().lower() == "moa":

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -946,7 +946,10 @@ def _credential_pool_provider_key(provider: str, base_url: str = "") -> str:
             return find_custom_provider_identity(base_url) or provider_norm
         if has_named_custom_provider(provider_norm):
             expected_identity = custom_provider_slug(provider_norm, provider_norm)
-            endpoint_identity = find_custom_provider_identity(base_url)
+            endpoint_identity = find_custom_provider_identity(
+                base_url,
+                provider_norm,
+            )
             if endpoint_identity == expected_identity:
                 return expected_identity
     except Exception:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -822,12 +822,16 @@ def has_named_custom_provider(requested_provider: str) -> bool:
         return False
 
 
-def find_custom_provider_identity(base_url: str) -> Optional[str]:
+def find_custom_provider_identity(
+    base_url: str,
+    provider_key: Optional[str] = None,
+) -> Optional[str]:
     """Map an endpoint URL back to its canonical ``custom:<name>`` menu key.
 
-    Returns the ``custom:<normalized-name>`` slug of the first ``providers:``
-    / ``custom_providers:`` entry whose base_url matches, or ``None`` when no
-    entry owns the URL.
+    Returns the ``custom:<normalized-name>`` slug of the matching ``providers:``
+    / ``custom_providers:`` entry, or ``None`` when no entry owns the URL.
+    When ``provider_key`` is supplied, require that exact new-style config key
+    as well as the endpoint match so providers sharing one URL stay distinct.
 
     Session persistence stores the agent's *resolved* provider, and for every
     named custom endpoint that is the literal string ``"custom"`` — the entry
@@ -848,6 +852,25 @@ def find_custom_provider_identity(base_url: str) -> Optional[str]:
 
     providers = config.get("providers")
     if isinstance(providers, dict):
+        requested_key = str(provider_key or "").strip().lower()
+        if requested_key:
+            from hermes_cli.config import is_provider_enabled
+
+            for ep_name, entry in providers.items():
+                if str(ep_name).strip().lower() != requested_key:
+                    continue
+                if not isinstance(entry, dict) or not is_provider_enabled(entry):
+                    return None
+                entry_url = (
+                    entry.get("api")
+                    or entry.get("url")
+                    or entry.get("base_url")
+                    or ""
+                )
+                if _normalize_base_url_for_match(entry_url) == target:
+                    return custom_provider_slug(str(ep_name), str(ep_name))
+                return None
+            return None
         for ep_name, entry in providers.items():
             if not isinstance(entry, dict):
                 continue

--- a/tests/agent/test_custom_pool_mismatch_guard.py
+++ b/tests/agent/test_custom_pool_mismatch_guard.py
@@ -36,6 +36,63 @@ def _agent(provider, base_url, pool_provider):
 
 class TestCustomPoolMismatchGuard:
 
+    def test_named_custom_runtime_identity_can_recover_matching_pool(self):
+        """A new-style ``providers.<name>`` runtime keeps the bare config key,
+        while its pool uses the endpoint-scoped ``custom:<name>`` identity."""
+        agent, pool = _agent(
+            "sensenova", "https://token.sensenova.cn/v1", "custom:sensenova"
+        )
+        pool.current.return_value = None
+
+        with patch(
+            "hermes_cli.runtime_provider.load_config",
+            return_value={
+                "providers": {
+                    "sensenova": {
+                        "name": "SenseNova",
+                        "api": "https://token.sensenova.cn/v1",
+                    }
+                }
+            },
+        ):
+            recovered, retried = recover_with_credential_pool(
+                agent,
+                status_code=429,
+                has_retried_429=False,
+                classified_reason=FailoverReason.rate_limit,
+            )
+
+        assert recovered is False
+        assert retried is True
+        pool.current.assert_called_once_with()
+
+    def test_named_custom_runtime_identity_with_other_endpoint_is_guarded(self):
+        agent, pool = _agent(
+            "sensenova", "https://other-endpoint.example/v1", "custom:sensenova"
+        )
+
+        with patch(
+            "hermes_cli.runtime_provider.load_config",
+            return_value={
+                "providers": {
+                    "sensenova": {
+                        "name": "SenseNova",
+                        "api": "https://token.sensenova.cn/v1",
+                    }
+                }
+            },
+        ):
+            recovered, retried = recover_with_credential_pool(
+                agent,
+                status_code=429,
+                has_retried_429=False,
+                classified_reason=FailoverReason.rate_limit,
+            )
+
+        assert recovered is False
+        assert retried is False
+        assert not pool.method_calls
+
     def test_unrelated_custom_pool_still_guarded(self):
         """agent=custom pointed at a DIFFERENT endpoint than the pool's
         custom provider must still skip pool mutation."""

--- a/tests/agent/test_custom_pool_mismatch_guard.py
+++ b/tests/agent/test_custom_pool_mismatch_guard.py
@@ -93,6 +93,31 @@ class TestCustomPoolMismatchGuard:
         assert retried is False
         assert not pool.method_calls
 
+    def test_named_custom_recovery_disambiguates_shared_endpoint(self):
+        shared_url = "https://shared.example/v1"
+        agent, pool = _agent("second", shared_url, "custom:second")
+        pool.current.return_value = None
+
+        with patch(
+            "hermes_cli.runtime_provider.load_config",
+            return_value={
+                "providers": {
+                    "first": {"name": "First", "api": shared_url},
+                    "second": {"name": "Second", "api": shared_url},
+                }
+            },
+        ):
+            recovered, retried = recover_with_credential_pool(
+                agent,
+                status_code=429,
+                has_retried_429=False,
+                classified_reason=FailoverReason.rate_limit,
+            )
+
+        assert recovered is False
+        assert retried is True
+        pool.current.assert_called_once_with()
+
     def test_unrelated_custom_pool_still_guarded(self):
         """agent=custom pointed at a DIFFERENT endpoint than the pool's
         custom provider must still skip pool mutation."""

--- a/tests/run_agent/test_switch_model_pool_reload_52727.py
+++ b/tests/run_agent/test_switch_model_pool_reload_52727.py
@@ -146,6 +146,39 @@ class TestSwitchModelReloadsCredentialPool:
         assert agent._credential_pool is custom_pool
         load_pool_mock.assert_called_once_with("custom:sensenova")
 
+    def test_switch_disambiguates_named_custom_providers_sharing_endpoint(self):
+        old_pool = _make_pool("openrouter")
+        custom_pool = _make_pool("custom:second")
+        agent = _make_agent("openrouter", "old-model", old_pool)
+        shared_url = "https://shared.example/v1"
+
+        with (
+            patch(
+                "hermes_cli.runtime_provider.load_config",
+                return_value={
+                    "providers": {
+                        "first": {"name": "First", "api": shared_url},
+                        "second": {"name": "Second", "api": shared_url},
+                    }
+                },
+            ),
+            patch(
+                "agent.credential_pool.load_pool",
+                return_value=custom_pool,
+            ) as load_pool_mock,
+        ):
+            switch_model(
+                agent,
+                new_model="second-model",
+                new_provider="second",
+                api_key="second-key",
+                base_url=shared_url,
+                api_mode="chat_completions",
+            )
+
+        assert agent._credential_pool is custom_pool
+        load_pool_mock.assert_called_once_with("custom:second")
+
     def test_switch_to_same_provider_does_not_reload_pool(self):
         """Re-selecting the current provider must NOT churn the pool reference."""
         existing_pool = _make_pool("opencode-go")

--- a/tests/run_agent/test_switch_model_pool_reload_52727.py
+++ b/tests/run_agent/test_switch_model_pool_reload_52727.py
@@ -110,6 +110,42 @@ class TestSwitchModelReloadsCredentialPool:
         # load_pool MUST have been called with the new provider.
         load_pool_mock.assert_called_once_with("groq")
 
+    def test_switch_to_named_custom_provider_uses_canonical_pool_key(self):
+        """New-style ``providers.<name>`` entries expose a bare runtime id,
+        but their credential pool is scoped under ``custom:<name>``."""
+        old_pool = _make_pool("openrouter")
+        custom_pool = _make_pool("custom:sensenova")
+        agent = _make_agent("openrouter", "old-model", old_pool)
+
+        with (
+            patch(
+                "hermes_cli.runtime_provider.load_config",
+                return_value={
+                    "providers": {
+                        "sensenova": {
+                            "name": "SenseNova",
+                            "api": "https://token.sensenova.cn/v1",
+                        }
+                    }
+                },
+            ),
+            patch(
+                "agent.credential_pool.load_pool",
+                return_value=custom_pool,
+            ) as load_pool_mock,
+        ):
+            switch_model(
+                agent,
+                new_model="deepseek-v4-flash",
+                new_provider="sensenova",
+                api_key="sensenova-key",
+                base_url="https://token.sensenova.cn/v1",
+                api_mode="chat_completions",
+            )
+
+        assert agent._credential_pool is custom_pool
+        load_pool_mock.assert_called_once_with("custom:sensenova")
+
     def test_switch_to_same_provider_does_not_reload_pool(self):
         """Re-selecting the current provider must NOT churn the pool reference."""
         existing_pool = _make_pool("opencode-go")


### PR DESCRIPTION
## What does this PR do?

Custom providers configured under `providers.<name>` can keep rotating credentials after a model switch instead of silently loading an empty pool. The fix preserves the canonical `custom:<name>` pool identity across switch-time reload and 401/429 recovery while keeping the cross-provider contamination guard fail-closed.

### Symptom

After switching to a new-style named custom provider, the runtime reloads credentials with the bare provider name even though its configured pool is stored under `custom:<name>`. A subsequent 401 or 429 then cannot use refresh or rotation because recovery rejects the runtime provider and pool as different identities.

### Impact

Users with multiple credentials for a named custom provider lose credential rotation after switching models. Rate-limited or expired credentials can therefore exhaust the retry path instead of recovering through another configured credential.

### Bug Cause

**Trigger:** `agent/agent_runtime_helpers.py` / `switch_model()` and `recover_with_credential_pool()` when the selected provider is a new-style `providers.<name>` entry.

**Causal chain:**
1. The model switch resolves the custom provider with its bare config key and live endpoint.
2. Pool reload uses that bare key, while credential seeding stores the pool under `custom:<name>`.
3. The empty or mismatched pool prevents 401/429 recovery from refreshing or rotating the selected provider's credentials.

**Why it is wrong:** Runtime provider identity and credential-pool identity use different naming conventions for the same configured endpoint. The recovery boundary also compared those non-canonical identities before allowing mutation.

**Working sibling / contrast:** Legacy `custom_providers` entries already expose a `custom:<name>` identity, so their switch and recovery paths do not lose the pool key.

**Ruled out:** Credential seeding is not the failure. Tests provide a correctly keyed custom pool and reproduce the loss at switch-time lookup and recovery matching.

### Fix

Resolve a live named custom provider to its canonical pool identity only when both its configured key and current endpoint match. Use that identity for pool reload and recovery matching, and disambiguate providers that intentionally share one endpoint. Built-in, fallback, disabled, and different-endpoint providers retain the existing mismatch protection.

## Related Issue

Closes #86230

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py` - canonicalize custom pool identity during model switches and credential recovery.
- `hermes_cli/runtime_provider.py` - support exact provider-key matching when reversing an endpoint to a custom identity.
- `tests/run_agent/test_switch_model_pool_reload_52727.py` - cover canonical reload and shared-endpoint selection.
- `tests/agent/test_custom_pool_mismatch_guard.py` - cover matching recovery and fail-closed endpoint guards.

## How to Test

1. Configure a named custom provider with multiple credentials.
2. Switch to that provider and exercise 401/429 recovery.
3. Run the focused automated suites:

```bash
scripts/run_tests.sh tests/run_agent/test_switch_model_pool_reload_52727.py tests/agent/test_custom_pool_mismatch_guard.py tests/hermes_cli/test_runtime_provider.py
```

The final review tip passed 67 related tests and 18 custom-provider identity/session-persistence tests on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for this bug fix
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing configuration or workflow changes
- [x] `cli-config.yaml.example`: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changes
- [x] Cross-platform impact considered - provider identity logic is platform-independent
- [x] Tool descriptions/schemas: N/A - no model tool behavior changed
