### PR TITLE
fix(desktop): spare detached/supervised gateways from the startup orphan reap (#86287)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1525,6 +1525,34 @@ def kill_gateway_processes(
     return killed
 
 
+def _is_detached_gateway_process(pid: int) -> bool:
+    """Return True when a gateway PID was launched service-style (detached).
+
+    The Windows scheduled-task / service wrappers (e.g. the ``Hermes_Gateway``
+    task, ``hermes gateway start``, and the post-update windowless respawn) set
+    ``HERMES_GATEWAY_DETACHED=1`` in the gateway's environment
+    (:func:`hermes_cli.gateway_windows._build_gateway_argv` /
+    :func:`windowless_gateway_restart_spec`). Such a gateway is *supervised* by
+    its launcher, not an orphan, so the desktop backend's startup reap must not
+    kill it — otherwise opening Hermes Desktop silently SIGTERMs the user's
+    independently-managed gateway (#86287).
+
+    Best-effort: if the target process environment can't be read (no psutil,
+    permission denied on a cross-session process, process already gone) we
+    conservatively return ``False`` so the legacy reap behaviour is unchanged.
+    """
+    if pid is None or pid <= 0:
+        return False
+    try:
+        import psutil  # type: ignore
+
+        env = psutil.Process(pid).environ()
+    except Exception:
+        return False
+    detached = (env or {}).get("HERMES_GATEWAY_DETACHED", "").strip().lower()
+    return detached in {"1", "true", "yes", "on"}
+
+
 def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool:
     """Kill no-supervisor gateway orphans the pidfile/runtime record can't see.
 
@@ -1569,6 +1597,13 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
         # find_gateway_pids() includes no-supervisor `gateway restart` runtimes
         # for the current profile when no systemd supervisor is present.
         orphans = [p for p in find_gateway_pids(exclude_pids=own) if p and p > 0]
+        # A detached gateway (Windows scheduled-task / service / `gateway start`
+        # launch, marked HERMES_GATEWAY_DETACHED=1) is *supervised* by its
+        # launcher, not an orphan. Reaping it would kill the user's
+        # independently-managed gateway whenever the desktop backend starts
+        # (#86287). The WSL/no-systemd `gateway restart` orphan the reap exists
+        # for (#51325) carries no such marker, so it stays reapable.
+        orphans = [p for p in orphans if not _is_detached_gateway_process(p)]
     except Exception:
         return False
     if not orphans:

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -227,7 +227,7 @@ class TestContainerSystemdSupport:
 
 @pytest.mark.skipif(
     sys.platform == "win32",
-    reason="systemd user-linger is Linux-only (drives os.getuid())",
+    reason="systemd user-linger is Linux-only (drives os.getuid())",  # windows-footgun: ok
 )
 def test_systemd_install_checks_linger_status(monkeypatch, tmp_path, capsys):
     unit_path = tmp_path / "systemd" / "user" / "hermes-gateway.service"
@@ -493,6 +493,116 @@ class TestReapUnsupervisedGatewayOrphansMacOS:
 
         assert result is False  # no orphans reaped
         assert killed_pids == []  # nothing was killed
+
+
+class TestReapUnsupervisedGatewayOrphansDetached:
+    """The orphan reaper must spare detached (service-supervised) gateways.
+
+    Regression guard for #86287: on Windows there is no systemd, so the reap
+    proceeds and would SIGTERM the scheduled-task / ``gateway start`` gateway
+    (launched with ``HERMES_GATEWAY_DETACHED=1``) every time the desktop
+    backend starts — dropping the user's independently-managed gateway.
+    """
+
+    def test_detached_gateway_is_spared_but_plain_orphan_is_reaped(self, monkeypatch):
+        detached_pid = 4321
+        orphan_pid = 99998
+
+        # No service supervisor (Windows/WSL-style) → reap proceeds to the scan.
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [
+                p for p in [detached_pid, orphan_pid] if p not in (exclude_pids or set())
+            ],
+        )
+        # Only the detached PID carries the supervised marker.
+        monkeypatch.setattr(
+            gateway,
+            "_is_detached_gateway_process",
+            lambda pid: pid == detached_pid,
+        )
+
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        monkeypatch.setattr("time.monotonic", lambda: 1.0)
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert result is True
+        killed = [pid for pid, _ in killed_pids]
+        assert orphan_pid in killed        # the real orphan was reaped
+        assert detached_pid not in killed  # the supervised gateway was spared
+
+    def test_only_detached_gateway_running_reaps_nothing(self, monkeypatch):
+        detached_pid = 4321
+
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [
+                p for p in [detached_pid] if p not in (exclude_pids or set())
+            ],
+        )
+        monkeypatch.setattr(gateway, "_is_detached_gateway_process", lambda pid: True)
+
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert result is False
+        assert killed_pids == []
+
+
+class TestIsDetachedGatewayProcess:
+    """Unit coverage for the HERMES_GATEWAY_DETACHED probe (#86287)."""
+
+    def test_marker_truthy_values_detected(self, monkeypatch):
+        import sys as _sys
+        import types
+
+        for raw in ("1", "true", "YES", "on"):
+            fake_psutil = types.SimpleNamespace(
+                Process=lambda pid, _raw=raw: types.SimpleNamespace(
+                    environ=lambda: {"HERMES_GATEWAY_DETACHED": _raw}
+                )
+            )
+            monkeypatch.setitem(_sys.modules, "psutil", fake_psutil)
+            assert gateway._is_detached_gateway_process(4321) is True
+
+    def test_missing_or_falsey_marker_not_detached(self, monkeypatch):
+        import sys as _sys
+        import types
+
+        for env in ({}, {"HERMES_GATEWAY_DETACHED": ""}, {"HERMES_GATEWAY_DETACHED": "0"}):
+            fake_psutil = types.SimpleNamespace(
+                Process=lambda pid, _env=env: types.SimpleNamespace(environ=lambda: _env)
+            )
+            monkeypatch.setitem(_sys.modules, "psutil", fake_psutil)
+            assert gateway._is_detached_gateway_process(4321) is False
+
+    def test_environ_read_failure_falls_back_to_false(self, monkeypatch):
+        import sys as _sys
+        import types
+
+        def _boom(pid):
+            raise RuntimeError("access denied")
+
+        fake_psutil = types.SimpleNamespace(Process=_boom)
+        monkeypatch.setitem(_sys.modules, "psutil", fake_psutil)
+        assert gateway._is_detached_gateway_process(4321) is False
+
+    def test_invalid_pid_short_circuits(self):
+        assert gateway._is_detached_gateway_process(0) is False
+        assert gateway._is_detached_gateway_process(-1) is False
 
 
 def test_module_has_logger():


### PR DESCRIPTION
## Problem

On Windows the Desktop backend (`hermes serve`, `HERMES_DESKTOP=1`) kills **every** gateway process on startup — including a gateway the user runs independently via the `Hermes_Gateway` scheduled task or `hermes gateway start`. Opening the desktop app then silently SIGTERMs that gateway: `hermes gateway status` reports "No gateway process detected" and messaging platforms (e.g. Weixin) drop, with no shutdown line in `gateway.log`.

Root cause: `_lifespan` calls `_reap_unsupervised_gateway_orphans()` on every desktop-backend startup. That reaper short-circuits when `supports_systemd_services()` is true, and already excludes launchd PIDs on macOS — but on Windows neither guard applies, so `find_gateway_pids()` returns the supervised gateway and it gets reaped.

## Fix

Service-style launches already tag the gateway environment with `HERMES_GATEWAY_DETACHED=1` (`gateway_windows._build_gateway_argv` for the scheduled task / `gateway start`, and `windowless_gateway_restart_spec` for the post-update respawn). This PR adds `_is_detached_gateway_process(pid)` — a best-effort `psutil.Process(pid).environ()` probe — and filters detached gateways out of the reap, mirroring the existing macOS launchd-PID exclusion.

- The WSL/no-systemd `gateway restart` orphan the reap exists for (#51325) carries **no** detached marker, so it stays reapable — the reaper's original purpose is preserved.
- The probe is best-effort: on missing `psutil`, a permission-denied cross-session read, or a vanished PID it returns `False`, leaving the legacy reap behaviour unchanged (and in the cross-session case `os.kill` already fails with the existing `PermissionError` guard, so no regression).

## Tests

`tests/hermes_cli/test_gateway.py`:
- `TestReapUnsupervisedGatewayOrphansDetached` — a detached gateway is spared while a plain (unmarked) orphan is still reaped; a lone detached gateway reaps nothing.
- `TestIsDetachedGatewayProcess` — truthy/falsey marker values, environ-read failure fallback, and invalid-PID short-circuit.

All 23 tests in the file pass; ruff + windows-footgun gates clean.

Fixes #86287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway process cleanup to preserve detached, launcher-supervised gateways.
  * Continued removing ordinary unsupervised orphaned gateway processes.
  * Added safer handling for missing, invalid, inaccessible, and false configuration values.

* **Tests**
  * Added regression coverage for detached gateway preservation and orphan cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->