### PR TITLE
fix(desktop): profile switch reuses the default socket after 0.20.1

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8020,7 +8020,11 @@ async function ensureBackend(profile) {
 
     // A shared backend still owes the caller its profile scope, so renderer-side
     // WebSocket, filesystem, and cache routing target the selected profile.
-    return route.descriptorProfile ? { ...connection, profile: route.descriptorProfile } : connection
+    // `sharedPrimary` marks this as the shared-primary route: pooled backends
+    // also carry `profile`, so only this descriptor gets the flag.
+    return route.descriptorProfile
+      ? { ...connection, profile: route.descriptorProfile, sharedPrimary: true }
+      : connection
   }
 
   const existing = backendPool.get(key)

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -534,6 +534,10 @@ export interface HermesConnection {
   // Set for pool (non-primary) backends so the renderer knows which profile a
   // connection belongs to.
   profile?: string
+  // True only when `profile` is a request scope on the shared primary backend.
+  // A pooled backend also carries `profile`, so presence alone cannot identify
+  // the shared-primary routing case.
+  sharedPrimary?: boolean
   windowButtonPosition: { x: number; y: number } | null
 }
 

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -1,19 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // The global-remote share (backend routing case 3): every profile is served
-// by the PRIMARY backend over one host, and getConnection() tags the shared
-// descriptor with `profile`. Dialing a second WebSocket at that descriptor
+// by the PRIMARY backend over one host, and getConnection() explicitly tags
+// the shared descriptor with `sharedPrimary`. Dialing a second WebSocket at it
 // used to fail over SSH (per-backend tunnel/ticket) and poison the active
 // gateway with a closed socket — "Hermes gateway is not connected" for every
