### PR TITLE
fix(auth): use global-root provider keys in named profiles

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6457,6 +6457,15 @@ def resolve_provider_client(
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
                 custom_key = _scoped_key_env(custom_key_env)
+            if not custom_key and custom_key_env:
+                try:
+                    from hermes_cli.config import get_env_value_prefer_dotenv
+
+                    custom_key = (
+                        get_env_value_prefer_dotenv(custom_key_env) or ""
+                    ).strip()
+                except Exception:
+                    custom_key = ""
             custom_key = custom_key or "no-key-required"
             if custom_key == "no-key-required":
                 logger.warning(

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2861,6 +2861,13 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
 def get_env_prefer_dotenv(key: str) -> str:
     env_file = load_env()
     raw = env_file.get(key, "").strip()
+    if not raw:
+        try:
+            from hermes_cli.config import get_global_root_env_value
+
+            raw = (get_global_root_env_value(key) or "").strip()
+        except Exception:
+            raw = ""
     scoped_value = (_get_secret(key, "") or "").strip()
     # If .env contains an unresolved op:// reference, prefer the
     # already-resolved value supplied by the active secret scope (or by

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -481,12 +481,12 @@ DEFAULT_CONTEXT_LENGTHS = {
     # https://platform.minimax.io/docs/api-reference/text-chat-openai
     "minimax-m3": 1000000,
     "minimax": 204800,
-    # GLM — GLM-5.2 ships with a 1M context window (verified empirically:
-    # needle-in-a-haystack retrieval at 789K prompt tokens succeeded with
-    # zero errors on api.z.ai/api/coding/paas/v4).  Older GLM models
-    # (5, 5.1, 5-turbo) are ~202K.  Longest-key-first substring matching
-    # ensures "glm-5.2" resolves to 1M while older variants still hit the
-    # generic 202K fallback.
+    # GLM — GLM-5.2 and GLM-5.3 ship with a 1M context window. Z.AI's
+    # GLM-5.3 model page documents 1M context and 128K maximum output.
+    # Older GLM models (5, 5.1, 5-turbo) are ~202K. Longest-key-first
+    # substring matching keeps 5.2 / 5.3 at 1M while older variants still
+    # hit the generic 202K fallback.
+    "glm-5.3": 1_048_576,
     "glm-5.2": 1_048_576,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -716,16 +716,17 @@ def _resolve_api_key_provider_secret(
 # Z.AI has separate billing for general vs coding plans, and global vs China
 # endpoints.  A key that works on one may return "Insufficient balance" on
 # another.  We probe at setup time and store the working endpoint.
-# Each entry lists candidate models to try in order — newer coding plan accounts
-# may only have access to recent models (glm-5.1, glm-5v-turbo) while older
-# ones still use glm-4.7.
+# Each entry lists candidate models to try in order. Newer coding plan accounts
+# may only have access to recent models (glm-5.3, glm-5.1, glm-5v-turbo) while
+# older ones still use glm-4.7. The Coding Plan chat endpoint may expose a new
+# model before the lagging /models listing does.
 
 ZAI_ENDPOINTS = [
     # (id, base_url, probe_models, label)
     ("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"],   "Global"),
     ("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"],   "China"),
-    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
-    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
+    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.3", "glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
+    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.3", "glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
 ]
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3832,6 +3832,7 @@ def load_env() -> Dict[str, str]:
 # (set_env_value, save_env, etc.) without relying on filesystem mtime
 # resolution.
 _env_cache: Optional[Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]] = None
+_global_env_cache: Optional[Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]] = None
 
 
 def invalidate_env_cache() -> None:
