### PR TITLE
feat(a2a): per-peer custom headers and User-Agent with destination-bound credentials

### DIFF
--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -68,7 +68,6 @@ def _resolve_peer(agent: str) -> Optional[dict]:
         "timeout": int(entry.get("timeout", _DEFAULT_TIMEOUT)),
         "capabilities": entry.get("capabilities", []) or [],
         "tenant": entry.get("tenant", ""),
-        "idempotency": bool(entry.get("idempotency", False)),
         "allowed_rpc_origins": entry.get("allowed_rpc_origins") or [],
     }
 
@@ -128,18 +127,15 @@ def _http_get_json(url: str, headers: dict, timeout: int,
         return json.loads(resp.read().decode("utf-8"))
 
 
-# Retry budget for Cloudflare 524 (origin timeout) on blocking POST, when the
-# peer has opted in. A 524 means the proxy gave up on the response, NOT that
-# the origin failed — the peer may have already executed the task. Retrying a
-# mutating send on a 524 is only safe when the peer deduplicates requests
-# (the retry re-sends the identical task id and message), which the operator
-# asserts per peer via `idempotency: true` in the peer config.
-# Default: no retry — the indeterminate outcome propagates to the caller.
-_POST_MAX_RETRIES = 3
+class _A2aIndeterminateError(Exception):
+    """A 524 (origin timeout) — the peer may have executed the task, but the
+    response was lost. Mutating sends are NEVER auto-retried on this class:
+    without a proven server-side idempotency contract a replay could execute
+    the task twice. The caller surfaces the indeterminate outcome; recovery
+    composes with explicit task-identity polling (upstream #94880) instead."""
 
 
 def _http_post_json(url: str, body: dict, headers: dict, timeout: int,
-                    retry_524: bool = False,
                     allowed_origins: tuple[str, ...] = ()) -> dict:
     data = json.dumps(body).encode("utf-8")
     # Custom peer headers are operator-controlled but Content-Type and
@@ -154,25 +150,16 @@ def _http_post_json(url: str, body: dict, headers: dict, timeout: int,
     }
     req = urllib.request.Request(url, data=data, headers=hdrs, method="POST")
 
-    attempts = _POST_MAX_RETRIES if retry_524 else 1
-    for attempt in range(attempts):
-        try:
-            with _open_url_no_redirect_leak(req, timeout, allowed_origins) as resp:  # noqa: S310 (configured peers)
-                return json.loads(resp.read().decode("utf-8"))
-        except urllib.error.HTTPError as e:
-            if (retry_524 and e.code == 524 and attempt < attempts - 1):
-                # Exponential backoff: 1s, 2s, 4s. Safe as a blocking sleep:
-                # plugin tools run on worker threads (orchestrate uses a
-                # ThreadPoolExecutor; handlers never touch the gateway's
-                # event loop).
-                logger.warning(
-                    "A2A: 524 from %s (origin may have completed the task); "
-                    "peer opted into idempotent retry, backing off %.0fs",
-                    url, 2 ** attempt)
-                time.sleep(2 ** attempt)
-                continue
-            raise
-    raise RuntimeError("A2A retry loop exited without a result")  # pragma: no cover
+    try:
+        with _open_url_no_redirect_leak(req, timeout, allowed_origins) as resp:  # noqa: S310 (configured peers)
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        if e.code == 524:
+            raise _A2aIndeterminateError(
+                f"peer origin timed out behind its proxy (HTTP 524); the task "
+                f"may have executed — outcome indeterminate, not retried"
+            ) from e
+        raise
 
 
 def _card_url(base_url: str) -> str:
@@ -294,10 +281,6 @@ def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> t
     base_url = peer.get("url", "")
     headers = {**_auth_header(peer.get("auth", {}) or {}), **(peer.get("headers", {}) or {})}
     timeout = int(peer.get("timeout", _DEFAULT_TIMEOUT))
-    # Operator asserts this peer dedupes on message identity (Hermes peers
-    # do), making 524 retries and stream-fallback resends safe. Without it, a
-    # 524 (origin may have completed the task) is surfaced, never retried.
-    idempotency = bool(peer.get("idempotency", False))
     auth = peer.get("auth", {}) or {}
     if auth and any(k.lower() == "authorization" for k in (peer.get("headers", {}) or {})):
         logger.warning(
@@ -350,7 +333,7 @@ def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> t
     protocol.persist_message(ctx, "user", safe_message, rpc_body["id"])
     protocol.metrics.outbound_total += 1
 
-    resp = _http_post_json(rpc_url, rpc_body, headers, timeout, retry_524=idempotency, allowed_origins=allowed)
+    resp = _http_post_json(rpc_url, rpc_body, headers, timeout, allowed_origins=allowed)
     if "error" in resp:
         err = resp["error"]
         raise ValueError(f"Peer '{agent_label}' returned an error: {err.get('message', err)}")
@@ -445,6 +428,11 @@ def a2a_call(args: dict, **_: Any) -> str:
 
     try:
         reply, reply_ctx, state = _send_task(agent, peer, message, context_id)
+    except _A2aIndeterminateError as e:
+        return (f"Error: call to '{agent}' is INDETERMINATE — {e}. "
+                f"Do not blindly retry a mutating request; check with the peer "
+                f"(task id {getattr(e, 'task_id', 'unknown')}) or retry only "
+                f"if the operation is safe to repeat.")
     except urllib.error.HTTPError as e:
         if e.code in (401, 403):
             return f"Error: peer '{agent}' rejected auth (HTTP {e.code}). Check the configured token."
@@ -555,9 +543,8 @@ def _call_peer_sync(agent_name: str, peer_entry: dict, message: str, context_id:
             "headers": peer_entry.get("headers", {}) or {},
             "tenant": peer_entry.get("tenant", ""),
             "timeout": int(peer_entry.get("timeout", _DEFAULT_TIMEOUT)),
-            # Forwarded so fan-out peers keep their 524-retry opt-in and
-            # cross-origin RPC allowlist (same semantics as a2a_call).
-            "idempotency": bool(peer_entry.get("idempotency", False)),
+            # Forwarded so fan-out peers keep their cross-origin RPC
+            # allowlist (same semantics as a2a_call).
             "allowed_rpc_origins": peer_entry.get("allowed_rpc_origins") or [],
         }
         reply, _ctx, _state = _send_task(agent_name, peer, message, context_id)

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -79,28 +79,68 @@ def _auth_header(auth: dict) -> dict:
     return {}
 
 
-# --------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # HTTP
-# --------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
-def _http_get_json(url: str, headers: dict, timeout: int) -> dict:
+# Redirects are a credential-exfiltration vector: urllib's default opener
+# follows 3xx responses and forwards the full header map (Authorization,
+# proxy service tokens) to whatever host the redirect points at. Peers are
+# semi-trusted (card-controlled), so every hop must stay inside the origin
+# policy or the send dies.
+class _NoCredentialRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Fail-closed redirect policy for credential-bearing requests.
+
+    A redirect hop is followed with the full header map only when its target
+    is same-origin with the ORIGINAL request URL or is one of the operator's
+    pinned allowed origins — the same policy that gated the initial URL.
+    Any other hop is refused (HTTPError), never followed. urllib's built-in
+    cross-host Authorization stripping is partial (scheme/port changes,
+    custom headers) — we enforce it uniformly here.
+    """
+
+    def __init__(self, allowed_origins: tuple[str, ...] = ()):
+        self.allowed_origins = allowed_origins
+        super().__init__()
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        original = req.full_url
+        if _url_same_origin(newurl, original) or any(
+                _url_same_origin(newurl, o) for o in self.allowed_origins):
+            return super().redirect_request(req, fp, code, msg, headers, newurl)
+        raise urllib.error.HTTPError(
+            req.full_url, code,
+            f"A2A redirect to cross-origin {newurl} refused (not same-origin, not in allowed_rpc_origins)",
+            headers, fp)
+
+
+def _open_url_no_redirect_leak(req: urllib.request.Request, timeout: int,
+                               allowed_origins: tuple[str, ...] = ()) -> Any:
+    """urlopen with fail-closed cross-origin redirect handling."""
+    opener = urllib.request.build_opener(_NoCredentialRedirectHandler(allowed_origins))
+    return opener.open(req, timeout=timeout)
+
+
+def _http_get_json(url: str, headers: dict, timeout: int,
+                   allowed_origins: tuple[str, ...] = ()) -> dict:
     req = urllib.request.Request(url, headers={"User-Agent": "Hermes-A2A/1.0", **headers}, method="GET")
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (configured peers)
+    with _open_url_no_redirect_leak(req, timeout, allowed_origins) as resp:  # noqa: S310 (configured peers)
         return json.loads(resp.read().decode("utf-8"))
 
 
 # Retry budget for Cloudflare 524 (origin timeout) on blocking POST, when the
 # peer has opted in. A 524 means the proxy gave up on the response, NOT that
 # the origin failed — the peer may have already executed the task. Retrying a
-# mutating send on a 524 is only safe when the peer dedupes on message
-# identity (stable Message.messageId is re-sent byte-identically), which the
-# operator asserts per peer via `idempotency: true` in the peer config.
+# mutating send on a 524 is only safe when the peer deduplicates requests
+# (the retry re-sends the identical task id and message), which the operator
+# asserts per peer via `idempotency: true` in the peer config.
 # Default: no retry — the indeterminate outcome propagates to the caller.
 _POST_MAX_RETRIES = 3
 
 
 def _http_post_json(url: str, body: dict, headers: dict, timeout: int,
-                    retry_524: bool = False) -> dict:
+                    retry_524: bool = False,
+                    allowed_origins: tuple[str, ...] = ()) -> dict:
     data = json.dumps(body).encode("utf-8")
     # Custom peer headers are operator-controlled but Content-Type and
     # A2A-Version are protocol-owned and must not be clobbered; a config typo
@@ -117,7 +157,7 @@ def _http_post_json(url: str, body: dict, headers: dict, timeout: int,
     attempts = _POST_MAX_RETRIES if retry_524 else 1
     for attempt in range(attempts):
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (configured peers)
+            with _open_url_no_redirect_leak(req, timeout, allowed_origins) as resp:  # noqa: S310 (configured peers)
                 return json.loads(resp.read().decode("utf-8"))
         except urllib.error.HTTPError as e:
             if (retry_524 and e.code == 524 and attempt < attempts - 1):
@@ -132,7 +172,7 @@ def _http_post_json(url: str, body: dict, headers: dict, timeout: int,
                 time.sleep(2 ** attempt)
                 continue
             raise
-    raise AssertionError("retry loop exited without a result")  # pragma: no cover
+    raise RuntimeError("A2A retry loop exited without a result")  # pragma: no cover
 
 
 def _card_url(base_url: str) -> str:
@@ -145,13 +185,14 @@ def _legacy_card_url(base_url: str) -> str:
     return base_url.rstrip("/") + "/.well-known/agent.json"
 
 
-def _fetch_card(base_url: str, headers: dict, timeout: int) -> dict:
+def _fetch_card(base_url: str, headers: dict, timeout: int,
+                allowed_origins: tuple[str, ...] = ()) -> dict:
     try:
-        return _http_get_json(_card_url(base_url), headers, timeout)
+        return _http_get_json(_card_url(base_url), headers, timeout, allowed_origins)
     except urllib.error.HTTPError as e:
         if e.code != 404:
             raise
-    return _http_get_json(_legacy_card_url(base_url), headers, timeout)
+    return _http_get_json(_legacy_card_url(base_url), headers, timeout, allowed_origins)
 
 
 def _select_jsonrpc_interface(card: Optional[dict]) -> Optional[dict]:
@@ -184,7 +225,9 @@ def _url_origin(url: str) -> tuple[str, str]:
     """(scheme, host:port) of a URL, lowercased; port defaulted per scheme."""
     parsed = urllib.parse.urlsplit(url.strip())
     host = (parsed.hostname or "").lower()
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    # parsed.port is None when absent; explicit :0 is a real (if unroutable)
+    # port and must not be silently defaulted.
+    port = parsed.port if parsed.port is not None else (443 if parsed.scheme == "https" else 80)
     return parsed.scheme.lower(), f"{host}:{port}"
 
 
@@ -197,11 +240,40 @@ def _url_same_origin(candidate: str, configured: str) -> bool:
 
 
 def _allowed_rpc_origins(peer: dict) -> list[str]:
-    """Operator-pinned cross-origin RPC URLs exempt from the origin check."""
+    """Operator-pinned cross-origin RPC URLs exempt from the origin check.
+
+    Entries are compared by ORIGIN (scheme + host + port), so an entry pins
+    the whole service, not one exact path: an allowlist entry
+    ``https://rpc.internal.example.com`` matches a card advertising
+    ``https://rpc.internal.example.com/anything``.
+    """
     raw = peer.get("allowed_rpc_origins") or []
     if isinstance(raw, str):
         raw = [raw]
     return [str(u).rstrip("/") for u in raw if str(u).strip()]
+
+
+def _origin_allowed(candidate: str, peer: dict) -> bool:
+    """True when candidate's origin is the configured origin or a pinned
+    allowed origin (origin-level match, not exact string)."""
+    try:
+        cand = _url_origin(candidate)
+    except ValueError:
+        return False
+    # Same origin as the configured base URL (any path) is always allowed —
+    # a card may move the RPC within its own service.
+    try:
+        if _url_same_origin(candidate, peer.get("url", "")):
+            return True
+    except ValueError:
+        pass
+    for entry in _allowed_rpc_origins(peer):
+        try:
+            if _url_origin(entry) == cand:
+                return True
+        except ValueError:
+            continue
+    return False
 
 
 # --------------------------------------------------------------------------
@@ -226,6 +298,13 @@ def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> t
     # do), making 524 retries and stream-fallback resends safe. Without it, a
     # 524 (origin may have completed the task) is surfaced, never retried.
     idempotency = bool(peer.get("idempotency", False))
+    auth = peer.get("auth", {}) or {}
+    if auth and any(k.lower() == "authorization" for k in (peer.get("headers", {}) or {})):
+        logger.warning(
+            "A2A: peer '%s' custom headers override the derived Authorization "
+            "header — deliberate proxy auth schemes only",
+            agent_label)
+    allowed = tuple(_allowed_rpc_origins(peer))
 
     # Best-effort card fetch (to learn the rpc URL); non-fatal on failure.
     # The card is fetched WITHOUT credential-bearing headers: it is served at
@@ -233,12 +312,12 @@ def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> t
     # the credential surface exactly where the operator pinned it.
     card = None
     try:
-        card = _fetch_card(base_url, {}, min(timeout, 30))
+        card = _fetch_card(base_url, headers, min(timeout, 30), allowed)
     except Exception:
         pass
 
     rpc_url = _rpc_url(base_url, card)
-    if not _url_same_origin(rpc_url, base_url) and str(rpc_url) not in _allowed_rpc_origins(peer):
+    if not _origin_allowed(rpc_url, peer):
         # The card advertised an RPC interface on a different origin than the
         # configured base URL. Sending there would forward operator secrets
         # (bearer tokens, proxy service tokens) to a card-controlled host.

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -307,9 +307,11 @@ def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> t
     allowed = tuple(_allowed_rpc_origins(peer))
 
     # Best-effort card fetch (to learn the rpc URL); non-fatal on failure.
-    # The card is fetched WITHOUT credential-bearing headers: it is served at
-    # the configured base URL (same origin), but keeping the fetch bare keeps
-    # the credential surface exactly where the operator pinned it.
+    # The card is fetched AT the configured origin with the full credential
+    # map — same destination the operator pinned the credentials for (a
+    # Cloudflare-Access-fronted peer otherwise 403s the card and streaming
+    # discovery is lost). The egress bound is enforced on the RPC destination
+    # after the fetch: a card-advertised cross-origin URL never receives them.
     card = None
     try:
         card = _fetch_card(base_url, headers, min(timeout, 30), allowed)
@@ -348,7 +350,7 @@ def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> t
     protocol.persist_message(ctx, "user", safe_message, rpc_body["id"])
     protocol.metrics.outbound_total += 1
 
-    resp = _http_post_json(rpc_url, rpc_body, headers, timeout, retry_524=idempotency)
+    resp = _http_post_json(rpc_url, rpc_body, headers, timeout, retry_524=idempotency, allowed_origins=allowed)
     if "error" in resp:
         err = resp["error"]
         raise ValueError(f"Peer '{agent_label}' returned an error: {err.get('message', err)}")

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -25,7 +25,9 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Optional, TypedDict
@@ -62,9 +64,12 @@ def _resolve_peer(agent: str) -> Optional[dict]:
     return {
         "url": entry.get("url", ""),
         "auth": entry.get("auth", {}) or {},
+        "headers": entry.get("headers", {}) or {},
         "timeout": int(entry.get("timeout", _DEFAULT_TIMEOUT)),
         "capabilities": entry.get("capabilities", []) or [],
         "tenant": entry.get("tenant", ""),
+        "idempotency": bool(entry.get("idempotency", False)),
+        "allowed_rpc_origins": entry.get("allowed_rpc_origins") or [],
     }
 
 
@@ -79,17 +84,55 @@ def _auth_header(auth: dict) -> dict:
 # --------------------------------------------------------------------------
 
 def _http_get_json(url: str, headers: dict, timeout: int) -> dict:
-    req = urllib.request.Request(url, headers=headers, method="GET")
+    req = urllib.request.Request(url, headers={"User-Agent": "Hermes-A2A/1.0", **headers}, method="GET")
     with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (configured peers)
         return json.loads(resp.read().decode("utf-8"))
 
 
-def _http_post_json(url: str, body: dict, headers: dict, timeout: int) -> dict:
+# Retry budget for Cloudflare 524 (origin timeout) on blocking POST, when the
+# peer has opted in. A 524 means the proxy gave up on the response, NOT that
+# the origin failed — the peer may have already executed the task. Retrying a
+# mutating send on a 524 is only safe when the peer dedupes on message
+# identity (stable Message.messageId is re-sent byte-identically), which the
+# operator asserts per peer via `idempotency: true` in the peer config.
+# Default: no retry — the indeterminate outcome propagates to the caller.
+_POST_MAX_RETRIES = 3
+
+
+def _http_post_json(url: str, body: dict, headers: dict, timeout: int,
+                    retry_524: bool = False) -> dict:
     data = json.dumps(body).encode("utf-8")
-    hdrs = {"Content-Type": "application/json", "A2A-Version": protocol.PROTOCOL_VERSION, **headers}
+    # Custom peer headers are operator-controlled but Content-Type and
+    # A2A-Version are protocol-owned and must not be clobbered; a config typo
+    # would otherwise cause peer rejection or protocol-version mismatches.
+    # User-Agent stays overridable (some proxies filter user agents).
+    hdrs = {
+        "User-Agent": "Hermes-A2A/1.0",
+        **headers,
+        "Content-Type": "application/json",
+        "A2A-Version": protocol.PROTOCOL_VERSION,
+    }
     req = urllib.request.Request(url, data=data, headers=hdrs, method="POST")
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (configured peers)
-        return json.loads(resp.read().decode("utf-8"))
+
+    attempts = _POST_MAX_RETRIES if retry_524 else 1
+    for attempt in range(attempts):
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (configured peers)
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            if (retry_524 and e.code == 524 and attempt < attempts - 1):
+                # Exponential backoff: 1s, 2s, 4s. Safe as a blocking sleep:
+                # plugin tools run on worker threads (orchestrate uses a
+                # ThreadPoolExecutor; handlers never touch the gateway's
+                # event loop).
+                logger.warning(
+                    "A2A: 524 from %s (origin may have completed the task); "
+                    "peer opted into idempotent retry, backing off %.0fs",
+                    url, 2 ** attempt)
+                time.sleep(2 ** attempt)
+                continue
+            raise
+    raise AssertionError("retry loop exited without a result")  # pragma: no cover
 
 
 def _card_url(base_url: str) -> str:
@@ -137,6 +180,30 @@ def _interface_tenant(card: Optional[dict], peer: dict) -> str:
     return str(peer.get("tenant") or "")
 
 
+def _url_origin(url: str) -> tuple[str, str]:
+    """(scheme, host:port) of a URL, lowercased; port defaulted per scheme."""
+    parsed = urllib.parse.urlsplit(url.strip())
+    host = (parsed.hostname or "").lower()
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    return parsed.scheme.lower(), f"{host}:{port}"
+
+
+def _url_same_origin(candidate: str, configured: str) -> bool:
+    """True when candidate and configured share scheme + host + port."""
+    try:
+        return _url_origin(candidate) == _url_origin(configured)
+    except ValueError:
+        return False
+
+
+def _allowed_rpc_origins(peer: dict) -> list[str]:
+    """Operator-pinned cross-origin RPC URLs exempt from the origin check."""
+    raw = peer.get("allowed_rpc_origins") or []
+    if isinstance(raw, str):
+        raw = [raw]
+    return [str(u).rstrip("/") for u in raw if str(u).strip()]
+
+
 # --------------------------------------------------------------------------
 # Shared send path (used by a2a_call and a2a_orchestrate)
 # --------------------------------------------------------------------------
@@ -153,15 +220,34 @@ def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> t
     outbound redaction, audit, persistence, and metrics.
     """
     base_url = peer.get("url", "")
-    headers = _auth_header(peer.get("auth", {}) or {})
+    headers = {**_auth_header(peer.get("auth", {}) or {}), **(peer.get("headers", {}) or {})}
     timeout = int(peer.get("timeout", _DEFAULT_TIMEOUT))
+    # Operator asserts this peer dedupes on message identity (Hermes peers
+    # do), making 524 retries and stream-fallback resends safe. Without it, a
+    # 524 (origin may have completed the task) is surfaced, never retried.
+    idempotency = bool(peer.get("idempotency", False))
 
     # Best-effort card fetch (to learn the rpc URL); non-fatal on failure.
+    # The card is fetched WITHOUT credential-bearing headers: it is served at
+    # the configured base URL (same origin), but keeping the fetch bare keeps
+    # the credential surface exactly where the operator pinned it.
     card = None
     try:
-        card = _fetch_card(base_url, headers, min(timeout, 30))
+        card = _fetch_card(base_url, {}, min(timeout, 30))
     except Exception:
         pass
+
+    rpc_url = _rpc_url(base_url, card)
+    if not _url_same_origin(rpc_url, base_url) and str(rpc_url) not in _allowed_rpc_origins(peer):
+        # The card advertised an RPC interface on a different origin than the
+        # configured base URL. Sending there would forward operator secrets
+        # (bearer tokens, proxy service tokens) to a card-controlled host.
+        # Refuse: fall back to the configured origin, never follow the card.
+        logger.warning(
+            "A2A: peer '%s' card advertised cross-origin RPC URL %s; not in "
+            "peer's allowed_rpc_origins — using configured origin %s instead",
+            agent_label, rpc_url, base_url)
+        rpc_url = base_url.rstrip("/")
 
     ctx = context_id or protocol.new_context_id()
     safe_message = security.redact_outbound(message)
@@ -183,7 +269,7 @@ def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> t
     protocol.persist_message(ctx, "user", safe_message, rpc_body["id"])
     protocol.metrics.outbound_total += 1
 
-    resp = _http_post_json(_rpc_url(base_url, card), rpc_body, headers, timeout)
+    resp = _http_post_json(rpc_url, rpc_body, headers, timeout, retry_524=idempotency)
     if "error" in resp:
         err = resp["error"]
         raise ValueError(f"Peer '{agent_label}' returned an error: {err.get('message', err)}")
@@ -385,7 +471,13 @@ def _call_peer_sync(agent_name: str, peer_entry: dict, message: str, context_id:
         peer = {
             "url": peer_entry.get("url", ""),
             "auth": peer_entry.get("auth", {}) or {},
+            "headers": peer_entry.get("headers", {}) or {},
+            "tenant": peer_entry.get("tenant", ""),
             "timeout": int(peer_entry.get("timeout", _DEFAULT_TIMEOUT)),
+            # Forwarded so fan-out peers keep their 524-retry opt-in and
+            # cross-origin RPC allowlist (same semantics as a2a_call).
+            "idempotency": bool(peer_entry.get("idempotency", False)),
+            "allowed_rpc_origins": peer_entry.get("allowed_rpc_origins") or [],
         }
         reply, _ctx, _state = _send_task(agent_name, peer, message, context_id)
         return (agent_name, reply or "(no reply)")
@@ -585,12 +677,20 @@ _HANDLERS = {
 def register_tools(ctx) -> None:
     """Register the client tools in the ``a2a`` toolset."""
     for name, schema in _SCHEMAS.items():
-        function_schema = schema["function"]
+        # The registry stores schemas as-is and ``get_definitions()`` wraps
+        # them in {"type": "function", "function": ...}. ``_SCHEMAS`` entries
+        # are pre-wrapped for OpenAI compatibility, so unwrap here — passing
+        # them wrapped would double-nest them and the model-facing tool defs
+        # (and ``tool_describe``) would come back empty.
+        # NOTE: upstream landed the same unwrap as cefeed4ca using hard
+        # indexing; this variant keeps the defensive ``.get()`` fallbacks
+        # and is a behavioral superset of it.
+        flat = schema.get("function", schema)
         ctx.register_tool(
             name=name,
             toolset="a2a",
-            schema=function_schema,
+            schema=flat,
             handler=_HANDLERS[name],
-            description=function_schema["description"],
+            description=flat.get("description", ""),
             emoji="\U0001f9e9",  # puzzle piece
         )

--- a/tests/plugins/test_a2a_headers_and_retry.py
+++ b/tests/plugins/test_a2a_headers_and_retry.py
@@ -1,0 +1,316 @@
+"""Focused coverage for per-peer headers, User-Agent, 524 retry policy,
+and destination-bound secret forwarding (PR #86322).
+
+Extracted from test_a2a_plugin.py when the 524 retry became opt-in
+(`idempotency: true`) and credential forwarding became origin-bound, per
+upstream review: keep this surface in its own module under the 2K-line
+test-file invariant.
+"""
+
+from __future__ import annotations
+
+import pytest
+import urllib.error as urlerr
+
+from plugins.platforms.a2a import protocol, tools
+
+
+# ---------------------------------------------------------------------------
+# Header propagation and precedence
+# ---------------------------------------------------------------------------
+
+class TestPerPeerHeaders:
+    def test_resolve_peer_carries_headers(self, monkeypatch):
+        cfg = {"a2a_agents": {"mac": {
+            "url": "http://localhost:9999",
+            "headers": {"CF-Access-Client-Id": "cf-id"},
+        }}}
+        monkeypatch.setattr(tools, "_load_config", lambda: cfg)
+        peer = tools._resolve_peer("mac")
+        assert peer is not None
+        assert peer["headers"] == {"CF-Access-Client-Id": "cf-id"}
+
+    def test_resolve_peer_defaults_headers_to_empty(self, monkeypatch):
+        cfg = {"a2a_agents": {"mac": {"url": "http://localhost:9999"}}}
+        monkeypatch.setattr(tools, "_load_config", lambda: cfg)
+        peer = tools._resolve_peer("mac")
+        assert peer is not None
+        assert peer["headers"] == {}
+
+    def test_call_sends_auth_and_custom_headers(self, monkeypatch):
+        cfg = {"a2a_agents": {"mac": {
+            "url": "http://localhost:9999",
+            "auth": {"type": "bearer", "token": "tok-123"},
+            "headers": {"CF-Access-Client-Id": "cf-id", "CF-Access-Client-Secret": "cf-sec"},
+        }}}
+        monkeypatch.setattr(tools, "_load_config", lambda: cfg)
+        monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: None)
+        captured = {}
+
+        def fake_post(url, body, headers, timeout, retry_524=False):
+            captured.update(headers)
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "ok"),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        tools.a2a_call({"agent": "mac", "message": "ping"})
+        assert captured["Authorization"] == "Bearer tok-123"
+        assert captured["CF-Access-Client-Id"] == "cf-id"
+        assert captured["CF-Access-Client-Secret"] == "cf-sec"
+
+    def test_custom_headers_take_precedence(self, monkeypatch):
+        """Peer config headers win over the derived Authorization header on
+        name collision (a proxy may require a different auth scheme)."""
+        cfg = {"a2a_agents": {"mac": {
+            "url": "http://localhost:9999",
+            "auth": {"type": "bearer", "token": "tok-123"},
+            "headers": {"Authorization": "***"},
+        }}}
+        monkeypatch.setattr(tools, "_load_config", lambda: cfg)
+        monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: None)
+        captured = {}
+
+        def fake_post(url, body, headers, timeout, retry_524=False):
+            captured.update(headers)
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "ok"),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        tools.a2a_call({"agent": "mac", "message": "ping"})
+        assert captured["Authorization"] == "***"
+
+    def test_orchestrate_fanout_sends_custom_headers(self, monkeypatch):
+        cfg = {"a2a_agents": {
+            "a": {"url": "http://localhost:9001", "capabilities": ["x"], "headers": {"X-Tenant": "t1"}},
+            "b": {"url": "http://localhost:9002", "capabilities": ["x"], "headers": {"X-Tenant": "t2"}},
+        }}
+        monkeypatch.setattr(tools, "_load_config", lambda: cfg)
+        monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: None)
+        seen = []
+
+        def fake_post(url, body, headers, timeout, retry_524=False):
+            seen.append((url, headers.get("X-Tenant")))
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "ok"),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        tools.a2a_orchestrate({"capability": "x", "message": "m"})
+        assert len(seen) == 2
+        assert {t for _, t in seen} == {"t1", "t2"}
+
+
+class TestClientHttpEdgeCases:
+    def test_get_json_sends_user_agent_and_custom_headers(self, monkeypatch):
+        seen = {}
+
+        class _Resp:
+            def read(self):
+                return b'{"name": "peer"}'
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(req, timeout=None):
+            seen["headers"] = dict(req.headers)
+            return _Resp()
+
+        monkeypatch.setattr(tools.urllib.request, "urlopen", fake_urlopen)
+        out = tools._http_get_json("http://peer/.well-known/agent-card.json",
+                                   {"CF-Access-Client-Id": "cf-id"}, 30)
+        assert out == {"name": "peer"}
+        lowered = {k.lower(): v for k, v in seen["headers"].items()}
+        assert lowered["user-agent"] == "Hermes-A2A/1.0"
+        assert lowered["cf-access-client-id"] == "cf-id"
+
+
+# ---------------------------------------------------------------------------
+# 524 retry policy: default off, opt-in per peer via `idempotency: true`
+# ---------------------------------------------------------------------------
+
+class Test524RetryPolicy:
+    def test_524_not_retried_by_default(self, monkeypatch):
+        """A 524 is indeterminate (origin may have completed the task).
+        Without the peer's idempotency opt-in, exactly one attempt is made
+        and the error surfaces to the caller."""
+        attempts = {"n": 0}
+
+        def fake_urlopen(req, timeout=None):
+            attempts["n"] += 1
+            raise urlerr.HTTPError(req.full_url, 524, "Origin Time-out", {}, None)
+
+        monkeypatch.setattr(tools.urllib.request, "urlopen", fake_urlopen)
+        with pytest.raises(urlerr.HTTPError) as ei:
+            tools._http_post_json("http://peer/", {"x": 1}, {}, 30)
+        assert ei.value.code == 524
+        assert attempts["n"] == 1
+
+    def test_524_retried_when_peer_opts_in(self, monkeypatch):
+        """With retry_524=True the full backoff ladder runs before giving
+        up on a persistently-524-ing peer."""
+        monkeypatch.setattr(tools.time, "sleep", lambda s: None)
+        attempts = {"n": 0}
+
+        def fake_urlopen(req, timeout=None):
+            attempts["n"] += 1
+            raise urlerr.HTTPError(req.full_url, 524, "Origin Time-out", {}, None)
+
+        monkeypatch.setattr(tools.urllib.request, "urlopen", fake_urlopen)
+        with pytest.raises(urlerr.HTTPError):
+            tools._http_post_json("http://peer/", {"x": 1}, {}, 30, retry_524=True)
+        assert attempts["n"] == tools._POST_MAX_RETRIES
+
+    def test_524_backoff_is_exponential_when_opted_in(self, monkeypatch):
+        sleeps = []
+        monkeypatch.setattr(tools.time, "sleep", lambda s: sleeps.append(s))
+        attempts = {"n": 0}
+
+        class _Resp:
+            def read(self):
+                return b'{"ok": true}'
+
+        class _Ctx:
+            def __enter__(self):
+                return _Resp()
+
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(req, timeout=None):
+            attempts["n"] += 1
+            if attempts["n"] < tools._POST_MAX_RETRIES:
+                raise urlerr.HTTPError(req.full_url, 524, "Origin Time-out", {}, None)
+            return _Ctx()
+
+        monkeypatch.setattr(tools.urllib.request, "urlopen", fake_urlopen)
+        out = tools._http_post_json("http://peer/", {"x": 1}, {}, 30, retry_524=True)
+        assert out == {"ok": True}
+        assert attempts["n"] == tools._POST_MAX_RETRIES
+        assert sleeps == [1, 2]
+
+    def test_other_errors_never_retried(self, monkeypatch):
+        attempts = {"n": 0}
+
+        def fake_urlopen(req, timeout=None):
+            attempts["n"] += 1
+            raise urlerr.HTTPError(req.full_url, 502, "Bad Gateway", {}, None)
+
+        monkeypatch.setattr(tools.urllib.request, "urlopen", fake_urlopen)
+        with pytest.raises(urlerr.HTTPError):
+            tools._http_post_json("http://peer/", {"x": 1}, {}, 30, retry_524=True)
+        assert attempts["n"] == 1
+
+    def test_call_passes_idempotency_flag_to_post(self, monkeypatch):
+        """Peer config `idempotency: true` reaches the POST as retry_524."""
+        cfg = {"a2a_agents": {"mac": {
+            "url": "http://localhost:9999",
+            "idempotency": True,
+        }}}
+        monkeypatch.setattr(tools, "_load_config", lambda: cfg)
+        monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: None)
+        captured = {}
+
+        def fake_post(url, body, headers, timeout, retry_524=False):
+            captured["retry_524"] = retry_524
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "ok"),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        tools.a2a_call({"agent": "mac", "message": "ping"})
+        assert captured["retry_524"] is True
+
+
+# ---------------------------------------------------------------------------
+# Destination-bound secret forwarding
+# ---------------------------------------------------------------------------
+
+class TestRpcOriginBinding:
+    def _peer(self, **extra):
+        return {"url": "https://configured.example", **extra}
+
+    def test_same_origin_card_url_used(self):
+        assert tools._url_same_origin("https://configured.example/rpc",
+                                      "https://configured.example")
+        assert not tools._url_same_origin("https://other.example/rpc",
+                                          "https://configured.example")
+
+    def test_port_and_scheme_are_part_of_origin(self):
+        assert not tools._url_same_origin("http://configured.example/rpc",
+                                          "https://configured.example")
+        assert not tools._url_same_origin("https://configured.example:8443/rpc",
+                                          "https://configured.example")
+
+    def test_cross_origin_rpc_rejected_without_allowlist(self, monkeypatch):
+        """A card advertising a foreign RPC origin must NOT receive the
+        credential-bearing header map: the send falls back to the
+        configured origin."""
+        card = {"supportedInterfaces": [{"protocolBinding": "JSONRPC",
+                                         "url": "https://evil.example/rpc"}]}
+        monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: card)
+        posted = {}
+
+        def fake_post(url, body, headers, timeout, retry_524=False):
+            posted["url"] = url
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "ok"),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        import logging as _logging
+        monkeypatch.setattr(tools, "logger", _logging.getLogger("test-a2a"))
+        reply, ctx, state = tools._send_task(
+            "peer-x", self._peer(auth={"type": "bearer", "token": "tok"}), "hi", "")
+        assert posted["url"] == "https://configured.example"
+
+    def test_cross_origin_rpc_allowed_via_allowlist(self, monkeypatch):
+        card = {"supportedInterfaces": [{"protocolBinding": "JSONRPC",
+                                         "url": "https://trusted.example/rpc"}]}
+        monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: card)
+        posted = {}
+
+        def fake_post(url, body, headers, timeout, retry_524=False):
+            posted["url"] = url
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "ok"),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        peer = self._peer(allowed_rpc_origins=["https://trusted.example/rpc"])
+        tools._send_task("peer-x", peer, "hi", "")
+        assert posted["url"] == "https://trusted.example/rpc"
+
+    def test_card_fetch_carries_no_credentials(self, monkeypatch):
+        """The card fetch itself must be bare: no bearer header, no custom
+        proxy headers — the card endpoint is discovery data, not a secret
+        destination."""
+        fetched = {}
+
+        def fake_fetch(url, headers, timeout):
+            fetched["headers"] = headers
+            return None
+
+        monkeypatch.setattr(tools, "_fetch_card", fake_fetch)
+
+        def fake_post(url, body, headers, timeout, retry_524=False):
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "ok"),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        peer = self._peer(auth={"type": "bearer", "token": "tok"},
+                          headers={"CF-Access-Client-Secret": "sec"})
+        tools._send_task("peer-x", peer, "hi", "")
+        assert fetched["headers"] == {}

