### PR TITLE
feat(quick-commands): substitute {args} into exec commands, shell-quoted

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16649,6 +16649,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if qcmd.get("type") == "exec":
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
+                        if "{args}" in exec_cmd:
+                            # Let a quick command take arguments: `/note 26056 ...`
+                            # substitutes into `{args}`. The command is handed to a
+                            # shell, so the user-supplied text must be quoted — an
+                            # unquoted substitution would make every quick command
+                            # an injection point for anyone allowed to invoke it.
+                            user_args = (event.get_command_args() or "").strip()
+                            exec_cmd = exec_cmd.replace(
+                                "{args}", shlex.quote(user_args) if user_args else ""
+                            )
                         try:
                             # Sanitize env to prevent credential leakage —
                             # quick commands run in the gateway process which

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16650,7 +16650,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         if "{args}" in exec_cmd:
-                            # Let a quick command take arguments: `/note 26056 ...`
+                            # Let a quick command take arguments: `/note some text ...`
                             # substitutes into `{args}`. The command is handed to a
                             # shell, so the user-supplied text must be quoted — an
                             # unquoted substitution would make every quick command

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -175,3 +175,45 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_exec_command_substitutes_args_placeholder(self):
+        """`{args}` in a quick command is replaced with what the user typed."""
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"note": {"type": "exec", "command": "printf %s {args}"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("note", "26056 Sodra skolan")
+        result = await runner._handle_message(event)
+        assert result == "26056 Sodra skolan"
+
+    @pytest.mark.asyncio
+    async def test_exec_command_args_are_shell_quoted(self):
+        """Substitution happens into a shell string, so args must be quoted."""
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"note": {"type": "exec", "command": "printf %s {args}"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("note", "; echo INJECTED")
+        result = await runner._handle_message(event)
+        assert result == "; echo INJECTED"
+
+    @pytest.mark.asyncio
+    async def test_exec_command_without_args_leaves_no_placeholder(self):
+        """An unused `{args}` must not leak the literal placeholder."""
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"note": {"type": "exec", "command": "printf [%s] {args}"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("note", "")
+        result = await runner._handle_message(event)
+        assert result == "[]"

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -186,9 +186,9 @@ class TestGatewayQuickCommands:
         runner._pending_messages = {}
         runner._is_user_authorized = MagicMock(return_value=True)
 
-        event = self._make_event("note", "26056 Sodra skolan")
+        event = self._make_event("note", "42 Example Project")
         result = await runner._handle_message(event)
-        assert result == "26056 Sodra skolan"
+        assert result == "42 Example Project"
 
     @pytest.mark.asyncio
     async def test_exec_command_args_are_shell_quoted(self):


### PR DESCRIPTION
## Problem

An `exec` quick command can only run a fixed string. Everything the user types
after the command name is parsed into `event.get_command_args()` and then
dropped, so `/note some text` runs exactly the same command as `/note`.

That forces one quick command per variation, or a wrapper script that reads the
argument from somewhere else.

## Change

If the configured command contains `{args}`, substitute what the user typed:

```yaml
quick_commands:
  note:
    type: exec
    command: "append-note.sh {args}"
```

`/note 42 Example Project` → `append-note.sh '42 Example Project'`

## Quoting

The command string is handed to `asyncio.create_subprocess_shell`, so the
substituted text is passed through `shlex.quote`. Without it every quick command
using `{args}` would be a shell-injection point for anyone authorized to invoke
it — `/note ; rm -rf ~` would run as two commands.

An unused placeholder collapses to the empty string rather than leaking the
literal `{args}` into the command line.

## Tests

Three cases in `tests/cli/test_quick_commands.py`, alongside the existing
gateway quick-command tests:

- args are substituted into the command
- `; echo INJECTED` is passed as one quoted argument, not executed
- an empty argument list leaves no `{args}` behind

Commands without `{args}` take an unchanged code path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick commands now support an `{args}` placeholder for passing command-line arguments.
  * Arguments are safely quoted before execution, and unused placeholders are removed when no arguments are provided.

* **Bug Fixes**
  * Prevented potentially unsafe command input from being interpreted by the shell.

* **Tests**
  * Added coverage for argument substitution, empty arguments, and shell-safe handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
