### PR TITLE
feat(state): transform_message_store / transform_message_load plugin hooks

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -162,6 +162,18 @@ VALID_HOOKS: Set[str] = {
     # Plugins return a string to replace the response text, or None/empty to leave unchanged.
     # First non-None string wins. Useful for vocabulary/personality transformation.
     "transform_llm_output",
+    # At-rest message content transforms. Fired on the sqlite boundary in
+    # hermes_state.HermesState, immediately before content is written and
+    # immediately after it is read. Callbacks receive ``content``, ``session_id``
+    # and ``role`` and return replacement content, or None to leave it unchanged.
+    # First non-None return wins.
+    #
+    # Unlike every other hook, callback exceptions PROPAGATE (invoked with
+    # strict=True): a store transform that silently no-ops writes untransformed
+    # content to disk, and a load transform that silently no-ops hands
+    # untransformed content to the model. Both are worse than a loud failure.
+    "transform_message_store",
+    "transform_message_load",
     "pre_llm_call",
     "post_llm_call",
     # Streaming LLM output observer hooks. Fired asynchronously off the token
@@ -4907,7 +4919,9 @@ class PluginManager:
         }
         return callback(**accepted_payload)
 
-    def invoke_hook(self, hook_name: str, **kwargs: Any) -> List[Any]:
+    def invoke_hook(
+        self, hook_name: str, *, strict: bool = False, **kwargs: Any
+    ) -> List[Any]:
         """Call all registered callbacks for *hook_name*.
 
         Hook payloads evolve additively. Callbacks that accept ``**kwargs``
@@ -4915,6 +4929,14 @@ class PluginManager:
         receive only the keyword arguments they declare. Each callback is
         wrapped in its own try/except so a misbehaving plugin cannot break the
         core agent loop.
+
+        Pass ``strict=True`` to propagate callback exceptions instead of
+        logging and continuing. This is for hooks where silently skipping a
+        callback is itself the failure — the at-rest content transforms
+        (``transform_message_store`` / ``transform_message_load``), where a
+        swallowed exception means untransformed content reaches disk or the
+        model. ``strict`` is keyword-only and is consumed here rather than
+        forwarded, so it cannot appear in a hook payload.
 
         Returns a list of non-``None`` return values from callbacks.
 
@@ -4944,6 +4966,8 @@ class PluginManager:
                 if ret is not None:
                     results.append(ret)
             except Exception as exc:
+                if strict:
+                    raise
                 logger.warning(
                     "Hook '%s' callback %s raised: %s",
                     hook_name,
@@ -5677,7 +5701,9 @@ def _delivery_manager() -> PluginManager:
     return manager
 
 
-def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
+def invoke_hook(
+    hook_name: str, *, strict: bool = False, **kwargs: Any
+) -> List[Any]:
     """Invoke a lifecycle hook on loaded plugins.
 
     Ensures plugins are discovered on first invocation so callers in
