### PR TITLE
fix(telegram): fail fast on long flood-control waits in send path

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4779,8 +4779,25 @@ class TelegramAdapter(BasePlatformAdapter):
                     except Exception as send_err:
                         retry_after = getattr(send_err, "retry_after", None)
                         if retry_after is not None or "retry after" in str(send_err).lower():
+                            wait = float(retry_after) if retry_after is not None else 1.0
+                            # Long flood waits (RetryAfter) block this send path —
+                            # and with it message processing — for tens of
+                            # seconds. The edit path treats wait > 5s as a hard
+                            # failure so streaming can fall back to a normal
+                            # final send; mirror that here instead of sleeping on
+                            # a multi-minute RetryAfter. Short waits are still
+                            # retried inline.
+                            if wait > 5.0:
+                                safe_send_error = _redact_telegram_error_text(send_err)
+                                logger.warning(
+                                    "[%s] Telegram flood control on send (attempt %d/3) requires %.1fs wait — failing fast: %s",
+                                    self.name,
+                                    _send_attempt + 1,
+                                    wait,
+                                    safe_send_error,
+                                )
+                                raise
                             if _send_attempt < 2:
-                                wait = float(retry_after) if retry_after is not None else 1.0
                                 safe_send_error = _redact_telegram_error_text(send_err)
                                 logger.warning(
                                     "[%s] Telegram flood control on send (attempt %d/3), retrying in %.1fs: %s",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4796,7 +4796,13 @@ class TelegramAdapter(BasePlatformAdapter):
                                     wait,
                                     safe_send_error,
                                 )
