### PR TITLE
gateway: optional durable lifecycle journal for external health monitors

### DIFF
--- a/gateway/churn.py
+++ b/gateway/churn.py
@@ -1,0 +1,220 @@
+"""Durable bounded gateway lifecycle facts for external health checks.
+
+The writer is optional and activates only when
+``HERMES_GATEWAY_CHURN_PATH`` names an absolute path. Records contain process
+identity metadata only; policy such as churn windows and thresholds belongs to
+the consumer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
+
+GATEWAY_CHURN_HOOK_VERSION = 1
+GATEWAY_CHURN_PATH_ENV = "HERMES_GATEWAY_CHURN_PATH"
+GATEWAY_CHURN_MAX_RECORDS = 256
+_GATEWAY_CHURN_READ_BYTES = 1024 * 1024
+_EVENT_TYPES = frozenset({"start", "replace"})
+_IS_WINDOWS = sys.platform == "win32"
+_WINDOWS_LOCK_OFFSET = 1024 * 1024
+
+
+def gateway_churn_record_path() -> Path | None:
+    """Return the configured absolute churn-record path, if enabled."""
+
+    raw = os.environ.get(GATEWAY_CHURN_PATH_ENV, "").strip()
+    if not raw:
+        return None
+    try:
+        path = Path(raw).expanduser()
+    except (OSError, RuntimeError):
+        return None
+    return path if path.is_absolute() else None
+
+
+def gateway_churn_hook_info() -> dict[str, object]:
+    """Return a side-effect-free feature-probe result for deployment checks."""
+
+    path = gateway_churn_record_path()
+    return {
+        "version": GATEWAY_CHURN_HOOK_VERSION,
+        "enabled": path is not None,
+        "path": str(path) if path is not None else None,
+        "max_records": GATEWAY_CHURN_MAX_RECORDS,
+    }
+
+
+def _validated_pid(name: str, value: int | None, *, required: bool) -> int | None:
+    if value is None and not required:
+        return None
+    if type(value) is not int or value <= 0:
+        suffix = " or None" if not required else ""
+        raise ValueError(f"{name} must be a positive integer{suffix}")
+    return value
+
+
+def _validated_timestamp(value: str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        raise ValueError("timestamp must be a timezone-aware ISO 8601 string")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError("timestamp must be a timezone-aware ISO 8601 string") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("timestamp must be a timezone-aware ISO 8601 string")
+    return value
+
+
+def _acquire_file_lock(handle) -> None:
+    if _IS_WINDOWS:
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write("\n")
+            handle.flush()
+        handle.seek(_WINDOWS_LOCK_OFFSET)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+    else:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _release_file_lock(handle) -> None:
+    try:
+        if _IS_WINDOWS:
+            handle.seek(_WINDOWS_LOCK_OFFSET)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass
+
+
+@contextmanager
+def _record_lock(path: Path) -> Iterator[None]:
+    lock_path = path.with_name(f".{path.name}.lock")
+    handle = lock_path.open("a+", encoding="utf-8")
+    try:
+        try:
+            lock_path.chmod(0o600)
+        except OSError:
+            pass
+        _acquire_file_lock(handle)
+        yield
+    finally:
+        _release_file_lock(handle)
+        handle.close()
+
+
+def _read_tail(path: Path) -> list[bytes]:
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as handle:
+            start = max(0, size - _GATEWAY_CHURN_READ_BYTES)
+            handle.seek(start)
+            data = handle.read(_GATEWAY_CHURN_READ_BYTES + 1)
+    except FileNotFoundError:
+        return []
+
+    lines = data.splitlines(keepends=True)
+    if start > 0 and lines:
+        lines = lines[1:]
+    complete = [line for line in lines if line.endswith((b"\n", b"\r"))]
+    return complete[-(GATEWAY_CHURN_MAX_RECORDS - 1) :]
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _atomic_append_capped(path: Path, encoded_record: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _record_lock(path):
+        payload = b"".join([*_read_tail(path), encoded_record])
+        temporary = path.with_name(
+            f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+        )
+        fd = -1
+        try:
+            fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "wb") as handle:
+                fd = -1
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, path)
+            try:
+                path.chmod(0o600)
+            except OSError:
+                pass
+            _fsync_directory(path.parent)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def append_gateway_churn_event(
+    event_type: str,
+    *,
+    pid_old: int | None,
+    pid_new: int,
+    timestamp: str | None = None,
+) -> bool:
+    """Append one lifecycle fact while preserving a bounded atomic window.
+
+    Returns ``False`` when the hook is disabled or the record cannot be written.
+    Invalid caller-supplied facts raise ``ValueError`` instead of serializing an
+    ambiguous record.
+    """
+
+    if event_type not in _EVENT_TYPES:
+        raise ValueError(f"event_type must be one of {sorted(_EVENT_TYPES)}")
+    old_pid = _validated_pid("pid_old", pid_old, required=False)
+    new_pid = _validated_pid("pid_new", pid_new, required=True)
+    observed_at = _validated_timestamp(timestamp)
+    path = gateway_churn_record_path()
+    if path is None:
+        return False
+
+    record = {
+        "event_type": event_type,
+        "timestamp": observed_at,
+        "pid_old": old_pid,
+        "pid_new": new_pid,
+    }
+    encoded = (
+        json.dumps(record, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        + "\n"
+    ).encode("ascii")
+    try:
+        _atomic_append_capped(path, encoded)
+    except OSError:
+        return False
+    return True

--- a/gateway/churn.py
+++ b/gateway/churn.py
@@ -9,6 +9,7 @@ the consumer.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
 import uuid
@@ -30,6 +31,31 @@ _GATEWAY_CHURN_READ_BYTES = 1024 * 1024
 _EVENT_TYPES = frozenset({"start", "replace"})
 _IS_WINDOWS = sys.platform == "win32"
 _WINDOWS_LOCK_OFFSET = 1024 * 1024
+
+
+def configure_gateway_churn_from_config(config: object) -> Path | None:
+    """Bridge an explicit gateway.churn_path setting to the writer."""
+
+    if not isinstance(config, dict):
+        return None
+    gateway_config = config.get("gateway")
+    if not isinstance(gateway_config, dict) or "churn_path" not in gateway_config:
+        return None
+
+    raw = gateway_config["churn_path"]
+    if isinstance(raw, str) and raw.strip():
+        try:
+            path = Path(raw.strip()).expanduser()
+        except (OSError, RuntimeError):
+            path = None
+        if path is not None and path.is_absolute():
+            os.environ[GATEWAY_CHURN_PATH_ENV] = str(path)
+            return path
+
+    logging.getLogger(__name__).warning(
+        "Ignoring gateway.churn_path: expected a nonempty absolute path"
+    )
+    return None
 
 
 def gateway_churn_record_path() -> Path | None:
@@ -124,13 +150,17 @@ def _read_tail(path: Path) -> list[bytes]:
         size = path.stat().st_size
         with path.open("rb") as handle:
             start = max(0, size - _GATEWAY_CHURN_READ_BYTES)
+            starts_mid_line = False
+            if start > 0:
+                handle.seek(start - 1)
+                starts_mid_line = handle.read(1) not in (b"\n", b"\r")
             handle.seek(start)
             data = handle.read(_GATEWAY_CHURN_READ_BYTES + 1)
     except FileNotFoundError:
         return []
 
     lines = data.splitlines(keepends=True)
-    if start > 0 and lines:
+    if starts_mid_line and lines:
         lines = lines[1:]
     complete = [line for line in lines if line.endswith((b"\n", b"\r"))]
     return complete[-(GATEWAY_CHURN_MAX_RECORDS - 1) :]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -29143,6 +29143,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         remove_pid_file,
         terminate_pid,
     )
+    replaced_pid: int | None = None
     existing_pid = get_running_pid()
     if existing_pid is not None and existing_pid != os.getpid():
         if replace:
@@ -29277,6 +29278,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                     logger.info("Released %d stale scoped lock(s) from old gateway.", _released)
             except Exception:
                 pass
+            replaced_pid = existing_pid
         else:
             hermes_home = str(get_hermes_home())
             logger.error(
@@ -29618,6 +29620,24 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             return True
         finally:
             _shutdown_gateway_health_export(runner)
+
+    # The gateway owns its PID/lock and its adapters completed startup: this is
+    # the lifecycle boundary where a start or takeover became real. Best-effort
+    # recording must never make the gateway unavailable, but a configured write
+    # failure is loud in gateway logs so deployment drift is not a silent skip.
+    if os.environ.get("HERMES_GATEWAY_CHURN_PATH", "").strip():
+        try:
+            from gateway.churn import append_gateway_churn_event
+
+            recorded = append_gateway_churn_event(
+                "replace" if replaced_pid is not None else "start",
+                pid_old=replaced_pid,
+                pid_new=os.getpid(),
+            )
+            if not recorded:
+                logger.warning("Configured gateway churn event could not be recorded")
+        except Exception as e:
+            logger.warning("Configured gateway churn hook failed: %s", e)
 
     # Start the background cron scheduler via the resolved provider so
     # scheduled jobs fire automatically. The built-in provider is the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2132,6 +2132,9 @@ if _config_path.exists():
             _cfg = managed_scope.apply_managed_overlay(_cfg)
         except Exception:
             pass
+        from gateway.churn import configure_gateway_churn_from_config
+
+        configure_gateway_churn_from_config(_cfg)
         # Top-level simple values (fallback only — don't override .env)
         for _key, _val in _cfg.items():
             if isinstance(_val, (str, int, float, bool)) and _key not in os.environ:

--- a/tests/gateway/test_churn.py
+++ b/tests/gateway/test_churn.py
@@ -1,0 +1,105 @@
+"""Gateway churn record durability and concurrency contract."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from concurrent.futures import ProcessPoolExecutor
+
+from gateway import churn
+
+
+def _records(path):
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def _append_replacement(pid):
+    return churn.append_gateway_churn_event(
+        "replace", pid_old=pid, pid_new=pid + 10_000
+    )
+
+
+def test_hook_info_is_side_effect_free(tmp_path, monkeypatch):
+    path = tmp_path / "gateway-churn.jsonl"
+    monkeypatch.setenv(churn.GATEWAY_CHURN_PATH_ENV, str(path))
+
+    info = churn.gateway_churn_hook_info()
+
+    assert info == {
+        "version": 1,
+        "enabled": True,
+        "path": str(path),
+        "max_records": churn.GATEWAY_CHURN_MAX_RECORDS,
+    }
+    assert not path.exists()
+
+
+def test_racing_writers_preserve_every_event(tmp_path, monkeypatch):
+    path = tmp_path / "gateway-churn.jsonl"
+    monkeypatch.setenv(churn.GATEWAY_CHURN_PATH_ENV, str(path))
+
+    with ProcessPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(_append_replacement, range(1, 65)))
+
+    records = _records(path)
+    assert all(results)
+    assert len(records) == 64
+    assert {record["pid_old"] for record in records} == set(range(1, 65))
+    assert all(set(record) == {"event_type", "timestamp", "pid_old", "pid_new"} for record in records)
+
+
+def test_record_drops_oldest_at_cap(tmp_path, monkeypatch):
+    path = tmp_path / "gateway-churn.jsonl"
+    monkeypatch.setenv(churn.GATEWAY_CHURN_PATH_ENV, str(path))
+
+    total = churn.GATEWAY_CHURN_MAX_RECORDS + 25
+    for pid in range(1, total + 1):
+        assert churn.append_gateway_churn_event("start", pid_old=None, pid_new=pid)
+
+    records = _records(path)
+    assert len(records) == churn.GATEWAY_CHURN_MAX_RECORDS
+    assert [record["pid_new"] for record in records] == list(
+        range(total - churn.GATEWAY_CHURN_MAX_RECORDS + 1, total + 1)
+    )
+
+
+def test_reader_never_sees_partial_window(tmp_path, monkeypatch):
+    path = tmp_path / "gateway-churn.jsonl"
+    monkeypatch.setenv(churn.GATEWAY_CHURN_PATH_ENV, str(path))
+    assert churn.append_gateway_churn_event("start", pid_old=None, pid_new=1)
+    finished = threading.Event()
+    failures: list[BaseException] = []
+
+    def writer():
+        try:
+            for pid in range(2, 350):
+                assert churn.append_gateway_churn_event(
+                    "replace", pid_old=pid - 1, pid_new=pid
+                )
+        except BaseException as exc:
+            failures.append(exc)
+        finally:
+            finished.set()
+
+    thread = threading.Thread(target=writer)
+    thread.start()
+    reads = 0
+    while not finished.is_set():
+        raw = path.read_bytes()
+        assert raw.endswith(b"\n")
+        lines = raw.splitlines()
+        assert 1 <= len(lines) <= churn.GATEWAY_CHURN_MAX_RECORDS
+        assert all(isinstance(json.loads(line), dict) for line in lines)
+        reads += 1
+    thread.join()
+
+    assert not failures
+    assert reads > 0
+
+
+def test_takeover_marker_contract_remains_separate():
+    from gateway import status
+
+    assert status.write_takeover_marker is not churn.append_gateway_churn_event
+    assert status.consume_takeover_marker_for_self.__module__ == "gateway.status"

