### PR TITLE
fix(cli): hermes desktop --cwd/--hermes-root accept Git Bash / MSYS paths

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7294,10 +7294,21 @@ def cmd_gui(args: argparse.Namespace):
         env["HERMES_DESKTOP_BOOT_FAKE"] = "1"
     if getattr(args, "ignore_existing", False):
         env["HERMES_DESKTOP_IGNORE_EXISTING"] = "1"
+    # Git Bash / MSYS hands the CLI POSIX-style paths (`--cwd ~` expands to
+    # `/c/Users/x` before Python ever sees it; MSYS2's path conversion is
+    # disabled for native executables). Translate the MSYS/Cygwin/WSL
+    # drive-root spellings to native Windows form first — no-op elsewhere —
+    # same fix as `--in` (#85865).
+    from tools.environments.local import _msys_to_windows_path
+
     if getattr(args, "hermes_root", None):
-        env["HERMES_DESKTOP_HERMES_ROOT"] = str(Path(args.hermes_root).expanduser().resolve())
+        env["HERMES_DESKTOP_HERMES_ROOT"] = str(
+            Path(_msys_to_windows_path(args.hermes_root)).expanduser().resolve()
+        )
     if getattr(args, "cwd", None):
-        env["HERMES_DESKTOP_CWD"] = str(Path(args.cwd).expanduser().resolve())
+        env["HERMES_DESKTOP_CWD"] = str(
+            Path(_msys_to_windows_path(args.cwd)).expanduser().resolve()
+        )
     else:
         env["HERMES_DESKTOP_CWD"] = os.getcwd()
 

--- a/tests/hermes_cli/test_gui_msys_paths.py
+++ b/tests/hermes_cli/test_gui_msys_paths.py
@@ -1,0 +1,40 @@
+"""``hermes desktop --cwd`` / ``--hermes-root`` accept Git Bash / MSYS paths.
+
+Sibling of the ``--in`` fix (tests/hermes_cli/test_in_dir_msys_paths.py,
+#85865): under Git Bash, ``hermes desktop --cwd ~`` reaches the native CLI
+as ``/c/Users/<user>`` — the shell expands ``~`` to an MSYS POSIX path and
+MSYS2's automatic argument conversion is disabled for native executables.
+``cmd_gui`` passed ``--cwd``/``--hermes-root`` straight through
+``Path(...).expanduser().resolve()`` with no MSYS translation, so
+``HERMES_DESKTOP_CWD``/``HERMES_DESKTOP_HERMES_ROOT`` would carry a bogus
+``<drive>:\\c\\Users\\...`` path on Windows (``Path(...).resolve()`` treats
+an untranslated ``/c/Users/alice`` as drive-relative to the CLI's own CWD).
+
+The translation itself (``_msys_to_windows_path``) has exhaustive unit
+coverage in tests/tools/test_local_env_windows_msys.py; this pins the
+``cmd_gui`` call sites actually applying it, using the same source-level
+guard technique as the ``--in`` test (cmd_gui's downstream Electron spawn
+makes a full behavioral invocation impractical to test safely).
+"""
+
+import inspect
+
+import hermes_cli.main as main_mod
+
+
+def test_cmd_gui_hermes_root_and_cwd_use_msys_translation():
+    """Guard: --hermes-root/--cwd resolution in cmd_gui must route through
+    _msys_to_windows_path, same as the --in fix. A plain expanduser/resolve
+    does not survive Git Bash's ~ expansion to /c/Users/... form."""
+    src = inspect.getsource(main_mod.cmd_gui)
+    idx = src.find('if getattr(args, "hermes_root", None):')
+    assert idx != -1, "cmd_gui's --hermes-root resolution block moved; update this test"
+    block = src[idx : idx + 800]
+    assert "_msys_to_windows_path" in block, (
+        "cmd_gui no longer translates MSYS paths for --hermes-root/--cwd; "
+        "Git Bash `hermes desktop --cwd ~` will resolve to a bogus "
+        "<drive>:\\c\\Users\\... path"
+    )
+    assert '"hermes_root"' in block and '"cwd"' in block, (
+        "expected both --hermes-root and --cwd handling in this block"
+    )


### PR DESCRIPTION
## What does this PR do?

5e8d25d7e7 fixed `--in` the same way for `hermes chat`: Git Bash hands the CLI POSIX-style paths (`--in ~` arrives as `/c/Users/<user>` — the shell expands `~` to an MSYS POSIX path before Python ever sees it, and MSYS2's automatic argument conversion is disabled for native executables), and `Path(...).resolve()` treats that as drive-relative to the CLI's own cwd instead of an absolute path, producing a bogus `<drive>:\c\Users\...` result.

`cmd_gui`'s `--hermes-root`/`--cwd` resolution (`hermes_cli/main.py`) has the exact same shape (`Path(args.X).expanduser().resolve()`, no translation) and was not covered by that fix. A Git Bash user running `hermes desktop --cwd ~` gets `HERMES_DESKTOP_CWD` set to a directory that doesn't exist.

## The fix

Routes both through the same `_msys_to_windows_path()` translator (MSYS + Cygwin + WSL drive-root spellings; no-op on non-Windows or already-native paths) before `expanduser`/`resolve`, matching the `--in` fix exactly.

## Testing

- Source-level guard (same technique as `tests/hermes_cli/test_in_dir_msys_paths.py`'s `test_main_call_site_uses_translation` — `cmd_gui`'s downstream Electron spawn makes a full behavioral invocation impractical to test safely) confirming both `--hermes-root` and `--cwd` route through `_msys_to_windows_path`.
- Mutation-verified: fails against the pre-fix code, passes with it restored.
- Not live-tested on real Windows (this environment is macOS); the translation function itself has exhaustive existing coverage in `tests/tools/test_local_env_windows_msys.py`.
- Neighbor suites: `tests/hermes_cli/{test_in_dir_msys_paths,test_desktop_exe_integrity,test_gui_command,test_subcommands_batch}`, `tests/tools/test_local_env_windows_msys.py` — all green.
- `ruff check` clean.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)