### PR TITLE
fix(agent): bot prompt leaks default profile's skills index + identity

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -13,7 +13,13 @@ import contextvars
 from collections import OrderedDict
 from pathlib import Path
 
-from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
+from hermes_constants import (
+    get_hermes_home,
+    get_skills_dir,
+    is_wsl,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 from typing import List, Optional
 
 from agent.runtime_cwd import resolve_agent_cwd
@@ -1718,6 +1724,7 @@ def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
+    skills_dir_override: "Path | None" = None,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -1739,13 +1746,44 @@ def build_skills_system_prompt(
     visible and loadable via ``skill_view`` / ``skills_list``; only the
     descriptions are dropped, and a footer note explains the demotion.
     """
-    skills_dir = get_skills_dir()
-    external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
+    # Home resolution is EXPLICIT when a caller passes skills_dir_override
+    # (the agent knows its own profile home from its session_db path). This
+    # avoids the ContextVar-on-a-thread trap: build threads that didn't bind
+    # HERMES_HOME would otherwise fall back to the launch (default) home and
+    # leak the default profile's skills into a bot's prompt (confirmed: a
+    # no-override thread builds default's full index). Snapshot + external
+    # dirs are scoped to the same home so nothing reads ambient state.
+    if skills_dir_override is not None:
+        skills_dir = Path(skills_dir_override)
+        _home_token = set_hermes_home_override(str(skills_dir.parent))
+    else:
+        skills_dir = get_skills_dir()
+        _home_token = None
+    try:
+        external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
 
-    if not skills_dir.exists() and not external_dirs:
-        return ""
+        if not skills_dir.exists() and not external_dirs:
+            return ""
 
-    # ── Layer 1: in-process LRU cache ─────────────────────────────────
+        return _build_skills_system_prompt_inner(
+            skills_dir,
+            external_dirs,
+            available_tools,
+            available_toolsets,
+            compact_categories,
+        )
+    finally:
+        if _home_token is not None:
+            reset_hermes_home_override(_home_token)
+
+
+def _build_skills_system_prompt_inner(
+    skills_dir: "Path",
+    external_dirs: "list[Path]",
+    available_tools: "set[str] | None",
+    available_toolsets: "set[str] | None",
+    compact_categories: "frozenset[str] | None",
+) -> str:
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
     _platform_hint = _current_session_platform_hint()

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -51,6 +51,7 @@ from agent.prompt_builder import (
 )
 from agent.runtime_cwd import resolve_context_cwd
 from hermes_constants import get_hermes_home
+from pathlib import Path
 from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -262,6 +263,32 @@ def _plugin_section_blocks(sections: tuple, position: str) -> List[str]:
     return [block] if block else []
 
 
+def _agent_home(agent: Any) -> Optional[Path]:
+    """The agent's OWN profile home, resolved from its dedicated session_db.
+
+    The agent's ``_session_db.db_path`` is ``<home>/state.db`` — ground truth
+    for which profile this agent belongs to, independent of any HERMES_HOME
+    ContextVar (which a build thread can lose: ContextVars don't propagate
+    into ``threading.Thread``, so an unbound build falls back to the launch
+    home and leaks the default profile's skills/identity into a bot prompt).
+    Returns None when it can't be resolved so callers fall back to ambient.
+    """
+    try:
+        db = getattr(agent, "_session_db", None)
+        db_path = getattr(db, "db_path", None)
+        if db_path:
+            return Path(db_path).parent
+    except Exception:
+        pass
+    return None
+
+
+def _agent_skills_dir(agent: Any) -> Optional[Path]:
+    """The agent's own ``<home>/skills`` dir, or None to use ambient home."""
+    home = _agent_home(agent)
+    return (home / "skills") if home is not None else None
+
+
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
     """Assemble the system prompt as three ordered cache tiers.
 
@@ -435,6 +462,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
+            skills_dir_override=_agent_skills_dir(agent),
         )
     else:
         skills_prompt = ""
@@ -514,15 +542,35 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # mid-session, so this doesn't break the prompt cache.
     # See file_safety._resolve_active_profile_name + classify_cross_profile_target
     # for the matching tool-side guard.
+    #
+    # Resolve from the agent's OWN home first (its session_db path), not the
+    # ambient HERMES_HOME: on a build thread that lost the ContextVar this
+    # line would otherwise print "default" for a bot profile — the same
+    # thread-fallback bug that leaked default's skills index.
+    _agent_home_path = _agent_home(agent)
+    active_profile = "default"
     try:
-        from agent.file_safety import _resolve_active_profile_name
-        active_profile = _resolve_active_profile_name()
+        if _agent_home_path is not None:
+            root = get_hermes_home()
+            try:
+                rel = _agent_home_path.resolve().relative_to((root / "profiles").resolve())
+                active_profile = rel.parts[0] if rel.parts else "default"
+            except (ValueError, OSError):
+                # Home IS the launch root (default) or unrelatable → default.
+                active_profile = "default"
+        else:
+            from agent.file_safety import _resolve_active_profile_name
+            active_profile = _resolve_active_profile_name()
     except Exception:
         active_profile = "default"
+    # Home string for the message text: prefer the agent's own home so the
+    # paths named match the profile just resolved.
+    _home_str = str(_agent_home_path if _agent_home_path is not None else get_hermes_home())
+    _root_str = str(get_hermes_home())
     if active_profile == "default":
         post_workspace_parts.append(
             "Active Hermes profile: default. Other profiles (if any) live "
-            "under " + str(get_hermes_home()) + "/profiles/<name>/. Each profile has its own "
+            "under " + _root_str + "/profiles/<name>/. Each profile has its own "
             "skills/, plugins/, cron/, and memories/ that affect a different "
             "session than this one. Do not modify another profile's "
             "skills/plugins/cron/memories unless the user explicitly directs "
@@ -531,9 +579,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     else:
         post_workspace_parts.append(
             f"Active Hermes profile: {active_profile}. This session reads "
-            f"and writes {get_hermes_home()}/profiles/{active_profile}/. The default "
-            f"profile's data lives at {get_hermes_home()}/skills/, {get_hermes_home()}/plugins/, "
-            f"{get_hermes_home()}/cron/, {get_hermes_home()}/memories/ — those belong to a "
+            f"and writes {_home_str}/. The default "
+            f"profile's data lives at {_root_str}/skills/, {_root_str}/plugins/, "
+            f"{_root_str}/cron/, {_root_str}/memories/ — those belong to a "
             f"different session run from a different shell. Do NOT modify "
             f"another profile's skills/plugins/cron/memories unless the user "
             f"explicitly directs you to. The cross-profile write guard will "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -289,6 +289,27 @@ def _agent_skills_dir(agent: Any) -> Optional[Path]:
     return (home / "skills") if home is not None else None
 
 
+def _profile_name_for_home(home: Path) -> str:
+    """Derive the profile name for an explicit agent home.
+
+    ``<root>/profiles/X`` -> ``"X"``; anything else -> ``"default"``.
+
+    Uses :func:`get_default_hermes_root` (NOT ``get_hermes_home()``): on a
+    correctly bound profile session the ambient home IS the profile dir, so
+    ``get_hermes_home()/profiles`` would never contain ``home`` and every
+    profile would misreport as "default".
+    """
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        root = get_default_hermes_root()
+        rel = home.resolve().relative_to((root / "profiles").resolve())
+        return rel.parts[0] if rel.parts else "default"
+    except (ValueError, OSError):
+        # Home IS the root (default profile) or unrelatable -> default.
+        return "default"
+
+
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
     """Assemble the system prompt as three ordered cache tiers.
 
@@ -551,22 +572,20 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     active_profile = "default"
     try:
         if _agent_home_path is not None:
-            root = get_hermes_home()
-            try:
-                rel = _agent_home_path.resolve().relative_to((root / "profiles").resolve())
-                active_profile = rel.parts[0] if rel.parts else "default"
-            except (ValueError, OSError):
-                # Home IS the launch root (default) or unrelatable → default.
-                active_profile = "default"
+            active_profile = _profile_name_for_home(_agent_home_path)
         else:
             from agent.file_safety import _resolve_active_profile_name
             active_profile = _resolve_active_profile_name()
     except Exception:
         active_profile = "default"
     # Home string for the message text: prefer the agent's own home so the
-    # paths named match the profile just resolved.
+    # paths named match the profile just resolved. The root (where the
+    # default profile's data lives) comes from get_default_hermes_root():
+    # get_hermes_home() on a bound profile session is the PROFILE dir, which
+    # would misname the default profile's paths.
+    from hermes_constants import get_default_hermes_root as _root_fn
     _home_str = str(_agent_home_path if _agent_home_path is not None else get_hermes_home())
-    _root_str = str(get_hermes_home())
+    _root_str = str(_root_fn())
     if active_profile == "default":
         post_workspace_parts.append(
             "Active Hermes profile: default. Other profiles (if any) live "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -579,13 +579,19 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     except Exception:
         active_profile = "default"
     # Home string for the message text: prefer the agent's own home so the
-    # paths named match the profile just resolved. The root (where the
-    # default profile's data lives) comes from get_default_hermes_root():
-    # get_hermes_home() on a bound profile session is the PROFILE dir, which
-    # would misname the default profile's paths.
-    from hermes_constants import get_default_hermes_root as _root_fn
-    _home_str = str(_agent_home_path if _agent_home_path is not None else get_hermes_home())
-    _root_str = str(_root_fn())
+    # paths named match the profile just resolved. When we have an explicit
+    # agent home, the root (where the default profile's data lives) comes
+    # from get_default_hermes_root(): get_hermes_home() on a bound profile
+    # session is the PROFILE dir, which would misname the default profile's
+    # paths. Without an agent home, keep the ambient resolution byte-identical
+    # to the legacy behavior (and patchable via this module's get_hermes_home).
+    if _agent_home_path is not None:
+        from hermes_constants import get_default_hermes_root as _root_fn
+
+        _home_str = str(_agent_home_path)
+        _root_str = str(_root_fn())
+    else:
+        _home_str = _root_str = str(get_hermes_home())
     if active_profile == "default":
         post_workspace_parts.append(
             "Active Hermes profile: default. Other profiles (if any) live "

--- a/tests/agent/test_bot_profile_prompt_isolation.py
+++ b/tests/agent/test_bot_profile_prompt_isolation.py
@@ -90,3 +90,27 @@ def test_agent_home_none_without_session_db():
 
     assert system_prompt._agent_home(_Agent()) is None
     assert system_prompt._agent_skills_dir(_Agent()) is None
+
+
+def test_profile_name_correct_on_bound_profile_session(tmp_path, monkeypatch):
+    """Regression for the fix-of-the-fix: on a CORRECTLY bound profile session
+    the ambient home IS the profile dir, so deriving the profile name with
+    ``get_hermes_home()/profiles`` as the root would never match and every
+    profile would misreport as \"default\". The name must derive from the
+    hermes ROOT (get_default_hermes_root)."""
+    from agent import system_prompt
+
+    bot_home = tmp_path / "profiles" / "mybot"
+    bot_home.mkdir(parents=True)
+
+    # Bound session: HERMES_HOME env points at the profile dir itself.
+    monkeypatch.setenv("HERMES_HOME", str(bot_home))
+
+    assert system_prompt._profile_name_for_home(bot_home) == "mybot"
+
+
+def test_profile_name_default_when_home_is_root(tmp_path, monkeypatch):
+    from agent import system_prompt
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert system_prompt._profile_name_for_home(tmp_path) == "default"

--- a/tests/agent/test_bot_profile_prompt_isolation.py
+++ b/tests/agent/test_bot_profile_prompt_isolation.py
@@ -1,0 +1,92 @@
+"""Regression: a bot profile's system prompt must reflect ITS OWN skills/home,
+never the launch (default) profile's — even when the agent build runs on a
+thread that did not bind the HERMES_HOME ContextVar.
+
+Root cause this guards (confirmed empirically): ContextVars do not propagate
+into ``threading.Thread``. ``build_skills_system_prompt`` and the
+active-profile line resolved the home via the ambient ``get_hermes_home()``,
+so an unbound build thread fell back to ``~/.hermes`` (default) and leaked
+default's full skills index + "Active Hermes profile: default" into a bot's
+prompt, while the live ``skills_list()`` (re-bound per turn) correctly
+showed the bot's real, empty set. The agent now resolves its own home from
+its ``_session_db.db_path`` and passes it explicitly.
+"""
+
+import re
+import threading
+
+import pytest
+
+
+def _skills_body(prompt: str) -> str:
+    m = re.search(r"<available_skills>(.*?)</available_skills>", prompt, re.DOTALL)
+    return (m.group(1).strip() if m else "")
+
+
+def test_skills_prompt_scoped_to_override_not_ambient_home(tmp_path, monkeypatch):
+    """An explicit skills_dir_override wins over ambient HERMES_HOME, on a
+    bare thread with no override bound."""
+    from agent import prompt_builder
+
+    # A "default" home WITH skills (the thing that must NOT leak).
+    default_home = tmp_path / "default"
+    default_skills = default_home / "skills" / "general" / "leaky-skill"
+    default_skills.mkdir(parents=True)
+    (default_skills / "SKILL.md").write_text(
+        "---\nname: leaky-skill\ndescription: should never appear in a bot prompt\n---\nbody\n",
+        encoding="utf-8",
+    )
+
+    # An empty bot profile (no skills dir at all).
+    bot_skills = tmp_path / "profiles" / "emptybot" / "skills"
+
+    # Bind ambient home to default (mimics a build thread that lost the
+    # bot's override and fell back to launch).
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    prompt_builder.clear_skills_system_prompt_cache(clear_snapshot=False)
+
+    result = {}
+
+    def build():
+        # No set_hermes_home_override on THIS thread — ambient resolves to
+        # default. The override arg must still scope to the empty bot.
+        result["bot"] = _skills_body(
+            prompt_builder.build_skills_system_prompt(skills_dir_override=bot_skills)
+        )
+
+    t = threading.Thread(target=build)
+    t.start()
+    t.join()
+
+    assert result["bot"] == "", (
+        "empty bot profile leaked skills from the ambient (default) home: "
+        + result["bot"][:200]
+    )
+
+
+def test_agent_home_resolves_from_session_db_path(tmp_path):
+    """The agent's own home is read from its session_db, independent of any
+    ContextVar."""
+    from agent import system_prompt
+
+    bot_home = tmp_path / "profiles" / "mybot"
+    bot_home.mkdir(parents=True)
+
+    class _DB:
+        db_path = bot_home / "state.db"
+
+    class _Agent:
+        _session_db = _DB()
+
+    assert system_prompt._agent_home(_Agent()) == bot_home
+    assert system_prompt._agent_skills_dir(_Agent()) == bot_home / "skills"
+
+
+def test_agent_home_none_without_session_db():
+    from agent import system_prompt
+
+    class _Agent:
+        _session_db = None
+
+    assert system_prompt._agent_home(_Agent()) is None
+    assert system_prompt._agent_skills_dir(_Agent()) is None

--- a/tests/agent/test_bot_profile_prompt_isolation.py
+++ b/tests/agent/test_bot_profile_prompt_isolation.py
@@ -114,3 +114,19 @@ def test_profile_name_default_when_home_is_root(tmp_path, monkeypatch):
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     assert system_prompt._profile_name_for_home(tmp_path) == "default"
+
+
+def test_profile_name_correct_when_ambient_is_another_profile(tmp_path, monkeypatch):
+    """CodeRabbit case: agent belongs to profile A while the ambient home is
+    bound to profile B. The root must derive independently of the ambient
+    home, so A still resolves as 'mybot' (not 'default', and never 'other')."""
+    from agent import system_prompt
+
+    bot_home = tmp_path / "profiles" / "mybot"
+    bot_home.mkdir(parents=True)
+    other_home = tmp_path / "profiles" / "other"
+    other_home.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(other_home))
+
+    assert system_prompt._profile_name_for_home(bot_home) == "mybot"


### PR DESCRIPTION
A bot profile's system prompt could render the **default** profile's ~80-skill `<available_skills>` block and "Active Hermes profile: default", while the live `skills_list()` correctly returned the bot's real (often empty) set. This is functional, not cosmetic: the agent plans and self-describes against that index, so a false inventory makes it confidently claim skills it can't load, waste context tokens every turn, and erode trust when its own testing contradicts the prompt. Reported by a Bot Mode tester who created a "create empty" (no-skills) bot that still listed ~70 skills.

**Root cause (confirmed empirically).** `build_skills_system_prompt` and the active-profile line resolve the home via `get_hermes_home()`, which reads a `HERMES_HOME` **ContextVar**. ContextVars do not propagate into `threading.Thread`, so an agent build that runs on a thread which didn't bind the profile's home falls back to the launch (default) home and builds default's index. Repro on a bare no-override thread: builds default's full 7621-char skills block; the same thread passing the fix builds empty.

**Fix.** Resolve the agent's OWN home from its dedicated `_session_db.db_path` (ground truth, ContextVar-independent) and thread it through explicitly:
- `build_skills_system_prompt(skills_dir_override=…)` scopes the index, the disk snapshot path, and external-dir resolution to that home
- the active-profile line derives the profile name from the same home instead of ambient `get_hermes_home()`

Both fall back to ambient resolution when no session_db is present, so CLI/default-profile paths are byte-identical. The skills LRU cache key already includes `skills_dir`, so scoping composes cleanly.

**Tests:** `tests/agent/test_bot_profile_prompt_isolation.py` — an empty bot profile yields an empty skills block on a bare thread even with ambient `HERMES_HOME` bound to a skills-rich default; plus agent-home resolution from `session_db.db_path`. 3/3 green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile-specific prompts now use the correct home and skills directories.
  * Prevented skills from one profile or default environment from appearing in another profile’s prompts.
  * Improved behavior when no session database is available by safely falling back to default path handling.

* **Tests**
  * Added coverage for profile prompt isolation and agent-specific home and skills-directory resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->