### PR TITLE
feat(cli): strip terminal decoration from copied assistant text

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -327,8 +327,63 @@ def _assistant_content_as_text(content: Any) -> str:
     return str(content)
 
 
+# Order matters: the single-character alternative `[@-Z\\-_]` also covers `]`,
+# so the OSC branch must be tried first or `\x1B]0;title\x07` is only half
+# consumed and the title text survives into the clipboard.
+_ANSI_SEQUENCE = re.compile(
+    r"\x1B(?:\][^\x07]*(?:\x07|\x1B\\)|\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])"
+)
+
+
+def _clean_copied_text(text: str) -> str:
+    """Strip terminal-only decoration from text on its way to the clipboard.
+
+    The TUI draws answers with ANSI colour, box-drawing borders and icon glyphs
+    from a patched font. Those are display artifacts — pasted into a document or
+    an email they become mojibake and stray rules. Meaningful punctuation is
+    left alone: an arrow or an em dash carries content, only frame glyphs and
+    private-use icons are decoration.
+    """
+    text = _ANSI_SEQUENCE.sub("", text)
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+
+    def clean_line(line: str) -> str:
+        out: List[str] = []
+        replaced_decoration = False
+        for ch in line:
+            code = ord(ch)
+            is_control = code < 0x20 and ch not in ("\n", "\r", "\t")
+            is_decoration = (
+                0x2500 <= code <= 0x27BF        # box drawing, blocks, shapes, dingbats
+                or 0xE000 <= code <= 0xF8FF     # private use — nerd-font icons
+                or 0xF0000 <= code <= 0xFFFFD   # supplementary private use A
+                or 0x100000 <= code <= 0x10FFFD  # supplementary private use B
+            )
+            if is_control or ch == "�":
+                continue
+            if is_decoration:
+                # Collapse the glyph to a single space so neighbouring words
+                # don't weld together, but never open a run of spaces.
+                if out and not out[-1].isspace() and not replaced_decoration:
+                    out.append(" ")
+                replaced_decoration = True
+                continue
+            if replaced_decoration and out and not out[-1].isspace() and not ch.isspace():
+                out.append(" ")
+            replaced_decoration = False
+            out.append(ch)
+        return "".join(out).rstrip(" \t")
+
+    lines = [clean_line(line) for line in text.split("\n")]
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+    return "\n".join(lines)
+
+
 def _assistant_copy_text(content: Any) -> str:
-    return _strip_reasoning_tags(_assistant_content_as_text(content))
+    return _clean_copied_text(_strip_reasoning_tags(_assistant_content_as_text(content)))
 
 
 # =============================================================================

--- a/cli.py
+++ b/cli.py
@@ -352,7 +352,7 @@ def _clean_copied_text(text: str) -> str:
         replaced_decoration = False
         for ch in line:
             code = ord(ch)