--- a/tests/plugins/test_a2a_headers_and_retry.py
+++ b/tests/plugins/test_a2a_headers_and_retry.py
@@ -1,10 +1,10 @@
-"""Focused coverage for per-peer headers, User-Agent, 524 retry policy,
-and destination-bound secret forwarding (PR #86322).
+"""Focused coverage for per-peer headers, User-Agent, 524 indeterminate
+handling, and destination-bound secret forwarding (PR #86322).
 
-Extracted from test_a2a_plugin.py when the 524 retry became opt-in
-(`idempotency: true`) and credential forwarding became origin-bound, per
-upstream review: keep this surface in its own module under the 2K-line
-test-file invariant.
+Extracted from test_a2a_plugin.py when credential forwarding became
+origin-bound and 524 responses became a typed indeterminate outcome
+(no automatic replay), per upstream review: keep this surface in its own
+module under the 2K-line test-file invariant.
 """
 
 from __future__ import annotations
@@ -135,110 +135,63 @@ class TestClientHttpEdgeCases:
 
 
 # ---------------------------------------------------------------------------
-# 524 retry policy: default off, opt-in per peer via `idempotency: true`
+# 524 handling: typed indeterminate, never auto-retried
 # ---------------------------------------------------------------------------
 
-class Test524RetryPolicy:
-    def test_524_not_retried_by_default(self, monkeypatch):
-        """A 524 is indeterminate (origin may have completed the task).
-        Without the peer's idempotency opt-in, exactly one attempt is made
-        and the error surfaces to the caller."""
+class Test524Indeterminate:
+    def test_524_raises_typed_indeterminate_error(self, monkeypatch):
+        """A 524 is indeterminate (origin may have completed the task) and is
+        NEVER auto-retried: it raises _A2aIndeterminateError so callers can
+        distinguish 'failed safely' from 'may have executed'."""
         attempts = {"n": 0}
 
-        def fake_open(req, timeout=None):
+        def fake_open(req, timeout, allowed=()):
             attempts["n"] += 1
             raise urlerr.HTTPError(req.full_url, 524, "Origin Time-out", {}, None)
 
         monkeypatch.setattr(tools, "_open_url_no_redirect_leak",
                             lambda req, timeout, allowed=(): fake_open(req, timeout))
-        with pytest.raises(urlerr.HTTPError) as ei:
+        with pytest.raises(tools._A2aIndeterminateError):
             tools._http_post_json("http://peer/", {"x": 1}, {}, 30)
-        assert ei.value.code == 524
         assert attempts["n"] == 1
 
-    def test_524_retried_when_peer_opts_in(self, monkeypatch):
-        """With retry_524=True the full backoff ladder runs before giving
-        up on a persistently-524-ing peer."""
-        monkeypatch.setattr(tools.time, "sleep", lambda s: None)
-        attempts = {"n": 0}
-
-        def fake_open(req, timeout=None):
-            attempts["n"] += 1
-            raise urlerr.HTTPError(req.full_url, 524, "Origin Time-out", {}, None)
-
-        monkeypatch.setattr(tools, "_open_url_no_redirect_leak",
-                            lambda req, timeout, allowed=(): fake_open(req, timeout))
-        with pytest.raises(urlerr.HTTPError):
-            tools._http_post_json("http://peer/", {"x": 1}, {}, 30, retry_524=True)
-        assert attempts["n"] == tools._POST_MAX_RETRIES
-
-    def test_524_backoff_is_exponential_when_opted_in(self, monkeypatch):
-        sleeps = []
-        monkeypatch.setattr(tools.time, "sleep", lambda s: sleeps.append(s))
-        attempts = {"n": 0}
-
-        class _Resp:
-            def read(self):
-                return b'{"ok": true}'
-
-        class _Ctx:
-            def __enter__(self):
-                return _Resp()
-
-            def __exit__(self, *a):
-                return False
-
-        def fake_open(req, timeout=None):
-            attempts["n"] += 1
-            if attempts["n"] < tools._POST_MAX_RETRIES:
-                raise urlerr.HTTPError(req.full_url, 524, "Origin Time-out", {}, None)
-            return _Ctx()
-
-        monkeypatch.setattr(tools, "_open_url_no_redirect_leak",
-                            lambda req, timeout, allowed=(): fake_open(req, timeout))
-        out = tools._http_post_json("http://peer/", {"x": 1}, {}, 30, retry_524=True)
-        assert out == {"ok": True}
-        assert attempts["n"] == tools._POST_MAX_RETRIES
-        assert sleeps == [1, 2]
-
-    def test_other_errors_never_retried(self, monkeypatch):
-        attempts = {"n": 0}
-
-        def fake_open(req, timeout=None):
-            attempts["n"] += 1
+    def test_other_errors_still_raise_httperror(self, monkeypatch):
+        def fake_open(req, timeout, allowed=()):
             raise urlerr.HTTPError(req.full_url, 502, "Bad Gateway", {}, None)
 
         monkeypatch.setattr(tools, "_open_url_no_redirect_leak",
                             lambda req, timeout, allowed=(): fake_open(req, timeout))
         with pytest.raises(urlerr.HTTPError):
-            tools._http_post_json("http://peer/", {"x": 1}, {}, 30, retry_524=True)
-        assert attempts["n"] == 1
+            tools._http_post_json("http://peer/", {"x": 1}, {}, 30)
 
-    def test_call_passes_idempotency_flag_to_post(self, monkeypatch):
-        """Peer config `idempotency: true` reaches the POST as retry_524."""
-        cfg = {"a2a_agents": {"mac": {
-            "url": "http://localhost:9999",
-            "idempotency": True,
-        }}}
-        monkeypatch.setattr(tools, "_load_config", lambda: cfg)
-        monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: None)
-        captured = {}
+    def test_a2a_call_surfaces_indeterminate_advice(self, monkeypatch):
+        monkeypatch.setattr(tools, "_load_config", lambda: {"a2a_agents": {"r": {
+            "url": "http://localhost:9999"}}})
 
-        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
-            captured["retry_524"] = retry_524
-            return protocol.jsonrpc_result(
-                body["id"],
-                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "ok"),
-            )
+        def fake_send(*a, **k):
+            raise tools._A2aIndeterminateError("peer origin timed out (HTTP 524)")
 
-        monkeypatch.setattr(tools, "_http_post_json", fake_post)
-        tools.a2a_call({"agent": "mac", "message": "ping"})
-        assert captured["retry_524"] is True
+        monkeypatch.setattr(tools, "_send_task", fake_send)
+        out = tools.a2a_call({"agent": "r", "message": "hello"})
+        assert "INDETERMINATE" in out
+        assert "Do not blindly retry" in out
 
+    def test_524_single_attempt_no_sleep(self, monkeypatch):
+        """No retry ladder, no backoff sleeps — exactly one request."""
+        sleeps = []
+        monkeypatch.setattr(tools.time, "sleep", lambda s: sleeps.append(s))
+        attempts = {"n": 0}
 
-# ---------------------------------------------------------------------------
-# User-Agent on the real POST path
-# ---------------------------------------------------------------------------
+        def fake_open(req, timeout, allowed=()):
+            attempts["n"] += 1
+            raise urlerr.HTTPError(req.full_url, 524, "Origin Time-out", {}, None)
+
+        monkeypatch.setattr(tools, "_open_url_no_redirect_leak",
+                            lambda req, timeout, allowed=(): fake_open(req, timeout))
+        with pytest.raises(tools._A2aIndeterminateError):
+            tools._http_post_json("http://peer/", {"x": 1}, {}, 30)
+        assert attempts["n"] == 1 and sleeps == []
+
 
 class TestPostUserAgent:
     def test_post_sends_hermes_user_agent(self, monkeypatch):

--- a/tests/plugins/test_a2a_headers_and_retry.py
+++ b/tests/plugins/test_a2a_headers_and_retry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import pytest
 import urllib.error as urlerr
+import urllib.request
 
 from plugins.platforms.a2a import protocol, tools
 
@@ -47,7 +48,7 @@ class TestPerPeerHeaders:
         monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: None)
         captured = {}
 
-        def fake_post(url, body, headers, timeout, retry_524=False):
+        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
             captured.update(headers)
             return protocol.jsonrpc_result(
                 body["id"],
@@ -72,7 +73,7 @@ class TestPerPeerHeaders:
         monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: None)
         captured = {}
 
-        def fake_post(url, body, headers, timeout, retry_524=False):
+        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
             captured.update(headers)
             return protocol.jsonrpc_result(
                 body["id"],
@@ -92,7 +93,7 @@ class TestPerPeerHeaders:
         monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: None)
         seen = []
 
-        def fake_post(url, body, headers, timeout, retry_524=False):
+        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
             seen.append((url, headers.get("X-Tenant")))
             return protocol.jsonrpc_result(
                 body["id"],
@@ -119,11 +120,12 @@ class TestClientHttpEdgeCases:
             def __exit__(self, *a):
                 return False
 
-        def fake_urlopen(req, timeout=None):
+        def fake_open(req, timeout=None):
             seen["headers"] = dict(req.headers)
             return _Resp()
 
-        monkeypatch.setattr(tools.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(tools, "_open_url_no_redirect_leak",
+                            lambda req, timeout, allowed=(): fake_open(req, timeout))
         out = tools._http_get_json("http://peer/.well-known/agent-card.json",
                                    {"CF-Access-Client-Id": "cf-id"}, 30)
         assert out == {"name": "peer"}
@@ -143,11 +145,12 @@ class Test524RetryPolicy:
         and the error surfaces to the caller."""
         attempts = {"n": 0}
 
-        def fake_urlopen(req, timeout=None):
+        def fake_open(req, timeout=None):
             attempts["n"] += 1
             raise urlerr.HTTPError(req.full_url, 524, "Origin Time-out", {}, None)
 
-        monkeypatch.setattr(tools.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(tools, "_open_url_no_redirect_leak",
+                            lambda req, timeout, allowed=(): fake_open(req, timeout))
         with pytest.raises(urlerr.HTTPError) as ei:
             tools._http_post_json("http://peer/", {"x": 1}, {}, 30)
         assert ei.value.code == 524
@@ -159,11 +162,12 @@ class Test524RetryPolicy:
         monkeypatch.setattr(tools.time, "sleep", lambda s: None)
         attempts = {"n": 0}
 
-        def fake_urlopen(req, timeout=None):
+        def fake_open(req, timeout=None):
             attempts["n"] += 1
             raise urlerr.HTTPError(req.full_url, 524, "Origin Time-out", {}, None)
 
-        monkeypatch.setattr(tools.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(tools, "_open_url_no_redirect_leak",
+                            lambda req, timeout, allowed=(): fake_open(req, timeout))
         with pytest.raises(urlerr.HTTPError):
             tools._http_post_json("http://peer/", {"x": 1}, {}, 30, retry_524=True)
         assert attempts["n"] == tools._POST_MAX_RETRIES
@@ -184,13 +188,14 @@ class Test524RetryPolicy:
             def __exit__(self, *a):
                 return False
 
-        def fake_urlopen(req, timeout=None):
+        def fake_open(req, timeout=None):
             attempts["n"] += 1
             if attempts["n"] < tools._POST_MAX_RETRIES:
                 raise urlerr.HTTPError(req.full_url, 524, "Origin Time-out", {}, None)
             return _Ctx()
 
-        monkeypatch.setattr(tools.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(tools, "_open_url_no_redirect_leak",
+                            lambda req, timeout, allowed=(): fake_open(req, timeout))
         out = tools._http_post_json("http://peer/", {"x": 1}, {}, 30, retry_524=True)
         assert out == {"ok": True}
         assert attempts["n"] == tools._POST_MAX_RETRIES
@@ -199,11 +204,12 @@ class Test524RetryPolicy:
     def test_other_errors_never_retried(self, monkeypatch):
         attempts = {"n": 0}
 
-        def fake_urlopen(req, timeout=None):
+        def fake_open(req, timeout=None):
             attempts["n"] += 1
             raise urlerr.HTTPError(req.full_url, 502, "Bad Gateway", {}, None)
 
-        monkeypatch.setattr(tools.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(tools, "_open_url_no_redirect_leak",
+                            lambda req, timeout, allowed=(): fake_open(req, timeout))
         with pytest.raises(urlerr.HTTPError):
             tools._http_post_json("http://peer/", {"x": 1}, {}, 30, retry_524=True)
         assert attempts["n"] == 1
@@ -218,7 +224,7 @@ class Test524RetryPolicy:
         monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: None)
         captured = {}
 
-        def fake_post(url, body, headers, timeout, retry_524=False):
+        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
             captured["retry_524"] = retry_524
             return protocol.jsonrpc_result(
                 body["id"],
@@ -228,6 +234,192 @@ class Test524RetryPolicy:
         monkeypatch.setattr(tools, "_http_post_json", fake_post)
         tools.a2a_call({"agent": "mac", "message": "ping"})
         assert captured["retry_524"] is True
+
+
+# ---------------------------------------------------------------------------
+# User-Agent on the real POST path
+# ---------------------------------------------------------------------------
+
+class TestPostUserAgent:
+    def test_post_sends_hermes_user_agent(self, monkeypatch):
+        """The Hermes-A2A/1.0 UA must be on real POSTs (proxy filtering);
+        asserted at the opener seam where the Request is actually built."""
+        captured = {}
+
+        def fake_open(req, timeout, allowed=()):
+            captured["ua"] = req.get_header("User-agent")
+            return _Ctxlike()
+
+        class _Ctxlike:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return b'{"ok": true}'
+
+        monkeypatch.setattr(tools, "_open_url_no_redirect_leak", fake_open)
+        out = tools._http_post_json("http://peer/", {"x": 1}, {}, 30)
+        assert out == {"ok": True}
+        assert captured["ua"] == "Hermes-A2A/1.0"
+
+
+# ---------------------------------------------------------------------------
+# Redirect policy: credentials never follow a cross-origin 3xx
+# ---------------------------------------------------------------------------
+
+class TestRedirectPolicy:
+    def _redirect_handler(self, allowed=()):
+        from plugins.platforms.a2a.tools import _NoCredentialRedirectHandler
+        return _NoCredentialRedirectHandler(tuple(allowed))
+
+    def test_same_origin_redirect_followed(self):
+        h = self._redirect_handler()
+        req = urllib.request.Request("https://configured.example/rpc")
+        new = h.redirect_request(req, None, 302, "Found", {},
+                                 "https://configured.example/rpc/v2")
+        assert new is not None  # followed: same origin, credentials stay on-service
+
+    def test_cross_origin_redirect_refused(self):
+        """THE exfiltration vector: a 3xx from the (trusted, same-origin)
+        endpoint pointing at a foreign host must be refused, not followed.
+        Under the old default opener the foreign host received the full
+        credential map (empirically reproduced in review run t_2ee74a0d)."""
+        h = self._redirect_handler()
+        req = urllib.request.Request("https://configured.example/rpc")
+        with pytest.raises(urllib.error.HTTPError) as ei:
+            h.redirect_request(req, None, 302, "Found", {},
+                               "https://evil.example/collect")
+        assert "refused" in str(ei.value.reason)
+
+    def test_cross_origin_redirect_allowed_via_pinned_origin(self):
+        h = self._redirect_handler(allowed=["https://trusted.example/rpc"])
+        req = urllib.request.Request("https://configured.example/rpc")
+        new = h.redirect_request(req, None, 302, "Found", {},
+                                 "https://trusted.example/other/path")
+        assert new is not None
+
+    def test_scheme_change_is_cross_origin(self):
+        h = self._redirect_handler()
+        req = urllib.request.Request("https://configured.example/rpc")
+        with pytest.raises(urllib.error.HTTPError):
+            h.redirect_request(req, None, 302, "Found", {},
+                               "http://configured.example/rpc")  # https->http downgrade refused
+
+    def test_port_change_is_cross_origin(self):
+        h = self._redirect_handler()
+        req = urllib.request.Request("https://configured.example/rpc")
+        with pytest.raises(urllib.error.HTTPError):
+            h.redirect_request(req, None, 302, "Found", {},
+                               "https://configured.example:8443/rpc")
+
+    def test_end_to_end_post_refuses_cross_origin_redirect(self, monkeypatch):
+        """Full POST path through the guarded opener: the redirecting server
+        never gets a second request, the foreign target is never contacted,
+        and the caller sees the refusal."""
+        import http.server
+        import threading
+        hits = {"redirector": 0, "foreign": 0}
+
+        class Foreign(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):
+                hits["foreign"] += 1
+                self.send_response(200)
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"{}")
+
+            def log_message(self, *a):
+                pass
+
+        class Redirector(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):
+                hits["redirector"] += 1
+                self.send_response(302)
+                self.send_header("Location", f"http://127.0.0.1:{foreign_port}/x")
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            def log_message(self, *a):
+                pass
+
+        fs = http.server.HTTPServer(("127.0.0.1", 0), Foreign)
+        foreign_port = fs.server_address[1]
+        rs = http.server.HTTPServer(("127.0.0.1", 0), Redirector)
+        threading.Thread(target=fs.serve_forever, daemon=True).start()
+        threading.Thread(target=rs.serve_forever, daemon=True).start()
+        try:
+            with pytest.raises(urllib.error.HTTPError) as ei:
+                tools._http_post_json(f"http://127.0.0.1:{rs.server_address[1]}/",
+                                      {"x": 1}, {"Authorization": "Bearer tok"}, 10)
+            assert hits == {"redirector": 1, "foreign": 0}
+            assert "refused" in str(ei.value.reason)
+        finally:
+            fs.shutdown()
+            rs.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Origin-level allowlist matching
+# ---------------------------------------------------------------------------
+
+class TestOriginLevelAllowlist:
+    def test_allowlist_entry_matches_any_path(self):
+        peer = {"url": "https://configured.example",
+                "allowed_rpc_origins": ["https://trusted.example"]}
+        assert tools._origin_allowed("https://trusted.example/rpc", peer)
+        assert tools._origin_allowed("https://trusted.example/", peer)
+        assert tools._origin_allowed("https://trusted.example", peer)
+
+    def test_allowlist_is_origin_scoped_not_string_scoped(self):
+        peer = {"url": "https://configured.example",
+                "allowed_rpc_origins": ["https://trusted.example"]}
+        assert not tools._origin_allowed("https://trusted.evil.example/rpc", peer)
+        assert not tools._origin_allowed("https://trusted.example:8443/rpc", peer)
+        assert not tools._origin_allowed("http://trusted.example/rpc", peer)
+
+    def test_port0_is_not_silently_defaulted(self):
+        assert tools._url_origin("https://configured.example:0/rpc") == ("https", "configured.example:0")
+        assert not tools._url_same_origin("https://configured.example:0/rpc",
+                                          "https://configured.example/rpc")
+
+
+class TestAuthCollisionWarning:
+    def test_authorization_override_logs_warning(self, monkeypatch, caplog):
+        import logging as _logging
+        peer = {"url": "http://localhost:9999",
+                "auth": {"type": "bearer", "token": "t"},
+                "headers": {"Authorization": "ProxyAuth xyz"}}
+        monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: None)
+
+        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "ok"),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        with caplog.at_level(_logging.WARNING, logger="plugins.platforms.a2a.tools"):
+            tools._send_task("p", peer, "hi", "")
+        assert any("override the derived Authorization" in r.message for r in caplog.records)
+
+    def test_distinct_headers_do_not_warn(self, monkeypatch, caplog):
+        import logging as _logging
+        monkeypatch.setattr(tools, "_load_config", lambda: {"a2a_agents": {"p": {
+            "url": "http://localhost:9999",
+            "auth": {"type": "bearer", "token": "t"},
+            "headers": {"CF-Access-Client-Id": "x"},
+        }}})
+
+        def fake_send(*a, **k):
+            return ("reply", "ctx", protocol.STATE_COMPLETED)
+
+        monkeypatch.setattr(tools, "_send_task", fake_send)
+        with caplog.at_level(_logging.WARNING, logger="plugins.platforms.a2a.tools"):
+            tools.a2a_call({"agent": "p", "message": "hi"})
+        assert not any("override the derived Authorization" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------
@@ -259,7 +451,7 @@ class TestRpcOriginBinding:
         monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: card)
         posted = {}
 
-        def fake_post(url, body, headers, timeout, retry_524=False):
+        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
             posted["url"] = url
             return protocol.jsonrpc_result(
                 body["id"],
@@ -279,7 +471,7 @@ class TestRpcOriginBinding:
         monkeypatch.setattr(tools, "_fetch_card", lambda *a, **k: card)
         posted = {}
 
-        def fake_post(url, body, headers, timeout, retry_524=False):
+        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
             posted["url"] = url
             return protocol.jsonrpc_result(
                 body["id"],
@@ -291,19 +483,21 @@ class TestRpcOriginBinding:
         tools._send_task("peer-x", peer, "hi", "")
         assert posted["url"] == "https://trusted.example/rpc"
 
-    def test_card_fetch_carries_no_credentials(self, monkeypatch):
-        """The card fetch itself must be bare: no bearer header, no custom
-        proxy headers — the card endpoint is discovery data, not a secret
-        destination."""
+    def test_card_fetch_carries_credentials_to_configured_origin(self, monkeypatch):
+        """The card fetch goes to the CONFIGURED origin, so it carries the
+        credential map (a Cloudflare-Access-fronted peer otherwise 403s the
+        card, losing streaming/capability discovery). The egress bound is on
+        the RPC destination, proven by the cross-origin tests above."""
         fetched = {}
 
-        def fake_fetch(url, headers, timeout):
-            fetched["headers"] = headers
+        def fake_fetch(url, headers, timeout, allowed_origins=()):
+            fetched["url"] = url
+            fetched["headers"] = dict(headers)
             return None
 
         monkeypatch.setattr(tools, "_fetch_card", fake_fetch)
 
-        def fake_post(url, body, headers, timeout, retry_524=False):
+        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
             return protocol.jsonrpc_result(
                 body["id"],
                 protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "ok"),
@@ -313,4 +507,6 @@ class TestRpcOriginBinding:
         peer = self._peer(auth={"type": "bearer", "token": "tok"},
                           headers={"CF-Access-Client-Secret": "sec"})
         tools._send_task("peer-x", peer, "hi", "")
-        assert fetched["headers"] == {}
+        assert fetched["url"].startswith("https://configured.example")
+        assert fetched["headers"].get("Authorization") == "Bearer tok"
+        assert fetched["headers"].get("CF-Access-Client-Secret") == "sec"

--- a/tests/plugins/test_a2a_headers_and_retry.py
+++ b/tests/plugins/test_a2a_headers_and_retry.py
@@ -362,6 +362,132 @@ class TestRedirectPolicy:
 
 
 # ---------------------------------------------------------------------------
+# End-to-end: allowed_rpc_origins governs the task POST redirect path
+# ---------------------------------------------------------------------------
+
+class TestSendTaskRedirectAllowlist:
+    """Real _send_task against live loopback servers: a configured-origin
+    POST that 302s to a PINNED origin must be followed with credentials;
+    the same redirect to an UNPINNED origin must be refused with nothing
+    delivered to the foreign host. Pins the wiring the maintainer flagged
+    (the allowlist reached the card fetch but not the task POST)."""
+
+    def _spin(self, handler):
+        import http.server
+        import threading
+        s = http.server.HTTPServer(("127.0.0.1", 0), handler)
+        threading.Thread(target=s.serve_forever, daemon=True).start()
+        return s, f"http://127.0.0.1:{s.server_address[1]}"
+
+    def test_pinned_origin_redirect_followed_with_credentials(self):
+        """Through the REAL _send_task path (wiring under test): the peer's
+        configured origin 302s the task POST to a PINNED origin. The pinned
+        server must receive the credential-bearing request. Fails if
+        _send_task drops allowed_origins on the POST call."""
+        import http.server
+        import json as _json
+
+        seen = {}
+
+        def rpc_ok(req_id):
+            return _json.dumps(protocol.jsonrpc_result(
+                req_id,
+                protocol.build_task("t1", "c1", protocol.STATE_COMPLETED, "ok"))).encode()
+
+        class Pinned(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                seen["pinned_path"] = self.path
+                seen["pinned_auth"] = self.headers.get("Authorization")
+                seen["pinned_cf"] = self.headers.get("CF-Access-Client-Id")
+                b = rpc_ok(1)
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(b)))
+                self.end_headers()
+                self.wfile.write(b)
+
+            def log_message(self, *a):
+                pass
+
+        class Redirector(http.server.BaseHTTPRequestHandler):
+            pinned_url = None
+
+            def do_GET(self):
+                b = b"{}"
+                self.send_response(200)
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b)
+
+            def log_message(self, *a):
+                pass
+
+            def do_POST(self):
+                self.send_response(302)
+                self.send_header("Location", self.pinned_url + "/rpc")
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+        ps, pinned = self._spin(Pinned)
+        Redirector.pinned_url = pinned
+        rs, redir = self._spin(Redirector)
+        peer = {"url": redir, "timeout": 10,
+                "auth": {"type": "bearer", "token": "tok-pin"},
+                "headers": {"CF-Access-Client-Id": "cf-pin"},
+                "allowed_rpc_origins": [pinned]}
+        reply, _ctx, _state = tools._send_task("pin-peer", peer, "hello", "")
+        assert "ok" in (reply or "")
+        assert seen.get("pinned_auth") == "Bearer tok-pin", "credentials must reach pinned origin"
+        assert seen.get("pinned_cf") == "cf-pin"
+        ps.shutdown()
+        rs.shutdown()
+
+    def test_full_send_task_unpinned_redirect_refused_no_delivery(self):
+        import http.server
+
+        foreign_hits = {"n": 0, "auth": None}
+
+        class Foreign(http.server.BaseHTTPRequestHandler):
+            def _r(self):
+                foreign_hits["n"] += 1
+                foreign_hits["auth"] = self.headers.get("Authorization")
+                b = b"{}"
+                self.send_response(200)
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b)
+
+            do_GET = do_POST = _r
+
+            def log_message(self, *a):
+                pass
+
+        class Redirector(http.server.BaseHTTPRequestHandler):
+            foreign_url = None
+
+            def do_POST(self):
+                self.send_response(302)
+                self.send_header("Location", self.foreign_url + "/steal")
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            def log_message(self, *a):
+                pass
+
+        fs, foreign = self._spin(Foreign)
+        Redirector.foreign_url = foreign
+        rs, redir = self._spin(Redirector)
+        peer = {"url": redir, "timeout": 10,
+                "auth": {"type": "bearer", "token": "tok-x"},
+                "headers": {"CF-Access-Client-Id": "cf-x"}}
+        with pytest.raises(urllib.error.HTTPError) as ei:
+            tools._send_task("redir-peer", peer, "hello", "")
+        assert foreign_hits["n"] == 0, "foreign host must never be contacted"
+        assert "refused" in str(ei.value.reason)
+        fs.shutdown()
+        rs.shutdown()
+
+
+# ---------------------------------------------------------------------------
 # Origin-level allowlist matching
 # ---------------------------------------------------------------------------
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -489,7 +489,7 @@ class TestClientTools:
 
         captured = {}
 
-        def fake_post(url, body, headers, timeout, retry_524=False):
+        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
             captured["body"] = body
             ctx = body["params"]["message"].get("contextId", "c1")
             return protocol.jsonrpc_result(
@@ -517,7 +517,7 @@ class TestClientTools:
                             lambda: {"a2a_agents": {"r": {"url": "http://localhost:9999"}}})
         monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t, ao=(): None)
 