-                                raise
+                                return SendResult(
+                                    success=False,
+                                    error=safe_send_error,
+                                    retryable=False,
+                                    retry_after=wait,
+                                    error_kind="rate_limited",
+                                )
                             if _send_attempt < 2:
                                 safe_send_error = _redact_telegram_error_text(send_err)
                                 logger.warning(

--- a/tests/gateway/test_telegram_flood_fail_fast.py
+++ b/tests/gateway/test_telegram_flood_fail_fast.py
@@ -65,6 +65,9 @@ async def test_send_long_flood_wait_fails_fast_without_sleep(monkeypatch):
 
     assert isinstance(result, SendResult)
     assert result.success is False
+    assert result.retryable is False
+    assert result.retry_after == 117.0
+    assert result.error_kind == "rate_limited"
     # The long wait must NOT be slept through — fail fast instead.
     assert sleeps == [], f"send() slept on a long flood wait: {sleeps}"
 

--- a/tests/gateway/test_telegram_flood_fail_fast.py
+++ b/tests/gateway/test_telegram_flood_fail_fast.py
@@ -1,0 +1,86 @@
+"""Telegram send flood-control retry must fail fast on long waits.
+
+Regression test for the 2026-08-14 incident: a RetryAfter of ~2 minutes
+blocked the legacy send path (and with it message processing) for the whole
+wait, because the send loop slept on any ``retry_after`` without a cap.
+The edit path already treated ``wait > 5s`` as a hard failure so streaming
+could fall back; the send path now mirrors that behaviour.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+class _FloodError(Exception):
+    """Minimal stand-in for ``telegram.error.RetryAfter`` (carries retry_after)."""
+
+    def __init__(self, retry_after):
+        super().__init__("Flood control exceeded. Retry in %d seconds" % retry_after)
+        self.retry_after = retry_after
+
+
+def _make_adapter(monkeypatch, send_side_effect):
+    """Build a TelegramAdapter whose legacy send path uses ``send_side_effect``."""
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    # Force the legacy MarkdownV2 path (skip the rich-message fast path).
+    monkeypatch.setattr(adapter, "_should_attempt_rich", lambda *a, **k: False)
+    adapter._bot = AsyncFloodBot(send_side_effect)
+    return adapter
+
+
+class AsyncFloodBot:
+    """send_message stub: pops one side effect per call until exhausted."""
+
+    def __init__(self, side_effects):
+        self._queue = list(side_effects)
+        self.calls = 0
+
+    async def send_message(self, *args, **kwargs):
+        self.calls += 1
+        if self._queue:
+            item = self._queue.pop(0)
+            if isinstance(item, BaseException):
+                raise item
+            return item
+        return SimpleNamespace(message_id="ok")
+
+
+@pytest.mark.asyncio
+async def test_send_long_flood_wait_fails_fast_without_sleep(monkeypatch):
+    """A RetryAfter > 5s must fail immediately — never sleep on the send path."""
+    sleeps = []
+    async def _fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    adapter = _make_adapter(monkeypatch, [_FloodError(retry_after=117.0)])
+    monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
+
+    result = await adapter.send("12345", "hello")
+
+    assert isinstance(result, SendResult)
+    assert result.success is False
+    # The long wait must NOT be slept through — fail fast instead.
+    assert sleeps == [], f"send() slept on a long flood wait: {sleeps}"
+
+
+@pytest.mark.asyncio
+async def test_send_short_flood_wait_still_retries(monkeypatch):
+    """A short RetryAfter (<= 5s) is still retried inline and can succeed."""
+    sleeps = []
+    async def _fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    # First call raises a short flood, second call succeeds.
+    adapter = _make_adapter(monkeypatch, [_FloodError(retry_after=2.0)])
+    monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
+
+    result = await adapter.send("12345", "hello")
+
+    assert result.success is True
+    assert sleeps == [2.0], f"expected one inline retry sleep(2.0), got {sleeps}"


### PR DESCRIPTION
## Problem

A Telegram `RetryAfter` (flood control / 429) of tens of seconds blocks the **legacy send path** for the entire wait. Because the send loop sleeps inline on any `retry_after` value without a cap, a single flood-control response of ~2 minutes:

1. blocks that send call for the full wait, and
2. in practice blocks message processing for the chat (the gateway's send path is shared) — the bot appears dead to the user while the sleep is in progress.

Observed in production: `[Telegram] Telegram flood control on send (attempt 1/3), retrying in 117.0s` followed by **no further log output for 16+ minutes**; the gateway stopped answering messages entirely until restarted.

## Root cause

`plugins/platforms/telegram/adapter.py`, legacy send loop flood branch:

```python
except Exception as send_err:
    retry_after = getattr(send_err, "retry_after", None)
    if retry_after is not None or "retry after" in str(send_err).lower():
        if _send_attempt < 2:
            wait = float(retry_after) if retry_after is not None else 1.0
            ...
            await asyncio.sleep(wait)   # <-- sleeps on ANY retry_after, incl. 117s
            continue
    raise
```

The **edit path** in the same file already treats long flood waits correctly:

```python
if wait > 5.0:
    return SendResult(success=False, error=f"flood_control:{wait}", retry_after=float(wait))
```

It fails fast so streaming can fall back to a normal final send instead of leaving a truncated partial — and never blocks for minutes.

## Fix

Mirror the edit path's threshold in the send path:

- `retry_after <= 5.0` → retry inline as before (unchanged behaviour for short waits).
- `retry_after > 5.0` → **fail fast**: log a warning and raise so the outer error handler returns a classified `SendResult(success=False, error_kind="rate_limited", ...)` immediately. No multi-minute sleep on the send path.

The raised error is caught by the existing outer `except Exception` in `send()`, which returns `SendResult` (never re-raises into the gateway), so callers (stream consumer / delivery) get a prompt failure they can react to — fallback, retry scheduling, or drop — instead of the gateway freezing.

## Tests

New `tests/gateway/test_telegram_flood_fail_fast.py`:

- `test_send_long_flood_wait_fails_fast_without_sleep` — `retry_after=117.0` fails immediately and `asyncio.sleep` is never called on the send path.
- `test_send_short_flood_wait_still_retries` — `retry_after=2.0` retries inline and succeeds on the second attempt.

All 23 tests in the flood/conflict/delivery/redaction set pass; the two pre-existing `TestTelegramGuestMentionGating` failures in `test_telegram_format.py` also fail on `main` (unrelated test-env issue: missing `platform` attribute on the adapter fixture).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Telegram message delivery now fails immediately when flood-control delays exceed five seconds.
  * Shorter delays continue to retry automatically as before.
* **Tests**
  * Added coverage for both immediate failure on long delays and successful retries for shorter waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->