### PR TITLE
fix(voice): xAI streaming TTS WebSocket protocol + websockets 15 compat

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -206,7 +206,136 @@ def test_xai_available_uses_oauth_credential_resolver(monkeypatch):
     assert ts.XAIStreamer.available() is False
 
 
-# ── Gemini SSE parsing ────────────────────────────────────────────────────
+# -- xAI WebSocket bridge (protocol fix: websockets>=15 + query-param handshake) --
+
+
+def _fake_xai_server(handler):
+    """Serve ``handler`` on a loopback WS server; return (url, server)."""
+    from websockets.sync.server import serve
+
+    server = serve(handler, "127.0.0.1", 0)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    port = server.socket.getsockname()[1]
+    return f"ws://127.0.0.1:{port}/tts", server
+
+
+def _patch_xai_creds(monkeypatch):
+    import tools.xai_http
+    monkeypatch.setattr(
+        tools.xai_http,
+        "resolve_xai_http_credentials",
+        lambda *a, **k: {"api_key": "test-xai-key"},
+    )
+
+
+def test_xai_streamer_speaks_the_real_wire_protocol(monkeypatch):
+    """Pin the exact wire format verified against the live xAI API: audio
+    params in the URL query string, bearer auth header, text.delta +
+    text.done out, base64 audio.delta in, audio.done terminates."""
+    import base64
+    import json
+
+    pcm1, pcm2 = b"\x01\x00" * 30, b"\x02\x00" * 30
+    seen = {}
+
+    def handler(ws):
+        seen["path"] = ws.request.path
+        seen["auth"] = ws.request.headers.get("Authorization")
+        seen["messages"] = []
+        for raw in ws:
+            msg = json.loads(raw)
+            seen["messages"].append(msg)
+            if msg.get("type") == "text.done":
+                break
+        for chunk in (pcm1, pcm2):
+            ws.send(json.dumps({
+                "type": "audio.delta",
+                "delta": base64.b64encode(chunk).decode(),
+            }))
+        ws.send(json.dumps({"type": "audio.done"}))
+
+    url, server = _fake_xai_server(handler)
+    try:
+        _patch_xai_creds(monkeypatch)
+        streamer = ts.XAIStreamer({}, {"streaming_url": url})
+        assert list(streamer.stream("A sentence.")) == [pcm1, pcm2]
+    finally:
+        server.shutdown()
+
+    assert "voice=eve" in seen["path"]
+    assert "language=en" in seen["path"]
+    assert "codec=pcm" in seen["path"]
+    assert "sample_rate=24000" in seen["path"]
+    assert seen["auth"] == "Bearer test-xai-key"
+    assert [m["type"] for m in seen["messages"]] == ["text.delta", "text.done"]
+    assert seen["messages"][0]["delta"] == "A sentence."
+
+
+def test_xai_streamer_passes_auth_via_additional_headers(monkeypatch):
+    """websockets 15 removed the ``extra_headers`` kwarg: the connect call
+    must carry the bearer token in ``additional_headers`` or every stream()
+    raises TypeError before any network traffic."""
+    import base64
+    import json
+
+    import websockets
+    captured = {}
+    real_connect = websockets.connect
+
+    def spy_connect(url, **kwargs):
+        captured.update(kwargs)
+        return real_connect(url, **kwargs)
+
+    pcm = b"\x03\x00" * 10
+
+    def handler(ws):
+        ws.send(json.dumps({
+            "type": "audio.delta",
+            "delta": base64.b64encode(pcm).decode(),
+        }))
+        ws.send(json.dumps({"type": "audio.done"}))
+
+    url, server = _fake_xai_server(handler)
+    try:
+        _patch_xai_creds(monkeypatch)
+        monkeypatch.setattr("websockets.connect", spy_connect)
+        streamer = ts.XAIStreamer({}, {"streaming_url": url})
+        list(streamer.stream("test."))
+    finally:
+        server.shutdown()
+
+    assert "additional_headers" in captured, (
+        "connect() must use additional_headers= (websockets 15 compat)"
+    )
+    assert "extra_headers" not in captured, (
+        "extra_headers= was removed in websockets 15 — must not be used"
+    )
+    assert captured["additional_headers"] == {"Authorization": "Bearer test-xai-key"}
+
+
+def test_xai_streamer_error_envelope_raises(monkeypatch):
+    """An error envelope from xAI must raise RuntimeError, not be silently
+    swallowed (old code logged + return -> truncated speech played as complete)."""
+    import json
+
+    def handler(ws):
+        for raw in ws:
+            msg = json.loads(raw)
+            if msg.get("type") == "text.done":
+                break
+        ws.send(json.dumps({"type": "error", "message": "voice is disabled"}))
+
+    url, server = _fake_xai_server(handler)
+    try:
+        _patch_xai_creds(monkeypatch)
+        streamer = ts.XAIStreamer({}, {"streaming_url": url})
+        with pytest.raises(RuntimeError, match="voice is disabled"):
+            list(streamer.stream("Hi."))
+    finally:
+        server.shutdown()
+
+
+# -- Gemini SSE parsing --
 
 
 # ── xAI WebSocket bridge ─────────────────────────────────────────────────

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -399,17 +399,23 @@ class GeminiStreamer(StreamingTTSProvider):
 
 @register("xai")
 class XAIStreamer(StreamingTTSProvider):
