### PR TITLE
fix(browser): managed-first browser-use CLI resolution

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1654,26 +1654,29 @@ def _ensure_browser_use_cli(*, verbose_hints: bool = False) -> None:
     "Browser Use" row. Failure is non-fatal: ``browser_exec`` can still run
     zero-install via ``uvx browser-use``, and the built-in browser tools
     remain the final fallback.
-    """
-    if shutil.which("browser-use"):
-        _print_success("    browser-use CLI found on PATH")
-    else:
-        _print_info("    Installing browser-use CLI (uv tool install browser-use)...")
-        try:
-            from tools.browser_use_cli import install_cli
 
-            ok, message = install_cli()
-        except Exception as exc:  # pragma: no cover — defensive
-            ok, message = False, f"install failed: {exc}"
-        if ok:
-            _print_success(f"    {message}")
+    MANAGED-FIRST: a browser-use on the user's PATH does NOT satisfy this
+    check — only the Hermes-managed ``$HERMES_HOME/bin`` copy does.
+    ``install_cli()`` short-circuits on the managed copy and otherwise
+    provisions it, so resolution always lands on a binary Hermes installs
+    and updates rather than a user-level side install.
+    """
+    _print_info("    Ensuring browser-use CLI (managed install)...")
+    try:
+        from tools.browser_use_cli import install_cli
+
+        ok, message = install_cli()
+    except Exception as exc:  # pragma: no cover — defensive
+        ok, message = False, f"install failed: {exc}"
+    if ok:
+        _print_success(f"    {message}")
+    else:
+        for line in str(message).splitlines():
+            _print_warning(f"    {line[:200]}")
+        if shutil.which("uvx"):
+            _print_info("    Falling back to zero-install runs via `uvx browser-use`")
         else:
-            for line in str(message).splitlines():
-                _print_warning(f"    {line[:200]}")
-            if shutil.which("uvx"):
-                _print_info("    Falling back to zero-install runs via `uvx browser-use`")
-            else:
-                _print_info("    Install manually: uv tool install browser-use  (https://docs.astral.sh/uv/)")
+            _print_info("    Install manually: uv tool install browser-use  (https://docs.astral.sh/uv/)")
     if verbose_hints:
         _print_info("    Local Chrome needs remote debugging: chrome://inspect/#remote-debugging")
         _print_info("    Cloud browsers: browser-use auth login  (or set BROWSER_USE_API_KEY)")

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3240,7 +3240,10 @@ function Install-BrowserUseCli {
     }
     $managedBin = Join-Path $HermesHome "bin"
     $managedBu = Join-Path $managedBin "browser-use.exe"
