### PR TITLE
chore: disable CodeRabbit auto-review (keep on-demand Disable Automatic CodeRabbit Reviews and Add Configuration Documentation review)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,18 @@
+# CodeRabbit configuration.
+#
+# Auto-review is DISABLED repo-wide: the app was enabled at the org level on
+# 2026-08-14 and immediately began reviewing every opened PR. This repo's
+# merge gate is CI ("All required checks pass") plus maintainer review —
+# CodeRabbit reviews carry no merge weight (protect-main ruleset requires
+# 0 approving reviews), so auto-firing on the full PR firehose adds comment
+# noise without gating value.
+#
+# The bot stays installed and summonable on demand: comment
+# `@coderabbitai review` on any PR to request a one-off review, or
+# `@coderabbitai ignore` to mute it on a PR it has already joined.
+#
+# To re-enable auto-review, flip `enabled: true` below (or delete this file —
+# the app default is on).
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
## Summary

Turns off CodeRabbit's auto-review while keeping the bot summonable on demand — `@coderabbitai review` on any PR still works.

## Context

The CodeRabbit GitHub App was enabled at the org level on 2026-08-14 (no corresponding commit — App-installation UI only) and began auto-reviewing every opened PR. Two observations from the first day:

- Its reviews carry no merge weight: the `protect-main` ruleset requires 0 approving reviews and gates only on the "All required checks pass" status (GitHub Actions), so auto-review adds comment volume to the PR firehose without gating value.
- On-demand is still available: with `reviews.auto_review.enabled: false`, the app stays installed and any maintainer can summon it per-PR with `@coderabbitai review`.

If the auto-review was enabled deliberately and is wanted, close this PR — it's a one-file toggle either way, and the file documents how to re-enable (`enabled: true` or delete the file).

## Changes

- `.coderabbit.yaml` (new): `reviews.auto_review.enabled: false`, with a comment block documenting the why, the on-demand escape hatch, and the re-enable path.

## Validation

| | |
|---|---|
| YAML parses | ✓ (`python -c "import yaml; yaml.safe_load(...)"`) |
| Schema | matches CodeRabbit's documented `reviews.auto_review.enabled` key |
| Merge gate impact | none — bot was never a required check |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic repository-wide CodeRabbit reviews.
  * Retained the ability to request reviews on demand.
  * Added configuration guidance for re-enabling automatic reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->