### PR TITLE
fix(models): map bedrock provider to models.dev amazon-bedrock

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -170,6 +170,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "openrouter": "openrouter",
     "novita": "novita-ai",
     "anthropic": "anthropic",
+    "bedrock": "amazon-bedrock",
     "openai": "openai",
     "openai-codex": "openai",
     "zai": "zai",

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -106,6 +106,7 @@ class TestProviderMapping:
         assert PROVIDER_TO_MODELS_DEV["stepfun"] == "stepfun"
         assert PROVIDER_TO_MODELS_DEV["kilocode"] == "kilo"
         assert PROVIDER_TO_MODELS_DEV["ai-gateway"] == "vercel"
+        assert PROVIDER_TO_MODELS_DEV["bedrock"] == "amazon-bedrock"
 
     def test_xai_oauth_uses_xai_catalog(self):
         assert PROVIDER_TO_MODELS_DEV["xai"] == "xai"
@@ -824,6 +825,42 @@ class TestGetModelCapabilities:
             caps = get_model_capabilities("gemini", "weird-model")
         assert caps is not None
         assert caps.supports_vision is False
+
+
+    def test_bedrock_opus_regional_slug_vision(self):
+        """Bedrock regional Opus slugs must resolve to vision-capable.
+
+        Regression: the ``bedrock`` provider was missing from
+        PROVIDER_TO_MODELS_DEV, so get_model_capabilities("bedrock", ...)
+        returned None for every Bedrock model. Image routing in auto mode
+        then fell back to the text pipeline (vision_analyze) instead of
+        attaching images natively, even though Opus supports vision
+        (hermes-agent image_routing issue: native vision lost with an
+        explicit auxiliary.vision fallback configured).
+        """
+        registry = {
+            "amazon-bedrock": {"id": "amazon-bedrock", "models": {
+                "us.anthropic.claude-opus-4-6-v1": {
+                    "id": "us.anthropic.claude-opus-4-6-v1",
+                    "attachment": True,
+                    "tool_call": True,
+                    "modalities": {"input": ["text", "image", "pdf"]},
+                    "limit": {"context": 1000000, "output": 128000},
+                },
+                "anthropic.claude-sonnet-4-6": {
+                    "id": "anthropic.claude-sonnet-4-6",
+                    "attachment": True,
+                    "tool_call": True,
+                    "modalities": {"input": ["text", "image", "pdf"]},
+                    "limit": {"context": 1000000, "output": 128000},
+                },
+            }},
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            caps = get_model_capabilities("bedrock", "us.anthropic.claude-opus-4-6-v1")
+        assert caps is not None
+        assert caps.supports_vision is True
+        assert caps.supports_tools is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# fix(models): map bedrock provider to models.dev amazon-bedrock

## Summary

Adds the missing `bedrock` → `amazon-bedrock` entry to `PROVIDER_TO_MODELS_DEV` in `agent/models_dev.py`, so `get_model_capabilities("bedrock", ...)` can resolve Bedrock model capability metadata from models.dev instead of always returning `None`. Includes a regression test covering a Bedrock regional Opus slug resolving to vision-capable.

## Motivation

The `PROVIDER_TO_MODELS_DEV` mapping had entries for `anthropic`, `openai`, `google`/`gemini`, `deepseek`, `xai`, etc., but no `bedrock` key. Any Hermes profile configured with `provider: bedrock` (e.g. `us.anthropic.claude-opus-4-6-v1` or `us.anthropic.claude-sonnet-4-6`) therefore failed the models.dev capability lookup — `_get_provider_models("bedrock")` returned `None` immediately.

That broke image routing in `agent/image_routing.py` (`decide_image_input_mode`, auto mode): with `supports_vision` unknown, the router fell through to the text pipeline, so user-attached images went through `vision_analyze` (described by the configured auxiliary vision backend) instead of being attached **natively** to a vision-capable main model. The models.dev cache actually contains the `amazon-bedrock` provider data with `attachment: true` / image input modalities for these models — the mapping just never routed to it.

## Changes

- `agent/models_dev.py` — one line added to `PROVIDER_TO_MODELS_DEV`:
  ```python
  "bedrock": "amazon-bedrock",
  ```
- `tests/agent/test_models_dev.py`:
  - `test_known_providers_mapped` asserts `PROVIDER_TO_MODELS_DEV["bedrock"] == "amazon-bedrock"`.
  - New `test_bedrock_opus_regional_slug_vision` patches `fetch_models_dev` with an `amazon-bedrock` registry and asserts `get_model_capabilities("bedrock", "us.anthropic.claude-opus-4-6-v1")` returns `supports_vision=True` — proving the full mapping → capabilities → vision path end to end. Verified the test fails without the mapping change and passes with it.

## Design decisions

- Single canonical provider key. The runtime resolves Bedrock as `provider: bedrock` (see `hermes_cli/runtime_provider.py` — `requested_provider in {"bedrock", "aws", "aws-bedrock", "amazon-bedrock", "amazon"}` normalizes to `bedrock`), so one mapping entry covers all accepted spellings.
- Test uses a patched registry rather than live network so the suite stays hermetic, matching the existing `CAPS_REGISTRY` pattern.

## Backwards compatibility

Zero breaking changes. The mapping only adds a previously-missing lookup path; models that had no Bedrock capability data before now get correct metadata. Providers with no models.dev entry are unaffected (`_get_provider_models` still returns `None`).

## Testing

```bash
python3 -m pytest tests/agent/test_models_dev.py tests/agent/test_image_routing.py -q
# 107 passed (includes the new regression test)
```

Also verified the regression test fails if the mapping line is reverted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Amazon Bedrock provider support to model metadata mapping.
  * Regional Bedrock Anthropic Opus and Sonnet models now correctly expose vision and tool capabilities.

* **Bug Fixes**
  * Improved model recognition for regional Bedrock model identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->