### PR TITLE
fix(agent): stop doubling the profile path in the system-prompt hint (#72894)

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -50,7 +50,7 @@ from agent.prompt_builder import (
     drain_truncation_warnings,
 )
 from agent.runtime_cwd import resolve_context_cwd
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from pathlib import Path
 from utils import is_truthy_value
 
@@ -586,10 +586,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # paths. Without an agent home, keep the ambient resolution byte-identical
     # to the legacy behavior (and patchable via this module's get_hermes_home).
     if _agent_home_path is not None:
-        from hermes_constants import get_default_hermes_root as _root_fn
-
         _home_str = str(_agent_home_path)
-        _root_str = str(_root_fn())
+        _root_str = str(get_default_hermes_root())
     else:
         _home_str = _root_str = str(get_hermes_home())
     if active_profile == "default":
@@ -602,11 +600,20 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             "you to."
         )
     else:
+        # A non-default name is only ever returned when the resolved home is
+        # ALREADY <root>/profiles/<name> — that is exactly how both
+        # _profile_name_for_home() and _resolve_active_profile_name() derive
+        # it. So the profile home is the session home itself; appending
+        # /profiles/<name> again doubled it (#72894). The default profile's
+        # data sits at the ROOT (get_default_hermes_root()), which in ambient
+        # profile mode is NOT get_hermes_home().
+        profile_home = _home_str
+        default_root = get_default_hermes_root()
         post_workspace_parts.append(
             f"Active Hermes profile: {active_profile}. This session reads "
-            f"and writes {_home_str}/. The default "
-            f"profile's data lives at {_root_str}/skills/, {_root_str}/plugins/, "
-            f"{_root_str}/cron/, {_root_str}/memories/ — those belong to a "
+            f"and writes {profile_home}/. The default "
+            f"profile's data lives at {default_root}/skills/, {default_root}/plugins/, "
+            f"{default_root}/cron/, {default_root}/memories/ — those belong to a "
             f"different session run from a different shell. Do NOT modify "
             f"another profile's skills/plugins/cron/memories unless the user "
             f"explicitly directs you to. The cross-profile write guard will "

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -116,72 +116,68 @@ class TestCodingContextBlock:
         assert "coding agent" not in _stable_prompt(agent)
 
 
-class TestNamedProfileHint:
-    """The profile hint must point at real paths (#72894).
+class TestNamedProfileHintIntegration:
+    """The same defect through the REAL resolution chain (#72894).
 
-    ``_resolve_active_profile_name()`` only returns a non-default name when
-    ``get_hermes_home()`` has already resolved to ``<root>/profiles/<name>``,
-    so appending ``/profiles/<name>`` to it doubled the segment, and using it
-    for the *default* profile's data pointed those inside the active profile.
+    ``TestNamedProfileHint`` mocks ``get_hermes_home``,
+    ``get_default_hermes_root`` and ``_resolve_active_profile_name``, so it
+    validates template rendering but not the relationship that causes the bug:
+    ``_resolve_active_profile_name`` returns a named profile *only* when the
+    active home is already ``<root>/profiles/<name>``, which is exactly why
+    appending that suffix again doubled it. Drive it with a real
+    ``HERMES_HOME`` and no resolver mocks.
     """
 
-    @staticmethod
-    def _full_prompt(monkeypatch, agent):
-        # Pin the prompt shape: with the coding posture off there is no
-        # workspace snapshot, so the hint's position doesn't depend on the
-        # cwd the suite happens to run from. Join both parts regardless.
+    def test_real_hermes_home_under_profiles_renders_correct_paths(
+        self, tmp_path, monkeypatch
+    ):
+        root = tmp_path / ".hermes"
+        profile_home = root / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
         monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+        # Sanity-check the real chain before asserting on the prompt.
+        from agent.file_safety import _resolve_active_profile_name
+        from hermes_constants import get_default_hermes_root, get_hermes_home
+
+        assert _resolve_active_profile_name() == "coder"
+        assert get_hermes_home() == profile_home
+        assert get_default_hermes_root() == root
+
+        agent = _make_agent(valid_tool_names=["read_file"])
         with patch("agent.coding_context._coding_mode", return_value="off"):
-            return "\n\n".join(_prompt_parts(agent).values())
+            prompt = "\n\n".join(_prompt_parts(agent).values())
 
-    @classmethod
-    def _named_profile_prompt(cls, monkeypatch, name="mac"):
-        import agent.system_prompt as system_prompt
+        assert "Active Hermes profile: coder." in prompt
+        assert f"reads and writes {profile_home}/." in prompt
+        # The doubled form must not appear anywhere.
+        assert f"{profile_home}/profiles/coder" not in prompt
+        # Default-profile pointers belong at the root, not inside the profile.
+        assert f"The default profile's data lives at {root}/skills/" in prompt
+        assert f"{profile_home}/skills/" not in prompt
 
-        agent = _make_agent(valid_tool_names=["read_file"])
-        monkeypatch.setattr(
-            system_prompt, "get_hermes_home", lambda: Path(f"/hermes/profiles/{name}")
-        )
-        monkeypatch.setattr(
-            system_prompt, "get_default_hermes_root", lambda: Path("/hermes")
-        )
-        monkeypatch.setattr(
-            "agent.file_safety._resolve_active_profile_name", lambda: name
-        )
-        return cls._full_prompt(monkeypatch, agent)
+    def test_real_default_home_renders_default_branch(self, tmp_path, monkeypatch):
+        """HERMES_HOME at the root resolves to the default profile, unchanged."""
+        root = tmp_path / ".hermes"
+        root.mkdir(parents=True)
 
-    def test_session_home_is_not_doubled(self, monkeypatch):
-        prompt = self._named_profile_prompt(monkeypatch)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(root))
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
 
-        assert "This session reads and writes /hermes/profiles/mac/." in prompt
-        assert "/hermes/profiles/mac/profiles/mac" not in prompt
+        from agent.file_safety import _resolve_active_profile_name
 
-    def test_default_profile_data_points_at_the_root(self, monkeypatch):
-        prompt = self._named_profile_prompt(monkeypatch)
-
-        assert (
-            "The default profile's data lives at /hermes/skills/, "
-            "/hermes/plugins/, /hermes/cron/, /hermes/memories/"
-        ) in prompt
-        # Never inside the active profile — that's the cross-profile
-        # confusion this hint exists to prevent.
-        assert "/hermes/profiles/mac/skills/" not in prompt
-        assert "/hermes/profiles/mac/memories/" not in prompt
-
-    def test_default_profile_hint_is_unchanged(self, monkeypatch):
-        import agent.system_prompt as system_prompt
+        assert _resolve_active_profile_name() == "default"
 
         agent = _make_agent(valid_tool_names=["read_file"])
-        monkeypatch.setattr(system_prompt, "get_hermes_home", lambda: Path("/hermes"))
-        monkeypatch.setattr(
-            "agent.file_safety._resolve_active_profile_name", lambda: "default"
-        )
-        prompt = self._full_prompt(monkeypatch, agent)
+        with patch("agent.coding_context._coding_mode", return_value="off"):
+            prompt = "\n\n".join(_prompt_parts(agent).values())
 
-        assert (
-            "Active Hermes profile: default. Other profiles (if any) live "
-            "under /hermes/profiles/<name>/."
-        ) in prompt
+        assert "Active Hermes profile: default." in prompt
+        assert f"under {root}/profiles/<name>/." in prompt
 
 
 def test_build_system_prompt_records_stable_prefix():

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -116,6 +116,74 @@ class TestCodingContextBlock:
         assert "coding agent" not in _stable_prompt(agent)
 
 
+class TestNamedProfileHint:
+    """The profile hint must point at real paths (#72894).
+
+    ``_resolve_active_profile_name()`` only returns a non-default name when
+    ``get_hermes_home()`` has already resolved to ``<root>/profiles/<name>``,
+    so appending ``/profiles/<name>`` to it doubled the segment, and using it
+    for the *default* profile's data pointed those inside the active profile.
+    """
+
+    @staticmethod
+    def _full_prompt(monkeypatch, agent):
+        # Pin the prompt shape: with the coding posture off there is no
+        # workspace snapshot, so the hint's position doesn't depend on the
+        # cwd the suite happens to run from. Join both parts regardless.
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        with patch("agent.coding_context._coding_mode", return_value="off"):
+            return "\n\n".join(_prompt_parts(agent).values())
+
+    @classmethod
+    def _named_profile_prompt(cls, monkeypatch, name="mac"):
+        import agent.system_prompt as system_prompt
+
+        agent = _make_agent(valid_tool_names=["read_file"])
+        monkeypatch.setattr(
+            system_prompt, "get_hermes_home", lambda: Path(f"/hermes/profiles/{name}")
+        )
+        monkeypatch.setattr(
+            system_prompt, "get_default_hermes_root", lambda: Path("/hermes")
+        )
+        monkeypatch.setattr(
+            "agent.file_safety._resolve_active_profile_name", lambda: name
+        )
+        return cls._full_prompt(monkeypatch, agent)
+
+    def test_session_home_is_not_doubled(self, monkeypatch):
+        prompt = self._named_profile_prompt(monkeypatch)
+
+        assert "This session reads and writes /hermes/profiles/mac/." in prompt
+        assert "/hermes/profiles/mac/profiles/mac" not in prompt
+
+    def test_default_profile_data_points_at_the_root(self, monkeypatch):
+        prompt = self._named_profile_prompt(monkeypatch)
+
+        assert (
+            "The default profile's data lives at /hermes/skills/, "
+            "/hermes/plugins/, /hermes/cron/, /hermes/memories/"
+        ) in prompt
+        # Never inside the active profile — that's the cross-profile
+        # confusion this hint exists to prevent.
+        assert "/hermes/profiles/mac/skills/" not in prompt
+        assert "/hermes/profiles/mac/memories/" not in prompt
+
+    def test_default_profile_hint_is_unchanged(self, monkeypatch):
+        import agent.system_prompt as system_prompt
+
+        agent = _make_agent(valid_tool_names=["read_file"])
+        monkeypatch.setattr(system_prompt, "get_hermes_home", lambda: Path("/hermes"))
+        monkeypatch.setattr(
+            "agent.file_safety._resolve_active_profile_name", lambda: "default"
+        )
+        prompt = self._full_prompt(monkeypatch, agent)
+
+        assert (
+            "Active Hermes profile: default. Other profiles (if any) live "
+            "under /hermes/profiles/<name>/."
+        ) in prompt
+
+
 def test_build_system_prompt_records_stable_prefix():
     agent = _make_agent()
     with (


### PR DESCRIPTION
## Summary
Named-profile sessions no longer render a doubled profile path (`profiles/<name>/profiles/<name>/`) in the system-prompt profile hint, and the default profile's data paths now point at the real Hermes root. Fixes #72894.

Salvage of #74979 by @jeff-mettel onto current main (the file moved under our #86313 agent-home refactor; his ambient-branch fix and real-resolver-chain integration tests are preserved with authorship).

Root cause: a non-default profile name is only ever resolved when the active home is ALREADY `<root>/profiles/<name>` — appending `/profiles/<name>` again doubled it, and using the profile home as the "default data" root mislocated default's skills/plugins/cron/memories.

## Changes
- `agent/system_prompt.py`: named-profile hint uses the resolved profile home directly + `get_default_hermes_root()` for default-data paths (composes with the agent-own-home resolution from #86313)
- `tests/agent/test_system_prompt.py`: `TestNamedProfileHintIntegration` — drives the hint through the REAL resolver chain with a real `HERMES_HOME`, no resolver mocks

## Validation
| | Before | After |
|---|---|---|
| Named-profile hint path | `<root>/profiles/x/profiles/x/` | `<root>/profiles/x/` |
| Default-data root in hint | profile home (wrong) | hermes root |
| tests/agent (system_prompt + isolation) | — | 26/26 pass |

## Infographic

![Profile hint fix](https://files.catbox.moe/o9e75a.png)