--- a/tests/gateway/test_churn.py
+++ b/tests/gateway/test_churn.py
@@ -35,6 +35,41 @@ def test_hook_info_is_side_effect_free(tmp_path, monkeypatch):
     assert not path.exists()
 
 
+def test_config_bridge_sets_churn_path(tmp_path, monkeypatch):
+    path = tmp_path / "gateway-churn.jsonl"
+    monkeypatch.setenv(
+        churn.GATEWAY_CHURN_PATH_ENV, str(tmp_path / "from-environment.jsonl")
+    )
+
+    configured = churn.configure_gateway_churn_from_config(
+        {"gateway": {"churn_path": str(path)}}
+    )
+
+    assert configured == path
+    assert churn.gateway_churn_record_path() == path
+
+
+def test_config_bridge_absent_leaves_environment_untouched(tmp_path, monkeypatch):
+    path = tmp_path / "from-environment.jsonl"
+    monkeypatch.setenv(churn.GATEWAY_CHURN_PATH_ENV, str(path))
+
+    assert churn.configure_gateway_churn_from_config({"gateway": {}}) is None
+    assert churn.gateway_churn_record_path() == path
+
+
+def test_config_bridge_rejects_malformed_values(tmp_path, monkeypatch, caplog):
+    original = tmp_path / "from-environment.jsonl"
+    monkeypatch.setenv(churn.GATEWAY_CHURN_PATH_ENV, str(original))
+
+    for value in ("relative/churn.jsonl", 123):
+        caplog.clear()
+        assert churn.configure_gateway_churn_from_config(
+            {"gateway": {"churn_path": value}}
+        ) is None
+        assert churn.gateway_churn_record_path() == original
+        assert len(caplog.records) == 1
+
+
 def test_racing_writers_preserve_every_event(tmp_path, monkeypatch):
     path = tmp_path / "gateway-churn.jsonl"
     monkeypatch.setenv(churn.GATEWAY_CHURN_PATH_ENV, str(path))
