### PR TITLE
feat(mcp): add Ambush Feeds integration

### DIFF
--- a/apps/desktop/src/lib/mcp-directory.ts
+++ b/apps/desktop/src/lib/mcp-directory.ts
@@ -36,6 +36,14 @@ export interface McpDirectoryEntry {
 
 export const MCP_DIRECTORY: McpDirectoryEntry[] = [
   {
+    description: 'Create and manage personalized news feeds and review emitted stories.',
+    docs: 'https://app.ambush.ai/developers',
+    hosts: ['ambush.ai'],
+    keywords: ['ambush feeds', 'news feed', 'news monitoring', 'personalized news'],
+    name: 'ambush-feeds',
+    url: 'https://api.ambush.ai/mcp'
+  },
+  {
     description: 'Jira issues and Confluence pages via Atlassian’s hosted MCP.',
     docs: 'https://support.atlassian.com/rovo/docs/getting-started-with-the-atlassian-remote-mcp-server/',
     hosts: ['atlassian.net', 'atlassian.com', 'jira.com'],

--- a/apps/desktop/src/store/suggestion-providers/mcp.test.ts
+++ b/apps/desktop/src/store/suggestion-providers/mcp.test.ts
@@ -26,6 +26,22 @@ describe('matchSuggestions', () => {
     ])
   })
 
+  it('suggests Ambush Feeds for feed intent without matching the common noun alone', () => {
+    const index = MCP_DIRECTORY.map(entry => ({
+      hosts: entry.hosts,
+      keywords: entry.keywords,
+      server: entry.name
+    }))
+
+    expect(matchSuggestions('set up ambush feeds for security news ', index)).toContainEqual({
+      keyword: 'ambush feeds',
+      server: 'ambush-feeds'
+    })
+    expect(matchSuggestions('the convoy drove into an ambush ', index)).not.toContainEqual(
+      expect.objectContaining({ server: 'ambush-feeds' })
+    )
+  })
+
   it('is case-insensitive against the draft', () => {
     expect(matchSuggestions('open FIGMA please', INDEX)).toEqual([{ keyword: 'figma', server: 'figma' }])
   })

--- a/optional-mcps/ambush-feeds/manifest.yaml
+++ b/optional-mcps/ambush-feeds/manifest.yaml
@@ -1,0 +1,45 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: ambush-feeds
+description: Create, manage, and review personalized real-time news feeds from Ambush.
+source: https://app.ambush.ai/developers
+
+# Ambush hosts a Streamable HTTP MCP server with native OAuth 2.1 discovery,
+# Dynamic Client Registration, and PKCE. Hermes handles the browser flow and
+# stores the resulting credentials; no API key or local process is required.
+transport:
+  type: http
+  url: https://api.ambush.ai/mcp
+
+auth:
+  type: oauth
+
+# Enable the complete day-to-day feed lifecycle by default while leaving the
+# irreversible delete_feed tool opt-in. Its MCP annotations are destructive,
+# but keeping it out of the default surface also prevents accidental selection
+# by models that do not enforce annotation-aware confirmations.
+tools:
+  default_enabled:
+    - list_feeds
+    - get_feed
+    - list_channels
+    - create_feed
+    - update_feed
+    - route_feed_channel
+    - update_feed_channel_route
+    - list_emissions
+
+post_install: |
+  Hermes opens a browser to sign in to Ambush and authorize this connection.
+  If you close that flow before it finishes, resume it with:
+    hermes mcp login ambush-feeds
+
+  Start a new Hermes session after authorization so the tools are loaded.
+  Feed data is scoped to the Ambush account that approved the connection; no
+  Ambush API key needs to be copied into Hermes.
+
+  Eight day-to-day tools are enabled by default. Permanent feed deletion is
+  available but unchecked; opt in only when you need it with:
+    hermes mcp configure ambush-feeds

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -158,6 +158,20 @@ class TestManifestParsing:
         assert cfg["url"] == "https://mcp.example.com/sse"
         assert cfg["headers"] == {"Authorization": "Bearer ${MCP_DEMO_API_KEY}"}
 
+    def test_http_oauth_builds_native_oauth_config(self, catalog_dir):
+        body = _basic_manifest(
+            transport={"type": "http", "url": "https://mcp.example.com/mcp"},
+            auth={"type": "oauth"},
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import _build_server_config
+
+        cfg = _build_server_config(_entry("demo"), None)
+        assert cfg == {
+            "url": "https://mcp.example.com/mcp",
+            "auth": "oauth",
+        }
+
     def test_http_api_key_requires_matching_env_declaration(self, catalog_dir):
         """http+api_key manifests must declare the env key the header references.
 


### PR DESCRIPTION
## What does this PR do?

### Why

Ambush exposes a hosted Streamable HTTP MCP server with OAuth 2.1, but Hermes users currently need to know and paste the endpoint manually. This adds Ambush Feeds to the official MCP catalog and Desktop discovery so installation is a short, native OAuth flow.

### How

- Add an `optional-mcps/ambush-feeds` manifest for `https://api.ambush.ai/mcp` using Hermes' native OAuth support.
- Enable the eight day-to-day feed tools by default while leaving the destructive `delete_feed` tool opt-in.
- Add Ambush Feeds to the Desktop MCP suggestion directory with explicit-intent keywords.
- Add coverage for Desktop matching and HTTP OAuth manifest translation.

## Related Issue

None.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add the approved-catalog manifest and post-install OAuth guidance.
- Surface Ambush Feeds when a Desktop prompt expresses feed/news-monitoring intent without matching the common noun "ambush" by itself.
- Verify HTTP + OAuth manifests produce Hermes' native `{url, auth: "oauth"}` server configuration.

## How to Test

1. Run `hermes mcp catalog` and confirm `ambush-feeds` is available.
2. Run `hermes mcp install ambush-feeds` and complete the browser authorization flow.
3. Start a new Hermes session and ask it to list feeds or recent emissions.
4. Run the targeted CLI and Desktop tests listed below.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q` — 22 passed.
- `npm --workspace apps/desktop run test:ui -- src/store/suggestion-providers/mcp.test.ts` — 15 passed.
- `npm --workspace apps/desktop run typecheck` — passed.
- Prettier and ESLint on the changed TypeScript files — passed.
- Ruff lint on `tests/hermes_cli/test_mcp_catalog.py` — passed.
- `git diff --check` — passed.
- Manual catalog install in an isolated `HERMES_HOME` produced the hosted URL, native OAuth mode, eight enabled tools, and `delete_feed` disabled.
- Hermes 0.20.1 completed the production DCR + PKCE OAuth flow, discovered all nine tools, and successfully made read-only `list_feeds`, `get_feed`, and `list_emissions` calls.
- Desktop's backend connection probe succeeded against the production endpoint and discovered all nine tools.
- Tested on macOS 26.5.1 (arm64), Python 3.11.14, and Node.js 24.19.0.
- `scripts/check-windows-footguns.py --diff origin/main` reports two pre-existing encoding warnings at lines 74 and 271 of `tests/hermes_cli/test_mcp_catalog.py`; this PR adds neither line and introduces no platform-specific behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted CLI and Desktop suites passed; the full suite was not run locally)
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.1 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (post-install guidance is included in the catalog manifest)
- [x] `cli-config.yaml.example` changes are N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A; architecture and workflows are unchanged
- [x] I've considered cross-platform impact; this adds data and platform-neutral matching/config translation
- [x] Tool description/schema changes are N/A; the remote MCP server owns its tool schemas

## Screenshots / Logs

Not applicable; verification output is summarized above.
