### PR TITLE
Pasting an image no longer stalls the send behind agent startup

### DIFF
--- a/apps/desktop/scripts/perf/gateway_attach_bench.py
+++ b/apps/desktop/scripts/perf/gateway_attach_bench.py
@@ -1,0 +1,188 @@
+"""Measure the gateway's attach-RPC dispatch, against the real dispatcher.
+
+Every attach handler (image.attach, image.attach_bytes, file.attach,
+clipboard.paste, pdf.attach) resolves its session through ``_sess()``, which
+blocks on the deferred agent build. None of them is in ``_LONG_HANDLERS``, so
+that block happens INLINE on the socket reader thread.
+
+This drives the real ``tui_gateway.server.dispatch`` with a session whose
+agent build has not completed, and times it. ``prompt.submit`` (which uses
+``_sess_nowait``) is timed alongside as the control — it is the path that
+stays instant today.
+
+    python3 scripts/perf/gateway_attach_bench.py [--build-seconds 8] [--rounds 3]
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import statistics
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO))
+
+os.environ.setdefault("HERMES_HOME", tempfile.mkdtemp(prefix="hermes-bench-home-"))
+
+
+class CollectTransport:
+    """Stand-in for the WS transport: records frames, never touches a socket."""
+
+    def __init__(self) -> None:
+        self.frames: list[dict] = []
+        self.lock = threading.Lock()
+
+    def write(self, obj: dict) -> bool:
+        with self.lock:
+            self.frames.append(obj)
+        return True
+
+    def close(self) -> None:
+        return None
+
+
+def make_session(server, sid: str, *, build_seconds: float, home: Path) -> dict:
+    """A session whose deferred agent build is still running.
+
+    Mirrors the shape ``_deferred_build`` leaves behind: an unset ``agent_ready``
+    event plus a live build thread. That is exactly the state a session is in
+    for the first seconds after ``session.create`` — which is when a user
+    pastes their first image.
+    """
+    ready = threading.Event()
+    session: dict = {
+        "agent": None,
+        "agent_ready": ready,
+        "agent_error": None,
+        "attached_images": [],
+        "cwd": str(home),
+        "history": [],
+        "history_lock": threading.RLock(),
+        "history_version": 0,
+        "image_counter": 0,
+        "profile_home": str(home),
+        "running": False,
+        "session_key": sid,
+        "transport": None,
+    }
+
+    def build() -> None:
+        time.sleep(build_seconds)
+        ready.set()
+
+    thread = threading.Thread(target=build, daemon=True)
+    session["_agent_build_thread"] = thread
+    thread.start()
+
+    server._sessions[sid] = session
+    return session
+
+
+def png_bytes(kb: int) -> bytes:
+    body = bytearray(b"\x89PNG\r\n\x1a\n")
+    body.extend(bytes((i * 37) & 0xFF for i in range(kb * 1024)))
+    return bytes(body)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--build-seconds", type=float, default=8.0)
+    ap.add_argument("--rounds", type=int, default=3)
+    ap.add_argument("--kb", type=int, default=900)
+    args = ap.parse_args()
+
+    from tui_gateway import server
+
+    # The build is already in flight for these sessions (that is the state the
+    # bench recreates), so the "start one if none is running" call is a no-op.
+    # Without this stub the real builder races the bench's controlled one and
+    # completes instantly, hiding the very wait being measured.
+    server._start_agent_build = lambda sid, session: None
+
+    # Keep the run readable: session.info frames go to the transport, not stdout.
+    server._emit = lambda *a, **k: None
+
+    home = Path(os.environ["HERMES_HOME"])
+    home.mkdir(parents=True, exist_ok=True)
+
+    content_b64 = base64.b64encode(png_bytes(args.kb)).decode("ascii")
+
+    scratch = home / "scratch.txt"
+    scratch.write_text("hello from the bench\n")
+
+    calls = [
+        (
+            "image.attach_bytes",
+            lambda sid: {
+                "session_id": sid,
+                "content_base64": content_b64,
+                "filename": "bench.png",
+            },
+        ),
+        (
+            "file.attach",
+            lambda sid: {
+                "session_id": sid,
+                "name": "scratch.txt",
+                "path": str(scratch),
+            },
+        ),
+        (
+            "prompt.submit",
+            lambda sid: {"session_id": sid, "text": "control: plain text"},
+        ),
+    ]
+
+    print(
+        f"agent build takes {args.build_seconds:.1f}s; "
+        f"image is {args.kb} KB; {args.rounds} rounds\n"
+    )
+    print(f"{'rpc':<22} {'in _LONG_HANDLERS':<19} {'mean':>8} {'max':>8}   blocks reader?")
+
+    for method, build_params in calls:
+        samples: list[float] = []
+
+        for round_index in range(args.rounds):
+            sid = f"bench-{method}-{round_index}"
+            make_session(server, sid, build_seconds=args.build_seconds, home=home)
+            transport = CollectTransport()
+            req = {
+                "jsonrpc": "2.0",
+                "id": round_index,
+                "method": method,
+                "params": build_params(sid),
+            }
+
+            start = time.perf_counter()
+            try:
+                server.dispatch(req, transport)
+            except Exception as exc:  # noqa: BLE001 - report, don't mask
+                print(f"  ! {method} raised {type(exc).__name__}: {exc}")
+            samples.append(time.perf_counter() - start)
+
+            server._sessions.pop(sid, None)
+
+        pooled = method in server._LONG_HANDLERS
+        mean = statistics.mean(samples)
+        worst = max(samples)
+        verdict = "no (pooled)" if pooled else ("YES" if mean > 1.0 else "no")
+
+        print(
+            f"{method:<22} {str(pooled):<19} {mean:>7.2f}s {worst:>7.2f}s   {verdict}"
+        )
+
+    print(
+        "\ndispatch() returns immediately for pooled handlers, so a pooled timing\n"
+        "is the enqueue cost — the work still happens, just off the reader thread."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/desktop/scripts/perf/gateway_attach_bench.py
+++ b/apps/desktop/scripts/perf/gateway_attach_bench.py
@@ -116,6 +116,12 @@ def main() -> int:
     scratch = home / "scratch.txt"
     scratch.write_text("hello from the bench\n")
 
+    image_on_disk = home / "on-disk.png"
+    image_on_disk.write_bytes(png_bytes(args.kb))
+
+    pdf_on_disk = home / "doc.pdf"
+    pdf_on_disk.write_bytes(b"%PDF-1.4\n" + b"0" * 2048 + b"\n%%EOF\n")
+
     calls = [
         (
             "image.attach_bytes",
@@ -126,12 +132,28 @@ def main() -> int:
             },
         ),
         (
+            "image.attach",
+            lambda sid: {"session_id": sid, "path": str(image_on_disk)},
+        ),
+        (
             "file.attach",
             lambda sid: {
                 "session_id": sid,
                 "name": "scratch.txt",
                 "path": str(scratch),
             },
+        ),
+        (
+            "pdf.attach",
+            lambda sid: {"session_id": sid, "path": str(pdf_on_disk)},
+        ),
+        (
+            "clipboard.paste",
+            lambda sid: {"session_id": sid},
+        ),
+        (
+            "image.detach",
+            lambda sid: {"session_id": sid, "path": "/tmp/nothing.png"},
         ),
         (
             "prompt.submit",
@@ -181,7 +203,58 @@ def main() -> int:
         "\ndispatch() returns immediately for pooled handlers, so a pooled timing\n"
         "is the enqueue cost — the work still happens, just off the reader thread."
     )
+
+    _report_surfaces()
     return 0
+
+
+def _report_surfaces() -> None:
+    """Which surfaces can even reach this code path.
+
+    The stall lives in the gateway's session resolver, so a surface is exposed
+    only if it attaches over the gateway. That is a fact about the call graph
+    rather than a timing, so it is read out of the source — and it moves if
+    the call graph moves.
+    """
+    print("\n\n=== which surfaces reach the gateway attach RPCs ===\n")
+
+    root = Path(__file__).resolve().parents[4]
+    attach_rpcs = ("image.attach", "image.attach_bytes", "file.attach", "clipboard.paste")
+
+    surfaces = {
+        "CLI (cli.py)": [root / "cli.py"],
+        "TUI (ui-tui)": sorted((root / "ui-tui" / "src").rglob("*.ts")),
+        "Desktop (apps/desktop)": sorted((root / "apps" / "desktop" / "src").rglob("*.ts")),
+    }
+
+    for label, paths in surfaces.items():
+        hits: set[str] = set()
+
+        for path in paths:
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for rpc in attach_rpcs:
+                if f"'{rpc}'" in text or f'"{rpc}"' in text:
+                    hits.add(rpc)
+
+        if hits:
+            print(f"  {label:<24} EXPOSED — calls {', '.join(sorted(hits))}")
+        else:
+            print(f"  {label:<24} not exposed — no gateway attach RPC")
+
+    print(
+        "\n  CLI attaches inline in its own turn path (cli.py → image_routing) with\n"
+        "  the agent already constructed. There is no gateway session to resolve,\n"
+        "  so the stall is structurally unreachable — matching the ~4s report.\n"
+        "\n  The TUI calls the SAME RPCs and was equally exposed. What differed was\n"
+        "  hit rate, not code path: Desktop mints sessions constantly (new chat,\n"
+        "  tabs, tiles), so a paste routinely lands inside the seconds-long window\n"
+        "  while a fresh session's agent is still building. A TUI user launches\n"
+        "  once and the build finishes while they type."
+    )
+    return None
 
 
 if __name__ == "__main__":

--- a/apps/desktop/scripts/perf/image-attach-bench.mjs
+++ b/apps/desktop/scripts/perf/image-attach-bench.mjs
@@ -1,0 +1,307 @@
+// Measures the desktop image-attach pipeline stage by stage on a real image,
+// against the real renderer helpers. No Electron, no LLM — just the transforms
+// an attached image goes through between the paperclip and prompt.submit.
+//
+//   node scripts/perf/image-attach-bench.mjs [--kb 900] [--rounds 7]
+
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { performance } from 'node:perf_hooks'
+
+const args = process.argv.slice(2)
+const flag = (name, fallback) => {
+  const i = args.indexOf(`--${name}`)
+
+  return i >= 0 ? Number(args[i + 1]) : fallback
+}
+
+const ROUNDS = flag('rounds', 7)
+const SIZES_KB = args.includes('--kb') ? [flag('kb', 900)] : [120, 900, 3200]
+
+const dir = mkdtempSync(join(tmpdir(), 'hermes-img-bench-'))
+
+/** A PNG-shaped byte blob of a given size. The pipeline treats it as opaque
+ *  bytes everywhere we measure, so the pixels don't matter — the length does. */
+function makeImage(kb) {
+  const bytes = Buffer.alloc(kb * 1024)
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(bytes)
+
+  for (let i = 8; i < bytes.length; i += 1) {
+    bytes[i] = (i * 2654435761) & 0xff
+  }
+
+  const path = join(dir, `img-${kb}kb.png`)
+  writeFileSync(path, bytes)
+
+  return path
+}
+
+const stat = samples => {
+  const s = [...samples].sort((a, b) => a - b)
+
+  return {
+    mean: s.reduce((a, b) => a + b, 0) / s.length,
+    p50: s[Math.floor(s.length * 0.5)],
+    p95: s[Math.min(s.length - 1, Math.floor(s.length * 0.95))],
+    max: s[s.length - 1]
+  }
+}
+
+const time = fn => {
+  const t0 = performance.now()
+  const out = fn()
+
+  return { ms: performance.now() - t0, out }
+}
+
+// --- the stages, transcribed from the shipped code paths -------------------
+
+// electron/hardening.ts :: readFileDataUrlForIpc — main-process side of
+// window.hermesDesktop.readFileDataUrl.
+const readFileDataUrl = path => {
+  const data = readFileSync(path)
+
+  return `data:image/png;base64,${data.toString('base64')}`
+}
+
+// use-prompt-actions/utils.ts :: base64FromDataUrl
+const base64FromDataUrl = dataUrl => {
+  const comma = dataUrl.indexOf(',')
+
+  return comma >= 0 ? dataUrl.slice(comma + 1) : ''
+}
+
+// The JSON-RPC frame the renderer sends for image.attach_bytes.
+const encodeRpcFrame = (base64, filename) =>
+  JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'image.attach_bytes',
+    params: { session_id: 'bench', content_base64: base64, filename }
+  })
+
+// lib/embedded-images.ts :: extractEmbeddedImages — runs on the optimistic
+// bubble text on EVERY DirectiveContent render, and the composer's base64
+// preview is what it scans.
+const DATA_IMAGE_PREFIX = 'data:image/'
+const BASE64_MARKER = ';base64,'
+const MIN_EMBEDDED_IMAGE_BASE64_LENGTH = 64
+
+const isImageMimeCode = c =>
+  (c >= 48 && c <= 57) || (c >= 65 && c <= 90) || (c >= 97 && c <= 122) || c === 43 || c === 45 || c === 46 || c === 95
+
+const isBase64Code = c =>
+  (c >= 48 && c <= 57) || (c >= 65 && c <= 90) || (c >= 97 && c <= 122) || c === 43 || c === 47 || c === 61
+
+function readDataImageUrl(text, start) {
+  if (!text.startsWith(DATA_IMAGE_PREFIX, start)) {
+    return null
+  }
+
+  let cursor = start + DATA_IMAGE_PREFIX.length
+
+  while (cursor < text.length && isImageMimeCode(text.charCodeAt(cursor))) {
+    cursor += 1
+  }
+
+  if (cursor === start + DATA_IMAGE_PREFIX.length || !text.startsWith(BASE64_MARKER, cursor)) {
+    return null
+  }
+
+  cursor += BASE64_MARKER.length
+  const base64Start = cursor
+
+  while (cursor < text.length && isBase64Code(text.charCodeAt(cursor))) {
+    cursor += 1
+  }
+
+  if (cursor - base64Start < MIN_EMBEDDED_IMAGE_BASE64_LENGTH) {
+    return null
+  }
+
+  return { end: cursor, url: text.slice(start, cursor) }
+}
+
+function extractEmbeddedImages(text) {
+  if (!text || !text.includes(DATA_IMAGE_PREFIX)) {
+    return { cleanedText: text, images: [] }
+  }
+
+  const images = []
+  const pieces = []
+  let appendCursor = 0
+  let searchCursor = 0
+
+  while (searchCursor < text.length) {
+    const dataStart = text.indexOf(DATA_IMAGE_PREFIX, searchCursor)
+
+    if (dataStart === -1) {
+      break
+    }
+
+    const dataUrl = readDataImageUrl(text, dataStart)
+
+    if (!dataUrl) {
+      searchCursor = dataStart + DATA_IMAGE_PREFIX.length
+
+      continue
+    }
+
+    pieces.push(text.slice(appendCursor, dataStart))
+    images.push(dataUrl.url)
+    appendCursor = dataUrl.end
+    searchCursor = dataUrl.end
+  }
+
+  if (!images.length) {
+    return { cleanedText: text, images: [] }
+  }
+
+  pieces.push(text.slice(appendCursor))
+
+  return {
+    cleanedText: pieces
+      .join('')
+      .replace(/[ \t]+\n/g, '\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim(),
+    images
+  }
+}
+
+// lib/render-weight.ts :: payloadCharacters — walks every string in a message's
+// content, including the data URL riding in attachmentRefs.
+const RENDER_WEIGHT_CHARS = 512
+const MAX_MEASURED_MESSAGE_CHARS = 300 * RENDER_WEIGHT_CHARS
+const NON_RENDERED_CONTENT_FIELDS = new Set(['id', 'role', 'toolCallId', 'toolName', 'type'])
+
+function payloadCharacters(roots, budget) {
+  const seen = new WeakSet()
+  const pending = [...roots]
+  let characters = 0
+
+  while (pending.length > 0 && characters < budget) {
+    const value = pending.pop()
+
+    if (typeof value === 'string') {
+      characters += Math.min(value.length, budget - characters)
+
+      continue
+    }
+
+    if (!value || typeof value !== 'object' || seen.has(value)) {
+      continue
+    }
+
+    seen.add(value)
+
+    if (Array.isArray(value)) {
+      for (const nested of value) {
+        pending.push(nested)
+      }
+
+      continue
+    }
+
+    for (const [key, nested] of Object.entries(value)) {
+      if (!NON_RENDERED_CONTENT_FIELDS.has(key)) {
+        pending.push(nested)
+      }
+    }
+  }
+
+  return characters
+}
+
+// store/composer.ts :: cloneDraft — every composer draft stash copies each
+// attachment object; previewUrl (the data URL) rides along by reference, but
+// the surrounding string ops on the draft still run.
+const cloneDraft = draft => ({
+  attachments: draft.attachments.map(a => ({ ...a })),
+  text: draft.text
+})
+
+// --- run -------------------------------------------------------------------
+
+const results = []
+
+for (const kb of SIZES_KB) {
+  const path = makeImage(kb)
+  const rows = {}
+  const record = (stage, ms) => {
+    ;(rows[stage] ??= []).push(ms)
+  }
+
+  let dataUrl = ''
+  let base64 = ''
+  let frame = ''
+  let bubbleText = ''
+
+  for (let round = 0; round < ROUNDS; round += 1) {
+    // 1. preview read (attachImagePath → attachmentPreviewDataUrl)
+    const preview = time(() => readFileDataUrl(path))
+    record('preview_read_dataurl', preview.ms)
+    dataUrl = preview.out
+
+    // 2. submit-time SECOND read of the same file (readImageForRemoteAttach)
+    const attachRead = time(() => readFileDataUrl(path))
+    record('attach_read_dataurl', attachRead.ms)
+
+    // 3. strip the data: prefix
+    const strip = time(() => base64FromDataUrl(attachRead.out))
+    record('base64_from_dataurl', strip.ms)
+    base64 = strip.out
+
+    // 4. JSON-RPC frame for image.attach_bytes
+    const encode = time(() => encodeRpcFrame(base64, 'img.png'))
+    record('rpc_frame_encode', encode.ms)
+    frame = encode.out
+
+    // 5. the optimistic bubble carries the data URL as its attachmentRef
+    bubbleText = dataUrl
+    const extract = time(() => extractEmbeddedImages(bubbleText))
+    record('extract_embedded_images', extract.ms)
+
+    // 6. render-weight walk over the message holding that ref
+    const content = [{ type: 'text', text: 'what is this' }, { attachmentRefs: [dataUrl] }]
+    const weigh = time(() => payloadCharacters(content, MAX_MEASURED_MESSAGE_CHARS))
+    record('render_weight_walk', weigh.ms)
+
+    // 7. draft stash clone with the attachment held
+    const draft = { attachments: [{ id: 'a', kind: 'image', label: 'i', previewUrl: dataUrl, path }], text: 'hi' }
+    const clone = time(() => cloneDraft(draft))
+    record('draft_clone', clone.ms)
+  }
+
+  results.push({
+    kb,
+    fileBytes: readFileSync(path).length,
+    dataUrlChars: dataUrl.length,
+    rpcFrameChars: frame.length,
+    rows
+  })
+}
+
+for (const r of results) {
+  console.log(`\n=== ${r.kb} KB image (${r.fileBytes} bytes on disk) ===`)
+  console.log(
+    `data URL: ${r.dataUrlChars.toLocaleString()} chars   RPC frame: ${r.rpcFrameChars.toLocaleString()} chars ` +
+      `(${(r.rpcFrameChars / r.fileBytes).toFixed(2)}x the file)`
+  )
+  console.log('')
+  console.log('stage                        mean      p50      p95      max')
+
+  let total = 0
+
+  for (const [stage, samples] of Object.entries(r.rows)) {
+    const s = stat(samples)
+    total += s.mean
+    console.log(
+      `${stage.padEnd(26)} ${s.mean.toFixed(2).padStart(7)}  ${s.p50.toFixed(2).padStart(7)}  ` +
+        `${s.p95.toFixed(2).padStart(7)}  ${s.max.toFixed(2).padStart(7)}   ms`
+    )
+  }
+
+  console.log(`${'TOTAL (mean)'.padEnd(26)} ${total.toFixed(2).padStart(7)} ms`)
+}

--- a/tests/tui_gateway/test_attach_does_not_wait_for_agent.py
+++ b/tests/tui_gateway/test_attach_does_not_wait_for_agent.py
@@ -1,0 +1,138 @@
+"""Attach RPCs must not block on the deferred agent build.
+
+``image.attach``, ``image.attach_bytes``, ``file.attach``, ``pdf.attach`` and
+``clipboard.paste`` need the session RECORD (cwd, profile_home,
+attached_images) — never the agent. They also run inline on the socket reader
+thread (none is in ``_LONG_HANDLERS``), so any wait there stalls every RPC
+queued behind them on the same socket, including the ``prompt.submit`` that
+carries the image.
+
+These are invariants, not timings: the handler must complete while the build
+event is still unset, and the staged image must still reach the turn.
+"""
+
+from __future__ import annotations
+
+import base64
+import threading
+
+import pytest
+
+from tui_gateway import server
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + bytes(range(256)) * 4
+
+
+def building_session(tmp_path, sid: str) -> dict:
+    """A session record whose deferred agent build has NOT completed."""
+    session = {
+        "agent": None,
+        "agent_ready": threading.Event(),  # deliberately never set
+        "agent_error": None,
+        "attached_images": [],
+        "cwd": str(tmp_path),
+        "history": [],
+        "history_lock": threading.RLock(),
+        "history_version": 0,
+        "image_counter": 0,
+        "profile_home": str(tmp_path),
+        "running": False,
+        "session_key": sid,
+        "transport": None,
+    }
+    server._sessions[sid] = session
+    return session
+
+
+@pytest.fixture
+def no_build(monkeypatch):
+    """Never let the real builder run — the point is the unfinished build."""
+    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+
+
+@pytest.fixture
+def session(tmp_path, no_build, request):
+    sid = f"attach-{request.node.name}"
+    record = building_session(tmp_path, sid)
+    yield sid, record
+    server._sessions.pop(sid, None)
+
+
+def call(method: str, params: dict) -> dict:
+    return server._methods[method](1, params)
+
+
+@pytest.mark.parametrize(
+    ("method", "extra"),
+    [
+        ("image.attach_bytes", {"content_base64": base64.b64encode(PNG_BYTES).decode(), "filename": "a.png"}),
+        ("file.attach", {"name": "notes.txt"}),
+    ],
+)
+def test_attach_completes_while_agent_is_still_building(session, tmp_path, method, extra):
+    """The handler returns without waiting on ``agent_ready``."""
+    sid, record = session
+
+    if method == "file.attach":
+        target = tmp_path / "notes.txt"
+        target.write_text("hello")
+        extra = {**extra, "path": str(target)}
+
+    response = call(method, {"session_id": sid, **extra})
+
+    assert "error" not in response, response
+    assert response["result"]["attached"] is True
+    # The invariant that makes this a fix rather than a coincidence: the build
+    # never finished, and the attach landed anyway.
+    assert not record["agent_ready"].is_set()
+
+
+def test_attached_image_is_queued_for_the_next_turn(session):
+    """Not blocking must not mean not staging — the turn still gets the image."""
+    sid, record = session
+
+    response = call(
+        "image.attach_bytes",
+        {
+            "session_id": sid,
+            "content_base64": base64.b64encode(PNG_BYTES).decode(),
+            "filename": "shot.png",
+        },
+    )
+
+    staged = response["result"]["path"]
+    assert record["attached_images"] == [staged]
+    assert response["result"]["count"] == 1
+
+
+def test_attach_still_rejects_an_unknown_session(no_build):
+    """Dropping the agent wait must not drop session validation."""
+    response = call("image.attach_bytes", {"session_id": "nope", "content_base64": "eA=="})
+
+    assert response["error"]["code"] == 4001
+
+
+def test_detach_completes_while_agent_is_still_building(session):
+    """Detach is the same class as attach — record-only, so it must not wait."""
+    sid, record = session
+    record["attached_images"] = ["/tmp/one.png", "/tmp/two.png"]
+
+    response = call("image.detach", {"session_id": sid, "path": "/tmp/one.png"})
+
+    assert response["result"]["detached"] is True
+    assert record["attached_images"] == ["/tmp/two.png"]
+    assert not record["agent_ready"].is_set()
+
+
+def test_sess_building_does_not_wait_but_sess_does(session, monkeypatch):
+    """The two resolvers differ in exactly one way: the wait."""
+    sid, _record = session
+    waited: list[str] = []
+
+    monkeypatch.setattr(server, "_wait_agent", lambda s, rid: waited.append(rid) or None)
+
+    server._sess_building({"session_id": sid}, "rid-building")
+    assert waited == []
+
+    server._sess({"session_id": sid}, "rid-sess")
+    assert waited == ["rid-sess"]

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -717,7 +717,7 @@ def _(rid, params: dict) -> dict:
 
 @method("clipboard.paste")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    session, err = _sess_building(params, rid)
     if err:
         return err
     try:
@@ -757,7 +757,7 @@ def _(rid, params: dict) -> dict:
 
 @method("image.attach")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    session, err = _sess_building(params, rid)
     if err:
         return err
     raw = str(params.get("path", "") or "").strip()
@@ -815,7 +815,7 @@ def _(rid, params: dict) -> dict:
       filename / ext (str, optional): extension hint. Without it, magic bytes
         identify PNG/JPEG/GIF/WebP/BMP, falling back to ``.png``.
     """
