### PR TITLE
fix(vertex): detect ADC credentials and surface Vertex models in desktop picker

### DIFF
--- a/agent/vertex_adapter.py
+++ b/agent/vertex_adapter.py
@@ -19,6 +19,7 @@ under the ``vertex:`` section; env vars take precedence over config.yaml.
 import logging
 import os
 import time
+from pathlib import Path
 from typing import Optional, Tuple
 
 from agent.secret_scope import get_secret as _get_secret, is_multiplex_active
@@ -217,12 +218,24 @@ def has_vertex_credentials() -> bool:
     """Fast check for whether Vertex credentials appear configured.
 
     No network calls and no google-auth import — safe for provider
-    auto-detection and setup-status display. True when either a service
-    account JSON path is resolvable, or an explicit project ID is configured
-    (env or config.yaml, implying ADC is intended).
+    auto-detection and setup-status display. True when a service account
+    JSON path is resolvable, an explicit project ID is configured (env or
+    config.yaml, implying ADC is intended), or the well-known ADC file
+    written by ``gcloud auth application-default login`` exists. The ADC
+    check matters for the common Gemini CLI setup: credentials live only in
+    ``~/.config/gcloud/application_default_credentials.json`` (no env var,
+    no explicit project), and without it ``get_vertex_credentials`` succeeds
+    via ``google.auth.default()`` while this gate reports False, silently
+    hiding Vertex from the model picker.
     """
     if _resolve_credentials_path(None):
         return True
     if _resolve_project_override():
         return True
+    try:
+        adc = Path.home() / ".config" / "gcloud" / "application_default_credentials.json"
+        if adc.exists():
+            return True
+    except Exception:
+        pass
     return False

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1955,6 +1955,26 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     except Exception:
         pass
 
+    # 5. Providers named in explicit model-routing slots of config.yaml
+    # (the fallback chain — fallback_providers merged with legacy
+    # fallback_model — and billing_provider) are explicit user
+    # configuration even when their credentials are ambient (e.g. Vertex
+    # ADC). Without this, desktop explicit-only pickers hide a provider
+    # the user deliberately wired into their fallback chain.
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        for entry in get_fallback_chain(load_config()):
+            if str(entry.get("provider") or "").strip().lower() == normalized:
+                return True
+        billing = load_config().get("billing_provider")
+        if isinstance(billing, dict):
+            if str(billing.get("provider") or "").strip().lower() == normalized:
+                return True
+    except Exception:
+        pass
+
     return False
 
 
@@ -7114,6 +7134,8 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
+    if target == "vertex":
+        return _get_vertex_auth_status()
     # API-key providers
     pconfig = PROVIDER_REGISTRY.get(target)
     if pconfig and pconfig.auth_type == "api_key":
@@ -7126,6 +7148,52 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         except ImportError:
             return {"logged_in": False, "provider": target, "error": "boto3 not installed"}
     return {"logged_in": False}
