### PR TITLE
fix(send_message): hand unresolved cron and react targets to the adapter again

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1859,8 +1859,13 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         )
 
         prepare_send_message_platforms()
+        # pass_unresolved_references: stored jobs have no model in the loop to react
+        # to a resolution error, and a target the directory doesn't know
+        # (fresh install, platform-native id) used to be handed to the
+        # adapter as written. Dropping it here silently loses the job's
+        # output.
         chat_id, thread_id, resolution_error = resolve_send_target(
-            platform_key, rest
+            platform_key, rest, pass_unresolved_references=True
         )
         if resolution_error:
             logger.warning(

--- a/tests/cron/test_cron_relay_delivery_guards.py
+++ b/tests/cron/test_cron_relay_delivery_guards.py
@@ -79,7 +79,7 @@ class TestOriginThreadStaleGuard:
             "tools.send_message_tool.prepare_send_message_platforms", lambda: None)
         monkeypatch.setattr(
             "tools.send_message_tool.resolve_send_target",
-            lambda platform, rest: (rest, None, None))
+            lambda platform, rest, **kw: (rest, None, None))
         job = {"origin": {"platform": "slack", "chat_id": "D0BJTDCSR7C",
                           "thread_id": SYNTH}}
         target = _resolve_single_delivery_target(job, "slack:D0BJTDCSR7C")
@@ -92,7 +92,7 @@ class TestOriginThreadStaleGuard:
             "tools.send_message_tool.prepare_send_message_platforms", lambda: None)
         monkeypatch.setattr(
             "tools.send_message_tool.resolve_send_target",
-            lambda platform, rest: (rest, None, None))
+            lambda platform, rest, **kw: (rest, None, None))
         job = {"origin": {"platform": "slack", "chat_id": "C0AGENERAL",
                           "thread_id": "1755040000.000100"}}
         target = _resolve_single_delivery_target(job, "slack:C0AGENERAL")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -254,6 +254,24 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