-// profile except the primary. These tests pin the fix: a profile routed to
-// the shared primary activates the primary socket instead of dialing.
+// profile except the primary. Pooled backends (own-remote override, local
+// named profile) also carry `profile` for WS URL minting, so `profile` alone
+// cannot identify the shared-primary route. These tests pin the fix: only a
+// `sharedPrimary` descriptor activates the primary socket; a pooled descriptor
+// that also carries `profile` must still dial its own socket.
+
+const gatewayMocks = vi.hoisted(() => ({
+  connect: vi.fn(async (_wsUrl: string): Promise<void> => {
+    throw new Error('dialed a socket for a shared-primary profile')
+  })
+}))
 
 vi.mock('@/hermes', () => ({
   HermesGateway: class {
     connectionState = 'closed'
-    connect = vi.fn(async () => {
-      throw new Error('dialed a socket for a shared-primary profile')
-    })
+    connect = gatewayMocks.connect
     onEvent = vi.fn(() => () => {})
     onState = vi.fn(() => () => {})
   }
@@ -47,32 +54,45 @@ afterEach(() => {
 })
 
 describe('ensureGatewayForProfile under a shared global remote', () => {
-  it('activates the primary socket for a profile tagged onto the shared descriptor', async () => {
+  it('activates the primary socket for an explicitly shared-primary descriptor', async () => {
     const primary = makePrimary()
     setPrimaryGateway(primary as never, 'default')
     installDesktop({
-      // Shared descriptor: primary connection tagged with the profile.
-      getConnection: vi.fn(async () => ({ port: 4242, profile: 'venture', token: 't' }))
+      // Shared descriptor: primary connection tagged with the profile scope
+      // AND the explicit sharedPrimary marker.
+      getConnection: vi.fn(async () => ({ port: 4242, profile: 'venture', sharedPrimary: true, token: 't' }))
     })
 
     await ensureGatewayForProfile('venture')
 
+    expect(gatewayMocks.connect).not.toHaveBeenCalled()
     expect($gateway.get()).toBe(primary)
   })
 
-  it('still pools a socket for profiles with their own descriptor (untagged)', async () => {
+  it('dials the exact WebSocket URL for a pooled profile descriptor that carries profile', async () => {
     const primary = makePrimary()
+    const remoteWsUrl = 'wss://remote.invalid/api/ws?token=fake-test-token'
+
     setPrimaryGateway(primary as never, 'default')
     installDesktop({
-      // Own descriptor: no profile tag → normal pooled path (dial attempted).
-      getConnection: vi.fn(async () => ({ port: 5151, token: 't2' }))
+      // Pooled descriptor: carries `profile` for WS URL minting but is NOT
+      // shared-primary (no marker) — it must dial its own socket, not reuse
+      // the primary. This is the local named / own-remote profile case.
+      getConnection: vi.fn(async () => ({
+        authMode: 'token',
+        baseUrl: 'https://remote.invalid',
+        mode: 'remote',
+        profile: 'worker',
+        token: 'fake-test-token',
+        wsUrl: remoteWsUrl
+      }))
     })
+    gatewayMocks.connect.mockResolvedValueOnce(undefined)
 
     await ensureGatewayForProfile('worker')
 
-    // The pooled path dialed (our stub throws, so the socket stays closed and
-    // reconnect is scheduled) — the important part is it did NOT silently
-    // reuse the primary.
+    expect(gatewayMocks.connect).toHaveBeenCalledOnce()
+    expect(gatewayMocks.connect).toHaveBeenCalledWith(remoteWsUrl)
     expect($gateway.get()).not.toBe(primary)
   })
 })

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -248,12 +248,14 @@ function createSecondary(profile: string): Secondary {
 }
 
 // True when `profile`'s backend route resolves to the SHARED primary backend
-// (global-remote case 3 in resolveProfileBackendRoute): the descriptor comes
-// back as the primary connection tagged with `profile`. Own-remote-override
-// and local pooled descriptors are never tagged. Dialing a second socket at
-// that descriptor is wrong — over SSH the second dial fails (tunnel/token are
-// per-backend) and the closed socket poisons the active gateway with
-// "not connected" even though the primary is open right next to it.
+// (global-remote case 3 in resolveProfileBackendRoute). Both shared-primary and
+// pooled descriptors carry `profile` so WebSocket URL minting targets the right
+// profile. `sharedPrimary` is the explicit discriminator; treating every tagged
+// descriptor as shared strands local/own-remote pooled profiles on the default
+// socket. Dialing a second socket at the shared descriptor is wrong — over SSH
+// the second dial fails (tunnel/token are per-backend) and the closed socket
+// poisons the active gateway with "not connected" even though the primary is
+// open right next to it.
 async function sharedPrimaryRoute(profile: string): Promise<boolean> {
   const desktop = window.hermesDesktop
 
@@ -264,7 +266,7 @@ async function sharedPrimaryRoute(profile: string): Promise<boolean> {
   try {
     const conn = await desktop.getConnection(profile)
 
-    return Boolean(conn && typeof conn === 'object' && (conn as { profile?: string }).profile)
+    return Boolean(conn && typeof conn === 'object' && (conn as { sharedPrimary?: boolean }).sharedPrimary === true)
   } catch {
     return false
   }


### PR DESCRIPTION
## What

After 0.20.1, selecting a **local named profile** (or a per-profile **remote override**) from the profile rail leaves Desktop attached to the **default** profile's socket. The named backend starts and passes its startup probe, the sidebar (REST) lists the right sessions — but no persistent WebSocket is opened for the profile, so chat, model, tools, and agent context stay on default. Resuming a remote-native session fails with "session not found".

Regression from [#85665](https://github.com/NousResearch/hermes-agent/pull/85665) (`d16e236`), merged 2026-08-13.

## Root cause

`sharedPrimaryRoute()` (`apps/desktop/src/store/gateway.ts`) decided a profile was "served by the shared primary" from the mere presence of `connection.profile`:

```ts
return Boolean(conn && typeof conn === 'object' && (conn as { profile?: string }).profile)
```

But **two** routes produce a `profile`-tagged descriptor:

1. **Shared-primary** (global remote, case 3): `ensureBackend` returns `{ ...connection, profile: descriptorProfile }` — the intended target of the check.
2. **Pooled backend** — a local named profile *and* a per-profile remote override. `spawnPoolBackend` returns `{ ...remote, profile, ... }`; the profile tag is needed so fresh WebSocket URL minting targets the right backend.

The check can't tell them apart, so every pooled profile is misclassified as shared-primary and `ensureGatewayForProfile` activates the primary (default) socket instead of dialing the profile's own WS.

## Fix

Tag only the true shared-primary descriptor with a dedicated, **typed** marker and check for that, not `profile`:

- `electron/main.ts` — the primary route with `descriptorProfile` returns `{ ...connection, profile, sharedPrimary: true }`.
- `src/global.d.ts` — `HermesConnection.sharedPrimary?: boolean`, documented as the discriminator.
- `src/store/gateway.ts` — `sharedPrimaryRoute` checks `conn.sharedPrimary === true`; pooled descriptors never carry the marker.

Covers both the local-pool and remote-override routes — the whole bug class, not one path.

## Worked example

| Profile route | Descriptor | Before | After |
|---|---|---|---|
| Global remote, `venture` | `{ profile: 'venture', sharedPrimary: true }` | primary socket ✅ | primary socket ✅ |
| Local named `fiction-writer` | `{ profile: 'fiction-writer' }` | primary socket ❌ (stuck on default) | dials own socket ✅ |
| Per-profile remote override `worker` | `{ profile: 'worker', wsUrl, mode: 'remote' }` | primary socket ❌ (LOCAL host answers) | dials own `wsUrl` ✅ |

## Test

`gateway-shared-remote.test.ts` pins both sides of the invariant:

- `{ profile, sharedPrimary: true }` → activates the primary socket and does **not** dial.
- a pooled descriptor carrying `{ profile, wsUrl }` → dials its **exact** WebSocket URL (`connect` called once, with `wsUrl`).

## Reproduction

1. Local `default` primary; add a second local named profile (or a per-profile remote override).
2. Select it from the profile rail; open/resume a session.
3. Before: chat answers from the default profile / LOCAL host; sidebar lists the right sessions. After: the profile's own backend answers.

---

Supersedes [#85750](https://github.com/NousResearch/hermes-agent/pull/85750) (Tigrannnnnnn — exact-WS-URL test), [#85778](https://github.com/NousResearch/hermes-agent/pull/85778) (Don Tuttle — typed marker, filed the issue), [#85932](https://github.com/NousResearch/hermes-agent/pull/85932) (plcunha). All three converged on the same `sharedPrimary` fix; this consolidates the typed base + the strongest test and drops out-of-scope session-targeting churn. Credit to all three via `Co-authored-by`.

Fixes #85777