### PR TITLE
fix: expose write approval review in CLI

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11368,8 +11368,52 @@ def _try_termux_fast_tui_launch() -> bool:
     return True
 
 
+def _write_approval_set_mode(subsystem: str):
+    def _set(enabled: bool) -> None:
+        from hermes_cli.config import load_config, save_config
+
+        config = load_config()
+        section = config.get(subsystem)
+        if not isinstance(section, dict):
+            section = {}
+            config[subsystem] = section
+        section["write_approval"] = bool(enabled)
+        save_config(config)
+    return _set
+
+
+def _cli_memory_store():
+    from hermes_cli.config import cfg_get, load_config
+    from tools.memory_tool import MemoryStore
+
+    cfg = load_config()
+    store = MemoryStore(
+        memory_char_limit=int(cfg_get(cfg, "memory", "memory_char_limit", default=2200) or 2200),
+        user_char_limit=int(cfg_get(cfg, "memory", "user_char_limit", default=1375) or 1375),
+    )
+    store.load_from_disk()
+    return store
+
+
 def cmd_memory(args):
     sub = getattr(args, "memory_command", None)
+    if sub in {"pending", "approve", "reject", "approval"}:
+        from hermes_cli.write_approval_commands import handle_pending_subcommand
+        from tools import write_approval as wa
+
+        rest = []
+        if sub in {"approve", "reject"}:
+            rest = [getattr(args, "id", "")]
+        elif sub == "approval" and getattr(args, "mode", None):
+            rest = [getattr(args, "mode")]
+        memory_store = _cli_memory_store() if sub == "approve" else None
+        print(handle_pending_subcommand(
+            wa.MEMORY,
+            [sub, *rest],
+            memory_store=memory_store,
+            set_mode_fn=_write_approval_set_mode(wa.MEMORY),
+        ))
+        return
     if sub == "off":
         from hermes_cli.config import load_config, save_config
 
@@ -11531,8 +11575,41 @@ def cmd_monitoring(args):
 
 
 def cmd_skills(args):
+    action = getattr(args, "skills_action", None)
+    if action in {"pending", "approve", "reject", "approval"}:
+        from hermes_cli.write_approval_commands import handle_pending_subcommand
+        from tools import write_approval as wa
+
+        rest = []
+        if action in {"approve", "reject"}:
+            rest = [getattr(args, "id", "")]
+        elif action == "approval" and getattr(args, "mode", None):
+            rest = [getattr(args, "mode")]
+        print(handle_pending_subcommand(
+            wa.SKILLS,
+            [action, *rest],
+            set_mode_fn=_write_approval_set_mode(wa.SKILLS),
+        ))
+        return
+
+    # `hermes skills diff <name>` already means "diff a bundled skill".  The
+    # write-approval docs also advertise `hermes skills diff <pending-id>`, so
+    # only route to the pending-review diff when the argument actually names a
+    # staged skill write; otherwise preserve the existing bundled-skill diff.
+    if action == "diff":
+        pending_id = getattr(args, "name", "")
+        if pending_id:
+            try:
+                from hermes_cli.write_approval_commands import handle_pending_subcommand
+                from tools import write_approval as wa
+                if wa.get_pending(wa.SKILLS, pending_id):
+                    print(handle_pending_subcommand(wa.SKILLS, ["diff", pending_id]))
+                    return
+            except Exception:
+                pass
+
     # Route 'config' action to skills_config module
-    if getattr(args, "skills_action", None) == "config":
+    if action == "config":
         _require_tty("skills config")
         from hermes_cli.skills_config import skills_command as skills_config_command
 

--- a/hermes_cli/subcommands/memory.py
+++ b/hermes_cli/subcommands/memory.py
@@ -34,6 +34,15 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
     )
     memory_sub.add_parser("status", help="Show current memory provider config")
     memory_sub.add_parser("off", help="Disable external provider (built-in only)")
+
+    memory_sub.add_parser("pending", help="List staged memory writes awaiting approval")
+    _approve_parser = memory_sub.add_parser("approve", help="Approve a staged memory write")
+    _approve_parser.add_argument("id", help="Pending write id, or 'all'")
+    _reject_parser = memory_sub.add_parser("reject", help="Reject a staged memory write")
+    _reject_parser.add_argument("id", help="Pending write id, or 'all'")
+    _approval_parser = memory_sub.add_parser("approval", help="Show or set memory.write_approval")
+    _approval_parser.add_argument("mode", nargs="?", choices=["on", "off", "true", "false", "yes", "no", "1", "0"], help="Approval gate mode")
+
     _reset_parser = memory_sub.add_parser(
         "reset",
         help="Erase all built-in memory (MEMORY.md and USER.md)",

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -197,6 +197,14 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         help="Output the list as JSON",
     )
 