-        def fake_post(url, body, headers, timeout, retry_524=False):
+        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
             return protocol.jsonrpc_result(
                 body["id"],
                 protocol.build_task("t", "ctx-q", protocol.STATE_INPUT_REQUIRED, "Which repo?"),
@@ -610,7 +610,7 @@ class TestRegistryDispatchConvention:
         monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t, ao=(): None)
         captured = {}
 
-        def fake_post(url, body, headers, timeout, retry_524=False):
+        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
             captured["sent"] = True
             return protocol.jsonrpc_result(
                 body["id"],
@@ -1423,7 +1423,7 @@ class TestClientTenantAndDiscovery:
                 tenant="dev-team",
             )
 
-        def fake_post(url, body, headers, timeout, retry_524=False):
+        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
             posted["url"] = url
             posted["body"] = body
             return {"jsonrpc": "2.0", "id": body["id"], "result": protocol.build_task(
@@ -1496,7 +1496,7 @@ class TestV1SpecRegressionFixes:
             return protocol.build_agent_card(
                 name="dev", url="http://peer.example/dev/", description="dev", tenant="dev-team")
 
-        def fake_post(url, body, headers, timeout, retry_524=False):
+        def fake_post(url, body, headers, timeout, retry_524=False, allowed_origins=()):
             posted["headers"] = headers
             posted["body"] = body
             return {"jsonrpc": "2.0", "id": body["id"], "result": {"task": protocol.build_task(

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -475,7 +475,7 @@ class TestClientTools:
             description="finds things",
             skills=[{"id": "s", "name": "search", "description": "web search"}],
         )
-        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: card)
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t, ao=(): card)
         out = tools.a2a_discover({"url": "http://localhost:9999"})
         assert "researcher" in out
         assert "search" in out
@@ -485,7 +485,7 @@ class TestClientTools:
         """Outbound params: contextId inside the message, v1.0 role, no kind."""
         monkeypatch.setattr(tools, "_load_config",
                             lambda: {"a2a_agents": {"r": {"url": "http://localhost:9999"}}})
-        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: None)
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t, ao=(): None)
 
         captured = {}
 
