### PR TITLE
Tag each sidebar project row with data-sessions-project

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
@@ -86,4 +86,10 @@ describe('ProjectOverviewRow', () => {
 
     expect(onNewSession).toHaveBeenCalledWith(null)
   })
+
+  it('tags the row with data-sessions-project so a skin can target one project', () => {
+    const { container } = render(<ProjectOverviewRow project={project} />)
+
+    expect(container.querySelector('[data-sessions-project="p1"]')).toBeTruthy()
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -158,7 +158,11 @@ export function ProjectOverviewRow({
   )
 
   return (
-    <div className={cn(dragging && 'relative z-10')} ref={ref} style={style}>
+    // Tag each project sibling with its id so a custom skin can target one
+    // project in the overview — the parallel to the entered-project wrapper's
+    // `data-sessions-project` (index.tsx), which only fires once you've drilled
+    // in. Here it's present on every row of the list.
+    <div className={cn(dragging && 'relative z-10')} data-sessions-project={project.id} ref={ref} style={style}>
       {/* Home has no per-project actions, so it gets no right-click menu. */}
       {project.isNoProject ? (
         shell


### PR DESCRIPTION
Follow-up to [#85869](https://github.com/NousResearch/hermes-agent/pull/85869) on user feedback: `data-sessions-project` was only on the sessions wrapper, and only once a project was *entered* — so in the project overview (and every other mode) it was nowhere to be found.

## What

Each project row in the overview now carries `data-sessions-project="<project id>"`.

## Why

The original request was for the sessions-area siblings to be identifiable **each** — so a custom UI can style one project differently. The wrapper attribute alone can only distinguish the single entered project; the overview list, where you actually see every project side by side, had nothing to hook onto.

## How

One attribute on `ProjectOverviewRow`'s outer element, set to the row's `project.id`. No behavior change — purely an identification hook.

### Usage

```css
/* style one project's row in the overview */
[data-sessions-project="my-project-id"] { /* … */ }
```

Combined with the wrapper's `data-sessions-mode` / `data-sessions-project` from [#85869](https://github.com/NousResearch/hermes-agent/pull/85869), a skin can target project mode as a whole, the entered project, or any individual project row.

Covered by a unit test asserting the row exposes the attribute with its id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Project overview rows now expose their project identifier for improved compatibility with session-related interactions.
* **Tests**
  * Added coverage confirming the project identifier is rendered correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->