### PR TITLE
fix(whatsapp): enforce owner-only bridge files

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -35,7 +35,8 @@ import json
 import logging
 import os
 import re
-from typing import Any, Dict, Optional
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
 
 from agent.secret_scope import UnscopedSecretError as _UnscopedSecretError
 from agent.secret_scope import get_secret as _scoped_get_secret
@@ -500,8 +501,28 @@ class WhatsAppBehaviorMixin:
 
 
 # ---------------------------------------------------------------------------
-# Shared bridge directory resolution for CLI and adapter
+# Shared bridge process command and directory resolution
 # ---------------------------------------------------------------------------
+
+_WHATSAPP_BRIDGE_BOOTSTRAP = """\
+if (process.platform !== 'win32') process.umask(0o077);
+const { pathToFileURL } = await import('node:url');
+await import(pathToFileURL(process.argv[1]).href);
+"""
+
+
+def build_whatsapp_bridge_command(
+    *, node: str, bridge_path: Path, bridge_args: Sequence[str]
+) -> list[str]:
+    """Launch the ESM bridge only after applying an owner-only POSIX umask."""
+    return [
+        node,
+        "--input-type=module",
+        "--eval",
+        _WHATSAPP_BRIDGE_BOOTSTRAP,
+        str(bridge_path),
+        *bridge_args,
+    ]
 
 def resolve_whatsapp_bridge_dir() -> Path:
     """Resolve the WhatsApp bridge directory, mirroring to HERMES_HOME if needed.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2987,7 +2987,10 @@ def cmd_whatsapp(args):
             print("  ⚠ No allowlist — the agent will respond to ALL incoming messages")
 
     # ── Step 4: Install bridge dependencies ──────────────────────────────
-    from gateway.platforms.whatsapp_common import resolve_whatsapp_bridge_dir
+    from gateway.platforms.whatsapp_common import (
+        build_whatsapp_bridge_command,
+        resolve_whatsapp_bridge_dir,
+    )
     bridge_dir = resolve_whatsapp_bridge_dir()
     bridge_script = bridge_dir / "bridge.js"
 
@@ -3069,13 +3072,11 @@ def cmd_whatsapp(args):
 
     try:
         subprocess.run(
-            [
-                find_node_executable("node") or "node",
-                str(bridge_script),
-                "--pair-only",
-                "--session",
-                str(session_dir),
-            ],
+            build_whatsapp_bridge_command(
+                node=find_node_executable("node") or "node",
+                bridge_path=bridge_script,
+                bridge_args=["--pair-only", "--session", str(session_dir)],
+            ),
             cwd=str(bridge_dir),
             env=with_hermes_node_path(),
         )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8762,7 +8762,10 @@ def _ensure_whatsapp_bridge_dependencies(bridge_dir: Path) -> None:
 
 
 def _spawn_whatsapp_pairing_process(session_path: Path, mode: str) -> subprocess.Popen:
-    from gateway.platforms.whatsapp_common import resolve_whatsapp_bridge_dir
+    from gateway.platforms.whatsapp_common import (
+        build_whatsapp_bridge_command,
+        resolve_whatsapp_bridge_dir,
+    )
     from hermes_constants import find_node_executable, with_hermes_node_path
 
     bridge_dir = resolve_whatsapp_bridge_dir()
@@ -8786,14 +8789,16 @@ def _spawn_whatsapp_pairing_process(session_path: Path, mode: str) -> subprocess
     env["WHATSAPP_MODE"] = mode
     env["WHATSAPP_DM_POLICY"] = "pairing"
     return subprocess.Popen(
-        [
-            node,
-            str(bridge_script),
-            "--pair-only",
-            "--pair-json",
-            "--session",
-            str(session_path),
-        ],
+        build_whatsapp_bridge_command(
+            node=node,
+            bridge_path=bridge_script,
+            bridge_args=[
+                "--pair-only",
+                "--pair-json",
+                "--session",
+                str(session_path),
+            ],
+        ),
         cwd=str(bridge_dir),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -22,6 +22,7 @@ import platform
 import re
 import signal
 import subprocess
+import tempfile
 
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
@@ -225,13 +226,34 @@ def _write_bridge_pidfile(session_path: Path, pid: int) -> None:
     exact process before signalling it, so a recycled PID can never be killed
     as a "stale bridge". Older single-line files remain readable.
     """
