### PR TITLE
fix(telegram): parse variable-length GFM fences safely

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -492,6 +492,81 @@ def _strip_mdv2(text: str) -> str:
     return cleaned
 
 
+_GFM_FENCE_OPEN_RE = re.compile(
+    r"^(?P<indent> {0,3})(?P<fence>`{3,}|~{3,})(?P<info>[^\r\n]*)$"
+)
+_TELEGRAM_CODE_LANGUAGE_RE = re.compile(r"^[A-Za-z0-9_+.-]+$")
+
+
+def _protect_gfm_fenced_blocks(
+    text: str,
+    stash: Callable[[str], str],
+) -> str:
+    """Normalize GFM fences to balanced Telegram MarkdownV2 pre blocks.
+
+    GFM permits backtick or tilde fences of length three or greater, and a
+    closing fence may be longer than its opener. Telegram only understands
+    triple backticks. Parse line-by-line so a four-backtick block may safely
+    contain triple-backtick text, then normalize the complete block. An
+    unclosed opener and its remainder are stashed as escaped literal text so
+    Telegram never receives a malformed pre entity.
+    """
+    lines = text.splitlines(keepends=True)
+    output: list[str] = []
+    index = 0
+
+    while index < len(lines):
+        opening_line = lines[index].rstrip("\r\n")
+        opening_match = _GFM_FENCE_OPEN_RE.match(opening_line)
+        if opening_match is None:
+            output.append(lines[index])
+            index += 1
+            continue
+
+        fence = opening_match.group("fence")
+        info = opening_match.group("info").strip()
+        if fence.startswith("`") and "`" in info:
+            output.append(lines[index])
+            index += 1
+            continue
+
+        closing_index = None
+        for candidate_index in range(index + 1, len(lines)):
+            candidate = lines[candidate_index].rstrip("\r\n")
+            stripped = candidate.lstrip(" ")
+            indent_width = len(candidate) - len(stripped)
+            if indent_width > 3 or not stripped:
+                continue
+            closing_run = stripped.rstrip(" \t")
+            trailing = stripped[len(closing_run):]
+            if trailing and not trailing.isspace():
+                continue
+            if (
+                closing_run
+                and set(closing_run) == {fence[0]}
+                and len(closing_run) >= len(fence)
+            ):
+                closing_index = candidate_index
+                break
+
+        if closing_index is None:
+            output.append(stash(_escape_mdv2("".join(lines[index:]))))
+            break
+
+        language = info.split()[0] if info else ""
+        if not _TELEGRAM_CODE_LANGUAGE_RE.fullmatch(language):
+            language = ""
+        body = "".join(lines[index + 1:closing_index])
+        body = body.replace("\\", "\\\\").replace("`", "\\`")
+        opening = f"```{language}\n"
+        output.append(stash(opening + body + "```"))
+        closing_line = lines[closing_index]
+        output.append(closing_line[len(closing_line.rstrip("\r\n")):])
+        index = closing_index + 1
+
+    return "".join(output)
+
+
 _CHUNK_INDICATOR_ON_FENCE_RE = re.compile(
     r'(?m)^``` (?P<indicator>(?:\\)?\(\d+/\d+(?:\\)?\))$'
 )
@@ -8006,23 +8081,9 @@ class TelegramAdapter(BasePlatformAdapter):
         #    before the normal MarkdownV2 conversions run.
         text = _wrap_markdown_tables(text)
 
-        # 1) Protect fenced code blocks (``` ... ```)
-        #    Per MarkdownV2 spec, \ and ` inside pre/code must be escaped.
-        def _protect_fenced(m):
-            raw = m.group(0)
-            # Split off opening ``` (with optional language) and closing ```
-            open_end = raw.index('\n') + 1 if '\n' in raw[3:] else 3
-            opening = raw[:open_end]
-            body_and_close = raw[open_end:]
-            body = body_and_close[:-3]
-            body = body.replace('\\', '\\\\').replace('`', '\\`')
-            return _ph(opening + body + '```')
-
-        text = re.sub(
-            r'(```(?:[^\n]*\n)?[\s\S]*?```)',
-            _protect_fenced,
-            text,
-        )
+        # 1) Protect and normalize complete GFM fenced blocks. Telegram only
+        #    accepts triple-backtick pre entities while GFM allows 3+.
+        text = _protect_gfm_fenced_blocks(text, _ph)
 
         # 2) Protect inline code (`...`)
         #    Escape \ inside inline code per MarkdownV2 spec.

