### PR TITLE
feat(gateway): route Matrix project sessions

### DIFF
--- a/gateway/project_router.py
+++ b/gateway/project_router.py
@@ -32,9 +32,18 @@ def select_project(db, session_key: str, key: str) -> Path:
     return path
 
 
-def active_project_path(db, session_key: str) -> Path | None:
-    key = db.get_meta(_META_PREFIX + session_key)
+def clear_project(db, session_key: str) -> None:
+    db.delete_meta(_META_PREFIX + session_key)
+
+
+def active_project(db, session_key: str) -> tuple[str, Path] | None:
+    key = (db.get_meta(_META_PREFIX + session_key) or "").strip().lower()
     if not key:
         return None
     path = project_path(key)
-    return path if path and path.is_dir() else None
+    return (key, path) if path and path.is_dir() else None
+
+
+def active_project_path(db, session_key: str) -> Path | None:
+    project = active_project(db, session_key)
+    return project[1] if project else None

--- a/gateway/project_router.py
+++ b/gateway/project_router.py
@@ -1,0 +1,32 @@
+"""Minimal Matrix project routing backed by Hermes state_meta."""
+from __future__ import annotations
+
+from pathlib import Path
+
+PROJECTS = {
+    "newmoon": "/home/rle/projects/NewMoonNailsAndSpa",
+}
+_META_PREFIX = "matrix_project_router:"
+
+
+def project_path(key: str) -> Path | None:
+    raw = PROJECTS.get((key or "").strip().lower())
+    return Path(raw) if raw else None
+
+
+def select_project(db, session_key: str, key: str) -> Path:
+    path = project_path(key)
+    if path is None:
+        raise ValueError("unknown project")
+    if not path.is_dir():
+        raise ValueError(f"configured project path does not exist: {path}")
+    db.set_meta(_META_PREFIX + session_key, key)
+    return path
+
+
+def active_project_path(db, session_key: str) -> Path | None:
+    key = db.get_meta(_META_PREFIX + session_key)
+    if not key:
+        return None
+    path = project_path(key)
+    return path if path and path.is_dir() else None

--- a/gateway/project_router.py
+++ b/gateway/project_router.py
@@ -1,30 +1,170 @@
-"""Minimal Matrix project routing backed by Hermes state_meta."""
+"""Matrix project routing backed by Hermes state_meta."""
 from __future__ import annotations
 
+import json
+import re
+from dataclasses import dataclass
 from pathlib import Path
 
