### PR TITLE
fix(desktop-update): complete Windows Desktop updates instead of self-locking the shim

### DIFF
--- a/contributors/emails/sascha.haase@textiletsg.com
+++ b/contributors/emails/sascha.haase@textiletsg.com
@@ -1,0 +1,2 @@
+shaase-ctrl
+# PR #85679 salvage (Windows desktop update shim self-lock)

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -672,23 +672,55 @@ try {
     # is unlocked; the venv-python holder guard (orphan reap included) stays
     # active. Our marker claim is adopted by the child via update_lock.py's
     # process-ancestry rule.
-    $hermesExe = Join-Path $InstallRoot "venv\Scripts\hermes.exe"
-    if (-not (Test-Path -LiteralPath $hermesExe)) {
+    #
+    # DRIVE THE UPDATE THROUGH venv\Scripts\python.exe, NOT venv\Scripts\hermes.exe.
+    # `uv pip install -e .` has to replace the console-script shims, so
+    # _quarantine_running_hermes_exe must first rename the running hermes.exe
+    # out of the way. On Windows that rename fails whenever ANY child process
+    # spawned from that hermes.exe is still alive: a child inherits a handle on
+    # the parent image, and the resulting sharing violation is indistinguishable
+    # from a user leaving a second Hermes window open. It is the inherited
+    # handle, not the trampoline itself, that pins the file -- killing the child
+    # makes the same rename succeed immediately, and the shim flavour (uv
+    # trampoline vs distlib launcher) makes no difference.
+    #
+    # The updater reliably spawns such children itself (npx cache warm, memory
+    # provider refresh -- hindsight-api runs as a daemon with --idle-timeout
+    # 300 and outlives the step that started it), so this is a race, not a
+    # deterministic failure: the same hand-off succeeds on one run and dies on
+    # the next. Step 2's preflight cannot catch it, because the shim genuinely
+    # IS unlocked at that moment.
+    #
+    # When the rename loses that race, _schedule_replace_on_reboot is the last
+    # resort -- and it writes to HKLM\...\PendingFileRenameOperations, which
+    # requires elevation. A Desktop-driven update runs non-elevated, so it
+    # returns ERROR_ACCESS_DENIED and `uv pip install -e .` exits 2. The ZIP
+    # fallback repeats the identical sequence, so the desktop build stage is
+    # never reached and apps/desktop/release is left missing -- an install whose
+    # Start Menu shortcut points at a Hermes.exe that no longer exists.
+    #
+    # Running the same code as `python.exe -m hermes_cli.main update` puts the
+    # inherited handles on python.exe, which uv never has to replace.
+    #
+    # posix.sh is deliberately left alone: unlinking a running executable is
+    # legal there, so the equivalent call is harmless.
+    $pythonExe = Join-Path $InstallRoot "venv\Scripts\python.exe"
+    if (-not (Test-Path -LiteralPath $pythonExe)) {
         $finalCode = 3
-        $finalMsg = "Update aborted: $hermesExe is missing. The install needs repair (run the Hermes installer or `hermes doctor`)."
+        $finalMsg = "Update aborted: $pythonExe is missing. The install needs repair (run the Hermes installer or `hermes doctor`)."
         Write-HandoffLog $finalMsg
         exit $finalCode
     }
-    $updateArgs = @("update", "--yes", "--gateway", "--force", "--branch", $Branch)
-    Write-HandoffLog ("running: hermes " + ($updateArgs -join " "))
-    $res = Invoke-HermesStep $hermesExe $updateArgs "update"
+    $updateArgs = @("-m", "hermes_cli.main", "update", "--yes", "--gateway", "--force", "--branch", $Branch)
+    Write-HandoffLog ("running: python " + ($updateArgs -join " "))
+    $res = Invoke-HermesStep $pythonExe $updateArgs "update"
     Write-HandoffLog "hermes update exit code: $($res.Code)"
 
     if ($res.Code -ne 0 -and $res.Code -ne 2) {
         # One retry for the update-boundary class (fresh code on disk, stale
         # code in memory). Exit 2 ("close all Hermes windows") is not retryable.
         Write-HandoffLog "first attempt failed; retrying once (freshly pulled fix loads on the second run)"
-        $res = Invoke-HermesStep $hermesExe $updateArgs "update"
+        $res = Invoke-HermesStep $pythonExe $updateArgs "update"
         Write-HandoffLog "retry exit code: $($res.Code)"
     }
 
@@ -700,7 +732,7 @@ try {
     $desktopBuildFailed = $false
     if ($res.Code -eq 0 -and $res.Output -match "Desktop build failed") {
         Write-HandoffLog "hermes update reported a desktop build failure (non-fatal there, fatal here); retrying build"
-        $rebuild = Invoke-HermesStep $hermesExe @("desktop", "--force-build", "--build-only") "rebuild"
+        $rebuild = Invoke-HermesStep $pythonExe @("-m", "hermes_cli.main", "desktop", "--force-build", "--build-only") "rebuild"
         Write-HandoffLog "desktop rebuild exit code: $($rebuild.Code)"
         if ($rebuild.Code -ne 0) { $desktopBuildFailed = $true }
     }

--- a/tests/test_desktop_update_windows_python_handoff.py
+++ b/tests/test_desktop_update_windows_python_handoff.py
@@ -1,0 +1,89 @@
+"""Regression: the Windows Desktop update hand-off must run through python.exe.
+
+`scripts/desktop-update/windows.ps1` drives `hermes update` for the in-app
+Desktop updater. It used to invoke the update through the venv's
+`venv\\Scripts\\hermes.exe` console-script launcher. On Windows that launcher is
+a real process that keeps `hermes.exe` mapped as its running image and spawns
+`python.exe` as a child. The update ends in `uv pip install -e .`, which rewrites
+the console-script shims -- including the `hermes.exe` the launcher still has
+mapped -- and Windows refuses to replace a file mapped as a running image
+("os error 32"). The rename fallback then defers to next reboot via
+`MOVEFILE_DELAY_UNTIL_REBOOT`, which needs elevation a Desktop-driven update
+does not have, so `uv pip install -e .` exits non-zero, the ZIP fallback repeats
+the same sequence, the desktop build stage is never reached, and the pre-build
+clean has already removed `apps/desktop/release` -- leaving an install whose
+Start Menu shortcut points at a `Hermes.exe` that no longer exists.
+
+Driving the update as `python.exe -m hermes_cli.main update` puts the inherited
+image handle on `python.exe`, which uv never has to replace, so the shim is an
+ordinary unlocked file when uv rewrites it.
+
+This test is source-level because Linux CI cannot execute the PowerShell
+hand-off. The invariant it guards is that every `Invoke-HermesStep` call site
+(the update, its retry, and the desktop rebuild) drives `$pythonExe`, never the
+`$hermesExe` shim. `hermes.exe` may still be *named* in the file for the
+step-2 unlock preflight -- that is a lock probe, not an invocation -- so we
+assert against the invocation sites specifically.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WINDOWS_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+
+def _read() -> str:
+    return WINDOWS_PS1.read_text(encoding="utf-8")
+
+
+def test_invoke_hermes_step_calls_drive_python_not_the_shim() -> None:
+    source = _read()
+
+    invocations = re.findall(r"Invoke-HermesStep\s+(\$\w+)", source)
+    assert invocations, (
+        "Expected at least one Invoke-HermesStep call in "
+        "scripts/desktop-update/windows.ps1; the update hand-off structure "
+        "changed -- update this guard."
+    )
+
+    offenders = [exe for exe in invocations if exe != "$pythonExe"]
+    assert not offenders, (
+        "Every Invoke-HermesStep call in scripts/desktop-update/windows.ps1 "
+        "must drive $pythonExe, not the hermes.exe shim. Driving the update "
+        "through the shim keeps hermes.exe mapped as a running image, so uv's "
+        "final shim rewrite fails with os error 32 and the Desktop update can "
+        "never complete. Offending target(s): "
+        f"{sorted(set(offenders))}."
+    )
+
+
+def test_update_invocation_uses_module_entrypoint() -> None:
+    source = _read()
+
+    assert '@("-m", "hermes_cli.main", "update"' in source, (
+        "The update step must invoke `python.exe -m hermes_cli.main update ...` "
+        "so the inherited image handle lands on python.exe, which uv never has "
+        "to replace."
+    )
+    assert (
+        '@("-m", "hermes_cli.main", "desktop", "--force-build", "--build-only")'
+        in source
+    ), (
+        "The desktop rebuild step must also go through "
+        "`python.exe -m hermes_cli.main desktop ...` for the same reason."
+    )
+
+
+def test_update_no_longer_invokes_the_hermes_exe_shim() -> None:
+    source = _read()
+
+    assert "Invoke-HermesStep $hermesExe" not in source, (
+        "scripts/desktop-update/windows.ps1 still invokes the update through "
+        "the hermes.exe shim (`Invoke-HermesStep $hermesExe`). That is the "
+        "exact self-lock this fix removes -- route it through $pythonExe "
+        "instead."
+    )


### PR DESCRIPTION
On Windows, the in-app Desktop updater's hand-off (`scripts/desktop-update/windows.ps1`) drives `hermes update` through the venv's `hermes.exe` console-script launcher. That launcher keeps `hermes.exe` mapped as its running image and spawns `python.exe` as a child, so when the update finishes with `uv pip install -e .` -- which rewrites the console-script shims, including that same `hermes.exe` -- Windows refuses to replace a file mapped as a running image (`os error 32`). The rename fallback then defers to next reboot via `MOVEFILE_DELAY_UNTIL_REBOOT`, which needs elevation a Desktop-driven (non-elevated) update doesn't have, so `uv pip install -e .` exits non-zero, the ZIP fallback repeats the identical sequence, the desktop build stage is never reached, and the pre-build clean has already removed `apps/desktop/release` -- leaving an install whose Start Menu shortcut points at a `Hermes.exe` that no longer exists (the "my Desktop app disappeared" reports).

This runs the update as `python.exe -m hermes_cli.main update` instead, at all three `Invoke-HermesStep` call sites (the update, its retry, and the desktop rebuild). The inherited image handle then lands on `python.exe`, which uv never has to replace, so the shim is an ordinary unlocked file when uv rewrites it. `scripts/desktop-update/posix.sh` is intentionally untouched: unlinking a running executable is legal there.

## Detection table

| Symptom on Windows | Cause | After this PR |
|---|---|---|
| `hermes update` from Desktop fails every run with `os error 32` on `Scripts/hermes.exe` | update runs from the `hermes.exe` launcher, which holds the shim mapped | update runs from `python.exe`; shim is unlocked when uv rewrites it |
| Update "succeeds" then Desktop app is gone after reboot | reboot-deferred shim rename removes `hermes.exe` with no replacement written | no reboot-deferred rename path taken; shim replaced in place |
| Looks flaky (succeeds once, fails next) | race with updater-spawned children (npx warm, `hindsight-api` daemon) inheriting the shim handle | children inherit the `python.exe` handle, not the shim |

## Worked example

Jango's thread: the update "doesn't finish," produces no completion, and the Desktop app disappears. `logs/desktop-update-handoff.log` shows `hermes update exit code: 0` then `1` on runs 18 min apart on one box -- the only variable being whether a long-lived child was alive during the quarantine. Driving the same code as `python.exe -m hermes_cli.main update` completed with exit 0 on the first attempt after three consecutive shim-driven failures on that install, and the subsequent `python.exe -m hermes_cli.main desktop --force-build --build-only` rebuilt `release/win-unpacked/Hermes.exe` cleanly.

## Tests

Adds `tests/test_desktop_update_windows_python_handoff.py` -- a source-level guard (Linux CI can't execute the PowerShell hand-off) asserting every `Invoke-HermesStep` call drives `$pythonExe`, the update/rebuild use `-m hermes_cli.main`, and `Invoke-HermesStep $hermesExe` never reappears. This fails on current `main` (three shim call sites) and passes here.

```
python -m pytest tests/test_desktop_update_windows_python_handoff.py -q
# 3 passed
```

Supersedes #85679 and #86101. Both authors landed on the same core insight (run the update off the shim, on `python.exe`); this takes #85679's surgical hand-off change as the base and keeps the footprint on the update path minimal. #86101's separate detached-grandchild trampoline (which also covers CLI-typed `hermes update`) is deliberately not included here -- it's a larger, independent change to the core update path and can land on its own merits if wanted.

Co-authored-by: Sascha Haase <sascha.haase@textiletsg.com>
Co-authored-by: adamcap926 <adamcap926@users.noreply.github.com>