### PR TITLE
fix(codex): advertise catalog-compatible client version

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1248,7 +1248,10 @@ def init_agent(
                 client_kwargs["default_headers"] = _ra()._qwen_portal_headers()
             elif base_url_host_matches(effective_base, "chatgpt.com"):
                 from agent.auxiliary_client import _codex_cloudflare_headers
-                client_kwargs["default_headers"] = _codex_cloudflare_headers(api_key)
+                client_kwargs["default_headers"] = _codex_cloudflare_headers(
+                    api_key,
+                    model=getattr(agent, "model", None),
+                )
             elif base_url_host_matches(effective_base, "x.ai"):
                 from tools.xai_http import hermes_xai_default_headers
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1191,7 +1191,10 @@ _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 _CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
 
-def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
+def _codex_cloudflare_headers(
+    access_token: str,
+    model: Optional[str] = None,
+) -> Dict[str, str]:
     """Headers required to avoid Cloudflare 403s on chatgpt.com/backend-api/codex.
 
     The Cloudflare layer in front of the Codex endpoint whitelists a small set of
@@ -1201,17 +1204,29 @@ def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
     a 403 with ``cf-mitigated: challenge`` regardless of auth correctness.
 
     We pin ``originator: codex_cli_rs`` to match the upstream codex-rs CLI, set
-    ``User-Agent`` to a codex_cli_rs-shaped string (beats SDK fingerprinting),
-    and extract ``ChatGPT-Account-ID`` (canonical casing, from codex-rs
-    ``auth.rs``) out of the OAuth JWT's ``chatgpt_account_id`` claim.
+    ``User-Agent`` / ``version`` from the selected model's catalog
+    ``minimal_client_version`` (falling back to other discovered mins, the local
+    Codex CLI cache version, then a known floor), and extract
+    ``ChatGPT-Account-ID`` (canonical casing, from codex-rs ``auth.rs``) out of
+    the OAuth JWT's ``chatgpt_account_id`` claim. Advertising a version below
+    the model's gate causes ChatGPT-account Codex to reject models such as
+    ``gpt-5.6-sol`` before inference.
 
     Malformed tokens are tolerated — we drop the account-ID header rather than
     raise, so a bad token still surfaces as an auth error (401) instead of a
     crash at client construction.
     """
+    from hermes_cli.codex_models import (
+        ensure_codex_minimal_client_versions,
+        resolve_codex_compat_client_version,
+    )
+
+    ensure_codex_minimal_client_versions(access_token)
+    compat_version = resolve_codex_compat_client_version(model)
     headers = {
-        "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
+        "User-Agent": f"codex_cli_rs/{compat_version} (Hermes Agent)",
         "originator": "codex_cli_rs",
+        "version": compat_version,
     }
     if not isinstance(access_token, str) or not access_token.strip():
         return headers
@@ -3678,7 +3693,7 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
     real_client = _create_openai_client(
         api_key=codex_token,
         base_url=base_url,
-        default_headers=_codex_cloudflare_headers(codex_token),
+        default_headers=_codex_cloudflare_headers(codex_token, model=model),
     )
     return CodexAuxiliaryClient(real_client, model), model
 
@@ -6316,7 +6331,7 @@ def resolve_provider_client(
             raw_client = _create_openai_client(
                 api_key=codex_token,
                 base_url=_CODEX_AUX_BASE_URL,
-                default_headers=_codex_cloudflare_headers(codex_token),
+                default_headers=_codex_cloudflare_headers(codex_token, model=model),
             )
             return (raw_client, final_model)
         # Standard path: wrap in CodexAuxiliaryClient adapter

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2411,6 +2411,18 @@ def _fetch_codex_oauth_context_lengths_with_source(
 
     entries = data.get("models", []) if isinstance(data, dict) else []
     result: Dict[str, int] = {}
+    if isinstance(entries, list):
+        try:
+            from hermes_cli.codex_models import (
+                remember_codex_minimal_client_versions,
+                remember_local_codex_cli_version,
+            )
+
+            remember_codex_minimal_client_versions(entries)
+            if isinstance(data, dict):
+                remember_local_codex_cli_version(data.get("client_version"))
+        except Exception:
+            pass
     for item in entries:
         if not isinstance(item, dict):
             continue

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -5,12 +5,150 @@ from __future__ import annotations
 import base64
 import json
 import logging
+import re
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import os
 
 logger = logging.getLogger(__name__)
+
+# Last-known ChatGPT Codex gate for GPT-5.6 models. Used only when discovery
+# has not yet supplied a per-model ``minimal_client_version``. Not a forever
+# pin — live /models + local models_cache are preferred.
+_CODEX_CLI_COMPAT_FLOOR = "0.144.0"
+
+# Process cache populated from live /models probes and ~/.codex/models_cache.json.
+_minimal_client_versions: Dict[str, str] = {}
+# Top-level ``client_version`` from the local Codex CLI models cache (the CLI
+# that fetched the cache), used when per-model mins are absent.
+_local_codex_cli_version: Optional[str] = None
+_hydrated_from_local_cache = False
+_live_min_version_probe_done = False
+
+
+def _parse_semver_tuple(value: str) -> Optional[Tuple[int, int, int]]:
+    """Parse a dotted semver prefix into (major, minor, patch)."""
+    if not isinstance(value, str):
+        return None
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", value.strip())
+    if not match:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def _max_semver(*versions: str) -> str:
+    """Return the highest parseable semver among ``versions`` (floor on empty)."""
+    best = _CODEX_CLI_COMPAT_FLOOR
+    best_tuple = _parse_semver_tuple(best) or (0, 0, 0)
+    for raw in versions:
+        parsed = _parse_semver_tuple(raw or "")
+        if parsed is None:
+            continue
+        if parsed > best_tuple:
+            best_tuple = parsed
+            best = ".".join(str(part) for part in parsed)
+    return best
+
+
+def remember_codex_minimal_client_versions(entries: Iterable[object]) -> None:
+    """Update the process cache from Codex /models (or models_cache) entries."""
+    for item in entries:
+        if not isinstance(item, dict):
+            continue
+        slug = item.get("slug")
+        if not isinstance(slug, str) or not slug.strip():
+            continue
+        min_ver = item.get("minimal_client_version")
+        if not isinstance(min_ver, str) or not min_ver.strip():
+            continue
+        if _parse_semver_tuple(min_ver) is None:
+            continue
+        _minimal_client_versions[slug.strip()] = min_ver.strip()
+
+
+def remember_local_codex_cli_version(version: Optional[str]) -> None:
+    """Remember the Codex CLI version that produced a local models cache."""
+    global _local_codex_cli_version
+    if not isinstance(version, str) or not version.strip():
+        return
+    if _parse_semver_tuple(version) is None:
+        return
+    _local_codex_cli_version = version.strip()
+
+
+def _hydrate_minimal_versions_from_local_cache() -> None:
+    """Load per-model mins + CLI version from ``~/.codex/models_cache.json`` once."""
+    global _hydrated_from_local_cache
+    if _hydrated_from_local_cache:
+        return
+    _hydrated_from_local_cache = True
+    codex_home_str = os.getenv("CODEX_HOME", "").strip() or str(Path.home() / ".codex")
+    cache_path = Path(codex_home_str).expanduser() / "models_cache.json"
+    if not cache_path.exists():
+        return
+    try:
+        raw = json.loads(cache_path.read_text(encoding="utf-8"))
+    except Exception:
+        return
+    if not isinstance(raw, dict):
+        return
+    remember_local_codex_cli_version(raw.get("client_version"))
+    entries = raw.get("models")
+    if isinstance(entries, list):
+        remember_codex_minimal_client_versions(entries)
+
+
+def ensure_codex_minimal_client_versions(access_token: Optional[str] = None) -> None:
+    """Best-effort warm of the minimal-client-version cache before inference.
+
+    Order: already-warm process cache → local models_cache.json → one live
+    /models probe when a token is provided and no per-model mins are known yet
+    (local CLI ``client_version`` alone is only a resolve fallback). Failures
+    are non-fatal; callers fall back to ``_CODEX_CLI_COMPAT_FLOOR``.
+    """
+    global _live_min_version_probe_done
+    if _minimal_client_versions:
+        return
+    _hydrate_minimal_versions_from_local_cache()
+    if _minimal_client_versions:
+        return
+    if _live_min_version_probe_done:
+        return
+    if access_token and isinstance(access_token, str) and access_token.strip():
+        _live_min_version_probe_done = True
+        _fetch_models_from_api(access_token)
+
+
+def resolve_codex_compat_client_version(model: Optional[str] = None) -> str:
+    """CLI-compat version to advertise on Codex inference requests.
+
+    Prefer the selected model's catalog ``minimal_client_version``. When the
+    model is unknown, use the max across cached models, then the local Codex
+    CLI cache's ``client_version``, then the known GPT-5.6 floor. Always at
+    least the floor.
+    """
+    _hydrate_minimal_versions_from_local_cache()
+    if isinstance(model, str) and model.strip():
+        known = _minimal_client_versions.get(model.strip())
+        if known:
+            return _max_semver(_CODEX_CLI_COMPAT_FLOOR, known)
+
+    candidates: List[str] = [_CODEX_CLI_COMPAT_FLOOR]
+    if _minimal_client_versions:
+        candidates.extend(_minimal_client_versions.values())
+    if _local_codex_cli_version:
+        candidates.append(_local_codex_cli_version)
+    return _max_semver(*candidates)
+
+
+def reset_codex_compat_version_cache_for_tests() -> None:
+    """Clear process caches (tests only)."""
+    global _local_codex_cli_version, _hydrated_from_local_cache, _live_min_version_probe_done
+    _minimal_client_versions.clear()
+    _local_codex_cli_version = None
+    _hydrated_from_local_cache = False
+    _live_min_version_probe_done = False
 
 DEFAULT_CODEX_MODELS: List[str] = [
     # GPT-5.6 series (Sol/Terra/Luna + -pro high-effort modes) — GA 2026-07-09
@@ -145,6 +283,13 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
         logger.debug("Failed to fetch Codex models from API: %s", exc)
         return []
 
+    # Remember mins from the same payload used for slug discovery so inference
+    # headers track OpenAI's per-model gate instead of a hardcoded CLI release.
+    if isinstance(entries, list):
+        remember_codex_minimal_client_versions(entries)
+    if isinstance(data, dict):
+        remember_local_codex_cli_version(data.get("client_version"))
+
     sortable = []
     for item in entries:
         if not isinstance(item, dict):
@@ -195,9 +340,13 @@ def _read_cache_models(codex_home: Path) -> List[str]:
     except Exception:
         return []
 
+    if isinstance(raw, dict):
+        remember_local_codex_cli_version(raw.get("client_version"))
+
     entries = raw.get("models") if isinstance(raw, dict) else None
     sortable = []
     if isinstance(entries, list):
+        remember_codex_minimal_client_versions(entries)
         for item in entries:
             if not isinstance(item, dict):
                 continue

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -103,21 +103,31 @@ def ensure_codex_minimal_client_versions(access_token: Optional[str] = None) -> 
     """Best-effort warm of the minimal-client-version cache before inference.
 
     Order: already-warm process cache → local models_cache.json → one live
-    /models probe when a token is provided and no per-model mins are known yet
-    (local CLI ``client_version`` alone is only a resolve fallback). Failures
-    are non-fatal; callers fall back to ``_CODEX_CLI_COMPAT_FLOOR``.
+    /models probe when a token is provided and no local compatibility version
+    is available. A failed live probe remains retryable; callers fall back to
+    ``_CODEX_CLI_COMPAT_FLOOR`` for that request.
     """
     global _live_min_version_probe_done
     if _minimal_client_versions:
         return
     _hydrate_minimal_versions_from_local_cache()
-    if _minimal_client_versions:
+    # The cache version is the identity of the real Codex CLI that fetched
+    # this catalog. It is sufficient for inference and avoids putting a hidden
+    # network request on every fresh Hermes client construction.
+    if _minimal_client_versions or _local_codex_cli_version:
         return
     if _live_min_version_probe_done:
         return
     if access_token and isinstance(access_token, str) and access_token.strip():
-        _live_min_version_probe_done = True
-        _fetch_models_from_api(access_token)
+        models = _fetch_models_from_api(access_token)
+        if models or _minimal_client_versions or _local_codex_cli_version:
+            _live_min_version_probe_done = True
+        else:
+            logger.warning(
+                "Codex compatibility version discovery failed; advertising floor %s "
+                "for this request and allowing a later retry",
+                _CODEX_CLI_COMPAT_FLOOR,
+            )
 
 
 def resolve_codex_compat_client_version(model: Optional[str] = None) -> str:
@@ -132,7 +142,11 @@ def resolve_codex_compat_client_version(model: Optional[str] = None) -> str:
     if isinstance(model, str) and model.strip():
         known = _minimal_client_versions.get(model.strip())
         if known:
-            return _max_semver(_CODEX_CLI_COMPAT_FLOOR, known)
+            return _max_semver(
+                _CODEX_CLI_COMPAT_FLOOR,
+                known,
+                _local_codex_cli_version or "",
+            )
 
     candidates: List[str] = [_CODEX_CLI_COMPAT_FLOOR]
     if _minimal_client_versions:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5957,7 +5957,8 @@ class AIAgent:
         elif base_url_host_matches(base_url, "chatgpt.com"):
             from agent.auxiliary_client import _codex_cloudflare_headers
             self._client_kwargs["default_headers"] = _codex_cloudflare_headers(
-                self._client_kwargs.get("api_key", "")
+                self._client_kwargs.get("api_key", ""),
+                model=getattr(self, "model", None),
             )
         elif base_url_host_matches(base_url, "x.ai"):
             # Cover both provider=xai and provider=xai-oauth (api.x.ai).

--- a/tests/agent/test_codex_cloudflare_headers.py
+++ b/tests/agent/test_codex_cloudflare_headers.py
@@ -71,13 +71,12 @@ def _isolate_codex_compat_cache(tmp_path, monkeypatch):
     reset_codex_compat_version_cache_for_tests()
 
 
-def _assert_codex_compat_headers(headers: dict, *, model: str | None = None) -> None:
-    from hermes_cli.codex_models import resolve_codex_compat_client_version
-
-    ver = resolve_codex_compat_client_version(model)
+def _assert_codex_compat_headers(headers: dict, *, expected_version: str) -> None:
     assert headers.get("originator") == "codex_cli_rs"
-    assert headers.get("version") == ver
-    assert headers.get("User-Agent") == f"codex_cli_rs/{ver} (Hermes Agent)"
+    assert headers.get("version") == expected_version
+    assert headers.get("User-Agent") == (
+        f"codex_cli_rs/{expected_version} (Hermes Agent)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -97,7 +96,7 @@ class TestCodexCloudflareHeaders:
             ]
         )
         headers = _codex_cloudflare_headers(_make_codex_jwt(), model="gpt-5.6-sol")
-        _assert_codex_compat_headers(headers, model="gpt-5.6-sol")
+        _assert_codex_compat_headers(headers, expected_version="0.144.0")
         assert headers["version"] == "0.144.0"
 
     def test_falls_back_to_floor_without_catalog(self):
@@ -106,7 +105,10 @@ class TestCodexCloudflareHeaders:
 
         headers = _codex_cloudflare_headers(_make_codex_jwt())
         assert headers["version"] == _CODEX_CLI_COMPAT_FLOOR
-        _assert_codex_compat_headers(headers)
+        _assert_codex_compat_headers(
+            headers,
+            expected_version=_CODEX_CLI_COMPAT_FLOOR,
+        )
 
     def test_canonical_header_casing(self):
         """Upstream codex-rs uses PascalCase with trailing -ID. Match exactly."""
@@ -162,7 +164,7 @@ class TestPrimaryClientWiring:
             )
             headers = agent._client_kwargs.get("default_headers") or {}
             assert headers.get("ChatGPT-Account-ID") == "acct-rotation"
-            _assert_codex_compat_headers(headers, model="gpt-5.6-sol")
+            _assert_codex_compat_headers(headers, expected_version="0.144.0")
 
     def test_apply_client_headers_clears_codex_headers_off_chatgpt(self):
         """Switching AWAY from chatgpt.com must drop the codex headers."""
@@ -217,7 +219,7 @@ class TestAuxiliaryClientWiring:
             assert client is not None
             headers = mock_openai.call_args.kwargs.get("default_headers") or {}
             assert headers.get("ChatGPT-Account-ID") == "acct-aux-try-codex"
-            _assert_codex_compat_headers(headers, model="gpt-5.4")
+            _assert_codex_compat_headers(headers, expected_version="0.144.0")
 
     def test_resolve_provider_client_raw_codex_passes_codex_headers(self, monkeypatch):
         """The ``raw_codex=True`` branch (used by the main agent loop for direct
@@ -236,4 +238,4 @@ class TestAuxiliaryClientWiring:
             assert client is not None
             headers = mock_openai.call_args.kwargs.get("default_headers") or {}
             assert headers.get("ChatGPT-Account-ID") == "acct-aux-raw-codex"
-            _assert_codex_compat_headers(headers, model="gpt-5.4")
+            _assert_codex_compat_headers(headers, expected_version="0.144.0")

--- a/tests/agent/test_codex_cloudflare_headers.py
+++ b/tests/agent/test_codex_cloudflare_headers.py
@@ -15,7 +15,7 @@ all emit the same headers.
 
 These tests pin:
 - the originator value (must be ``codex_cli_rs`` — the whitelisted one)
-- the User-Agent shape (codex_cli_rs-prefixed)
+- User-Agent / ``version`` tracking catalog ``minimal_client_version``
 - ``ChatGPT-Account-ID`` extraction from the OAuth JWT (canonical casing,
   from codex-rs ``auth.rs``)
 - graceful handling of malformed tokens (drop the account-ID header, don't
@@ -29,6 +29,7 @@ import base64
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -53,17 +54,59 @@ def _make_codex_jwt(account_id: str = "acct-test-123") -> str:
     return f"{header}.{payload}.{sig}"
 
 
+@pytest.fixture(autouse=True)
+def _isolate_codex_compat_cache(tmp_path, monkeypatch):
+    """Keep header tests hermetic from the developer's real ~/.codex cache."""
+    from hermes_cli.codex_models import reset_codex_compat_version_cache_for_tests
+
+    reset_codex_compat_version_cache_for_tests()
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(
+        "hermes_cli.codex_models._fetch_models_from_api",
+        lambda access_token: [],
+    )
+    yield
+    reset_codex_compat_version_cache_for_tests()
+
+
+def _assert_codex_compat_headers(headers: dict, *, model: str | None = None) -> None:
+    from hermes_cli.codex_models import resolve_codex_compat_client_version
+
+    ver = resolve_codex_compat_client_version(model)
+    assert headers.get("originator") == "codex_cli_rs"
+    assert headers.get("version") == ver
+    assert headers.get("User-Agent") == f"codex_cli_rs/{ver} (Hermes Agent)"
+
+
 # ---------------------------------------------------------------------------
 # _codex_cloudflare_headers — the shared helper
 # ---------------------------------------------------------------------------
 
 class TestCodexCloudflareHeaders:
 
-    def test_user_agent_advertises_codex_cli_rs(self):
+    def test_user_agent_and_version_follow_catalog_minimal_client_version(self):
         from agent.auxiliary_client import _codex_cloudflare_headers
-        headers = _codex_cloudflare_headers(_make_codex_jwt())
-        assert headers["User-Agent"].startswith("codex_cli_rs/")
+        from hermes_cli.codex_models import remember_codex_minimal_client_versions
 
+        remember_codex_minimal_client_versions(
+            [
+                {"slug": "gpt-5.6-sol", "minimal_client_version": "0.144.0"},
+                {"slug": "gpt-5.4", "minimal_client_version": "0.130.0"},
+            ]
+        )
+        headers = _codex_cloudflare_headers(_make_codex_jwt(), model="gpt-5.6-sol")
+        _assert_codex_compat_headers(headers, model="gpt-5.6-sol")
+        assert headers["version"] == "0.144.0"
+
+    def test_falls_back_to_floor_without_catalog(self):
+        from agent.auxiliary_client import _codex_cloudflare_headers
+        from hermes_cli.codex_models import _CODEX_CLI_COMPAT_FLOOR
+
+        headers = _codex_cloudflare_headers(_make_codex_jwt())
+        assert headers["version"] == _CODEX_CLI_COMPAT_FLOOR
+        _assert_codex_compat_headers(headers)
 
     def test_canonical_header_casing(self):
         """Upstream codex-rs uses PascalCase with trailing -ID. Match exactly."""
@@ -112,14 +155,14 @@ class TestPrimaryClientWiring:
                 skip_memory=True,
             )
             # Simulate rotation into a Codex credential
+            agent.model = "gpt-5.6-sol"
             agent._client_kwargs["api_key"] = token
             agent._apply_client_headers_for_base_url(
                 "https://chatgpt.com/backend-api/codex"
             )
             headers = agent._client_kwargs.get("default_headers") or {}
-            assert headers.get("originator") == "codex_cli_rs"
             assert headers.get("ChatGPT-Account-ID") == "acct-rotation"
-            assert headers.get("User-Agent", "").startswith("codex_cli_rs/")
+            _assert_codex_compat_headers(headers, model="gpt-5.6-sol")
 
     def test_apply_client_headers_clears_codex_headers_off_chatgpt(self):
         """Switching AWAY from chatgpt.com must drop the codex headers."""
@@ -173,9 +216,8 @@ class TestAuxiliaryClientWiring:
             client, model = auxiliary_client._build_codex_client("gpt-5.4")
             assert client is not None
             headers = mock_openai.call_args.kwargs.get("default_headers") or {}
-            assert headers.get("originator") == "codex_cli_rs"
             assert headers.get("ChatGPT-Account-ID") == "acct-aux-try-codex"
-            assert headers.get("User-Agent", "").startswith("codex_cli_rs/")
+            _assert_codex_compat_headers(headers, model="gpt-5.4")
 
     def test_resolve_provider_client_raw_codex_passes_codex_headers(self, monkeypatch):
         """The ``raw_codex=True`` branch (used by the main agent loop for direct
@@ -193,6 +235,5 @@ class TestAuxiliaryClientWiring:
             )
             assert client is not None
             headers = mock_openai.call_args.kwargs.get("default_headers") or {}
-            assert headers.get("originator") == "codex_cli_rs"
             assert headers.get("ChatGPT-Account-ID") == "acct-aux-raw-codex"
-            assert headers.get("User-Agent", "").startswith("codex_cli_rs/")
+            _assert_codex_compat_headers(headers, model="gpt-5.4")

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -90,8 +90,9 @@ def test_fetch_from_api_remembers_minimal_client_versions(monkeypatch, tmp_path)
 
     models = codex_models._fetch_models_from_api(access_token="tok")
     assert "gpt-5.6-sol" in models
-    assert codex_models.resolve_codex_compat_client_version("gpt-5.6-sol") == "0.144.0"
-    # Unknown / missing model still meets the max known gate (and floor).
+    # Advertise the real CLI version when it is newer than the model's gate.
+    assert codex_models.resolve_codex_compat_client_version("gpt-5.6-sol") == "0.147.0"
+    # Unknown / missing models use the same current compatible identity.
     assert codex_models.resolve_codex_compat_client_version("gpt-unknown") == "0.147.0"
 
 
@@ -128,6 +129,51 @@ def test_resolve_falls_back_to_local_cli_cache_version(tmp_path, monkeypatch):
     )
     codex_models.reset_codex_compat_version_cache_for_tests()
     assert codex_models.resolve_codex_compat_client_version("gpt-5.6-sol") == "0.147.0"
+
+
+def test_local_cli_cache_avoids_live_probe(tmp_path, monkeypatch):
+    from hermes_cli import codex_models
+
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    (codex_home / "models_cache.json").write_text(
+        json.dumps({"client_version": "0.147.0", "models": []}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    probes = []
+    monkeypatch.setattr(
+        codex_models,
+        "_fetch_models_from_api",
+        lambda token: probes.append(token) or [],
+    )
+    codex_models.reset_codex_compat_version_cache_for_tests()
+
+    codex_models.ensure_codex_minimal_client_versions("token")
+
+    assert probes == []
+    assert codex_models.resolve_codex_compat_client_version() == "0.147.0"
+
+
+def test_failed_live_probe_remains_retryable(tmp_path, monkeypatch, caplog):
+    from hermes_cli import codex_models
+
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    probes = []
+    monkeypatch.setattr(
+        codex_models,
+        "_fetch_models_from_api",
+        lambda token: probes.append(token) or [],
+    )
+    codex_models.reset_codex_compat_version_cache_for_tests()
+
+    codex_models.ensure_codex_minimal_client_versions("token")
+    codex_models.ensure_codex_minimal_client_versions("token")
+
+    assert probes == ["token", "token"]
+    assert "allowing a later retry" in caplog.text
 
 
 
@@ -256,4 +302,3 @@ class TestNormalizeModelForProvider:
         assert changed is True
         # Uses first from available list
         assert cli.model == "gpt-5.3-codex"
-

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -44,12 +44,90 @@ def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
             return _FakeResp()
 
     monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+    codex_models.reset_codex_compat_version_cache_for_tests()
 
     models = codex_models._fetch_models_from_api(access_token="tok")
 
     assert "gpt-5.5" in models
     assert "gpt-5.3-codex-spark" in models
     assert "gpt-5-internal" not in models
+
+
+def test_fetch_from_api_remembers_minimal_client_versions(monkeypatch, tmp_path):
+    """Live /models payloads must seed the inference-header version cache."""
+    import sys
+    from hermes_cli import codex_models
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {
+                "client_version": "0.147.0",
+                "models": [
+                    {
+                        "slug": "gpt-5.6-sol",
+                        "priority": 0,
+                        "minimal_client_version": "0.144.0",
+                    },
+                    {
+                        "slug": "gpt-5.4",
+                        "priority": 1,
+                        "minimal_client_version": "0.130.0",
+                    },
+                ],
+            }
+
+    class _FakeHttpx:
+        @staticmethod
+        def get(url, headers=None, timeout=None):
+            return _FakeResp()
+
+    monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
+    (tmp_path / "codex").mkdir()
+    codex_models.reset_codex_compat_version_cache_for_tests()
+
+    models = codex_models._fetch_models_from_api(access_token="tok")
+    assert "gpt-5.6-sol" in models
+    assert codex_models.resolve_codex_compat_client_version("gpt-5.6-sol") == "0.144.0"
+    # Unknown / missing model still meets the max known gate (and floor).
+    assert codex_models.resolve_codex_compat_client_version("gpt-unknown") == "0.147.0"
+
+
+def test_resolve_codex_compat_client_version_prefers_selected_model(tmp_path, monkeypatch):
+    from hermes_cli import codex_models
+
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
+    (tmp_path / "codex").mkdir()
+    codex_models.reset_codex_compat_version_cache_for_tests()
+    codex_models.remember_codex_minimal_client_versions(
+        [
+            {"slug": "gpt-5.6-sol", "minimal_client_version": "0.150.0"},
+            {"slug": "gpt-5.4", "minimal_client_version": "0.130.0"},
+        ]
+    )
+    assert codex_models.resolve_codex_compat_client_version("gpt-5.6-sol") == "0.150.0"
+    assert codex_models.resolve_codex_compat_client_version("gpt-5.4") == "0.144.0"
+
+
+def test_resolve_falls_back_to_local_cli_cache_version(tmp_path, monkeypatch):
+    from hermes_cli import codex_models
+
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
+    cache_dir = tmp_path / "codex"
+    cache_dir.mkdir()
+    (cache_dir / "models_cache.json").write_text(
+        json.dumps(
+            {
+                "client_version": "0.147.0",
+                "models": [{"slug": "gpt-5.6-sol", "priority": 0}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    codex_models.reset_codex_compat_version_cache_for_tests()
+    assert codex_models.resolve_codex_compat_client_version("gpt-5.6-sol") == "0.147.0"
 
 
 


### PR DESCRIPTION
## Summary

Restore ChatGPT-account Codex requests for models whose backend catalog requires a newer client identity, including `gpt-5.6-sol`.

Hermes currently advertises `codex_cli_rs/0.0.0`. The Codex backend can reject an otherwise valid OAuth request with HTTP 400 when that identity is below the selected model's catalog `minimal_client_version`.

This PR:

- captures `minimal_client_version` and the catalog `client_version` from live and local Codex model catalogs;
- advertises the highest compatible client identity in `User-Agent` and `version` headers;
- threads the selected model through all four primary/auxiliary Codex client construction paths;
- keeps the compatibility probe scoped to the ChatGPT-account Codex route;
- allows a later retry after a failed live catalog probe and logs the degraded floor fallback;
- uses a known GPT-5.6 compatibility floor only when neither live nor local catalog data is available.

## Prior work and review feedback

This preserves the original implementation and authorship from #81576, then addresses the review feedback left there:

- a failed first probe no longer permanently marks discovery complete;
- header tests assert concrete expected versions rather than deriving expectations from the resolver under test;
- fallback to the compatibility floor is logged and remains retryable.

## Verification

- `uv run --extra dev pytest -q tests/agent/test_codex_cloudflare_headers.py tests/hermes_cli/test_codex_models.py`
  - **19 passed**
- Regression-test sabotage: temporarily restored the pre-fix hardcoded `0.144.0` resolver
  - **3 targeted tests failed as expected**
  - restored the fix and reran: **19 passed**
- `uv run --extra dev ruff check` on all seven changed Python files
  - **passed**
- Read-only reviewer verdict: **APPROVE**, no blocking findings
- Live downstream smoke verification on the reporter's environment:
  - `openai-codex/gpt-5.6-sol` returned successfully;
  - logs confirmed a single direct Codex API call with no fallback provider.

## Scope

API-key traffic to `api.openai.com` is unaffected. The new headers and compatibility discovery are limited to the ChatGPT-account Codex backend.

Fixes #81558
Supersedes #81576


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex compatibility when using models with specific minimum client-version requirements.
  * Prevented requests from failing due to outdated or incompatible client version headers.
  * Added reliable fallback handling when compatibility information is unavailable.

* **Tests**
  * Expanded coverage for model compatibility selection, cached versions, fallback behavior, and retry handling.
  * Added regression checks for Cloudflare request headers across supported client paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->