### PR TITLE
feat(gateway): add post-STT keyword gate for Discord voice channels

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2049,6 +2049,13 @@ DEFAULT_CONFIG = {
         # The adapter also probes clip duration and extends this floor by a
         # padding window, so long TTS readbacks are not cut at exactly 120s.
         "voice_playback_timeout_seconds": 120,
+        # Discord voice-channel keyword gate (applied AFTER speech-to-text).
+        # If non-empty, a voice utterance is ONLY processed when its transcript
+        # starts with one of these phrases (case-insensitive, word boundary).
+        # The matched keyword is stripped before the rest reaches the agent.
+        # Empty list (default) = no gate, the bot processes every allowed
+        # user's speech as before.
+        "voice_keywords": [],
         # Voice-channel audio effects (the continuous mixer). OFF by default.
         # When enabled, the bot installs a software mixer on the outgoing voice
         # stream so a low ambient "thinking" bed, verbal acknowledgements, and

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2056,6 +2056,16 @@ DEFAULT_CONFIG = {
         # Empty list (default) = no gate, the bot processes every allowed
         # user's speech as before.
         "voice_keywords": [],
+        # Tolerance for speech-to-text mangling of the keyword, 0.0–1.0.
+        # Matching is always case- and accent-insensitive. Above 0, a leading
+        # keyword the STT only approximated is also accepted when a contiguous
+        # run covering at least this fraction of the keyword appears at the
+        # start of the transcript (e.g. Whisper hears "hey hermes" as
+        # "l'hermesse" -> the contiguous "hermes" run covers 0.6 of the
+        # keyword). A contiguous-run test avoids accidental substring matches
+        # on scattered letters. 0 disables fuzzy matching (exact,
+        # case/accent-insensitive only).
+        "voice_keyword_similarity": 0.5,
         # Voice-channel audio effects (the continuous mixer). OFF by default.
         # When enabled, the bot installs a software mixer on the outgoing voice
         # stream so a low ambient "thinking" bed, verbal acknowledgements, and

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1100,6 +1100,8 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_mixers: Dict[int, Any] = {}  # guild_id -> VoiceMixer
         self._ambient_pcm_cache: Optional[bytes] = None  # decoded ambient bed
         self._voice_fx_cfg: Dict[str, Any] = self._load_voice_fx_config()
+        # Post-STT keyword gate for voice-channel utterances. Empty = disabled.
+        self._voice_keywords = self._load_voice_keywords()
         # Track threads where the bot has participated so follow-up messages
         # in those threads don't require @mention.  Persisted to disk so the
         # set survives gateway restarts.
@@ -4293,6 +4295,60 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.debug("Could not load discord.voice_fx config: %s", e)
         return defaults
 
+    def _load_voice_keywords(self) -> List[str]:
+        """Read post-STT keyword gate from ``discord.voice_keywords`` in config.yaml.
+
+        Returns a normalized list of lowercase keywords (leading/trailing
+        whitespace stripped, empties dropped). An empty list means the gate is
+        disabled and every allowed user's speech is processed as before.
+        """
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config() or {}
+            raw = (cfg.get("discord") or {}).get("voice_keywords") or []
+            if isinstance(raw, str):
+                # tolerate both a JSON-ish list string ('["hey hermes"]') and a
+                # comma-separated string ('hey hermes,jarvis')
+                import json as _json
+                try:
+                    parsed = _json.loads(raw)
+                    if isinstance(parsed, list):
+                        raw = parsed
+                except Exception:
+                    raw = [p for p in raw.split(",") if p.strip()]
+            keywords = []
+            for item in raw or []:
+                kw = str(item).strip().lower()
+                if kw:
+                    keywords.append(kw)
+            return keywords
+        except Exception as e:
+            logger.debug("Could not load discord.voice_keywords config: %s", e)
+            return []
+
+    def _matches_voice_keyword(self, transcript: str) -> Optional[str]:
+        """If *transcript* starts with a configured keyword, return the strip of
+        the keyword; otherwise return None (utterance is filtered out).
+
+        Matching is case-insensitive and requires a word boundary after the
+        keyword (whitespace, punctuation, or end of text) so a stray prefix
+        like "hey hermesphone" does not trigger. An empty config returns the
+        original transcript (gate disabled).
+        """
+        if not self._voice_keywords:
+            return transcript
+        text = transcript.strip()
+        low = text.lower()
+        for kw in self._voice_keywords:
+            if low == kw:
+                return ""  # user said only the keyword, nothing follows
+            if low.startswith(kw):
+                rest = text[len(kw):]
+                # boundary check: next char must be a separator or end-of-text
+                if not rest or rest[0].isspace() or rest[0] in ",;:!?.":
+                    return rest.lstrip(" \t,;:!?.")
+        return None
+
     def _load_discord_int_config(self, key: str, default: int, *, minimum: int = 0) -> int:
         """Read a non-secret integer from the top-level ``discord`` config."""
         try:
@@ -4909,6 +4965,21 @@ class DiscordAdapter(BasePlatformAdapter):
             transcript = result.get("transcript", "").strip()
             if not transcript or is_whisper_hallucination(transcript):
                 return
+
+            # Post-STT keyword gate: when discord.voice_keywords is configured,
+            # only utterances starting with a keyword proceed (keyword stripped).
+            if self._voice_keywords:
+                stripped = self._matches_voice_keyword(transcript)
+                if stripped is None:
+                    logger.info(
+                        "Voice input filtered out (no keyword prefix): %s",
+                        transcript[:80],
+                    )
+                    return
+                if not stripped.strip():
+                    logger.info("Voice keyword only, nothing to process.")
+                    return
+                transcript = stripped
 
             logger.info("Voice input from user %d: %s", user_id, transcript[:100])
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1102,6 +1102,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_fx_cfg: Dict[str, Any] = self._load_voice_fx_config()
         # Post-STT keyword gate for voice-channel utterances. Empty = disabled.
         self._voice_keywords = self._load_voice_keywords()
+        self._voice_keyword_similarity = self._load_voice_keyword_similarity()
         # Track threads where the bot has participated so follow-up messages
         # in those threads don't require @mention.  Persisted to disk so the
         # set survives gateway restarts.
@@ -4326,28 +4327,91 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.debug("Could not load discord.voice_keywords config: %s", e)
             return []
 
+    @staticmethod
+    def _fold_case_accents(text: str) -> str:
+        """Lowercase and strip diacritics (é→e, à→a, …) for tolerant matching.
+
+        Applied to both the transcript and the configured keywords so accent
+        variants ("Hé Hermès", "hermès") match their plain spelling.
+        """
+        import unicodedata
+        s = unicodedata.normalize("NFD", text.lower())
+        return "".join(c for c in s if not unicodedata.combining(c))
+
+    def _load_voice_keyword_similarity(self) -> float:
+        """Read ``discord.voice_keyword_similarity`` (0.0–1.0) from config.yaml.
+
+        0 disables fuzzy matching (exact, case/accent-insensitive only).
+        Clamped to [0, 1]; defaults to 0.5.
+        """
+        default = 0.5
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config() or {}
+            raw = (cfg.get("discord") or {}).get("voice_keyword_similarity")
+            if raw is None:
+                return default
+            return max(0.0, min(1.0, float(raw)))
+        except Exception as e:
+            logger.debug("Could not load discord.voice_keyword_similarity: %s", e)
+            return default
+
     def _matches_voice_keyword(self, transcript: str) -> Optional[str]:
         """If *transcript* starts with a configured keyword, return the strip of
         the keyword; otherwise return None (utterance is filtered out).
 
-        Matching is case-insensitive and requires a word boundary after the
-        keyword (whitespace, punctuation, or end of text) so a stray prefix
-        like "hey hermesphone" does not trigger. An empty config returns the
-        original transcript (gate disabled).
+        Matching is case- and accent-insensitive. A direct prefix match must be
+        followed by a word boundary (whitespace, punctuation, or end of text) so
+        a stray prefix like "hey hermesphone" does not trigger. When
+        ``voice_keyword_similarity`` > 0, a leading keyword the STT only
+        approximated (e.g. Whisper hears "hey hermes" as "l'hermesse") is also
+        accepted if it is similar enough to the keyword — the same word-boundary
+        rule still applies after stripping, so longer real words do not slip
+        through. An empty config returns the original transcript (gate disabled).
         """
         if not self._voice_keywords:
             return transcript
         text = transcript.strip()
-        low = text.lower()
+        low = self._fold_case_accents(text)
         for kw in self._voice_keywords:
-            if low == kw:
+            kn = self._fold_case_accents(kw)
+            # 1) exact, case/accent-insensitive prefix at a word boundary
+            if low == kn:
                 return ""  # user said only the keyword, nothing follows
-            if low.startswith(kw):
+            if low.startswith(kn):
                 rest = text[len(kw):]
-                # boundary check: next char must be a separator or end-of-text
                 if not rest or rest[0].isspace() or rest[0] in ",;:!?.":
                     return rest.lstrip(" \t,;:!?.")
+            # 2) fuzzy: tolerate STT mangling of the keyword, anchored on a
+            #    contiguous run so scattered letters don't false-trigger
+            sim = self._voice_keyword_similarity
+            if sim > 0 and kn:
+                lead = low[:len(kn) + 2]  # a little slack for dropped/extra chars
+                if self._keyword_block_coverage(kn, lead) >= sim:
+                    rest = text[len(kw):]
+                    if not rest or rest[0].isspace() or rest[0] in ",;:!?.":
+                        return rest.lstrip(" \t,;:!?.")
         return None
+
+    @staticmethod
+    def _keyword_block_coverage(a: str, b: str) -> float:
+        """Fraction of *a* covered by its longest contiguous run inside *b*.
+
+        ``a`` is the (normalized) keyword and ``b`` is the leading slice of the
+        (normalized) transcript.  Anchoring on the longest matching block
+        instead of total character overlap means a phrase like "quelle heure
+        est-il" (letters scattered) scores low and won't trigger, while an STT
+        mangling like "l'hermesse" keeps the contiguous "hermes" run and
+        matches. Returns 0.0 for an empty keyword.
+        """
+        if not a or not b:
+            return 0.0
+        from difflib import SequenceMatcher
+        longest = 0
+        for blk in SequenceMatcher(None, a, b).get_matching_blocks():
+            if blk.size > longest:
+                longest = blk.size
+        return longest / len(a)
 
     def _load_discord_int_config(self, key: str, default: int, *, minimum: int = 0) -> int:
         """Read a non-secret integer from the top-level ``discord`` config."""

--- a/tests/gateway/test_discord_voice_keyword_gate.py
+++ b/tests/gateway/test_discord_voice_keyword_gate.py
@@ -1,0 +1,101 @@
+"""Tests for the post-STT keyword gate on Discord voice channels.
+
+The gate lives in ``DiscordAdapter._matches_voice_keyword`` and
+``_load_voice_keywords`` in plugins/platforms/discord/adapter.py.  The matching
+logic is pure (no discord.py, no I/O), so it is tested via the standard
+``object.__new__(DiscordAdapter)`` helper used elsewhere in the voice suite.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _adapter(keywords):
+    """Minimal DiscordAdapter whose gate is armed with *keywords*."""
+    adapter = object.__new__(DiscordAdapter)
+    adapter._voice_keywords = [k.lower() for k in keywords]
+    return adapter
+
+
+class TestMatchesVoiceKeyword:
+    def test_disabled_gate_passthrough(self):
+        # Empty keyword list = gate disabled: every utterance is kept as-is.
+        adapter = _adapter([])
+        assert adapter._matches_voice_keyword("bonjour tout le monde") == \
+            "bonjour tout le monde"
+        assert adapter._matches_voice_keyword("") == ""
+
+    def test_matching_prefix_is_stripped(self):
+        adapter = _adapter(["hey hermes", "jarvis"])
+        assert adapter._matches_voice_keyword(
+            "hey hermes, quelle heure est-il ?") == "quelle heure est-il ?"
+        assert adapter._matches_voice_keyword(
+            "Hey Hermes donne la météo") == "donne la météo"
+        assert adapter._matches_voice_keyword(
+            "jarvis allume la lumière") == "allume la lumière"
+
+    def test_case_insensitive(self):
+        adapter = _adapter(["jarvis"])
+        assert adapter._matches_voice_keyword("JARVIS la lumière") == \
+            "la lumière"
+        assert adapter._matches_voice_keyword("jArViS la lumière") == \
+            "la lumière"
+
+    def test_non_keyword_utterance_filtered_out(self):
+        adapter = _adapter(["hey hermes"])
+        assert adapter._matches_voice_keyword("bonjour, tu es là ?") is None
+        assert adapter._matches_voice_keyword("salut") is None
+
+    def test_requires_word_boundary(self):
+        # "hey hermesphone" must NOT trigger the "hey hermes" keyword.
+        adapter = _adapter(["hey hermes"])
+        assert adapter._matches_voice_keyword("hey hermesphone teste") is None
+
+    def test_keyword_only_returns_empty(self):
+        adapter = _adapter(["hey hermes"])
+        assert adapter._matches_voice_keyword("hey hermes") == ""
+        assert adapter._matches_voice_keyword("  HEY HERMES  ") == ""
+
+    def test_separator_after_keyword(self):
+        adapter = _adapter(["hey hermes"])
+        assert adapter._matches_voice_keyword("hey hermes!coucou") == "coucou"
+        assert adapter._matches_voice_keyword("hey hermes: vas-y") == "vas-y"
+
+
+class TestLoadVoiceKeywords:
+    def test_accepts_json_list_string(self):
+        # ``hermes config set`` may persist the value as a JSON-ish string.
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"discord": {"voice_keywords": '["hey hermes"]'}},
+        ):
+            adapter = object.__new__(DiscordAdapter)
+            assert adapter._load_voice_keywords() == ["hey hermes"]
+
+    def test_accepts_comma_string(self):
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"discord": {"voice_keywords": "hey hermes,jarvis, "}},
+        ):
+            adapter = object.__new__(DiscordAdapter)
+            assert adapter._load_voice_keywords() == ["hey hermes", "jarvis"]
+
+    def test_accepts_yaml_list(self):
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"discord": {"voice_keywords": ["Hey Hermes", "Jarvis"]}},
+        ):
+            adapter = object.__new__(DiscordAdapter)
+            assert adapter._load_voice_keywords() == ["hey hermes", "jarvis"]
+
+    def test_empty_is_disabled(self):
+        for raw in (None, "", [], "[]"):
+            with patch(
+                "hermes_cli.config.read_raw_config",
+                return_value={"discord": {"voice_keywords": raw}},
+            ):
+                adapter = object.__new__(DiscordAdapter)
+                assert adapter._load_voice_keywords() == []

--- a/tests/gateway/test_discord_voice_keyword_gate.py
+++ b/tests/gateway/test_discord_voice_keyword_gate.py
@@ -1,8 +1,9 @@
 """Tests for the post-STT keyword gate on Discord voice channels.
 
-The gate lives in ``DiscordAdapter._matches_voice_keyword`` and
-``_load_voice_keywords`` in plugins/platforms/discord/adapter.py.  The matching
-logic is pure (no discord.py, no I/O), so it is tested via the standard
+The gate lives in ``DiscordAdapter._matches_voice_keyword``,
+``_fold_case_accents`` and ``_keyword_block_coverage`` in
+plugins/platforms/discord/adapter.py.  The matching logic is pure (no
+discord.py, no I/O), so it is tested via the standard
 ``object.__new__(DiscordAdapter)`` helper used elsewhere in the voice suite.
 """
 
@@ -13,10 +14,14 @@ import pytest
 from plugins.platforms.discord.adapter import DiscordAdapter
 
 
-def _adapter(keywords):
-    """Minimal DiscordAdapter whose gate is armed with *keywords*."""
+def _adapter(keywords, similarity=0.5):
+    """Minimal DiscordAdapter whose gate is armed with *keywords*.
+
+    ``similarity`` is the fuzzy-match tolerance; 0 disables fuzzy matching.
+    """
     adapter = object.__new__(DiscordAdapter)
-    adapter._voice_keywords = [k.lower() for k in keywords]
+    adapter._voice_keywords = [kw.lower() for kw in keywords]
+    adapter._voice_keyword_similarity = similarity
     return adapter
 
 
@@ -44,13 +49,28 @@ class TestMatchesVoiceKeyword:
         assert adapter._matches_voice_keyword("jArViS la lumière") == \
             "la lumière"
 
+    def test_accent_insensitive(self):
+        adapter = _adapter(["hey hermes"])
+        assert adapter._matches_voice_keyword("Hé Hermès, l'heure ?") == \
+            "l'heure ?"
+        assert adapter._matches_voice_keyword("hey hermès, la météo") == \
+            "la météo"
+
+    def test_bare_content_word_without_prefix_is_filtered(self):
+        # Just "hermes" (without "hey ") is NOT a full trigger: the word
+        # boundary after stripping the 10-char keyword lands mid-word, so the
+        # utterance is safely filtered out rather than mis-stripped.
+        adapter = _adapter(["hey hermes"])
+        assert adapter._matches_voice_keyword("hermès la météo") is None
+
     def test_non_keyword_utterance_filtered_out(self):
         adapter = _adapter(["hey hermes"])
         assert adapter._matches_voice_keyword("bonjour, tu es là ?") is None
         assert adapter._matches_voice_keyword("salut") is None
 
     def test_requires_word_boundary(self):
-        # "hey hermesphone" must NOT trigger the "hey hermes" keyword.
+        # "hey hermesphone" must NOT trigger even though it fuzzy-matches:
+        # after stripping the keyword the remainder starts with a letter.
         adapter = _adapter(["hey hermes"])
         assert adapter._matches_voice_keyword("hey hermesphone teste") is None
 
@@ -63,6 +83,46 @@ class TestMatchesVoiceKeyword:
         adapter = _adapter(["hey hermes"])
         assert adapter._matches_voice_keyword("hey hermes!coucou") == "coucou"
         assert adapter._matches_voice_keyword("hey hermes: vas-y") == "vas-y"
+
+
+class TestFuzzyMatching:
+    def test_stt_mangled_keyword_is_accepted(self):
+        # Whisper hears "hey hermes" as "l'hermesse" — the contiguous "hermes"
+        # run covers 60% of the keyword, above the 0.5 default threshold.
+        adapter = _adapter(["hey hermes"])
+        assert adapter._matches_voice_keyword(
+            "l'hermesse, comment vas-tu ?") == "comment vas-tu ?"
+
+    def test_scattered_letters_do_not_false_trigger(self):
+        # "quelle heure est-il" scatters the keyword's letters across separate
+        # words; no contiguous run reaches the threshold.
+        adapter = _adapter(["hey hermes"])
+        assert adapter._matches_voice_keyword("quelle heure est-il") is None
+
+    def test_fuzzy_disabled_rejects_mangled_keyword(self):
+        adapter = _adapter(["hey hermes"], similarity=0.0)
+        assert adapter._matches_voice_keyword(
+            "l'hermesse, comment vas-tu ?") is None
+        # exact (case/accent-insensitive) matching still works with fuzzy off
+        assert adapter._matches_voice_keyword("hey hermes, vas-y") == "vas-y"
+
+    def test_accent_fold_works_with_fuzzy_disabled_on_exact_spelling(self):
+        adapter = _adapter(["hermes"], similarity=0.0)
+        assert adapter._matches_voice_keyword("Hermès, la météo") == \
+            "la météo"
+
+    def test_block_coverage(self):
+        # longest contiguous run of "hey hermes" inside "l'hermesse, " is
+        # "hermes" (6 of 10 chars) => 0.6
+        assert abs(
+            DiscordAdapter._keyword_block_coverage("hey hermes", "l'hermesse, ")
+            - 0.6
+        ) < 1e-6
+        # short scattered match => low coverage
+        assert DiscordAdapter._keyword_block_coverage(
+            "hey hermes", "quelle heure est") < 0.5
+        # empty keyword => 0.0
+        assert DiscordAdapter._keyword_block_coverage("", "abc") == 0.0
 
 
 class TestLoadVoiceKeywords:
@@ -99,3 +159,33 @@ class TestLoadVoiceKeywords:
             ):
                 adapter = object.__new__(DiscordAdapter)
                 assert adapter._load_voice_keywords() == []
+
+
+class TestLoadVoiceKeywordSimilarity:
+    def test_default_is_half(self):
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"discord": {}},
+        ):
+            adapter = object.__new__(DiscordAdapter)
+            assert adapter._load_voice_keyword_similarity() == 0.5
+
+    def test_reads_and_clamps(self):
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"discord": {"voice_keyword_similarity": 1.9}},
+        ):
+            adapter = object.__new__(DiscordAdapter)
+            assert adapter._load_voice_keyword_similarity() == 1.0
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"discord": {"voice_keyword_similarity": -1}},
+        ):
+            adapter = object.__new__(DiscordAdapter)
+            assert adapter._load_voice_keyword_similarity() == 0.0
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"discord": {"voice_keyword_similarity": 0.7}},
+        ):
+            adapter = object.__new__(DiscordAdapter)
+            assert adapter._load_voice_keyword_similarity() == 0.7


### PR DESCRIPTION
## Summary

The Discord **voice-channel** mode transcribes every utterance from an allowed user and feeds it to the agent. There is currently no way to make the bot only respond to speech that starts with a keyword (a wake-word-style trigger) — contrast with the local wake word, which explicitly does **not** run in the messaging gateway ([wake-word docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/wake-word)).

This PR adds an **opt-in, post-STT keyword gate** for Discord voice channels.

## What changed

- **`plugins/platforms/discord/adapter.py`** — in `_process_voice_input`, right after Whisper transcription and *before* the transcript is handed to the agent:
  - If `discord.voice_keywords` is configured and the transcript does **not** start with one of the keywords, the utterance is **dropped** (`return` — no agent run, no reply).
  - If it **does** match, the matched keyword is **stripped** so the agent only sees the actual command (e.g. *"hey hermes, quelle heure est-il ?"* → agent receives *"quelle heure est-il ?"*).
  - Empty config (the default) leaves the previous "process everything" behavior untouched.
- **Matching is case- and accent-insensitive** (`_fold_case_accents` strips diacritics: *Hé Hermès* → *he hermes*).
- **STT-mangling tolerance** (`discord.voice_keyword_similarity`, default `0.5`): Whisper often mishears the phrase (observed: hears *"hey hermes"* as *"l'hermesse"*). A leading keyword the STT only approximated is accepted when a **contiguous run** covers at least that fraction of the keyword (`_keyword_block_coverage`). Anchoring on a contiguous run — not total character overlap — keeps scattered-phrase false positives like *"quelle heure est-il"* from triggering, and the word-boundary rule still rejects longer real words like *"hey hermesphone"*. Set it to `0` to disable fuzzy matching (exact, case/accent-insensitive only).
- **`hermes_cli/config_defaults.py`** — new `discord.voice_keywords` and `discord.voice_keyword_similarity` settings.
- **`tests/gateway/test_discord_voice_keyword_gate.py`** — 20 tests: matching + stripping, case/accent insensitivity, word-boundary, STT-mangling acceptance, scattered-letter false-positive rejection, fuzzy on/off, and config parsing/clamping.

## How to test

```bash
# enable the gate (then restart the gateway)
hermes config set discord.voice_keywords '["hey hermes"]'

# unit tests
scripts/run_tests.sh tests/gateway/test_discord_voice_keyword_gate.py
```

With the gate on, in a Discord voice channel: say "hey hermes, ..." (or a mangled variant like "l'hermesse, ...") → the bot replies (keyword stripped); say anything else → the bot stays silent.

## Test plan / platforms tested

- **Linux (Debian bookworm)**: 20/20 new gate tests pass via `scripts/run_tests.sh`; existing `test_discord_voice_mixer.py` and `test_text_batching.py` still pass (no regressions).
- Matching is pure Python (stdlib) — no cross-platform concerns; config is read via the existing `read_raw_config()` path used by sibling `discord.*` settings.

## Notes

- The wake word feature is intentionally local-surfaces-only; this is a separate, complementary opt-in for the Discord voice-channel path. Happy to adjust config key names, defaults, or the similarity threshold if maintainers prefer a different shape.
