### PR TITLE
test(cli): pin the session type in /copy tests, cover the OSC 52 branch

### DIFF
--- a/tests/cli/test_cli_copy_command.py
+++ b/tests/cli/test_cli_copy_command.py
@@ -1,4 +1,11 @@
-"""Tests for CLI /copy command."""
+"""Tests for CLI /copy command.
+
+/copy takes one of two paths: native clipboard tools locally, or OSC 52 when
+the session is remote, so the text reaches the terminal the user is actually
+sitting at rather than the remote host's clipboard. Which path runs depends on
+``is_remote_shell_session()``, so every test pins it — otherwise the suite
+passes on a desktop and fails over SSH.
+"""
 
 from unittest.mock import MagicMock, patch
 
@@ -25,7 +32,8 @@ def test_copy_copies_latest_assistant_message():
         {"role": "assistant", "content": "latest"},
     ]
 
-    with patch("hermes_cli.clipboard.write_clipboard_text", return_value=True) as mock_copy:
+    with patch("hermes_cli.clipboard.is_remote_shell_session", return_value=False), \
+         patch("hermes_cli.clipboard.write_clipboard_text", return_value=True) as mock_copy:
         result = cli_obj.process_command("/copy")
 
     assert result is True
@@ -39,7 +47,8 @@ def test_copy_with_index_uses_requested_assistant_message():
         {"role": "assistant", "content": "two"},
     ]
 
-    with patch("hermes_cli.clipboard.write_clipboard_text", return_value=True) as mock_copy:
+    with patch("hermes_cli.clipboard.is_remote_shell_session", return_value=False), \
+         patch("hermes_cli.clipboard.write_clipboard_text", return_value=True) as mock_copy:
         cli_obj.process_command("/copy 1")
 
     mock_copy.assert_called_once_with("one")
@@ -54,7 +63,8 @@ def test_copy_strips_reasoning_blocks_before_copy():
         }
     ]
 
-    with patch("hermes_cli.clipboard.write_clipboard_text", return_value=True) as mock_copy:
+    with patch("hermes_cli.clipboard.is_remote_shell_session", return_value=False), \
+         patch("hermes_cli.clipboard.write_clipboard_text", return_value=True) as mock_copy:
         cli_obj.process_command("/copy")
 
     mock_copy.assert_called_once_with("Visible answer")
@@ -90,3 +100,28 @@ def test_copy_native_first_when_local():
     mock_osc52.assert_not_called()
 
 
+def test_copy_uses_osc52_when_the_session_is_remote():
+    """Over SSH the native tools would write the remote host's clipboard."""
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [{"role": "assistant", "content": "svaret"}]
+    cli_obj._write_osc52_clipboard = MagicMock()
+
+    with patch("hermes_cli.clipboard.is_remote_shell_session", return_value=True), \
+         patch("hermes_cli.clipboard.write_clipboard_text", return_value=True) as mock_copy:
+        cli_obj.process_command("/copy")
+
+    cli_obj._write_osc52_clipboard.assert_called_once_with("svaret")
+    mock_copy.assert_not_called()
+
+
+def test_copy_falls_back_to_osc52_when_native_tools_fail():
+    """A failed native write must not silently drop the copy."""
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [{"role": "assistant", "content": "svaret"}]
+    cli_obj._write_osc52_clipboard = MagicMock()
+
+    with patch("hermes_cli.clipboard.is_remote_shell_session", return_value=False), \
+         patch("hermes_cli.clipboard.write_clipboard_text", return_value=False):
+        cli_obj.process_command("/copy")
+
+    cli_obj._write_osc52_clipboard.assert_called_once_with("svaret")


### PR DESCRIPTION
## Problem

`tests/cli/test_cli_copy_command.py` fails on `main` when the suite is run over
SSH:

```
FAILED test_copy_copies_latest_assistant_message
FAILED test_copy_with_index_uses_requested_assistant_message
FAILED test_copy_strips_reasoning_blocks_before_copy
AssertionError: Expected 'write_clipboard_text' to be called once. Called 0 times.
```

There is no bug in `/copy`. `_handle_copy_command` picks one of two paths:

```python
if is_remote_shell_session():
    self._write_osc52_clipboard(text)   # ← taken over SSH, returns early
    return
if write_clipboard_text(text):
    ...
```

Over SSH the native tools would write the *remote host's* clipboard, so OSC 52
is correct — it reaches the terminal the user is actually sitting at. The three
tests patch `write_clipboard_text` and assert it was called, without pinning
`is_remote_shell_session()`, so the outcome depends on how the developer or CI
runner happens to be connected: green on a desktop, red on a remote checkout.

## Change

- Pin `is_remote_shell_session()` to `False` in the three existing tests, so
  they deterministically exercise the local path they were written for.
- Add coverage for the two branches that had none:
  - OSC 52 is used, and the native write is *not* attempted, when the session
    is remote.
  - OSC 52 is used as a fallback when the native write returns `False`.

No production code changes. 7 tests pass in both a local and an SSH session.

## Why it matters beyond the noise

The remote branch is the one users hit on a server, and it was untested — a
regression there would have been invisible to the suite while the three
local-path tests looked like they covered `/copy`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard copying in remote sessions by using OSC 52 when appropriate.
  * Added a fallback to OSC 52 when native clipboard tools are unavailable or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->