### PR TITLE
fix(agent): stop web research cleanly at the per-turn budget

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1327,10 +1327,41 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
+_WEB_RESEARCH_TOOL_NAMES = frozenset({"web_search", "web_extract"})
+
+
+def _tool_definition_name(tool: object) -> str:
+    """Best-effort extraction for the canonical OpenAI-style tool schema."""
+    if not isinstance(tool, dict):
+        return ""
+    function = tool.get("function")
+    if isinstance(function, dict):
+        return str(function.get("name") or "")
+    return str(tool.get("name") or "")
+
+
+def _filter_exhausted_web_tools(agent, tools_for_api: list | None) -> list | None:
+    """Return a request-local tool list without web tools after budget use.
+
+    Never mutate ``agent.tools`` or a prompt-cache-derived list: the budget is
+    per turn, so the complete registry must be available again after reset.
+    """
+    guardrails = getattr(agent, "_tool_guardrails", None)
+    if not getattr(guardrails, "web_budget_exhausted", False):
+        return tools_for_api
+    if not tools_for_api:
+        return tools_for_api
+    return [
+        tool for tool in tools_for_api
+        if _tool_definition_name(tool) not in _WEB_RESEARCH_TOOL_NAMES
+    ]
+
+
 def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     if tools_for_api is None:
         tools_for_api = agent.tools
+    tools_for_api = _filter_exhausted_web_tools(agent, tools_for_api)
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -145,8 +145,9 @@ class LoopCapConfig:
     loops. Here the caps count *within a single agent loop* (one turn): the
     counters reset in ``reset_for_turn`` at the start of every
     ``run_conversation``, so a legitimate multi-turn session is never starved,
-    but a single turn that spirals into an unbounded search / delegation loop
-    is stopped.
+    but a single turn cannot keep executing an unbounded search / delegation
+    loop. Web calls beyond the budget are denied so the model can synthesize
+    from collected results; runaway delegation still halts the turn.
 
     Semantics differ from the per-turn loop *detector* above (which keys on
     repeated identical/failing calls): these caps are a hard ceiling on the
@@ -194,7 +195,7 @@ class ToolCallSignature:
 class ToolGuardrailDecision:
     """Decision returned by the tool-call guardrail controller."""
 
-    action: str = "allow"  # allow | warn | block | halt
+    action: str = "allow"  # allow | warn | deny | block | halt
     code: str = "allow"
     message: str = ""
     tool_name: str = ""
@@ -299,7 +300,7 @@ class ToolCallGuardrailController:
         # These are hard ceilings on how many times a runaway-prone tool may
         # be called within a single agent loop (turn). They apply regardless
         # of hard_stop_enabled (which only governs the per-turn loop detector).
-        # We block BEFORE the call runs once the count is already at the cap,
+        # We deny BEFORE the call runs once the count is already at the cap,
         # then increment for an allowed call so the (cap+1)-th is refused.
         cap_block = self._check_loop_cap(tool_name, _coerce_args(args), signature)
         if cap_block is not None:
@@ -463,21 +464,20 @@ class ToolCallGuardrailController:
             cap = caps.max_web_searches
             if cap and self._turn_web_request_count >= cap:
                 decision = ToolGuardrailDecision(
-                    action="block",
+                    action="deny",
                     code="loop_web_research_cap",
                     message=(
                         f"Blocked {tool_name}: this turn has already made {cap} "
-                        "web search/extract requests, the per-turn limit. Stop "
-                        "reformulating the same research path. Work with the "
-                        "results already collected, use a non-web source when "
-                        "available, or clearly report that verification was "
-                        "not possible."
+                        "web search/extract requests, the per-turn limit. Do not "
+                        "call web_search or web_extract again in this turn. "
+                        "Synthesize the answer now from the results already "
+                        "collected, explicitly distinguishing verified facts, "
+                        "candidates, and missing evidence."
                     ),
                     tool_name=tool_name,
                     count=self._turn_web_request_count,
                     signature=signature,
                 )
-                self._halt_decision = decision
                 return decision
             self._turn_web_request_count += 1
             return None

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -288,10 +288,22 @@ class ToolCallGuardrailController:
         # single agent loop rather than accumulating across the session.
         self._turn_web_request_count = 0
         self._turn_subagent_count = 0
+        self._web_budget_exhausted = False
+        self._web_budget_denial_count = 0
 
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
         return self._halt_decision
