### PR TITLE
fix(desktop): stop tabs double-click-hiding the tab strip; body double-tap reveals it

### DIFF
--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -95,8 +95,8 @@ function tileZoneHost(groupId: string): { chat: boolean; pane: string } | null {
 /**
  * Begin dragging a session — a sidebar row OR a tile's own tab (same drop
  * language either way: stack, split, or composer link). Sub-threshold releases
- * stay ordinary clicks, so `opts.onTap` (activate the tile) and `opts.double`
- * (hide the tab bar) ride the tab's gestures; Esc aborts instantly. A stack/
+ * stay ordinary clicks, so `opts.onTap` (activate the tile) rides the tab's
+ * gesture; Esc aborts instantly. A stack/
  * split commits through `openSessionTile`, which OPENS a new tile from a sidebar
  * row and MOVES the existing one when its tab is the drag source.
  */

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -616,9 +616,9 @@ export const watchSessionTiles = paneMirror<SessionTile>({
     </SessionTabMenu>
   ),
   // A tile's tab drags like a sidebar row — stack / split / drop-to-link — with
-  // its tap (activate) + double-tap (hide bar) preserved. Always takes the drag.
-  tabDrag: (storedSessionId, event, onTap, double) => {
-    startSessionDrag(tileDragPayload(storedSessionId), event, { double, onTap })
+  // its tap (activate) preserved. Always takes the drag.
+  tabDrag: (storedSessionId, event, onTap) => {
+    startSessionDrag(tileDragPayload(storedSessionId), event, { onTap })
 
     return true
   },

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -147,9 +147,8 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
     />
   )
 
-  // FULL-PAGE views (not chat) mark the zone body `data-zone-no-header`: a
-  // page is not a tab-able surface, so the zone's double-click header toggle
-  // stands down while one is showing (see onZoneDoubleClick).
+  // FULL-PAGE views (not chat): a page is not a tab-able surface, so the
+  // zone's tab strip stands down while one is showing (paneChrome.headerVeto).
   const page = (view: ReactNode) => (
     <div className="contents" data-zone-no-header>
       <Suspense fallback={null}>{view}</Suspense>

--- a/apps/desktop/src/components/pane-shell/tree/renderer/drag-session.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/drag-session.ts
@@ -158,7 +158,7 @@ const sameHint = (a: DropHint | null, b: DropHint | null) =>
 /** Double-tap detection for drag handles. Pane handles preventDefault
  *  pointerdown, which suppresses native `dblclick` — so rapid same-handle
  *  taps are detected here instead. */
-const DOUBLE_TAP_MS = 400
+export const DOUBLE_TAP_MS = 400
 let lastTap: { key: string; time: number } | null = null
 
 export interface DoubleTapContext {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tab-strip-hide.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tab-strip-hide.test.tsx
@@ -1,0 +1,133 @@
+import { useStore } from '@nanostores/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import { group, split } from '../model'
+import { $layoutTree, markCollapsePane, registerPaneCloser } from '../store'
+
+import { TreeGroup } from './tree-group'
+
+/** TreeGroup reads its node from props; subscribe so store writes re-render. */
+function LiveTreeGroup() {
+  useStore($layoutTree)
+
+  return <TreeGroup node={zoneAt(0)} parentAxis="column" />
+}
+
+// Pins the tab-strip hide/recovery grammar: hiding the strip is an EXPLICIT
+// verb (zone menu / main tab menu) — a double-click on a tab must NOT vanish
+// the bar (it used to, stranding the zone with no ✕), and a double-tap on the
+// zone body restores a strip that WAS hidden explicitly.
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  // jsdom lacks CSS.escape, which tab-strip-scroll uses in a layout effect.
+  vi.stubGlobal('CSS', { ...globalThis.CSS, escape: (value: string) => value })
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => undefined
+  Element.prototype.releasePointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+const disposers: (() => void)[] = []
+
+beforeEach(async () => {
+  window.localStorage.clear()
+
+  const { $dismissedPanes, $hiddenTreePanes } = await import('../store')
+  $dismissedPanes.set(new Set())
+  $hiddenTreePanes.set(new Set())
+
+  for (const [id, data] of [
+    ['workspace', { placement: 'main', uncloseable: true }],
+    ['terminal', { placement: 'bottom' }]
+  ] as const) {
+    disposers.push(registry.register({ area: 'panes', data, id, render: () => null, title: id }))
+  }
+
+  markCollapsePane('terminal')
+  registerPaneCloser('terminal', () => undefined)
+})
+
+afterEach(() => {
+  cleanup()
+  disposers.splice(0).forEach(dispose => dispose())
+})
+
+const zoneAt = (index: number) => {
+  const node = $layoutTree.get()!
+
+  return (node.type === 'split' ? node.children[index] : node) as never
+}
+
+const groupNode = () => {
+  const node = $layoutTree.get()!
+
+  return (node.type === 'split' ? node.children[0] : node) as { headerHidden?: boolean; panes: string[] }
+}
+
+const tablist = () => document.querySelector('[role="tablist"]')
+
+const doublePointerDown = (target: Element) => {
+  fireEvent.pointerDown(target, { button: 0, pointerType: 'mouse' })
+  fireEvent.pointerDown(target, { button: 0, pointerType: 'mouse' })
+}
+
+describe('tab strip hide/recovery grammar', () => {
+  it('double-clicking a tab does NOT hide the strip', () => {
+    // $layoutTree.set, not declareDefaultTree — the latter only adopts into an
+    // existing tree, and the store is module state that survives between tests.
+    $layoutTree.set(
+      split('column', [group(['workspace', 'terminal'], { active: 'terminal', id: 'grp-main' })])
+    )
+    render(<LiveTreeGroup />)
+
+    const tab = document.querySelector<HTMLElement>('[data-tree-tab="terminal"]')
+    expect(tab).toBeTruthy()
+
+    doublePointerDown(tab!)
+
+    // The strip is still there and the tree never recorded a hide.
+    expect(tablist()).toBeTruthy()
+    expect(groupNode().headerHidden).not.toBe(true)
+  })
+
+  it('double-tapping the zone body restores an explicitly hidden strip', () => {
+    $layoutTree.set(
+      split('column', [group(['terminal'], { active: 'terminal', headerHidden: true, id: 'grp-tools' })])
+    )
+    render(<LiveTreeGroup />)
+
+    // Hidden strip: no tablist, no ✕ anywhere in the zone.
+    expect(tablist()).toBeNull()
+
+    const body = document.querySelector<HTMLElement>('[data-tree-group="grp-tools"]')
+    expect(body).toBeTruthy()
+
+    doublePointerDown(body!)
+
+    expect(tablist()).toBeTruthy()
+    expect(groupNode().headerHidden).toBe(false)
+  })
+
+  it('a single body tap does not toggle the strip back', () => {
+    $layoutTree.set(
+      split('column', [group(['terminal'], { active: 'terminal', headerHidden: true, id: 'grp-tools' })])
+    )
+    render(<LiveTreeGroup />)
+
+    const body = document.querySelector<HTMLElement>('[data-tree-group="grp-tools"]')!
+    fireEvent.pointerDown(body, { button: 0, pointerType: 'mouse' })
+
+    expect(tablist()).toBeNull()
+    expect(groupNode().headerHidden).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -10,7 +10,15 @@
  */
 
 import { useStore } from '@nanostores/react'
-import { type CSSProperties, Fragment, type ReactNode, type RefObject, useRef, useState } from 'react'
+import {
+  type CSSProperties,
+  Fragment,
+  type ReactNode,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+  useRef,
+  useState
+} from 'react'
 
 import { ActionsContextMenu, type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
 import { Codicon } from '@/components/ui/codicon'
@@ -71,7 +79,7 @@ import {
   toggleTabSelected
 } from '../tab-selection'
 
-import { type DoubleTapContext, startPaneDrag } from './drag-session'
+import { DOUBLE_TAP_MS, type DoubleTapContext, startPaneDrag } from './drag-session'
 import { forceLoneHeaderForPanes } from './lone-header'
 import { useActiveTabVisible } from './tab-strip-scroll'
 import { paneChrome } from './track-model'
@@ -291,15 +299,52 @@ export function TreeGroup({
     tabCount: shown.length
   })
 
-  // Drag handles preventDefault pointerdown (no native dblclick), so the
-  // header + chips share a synthesized double-tap: restore if collapsed
-  // (undoing the first tap's minimize toggle) and hide the chrome.
+  // The STRIP background keeps the synthesized double-tap hide — it is the
+  // documented explicit gesture (model.ts) and the open PR #84458 reveal edge
+  // is its recovery for that surface. TABS must not carry it: a tab is where
+  // people double-click for mundane reasons (select a title, retry a click),
+  // and every tab drag forwarded the gesture, so a routine double-click
+  // vanished the whole bar and stranded the zone with no ✕ and no way back
+  // but a right-click. The body below carries the inverse gesture as the
+  // recovery path when a strip IS hidden.
   const hideHeaderDoubleTap: DoubleTapContext = {
     key: `hide-header-${node.id}`,
     onDoubleTap: () => {
       setTreeGroupMinimized(node.id, false)
       setTreeGroupHeaderHidden(node.id, true)
     }
+  }
+
+  // Recovery for an explicitly hidden strip: double-tap the zone BODY brings
+  // the bar back. The body is otherwise inert (panes own their clicks; drags
+  // engage past a movement threshold), so the gesture can't fire by accident.
+  const showHeaderDoubleTap: DoubleTapContext = {
+    key: `show-header-${node.id}`,
+    onDoubleTap: () => setTreeGroupHeaderHidden(node.id, false)
+  }
+
+  const bodyTapRef = useRef<{ time: number; x: number; y: number } | null>(null)
+
+  const onBodyPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0 || !headerHidden || node.minimized || editMode) {
+      return
+    }
+
+    const now = Date.now()
+    const last = bodyTapRef.current
+
+    if (
+      last &&
+      now - last.time < DOUBLE_TAP_MS &&
+      Math.hypot(event.clientX - last.x, event.clientY - last.y) < 24
+    ) {
+      bodyTapRef.current = null
+      showHeaderDoubleTap.onDoubleTap()
+
+      return
+    }
+
+    bodyTapRef.current = { time: now, x: event.clientX, y: event.clientY }
   }
 
   // Zone-menu close targets read the layout tree, but this component must NOT
@@ -355,11 +400,10 @@ export function TreeGroup({
     targetPane
   }
 
-  // NO body double-click toggle: virtualized content (the thread) recreates
-  // its nodes between clicks, so the gesture was hopelessly unreliable. The
-  // bar's lifecycle is explicit instead — gaining a tab sticky-shows it
-  // (insertAtGroup pins headerHidden false), the main tab's context menu
-  // hides it, and full-page views veto it via paneChrome.headerVeto.
+  // The bar's lifecycle is explicit: gaining a tab sticky-shows it
+  // (insertAtGroup pins headerHidden false), the zone menu (and the main
+  // tab's menu) hide it, full-page views veto it via paneChrome.headerVeto,
+  // and a double-tap on the body restores it while hidden.
 
   return (
     <div
@@ -376,6 +420,7 @@ export function TreeGroup({
       onContextMenu={e => {
         setMenuPane((e.target as HTMLElement).closest('[data-tree-tab]')?.getAttribute('data-tree-tab') ?? undefined)
       }}
+      onPointerDown={onBodyPointerDown}
       ref={ref}
       style={wcOverlap ? { paddingTop: wcOverlap.y + wcOverlap.height } : undefined}
     >
@@ -442,8 +487,9 @@ export function TreeGroup({
             listRef={tabsRef}
             onPointerDown={e =>
               // Tap the header to collapse to it / expand back — the DetailPane
-              // / sidebar-section gesture (never for the main zone). Double-tap
-              // hides the header entirely. Drag still moves the pane.
+              // / sidebar-section gesture (never for the main zone). The
+              // double-tap hide rides the strip background below, not the tabs.
+              // Drag still moves the pane.
               startPaneDrag(
                 activeId,
                 e,
@@ -545,7 +591,7 @@ export function TreeGroup({
                         e,
                         onTap,
                         stripRef.current ? { groupId: node.id, strip: stripRef.current } : undefined,
-                        hideHeaderDoubleTap,
+                        undefined,
                         t.zones.tabCount(dragSelection.length),
                         dragSelection
                       )
@@ -557,13 +603,13 @@ export function TreeGroup({
                     // session drop language — link/stack/split); `false` defers
                     // to the generic pane move (the workspace tab on a fresh
                     // draft has no session to link).
-                    if (!chrome.tabDrag?.(e, onTap, hideHeaderDoubleTap)) {
+                    if (!chrome.tabDrag?.(e, onTap)) {
                       startPaneDrag(
                         paneId,
                         e,
                         onTap,
                         stripRef.current ? { groupId: node.id, strip: stripRef.current } : undefined,
-                        hideHeaderDoubleTap,
+                        undefined,
                         title
                       )
                     }


### PR DESCRIPTION
## What does this PR do?

A zone's tab strip hides on a synthesized double-tap (`hideHeaderDoubleTap` in `tree-group.tsx`). The problem is *where that gesture was wired*: it rode **every tab's** pointerdown (both the generic pane drag and each pane's own `tabDrag`), plus the strip background. Tabs are where people double-click for mundane reasons — selecting a title, retrying a missed click — so a routine double-click on any session/tool tab vanished the whole bar, leaving the zone with no tab, no ✕, and no way back except a right-click into the zone menu ("Show tab bar"). In practice this reads as panes that are "stuck open and cannot be closed" (hit it live with a plugin pane and with session tabs on Windows 11).

The hide gesture is documented and intentional for the **strip background** (`model.ts`: "double-click the header to hide"), and open PR #84458 adds a reveal edge as the recovery for that surface — deliberately kept intact here. This PR narrows the gesture to that documented surface and adds a recovery that works everywhere:

- **Tabs no longer carry the hide gesture.** The strip's own `onPointerDown` (background) keeps it; the per-tab `startPaneDrag` calls and the `tabDrag` contract (`session-tile.tsx`) pass `undefined` for `double`.
- **Double-tap on a zone's body restores a hidden strip** (`onBodyPointerDown` on the zone root, gated to `headerHidden === true`, non-minimized, non-edit-mode; two left-button presses within 400ms and 24px). The body is otherwise inert — panes own their clicks and drags only engage past a movement threshold — so the gesture cannot fire by accident, and it mirrors the strip's hide gesture.

### Relationship to other open PRs (not a duplicate)

- **#84458** (reveal edge for explicitly-hidden zones): complementary. It keeps the strip double-tap hide as-is and adds a visible recovery strip; this PR removes the *accidental* trigger surface (tabs) and adds a body-gesture recovery. If #84458 lands first, this PR still applies cleanly in intent (the strip background keeps the hide; tabs never did in #84458's model either) — happy to rebase if the trees touch.
- **#86191** (lone tile header vs persisted `headerHidden`): adjacent dead-zone family, different mechanism (`forceLoneHeaderForPanes` vs the hide gesture); no overlapping code paths beyond shared files.
- **#81638** (workspace bar reveal via sidebar menu): workspace-specific; this PR is zone-agnostic.

## Related Issue

No existing issue — found while using the desktop app (a double-click on a session tab stranded the zone). Happy to file one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx` — stop forwarding `hideHeaderDoubleTap` through the three per-tab `startPaneDrag` paths and the `chrome.tabDrag` call (strip background keeps it); add `showHeaderDoubleTap` + `onBodyPointerDown` recovery on the zone root; update the now-stale gesture comments.
- `apps/desktop/src/components/pane-shell/tree/renderer/drag-session.ts` — export `DOUBLE_TAP_MS` so the body recovery shares the strip's timing constant.
- `apps/desktop/src/app/chat/session-tile.tsx` — tile `tabDrag` no longer forwards `double` into `startSessionDrag`.
- `apps/desktop/src/app/chat/session-drag.ts`, `apps/desktop/src/app/contrib/surfaces.tsx` — comment-only: remove references to the removed tab double-tap behavior.
- `apps/desktop/src/components/pane-shell/tree/renderer/tab-strip-hide.test.tsx` — new regression suite (3 tests): tab double-click never hides the strip; body double-tap restores an explicitly hidden strip; a single body tap does not toggle.

## How to Test

1. Stack two panes in a zone (e.g. main chat + terminal) so the strip shows tabs.
2. Double-click a **tab** — before: the whole strip vanished and the zone had no ✕; after: nothing hides (the tab just activates).
3. Double-click the **strip background** (right of the tabs) — the strip hides, as documented (unchanged behavior).
4. Double-click anywhere on the zone's **body** — the strip returns.
5. Right-click the zone → Hide/Show tab bar still works; single clicks, text selection, and pane drags are unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see relationship notes above (#84458, #86191, #81638)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: renderer-only change, no Python touched
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (unit/regression suites; the gesture change is pointer-event logic covered by the new tests)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (code comments updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pointer events only, no platform APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Verification

On `origin/main` (a90d5369f) with this change applied:

- `tsc --noEmit -p tsconfig.json` (apps/desktop): clean
- `eslint` on all touched files: 0 errors
- `vitest run src/components/pane-shell src/app/chat/session-drag.test.ts`: 22 files / 112 tests passed
- `vitest run src/app/chat`: 67 files / 549 tests passed
