### PR TITLE
fix(mcp-oauth): honor oauth.authorization_params and require_refresh_token

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -930,3 +930,80 @@ def test_humanize_non_registration_403_passthrough():
         )
         is None
     )
+
+
+# ---------------------------------------------------------------------------
+# oauth.authorization_params / oauth.require_refresh_token
+# ---------------------------------------------------------------------------
+
+class TestExtraAuthorizeParams:
+    """Provider-specific authorize-URL params (e.g. Dropbox token_access_type).
+
+    The SDK builds the authorization URL itself, so the redirect handler is
+    the only seam where config-declared ``authorization_params`` can be
+    appended. Without them Dropbox never issues a refresh_token and the grant
+    dies with the first access token.
+    """
+
+    def _capture_url(self, monkeypatch):
+        captured = {}
+
+        class _Flow:
+            async def publish_authorization_url(self, url):
+                captured["url"] = url
+
+        monkeypatch.setattr(
+            "tools.mcp_dashboard_oauth.get_dashboard_oauth_flow",
+            lambda: _Flow(),
+        )
+        return captured
+
+    def test_params_appended_to_authorization_url(self, monkeypatch):
+        captured = self._capture_url(monkeypatch)
+        handler = _make_redirect_handler(
+            0, extra_authorize_params={"token_access_type": "offline"}
+        )
+        asyncio.run(handler("https://x.example/authorize?client_id=abc"))
+        assert captured["url"] == (
+            "https://x.example/authorize?client_id=abc&token_access_type=offline"
+        )
+
+    def test_existing_query_keys_are_not_overridden(self, monkeypatch):
+        captured = self._capture_url(monkeypatch)
+        handler = _make_redirect_handler(
+            0,
+            extra_authorize_params={"client_id": "evil", "token_access_type": "offline"},
+        )
+        asyncio.run(handler("https://x.example/authorize?client_id=abc"))
+        assert "evil" not in captured["url"]
+        assert "token_access_type=offline" in captured["url"]
+
+    def test_no_params_leaves_url_untouched(self, monkeypatch):
+        captured = self._capture_url(monkeypatch)
+        handler = _make_redirect_handler(0)
+        asyncio.run(handler("https://x.example/authorize?client_id=abc"))
+        assert captured["url"] == "https://x.example/authorize?client_id=abc"
+
+
+class TestRequireRefreshToken:
+    def test_missing_refresh_token_logs_error(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("dropbox", require_refresh_token=True)
+        token = MagicMock()
+        token.model_dump.return_value = {"access_token": "at", "expires_in": 14400}
+        with caplog.at_level("ERROR", logger="tools.mcp_oauth"):
+            asyncio.run(storage.set_tokens(token))
+        assert any("no refresh_token" in r.message for r in caplog.records)
+
+    def test_refresh_token_present_is_silent(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("dropbox", require_refresh_token=True)
+        token = MagicMock()
+        token.model_dump.return_value = {
+            "access_token": "at",
+            "refresh_token": "rt",
+            "expires_in": 14400,
+        }
+        with caplog.at_level("ERROR", logger="tools.mcp_oauth"):
+            asyncio.run(storage.set_tokens(token))
+        assert not caplog.records

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -436,9 +436,16 @@ class HermesTokenStorage:
         HERMES_HOME/mcp-tokens/<server_name>.meta.json     -- oauth server metadata
     """
 
-    def __init__(self, server_name: str, *, hermes_home: str | Path | None = None):
+    def __init__(
+        self,
+        server_name: str,
+        *,
+        hermes_home: str | Path | None = None,
+        require_refresh_token: bool = False,
+    ):
         self._server_name = _safe_filename(server_name)
         self._hermes_home = Path(hermes_home) if hermes_home is not None else None
+        self._require_refresh_token = require_refresh_token
 
     def _tokens_path(self) -> Path:
         return _get_token_dir(self._hermes_home) / f"{self._server_name}.json"
@@ -511,6 +518,21 @@ class HermesTokenStorage:
                 pass
         _write_json(self._tokens_path(), payload)
         logger.debug("OAuth tokens saved for %s", self._server_name)
+        # oauth.require_refresh_token: surface a refresh-less grant loudly at
+        # the moment it is issued, instead of as an opaque parked-server
+        # failure hours later when the access token expires. Warn-only — the
+        # access token is still usable and failing here would strand the flow.
+        if self._require_refresh_token and not payload.get("refresh_token"):
+            logger.error(
+                "OAuth grant for '%s' returned no refresh_token although "
+                "oauth.require_refresh_token is set — the connection will die "
+                "when this access token expires (expires_in=%s). Check that "
+                "oauth.authorization_params (e.g. token_access_type=offline) "
+                "reached the provider, then re-run `hermes mcp login %s`.",
+                self._server_name,
+                payload.get("expires_in"),
+                self._server_name,
+            )
 
     # -- client info -------------------------------------------------------
 
@@ -694,7 +716,11 @@ def _make_callback_handler() -> tuple[type, dict]:
 # ---------------------------------------------------------------------------
 
 
-def _make_redirect_handler(port: int, redirect_uri: str | None = None):
+def _make_redirect_handler(
+    port: int,
+    redirect_uri: str | None = None,
+    extra_authorize_params: dict | None = None,
+):
     """Return a redirect handler closure that closes over the given port.
 
     Using a closure instead of reading the module-level ``_oauth_port`` avoids
@@ -705,6 +731,14 @@ def _make_redirect_handler(port: int, redirect_uri: str | None = None):
     URL), or ``None`` for the loopback default. It tailors the remote-session
     hint: a proxied callback reaches this machine on its own, so the loopback
     SSH-tunnel guidance would be misleading.
+
+    ``extra_authorize_params`` come from ``oauth.authorization_params`` in the
+    server's config block. The SDK's ``OAuthClientProvider`` offers no hook
+    for provider-specific authorize-URL params, but it hands the fully built
+    URL to this handler — so this is the one place they can be appended.
+    Needed e.g. for Dropbox's ``token_access_type: offline``, without which
+    no refresh_token is ever issued and the grant dies with the first access
+    token (~4h).
     """
     async def _redirect_handler(authorization_url: str) -> None:
         """Show the authorization URL to the user.
@@ -713,6 +747,22 @@ def _make_redirect_handler(port: int, redirect_uri: str | None = None):
         as a fallback for headless/SSH/gateway environments.
         """
         from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
+
+        if extra_authorize_params:
+            from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+            parts = urlsplit(authorization_url)
+            present = {k for k, _ in parse_qsl(parts.query, keep_blank_values=True)}
+            extra = {
+                str(k): str(v)
+                for k, v in extra_authorize_params.items()
+                if str(k) not in present
+            }
+            if extra:
+                query = parts.query + ("&" if parts.query else "") + urlencode(extra)
+                authorization_url = urlunsplit(
+                    (parts.scheme, parts.netloc, parts.path, query, parts.fragment)
+                )
 
         dashboard_flow = get_dashboard_oauth_flow()
         if dashboard_flow is not None:
@@ -1395,7 +1445,10 @@ def build_oauth_auth(
     apply_oauth_provider_defaults(
         cfg, server_name=server_name, server_url=server_url
     )
-    storage = HermesTokenStorage(server_name)
+    storage = HermesTokenStorage(
+        server_name,
+        require_refresh_token=bool(cfg.get("require_refresh_token")),
+    )
 
     if not _is_interactive() and not storage.has_cached_tokens():
         raise OAuthNonInteractiveError(
@@ -1413,7 +1466,9 @@ def build_oauth_auth(
     # Use closure factories to avoid global state pollution (#44588, #34260).
     resolved_port = cfg.get("_resolved_port", _oauth_port)
     redirect_handler = _make_redirect_handler(
-        resolved_port, redirect_uri=cfg.get("redirect_uri") or None
+        resolved_port,
+        redirect_uri=cfg.get("redirect_uri") or None,
+        extra_authorize_params=cfg.get("authorization_params") or None,
     )
     callback_handler = _make_callback_waiter(resolved_port)
 

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -551,7 +551,10 @@ class MCPOAuthManager:
         apply_oauth_provider_defaults(
             cfg, server_name=server_name, server_url=entry.server_url
         )
-        storage = HermesTokenStorage(server_name)
+        storage = HermesTokenStorage(
+            server_name,
+            require_refresh_token=bool(cfg.get("require_refresh_token")),
+        )
 
         from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
 
@@ -573,7 +576,10 @@ class MCPOAuthManager:
         _maybe_preregister_client(storage, cfg, client_metadata)
 
         resolved_port = cfg.get("_resolved_port", 0)
-        redirect_handler = _make_redirect_handler(resolved_port)
+        redirect_handler = _make_redirect_handler(
+            resolved_port,
+            extra_authorize_params=cfg.get("authorization_params") or None,
+        )
         callback_handler = _make_callback_waiter(resolved_port)
 
         return _HERMES_PROVIDER_CLS(


### PR DESCRIPTION
## Problem

`mcp_servers.<name>.oauth` accepts `authorization_params` and `require_refresh_token` in config, but nothing reads either key — `build_oauth_auth()` only consumes client_name/scope/redirect/client_id/client_secret/token_endpoint_auth_method/timeout.

Concrete failure: Dropbox's MCP server only issues a refresh token when `token_access_type=offline` is present on the authorize URL. Since the configured `authorization_params` never reached the provider, Dropbox issued 4-hour access tokens with **no refresh token**; when the token expired the server hard-parked on every gateway start (`OAuthNonInteractiveError`) until a human re-ran `hermes mcp login dropbox` — every 4 hours, forever.

## Fix

- `authorization_params` are appended to the SDK-built authorization URL inside the redirect handler — the one seam the MCP SDK exposes (`OAuthClientProvider` builds the URL itself and hands it to the handler). Existing query keys are never overridden. Covers both provider construction paths (`build_oauth_auth` and `mcp_oauth_manager._build_provider`).
- `require_refresh_token` now logs a loud error at token-save time when a grant comes back without a refresh token, instead of an opaque parked-server failure hours later. Warn-only: the access token is still usable and failing the flow would strand it.

Verified live: with this patch the Dropbox authorize URL carries `token_access_type=offline` and the stored grant includes a refresh token; the server now self-heals across restarts.

## Testing

New regression tests in `tests/tools/test_mcp_oauth.py` (params appended, existing keys not overridden, URL untouched without config; error logged iff refresh token missing) — 49/49 pass. The 9 pre-existing failures in `test_mcp_oauth_cold_load_expiry.py` are unrelated (present on clean main with mcp 1.28.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for provider-specific authorization parameters during OAuth sign-in.
  - Prevented configured parameters from overwriting existing authorization URL values.
  - Added configurable enforcement for refresh tokens during OAuth token storage.

- **Bug Fixes**
  - OAuth flows now clearly report when a required refresh token is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->