### PR TITLE
fix: deliver cron origin to api server sessions

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -886,9 +886,19 @@ def _resolve_origin(job: dict) -> Optional[dict]:
         return None
     platform = origin.get("platform")
     chat_id = origin.get("chat_id")
-    if platform and chat_id:
-        return origin
-    return None
+    if not (platform and chat_id):
+        return None
+
+    # Compatibility for jobs created by browser/WebUI sessions before origin
+    # capture normalized non-push sessions. ``webui`` is an observed session
+    # surface, not a gateway delivery Platform; the durable return path is the
+    # existing api_server wake/self-post session id. Copy rather than mutate the
+    # job record so resolution remains side-effect free.
+    if str(platform).strip().lower() == "webui":
+        normalized = dict(origin)
+        normalized["platform"] = "api_server"
+        return normalized
+    return origin
 
 
 def _cron_mirror_delivery_enabled(job: dict, cfg: Optional[dict] = None) -> bool:
@@ -2123,7 +2133,47 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 thread_id = new_thread_id
                 opened_thread_id = new_thread_id
 
-        if live_adapter_ready:
+        if live_adapter_ready and runtime_adapter is not None:
+            from gateway.wake import adapter_supports_push
+
+            if not adapter_supports_push(runtime_adapter):
+                # Stateless request/response surfaces (api_server/WebUI) are
+                # not push channels. Use the shared wake self-post primitive
+                # that async completions already use so the cron result resumes
+                # the raw UI/API session instead of trying send_message-style
+                # platform delivery or a standalone API-server send.
+                text_to_send = cleaned_delivery_content.strip()
+                if not text_to_send:
+                    delivered = True
+                else:
+                    from agent.async_utils import safe_schedule_threadsafe
+                    from gateway.wake import WAKE_TURN_TIMEOUT_SECONDS, deliver_wake
+
+                    try:
+                        future = safe_schedule_threadsafe(
+                            deliver_wake(
+                                runtime_adapter,
+                                text=text_to_send,
+                                session_id=str(chat_id),
+                            ),
+                            loop,
+                        )
+                        if future is None:
+                            msg = "wake self-post scheduling failed"
+                            target_errors.append(msg)
+                        else:
+                            future.result(timeout=WAKE_TURN_TIMEOUT_SECONDS + 5)
+                            logger.info(
+                                "Job '%s': delivered to %s session %s via wake self-post",
+                                job["id"], platform_name, chat_id,
+                            )
+                            delivered = True
+                    except Exception as e:
+                        msg = f"wake self-post delivery to {platform_name}:{chat_id} failed: {e}"
+                        logger.warning("Job '%s': %s", job["id"], msg)
+                        target_errors.append(msg)
+
+        if live_adapter_ready and not delivered:
             # Telegram topic routing (#22773, regression fixed #52060): a
             # ``telegram:<positive_chat_id>:<numeric_thread_id>`` cron target is
             # ambiguous — a forum-style topic in a private chat and a genuine

--- a/tests/cron/test_origin_webui_api_server.py
+++ b/tests/cron/test_origin_webui_api_server.py
@@ -1,0 +1,92 @@
+"""Regression tests for WebUI/API-server cron origin delivery."""
+
+from concurrent.futures import Future
+from types import SimpleNamespace
+
+from cron.scheduler import _deliver_result, _resolve_delivery_target, _resolve_origin
+from gateway.config import Platform
+from gateway.session_context import clear_session_vars, set_session_vars
+from tools.cronjob_tools import _origin_from_env
+
+
+def test_webui_session_origin_captures_api_server_raw_session_id():
+    tokens = set_session_vars(
+        platform="webui",
+        chat_id="transcript-session-id",
+        ui_session_id="raw-ui-session-id",
+        async_delivery=False,
+    )
+    try:
+        origin = _origin_from_env()
+    finally:
+        clear_session_vars(tokens)
+
+    assert origin["platform"] == "api_server"
+    assert origin["chat_id"] == "raw-ui-session-id"
+    assert origin["thread_id"] is None
+
+
+def test_legacy_webui_origin_normalizes_to_api_server_without_mutating_job():
+    job = {
+        "id": "legacy-webui-job",
+        "deliver": "origin",
+        "origin": {"platform": "webui", "chat_id": "raw-ui-session-id"},
+    }
+
+    assert _resolve_origin(job) == {
+        "platform": "api_server",
+        "chat_id": "raw-ui-session-id",
+    }
+    assert job["origin"]["platform"] == "webui"
+    assert _resolve_delivery_target(job) == {
+        "platform": "api_server",
+        "chat_id": "raw-ui-session-id",
+        "thread_id": None,
+    }
+
+
+def test_api_server_origin_delivery_uses_wake_self_post(monkeypatch):
+    calls = []
+
+    async def fake_deliver_wake(adapter, *, text, session_id="", source=None):
+        calls.append({"adapter": adapter, "text": text, "session_id": session_id, "source": source})
+
+    def fake_schedule(coro, loop):
+        future = Future()
+        try:
+            import asyncio
+
+            future.set_result(asyncio.run(coro))
+        except BaseException as exc:  # pragma: no cover - failure assertion path
+            future.set_exception(exc)
+        return future
+
+    pconfig = SimpleNamespace(enabled=True, extra={})
+    adapter = SimpleNamespace(supports_async_delivery=False)
+    loop = SimpleNamespace(is_running=lambda: True)
+    config = SimpleNamespace(platforms={Platform.API_SERVER: pconfig})
+    transport = SimpleNamespace(config=pconfig, adapter=adapter, is_relay=False)
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
+    monkeypatch.setattr("gateway.delivery.resolve_delivery_transport", lambda *args, **kwargs: transport)
+    monkeypatch.setattr("gateway.wake.deliver_wake", fake_deliver_wake)
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", fake_schedule)
+
+    err = _deliver_result(
+        {
+            "id": "webui-cron",
+            "name": "WebUI cron",
+            "deliver": "origin",
+            "origin": {"platform": "webui", "chat_id": "raw-ui-session-id"},
+        },
+        "done",
+        adapters={Platform.API_SERVER: adapter},
+        loop=loop,
+    )
+
+    assert err is None
+    assert len(calls) == 1
+    assert calls[0]["adapter"] is adapter
+    assert calls[0]["session_id"] == "raw-ui-session-id"
+    assert "Cronjob Response: WebUI cron" in calls[0]["text"]
+    assert calls[0]["source"] is None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -317,6 +317,18 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
     from gateway.session_context import get_session_env
     origin_platform = get_session_env("HERMES_SESSION_PLATFORM")
     origin_chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
