### PR TITLE
fix(desktop): show per-model pricing in the catalog menu and refresh it on demand

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -105,4 +105,43 @@ describe('the catalog owns model curation', () => {
 
     expect($modelVisibilityOpen.get()).toBe(true)
   })
+
+  it('renders a per-model price tag when the catalog carries pricing', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        {
+          models: ['gemini-2.5-flash'],
+          name: 'Google',
+          slug: 'google',
+          pricing: {
+            'gemini-2.5-flash': { input: '$0.35', output: '$1.25', cache: null, free: false }
+          }
+        }
+      ]
+    })
+
+    renderMenu()
+    await screen.findByText(/Gemini 2\.5 Flash/i)
+
+    // The compact In/Out $/Mtok tag, matching the overlay picker's columns.
+    expect(screen.getByText(/\$0\.35 \/ \$1\.25/i)).toBeTruthy()
+  })
+
+  it('renders a Free badge for a no-cost model', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        {
+          models: ['gemini-2.5-flash'],
+          name: 'Google',
+          slug: 'google',
+          pricing: { 'gemini-2.5-flash': { input: 'free', output: 'free', cache: null, free: true } }
+        }
+      ]
+    })
+
+    renderMenu()
+    await screen.findByText(/Gemini 2\.5 Flash/i)
+
+    expect(screen.getAllByText('Free').length).toBeGreaterThan(0)
+  })
 })

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -38,6 +38,7 @@ import { $collapsedProviders, toggleCollapsedProvider } from '@/store/provider-c
 import { $defaultReasoningEffort } from '@/store/session'
 import type { ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
 
+import { ModelPrice } from '@/components/model-picker'
 import { type FastControl, ModelEditSubmenu, resolveFastControl } from './model-edit-submenu'
 
 // Lets the host dropdown (model-pill, a kanban field trigger, …) hand the panel
@@ -441,6 +442,7 @@ export function ModelCatalogMenu({
                             <HighlightMatches query={search} text={name} />
                             {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
                           </span>
+                          <ModelPrice isCurrent={isCurrent} price={group.provider.pricing?.[family.id]} />
                           {isCurrent ? (
                             <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" />
                           ) : null}

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -253,7 +253,7 @@ function ModelResults({
 
 // Compact In/Out $/Mtok price tag, mirroring the CLI picker's price columns.
 // Renders nothing when pricing is unavailable for the model.
-function ModelPrice({ price, isCurrent }: { price?: ModelPricing; isCurrent: boolean }) {
+export function ModelPrice({ price, isCurrent }: { price?: ModelPricing; isCurrent: boolean }) {
   const { t } = useI18n()
   const copy = t.modelPicker
 

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -267,7 +267,7 @@ def build_models_payload(
     if canonical_order:
         rows = _reorder_canonical(rows)
     if pricing:
-        _apply_pricing(rows, force_fresh_nous_tier=force_fresh_nous_tier)
+        _apply_pricing(rows, force_fresh_nous_tier=force_fresh_nous_tier, force_refresh=refresh)
     if capabilities:
         _apply_capabilities(rows)
     if featured:
@@ -720,6 +720,7 @@ def _apply_pricing(
     rows: list[dict],
     *,
     force_fresh_nous_tier: bool = False,
+    force_refresh: bool = False,
 ) -> None:
     """Enrich each provider row with per-model pricing + Nous tier gating.
 
@@ -737,6 +738,11 @@ def _apply_pricing(
     Prices are pre-formatted via ``_format_price_per_mtok`` so the GUI just
     renders strings — identical formatting to the CLI picker. All failures
     are swallowed (best-effort): a row simply gets no ``pricing`` key.
+
+    ``force_refresh`` busts the in-process pricing catalog cache so an
+    explicit "refresh models" action re-pulls live prices instead of showing
+    the process-start snapshot (the cache has no TTL for successful fetches).
+    Normal picker opens leave it false.
     """
     from hermes_cli.models import (
         _format_price_per_mtok,
@@ -755,7 +761,7 @@ def _apply_pricing(
         if not models:
             continue
         try:
-            raw_pricing = get_pricing_for_provider(slug) or {}
+            raw_pricing = get_pricing_for_provider(slug, force_refresh=force_refresh) or {}
         except Exception:
             raw_pricing = {}
         if not raw_pricing:

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -123,6 +123,36 @@ def test_cli_model_picker_forwards_force_refresh_to_probe_flags():
     assert mock_list.call_args.kwargs["probe_current_custom_provider"] is False
 
 
+def test_refresh_models_busts_pricing_cache():
+    """The picker's "refresh models" action must also refresh live prices.
+
+    Pricing is cached in-process with no TTL for successful fetches, so a
+    long-running gateway/desktop backend would otherwise keep showing the
+    process-start price snapshot. An explicit refresh (refresh=True) must
+    forward force_refresh to the pricing fetch.
+    """
+    ctx = _empty_ctx()
+
+    def assert_called_with(force_refresh: bool) -> None:
+        with _list_auth_returning([_nous_row()]), patch(
+            "hermes_cli.models.get_pricing_for_provider",
+            return_value={},
+        ) as mock_pricing:
+            build_models_payload(
+                ctx,
+                pricing=True,
+                refresh=force_refresh,
+            )
+        assert mock_pricing.call_args.kwargs.get("force_refresh") is force_refresh
+
+    # Normal open — pricing comes from the in-process cache.
+    assert_called_with(force_refresh=False)
+
+    # Explicit refresh — bust the cache and re-pull live prices.
+    assert_called_with(force_refresh=True)
+
+
+
 def test_list_authenticated_providers_force_fresh_is_keyword_only():
     """``force_fresh_nous_tier`` must be keyword-only on the public listing API.
 


### PR DESCRIPTION
## Why

Two related gaps in the desktop model picker:

1. **No prices in the catalog menu.** The composer model pill (and every surface
   that shares `ModelCatalogMenu` — kanban, plugin surfaces) shows only the model
   name and fast/reasoning meta. The overlay picker (`ModelPickerDialog`) already
   renders a compact In/Out $/Mtok tag per model. Same backend payload, two
   different renderers — so one surface shows cost and the other hides it.

2. **Stale prices in long-running processes.** Pricing is cached in-process with
   **no TTL for successful fetches** (`hermes_cli/models.py` `_pricing_cache`).
   A gateway/desktop backend that runs for weeks keeps showing the price snapshot
   from when it started. The picker's explicit "Refresh Models" action refreshed
   model lists but not prices, so the only way to get fresh prices was a restart.

## What

- **Extract & reuse `ModelPrice`** — export the existing component from
  `ModelPickerDialog` and render it per family row in `ModelCatalogMenu`, so
  every picker surface shows the same price columns.
- **Refresh busts the pricing cache** — the `refresh` flag on
  `build_models_payload` now forwards `force_refresh` to
  `get_pricing_for_provider`, so the existing "Refresh Models" button also
  re-pulls live prices instead of leaving them stale until restart.

## Tests

- Backend: `tests/hermes_cli/test_inventory.py` — verifies `refresh=True`
  forwards `force_refresh` to the pricing fetch (and normal opens leave it off).
- UI: `apps/desktop/src/app/shell/model-catalog-menu.test.tsx` — verifies a
  price tag renders when the catalog carries pricing, and a Free badge for a
  no-cost model.

All passed locally: 15 backend tests, 62 shell UI tests.
