### PR TITLE
fix(browser): auto-recover Camofox tabs from 410 (page crash) as well as 404

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -1,6 +1,8 @@
 """Tests for the Camofox browser backend."""
 
 import json
+
+import requests
 from unittest.mock import MagicMock, patch
 
 
@@ -360,5 +362,81 @@ class TestBrowserToolRouting:
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
         from tools.browser_tool import check_browser_requirements
         assert check_browser_requirements() is True
+
+
+# ---------------------------------------------------------------------------
+# Stale-tab recovery — 404/410 must open a fresh tab, not loop on the dead id
+# ---------------------------------------------------------------------------
+
+
+def _http_error(status: int) -> requests.HTTPError:
+    resp = MagicMock()
+    resp.status_code = status
+    return requests.HTTPError(f"HTTP {status}", response=resp)
+
+
+class TestCamofoxStaleTabRecovery:
+    """A crashed/garbage-collected Camofox tab (410 page crash / tab
+    destroyed, 404 garbage-collected) must be replaced with a fresh tab and
+    retried once — otherwise every tool call loops on the dead tab_id until
+    the gateway restarts and drops the in-memory session cache."""
+
+    @patch("tools.browser_camofox._get_session")
+    @patch("tools.browser_camofox._ensure_tab")
+    @patch("tools.browser_camofox._get")
+    @patch("tools.browser_camofox._post")
+    def test_navigate_recovers_from_410(self, mock_post, mock_get, mock_ensure, mock_session, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        session = {"user_id": "u1", "session_key": "k1", "tab_id": "dead-tab", "adopt_existing_tab": False}
+        mock_session.return_value = session
+        mock_post.side_effect = [
+            _http_error(410),
+            {"ok": True, "url": "https://x.com"},
+        ]
+        mock_get.return_value = {"snapshot": "- text: ok", "refsCount": 0}
+        mock_ensure.side_effect = lambda task_id, url="about:blank": session.update(tab_id="fresh-tab")
+
+        result = json.loads(camofox_navigate("https://x.com", task_id="t410"))
+
+        assert result["success"] is True
+        assert session["tab_id"] == "fresh-tab"
+        assert mock_post.call_count == 2
+        # The retried call must target the freshly created tab
+        assert mock_post.call_args_list[1].args[0] == "/tabs/fresh-tab/navigate"
+
+    @patch("tools.browser_camofox._get_session")
+    @patch("tools.browser_camofox._ensure_tab")
+    @patch("tools.browser_camofox._get")
+    def test_snapshot_recovers_from_404(self, mock_get, mock_ensure, mock_session, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        session = {"user_id": "u1", "session_key": "k1", "tab_id": "dead-tab", "adopt_existing_tab": False}
+        mock_session.return_value = session
+        mock_get.side_effect = [
+            _http_error(404),
+            {"snapshot": "- text: fresh page", "refsCount": 1},
+        ]
+        mock_ensure.side_effect = lambda task_id, url="about:blank": session.update(tab_id="fresh-tab")
+
+        result = json.loads(camofox_snapshot(task_id="t404"))
+
+        assert result["success"] is True
+        assert "fresh page" in result["snapshot"]
+        assert mock_get.call_count == 2
+        assert mock_get.call_args_list[1].args[0] == "/tabs/fresh-tab/snapshot"
+
+    @patch("tools.browser_camofox._get_session")
+    @patch("tools.browser_camofox._ensure_tab")
+    @patch("tools.browser_camofox._get")
+    def test_non_stale_error_propagates_without_retry(self, mock_get, mock_ensure, mock_session, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        session = {"user_id": "u1", "session_key": "k1", "tab_id": "live-tab", "adopt_existing_tab": False}
+        mock_session.return_value = session
+        mock_get.side_effect = _http_error(500)
+
+        result = json.loads(camofox_snapshot(task_id="t500"))
+
+        assert result["success"] is False
+        assert mock_get.call_count == 1
+        mock_ensure.assert_not_called()
 
 

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -489,6 +489,55 @@ def _delete(path: str, body: dict = None, timeout: Optional[int] = None) -> dict
     return resp.json()
 
 
+# Status codes Camofox returns when the cached tab is dead: 404 (tab
+# garbage-collected / unknown) and 410 (page crashed / tab destroyed /
+# browser restarted — the server response includes ``recovery:
+# create_new_tab``).  Both signal the same recovery: forget the cached
+# tab_id and open a fresh tab.
+_STALE_TAB_STATUS_CODES = (404, 410)
+
+
+def _is_stale_tab_error(exc: Exception) -> bool:
+    """Return True when a Camofox HTTP error means the cached tab is dead."""
+    return (
+        isinstance(exc, requests.HTTPError)
+        and exc.response is not None
+        and exc.response.status_code in _STALE_TAB_STATUS_CODES
+    )
+
+
+def _retry_on_stale_tab(
+    task_id: Optional[str],
+    session: Dict[str, Any],
+    fn,
+    *args,
+    **kwargs,
+):
+    """Run ``fn`` against the session's cached tab, retrying once on a
+    stale-tab error (404/410) after opening a fresh tab.
+
+    Without this, every tool call after a Camofox page crash (410) or tab
+    garbage collection (404) keeps hitting the dead tab_id and loops on the
+    error until the gateway restarts and drops the in-memory session cache.
+    ``fn`` must re-read ``session["tab_id"]`` at call time so the retry
+    targets the freshly created tab.
+    """
+    try:
+        return fn(*args, **kwargs)
+    except requests.HTTPError as e:
+        if not _is_stale_tab_error(e):
+            raise
+        logger.warning(
+            "Camofox tab %s returned %s — tab crashed or was garbage collected; "
+            "opening a fresh tab and retrying once.",
+            session.get("tab_id"),
+            e.response.status_code,
+        )
+        session["tab_id"] = None
+        _ensure_tab(task_id)
+        return fn(*args, **kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Tool implementations
 # ---------------------------------------------------------------------------
@@ -503,25 +552,17 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
             session = _ensure_tab(task_id, browser_url)
             data = {"ok": True, "url": browser_url}
         else:
-            # Navigate existing tab — recover from stale tab 404
-            try:
-                data = _post(
+            # Navigate existing tab — recover from a stale/crashed tab
+            # (404 = garbage-collected, 410 = page crashed / tab destroyed).
+            data = _retry_on_stale_tab(
+                task_id,
+                session,
+                lambda: _post(
                     f"/tabs/{session['tab_id']}/navigate",
                     {"userId": session["user_id"], "url": browser_url},
                     timeout=60,
-                )
-            except requests.HTTPError as e:
-                if e.response is not None and e.response.status_code == 404:
-                    logger.warning(
-                        "Camofox tab %s returned 404 — tab was garbage collected. "
-                        "Creating a fresh tab.",
-                        session["tab_id"],
-                    )
-                    session["tab_id"] = None
-                    session = _ensure_tab(task_id, browser_url)
-                    data = {"ok": True, "url": browser_url}
-                else:
-                    raise
+                ),
+            )
         result = {
             "success": True,
             "url": data.get("url", browser_url),
@@ -620,9 +661,13 @@ def camofox_snapshot(full: bool = False, task_id: Optional[str] = None,
         if blocked:
             return blocked
 
-        data = _get(
-            f"/tabs/{session['tab_id']}/snapshot",
-            params={"userId": session["user_id"]},
+        data = _retry_on_stale_tab(
+            task_id,
+            session,
+            lambda: _get(
+                f"/tabs/{session['tab_id']}/snapshot",
+                params={"userId": session["user_id"]},
+            ),
         )
 
         snapshot = data.get("snapshot", "")
@@ -664,9 +709,13 @@ def camofox_click(ref: str, task_id: Optional[str] = None) -> str:
         # Strip @ prefix if present (our tool convention)
         clean_ref = ref.lstrip("@")
 
-        data = _post(
-            f"/tabs/{session['tab_id']}/click",
-            {"userId": session["user_id"], "ref": clean_ref},
+        data = _retry_on_stale_tab(
+            task_id,
+            session,
+            lambda: _post(
+                f"/tabs/{session['tab_id']}/click",
+                {"userId": session["user_id"], "ref": clean_ref},
+            ),
         )
         return json.dumps({
             "success": True,
@@ -690,9 +739,13 @@ def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
 
         clean_ref = ref.lstrip("@")
 
-        _post(
-            f"/tabs/{session['tab_id']}/type",
-            {"userId": session["user_id"], "ref": clean_ref, "text": text},
+        _retry_on_stale_tab(
+            task_id,
+            session,
+            lambda: _post(
+                f"/tabs/{session['tab_id']}/type",
+                {"userId": session["user_id"], "ref": clean_ref, "text": text},
+            ),
         )
         from agent.display import (
             redact_browser_typed_text_for_display,
@@ -725,9 +778,13 @@ def camofox_scroll(direction: str, task_id: Optional[str] = None) -> str:
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
-        _post(
-            f"/tabs/{session['tab_id']}/scroll",
-            {"userId": session["user_id"], "direction": direction},
+        _retry_on_stale_tab(
+            task_id,
+            session,
+            lambda: _post(
+                f"/tabs/{session['tab_id']}/scroll",
+                {"userId": session["user_id"], "direction": direction},
+            ),
         )
         return json.dumps({"success": True, "scrolled": direction})
     except Exception as e:
@@ -741,9 +798,13 @@ def camofox_back(task_id: Optional[str] = None) -> str:
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
-        data = _post(
-            f"/tabs/{session['tab_id']}/back",
-            {"userId": session["user_id"]},
+        data = _retry_on_stale_tab(
+            task_id,
+            session,
+            lambda: _post(
+                f"/tabs/{session['tab_id']}/back",
+                {"userId": session["user_id"]},
+            ),
         )
         return json.dumps({"success": True, "url": data.get("url", "")})
     except Exception as e:
@@ -761,9 +822,13 @@ def camofox_press(key: str, task_id: Optional[str] = None) -> str:
         if blocked:
             return blocked
 
-        _post(
-            f"/tabs/{session['tab_id']}/press",
-            {"userId": session["user_id"], "key": key},
+        _retry_on_stale_tab(
+            task_id,
+            session,
+            lambda: _post(
+                f"/tabs/{session['tab_id']}/press",
+                {"userId": session["user_id"], "key": key},
+            ),
         )
         return json.dumps({"success": True, "pressed": key})
     except Exception as e:
@@ -802,9 +867,13 @@ def camofox_get_images(task_id: Optional[str] = None) -> str:
 
         import re
 
-        data = _get(
-            f"/tabs/{session['tab_id']}/snapshot",
-            params={"userId": session["user_id"]},
+        data = _retry_on_stale_tab(
+            task_id,
+            session,
+            lambda: _get(
+                f"/tabs/{session['tab_id']}/snapshot",
+                params={"userId": session["user_id"]},
+            ),
         )
         snapshot = data.get("snapshot", "")
 
@@ -849,9 +918,13 @@ def camofox_vision(question: str, annotate: bool = False,
             return blocked
 
         # Get screenshot as binary PNG
-        resp = _get_raw(
-            f"/tabs/{session['tab_id']}/screenshot",
-            params={"userId": session["user_id"]},
+        resp = _retry_on_stale_tab(
+            task_id,
+            session,
+            lambda: _get_raw(
+                f"/tabs/{session['tab_id']}/screenshot",
+                params={"userId": session["user_id"]},
+            ),
         )
 
         # Save screenshot to cache


### PR DESCRIPTION
## Problem

Camofox returns **410 Gone** (`Page crashed` / `Tab was destroyed` / `browser restarted`) when a cached tab is dead — the server's own response includes `recovery: "create_new_tab"`. But the Hermes Camofox client only recovered from **404** (garbage-collected tab), and only in `camofox_navigate`:

```python
except requests.HTTPError as e:
    if e.response is not None and e.response.status_code == 404:
        session["tab_id"] = None
        session = _ensure_tab(task_id, browser_url)
        ...
    else:
        raise
```

So after any page crash or browser restart:

1. `camofox_navigate` raises the 410 to the model (and every other tab operation — `snapshot`, `click`, `type`, `scroll`, `back`, `press`, `get_images`, `vision` — has **no** stale-tab handling at all).
2. The dead `tab_id` stays cached in the module-level `_sessions` dict.
3. Every subsequent call hits the same crashed tab and loops on 410 until the gateway process restarts and drops the in-memory cache.

## Fix

Add a shared helper that treats 404 and 410 as the same "cached tab is dead" signal, and apply it to all nine tab operations:

```python
_STALE_TAB_STATUS_CODES = (404, 410)

def _retry_on_stale_tab(task_id, session, fn, *args, **kwargs):
    try:
        return fn(*args, **kwargs)
    except requests.HTTPError as e:
        if not (e.response is not None and e.response.status_code in _STALE_TAB_STATUS_CODES):
            raise
        session["tab_id"] = None
        _ensure_tab(task_id)
        return fn(*args, **kwargs)
```

The retried call re-reads `session["tab_id"]` at call time so it targets the freshly created tab. Exactly one retry — no loop.

## Testing

- Unit tests added (`tests/tools/test_browser_camofox.py` → `TestCamofoxStaleTabRecovery`): navigate recovers from 410, snapshot recovers from 404, non-stale errors (500) propagate without retry.
- Behavior verified against a live Camofox instance: a crashed tab (410) previously looped forever; with the fix the client opens a fresh tab and the retried call succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved browser reliability by automatically recovering from stale tabs during navigation and common browser actions.
  - Failed tab sessions are refreshed and the action is retried once for applicable errors.
  - Other server errors continue to be reported without unnecessary retries.

- **Tests**
  - Added coverage for stale-tab recovery and proper handling of non-recoverable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->