### PR TITLE
chore: add SeashoreShi to contributor email map

### DIFF
--- a/contributors/emails/seashore.shi@gmail.com
+++ b/contributors/emails/seashore.shi@gmail.com
@@ -1,0 +1,1 @@
+SeashoreShi


### PR DESCRIPTION
## Summary
Adds `seashore.shi@gmail.com` → `SeashoreShi` mapping to `contributors/emails/` so the attribution audit passes for the salvage of PR #83207.

## Context
PR #83207 fixes an `AttributeError` crash when `gateway.platforms` is a list (what `hermes gateway setup` writes). The contributor's email is not yet mapped, which blocks CI on the salvage PR.