### PR TITLE
fix: propagate CLI execution failures

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14755,6 +14755,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # this to True. Early returns (credential refresh failure, etc.)
         # leave it False, which is correct — those aren't user interrupts.
         self._last_turn_interrupted = False
+        # Preserve the raw turn outcome for single-query callers. ``chat()``
+        # renders an empty failed result as an ``Error: ...`` string for humans,
+        # so its return value alone cannot distinguish a model reply from a
+        # backend abort that produced no assistant message.
+        self._last_turn_result = None
 
         # Refresh provider credentials if needed (handles key rotation transparently)
         if not self._ensure_runtime_credentials():
@@ -15279,6 +15284,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             time.sleep(0.15)
 
             # Update history with full conversation
+            self._last_turn_result = result
             self.conversation_history = result.get("messages", self.conversation_history) if result else self.conversation_history
 
             # If auto-compression fired mid-turn, the agent created a new
@@ -19650,8 +19656,25 @@ def main(
                 # Surface security advisories before the agent runs — short
                 # banner, doesn't depend on the welcome banner being shown.
                 cli._show_security_advisories()
-                cli.chat(query, images=single_query_images or None)
+                _single_query_response = cli.chat(
+                    query, images=single_query_images or None
+                )
                 cli._print_exit_summary(clear_screen=False)
+                _single_query_result = getattr(cli, "_last_turn_result", None)
+                _raw_final_response = (
+                    _single_query_result.get("final_response", "")
+                    if isinstance(_single_query_result, dict)
+                    else ""
+                )
+                if not (_single_query_response or "").strip() or (
+                    isinstance(_single_query_result, dict)
+                    and (
+                        _single_query_result.get("failed")
+                        or _single_query_result.get("partial")
+                    )
+                    and not (_raw_final_response or "").strip()
+                ):
+                    sys.exit(1)
         finally:
             _finalize_single_query(cli)
         return

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -769,7 +769,7 @@ def cmd_mcp_test(args):
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000
         _error(f"Connection failed ({elapsed_ms:.0f}ms): {exc}")
-        return
+        raise SystemExit(1) from exc
 
     _success(f"Connected ({elapsed_ms:.0f}ms)")
     _success(f"Tools discovered: {len(tools)}")

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -133,6 +133,54 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
     ]
 
 
+def test_human_single_query_main_propagates_failed_turn_exit_code(monkeypatch):
+    calls = []
+
+    import cli as cli_mod
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = SimpleNamespace(print=lambda *_args, **_kwargs: None)
+            self.session_id = "failed-query-session"
+            self.agent = SimpleNamespace(
+                session_id="failed-query-session",
+                platform="cli",
+            )
+            self._last_turn_result = None
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            return True
+
+        def _show_security_advisories(self):
+            pass
+
+        def chat(self, query, images=None):
+            self._last_turn_result = {
+                "final_response": "",
+                "messages": [],
+                "error": "HTTP 402 payment required",
+                "failed": True,
+            }
+            return "Error: HTTP 402 payment required"
+
+        def _print_exit_summary(self, clear_screen=True):
+            calls.append("summary")
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "_finalize_single_query",
+        lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(query="Return exactly OK", quiet=False, toolsets="terminal")
+
+    assert exc_info.value.code == 1
+    assert calls == ["summary", ("finalize", "failed-query-session")]
+
+
 def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatch):
     calls = []
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -302,6 +302,25 @@ class TestMcpTest:
         assert "Connected" in out
         assert "Tools discovered: 2" in out
 
+    def test_connection_failure_exits_nonzero(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "broken": {"command": "missing-mcp-server"},
+        })
+
+        def mock_probe(name, config, **kw):
+            raise ConnectionError("connection refused")
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_test(_make_args(name="broken"))
+
+        assert exc_info.value.code == 1
+        assert "Connection failed" in capsys.readouterr().out
+
     def test_probe_uses_configured_connect_timeout(self, monkeypatch):
         """OAuth-capable probes must not hard-code a short 30s timeout."""
         import asyncio


### PR DESCRIPTION
## Summary
- make `hermes mcp test NAME` exit 1 when the connection probe fails
- make human-facing `hermes chat -q` exit 1 when model execution aborts before producing an assistant response
- preserve successful and interactive behavior

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py tests/cli/test_single_query_session_finalize.py tests/cli/test_chat_q_exit_clear.py -q` (49 passed)
- `python -m py_compile` on changed Python files
- `ruff check` on changed Python files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Single-query commands now return a failure status when a turn fails, is incomplete, or produces no final response.
  - Session finalization and exit summaries still run when single-query execution fails.
  - MCP connection test failures now correctly exit with status 1 and report the connection failure.

- **Tests**
  - Added regression coverage for failed single-query turns and MCP connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->