-            is_control = code < 0x20 and ch not in ("\n", "\r", "\t")
+            is_control = (code < 0x20 or 0x7F <= code <= 0x9F) and ch not in ("\n", "\r", "\t")
             is_decoration = (
                 0x2500 <= code <= 0x27BF        # box drawing, blocks, shapes, dingbats
                 or 0xE000 <= code <= 0xF8FF     # private use — nerd-font icons
@@ -362,13 +362,12 @@ def _clean_copied_text(text: str) -> str:
             if is_control or ch == "�":
                 continue
             if is_decoration:
-                # Collapse the glyph to a single space so neighbouring words
-                # don't weld together, but never open a run of spaces.
-                if out and not out[-1].isspace() and not replaced_decoration:
-                    out.append(" ")
+                # Mark that a glyph was removed; the replacement space is
+                # deferred until the next non-whitespace character, so an
+                # existing run of spaces is never widened.
                 replaced_decoration = True
                 continue
-            if replaced_decoration and out and not out[-1].isspace() and not ch.isspace():
+            if replaced_decoration and not ch.isspace() and out and not out[-1].isspace():
                 out.append(" ")
             replaced_decoration = False
             out.append(ch)

--- a/tests/cli/test_copy_clean.py
+++ b/tests/cli/test_copy_clean.py
@@ -54,6 +54,18 @@ def test_crlf_is_normalised():
     assert _clean_copied_text("rad1\r\nrad2") == "rad1\nrad2"
 
 
+def test_del_and_c1_controls_are_removed():
+    """DEL (U+007F) and C1 controls (U+0080–U+009F) are not content."""
+    assert _clean_copied_text("a\x7fb\x9cc") == "abc"
+    assert _clean_copied_text("a\tb") == "a\tb"
+
+
+def test_decoration_followed_by_existing_space_does_not_widen_the_run():
+    """A removed glyph must not widen a following run of spaces."""
+    assert _clean_copied_text("vänster│ höger") == "vänster höger"
+    assert _clean_copied_text("vänster│   höger") == "vänster   höger"
+
+
 def test_leading_and_trailing_blank_lines_are_trimmed():
     assert _clean_copied_text("\n\n  \nhej\n\n \n") == "hej"
 

--- a/tests/cli/test_copy_clean.py
+++ b/tests/cli/test_copy_clean.py
@@ -1,0 +1,66 @@
+"""Copied assistant text must not carry terminal decoration into the clipboard.
+
+The TUI renders answers with ANSI colour, box-drawing borders and icon glyphs
+from a patched font. Those are display artifacts: pasting them into a document,
+an email or a ticket produces mojibake and stray rules. Copying should yield the
+text the user can read, not the bytes the terminal drew.
+"""
+from __future__ import annotations
+
+from cli import _clean_copied_text
+
+
+def test_ansi_escape_sequences_are_removed():
+    assert _clean_copied_text("\x1b[31mvarning\x1b[0m") == "varning"
+
+
+def test_osc_sequences_are_removed():
+    assert _clean_copied_text("\x1b]0;title\x07hej") == "hej"
+
+
+def test_box_drawing_glyphs_are_removed():
+    assert "─" not in _clean_copied_text("── rubrik ──")
+    assert "rubrik" in _clean_copied_text("── rubrik ──")
+
+
+def test_private_use_icons_are_removed():
+    """Nerd-font icons live in the private use area."""
+    cleaned = _clean_copied_text(" fil.py")
+    assert "" not in cleaned
+    assert cleaned.strip() == "fil.py"
+
+
+def test_indentation_is_preserved():
+    """Leading whitespace is content in a code block, not decoration."""
+    assert _clean_copied_text("def f():\n    return 1") == "def f():\n    return 1"
+
+
+def test_decoration_between_words_becomes_a_space():
+    """Removing a glyph must not weld two words together."""
+    assert _clean_copied_text("vänster│höger") == "vänster höger"
+
+
+def test_ordinary_text_survives_unchanged():
+    assert _clean_copied_text("Kabeln är 5G2.5 och kostar 42 kr/m.") == "Kabeln är 5G2.5 och kostar 42 kr/m."
+
+
+def test_meaningful_punctuation_is_not_decoration():
+    """An arrow or em dash carries meaning in prose — only frame glyphs go."""
+    assert _clean_copied_text("A → B") == "A → B"
+    assert _clean_copied_text("Katrineholm — åäöÅÄÖ") == "Katrineholm — åäöÅÄÖ"
+
+
+def test_crlf_is_normalised():
+    assert _clean_copied_text("rad1\r\nrad2") == "rad1\nrad2"
+
+
+def test_leading_and_trailing_blank_lines_are_trimmed():
+    assert _clean_copied_text("\n\n  \nhej\n\n \n") == "hej"
+
+
+def test_internal_blank_lines_are_kept():
+    assert _clean_copied_text("stycke1\n\nstycke2") == "stycke1\n\nstycke2"
+
+
+def test_trailing_whitespace_per_line_is_trimmed():
+    assert _clean_copied_text("rad   \nnästa\t") == "rad\nnästa"


### PR DESCRIPTION
## Problem

`/copy` puts the assistant message on the clipboard as rendered, so ANSI colour
sequences, box-drawing borders and private-use icon glyphs from a patched font
travel with it. Pasting an answer into a document, an email or an issue produces
stray rules and mojibake that then has to be cleaned by hand.

Those glyphs are how the terminal draws the answer, not part of it.

## Change

`_clean_copied_text` runs on the way to the clipboard and removes:

- ANSI CSI and OSC escape sequences
- control characters and U+FFFD
- box drawing, block elements, geometric shapes and dingbats (U+2500–U+27BF)
- the private use areas, where nerd-font icons live

A removed glyph collapses to a single space so neighbouring words don't weld
together, and runs of spaces are not opened.

## What is deliberately kept

- **Meaningful punctuation.** An arrow or an em dash carries content in prose,
  so the decoration range starts at U+2500 and leaves U+2190–U+21FF alone.
- **Indentation.** Only trailing whitespace is trimmed per line, so copied code
  keeps its structure. Leading and trailing blank lines are dropped; blank lines
  between paragraphs are not.

## One ordering detail worth reviewing

In the escape pattern the OSC branch must precede the single-character branch.
`[@-Z\\-_]` spans U+005C–U+005F and so also matches `]`; with the intuitive
ordering `\x1B]0;title\x07` is only half consumed and the window title survives
into the clipboard as literal text. There is a test for this.

## Tests

12 cases in `tests/cli/test_copy_clean.py` covering each removal class, the
punctuation and indentation carve-outs, CRLF normalisation and blank-line
trimming.

Note for reviewers: three tests in `tests/cli/test_cli_copy_command.py` already
fail on `main` at the time of writing (`write_clipboard_text` is never called) —
unrelated to this change, and unaffected by it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved copied text from the CLI by removing terminal formatting, control characters, and decorative symbols.
  - Normalized line endings and whitespace while preserving indentation, meaningful punctuation, and internal blank lines.
  - Trimmed unnecessary blank lines and trailing spaces for cleaner, more readable copied content.

- **Tests**
  - Added coverage for terminal sequences, decorative characters, whitespace handling, and preservation of ordinary text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->