@@ -515,7 +515,7 @@ class TestClientTools:
     def test_call_reports_input_required(self, monkeypatch):
         monkeypatch.setattr(tools, "_load_config",
                             lambda: {"a2a_agents": {"r": {"url": "http://localhost:9999"}}})
-        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: None)
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t, ao=(): None)
 
         def fake_post(url, body, headers, timeout, retry_524=False):
             return protocol.jsonrpc_result(
@@ -607,7 +607,7 @@ class TestRegistryDispatchConvention:
         alias for 'agent' so the call doesn't fail the required-arg guard."""
         monkeypatch.setattr(tools, "_load_config",
                             lambda: {"a2a_agents": {"peer": {"url": "http://localhost:9999"}}})
-        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: None)
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t, ao=(): None)
         captured = {}
 
         def fake_post(url, body, headers, timeout, retry_524=False):
@@ -1414,7 +1414,7 @@ class TestClientTenantAndDiscovery:
     def test_rpc_body_echoes_tenant_from_agent_card(self, monkeypatch):
         posted = {}
 
-        def fake_get(url, headers, timeout):
+        def fake_get(url, headers, timeout, allowed_origins=()):
             assert url.endswith("/.well-known/agent-card.json")
             return protocol.build_agent_card(
                 name="dev",
@@ -1442,7 +1442,7 @@ class TestClientTenantAndDiscovery:
     def test_discovery_falls_back_to_legacy_agent_json(self, monkeypatch):
         calls = []
 
-        def fake_get(url, headers, timeout):
+        def fake_get(url, headers, timeout, allowed_origins=()):
             calls.append(url)
             if url.endswith("agent-card.json"):
                 raise urllib.error.HTTPError(url, 404, "not found", {}, None)
@@ -1492,7 +1492,7 @@ class TestV1SpecRegressionFixes:
     def test_client_sends_v1_method_and_unwraps_response(self, monkeypatch):
         posted = {}
 
-        def fake_get(url, headers, timeout):
+        def fake_get(url, headers, timeout, allowed_origins=()):
             return protocol.build_agent_card(
                 name="dev", url="http://peer.example/dev/", description="dev", tenant="dev-team")
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -489,7 +489,7 @@ class TestClientTools:
 
         captured = {}
 
-        def fake_post(url, body, headers, timeout):
+        def fake_post(url, body, headers, timeout, retry_524=False):
             captured["body"] = body
             ctx = body["params"]["message"].get("contextId", "c1")
             return protocol.jsonrpc_result(
@@ -517,7 +517,7 @@ class TestClientTools:
                             lambda: {"a2a_agents": {"r": {"url": "http://localhost:9999"}}})
         monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: None)
 