@@ -3842,8 +3843,112 @@ def invalidate_env_cache() -> None:
     filesystems with coarse mtime resolution. Reads invalidate naturally
     via the mtime/size check.
     """
-    global _env_cache
+    global _env_cache, _global_env_cache
     _env_cache = None
+    _global_env_cache = None
+
+
+def _global_root_env_path() -> Optional[Path]:
+    """Return the global-root ``.env`` when HERMES_HOME is a named profile.
+
+    ``None`` in classic mode (profile home == global root) so we do not
+    double-read the same file. Mirrors ``hermes_cli.auth._global_auth_file_path``.
+    """
+    try:
+        from hermes_constants import get_default_hermes_root, get_hermes_home
+
+        global_root = get_default_hermes_root()
+        profile_home = get_hermes_home()
+        if profile_home.resolve(strict=False) == global_root.resolve(strict=False):
+            return None
+        return global_root / ".env"
+    except Exception:
+        return None
+
+
+def _is_provider_api_key_env(key: str) -> bool:
+    """True for env vars that belong to a registered LLM provider.
+
+    Identity-scoped secrets (SUPERMEMORY_*, TELEGRAM_BOT_TOKEN, Discord
+    tokens) must stay profile-local. Only provider API keys fall back to
+    the global-root ``.env`` — the #18594 sibling of auth.json pool
+    fallback.
+    """
+    if not key:
+        return False
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        for pcfg in PROVIDER_REGISTRY.values():
+            if key in (getattr(pcfg, "api_key_env_vars", None) or ()):
+                return True
+    except Exception:
+        return key in {"GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"}
+    return False
+
+
+def load_global_root_env() -> Dict[str, str]:
+    """Read-only parse of the global-root ``.env`` for named-profile processes.
+
+    Under pytest, refuses the real user's ``~/.hermes/.env`` the same way
+    ``_load_global_auth_store`` does, so a mis-isolated test cannot leak
+    live credentials into the suite.
+    """
+    global _global_env_cache
+    path = _global_root_env_path()
+    if path is None:
+        return {}
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        real_home_env = os.environ.get("HOME", "")
+        if real_home_env:
+            real_env = Path(real_home_env) / ".hermes" / ".env"
+            try:
+                if path.resolve(strict=False) == real_env.resolve(strict=False):
+                    return {}
+            except Exception:
+                pass
+
+    try:
+        mtime = path.stat().st_mtime
+        size = path.stat().st_size
+        cache_key = (str(path), mtime, size)
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        cache_key = None
+
+    if cache_key is not None and _global_env_cache is not None:
+        cached_key, cached_vars = _global_env_cache
+        if cached_key == cache_key:
+            return dict(cached_vars)
+
+    env_vars: Dict[str, str] = {}
+    if path.exists():
+        open_kw = {"encoding": "utf-8-sig", "errors": "replace"}
+        with open(path, **open_kw) as f:
+            raw_lines = f.readlines()
+        for line in _sanitize_env_lines(raw_lines):
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                if line.startswith("export "):
+                    line = line[7:]
+                key, _, value = line.partition("=")
+                env_vars[key.strip()] = _parse_env_value(value)
+
+    if cache_key is not None:
+        _global_env_cache = (cache_key, dict(env_vars))
+    return env_vars
+
+
+def get_global_root_env_value(key: str) -> Optional[str]:
+    """Return a provider API key from the global-root ``.env``, or None.
+
+    Non-provider keys are never inherited. Empty / missing values return None.
+    """
+    if not _is_provider_api_key_env(key):
+        return None
+    val = (load_global_root_env().get(key) or "").strip()
+    return val or None
 
 
 def _sanitize_env_lines(lines: list) -> list:
@@ -4282,11 +4387,23 @@ def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
     that, under an active profile scope (multiplexed gateway turn), this read
     is scope-checked rather than leaking another profile's raw ``os.environ``
     value — matching the credential-pool seeding path's behaviour.
+
+    When ``HERMES_HOME`` is a named profile, provider API keys that are
+    missing from the profile ``.env`` fall back to the global-root
+    ``~/.hermes/.env`` (the #18594 sibling of ``read_credential_pool``).
+    Identity-scoped secrets are not inherited.
     """
     env_vars = load_env()
     val = env_vars.get(key)
     if val:
         return val