+    temp_path: Path | None = None
     try:
         from gateway.status import get_process_start_time
         start = get_process_start_time(pid)
         text = str(pid) if start is None else "{}\n{}".format(pid, start)
-        (session_path / "bridge.pid").write_text(text, encoding="utf-8")
+        fd, temp_name = tempfile.mkstemp(prefix=".bridge.pid.", dir=session_path)
+        temp_path = Path(temp_name)
+        try:
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                fd = -1
+                handle.write(text)
+                handle.flush()
+                os.fsync(handle.fileno())
+        finally:
+            if fd >= 0:
+                os.close(fd)
+        os.replace(temp_path, session_path / "bridge.pid")
+        temp_path = None
     except OSError:
         pass
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
 
 
 def _terminate_bridge_process(proc, *, force: bool = False) -> None:
@@ -280,11 +302,15 @@ def _terminate_bridge_process(proc, *, force: bool = False) -> None:
     except psutil.NoSuchProcess:
         return
 
+
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+from gateway.platforms.whatsapp_common import (
+    WhatsAppBehaviorMixin,
+    build_whatsapp_bridge_command,
+)
 from gateway.whatsapp_identity import to_whatsapp_jid
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -733,13 +759,18 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env["HERMES_DOCUMENT_CACHE_DIR"] = str(_get_doc_dir())
 
             self._bridge_process = subprocess.Popen(
-                [
-                    find_node_executable("node") or "node",
-                    str(bridge_path),
-                    "--port", str(self._bridge_port),
-                    "--session", str(self._session_path),
-                    "--mode", whatsapp_mode,
-                ],
+                build_whatsapp_bridge_command(
+                    node=find_node_executable("node") or "node",
+                    bridge_path=bridge_path,
+                    bridge_args=[
+                        "--port",
+                        str(self._bridge_port),
+                        "--session",
+                        str(self._session_path),
+                        "--mode",
+                        whatsapp_mode,
+                    ],
+                ),
                 stdout=bridge_log_fh,
                 stderr=bridge_log_fh,
                 env=bridge_env,

--- a/tests/gateway/test_whatsapp_bridge_pidfile.py
+++ b/tests/gateway/test_whatsapp_bridge_pidfile.py
@@ -61,6 +61,31 @@ class TestWriteAndRoundTrip:
             proc.kill()
             proc.wait()
 
+    @pytest.mark.parametrize("alias_kind", ["symlink", "hardlink"])
+    def test_pidfile_atomically_replaces_alias_without_touching_target(
+        self, tmp_path, alias_kind
+    ):
+        outside = tmp_path / "outside"
+        outside.write_text("preserve")
+        pid_file = tmp_path / "bridge.pid"
+        if alias_kind == "symlink":
+            pid_file.symlink_to(outside)
+        else:
+            os.link(outside, pid_file)
+
+        proc = _spawn_sleeper()
+        try:
+            _write_bridge_pidfile(tmp_path, proc.pid)
+            assert outside.read_text() == "preserve"
+            assert not pid_file.is_symlink()
+            assert pid_file.stat().st_ino != outside.stat().st_ino
+            if os.name == "posix":
+                assert (pid_file.stat().st_mode & 0o777) == 0o600
+            assert int(pid_file.read_text().split("\n")[0]) == proc.pid
+        finally:
+            proc.kill()
+            proc.wait()
+
 
 class TestIdentityGuard:
     def test_kills_when_start_time_matches(self, tmp_path):

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -13,7 +13,10 @@ Regression tests for two bugs in WhatsAppAdapter.connect():
 """
 
 import asyncio
+import os
+import shutil
 import signal
+import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -103,6 +106,71 @@ def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
     if mock_client_cls is not None:
         base.append(patch("aiohttp.ClientSession", mock_client_cls))
     return base
+
+
+class TestBridgeCommand:
+    def test_owner_only_bootstrap_precedes_bridge_entry(self):
+        import gateway.platforms.whatsapp_common as whatsapp_common
+
+        build_command = getattr(
+            whatsapp_common, "build_whatsapp_bridge_command", None
+        )
+        assert build_command is not None
+        bridge_path = Path("/opt/hermes/whatsapp/bridge.js")
+        command = build_command(
+            node="/opt/hermes/node",
+            bridge_path=bridge_path,
+            bridge_args=[
+                "--port",
+                "3000",
+                "--session",
+                "/home/user/.hermes/whatsapp/session",
+                "--mode",
+                "self-chat",
+            ],
+        )
+
+        assert command[:3] == ["/opt/hermes/node", "--input-type=module", "--eval"]
+        assert "process.umask(0o077)" in command[3]
+        assert command[3].index("process.umask") < command[3].index("import(")
+        assert command[4:] == [
+            "/opt/hermes/whatsapp/bridge.js",
+            "--port",
+            "3000",
+            "--session",
+            "/home/user/.hermes/whatsapp/session",
+            "--mode",
+            "self-chat",
+        ]
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX file modes only")
+    def test_bootstrap_applies_umask_before_static_esm_dependency(self, tmp_path):
+        from gateway.platforms.whatsapp_common import build_whatsapp_bridge_command
+
+        node = shutil.which("node")
+        if not node:
+            pytest.skip("Node.js is unavailable")
+        module_dir = tmp_path / "path with spaces"
+        module_dir.mkdir()
+        output = module_dir / "created-during-import"
+        (module_dir / "dependency.mjs").write_text(
+            "import { writeFileSync } from 'node:fs';\n"
+            "writeFileSync(process.env.HERMES_UMASK_PROBE, 'secret');\n"
+        )
+        entry = module_dir / "entry.mjs"
+        entry.write_text("import './dependency.mjs';\n")
+        command = build_whatsapp_bridge_command(
+            node=node,
+            bridge_path=entry,
+            bridge_args=["--session", str(module_dir / "session path")],
+        )
+
+        env = os.environ.copy()
+        env["HERMES_UMASK_PROBE"] = str(output)
+        result = subprocess.run(command, env=env, capture_output=True, text=True)
+
+        assert result.returncode == 0, result.stderr
+        assert (output.stat().st_mode & 0o777) == 0o600
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- launch every Baileys bridge path—gateway, CLI pairing, and dashboard pairing—through one shared Node bootstrap
- set POSIX umask `0077` before dynamically importing `bridge.js`, including its static dependency side effects
- create `bridge.pid` through a `0600` temporary file and atomically replace the final directory entry
- preserve Windows behavior by skipping the POSIX umask call

## Security rationale

Baileys creates long-lived authentication and encryption files during both first-time pairing and normal bridge operation. The inline Node bootstrap applies the restrictive umask before bridge ESM evaluation without depending on a separate file in writable bridge mirrors. Atomic PID replacement avoids following or modifying an existing final-component symlink or hardlink alias.

This focused change intentionally does **not** recursively migrate pre-existing session trees or redesign stale-process cleanup. Existing installations should harden old session material once before relying on creation-time protection.

## Test plan

- `pytest -q tests/gateway -k whatsapp` — 183 passed, 4 skipped
- real ESM import-side-effect regression verifies mode `0600` from a path containing spaces
- `node --test *.test.mjs` in `scripts/whatsapp-bridge` — 22 passed
- `npm ci --ignore-scripts && npm audit --omit=dev` — 0 vulnerabilities
- `node --check bridge.js`
- Ruff and `py_compile` on modified Python files
- `git diff --check`