+    def test_unresolved_target_still_delivered_as_written(self):
+        """A stored job's platform-native target keeps delivering when neither
+        parser nor directory recognizes it. Routing cron through
+        resolve_send_target turned these into a warning plus a silently
+        dropped delivery; pass_unresolved_references hands the raw id to the adapter
+        again."""
+        job = {"deliver": "telegram:ops-room"}
+        with patch(
+            "gateway.channel_directory.resolve_channel_name",
+            return_value=None,
+        ):
+            result = _resolve_delivery_target(job)
+        assert result == {
+            "platform": "telegram",
+            "chat_id": "ops-room",
+            "thread_id": None,
+        }
+
 
     def test_list_form_deliver_is_normalized(self, monkeypatch):
         """deliver=['telegram'] (Python list) should resolve like 'telegram' string.

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -206,3 +206,107 @@ def test_unresolved_builtin_target_keeps_directory_error() -> None:
     }
     send_mock.assert_not_awaited()
 
+
+
+def test_unresolved_builtin_target_passes_through_when_requested() -> None:
+    """Cron and react keep the old pass-through behavior for unresolved
+    built-in targets: with no model in the loop to react to an error, the
+    raw id must reach the adapter, as it did before resolve_send_target
+    took over these callers."""
+    from tools.send_message_tool import resolve_send_target
+
+    with patch("gateway.channel_directory.resolve_channel_name", return_value=None):
+        chat_id, thread_id, error = resolve_send_target(
+            "telegram", "ops-room", pass_unresolved_references=True
+        )
+
+    assert error is None
+    assert chat_id == "ops-room"
+    assert thread_id is None
+
+
+def test_unresolved_builtin_target_still_errors_for_the_model_tool() -> None:
+    """The model-facing default stays strict: unresolved targets error with a hint."""
+    from tools.send_message_tool import resolve_send_target
+
+    with patch("gateway.channel_directory.resolve_channel_name", return_value=None):
+        chat_id, _thread_id, error = resolve_send_target("telegram", "ops-room")
+
+    assert chat_id is None
+    assert error is not None
+
+
+def test_photon_group_guid_passes_through_when_requested() -> None:
+    """The reported regression case: a photon group GUID matches no parser
+    pattern (only DM GUIDs have an explicit rule) and no directory entry.
+    Photon registers as a parser-less plugin platform, so the pass-through
+    applies once platforms are prepared."""
+    from tools.send_message_tool import (
+        prepare_send_message_platforms,
+        resolve_send_target,
+    )
+
+    prepare_send_message_platforms()
+    with patch("gateway.channel_directory.resolve_channel_name", return_value=None):
+        chat_id, thread_id, error = resolve_send_target(
+            "photon", "iMessage;+;chat527148912345", pass_unresolved_references=True
+        )
+
+    assert error is None
+    assert chat_id == "iMessage;+;chat527148912345"
+    assert thread_id is None
+
+
+def test_parserless_plugin_target_passes_through_when_requested() -> None:
+    """A plugin platform that declares no parser has no explicit syntax at
+    all, so passing the raw id through is the only way cron can target it."""
+    from gateway.platform_registry import PlatformEntry, platform_registry
+    from tools.send_message_tool import resolve_send_target
+
+    platform_name = "opaque-cron-fallback-test"
+    entry = PlatformEntry(
+        name=platform_name,
+        label="Opaque cron fallback test",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+    )
+    platform_registry.register(entry)
+    try:
+        with patch("gateway.channel_directory.resolve_channel_name", return_value=None):
+            chat_id, thread_id, error = resolve_send_target(
+                platform_name, "dm:panyaozhen", pass_unresolved_references=True
+            )
+    finally:
+        platform_registry.unregister(platform_name)
+
+    assert error is None
+    assert chat_id == "dm:panyaozhen"
+    assert thread_id is None
+
+
+def test_plugin_parser_stays_authoritative_despite_fallback() -> None:
+    """A plugin that DOES declare a parser stays strict for every caller:
+    its parser is the authority on native syntax, so an unrecognized
+    target errors even with pass_unresolved_references."""
+    from gateway.platform_registry import PlatformEntry, platform_registry
+    from tools.send_message_tool import resolve_send_target
+
+    platform_name = "opaque-parser-strict-test"
+    entry = PlatformEntry(
+        name=platform_name,
+        label="Opaque parser strict test",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        parse_target_ref_fn=lambda ref: None,
+    )
+    platform_registry.register(entry)
+    try:
+        with patch("gateway.channel_directory.resolve_channel_name", return_value=None):
+            chat_id, _thread_id, error = resolve_send_target(
+                platform_name, "dm:panyaozhen", pass_unresolved_references=True
+            )
+    finally:
+        platform_registry.unregister(platform_name)
+
+    assert chat_id is None
+    assert error is not None

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -296,8 +296,11 @@ def _handle_react(args, remove=False):
     chat_id = None
     prepare_send_message_platforms()
     if target_ref:
+        # Platform-native ids (e.g. photon space GUIDs like 'any;-;+1555...')
+        # match no parser pattern and no directory entry, so hand them to
+        # the adapter unchanged; it validates them.
         chat_id, _thread_id, resolution_error = resolve_send_target(
-            platform_name, target_ref
+            platform_name, target_ref, pass_unresolved_references=True
         )
         if resolution_error:
             return tool_error(resolution_error)
@@ -622,14 +625,26 @@ def _parse_target_ref(platform_name: str, target_ref: str):
 
 
 def resolve_send_target(
-    platform_name: str, target_ref: str
+    platform_name: str, target_ref: str, *, pass_unresolved_references: bool = False
 ) -> tuple[str | None, str | None, str | None]:
-    """Resolve one send target identically for model/CLI/cron surfaces.
+    """Resolve one send target the same way for every caller (model tool, CLI, cron).
 
     Channel-directory IDs are trusted. Plugin platforms must explicitly parse
-    native target syntax; unresolved strings never receive an opaque fallback.
-    The optional validator is the final authority over parser-normalized and
-    directory-resolved IDs.
+    native target syntax; for the model-facing send tool (the default), a
+    target that can't be resolved is an error — the model can read the error
+    and pick a listed target instead.
+
+    ``pass_unresolved_references=True`` restores the old pass-through behavior for
+    callers that have no model in the loop (cron delivering a stored job's
+    output, react/unreact on platform-native message ids): if the target
+    can't be resolved and the platform is built in, or is a plugin platform
+    that declares no parser, the string is handed to the adapter exactly as
+    written and the adapter decides whether it's valid. A plugin platform
+    that DOES declare a parser stays strict for every caller — its parser is
+    the authority on native syntax.
+
+    The optional validator has the final say over parser-normalized,
+    directory-resolved, and passed-through IDs alike.
     """
     from gateway.config import Platform
     from gateway.platform_registry import platform_registry
