### PR TITLE
fix(desktop): isolate runtime plugin loader failures

### DIFF
--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -4,7 +4,7 @@ import type { HermesReadDirResult } from '@/global'
 import type * as HermesModule from '@/hermes'
 
 import { $pluginRecords, setPluginEnabled } from './plugins-store'
-import { discoverRuntimePlugins, watchRuntimePlugins } from './runtime-loader'
+import { discoverRuntimePlugins, loadRuntimePlugin, unloadRuntimePlugin, watchRuntimePlugins } from './runtime-loader'
 
 // getStatus would supply the connected backend's hermes_home — a REMOTE path in
 // remote mode. The disk scanner must NOT derive the plugin root from it (#66899).
@@ -21,7 +21,39 @@ const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
 const readFileText = vi.fn<(path: string) => Promise<{ text: string }>>()
 const watchDirectory = vi.fn<(path: string) => Promise<{ id: string }>>()
 const watchPreviewFile = vi.fn<(path: string) => Promise<{ id: string }>>()
+const stopPreviewFileWatch = vi.fn<(id: string) => Promise<void>>()
 const onPreviewFileChanged = vi.fn()
+
+function installRuntimeImportShim(): () => void {
+  // The loader evaluates plugins via blob-URL import(), which vite's module
+  // runner can't resolve in tests — reroute to a data: URL, which node's
+  // native ESM loader handles.
+  const createObjectURL = vi
+    .spyOn(URL, 'createObjectURL')
+    .mockImplementation(
+      blob =>
+        `data:text/javascript;base64,${Buffer.from((blob as unknown as { parts: string[] }).parts.join('')).toString('base64')}`
+    )
+
+  const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+  const RealBlob = globalThis.Blob
+
+  vi.stubGlobal(
+    'Blob',
+    class {
+      parts: string[]
+      constructor(parts: string[]) {
+        this.parts = parts
+      }
+    }
+  )
+
+  return () => {
+    createObjectURL.mockRestore()
+    revokeObjectURL.mockRestore()
+    vi.stubGlobal('Blob', RealBlob)
+  }
+}
 
 beforeEach(() => {
   desktopPluginsRoot.mockReset()
@@ -30,6 +62,7 @@ beforeEach(() => {
   readFileText.mockReset()
   watchDirectory.mockReset()
   watchPreviewFile.mockReset()
+  stopPreviewFileWatch.mockReset()
   onPreviewFileChanged.mockReset()
   getStatus.mockClear()
   ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
@@ -38,6 +71,7 @@ beforeEach(() => {
     onPreviewFileChanged,
     readDir,
     readFileText,
+    stopPreviewFileWatch,
     watchDirectory,
     watchPreviewFile
   }
@@ -118,27 +152,7 @@ describe('scanDiskPlugins (#66899)', () => {
     })
     watchPreviewFile.mockResolvedValue({ id: 'w-uni' })
 
-    // The loader evaluates plugins via blob-URL import(), which vite's module
-    // runner can't resolve in tests — reroute to a data: URL, which node's
-    // native ESM loader handles.
-    const createObjectURL = vi
-      .spyOn(URL, 'createObjectURL')
-      .mockImplementation(
-        blob =>
-          `data:text/javascript;base64,${Buffer.from((blob as unknown as { parts: string[] }).parts.join('')).toString('base64')}`
-      )
-
-    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
-    const RealBlob = globalThis.Blob
-    vi.stubGlobal(
-      'Blob',
-      class {
-        parts: string[]
-        constructor(parts: string[]) {
-          this.parts = parts
-        }
-      }
-    )
+    const restoreRuntimeImport = installRuntimeImportShim()
 
     try {
       await discoverRuntimePlugins()
@@ -153,10 +167,84 @@ describe('scanDiskPlugins (#66899)', () => {
       expect(register).toHaveBeenCalledTimes(1)
       expect($pluginRecords.get().uni.status).toBe('loaded')
     } finally {
-      createObjectURL.mockRestore()
-      revokeObjectURL.mockRestore()
-      vi.stubGlobal('Blob', RealBlob)
+      restoreRuntimeImport()
       delete (globalThis as unknown as { __uniRegister?: unknown }).__uniRegister
+    }
+  })
+
+  it('keeps colliding healthy and malformed cross-root plugins independently visible', async () => {
+    const name = 'inventory-collision'
+    const standaloneFile = `/local/.hermes/desktop-plugins/${name}/plugin.js`
+    const unifiedFile = `/local/.hermes/plugins/${name}/desktop/plugin.js`
+
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')
+    readDir.mockImplementation(async root => ({
+      entries: [
+        {
+          isDirectory: true,
+          name,
+          path:
+            root === '/local/.hermes/desktop-plugins'
+              ? `/local/.hermes/desktop-plugins/${name}`
+              : `/local/.hermes/plugins/${name}`
+        }
+      ]
+    }))
+    readFileText.mockImplementation(async file => ({
+      text: file === standaloneFile ? `export default { id: '${name}', register() {} }` : 'export default {}'
+    }))
+    watchPreviewFile.mockImplementation(async file => ({ id: `watch:${file}` }))
+
+    const restoreRuntimeImport = installRuntimeImportShim()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    try {
+      await discoverRuntimePlugins()
+
+      expect($pluginRecords.get()[name]).toMatchObject({ file: standaloneFile, status: 'loaded' })
+      expect(Object.values($pluginRecords.get()).find(record => record.file === unifiedFile)).toMatchObject({
+        name,
+        status: 'error'
+      })
+    } finally {
+      consoleError.mockRestore()
+      restoreRuntimeImport()
+    }
+  })
+})
+
+describe('runtime plugin unload isolation', () => {
+  it('runs every disposer and does not let one failure escape', async () => {
+    const laterDispose = vi.fn()
+
+    const register = (ctx: { onDispose: (dispose: () => void) => void }) => {
+      ctx.onDispose(() => {
+        throw new Error('broken disposer')
+      })
+      ctx.onDispose(laterDispose)
+    }
+
+    ;(globalThis as unknown as { __disposerIsolationRegister: unknown }).__disposerIsolationRegister = register
+    const restoreRuntimeImport = installRuntimeImportShim()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    try {
+      expect(
+        await loadRuntimePlugin(
+          `export default { id: 'disposer-isolation', register: globalThis.__disposerIsolationRegister }`,
+          'disposer-isolation'
+        )
+      ).toBe('disposer-isolation')
+
+      expect(() => unloadRuntimePlugin('disposer-isolation')).not.toThrow()
+      expect(laterDispose).toHaveBeenCalledOnce()
+      unloadRuntimePlugin('disposer-isolation')
+      expect(laterDispose).toHaveBeenCalledOnce()
+    } finally {
+      consoleError.mockRestore()
+      restoreRuntimeImport()
+      delete (globalThis as unknown as { __disposerIsolationRegister?: unknown }).__disposerIsolationRegister
     }
   })
 })

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -100,8 +100,19 @@ async function verifyIntegrity(source: string, integrity: string): Promise<boole
 }
 
 export function unloadRuntimePlugin(id: string): void {
-  loaded.get(id)?.forEach(dispose => dispose())
+  const disposers = loaded.get(id) ?? []
+
+  // Release loader ownership before invoking plugin code. A broken cleanup
+  // must not keep this incarnation live or prevent the remaining cleanup.
   loaded.delete(id)
+
+  for (const dispose of disposers) {
+    try {
+      dispose()
+    } catch (error) {
+      console.error(`[plugins] runtime unload failed (${id})`, error)
+    }
+  }
 }
 
 /** Evaluate + register one runtime plugin. Returns its id, or null on failure. */
@@ -174,7 +185,10 @@ export async function loadRuntimePlugin(
     console.error(`[plugins] runtime load failed (${origin})`, error)
     notifyError(error, `Plugin "${origin}" failed to load`)
     publishPlugin({
-      id: origin,
+      // A disk entry's file path is unique across every supported root. The
+      // folder/origin is only a display label and can equal another plugin's
+      // logical id, so keying failures by it would overwrite the healthy row.
+      id: options.file ?? origin,
       name: origin,
       kind: options.kind ?? 'disk',
       file: options.file,
@@ -262,19 +276,6 @@ const disk = new Map<string, DiskPlugin>()
 let watching = false
 let scanning = false
 
-/** Drop a folder-named error record — unless that name is the live plugin id
- *  of ANOTHER disk entry (two roots can carry same-named folders; a broken one
- *  must not clobber its healthy namesake's inventory row). */
-function dropOriginRecord(origin: string, except: DiskPlugin): void {
-  for (const other of disk.values()) {
-    if (other !== except && other.id === origin) {
-      return
-    }
-  }
-
-  dropPlugin(origin)
-}
-
 async function loadDiskPlugin(entry: DiskPlugin): Promise<void> {
   const desktop = window.hermesDesktop!
   const prevId = entry.id
@@ -297,10 +298,10 @@ async function loadDiskPlugin(entry: DiskPlugin): Promise<void> {
 
     entry.id = id ?? entry.id
 
-    // A fixing save under a different plugin id — drop the folder-named
-    // error record so the inventory shows one row, not a ghost.
-    if (id && id !== entry.origin) {
-      dropOriginRecord(entry.origin, entry)
+    // A fixing save replaces this entry's path-keyed error row with the
+    // plugin's logical-id row.
+    if (id && id !== entry.file) {
+      dropPlugin(entry.file)
     }
   } catch {
     // File vanished mid-read — the next scan reconciles.
@@ -381,7 +382,7 @@ async function scanDiskPlugins(): Promise<void> {
         dropPlugin(record.id)
       }
 
-      dropOriginRecord(record.origin, record)
+      dropPlugin(record.file)
 
       if (record.watchId) {
         void desktop.stopPreviewFileWatch(record.watchId)


### PR DESCRIPTION
## Problem

The Desktop runtime plugin loader had two error-isolation gaps:

- one throwing disposer aborted the rest of unload cleanup and escaped into the app;
- a malformed disk plugin used its folder name as its inventory key, so it could overwrite a healthy same-named plugin loaded from the other supported root.

## Approach

- Release loader ownership before invoking disposers, isolate each disposer failure, and continue cleanup.
- Key disk-plugin load errors by their unique entry-file path while retaining the folder name for display, reveal, repair, and deletion cleanup.
- Add deterministic regression coverage for both independently reproduced failures.

## Verification

- `npx vitest run --project ui src/contrib/runtime-loader.test.ts` (8 passed)
- `npm run test:ui` (428 files, 3844 tests passed)
- `npx eslint src/contrib/runtime-loader.ts src/contrib/runtime-loader.test.ts`
- `npx prettier --check src/contrib/runtime-loader.ts src/contrib/runtime-loader.test.ts`
- `npx tsc -p . --noEmit`
- `npx tsc -p tsconfig.electron.json --noEmit`
- `git diff --check`

Each regression was mutation-checked independently: restoring the original disposer loop failed the unload test, and restoring the origin-keyed error record failed the cross-root inventory test.

## Risk

Low and loader-local. Runtime load errors without a disk file keep their existing origin identity; only disk error-row identity changes, with matching repair/removal cleanup.