-    if ((Get-Command browser-use -ErrorAction SilentlyContinue) -or (Test-Path $managedBu)) {
+    # MANAGED-FIRST: only Hermes' managed copy short-circuits. A browser-use
+    # on the user's PATH is a side install -- resolution prefers the managed
+    # copy, so it must be provisioned regardless.
+    if (Test-Path $managedBu) {
         Write-Success "Browser Use CLI already installed"
         return
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2443,7 +2443,10 @@ install_browser_use_cli() {
         log_info "Skipping Browser Use CLI install (uv unavailable)"
         return 0
     fi
-    if command -v browser-use >/dev/null 2>&1 || [ -x "$HERMES_HOME/bin/browser-use" ]; then
+    # MANAGED-FIRST: only Hermes' managed copy short-circuits. A browser-use
+    # on the user's PATH is a side install — resolution prefers the managed
+    # copy, so it must be provisioned regardless.
+    if [ -x "$HERMES_HOME/bin/browser-use" ]; then
         log_success "Browser Use CLI already installed"
         return 0
     fi

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -650,14 +650,20 @@ class TestBrowserUseCliInstalledForAllNonCamofoxBackends:
             _run_post_setup("camofox")
         ensure.assert_not_called()
 
-    def test_ensure_helper_short_circuits_when_cli_on_path(self):
+    def test_ensure_helper_always_delegates_to_install_cli(self):
+        """MANAGED-FIRST: a browser-use on PATH must not short-circuit the
+        helper — install_cli() owns the managed-copy check and provisions
+        $HERMES_HOME/bin when only side installs exist."""
         with patch(
             "hermes_cli.tools_config.shutil.which", return_value="/usr/bin/browser-use"
-        ), patch("tools.browser_use_cli.install_cli") as install:
+        ), patch(
+            "tools.browser_use_cli.install_cli",
+            return_value=(True, "browser-use CLI already installed (/managed/bin/browser-use)"),
+        ) as install:
             from hermes_cli.tools_config import _ensure_browser_use_cli
 
             _ensure_browser_use_cli()
-        install.assert_not_called()
+        install.assert_called_once()
 
     def test_ensure_helper_install_failure_is_non_fatal(self):
         """A failed install must warn and fall back, never raise — the

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -706,7 +706,8 @@ class TestBrowserExec:
 
 
 class TestFindCliManagedBin:
-    """_find_cli probes ~/.local/bin and $HERMES_HOME/bin after PATH."""
+    """MANAGED-FIRST: _find_cli probes $HERMES_HOME/bin before PATH and
+    ~/.local/bin, so the Hermes-installed copy always wins."""
 
     @pytest.fixture(autouse=True)
     def _hermetic_home(self, tmp_path, monkeypatch):
@@ -746,9 +747,11 @@ class TestFindCliManagedBin:
         cli.chmod(cli.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(cli)]
 
-    def test_user_local_bin_precedes_managed_bin(self, tmp_path, monkeypatch):
-        """A user-level install wins over Hermes' managed copy — mirrors the
-        PATH-first preference (user intent beats bootstrap)."""
+    def test_managed_bin_precedes_user_local_bin(self, tmp_path, monkeypatch):
+        """MANAGED-FIRST: Hermes' managed copy wins over a user-level side
+        install — every backend selection provisions/updates the managed
+        copy, so resolution must land on the binary we control (no version
+        drift from stray `uv tool install` runs)."""
         user_dir = tmp_path / "userhome" / ".local" / "bin"
         user_dir.mkdir(parents=True)
         user_cli = user_dir / "browser-use"
@@ -759,7 +762,22 @@ class TestFindCliManagedBin:
         managed_cli = managed_dir / "browser-use"
         managed_cli.write_text("#!/bin/sh\n")
         managed_cli.chmod(managed_cli.stat().st_mode | stat.S_IXUSR)
-        assert bu_cli._find_cli_unpatched() == [str(user_cli)]
+        assert bu_cli._find_cli_unpatched() == [str(managed_cli)]
+
+    def test_managed_bin_precedes_path(self, tmp_path, monkeypatch):
+        """MANAGED-FIRST: the managed copy also wins over one on PATH."""
+        path_dir = tmp_path / "onpath"
+        path_dir.mkdir()
+        path_cli = path_dir / "browser-use"
+        path_cli.write_text("#!/bin/sh\n")
+        path_cli.chmod(path_cli.stat().st_mode | stat.S_IXUSR)
+        monkeypatch.setenv("PATH", str(path_dir))
+        managed_dir = tmp_path / "home" / "bin"
+        managed_dir.mkdir(parents=True)
+        managed_cli = managed_dir / "browser-use"
+        managed_cli.write_text("#!/bin/sh\n")
+        managed_cli.chmod(managed_cli.stat().st_mode | stat.S_IXUSR)
+        assert bu_cli._find_cli_unpatched() == [str(managed_cli)]
 
     def test_user_local_bin_uvx_fallback(self, tmp_path, monkeypatch):
         cli_dir = tmp_path / "userhome" / ".local" / "bin"
@@ -771,9 +789,32 @@ class TestFindCliManagedBin:
 
 
 class TestInstallCli:
-    def test_already_installed_on_path(self, tmp_path, monkeypatch):
+    def test_path_install_does_not_short_circuit(self, tmp_path, monkeypatch):
+        """MANAGED-FIRST: a browser-use on PATH is a user-level side install
+        and must NOT satisfy install_cli() — only the managed copy does,
+        otherwise resolution stays pinned to a binary Hermes can't update."""
         cli = _fake_cli(tmp_path, "")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
         monkeypatch.setattr(bu_cli.shutil, "which", lambda name, path=None: cli if name == "browser-use" and path is None else None)
+        import sys as _sys
+        import types as _types
+        fake = _types.ModuleType("hermes_cli.managed_uv")
+        fake.ensure_uv = lambda **kw: None
+        monkeypatch.setitem(_sys.modules, "hermes_cli.managed_uv", fake)
+        ok, msg = bu_cli.install_cli()
+        # No uv available in this fixture, so the attempted managed install
+        # fails — the point is that the PATH copy did not short-circuit.
+        assert ok is False
+        assert "already installed" not in msg
+
+    def test_already_installed_in_managed_bin(self, tmp_path, monkeypatch):
+        bin_dir = tmp_path / "home" / "bin"
+        bin_dir.mkdir(parents=True)
+        cli = bin_dir / "browser-use"
+        cli.write_text("#!/bin/sh\n")
+        cli.chmod(cli.stat().st_mode | stat.S_IXUSR)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        monkeypatch.setenv("PATH", str(tmp_path / "empty"))
         ok, msg = bu_cli.install_cli()
         assert ok is True
         assert "already installed" in msg

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -223,14 +223,16 @@ def _user_local_bin_dir() -> Optional[str]:
 def _find_cli() -> Optional[List[str]]:
     """Locate the browser-use CLI, or None when it can't be run.
 
-    Prefers an installed browser-use binary (PATH, then the user-level tool
-    dir, then Hermes' managed $HERMES_HOME/bin); falls back to running it
-    through uvx across the same probe set. The extra probes matter because
-    Hermes bootstraps its own uv into $HERMES_HOME/bin (not on the user's
-    PATH), and Desktop/TUI workers can spawn with a minimal PATH that omits
-    ~/.local/bin where `uv tool install` links binaries by default.
+    MANAGED-FIRST resolution: Hermes' own ``$HERMES_HOME/bin`` copy — the
+    one every browser backend selection installs and updates via
+    ``install_cli()`` — always wins, so all sessions drive one canonical,
+    Hermes-controlled binary. PATH and the user-level tool dir
+    (~/.local/bin / %APPDATA%\\uv\\bin, where a manual ``uv tool install``
+    links binaries) are fallbacks for setups that never ran our install,
+    and cover Desktop/TUI workers that spawn with a minimal PATH. The uvx
+    zero-install path (same probe order) is the final fallback.
     """
-    probe_paths = (None, _user_local_bin_dir(), _managed_bin_dir())
+    probe_paths = (_managed_bin_dir(), None, _user_local_bin_dir())
     for probe_path in probe_paths:
         if probe_path is None or probe_path:
             direct = shutil.which("browser-use", path=probe_path)
@@ -254,9 +256,11 @@ def install_cli(timeout_s: int = 600) -> Tuple[bool, str]:
 
     Returns ``(ok, message)`` — never raises.
     """
-    direct = shutil.which("browser-use")
-    if direct:
-        return True, f"browser-use CLI already installed ({direct})"
+    # MANAGED-FIRST: only the managed copy short-circuits the install. A
+    # browser-use found on PATH is a user-level side install — it must NOT
+    # prevent provisioning the canonical Hermes-managed copy, or resolution
+    # stays pinned to a binary we don't control (version drift, no updates
+    # through hermes tools).
     bin_dir = _managed_bin_dir()
     if bin_dir:
         managed = shutil.which("browser-use", path=bin_dir)


### PR DESCRIPTION
## Summary
Browser Use CLI resolution is now managed-first: the copy Hermes installs into `$HERMES_HOME/bin` always wins, so every session drives one canonical, Hermes-controlled binary and a user's own `uv tool install browser-use` can no longer shadow it with a drifted version.

Follow-up to #86240 (every non-Camofox backend installs the CLI) and #86320 (user-dir discovery): with a managed install guaranteed at selection time, flipping precedence closes the whole shadowing/version-drift class instead of guarding individual probe sites.

## Changes
- `tools/browser_use_cli.py` — `_find_cli()` probe order: managed bin → PATH → user-level tool dir (binary pass, then uvx pass); `install_cli()` no longer short-circuits on a PATH copy — only the managed copy counts as installed.
- `hermes_cli/tools_config.py` — `_ensure_browser_use_cli()` drops its own PATH check and always delegates to `install_cli()`, the single owner of the managed-copy policy.
- `scripts/install.sh` / `scripts/install.ps1` — installer short-circuits likewise ignore PATH copies; only `$HERMES_HOME/bin/browser-use` counts.
- Tests updated to pin the new contract: managed beats PATH and user-local, PATH install doesn't satisfy `install_cli()`, helper always delegates.

## Validation
| | Before | After |
|---|---|---|
| user `uv tool install` + Hermes-managed copy | user copy shadowed ours | managed copy wins |
| backend selection with side install on PATH | skipped provisioning managed copy | provisions managed copy |
| no managed copy anywhere | PATH → user-dir → uvx fallback | unchanged |
| targeted tests (browser_use_cli + tools_config + post_setup_gating) | — | 132/132 passing |

E2E: real-file precedence chain (managed → PATH → user-local, removing each in turn) and a real `install_cli()` run with only side installs present — verified with real imports, no mocks.

## Infographic

![Managed-first browser-use resolution](https://files.catbox.moe/prkhhs.png)
