### PR TITLE
fix(tui): prepend Hermes tool dirs to slash_worker PATH (salvage #83854)

### DIFF
--- a/tests/gateway/test_tui_slash_worker_path.py
+++ b/tests/gateway/test_tui_slash_worker_path.py
@@ -1,0 +1,42 @@
+"""Regression test for slash_worker PATH construction (#83845).
+
+When the gateway is launched by the Desktop/Dashboard app it can inherit a
+minimal PATH (/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/sbin:/usr/sbin)
+that omits the Hermes venv bin dir and ~/.local/bin. The spawned
+tui_gateway.slash_worker then cannot resolve Hermes-managed CLIs such as
+browser-use/uvx via shutil.which, breaking browser_exec.
+
+`tui_gateway.server._prepend_tool_paths` prepends those two directories to
+the worker env PATH while preserving the inherited PATH.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+from tui_gateway import server as tui_server
+
+
+class TestPrependToolPaths:
+    def test_prepends_venv_and_user_bin(self):
+        env = {"PATH": "/usr/bin"}
+        result = tui_server._prepend_tool_paths(env)
+
+        parts = result["PATH"].split(os.pathsep)
+        # venv bin first, then user-local bin, then the original PATH preserved
+        assert parts[0] == str(Path(sys.executable).parent)
+        assert str(Path.home() / ".local" / "bin") in parts
+        assert parts[-1] == "/usr/bin"
+
+    def test_preserves_existing_path_when_empty(self):
+        env = {}
+        result = tui_server._prepend_tool_paths(env)
+
+        parts = result["PATH"].split(os.pathsep)
+        assert parts[0] == str(Path(sys.executable).parent)
+        assert str(Path.home() / ".local" / "bin") in parts
+
+    def test_venv_bin_points_at_sys_executable_dir(self):
+        env = {"PATH": "/bin"}
+        result = tui_server._prepend_tool_paths(env)
+        assert result["PATH"].split(os.pathsep)[0] == str(Path(sys.executable).parent)

--- a/tests/gateway/test_tui_slash_worker_path.py
+++ b/tests/gateway/test_tui_slash_worker_path.py
@@ -18,25 +18,31 @@ from tui_gateway import server as tui_server
 
 
 class TestPrependToolPaths:
-    def test_prepends_venv_and_user_bin(self):
+    def test_prepends_managed_venv_and_user_bin(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hh"))
         env = {"PATH": "/usr/bin"}
         result = tui_server._prepend_tool_paths(env)
 
         parts = result["PATH"].split(os.pathsep)
-        # venv bin first, then user-local bin, then the original PATH preserved
-        assert parts[0] == str(Path(sys.executable).parent)
+        # managed bin first (managed-first policy), then venv bin, then
+        # user-local bin, then the original PATH preserved
+        assert parts[0] == str(tmp_path / "hh" / "bin")
+        assert parts[1] == str(Path(sys.executable).parent)
         assert str(Path.home() / ".local" / "bin") in parts
         assert parts[-1] == "/usr/bin"
 
-    def test_preserves_existing_path_when_empty(self):
+    def test_preserves_existing_path_when_empty(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hh"))
         env = {}
         result = tui_server._prepend_tool_paths(env)
 
         parts = result["PATH"].split(os.pathsep)
-        assert parts[0] == str(Path(sys.executable).parent)
+        assert parts[0] == str(tmp_path / "hh" / "bin")
+        assert str(Path(sys.executable).parent) in parts
         assert str(Path.home() / ".local" / "bin") in parts
 
-    def test_venv_bin_points_at_sys_executable_dir(self):
+    def test_managed_bin_leads_path(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hh"))
         env = {"PATH": "/bin"}
         result = tui_server._prepend_tool_paths(env)
-        assert result["PATH"].split(os.pathsep)[0] == str(Path(sys.executable).parent)
+        assert result["PATH"].split(os.pathsep)[0] == str(tmp_path / "hh" / "bin")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -362,6 +362,20 @@ _stdio_transport = StdioTransport(lambda: _real_stdout, _stdout_lock)
 _detached_ws_transport = _DropTransport()
 
 
+def _prepend_tool_paths(env: dict[str, str]) -> dict[str, str]:
+    """Prepend the Hermes venv bin dir and the user-local bin dir to PATH
+    so slash_worker child processes can resolve Hermes-managed CLIs
+    (browser-use, uvx) even when the parent gateway was launched with a
+    minimal PATH (e.g. by the Desktop/Dashboard app)."""
+    venv_bin = str(Path(sys.executable).parent)  # <venv>/bin (POSIX) or <venv>/Scripts (Windows)
+    user_bin = str(Path.home() / ".local" / "bin")
+    existing = env.get("PATH") or ""
+    env["PATH"] = os.pathsep.join(
+        [p for p in (venv_bin, user_bin) if p] + ([existing] if existing else [])
+    )
+    return env
+
+
 class _SlashWorker:
     """Persistent HermesCLI subprocess for slash commands."""
 
@@ -398,6 +412,11 @@ class _SlashWorker:
             inherit_profile_home=False,  # base already carries the HOME contract
             extra={"HERMES_HOME": str(profile_home)} if profile_home else None,
         )
+        # Prepend the Hermes venv bin dir and the user-local bin dir to PATH so
+        # slash_worker child processes can resolve Hermes-managed CLIs
+        # (browser-use, uvx) even when the parent gateway was launched with a
+        # minimal PATH (e.g. by the Desktop/Dashboard app). See #83845.
+        env = _prepend_tool_paths(env)
 
         # start_new_session=True detaches the slash worker into its own
         # process group / session. Without this, the worker inherits the

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -363,15 +363,25 @@ _detached_ws_transport = _DropTransport()
 
 
 def _prepend_tool_paths(env: dict[str, str]) -> dict[str, str]:
-    """Prepend the Hermes venv bin dir and the user-local bin dir to PATH
-    so slash_worker child processes can resolve Hermes-managed CLIs
-    (browser-use, uvx) even when the parent gateway was launched with a
-    minimal PATH (e.g. by the Desktop/Dashboard app)."""
+    """Prepend Hermes' managed bin, the venv bin dir, and the user-local
+    bin dir to PATH so slash_worker child processes can resolve
+    Hermes-managed CLIs (browser-use, uvx, uv) even when the parent
+    gateway was launched with a minimal PATH (e.g. by the
+    Desktop/Dashboard app). Managed bin leads, matching the managed-first
+    resolution policy for the Browser Use CLI."""
+    managed_bin = ""
+    try:
+        from hermes_constants import get_hermes_home
+
+        managed_bin = str(Path(get_hermes_home()) / "bin")
+    except Exception:
+        pass
     venv_bin = str(Path(sys.executable).parent)  # <venv>/bin (POSIX) or <venv>/Scripts (Windows)
     user_bin = str(Path.home() / ".local" / "bin")
     existing = env.get("PATH") or ""
     env["PATH"] = os.pathsep.join(
-        [p for p in (venv_bin, user_bin) if p] + ([existing] if existing else [])
+        [p for p in (managed_bin, venv_bin, user_bin) if p]
+        + ([existing] if existing else [])
     )
     return env
 


### PR DESCRIPTION
## Summary
Dashboard/Desktop-spawned `slash_worker` processes can now resolve Hermes-managed CLIs (browser-use, uvx, uv): the worker env PATH is prepended with Hermes' managed bin, the venv bin dir, and the user-local bin dir, so a minimal inherited PATH (the Desktop launch case) no longer breaks `browser_exec` CLI discovery.

Fixes #83845. Salvage of #83854 by @webtecnica (clean cherry-pick, authorship preserved) plus a follow-up commit leading the prepend with `$HERMES_HOME/bin` to match the managed-first Browser Use resolution policy (#86339) — the worker resolves the same canonical binary as the agent process.

## Changes
- `tui_gateway/server.py`: `_prepend_tool_paths()` — managed bin → venv bin → `~/.local/bin` → inherited PATH; wired into `_SlashWorker` env construction.
- `tests/gateway/test_tui_slash_worker_path.py`: new regression tests (contributor's, extended to pin managed-bin-first ordering with hermetic HERMES_HOME).

## Validation
| | Before | After |
|---|---|---|
| Desktop-launched gateway, minimal PATH | slash_worker can't find browser-use/uvx | resolves via prepended dirs |
| tests/gateway/test_tui_slash_worker_path.py | — | 3/3 passing |

## Infographic

![Worker PATH wired to ours](https://files.catbox.moe/qiz014.png)
