### PR TITLE
Resume a session in your own terminal from the session menu

### DIFF
--- a/apps/desktop/electron/external-terminal.test.ts
+++ b/apps/desktop/electron/external-terminal.test.ts
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  buildTerminalScript,
+  posixQuote,
+  resolveTerminalLaunch,
+  terminalScriptEnv,
+  terminalScriptExtension,
+  tuiResumeArgs,
+  windowsQuote
+} from './external-terminal'
+
+const never = () => null
+const always = (command: string) => `/usr/bin/${command}`
+
+test('tuiResumeArgs resumes the session in the TUI', () => {
+  assert.deepEqual(tuiResumeArgs('20260814_101010_abc123'), ['--tui', '--resume', '20260814_101010_abc123'])
+})
+
+test('tuiResumeArgs pins the profile ahead of the mode flag', () => {
+  assert.deepEqual(tuiResumeArgs('sess', 'work'), ['--profile', 'work', '--tui', '--resume', 'sess'])
+})
+
+test('posixQuote survives embedded single quotes', () => {
+  assert.equal(posixQuote("/tmp/o'brien"), `'/tmp/o'\\''brien'`)
+})
+
+test('windowsQuote doubles embedded quotes', () => {
+  assert.equal(windowsQuote('C:\\a "b"'), '"C:\\a ""b"""')
+})
+
+test('terminalScriptEnv drops PATH in any casing and keeps the rest', () => {
+  const env = terminalScriptEnv({ Path: 'C:\\junk', PATH: '/junk', PYTHONPATH: '/repo', PYTHONUTF8: '1' }, '/home/b/.hermes')
+
+  assert.deepEqual(env, { PYTHONPATH: '/repo', PYTHONUTF8: '1', HERMES_HOME: '/home/b/.hermes' })
+})
+
+test('terminalScriptEnv skips empty values and an absent home', () => {
+  assert.deepEqual(terminalScriptEnv({ PYTHONPATH: '' }), {})
+})
+
+test('buildTerminalScript execs the resolved runtime with its env', () => {
+  const script = buildTerminalScript({
+    args: ['-m', 'hermes_cli.main', '--tui', '--resume', 'sess'],
+    command: '/home/b/.hermes/hermes-agent/venv/bin/python',
+    cwd: "/home/b/o'brien",
+    env: { PYTHONPATH: '/home/b/.hermes/hermes-agent' },
+    platform: 'darwin'
+  })
+
+  assert.equal(
+    script,
+    [
+      '#!/bin/sh',
+      `cd '/home/b/o'\\''brien' || exit 1`,
+      `export PYTHONPATH='/home/b/.hermes/hermes-agent'`,
+      `exec '/home/b/.hermes/hermes-agent/venv/bin/python' '-m' 'hermes_cli.main' '--tui' '--resume' 'sess'`,
+      ''
+    ].join('\n')
+  )
+})
+
+test('buildTerminalScript emits a cmd script on Windows', () => {
+  const script = buildTerminalScript({
+    args: ['--tui', '--resume', 'sess'],
+    command: 'C:\\hermes\\venv\\Scripts\\hermes.exe',
+    cwd: 'C:\\Users\\b',
+    env: { PYTHONUTF8: '1' },
+    platform: 'win32'
+  })
+
+  assert.deepEqual(script.split('\r\n'), [
+    '@echo off',
+    'cd /d "C:\\Users\\b"',
+    'set "PYTHONUTF8=1"',
+    '"C:\\hermes\\venv\\Scripts\\hermes.exe" "--tui" "--resume" "sess"',
+    ''
+  ])
+})
+
+test('terminalScriptExtension matches what the platform binds to a terminal', () => {
+  assert.equal(terminalScriptExtension('darwin'), '.command')
+  assert.equal(terminalScriptExtension('win32'), '.cmd')
+  assert.equal(terminalScriptExtension('linux'), '.sh')
+})
+
+test('macOS opens the script with no -a so LaunchServices picks the user handler', () => {
+  assert.deepEqual(resolveTerminalLaunch({ findOnPath: never, platform: 'darwin', scriptPath: '/tmp/x.command' }), {
+    command: 'open',
+    args: ['/tmp/x.command']
+  })
+})
+
+test('Windows prefers Windows Terminal and falls back to a cmd console', () => {
+  assert.deepEqual(
+    resolveTerminalLaunch({
+      findOnPath: command => (command === 'wt.exe' ? 'C:\\wt.exe' : null),
+      platform: 'win32',
+      scriptPath: 'C:\\x.cmd'
+    }),
+    { command: 'C:\\wt.exe', args: ['cmd.exe', '/k', 'C:\\x.cmd'] }
+  )
+
+  assert.deepEqual(resolveTerminalLaunch({ findOnPath: never, platform: 'win32', scriptPath: 'C:\\x.cmd' }), {
+    command: 'cmd.exe',
+    args: ['/c', 'start', '', 'cmd.exe', '/k', 'C:\\x.cmd']
+  })
+})
+
+test("Linux leads with the user's x-terminal-emulator alternative", () => {
+  assert.deepEqual(resolveTerminalLaunch({ findOnPath: always, platform: 'linux', scriptPath: '/tmp/x.sh' }), {
+    command: '/usr/bin/x-terminal-emulator',
+    args: ['-e', '/bin/sh', '/tmp/x.sh']
+  })
+})
+
+test('Linux falls down the emulator ladder and omits a flagless terminal', () => {
+  const onlyKitty = (command: string) => (command === 'kitty' ? '/usr/bin/kitty' : null)
+
+  assert.deepEqual(resolveTerminalLaunch({ findOnPath: onlyKitty, platform: 'linux', scriptPath: '/tmp/x.sh' }), {
+    command: '/usr/bin/kitty',
+    args: ['/bin/sh', '/tmp/x.sh']
+  })
+})
+
+test('Linux with no emulator installed reports no launch', () => {
+  assert.equal(resolveTerminalLaunch({ findOnPath: never, platform: 'linux', scriptPath: '/tmp/x.sh' }), null)
+})