@@ -715,13 +730,30 @@ def resolve_send_target(
     is_builtin = platform_name in {member.value for member in Platform}
     if entry is None and not is_builtin:
         return None, None, f"Unknown or unregistered plugin platform: {platform_name}"
+
+    def _pass_through_unresolved():
+        """Hand the raw target to the adapter unchanged (it validates)."""
+        error = _validate(target_ref)
+        if error:
+            return None, None, error
+        logger.debug(
+            "Handing unresolved target '%s' to the %s adapter unchanged "
+            "(the adapter validates it)",
+            target_ref, platform_name,
+        )
+        return target_ref, None, None
+
     if entry is not None and entry.source == "plugin" and not is_builtin:
+        if pass_unresolved_references and entry.parse_target_ref_fn is None:
+            return _pass_through_unresolved()
         return (
             None,
             None,
             f"Could not resolve '{target_ref}' on {platform_name}. "
             "The plugin parser did not recognize it and no channel-directory entry matched.",
         )
+    if pass_unresolved_references:
+        return _pass_through_unresolved()
     hint = (
         "Try using a numeric channel ID instead."
         if resolution_failed


### PR DESCRIPTION
## Summary
Restores pass-through behavior for cron delivery and react/unreact that was lost when d409f6748 routed them through `resolve_send_target`. Stored cron job targets the channel directory doesn't recognize (e.g. `telegram:ops-room` on a fresh install, photon group GUIDs) used to go to the adapter verbatim; after d409f6748 they were silently dropped. Same for react on platform-native ids.

Adds an opt-in `pass_unresolved_references` flag to `resolve_send_target`, passed only by cron and react. Model-facing send tool stays strict. Plugin platforms with a parser stay strict for all callers. The optional validator still has the final say over passed-through ids.

Salvage of #85129 by @Adolanium. Follow-up fixes:
- Updated 2 mock lambdas in `test_cron_relay_delivery_guards.py` to accept `**kw` (file added to main after the PR's branch point; the lambdas didn't accept the new keyword argument and raised `TypeError`)
- Consolidated duplicated pass-through blocks (parser-less plugin + built-in) into a `_pass_through_unresolved` local helper

Fixes #85128

## Changes
- `tools/send_message_tool.py`: `resolve_send_target` gains `pass_unresolved_references: bool = False` (keyword-only). When resolution comes up empty it hands the raw target to the adapter (after running the validator) for built-in platforms and parser-less plugin platforms. Two duplicated pass-through blocks consolidated into `_pass_through_unresolved` helper. `_handle_react` passes the flag.
- `cron/scheduler.py`: `_resolve_single_delivery_target` passes the flag, with a comment on why cron can't afford the strict behavior.
- `tests/tools/test_send_message_target_parse.py`: 5 new tests covering pass-through for built-ins, photon group GUID case, parser-less plugin case, parser plugin stays authoritative, and model-facing default stays strict.
- `tests/cron/test_scheduler.py`: 1 new test proving unresolved `telegram:ops-room` job target is delivered as written.
- `tests/cron/test_cron_relay_delivery_guards.py`: 2 mock lambdas updated to accept `**kw`.

## Validation
| | Before (main) | After (this PR) |
|---|---|---|
| Cron unresolved target | Silently dropped | Passed to adapter |
| React on native id | Resolution error | Passed to adapter |
| Model send tool (unresolved) | Error with hint | Error with hint (unchanged) |
| Plugin with parser (unresolved) | Error | Error (unchanged) |
| Test suite | 104 passed | 104 passed |
| E2E smoke (real imports) | — | 6/6 pass |
| Ruff lint | — | Clean |