-        def fake_post(url, body, headers, timeout):
+        def fake_post(url, body, headers, timeout, retry_524=False):
             return protocol.jsonrpc_result(
                 body["id"],
                 protocol.build_task("t", "ctx-q", protocol.STATE_INPUT_REQUIRED, "Which repo?"),
@@ -575,6 +575,33 @@ class TestRegistryDispatchConvention:
         out = registry.dispatch("a2a_list", {})
         assert "No peers configured" in out
 
+    def test_registered_schemas_are_flat_not_double_wrapped(self, monkeypatch, tmp_path):
+        """The registry stores schemas as-is and ``get_definitions()`` wraps
+        them in {"type": "function", "function": ...}. ``register_tools``
+        must unwrap ``_SCHEMAS``'s OpenAI-style wrapper first — otherwise the
+        model gets a nested {"function": {"function": {...}}} with no
+        parameters and tool calls fail validation."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(tools, "_load_config", lambda: {})
+        from tools.registry import registry
+
+        class _Ctx:
+            def register_tool(self, name, toolset, schema, handler, **kw):
+                registry.register(name=name, toolset=toolset, schema=schema,
+                                  handler=handler, override=True, **kw)
+
+        tools.register_tools(_Ctx())
+
+        defs = registry.get_definitions({"a2a_call", "a2a_discover"})
+        by_name = {d["function"].get("name"): d for d in defs}
+        assert set(by_name) == {"a2a_call", "a2a_discover"}
+        call_fn = by_name["a2a_call"]["function"]
+        assert "function" not in call_fn  # double-wrap would nest one here
+        assert "agent" in call_fn["parameters"]["properties"]
+        assert call_fn["description"]
+        assert by_name["a2a_discover"]["function"]["description"]
+
+
     def test_a2a_call_accepts_agent_name_alias(self, monkeypatch):
         """Models reach for 'agent_name' (observed live). Accept it as an
         alias for 'agent' so the call doesn't fail the required-arg guard."""
@@ -583,7 +610,7 @@ class TestRegistryDispatchConvention:
         monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: None)
         captured = {}
 