@@ -62,6 +97,28 @@ def test_record_drops_oldest_at_cap(tmp_path, monkeypatch):
     assert [record["pid_new"] for record in records] == list(
         range(total - churn.GATEWAY_CHURN_MAX_RECORDS + 1, total + 1)
     )
+
+
+def test_tail_keeps_first_record_when_window_starts_at_line_boundary(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "gateway-churn.jsonl"
+    monkeypatch.setenv(churn.GATEWAY_CHURN_PATH_ENV, str(path))
+    monkeypatch.setattr(churn, "_GATEWAY_CHURN_READ_BYTES", 8)
+    monkeypatch.setattr(churn, "GATEWAY_CHURN_MAX_RECORDS", 10)
+    path.write_bytes(b"old\nfirst\nx")
+
+    assert churn.append_gateway_churn_event("start", pid_old=None, pid_new=1)
+
+    assert path.read_bytes().startswith(b"first\n")
+
+
+def test_tail_drops_partial_record_when_window_starts_mid_line(tmp_path, monkeypatch):
+    path = tmp_path / "gateway-churn.jsonl"
+    monkeypatch.setattr(churn, "_GATEWAY_CHURN_READ_BYTES", 8)
+    path.write_bytes(b"oldxx\nfirst\n")
+
+    assert churn._read_tail(path) == [b"first\n"]
 
 
 def test_reader_never_sees_partial_window(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

This adds an opt-in journal that records gateway lifecycle events (start, replace) to a bounded JSONL file. It is off by default and activates only when `HERMES_GATEWAY_CHURN_PATH` names an absolute path. Nothing else changes.

## Motivation

We run Hermes unattended on a dedicated machine, with an external watchdog that pages a human when something breaks. The hardest failure to catch from outside is silent gateway churn: the process dies and relaunches (or gets replaced during an update), everything looks healthy afterward, and whatever was in flight during the gap is just gone. Log scraping is fragile across restarts and rotation, and polling the process table misses fast replacements.

A small durable journal solves this: the gateway appends one record per lifecycle event, and any monitor can read the file and apply its own idea of how much churn is too much. We have carried this as a local patch since July and re-applied it across every update. It has caught real incidents for us, including a crash loop after an OS update and a replacement that dropped an in-flight change. Upstreaming it means any install can get the same visibility without carrying a diff.

## What's in the PR

- `gateway/churn.py` (new, ~220 lines): the writer. Bounded at 256 records with atomic rewrite at the cap, advisory file locking (fcntl on POSIX, msvcrt on Windows), and records limited to process identity: event type, timestamp, old pid, new pid. No thresholds and no policy; deciding what churn is acceptable belongs to whatever reads the file.
- Wiring in `gateway/run.py` (20 inserted lines, nothing removed): after the gateway owns its PID and finishes adapter startup, it writes a start record, or a replace record when it took over a running instance. Both are no-ops when the env var is unset.
- `tests/gateway/test_churn.py`: activation gating, the record cap, racing writers across processes, readers never seeing a partial window, and separation from the existing takeover-marker contract.

## Design choices

The writer is deliberately dumb. It does not rotate by time, does not interpret events, and refuses relative paths instead of guessing a base directory. A write failure logs a warning and never affects gateway startup: visibility must not become a new way to go down. Records are one JSON object per line, so consumers need nothing beyond the standard library.

## Compatibility and testing

Off by default, zero behavior change with the env var unset, no new dependencies. On current main: `tests/gateway` collects clean with this change (5,637 tests, same as without it) and the new file passes (5 tests). The run.py diff is insertion-only.