-    session, err = _sess(params, rid)
+    session, err = _sess_building(params, rid)
     if err:
         return err
 
@@ -875,7 +875,7 @@ def _(rid, params: dict) -> dict:
     import subprocess
     import tempfile
 
-    session, err = _sess(params, rid)
+    session, err = _sess_building(params, rid)
     if err:
         return err
 
@@ -1004,7 +1004,7 @@ def _(rid, params: dict) -> dict:
         required when the path isn't visible to the gateway.
       name (str, optional): preferred filename.
     """
-    session, err = _sess(params, rid)
+    session, err = _sess_building(params, rid)
     if err:
         return err
     raw = str(params.get("path", "") or "").strip()
@@ -1034,7 +1034,7 @@ def _(rid, params: dict) -> dict:
 
 @method("image.detach")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    session, err = _sess_building(params, rid)
     if err:
         return err
     raw = str(params.get("path", "") or "").strip()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2389,11 +2389,42 @@ def _sess_nowait(params, rid):
 
 
 def _sess(params, rid):
+    s, err = _sess_building(params, rid)
+    if err:
+        return (None, err)
+    return (s, _wait_agent(s, rid))
+
+
+def _sess_building(params, rid):
+    """Resolve a session and warm its agent build WITHOUT waiting for it.
+
+    For handlers that need the session record but not the agent. The attach
+    RPCs are the whole reason this exists: ``image.attach``,
+    ``image.attach_bytes``, ``file.attach``, ``pdf.attach``,
+    ``clipboard.paste`` and ``image.detach`` only read ``cwd`` /
+    ``profile_home`` and mutate ``attached_images`` — every one of those
+    fields is populated when the session record is created, so ``_sess``'s
+    ``_wait_agent`` was buying nothing and charging up to 30 seconds for it.
+
+    That charge landed in the worst possible place. Attach runs BEFORE
+    ``prompt.submit``, none of these methods is in ``_LONG_HANDLERS``, and a
+    non-pooled handler runs inline on the socket reader thread — so pasting an
+    image into a session whose deferred build was still running (MCP
+    discovery, model metadata, skills scan: routinely tens of seconds on a
+    cold start) stalled the send AND every RPC queued behind it on the same
+    socket, with no spinner to explain it. Plain text was unaffected because
+    ``prompt.submit`` already resolves via ``_sess_nowait`` and waits later,
+    off the reader thread — which is exactly why the bug reads as "text is
+    instant, images hang."
+
+    The build is still kicked off (it warms the agent the following
+    ``prompt.submit`` needs); we simply stop blocking on it here.
+    """
     s, err = _sess_nowait(params, rid)
     if err:
         return (None, err)
     _start_agent_build(params.get("session_id") or "", s)
-    return (s, _wait_agent(s, rid))
+    return (s, None)
 
 
 def _normalize_completion_path(path_part: str) -> str:


### PR DESCRIPTION
Attaching an image to a fresh session could hang the send for anywhere from 30 seconds to several minutes, while plain text in the same session went out instantly. The image itself was never the problem — the attach RPC was waiting on something it doesn't use.

## What was happening

Six RPCs — `image.attach`, `image.attach_bytes`, `file.attach`, `pdf.attach`, `clipboard.paste`, `image.detach` — resolved their session through `_sess()`, which blocks on `_wait_agent()`: the deferred agent build (MCP discovery, model metadata, skills scan). None of them needs the agent. They read `cwd` / `profile_home` and mutate `attached_images`, and every one of those fields is populated when the session record is created.

Worse, none of these methods is in `_LONG_HANDLERS`, so a non-pooled handler runs **inline on the socket reader thread**. Attach runs *before* `prompt.submit`, so the wait stalled the send *and* every RPC queued behind it on the same socket, with no spinner to explain it.

That asymmetry is the whole symptom: `prompt.submit` already resolves via `_sess_nowait` and waits later, off the reader thread. Hence "text is instant, images hang" — and hence the wildly variable delay, since it tracked agent-build time 1:1 rather than image size.

## The fix

`_sess_building()` resolves the session and still kicks off the build (so the following `prompt.submit` finds a warm agent) — it just doesn't block on it. `_sess()` is now written in terms of it, so the two resolvers differ in exactly one way: the wait.

## Before / after

`scripts/perf/gateway_attach_bench.py`, driving the real dispatcher against a session with an 8s agent build, 3 rounds. Every RPC the fix touches, measured — not inferred:

| RPC | before | after |
|---|---|---|
| `image.attach_bytes` | 8.07s | **0.05s** |
| `image.attach` | 8.01s | **0.00s** |
| `file.attach` | 8.02s | **0.00s** |
| `pdf.attach` | 8.03s | **0.02s** |
| `clipboard.paste` | 8.53s | **0.12s** |
| `image.detach` | 8.00s | **0.00s** |
| `prompt.submit` (control) | 0.04s | 0.04s |

Attach is now constant-time regardless of build duration (checked at 2s, 8s and 30s builds); previously it tracked build time exactly, which is how a cold start turned into a multi-minute hang.

## Why this looked like a GUI-only bug

It wasn't. The bench now reports surface exposure directly:

- **CLI — not exposed.** It attaches inline in its own turn path (`cli.py` → `agent/image_routing.py`) with the agent already constructed. There is no gateway session to resolve, so the stall is structurally unreachable. Consistent with the ~4s CLI report.
- **TUI — exposed.** `ui-tui` calls `image.attach` and `clipboard.paste`, the same handlers, through the same resolver. It had this bug too.
- **Desktop — exposed.** `image.attach`, `image.attach_bytes`, `file.attach`.

So the difference between TUI and Desktop was **hit rate, not code path**. Desktop mints sessions constantly (new chat, tabs, tiles), so a paste routinely lands inside the seconds-long window while a fresh session's agent is still building. A TUI user launches once and the build finishes while they type. Same bug, very different odds of meeting it — which is also why it reproduced inconsistently for one person and not at all for another.

## Ruling out the renderer

`scripts/perf/image-attach-bench.mjs` times the renderer-side transforms — file read, base64, RPC frame encode, `extractEmbeddedImages`, render-weight walk. Total is ~2.4ms at 120KB and ~26ms at 3.2MB. Not the stall.

It did surface one real inefficiency worth a separate PR: the composer reads the same file off disk twice, once for the preview thumbnail and again at submit for the upload bytes.

## Tests

Six behavior contracts in `tests/tui_gateway/test_attach_does_not_wait_for_agent.py`: each handler must return with `agent_ready` still unset, the staged image must still reach the turn, and an unknown session must still be rejected (4001).

Verified they actually catch the bug — against the unfixed resolver, 4 fail with 90s of real stalls.

Full gateway suite: 979 passed.