### PR TITLE
fix(gateway): tolerate list-shaped gateway.platforms from setup (#83185)

### DIFF
--- a/gateway/relay/__init__.py
+++ b/gateway/relay/__init__.py
@@ -393,7 +393,10 @@ def relay_relevance_policy(platform: Optional[str] = None) -> Optional[dict]:
         cfg = _load_gateway_config() or {}
         plat_cfg = cfg.get(platform)
         if not isinstance(plat_cfg, dict):
-            plat_cfg = ((cfg.get("gateway") or {}).get("platforms") or {}).get(platform)
+            _gw_platforms = (cfg.get("gateway") or {}).get("platforms") or {}
+            if not isinstance(_gw_platforms, dict):
+                _gw_platforms = {}
+            plat_cfg = _gw_platforms.get(platform)
         if not isinstance(plat_cfg, dict):
             plat_cfg = (cfg.get("platforms") or {}).get(platform)
         plat_cfg = plat_cfg if isinstance(plat_cfg, dict) else {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5184,6 +5184,12 @@ class TurnRunner:
         # slower than Linux. Off by default; soul identity is preserved so
         # the persona survives even with minimal context.
         _platforms_gw_cfg = (ctx.user_config.get("gateway") or {}).get("platforms") or {}
+        # ``hermes gateway setup`` writes ``gateway.platforms`` as a LIST of
+        # enabled platform names (e.g. ``- telegram``), not a dict.  Treat any
+        # non-dict shape as "no per-platform overrides" instead of crashing
+        # on ``.get()`` for every incoming turn (#83185).
+        if not isinstance(_platforms_gw_cfg, dict):
+            _platforms_gw_cfg = {}
         _plat_gw_cfg = _platforms_gw_cfg.get(platform_key) or {}
         _skip_context = _plat_gw_cfg.get("skip_context_files")
         skip_context_files = bool(_skip_context) if _skip_context is not None else False

--- a/tests/gateway/test_skip_context_files_wiring.py
+++ b/tests/gateway/test_skip_context_files_wiring.py
@@ -72,11 +72,17 @@ class TestSkipContextFilesConfigResolution:
             ({"gateway": {"platforms": {"discord": {"skip_context_files": True}}}}, "telegram", False),
             # Truthy non-bool values coerce.
             ({"gateway": {"platforms": {"telegram": {"skip_context_files": 1}}}}, "telegram", True),
+            # ``hermes gateway setup`` writes platforms as a LIST of enabled
+            # platform names — must not crash and must default to False (#83185).
+            ({"gateway": {"platforms": ["telegram", "discord"]}}, "telegram", False),
+            ({"gateway": {"platforms": []}}, "telegram", False),
         ],
     )
     def test_resolution(self, cfg, platform_key, expected):
         # Mirror the production resolution in TurnRunner exactly.
         _platforms_gw_cfg = (cfg.get("gateway") or {}).get("platforms") or {}
+        if not isinstance(_platforms_gw_cfg, dict):
+            _platforms_gw_cfg = {}
         _plat_gw_cfg = _platforms_gw_cfg.get(platform_key) or {}
         _skip_context = _plat_gw_cfg.get("skip_context_files")
         skip_context_files = bool(_skip_context) if _skip_context is not None else False


### PR DESCRIPTION
## Summary
Salvage of #83207 by @SeashoreShi — fixes `AttributeError: 'list' object has no attribute 'get'` crash on every gateway turn when `gateway.platforms` is a list (what `hermes gateway setup` writes).

`hermes gateway setup` writes `gateway.platforms` as a LIST (e.g. `["telegram", "discord"]`), but the per-platform `skip_context_files` resolution in `TurnRunner` assumed it was always a dict and called `.get()` on it. Non-empty lists are truthy, so the `or {}` fallback didn't catch them.

## Changes
- `gateway/run.py`: guard `_platforms_gw_cfg` with `isinstance(..., dict)` before `.get(platform_key)` (cherry-picked from @SeashoreShi's commit)
- `tests/gateway/test_skip_context_files_wiring.py`: parametrized test cases for list-shaped `gateway.platforms` (cherry-picked)
- `gateway/relay/__init__.py`: same `isinstance` guard for the sibling site at line 396, which had the identical bug pattern on the same config key

## Credit
Original fix by @SeashoreShi in #83207. Cherry-picked with authorship preserved. Sibling-site fix added as a follow-up commit.

Closes #83207
Fixes #83185

## Test plan
| | Before | After |
|---|---|---|
| `tests/gateway/test_skip_context_files_wiring.py` | 9 passed | 11 passed (2 new list-shape cases) |
| `tests/gateway/relay/` | 177 passed | 177 passed |
| E2E: list-shaped `gateway.platforms` | `AttributeError` crash | resolves to `skip_context_files=False` |