+    skills_subparsers.add_parser("pending", help="List staged skill writes awaiting approval")
+    skills_pending_approve = skills_subparsers.add_parser("approve", help="Approve a staged skill write")
+    skills_pending_approve.add_argument("id", help="Pending write id, or 'all'")
+    skills_pending_reject = skills_subparsers.add_parser("reject", help="Reject a staged skill write")
+    skills_pending_reject.add_argument("id", help="Pending write id, or 'all'")
+    skills_approval = skills_subparsers.add_parser("approval", help="Show or set skills.write_approval")
+    skills_approval.add_argument("mode", nargs="?", choices=["on", "off", "true", "false", "yes", "no", "1", "0"], help="Approval gate mode")
+
     skills_diff = skills_subparsers.add_parser(
         "diff",
         help="Show how your copy of a bundled skill differs from the stock version",

--- a/tests/hermes_cli/test_write_approval_cli_subcommands.py
+++ b/tests/hermes_cli/test_write_approval_cli_subcommands.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from tools import write_approval as wa
+
+
+def test_memory_parser_exposes_write_approval_review_commands():
+    from hermes_cli.subcommands.memory import build_memory_parser
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    build_memory_parser(sub, cmd_memory=lambda args: None)
+
+    args = parser.parse_args(["memory", "pending"])
+    assert args.memory_command == "pending"
+
+    args = parser.parse_args(["memory", "approve", "abc123"])
+    assert args.memory_command == "approve"
+    assert args.id == "abc123"
+
+    args = parser.parse_args(["memory", "approval", "on"])
+    assert args.memory_command == "approval"
+    assert args.mode == "on"
+
+
+def test_skills_parser_exposes_write_approval_review_commands():
+    from hermes_cli.subcommands.skills import build_skills_parser
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    build_skills_parser(sub, cmd_skills=lambda args: None)
+
+    args = parser.parse_args(["skills", "pending"])
+    assert args.skills_action == "pending"
+
+    args = parser.parse_args(["skills", "reject", "abc123"])
+    assert args.skills_action == "reject"
+    assert args.id == "abc123"
+
+    args = parser.parse_args(["skills", "approval", "off"])
+    assert args.skills_action == "approval"
+    assert args.mode == "off"
+
+
+def test_cmd_memory_pending_uses_shared_pending_store(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.main import cmd_memory
+
+    wa.stage_write(
+        wa.MEMORY,
+        {"action": "add", "target": "user", "content": "User prefers concise receipts."},
+        summary="add to user profile: User prefers concise receipts.",
+        origin="background_review",
+    )
+
+    cmd_memory(argparse.Namespace(memory_command="pending"))
+    out = capsys.readouterr().out
+    assert "Pending memory writes (1):" in out
+    assert "[auto]" in out
+    assert "User prefers concise receipts" in out
+
+
+def test_cmd_skills_diff_pending_id_takes_precedence_over_bundled_diff(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.main import cmd_skills
+
+    rec = wa.stage_write(
+        wa.SKILLS,
+        {
+            "action": "patch",
+            "name": "demo-skill",
+            "old_string": "old",
+            "new_string": "new",
+        },
+        summary="patch 'demo-skill' SKILL.md (+1/-1 lines)",
+        origin="foreground",
+    )
+
+    cmd_skills(argparse.Namespace(skills_action="diff", name=rec["id"]))
+    out = capsys.readouterr().out
+    assert f"Pending skill write {rec['id']}" in out
+    assert "demo-skill" in out
+
+
+def test_cmd_memory_approve_applies_pending_record(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.main import cmd_memory
+
+    rec = wa.stage_write(
+        wa.MEMORY,
+        {"action": "add", "target": "user", "content": "User likes verified fixes."},
+        summary="add to user profile: User likes verified fixes.",
+        origin="foreground",
+    )
+
+    cmd_memory(argparse.Namespace(memory_command="approve", id=rec["id"]))
+    out = capsys.readouterr().out
+    assert "Approved 1 memory write(s)." in out
+    assert not wa.get_pending(wa.MEMORY, rec["id"])
+    assert "User likes verified fixes." in (tmp_path / "memories" / "USER.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- expose documented top-level CLI review commands for staged memory writes: `hermes memory pending|approve|reject|approval`
- expose documented top-level CLI review commands for staged skill writes: `hermes skills pending|approve|reject|approval`
- reuse the existing shared write-approval handler instead of inventing a parallel review system
- preserve existing `hermes skills diff <name>` bundled-skill behavior, routing to pending diff only when the argument matches an actual pending skill write id

## Verification

- `python -m py_compile hermes_cli/main.py hermes_cli/subcommands/memory.py hermes_cli/subcommands/skills.py tests/hermes_cli/test_write_approval_cli_subcommands.py`
- `git diff --check`
- `uv run --with pytest pytest --basetemp='C:/Users/davep/AppData/Local/hermes/hermes-agent-learning-gates-fix/.pytest-run-tmp/base' tests/hermes_cli/test_write_approval_cli_subcommands.py -q` → 5 passed, 1 warning
- temp-`HERMES_HOME` smoke: `hermes memory --help`, `hermes skills --help`, `hermes memory pending`, `hermes skills pending`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added write-approval workflows for memory and skills, including pending, approve, reject, and approval-mode commands.
  - Supports approving or rejecting individual pending writes or all pending writes.
  - Added pending skill write review through `skills diff`.
  - Added configurable approval modes for memory and skills.

- **Bug Fixes**
  - Ensured pending skill identifiers take precedence when reviewing skill changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->