### PR TITLE
fix(slack): drop non-Slack thread ids in standalone delivery instead of failing (#86264)

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5760,6 +5760,32 @@ async def _standalone_upload_file(
     return {"success": True, "message_id": message_id, "raw": result}
 
 
+_SLACK_THREAD_TS_RE = re.compile(r"^\d+\.\d+$")
+
+
+def _coerce_slack_thread_ts(thread_id):
+    """Return a valid Slack ``thread_ts`` or ``None``.
+
+    A Slack thread anchor is always a ``<seconds>.<microseconds>`` (dotted)
+    timestamp. A bare numeric id — e.g. a Telegram topic ``15900`` left in a
+    cron delivery target after a cross-platform migration — is not a valid
+    ``thread_ts``: ``chat.postMessage`` rejects it with ``invalid_thread_ts``
+    and the whole delivery fails while the job still reports ``ok`` (#86264).
+    Drop an unparseable anchor and post to the channel root instead of erroring.
+    """
+    if thread_id is None:
+        return None
+    ts = str(thread_id).strip()
+    if _SLACK_THREAD_TS_RE.fullmatch(ts):
+        return ts
+    logger.warning(
+        "[Slack] dropping invalid thread_ts %r (not a dotted Slack ts); "
+        "delivering to channel root instead",
+        thread_id,
+    )
+    return None
+
+
 async def _standalone_send_media(
     token: str, chat_id: str, media_files: list, thread_id: Optional[str], formatted: Optional[str],
     formatted_caption: Optional[str], unfurl_kwargs: Dict[str, Any]) -> Dict[str, Any]:
@@ -5851,6 +5877,11 @@ async def _standalone_send(
     with the gateway: text via ``chat.postMessage`` (aiohttp), media via ``files_upload_v2``."""
     del force_document  # signature parity with other standalone senders
     media_files = media_files or []
+    # A cross-platform delivery target (Telegram topic, Discord thread, …) can leak a bare numeric
+    # id into ``thread_id``; Slack only accepts a dotted ``thread_ts``. Coerce here — the single
+    # entry point feeding both the media and text dispatch below — so every postMessage/upload path
+    # fails open to the channel root instead of erroring the whole delivery (#86264).
+    thread_id = _coerce_slack_thread_ts(thread_id)
     # Under multiplex os.environ may hold ANOTHER profile's token: read via the secret scope.
     raw_token = getattr(pconfig, "token", None) or get_secret("SLACK_BOT_TOKEN", "")
     # Comma-separated multi-workspace list plus slack_tokens.json; no team map, so try each.

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5760,7 +5760,10 @@ async def _standalone_upload_file(
     return {"success": True, "message_id": message_id, "raw": result}
 
 
-_SLACK_THREAD_TS_RE = re.compile(r"^\d+\.\d+$")
+# ASCII digits only: Python's ``\d`` also matches Unicode decimal digits, so a
+# value like "١٧١٨٠٠٠٠٠٠.١٢٣٤٥٦" would pass and reach Slack (which rejects it)
+# instead of falling back to the channel root.
+_SLACK_THREAD_TS_RE = re.compile(r"^[0-9]+\.[0-9]+$")
 
 
 def _coerce_slack_thread_ts(thread_id):

--- a/tests/tools/test_send_message_slack.py
+++ b/tests/tools/test_send_message_slack.py
@@ -172,3 +172,27 @@ def test_standalone_send_keeps_valid_thread_ts(monkeypatch, _standalone_send):
     assert len(fake_session.calls) == 1
     _token, body = fake_session.calls[0]
     assert body.get("thread_ts") == "1718000000.123456"
+
+
+def test_standalone_send_drops_unicode_digit_thread_ts(
+    monkeypatch, _standalone_send
+):
+    """A dotted ts written with non-ASCII (Unicode) digits is not a valid Slack
+    ``thread_ts``. Python's ``\\d`` would match it, so the anchor must be
+    validated against ASCII digits only and dropped in favour of the channel
+    root — otherwise Slack rejects it with ``invalid_thread_ts`` (#86264)."""
+    fake_session = _SlackSession()
+    monkeypatch.setattr("aiohttp.ClientSession", lambda *a, **k: fake_session)
+
+    pconfig = SimpleNamespace(enabled=True, token="good-token", extra={})
+    result = asyncio.run(
+        # "1718000000.123456" in Arabic-Indic digits.
+        _standalone_send(
+            pconfig, "C123", "hello", thread_id="١٧١٨٠٠٠٠٠٠.١٢٣٤٥٦"
+        )
+    )
+
+    assert "error" not in result
+    assert len(fake_session.calls) == 1
+    _token, body = fake_session.calls[0]
+    assert "thread_ts" not in body

--- a/tests/tools/test_send_message_slack.py
+++ b/tests/tools/test_send_message_slack.py
@@ -137,3 +137,38 @@ def test_standalone_send_stops_on_non_token_error(monkeypatch, _standalone_send)
 
     assert result == {"error": "Slack API error: msg_too_long"}
     assert len(fake_session.calls) == 1
+
+
+def test_standalone_send_drops_non_dotted_thread_ts(monkeypatch, _standalone_send):
+    """A bare numeric thread id (e.g. a migrated Telegram topic) must not be
+    passed to Slack as ``thread_ts`` — Slack rejects it with
+    ``invalid_thread_ts`` and the whole cron delivery fails silently (#86264).
+    Drop it and post to the channel root instead."""
+    fake_session = _SlackSession()
+    monkeypatch.setattr("aiohttp.ClientSession", lambda *a, **k: fake_session)
+
+    pconfig = SimpleNamespace(enabled=True, token="good-token", extra={})
+    result = asyncio.run(
+        _standalone_send(pconfig, "C123", "hello", thread_id="15900")
+    )
+
+    assert "error" not in result
+    assert len(fake_session.calls) == 1
+    _token, body = fake_session.calls[0]
+    assert "thread_ts" not in body
+
+
+def test_standalone_send_keeps_valid_thread_ts(monkeypatch, _standalone_send):
+    """A well-formed dotted Slack ts is preserved as the thread anchor."""
+    fake_session = _SlackSession()
+    monkeypatch.setattr("aiohttp.ClientSession", lambda *a, **k: fake_session)
+
+    pconfig = SimpleNamespace(enabled=True, token="good-token", extra={})
+    result = asyncio.run(
+        _standalone_send(pconfig, "C123", "hello", thread_id="1718000000.123456")
+    )
+
+    assert "error" not in result
+    assert len(fake_session.calls) == 1
+    _token, body = fake_session.calls[0]
+    assert body.get("thread_ts") == "1718000000.123456"

--- a/tests/tools/test_send_message_slack.py
+++ b/tests/tools/test_send_message_slack.py
@@ -196,3 +196,119 @@ def test_standalone_send_drops_unicode_digit_thread_ts(
     assert len(fake_session.calls) == 1
     _token, body = fake_session.calls[0]
     assert "thread_ts" not in body
+
+
+class _FakeAsyncWebClient:
+    """Records ``chat_postMessage`` / ``files_upload_v2`` kwargs for the media
+    path so tests can assert the ``thread_ts`` that reaches Slack uploads."""
+
+    created: list = []
+
+    def __init__(self, token=None, **_kwargs):
+        self.token = token
+        self.post_calls: list = []
+        self.upload_calls: list = []
+        _FakeAsyncWebClient.created.append(self)
+
+    async def chat_postMessage(self, **kwargs):
+        self.post_calls.append(kwargs)
+        return {"ok": True, "ts": "1718000000.999999"}
+
+    async def files_upload_v2(self, **kwargs):
+        self.upload_calls.append(kwargs)
+        return {"ok": True, "file": {"timestamp": "1718000000.888888"}}
+
+
+@pytest.fixture
+def _fake_web_client(monkeypatch):
+    """Inject a recording ``AsyncWebClient`` for ``_standalone_send``'s media
+    path (function-local ``from slack_sdk.web.async_client import ...``)."""
+    _ensure_slack_mock(monkeypatch)
+    _FakeAsyncWebClient.created = []
+    monkeypatch.setitem(
+        sys.modules,
+        "slack_sdk.web.async_client",
+        SimpleNamespace(AsyncWebClient=_FakeAsyncWebClient),
+    )
+    return _FakeAsyncWebClient
+
+
+def test_standalone_send_media_upload_drops_invalid_thread_ts(
+    tmp_path, _standalone_send, _fake_web_client
+):
+    """The coerced ``thread_ts`` must also gate the ``files_upload_v2`` media
+    path — a bare numeric id has to be dropped from the upload, not just from
+    the text ``chat.postMessage``, or media cron sends fail with
+    ``invalid_thread_ts`` (#86264)."""
+    media = tmp_path / "chart.png"
+    media.write_bytes(b"\x89PNG\r\n")
+
+    pconfig = SimpleNamespace(enabled=True, token="good-token", extra={})
+    result = asyncio.run(
+        _standalone_send(
+            pconfig,
+            "C123",
+            "",
+            thread_id="15900",
+            media_files=[(str(media), False)],
+            caption="here you go",
+        )
+    )
+
+    assert "error" not in result
+    client = _fake_web_client.created[-1]
+    assert len(client.upload_calls) == 1
+    assert "thread_ts" not in client.upload_calls[0]
+    assert client.upload_calls[0]["initial_comment"]
+
+
+def test_standalone_send_media_upload_keeps_valid_thread_ts(
+    tmp_path, _standalone_send, _fake_web_client
+):
+    """A well-formed dotted ts is preserved as the upload's ``thread_ts`` so a
+    valid media reply still lands in-thread."""
+    media = tmp_path / "chart.png"
+    media.write_bytes(b"\x89PNG\r\n")
+
+    pconfig = SimpleNamespace(enabled=True, token="good-token", extra={})
+    result = asyncio.run(
+        _standalone_send(
+            pconfig,
+            "C123",
+            "",
+            thread_id="1718000000.123456",
+            media_files=[(str(media), False)],
+            caption="here you go",
+        )
+    )
+
+    assert "error" not in result
+    client = _fake_web_client.created[-1]
+    assert len(client.upload_calls) == 1
+    assert client.upload_calls[0].get("thread_ts") == "1718000000.123456"
+
+
+def test_standalone_send_caption_fallback_drops_invalid_thread_ts(
+    tmp_path, _standalone_send, _fake_web_client
+):
+    """When the media file is missing, the caption rides a fallback
+    ``chat.postMessage`` — that request must drop an invalid ``thread_ts`` too."""
+    missing = tmp_path / "gone.png"
+
+    pconfig = SimpleNamespace(enabled=True, token="good-token", extra={})
+    result = asyncio.run(
+        _standalone_send(
+            pconfig,
+            "C123",
+            "",
+            thread_id="15900",
+            media_files=[(str(missing), False)],
+            caption="caption text",
+        )
+    )
+
+    assert "warnings" in result
+    client = _fake_web_client.created[-1]
+    assert client.upload_calls == []
+    assert len(client.post_calls) == 1
+    assert "thread_ts" not in client.post_calls[0]


### PR DESCRIPTION
## What

Cron delivery to Slack fails with `invalid_thread_ts` when the delivery target
carries a **non-Slack** `thread_id`. The out-of-process Slack sender
(`_standalone_send`) passed `thread_id` straight through to `chat.postMessage`
as `thread_ts`:

```python
if thread_id:
    post_kwargs["thread_ts"] = thread_id
```

A Slack `thread_ts` is always a dotted `<seconds>.<microseconds>` timestamp. A
bare numeric id — e.g. a Telegram topic `15900` left in a
`deliver=slack:<channel>:<topic>` target after a Telegram→Slack migration —
is rejected by Slack:

```
{'ok': False, 'error': 'invalid_thread_ts',
 'response_metadata': {'messages': ['[ERROR] 15900000000 is not a valid thread_ts']}}
```

The job still reports `last_status: ok` (only `last_delivery_error` is
populated), so the operator sees a silent delivery failure — nothing lands in
the channel.

## Fix

Coerce `thread_id` at the authoritative outbound sink (`_standalone_send`,
`plugins/platforms/slack/adapter.py`): keep it only when it matches Slack's
dotted-ts format (`^\d+\.\d+$`), otherwise **drop it and deliver to the channel
root** instead of hard-failing the whole delivery. Legit Slack thread replies
(dotted ts) are unaffected; native Slack thread_ids are always dotted, so this
can never strip a valid anchor. This closes the whole class — any cross-platform
`thread_id` (Telegram topic, Discord thread, …) that reaches the Slack sink now
fails open rather than erroring.

This is the minimal variant of the issue's suggested fix ("validate `thread_ts`
against Slack's `^\d+\.\d+$` format and fall back to channel-root delivery
instead of erroring").

## Tests

`tests/tools/test_send_message_slack.py`:
- `test_standalone_send_drops_non_dotted_thread_ts` — `thread_id="15900"` →
  no `thread_ts` in the `chat.postMessage` body, delivery succeeds. (Fails on
  `main`, which sends `thread_ts="15900"`.)
- `test_standalone_send_keeps_valid_thread_ts` — a well-formed dotted ts is
  preserved as the thread anchor.

Fixes #86264


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack message and file delivery when thread identifiers are invalid or incomplete.
  * Invalid thread IDs now fall back to posting in the channel rather than failing.
  * Valid Slack thread timestamps continue to post within the intended thread.

* **Tests**
  * Added coverage for valid and invalid Slack thread identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->