-PROJECTS = {
+# One-time legacy seed. Runtime lookups use the persisted registry exclusively.
+_BOOTSTRAP_PROJECTS = {
     "newmoon": "/home/rle/projects/NewMoonNailsAndSpa",
     "fivehours": "/home/rle/projects/savefivehours",
 }
 _META_PREFIX = "matrix_project_router:"
+_REGISTRY_META_KEY = "matrix_project_router:registry"
+_REGISTRY_VERSION = 1
+_PROJECT_MARKERS = (
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "requirements.txt",
+    "package.json",
+    "tsconfig.json",
+    "Cargo.toml",
+    "go.mod",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "Gemfile",
+    "composer.json",
+    "mix.exs",
+    "pubspec.yaml",
+    "CMakeLists.txt",
+    "Makefile",
+    "Dockerfile",
+)
+_CONTEXT_PATHS = (
+    ("AGENTS.md", lambda root: (root / "AGENTS.md").is_file()),
+    ("README*", lambda root: any(path.is_file() for path in root.glob("README*"))),
+    ("CONTRIBUTING.md", lambda root: (root / "CONTRIBUTING.md").is_file()),
+    ("package.json", lambda root: (root / "package.json").is_file()),
+    ("pyproject.toml", lambda root: (root / "pyproject.toml").is_file()),
+    ("Cargo.toml", lambda root: (root / "Cargo.toml").is_file()),
+    ("go.mod", lambda root: (root / "go.mod").is_file()),
+    ("docs/", lambda root: (root / "docs").is_dir()),
+    ("docs/STATUS.md", lambda root: (root / "docs" / "STATUS.md").is_file()),
+    ("docs/decisions/", lambda root: (root / "docs" / "decisions").is_dir()),
+)
 
 
-def project_keys() -> tuple[str, ...]:
-    return tuple(sorted(PROJECTS))
+@dataclass(frozen=True)
+class RegisteredProject:
+    key: str
+    path: Path
+    context: tuple[tuple[str, bool], ...]
 
 
-def project_path(key: str) -> Path | None:
-    raw = PROJECTS.get((key or "").strip().lower())
-    return Path(raw) if raw else None
+def normalize_project_key(value: str) -> str:
+    """Return a Matrix-friendly key derived from a directory or project name."""
+    return re.sub(r"[^a-z0-9]+", "", (value or "").casefold())
+
+
+def _bootstrap_registry_value() -> dict:
+    return {
+        "version": _REGISTRY_VERSION,
+        "projects": {
+            key: {"path": path, "metadata": {}}
+            for key, path in sorted(_BOOTSTRAP_PROJECTS.items())
+        },
+    }
+
+
+def _load_registry(db) -> dict:
+    raw = db.get_meta(_REGISTRY_META_KEY)
+    if raw is None:
+        registry = _bootstrap_registry_value()
+        db.set_meta(_REGISTRY_META_KEY, json.dumps(registry, sort_keys=True))
+        return registry
+    try:
+        registry = json.loads(raw)
+        projects = registry["projects"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise ValueError("project registry state is invalid") from exc
+    if registry.get("version") != _REGISTRY_VERSION or not isinstance(projects, dict):
+        raise ValueError("project registry state is invalid")
+    for key, entry in projects.items():
+        if not isinstance(key, str) or key != normalize_project_key(key):
+            raise ValueError("project registry state is invalid")
+        if not isinstance(entry, dict) or not isinstance(entry.get("path"), str):
+            raise ValueError("project registry state is invalid")
+    return registry
+
+
+def _save_registry(db, registry: dict) -> None:
+    db.set_meta(_REGISTRY_META_KEY, json.dumps(registry, sort_keys=True))
+
+
+def bootstrap_registry(db) -> None:
+    """Create the legacy registry only when no persisted registry exists."""
+    _load_registry(db)
+
+
+def _registry_projects(db) -> dict:
+    return _load_registry(db)["projects"]
+
+
+def project_keys(db) -> tuple[str, ...]:
+    return tuple(sorted(_registry_projects(db)))
+
+
+def project_path(db, key: str) -> Path | None:
+    entry = _registry_projects(db).get(normalize_project_key(key))
+    return Path(entry["path"]) if entry else None
+
+
+def inspect_project_context(path: Path) -> tuple[tuple[str, bool], ...]:
+    """Inspect bounded, static repository context without executing project code."""
+    return tuple((label, present(path)) for label, present in _CONTEXT_PATHS)
+
+
+def _appears_to_be_project(path: Path) -> bool:
+    return (path / ".git").exists() or any((path / marker).is_file() for marker in _PROJECT_MARKERS)
+
+
+def register_project(db, raw_path: str, *, key: str | None = None) -> RegisteredProject:
+    """Validate and persist a project without modifying its repository files."""
+    candidate = Path((raw_path or "").strip())
+    if not candidate.is_absolute():
+        raise ValueError("project path must be absolute")
+    if not candidate.exists():
+        raise ValueError(f"project path does not exist: {candidate}")
+    if not candidate.is_dir():
+        raise ValueError(f"project path is not a directory: {candidate}")
+    path = candidate.resolve()
+    if not _appears_to_be_project(path):
+        raise ValueError(f"project path does not appear to be a project or repository: {path}")
+
+    normalized_key = normalize_project_key(key if key is not None else path.name)
+    if not normalized_key:
+        raise ValueError("project key must contain at least one ASCII letter or number")
+
+    registry = _load_registry(db)
+    projects = registry["projects"]
+    existing = projects.get(normalized_key)
+    if existing:
+        existing_path = Path(existing["path"])
+        if existing_path == path:
+            raise ValueError(f"project key '{normalized_key}' is already registered for this path")
+        raise ValueError(
+            f"project key '{normalized_key}' is already registered for: {existing_path}"
+        )
+    for existing_key, entry in projects.items():
+        if Path(entry["path"]) == path:
+            raise ValueError(f"project path is already registered as '{existing_key}'")
+
+    context = inspect_project_context(path)
+    projects[normalized_key] = {"path": str(path), "metadata": {}}
+    _save_registry(db, registry)
+    return RegisteredProject(normalized_key, path, context)
 
 
 def select_project(db, session_key: str, key: str) -> Path:
-    normalized_key = (key or "").strip().lower()
-    path = project_path(normalized_key)
+    normalized_key = normalize_project_key(key)
+    path = project_path(db, normalized_key)
     if path is None:
         raise ValueError(
-            f"unknown project '{normalized_key}'. Valid projects: {', '.join(project_keys())}"
+            f"unknown project '{normalized_key}'. Valid projects: {', '.join(project_keys(db))}"
         )
     if not path.is_dir():
         raise ValueError(f"configured project path does not exist: {path}")
@@ -37,10 +177,10 @@ def clear_project(db, session_key: str) -> None:
 
 
 def active_project(db, session_key: str) -> tuple[str, Path] | None:
-    key = (db.get_meta(_META_PREFIX + session_key) or "").strip().lower()
+    key = normalize_project_key(db.get_meta(_META_PREFIX + session_key) or "")
     if not key:
         return None
-    path = project_path(key)
+    path = project_path(db, key)
     return (key, path) if path and path.is_dir() else None
 
 

--- a/gateway/project_router.py
+++ b/gateway/project_router.py
@@ -5,8 +5,13 @@ from pathlib import Path
 
 PROJECTS = {
     "newmoon": "/home/rle/projects/NewMoonNailsAndSpa",
+    "fivehours": "/home/rle/projects/savefivehours",
 }
 _META_PREFIX = "matrix_project_router:"
+
+
+def project_keys() -> tuple[str, ...]:
+    return tuple(sorted(PROJECTS))
 
 
 def project_path(key: str) -> Path | None:
@@ -15,12 +20,15 @@ def project_path(key: str) -> Path | None:
 
 
 def select_project(db, session_key: str, key: str) -> Path:
-    path = project_path(key)
+    normalized_key = (key or "").strip().lower()
+    path = project_path(normalized_key)
     if path is None:
-        raise ValueError("unknown project")
+        raise ValueError(
+            f"unknown project '{normalized_key}'. Valid projects: {', '.join(project_keys())}"
+        )
     if not path.is_dir():
         raise ValueError(f"configured project path does not exist: {path}")
-    db.set_meta(_META_PREFIX + session_key, key)
+    db.set_meta(_META_PREFIX + session_key, normalized_key)
     return path
 
 

--- a/gateway/project_router.py
+++ b/gateway/project_router.py
@@ -58,6 +58,28 @@ class RegisteredProject:
     context: tuple[tuple[str, bool], ...]
 
 
+@dataclass(frozen=True)
+class SetupRecommendation:
+    """A proposed repository-context change for a future explicit apply step."""
+
+    action: str
+    target: str
+    reason: str
+    category: str
+
+
+@dataclass(frozen=True)
+class ProjectSetupPlan:
+    """Read-only repository-context analysis; it deliberately holds no pending state."""
+
+    key: str
+    path: Path
+    found: tuple[str, ...]
+    recommendations: tuple[SetupRecommendation, ...]
+    not_needed: tuple[str, ...]
+    authoritative_sources: tuple[tuple[str, str], ...]
+
+
 def normalize_project_key(value: str) -> str:
     """Return a Matrix-friendly key derived from a directory or project name."""
     return re.sub(r"[^a-z0-9]+", "", (value or "").casefold())
@@ -119,6 +141,183 @@ def project_path(db, key: str) -> Path | None:
 def inspect_project_context(path: Path) -> tuple[tuple[str, bool], ...]:
     """Inspect bounded, static repository context without executing project code."""
     return tuple((label, present(path)) for label, present in _CONTEXT_PATHS)
+
+
+def _existing_files(path: Path, pattern: str) -> tuple[Path, ...]:
+    return tuple(sorted(candidate for candidate in path.glob(pattern) if candidate.is_file()))
+
+
+def _has_static_content(path: Path) -> bool:
+    """Check whether a text context file has content without executing it."""
+    try:
+        return bool(path.read_text(encoding="utf-8", errors="replace").strip())
+    except OSError:
+        return False
+
+
+def _setup_adr_paths(path: Path) -> tuple[str, ...]:
+    """Return established ADR/decision locations in deterministic preference order."""
+    candidates = (
+        "docs/decisions",
+        "docs/adr",
+        "docs/adrs",
+        "decisions",
+        "adr",
+        "adrs",
+        "docs/ADR.md",
+        "ADR.md",
+    )
+    return tuple(
+        candidate + "/" if (path / candidate).is_dir() else candidate
+        for candidate in candidates
+        if (path / candidate).is_dir() or (path / candidate).is_file()
+    )
+
+
+def analyze_project_setup(db, key: str) -> ProjectSetupPlan:
+    """Analyze one registered repository using only static filesystem inspection.
+
+    This function neither executes repository content nor writes repository or
+    registry state. The structured recommendations are intentionally suitable
+    for a later, separately authorized apply command.
+    """
+    normalized_key = normalize_project_key(key)
+    path = project_path(db, normalized_key)
+    if path is None:
+        raise ValueError(
+            f"unknown project '{normalized_key}'. Valid projects: {', '.join(project_keys(db))}"
+        )
+    if not path.is_dir():
+        raise ValueError(f"configured project path does not exist: {path}")
+
+    agents = path / "AGENTS.md"
+    claude = path / "CLAUDE.md"
+    contributing = path / "CONTRIBUTING.md"
+    docs = path / "docs"
+    status = docs / "STATUS.md"
+    readmes = _existing_files(path, "README*")
+    requirements = _existing_files(path, "requirements*.txt")
+    manifests = tuple(
+        candidate
+        for candidate in (path / "package.json", path / "pyproject.toml", path / "Cargo.toml", path / "go.mod")
+        if candidate.is_file()
+    ) + requirements
+    adr_paths = _setup_adr_paths(path)
+    github_context = tuple(
+        f".github/{candidate.name}"
+        for candidate in _existing_files(path / ".github", "*.md")
+        if candidate.name.upper() in {"CONTRIBUTING.MD", "INSTRUCTIONS.MD", "AGENTS.MD"}
+    )
+    github_agent_context = tuple(
+        candidate
+        for candidate in _existing_files(path / ".github", "*.md")
+        if candidate.name.upper() in {"INSTRUCTIONS.MD", "AGENTS.MD"}
+    )
+
+    found: list[str] = []
+    for candidate in (agents, *readmes, contributing, claude, *manifests):
+        if candidate.is_file():
+            found.append(candidate.relative_to(path).as_posix())
+    if docs.is_dir():
+        found.append("docs/")
+    if status.is_file():
+        found.append("docs/STATUS.md")
+    found.extend(adr_paths)
+    found.extend(github_context)
+
+    recommendations: list[SetupRecommendation] = []
+    not_needed: list[str] = []
+    has_agent_convention = any(
+        _has_static_content(candidate) for candidate in (agents, claude, *github_agent_context)
+    )
+    if has_agent_convention:
+        not_needed.append("AGENTS.md — existing repository agent instructions are present")
+    else:
+        recommendations.append(
+            SetupRecommendation(
+                action="create",
+                target="AGENTS.md",
+                reason="minimal repo-specific agent operating context is absent",
+                category="recommended",
+            )
+        )
+
+    if status.is_file():
+        not_needed.append("docs/STATUS.md — current-state context already exists")
+    elif docs.is_dir():
+        recommendations.append(
+            SetupRecommendation(
+                action="create",
+                target="docs/STATUS.md",
+                reason="concise current-state snapshot would aid ongoing work",
+                category="recommended",
+            )
+        )
+    else:
+        not_needed.append("docs/STATUS.md — no documentation convention detected")
+
+    if adr_paths:
+        not_needed.append(f"docs/decisions/ — existing ADR convention: {adr_paths[0]}")
+    elif docs.is_dir() and (contributing.is_file() or has_agent_convention) and manifests:
+        recommendations.append(
+            SetupRecommendation(
+                action="create",
+                target="docs/decisions/",
+                reason="durable technical decisions are likely useful for this documented repository",
+                category="recommended",
+            )
+        )
+    elif docs.is_dir():
+        not_needed.append("docs/decisions/ — no clear durable-decision need detected")
+    else:
+        not_needed.append("docs/decisions/ — no documentation or ADR convention detected")
+
+    authoritative_sources: list[tuple[str, str]] = []
+    for candidate, role in (
+        (agents, "repository agent instructions"),
+        (readmes[0] if readmes else None, "project overview"),
+        (contributing, "contribution conventions"),
+        (claude, "repository agent instructions"),
+        (status, "current implementation state"),
+    ):
+        if candidate is not None and candidate.is_file() and _has_static_content(candidate):
+            authoritative_sources.append((candidate.relative_to(path).as_posix(), role))
+
+    return ProjectSetupPlan(
+        key=normalized_key,
+        path=path,
+        found=tuple(found),
+        recommendations=tuple(recommendations),
+        not_needed=tuple(not_needed),
+        authoritative_sources=tuple(authoritative_sources),
+    )
+
+
+def render_project_setup_plan(plan: ProjectSetupPlan) -> str:
+    """Render a concise, deterministic Matrix-safe representation of a plan."""
+    lines = [f"Project setup analysis: {plan.key}", f"Path: {plan.path}"]
+    if plan.found:
+        lines.extend(["", "Found:", *(f"- {item}" for item in plan.found)])
+    if plan.recommendations:
+        lines.extend(
+            [
+                "",
+                "Recommended:",
+                *(f"- {item.target} — {item.reason}" for item in plan.recommendations),
+            ]
+        )
+    if plan.not_needed:
+        lines.extend(["", "Not currently needed:", *(f"- {item}" for item in plan.not_needed)])
+    if plan.authoritative_sources:
+        lines.extend(
+            [
+                "",
+                "Authoritative sources:",
+                *(f"- {source} — {role}" for source, role in plan.authoritative_sources),
+            ]
+        )
+    lines.extend(["", "No repository files were changed."])
+    return "\n".join(lines)
 
 
 def _appears_to_be_project(path: Path) -> bool:

--- a/gateway/project_router.py
+++ b/gateway/project_router.py
@@ -14,6 +14,9 @@ _BOOTSTRAP_PROJECTS = {
 _META_PREFIX = "matrix_project_router:"
 _REGISTRY_META_KEY = "matrix_project_router:registry"
 _REGISTRY_VERSION = 1
+# Relative `!project add` references are resolved only beneath this root.
+# Keep this in one place so a future gateway configuration can override it.
+DEFAULT_PROJECTS_ROOT = Path("/home/rle/projects")
 _PROJECT_MARKERS = (
     "pyproject.toml",
     "setup.py",
@@ -122,16 +125,42 @@ def _appears_to_be_project(path: Path) -> bool:
     return (path / ".git").exists() or any((path / marker).is_file() for marker in _PROJECT_MARKERS)
 
 
-def register_project(db, raw_path: str, *, key: str | None = None) -> RegisteredProject:
-    """Validate and persist a project without modifying its repository files."""
-    candidate = Path((raw_path or "").strip())
-    if not candidate.is_absolute():
-        raise ValueError("project path must be absolute")
-    if not candidate.exists():
-        raise ValueError(f"project path does not exist: {candidate}")
-    if not candidate.is_dir():
-        raise ValueError(f"project path is not a directory: {candidate}")
-    path = candidate.resolve()
+def _resolve_project_path(raw_path: str, projects_root: Path) -> Path:
+    """Resolve an absolute path or an exact relative path beneath projects_root."""
+    value = (raw_path or "").strip()
+    if not value:
+        raise ValueError("project path must not be empty")
+
+    candidate = Path(value)
+    if candidate.is_absolute():
+        path = candidate.resolve()
+    else:
+        root = Path(projects_root).resolve()
+        path = (root / candidate).resolve()
+        try:
+            path.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(
+                f"relative project path must remain beneath projects root: {root}"
+            ) from exc
+
+    if not path.exists():
+        raise ValueError(f"project path does not exist: {path}")
+    if not path.is_dir():
+        raise ValueError(f"project path is not a directory: {path}")
+    return path
+
+
+def register_project(
+    db, raw_path: str, *, key: str | None = None, projects_root: Path | None = None
+) -> RegisteredProject:
+    """Validate and persist a project without modifying its repository files.
+
+    Absolute paths retain their existing behavior. Relative paths are exact,
+    potentially nested references beneath projects_root (the default projects root
+    in production), and cannot escape it after canonicalization.
+    """
+    path = _resolve_project_path(raw_path, projects_root or DEFAULT_PROJECTS_ROOT)
     if not _appears_to_be_project(path):
         raise ValueError(f"project path does not appear to be a project or repository: {path}")
 

--- a/gateway/project_router.py
+++ b/gateway/project_router.py
@@ -228,6 +228,28 @@ def project_path(db, key: str) -> Path | None:
     return Path(entry["path"]) if entry else None
 
 
+def project_details(db, key: str) -> tuple[str, str, tuple[str, ...], Path]:
+    """Return one project's normalized key, display metadata, and canonical path."""
+    normalized_key = normalize_project_key(key)
+    entry = _registry_projects(db).get(normalized_key)
+    if entry is None:
+        raise ValueError(
+            f"unknown project '{normalized_key}'. Valid projects: {', '.join(project_keys(db))}"
+        )
+    metadata = entry["metadata"]
+    return (
+        normalized_key,
+        metadata["display_name"],
+        tuple(metadata["aliases"]),
+        Path(entry["path"]),
+    )
+
+
+def registered_project_details(db) -> tuple[tuple[str, str, tuple[str, ...], Path], ...]:
+    """Return every registered project in deterministic key and alias order."""
+    return tuple(project_details(db, key) for key in project_keys(db))
+
+
 def _routing_phrases(key: str, metadata: dict) -> tuple[str, ...]:
     phrases = {_normalize_routing_phrase(key)}
     display_name = metadata.get("display_name")

--- a/gateway/project_router.py
+++ b/gateway/project_router.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -78,6 +79,19 @@ class ProjectSetupPlan:
     recommendations: tuple[SetupRecommendation, ...]
     not_needed: tuple[str, ...]
     authoritative_sources: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True)
+class ProjectSetupApplyResult:
+    """Result of an explicit apply based only on a freshly analyzed plan."""
+
+    key: str
+    path: Path
+    recommended_count: int
+    created: tuple[str, ...]
+    skipped: tuple[tuple[str, str], ...]
+    had_unrelated_changes: bool
+    plan: ProjectSetupPlan
 
 
 def normalize_project_key(value: str) -> str:
@@ -317,6 +331,157 @@ def render_project_setup_plan(plan: ProjectSetupPlan) -> str:
             ]
         )
     lines.extend(["", "No repository files were changed."])
+    return "\n".join(lines)
+
+
+def _agents_content(plan: ProjectSetupPlan) -> str:
+    """Render compact instructions derived only from the current static plan."""
+    sources = [f"- {source} — {role}" for source, role in plan.authoritative_sources]
+    manifests = [
+        item
+        for item in plan.found
+        if item in {"package.json", "pyproject.toml", "Cargo.toml", "go.mod"}
+        or item.startswith("requirements")
+    ]
+    lines = ["# Agent Instructions", "", "## Project context"]
+    if sources:
+        lines.extend(sources)
+    else:
+        lines.append("- Confirm the repository's authoritative sources before making changes.")
+    if manifests:
+        lines.extend(["", "## Static project evidence", *(f"- {item}" for item in manifests)])
+    lines.extend(
+        [
+            "",
+            "## Working rules",
+            "- Read the listed authoritative sources before changing repository behavior.",
+            "- Keep changes scoped to the requested work and preserve existing conventions.",
+            "",
+            "## Validation",
+            "- Validation commands must be confirmed from repository documentation or manifests before running them.",
+            "",
+            "## Safety",
+            "- Do not overwrite existing repository context files without explicit approval.",
+            "- Do not create branches, commit, or push unless explicitly requested.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _status_content(plan: ProjectSetupPlan) -> str:
+    """Render a static-evidence status note without inferring project state."""
+    evidence = [item for item in plan.found if item not in {"docs/", "docs/STATUS.md"}]
+    lines = [
+        "# Current Status",
+        "",
+        "This snapshot records only static repository context observed during setup.",
+        "Confirm current behavior, priorities, and validation before treating it as project status.",
+    ]
+    if evidence:
+        lines.extend(["", "## Static evidence", *(f"- {item} is present." for item in evidence)])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _decision_readme_content() -> str:
+    return (
+        "# Decision Records\n\n"
+        "Use this directory for durable technical decisions when the repository needs them.\n"
+        "No decision records were created automatically.\n"
+    )
+
+
+def _write_new_file(path: Path, content: str) -> None:
+    """Atomically create a UTF-8 file without replacing an existing target."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("x", encoding="utf-8") as handle:
+        handle.write(content)
+
+
+def _recommended_writes(plan: ProjectSetupPlan) -> tuple[tuple[str, Path, str], ...]:
+    """Map only known recommended actions to their v1 create-only file targets."""
+    writes: list[tuple[str, Path, str]] = []
+    for recommendation in plan.recommendations:
+        if recommendation.category != "recommended":
+            continue
+        if recommendation.action != "create":
+            raise ValueError(f"unsupported recommended setup action: {recommendation.action}")
+        if recommendation.target == "AGENTS.md":
+            writes.append(("AGENTS.md", plan.path / "AGENTS.md", _agents_content(plan)))
+        elif recommendation.target == "docs/STATUS.md":
+            writes.append(("docs/STATUS.md", plan.path / "docs" / "STATUS.md", _status_content(plan)))
+        elif recommendation.target == "docs/decisions/":
+            writes.append(
+                (
+                    "docs/decisions/README.md",
+                    plan.path / "docs" / "decisions" / "README.md",
+                    _decision_readme_content(),
+                )
+            )
+        else:
+            raise ValueError(f"unsupported recommended setup target: {recommendation.target}")
+    return tuple(writes)
+
+
+def _has_unrelated_worktree_changes(path: Path) -> bool:
+    """Inspect Git status read-only; non-Git directories simply report false."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "status", "--porcelain"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def apply_project_setup(db, key: str) -> ProjectSetupApplyResult:
+    """Apply the current create-only recommendations without relying on saved plans."""
+    current_plan = analyze_project_setup(db, key)
+    had_unrelated_changes = _has_unrelated_worktree_changes(current_plan.path)
+    writes = _recommended_writes(current_plan)
+    created: list[str] = []
+    skipped: list[tuple[str, str]] = []
+    for label, target, content in writes:
+        try:
+            _write_new_file(target, content)
+        except FileExistsError:
+            skipped.append((label, "target already exists"))
+        else:
+            created.append(label)
+    post_write_plan = analyze_project_setup(db, key)
+    return ProjectSetupApplyResult(
+        key=current_plan.key,
+        path=current_plan.path,
+        recommended_count=len(writes),
+        created=tuple(created),
+        skipped=tuple(skipped),
+        had_unrelated_changes=had_unrelated_changes,
+        plan=post_write_plan,
+    )
+
+
+def render_project_setup_apply_result(result: ProjectSetupApplyResult) -> str:
+    """Render deterministic, explicit output for an authorized setup apply."""
+    if not result.recommended_count:
+        return (
+            f"Project setup analysis: {result.key}\n\n"
+            "No setup changes are currently recommended.\nNothing to apply.\n\n"
+            "No repository files were changed."
+        )
+    lines = [f"Project setup applied: {result.key}", "", "Created:"]
+    lines.extend(f"- {target}" for target in result.created) if result.created else lines.append("- none")
+    lines.extend(["", "Skipped:"])
+    lines.extend(f"- {target} — {reason}" for target, reason in result.skipped)
+    if not result.skipped:
+        lines.append("- none")
+    lines.extend(["", "No existing files were overwritten."])
+    if result.had_unrelated_changes:
+        lines.append("Unrelated working-tree changes already existed and were preserved.")
+    lines.append("Changes remain uncommitted for review.")
     return "\n".join(lines)
 
 

--- a/gateway/project_router.py
+++ b/gateway/project_router.py
@@ -9,12 +9,24 @@ from pathlib import Path
 
 # One-time legacy seed. Runtime lookups use the persisted registry exclusively.
 _BOOTSTRAP_PROJECTS = {
-    "newmoon": "/home/rle/projects/NewMoonNailsAndSpa",
-    "fivehours": "/home/rle/projects/savefivehours",
+    "newmoon": {
+        "path": "/home/rle/projects/NewMoonNailsAndSpa",
+        "metadata": {
+            "display_name": "New Moon Nails",
+            "aliases": ["new moon", "new moon nails", "nail site", "nails site"],
+        },
+    },
+    "fivehours": {
+        "path": "/home/rle/projects/savefivehours",
+        "metadata": {
+            "display_name": "Five Hours",
+            "aliases": ["five hours", "save five hours"],
+        },
+    },
 }
 _META_PREFIX = "matrix_project_router:"
 _REGISTRY_META_KEY = "matrix_project_router:registry"
-_REGISTRY_VERSION = 1
+_REGISTRY_VERSION = 2
 # Relative `!project add` references are resolved only beneath this root.
 # Keep this in one place so a future gateway configuration can override it.
 DEFAULT_PROJECTS_ROOT = Path("/home/rle/projects")
@@ -99,34 +111,98 @@ def normalize_project_key(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", (value or "").casefold())
 
 
+def _normalize_routing_phrase(value: str) -> str:
+    """Normalize routing evidence into a boundary-aware, comparable phrase."""
+    return re.sub(r"[^a-z0-9]+", " ", (value or "").casefold()).strip()
+
+
+def _default_display_name(value: str) -> str:
+    words = _normalize_routing_phrase(value).split()
+    return " ".join(word.capitalize() for word in words)
+
+
+def _validated_metadata(metadata: object) -> dict:
+    if metadata is None:
+        metadata = {}
+    if not isinstance(metadata, dict):
+        raise ValueError("project registry state is invalid")
+    result = dict(metadata)
+    display_name = result.get("display_name")
+    if display_name is not None:
+        if not isinstance(display_name, str) or not _normalize_routing_phrase(display_name):
+            raise ValueError("project registry state is invalid")
+        result["display_name"] = " ".join(display_name.split())
+    aliases = result.get("aliases", [])
+    if not isinstance(aliases, list) or not all(isinstance(alias, str) for alias in aliases):
+        raise ValueError("project registry state is invalid")
+    normalized_aliases = sorted({_normalize_routing_phrase(alias) for alias in aliases})
+    if any(not alias for alias in normalized_aliases):
+        raise ValueError("project registry state is invalid")
+    result["aliases"] = normalized_aliases
+    return result
+
+
 def _bootstrap_registry_value() -> dict:
     return {
         "version": _REGISTRY_VERSION,
         "projects": {
-            key: {"path": path, "metadata": {}}
-            for key, path in sorted(_BOOTSTRAP_PROJECTS.items())
+            key: {
+                "path": project["path"],
+                "metadata": {
+                    "display_name": project["metadata"]["display_name"],
+                    "aliases": list(project["metadata"]["aliases"]),
+                },
+            }
+            for key, project in sorted(_BOOTSTRAP_PROJECTS.items())
         },
     }
+
+
+def _migrate_registry(registry: dict) -> tuple[dict, bool]:
+    if registry.get("version") not in {1, _REGISTRY_VERSION} or not isinstance(
+        registry.get("projects"), dict
+    ):
+        raise ValueError("project registry state is invalid")
+    migrated = dict(registry)
+    if not all(isinstance(key, str) and isinstance(entry, dict) for key, entry in registry["projects"].items()):
+        raise ValueError("project registry state is invalid")
+    projects = {key: dict(entry) for key, entry in registry["projects"].items()}
+    changed = registry.get("version") != _REGISTRY_VERSION
+    for key, entry in projects.items():
+        if not isinstance(key, str) or key != normalize_project_key(key):
+            raise ValueError("project registry state is invalid")
+        if not isinstance(entry.get("path"), str):
+            raise ValueError("project registry state is invalid")
+        original_metadata = entry.get("metadata")
+        raw_metadata = original_metadata if isinstance(original_metadata, dict) else {}
+        metadata = _validated_metadata(original_metadata)
+        bootstrap = _BOOTSTRAP_PROJECTS.get(key, {}).get("metadata", {})
+        for field, value in bootstrap.items():
+            if field not in raw_metadata:
+                metadata[field] = list(value) if isinstance(value, list) else value
+        if "display_name" not in raw_metadata and "display_name" not in bootstrap:
+            metadata["display_name"] = _default_display_name(Path(entry["path"]).name) or key
+        if original_metadata != metadata:
+            changed = True
+        entry["metadata"] = metadata
+    migrated["version"] = _REGISTRY_VERSION
+    migrated["projects"] = projects
+    return migrated, changed
 
 
 def _load_registry(db) -> dict:
     raw = db.get_meta(_REGISTRY_META_KEY)
     if raw is None:
         registry = _bootstrap_registry_value()
-        db.set_meta(_REGISTRY_META_KEY, json.dumps(registry, sort_keys=True))
+        _save_registry(db, registry)
         return registry
     try:
         registry = json.loads(raw)
-        projects = registry["projects"]
-    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+    except (json.JSONDecodeError, TypeError) as exc:
         raise ValueError("project registry state is invalid") from exc
-    if registry.get("version") != _REGISTRY_VERSION or not isinstance(projects, dict):
-        raise ValueError("project registry state is invalid")
-    for key, entry in projects.items():
-        if not isinstance(key, str) or key != normalize_project_key(key):
-            raise ValueError("project registry state is invalid")
-        if not isinstance(entry, dict) or not isinstance(entry.get("path"), str):
-            raise ValueError("project registry state is invalid")
+    registry, migrated = _migrate_registry(registry)
+    if migrated:
+        _save_registry(db, registry)
     return registry
 
 
@@ -135,7 +211,7 @@ def _save_registry(db, registry: dict) -> None:
 
 
 def bootstrap_registry(db) -> None:
-    """Create the legacy registry only when no persisted registry exists."""
+    """Create or migrate the registry without overwriting saved metadata."""
     _load_registry(db)
 
 
@@ -150,6 +226,79 @@ def project_keys(db) -> tuple[str, ...]:
 def project_path(db, key: str) -> Path | None:
     entry = _registry_projects(db).get(normalize_project_key(key))
     return Path(entry["path"]) if entry else None
+
+
+def _routing_phrases(key: str, metadata: dict) -> tuple[str, ...]:
+    phrases = {_normalize_routing_phrase(key)}
+    display_name = metadata.get("display_name")
+    if isinstance(display_name, str):
+        phrases.add(_normalize_routing_phrase(display_name))
+    phrases.update(metadata.get("aliases", []))
+    return tuple(sorted(phrase for phrase in phrases if phrase))
+
+
+def _contains_routing_phrase(text: str, phrase: str) -> bool:
+    words = phrase.split()
+    pattern = r"(?<!\w)" + r"[^a-z0-9]+".join(map(re.escape, words)) + r"(?!\w)"
+    return re.search(pattern, text.casefold()) is not None
+
+
+def resolve_project_reference(db, text: str) -> tuple[str, ...]:
+    """Return every registered project with exact key/name/alias evidence."""
+    if not isinstance(text, str) or not text.strip():
+        return ()
+    return tuple(
+        key
+        for key, entry in sorted(_registry_projects(db).items())
+        if any(
+            _contains_routing_phrase(text, phrase)
+            for phrase in _routing_phrases(key, entry["metadata"])
+        )
+    )
+
+
+def add_project_alias(db, key: str, alias: str) -> str:
+    """Persist an alias only when it cannot route to another registered project."""
+    normalized_key = normalize_project_key(key)
+    normalized_alias = _normalize_routing_phrase(alias)
+    if not normalized_alias:
+        raise ValueError("project alias must contain at least one ASCII letter or number")
+    registry = _load_registry(db)
+    projects = registry["projects"]
+    entry = projects.get(normalized_key)
+    if entry is None:
+        raise ValueError(
+            f"unknown project '{normalized_key}'. Valid projects: {', '.join(sorted(projects))}"
+        )
+    for other_key, other_entry in sorted(projects.items()):
+        if other_key != normalized_key and normalized_alias in _routing_phrases(
+            other_key, other_entry["metadata"]
+        ):
+            raise ValueError(f"project alias '{normalized_alias}' conflicts with project '{other_key}'")
+    aliases = entry["metadata"]["aliases"]
+    if normalized_alias not in aliases:
+        aliases.append(normalized_alias)
+        aliases.sort()
+        _save_registry(db, registry)
+    return normalized_alias
+
+
+def remove_project_alias(db, key: str, alias: str) -> str:
+    """Remove one normalized alias without changing any other project metadata."""
+    normalized_key = normalize_project_key(key)
+    normalized_alias = _normalize_routing_phrase(alias)
+    registry = _load_registry(db)
+    entry = registry["projects"].get(normalized_key)
+    if entry is None:
+        raise ValueError(
+            f"unknown project '{normalized_key}'. Valid projects: {', '.join(project_keys(db))}"
+        )
+    aliases = entry["metadata"]["aliases"]
+    if normalized_alias not in aliases:
+        raise ValueError(f"project alias '{normalized_alias}' is not registered for '{normalized_key}'")
+    aliases.remove(normalized_alias)
+    _save_registry(db, registry)
+    return normalized_alias
 
 
 def inspect_project_context(path: Path) -> tuple[tuple[str, bool], ...]:
@@ -547,7 +696,10 @@ def register_project(
             raise ValueError(f"project path is already registered as '{existing_key}'")
 
     context = inspect_project_context(path)
-    projects[normalized_key] = {"path": str(path), "metadata": {}}
+    projects[normalized_key] = {
+        "path": str(path),
+        "metadata": {"display_name": _default_display_name(path.name) or normalized_key, "aliases": []},
+    }
     _save_registry(db, registry)
     return RegisteredProject(normalized_key, path, context)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16163,9 +16163,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _matrix_project_args = _matrix_parts[1] if len(_matrix_parts) > 1 else ""
         if _matrix_project_args is not None:
             arg = _matrix_project_args.strip().lower()
-            from gateway.project_router import select_project
+            from gateway.project_router import active_project, clear_project, select_project
 
             session_key = self._session_key_for_source(source)
+            if arg == "clear":
+                clear_project(self._session_db._db, session_key)
+                from agent.runtime_cwd import clear_session_cwd
+
+                clear_session_cwd()
+                self._evict_cached_agent(session_key)
+                return "Project context cleared."
+            if arg == "status":
+                project = active_project(self._session_db._db, session_key)
+                if project is None:
+                    return "Active project: none"
+                key, path = project
+                return f"Active project: {key}\nPath: {path}"
             try:
                 path = select_project(self._session_db._db, session_key, arg)
             except ValueError as exc:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16163,15 +16163,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _matrix_project_args = _matrix_parts[1] if len(_matrix_parts) > 1 else ""
         if _matrix_project_args is not None:
             arg = _matrix_project_args.strip().lower()
-            if arg == "newmoon":
-                from gateway.project_router import select_project
-                session_key = self._session_key_for_source(source)
-                try:
-                    path = select_project(self._session_db._db, session_key, arg)
-                except ValueError as exc:
-                    return f"Project selection failed: {exc}"
-                self._evict_cached_agent(session_key)
-                return f"Active project: newmoon ({path})"
+            from gateway.project_router import select_project
+
+            session_key = self._session_key_for_source(source)
+            try:
+                path = select_project(self._session_db._db, session_key, arg)
+            except ValueError as exc:
+                return f"Project selection failed: {exc}"
+            self._evict_cached_agent(session_key)
+            return f"Active project: {arg} ({path})"
 
         from hermes_cli.commands import (
             GATEWAY_KNOWN_COMMANDS,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16149,6 +16149,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Check for commands
         command = event.get_command()
 
+        # Matrix-only, explicit project selection. Matrix adapters normalize
+        # only registered bang commands, so this unregistered command arrives
+        # here as ``!project`` rather than ``/project``.
+        _matrix_project_args = None
+        if source.platform == Platform.MATRIX:
+            _matrix_text = (event.text or "").lstrip()
+            if command == "project":
+                _matrix_project_args = event.get_command_args()
+            elif _matrix_text.startswith("!"):
+                _matrix_parts = _matrix_text[1:].split(maxsplit=1)
+                if _matrix_parts and _matrix_parts[0].lower() == "project":
+                    _matrix_project_args = _matrix_parts[1] if len(_matrix_parts) > 1 else ""
+        if _matrix_project_args is not None:
+            arg = _matrix_project_args.strip().lower()
+            if arg == "newmoon":
+                from gateway.project_router import select_project
+                session_key = self._session_key_for_source(source)
+                try:
+                    path = select_project(self._session_db._db, session_key, arg)
+                except ValueError as exc:
+                    return f"Project selection failed: {exc}"
+                self._evict_cached_agent(session_key)
+                return f"Active project: newmoon ({path})"
+
         from hermes_cli.commands import (
             GATEWAY_KNOWN_COMMANDS,
             is_gateway_known_command,
@@ -23028,6 +23052,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _adapters = getattr(self, "adapters", None) or {}
         _adapter = _adapters.get(context.source.platform)
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
+        _project_cwd = ""
+        _session_db = getattr(self, "_session_db", None)
+        if context.source.platform == Platform.MATRIX and _session_db is not None:
+            from gateway.project_router import active_project_path
+
+            _project_path = active_project_path(_session_db._db, context.session_key)
+            if _project_path is not None:
+                _project_cwd = str(_project_path)
         return set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
@@ -23045,6 +23077,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,
             cron_session="",
+            cwd=_project_cwd,
         )
 
     def _clear_session_env(self, tokens: list) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16162,29 +16162,62 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _matrix_parts and _matrix_parts[0].lower() == "project":
                     _matrix_project_args = _matrix_parts[1] if len(_matrix_parts) > 1 else ""
         if _matrix_project_args is not None:
-            arg = _matrix_project_args.strip().lower()
-            from gateway.project_router import active_project, clear_project, select_project
+            arg = _matrix_project_args.strip()
+            action, _, remainder = arg.partition(" ")
+            action = action.lower()
+            from gateway.project_router import (
+                active_project,
+                clear_project,
+                project_keys,
+                project_path,
+                register_project,
+                select_project,
+            )
 
             session_key = self._session_key_for_source(source)
-            if arg == "clear":
+            if action == "clear" and not remainder.strip():
                 clear_project(self._session_db._db, session_key)
                 from agent.runtime_cwd import clear_session_cwd
 
                 clear_session_cwd()
                 self._evict_cached_agent(session_key)
                 return "Project context cleared."
-            if arg == "status":
+            if action == "status" and not remainder.strip():
                 project = active_project(self._session_db._db, session_key)
                 if project is None:
                     return "Active project: none"
                 key, path = project
                 return f"Active project: {key}\nPath: {path}"
+            if action == "list" and not remainder.strip():
+                projects = project_keys(self._session_db._db)
+                lines = ["Registered projects:"]
+                lines.extend(
+                    f"- {key} → {project_path(self._session_db._db, key)}" for key in projects
+                )
+                return "\n".join(lines)
+            if action == "add":
+                try:
+                    project = register_project(self._session_db._db, remainder.strip())
+                except ValueError as exc:
+                    return f"Project registration failed: {exc}"
+                context = "\n".join(
+                    f"- {label}: {'found' if found else 'missing'}"
+                    for label, found in project.context
+                )
+                response = (
+                    f"Project registered: {project.key}\nPath: {project.path}\n\nContext:\n{context}"
+                )
+                if not dict(project.context).get("AGENTS.md"):
+                    response += (
+                        "\n\nProject routing is available, but repository agent context is incomplete."
+                    )
+                return response
             try:
                 path = select_project(self._session_db._db, session_key, arg)
             except ValueError as exc:
                 return f"Project selection failed: {exc}"
             self._evict_cached_agent(session_key)
-            return f"Active project: {arg} ({path})"
+            return f"Active project: {action} ({path})"
 
         from hermes_cli.commands import (
             GATEWAY_KNOWN_COMMANDS,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16168,10 +16168,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from gateway.project_router import (
                 active_project,
                 analyze_project_setup,
+                apply_project_setup,
                 clear_project,
                 project_keys,
                 project_path,
                 register_project,
+                render_project_setup_apply_result,
                 render_project_setup_plan,
                 select_project,
             )
@@ -16198,11 +16200,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return "\n".join(lines)
             if action == "setup":
-                try:
-                    plan = analyze_project_setup(self._session_db._db, remainder.strip())
-                except ValueError as exc:
-                    return f"Project setup failed: {exc}"
-                return render_project_setup_plan(plan)
+                setup_args = remainder.split()
+                if len(setup_args) == 1:
+                    try:
+                        plan = analyze_project_setup(self._session_db._db, setup_args[0])
+                    except ValueError as exc:
+                        return f"Project setup failed: {exc}"
+                    return render_project_setup_plan(plan)
+                if len(setup_args) == 2 and setup_args[1] == "--apply":
+                    try:
+                        result = apply_project_setup(self._session_db._db, setup_args[0])
+                    except ValueError as exc:
+                        return f"Project setup failed: {exc}"
+                    return render_project_setup_apply_result(result)
+                return "Project setup failed: usage: !project setup <key> [--apply]"
             if action == "add":
                 try:
                     project = register_project(self._session_db._db, remainder.strip())

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16167,12 +16167,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             action = action.lower()
             from gateway.project_router import (
                 active_project,
+                add_project_alias,
                 analyze_project_setup,
                 apply_project_setup,
                 clear_project,
                 project_keys,
                 project_path,
                 register_project,
+                remove_project_alias,
                 render_project_setup_apply_result,
                 render_project_setup_plan,
                 select_project,
@@ -16199,6 +16201,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"- {key} → {project_path(self._session_db._db, key)}" for key in projects
                 )
                 return "\n".join(lines)
+            if action == "alias":
+                alias_args = remainder.strip().split(maxsplit=2)
+                if len(alias_args) != 3 or alias_args[0] not in {"add", "remove"}:
+                    return "Project alias failed: usage: !project alias add|remove <key> <alias>"
+                operation, key, alias = alias_args
+                try:
+                    normalized_alias = (
+                        add_project_alias(self._session_db._db, key, alias)
+                        if operation == "add"
+                        else remove_project_alias(self._session_db._db, key, alias)
+                    )
+                except ValueError as exc:
+                    return f"Project alias failed: {exc}"
+                verb = "added" if operation == "add" else "removed"
+                return f"Project alias {verb}: {key} → {normalized_alias}"
             if action == "setup":
                 setup_args = remainder.split()
                 if len(setup_args) == 1:
@@ -16237,6 +16254,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return f"Project selection failed: {exc}"
             self._evict_cached_agent(session_key)
             return f"Active project: {action} ({path})"
+
+        # Explicit !project commands above always win. Ordinary Matrix messages
+        # get only deterministic registry evidence: key, display name, or alias.
+        # A generic follow-up leaves an existing binding unchanged; no classifier
+        # or speculative switch is attempted.
+        if source.platform == Platform.MATRIX:
+            from gateway.project_router import active_project, resolve_project_reference, select_project
+
+            session_key = self._session_key_for_source(source)
+            matches = resolve_project_reference(self._session_db._db, event.text or "")
+            if len(matches) > 1:
+                lines = ["I found multiple possible projects:", *(f"- {key}" for key in matches)]
+                lines.append("Which one do you want to use?")
+                return "\n".join(lines)
+            if len(matches) == 1:
+                matched_key = matches[0]
+                current = active_project(self._session_db._db, session_key)
+                if current is None or current[0] != matched_key:
+                    select_project(self._session_db._db, session_key, matched_key)
+                    self._evict_cached_agent(session_key)
+                    await self._adapter_for_source(source).send(
+                        chat_id=source.chat_id, content=f"Using project: {matched_key}"
+                    )
 
         from hermes_cli.commands import (
             GATEWAY_KNOWN_COMMANDS,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16167,10 +16167,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             action = action.lower()
             from gateway.project_router import (
                 active_project,
+                analyze_project_setup,
                 clear_project,
                 project_keys,
                 project_path,
                 register_project,
+                render_project_setup_plan,
                 select_project,
             )
 
@@ -16195,6 +16197,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"- {key} → {project_path(self._session_db._db, key)}" for key in projects
                 )
                 return "\n".join(lines)
+            if action == "setup":
+                try:
+                    plan = analyze_project_setup(self._session_db._db, remainder.strip())
+                except ValueError as exc:
+                    return f"Project setup failed: {exc}"
+                return render_project_setup_plan(plan)
             if action == "add":
                 try:
                     project = register_project(self._session_db._db, remainder.strip())

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16171,9 +16171,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 analyze_project_setup,
                 apply_project_setup,
                 clear_project,
-                project_keys,
-                project_path,
+                project_details,
                 register_project,
+                registered_project_details,
                 remove_project_alias,
                 render_project_setup_apply_result,
                 render_project_setup_plan,
@@ -16195,11 +16195,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 key, path = project
                 return f"Active project: {key}\nPath: {path}"
             if action == "list" and not remainder.strip():
-                projects = project_keys(self._session_db._db)
                 lines = ["Registered projects:"]
-                lines.extend(
-                    f"- {key} → {project_path(self._session_db._db, key)}" for key in projects
-                )
+                for key, display_name, aliases, path in registered_project_details(self._session_db._db):
+                    alias_text = ", ".join(aliases) if aliases else "none"
+                    lines.extend(
+                        [
+                            "",
+                            f"- {key}",
+                            f"  Name: {display_name}",
+                            f"  Aliases: {alias_text}",
+                            f"  Path: {path}",
+                        ]
+                    )
+                return "\n".join(lines)
+            if action == "aliases":
+                alias_key = remainder.strip()
+                if not alias_key:
+                    lines = ["Project aliases:"]
+                    for key, display_name, aliases, _path in registered_project_details(self._session_db._db):
+                        lines.extend(["", f"- {key} ({display_name})"])
+                        lines.extend(f"  - {alias}" for alias in aliases)
+                        if not aliases:
+                            lines.append("  - none")
+                    return "\n".join(lines)
+                if len(alias_key.split()) != 1:
+                    return "Project aliases failed: usage: !project aliases [<key>]"
+                try:
+                    key, display_name, aliases, _path = project_details(self._session_db._db, alias_key)
+                except ValueError as exc:
+                    return f"Project aliases failed: {exc}"
+                lines = [f"Project: {key}", f"Name: {display_name}", "Aliases:"]
+                lines.extend(f"- {alias}" for alias in aliases)
+                if not aliases:
+                    lines.append("- none")
                 return "\n".join(lines)
             if action == "alias":
                 alias_args = remainder.strip().split(maxsplit=2)
@@ -16212,10 +16240,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if operation == "add"
                         else remove_project_alias(self._session_db._db, key, alias)
                     )
+                    normalized_key, _display_name, aliases, _path = project_details(
+                        self._session_db._db, key
+                    )
                 except ValueError as exc:
                     return f"Project alias failed: {exc}"
                 verb = "added" if operation == "add" else "removed"
-                return f"Project alias {verb}: {key} → {normalized_alias}"
+                lines = [f"Alias {verb}: {normalized_alias}", f"Project: {normalized_key}", "Aliases:"]
+                lines.extend(f"- {current_alias}" for current_alias in aliases)
+                if not aliases:
+                    lines.append("- none")
+                return "\n".join(lines)
             if action == "setup":
                 setup_args = remainder.split()
                 if len(setup_args) == 1:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10715,6 +10715,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
         self._execute_write(_do)
 
+    def delete_meta(self, key: str) -> None:
+        """Remove a value from the state_meta key/value store."""
+        def _do(conn):
+            conn.execute("DELETE FROM state_meta WHERE key = ?", (key,))
+
+        self._execute_write(_do)
+
     def retag_kanban_worker_sessions(self, workspaces_root: str) -> int:
         """Retag legacy kanban worker rows from ``cli`` to ``kanban``.
 

--- a/tests/gateway/test_matrix_project_router.py
+++ b/tests/gateway/test_matrix_project_router.py
@@ -1,0 +1,157 @@
+"""Focused Matrix project-router vertical-slice coverage."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent.runtime_cwd import resolve_agent_cwd, resolve_context_cwd
+from agent.prompt_builder import build_context_files_prompt
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.project_router import PROJECTS, active_project_path, project_path
+from gateway.session import SessionContext, SessionEntry, SessionSource, build_session_key
+from hermes_state import SessionDB
+
+
+PROJECT_PATH = PROJECTS["newmoon"]
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.MATRIX,
+        user_id="matrix-user",
+        chat_id="matrix-room",
+        user_name="tester",
+        chat_type="room",
+    )
+
+
+def _event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_source(),
+        message_id="message-1",
+        internal=True,
+    )
+
+
+def _session_entry() -> SessionEntry:
+    source = _source()
+    return SessionEntry(
+        session_key=build_session_key(source),
+        session_id="matrix-session",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.MATRIX,
+        chat_type="room",
+        total_tokens=0,
+    )
+
+
+def _runner(tmp_path):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.MATRIX: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter._pending_messages = {}
+    runner.adapters = {Platform.MATRIX: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(), emit_collect=AsyncMock(return_value=[]), loaded_hooks=False
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = _session_entry()
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._queued_events = {}
+    runner._session_db = SimpleNamespace(_db=SessionDB(db_path=tmp_path / "state.db"))
+    runner._session_db._db.get_session_title = MagicMock(return_value=None)
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._update_prompt_pending = {}
+    runner._busy_input_mode = "interrupt"
+    runner._draining = False
+    runner._session_run_generation = {}
+    runner._session_sources = {}
+    runner._pending_native_image_paths_by_session = {}
+    runner._background_tasks = {}
+    runner._background_task_counter = 0
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._service_tier = None
+    runner._fast_mode_by_session = {}
+    runner._goal_state_by_session = {}
+    runner._goal_runs_in_progress = set()
+    runner._goal_queued_by_session = set()
+    runner._is_telegram_topic_root_lobby = lambda _source: False
+    runner._should_send_telegram_lobby_reminder = lambda _source: False
+    runner._check_slash_access = lambda _source, _command: None
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._release_running_agent_state = lambda key: runner._running_agents.pop(key, None)
+    runner._evict_cached_agent = MagicMock()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_project_newmoon_intercepts_persists_and_evicts_cached_agent(tmp_path):
+    runner = _runner(tmp_path)
+    session_key = build_session_key(_source())
+    runner._handle_message_with_agent = AsyncMock()
+
+    response = await runner._handle_message(_event("!project newmoon"))
+
+    assert response == f"Active project: newmoon ({PROJECT_PATH})"
+    assert active_project_path(runner._session_db._db, session_key) == project_path("newmoon")
+    runner._evict_cached_agent.assert_called_once_with(session_key)
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+def test_selected_matrix_session_binds_project_cwd_and_discovers_agents_md(tmp_path):
+    runner = _runner(tmp_path)
+    session_key = build_session_key(_source())
+    runner._session_db._db.set_meta("matrix_project_router:" + session_key, "newmoon")
+    context = SessionContext(
+        source=_source(), connected_platforms=[], home_channels={}, session_key=session_key
+    )
+
+    tokens = runner._set_session_env(context)
+    try:
+        assert resolve_agent_cwd() == project_path("newmoon")
+        assert resolve_context_cwd() == project_path("newmoon")
+        prompt = build_context_files_prompt(cwd=str(resolve_context_cwd()), skip_soul=True)
+        assert "# AGENTS.md" in prompt
+        assert "Authoritative context" in prompt
+    finally:
+        runner._clear_session_env(tokens)
+
+
+@pytest.mark.asyncio
+async def test_unbound_matrix_session_dispatches_normally(tmp_path):
+    runner = _runner(tmp_path)
+    expected = {"final_response": "ordinary dispatch", "messages": []}
+    runner._handle_message_with_agent = AsyncMock(return_value=expected)
+
+    result = await runner._handle_message(_event("ordinary Matrix message"))
+
+    assert result == expected
+    runner._handle_message_with_agent.assert_awaited_once()

--- a/tests/gateway/test_matrix_project_router.py
+++ b/tests/gateway/test_matrix_project_router.py
@@ -13,13 +13,29 @@ from agent.runtime_cwd import resolve_agent_cwd, resolve_context_cwd
 from agent.prompt_builder import build_context_files_prompt
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
-from gateway.project_router import PROJECTS, active_project_path, project_path
+from gateway.project_router import (
+    active_project_path,
+    bootstrap_registry,
+    project_keys,
+    project_path,
+    register_project,
+)
 from gateway.session import SessionContext, SessionEntry, SessionSource, build_session_key
 from hermes_state import SessionDB
 
 
-NEWMOON_PATH = PROJECTS["newmoon"]
-FIVEHOURS_PATH = "/home/rle/projects/savefivehours"
+NEWMOON_PATH = Path("/home/rle/projects/NewMoonNailsAndSpa")
+FIVEHOURS_PATH = Path("/home/rle/projects/savefivehours")
+
+
+def _make_project(tmp_path: Path, name: str, *, agents: bool = True) -> Path:
+    project = tmp_path / name
+    project.mkdir()
+    (project / ".git").mkdir()
+    (project / "README.md").write_text("# Test project\n")
+    if agents:
+        (project / "AGENTS.md").write_text("# Agent context\n")
+    return project
 
 
 def _source() -> SessionSource:
@@ -128,7 +144,9 @@ async def test_project_selection_intercepts_persists_and_evicts_cached_agent(tmp
 
     assert response == f"Active project: {key} ({path})"
     assert runner._session_db._db.get_meta("matrix_project_router:" + session_key) == key
-    assert active_project_path(runner._session_db._db, session_key) == project_path(key)
+    assert active_project_path(runner._session_db._db, session_key) == project_path(
+        runner._session_db._db, key
+    )
     runner._evict_cached_agent.assert_called_once_with(session_key)
     runner._handle_message_with_agent.assert_not_awaited()
 
@@ -174,9 +192,12 @@ async def test_project_selection_switches_active_project_and_evicts_each_time(tm
     await runner._handle_message(_event(f"!project {first}"))
     response = await runner._handle_message(_event(f"!project {second}"))
 
-    assert response == f"Active project: {second} ({PROJECTS[second]})"
+    expected_path = FIVEHOURS_PATH if second == "fivehours" else NEWMOON_PATH
+    assert response == f"Active project: {second} ({expected_path})"
     assert runner._session_db._db.get_meta("matrix_project_router:" + session_key) == second
-    assert active_project_path(runner._session_db._db, session_key) == project_path(second)
+    assert active_project_path(runner._session_db._db, session_key) == project_path(
+        runner._session_db._db, second
+    )
     assert runner._evict_cached_agent.call_args_list == [call(session_key), call(session_key)]
     runner._handle_message_with_agent.assert_not_awaited()
 
@@ -287,3 +308,105 @@ async def test_unbound_matrix_session_dispatches_normally(tmp_path):
 
     assert result == expected
     runner._handle_message_with_agent.assert_awaited_once()
+
+
+def test_registry_bootstraps_legacy_projects_once_without_overwriting_additions(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    bootstrap_registry(db)
+    assert project_keys(db) == ("fivehours", "newmoon")
+
+    project = _make_project(tmp_path, "custom-project")
+    registered = register_project(db, str(project))
+    assert registered.key == "customproject"
+
+    bootstrap_registry(db)
+    assert project_keys(db) == ("customproject", "fivehours", "newmoon")
+
+
+def test_registered_project_uses_canonical_path_and_survives_reopening_state(tmp_path):
+    db_path = tmp_path / "state.db"
+    project = _make_project(tmp_path, "My Cool App")
+    db = SessionDB(db_path=db_path)
+
+    registered = register_project(db, str(project / "."))
+
+    assert registered.key == "mycoolapp"
+    assert registered.path == project.resolve()
+    reopened = SessionDB(db_path=db_path)
+    assert project_path(reopened, "mycoolapp") == project.resolve()
+
+
+def test_register_project_rejects_duplicate_keys_and_paths(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    first = _make_project(tmp_path, "first")
+    second = _make_project(tmp_path, "second")
+    register_project(db, str(first), key="shared")
+
+    with pytest.raises(ValueError, match="already registered for this path"):
+        register_project(db, str(first), key="shared")
+    with pytest.raises(ValueError, match="key 'shared'.*already registered"):
+        register_project(db, str(second), key="shared")
+    with pytest.raises(ValueError, match="already registered as 'shared'"):
+        register_project(db, str(first), key="other")
+
+
+@pytest.mark.parametrize("raw_path", ["relative-project", "/does/not/exist"])
+def test_register_project_rejects_invalid_paths(tmp_path, raw_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    with pytest.raises(ValueError):
+        register_project(db, raw_path)
+
+
+def test_register_project_rejects_directory_that_is_not_a_project(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    directory = tmp_path / "not-a-project"
+    directory.mkdir()
+
+    with pytest.raises(ValueError, match="does not appear to be a project or repository"):
+        register_project(db, str(directory))
+
+
+@pytest.mark.asyncio
+async def test_project_add_registers_without_modifying_repository_and_can_be_selected(tmp_path):
+    runner = _runner(tmp_path)
+    runner._handle_message_with_agent = AsyncMock()
+    project = _make_project(tmp_path, "My Cool App", agents=False)
+    readme_before = (project / "README.md").read_text()
+
+    response = await runner._handle_message(_event(f"!project add {project}"))
+
+    assert response == (
+        f"Project registered: mycoolapp\nPath: {project.resolve()}\n\nContext:\n"
+        "- AGENTS.md: missing\n- README*: found\n- CONTRIBUTING.md: missing\n"
+        "- package.json: missing\n- pyproject.toml: missing\n- Cargo.toml: missing\n"
+        "- go.mod: missing\n- docs/: missing\n- docs/STATUS.md: missing\n"
+        "- docs/decisions/: missing\n\n"
+        "Project routing is available, but repository agent context is incomplete."
+    )
+    assert (project / "README.md").read_text() == readme_before
+    assert not (project / "AGENTS.md").exists()
+
+    selected = await runner._handle_message(_event("!project mycoolapp"))
+    assert selected == f"Active project: mycoolapp ({project.resolve()})"
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_project_list_is_deterministic_and_unknown_keys_are_dynamic(tmp_path):
+    runner = _runner(tmp_path)
+    runner._handle_message_with_agent = AsyncMock()
+    project = _make_project(tmp_path, "Zebra App")
+    await runner._handle_message(_event(f"!project add {project}"))
+
+    listed = await runner._handle_message(_event("!project list"))
+    unknown = await runner._handle_message(_event("!project unknown"))
+
+    assert listed == (
+        "Registered projects:\n"
+        "- fivehours → /home/rle/projects/savefivehours\n"
+        "- newmoon → /home/rle/projects/NewMoonNailsAndSpa\n"
+        f"- zebraapp → {project.resolve()}"
+    )
+    assert "Valid projects: fivehours, newmoon, zebraapp" in unknown

--- a/tests/gateway/test_matrix_project_router.py
+++ b/tests/gateway/test_matrix_project_router.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from datetime import datetime
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
@@ -17,7 +18,8 @@ from gateway.session import SessionContext, SessionEntry, SessionSource, build_s
 from hermes_state import SessionDB
 
 
-PROJECT_PATH = PROJECTS["newmoon"]
+NEWMOON_PATH = PROJECTS["newmoon"]
+FIVEHOURS_PATH = "/home/rle/projects/savefivehours"
 
 
 def _source() -> SessionSource:
@@ -113,36 +115,82 @@ def _runner(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_project_newmoon_intercepts_persists_and_evicts_cached_agent(tmp_path):
+@pytest.mark.parametrize(
+    ("key", "path"),
+    [("newmoon", NEWMOON_PATH), ("fivehours", FIVEHOURS_PATH)],
+)
+async def test_project_selection_intercepts_persists_and_evicts_cached_agent(tmp_path, key, path):
     runner = _runner(tmp_path)
     session_key = build_session_key(_source())
     runner._handle_message_with_agent = AsyncMock()
 
-    response = await runner._handle_message(_event("!project newmoon"))
+    response = await runner._handle_message(_event(f"!project {key}"))
 
-    assert response == f"Active project: newmoon ({PROJECT_PATH})"
-    assert active_project_path(runner._session_db._db, session_key) == project_path("newmoon")
+    assert response == f"Active project: {key} ({path})"
+    assert runner._session_db._db.get_meta("matrix_project_router:" + session_key) == key
+    assert active_project_path(runner._session_db._db, session_key) == project_path(key)
     runner._evict_cached_agent.assert_called_once_with(session_key)
     runner._handle_message_with_agent.assert_not_awaited()
 
 
-def test_selected_matrix_session_binds_project_cwd_and_discovers_agents_md(tmp_path):
+@pytest.mark.parametrize(
+    ("key", "path", "agents_text"),
+    [
+        ("newmoon", NEWMOON_PATH, "Authoritative context"),
+        ("fivehours", FIVEHOURS_PATH, "Authoritative sources"),
+    ],
+)
+def test_selected_matrix_session_binds_project_cwd_and_discovers_agents_md(
+    tmp_path, key, path, agents_text
+):
     runner = _runner(tmp_path)
     session_key = build_session_key(_source())
-    runner._session_db._db.set_meta("matrix_project_router:" + session_key, "newmoon")
+    runner._session_db._db.set_meta("matrix_project_router:" + session_key, key)
     context = SessionContext(
         source=_source(), connected_platforms=[], home_channels={}, session_key=session_key
     )
 
     tokens = runner._set_session_env(context)
     try:
-        assert resolve_agent_cwd() == project_path("newmoon")
-        assert resolve_context_cwd() == project_path("newmoon")
+        assert resolve_agent_cwd() == Path(path)
+        assert resolve_context_cwd() == Path(path)
         prompt = build_context_files_prompt(cwd=str(resolve_context_cwd()), skip_soul=True)
         assert "# AGENTS.md" in prompt
-        assert "Authoritative context" in prompt
+        assert agents_text in prompt
     finally:
         runner._clear_session_env(tokens)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [("newmoon", "fivehours"), ("fivehours", "newmoon")],
+)
+async def test_project_selection_switches_active_project_and_evicts_each_time(tmp_path, first, second):
+    runner = _runner(tmp_path)
+    session_key = build_session_key(_source())
+    runner._handle_message_with_agent = AsyncMock()
+
+    await runner._handle_message(_event(f"!project {first}"))
+    response = await runner._handle_message(_event(f"!project {second}"))
+
+    assert response == f"Active project: {second} ({PROJECTS[second]})"
+    assert runner._session_db._db.get_meta("matrix_project_router:" + session_key) == second
+    assert active_project_path(runner._session_db._db, session_key) == project_path(second)
+    assert runner._evict_cached_agent.call_args_list == [call(session_key), call(session_key)]
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unknown_project_does_not_dispatch_and_lists_valid_keys(tmp_path):
+    runner = _runner(tmp_path)
+    runner._handle_message_with_agent = AsyncMock()
+
+    response = await runner._handle_message(_event("!project unknown"))
+
+    assert response == "Project selection failed: unknown project 'unknown'. Valid projects: fivehours, newmoon"
+    runner._evict_cached_agent.assert_not_called()
+    runner._handle_message_with_agent.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_matrix_project_router.py
+++ b/tests/gateway/test_matrix_project_router.py
@@ -182,6 +182,90 @@ async def test_project_selection_switches_active_project_and_evicts_each_time(tm
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("key", "path"),
+    [("newmoon", NEWMOON_PATH), ("fivehours", FIVEHOURS_PATH)],
+)
+async def test_project_status_reports_active_project(tmp_path, key, path):
+    runner = _runner(tmp_path)
+    runner._handle_message_with_agent = AsyncMock()
+
+    await runner._handle_message(_event(f"!project {key}"))
+    runner._evict_cached_agent.reset_mock()
+    response = await runner._handle_message(_event("!project status"))
+
+    assert response == f"Active project: {key}\nPath: {path}"
+    runner._evict_cached_agent.assert_not_called()
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_project_status_reports_none_when_no_project_is_active(tmp_path):
+    runner = _runner(tmp_path)
+    runner._handle_message_with_agent = AsyncMock()
+
+    response = await runner._handle_message(_event("!project status"))
+
+    assert response == "Active project: none"
+    runner._evict_cached_agent.assert_not_called()
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_project_clear_removes_state_evicts_agent_and_unbinds_follow_up(tmp_path):
+    runner = _runner(tmp_path)
+    session_key = build_session_key(_source())
+    expected = {"final_response": "ordinary dispatch", "messages": []}
+    runner._handle_message_with_agent = AsyncMock(return_value=expected)
+
+    await runner._handle_message(_event("!project fivehours"))
+    context = SessionContext(
+        source=_source(), connected_platforms=[], home_channels={}, session_key=session_key
+    )
+    tokens = runner._set_session_env(context)
+    assert resolve_context_cwd() == Path(FIVEHOURS_PATH)
+    runner._evict_cached_agent.reset_mock()
+    response = await runner._handle_message(_event("!project clear"))
+
+    assert response == "Project context cleared."
+    assert runner._session_db._db.get_meta("matrix_project_router:" + session_key) is None
+    assert active_project_path(runner._session_db._db, session_key) is None
+    runner._evict_cached_agent.assert_called_once_with(session_key)
+    try:
+        assert resolve_context_cwd() is None
+        assert resolve_agent_cwd() not in {Path(NEWMOON_PATH), Path(FIVEHOURS_PATH)}
+        prompt = build_context_files_prompt(cwd=None, skip_soul=True)
+        assert "Authoritative context" not in prompt
+        assert "Authoritative sources" not in prompt
+    finally:
+        runner._clear_session_env(tokens)
+
+    result = await runner._handle_message(_event("ordinary Matrix message"))
+    assert result == expected
+    runner._handle_message_with_agent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_project_selection_works_after_clear(tmp_path):
+    runner = _runner(tmp_path)
+    session_key = build_session_key(_source())
+    runner._handle_message_with_agent = AsyncMock()
+
+    await runner._handle_message(_event("!project newmoon"))
+    await runner._handle_message(_event("!project clear"))
+    response = await runner._handle_message(_event("!project fivehours"))
+
+    assert response == f"Active project: fivehours ({FIVEHOURS_PATH})"
+    assert runner._session_db._db.get_meta("matrix_project_router:" + session_key) == "fivehours"
+    assert runner._evict_cached_agent.call_args_list == [
+        call(session_key),
+        call(session_key),
+        call(session_key),
+    ]
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_unknown_project_does_not_dispatch_and_lists_valid_keys(tmp_path):
     runner = _runner(tmp_path)
     runner._handle_message_with_agent = AsyncMock()

--- a/tests/gateway/test_matrix_project_router.py
+++ b/tests/gateway/test_matrix_project_router.py
@@ -23,6 +23,7 @@ from gateway.project_router import (
     analyze_project_setup,
     apply_project_setup,
     bootstrap_registry,
+    project_details,
     project_keys,
     project_path,
     register_project,
@@ -447,21 +448,87 @@ def test_project_aliases_persist_and_conflicts_never_reassign(tmp_path):
 
     reopened = SessionDB(db_path=db_path)
     assert resolve_project_reference(reopened, "NAIL WEBSITE") == ("newmoon",)
+    assert project_details(reopened, "newmoon")[2] == (
+        "nail site",
+        "nail website",
+        "nails site",
+        "new moon",
+        "new moon nails",
+    )
     fresh = SessionDB(db_path=tmp_path / "fresh-state.db")
     assert resolve_project_reference(fresh, "nail website") == ()
 
 
 @pytest.mark.asyncio
-async def test_project_alias_commands_mutate_registry_without_agent_dispatch(tmp_path):
+async def test_project_alias_commands_mutate_registry_show_sorted_aliases_and_bypass_routing(tmp_path):
     runner = _runner(tmp_path)
     runner._handle_message_with_agent = AsyncMock()
 
-    added = await runner._handle_message(_event("!project alias add newmoon nail website"))
+    added = await runner._handle_message(_event("!project alias add newmoon Nail Website"))
     removed = await runner._handle_message(_event("!project alias remove newmoon nail website"))
 
-    assert added == "Project alias added: newmoon → nail website"
-    assert removed == "Project alias removed: newmoon → nail website"
+    assert added == (
+        "Alias added: nail website\n"
+        "Project: newmoon\n"
+        "Aliases:\n"
+        "- nail site\n"
+        "- nail website\n"
+        "- nails site\n"
+        "- new moon\n"
+        "- new moon nails"
+    )
+    assert removed == (
+        "Alias removed: nail website\n"
+        "Project: newmoon\n"
+        "Aliases:\n"
+        "- nail site\n"
+        "- nails site\n"
+        "- new moon\n"
+        "- new moon nails"
+    )
     assert resolve_project_reference(runner._session_db._db, "nail website") == ()
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_project_aliases_lists_all_or_one_and_unknown_key_is_safe(tmp_path):
+    runner = _runner(tmp_path)
+    runner._handle_message_with_agent = AsyncMock()
+    trinity = _make_project(tmp_path, "trinity-water")
+    register_project(runner._session_db._db, str(trinity))
+
+    all_aliases = await runner._handle_message(_event("!project aliases"))
+    one_aliases = await runner._handle_message(_event("!project aliases newmoon"))
+    no_aliases = await runner._handle_message(_event("!project aliases trinitywater"))
+    unknown = await runner._handle_message(_event("!project aliases missing"))
+
+    assert all_aliases == (
+        "Project aliases:\n\n"
+        "- fivehours (Five Hours)\n"
+        "  - five hours\n"
+        "  - save five hours\n\n"
+        "- newmoon (New Moon Nails)\n"
+        "  - nail site\n"
+        "  - nails site\n"
+        "  - new moon\n"
+        "  - new moon nails\n\n"
+        "- trinitywater (Trinity Water)\n"
+        "  - none"
+    )
+    assert one_aliases == (
+        "Project: newmoon\n"
+        "Name: New Moon Nails\n"
+        "Aliases:\n"
+        "- nail site\n"
+        "- nails site\n"
+        "- new moon\n"
+        "- new moon nails"
+    )
+    assert no_aliases == "Project: trinitywater\nName: Trinity Water\nAliases:\n- none"
+    assert unknown == (
+        "Project aliases failed: unknown project 'missing'. "
+        "Valid projects: fivehours, newmoon, trinitywater"
+    )
     runner._handle_message_with_agent.assert_not_awaited()
 
 
@@ -626,10 +693,19 @@ async def test_project_list_is_deterministic_and_unknown_keys_are_dynamic(tmp_pa
     unknown = await runner._handle_message(_event("!project unknown"))
 
     assert listed == (
-        "Registered projects:\n"
-        "- fivehours → /home/rle/projects/savefivehours\n"
-        "- newmoon → /home/rle/projects/NewMoonNailsAndSpa\n"
-        f"- zebraapp → {project.resolve()}"
+        "Registered projects:\n\n"
+        "- fivehours\n"
+        "  Name: Five Hours\n"
+        "  Aliases: five hours, save five hours\n"
+        "  Path: /home/rle/projects/savefivehours\n\n"
+        "- newmoon\n"
+        "  Name: New Moon Nails\n"
+        "  Aliases: nail site, nails site, new moon, new moon nails\n"
+        "  Path: /home/rle/projects/NewMoonNailsAndSpa\n\n"
+        "- zebraapp\n"
+        "  Name: Zebra App\n"
+        "  Aliases: none\n"
+        f"  Path: {project.resolve()}"
     )
     assert "Valid projects: fivehours, newmoon, zebraapp" in unknown
 

--- a/tests/gateway/test_matrix_project_router.py
+++ b/tests/gateway/test_matrix_project_router.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call
 
@@ -14,8 +15,11 @@ from agent.prompt_builder import build_context_files_prompt
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.project_router import (
+    ProjectSetupPlan,
+    SetupRecommendation,
     active_project_path,
     analyze_project_setup,
+    apply_project_setup,
     bootstrap_registry,
     project_keys,
     project_path,
@@ -625,3 +629,201 @@ def test_setup_analysis_detects_readme_variants_and_claude_instruction_conventio
         ("README.rst", "project overview"),
         ("CLAUDE.md", "repository agent instructions"),
     )
+
+
+def test_setup_apply_with_no_recommendations_does_not_mutate(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    project = _make_project(tmp_path, "complete")
+    (project / "docs" / "decisions").mkdir(parents=True)
+    (project / "docs" / "STATUS.md").write_text("# Status\n")
+    register_project(db, str(project))
+    before = _repository_snapshot(project)
+
+    result = apply_project_setup(db, "complete")
+
+    assert result.created == ()
+    assert result.skipped == ()
+    assert result.plan.recommendations == ()
+    assert _repository_snapshot(project) == before
+
+
+@pytest.mark.asyncio
+async def test_project_setup_apply_reports_no_changes_for_empty_current_plan(tmp_path):
+    runner = _runner(tmp_path)
+    runner._handle_message_with_agent = AsyncMock()
+    project = _make_project(tmp_path, "Complete App")
+    (project / "docs" / "decisions").mkdir(parents=True)
+    (project / "docs" / "STATUS.md").write_text("# Status\n")
+    register_project(runner._session_db._db, str(project))
+
+    response = await runner._handle_message(_event("!project setup completeapp --apply"))
+
+    assert response == (
+        "Project setup analysis: completeapp\n\n"
+        "No setup changes are currently recommended.\nNothing to apply.\n\n"
+        "No repository files were changed."
+    )
+
+
+@pytest.mark.asyncio
+async def test_project_setup_apply_renders_deterministic_created_and_skipped_sections(tmp_path):
+    runner = _runner(tmp_path)
+    runner._handle_message_with_agent = AsyncMock()
+    project = _make_project(tmp_path, "Apply App", agents=False)
+    register_project(runner._session_db._db, str(project))
+
+    response = await runner._handle_message(_event("!project setup applyapp --apply"))
+
+    assert response == (
+        "Project setup applied: applyapp\n\nCreated:\n- AGENTS.md\n\nSkipped:\n- none\n\n"
+        "No existing files were overwritten.\nChanges remain uncommitted for review."
+    )
+    assert (project / "AGENTS.md").is_file()
+
+
+def test_setup_apply_creates_recommended_agents_from_static_evidence_without_scripts(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    project = _make_project(tmp_path, "minimal", agents=False)
+    (project / "package.json").write_text('{"scripts":{"prepare":"touch executed"}}\n')
+    register_project(db, str(project))
+
+    result = apply_project_setup(db, "minimal")
+
+    assert result.created == ("AGENTS.md",)
+    assert result.skipped == ()
+    content = (project / "AGENTS.md").read_text()
+    assert "# Agent Instructions" in content
+    assert "README.md" in content
+    assert "package.json" in content
+    assert "must be confirmed" in content
+    assert not (project / "executed").exists()
+    assert all(item.target != "AGENTS.md" for item in result.plan.recommendations)
+
+
+def test_setup_apply_reanalyzes_and_never_overwrites_agents_created_after_a_stale_plan(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    project = _make_project(tmp_path, "stale", agents=False)
+    register_project(db, str(project))
+    stale_plan = analyze_project_setup(db, "stale")
+    assert any(item.target == "AGENTS.md" for item in stale_plan.recommendations)
+    agents = project / "AGENTS.md"
+    agents.write_text("# Existing instructions\n")
+
+    result = apply_project_setup(db, "stale")
+
+    assert result.created == ()
+    assert agents.read_text() == "# Existing instructions\n"
+    assert result.plan.recommendations == ()
+
+
+def test_setup_apply_creates_only_recommended_status_file(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    project = _make_project(tmp_path, "status")
+    (project / "docs").mkdir()
+    register_project(db, str(project))
+
+    result = apply_project_setup(db, "status")
+
+    assert result.created == ("docs/STATUS.md",)
+    assert (project / "docs" / "STATUS.md").read_text().startswith("# Current Status\n")
+    assert not (project / "docs" / "decisions").exists()
+    assert all(item.target != "docs/STATUS.md" for item in result.plan.recommendations)
+
+
+def test_setup_apply_creates_decision_scaffold_only_when_recommended(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    project = _make_project(tmp_path, "decisions")
+    (project / "CONTRIBUTING.md").write_text("# Contributing\n")
+    (project / "package.json").write_text("{}\n")
+    (project / "docs").mkdir()
+    register_project(db, str(project))
+
+    result = apply_project_setup(db, "decisions")
+
+    assert result.created == ("docs/STATUS.md", "docs/decisions/README.md")
+    assert (project / "docs" / "decisions" / "README.md").is_file()
+    assert not list((project / "docs" / "decisions").glob("[0-9]*"))
+    assert result.plan.recommendations == ()
+
+
+def test_setup_apply_refuses_a_target_that_appears_after_current_analysis(tmp_path, monkeypatch):
+    import gateway.project_router as project_router
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    project = _make_project(tmp_path, "race", agents=False)
+    register_project(db, str(project))
+    original_write = project_router._write_new_file
+
+    def create_conflict(path, content):
+        if path.name == "AGENTS.md":
+            path.write_text("# Concurrent instructions\n")
+        return original_write(path, content)
+
+    monkeypatch.setattr(project_router, "_write_new_file", create_conflict)
+    result = apply_project_setup(db, "race")
+
+    assert result.created == ()
+    assert result.skipped == (("AGENTS.md", "target already exists"),)
+    assert (project / "AGENTS.md").read_text() == "# Concurrent instructions\n"
+
+
+def test_setup_apply_never_applies_non_recommended_items(tmp_path, monkeypatch):
+    import gateway.project_router as project_router
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    project = _make_project(tmp_path, "categories", agents=False)
+    register_project(db, str(project))
+    plan = ProjectSetupPlan(
+        key="categories",
+        path=project,
+        found=(),
+        recommendations=(
+            SetupRecommendation("create", "AGENTS.md", "not selected", "optional"),
+            SetupRecommendation("create", "docs/STATUS.md", "not selected", "found"),
+        ),
+        not_needed=(),
+        authoritative_sources=(),
+    )
+    monkeypatch.setattr(project_router, "analyze_project_setup", lambda _db, _key: plan)
+
+    result = apply_project_setup(db, "categories")
+
+    assert result.created == ()
+    assert not (project / "AGENTS.md").exists()
+    assert not (project / "docs").exists()
+
+
+def test_setup_apply_preserves_unrelated_existing_repository_changes(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    project = _make_project(tmp_path, "unrelated", agents=False)
+    unrelated = project / "notes.txt"
+    unrelated.write_text("uncommitted local note\n")
+    register_project(db, str(project))
+
+    result = apply_project_setup(db, "unrelated")
+
+    assert result.created == ("AGENTS.md",)
+    assert unrelated.read_text() == "uncommitted local note\n"
+
+
+def test_setup_apply_preserves_unrelated_git_changes_without_staging_or_branch_mutation(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    project = _make_project(tmp_path, "git-unrelated", agents=False)
+    subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+    subprocess.run(["git", "config", "user.email", "tests@example.invalid"], cwd=project, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=project, check=True)
+    subprocess.run(["git", "add", "README.md"], cwd=project, check=True)
+    subprocess.run(["git", "commit", "-qm", "initial"], cwd=project, check=True)
+    unrelated = project / "local-note.txt"
+    unrelated.write_text("preserve me\n")
+    branch_before = subprocess.check_output(["git", "branch", "--show-current"], cwd=project, text=True)
+    head_before = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=project, text=True)
+    register_project(db, str(project))
+
+    result = apply_project_setup(db, "gitunrelated")
+
+    assert result.had_unrelated_changes is True
+    assert unrelated.read_text() == "preserve me\n"
+    assert subprocess.check_output(["git", "branch", "--show-current"], cwd=project, text=True) == branch_before
+    assert subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=project, text=True) == head_before
+    assert subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=project).returncode == 0

--- a/tests/gateway/test_matrix_project_router.py
+++ b/tests/gateway/test_matrix_project_router.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+import json
 from pathlib import Path
 import subprocess
 from types import SimpleNamespace
@@ -17,6 +18,7 @@ from gateway.platforms.base import MessageEvent, MessageType
 from gateway.project_router import (
     ProjectSetupPlan,
     SetupRecommendation,
+    add_project_alias,
     active_project_path,
     analyze_project_setup,
     apply_project_setup,
@@ -24,6 +26,7 @@ from gateway.project_router import (
     project_keys,
     project_path,
     register_project,
+    resolve_project_reference,
 )
 from gateway.session import SessionContext, SessionEntry, SessionSource, build_session_key
 from hermes_state import SessionDB
@@ -323,6 +326,60 @@ async def test_unbound_matrix_session_dispatches_normally(tmp_path):
     runner._handle_message_with_agent.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_natural_project_reference_switches_and_continues_same_message(tmp_path):
+    runner = _runner(tmp_path)
+    session_key = build_session_key(_source())
+    expected = {"final_response": "ordinary dispatch", "messages": []}
+    runner._handle_message_with_agent = AsyncMock(return_value=expected)
+
+    result = await runner._handle_message(_event("For Five Hours, update the homepage."))
+
+    assert result == expected
+    assert active_project_path(runner._session_db._db, session_key) == FIVEHOURS_PATH
+    runner._evict_cached_agent.assert_called_once_with(session_key)
+    runner._handle_message_with_agent.assert_awaited_once()
+    runner.adapters[Platform.MATRIX].send.assert_awaited_once_with(
+        chat_id="matrix-room", content="Using project: fivehours"
+    )
+
+
+@pytest.mark.asyncio
+async def test_active_project_stays_bound_for_generic_follow_up_and_switches_for_other_reference(tmp_path):
+    runner = _runner(tmp_path)
+    session_key = build_session_key(_source())
+    runner._handle_message_with_agent = AsyncMock(return_value={"final_response": "ok", "messages": []})
+
+    await runner._handle_message(_event("!project newmoon"))
+    runner._evict_cached_agent.reset_mock()
+    await runner._handle_message(_event("Change the CTA to Get Started."))
+    assert active_project_path(runner._session_db._db, session_key) == NEWMOON_PATH
+    runner._evict_cached_agent.assert_not_called()
+
+    await runner._handle_message(_event("Let's go back to Five Hours and change pricing."))
+    assert active_project_path(runner._session_db._db, session_key) == FIVEHOURS_PATH
+    runner._evict_cached_agent.assert_called_once_with(session_key)
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_natural_project_reference_asks_without_dispatch(tmp_path):
+    runner = _runner(tmp_path)
+    runner._handle_message_with_agent = AsyncMock()
+    db = runner._session_db._db
+    project = _make_project(tmp_path, "Other Project")
+    register_project(db, str(project))
+    registry = json.loads(db.get_meta("matrix_project_router:registry"))
+    registry["projects"]["newmoon"]["metadata"]["aliases"] = ["website"]
+    registry["projects"]["otherproject"]["metadata"]["aliases"] = ["website"]
+    db.set_meta("matrix_project_router:registry", json.dumps(registry))
+
+    result = await runner._handle_message(_event("I want to work on the website."))
+
+    assert result == "I found multiple possible projects:\n- newmoon\n- otherproject\nWhich one do you want to use?"
+    runner._handle_message_with_agent.assert_not_awaited()
+    runner._evict_cached_agent.assert_not_called()
+
+
 def test_registry_bootstraps_legacy_projects_once_without_overwriting_additions(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
 
@@ -335,6 +392,77 @@ def test_registry_bootstraps_legacy_projects_once_without_overwriting_additions(
 
     bootstrap_registry(db)
     assert project_keys(db) == ("customproject", "fivehours", "newmoon")
+
+
+def test_registry_migration_adds_default_metadata_without_overwriting_custom_metadata(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.set_meta(
+        "matrix_project_router:registry",
+        json.dumps(
+            {
+                "version": 1,
+                "projects": {
+                    "fivehours": {
+                        "path": str(FIVEHOURS_PATH),
+                        "metadata": {"display_name": "Custom Hours", "aliases": ["custom hours"]},
+                    }
+                },
+            }
+        ),
+    )
+
+    bootstrap_registry(db)
+
+    assert resolve_project_reference(db, "CUSTOM HOURS") == ("fivehours",)
+    assert resolve_project_reference(db, "five hours") == ()
+    registry = json.loads(db.get_meta("matrix_project_router:registry"))
+    assert registry["version"] == 2
+    assert registry["projects"]["fivehours"]["metadata"] == {
+        "aliases": ["custom hours"],
+        "display_name": "Custom Hours",
+    }
+
+
+def test_resolve_project_reference_matches_key_display_name_and_aliases_with_boundaries(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    trinity = _make_project(tmp_path, "trinity-water")
+    register_project(db, str(trinity))
+
+    assert resolve_project_reference(db, "Let's work on Five Hours.") == ("fivehours",)
+    assert resolve_project_reference(db, "Go back to New Moon Nails") == ("newmoon",)
+    assert resolve_project_reference(db, "I want to change something on the nail site.") == ("newmoon",)
+    assert resolve_project_reference(db, "For Trinity Water, change the homepage") == ("trinitywater",)
+    assert resolve_project_reference(db, "FIVE HOURS should work") == ("fivehours",)
+    assert resolve_project_reference(db, "fivehoursly is not a project reference") == ()
+
+
+def test_project_aliases_persist_and_conflicts_never_reassign(tmp_path):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+
+    assert add_project_alias(db, "newmoon", "Nail Website") == "nail website"
+    assert resolve_project_reference(db, "Let's work on the nail website.") == ("newmoon",)
+    with pytest.raises(ValueError, match="conflicts with project 'newmoon'"):
+        add_project_alias(db, "fivehours", "nail website")
+
+    reopened = SessionDB(db_path=db_path)
+    assert resolve_project_reference(reopened, "NAIL WEBSITE") == ("newmoon",)
+    fresh = SessionDB(db_path=tmp_path / "fresh-state.db")
+    assert resolve_project_reference(fresh, "nail website") == ()
+
+
+@pytest.mark.asyncio
+async def test_project_alias_commands_mutate_registry_without_agent_dispatch(tmp_path):
+    runner = _runner(tmp_path)
+    runner._handle_message_with_agent = AsyncMock()
+
+    added = await runner._handle_message(_event("!project alias add newmoon nail website"))
+    removed = await runner._handle_message(_event("!project alias remove newmoon nail website"))
+
+    assert added == "Project alias added: newmoon → nail website"
+    assert removed == "Project alias removed: newmoon → nail website"
+    assert resolve_project_reference(runner._session_db._db, "nail website") == ()
+    runner._handle_message_with_agent.assert_not_awaited()
 
 
 def test_registered_project_uses_canonical_path_and_survives_reopening_state(tmp_path):

--- a/tests/gateway/test_matrix_project_router.py
+++ b/tests/gateway/test_matrix_project_router.py
@@ -15,6 +15,7 @@ from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.project_router import (
     active_project_path,
+    analyze_project_setup,
     bootstrap_registry,
     project_keys,
     project_path,
@@ -36,6 +37,14 @@ def _make_project(tmp_path: Path, name: str, *, agents: bool = True) -> Path:
     if agents:
         (project / "AGENTS.md").write_text("# Agent context\n")
     return project
+
+
+def _repository_snapshot(path: Path) -> dict[str, tuple[bytes, int]]:
+    return {
+        str(candidate.relative_to(path)): (candidate.read_bytes(), candidate.stat().st_mtime_ns)
+        for candidate in sorted(path.rglob("*"))
+        if candidate.is_file()
+    }
 
 
 def _source() -> SessionSource:
@@ -491,3 +500,128 @@ async def test_project_list_is_deterministic_and_unknown_keys_are_dynamic(tmp_pa
         f"- zebraapp → {project.resolve()}"
     )
     assert "Valid projects: fivehours, newmoon, zebraapp" in unknown
+
+
+def test_setup_analysis_for_minimal_repo_recommends_agent_context_without_writes(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    project = _make_project(tmp_path, "minimal", agents=False)
+    (project / "package.json").write_text('{"scripts":{"prepare":"touch executed"}}\n')
+    before = _repository_snapshot(project)
+    register_project(db, str(project))
+
+    plan = analyze_project_setup(db, "minimal")
+
+    assert plan.key == "minimal"
+    assert plan.path == project.resolve()
+    assert plan.found == ("README.md", "package.json")
+    assert [(item.action, item.target, item.category) for item in plan.recommendations] == [
+        ("create", "AGENTS.md", "recommended"),
+    ]
+    assert plan.not_needed == (
+        "docs/STATUS.md — no documentation convention detected",
+        "docs/decisions/ — no documentation or ADR convention detected",
+    )
+    assert plan.authoritative_sources == (("README.md", "project overview"),)
+    assert _repository_snapshot(project) == before
+    assert not (project / "executed").exists()
+
+
+@pytest.mark.asyncio
+async def test_project_setup_known_project_returns_deterministic_read_only_plan(tmp_path):
+    runner = _runner(tmp_path)
+    runner._handle_message_with_agent = AsyncMock()
+    project = _make_project(tmp_path, "Mature App")
+    (project / "CONTRIBUTING.md").write_text("# Contributing\n")
+    (project / "docs").mkdir()
+    (project / "docs" / "adr").mkdir()
+    (project / "docs" / "adr" / "0001-record.md").write_text("# ADR\n")
+    register_project(runner._session_db._db, str(project))
+    before = _repository_snapshot(project)
+
+    response = await runner._handle_message(_event("!project setup matureapp"))
+
+    assert response == (
+        f"Project setup analysis: matureapp\nPath: {project.resolve()}\n\n"
+        "Found:\n- AGENTS.md\n- README.md\n- CONTRIBUTING.md\n- docs/\n- docs/adr/\n\n"
+        "Recommended:\n- docs/STATUS.md — concise current-state snapshot would aid ongoing work\n\n"
+        "Not currently needed:\n- AGENTS.md — existing repository agent instructions are present\n"
+        "- docs/decisions/ — existing ADR convention: docs/adr/\n\n"
+        "Authoritative sources:\n- AGENTS.md — repository agent instructions\n"
+        "- README.md — project overview\n- CONTRIBUTING.md — contribution conventions\n\n"
+        "No repository files were changed."
+    )
+    assert _repository_snapshot(project) == before
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_project_setup_unknown_key_lists_dynamic_keys_without_dispatch(tmp_path):
+    runner = _runner(tmp_path)
+    runner._handle_message_with_agent = AsyncMock()
+    project = _make_project(tmp_path, "Zebra App")
+    register_project(runner._session_db._db, str(project))
+
+    response = await runner._handle_message(_event("!project setup missing"))
+
+    assert response == (
+        "Project setup failed: unknown project 'missing'. "
+        "Valid projects: fivehours, newmoon, zebraapp"
+    )
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+def test_setup_analysis_respects_claude_and_existing_personal_context_conventions(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    project = _make_project(tmp_path, "personal")
+    (project / "CLAUDE.md").write_text("# Repository instructions\n")
+    (project / "docs").mkdir()
+    (project / "docs" / "STATUS.md").write_text("# Current status\n")
+    (project / "docs" / "decisions").mkdir()
+    (project / "docs" / "decisions" / "001.md").write_text("# Decision\n")
+    register_project(db, str(project))
+
+    plan = analyze_project_setup(db, "personal")
+
+    assert plan.found == (
+        "AGENTS.md",
+        "README.md",
+        "CLAUDE.md",
+        "docs/",
+        "docs/STATUS.md",
+        "docs/decisions/",
+    )
+    assert plan.recommendations == ()
+    assert plan.not_needed == (
+        "AGENTS.md — existing repository agent instructions are present",
+        "docs/STATUS.md — current-state context already exists",
+        "docs/decisions/ — existing ADR convention: docs/decisions/",
+    )
+    assert plan.authoritative_sources == (
+        ("AGENTS.md", "repository agent instructions"),
+        ("README.md", "project overview"),
+        ("CLAUDE.md", "repository agent instructions"),
+        ("docs/STATUS.md", "current implementation state"),
+    )
+
+
+def test_setup_analysis_detects_readme_variants_and_claude_instruction_convention(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    project = _make_project(tmp_path, "variant", agents=False)
+    (project / "README.md").unlink()
+    (project / "README.rst").write_text("Variant project overview\n")
+    (project / "CLAUDE.md").write_text("Repository agent instructions\n")
+    (project / "requirements-dev.txt").write_text("pytest\n")
+    (project / "docs").mkdir()
+    register_project(db, str(project))
+
+    first = analyze_project_setup(db, "variant")
+    second = analyze_project_setup(db, "variant")
+
+    assert first == second
+    assert first.found == ("README.rst", "CLAUDE.md", "requirements-dev.txt", "docs/")
+    assert all(item.target != "AGENTS.md" for item in first.recommendations)
+    assert first.not_needed[0] == "AGENTS.md — existing repository agent instructions are present"
+    assert first.authoritative_sources[:2] == (
+        ("README.rst", "project overview"),
+        ("CLAUDE.md", "repository agent instructions"),
+    )

--- a/tests/gateway/test_matrix_project_router.py
+++ b/tests/gateway/test_matrix_project_router.py
@@ -337,6 +337,87 @@ def test_registered_project_uses_canonical_path_and_survives_reopening_state(tmp
     assert project_path(reopened, "mycoolapp") == project.resolve()
 
 
+def test_register_project_resolves_exact_short_name_under_injected_projects_root(tmp_path):
+    projects_root = tmp_path / "projects"
+    projects_root.mkdir()
+    project = _make_project(projects_root, "trinity-water")
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    registered = register_project(db, "trinity-water", projects_root=projects_root)
+
+    assert registered.key == "trinitywater"
+    assert registered.path == project.resolve()
+    assert project_path(db, "trinitywater") == project.resolve()
+
+
+def test_register_project_accepts_absolute_path_with_injected_projects_root(tmp_path):
+    projects_root = tmp_path / "projects"
+    projects_root.mkdir()
+    project = _make_project(tmp_path, "outside-project")
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    registered = register_project(db, str(project / "."), projects_root=projects_root)
+
+    assert registered.path == project.resolve()
+
+
+@pytest.mark.parametrize("short_name", ["trinity", "trin*"])
+def test_register_project_rejects_nonexistent_short_name(tmp_path, short_name):
+    projects_root = tmp_path / "projects"
+    projects_root.mkdir()
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    with pytest.raises(ValueError, match="project path does not exist"):
+        register_project(db, short_name, projects_root=projects_root)
+
+
+@pytest.mark.parametrize("relative_path", ["../outside-project", "foo/../../../outside-project"])
+def test_register_project_rejects_relative_path_that_escapes_projects_root(tmp_path, relative_path):
+    projects_root = tmp_path / "projects"
+    projects_root.mkdir()
+    escaped_project = _make_project(tmp_path, "outside-project")
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    with pytest.raises(ValueError, match="must remain beneath projects root"):
+        register_project(db, relative_path, projects_root=projects_root)
+
+    assert project_path(db, "outsideproject") is None
+    assert (escaped_project / "README.md").read_text() == "# Test project\n"
+
+
+def test_register_project_supports_exact_nested_relative_path(tmp_path):
+    projects_root = tmp_path / "projects"
+    nested_root = projects_root / "experiments"
+    nested_root.mkdir(parents=True)
+    project = _make_project(nested_root, "my-app")
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    registered = register_project(db, "experiments/my-app", projects_root=projects_root)
+
+    assert registered.key == "myapp"
+    assert registered.path == project.resolve()
+
+
+@pytest.mark.asyncio
+async def test_project_add_resolves_short_name_from_default_projects_root(tmp_path, monkeypatch):
+    import gateway.project_router as project_router
+
+    projects_root = tmp_path / "projects"
+    projects_root.mkdir()
+    project = _make_project(projects_root, "trinity-water", agents=False)
+    monkeypatch.setattr(project_router, "DEFAULT_PROJECTS_ROOT", projects_root)
+    runner = _runner(tmp_path)
+    runner._handle_message_with_agent = AsyncMock()
+
+    response = await runner._handle_message(_event("!project add trinity-water"))
+
+    assert response.startswith(
+        f"Project registered: trinitywater\nPath: {project.resolve()}\n\nContext:\n"
+    )
+    assert project_path(runner._session_db._db, "trinitywater") == project.resolve()
+    assert (project / "README.md").read_text() == "# Test project\n"
+
+
 def test_register_project_rejects_duplicate_keys_and_paths(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     first = _make_project(tmp_path, "first")


### PR DESCRIPTION
## Purpose

Adds explicit per-Matrix-session project routing and management commands. `!project <argument>` is intercepted before ordinary command or model dispatch.

## Registry

- `newmoon` → `/home/rle/projects/NewMoonNailsAndSpa`
- `fivehours` → `/home/rle/projects/savefivehours`

`!project newmoon` and `!project fivehours` validate the canonical directory, persist the normalized key in `state_meta` as `matrix_project_router:<session_key>`, evict the cached agent, and return a concise confirmation.

## Context management

- `!project status` returns the active key and canonical path, or `Active project: none`; it does not dispatch to the model or evict the agent.
- `!project clear` deletes the session’s `state_meta` project binding, clears the task-local logical CWD, evicts the cached agent, and returns `Project context cleared.`

Follow-up Matrix turns resolve their logical CWD exclusively through the persisted registry binding. After clear, ordinary messages are unbound and do not load New Moon or Five Hours repository context unless the user selects a project again.

## Unknown projects

Unknown `!project` keys are consumed by the interceptor, list valid configured keys, and never reach ordinary model dispatch.

## Verification

- `scripts/run_tests.sh tests/gateway/test_matrix_project_router.py -q` — **13 passed**
- `.venv/bin/python -m py_compile hermes_state.py gateway/project_router.py gateway/run.py tests/gateway/test_matrix_project_router.py` — passed
- `git diff --check` — passed

## Deliberately out of scope

No aliases, natural-language detection, semantic routing, RAG, or embeddings.