+
+    @property
+    def web_budget_exhausted(self) -> bool:
+        """Whether web tools must be hidden for the rest of this turn."""
+        return self._web_budget_exhausted
+
+    @property
+    def web_budget_denial_count(self) -> int:
+        """Number of post-budget web calls rejected in this turn."""
+        return self._web_budget_denial_count
 
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
@@ -463,6 +475,8 @@ class ToolCallGuardrailController:
         if tool_name in {"web_search", "web_extract"}:
             cap = caps.max_web_searches
             if cap and self._turn_web_request_count >= cap:
+                self._web_budget_exhausted = True
+                self._web_budget_denial_count += 1
                 decision = ToolGuardrailDecision(
                     action="deny",
                     code="loop_web_research_cap",

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -132,7 +132,7 @@ class ToolCallGuardrailConfig:
 # single turn" rather than cumulative over the whole session. A single loop
 # issuing dozens of web searches or spawning dozens of subagents is already
 # pathological, so the defaults are deliberately low.
-_DEFAULT_MAX_WEB_SEARCHES_PER_TURN = 50
+_DEFAULT_MAX_WEB_SEARCHES_PER_TURN = 12
 _DEFAULT_MAX_SUBAGENTS_PER_TURN = 50
 
 
@@ -285,7 +285,7 @@ class ToolCallGuardrailController:
         # Per-turn runaway-loop cap counters. Reset every turn (this method
         # runs at the start of each run_conversation), so the caps bound a
         # single agent loop rather than accumulating across the session.
-        self._turn_web_search_count = 0
+        self._turn_web_request_count = 0
         self._turn_subagent_count = 0
 
     @property
@@ -459,25 +459,27 @@ class ToolCallGuardrailController:
         """
         caps = self.config.loop_caps
 
-        if tool_name == "web_search":
+        if tool_name in {"web_search", "web_extract"}:
             cap = caps.max_web_searches
-            if cap and self._turn_web_search_count >= cap:
+            if cap and self._turn_web_request_count >= cap:
                 decision = ToolGuardrailDecision(
                     action="block",
-                    code="loop_web_search_cap",
+                    code="loop_web_research_cap",
                     message=(
-                        f"Blocked web_search: this turn has already made {cap} "
-                        "web searches, the per-turn limit. This looks like a "
-                        "runaway search loop. Work with the results you already "
-                        "have and give the user your answer."
+                        f"Blocked {tool_name}: this turn has already made {cap} "
+                        "web search/extract requests, the per-turn limit. Stop "
+                        "reformulating the same research path. Work with the "
+                        "results already collected, use a non-web source when "
+                        "available, or clearly report that verification was "
+                        "not possible."
                     ),
                     tool_name=tool_name,
-                    count=self._turn_web_search_count,
+                    count=self._turn_web_request_count,
                     signature=signature,
                 )
                 self._halt_decision = decision
                 return decision
-            self._turn_web_search_count += 1
+            self._turn_web_request_count += 1
             return None
 
         if tool_name == "delegate_task":

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -615,7 +615,7 @@ DEFAULT_CONFIG = {
         # searches or spawning dozens of subagents is already pathological, so
         # the defaults are low. Set either to 0 to disable that cap (unlimited).
         "loop_caps": {
-            "max_web_searches": 50,   # max web_search calls per turn (0 = unlimited)
+            "max_web_searches": 12,   # shared web_search/web_extract budget per turn (0 = unlimited)
             "max_subagents": 50,      # max subagents spawned per turn (0 = unlimited)
         },
     },

--- a/run_agent.py
+++ b/run_agent.py
@@ -7851,6 +7851,16 @@ class AIAgent:
 
     def _guardrail_block_result(self, decision: ToolGuardrailDecision) -> str:
         self._set_tool_guardrail_halt(decision)
+        if decision.code == "loop_web_research_cap":
+            denial_count = self._tool_guardrails.web_budget_denial_count
+            log = logger.warning if denial_count == 1 else logger.debug
+            log(
+                "%sWeb research budget exhausted; rejected %s call %d and "
+                "will omit web tools from subsequent requests this turn",
+                self.log_prefix,
+                decision.tool_name,
+                denial_count,
+            )
         return toolguard_synthetic_result(decision)
 
     def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -7813,6 +7813,14 @@ class AIAgent:
             self._tool_guardrail_halt_decision = decision
 
     def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
+        if decision.code == "loop_web_research_cap":
+            return (
+                "Web research stopped safely after reaching its per-turn budget "
+                f"of {decision.count} search/extract requests without enough "
+                "progress. Results collected so far may be incomplete. Retry "
+                "later, use a direct/official data source, or configure an "
+                "extraction-capable web provider."
+            )
         tool = decision.tool_name or "a tool"
         return (
             f"I stopped retrying {tool} because it hit the tool-call guardrail "

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -147,7 +147,7 @@ from agent.tool_guardrails import LoopCapConfig  # noqa: E402
 def test_loop_cap_zero_disables_and_junk_falls_back():
     # 0 is a legitimate "unlimited" value; negatives / junk fall back to default.
     assert LoopCapConfig.from_mapping({"max_web_searches": 0}).max_web_searches == 0
-    assert LoopCapConfig.from_mapping({"max_web_searches": -5}).max_web_searches == 50
+    assert LoopCapConfig.from_mapping({"max_web_searches": -5}).max_web_searches == 12
     assert LoopCapConfig.from_mapping({"max_subagents": "nope"}).max_subagents == 50
 
 
@@ -165,10 +165,27 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
         assert controller.before_call("web_search", {"query": f"q{i}"}).action == "allow"
     decision = controller.before_call("web_search", {"query": "q4"})
     assert decision.action == "block"
-    assert decision.code == "loop_web_search_cap"
+    assert decision.code == "loop_web_research_cap"
     assert decision.should_halt is True
 
 
+def test_web_search_and_extract_share_one_research_budget():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_web_searches=3))
+    )
+
+    assert controller.before_call("web_search", {"query": "a"}).action == "allow"
+    assert controller.before_call(
+        "web_extract", {"urls": ["https://example.com/a"]}
+    ).action == "allow"
+    assert controller.before_call("web_search", {"query": "b"}).action == "allow"
+
+    decision = controller.before_call(
+        "web_extract", {"urls": ["https://example.com/b"]}
+    )
+    assert decision.action == "block"
+    assert decision.code == "loop_web_research_cap"
+    assert decision.count == 3
 
 
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -169,6 +169,16 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.allows_execution is False
     assert decision.should_halt is False
     assert controller.halt_decision is None
+    assert controller.web_budget_exhausted is True
+    assert controller.web_budget_denial_count == 1
+
+    controller.before_call("web_extract", {"urls": ["https://example.com"]})
+    assert controller.web_budget_denial_count == 2
+
+    controller.reset_for_turn()
+    assert controller.web_budget_exhausted is False
+    assert controller.web_budget_denial_count == 0
+    assert controller.before_call("web_search", {"query": "fresh turn"}).action == "allow"
 
 
 def test_web_search_and_extract_share_one_research_budget():
@@ -189,7 +199,6 @@ def test_web_search_and_extract_share_one_research_budget():
     assert decision.code == "loop_web_research_cap"
     assert decision.count == 3
     assert decision.should_halt is False
-
 
 
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -164,9 +164,11 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     for i in range(3):
         assert controller.before_call("web_search", {"query": f"q{i}"}).action == "allow"
     decision = controller.before_call("web_search", {"query": "q4"})
-    assert decision.action == "block"
+    assert decision.action == "deny"
     assert decision.code == "loop_web_research_cap"
-    assert decision.should_halt is True
+    assert decision.allows_execution is False
+    assert decision.should_halt is False
+    assert controller.halt_decision is None
 
 
 def test_web_search_and_extract_share_one_research_budget():
@@ -183,10 +185,10 @@ def test_web_search_and_extract_share_one_research_budget():
     decision = controller.before_call(
         "web_extract", {"urls": ["https://example.com/b"]}
     )
-    assert decision.action == "block"
+    assert decision.action == "deny"
     assert decision.code == "loop_web_research_cap"
     assert decision.count == 3
-
+    assert decision.should_halt is False
 
 
 

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -438,3 +438,42 @@ def test_web_budget_halt_response_is_actionable_and_not_an_internal_loop_dump():
     assert "12 search/extract requests" in response
     assert "direct/official data source" in response
     assert "loop_web_research_cap" not in response
+
+
+def test_web_budget_denial_allows_next_model_iteration_to_synthesize():
+    agent = _make_agent(
+        "web_search",
+        max_iterations=4,
+        config={
+            "tool_loop_guardrails": {
+                "loop_caps": {"max_web_searches": 1},
+            }
+        },
+    )
+    calls = [
+        _mock_tool_call("web_search", json.dumps({"query": "focused"}), "c-allowed"),
+        _mock_tool_call("web_search", json.dumps({"query": "fanout"}), "c-denied"),
+    ]
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=calls),
+        _mock_response(content="Encontré un resultado verificado.", finish_reason="stop"),
+    ]
+    agent._disable_streaming = True
+
+    with (
+        patch("run_agent.handle_function_call", return_value=json.dumps({"success": True})),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("find results")
+
+    assert result["turn_exit_reason"].startswith("text_response")
+    assert result["final_response"] == "Encontré un resultado verificado."
+    assert "guardrail" not in result
+    denied = [
+        message for message in result["messages"]
+        if message.get("tool_call_id") == "c-denied"
+    ]
+    assert len(denied) == 1
+    assert "loop_web_research_cap" in denied[0]["content"]

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -420,3 +420,21 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+
+def test_web_budget_halt_response_is_actionable_and_not_an_internal_loop_dump():
+    from agent.tool_guardrails import ToolGuardrailDecision
+
+    agent = _make_agent("web_search")
+    response = agent._toolguard_controlled_halt_response(
+        ToolGuardrailDecision(
+            action="block",
+            code="loop_web_research_cap",
+            tool_name="web_search",
+            count=12,
+        )
+    )
+
+    assert "12 search/extract requests" in response
+    assert "direct/official data source" in response
+    assert "loop_web_research_cap" not in response

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -442,7 +442,7 @@ def test_web_budget_halt_response_is_actionable_and_not_an_internal_loop_dump():
 
 def test_web_budget_denial_allows_next_model_iteration_to_synthesize():
     agent = _make_agent(
-        "web_search",
+        "web_search", "web_extract", "terminal",
         max_iterations=4,
         config={
             "tool_loop_guardrails": {
@@ -471,9 +471,25 @@ def test_web_budget_denial_allows_next_model_iteration_to_synthesize():
     assert result["turn_exit_reason"].startswith("text_response")
     assert result["final_response"] == "Encontré un resultado verificado."
     assert "guardrail" not in result
-    denied = [
+    batch_results = [
         message for message in result["messages"]
-        if message.get("tool_call_id") == "c-denied"
+        if message.get("tool_call_id") in {"c-allowed", "c-denied"}
     ]
+    denied = [
+        message for message in batch_results
+        if "loop_web_research_cap" in message.get("content", "")
+    ]
+    allowed = [message for message in batch_results if message not in denied]
+    assert len(batch_results) == 2
     assert len(denied) == 1
     assert "loop_web_research_cap" in denied[0]["content"]
+    assert len(allowed) == 1
+    assert '"success": true' in allowed[0]["content"]
+
+    assert agent.client.chat.completions.create.call_count == 2
+    second_tools = agent.client.chat.completions.create.call_args_list[1].kwargs["tools"]
+    second_names = {tool["function"]["name"] for tool in second_tools}
+    assert second_names == {"terminal"}
+    assert {tool["function"]["name"] for tool in agent.tools} == {
+        "web_search", "web_extract", "terminal",
+    }

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -445,6 +445,38 @@ class TestCheckWebApiKey:
                     assert check_web_api_key() is True
 
 
+def test_capability_checks_hide_extract_for_search_only_provider():
+    """DDGS-like providers expose search without advertising web_extract."""
+    from tools.web_tools import (
+        check_web_api_key,
+        check_web_extract_available,
+        check_web_search_available,
+    )
+
+    search_only = MagicMock()
+    with patch(
+        "agent.web_search_registry.get_active_search_provider",
+        return_value=search_only,
+    ), patch(
+        "agent.web_search_registry.get_active_extract_provider",
+        return_value=None,
+    ), patch("tools.web_tools._ensure_web_plugins_loaded"):
+        assert check_web_search_available() is True
+        assert check_web_extract_available() is False
+        assert check_web_api_key() is True
+
+
+def test_web_registry_uses_capability_specific_availability_checks():
+    from tools.web_tools import (
+        check_web_extract_available,
+        check_web_search_available,
+    )
+    from tools.registry import registry
+
+    assert registry.get_entry("web_search").check_fn is check_web_search_available
+    assert registry.get_entry("web_extract").check_fn is check_web_extract_available
+
+
 def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -316,6 +316,14 @@ class TestWebSearchSchema:
         assert limit_schema["default"] == 5
         assert "limit" not in tools.web_tools.WEB_SEARCH_SCHEMA["parameters"]["required"]
 
+    def test_schema_tells_model_to_inspect_then_synthesize(self):
+        import tools.web_tools
+
+        description = tools.web_tools.WEB_SEARCH_SCHEMA["description"]
+        assert "inspect each batch before reformulating" in description
+        assert "browser tools otherwise" in description
+        assert "verified subset" in description
+
 
     def test_web_search_clamps_limit_before_backend_call(self):
         import tools.web_tools

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -630,7 +630,8 @@ def web_search_tool(query: str, limit: int = 5) -> str:
     with multiple backends (Parallel or Firecrawl).
 
     Note: This function returns search result metadata only (URLs, titles, descriptions).
-    Use web_extract_tool to get full content from specific URLs.
+    Use web_extract_tool to get full content from specific URLs when it is
+    available; otherwise open promising results with the browser tools.
     
     Args:
         query (str): The search query to look up
@@ -1195,7 +1196,7 @@ from tools.registry import registry, tool_error
 
 WEB_SEARCH_SCHEMA = {
     "name": "web_search",
-    "description": "Search the web for information. Returns up to 5 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
+    "description": "Search the web for information. Returns up to 5 results by default with titles, URLs, and descriptions. Use a small number of focused searches, inspect each batch before reformulating, and stop searching once enough relevant candidates exist. Open promising URLs with web_extract when available or browser tools otherwise. If the available evidence supports fewer items than requested, answer with the verified subset and state the gap instead of issuing a broad query fan-out. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
     "parameters": {
         "type": "object",
         "properties": {

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1053,42 +1053,62 @@ async def web_extract_tool(
 
 
 # Convenience function to check Firecrawl credentials
-def check_web_api_key() -> bool:
-    """Check whether the configured web backend is available.
+def _check_web_capability(capability: str) -> bool:
+    """Return whether at least one provider can serve *capability*.
 
-    Used as the ``check_fn`` gate for the ``web_search`` and ``web_extract``
-    tool registry entries — so a plugin-registered provider that reports
-    ``is_available()`` must light the tools up even when no built-in backend
-    has credentials (issues #28651, #31873). Resolution funnels through
-    :func:`_is_backend_available`, which delegates non-legacy names to the
-    registry.
+    Search-only providers must not make ``web_extract`` visible to the model.
+    Advertising a tool that cannot run encourages futile fallback loops (for
+    example DDGS search -> web_extract -> DDGS capability error -> more search).
+    Keep this probe capability-aware and network-free; provider
+    ``is_available()`` implementations are required to be cheap local checks.
     """
-    # ``or ""``: a null ``web.backend`` value yields None from ``.get``, and
-    # ``None.lower()`` would raise. Mirrors ``_get_backend``.
-    configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured and _is_backend_available(configured):
-        return True
-    # Any built-in backend with credentials present. This is a boolean OR, so
-    # unlike _get_backend() the probe order is irrelevant.
-    if any(_is_backend_available(backend) for backend in _LEGACY_WEB_BACKENDS):
-        return True
-    # Any plugin-registered provider the registry considers active for either
-    # capability. Delegating to the registry's own availability-filtered
-    # resolvers keeps a single authority for "is a custom provider usable"
-    # rather than re-implementing the walk here.
     try:
+        _ensure_web_plugins_loaded()
         from agent.web_search_registry import (
-            get_active_search_provider,
             get_active_extract_provider,
+            get_active_search_provider,
         )
 
-        return (
-            get_active_search_provider() is not None
-            or get_active_extract_provider() is not None
+        resolver = (
+            get_active_search_provider
+            if capability == "search"
+            else get_active_extract_provider
         )
-    except Exception as exc:  # noqa: BLE001 — registry optional; never fatal
-        logger.debug("web provider registry availability check failed: %s", exc)
+        if resolver() is not None:
+            return True
+
+        # Registry discovery can be deliberately unavailable in stripped
+        # installs and tests. Preserve the legacy built-in probes, but filter
+        # them by capability so a search-only backend never enables extract.
+        builtins = (
+            _LEGACY_WEB_BACKENDS
+            if capability == "search"
+            else frozenset({"firecrawl", "tavily", "exa", "parallel"})
+        )
+        return any(_is_backend_available(name) for name in builtins)
+    except Exception as exc:  # noqa: BLE001 — availability is best-effort
+        logger.debug("web %s capability check failed: %s", capability, exc)
         return False
+
+
+def check_web_search_available() -> bool:
+    """Return whether the configured providers support web search."""
+    return _check_web_capability("search")
+
+
+def check_web_extract_available() -> bool:
+    """Return whether the configured providers support URL extraction."""
+    return _check_web_capability("extract")
+
+
+def check_web_api_key() -> bool:
+    """Backward-compatible check for any configured web capability.
+
+    External callers historically used this as an "any web tool" probe, so
+    retain that contract while registry entries use the capability-specific
+    checks below.
+    """
+    return check_web_search_available() or check_web_extract_available()
 
 
 if __name__ == "__main__":
@@ -1222,7 +1242,7 @@ registry.register(
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
     handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
-    check_fn=check_web_api_key,
+    check_fn=check_web_search_available,
     requires_env=_web_requires_env(),
     emoji="🔍",
     max_result_size_chars=100_000,
@@ -1236,7 +1256,7 @@ registry.register(
         "markdown",
         char_limit=args.get("char_limit"),
     ),
-    check_fn=check_web_api_key,
+    check_fn=check_web_extract_available,
     requires_env=_web_requires_env(),
     is_async=True,
     emoji="📄",

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1670,7 +1670,7 @@ tool_loop_guardrails:
 
 ### Per-turn runaway-loop caps
 
-Separate from the failure-based thresholds above, `loop_caps` sets hard ceilings on the shared `web_search`/`web_extract` request budget and on subagent spawns within a single agent loop (turn). The counters reset at the start of every turn, so a legitimate multi-turn session is never starved — but a single turn that spirals into an unbounded research or delegation loop is stopped. These are always on and fire regardless of `hard_stop_enabled`. When a cap is reached, the offending tool call is blocked with an explanatory message and the turn stops cleanly instead of burning the rest of the budget. Set either value to `0` to disable that cap entirely.
+Separate from the failure-based thresholds above, `loop_caps` sets hard ceilings on the shared `web_search`/`web_extract` request budget and on subagent spawns within a single agent loop (turn). The counters reset at the start of every turn, so a legitimate multi-turn session is never starved. These limits are always on and fire regardless of `hard_stop_enabled`. When the web budget is reached, additional search/extract calls are denied and the model is instructed to synthesize an answer from the evidence already collected; the turn is not aborted. A subagent-cap violation still halts the turn. Set either value to `0` to disable that cap entirely.
 
 A single `delegate_task` batch counts each task toward `max_subagents` (a batch of 3 spends 3), so the cap tracks real subagents spawned rather than `delegate_task` invocations.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1662,7 +1662,7 @@ tool_loop_guardrails:
     same_tool_failure: 8
     idempotent_no_progress: 5
   loop_caps:
-    max_web_searches: 50       # max web_search calls per turn (0 = unlimited)
+    max_web_searches: 12       # shared web_search/web_extract budget per turn (0 = unlimited)
     max_subagents: 50          # max subagents spawned per turn (0 = unlimited)
 ```
 
@@ -1670,7 +1670,7 @@ tool_loop_guardrails:
 
 ### Per-turn runaway-loop caps
 
-Separate from the failure-based thresholds above, `loop_caps` sets hard ceilings on how many `web_search` calls and subagent spawns a single agent loop (turn) may make. The counters reset at the start of every turn, so a legitimate multi-turn session is never starved — but a single turn that spirals into an unbounded search or delegation loop is stopped. These are always on and fire regardless of `hard_stop_enabled`. A single turn issuing dozens of web searches or spawning dozens of subagents is already pathological, so the defaults are low. When a cap is reached, the offending tool call is blocked with an explanatory message and the turn stops cleanly instead of burning the rest of the budget. Set either value to `0` to disable that cap entirely.
+Separate from the failure-based thresholds above, `loop_caps` sets hard ceilings on the shared `web_search`/`web_extract` request budget and on subagent spawns within a single agent loop (turn). The counters reset at the start of every turn, so a legitimate multi-turn session is never starved — but a single turn that spirals into an unbounded research or delegation loop is stopped. These are always on and fire regardless of `hard_stop_enabled`. When a cap is reached, the offending tool call is blocked with an explanatory message and the turn stops cleanly instead of burning the rest of the budget. Set either value to `0` to disable that cap entirely.
 
 A single `delegate_task` batch counts each task toward `max_subagents` (a batch of 3 spends 3), so the cap tracks real subagents spawned rather than `delegate_task` invocations.
 


### PR DESCRIPTION
## What does this PR do?

Stops broad web-research requests cleanly when they reach the per-turn budget, instead of halting the turn or letting the model keep issuing denied web calls.

The failure mode is provider-agnostic: a model can fan out many related queries, hit the guardrail, receive a denial, and still see web tools in the next API schema. That makes another web call possible and can turn a 12-request research budget into dozens of non-progressing model iterations.

This PR makes the full path capability-aware and bounded:

- Advertise web_search and web_extract independently, based on actual provider capability.
- Count web_search and web_extract against one configurable per-turn research budget.
- Lower the default budget from 50 to 12 requests.
- Return one synthetic tool result that tells the model to synthesize from collected evidence.
- Remove both web tools from every subsequent API request in that turn, while preserving all non-web tools.
- Reset the complete tool registry and budget state at the next user turn.
- Log the first post-budget denial as a warning and residual stale calls at debug level.

No public API or configuration key changes are introduced. max_web_searches remains configurable and 0 still means unlimited.

## Related Issue

No issue filed. This was reproduced in production with broad local-research queries that exhausted the budget and continued retrying web_search without progress.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- agent/tool_guardrails.py: shared search/extract accounting, soft denial state, and per-turn reset.
- agent/chat_completion_helpers.py: request-local removal of exhausted web tools across Chat Completions, Responses, Anthropic Messages, and Bedrock paths.
- tools/web_tools.py: capability-specific provider gates and non-fatal budget guidance.
- run_agent.py: controlled synthesis behavior and bounded diagnostics.
- hermes_cli/config_defaults.py and configuration docs: default budget of 12.
- Tests cover provider capability, exact budget boundaries, request payload filtering, registry preservation, reset behavior, and end-to-end synthesis.

## How to Test

1. Configure max_web_searches to 1 and expose web_search, web_extract, and terminal.
2. Return a model response containing two web calls.
3. Verify exactly one web call executes and exactly one receives loop_web_research_cap.
4. Verify the next model request contains terminal but omits web_search and web_extract.
5. Verify the turn ends with a normal text response in two API calls.
6. Start another turn and verify the web tools and budget are restored.

Executed locally:

    PYTHONPATH=/tmp/hermes-pr-web-deps-20260814 python -m pytest       tests/agent/test_tool_guardrails.py       tests/run_agent/test_tool_call_guardrail_runtime.py       tests/integration/test_web_tools.py       tests/plugins/web/test_web_search_provider_plugins.py       tests/tools/test_web_tools_config.py       tests/tools/test_web_tools_dict_urls.py       tests/tools/test_web_tools_tavily.py       tests/tools/test_web_tools_truncate.py -q

Result: 107 passed.

Also passed:

    ruff check agent/chat_completion_helpers.py agent/tool_guardrails.py run_agent.py tools/web_tools.py tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/tools/test_web_tools_config.py
    python -m compileall -q agent tools run_agent.py tests/agent tests/run_agent tests/tools
    git diff --check origin/main...HEAD

Tested on macOS 26.3.1, Python 3.11.9. The same runtime patch has also been exercised in a Linux Docker deployment based on Hermes v0.20.0.

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] Commit messages follow Conventional Commits.
- [x] I searched open and closed PRs for duplicate web-search guardrail work.
- [x] The PR contains only changes required for capability-aware bounded web research.
- [ ] Full pytest tests/ -q suite run locally; targeted affected suites pass and CI will run the full matrix.
- [x] Regression tests are included.
- [x] Tested on macOS 26.3.1 and in the Linux container runtime.

### Documentation and Housekeeping

- [x] Updated the relevant configuration documentation.
- [x] cli-config.yaml.example is N/A because no key was added or renamed.
- [x] CONTRIBUTING.md and AGENTS.md are N/A.
- [x] Cross-platform impact considered: filtering is pure request-local Python with no OS-specific behavior.
- [x] Tool descriptions and availability gates were updated where behavior changed.
