### PR TITLE
fix(telegram): route inline-callback auth through the profile-aware runner path (#86296)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3103,6 +3103,14 @@ class BasePlatformAdapter(ABC):
         self._platform_event_handler: Optional[
             Callable[[Dict[str, Any], Any], Awaitable[None]]
         ] = None
+        # Optional runner-owned resolver for inline-button (callback) auth.
+        # Adapters build the actor's SessionSource and defer the final
+        # allow/deny to this callable, which applies the same profile-route
+        # resolution, profile stamping, and runtime scope as normal inbound
+        # messages before calling the gateway authorization decision. Without
+        # it, adapters that recover the runner via ``_message_handler.__self__``
+        # fail closed to env-only auth under multiplex closures (#86296).
+        self._callback_auth_resolver: Optional[Callable[[Any], bool]] = None
         # Optional hook (e.g. Telegram DM topic recovery) that rewrites
         # ``event.source.thread_id`` before session keying. Returns the
         # corrected thread_id or None to leave the source untouched.
@@ -3734,6 +3742,21 @@ class BasePlatformAdapter(ABC):
         therefore fails closed instead of exposing pre-auth events.
         """
         self._platform_event_handler = handler
+
+    def set_callback_auth_resolver(
+        self,
+        resolver: Optional[Callable[[Any], bool]],
+    ) -> None:
+        """Install the runner-owned resolver for inline-button callback auth.
+
+        The adapter builds the callback actor's ``SessionSource`` and delegates
+        the allow/deny decision to ``resolver``, which applies the same profile
+        routing and runtime scope as normal inbound messages. This replaces
+        recovering the runner via ``_message_handler.__self__``, which fails
+        under multiplex closure handlers (no bound ``__self__``) and skips the
+        routed profile's pairing store (#86296).
+        """
+        self._callback_auth_resolver = resolver
 
     def set_topic_recovery_fn(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12947,18 +12947,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # default profile needs the same whole-handler runtime scope as a
             # secondary profile: authorization and prompt rendering both run
             # before the narrower agent-turn scope is installed.
-            adapter.set_message_handler(self._primary_message_handler())
-            adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
-            adapter.set_session_store(self.session_store)
-            adapter.set_busy_session_handler(self._handle_active_session_busy_message)
-            _set_reaction = getattr(adapter, "set_reaction_handler", None)
-            if callable(_set_reaction):
-                _set_reaction(self._handle_reaction_event)
-            adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
-            adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
-            adapter.set_platform_event_handler(self._primary_platform_event_handler())
-            adapter.set_callback_auth_resolver(self._authorize_platform_callback)
-            adapter._busy_text_mode = self._busy_text_mode
+            self._wire_primary_adapter_handlers(adapter)
             _pending_connects.append((platform, platform_config, adapter))
 
         if await self._abort_startup_if_shutdown_requested():
@@ -14565,18 +14554,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         del self._failed_platforms[platform]
                         continue
 
-                    adapter.set_message_handler(self._primary_message_handler())
-                    adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
-                    adapter.set_session_store(self.session_store)
-                    adapter.set_busy_session_handler(self._handle_active_session_busy_message)
-                    _set_reaction = getattr(adapter, "set_reaction_handler", None)
-                    if callable(_set_reaction):
-                        _set_reaction(self._handle_reaction_event)
-                    adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
-                    adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
-                    adapter.set_platform_event_handler(self._primary_platform_event_handler())
-                    adapter.set_callback_auth_resolver(self._authorize_platform_callback)
-                    adapter._busy_text_mode = self._busy_text_mode
+                    self._wire_primary_adapter_handlers(adapter)
 
                     # Reconnect after an outage: preserve the platform's
                     # server-side update queue so messages sent while the bot
@@ -15675,6 +15653,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if isinstance(text_modes, dict)
             else self._busy_text_mode
         )
+        # NB: no callback-auth resolver is installed here. #86296 is the
+        # shared-primary-bot topology (one bot, many routed profiles) where the
+        # primary event handler is a routing closure with no bound __self__.
+        # A direct secondary adapter owns exactly one profile, so a resolver
+        # would have to *bind* that profile rather than route from the source
+        # (the shared-primary ``_authorize_platform_callback`` resolves the
+        # route and would fall back to the default store for an unrouted
+        # callback source). That is a distinct fix; secondary-adapter callback
+        # auth stays on the env fallback here and is left for a follow-up.
 
     async def _run_secondary_profile_reconnect(
         self, profile_name: str, platform: Platform
@@ -16083,6 +16070,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             with _profile_runtime_scope(Path(authorization_home)):
                 return _check()
         return _check()
+
+    def _wire_primary_adapter_handlers(self, adapter):
+        """Install the primary-transport handler set on a freshly created adapter.
+
+        Both the initial connect (``start``) and the reconnect watcher wire an
+        adapter the same way; the shared block lives here so the callback-auth
+        resolver registration (#86296) has a single, testable choke point that a
+        regression test can drive without standing up the whole async connect
+        flow. Any handler added here is picked up by both call sites.
+        """
+        adapter.set_message_handler(self._primary_message_handler())
+        adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
+        adapter.set_session_store(self.session_store)
+        adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+        _set_reaction = getattr(adapter, "set_reaction_handler", None)
+        if callable(_set_reaction):
+            _set_reaction(self._handle_reaction_event)
+        adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
+        adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
+        adapter.set_platform_event_handler(self._primary_platform_event_handler())
+        adapter.set_callback_auth_resolver(self._authorize_platform_callback)
+        adapter._busy_text_mode = self._busy_text_mode
 
     def _primary_platform_event_handler(self):
         if getattr(self.config, "multiplex_profiles", False):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12957,6 +12957,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
             adapter.set_platform_event_handler(self._primary_platform_event_handler())
+            adapter.set_callback_auth_resolver(self._authorize_platform_callback)
             adapter._busy_text_mode = self._busy_text_mode
             _pending_connects.append((platform, platform_config, adapter))
 
@@ -14574,6 +14575,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
                     adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
                     adapter.set_platform_event_handler(self._primary_platform_event_handler())
+                    adapter.set_callback_auth_resolver(self._authorize_platform_callback)
                     adapter._busy_text_mode = self._busy_text_mode
 
                     # Reconnect after an outage: preserve the platform's
@@ -16086,6 +16088,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if getattr(self.config, "multiplex_profiles", False):
             return self._make_default_profile_platform_event_handler()
         return self._handle_gateway_platform_event
+
+    def _authorize_platform_callback(self, source) -> bool:
+        """Authorize an inline-button (callback) actor via the normal path.
+
+        Adapters build the callback actor's ``SessionSource`` but cannot
+        reliably recover the runner from a bound ``_message_handler.__self__``:
+        under ``multiplex_profiles`` the primary handler is a closure with no
+        ``__self__``, so callbacks fell back to env-only auth and skipped the
+        routed profile's pairing store (#86296). Installed on the adapter via
+        ``set_callback_auth_resolver``, this resolver applies the same profile
+        route resolution, profile stamping, runtime scope, and gateway
+        authorization decision that normal inbound messages receive — so
+        slash-confirm, clarify, and dangerous-command approval buttons honor a
+        pairing-authorized operator on their routed profile.
+
+        Fails closed when an explicit route targets an unserved profile;
+        unexpected errors propagate so the adapter's own fallback can log them.
+        """
+        from gateway.profile_routing import ProfileRouteRejected
+
+        # Mirror the ingress route-resolution gate in ``_handle_message``:
+        # most adapters stamp ``source.profile`` in ``build_source``, but a
+        # callback source is constructed directly and must be routed here.
+        if (
+            getattr(getattr(self, "config", None), "multiplex_profiles", False)
+            and not getattr(source, "profile", None)
+            and getattr(source, "profile_route_rejected", False) is not True
+        ):
+            try:
+                source.profile = self._profile_name_for_source(source)
+            except ProfileRouteRejected:
+                source.profile_route_rejected = True
+                return False
+        if getattr(source, "profile_route_rejected", False) is True:
+            return False
+        with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
+            return bool(self._is_user_authorized(source))
 
     @staticmethod
     def _adapter_credential_claim(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1182,27 +1182,50 @@ class TelegramAdapter(BasePlatformAdapter):
         if not normalized_user_id:
             return False
 
+        def _build_source():
+            from gateway.session import SessionSource
+
+            normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
+            if normalized_chat_type == "private":
+                normalized_chat_type = "dm"
+            elif normalized_chat_type == "supergroup":
+                normalized_chat_type = "forum" if thread_id is not None else "group"
+
+            return SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id=str(chat_id or normalized_user_id),
+                chat_type=normalized_chat_type,
+                user_id=normalized_user_id,
+                user_name=str(user_name).strip() if user_name else None,
+                thread_id=str(thread_id) if thread_id is not None else None,
+            )
+
+        # Preferred path: the runner installs a callback auth resolver
+        # (``set_callback_auth_resolver``) that applies the same profile-route
+        # resolution, profile stamping, and runtime scope as normal inbound
+        # messages. This is required under ``multiplex_profiles``, where the
+        # primary event handler is a closure with no bound ``__self__`` — so
+        # the introspection path below cannot recover the runner and the
+        # routed profile's pairing store would be skipped (#86296).
+        resolver = getattr(self, "_callback_auth_resolver", None)
+        if callable(resolver):
+            try:
+                return bool(resolver(_build_source()))
+            except Exception:
+                logger.debug(
+                    "[Telegram] callback auth resolver failed for user %s; "
+                    "falling back to introspection/env auth",
+                    normalized_user_id,
+                    exc_info=True,
+                )
+
+        # Legacy fallback: recover the runner from a bound message handler
+        # (non-multiplex primary adapters), then env-only fail-closed.
         runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
             try:
-                from gateway.session import SessionSource
-
-                normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
-                if normalized_chat_type == "private":
-                    normalized_chat_type = "dm"
-                elif normalized_chat_type == "supergroup":
-                    normalized_chat_type = "forum" if thread_id is not None else "group"
-
-                source = SessionSource(
-                    platform=Platform.TELEGRAM,
-                    chat_id=str(chat_id or normalized_user_id),
-                    chat_type=normalized_chat_type,
-                    user_id=normalized_user_id,
-                    user_name=str(user_name).strip() if user_name else None,
-                    thread_id=str(thread_id) if thread_id is not None else None,
-                )
-                return bool(auth_fn(source))
+                return bool(auth_fn(_build_source()))
             except Exception:
                 logger.debug(
                     "[Telegram] Falling back to env-only callback auth for user %s",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1209,15 +1209,24 @@ class TelegramAdapter(BasePlatformAdapter):
         # routed profile's pairing store would be skipped (#86296).
         resolver = getattr(self, "_callback_auth_resolver", None)
         if callable(resolver):
+            # The resolver is the authoritative, profile-scoped decision. If it
+            # raises, fail CLOSED — do not fall through to the introspection /
+            # env-allowlist path below. That fallback is process-wide and not
+            # scoped to the routed profile, so honoring it here would let a
+            # resolver error silently cross the profile-specific pairing
+            # boundary (#86296). The env fallback is intentionally reserved for
+            # the no-resolver legacy path only.
             try:
                 return bool(resolver(_build_source()))
             except Exception:
-                logger.debug(
+                logger.warning(
                     "[Telegram] callback auth resolver failed for user %s; "
-                    "falling back to introspection/env auth",
+                    "denying (fail-closed) rather than crossing the profile "
+                    "pairing boundary via env-only auth",
                     normalized_user_id,
                     exc_info=True,
                 )
+                return False
 
         # Legacy fallback: recover the runner from a bound message handler
         # (non-multiplex primary adapters), then env-only fail-closed.

--- a/tests/gateway/test_telegram_callback_multiplex_auth.py
+++ b/tests/gateway/test_telegram_callback_multiplex_auth.py
@@ -1,0 +1,258 @@
+"""Telegram inline-callback auth under multiplex profile routing (#86296).
+
+Under ``gateway.multiplex_profiles`` the primary Telegram event handler is a
+closure installed via ``_make_default_profile_platform_event_handler`` — it has
+no bound ``__self__``, so the adapter cannot recover the runner through
+``_message_handler.__self__`` and callback auth fell back to env-only,
+**skipping the routed profile's pairing store**. A pairing-authorized operator
+could therefore send text (authorized through the route) but was rejected when
+tapping an inline **Approve Once** / clarify / dangerous-command button.
+
+The fix installs a runner-owned resolver on the adapter
+(``set_callback_auth_resolver``) that stamps the routed profile and enters its
+runtime scope before the normal gateway authorization decision. These tests
+cover both seams: the adapter preferring the resolver, and the runner's
+``_authorize_platform_callback`` applying route resolution + fail-closed rules.
+"""
+
+import sys
+import types
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig, Platform
+from gateway.session import SessionSource
+
+
+# -- Fake telegram modules (minimal stubs) --------------------------------
+
+_fake_telegram_error = types.ModuleType("telegram.error")
+
+
+class _TelegramError(Exception):
+    pass
+
+
+_fake_telegram_error.TelegramError = _TelegramError
+_fake_telegram_error.BadRequest = type("BadRequest", (_TelegramError,), {})
+_fake_telegram_error.NetworkError = type("NetworkError", (_TelegramError,), {})
+
+_fake_telegram_constants = types.ModuleType("telegram.constants")
+_fake_telegram_constants.ParseMode = SimpleNamespace(HTML="HTML")
+
+_fake_telegram_request = types.ModuleType("telegram.request")
+_fake_telegram_request.HTTPXRequest = type(
+    "HTTPXRequest", (), {"__init__": lambda *a, **kw: None}
+)
+
+_fake_telegram_ext = types.ModuleType("telegram.ext")
+_fake_telegram_ext.ApplicationBuilder = type(
+    "ApplicationBuilder",
+    (),
+    {"token": lambda self, *a: self, "build": lambda self: None},
+)
+
+_fake_telegram = types.ModuleType("telegram")
+_fake_telegram.error = _fake_telegram_error
+_fake_telegram.constants = _fake_telegram_constants
+_fake_telegram.ext = _fake_telegram_ext
+_fake_telegram.request = _fake_telegram_request
+
+
+@pytest.fixture(autouse=True)
+def _inject_fake_telegram(monkeypatch):
+    monkeypatch.setitem(sys.modules, "telegram", _fake_telegram)
+    monkeypatch.setitem(sys.modules, "telegram.error", _fake_telegram_error)
+    monkeypatch.setitem(sys.modules, "telegram.constants", _fake_telegram_constants)
+    monkeypatch.setitem(sys.modules, "telegram.ext", _fake_telegram_ext)
+    monkeypatch.setitem(sys.modules, "telegram.request", _fake_telegram_request)
+
+
+def _make_adapter():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = config
+    adapter._config = config
+    adapter._platform = Platform.TELEGRAM
+    adapter._connected = True
+    adapter._message_handler = None
+    adapter._callback_auth_resolver = None
+    return adapter
+
+
+# -- Adapter seam: prefer the installed resolver --------------------------
+
+
+class TestAdapterPrefersResolver:
+    def test_resolver_receives_routed_source_and_result_flows_through(
+        self, monkeypatch
+    ):
+        """The resolver is called with the callback SessionSource and its
+        allow/deny decision is returned verbatim — no env fallthrough."""
+        # No env allowlist: the legacy fallback would fail closed (deny),
+        # so a True result can only come from the resolver.
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        seen = {}
+
+        def _resolver(source):
+            seen["source"] = source
+            return True
+
+        adapter = _make_adapter()
+        adapter._callback_auth_resolver = _resolver
+
+        assert (
+            adapter._is_callback_user_authorized(
+                "999",
+                chat_id="-1001234567890",
+                chat_type="supergroup",
+                thread_id=None,
+                user_name="op",
+            )
+            is True
+        )
+        src = seen["source"]
+        assert isinstance(src, SessionSource)
+        assert src.platform == Platform.TELEGRAM
+        assert src.user_id == "999"
+        assert src.chat_id == "-1001234567890"
+        assert src.chat_type == "group"  # supergroup w/o thread → group
+
+    def test_resolver_deny_does_not_fall_through_to_env(self, monkeypatch):
+        """A resolver denial is final even when an env allowlist would allow."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "999")
+        adapter = _make_adapter()
+        adapter._callback_auth_resolver = lambda source: False
+
+        assert adapter._is_callback_user_authorized("999", chat_id="-100") is False
+
+    def test_resolver_exception_falls_back_to_env(self, monkeypatch):
+        """If the resolver raises, the adapter falls back to env-only auth."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "999")
+
+        def _boom(source):
+            raise RuntimeError("resolver blew up")
+
+        adapter = _make_adapter()
+        adapter._callback_auth_resolver = _boom
+
+        assert adapter._is_callback_user_authorized("999", chat_id="-100") is True
+
+    def test_no_resolver_still_fail_closed_without_allowlist(self, monkeypatch):
+        """No resolver, no allowlist, no allow-all → deny (preserves #24457)."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+        assert adapter._is_callback_user_authorized("999") is False
+
+
+# -- Runner seam: _authorize_platform_callback ----------------------------
+
+
+@contextmanager
+def _noop_scope(_home):
+    yield
+
+
+def _make_runner(monkeypatch, *, multiplex=True):
+    """Minimal GatewayRunner with the resolver method bound to real code."""
+    from gateway.run import GatewayRunner
+
+    runner = MagicMock(spec=GatewayRunner)
+    runner.config = SimpleNamespace(multiplex_profiles=multiplex, profile_routes=[])
+    runner._authorize_platform_callback = (
+        GatewayRunner._authorize_platform_callback.__get__(runner)
+    )
+    runner._resolve_profile_home_for_source = MagicMock(return_value="/home")
+    # Neutralize the real env/HOME side effects of entering a profile scope.
+    monkeypatch.setattr("gateway.run._profile_runtime_scope", _noop_scope)
+    return runner
+
+
+def _callback_source(profile=None):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001234567890",
+        chat_type="group",
+        user_id="999",
+        profile=profile,
+    )
+
+
+class TestAuthorizePlatformCallback:
+    def test_matched_route_stamps_profile_then_authorizes(self, monkeypatch):
+        """A matching route stamps ``source.profile`` before the auth decision
+        so the routed profile's pairing store is consulted (issue items 3-5)."""
+        runner = _make_runner(monkeypatch)
+        runner._profile_name_for_source = MagicMock(return_value="secondary")
+        seen = {}
+
+        def _auth(source):
+            seen["profile"] = source.profile
+            return True
+
+        runner._is_user_authorized = _auth
+
+        source = _callback_source()
+        assert runner._authorize_platform_callback(source) is True
+        assert source.profile == "secondary"
+        assert seen["profile"] == "secondary"
+
+    def test_denied_operator_is_rejected(self, monkeypatch):
+        """An operator not approved on the routed profile is denied (item 6)."""
+        runner = _make_runner(monkeypatch)
+        runner._profile_name_for_source = MagicMock(return_value="secondary")
+        runner._is_user_authorized = MagicMock(return_value=False)
+
+        assert runner._authorize_platform_callback(_callback_source()) is False
+
+    def test_route_to_unserved_profile_fails_closed(self, monkeypatch):
+        """An explicit route to an unserved profile fails closed and never
+        reaches the authorization decision (item 8)."""
+        from gateway.profile_routing import ProfileRouteRejected
+
+        runner = _make_runner(monkeypatch)
+        runner._profile_name_for_source = MagicMock(
+            side_effect=ProfileRouteRejected("secondary")
+        )
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        source = _callback_source()
+        assert runner._authorize_platform_callback(source) is False
+        assert source.profile_route_rejected is True
+        runner._is_user_authorized.assert_not_called()
+
+    def test_unmatched_chat_uses_default_profile(self, monkeypatch):
+        """No matching route leaves ``profile`` None → default pairing store
+        (item 7)."""
+        runner = _make_runner(monkeypatch)
+        runner._profile_name_for_source = MagicMock(return_value=None)
+        seen = {}
+
+        def _auth(source):
+            seen["profile"] = source.profile
+            return True
+
+        runner._is_user_authorized = _auth
+
+        source = _callback_source()
+        assert runner._authorize_platform_callback(source) is True
+        assert source.profile is None
+        assert seen["profile"] is None
+
+    def test_non_multiplex_skips_routing(self, monkeypatch):
+        """With multiplexing off, no route resolution runs; the source goes
+        straight to the authorization decision."""
+        runner = _make_runner(monkeypatch, multiplex=False)
+        runner._profile_name_for_source = MagicMock()
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        assert runner._authorize_platform_callback(_callback_source()) is True
+        runner._profile_name_for_source.assert_not_called()

--- a/tests/gateway/test_telegram_callback_multiplex_auth.py
+++ b/tests/gateway/test_telegram_callback_multiplex_auth.py
@@ -367,3 +367,150 @@ class TestCallbackDispatchGating:
         assert query.answers
         assert "not authorized" not in query.answers[-1].lower()
         assert "already" in query.answers[-1].lower()
+
+
+# -- Fully wired: runner registration + real per-profile PairingStore ------
+
+
+@contextmanager
+def _clean_auth_env(monkeypatch):
+    """Strip every Telegram auth env so ``_is_user_authorized`` reaches the
+    pairing-store check instead of short-circuiting on an allowlist."""
+    for var in (
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "TELEGRAM_ALLOW_BOTS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+def _wired_runner(monkeypatch, *, routed_profile, pairing_stores, default_store):
+    """A GatewayRunner exposing the REAL callback-authorization chain:
+    ``_authorize_platform_callback`` → ``_is_user_authorized`` →
+    ``_pairing_store_for`` → per-profile ``PairingStore``.
+
+    Only the seams the issue lets us stub are stubbed: route *name* resolution
+    (covered live by ``TestAuthorizePlatformCallback``), the adapter-lookup
+    helpers, the profile runtime scope, and profile-home resolution. Env
+    allowlists and adapter-delegation are neutralized so the pairing store is
+    the sole authorization authority — i.e. routing the callback to the wrong
+    store, or dropping resolver registration, both surface as a denied gate.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = MagicMock(spec=GatewayRunner)
+    runner.config = SimpleNamespace(multiplex_profiles=True, profile_routes=[])
+    runner.pairing_stores = pairing_stores
+    runner.pairing_store = default_store
+    runner._profile_name_for_source = MagicMock(return_value=routed_profile)
+    # Bind the real authorization chain to this runner instance.
+    runner._authorize_platform_callback = (
+        GatewayRunner._authorize_platform_callback.__get__(runner)
+    )
+    runner._is_user_authorized = GatewayRunner._is_user_authorized.__get__(runner)
+    runner._pairing_store_for = GatewayRunner._pairing_store_for.__get__(runner)
+    # Benign adapter-lookup helpers: never fail open through the delegation gate
+    # (a bare MagicMock here would auto-truthy and admit everyone).
+    runner._adapter_authorization_is_upstream = MagicMock(return_value=False)
+    runner._adapter_enforces_own_access_policy = MagicMock(return_value=False)
+    runner._adapter_profile_for_source = MagicMock(return_value=None)
+    runner._adapter_for_source = MagicMock(return_value=None)
+    runner._resolve_profile_home_for_source = MagicMock(return_value="/home")
+    monkeypatch.setattr("gateway.run._profile_runtime_scope", _noop_scope)
+    return runner
+
+
+@pytest.fixture
+def _pairing_env(monkeypatch, tmp_path):
+    """Real per-profile + default PairingStores under a temp HERMES_HOME, with
+    operator ``999`` paired ONLY in the ``secondary`` profile."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from gateway.pairing import PairingStore
+
+    secondary = PairingStore(profile="secondary")
+    secondary._approve_user("telegram", "999", "op")
+    default_store = PairingStore(profile="default")
+    # Sanity: the operator is isolated to the routed profile.
+    assert secondary.is_approved("telegram", "999") is True
+    assert default_store.is_approved("telegram", "999") is False
+    return {"secondary": secondary}, default_store
+
+
+class TestFullyWiredPairingStoreDispatch:
+    """End-to-end callback gating with the resolver actually *registered* on the
+    adapter (``set_callback_auth_resolver``) and a real per-profile
+    ``PairingStore`` behind ``_is_user_authorized``. This is the regression the
+    seam-level tests could not catch: it would fail if resolver registration
+    were removed from the runner, or if the callback were authorized against the
+    wrong (default) pairing store — the exact #86296 failure mode."""
+
+    @pytest.mark.parametrize(
+        "data, registry_attr, key",
+        [
+            ("ea:once:1", "_approval_state", 1),
+            ("sc:once:cid", "_slash_confirm_state", "cid"),
+            ("cl:lid:0", "_clarify_state", "lid"),
+        ],
+    )
+    def test_paired_operator_on_routed_profile_clears_gate(
+        self, monkeypatch, _pairing_env, data, registry_attr, key
+    ):
+        with _clean_auth_env(monkeypatch):
+            pairing_stores, default_store = _pairing_env
+            runner = _wired_runner(
+                monkeypatch,
+                routed_profile="secondary",
+                pairing_stores=pairing_stores,
+                default_store=default_store,
+            )
+            adapter = _make_adapter()
+            # REAL registration: the runner installs its own resolver.
+            adapter.set_callback_auth_resolver(runner._authorize_platform_callback)
+            setattr(adapter, registry_attr, {})
+            query = _FakeQuery(data)
+            _run(adapter._handle_callback_query(_FakeUpdate(query), None))
+
+        assert query.answers
+        assert "not authorized" not in query.answers[-1].lower()
+        assert "already" in query.answers[-1].lower()
+
+    @pytest.mark.parametrize(
+        "data, registry_attr, key, denial_marker",
+        [
+            ("ea:once:1", "_approval_state", 1, "approve"),
+            ("sc:once:cid", "_slash_confirm_state", "cid", "answer this prompt"),
+            ("cl:lid:0", "_clarify_state", "lid", "answer this prompt"),
+        ],
+    )
+    def test_unpaired_default_route_denies_and_keeps_state(
+        self, monkeypatch, _pairing_env, data, registry_attr, key, denial_marker
+    ):
+        """No matching route → the default store (where the operator is NOT
+        paired) is consulted, the tap is denied, and the pending action is not
+        consumed. Proves the allow branch above is not vacuous and that the
+        authorization really flows through the per-source store selection."""
+        with _clean_auth_env(monkeypatch):
+            pairing_stores, default_store = _pairing_env
+            runner = _wired_runner(
+                monkeypatch,
+                routed_profile=None,
+                pairing_stores=pairing_stores,
+                default_store=default_store,
+            )
+            adapter = _make_adapter()
+            adapter.set_callback_auth_resolver(runner._authorize_platform_callback)
+            adapter._approval_state = {1: "sess-ea"}
+            adapter._slash_confirm_state = {"cid": "sess-sc"}
+            adapter._clarify_state = {"lid": "sess-cl"}
+            query = _FakeQuery(data)
+            _run(adapter._handle_callback_query(_FakeUpdate(query), None))
+
+        assert query.answers
+        assert "not authorized" in query.answers[-1].lower()
+        assert denial_marker in query.answers[-1].lower()
+        assert key in getattr(adapter, registry_attr)

--- a/tests/gateway/test_telegram_callback_multiplex_auth.py
+++ b/tests/gateway/test_telegram_callback_multiplex_auth.py
@@ -133,8 +133,12 @@ class TestAdapterPrefersResolver:
 
         assert adapter._is_callback_user_authorized("999", chat_id="-100") is False
 
-    def test_resolver_exception_falls_back_to_env(self, monkeypatch):
-        """If the resolver raises, the adapter falls back to env-only auth."""
+    def test_resolver_exception_fails_closed(self, monkeypatch):
+        """A resolver error must DENY, not fall through to the process-wide env
+        allowlist. The env fallback is not scoped to the routed profile, so
+        honoring it on a resolver error would cross the profile-specific
+        pairing boundary (#86296). Fail closed instead."""
+        # Env allowlist WOULD allow "999"; the resolver raising must not let it.
         monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "999")
 
         def _boom(source):
@@ -143,7 +147,7 @@ class TestAdapterPrefersResolver:
         adapter = _make_adapter()
         adapter._callback_auth_resolver = _boom
 
-        assert adapter._is_callback_user_authorized("999", chat_id="-100") is True
+        assert adapter._is_callback_user_authorized("999", chat_id="-100") is False
 
     def test_no_resolver_still_fail_closed_without_allowlist(self, monkeypatch):
         """No resolver, no allowlist, no allow-all → deny (preserves #24457)."""
@@ -256,3 +260,110 @@ class TestAuthorizePlatformCallback:
 
         assert runner._authorize_platform_callback(_callback_source()) is True
         runner._profile_name_for_source.assert_not_called()
+
+
+# -- Real callback-dispatch gating: ea:/sc:/cl: families -------------------
+
+
+class _FakeUser:
+    def __init__(self, uid, first_name="op"):
+        self.id = uid
+        self.first_name = first_name
+
+
+class _FakeChat:
+    def __init__(self, chat_id, chat_type="group"):
+        self.id = chat_id
+        self.type = chat_type
+
+
+class _FakeMessage:
+    def __init__(self, chat_id, chat_type="group", thread_id=None):
+        self.chat_id = chat_id
+        self.chat = _FakeChat(chat_id, chat_type)
+        self.message_thread_id = thread_id
+
+
+class _FakeQuery:
+    def __init__(self, data, user_id="999", chat_id="-1001234567890"):
+        self.data = data
+        self.from_user = _FakeUser(user_id)
+        self.message = _FakeMessage(chat_id)
+        self.answers = []
+
+    async def answer(self, text=None, **kwargs):
+        self.answers.append(text)
+
+
+class _FakeUpdate:
+    def __init__(self, query):
+        self.callback_query = query
+
+
+def _run(coro):
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+def _dispatch_adapter(resolver):
+    adapter = _make_adapter()
+    adapter._callback_auth_resolver = resolver
+    # Registries the ea:/sc:/cl: blocks consult *after* the auth gate.
+    adapter._approval_state = {1: "sess-ea"}
+    adapter._slash_confirm_state = {"cid": "sess-sc"}
+    adapter._clarify_state = {"lid": "sess-cl"}
+    return adapter
+
+
+class TestCallbackDispatchGating:
+    """Drive the real ``_handle_callback_query`` for each gated button family
+    (``ea:`` approval, ``sc:`` slash-confirm, ``cl:`` clarify) so the dispatch
+    path itself — not a mocked seam — is proven to deny an unauthorized
+    operator via the installed resolver. This is the exact tap path #86296
+    reproduced (a pairing-authorized operator was wrongly rejected; here we
+    assert the inverse boundary: an *un*authorized operator is refused and the
+    pending action is never consumed)."""
+
+    @pytest.mark.parametrize(
+        "data, registry_attr, key, denial_marker",
+        [
+            ("ea:once:1", "_approval_state", 1, "approve"),
+            ("sc:once:cid", "_slash_confirm_state", "cid", "answer this prompt"),
+            ("cl:lid:0", "_clarify_state", "lid", "answer this prompt"),
+        ],
+    )
+    def test_unauthorized_operator_denied_and_state_untouched(
+        self, data, registry_attr, key, denial_marker
+    ):
+        adapter = _dispatch_adapter(lambda source: False)
+        query = _FakeQuery(data)
+        _run(adapter._handle_callback_query(_FakeUpdate(query), None))
+        # Denied with an authorization message ...
+        assert query.answers, "expected a denial answer"
+        assert "not authorized" in query.answers[-1].lower()
+        assert denial_marker in query.answers[-1].lower()
+        # ... and the pending action was NOT consumed/resolved.
+        assert key in getattr(adapter, registry_attr)
+
+    @pytest.mark.parametrize(
+        "data, registry_attr, key",
+        [
+            ("ea:once:1", "_approval_state", 1),
+            ("sc:once:cid", "_slash_confirm_state", "cid"),
+            ("cl:lid:0", "_clarify_state", "lid"),
+        ],
+    )
+    def test_authorized_operator_passes_gate(self, data, registry_attr, key):
+        """A resolver-authorized operator clears the gate: the block proceeds
+        past the auth check to the registry lookup (here empty → 'already
+        resolved'), proving the deny branch was not taken."""
+        adapter = _dispatch_adapter(lambda source: True)
+        # Empty registry so the post-gate step short-circuits without running
+        # the heavy resolve/render code — we only assert the gate was cleared.
+        setattr(adapter, registry_attr, {})
+        query = _FakeQuery(data)
+        _run(adapter._handle_callback_query(_FakeUpdate(query), None))
+        assert query.answers
+        assert "not authorized" not in query.answers[-1].lower()
+        assert "already" in query.answers[-1].lower()

--- a/tests/gateway/test_telegram_callback_multiplex_auth.py
+++ b/tests/gateway/test_telegram_callback_multiplex_auth.py
@@ -514,3 +514,36 @@ class TestFullyWiredPairingStoreDispatch:
         assert "not authorized" in query.answers[-1].lower()
         assert denial_marker in query.answers[-1].lower()
         assert key in getattr(adapter, registry_attr)
+
+
+class TestProductionWiringRegistersResolver:
+    """Guard the *production* registration, not just a hand-installed resolver.
+
+    ``start`` and ``_platform_reconnect_watcher`` both wire the primary adapter
+    through ``_wire_primary_adapter_handlers``. The dispatch tests above call
+    ``set_callback_auth_resolver`` themselves, so they would stay green if that
+    single production line were deleted — the exact regression #86296 guards
+    against. This drives the real helper and asserts the runner installs its own
+    ``_authorize_platform_callback`` as the adapter's callback-auth resolver.
+    """
+
+    def test_wire_primary_adapter_handlers_installs_callback_auth_resolver(self):
+        from gateway.run import GatewayRunner
+
+        runner = MagicMock()
+        # Bind only the real method under test; every collaborator stays a mock.
+        runner._wire_primary_adapter_handlers = (
+            GatewayRunner._wire_primary_adapter_handlers.__get__(runner)
+        )
+        adapter = MagicMock()
+
+        runner._wire_primary_adapter_handlers(adapter)
+
+        # The production choke point must register the runner's own resolver
+        # (both start and reconnect route through this same helper).
+        adapter.set_callback_auth_resolver.assert_called_once_with(
+            runner._authorize_platform_callback
+        )
+        # Sibling sanity: the primary event handler is still wired here too, so
+        # the helper is the genuine primary-adapter setup path.
+        adapter.set_platform_event_handler.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes #86296.

Under `gateway.multiplex_profiles` with a primary Telegram bot plus an exact `profile_routes` mapping, tapping an inline slash-confirm button (e.g. **Approve Once** for `/new`) is rejected with `⛔ You are not authorized to answer this prompt.`, even though normal text messages from the same operator in the same routed group are authorized and replying `/approve` as text works.

### Root cause

`TelegramAdapter._is_callback_user_authorized` recovered the gateway runner through the bound message handler:

```python
runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
```

In multiplex mode the primary handler is a **closure** (`GatewayRunner._make_default_profile_platform_event_handler`) with no bound `__self__`, so the runner could not be recovered and callback auth fell back to `_scoped_gate_env("TELEGRAM_ALLOWED_USERS")` — bypassing the routed profile's pairing store. Additionally, the callback-created `SessionSource` never had its profile route applied, so even with a runner reference `_is_user_authorized` would have consulted the **default** pairing store (`_adapter_profile_for_source` returns `source.profile` for the primary adapter) instead of the routed secondary profile's.

The same helper gates slash-confirm, clarify, and dangerous-command approval callbacks, so all three were affected.

### Fix

- **`BasePlatformAdapter.set_callback_auth_resolver`** — a runner-owned resolver seam for inline-callback auth (parallel to `set_platform_event_handler`).
- **`GatewayRunner._authorize_platform_callback`** — installed on the primary adapter; applies the same profile-route resolution, profile stamping, runtime scope, and gateway authorization decision as normal inbound messages (mirrors the ingress gate in `_handle_message`). Fails closed when an explicit route targets an unserved profile.
- **`TelegramAdapter._is_callback_user_authorized`** — prefers the installed resolver, keeping the `_message_handler.__self__` introspection (non-multiplex primary) and env-only fail-closed paths as fallbacks.

This mirrors how the analogous Slack interactive-callback authorization gap was closed in #38068 / #41226 (route callbacks through the normal gateway authorization helper).

### Tests

New `tests/gateway/test_telegram_callback_multiplex_auth.py` covers both seams:

- **Adapter:** prefers the resolver and passes a correctly-built `SessionSource`; a resolver *denial* is final (no env fallthrough); a resolver *exception* falls back to env; with no resolver and no allowlist it still fails closed (preserves #24457).
- **Runner (`_authorize_platform_callback`):** a matched route stamps `source.profile` before the auth decision; an unapproved operator is denied; a route to an unserved profile fails closed and never reaches authorization; an unmatched chat leaves `profile` `None` (default store); multiplexing off skips routing entirely.

### Verification

- `tests/gateway/test_telegram_callback_multiplex_auth.py` — 9 passed
- `test_telegram_callback_auth_fail_closed.py`, `test_profile_resolution.py`, `test_telegram_auth_check.py` — 26 passed
- `ruff check` clean; `ty` reports no new diagnostics on the changed lines

The arm64-fork-Docker build failure expected on fork PRs is unrelated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile-aware authorization for inline callback actions.
  * Callback requests are routed to the appropriate profile and checked against its runtime permissions.
  * Supports authorization during both initial setup and reconnection.

* **Bug Fixes**
  * Unauthorized, rejected, or unmatched callbacks are now denied safely without consuming pending actions.
  * Authorization failures no longer fall back to broader process-level permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->