+
+
+def _get_vertex_auth_status() -> Dict[str, Any]:
+    """Structural auth status for Google Vertex AI.
+
+    Vertex auth is OAuth2 via a service-account JSON or Application Default
+    Credentials (ADC) — there is no static API key to spot-check. The check
+    is purely structural (file existence + google-auth importable); it never
+    mints a token or touches the network, keeping CLI/menu latency flat the
+    same way _get_azure_foundry_auth_status does for Entra ID.
+
+    Covers the three resolution paths of agent.vertex_adapter:
+      * explicit credentials file (VERTEX_CREDENTIALS_PATH /
+        GOOGLE_APPLICATION_CREDENTIALS),
+      * explicit project override (env or config.yaml — implies ADC intent),
+      * the well-known ADC file written by
+        gcloud auth application-default login — required so ADC-only
+        setups (the common Gemini CLI case) show as configured.
+    """
+    info: Dict[str, Any] = {"provider": "vertex", "logged_in": False}
+    try:
+        from agent import vertex_adapter
+    except Exception:
+        info["error"] = "vertex adapter unavailable (google-auth missing?)"
+        return info
+
+    try:
+        creds_path = vertex_adapter._resolve_credentials_path(None)
+        project_override = vertex_adapter._resolve_project_override()
+    except Exception:
+        creds_path, project_override = None, None
+
+    adc_path = ""
+    if not creds_path and not project_override:
+        try:
+            candidate = Path.home() / ".config" / "gcloud" / "application_default_credentials.json"
+            if candidate.exists():
+                adc_path = str(candidate)
+        except Exception:
+            adc_path = ""
+
+    info["credentials_path"] = creds_path or ""
+    info["adc_path"] = adc_path
+    info["project_override"] = project_override or ""
+    info["logged_in"] = bool(creds_path or project_override or adc_path)
+    return info
 
 
 def _get_azure_foundry_auth_status() -> Dict[str, Any]:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -599,6 +599,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # Entries validated live against a GCP project (global region,
     # HTTP 200) as of 2026-07-21 (PR #68767).
     "vertex": [
+        "google/gemini-3.7-flash",
         "google/gemini-3.1-pro-preview",
         "google/gemini-3-pro-preview",
         "google/gemini-3.6-flash",

--- a/tests/hermes_cli/test_vertex_auth_and_picker.py
+++ b/tests/hermes_cli/test_vertex_auth_and_picker.py
@@ -1,0 +1,39 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agent.vertex_adapter import has_vertex_credentials
+from hermes_cli.auth import get_auth_status, is_provider_explicitly_configured
+from hermes_cli.models import _PROVIDER_MODELS
+
+
+class TestVertexAuthAndPicker(unittest.TestCase):
+    def test_has_vertex_credentials_with_adc_file(self):
+        with patch("pathlib.Path.exists", return_value=True):
+            self.assertTrue(has_vertex_credentials())
+
+    def test_get_vertex_auth_status_logged_in(self):
+        with patch("pathlib.Path.exists", return_value=True):
+            status = get_auth_status("vertex")
+            self.assertEqual(status.get("provider"), "vertex")
+            self.assertTrue(status.get("logged_in"))
+
+    def test_vertex_in_fallback_chain_is_explicitly_configured(self):
+        fake_cfg = {
+            "fallback_providers": [
+                {"provider": "openai-codex", "model": "gpt-5.6-luna"},
+                {"provider": "vertex", "model": "google/gemini-3.7-flash"},
+            ]
+        }
+        with patch("hermes_cli.config.load_config", return_value=fake_cfg):
+            self.assertTrue(is_provider_explicitly_configured("vertex"))
+            self.assertFalse(is_provider_explicitly_configured("unknown-provider"))
+
+    def test_vertex_curated_models_contains_gemini_37_flash(self):
+        vertex_models = _PROVIDER_MODELS.get("vertex", [])
+        self.assertIn("google/gemini-3.7-flash", vertex_models)
+        self.assertEqual(vertex_models[0], "google/gemini-3.7-flash")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR resolves three interconnected issues where Google Vertex AI models (configured via Application Default Credentials, e.g. from `gcloud auth application-default login` or the Gemini CLI) fail to surface in the desktop model picker and status APIs despite working properly at runtime:

1. **ADC credential detection**: `has_vertex_credentials()` in `agent/vertex_adapter.py` only checked for explicit env vars (`VERTEX_CREDENTIALS_PATH` / `GOOGLE_APPLICATION_CREDENTIALS`) or explicit project overrides. In common ADC-only setups, `get_vertex_credentials()` succeeds via `google.auth.default()` while `has_vertex_credentials()` returned `False`, silently skipping Vertex in provider discovery.
2. **Structural auth status**: Added `_get_vertex_auth_status()` in `hermes_cli/auth.py` (mirroring Azure Foundry pattern) to report `logged_in: True` based on local credential file existence without blocking on network requests.
3. **Explicit configuration recognition**: Updated `is_provider_explicitly_configured()` in `hermes_cli/auth.py` to treat providers in the `fallback_providers` / `fallback_model` chain or `billing_provider` as explicitly configured so desktop `explicit_only` pickers do not hide them.
4. **Curated models**: Added `google/gemini-3.7-flash` to the curated Vertex model catalog in `hermes_cli/models.py`.

## Test Plan

- [x] Added unit tests in `tests/hermes_cli/test_vertex_auth_and_picker.py` covering:
  - `has_vertex_credentials()` with ADC file
  - `get_auth_status("vertex")` returning `logged_in: True`
  - `is_provider_explicitly_configured("vertex")` recognizing fallback chain entry
  - Curated model catalog containing `google/gemini-3.7-flash`
- [x] Verified locally with `python -m unittest tests/hermes_cli/test_vertex_auth_and_picker.py` (all 4 tests pass).