### PR TITLE
fix(gateway): reject failed session chat results

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1100,6 +1100,9 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
     }
 
 
+_AGENT_INCOMPLETE_MESSAGE = "Agent run did not complete successfully."
+
+
 _api_agent_request_reservation: ContextVar[Optional[dict[str, bool]]] = ContextVar(
     "api_agent_request_reservation", default=None
 )
@@ -3743,10 +3746,26 @@ class APIServerAdapter(BasePlatformAdapter):
             **agent_overrides,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
-        final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
         headers = {"X-Hermes-Session-Id": effective_session_id or session_id}
         if gateway_session_key:
             headers["X-Hermes-Session-Key"] = gateway_session_key
+        if isinstance(result, dict) and result.get("failed"):
+            err_body = _openai_error(
+                _AGENT_INCOMPLETE_MESSAGE,
+                err_type="server_error",
+                code="agent_incomplete",
+            )
+            err_body["error"]["hermes"] = {
+                "completed": bool(result.get("completed", False)),
+                "partial": bool(result.get("partial", False)),
+                "failed": True,
+            }
+            headers["X-Hermes-Completed"] = "false"
+            headers["X-Hermes-Partial"] = (
+                "true" if result.get("partial") else "false"
+            )
+            return web.json_response(err_body, status=502, headers=headers)
+        final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
         runtime = {}
         if isinstance(result, dict):
             runtime = result.get("runtime") or {}
@@ -3915,6 +3934,18 @@ class APIServerAdapter(BasePlatformAdapter):
                     confirmed_runtime_lock=lock_active,
                     **agent_overrides,
                 )
+                if isinstance(result, dict) and result.get("failed"):
+                    self._set_run_status(
+                        run_id,
+                        "failed",
+                        error=_AGENT_INCOMPLETE_MESSAGE,
+                        last_event="run.failed",
+                    )
+                    await queue.put(_event_payload(
+                        "error",
+                        {"message": _AGENT_INCOMPLETE_MESSAGE},
+                    ))
+                    return
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
                 turn_messages = self._turn_transcript_messages(history, user_message, result) if isinstance(result, dict) else []

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1055,6 +1055,133 @@ class TestChatCompletionsEndpoint:
 
 
     @pytest.mark.asyncio
+    async def test_session_chat_failed_result_returns_redacted_502(self, adapter):
+        secret = "sk-internal-failed-result-1234567890"
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            with (
+                patch.object(
+                    adapter,
+                    "_get_existing_session_or_404",
+                    return_value=({"id": "s1"}, None),
+                ),
+                patch.object(adapter, "_conversation_history_for_session", return_value=[]),
+                patch.object(
+                    adapter,
+                    "_run_agent",
+                    new=AsyncMock(
+                        return_value=(
+                            {
+                                "final_response": f"internal assistant content {secret}",
+                                "messages": [{"role": "assistant", "content": secret}],
+                                "completed": False,
+                                "failed": True,
+                                "error": f"provider exception OPENAI_API_KEY={secret}",
+                            },
+                            {"input_tokens": 1, "output_tokens": 0, "total_tokens": 1},
+                        )
+                    ),
+                ),
+            ):
+                resp = await cli.post("/api/sessions/s1/chat", json={"message": "hi"})
+                data = await resp.json()
+
+        assert resp.status == 502
+        assert data["error"]["type"] == "server_error"
+        assert data["error"]["code"] == "agent_incomplete"
+        assert data["error"]["message"] == "Agent run did not complete successfully."
+        assert data["error"]["hermes"] == {
+            "completed": False,
+            "partial": False,
+            "failed": True,
+        }
+        assert "message" not in data
+        assert secret not in json.dumps(data)
+
+
+    @pytest.mark.asyncio
+    async def test_session_chat_stream_failed_result_emits_error_then_done(self, adapter):
+        secret = "sk-internal-stream-failure-1234567890"
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            with (
+                patch.object(
+                    adapter,
+                    "_get_existing_session_or_404",
+                    return_value=({"id": "s1"}, None),
+                ),
+                patch.object(adapter, "_conversation_history_for_session", return_value=[]),
+                patch.object(
+                    adapter,
+                    "_run_agent",
+                    new=AsyncMock(
+                        return_value=(
+                            {
+                                "final_response": f"internal assistant content {secret}",
+                                "messages": [{"role": "assistant", "content": secret}],
+                                "completed": False,
+                                "failed": True,
+                                "error": f"provider exception OPENAI_API_KEY={secret}",
+                            },
+                            {"input_tokens": 1, "output_tokens": 0, "total_tokens": 1},
+                        )
+                    ),
+                ),
+            ):
+                resp = await cli.post(
+                    "/api/sessions/s1/chat/stream",
+                    json={"message": "hi"},
+                )
+                body = await resp.text()
+
+        assert resp.status == 200
+        assert "event: error" in body
+        assert "event: done" in body
+        assert body.index("event: error") < body.index("event: done")
+        assert "event: assistant.completed" not in body
+        assert "event: run.completed" not in body
+        assert '"messages"' not in body
+        assert secret not in body
+        assert "Agent run did not complete successfully." in body
+
+
+    @pytest.mark.asyncio
+    async def test_session_chat_success_still_returns_assistant_message(self, adapter):
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            with (
+                patch.object(
+                    adapter,
+                    "_get_existing_session_or_404",
+                    return_value=({"id": "s1"}, None),
+                ),
+                patch.object(adapter, "_conversation_history_for_session", return_value=[]),
+                patch.object(
+                    adapter,
+                    "_run_agent",
+                    new=AsyncMock(
+                        return_value=(
+                            {
+                                "final_response": "ok",
+                                "messages": [{"role": "assistant", "content": "ok"}],
+                                "completed": True,
+                                "failed": False,
+                            },
+                            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                        )
+                    ),
+                ),
+            ):
+                resp = await cli.post(
+                    "/api/sessions/s1/chat",
+                    json={"message": "hi"},
+                )
+                data = await resp.json()
+
+        assert resp.status == 200
+        assert data["object"] == "hermes.session.chat.completion"
+        assert data["session_id"] == "s1"
+        assert data["message"] == {"role": "assistant", "content": "ok"}
+
+
+    @pytest.mark.asyncio
     async def test_stream_task_done_callback_enqueues_eos_for_chat_completions(self, adapter):
         """Regression guard for #24451: completion callback must signal SSE EOS."""
         app = _create_app(adapter)


### PR DESCRIPTION
Failed agent runs in the session chat API were serialized as successful assistant messages. This could persist internal failure text into downstream conversation surfaces.

This change keeps successful responses unchanged and makes failures explicit and redacted:

- synchronous session chat returns the existing OpenAI-style 502 `agent_incomplete` envelope with no assistant message;
- streaming session chat emits `error` followed by `done`, with no `assistant.completed`, `run.completed`, or transcript payload.

Verification: focused failure/success coverage 3/3; full `tests/gateway/test_api_server.py` 102/102; Ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session chat now clearly reports agent failures with an appropriate error response instead of indicating successful completion.
  * Streaming chat now emits a failure status and error event when processing cannot complete.
  * Sensitive information is excluded from failure responses.
  * Successful assistant responses continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->