--- a/tests/conformance/vectors/telegram.json
+++ b/tests/conformance/vectors/telegram.json
@@ -2,7 +2,7 @@
   "$comment": "GENERATED — do not hand-edit. Regenerate with hermes-agent scripts/generate_conformance_vectors.py; the native renderers are the oracle (executable spec).",
   "oracle": {
     "repo": "NousResearch/hermes-agent",
-    "commit": "40eebc7d70f3d8e95c429c8aa482f31ba6c867f6",
+    "commit": "86807d42fc8bfa270cff0cc2f2893a01a84f2583",
     "generator": "scripts/generate_conformance_vectors.py",
     "generator_version": 1
   },
@@ -224,7 +224,7 @@
       "category": "scar",
       "expect": "semantic",
       "input": "`C:\\Users\\ben\\file.txt` and ```\npath = \"a\\\\b\"\n```",
-      "native_output": "`C:\\\\Users\\\\ben\\\\file.txt` and ```\npath = \"a\\\\\\\\b\"\n```"
+      "native_output": "`C:\\\\Users\\\\ben\\\\file.txt` and \\`\\`\\`\npath \\= \"a\\\\\\\\b\"\n\\`\\`\\`"
     },
     {
       "id": "backtick-in-fence",
@@ -319,7 +319,7 @@
       "category": "adversarial",
       "expect": "semantic",
       "input": "```\na\n```\nmid\n```\nb\n```\nend ```inline``` tail",
-      "native_output": "```\na\n```\nmid\n```\nb\n```\nend ```inline``` tail"
+      "native_output": "```\na\n```\nmid\n```\nb\n```\nend \\`\\``inline`\\`\\` tail"
     }
   ]
 }

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -38,9 +38,11 @@ _ensure_telegram_mock()
 from plugins.platforms.telegram.adapter import (  # noqa: E402
     TelegramAdapter,
     _escape_mdv2,
+    _separate_chunk_indicator_from_fence,
     _strip_mdv2,
     _wrap_markdown_tables,
 )
+from gateway.platforms.base import utf16_len  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -130,6 +132,65 @@ class TestFormatMessageCodeBlocks:
         text = "```\necho `hostname`\n```"
         result = adapter.format_message(text)
         assert r"echo \`hostname\`" in result
+
+    def test_four_backtick_fence_with_triple_backticks_is_normalized(self, adapter):
+        text = "````text\nouter\n```\ninner\n```\nend\n````"
+        result = adapter.format_message(text)
+
+        assert result.startswith("```text\n")
+        assert result.endswith("```")
+        assert "\\`\\`\\`\ninner\n\\`\\`\\`" in result
+        assert "````" not in result
+
+    def test_inline_triple_backticks_are_escaped_as_literal_text(self, adapter):
+        result = adapter.format_message("the syntax is ```like this``` inline")
+
+        assert "like this" in result
+        assert "```" not in result
+
+    def test_tilde_fence_and_longer_closing_fence_are_normalized(self, adapter):
+        result = adapter.format_message("~~~python\nprint('ok')\n~~~~~   \nnext")
+
+        assert result.startswith("```python\nprint('ok')\n```\n")
+        assert result.endswith("next")
+        assert "~~~" not in result
+
+    def test_fence_preserves_newline_after_closing_line(self, adapter):
+        result = adapter.format_message("```sh\nmake deploy\n```\n\nAfter")
+
+        assert "```sh\nmake deploy\n```\n\nAfter" in result
+
+    def test_unclosed_gfm_fence_becomes_escaped_literal_text(self, adapter):
+        result = adapter.format_message("````text\nunclosed *body*")
+
+        assert result.startswith(r"\`\`\`\`text")
+        assert r"\*body\*" in result
+        assert "```text\n" not in result
+
+    def test_long_four_backtick_block_chunks_as_balanced_markdownv2(self, adapter):
+        body = ("línea 😀 con ``` interno y C:\\tmp\n" * 220)
+        formatted = adapter.format_message(f"````text\n{body}````\n")
+        chunks = adapter.truncate_message(
+            formatted,
+            adapter.MAX_MESSAGE_LENGTH,
+            len_fn=utf16_len,
+        )
+        chunks = [
+            _separate_chunk_indicator_from_fence(
+                re.sub(r" \((\d+)/(\d+)\)$", r" \\(\1/\2\\)", chunk)
+            )
+            for chunk in chunks
+        ]
+
+        assert len(chunks) > 1
+        assert all(utf16_len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in chunks)
+        assert all(chunk.count("```") == 2 for chunk in chunks)
+        assert all(chunk.startswith("```text\n") for chunk in chunks)
+        without_indicators = [
+            re.sub(r"\n ?\\\(\d+/\d+\\\)$", "", chunk)
+            for chunk in chunks
+        ]
+        assert all(chunk.endswith("\n```") for chunk in without_indicators)
 
     def test_inline_code_no_double_escape(self, adapter):
         r"""Already-escaped backslashes should not be quadruple-escaped."""


