### PR TITLE
fix(acp): advertise configured fallback models

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -720,7 +720,7 @@ class HermesACPAgent(acp.Agent):
                 context,
                 explicit_only=True,
                 include_unconfigured=False,
-                picker_hints=False,
+                picker_hints=True,
                 canonical_order=True,
                 pricing=False,
                 capabilities=False,
@@ -732,13 +732,19 @@ class HermesACPAgent(acp.Agent):
 
             available_models: list[ModelInfo] = []
             seen_ids: set[str] = set()
+            inventory_provider_labels: dict[str, str] = {}
             for row in payload.get("providers") or []:
-                row_provider = normalize_provider(str(row.get("slug") or "").strip())
-                if not row_provider:
+                if not isinstance(row, dict):
                     continue
+                raw_slug = row.get("slug")
+                if not isinstance(raw_slug, str) or not raw_slug.strip():
+                    continue
+                row_provider = normalize_provider(raw_slug.strip())
                 provider_name = str(row.get("name") or "").strip() or provider_label(
                     row_provider
                 )
+                if row.get("authenticated") is True:
+                    inventory_provider_labels[row_provider] = provider_name
                 for model_entry in row.get("models") or []:
                     if isinstance(model_entry, dict):
                         rendered_model = str(
@@ -768,6 +774,52 @@ class HermesACPAgent(acp.Agent):
                         )
                     )
                     seen_ids.add(choice_id)
+
+            # A provider catalog can lag a model that the configured provider
+            # already serves. Add only strict provider/model entries for
+            # providers present in the authenticated inventory; custom route
+            # metadata remains outside this narrow ACP catalog-lag fallback.
+            try:
+                from hermes_cli.config import load_config
+
+                config = load_config()
+            except Exception:
+                config = {}
+            raw_fallbacks = (
+                config.get("fallback_providers") if isinstance(config, dict) else []
+            )
+            if not isinstance(raw_fallbacks, list):
+                raw_fallbacks = []
+            for fallback in raw_fallbacks:
+                if not isinstance(fallback, dict):
+                    continue
+                raw_provider = fallback.get("provider")
+                raw_model = fallback.get("model")
+                if not isinstance(raw_provider, str) or not isinstance(raw_model, str):
+                    continue
+                raw_provider = raw_provider.strip()
+                fallback_model = raw_model.strip()
+                if not raw_provider or not fallback_model:
+                    continue
+                fallback_provider = normalize_provider(raw_provider)
+                if fallback_provider not in inventory_provider_labels:
+                    continue
+                fallback_choice = self._encode_model_choice(
+                    fallback_provider, fallback_model
+                )
+                if not fallback_choice or fallback_choice in seen_ids:
+                    continue
+                fallback_label = inventory_provider_labels[fallback_provider]
+                available_models.append(
+                    ModelInfo(
+                        model_id=fallback_choice,
+                        name=f"{fallback_label} · {fallback_model}",
+                        description=(
+                            f"Provider: {fallback_label} • configured fallback"
+                        ),
+                    )
+                )
+                seen_ids.add(fallback_choice)
 
             # Named user-defined endpoints (providers: / custom_providers:)
             # are invisible to canonical provider enumeration — append them
@@ -829,8 +881,10 @@ class HermesACPAgent(acp.Agent):
         try:
             from hermes_cli.models import detect_provider_for_model, parse_model_input
 
+            original_model = new_model
             target_provider, new_model = parse_model_input(new_model, current_provider)