+    ui_session_id = get_session_env("HERMES_UI_SESSION_ID") or ""
+
+    # Browser/WebUI turns are not gateway push platforms. They expose the raw
+    # UI/API session id, and background completions already route those through
+    # the api_server wake/self-post path. Persist that same shared origin shape
+    # instead of recording ``webui`` as a fake Platform value that cron cannot
+    # deliver to. Prefer the raw UI session id when present; fall back to the
+    # chat id for older/bare bindings where it already carries the session id.
+    if str(origin_platform or "").strip().lower() == "webui":
+        origin_platform = "api_server"
+        origin_chat_id = ui_session_id or origin_chat_id
+
     if origin_platform and origin_chat_id:
         thread_id = get_session_env("HERMES_SESSION_THREAD_ID") or None
         # Slack thread-per-message session keying (native parity: thread_ts =


### PR DESCRIPTION
## Summary
- normalize WebUI-created cron origins to the existing `api_server` session return path
- normalize legacy persisted `origin.platform = "webui"` jobs at delivery-resolution time without mutating stored jobs
- deliver non-push API-server cron results through the shared `gateway.wake.deliver_wake()` self-post path instead of `send_message` platform delivery

## Tests
- `TMPDIR='C:/Users/davep/AppData/Local/hermes/hermes-agent-cron-origin-fix/.pytest-tmp' TEMP='C:/Users/davep/AppData/Local/hermes/hermes-agent-cron-origin-fix/.pytest-tmp' TMP='C:/Users/davep/AppData/Local/hermes/hermes-agent-cron-origin-fix/.pytest-tmp' uv run --with pytest pytest --basetemp='C:/Users/davep/AppData/Local/hermes/hermes-agent-cron-origin-fix/.pytest-tmp/base' tests/cron/test_origin_webui_api_server.py -q`
- `TMPDIR='C:/Users/davep/AppData/Local/hermes/hermes-agent-cron-origin-fix/.pytest-tmp' TEMP='C:/Users/davep/AppData/Local/hermes/hermes-agent-cron-origin-fix/.pytest-tmp' TMP='C:/Users/davep/AppData/Local/hermes/hermes-agent-cron-origin-fix/.pytest-tmp' uv run --with pytest pytest --basetemp='C:/Users/davep/AppData/Local/hermes/hermes-agent-cron-origin-fix/.pytest-tmp/base2' tests/cron/test_scheduler.py::TestResolveOrigin tests/cron/test_scheduler.py::TestResolveDeliveryTarget -q`
- `python -m py_compile cron/scheduler.py tools/cronjob_tools.py tests/cron/test_origin_webui_api_server.py`
- `git diff --check`

## Notes
A broader `tests/cron -q` run completed with `562 passed, 19 skipped, 14 failed`; the failures appear unrelated to this patch on this Windows/MSYS host: file permission mode assertions, HOME/tilde normalization, NUL-path script handling, and monitor-kind tests blocked by provider drift-skip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cron job delivery for API-server sessions, including adapters that do not support push notifications.
  * Added support for legacy WebUI-originated sessions by normalizing them to the correct API-server destination.
  * Improved handling of scheduling, timeouts, empty responses, and delivery errors.
  * Preserved session information more reliably when creating cron jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->