--- a/apps/desktop/electron/external-terminal.ts
+++ b/apps/desktop/electron/external-terminal.ts
@@ -1,0 +1,173 @@
+// Launching the Hermes TUI in the user's OWN terminal emulator.
+//
+// This is deliberately NOT the in-app terminal pane: the point of the verb is
+// to hand a session to the terminal the user already lives in, running
+// `hermes --tui --resume <id>` there. Two problems have to be solved for that
+// to work anywhere:
+//
+//  1. WHAT to run. The desktop's Hermes runtime is often a venv Python invoked
+//     as `python -m hermes_cli.main`, not a `hermes` on PATH — so the command
+//     and its PYTHONPATH have to be carried over verbatim. We write them into a
+//     small launcher script instead of trying to quote a nested command through
+//     a terminal emulator's `-e` argument, which every emulator parses
+//     differently.
+//  2. WHERE to run it. There is no portable "default terminal" API, so each
+//     platform gets its own resolution:
+//       - macOS: `open` the `.command` script with NO `-a`, letting
+//         LaunchServices route it to whichever app the user has bound to shell
+//         scripts (Terminal.app by default, iTerm2/Ghostty/WezTerm when they've
+//         claimed it). That is the closest thing macOS has to "their terminal".
+//       - Linux: an ordered ladder of emulators, led by Debian's
+//         `x-terminal-emulator` alternative — which IS the user's configured
+//         choice — before falling back to the common concrete emulators.
+//       - Windows: Windows Terminal when installed, else a `cmd.exe` console.
+//
+// Everything here is pure so it can be unit-tested without Electron; the side
+// effects (writing the script, spawning) live in main.ts.
+
+/** Argv for resuming a session in the TUI, profile-pinned when we know it. */
+export function tuiResumeArgs(sessionId: string, profile?: string): string[] {
+  const head = profile ? ['--profile', profile] : []
+
+  return [...head, '--tui', '--resume', sessionId]
+}
+
+/** Single-quote a value for /bin/sh (the POSIX launcher script). */
+export function posixQuote(value: string): string {
+  return `'${String(value ?? '').replaceAll("'", `'\\''`)}'`
+}
+
+/** Quote a value for a cmd.exe script line. */
+export function windowsQuote(value: string): string {
+  return `"${String(value ?? '').replaceAll('"', '""')}"`
+}
+
+/**
+ * The environment the launcher script exports.
+ *
+ * PATH is deliberately dropped: the script runs inside a login shell that
+ * already has the user's own PATH, and the desktop's PATH (assembled for a
+ * headless child) is the wrong answer for an interactive terminal. The Hermes
+ * command is invoked by absolute path, so nothing here depends on PATH.
+ */
+export function terminalScriptEnv(
+  backendEnv: Record<string, string | undefined> = {},
+  hermesHome?: string
+): Record<string, string> {
+  const out: Record<string, string> = {}
+
+  for (const [key, value] of Object.entries(backendEnv)) {
+    if (key.toUpperCase() === 'PATH' || value === undefined || value === '') {
+      continue
+    }
+
+    out[key] = value
+  }
+
+  if (hermesHome) {
+    out.HERMES_HOME = hermesHome
+  }
+
+  return out
+}
+
+export interface TerminalScriptSpec {
+  command: string
+  args: string[]
+  cwd: string
+  env?: Record<string, string>
+  platform?: NodeJS.Platform
+}
+
+/**
+ * The launcher script contents. `exec` on POSIX so the terminal window belongs
+ * to the TUI itself rather than an idle shell wrapping it.
+ */
+export function buildTerminalScript({ command, args, cwd, env = {}, platform = process.platform }: TerminalScriptSpec) {
+  const entries = Object.entries(env)
+
+  if (platform === 'win32') {
+    return [
+      '@echo off',
+      `cd /d ${windowsQuote(cwd)}`,
+      ...entries.map(([key, value]) => `set ${windowsQuote(`${key}=${value}`)}`),
+      [command, ...args].map(windowsQuote).join(' '),
+      ''
+    ].join('\r\n')
+  }
+
+  return [
+    '#!/bin/sh',
+    `cd ${posixQuote(cwd)} || exit 1`,
+    ...entries.map(([key, value]) => `export ${key}=${posixQuote(value)}`),
+    `exec ${[command, ...args].map(posixQuote).join(' ')}`,
+    ''
+  ].join('\n')
+}
+
+export function terminalScriptExtension(platform: NodeJS.Platform = process.platform): string {
+  if (platform === 'win32') {
+    return '.cmd'
+  }
+
+  // `.command` is the UTI macOS binds to a terminal app; on Linux the
+  // extension is cosmetic (we always name the interpreter explicitly).
+  return platform === 'darwin' ? '.command' : '.sh'
+}
+
+// Linux emulators in resolution order, with the flag that precedes a program
+// to run. `x-terminal-emulator` is Debian/Ubuntu's alternatives symlink to the
+// user's chosen terminal, so it leads; the rest are the common concretes.
+const LINUX_TERMINALS: Array<{ command: string; flag: string }> = [
+  { command: 'x-terminal-emulator', flag: '-e' },
+  { command: 'gnome-terminal', flag: '--' },
+  { command: 'konsole', flag: '-e' },
+  { command: 'xfce4-terminal', flag: '-x' },
+  { command: 'tilix', flag: '-e' },
+  { command: 'kitty', flag: '' },
+  { command: 'alacritty', flag: '-e' },
+  { command: 'wezterm', flag: '-e' },
+  { command: 'foot', flag: '' },
+  { command: 'xterm', flag: '-e' }
+]
+
+export interface TerminalLaunchOptions {
+  scriptPath: string
+  findOnPath: (command: string) => null | string
+  platform?: NodeJS.Platform
+}
+
+/**
+ * Resolve the argv that opens `scriptPath` in a terminal window, or null when
+ * no terminal emulator could be found (Linux boxes with none installed).
+ */
+export function resolveTerminalLaunch({
+  scriptPath,
+  findOnPath,
+  platform = process.platform
+}: TerminalLaunchOptions): { command: string; args: string[] } | null {
+  if (platform === 'darwin') {
+    // No `-a`: LaunchServices picks the user's handler for shell scripts.
+    return { command: 'open', args: [scriptPath] }
+  }
+
+  if (platform === 'win32') {
+    const windowsTerminal = findOnPath('wt.exe')
+
+    if (windowsTerminal) {
+      return { command: windowsTerminal, args: ['cmd.exe', '/k', scriptPath] }
+    }
+
+    return { command: 'cmd.exe', args: ['/c', 'start', '', 'cmd.exe', '/k', scriptPath] }
+  }
+
+  for (const { command, flag } of LINUX_TERMINALS) {
+    const resolved = findOnPath(command)
+
+    if (resolved) {
+      return { command: resolved, args: [...(flag ? [flag] : []), '/bin/sh', scriptPath] }
+    }
+  }
+
+  return null
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -96,6 +96,13 @@ import {
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
 import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
+import {
+  buildTerminalScript,
+  resolveTerminalLaunch,
+  terminalScriptEnv,
+  terminalScriptExtension,
+  tuiResumeArgs
+} from './external-terminal'
 import { findGitBash as _findGitBash } from './find-git-bash'
 import { installFoundInPageForwarder, performFind, stopFind } from './find-in-page'
 import { createFirstRunSetupGate } from './first-run-setup-gate'
@@ -10092,6 +10099,70 @@ ipcMain.handle('hermes:window:openInstance', async () => {
   createInstanceWindow()
 
   return { ok: true }
+})
+
+// Hand a session to the user's OWN terminal emulator, running the TUI against
+// it (`hermes --tui --resume <id>`). Not the in-app terminal pane: the point is
+// to continue the chat in the terminal they already live in.
+//
+// The desktop's runtime is usually a venv Python invoked as
+// `python -m hermes_cli.main`, so we resolve the SAME backend the app itself
+// launches and carry its argv + PYTHONPATH into a launcher script rather than
+// hoping a `hermes` exists on the user's interactive PATH. Resolution only —
+// never ensureRuntime(), which would kick off a first-run install from a menu
+// click; an unresolved runtime is reported instead.
+ipcMain.handle('hermes:window:openInTerminal', async (_event, sessionId, opts) => {
+  if (typeof sessionId !== 'string' || !sessionId.trim()) {
+    return { ok: false, error: 'invalid-session-id' }
+  }
+
+  try {
+    const profile = typeof opts?.profile === 'string' ? opts.profile.trim() : ''
+    const backend = resolveHermesBackend(tuiResumeArgs(sessionId.trim(), profile || undefined))
+
+    if (!backend.command) {
+      return { ok: false, error: 'Hermes is not installed yet' }
+    }
+
+    const { cwd } = sanitizeWorkspaceCwd(opts?.cwd)
+    const scriptDir = path.join(app.getPath('userData'), 'open-in-terminal')
+    fs.mkdirSync(scriptDir, { recursive: true })
+
+    const scriptPath = path.join(
+      scriptDir,
+      `hermes-${crypto.randomBytes(6).toString('hex')}${terminalScriptExtension()}`
+    )
+
+    fs.writeFileSync(
+      scriptPath,
+      buildTerminalScript({
+        args: backend.args,
+        command: backend.command,
+        cwd,
+        env: terminalScriptEnv(backend.env, HERMES_HOME)
+      }),
+      { mode: 0o700 }
+    )
+
+    const launch = resolveTerminalLaunch({ findOnPath, scriptPath })
+
+    if (!launch) {
+      return { ok: false, error: 'No terminal emulator found' }
+    }
+
+    rememberLog(`[terminal] opening session ${sessionId} via ${launch.command}`)
+
+    // Detached + unref'd: the terminal window outlives the desktop app, and
+    // never inherits our stdio (a closed pipe would kill the TUI).
+    const child = spawn(launch.command, launch.args, { detached: true, stdio: 'ignore' })
+    child.unref()
+
+    return { ok: true }
+  } catch (error) {
+    rememberLog(`[terminal] open in terminal failed: ${error.message}`)
+
+    return { ok: false, error: error.message }
+  }
 })
 ipcMain.handle('hermes:wake-indicator:get', () => wakeIndicatorController.getState())
 ipcMain.on('hermes:wake-indicator:set', (_event, state) => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -6,6 +6,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   touchBackend: profile => ipcRenderer.invoke('hermes:backend:touch', profile),
   getGatewayWsUrl: profile => ipcRenderer.invoke('hermes:gateway:ws-url', profile),
   openSessionWindow: (sessionId, opts) => ipcRenderer.invoke('hermes:window:openSession', sessionId, opts),
+  openSessionInTerminal: (sessionId, opts) => ipcRenderer.invoke('hermes:window:openInTerminal', sessionId, opts),
   openWindow: () => ipcRenderer.invoke('hermes:window:openInstance'),
   claimAmbientCue: key => ipcRenderer.invoke('hermes:ambient:claim', key),
   wakeIndicator: {

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -65,6 +65,7 @@ vi.mock('@/store/projects', () => ({
 }))
 vi.mock('@/store/session', () => ({
   $activeSessionId: atom<null | string>(null),
+  $connection: atom<null | { mode: string }>(null),
   $selectedStoredSessionId: atom<null | string>(null),
   $sessions: atom<unknown[]>([]),
   sessionMatchesStoredId: vi.fn(() => false),
@@ -80,8 +81,10 @@ vi.mock('@/store/session-states', () => ({
   openSessionTile: vi.fn()
 }))
 vi.mock('@/store/windows', () => ({
+  canOpenSessionInTerminal: () => false,
   canOpenSessionWindow: () => false,
-  openSessionInNewWindow: vi.fn()
+  openSessionInNewWindow: vi.fn(),
+  openSessionInTerminal: vi.fn()
 }))
 
 function renderMenu() {

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -33,6 +33,7 @@ import { notify, notifyError } from '@/store/notifications'
 import { $projectTree, moveSessionToProject, projectIdForCwd, projectRootCwd } from '@/store/projects'
 import {
   $activeSessionId,
+  $connection,
   $selectedStoredSessionId,
   $sessions,
   sessionMatchesStoredId,
@@ -41,7 +42,7 @@ import {
 } from '@/store/session'
 import { $sessionColorOverrides, setSessionColorOverride } from '@/store/session-color'
 import { $sessionTiles } from '@/store/session-states'
-import { canOpenSessionWindow } from '@/store/windows'
+import { canOpenSessionInTerminal, canOpenSessionWindow, openSessionInTerminal } from '@/store/windows'
 
 import type { SessionTitleResponse } from '../../types'
 
@@ -191,6 +192,7 @@ function useSessionActions({
   const [renameOpen, setRenameOpen] = useState(false)
   const tiles = useStore($sessionTiles)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  const isRemote = useStore($connection)?.mode === 'remote'
 
   // Already showing as a tab somewhere (a tile, or loaded in main — main IS
   // a tab): offering "Open in new tab" again is noise.
@@ -226,6 +228,26 @@ function useSessionActions({
             onSelect: () => {
               triggerHaptic('selection')
               openSession(sessionId, () => undefined, 'window')
+            }
+          })
+        ]
+      : []),
+    // The user's OWN terminal, not the in-app pane: resumes the session in the
+    // TUI. Hidden on a remote connection — the emulator we'd open runs on this
+    // machine while the session (and its runtime) lives on the remote host.
+    ...(canOpenSessionInTerminal() && !isRemote
+      ? [
+          spec({
+            disabled: !sessionId,
+            icon: 'terminal',
+            label: r.openInTerminal,
+            onSelect: () => {
+              triggerHaptic('selection')
+              // Read the row lazily: subscribing every row's menu to $sessions
+              // would re-render the whole sidebar on each session update.
+              const cwd = $sessions.get().find(s => sessionMatchesStoredId(s, sessionId))?.cwd?.trim() || undefined
+
+              void openSessionInTerminal(sessionId, { cwd, profile })
             }
           })
         ]

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -35,6 +35,12 @@ declare global {
       // a spectator window (lazy resume — no agent build) for live-streaming
       // a running subagent's session.
       openSessionWindow: (sessionId: string, opts?: { watch?: boolean }) => Promise<{ ok: boolean; error?: string }>
+      // Resume this session in the user's own terminal emulator (`hermes --tui
+      // --resume <id>`) — the external terminal, not the in-app pane.
+      openSessionInTerminal: (
+        sessionId: string,
+        opts?: { cwd?: string; profile?: string }
+      ) => Promise<{ ok: boolean; error?: string }>
       // Open a new full-chrome app window — a peer instance of the primary that
       // renders the complete app against the shared backend, so the user can run
       // multiple GUI windows at once.

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1647,6 +1647,7 @@ export const ar = defineLocale({
       rename: 'إعادة تسمية',
       archive: 'أرشفة',
       newWindow: 'فتح في نافذة جديدة',
+      openInTerminal: 'فتح في الطرفية',
       copyIdFailed: 'فشل نسخ المعرف',
 
       sessionActions: 'إجراءات الجلسة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1977,6 +1977,7 @@ export const en: Translations = {
       rename: 'Rename',
       archive: 'Archive',
       newWindow: 'New window',
+      openInTerminal: 'Open in terminal',
       hideTabBar: 'Hide tab bar',
       openInNewTab: 'Open in new tab',
       openInSplit: 'Open in split',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1794,6 +1794,7 @@ export const ja = defineLocale({
       rename: '名前を変更',
       archive: 'アーカイブ',
       newWindow: '新しいウィンドウ',
+      openInTerminal: 'ターミナルで開く',
       copyIdFailed: 'セッション ID をコピーできませんでした',
 
       sessionActions: 'セッションアクション',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1664,6 +1664,7 @@ export interface Translations {
       rename: string
       archive: string
       newWindow: string
+      openInTerminal: string
       hideTabBar: string
       openInNewTab: string
       openInSplit: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1736,6 +1736,7 @@ export const zhHant = defineLocale({
       rename: '重新命名',
       archive: '封存',
       newWindow: '新視窗',
+      openInTerminal: '在終端機中開啟',
       copyIdFailed: '無法複製工作階段 ID',
 
       sessionActions: '工作階段動作',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2166,6 +2166,7 @@ export const zh: Translations = {
       rename: '重命名',
       archive: '归档',
       newWindow: '新窗口',
+      openInTerminal: '在终端中打开',
       hideTabBar: '隐藏标签栏',
       openInNewTab: '在新标签页中打开',
       openInSplit: '在分屏中打开',

--- a/apps/desktop/src/store/windows.ts
+++ b/apps/desktop/src/store/windows.ts
@@ -110,6 +110,13 @@ export function canOpenNewWindow(): boolean {
   return typeof window !== 'undefined' && typeof window.hermesDesktop?.openWindow === 'function'
 }
 
+// True when the shell can hand a session to the user's own terminal emulator.
+// Desktop-only, and a REMOTE connection is excluded by the caller: the terminal
+// we'd open is on this machine, but the session lives on the remote host.
+export function canOpenSessionInTerminal(): boolean {
+  return typeof window !== 'undefined' && typeof window.hermesDesktop?.openSessionInTerminal === 'function'
+}
+
 type WindowOpenResult = { ok: boolean; error?: string } | undefined
 
 // Run a window-open bridge call, surfacing any failure as a toast. Shared by the
@@ -148,4 +155,21 @@ export async function openNewWindow(): Promise<void> {
   }
 
   await runWindowOpen(() => window.hermesDesktop.openWindow(), 'Could not open a new window')
+}
+
+// Resume a session in the user's own terminal emulator, running the TUI there.
+// `cwd` starts the shell in the session's workspace; `profile` pins the runtime
+// to the profile that owns the session. No-ops gracefully outside Electron.
+export async function openSessionInTerminal(
+  sessionId: string,
+  opts?: { cwd?: string; profile?: string }
+): Promise<void> {
+  if (!sessionId || !canOpenSessionInTerminal()) {
+    return
+  }
+
+  await runWindowOpen(
+    () => window.hermesDesktop.openSessionInTerminal(sessionId, opts),
+    'Could not open chat in a terminal'
+  )
 }


### PR DESCRIPTION
Adds an **Open in terminal** row to the session kebab and right-click menus, next to New window. It hands the chat to the terminal emulator the user actually lives in — not the in-app terminal pane — and resumes it there with `hermes --tui --resume <id>`.

Two things have to be right for that to work anywhere.

**What to run.** The desktop's runtime is usually a venv Python invoked as `python -m hermes_cli.main`, not a `hermes` on the user's interactive PATH. So the same backend resolution the app uses for its own gateway supplies the command, argv, and PYTHONPATH, and they're written into a small launcher script rather than quoted through an emulator's `-e` flag — every emulator parses that differently. Resolution only, never `ensureRuntime()`: a menu click should not kick off a first-run install, so an unresolved runtime is reported as an error instead. PATH is deliberately dropped from the script; the login shell already has the user's own, and the runtime is invoked by absolute path.

**Where to run it.** There's no portable "default terminal" API, so each platform gets its own answer:

| Platform | Resolution |
| --- | --- |
| macOS | `open` the `.command` with no `-a`, letting LaunchServices route to whichever app claimed shell scripts (Terminal.app, iTerm2, Ghostty, WezTerm) |
| Linux | An ordered ladder led by Debian's `x-terminal-emulator` alternative — the user's configured choice — then gnome-terminal, konsole, xfce4-terminal, tilix, kitty, alacritty, wezterm, foot, xterm |
| Windows | Windows Terminal when installed, else a `cmd.exe` console |

The row starts the shell in the session's workspace and pins `--profile` to the profile that owns it. It's hidden on a remote connection, where the emulator we'd open is on this machine but the session and its runtime are on the remote host.

Worked example — the script generated for a session on this machine, and running it against the real runtime:

```sh
#!/bin/sh
cd '/Users/brooklyn' || exit 1
export PYTHONPATH='/Users/brooklyn/www/hermes-agent'
export PYTHONUTF8='1'
export HERMES_HOME='/Users/brooklyn/.hermes'
exec '…/.venv/bin/python3' '-m' 'hermes_cli.main' '--tui' '--resume' '20260814_101010_abc123'
```

Verified end to end on macOS: the argv parses on the real `hermes_cli` top-level parser (including `--profile` stripped pre-argparse), the generated script executes the resolved runtime, and `open` on a `.command` routes to the user's bound handler (`TERM_PROGRAM=Apple_Terminal`). 14 new unit tests cover argv, quoting, script shape, and emulator resolution per platform; renderer and electron typechecks, eslint, and the touched UI tests are clean.
