### PR TITLE
fix(update-check): local-ahead checkouts read up to date, not 'update available'

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2578,17 +2578,22 @@ async function checkUpdates() {
     // fabricate a "1 commit behind". Recover the exact count via the GitHub
     // compare API when possible; otherwise behind stays null ("update
     // available, count unknown") and updateAvailable carries the signal.
-    const upToDate = Boolean(currentSha && currentSha === targetSha)
+    // ahead_by === 0 with differing tips means the remote tip is reachable
+    // from our HEAD — a local carried commit sitting AHEAD, not behind:
+    // flagging that as an update nudges the user into wiping their work.
+    const tipsEqual = Boolean(currentSha && currentSha === targetSha)
 
-    const sshBehind = upToDate
+    const sshBehind = tipsEqual
       ? 0
       : await fetchCompareBehindCount({ currentSha, originUrl: OFFICIAL_REPO_HTTPS_URL, targetSha })
+
+    const upToDate = tipsEqual || sshBehind === 0
 
     return {
       supported: true,
       branch,
       currentBranch,
-      behind: sshBehind,
+      behind: upToDate ? 0 : sshBehind,
       updateAvailable: !upToDate,
       currentSha,
       targetSha,

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -239,12 +239,8 @@ def _is_full_sha(value: Optional[str]) -> bool:
     )
 
 
-def _check_via_rev(local_rev: str) -> Optional[int]:
-    """Compare an embedded git revision to upstream main via ls-remote.
-
-    Returns 0 if up-to-date, ``UPDATE_AVAILABLE_NO_COUNT`` if behind,
-    or ``None`` on failure.
-    """
+def _upstream_main_sha() -> Optional[str]:
+    """Tip SHA of upstream main via HTTPS ls-remote (no auth, no prompts)."""
     try:
         result = subprocess.run(
             ["git", "ls-remote", _UPSTREAM_REPO_URL, "refs/heads/main"],
@@ -256,6 +252,17 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     if result.returncode != 0 or not result.stdout:
         return None
     upstream_rev = result.stdout.split()[0]
+    return upstream_rev or None
+
+
+def _check_via_rev(local_rev: str) -> Optional[int]:
+    """Compare an embedded git revision to upstream main via ls-remote.
+
+    Returns 0 if up-to-date, the exact behind-count when the GitHub compare
+    API can recover it, ``UPDATE_AVAILABLE_NO_COUNT`` if behind by an unknown
+    amount, or ``None`` on failure.
+    """
+    upstream_rev = _upstream_main_sha()
     if not upstream_rev:
         return None
     if upstream_rev == local_rev:
@@ -273,17 +280,32 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
-        # ls-remote against the upstream URL only tells us tip SHAs — there
-        # is no local history to count commits against. Return the
-        # UPDATE_AVAILABLE_NO_COUNT sentinel so the banner and CLI renderers
-        # print "update available" instead of fabricating a "1 commit behind"
-        # message. The dashboard's REST /api/hermes/update/check already
-        # treats any nonzero behind as update_available=true (see
-        # hermes_cli/web_server.py::check_hermes_update), and the desktop
-        # store clamps behind<=0 to 0 and reads update_available separately
-        # (apps/desktop/src/store/updates.ts::mapBackendCheck), so no UI
-        # consumer depends on a fabricated count here.
-        return _check_via_rev(head_rev) if head_rev else None
+        if not head_rev:
+            return None
+        # Passive probe via HTTPS ls-remote (never SSH — no hardware-key
+        # prompts). Tip SHAs alone can't distinguish "behind" from a local
+        # carried commit sitting AHEAD of origin/main, and misreporting an
+        # ahead checkout as behind nudges the user into `hermes update`,
+        # which can wipe their carried work.
+        upstream_rev = _upstream_main_sha()
+        if upstream_rev is None:
+            return None
+        if upstream_rev == head_rev:
+            return 0
+        # Local-ahead: the remote tip is an ancestor of HEAD. Checked against
+        # the FRESH upstream SHA (not the possibly stale origin/main tracking
+        # ref) so a stale ref can't fake an up-to-date report.
+        ancestor = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", upstream_rev, "HEAD"],
+            capture_output=True, timeout=5, cwd=str(repo_dir),
+        )
+        if ancestor.returncode == 0:
+            return 0
+        # Genuinely behind (or diverged). Recover the exact count via the
+        # GitHub compare API; a local-only HEAD 404s there, which safely
+        # degrades to the honest no-count sentinel — never a fabricated 1.
+        counted = _github_compare_behind(head_rev, upstream_rev)
+        return counted if counted is not None else UPDATE_AVAILABLE_NO_COUNT
 
     # Installer checkouts are shallow (`git clone --depth 1`). On a shallow
     # clone the history stops at a single commit, so a plain `git fetch` would

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -41,3 +41,88 @@ def test_get_git_banner_state_reads_origin_and_head(tmp_path):
     assert state == {"upstream": "b2f477a3", "local": "af8aad31", "ahead": 3}
 
 
+def test_check_via_local_git_ssh_fastpath_ahead_not_behind(tmp_path):
+    """SSH fast path must not report an ahead (carried) HEAD as behind.
+
+    A carried local commit means tip SHAs differ, but the fresh upstream tip
+    is an ancestor of HEAD — that is "ahead", and reporting it as behind
+    nudges the user into `hermes update`, which can wipe the carried work.
+    """
+    from unittest.mock import MagicMock
+
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    def fake_git_stdout(args, *, cwd, timeout=5):
+        if args == ["remote", "get-url", "origin"]:
+            return "git@github.com:NousResearch/hermes-agent.git"
+        if args == ["rev-parse", "HEAD"]:
+            return "b" * 40  # carried commit, differs from upstream tip
+        raise AssertionError(f"unexpected git call: {args}")
+
+    with (
+        patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
+        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        # merge-base --is-ancestor exits 0: upstream tip IS an ancestor of HEAD
+        patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=0)),
+    ):
+        behind = banner._check_via_local_git(repo_dir)
+
+    assert behind == 0
+
+
+def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
+    """SSH fast path reports the exact count (compare API) when behind."""
+    from unittest.mock import MagicMock
+
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    def fake_git_stdout(args, *, cwd, timeout=5):
+        if args == ["remote", "get-url", "origin"]:
+            return "git@github.com:NousResearch/hermes-agent.git"
+        if args == ["rev-parse", "HEAD"]:
+            return "b" * 40
+        raise AssertionError(f"unexpected git call: {args}")
+
+    with (
+        patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
+        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        # merge-base --is-ancestor exits 1: not an ancestor -> genuinely behind
+        patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
+        patch.object(banner, "_github_compare_behind", return_value=3),
+    ):
+        behind = banner._check_via_local_git(repo_dir)
+
+    assert behind == 3
+
+
+def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
+    """Behind + compare API unreachable = honest no-count sentinel, never 1."""
+    from unittest.mock import MagicMock
+
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    def fake_git_stdout(args, *, cwd, timeout=5):
+        if args == ["remote", "get-url", "origin"]:
+            return "git@github.com:NousResearch/hermes-agent.git"
+        if args == ["rev-parse", "HEAD"]:
+            return "b" * 40
+        raise AssertionError(f"unexpected git call: {args}")
+
+    with (
+        patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
+        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
+        patch.object(banner, "_github_compare_behind", return_value=None),
+    ):
+        behind = banner._check_via_local_git(repo_dir)
+
+    assert behind == banner.UPDATE_AVAILABLE_NO_COUNT


