### PR TITLE
fix(tui): stop status-bar re-render churn during streaming (#41480)

### DIFF
--- a/ui-tui/src/__tests__/mergeUsageStable.test.ts
+++ b/ui-tui/src/__tests__/mergeUsageStable.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { mergeUsageStable, usageChanged } from '../app/createGatewayEventHandler.js'
+import type { Usage } from '../types.js'
+
+const baseUsage: Usage = {
+  calls: 3,
+  input: 1200,
+  output: 400,
+  total: 1600,
+  context_max: 200000,
+  context_percent: 12,
+  context_used: 24000
+}
+
+describe('mergeUsageStable (#41480 status-bar flicker)', () => {
+  it('returns the PRIOR reference when a patch changes nothing', () => {
+    // The load-bearing behavior: an unchanged-value patch must NOT mint a new
+    // object, or every $uiState subscriber re-renders per streaming delta.
+    const patch = { calls: 3, total: 1600 }
+    expect(mergeUsageStable(baseUsage, patch)).toBe(baseUsage)
+  })
+
+  it('returns the prior reference for an undefined patch', () => {
+    expect(mergeUsageStable(baseUsage, undefined)).toBe(baseUsage)
+  })
+
+  it('returns a new merged object when a value actually changes', () => {
+    const merged = mergeUsageStable(baseUsage, { total: 1700 })
+    expect(merged).not.toBe(baseUsage)
+    expect(merged.total).toBe(1700)
+    expect(merged.calls).toBe(3)
+  })
+
+  it('detects an active_subagents-only update (field the original PR missed)', () => {
+    // usageChanged iterates the key union generically, so optional fields the
+    // status rule consumes (active_subagents drives the ⛓ segment and the
+    // resume hint) can never be silently dropped from the comparison.
+    const withSubagents = mergeUsageStable(baseUsage, { active_subagents: 2 })
+    expect(withSubagents).not.toBe(baseUsage)
+    expect(withSubagents.active_subagents).toBe(2)
+
+    // And clearing it back down is also a change.
+    const cleared = mergeUsageStable(withSubagents, { active_subagents: 0 })
+    expect(cleared).not.toBe(withSubagents)
+    expect(cleared.active_subagents).toBe(0)
+  })
+
+  it('treats a key present on only one side as a change', () => {
+    expect(usageChanged(baseUsage, { ...baseUsage, cost_usd: 0.01 })).toBe(true)
+    expect(usageChanged({ ...baseUsage, cost_usd: 0.01 }, baseUsage)).toBe(true)
+  })
+
+  it('reports no change for deep-equal usages', () => {
+    expect(usageChanged(baseUsage, { ...baseUsage })).toBe(false)
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -23,7 +23,7 @@ import { isPaintableHex, setTerminalBackground, setTerminalForeground } from '..
 import { formatAbandonedClarify, formatToolCall, stripAnsi } from '../lib/text.js'
 import { bootSeededPin, invalidateBootBackground, writeBootTheme } from '../lib/themeBoot.js'
 import { defaultThemeForCurrentBackground, fromSkin, skinIsLight, type Theme, themeToneHex } from '../theme.js'
-import type { Msg, SubagentProgress, SubagentStatus } from '../types.js'
+import type { Msg, SubagentProgress, SubagentStatus, Usage } from '../types.js'
 
 import { applyDelegationStatus, getDelegationState } from './delegationStore.js'
 import type { GatewayEventHandlerContext } from './interfaces.js'
@@ -40,6 +40,28 @@ type VoiceSubmitMode = 'direct' | 'draft'
 
 const normalizeVoiceSubmitMode = (value: unknown): VoiceSubmitMode =>
   typeof value === 'string' && value.trim().toLowerCase() === 'draft' ? 'draft' : 'direct'
+
+// Shallow-compare Usage to avoid creating a new object reference when values
+// haven't changed. A fresh reference on every streaming event forces every
+// $uiState subscriber (including the status rule) to re-render, which showed
+// up as per-delta status-bar flicker on iTerm2 (#41480). The comparator
+// iterates the union of keys generically so a future Usage field (e.g.
+// active_subagents, consumed by the status rule's subagent segment) can never
+// be silently dropped from the comparison.
+const usageChanged = (prev: Usage, next: Usage): boolean => {
+  const keys = new Set([...Object.keys(prev), ...Object.keys(next)]) as Set<keyof Usage>
+  for (const key of keys) {
+    if (prev[key] !== next[key]) return true
+  }
+  return false
+}
+
+const mergeUsageStable = (prev: Usage, patch: Partial<Usage> | undefined): Usage => {
+  if (!patch) return prev
+  const merged: Usage = { ...prev, ...patch }
+  return usageChanged(prev, merged) ? merged : prev
+}
+
 
 const statusFromBusy = () => (getUiState().busy ? 'running…' : 'ready')
 
@@ -745,7 +767,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           ...state,
           info,
           status: state.status === 'starting agent…' ? 'ready' : state.status,
-          usage: info.usage ? { ...state.usage, ...info.usage } : state.usage
+          usage: info.usage ? mergeUsageStable(state.usage, info.usage) : state.usage
         }))
 
         setHistoryItems(prev => prev.map(m => (m.kind === 'intro' ? { ...m, info } : m)))
@@ -1370,7 +1392,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         setStatus('ready')
 
         if (ev.payload?.usage) {
-          patchUiState(state => ({ ...state, usage: { ...state.usage, ...ev.payload!.usage } }))
+          patchUiState(state => ({ ...state, usage: mergeUsageStable(state.usage, ev.payload!.usage) }))
         }
 
         // Billing wall (out of credits / payment required): open a proper

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -50,15 +50,23 @@ const normalizeVoiceSubmitMode = (value: unknown): VoiceSubmitMode =>
 // be silently dropped from the comparison.
 export const usageChanged = (prev: Usage, next: Usage): boolean => {
   const keys = new Set([...Object.keys(prev), ...Object.keys(next)]) as Set<keyof Usage>
+
   for (const key of keys) {
-    if (prev[key] !== next[key]) return true
+    if (prev[key] !== next[key]) {
+      return true
+    }
   }
+
   return false
 }
 
 export const mergeUsageStable = (prev: Usage, patch: Partial<Usage> | undefined): Usage => {
-  if (!patch) return prev
+  if (!patch) {
+    return prev
+  }
+
   const merged: Usage = { ...prev, ...patch }
+
   return usageChanged(prev, merged) ? merged : prev
 }
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -48,7 +48,7 @@ const normalizeVoiceSubmitMode = (value: unknown): VoiceSubmitMode =>
 // iterates the union of keys generically so a future Usage field (e.g.
 // active_subagents, consumed by the status rule's subagent segment) can never
 // be silently dropped from the comparison.
-const usageChanged = (prev: Usage, next: Usage): boolean => {
+export const usageChanged = (prev: Usage, next: Usage): boolean => {
   const keys = new Set([...Object.keys(prev), ...Object.keys(next)]) as Set<keyof Usage>
   for (const key of keys) {
     if (prev[key] !== next[key]) return true
@@ -56,7 +56,7 @@ const usageChanged = (prev: Usage, next: Usage): boolean => {
   return false
 }
 
-const mergeUsageStable = (prev: Usage, patch: Partial<Usage> | undefined): Usage => {
+export const mergeUsageStable = (prev: Usage, patch: Partial<Usage> | undefined): Usage => {
   if (!patch) return prev
   const merged: Usage = { ...prev, ...patch }
   return usageChanged(prev, merged) ? merged : prev


### PR DESCRIPTION
## Summary
The TUI status bar stops flickering during streaming: usage patches that change no values no longer mint a fresh object reference, so `$uiState` subscribers (the status rule included) stop re-rendering on every thinking/tool/usage delta (fixes #41480).

Root cause: both usage merge sites spread `{ ...state.usage, ...patch }` unconditionally, producing a new reference per streaming event even when nothing changed. Every nanostore subscriber re-rendered per delta; on iTerm2 the per-delta single-row repaint is visible flicker localized to the bar.

## Changes (salvages PR #41484 by @liuhao1024, authorship preserved)
- `createGatewayEventHandler.ts` — `mergeUsageStable()` shallow-compares and returns the PRIOR reference when a patch is a no-op; applied at both merge sites (session info + turn completion)
- Follow-up commit (ours): the comparator iterates the union of Usage keys generically instead of the original hardcoded field list, which omitted `active_subagents` (consumed by the status rule's ⛓ segment and resume hint) and would have suppressed legitimate updates
- The original PR's `memo(StatusRule)` half is intentionally dropped: main's StatusRule has since grown battery/subagent/resume-hint segments and the wrapper broke the direct-call test seam flagged in the earlier review. The stable-reference fix removes the re-render churn at its source
- Regression tests: unchanged-reference retention, `active_subagents`-only update detection, key-union asymmetry

## Validation
| Check | Result |
|---|---|
| vitest mergeUsageStable + createGatewayEventHandler | 104 passed |
| tsc --noEmit (ui-tui) | clean |
| Diff | 2 files, +82/−3 |
| attribution audit | mapped |

## Infographic

![status bar flicker terminated](https://files.catbox.moe/wrm9tv.png)
