### PR TITLE
Fix Desktop SSH lifecycle for Fish shells

### DIFF
--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -16,6 +16,7 @@ import {
   openForward,
   ownershipDirectory,
   pidIsOurDashboard,
+  probeRemoteHermesHome,
   probeRemotePlatform,
   PROTOCOL_VERSION,
   readLockfile,
@@ -58,13 +59,19 @@ function fakeSsh(rules: any[] = []) {
   return {
     calls,
     async exec(cmd) {
-      calls.push(cmd)
+      // Lifecycle commands are wrapped in a portable POSIX-shell transport.
+      // Expose the decoded payload too so existing behavioral matchers keep
+      // asserting the command they are meant to cover.
+      const encoded = /printf %s ([A-Za-z0-9+/=]+)/.exec(cmd)?.[1]
+      const visibleCommand = encoded ? `${cmd}\n${Buffer.from(encoded, 'base64').toString('utf8')}` : cmd
+
+      calls.push(visibleCommand)
 
       for (const [matcher, resp] of rules) {
-        const hit = typeof matcher === 'function' ? matcher(cmd) : matcher.test(cmd)
+        const hit = typeof matcher === 'function' ? matcher(visibleCommand) : matcher.test(visibleCommand)
 
         if (hit) {
-          const out = typeof resp === 'function' ? resp(cmd) : resp
+          const out = typeof resp === 'function' ? resp(visibleCommand) : resp
 
           if (out instanceof Error) {
             throw out
@@ -207,6 +214,14 @@ test('probeRemotePlatform rejects unsupported remote platforms', async () => {
       return true
     }
   )
+})
+
+test('remote-home discovery runs through POSIX sh for Fish login shells', async () => {
+  const ssh = fakeSsh([[/base64/, '/Users/rook/.hermes\n']])
+
+  assert.equal(await probeRemoteHermesHome(ssh), '/Users/rook/.hermes')
+  assert.match(ssh.calls[0], /^\/bin\/sh -lc /)
+  assert.match(ssh.calls[0], /base64/)
 })
 
 test('ownership paths are isolated by ownership ID and spawn nonce', () => {
@@ -861,21 +876,23 @@ test('spawnRemoteDashboard streams the token over stdin, not argv/env', async ()
   const ssh = {
     calls,
     async exec(cmd, opts?) {
-      calls.push(cmd)
+      const encoded = /printf %s ([A-Za-z0-9+/=]+)/.exec(cmd)?.[1]
+      const visibleCommand = encoded ? `${cmd}\n${Buffer.from(encoded, 'base64').toString('utf8')}` : cmd
+      calls.push(visibleCommand)
 
       if (opts?.stdinData) {
         stdinCalls.push(opts.stdinData)
       }
 
-      if (/grep -q ssh-session-token-file/.test(cmd)) {
+      if (/grep -q ssh-session-token-file/.test(visibleCommand)) {
         return 'YES\n'
       }
 
-      if (/python3 -c/.test(cmd)) {
+      if (/python3 -c/.test(visibleCommand)) {
         return ''
       }
 
-      if (/setsid|nohup/.test(cmd)) {
+      if (/setsid|nohup/.test(visibleCommand)) {
         return '4242\n'
       }
 
@@ -912,17 +929,19 @@ test('spawnRemoteDashboard upload uses exclusive-create and O_NOFOLLOW', async (
   const ssh = {
     calls,
     async exec(cmd, opts?) {
-      calls.push(cmd)
+      const encoded = /printf %s ([A-Za-z0-9+/=]+)/.exec(cmd)?.[1]
+      const visibleCommand = encoded ? `${cmd}\n${Buffer.from(encoded, 'base64').toString('utf8')}` : cmd
+      calls.push(visibleCommand)
 
-      if (/grep -q ssh-session-token-file/.test(cmd)) {
+      if (/grep -q ssh-session-token-file/.test(visibleCommand)) {
         return 'YES\n'
       }
 
-      if (/python3 -c/.test(cmd)) {
+      if (/python3 -c/.test(visibleCommand)) {
         return ''
       }
 
-      if (/setsid|nohup/.test(cmd)) {
+      if (/setsid|nohup/.test(visibleCommand)) {
         return '4242\n'
       }
 

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -243,7 +243,7 @@ async function probeRemotePlatform(ssh) {
 // state store; best-effort.
 async function probeRemoteHermesHome(ssh) {
   try {
-    const out = (await ssh.exec('echo "${HERMES_HOME:-$HOME/.hermes}"')).trim().split('\n').pop()
+    const out = (await execRemotePosix(ssh, 'printf %s\\n "${HERMES_HOME:-$HOME/.hermes}"')).trim().split('\n').pop()
 
     return out || '~/.hermes'
   } catch (cause) {
@@ -254,12 +254,24 @@ async function probeRemoteHermesHome(ssh) {
   }
 }
 
+// SSH executes a remote command through the account's login shell. Keep the
+// desktop lifecycle protocol POSIX even when that login shell is Fish.
+function execRemotePosix(ssh, command, options?: any) {
+  // Base64 avoids nested shell quoting while preserving stdin for the
+  // one-time session token upload.
+  const encoded = Buffer.from(String(command), 'utf8').toString('base64')
+  return ssh.exec(
+    `/bin/sh -lc 'eval "$(printf %s ${encoded} | (base64 -d 2>/dev/null || base64 -D))"'`,
+    options
+  )
+}
+
 async function readLockfile(ssh, ownershipId) {
   const lpath = lockfilePath(ownershipId)
   let raw
 
   try {
-    raw = await ssh.exec(`if [ ! -e ${expandRemotePath(lpath)} ]; then exit 0; fi; cat ${expandRemotePath(lpath)}`)
+    raw = await execRemotePosix(ssh, `if [ ! -e ${expandRemotePath(lpath)} ]; then exit 0; fi; cat ${expandRemotePath(lpath)}`)
   } catch (cause) {
     const error: any = new Error('Could not read the SSH backend ownership record.')
     error.kind = 'transient-transport-error'
@@ -328,7 +340,8 @@ async function writeLockfile(ssh, ownershipId, lock) {
   const lpath = lockfilePath(ownershipId)
   const temporaryPath = `${directory}/.${crypto.randomBytes(8).toString('hex')}.lock.tmp`
   const json = JSON.stringify({ ...lock, schemaVersion: LOCKFILE_SCHEMA_VERSION })
-  await ssh.exec(
+  await execRemotePosix(
+    ssh,
     `umask 077 && mkdir -p ${expandRemotePath(directory)} && ` +
       `printf '%s' ${shq(json)} > ${expandRemotePath(temporaryPath)} && ` +
       `mv -f ${expandRemotePath(temporaryPath)} ${expandRemotePath(lpath)}`
@@ -339,7 +352,7 @@ async function removeLockfile(ssh, ownershipId) {
   const lpath = lockfilePath(ownershipId)
 
   try {
-    await ssh.exec(`rm -f ${expandRemotePath(lpath)}`)
+    await execRemotePosix(ssh, `rm -f ${expandRemotePath(lpath)}`)
   } catch {
     // best effort
   }
@@ -351,7 +364,7 @@ async function remotePidAlive(ssh, pid) {
   }
 
   try {
-    const out = (await ssh.exec(`kill -0 ${Number(pid)} 2>/dev/null && echo ALIVE || echo DEAD`)).trim()
+    const out = (await execRemotePosix(ssh, `kill -0 ${Number(pid)} 2>/dev/null && echo ALIVE || echo DEAD`)).trim()
 
     return out === 'ALIVE'
   } catch (cause) {
@@ -391,7 +404,7 @@ async function pidIsOurDashboard(ssh, pid, spawnNonce, hermesPath = '') {
       'except (ValueError,IndexError):pass\n' +
       'print("OWNED" if ok else "FOREIGN")'
 
-    const out = await ssh.exec(`python3 -c ${shq(script)}`)
+    const out = await execRemotePosix(ssh, `python3 -c ${shq(script)}`)
 
     return String(out || '').trim() === 'OWNED'
   } catch (cause) {
@@ -407,7 +420,8 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
   if (pidAlive && lock && (await pidIsOurDashboard(ssh, lock.pid, lock.spawnNonce, lock.hermesPath))) {
     try {
       const result = (
-        await ssh.exec(
+        await execRemotePosix(
+          ssh,
           `kill ${Number(lock.pid)} && ` +
             `i=0; while kill -0 ${Number(lock.pid)} 2>/dev/null; do ` +
             `i=$((i+1)); [ "$i" -ge 50 ] && exit 1; sleep 0.1; done`
@@ -427,7 +441,7 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
 
   if (lock?.logPath === expectedLogPath) {
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(lock.logPath)}`)
+      await execRemotePosix(ssh, `rm -f ${expandRemotePath(lock.logPath)}`)
     } catch {
       void 0
     }
@@ -461,7 +475,8 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
 async function remoteSupportsSshOwnership(ssh, hermesPath) {
   const hermes = expandRemotePath(hermesPath)
 
-  const out = await ssh.exec(
+  const out = await execRemotePosix(
+    ssh,
     `help="$(${hermes} serve --help 2>&1)"; ` +
       `printf '%s' "$help" | grep -q ssh-session-token-file && ` +
       `printf '%s' "$help" | grep -q ssh-owner-nonce && echo YES || echo NO`
@@ -488,7 +503,7 @@ async function scrapeReadyPort(ssh, logPath, { timeoutMs = DEFAULT_READY_TIMEOUT
     let tail
 
     try {
-      tail = await ssh.exec(`cat ${remoteLog} 2>/dev/null || true`)
+      tail = await execRemotePosix(ssh, `cat ${remoteLog} 2>/dev/null || true`)
     } catch {
       tail = ''
     }
@@ -554,10 +569,10 @@ async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownership
     'finally:os.close(dd)'
 
   try {
-    await ssh.exec(`python3 -c ${shq(tokenUploadPy)}`, { stdinData: token })
+    await execRemotePosix(ssh, `python3 -c ${shq(tokenUploadPy)}`, { stdinData: token })
   } catch (error) {
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      await execRemotePosix(ssh, `rm -f ${expandRemotePath(tokenFilePath)}`)
     } catch {
       void 0
     }
@@ -568,10 +583,10 @@ async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownership
   let out
 
   try {
-    out = await ssh.exec(buildSpawnCommand(hermesPath, profile, { spawnNonce, tokenFilePath, logPath }))
+    out = await execRemotePosix(ssh, buildSpawnCommand(hermesPath, profile, { spawnNonce, tokenFilePath, logPath }))
   } catch (error) {
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      await execRemotePosix(ssh, `rm -f ${expandRemotePath(tokenFilePath)}`)
     } catch {
       void 0
     }
@@ -589,7 +604,7 @@ async function spawnRemoteDashboard(ssh, { hermesPath, profile, token, ownership
 
   if (!Number.isInteger(pid) || pid <= 0) {
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      await execRemotePosix(ssh, `rm -f ${expandRemotePath(tokenFilePath)}`)
     } catch {
       void 0
     }
@@ -860,7 +875,7 @@ async function connect(deps) {
     }
 
     try {
-      await ssh.exec(`rm -f ${expandRemotePath(tokenFilePath)}`)
+      await execRemotePosix(ssh, `rm -f ${expandRemotePath(tokenFilePath)}`)
     } catch {
       void 0
     }


### PR DESCRIPTION
Runs Desktop SSH lifecycle commands through POSIX sh, preserving token stdin handling. Fixes Fish login shells rejecting the existing POSIX and Bash command syntax before Hermes can start. Validated with the Electron suite: 1,056 passed and 2 skipped.