### PR DESCRIPTION
## What does this PR do?

Replaces Telegram's triple-backtick-only regex with a line-oriented GFM fence parser before MarkdownV2 formatting and chunking.

The production failure was a long response wrapped in a four-backtick text fence whose body contained triple-backtick examples. The existing non-greedy regex closed on the first internal triple sequence, emitted an unbalanced Telegram pre entity after chunking, and triggered:

    MarkdownV2 parse failed: Can't parse entities: can't find end of pre entity

Hermes delivered plain text through its fallback, but all formatting was lost.

The new parser follows the relevant GFM fence rules and normalizes complete blocks to Telegram-compatible triple-backtick pre entities:

- Backtick and tilde openers of length 3 or greater.
- Closing fences using the same character and at least the opener length.
- Up to three leading spaces and optional trailing whitespace.
- Internal shorter backtick runs preserved as escaped code content.
- Safe language-token normalization.
- Exact preservation of the newline following a closing fence.
- Unclosed fences converted to escaped literal text rather than malformed MarkdownV2.
- Balanced chunks within Telegram's 4096 UTF-16-unit limit, with pagination markers outside closing fences.

## Relationship to #85398

PR #85398 fixes a narrower bug in the same old regex: inline triple-backtick text was incorrectly treated as a fenced block. This PR also fixes that case, but it was developed from a different production reproduction and replaces the regex with a complete variable-length parser. It additionally covers four-or-more-backtick fences containing shorter runs, tilde fences, longer closers, unclosed fences, newline preservation, and long UTF-16 chunking.

The regenerated conformance vectors include the same intentional inline-triple escaping expected by #85398. If #85398 lands first, this branch can be rebased while retaining the broader parser and regression coverage.

## Related Issue

No new issue filed. Related narrower report: #85381, addressed by #85398.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- plugins/platforms/telegram/adapter.py:
  - Parse GFM fences line-by-line.
  - Normalize valid blocks to MarkdownV2 pre entities.
  - Escape malformed or unclosed blocks safely.
  - Preserve post-fence line endings.
- tests/gateway/test_telegram_format.py:
  - Four-backtick block containing internal triple backticks.
  - Inline triple-backtick literal text.
  - Tilde opener with a longer closing fence.
  - Post-fence newline preservation.
  - Unclosed fence degradation.
  - Long emoji-containing blocks split by UTF-16 units.
- tests/conformance/vectors/telegram.json:
  - Regenerated Telegram renderer vectors.

## How to Test

1. Format a response opened and closed with four backticks.
2. Include triple-backtick examples, backslashes, emoji, and enough content to exceed 4096 UTF-16 units.
3. Verify the formatter emits Telegram-compatible triple fences and escapes internal backticks.
4. Split the result and verify every chunk has one balanced opening/closing pair.
5. Verify every chunk is at most 4096 UTF-16 units and its pagination marker is outside the closing fence.
6. Verify inline and unclosed fences never leave a raw unbalanced pre entity.

Executed locally:

    PYTHONPATH=/tmp/hermes-pr-telegram-deps-20260814 python -m pytest       tests/gateway/test_telegram_format.py       tests/conformance/test_vector_generator.py -q

Result: 52 passed.

Also passed:

    ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_format.py
    python -m compileall -q plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_format.py
    git diff --check origin/main...HEAD

Tested on macOS 26.3.1, Python 3.11.9. The formatter and long-message fixture were also exercised in a Linux Docker deployment based on Hermes v0.20.0.

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] The commit message follows Conventional Commits.
- [x] I searched open and closed Telegram MarkdownV2 PRs and documented the overlap with #85398.
- [x] The PR contains only Telegram fence parsing, conformance output, and regression tests.
- [ ] Full pytest tests/ -q suite run locally; targeted affected suites pass and CI will run the full matrix.
- [x] Regression tests are included.
- [x] Tested on macOS 26.3.1 and in the Linux container runtime.

### Documentation and Housekeeping

- [x] Documentation is N/A; this restores expected GFM compatibility.
- [x] cli-config.yaml.example is N/A.
- [x] CONTRIBUTING.md and AGENTS.md are N/A.
- [x] Cross-platform impact considered: parsing uses Python strings and explicit CRLF/LF preservation.
- [x] Tool descriptions and schemas are N/A.