### PR DESCRIPTION
## Summary

A checkout carrying local commits on top of upstream main no longer reads as "update available" — the last false-positive shape in the behind-count class from #86257/#86318.

Problem: the SSH-official passive paths (CLI banner and desktop) only compare tip SHAs. A carried local commit makes tips differ, so an AHEAD checkout was flagged as an update — and the `hermes update` nudge is exactly what wipes carried work.

Salvaged from @andyst-dev's #84860 (the CLI-banner half), adapted and widened:

- Their tracking-ref `rev-list` guard is replaced with a `merge-base --is-ancestor` check against the FRESH upstream SHA from ls-remote (a stale `origin/main` tracking ref can't fake an up-to-date report), plus the compare-API `ahead_by == 0` signal as the network-side proof.
- Widened to the desktop sibling: the SSH-official path in `checkUpdates()` now treats a recovered `ahead_by === 0` as up to date instead of "update available, count unknown".
- Refactored `_check_via_rev` to share a `_upstream_main_sha()` helper with the fast path.

## Changes

- `hermes_cli/banner.py`: SSH fast path — fresh-tip equality → ancestor check → compare-API count; `_upstream_main_sha()` extracted
- `apps/desktop/electron/main.ts`: SSH-official path treats `ahead_by === 0` as up to date
- `tests/hermes_cli/test_banner_git_state.py`: 3 tests — local-ahead reads 0, genuinely-behind reads exact count, offline keeps the honest sentinel

## Validation

| Check | Result |
|---|---|
| `test_banner_git_state.py` + update-check suites (26 tests) | pass |
| Desktop vitest (74) + full typecheck (3 tsconfigs) | pass |
| ruff on touched files | clean |

Closes #84860 (salvage, authorship preserved). Completes the local-ahead half of the #84591 class.

## Infographic

![ahead is not behind](https://files.catbox.moe/plu8gd.png)
