### PR TITLE
fix(cli): propagate noninteractive failures

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -19661,18 +19661,20 @@ def main(
                 )
                 cli._print_exit_summary(clear_screen=False)
                 _single_query_result = getattr(cli, "_last_turn_result", None)
-                _raw_final_response = (
-                    _single_query_result.get("final_response", "")
+                _single_query_messages = (
+                    _single_query_result.get("messages", [])
                     if isinstance(_single_query_result, dict)
-                    else ""
+                    else []
+                )
+                _has_assistant_result = any(
+                    isinstance(message, dict)
+                    and message.get("role") == "assistant"
+                    and (message.get("content") or message.get("tool_calls"))
+                    for message in _single_query_messages
                 )
                 if not (_single_query_response or "").strip() or (
                     isinstance(_single_query_result, dict)
-                    and (
-                        _single_query_result.get("failed")
-                        or _single_query_result.get("partial")
-                    )
-                    and not (_raw_final_response or "").strip()
+                    and not _has_assistant_result
                 ):
                     sys.exit(1)
         finally:

--- a/cli.py
+++ b/cli.py
@@ -14755,6 +14755,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # this to True. Early returns (credential refresh failure, etc.)
         # leave it False, which is correct — those aren't user interrupts.
         self._last_turn_interrupted = False
+        # Preserve the raw turn outcome for single-query callers. ``chat()``
+        # renders an empty failed result as an ``Error: ...`` string for humans,
+        # so its return value alone cannot distinguish a model reply from a
+        # backend abort that produced no assistant message.
+        self._last_turn_result = None
 
         # Refresh provider credentials if needed (handles key rotation transparently)
         if not self._ensure_runtime_credentials():
@@ -15279,6 +15284,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             time.sleep(0.15)
 
             # Update history with full conversation
+            self._last_turn_result = result
             self.conversation_history = result.get("messages", self.conversation_history) if result else self.conversation_history
 
             # If auto-compression fired mid-turn, the agent created a new
@@ -19650,8 +19656,25 @@ def main(
                 # Surface security advisories before the agent runs — short
                 # banner, doesn't depend on the welcome banner being shown.
                 cli._show_security_advisories()
-                cli.chat(query, images=single_query_images or None)
+                _single_query_response = cli.chat(
+                    query, images=single_query_images or None
+                )
                 cli._print_exit_summary(clear_screen=False)
+                _single_query_result = getattr(cli, "_last_turn_result", None)
+                _raw_final_response = (
+                    _single_query_result.get("final_response", "")
+                    if isinstance(_single_query_result, dict)
+                    else ""
+                )
+                if not (_single_query_response or "").strip() or (
+                    isinstance(_single_query_result, dict)
+                    and (
+                        _single_query_result.get("failed")
+                        or _single_query_result.get("partial")
+                    )
+                    and not (_raw_final_response or "").strip()
+                ):
+                    sys.exit(1)
         finally:
             _finalize_single_query(cli)
         return

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -769,7 +769,7 @@ def cmd_mcp_test(args):
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000
         _error(f"Connection failed ({elapsed_ms:.0f}ms): {exc}")
-        return
+        raise SystemExit(1) from exc
 
     _success(f"Connected ({elapsed_ms:.0f}ms)")
     _success(f"Tools discovered: {len(tools)}")

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -156,10 +156,11 @@ def test_human_single_query_main_propagates_failed_turn_exit_code(monkeypatch):
 
         def chat(self, query, images=None):
             self._last_turn_result = {
-                "final_response": "",
-                "messages": [],
+                "final_response": "Billing or credits exhausted: HTTP 402",
+                "messages": [
+                    {"role": "user", "content": "Return exactly OK"},
+                ],
                 "error": "HTTP 402 payment required",
-                "failed": True,
             }
             return "Error: HTTP 402 payment required"
 

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -133,6 +133,54 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
     ]
 
 
+def test_human_single_query_main_propagates_failed_turn_exit_code(monkeypatch):
+    calls = []
+
+    import cli as cli_mod
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = SimpleNamespace(print=lambda *_args, **_kwargs: None)
+            self.session_id = "failed-query-session"
+            self.agent = SimpleNamespace(
+                session_id="failed-query-session",
+                platform="cli",
+            )
+            self._last_turn_result = None
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            return True
+
+        def _show_security_advisories(self):
+            pass
+
+        def chat(self, query, images=None):
+            self._last_turn_result = {
+                "final_response": "",
+                "messages": [],
+                "error": "HTTP 402 payment required",
+                "failed": True,
+            }
+            return "Error: HTTP 402 payment required"
+
+        def _print_exit_summary(self, clear_screen=True):
+            calls.append("summary")
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        cli_mod,
+        "_finalize_single_query",
+        lambda fake_cli: calls.append(("finalize", fake_cli.session_id)),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(query="Return exactly OK", quiet=False, toolsets="terminal")
+
+    assert exc_info.value.code == 1
+    assert calls == ["summary", ("finalize", "failed-query-session")]
+
+
 def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatch):
     calls = []
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -302,6 +302,25 @@ class TestMcpTest:
         assert "Connected" in out
         assert "Tools discovered: 2" in out
 
+    def test_connection_failure_exits_nonzero(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "broken": {"command": "missing-mcp-server"},
+        })
+
+        def mock_probe(name, config, **kw):
+            raise ConnectionError("connection refused")
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_mcp_test(_make_args(name="broken"))
+
+        assert exc_info.value.code == 1
+        assert "Connection failed" in capsys.readouterr().out
+
     def test_probe_uses_configured_connect_timeout(self, monkeypatch):
         """OAuth-capable probes must not hard-code a short 30s timeout."""
         import asyncio


### PR DESCRIPTION
## Summary
- return a nonzero exit status when `hermes mcp test` cannot connect
- return a nonzero exit status when single-query chat aborts without an assistant response
- preserve normal successful and finalized-session behavior

## Why
Scheduled watchdogs and specialist jobs could print fatal MCP/provider errors while still exiting 0, masking the real incident class.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py tests/cli/test_single_query_session_finalize.py -q`
- 45 tests passed
- live broken MCP probe changed from exit 0 to exit 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Single-query commands now return a failure status when no response is produced or when a turn fails or is incomplete.
  * Failed single-query sessions still display their exit summary and finalize correctly.
  * MCP connection tests now return a failure status when the server connection cannot be established.

* **Tests**
  * Added coverage for failed single-query sessions and MCP connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->