### PR TITLE
feat(desktop): equalize visible conversation pane sizes

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -1003,7 +1003,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // Pane-registered tools (preview's monitor/devtools cluster) anchor flush
   // against the static system cluster — in the tree layout the titlebar band
   // sits ABOVE the grid, so AppShell's pane-width anchoring doesn't apply.
-  const SYSTEM_TOOL_COUNT = 4
+  const SYSTEM_TOOL_COUNT = 5
   const paneToolCount = rightTitlebarTools.filter(tool => !tool.hidden).length
   const systemToolsWidth = titlebarToolsWidthCss(SYSTEM_TOOL_COUNT)
 

--- a/apps/desktop/src/app/shell/titlebar-controls.test.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { TitlebarControls } from './titlebar-controls'
+
+const actions = vi.hoisted(() => ({
+  equalize: vi.fn(),
+  reset: vi.fn()
+}))
+
+vi.mock('@/app/hud/handoff', () => ({ hudTargetSessionId: vi.fn() }))
+
+vi.mock('@/components/pane-shell/tree/store', () => ({
+  equalizeVisibleSessionPanes: actions.equalize,
+  resetLayoutTree: actions.reset
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TipKeybindLabel: ({ text }: { text: string }) => <>{text}</>
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      shell: {
+        appControls: 'App controls',
+        paneControls: 'Pane controls',
+        windowControls: 'Window controls'
+      },
+      titlebar: {
+        enterHud: 'HUD mode',
+        equalizeConversationPanes: 'Equalize conversation panes',
+        hideRightSidebar: 'Hide right sidebar',
+        hideSidebar: 'Hide sidebar',
+        layoutEditor: 'Layout editor',
+        layoutEditorTitle: 'Layout editor — ⌘-click resets the layout',
+        muteHaptics: 'Mute haptics',
+        openSettings: 'Open settings',
+        showRightSidebar: 'Show right sidebar',
+        showSidebar: 'Show sidebar',
+        swapSidebarSides: 'Swap sidebar sides',
+        unmuteHaptics: 'Unmute haptics'
+      }
+    }
+  })
+}))
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('TitlebarControls conversation layout action', () => {
+  it('places equalize immediately after the layout editor and invokes it', () => {
+    render(
+      <MemoryRouter>
+        <TitlebarControls onOpenSettings={vi.fn()} />
+      </MemoryRouter>
+    )
+
+    const appControls = screen.getByLabelText('App controls')
+
+    const firstTwoLabels = within(appControls)
+      .getAllByRole('button')
+      .slice(0, 2)
+      .map(button => button.getAttribute('aria-label'))
+
+    expect(firstTwoLabels).toEqual(['Layout editor', 'Equalize conversation panes'])
+
+    fireEvent.click(within(appControls).getByRole('button', { name: 'Equalize conversation panes' }))
+
+    expect(actions.equalize).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from 'react-router'
 
 import { hudTargetSessionId } from '@/app/hud/handoff'
 import { toggleLayoutEditMode } from '@/components/pane-shell/edit-mode'
-import { resetLayoutTree } from '@/components/pane-shell/tree/store'
+import { equalizeVisibleSessionPanes, resetLayoutTree } from '@/components/pane-shell/tree/store'
 import { Button } from '@/components/ui/button'
 import { Tip, TipKeybindLabel } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
@@ -186,6 +186,15 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
         toggleLayoutEditMode()
       },
       title: t.titlebar.layoutEditorTitle
+    },
+    {
+      icon: <TitlebarIcon name="layout-centered" />,
+      id: 'equalize-conversation-panes',
+      label: t.titlebar.equalizeConversationPanes,
+      onSelect: () => {
+        triggerHaptic('tap')
+        equalizeVisibleSessionPanes()
+      }
     },
     {
       // No `title`: TitlebarToolButton passes `title` to TipKeybindLabel as a

--- a/apps/desktop/src/components/pane-shell/tree/equalize-session-panes.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/equalize-session-panes.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import { group, type LayoutNode, split, type SplitNode } from './model'
+import {
+  $hiddenTreePanes,
+  $layoutEqualizeMotion,
+  $layoutTree,
+  cancelLayoutEqualizeMotion,
+  equalizeVisibleSessionPanes,
+  LAYOUT_EQUALIZE_MOTION_MS,
+  setTreeGroupMinimized
+} from './store'
+
+const disposers: (() => void)[] = []
+
+function registerPane(id: string, placement: 'left' | 'main' | 'right' = 'main') {
+  disposers.push(registry.register({ area: 'panes', data: { placement }, id, render: () => null, title: id }))
+}
+
+function childSplit(node: LayoutNode, index: number): SplitNode {
+  const child = (node as SplitNode).children[index]
+
+  if (child.type !== 'split') {
+    throw new Error(`Expected child ${index} to be a split`)
+  }
+
+  return child
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  $hiddenTreePanes.set(new Set())
+
+  for (const id of [
+    'workspace',
+    'session-tile:a',
+    'session-tile:b',
+    'session-tile:c',
+    'session-tile:d',
+    'session-tile:hidden',
+    'files',
+    'preview',
+    'page'
+  ]) {
+    registerPane(id, id === 'files' ? 'left' : id === 'preview' ? 'right' : 'main')
+  }
+})
+
+afterEach(() => {
+  cancelLayoutEqualizeMotion()
+  vi.useRealTimers()
+  disposers.splice(0).forEach(dispose => dispose())
+})
+
+describe('equalizeVisibleSessionPanes', () => {
+  for (const orientation of ['row', 'column'] as const) {
+    it(`gives visible conversations equal ${orientation} shares`, () => {
+      $layoutTree.set(
+        split(
+          orientation,
+          [
+            group(['workspace'], { id: 'g-workspace' }),
+            group(['session-tile:a'], { id: 'g-a' }),
+            group(['session-tile:b'], { id: 'g-b' })
+          ],
+          [2, 7, 3],
+          's-root'
+        )
+      )
+
+      equalizeVisibleSessionPanes()
+
+      expect(($layoutTree.get() as SplitNode).weights).toEqual([4, 4, 4])
+      expect(JSON.parse(window.localStorage.getItem('hermes.desktop.layoutTree.v2') ?? 'null').weights).toEqual([
+        4, 4, 4
+      ])
+    })
+  }
+
+  it('uses descendant conversation counts in nested mixed-axis layouts', () => {
+    $layoutTree.set(
+      split(
+        'row',
+        [
+          group(['files'], { id: 'g-left' }),
+          group(['workspace'], { id: 'g-workspace' }),
+          split(
+            'column',
+            [group(['session-tile:a'], { id: 'g-a' }), group(['session-tile:b'], { id: 'g-b' })],
+            [9, 1],
+            's-nested'
+          ),
+          group(['preview'], { id: 'g-right' })
+        ],
+        [7, 5, 1, 11],
+        's-root'
+      )
+    )
+
+    equalizeVisibleSessionPanes()
+
+    const result = $layoutTree.get() as SplitNode
+
+    // The left/right sections keep their allocation. The two conversation-
+    // bearing branches keep their combined weight (6), divided 1:2 because
+    // the nested branch contains two visible conversations.
+    expect(result.weights).toEqual([7, 2, 4, 11])
+    expect(childSplit(result, 2).weights).toEqual([5, 5])
+  })
+
+  it('counts only the pane a group actually shows', () => {
+    $hiddenTreePanes.set(new Set(['session-tile:hidden']))
+    $layoutTree.set(
+      split(
+        'row',
+        [
+          group(['session-tile:a', 'page'], { active: 'page', id: 'g-page' }),
+          group(['session-tile:b', 'session-tile:hidden'], { active: 'session-tile:hidden', id: 'g-hidden' }),
+          group(['session-tile:c'], { id: 'g-minimized', minimized: true }),
+          group(['session-tile:missing', 'session-tile:d'], { active: 'session-tile:missing', id: 'g-missing' })
+        ],
+        [10, 2, 20, 6],
+        's-root'
+      )
+    )
+
+    equalizeVisibleSessionPanes()
+
+    // g-page shows a non-session tab; g-minimized shows no body. The hidden
+    // and unregistered active ids fall back to B and D, the same way TreeGroup
+    // renders them, so only those two tracks are equalized.
+    expect(($layoutTree.get() as SplitNode).weights).toEqual([10, 4, 20, 4])
+  })
+
+  it('preserves the tree reference when fewer than two conversations are visible', () => {
+    const original = split(
+      'row',
+      [group(['workspace'], { id: 'g-workspace' }), group(['page'], { id: 'g-page' })],
+      [3, 7],
+      's-root'
+    )
+
+    $layoutTree.set(original)
+    equalizeVisibleSessionPanes()
+
+    expect($layoutTree.get()).toBe(original)
+    expect(window.localStorage.getItem('hermes.desktop.layoutTree.v2')).toBeNull()
+  })
+
+  it('preserves the tree reference when visible conversations are already balanced', () => {
+    const original = split(
+      'column',
+      [group(['workspace'], { id: 'g-workspace' }), group(['session-tile:a'], { id: 'g-a' })],
+      [1, 1],
+      's-root'
+    )
+
+    $layoutTree.set(original)
+    equalizeVisibleSessionPanes()
+
+    expect($layoutTree.get()).toBe(original)
+  })
+
+  it('opens one bounded motion window only when equalization changes the tree', () => {
+    vi.useFakeTimers()
+    $layoutTree.set(
+      split(
+        'row',
+        [group(['session-tile:a'], { id: 'g-a' }), group(['session-tile:b'], { id: 'g-b' })],
+        [3, 1],
+        's-root'
+      )
+    )
+
+    equalizeVisibleSessionPanes()
+
+    expect($layoutEqualizeMotion.get()).toBe(true)
+    vi.advanceTimersByTime(LAYOUT_EQUALIZE_MOTION_MS)
+    expect($layoutEqualizeMotion.get()).toBe(false)
+
+    equalizeVisibleSessionPanes()
+    expect($layoutEqualizeMotion.get()).toBe(false)
+  })
+
+  it('ends equalization motion before an unrelated layout mutation', () => {
+    vi.useFakeTimers()
+    $layoutTree.set(
+      split(
+        'row',
+        [group(['session-tile:a'], { id: 'g-a' }), group(['session-tile:b'], { id: 'g-b' })],
+        [3, 1],
+        's-root'
+      )
+    )
+
+    equalizeVisibleSessionPanes()
+    expect($layoutEqualizeMotion.get()).toBe(true)
+
+    setTreeGroupMinimized('g-a', true)
+
+    expect($layoutEqualizeMotion.get()).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split-motion.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split-motion.test.tsx
@@ -1,0 +1,43 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { group, split } from '../model'
+import { $layoutEqualizeMotion } from '../store'
+
+import { TreeSplit } from './tree-split'
+
+vi.mock('./tree-node', () => ({
+  TreeNode: () => <div />
+}))
+
+afterEach(() => {
+  act(() => $layoutEqualizeMotion.set(false))
+  cleanup()
+})
+
+describe('TreeSplit equalization motion', () => {
+  it('transitions split tracks only during the equalization motion window', () => {
+    const node = split(
+      'row',
+      [group([], { id: 'g-a' }), group([], { id: 'g-b' })],
+      [3, 1],
+      's-root'
+    )
+
+    const { container } = render(<TreeSplit node={node} />)
+
+    const wrappers = () => [...container.querySelectorAll(':scope > [data-tree-split] > div')]
+
+    expect(wrappers()).toHaveLength(2)
+    expect(wrappers().every(wrapper => !wrapper.className.includes('transition-'))).toBe(true)
+
+    act(() => $layoutEqualizeMotion.set(true))
+
+    expect(
+      wrappers().every(wrapper =>
+        wrapper.className.includes('transition-[flex-grow,flex-shrink,flex-basis]')
+      )
+    ).toBe(true)
+    expect(wrappers().every(wrapper => wrapper.className.includes('motion-reduce:transition-none'))).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -22,7 +22,9 @@ import { allPaneIds } from '../model'
 import {
   $collapsedTreeSides,
   $hiddenTreePanes,
+  $layoutEqualizeMotion,
   $narrowViewport,
+  cancelLayoutEqualizeMotion,
   isCollapsePane,
   persistTree,
   presetSplitWeights,
@@ -96,6 +98,7 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
   const overrides = useSubtreeOverrides(useMemo(() => allPaneIds(node), [node]))
   const editMode = useStore($layoutEditMode)
   const collapsedSides = useStore($collapsedTreeSides)
+  const equalizeMotion = useStore($layoutEqualizeMotion)
   const horizontal = node.orientation === 'row'
   const axis = node.orientation
 
@@ -187,6 +190,7 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
         return
       }
 
+      cancelLayoutEqualizeMotion()
       e.preventDefault()
 
       const handle = e.currentTarget
@@ -583,7 +587,11 @@ export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boo
 
         return (
           <div
-            className="relative flex min-h-0 min-w-0"
+            className={cn(
+              'relative flex min-h-0 min-w-0',
+              equalizeMotion &&
+                'transition-[flex-grow,flex-shrink,flex-basis] duration-200 ease-out motion-reduce:transition-none'
+            )}
             key={child.id}
             style={
               collapsed

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -73,6 +73,33 @@ function persist(tree: LayoutNode | null) {
  *  own routed session. */
 export const $layoutTree = atom<LayoutNode | null>(isSecondaryWindow() ? null : loadPersisted())
 
+/** Short renderer-only motion window for the one-shot equalize action. Sash
+ * drags and every other tree mutation remain immediate. */
+export const LAYOUT_EQUALIZE_MOTION_MS = 200
+export const $layoutEqualizeMotion = atom(false)
+let layoutEqualizeMotionTimer: ReturnType<typeof setTimeout> | null = null
+
+export function cancelLayoutEqualizeMotion(): void {
+  if (layoutEqualizeMotionTimer !== null) {
+    clearTimeout(layoutEqualizeMotionTimer)
+    layoutEqualizeMotionTimer = null
+  }
+
+  $layoutEqualizeMotion.set(false)
+}
+
+function beginLayoutEqualizeMotion(): void {
+  if (layoutEqualizeMotionTimer !== null) {
+    clearTimeout(layoutEqualizeMotionTimer)
+  }
+
+  $layoutEqualizeMotion.set(true)
+  layoutEqualizeMotionTimer = setTimeout(() => {
+    layoutEqualizeMotionTimer = null
+    $layoutEqualizeMotion.set(false)
+  }, LAYOUT_EQUALIZE_MOTION_MS)
+}
+
 /**
  * Which layout preset the current tree came from; `'custom'` after the user
  * rearranges anything. Drives the picker's active highlight.
@@ -622,6 +649,79 @@ function shownPanesInGroup(group: { panes: readonly string[] }): string[] {
 
     return true
   })
+}
+
+interface EqualizedSessionSubtree {
+  node: LayoutNode
+  sessionCount: number
+}
+
+/** Equalize visible conversation AREA without disturbing unrelated panes.
+ *
+ * A local 1:1 at every split is wrong for nested layouts: one conversation
+ * beside a subtree of two needs a 1:2 parent split, then 1:1 inside the
+ * subtree. Each split therefore divides the weight ALREADY owned by its
+ * session-bearing children in proportion to their descendant visible-session
+ * counts. Non-session children keep their exact weights, so left/right
+ * sections and contributed tools retain their allocation.
+ *
+ * Visibility mirrors TreeGroup: only the shown active pane counts; a hidden or
+ * unregistered active id falls back to the first shown tab, and a minimized
+ * group has no visible conversation body. */
+function equalizeSessionSubtree(node: LayoutNode): EqualizedSessionSubtree {
+  if (node.type === 'group') {
+    const shown = shownPanesInGroup(node)
+    const active = shown.includes(node.active) ? node.active : shown[0]
+
+    return {
+      node,
+      sessionCount: !node.minimized && active && isSessionStripPane(active) ? 1 : 0
+    }
+  }
+
+  const results = node.children.map(equalizeSessionSubtree)
+  const children = results.map(result => result.node)
+  const sessionCount = results.reduce((sum, result) => sum + result.sessionCount, 0)
+  const sessionChildren = results.flatMap((result, index) => (result.sessionCount > 0 ? [index] : []))
+  let weights = node.weights
+
+  if (sessionChildren.length >= 2) {
+    const sessionWeight = sessionChildren.reduce((sum, index) => sum + node.weights[index], 0)
+    const next = [...node.weights]
+
+    for (const index of sessionChildren) {
+      next[index] = sessionWeight * (results[index].sessionCount / sessionCount)
+    }
+
+    if (next.some((weight, index) => Math.abs(weight - node.weights[index]) > 1e-9)) {
+      weights = next
+    }
+  }
+
+  const childrenChanged = children.some((child, index) => child !== node.children[index])
+
+  return {
+    node: childrenChanged || weights !== node.weights ? { ...node, children, weights } : node,
+    sessionCount
+  }
+}
+
+/** One-shot titlebar action: equalize every visible conversation pane and
+ * persist the resulting tree once. Reference-stable when fewer than two
+ * conversations are visible or the tree is already balanced. */
+export function equalizeVisibleSessionPanes(): void {
+  const tree = $layoutTree.get()
+
+  if (!tree) {
+    return
+  }
+
+  const result = equalizeSessionSubtree(tree)
+
+  if (result.sessionCount >= 2 && result.node !== tree) {
+    beginLayoutEqualizeMotion()
+    commit(result.node, { keepEqualizeMotion: true })
+  }
 }
 
 /** ⌘1…⌘9: activate the Nth *visible* tab of the target zone — the first of
@@ -1197,9 +1297,16 @@ export function watchContributedPanes(): void {
   registry.subscribe(adoptContributedPanes)
 }
 
-function commit(next: LayoutNode | null) {
+function commit(next: LayoutNode | null, { keepEqualizeMotion = false }: { keepEqualizeMotion?: boolean } = {}) {
   if (!next) {
     return
+  }
+
+  // The transition belongs only to the equalize mutation that opened it.
+  // Any subsequent layout intent must paint immediately rather than inheriting
+  // the remainder of that short motion window.
+  if (!keepEqualizeMotion) {
+    cancelLayoutEqualizeMotion()
   }
 
   $layoutTree.set(next)
@@ -1657,6 +1764,7 @@ export function setTreeSplitWeights(splitId: string, weights: number[]) {
 
   if (tree) {
     // Weight drags are high-frequency: update live, persist on the trailing edge.
+    cancelLayoutEqualizeMotion()
     $layoutTree.set(setSplitWeightsOp(tree, splitId, weights))
   }
 }
@@ -1708,6 +1816,7 @@ export function persistTree() {
 }
 
 export function resetLayoutTree() {
+  cancelLayoutEqualizeMotion()
   persist(null)
   clearAllPaneSizeOverrides()
   // Reset restores EVERYTHING — closed panes included — and hands pane

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -176,7 +176,8 @@ export const ar = defineLocale({
     enterHud: 'وضع HUD',
     exitHud: 'إنهاء وضع HUD',
     layoutEditor: 'محرر التخطيط',
-    layoutEditorTitle: 'محرر التخطيط — انقر مع ⌘ لإعادة ضبط التخطيط'
+    layoutEditorTitle: 'محرر التخطيط — انقر مع ⌘ لإعادة ضبط التخطيط',
+    equalizeConversationPanes: 'توحيد أحجام المحادثات'
   },
   keybinds: {
     title: 'اختصارات لوحة المفاتيح',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -206,7 +206,8 @@ export const en: Translations = {
     enterHud: 'HUD mode',
     exitHud: 'Exit HUD mode',
     layoutEditor: 'Layout editor',
-    layoutEditorTitle: 'Layout editor — ⌘-click resets the layout'
+    layoutEditorTitle: 'Layout editor — ⌘-click resets the layout',
+    equalizeConversationPanes: 'Equalize conversation panes'
   },
 
   keybinds: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -203,7 +203,8 @@ export const ja = defineLocale({
     muteHaptics: '触覚フィードバックをオフ',
     unmuteHaptics: '触覚フィードバックをオン',
     openSettings: '設定を開く',
-    openStarmap: 'メモリグラフを開く'
+    openStarmap: 'メモリグラフを開く',
+    equalizeConversationPanes: '会話ペインを均等化'
   },
 
   language: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -249,6 +249,7 @@ export interface Translations {
     exitHud: string
     layoutEditor: string
     layoutEditorTitle: string
+    equalizeConversationPanes: string
   }
 
   keybinds: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -197,7 +197,8 @@ export const zhHant = defineLocale({
     muteHaptics: '靜音觸感回饋',
     unmuteHaptics: '開啟觸感回饋',
     openSettings: '開啟設定',
-    openStarmap: '開啟記憶圖譜'
+    openStarmap: '開啟記憶圖譜',
+    equalizeConversationPanes: '均分對話窗格'
   },
 
   language: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -201,7 +201,8 @@ export const zh: Translations = {
     enterHud: 'HUD 模式',
     exitHud: '退出 HUD 模式',
     layoutEditor: '布局编辑器',
-    layoutEditorTitle: '布局编辑器 — ⌘ 点击重置布局'
+    layoutEditorTitle: '布局编辑器 — ⌘ 点击重置布局',
+    equalizeConversationPanes: '均分对话窗格'
   },
 
   keybinds: {


### PR DESCRIPTION
## Summary

Add an Equalize conversation panes action immediately beside the Desktop layout editor. It recursively balances the visible conversation area in nested row/column layouts without changing left/right sidebars or tool-panel allocations.

## Changes

- add an accessible titlebar action with the repository's `layout-centered` codicon and locale coverage
- equalize session-bearing branches by visible descendant conversation count, matching existing hidden, minimized, inactive, and unregistered-pane semantics
- preserve non-conversation weights and persist the resulting layout once
- animate the one-shot rebalance for 200 ms, honor reduced-motion preferences, and cancel motion on any subsequent direct layout manipulation
- add behavioral coverage for row, column, nested mixed-axis, visibility, persistence, no-op identity, titlebar ordering, and motion lifecycle

## Validation

- `npx vitest run --project ui src/components/pane-shell/tree/equalize-session-panes.test.ts src/components/pane-shell/tree/renderer/tree-split-motion.test.tsx src/app/shell/titlebar-controls.test.tsx` — 10/10 passed
- `npm run test:ui` — 431 files, 3,858 tests passed
- `npm run check:lint` — passed (0 errors; 88 pre-existing warnings)
- `npm run build` — passed, including `assert-dist-built`
- visual acceptance on macOS in an isolated worktree Desktop instance with six conversation panes, nested rows/columns, left sidebar, right file rail, and terminal; the production Desktop remained running
- `git diff --check upstream/main...HEAD` — passed

Fixes #86266