-            if target_provider == current_provider:
+            had_explicit_provider = new_model != original_model
+            if not had_explicit_provider and target_provider == current_provider:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:
                     target_provider, new_model = detected

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -194,11 +194,13 @@ class TestSessionOps:
                 {
                     "slug": "anthropic",
                     "name": "Anthropic",
+                    "authenticated": True,
                     "models": ["claude-sonnet-4-6", "claude-sonnet-4-6"],
                 },
                 {
                     "slug": "openai-codex",
                     "name": "OpenAI Codex",
+                    "authenticated": True,
                     "models": [
                         {"id": "gpt-5.4"},
                         "gpt-5.4-mini",
@@ -236,7 +238,7 @@ class TestSessionOps:
             picker_context,
             explicit_only=True,
             include_unconfigured=False,
-            picker_hints=False,
+            picker_hints=True,
             canonical_order=True,
             pricing=False,
             capabilities=False,
@@ -245,6 +247,80 @@ class TestSessionOps:
             probe_current_custom_provider=False,
             max_models=ACP_MAX_MODELS_PER_PROVIDER,
         )
+
+    @pytest.mark.asyncio
+    async def test_new_session_adds_valid_configured_model_for_inventory_provider(self):
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(
+                model="gpt-5.6-sol",
+                provider="openai-codex",
+                base_url="https://chatgpt.com/backend-api/codex",
+            )
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        picker_context = MagicMock()
+        picker_context.with_overrides.return_value = picker_context
+        payload = {
+            "providers": [
+                {
+                    "slug": "openai-codex",
+                    "name": "OpenAI Codex",
+                    "authenticated": True,
+                    "models": ["gpt-5.6-sol"],
+                },
+                {
+                    "slug": "zai",
+                    "name": "Z.AI",
+                    "authenticated": True,
+                    "models": ["glm-5.2"],
+                },
+                {"name": "Malformed", "authenticated": True, "models": []},
+                {
+                    "slug": "private-gateway",
+                    "name": "Private Gateway",
+                    "authenticated": False,
+                    "models": ["old-model"],
+                },
+            ],
+        }
+        config = {
+            "fallback_providers": [
+                {"provider": "zai", "model": "glm-5.2"},
+                {"provider": "zai", "model": "glm-5.3"},
+                {"provider": "private-gateway", "model": "gateway-model"},
+                {"provider": "   ", "model": "unexpected"},
+                {"provider": ["zai"], "model": "bad-provider"},
+                {"provider": "zai", "model": {"name": "bad-model"}},
+            ]
+        }
+
+        with (
+            patch("hermes_cli.inventory.load_picker_context", return_value=picker_context),
+            patch("hermes_cli.inventory.build_models_payload", return_value=payload),
+            patch("hermes_cli.config.load_config", return_value=config),
+            patch("acp_adapter.server._named_custom_provider_catalogs", return_value=[]),
+        ):
+            resp = await acp_agent.new_session(cwd="/tmp")
+
+        ids = [model.model_id for model in resp.models.available_models]
+        assert "zai:glm-5.3" in ids
+        assert ids.count("zai:glm-5.2") == 1
+        assert "private-gateway:gateway-model" not in ids
+        assert "openrouter:unexpected" not in ids
+        assert all("bad-provider" not in model_id for model_id in ids)
+        assert all("bad-model" not in model_id for model_id in ids)
+
+    def test_explicit_current_provider_choice_bypasses_model_detection(self):
+        with patch(
+            "hermes_cli.models.detect_provider_for_model",
+            return_value=("anthropic", "claude-sonnet-4-6"),
+        ) as detect:
+            provider, model = HermesACPAgent._resolve_model_selection(
+                "ai-gateway:claude-sonnet-4-6", "ai-gateway"
+            )
+
+        assert (provider, model) == ("ai-gateway", "claude-sonnet-4-6")
+        detect.assert_not_called()
 
 
 


### PR DESCRIPTION
## Summary

- append configured list-form fallback models when their provider appears as explicitly authenticated in ACP inventory
- request canonical picker authentication hints from the inventory producer
- require non-empty string `provider` and `model` values before normalization
- reject malformed inventory slugs before normalization and ignore unauthenticated provider rows for fallback authorization
- deduplicate choices already supplied by the provider catalog

## Why

An authenticated configured provider can serve a model before its catalog advertises that model. ACP clients then omit a valid configured fallback even though the provider is available and represented in inventory. This focused change fills only that model-catalog gap without allowing malformed values to normalize into plausible routes.

The change intentionally does **not** add custom endpoint or credential bindings, unknown providers, singular/legacy fallback forms, or session restoration behavior.

## Test plan

- `pytest -q tests/acp` — 128 passed
- regressions cover missing configured model, catalog deduplication, unauthenticated/absent providers, blank values, malformed slugs, non-string provider/model values, and explicit current-provider round trips
- Ruff on modified Python files
- `git diff --check`