+    # Named-profile HERMES_HOME only sees <profile>/.env via load_env().
+    # Provider keys configured at the global root (the live Z.AI / GLM
+    # coding-plan key) must still resolve — otherwise /model glm-5.3
+    # succeeds and the next turn 401s with Bearer no-key-required.
+    global_val = get_global_root_env_value(key)
+    if global_val:
+        return global_val
     try:
         from agent.secret_scope import (
             UnscopedSecretError,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1344,6 +1344,7 @@ def switch_model(
     new_model = raw_input.strip()
     target_provider = current_provider
     resolved_moa_preset = False
+    config_routed = False
 
     # =================================================================
     # PATH A: Explicit --provider given
@@ -1474,6 +1475,21 @@ def switch_model(
         if alias_result is not None:
             _, new_model, resolved_alias = alias_result
 
+        if not resolved_alias:
+            configured_matches = _configured_provider_matches(
+                new_model, user_providers, custom_providers
+            )
+            explicit_candidates = {
+                target_provider,
+                explicit_provider.strip().lower(),
+                f"custom:{explicit_provider.strip().lower()}",
+            }
+            for candidate in explicit_candidates:
+                if candidate in configured_matches:
+                    new_model = configured_matches[candidate]
+                    config_routed = True
+                    break
+
     # =================================================================
     # PATH B: No explicit provider — resolve from model input
     # =================================================================
@@ -1603,7 +1619,6 @@ def switch_model(
         # detection.  Unlike step e this is deliberately NOT gated on
         # ``not is_custom`` — switching from a local/custom provider A to a
         # configured provider B that declares the typed model is the point.
-        config_routed = False
         if (
             not resolved_alias
             and not resolved_in_current_catalog
@@ -1816,6 +1831,20 @@ def switch_model(
             "recognized": False,
             "message": f"Could not validate `{new_model}`: {e}",
         }
+
+    # An exact saved declaration is authoritative for model identity, but not
+    # for endpoint health. Keep validation and all hard failures; suppress only
+    # the non-blocking discovery warning emitted when an optional custom
+    # endpoint /models listing is unavailable or lags the inference endpoint.
+    validation_message = str(validation.get("message") or "")
+    if (
+        config_routed
+        and validation.get("accepted")
+        and not validation.get("recognized")
+        and "custom endpoint" in validation_message.lower()
+        and "model listing" in validation_message.lower()
+    ):
+        validation = {**validation, "message": None}
 
     # Override rejection if model is in the user's saved provider config.
     # API /v1/models may not list cloud/aliased models even though the server supports them.

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -328,6 +328,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3.1-flash-lite-preview",
     ],
     "zai": [
+        "glm-5.3",
         "glm-5.2",
         "glm-5.1",
         "glm-5",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -723,6 +723,19 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             # Resolve the API key from the env var name stored in key_env
             key_env = str(entry.get("key_env", "") or "").strip()
             resolved_api_key = _getenv(key_env, "").strip() if key_env else ""
+            # Profile-scoped getenv misses keys that live only in the
+            # global-root .env (named-profile HERMES_HOME). Re-read through
+            # the provider-key dotenv chain so custom:zai / providers.zai
+            # does not send Bearer no-key-required.
+            if not resolved_api_key and key_env:
+                try:
+                    from hermes_cli.config import get_env_value_prefer_dotenv
+
+                    resolved_api_key = (
+                        get_env_value_prefer_dotenv(key_env) or ""
+                    ).strip()
+                except Exception:
+                    resolved_api_key = ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
                 resolved_api_key = str(entry.get("api_key", "") or "").strip()
@@ -739,6 +752,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         "name": entry.get("name", ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
+                        "key_env": key_env,
                         "model": entry.get("default_model", ""),
                     }
                     extra_body = entry.get("extra_body")
@@ -1139,10 +1153,20 @@ def _resolve_named_custom_runtime(
 
     _cp_is_openai_url   = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
     _cp_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
+    _cp_key_env = str(custom_provider.get("key_env", "") or "").strip()
+    _cp_dotenv_key = ""
+    if _cp_key_env:
+        try:
+            from hermes_cli.config import get_env_value_prefer_dotenv
+
+            _cp_dotenv_key = (get_env_value_prefer_dotenv(_cp_key_env) or "").strip()
+        except Exception:
+            _cp_dotenv_key = ""
     api_key_candidates = [
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
-        _getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+        _getenv(_cp_key_env, "").strip(),
+        _cp_dotenv_key,
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).
         (_getenv("OPENAI_API_KEY", "").strip()     if _cp_is_openai_url  else ""),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -99,7 +99,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "google/gemini-3-flash-preview", "google/gemini-3.1-flash-lite-preview",
         "google/gemini-2.5-pro", "google/gemini-2.5-flash",
     ],
-    "zai": ["glm-5.2", "glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
+    "zai": ["glm-5.3", "glm-5.2", "glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k3", "kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "kimi-coding-cn": ["kimi-k3", "kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "stepfun": ["step-3.5-flash", "step-3.5-flash-2603"],

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -22,6 +22,10 @@ two enabled levels — ``high`` and ``max`` — on the OpenAI-compatible endpoin
 (per Z.AI / BigModel docs).  Hermes' richer effort scale is collapsed onto
 those two so the user's effort preference actually reaches the model instead
 of being silently dropped.
+
+GLM-5.3 dropped ``thinking.type: "disabled"``. Its native effort levels are
+``low``, ``high``, and ``max``. Turning thinking off maps to enabled + low,
+the lightest legal request, instead of sending a payload the endpoint rejects.
 """
 
 from __future__ import annotations
@@ -59,6 +63,31 @@ def _is_glm_5_2(model: str | None) -> bool:
     return any(token in m for token in ("glm-5.2", "glm-5-2", "glm-5p2"))
 
 
+def _is_glm_5_3(model: str | None) -> bool:
+    """Detect GLM-5.3 across canonical, relay, and vendor-prefixed forms."""
+    m = (model or "").strip().lower()
+    if not m:
+        return False
+    return any(token in m for token in ("glm-5.3", "glm-5-3", "glm-5p3"))
+
+
+def _glm_5_3_reasoning_effort(reasoning_config: dict | None) -> str | None:
+    """Map Hermes effort onto GLM-5.3's low / high / max contract."""
+    if not isinstance(reasoning_config, dict):
+        return None
+    if reasoning_config.get("enabled") is False:
+        return "low"
+
+    effort = (reasoning_config.get("effort") or "").strip().lower()
+    if not effort:
+        return None
+    if effort in {"none", "minimal", "low"}:
+        return "low"
+    if effort in {"xhigh", "max", "ultra"}:
+        return "max"
+    return "high"
+
+
 def _glm_5_2_reasoning_effort(reasoning_config: dict | None) -> str | None:
     """Map Hermes reasoning effort onto GLM-5.2's native ``high``/``max``.
 
@@ -83,7 +112,7 @@ def _glm_5_2_reasoning_effort(reasoning_config: dict | None) -> str | None:
 
 
 class ZaiProfile(ProviderProfile):
-    """Z.AI / GLM — extra_body.thinking on/off + GLM-5.2 reasoning_effort."""
+    """Z.AI / GLM — thinking controls plus GLM-5.2 / 5.3 effort."""
 
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
@@ -91,7 +120,19 @@ class ZaiProfile(ProviderProfile):
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}
 
-        if not _model_supports_thinking(model) and not _is_glm_5_2(model):
+        if (
+            not _model_supports_thinking(model)
+            and not _is_glm_5_2(model)
+            and not _is_glm_5_3(model)
+        ):
+            return extra_body, top_level
+
+        if _is_glm_5_3(model):
+            if isinstance(reasoning_config, dict):
+                extra_body["thinking"] = {"type": "enabled"}
+                effort = _glm_5_3_reasoning_effort(reasoning_config)
+                if effort is not None:
+                    top_level["reasoning_effort"] = effort
             return extra_body, top_level
 
         # Only emit when the user expressed a preference; omitting the field
@@ -116,6 +157,7 @@ zai = ZaiProfile(
     description="Z.AI / GLM — Zhipu AI models",
     signup_url="https://z.ai/",
     fallback_models=(
+        "glm-5.3",
         "glm-5.2",
         "glm-5",
         "glm-4-9b",

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -288,3 +288,115 @@ def test_write_pool_never_merges_cooldown_onto_reauthed_entry(classic_env):
     assert persisted["access_token"] == "sk-new"
     assert persisted.get("last_status") != "exhausted"
     assert persisted.get("last_error_code") is None
+
+
+# ---------------------------------------------------------------------------
+# Global-root .env fallback for provider keys (named-profile HERMES_HOME)
+# ---------------------------------------------------------------------------
+# Sibling of #18594: auth.json pool entries fall back to the global root, but
+# env-sourced Z.AI rows store only a fingerprint. The live key lives in
+# ~/.hermes/.env. A profile gateway (HERMES_HOME=~/.hermes/profiles/cfo)
+# previously read only the profile .env, sent Bearer no-key-required, and
+# Telegram showed "unexpected error" / "Provider authentication failed"
+# after /model glm-5.3.
+
+
+def test_profile_resolves_zai_key_from_global_root_env(profile_env, monkeypatch):
+    """Provider keys configured only at the global root must resolve in-profile."""
+    (profile_env["global"] / ".env").write_text(
+        "ZAI_API_KEY=sk-global-zai-root\n", encoding="utf-8"
+    )
+    (profile_env["profile"] / ".env").write_text(
+        "KIMI_API_KEY=sk-profile-only\n", encoding="utf-8"
+    )
+    for key in ("ZAI_API_KEY", "GLM_API_KEY", "Z_AI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    from hermes_cli.config import get_env_value_prefer_dotenv, invalidate_env_cache
+    from hermes_cli.auth import PROVIDER_REGISTRY, _resolve_api_key_provider_secret
+
+    invalidate_env_cache()
+
+    assert get_env_value_prefer_dotenv("ZAI_API_KEY") == "sk-global-zai-root"
+
+    key, source = _resolve_api_key_provider_secret("zai", PROVIDER_REGISTRY["zai"])
+    assert key == "sk-global-zai-root"
+    assert source == "ZAI_API_KEY"
+
+
+def test_profile_env_wins_over_global_root_provider_key(profile_env, monkeypatch):
+    (profile_env["global"] / ".env").write_text(
+        "ZAI_API_KEY=sk-global-zai\n", encoding="utf-8"
+    )
+    (profile_env["profile"] / ".env").write_text(
+        "ZAI_API_KEY=sk-profile-zai\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("ZAI_API_KEY", raising=False)
+
+    from hermes_cli.config import get_env_value_prefer_dotenv, invalidate_env_cache
+
+    invalidate_env_cache()
+    assert get_env_value_prefer_dotenv("ZAI_API_KEY") == "sk-profile-zai"
+
+
+def test_global_root_env_does_not_inherit_non_provider_keys(profile_env, monkeypatch):
+    """Identity-scoped secrets stay profile-local; only provider API keys fall back."""
+    (profile_env["global"] / ".env").write_text(
+        "ZAI_API_KEY=sk-global-zai\n"
+        "SUPERMEMORY_API_KEY=sm-global\n"
+        "TELEGRAM_BOT_TOKEN=tg-global\n",
+        encoding="utf-8",
+    )
+    (profile_env["profile"] / ".env").write_text(
+        "KIMI_API_KEY=sk-kimi\n", encoding="utf-8"
+    )
+    for key in (
+        "ZAI_API_KEY",
+        "SUPERMEMORY_API_KEY",
+        "TELEGRAM_BOT_TOKEN",
+        "GLM_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    from hermes_cli.config import (
+        get_env_value,
+        get_env_value_prefer_dotenv,
+        invalidate_env_cache,
+    )
+
+    invalidate_env_cache()
+    assert get_env_value_prefer_dotenv("ZAI_API_KEY") == "sk-global-zai"
+    assert not get_env_value_prefer_dotenv("SUPERMEMORY_API_KEY")
+    assert not get_env_value("SUPERMEMORY_API_KEY")
+    assert not get_env_value("TELEGRAM_BOT_TOKEN")
+
+
+def test_named_custom_zai_uses_global_root_key(profile_env, monkeypatch):
+    """config.yaml providers.zai (custom:zai) must not 401 with no-key-required."""
+    (profile_env["global"] / ".env").write_text(
+        "ZAI_API_KEY=sk-global-zai-root\n", encoding="utf-8"
+    )
+    (profile_env["profile"] / ".env").write_text(
+        "KIMI_API_KEY=sk-profile-only\n", encoding="utf-8"
+    )
+    (profile_env["profile"] / "config.yaml").write_text(
+        "providers:\n"
+        "  zai:\n"
+        "    api: https://api.z.ai/api/coding/paas/v4\n"
+        "    default_model: glm-5.3\n"
+        "    key_env: ZAI_API_KEY\n"
+        "    models:\n"
+        "      - glm-5.3\n",
+        encoding="utf-8",
+    )
+    for key in ("ZAI_API_KEY", "GLM_API_KEY", "Z_AI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    from hermes_cli.config import invalidate_env_cache
+    from hermes_cli.runtime_provider import _get_named_custom_provider
+
+    invalidate_env_cache()
+    entry = _get_named_custom_provider("custom:zai")
+    assert entry is not None
+    assert entry.get("base_url") == "https://api.z.ai/api/coding/paas/v4"
+    assert entry.get("api_key") == "sk-global-zai-root"

--- a/tests/hermes_cli/test_model_switch_configured_provider_routing.py
+++ b/tests/hermes_cli/test_model_switch_configured_provider_routing.py
@@ -48,6 +48,7 @@ def _run_switch(
     validation=_ACCEPTED,
     current_model="old-model",
     current_base_url="",
+    explicit_provider="",
 ):
     """Drive ``switch_model`` with the resolution chain mocked out.
 
@@ -79,6 +80,7 @@ def _run_switch(
             current_base_url=current_base_url,
             user_providers=user_providers or {},
             custom_providers=custom_providers or [],
+            explicit_provider=explicit_provider,
         )
 
 
@@ -103,6 +105,74 @@ def test_default_model_only_declaration_routes():
     assert result.success is True, result.error_message
     assert result.target_provider == "local-ollama"
     assert result.new_model == "qwen3.5-4b"
+
+
+def test_exact_configured_model_does_not_warn_when_models_listing_lags():
+    """An exact saved declaration is authoritative for model identity.
+
+    Some OpenAI-compatible endpoints accept a newly launched model before
+    exposing it from ``/models``.  A failed discovery probe must not produce a
+    misleading custom-endpoint warning for a model the operator explicitly
+    declared in that provider's configuration.
+    """
+    user_providers = {
+        "zai": {
+            "name": "Z.AI",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "default_model": "glm-5.3",
+            "key_env": "ZAI_API_KEY",
+            "models": ["glm-5.3"],
+        }
+    }
+    unavailable_listing = {
+        "accepted": True,
+        "persist": True,
+        "recognized": False,
+        "message": "could not reach this custom endpoint's model listing",
+    }
+
+    result = _run_switch(
+        raw_input="glm-5.3",
+        current_provider="custom:zai",
+        current_model="glm-5.2",
+        current_base_url="https://api.z.ai/api/coding/paas/v4",
+        user_providers=user_providers,
+        validation=unavailable_listing,
+    )
+
+    assert result.success is True, result.error_message
+    assert result.target_provider == "zai"
+    assert result.new_model == "glm-5.3"
+    assert result.warning_message == ""
+
+
+def test_explicit_configured_model_does_not_warn_when_models_listing_lags():
+    user_providers = {
+        "zai": {
+            "name": "Z.AI",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "key_env": "ZAI_API_KEY",
+            "models": ["glm-5.3"],
+        }
+    }
+    unavailable_listing = {
+        "accepted": True,
+        "persist": True,
+        "recognized": False,
+        "message": "could not reach this custom endpoint's model listing",
+    }
+
+    result = _run_switch(
+        raw_input="glm-5.3",
+        current_provider="kimi-coding",
+        user_providers=user_providers,
+        validation=unavailable_listing,
+        explicit_provider="zai",
+    )
+
+    assert result.success is True, result.error_message
+    assert result.target_provider == "zai"
+    assert result.warning_message == ""
 
 
 

--- a/tests/hermes_cli/test_zai_glm53_catalog.py
+++ b/tests/hermes_cli/test_zai_glm53_catalog.py
@@ -1,0 +1,39 @@
+"""Regression coverage for direct Z.AI GLM-5.3 discovery and context."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from agent.model_metadata import get_model_context_length
+from hermes_cli.models import _PROVIDER_MODELS, validate_requested_model
+
+
+def test_glm_53_uses_one_million_token_context() -> None:
+    with (
+        patch("agent.model_metadata.get_cached_context_length", return_value=None),
+        patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+        patch("agent.models_dev.lookup_models_dev_context", return_value=None),
+    ):
+        assert get_model_context_length("glm-5.3", provider="zai") == 1_048_576
+
+
+def test_zai_picker_leads_with_glm_53() -> None:
+    assert _PROVIDER_MODELS["zai"][0] == "glm-5.3"
+
+
+def test_zai_validation_uses_curated_glm_53_when_models_endpoint_lags() -> None:
+    with patch("hermes_cli.models.fetch_api_models", return_value=None):
+        result = validate_requested_model(
+            "glm-5.3",
+            "zai",
+            api_key="test-key",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        )
+
+    assert result == {
+        "accepted": True,
+        "persist": True,
+        "recognized": True,
+        "message": None,
+    }

--- a/tests/plugins/model_providers/test_zai_profile.py
+++ b/tests/plugins/model_providers/test_zai_profile.py
@@ -176,3 +176,17 @@ class TestZaiFullKwargsIntegration:
         )
         assert kwargs["reasoning_effort"] == "max"
         assert kwargs["extra_body"]["thinking"] == {"type": "enabled"}
+
+
+class TestZaiGLM53Contract:
+    def test_disabled_thinking_becomes_enabled_low(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="glm-5.3",
+        )
+
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": "low"}
+
+    def test_fallback_catalog_leads_with_glm_53(self, zai_profile):
+        assert zai_profile.fallback_models[0] == "glm-5.3"


### PR DESCRIPTION
## What does this PR do?

Switching a named-profile Telegram bot to `glm-5.3` confirmed the model, then the next "Hello" came back as an unexpected error / provider authentication failed. The request went to Z.AI's coding endpoint with `Authorization: Bearer no-key-required` and HTTP 401.

The key was already configured at the global root (`~/.hermes/.env` and env-sourced `auth.json` fingerprints). The profile gateway (`HERMES_HOME=~/.hermes/profiles/<name>`) only read the profile `.env`, so resolution returned empty. `auth.json` already falls back to the global root (#18594); `.env` did not.

This PR fills that gap for registered provider API keys only. Profile values still win. Identity-scoped secrets (`SUPERMEMORY_*`, Telegram/Discord tokens) stay profile-local. `custom:zai` / `providers.zai` `key_env` uses the same chain so the named-custom path does not paper over a miss with `no-key-required`.

A second commit recognizes GLM-5.3 in the catalog and maps Hermes reasoning-off to `enabled` + `low` (the endpoint dropped `thinking.type: disabled`). Several open PRs already cover that catalog/thinking work; the unique fix here is the named-profile credential miss.

## Related Issue

Related: #18594
Related: https://github.com/NousResearch/hermes-agent/pull/84097
Related: https://github.com/NousResearch/hermes-agent/pull/85891
Related: https://github.com/NousResearch/hermes-agent/pull/86088

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Named-profile provider-key reads fall back to the global-root `.env` after the profile `.env` miss.
- `custom:zai` / `providers.zai` `key_env` resolution uses that chain instead of sending a placeholder bearer token.
- GLM-5.3 catalog, 1M context, coding-plan probe order, and thinking-wire mapping.

## How to Test

1. `python -m pytest tests/hermes_cli/test_auth_profile_fallback.py tests/tools/test_credential_pool_env_fallback.py tests/hermes_cli/test_get_env_value_scope.py tests/hermes_cli/test_zai_glm53_catalog.py tests/plugins/model_providers/test_zai_profile.py tests/hermes_cli/test_model_switch_configured_provider_routing.py tests/hermes_cli/test_runtime_provider_resolution.py tests/agent/test_auxiliary_named_custom_providers.py -q`
2. With `HERMES_HOME` pointed at a named profile that has no `ZAI_API_KEY` / `GLM_API_KEY` in its `.env`, and those keys present only in the global-root `.env`, `_resolve_api_key_provider_secret("zai")` and `_get_named_custom_provider("custom:zai")` must return the global key.
3. Confirm `SUPERMEMORY_API_KEY` / `TELEGRAM_BOT_TOKEN` present only in the global-root `.env` are not inherited.

Local result: the new fallback tests failed before the change (prefer_dotenv returned `None`; `custom:zai` api_key was empty) and passed after. 68 + 179 related tests passed. Against the live cfo profile home, zai resolution went from empty to a usable key (source `GLM_API_KEY`) without printing the secret.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux 7.0.0-28-generic), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Gateway logs for the failing Telegram turn: `named custom provider 'zai' has no resolvable api_key` then `HTTP 401: token expired or incorrect` against `https://api.z.ai/api/coding/paas/v4` with `Authorization: Bearer no-key-required`. After the fix, the same profile home resolves a usable Z.AI key from the global-root `.env`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
