### PR TITLE
Pasted images upload from the preview cache instead of re-reading the disk

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -4375,6 +4375,85 @@ describe('uploadComposerAttachment remote read failures', () => {
   })
 })
 
+describe('uploadComposerAttachment preview reuse', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reuses the chip previewUrl instead of re-reading the image off disk', async () => {
+    // attachImagePath already read the full file for the thumbnail; submit
+    // must not pay the disk read + IPC round-trip a second time.
+    const readFileDataUrl = vi.fn(async () => 'data:image/png;base64,ZnJvbS1kaXNr')
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl }
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'image.attach_bytes') {
+        return { attached: true, path: '/gw/images/shot.png' } as never
+      }
+
+      return {} as never
+    })
+
+    const uploaded = await uploadComposerAttachment(
+      {
+        id: 'image:shot.png',
+        kind: 'image',
+        label: 'shot.png',
+        path: '/local/shot.png',
+        previewUrl: 'data:image/png;base64,ZnJvbS1wcmV2aWV3'
+      },
+      { remote: true, requestGateway, sessionId: RUNTIME_SESSION_ID }
+    )
+
+    expect(readFileDataUrl).not.toHaveBeenCalled()
+    expect(requestGateway).toHaveBeenCalledWith('image.attach_bytes', {
+      content_base64: 'ZnJvbS1wcmV2aWV3',
+      filename: 'shot.png',
+      session_id: RUNTIME_SESSION_ID
+    })
+    expect(uploaded.path).toBe('/gw/images/shot.png')
+  })
+
+  it('falls back to the disk read when previewUrl is not a base64 data URL', async () => {
+    // A non-data previewUrl (e.g. a gateway media URL) carries no bytes —
+    // the upload must still read the real file.
+    const readFileDataUrl = vi.fn(async () => 'data:image/png;base64,ZnJvbS1kaXNr')
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { readFileDataUrl }
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'image.attach_bytes') {
+        return { attached: true, path: '/gw/images/shot.png' } as never
+      }
+
+      return {} as never
+    })
+
+    await uploadComposerAttachment(
+      {
+        id: 'image:shot.png',
+        kind: 'image',
+        label: 'shot.png',
+        path: '/local/shot.png',
+        previewUrl: 'https://gateway.example/media/shot.png'
+      },
+      { remote: true, requestGateway, sessionId: RUNTIME_SESSION_ID }
+    )
+
+    expect(readFileDataUrl).toHaveBeenCalledWith('/local/shot.png')
+    expect(requestGateway).toHaveBeenCalledWith('image.attach_bytes', {
+      content_base64: 'ZnJvbS1kaXNr',
+      filename: 'shot.png',
+      session_id: RUNTIME_SESSION_ID
+    })
+  })
+})
+
 // The actions bag is a STABLE ref that wiring.tsx mutates in place
 // (Object.assign), and the pane surfaces are memoized on that stable ref — so a
 // surface does NOT re-render when the active session changes and its props keep

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -133,14 +133,16 @@ export async function uploadComposerAttachment(
 
   // Read bytes/paths ONCE, outside the retry. Only the session-scoped RPC is
   // replayed on recovery — re-reading a multi-MB file to retry a dead session
-  // id would double the disk/IPC cost of every recovered attach.
+  // id would double the disk/IPC cost of every recovered attach. For images,
+  // the chip's previewUrl already holds the full file as a base64 data URL,
+  // so passing it avoids re-reading the same bytes off disk at submit.
   let imagePayload: Awaited<ReturnType<typeof readImageForRemoteAttach>> | null = null
   let fileDataUrl: null | string = null
 
   if (uploadBytes) {
     try {
       if (attachment.kind === 'image') {
-        imagePayload = await readImageForRemoteAttach(path)
+        imagePayload = await readImageForRemoteAttach(path, attachment.previewUrl)
       } else {
         fileDataUrl = await readFileDataUrlForAttach(path)
       }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -279,9 +279,25 @@ export function imageFilenameFromPath(filePath: string): string {
 // Remote gateway: the local composer-image file lives on THIS machine's disk,
 // not the gateway's, so read the bytes here and upload them via
 // image.attach_bytes. Returns null when the file can't be read.
+//
+// `cachedDataUrl` is the attachment's `previewUrl` when the composer already
+// read the file for the chip thumbnail — that preview is the FULL file as a
+// base64 data URL (attachmentPreviewDataUrl → readFileDataUrl), not a
+// downscaled copy, so reusing it skips a second disk read + IPC round-trip of
+// the same bytes at submit. Only a `;base64,` data URL qualifies; anything
+// else falls through to the disk read.
 export async function readImageForRemoteAttach(
-  filePath: string
+  filePath: string,
+  cachedDataUrl?: string
 ): Promise<{ contentBase64: string; filename: string } | null> {
+  if (cachedDataUrl?.includes(';base64,')) {
+    const cached = base64FromDataUrl(cachedDataUrl)
+
+    if (cached) {
+      return { contentBase64: cached, filename: imageFilenameFromPath(filePath) }
+    }
+  }
+
   const dataUrl = await window.hermesDesktop?.readFileDataUrl(filePath)
   const contentBase64 = dataUrl ? base64FromDataUrl(dataUrl) : ''
 


### PR DESCRIPTION
Follow-up to #86302, whose renderer bench flagged this: the composer reads the same image file off disk twice — once in `attachImagePath` for the chip thumbnail, and again inside `uploadComposerAttachment` at submit for the upload bytes.

The thumbnail read is not a downscaled copy: `attachmentPreviewDataUrl` → `readFileDataUrl` returns the FULL file as a base64 data URL, and it sits on the attachment as `previewUrl` for the life of the chip. So the submit-time read was buying nothing.

## The fix

`readImageForRemoteAttach` accepts the attachment's `previewUrl` and reuses its bytes when it is a `;base64,` data URL — skipping the second disk read and IPC round-trip. Anything else (a gateway media URL, a missing preview) falls through to the disk read unchanged, so the eager-upload race documented in `eagerlyUploadAttachment` is untouched: images still upload at submit, just from memory.

## Tests

Two behavior contracts in the existing `uploadComposerAttachment` suites:
- reuse: with a base64 `previewUrl`, `readFileDataUrl` is never called and the gateway receives the preview's bytes
- fallback: with a non-data `previewUrl`, the file is read from disk as before

`vitest run src/app/session/hooks/use-prompt-actions`: 171 passed. `npm run typecheck` (all three tsconfigs): clean. eslint: clean.