### PR TITLE
fix(discord): honor auto_thread_free_response in routing

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -8124,7 +8124,20 @@ class DiscordAdapter(BasePlatformAdapter):
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels = self._get_no_thread_channels()
-            skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
+            auto_thread_free_response_raw = self._config_value(
+                "auto_thread_free_response",
+                False,
+                env_key="DISCORD_AUTO_THREAD_FREE_RESPONSE",
+            )
+            if isinstance(auto_thread_free_response_raw, str):
+                auto_thread_free_response = auto_thread_free_response_raw.lower() in {
+                    "true", "1", "yes",
+                }
+            else:
+                auto_thread_free_response = bool(auto_thread_free_response_raw)
+            skip_thread = bool(channel_keys & no_thread_channels) or (
+                is_free_channel and not auto_thread_free_response
+            )
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
@@ -10367,6 +10380,14 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
             os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
     if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
         os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+    if "auto_thread_free_response" in discord_cfg:
+        seeded_extra["auto_thread_free_response"] = discord_cfg[
+            "auto_thread_free_response"
+        ]
+        if not _skip_env_bridge and not os.getenv("DISCORD_AUTO_THREAD_FREE_RESPONSE"):
+            os.environ["DISCORD_AUTO_THREAD_FREE_RESPONSE"] = str(
+                discord_cfg["auto_thread_free_response"]
+            ).lower()
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
         os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
     backfill_cfg = discord_cfg.get("missed_message_backfill")

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -110,6 +110,7 @@ def adapter(monkeypatch):
         "DISCORD_THREAD_REQUIRE_MENTION",
         "DISCORD_FREE_RESPONSE_CHANNELS",
         "DISCORD_AUTO_THREAD",
+        "DISCORD_AUTO_THREAD_FREE_RESPONSE",
         "DISCORD_NO_THREAD_CHANNELS",
         "DISCORD_ALLOWED_CHANNELS",
         "DISCORD_IGNORED_CHANNELS",
@@ -305,6 +306,49 @@ async def test_discord_free_response_channel_skips_auto_thread(adapter, monkeypa
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "casual chat in free-response channel"
     assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_discord_free_response_channel_auto_threads_when_opted_in(adapter, monkeypatch):
+    """Explicit opt-in makes a free-response parent create a thread."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD_FREE_RESPONSE", "true")
+    thread = FakeThread(channel_id=456, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=thread)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="new task in free-response parent",
+    )
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once_with(message)
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "456"
+    assert event.source.chat_type == "thread"
+    assert event.source.auto_thread_created is True
+
+
+@pytest.mark.asyncio
+async def test_discord_free_response_auto_thread_uses_platform_extra(adapter, monkeypatch):
+    """The supported YAML config path reaches routing through config.extra."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    adapter.config.extra["auto_thread_free_response"] = True
+    thread = FakeThread(channel_id=456, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=thread)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="new task from YAML config",
+    )
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once_with(message)
+    assert adapter.handle_message.await_args.args[0].source.chat_id == "456"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- restore the existing `discord.auto_thread_free_response` opt-in in the current plugin Discord adapter
- seed the supported YAML key into `PlatformConfig.extra` while preserving legacy env compatibility
- keep free-response channels inline by default and keep `no_thread_channels` as the hard override
- add focused regression coverage for env and config-extra routing

## Reproduction
With `free_response_channels` containing the parent, `auto_thread: true`, and `auto_thread_free_response: true`, current `main` still executes:

```python
skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
```

That unconditional `or is_free_channel` makes the public opt-in ineffective and routes replies into the parent channel.

## Verification
- `python -m pytest tests/gateway/test_discord_free_response.py -q -o addopts=` → 23 passed
- focused routing/config selection → 4 passed
- direct `_apply_yaml_config` probe confirms `auto_thread_free_response` is seeded and legacy env is bridged
- `git diff --check`

## Related work
Several older PRs address similar behavior using alternate config names or pre-plugin paths. This patch targets the current `plugins/platforms/discord/adapter.py` implementation and the already-present public key `auto_thread_free_response`.