-    """xAI WebSocket TTS → binary PCM frames (24 kHz mono int16).
+    """xAI WebSocket TTS -> base64 PCM ``audio.delta`` frames (24 kHz mono int16).
 
-    Salvaged from PR #47588 (@Cdddo): xAI's chunked TTS API is
-    WebSocket-only (``wss://api.x.ai/v1/tts``). Credentials route through
-    ``resolve_xai_http_credentials`` (OAuth or XAI_API_KEY), same as the
-    sync ``_generate_xai_tts`` path. The async WS loop is bridged to the
-    sync iterator contract via ``_collect_async`` — the seam unit tests
-    monkeypatch.
+    Salvaged from PR #47588 (@Cdddo) and rewritten against the real wire
+    protocol: voice/language/codec/sample_rate ride in the URL query string
+    (the server 400s the bare path at handshake), the client sends
+    ``text.delta`` + ``text.done``, and the server streams JSON
+    ``audio.delta`` envelopes (base64 PCM in ``delta``) until ``audio.done``.
+    Credentials route through ``resolve_xai_http_credentials`` (OAuth or
+    XAI_API_KEY), same as the sync ``_generate_xai_tts`` path. The async WS
+    loop runs on a background thread feeding a queue, so ``stream()`` yields
+    chunks as they arrive and works from sync CLI code and from gateway
+    adapters that already run an event loop.
     """
 
     sample_rate = 24000
+
+    _RECV_TIMEOUT_S = 60  # a sentence of TTS should never gap this long
 
     @staticmethod
     def available() -> bool:
@@ -422,27 +428,65 @@ class XAIStreamer(StreamingTTSProvider):
             return False
 
     def stream(self, text: str) -> Iterator[bytes]:
-        yield from _capped(iter(self._collect_async(text)), "xAI streaming TTS")
+        yield from _capped(self._queued_frames(text), "xAI streaming TTS")
 
-    # -- async→sync bridge (test seam) ------------------------------------
+    # -- async->sync bridge -------------------------------------------------
 
-    def _collect_async(self, text: str) -> List[bytes]:
+    def _queued_frames(self, text: str) -> Iterator[bytes]:
+        """Yield PCM chunks as the WS delivers them, on a pump thread.
+
+        The thread owns a fresh event loop, so ``asyncio.run`` never fights
+        a loop the caller is already running (gateway adapters are async).
+        Exceptions from the pump are re-raised on the consumer side so the
+        caller's "raise on failure" contract holds.
+
+        ``_capped()`` runs on the consumer side of the queue, after
+        ``q.get()`` -- so the byte budget is ALSO enforced in the pump before
+        each enqueue (see ``_pump``), and a consumer that stops early flips
+        ``stop`` so the pump closes the socket instead of piling decoded PCM
+        into a queue nobody drains.
+        """
         import asyncio
+        import queue
+        import threading
 
-        return asyncio.run(self._drain_async(text))
+        q: "queue.Queue[object]" = queue.Queue()
+        done = object()
+        stop = threading.Event()
 
-    async def _drain_async(self, text: str) -> List[bytes]:
-        frames: List[bytes] = []
-        async for frame in self._async_frames(text):
-            frames.append(frame)
-        return frames
+        def _pump_thread() -> None:
+            try:
+                asyncio.run(self._pump(text, q, stop))
+            except BaseException as exc:  # hand failures to the consumer
+                q.put(exc)
+            finally:
+                q.put(done)
 
-    async def _async_frames(self, text: str):
+        threading.Thread(
+            target=_pump_thread, name="xai-tts-pump", daemon=True
+        ).start()
+        try:
+            while True:
+                item = q.get()
+                if item is done:
+                    return
+                if isinstance(item, BaseException):
+                    raise item
+                yield item
+        finally:
+            # Generator closed early (cap, playback failure, caller dropped
+            # it): stop the pump at its next frame.
+            stop.set()
+
+    async def _pump(self, text: str, q, stop) -> None:
+        import asyncio
+        import base64
         import json as _json
+        from urllib.parse import urlencode
 
         import websockets
 
-        from tools.tts_tool import DEFAULT_XAI_VOICE_ID
+        from tools.tts_tool import DEFAULT_XAI_LANGUAGE, DEFAULT_XAI_VOICE_ID
         from tools.xai_http import resolve_xai_http_credentials
 
         creds = resolve_xai_http_credentials()
@@ -450,39 +494,71 @@ class XAIStreamer(StreamingTTSProvider):
         if not api_key:
             raise RuntimeError("No xAI credentials for streaming TTS")
         voice = str(self.section.get("voice_id", DEFAULT_XAI_VOICE_ID)).strip() or DEFAULT_XAI_VOICE_ID
-        ws_url = str(
+        language = str(self.section.get("language", DEFAULT_XAI_LANGUAGE)).strip() or DEFAULT_XAI_LANGUAGE
+        base = str(
             self.section.get("streaming_url") or "wss://api.x.ai/v1/tts"
         ).strip()
+        params = urlencode({
+            "voice": voice,
+            "language": language,
+            "codec": "pcm",
+            "sample_rate": self.sample_rate,
+        })
+        sep = "&" if "?" in base else "?"
+        ws_url = f"{base}{sep}{params}"
 
         async with websockets.connect(
-            ws_url, extra_headers={"Authorization": f"Bearer {api_key}"}
+            ws_url, additional_headers={"Authorization": f"Bearer {api_key}"}
         ) as ws:
-            await ws.send(_json.dumps({
-                "text": text,
-                "voice_id": voice,
-                "response_format": "pcm",
-            }))
-            try:
-                while True:
-                    message = await ws.recv()
-                    if isinstance(message, (bytes, bytearray, memoryview)):
-                        yield bytes(message)
-                        continue
-                    try:
-                        envelope = _json.loads(message)
-                    except (ValueError, TypeError):
-                        if message == "done":
+            await ws.send(_json.dumps({"type": "text.delta", "delta": text}))
+            await ws.send(_json.dumps({"type": "text.done"}))
+            enqueued = 0
+            while True:
+                try:
+                    message = await asyncio.wait_for(
+                        ws.recv(), timeout=self._RECV_TIMEOUT_S
+                    )
+                except asyncio.TimeoutError:
+                    raise RuntimeError("xAI streaming TTS: no audio for 60s")
+                except websockets.exceptions.ConnectionClosedOK:
+                    return  # clean close, with or without audio.done
+                except websockets.exceptions.ConnectionClosedError as exc:
+                    raise RuntimeError(f"xAI WS closed mid-stream: {exc}") from exc
+                if isinstance(message, (bytes, bytearray, memoryview)):
+                    continue  # the server speaks JSON; binary is not expected
+                try:
+                    envelope = _json.loads(message)
+                except (ValueError, TypeError):
+                    continue
+                msg_type = envelope.get("type")
+                if msg_type == "audio.delta":
+                    b64 = envelope.get("delta") or ""
+                    if b64:
+                        pcm = base64.b64decode(b64)
+                        enqueued += len(pcm)
+                        if enqueued > _STREAM_SENTENCE_BYTE_CAP:
+                            # Enforce the per-sentence byte budget BEFORE
+                            # enqueueing: the consumer-side _capped() only
+                            # runs after q.get(), so without this a runaway
+                            # upstream piles decoded PCM into the queue.
+                            # Returning exits the context manager, which
+                            # closes the socket -- we stop reading upstream.
+                            logger.warning(
+                                "xAI streaming TTS exceeded %d bytes for one "
+                                "sentence; closing upstream",
+                                _STREAM_SENTENCE_BYTE_CAP,
+                            )
                             return
-                        continue
-                    etype = envelope.get("type")
-                    if etype == "done":
-                        return
-                    if etype == "error":
-                        logger.warning("xAI WS error envelope: %s",
-                                       envelope.get("error") or envelope.get("message") or envelope)
-                        return
-            except Exception as exc:
-                if exc.__class__.__name__ == "ConnectionClosed":
+                        if stop.is_set():
+                            # Consumer went away (cap, playback failure):
+                            # close and stop reading rather than filling a
+                            # queue nobody drains.
+                            return
+                        q.put(pcm)
+                elif msg_type == "audio.done":
                     return
-                logger.warning("xAI WS receive failed: %s", exc)
-                return
+                elif msg_type == "error":
+                    detail = (
+                        envelope.get("message") or envelope.get("error") or envelope
+                    )
+                    raise RuntimeError(f"xAI streaming TTS error: {detail}")


### PR DESCRIPTION
**Symptom:** Hermes Desktop voice (live real-time) hears your speech (STT works) but never speaks back, even though connected to xAI.

**Root cause:** XAIStreamer in tools/tts_streaming.py was broken two ways against the live xAI WebSocket streaming TTS API (wss://api.x.ai/v1/tts):

1. websockets 15.0.1 compat — called websockets.connect(..., extra_headers=...), but websockets >=15 renamed the kwarg to additional_headers=. Every stream attempt threw TypeError. STT was unaffected (uses REST /v1/stt); only the streaming output path was dead.

2. Wrong wire protocol — xAI configures voice via query parameters at WebSocket handshake (language is REQUIRED; missing it -> HTTP 400), and the client/server envelope protocol is text.delta/text.done (client->server) and audio.delta (field: delta, base64 PCM) / audio.done (server->client). The old code sent a wrong-shape JSON payload after connecting with no query params, and tried to read raw bytes + a "done" message that xAI never sends.

**Fix:**
- Build WS URL with query params: voice, language, codec=pcm, sample_rate
- Use additional_headers= instead of extra_headers=
- Send text.delta + text.done envelopes
- Parse audio.delta (base64 decode from delta field) + audio.done
- Handle error envelopes

**Tests:** 3 new protocol-level unit tests, all passing.

**Note:** User must restart the Hermes Desktop app to pick up the fixed bytecode.