@@ -5686,8 +5712,11 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     callbacks registered by user plugins (tracking #64178).
 
     Returns a list of non-``None`` return values from plugin callbacks.
+
+    ``strict=True`` propagates callback exceptions rather than logging them;
+    see :meth:`PluginManager.invoke_hook`.
     """
-    return _delivery_manager().invoke_hook(hook_name, **kwargs)
+    return _delivery_manager().invoke_hook(hook_name, strict=strict, **kwargs)
 
 
 def render_system_prompt_sections(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7946,7 +7946,71 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     _CONTENT_JSON_PREFIX = "\x00json:"
 
     @classmethod
-    def _encode_content(cls, content: Any) -> Any:
+    def _apply_content_hook(
+        cls,
+        hook_name: str,
+        content: Any,
+        session_id: Optional[str],
+        role: Optional[str],
+    ) -> Any:
+        """Run an at-rest content transform, returning replacement content.
+
+        Fired on the sqlite boundary so a plugin can rewrite message content
+        on the way in and back on the way out without core owning any policy.
+        The first non-``None`` return wins; with no plugin registered the cost
+        is one dict lookup on the memoized manager.
+
+        ``plugins.invoke_hook`` is called directly rather than through
+        ``hermes_cli.lifecycle`` so ``observe_lifecycle`` does not run on a
+        path that executes for every message read and write.
+
+        Invoked with ``strict=True``: a swallowed exception here means
+        untransformed content reaches disk (store) or the model (load), so
+        callback failures must propagate. An unimportable plugin layer is a
+        separate case. The state layer is used standalone by migrations and
+        tooling, where "no plugins" legitimately means "no transform".
+        """
+        try:
+            from hermes_cli import plugins as _plugins
+        except Exception:
+            return content
+        if not _plugins.has_hook(hook_name):
+            return content
+        for result in _plugins.invoke_hook(
+            hook_name,
+            strict=True,
+            content=content,
+            session_id=session_id or "",
+            role=role or "",
+        ):
+            if result is not None:
+                return result
+        return content
+
+    @classmethod
+    def _encode_content(
+        cls,
+        content: Any,
+        *,
+        session_id: Optional[str] = None,
+        role: Optional[str] = None,
+    ) -> Any:
+        """Serialize content for sqlite, then apply the at-rest store transform.
+
+        ``session_id`` and ``role`` are optional so existing callers keep
+        working; they are threaded through wherever available so a plugin can
+        select a per-session key. See :meth:`_serialize_content` for the
+        serialization contract and :meth:`_apply_content_hook` for the hook.
+        """
+        return cls._apply_content_hook(
+            "transform_message_store",
+            cls._serialize_content(content),
+            session_id,
+            role,
+        )
+
+    @classmethod
+    def _serialize_content(cls, content: Any) -> Any:
         """Serialize structured (list/dict) message content for sqlite.
 
         sqlite3 can only bind ``str``, ``bytes``, ``int``, ``float``, and ``None``
@@ -7958,6 +8022,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Returns the value unchanged when it's already a safe scalar, or a
         sentinel-prefixed JSON string for lists/dicts. Paired with
         :meth:`_decode_content` on read.
+
+        Transforms compose outside this method: the store hook runs on the
+        serialized form, and the load hook runs before deserialization, so a
+        plugin always sees the same flat representation in both directions.
         """
         if isinstance(content, str):
             # Lone UTF-16 surrogates reach here inside tool results scraped
@@ -7981,8 +8049,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return _sanitize_surrogates(str(content))
 
     @classmethod
-    def _decode_content(cls, content: Any) -> Any:
-        """Reverse :meth:`_encode_content`; returns scalars unchanged."""
+    def _decode_content(
+        cls,
+        content: Any,
+        *,
+        session_id: Optional[str] = None,
+        role: Optional[str] = None,
+    ) -> Any:
+        """Reverse :meth:`_encode_content`; returns scalars unchanged.
+
+        Applies the at-rest load transform first, so the plugin sees exactly
+        the bytes it produced on store, then deserializes.
+        """
+        content = cls._apply_content_hook(
+            "transform_message_load", content, session_id, role
+        )
         if isinstance(content, str) and content.startswith(cls._CONTENT_JSON_PREFIX):
             try:
                 return json.loads(content[len(cls._CONTENT_JSON_PREFIX):])
@@ -8163,7 +8244,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
-        stored_content = self._encode_content(content)
+        stored_content = self._encode_content(
+            content, session_id=session_id, role=role
+        )
 
         message_timestamp = time.time()
         if timestamp is not None:
@@ -8330,7 +8413,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             row = conn.execute(
                 "SELECT id FROM messages WHERE session_id = ? AND role = ? "
                 "AND content = ? AND active = 1 ORDER BY id DESC LIMIT 1",
-                (session_id, role, self._encode_content(content)),
+                (session_id, role, self._encode_content(
+                        content, session_id=session_id, role=role
+                    )),
             ).fetchone()
             if row is None:
                 return False
@@ -8474,7 +8559,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         continue
                     reaction["seen"] = True
                     changed = True
-                    content = self._decode_content(row["content"])
+                    content = self._decode_content(
+                        row["content"], session_id=session_id, role=row["role"]
+                    )
                     pending.append(
                         {
                             "row_id": row["id"],
@@ -8616,7 +8703,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (
                     session_id,
                     role,
-                    self._encode_content(msg.get("content")),
+                    self._encode_content(
+                        msg.get("content"), session_id=session_id, role=role
+                    ),
                     msg.get("tool_call_id"),
                     tool_calls_json,
                     _scrub_surrogates(msg.get("tool_name")),
@@ -8838,7 +8927,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         tail shape), nothing is written. Returns the number of rows updated
         (0 or 1).
         """
-        encoded = self._encode_content(content)
+        encoded = self._encode_content(
+            content, session_id=session_id, role="user"
+        )
 
         def _do(conn):
             cursor = conn.execute(
@@ -8909,7 +9000,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         for row in rows:
             msg = dict(row)
             if "content" in msg:
-                msg["content"] = self._decode_content(msg["content"])
+                msg["content"] = self._decode_content(
+                    msg["content"], session_id=session_id, role=msg.get("role")
+                )
             if msg.get("tool_calls"):
                 try:
                     msg["tool_calls"] = json.loads(msg["tool_calls"])
@@ -9003,7 +9096,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         for row in rows:
             msg = dict(row)
             if "content" in msg:
-                msg["content"] = self._decode_content(msg["content"])
+                msg["content"] = self._decode_content(
+                    msg["content"], session_id=session_id, role=msg.get("role")
+                )
             if msg.get("tool_calls"):
                 try:
                     msg["tool_calls"] = json.loads(msg["tool_calls"])
@@ -9154,7 +9249,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
             rows = conn.execute(
-                f"SELECT {self._CONVERSATION_ROW_COLUMNS} "
+                f"SELECT session_id, {self._CONVERSATION_ROW_COLUMNS} "
                 f"FROM messages WHERE session_id IN ({placeholders})"
                 # Order by AUTOINCREMENT id (true insertion order), NOT timestamp:
                 # append_message stamps rows with time.time(), which is not
@@ -9204,7 +9299,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         messages = []
         for row in rows:
-            content = self._decode_content(row["content"])
+            # include_ancestors=True mixes rows from parent sessions into this
+            # result, so a transform must see the session that stored the row -
+            # not the tip session that asked for it.
+            content = self._decode_content(
+                row["content"], session_id=row["session_id"], role=row["role"]
+            )
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
             msg = {"role": row["role"], "content": content}
@@ -9596,7 +9696,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
 
         # Decode content for callers (prefill the prompt buffer).
-        target_row["content"] = self._decode_content(target_row.get("content"))
+        target_row["content"] = self._decode_content(
+            target_row.get("content"),
+            session_id=session_id,
+            role=target_row.get("role"),
+        )
 
         rewound: List[int] = []
 

--- a/tests/test_hermes_state_content_hooks.py
+++ b/tests/test_hermes_state_content_hooks.py
@@ -1,0 +1,125 @@
+"""At-rest content transforms: transform_message_store / transform_message_load.
+
+The hooks fire on the sqlite boundary in :class:`hermes_state.SessionDB`. What
+matters is that content round-trips exactly, that the stored form is whatever the
+plugin produced, and that a failing callback raises instead of silently storing
+or returning untransformed content.
+"""
+
+import base64
+import os
+
+import pytest
+
+from hermes_cli import plugins
+from hermes_state import SessionDB
+
+
+def _wrap(content, session_id, role, **_kwargs):
+    """Reversible non-deterministic transform: same input, different output."""
+    if not isinstance(content, str):
+        return None
+    salt = base64.b64encode(os.urandom(6)).decode()
+    return "W1:" + salt + ":" + base64.b64encode(content.encode()).decode()
+
+
+def _unwrap(content, session_id, role, **_kwargs):
+    if isinstance(content, str) and content.startswith("W1:"):
+        return base64.b64decode(content.split(":", 2)[2]).decode()
+    return None
+
+
+@pytest.fixture
+def registered():
+    """Register the transform pair and restore the registry afterwards."""
+    manager = plugins.get_plugin_manager()
+    saved = {name: list(cbs) for name, cbs in manager._hooks.items()}
+    manager._hooks.setdefault("transform_message_store", []).append(_wrap)
+    manager._hooks.setdefault("transform_message_load", []).append(_unwrap)
+    yield manager
+    manager._hooks.clear()
+    manager._hooks.update(saved)
+
+
+def test_no_plugin_registered_leaves_content_untouched():
+    """Inert until something registers, so existing callers are unaffected."""
+    assert SessionDB._encode_content("plain") == "plain"
+    assert SessionDB._decode_content("plain") == "plain"
+
+
+def test_string_round_trip(registered):
+    stored = SessionDB._encode_content("hello there", session_id="s1", role="user")
+    assert stored.startswith("W1:")
+    assert "hello there" not in stored
+    assert (
+        SessionDB._decode_content(stored, session_id="s1", role="user")
+        == "hello there"
+    )
+
+
+def test_non_deterministic_transform_is_supported(registered):
+    """Transforming the same input twice is allowed to produce different output."""
+    first = SessionDB._encode_content("same", session_id="s1", role="user")
+    second = SessionDB._encode_content("same", session_id="s1", role="user")
+    assert first != second
+    assert SessionDB._decode_content(first) == SessionDB._decode_content(second) == "same"
+
+
+def test_structured_content_round_trips(registered):
+    """Multimodal content is serialized before the store hook and rebuilt after load."""
+    parts = [
+        {"type": "text", "text": "hi"},
+        {"type": "image_url", "image_url": {"url": "x"}},
+    ]
+    stored = SessionDB._encode_content(parts, session_id="s2", role="assistant")
+    assert "image_url" not in stored
+    assert SessionDB._decode_content(stored, session_id="s2", role="assistant") == parts
+
+
+def test_payload_carries_session_id_and_role(registered):
+    """Per-session transforms are only possible if the session reaches the callback."""
+    seen = []
+
+    def observe(content, session_id, role, **_kwargs):
+        seen.append((session_id, role))
+        return None
+
+    registered._hooks["transform_message_store"] = [observe]
+    SessionDB._encode_content("x", session_id="s3", role="assistant")
+    assert seen == [("s3", "assistant")]
+
+
+def test_non_string_scalars_pass_through(registered):
+    assert SessionDB._encode_content(None, session_id="s1") is None
+
+
+def test_failing_store_callback_propagates(registered):
+    """Swallowing here would write untransformed content to disk."""
+
+    def boom(content, session_id, role, **_kwargs):
+        raise RuntimeError("transform unavailable")
+
+    registered._hooks["transform_message_store"] = [boom]
+    with pytest.raises(RuntimeError, match="transform unavailable"):
+        SessionDB._encode_content("value", session_id="s1", role="user")
+
+
+def test_failing_load_callback_propagates(registered):
+    """Swallowing here would hand the stored form back to the model."""
+
+    def boom(content, session_id, role, **_kwargs):
+        raise RuntimeError("transform unavailable")
+
+    registered._hooks["transform_message_load"] = [boom]
+    with pytest.raises(RuntimeError, match="transform unavailable"):
+        SessionDB._decode_content("W1:whatever", session_id="s1", role="user")
+
+
+def test_other_hooks_still_swallow_exceptions(registered):
+    """strict is opt-in; every other hook keeps its isolate-the-plugin behaviour."""
+
+    def boom(**_kwargs):
+        raise RuntimeError("boom")
+
+    registered._hooks["some_other_hook"] = [boom]
+    assert plugins.invoke_hook("some_other_hook", content="x") == []


### PR DESCRIPTION
Closes #86297.

Adds two plugin hooks on the sqlite boundary in `hermes_state.SessionDB`:

| Hook | Fires | Receives |
|---|---|---|
| `transform_message_store` | on the serialized form, before the write | `content`, `session_id`, `role` |
| `transform_message_load` | on the stored value, before deserialization | `content`, `session_id`, `role` |

Return replacement content, or `None` to leave it unchanged. First non-`None` wins, matching
`transform_llm_output`.

## Why

`hermes_state.py` dispatches no hooks at all, so message content is the one part of the agent plugins
cannot observe or modify. #7486, #39095, #65007, #66238 and #34352 each hit that gap; #34352 reports
it as the reason tenant isolation currently requires forking core.

## How

`_encode_content` / `_decode_content` are already a documented pair and the only place raw content
crosses the sqlite boundary.

- Serialization split out unchanged as `_serialize_content`, so the hook applies to every return path.
- `session_id` and `role` threaded through all nine call sites as optional keyword arguments. Rows
  decode under the session that stored them, which matters when `include_ancestors=True` mixes in
  parent-session rows.
- Guarded by `plugins.has_hook()`, calling `plugins.invoke_hook` directly so `observe_lifecycle` does
  not run per message.
- `invoke_hook` gains a keyword-only `strict` flag that re-raises instead of logging: a silently
  skipped storage transform writes the wrong bytes to disk. Default unchanged, only these two opt in.

## Limits

`messages_fts` is trigger-populated from `new.content`, below the Python layer, so a transform that
changes the stored bytes makes those rows unsearchable.
`set_latest_matching_message_display_kind()` matches on `content = ?`, so it only works for
deterministic transforms.

## Tests

`tests/test_hermes_state_content_hooks.py`, 9 tests. I could not run the upstream suite; cloning ran
at ~16 KB/s here. I validated against an installed 0.20.0 in a shadowed `sys.path` copy and all
passed, but they have not run under your CI.

No schema change, no new dependency, no behaviour change when no plugin is registered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for transforming message content before it is stored and after it is loaded.
  - Added optional strict hook handling so transformation errors can be surfaced when required.
  - Preserved safe default behavior for unrelated plugin errors, preventing them from interrupting normal processing.

- **Bug Fixes**
  - Improved handling of encrypted, structured, scalar, and randomized message content while preserving session and role context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->