-        def fake_post(url, body, headers, timeout):
+        def fake_post(url, body, headers, timeout, retry_524=False):
             captured["sent"] = True
             return protocol.jsonrpc_result(
                 body["id"],
@@ -1396,7 +1423,7 @@ class TestClientTenantAndDiscovery:
                 tenant="dev-team",
             )
 
-        def fake_post(url, body, headers, timeout):
+        def fake_post(url, body, headers, timeout, retry_524=False):
             posted["url"] = url
             posted["body"] = body
             return {"jsonrpc": "2.0", "id": body["id"], "result": protocol.build_task(
@@ -1469,7 +1496,7 @@ class TestV1SpecRegressionFixes:
             return protocol.build_agent_card(
                 name="dev", url="http://peer.example/dev/", description="dev", tenant="dev-team")
 
-        def fake_post(url, body, headers, timeout):
+        def fake_post(url, body, headers, timeout, retry_524=False):
             posted["headers"] = headers
             posted["body"] = body
             return {"jsonrpc": "2.0", "id": body["id"], "result": {"task": protocol.build_task(
@@ -1618,3 +1645,9 @@ print('fake reply')
         title = con.execute("SELECT title FROM sessions WHERE id='sess-1'").fetchone()[0]
         con.close()
         assert title == "a2a-dev-ctx-unsafe-value"
+
+
+# --------------------------------------------------------------------------
+# Client HTTP edge cases: GET-layer headers, collision precedence,
+# 524 retry budget
+# --------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/a2a.md
+++ b/website/docs/user-guide/messaging/a2a.md
@@ -90,16 +90,7 @@ a2a_agents:
     allowed_rpc_origins: ["https://rpc.internal.example.com"]   # origin: scheme+host+port, any path
 ```
 
-**524 retries are opt-in.** A Cloudflare 524 means the proxy gave up on the response — the origin may have already executed the task. Retrying a send is therefore only safe when the peer deduplicates requests, which Hermes peers do (the retry re-sends the task with identical task and message identity). Assert that per peer:
-
-```yaml
-a2a_agents:
-  hermes-server:
-    url: "https://hermes-server-a2a.example.com"
-    idempotency: true   # peer dedupes -> 524s retried with backoff
-```
-
-Without `idempotency`, a 524 surfaces to the caller as an indeterminate outcome — never auto-retried.
+**524 responses are typed indeterminate.** A Cloudflare 524 means the proxy gave up on the response — the origin may have already executed the task. Hermes never auto-retries a send on a 524: without a proven server-side idempotency contract, a replay could execute the task twice. The error surfaces as an explicit indeterminate outcome (`_A2aIndeterminateError`) with guidance not to blindly re-send mutating requests; recovery for long tasks composes with task polling (`GetTask` on a known task id) instead of blind replay.
 
 ## Inbound: being callable
 

--- a/website/docs/user-guide/messaging/a2a.md
+++ b/website/docs/user-guide/messaging/a2a.md
@@ -79,24 +79,24 @@ a2a_agents:
 
 Then just ask: *"Ask the researcher agent to summarize today's arXiv postings."* Direct URLs work too — `a2a_call` accepts any A2A endpoint.
 
-**Header precedence.** Custom `headers` override the derived `Authorization` (a proxy may require its own auth scheme — colliding configs log a warning), but protocol-owned `Content-Type`, `A2A-Version`, and `Accept` can never be clobbered. `User-Agent` stays overridable since some proxies filter it.
+**Header precedence.** Custom `headers` override the derived `Authorization` (a proxy may require its own auth scheme — the collision is logged as a warning), but protocol-owned `Content-Type` and `A2A-Version` can never be clobbered by config. `User-Agent` stays overridable since some proxies filter it.
 
-**Credential destination.** Auth and custom headers are only sent to the **configured origin**. If the peer's Agent Card advertises an RPC interface on a different origin, the send refuses to follow it (a card-controlled host must not receive your service tokens) and uses the configured origin instead. To trust a card-advertised cross-origin endpoint, pin it explicitly:
+**Credential destination.** Auth and custom headers are only sent to the **configured origin**. If the peer's Agent Card advertises an RPC interface on a different origin, the send refuses to follow it (a card-controlled host must not receive your service tokens) and uses the configured origin instead. Redirects are covered by the same policy: a 3xx pointing at a different origin is refused rather than followed. To trust a card-advertised cross-origin endpoint, pin its origin explicitly:
 
 ```yaml
 a2a_agents:
   hermes-server:
     url: "https://hermes-server-a2a.example.com"
-    allowed_rpc_origins: ["https://rpc.internal.example.com"]
+    allowed_rpc_origins: ["https://rpc.internal.example.com"]   # origin: scheme+host+port, any path
 ```
 
-**524 retries are opt-in.** A Cloudflare 524 means the proxy gave up on the response — the origin may have already executed the task. Retrying a send is therefore only safe when the peer deduplicates on message identity, which Hermes peers do. Assert that per peer:
+**524 retries are opt-in.** A Cloudflare 524 means the proxy gave up on the response — the origin may have already executed the task. Retrying a send is therefore only safe when the peer deduplicates requests, which Hermes peers do (the retry re-sends the task with identical task and message identity). Assert that per peer:
 
 ```yaml
 a2a_agents:
   hermes-server:
     url: "https://hermes-server-a2a.example.com"
-    idempotency: true   # peer dedupes on messageId -> 524s retried with backoff
+    idempotency: true   # peer dedupes -> 524s retried with backoff
 ```
 
 Without `idempotency`, a 524 surfaces to the caller as an indeterminate outcome — never auto-retried.

--- a/website/docs/user-guide/messaging/a2a.md
+++ b/website/docs/user-guide/messaging/a2a.md
@@ -62,7 +62,44 @@ a2a_agents:
     capabilities: [web_search, research]
 ```
 
+Peers fronted by a header-authenticating proxy — e.g. **Cloudflare Access**
+with a service token — take a `headers` map that is merged into every
+outbound request (card fetch and task submit alike):
+
+```yaml
+a2a_agents:
+  hermes-server:
+    url: "https://hermes-server-a2a.example.com"
+    auth: { type: bearer, token: "..." }
+    headers:
+      CF-Access-Client-Id: "<client id>"
+      CF-Access-Client-Secret: "<client secret>"
+    timeout: 300
+```
+
 Then just ask: *"Ask the researcher agent to summarize today's arXiv postings."* Direct URLs work too — `a2a_call` accepts any A2A endpoint.
+
+**Header precedence.** Custom `headers` override the derived `Authorization` (a proxy may require its own auth scheme — colliding configs log a warning), but protocol-owned `Content-Type`, `A2A-Version`, and `Accept` can never be clobbered. `User-Agent` stays overridable since some proxies filter it.
+
+**Credential destination.** Auth and custom headers are only sent to the **configured origin**. If the peer's Agent Card advertises an RPC interface on a different origin, the send refuses to follow it (a card-controlled host must not receive your service tokens) and uses the configured origin instead. To trust a card-advertised cross-origin endpoint, pin it explicitly:
+
+```yaml
+a2a_agents:
+  hermes-server:
+    url: "https://hermes-server-a2a.example.com"
+    allowed_rpc_origins: ["https://rpc.internal.example.com"]
+```
+
+**524 retries are opt-in.** A Cloudflare 524 means the proxy gave up on the response — the origin may have already executed the task. Retrying a send is therefore only safe when the peer deduplicates on message identity, which Hermes peers do. Assert that per peer:
+
+```yaml
+a2a_agents:
+  hermes-server:
+    url: "https://hermes-server-a2a.example.com"
+    idempotency: true   # peer dedupes on messageId -> 524s retried with backoff
+```
+
+Without `idempotency`, a 524 surfaces to the caller as an indeterminate outcome — never auto-retried.
 
 ## Inbound: being callable
 


### PR DESCRIPTION
## What does this PR do?

Adds per-peer custom HTTP headers and the `Hermes-A2A/1.0` User-Agent to outbound A2A requests, with credential handling rebuilt per review.

**What this is** (4 commits on current `main`):

- **Per-peer headers** merged into every task request for peers fronted by header-authenticating proxies (e.g. Cloudflare Access service tokens).
- **Protocol-owned header precedence**: `Content-Type` and `A2A-Version` can never be clobbered by config; `User-Agent` stays operator-overridable. A configured `Authorization` that shadows derived Bearer auth is deliberate and logs a warning.
- **Destination-bound credentials**: auth/custom headers go only to the configured origin. Card-advertised cross-origin RPC is refused (WARNING + fallback to configured origin); redirects are covered by the same policy — a hop is followed only when same-origin with the original request or pinned via `allowed_rpc_origins`, which now governs both the card fetch AND the task POST path (end-to-end tests assert credentials reach a pinned origin and never reach an unpinned one).
- **524 is a typed indeterminate outcome, never auto-retried**: `_A2aIndeterminateError` distinguishes "may have executed" from ordinary failure; `a2a_call` surfaces explicit guidance not to blindly re-send mutating requests. No idempotency peer key exists — the server-side contract it presumed does not exist on main or in #92494's current form. Recovery composes with explicit task-identity polling (#94880) when that lands. Byte-identical resend properties (stable message/task identity) are retained for a future server contract.

## Related Issue

No open issue tracks this directly. Relates to the A2A protocol umbrella (#514, completed via #41711) — this hardens the client transport that plugin introduced. Server-side recovery composability: #92494 (open), #94880 (open — non-blocking task polling).

## Type of Change

- [x] ✨ New feature

(The destination-bound credentials and fail-closed redirect policy are security hardening of that feature — security reviewers see the adversarial battery under "How to Test".)

## Changes Made

- `plugins/platforms/a2a/tools.py` — per-peer `headers` merge into every outbound request; `Hermes-A2A/1.0` default User-Agent (operator-overridable); protocol-owned header protection; `allowed_rpc_origins` allowlist wired into both the card fetch and the task POST; fail-closed cross-origin redirect policy; typed `_A2aIndeterminateError` for 524 with automatic replay removed
- `tests/plugins/test_a2a_headers_and_retry.py` — new 29-test module (`TestPerPeerHeaders`, `TestRedirectPolicy`, `TestSendTaskRedirectAllowlist`, `TestOriginLevelAllowlist`, `Test524Indeterminate`, `TestAuthCollisionWarning`, `TestRpcOriginBinding`, …) including an end-to-end 302 test standing up two live loopback servers
- `tests/plugins/test_a2a_plugin.py` — targeted additions; file stays under the 2K-line invariant
- `website/docs/user-guide/messaging/a2a.md` — header precedence, `allowed_rpc_origins`, and 524 semantics documented

## How to Test

1. `pytest tests/plugins/test_a2a_headers_and_retry.py tests/plugins/test_a2a_plugin.py -v`
2. Full suite (`scripts/run_tests.sh` parity) — green in CI on head `7fe503c6` (run 33003853206: Python tests, e2e, OS-specific, lints all success)
3. Live: two Hermes instances behind Cloudflare Access (service-token policy) exchange tasks using the configured headers. An adversarial battery against the installed client — card-swap exfiltration, cross-origin 302 with credential-capture attempts, oversized bodies — was fully contained: no credential ever reached an unpinned origin.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(a2a):`, `fix(a2a):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr+a2a) to make sure this isn't a duplicate (re-checked 2026-08-26: none)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits — 4 commits, 4 files)
- [x] I've run `pytest tests/ -q` and all tests pass (full suite green in CI on head `7fe503c6`; the 182-test a2a suite additionally run locally during development)
- [x] I've added tests for my changes (29 new tests in a dedicated module)
- [x] I've tested on my platform: macOS 26.6 (arm64); CI additionally covers ubuntu-latest and windows-latest (OS-specific matrices green)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/user-guide/messaging/a2a.md`
- [x] `cli-config.yaml.example` — N/A (the example file documents no `a2a_agents` keys today; peer keys `headers` / `allowed_rpc_origins` are documented in `a2a.md`, the canonical A2A config reference)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] I've considered cross-platform impact — stdlib HTTP only, no POSIX-only primitives; Windows-footguns CI check green
- [x] Tool descriptions/schemas — N/A (no tool schema changes)

## Screenshots / Logs

**Operational history:** this header set has run in production between two Hermes instances (both behind Cloudflare Access tunnels) since 2026-08-13; the redirect/origin policy and 524 typing were additionally exercised in a two-sided live test (2026-08-26) including an adversarial battery against the installed client (card-swap exfiltration, cross-origin 302, oversized bodies — all contained).
