### PR TITLE
fix(sessions): prevent concurrent resumes from losing completed replies

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -699,8 +699,8 @@ def finalize_turn(
             "health (`hermes doctor`), then send your message again"
         )
         # Machine-readable cause for the gateway/desktop: exactly
-        # 'session_persistence_failed:<locked|disk|unknown>'. Never clobber a
-        # failure_reason another path already stamped on this result.
+        # 'session_persistence_failed:<locked|compression|turn_lease|disk|unknown>'.
+        # Never clobber a failure_reason another path already stamped.
         if "failure_reason" not in result:
             _cause = getattr(agent, "_last_persistence_error_cause", None)
             result["failure_reason"] = (

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1492,7 +1492,7 @@ def is_disk_full_error(exc: BaseException | str | None) -> bool:
 # enumerate causes (e.g. the cron scheduler's explainer-variant suppression)
 # must iterate this tuple instead of hardcoding the list, so adding a bucket
 # can never silently desynchronize them.
-PERSISTENCE_ERROR_CAUSES = ("locked", "disk", "unknown")
+PERSISTENCE_ERROR_CAUSES = ("locked", "compression", "disk", "unknown")
 
 
 def classify_persistence_error(exc_or_str) -> str:
@@ -1505,9 +1505,10 @@ def classify_persistence_error(exc_or_str) -> str:
     send it again", while a full disk or read-only database needs the
     disk-space/permissions advice. Returns one of PERSISTENCE_ERROR_CAUSES:
 
-    * ``"locked"``  — lock/busy contention (another process holds the write
-      lock, or a live compression lease refused the write); transient,
-      retry-later guidance applies.
+    * ``"locked"``  — SQLite lock/busy contention (another process holds the
+      database write lock); transient, retry-later guidance applies.
+    * ``"compression"`` — a live compression lease refused the transcript
+      write; the database itself is healthy and unlocked.
     * ``"disk"``    — disk full / read-only / permission-shaped failures
       (delegates the disk-full patterns to :func:`is_disk_full_error` so the
       two classifiers can never drift apart — e.g. ENOSPC).
@@ -1521,13 +1522,13 @@ def classify_persistence_error(exc_or_str) -> str:
     # "busy", so it must be matched by type and by phrase (for strings that
     # survived RPC wrapping).
     if isinstance(exc_or_str, CompressionSessionBusyError):
-        return "locked"
+        return "compression"
     text = str(exc_or_str).lower()
+    if "being compressed" in text or "compression lease" in text:
+        return "compression"
     if (
         "locked" in text
         or "busy" in text
-        or "being compressed" in text
-        or "compression lease" in text
     ):
         return "locked"
     if (
@@ -5738,6 +5739,136 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "release_compression_lock(%s) failed: %s",
                 session_id, exc,
             )
+
+    def _session_turn_lease_key(self, session_id: str) -> str:
+        """Return the stable serialization key for every compression segment."""
+        if not session_id:
+            return session_id
+        try:
+            current = self.get_session(session_id)
+            seen = {session_id}
+            while current and self._is_compression_child_row(current):
+                parent_id = current.get("parent_session_id")
+                if not parent_id or parent_id in seen:
+                    break
+                parent = self.get_session(parent_id)
+                if not parent:
+                    break
+                seen.add(parent_id)
+                current = parent
+            return str(current.get("id") or session_id) if current else session_id
+        except Exception:
+            return session_id
+
+    def try_acquire_session_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        *,
+        ttl_seconds: float = 300.0,
+    ) -> bool:
+        """Atomically acquire the cross-process turn lease for a conversation.
+
+        Compression rotates a session into child segments, so the durable key
+        is the lineage root rather than the current segment id. Expired leases
+        and leases whose structured local holder PID is known dead are reclaimed
+        in the same write transaction as acquisition.
+        """
+        if not session_id or not holder:
+            return False
+        conversation_id = self._session_turn_lease_key(session_id)
+        now = time.time()
+        expires_at = now + max(0.1, float(ttl_seconds))
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT holder, expires_at FROM session_turn_leases "
+                "WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            if row is not None:
+                current_holder = row["holder"]
+                if (
+                    float(row["expires_at"]) <= now
+                    or _compression_lock_holder_process_is_dead(current_holder)
+                ):
+                    conn.execute(
+                        "DELETE FROM session_turn_leases "
+                        "WHERE conversation_id = ? AND holder = ?",
+                        (conversation_id, current_holder),
+                    )
+            conn.execute(
+                "INSERT OR IGNORE INTO session_turn_leases "
+                "(conversation_id, holder, acquired_at, expires_at) "
+                "VALUES (?, ?, ?, ?)",
+                (conversation_id, holder, now, expires_at),
+            )
+            owner = conn.execute(
+                "SELECT holder FROM session_turn_leases WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            return owner is not None and owner["holder"] == holder
+
+        return bool(self._execute_write(_do))
+
+    def acquire_session_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        *,
+        ttl_seconds: float = 300.0,
+        wait_seconds: float = 1800.0,
+        poll_interval_seconds: float = 0.1,
+    ) -> bool:
+        """Wait for a cross-process turn lease without holding a SQLite lock."""
+        deadline = time.monotonic() + max(0.0, float(wait_seconds))
+        while True:
+            if self.try_acquire_session_turn_lease(
+                session_id, holder, ttl_seconds=ttl_seconds
+            ):
+                return True
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            time.sleep(min(max(0.01, float(poll_interval_seconds)), remaining))
+
+    def refresh_session_turn_lease(
+        self,
+        session_id: str,
+        holder: str,
+        *,
+        ttl_seconds: float = 300.0,
+    ) -> bool:
+        """Extend a turn lease only while ``holder`` still owns it."""
+        if not session_id or not holder:
+            return False
+        conversation_id = self._session_turn_lease_key(session_id)
+        expires_at = time.time() + max(0.1, float(ttl_seconds))
+
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE session_turn_leases SET expires_at = ? "
+                "WHERE conversation_id = ? AND holder = ?",
+                (expires_at, conversation_id, holder),
+            )
+            return cursor.rowcount > 0
+
+        return bool(self._execute_write(_do))
+
+    def release_session_turn_lease(self, session_id: str, holder: str) -> None:
+        """Release a turn lease iff ``holder`` still owns it; idempotent."""
+        if not session_id or not holder:
+            return
+        conversation_id = self._session_turn_lease_key(session_id)
+
+        def _do(conn):
+            conn.execute(
+                "DELETE FROM session_turn_leases "
+                "WHERE conversation_id = ? AND holder = ?",
+                (conversation_id, holder),
+            )
+
+        self._execute_write(_do)
 
     def get_compression_lock_holder(self, session_id: str) -> Optional[str]:
         """Return the current (non-expired) holder for ``session_id``, or None.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1492,7 +1492,13 @@ def is_disk_full_error(exc: BaseException | str | None) -> bool:
 # enumerate causes (e.g. the cron scheduler's explainer-variant suppression)
 # must iterate this tuple instead of hardcoding the list, so adding a bucket
 # can never silently desynchronize them.
-PERSISTENCE_ERROR_CAUSES = ("locked", "compression", "disk", "unknown")
+PERSISTENCE_ERROR_CAUSES = (
+    "locked",
+    "compression",
+    "turn_lease",
+    "disk",
+    "unknown",
+)
 
 
 def classify_persistence_error(exc_or_str) -> str:
@@ -1509,6 +1515,9 @@ def classify_persistence_error(exc_or_str) -> str:
       database write lock); transient, retry-later guidance applies.
     * ``"compression"`` — a live compression lease refused the transcript
       write; the database itself is healthy and unlocked.
+    * ``"turn_lease"`` — a presented session-turn-lease holder no longer
+      owns the conversation (expired, released, or reclaimed); fail-fast
+      fencing, not a storage fault.
     * ``"disk"``    — disk full / read-only / permission-shaped failures
       (delegates the disk-full patterns to :func:`is_disk_full_error` so the
       two classifiers can never drift apart — e.g. ENOSPC).
@@ -1521,9 +1530,13 @@ def classify_persistence_error(exc_or_str) -> str:
     # writer" / "Compression lease lost") contains neither "locked" nor
     # "busy", so it must be matched by type and by phrase (for strings that
     # survived RPC wrapping).
+    if isinstance(exc_or_str, SessionTurnLeaseLostError):
+        return "turn_lease"
     if isinstance(exc_or_str, CompressionSessionBusyError):
         return "compression"
     text = str(exc_or_str).lower()
+    if "turn lease" in text:
+        return "turn_lease"
     if "being compressed" in text or "compression lease" in text:
         return "compression"
     if (
@@ -2320,6 +2333,16 @@ class SessionCompressionInProgressError(CompressionSessionBusyError):
 
     Subclassing keeps every existing ``except CompressionSessionBusyError``
     handler working unchanged.
+    """
+
+
+class SessionTurnLeaseLostError(RuntimeError):
+    """A transcript write presented a turn-lease holder that no longer owns it.
+
+    Fail-fast fencing: do not retry inside ``_execute_write``. The caller
+    either still thinks it owns the conversation after expiry/reclaim, or
+    the lease row is gone. A later writer may already be persisting a
+    newer turn; landing this write would interleave a stale reply.
     """
 
 
@@ -8240,7 +8263,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return None
 
     def _check_transcript_write_guards(
-        self, conn, session_id: str, compression_lock_holder: Optional[str]
+        self,
+        conn,
+        session_id: str,
+        compression_lock_holder: Optional[str],
+        turn_lease_holder: Optional[str] = None,
     ) -> None:
         """Transcript-append admission checks, run INSIDE the write txn.
 
@@ -8261,6 +8288,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             raise SessionCompressionInProgressError(
                 f"Session {session_id!r} is being compressed by another writer"
             )
+        if turn_lease_holder:
+            conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
+            lease = conn.execute(
+                "SELECT holder, expires_at FROM session_turn_leases "
+                "WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            if (
+                lease is None
+                or lease["holder"] != turn_lease_holder
+                or float(lease["expires_at"]) <= time.time()
+            ):
+                raise SessionTurnLeaseLostError(
+                    f"Session turn lease lost; refusing transcript write "
+                    f"for {session_id!r}"
+                )
         session = conn.execute(
             "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
             (session_id,),
@@ -8340,6 +8383,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         display_kind: Optional[str] = None,
         display_metadata: Optional[Dict[str, Any]] = None,
         compression_lock_holder: Optional[str] = None,
+        turn_lease_holder: Optional[str] = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -8398,7 +8442,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         def _do(conn):
             self._check_transcript_write_guards(
-                conn, session_id, compression_lock_holder
+                conn,
+                session_id,
+                compression_lock_holder,
+                turn_lease_holder=turn_lease_holder,
             )
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
@@ -8460,6 +8507,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         session_id: str,
         messages: List[Dict[str, Any]],
         compression_lock_holder: Optional[str] = None,
+        turn_lease_holder: Optional[str] = None,
         chunk_rows: Optional[int] = None,
     ) -> int:
         """Append multiple messages atomically in ONE write transaction.
@@ -8499,12 +8547,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     session_id,
                     messages[start:start + chunk_rows],
                     compression_lock_holder=compression_lock_holder,
+                    turn_lease_holder=turn_lease_holder,
                 )
             return inserted_total
 
         def _do(conn):
             self._check_transcript_write_guards(
-                conn, session_id, compression_lock_holder
+                conn,
+                session_id,
+                compression_lock_holder,
+                turn_lease_holder=turn_lease_holder,
             )
             inserted, tool_calls_total = self._insert_message_rows(
                 conn, session_id, messages

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5818,9 +5818,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         *,
         ttl_seconds: float = 300.0,
         wait_seconds: float = 1800.0,
-        poll_interval_seconds: float = 0.1,
+        poll_interval_seconds: float = 1.0,
         on_wait=None,
         wait_notice_interval_seconds: float = 15.0,
+        should_abort=None,
     ) -> bool:
         """Wait for a cross-process turn lease without holding a SQLite lock.
 
@@ -5828,12 +5829,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         attempt fails (elapsed ~0) and again about every
         ``wait_notice_interval_seconds`` while still waiting, so UIs can show
         that another process holds the conversation.
+
+        When ``should_abort()`` returns True (for example the agent received
+        ``/stop`` while waiting), acquisition stops immediately and returns
+        False without consuming the full ``wait_seconds`` budget.
         """
         deadline = time.monotonic() + max(0.0, float(wait_seconds))
         wait_started = None
         last_notice_at = None
         notice_every = max(0.0, float(wait_notice_interval_seconds))
         while True:
+            if should_abort is not None:
+                try:
+                    if should_abort():
+                        return False
+                except Exception:
+                    logger.debug(
+                        "session turn lease should_abort callback failed",
+                        exc_info=True,
+                    )
             if self.try_acquire_session_turn_lease(
                 session_id, holder, ttl_seconds=ttl_seconds
             ):

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8268,6 +8268,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         session_id: str,
         compression_lock_holder: Optional[str],
         turn_lease_holder: Optional[str] = None,
+        turn_lease_ttl_seconds: float = 300.0,
     ) -> None:
         """Transcript-append admission checks, run INSIDE the write txn.
 
@@ -8295,14 +8296,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "WHERE conversation_id = ?",
                 (conversation_id,),
             ).fetchone()
-            if (
-                lease is None
-                or lease["holder"] != turn_lease_holder
-                or float(lease["expires_at"]) <= time.time()
-            ):
+            if lease is None or lease["holder"] != turn_lease_holder:
                 raise SessionTurnLeaseLostError(
                     f"Session turn lease lost; refusing transcript write "
                     f"for {session_id!r}"
+                )
+            now = time.time()
+            if float(lease["expires_at"]) <= now:
+                # Expiry makes the row reclaimable; it does not prove that a
+                # takeover occurred. BEGIN IMMEDIATE serializes this renewal
+                # with acquisition, so a still-matching owner can recover from
+                # a starved refresher without weakening the foreign-holder fence.
+                conn.execute(
+                    "UPDATE session_turn_leases SET expires_at = ? "
+                    "WHERE conversation_id = ? AND holder = ?",
+                    (
+                        now + max(0.1, float(turn_lease_ttl_seconds)),
+                        conversation_id,
+                        turn_lease_holder,
+                    ),
                 )
         session = conn.execute(
             "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
@@ -8384,6 +8396,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         display_metadata: Optional[Dict[str, Any]] = None,
         compression_lock_holder: Optional[str] = None,
         turn_lease_holder: Optional[str] = None,
+        turn_lease_ttl_seconds: float = 300.0,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -8446,6 +8459,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 session_id,
                 compression_lock_holder,
                 turn_lease_holder=turn_lease_holder,
+                turn_lease_ttl_seconds=turn_lease_ttl_seconds,
             )
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
@@ -8509,6 +8523,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         compression_lock_holder: Optional[str] = None,
         turn_lease_holder: Optional[str] = None,
         chunk_rows: Optional[int] = None,
+        turn_lease_ttl_seconds: float = 300.0,
     ) -> int:
         """Append multiple messages atomically in ONE write transaction.
 
@@ -8548,6 +8563,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     messages[start:start + chunk_rows],
                     compression_lock_holder=compression_lock_holder,
                     turn_lease_holder=turn_lease_holder,
+                    turn_lease_ttl_seconds=turn_lease_ttl_seconds,
                 )
             return inserted_total
 
@@ -8557,6 +8573,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 session_id,
                 compression_lock_holder,
                 turn_lease_holder=turn_lease_holder,
+                turn_lease_ttl_seconds=turn_lease_ttl_seconds,
             )
             inserted, tool_calls_total = self._insert_message_rows(
                 conn, session_id, messages

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5740,25 +5740,56 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 session_id, exc,
             )
 
-    def _session_turn_lease_key(self, session_id: str) -> str:
-        """Return the stable serialization key for every compression segment."""
+    def _session_turn_lease_key_on_conn(self, conn, session_id: str) -> str:
+        """Walk compression parents on ``conn`` to the conversation lease key.
+
+        Must run on the same connection as the lease INSERT/UPDATE/DELETE.
+        A prior ``get_session`` failure must not compute a child id that the
+        later write then persists: refresh would walk to the parent and
+        fail-close. Markers bind to ``parent_session_id`` (same contract as
+        ``_NON_CONTINUATION_CHILD_FILTER_SQL``). Lock errors propagate so
+        ``_execute_write`` / ``acquire_session_turn_lease`` can retry.
+        """
         if not session_id:
             return session_id
-        try:
-            current = self.get_session(session_id)
-            seen = {session_id}
-            while current and self._is_compression_child_row(current):
-                parent_id = current.get("parent_session_id")
-                if not parent_id or parent_id in seen:
-                    break
-                parent = self.get_session(parent_id)
-                if not parent:
-                    break
-                seen.add(parent_id)
-                current = parent
-            return str(current.get("id") or session_id) if current else session_id
-        except Exception:
+
+        def _row(sid: str):
+            row = conn.execute(
+                "SELECT id, parent_session_id, source, model_config, end_reason "
+                "FROM sessions WHERE id = ?",
+                (sid,),
+            ).fetchone()
+            return dict(row) if row else None
+
+        current = _row(session_id)
+        seen = {session_id}
+        while current:
+            parent_id = current.get("parent_session_id")
+            if (
+                not parent_id
+                or parent_id in seen
+                or self._is_explicit_fork_child_row(current)
+            ):
+                break
+            parent = _row(parent_id)
+            if not parent or parent.get("end_reason") != "compression":
+                break
+            seen.add(parent_id)
+            current = parent
+        return str(current.get("id") or session_id) if current else session_id
+
+    def _session_turn_lease_key(self, session_id: str) -> str:
+        """Return the stable serialization key for every compression segment.
+
+        Acquire/refresh/release resolve this inside their write transaction.
+        This helper is for tests and diagnostics; it does not swallow lock
+        errors (a swallowed walk plus a later successful write was the
+        fail-open that replayed the post-rotation refresh miss).
+        """
+        if not session_id:
             return session_id
+        with self._read_ctx() as conn:
+            return self._session_turn_lease_key_on_conn(conn, session_id)
 
     def try_acquire_session_turn_lease(
         self,
@@ -5766,21 +5797,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         holder: str,
         *,
         ttl_seconds: float = 300.0,
+        patience_s: Optional[float] = None,
     ) -> bool:
         """Atomically acquire the cross-process turn lease for a conversation.
 
         Compression rotates a session into child segments, so the durable key
-        is the lineage root rather than the current segment id. Expired leases
-        and leases whose structured local holder PID is known dead are reclaimed
-        in the same write transaction as acquisition.
+        is the lineage root rather than the current segment id. The walk and
+        INSERT share one write transaction. Expired leases and leases whose
+        structured local holder PID is known dead are reclaimed in that same
+        transaction.
         """
         if not session_id or not holder:
             return False
-        conversation_id = self._session_turn_lease_key(session_id)
         now = time.time()
         expires_at = now + max(0.1, float(ttl_seconds))
 
         def _do(conn):
+            conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
             row = conn.execute(
                 "SELECT holder, expires_at FROM session_turn_leases "
                 "WHERE conversation_id = ?",
@@ -5809,7 +5842,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ).fetchone()
             return owner is not None and owner["holder"] == holder
 
-        return bool(self._execute_write(_do))
+        return bool(self._execute_write(_do, patience_s=patience_s))
 
     def acquire_session_turn_lease(
         self,
@@ -5822,6 +5855,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         on_wait=None,
         wait_notice_interval_seconds: float = 15.0,
         should_abort=None,
+        acquire_patience_s: float = 0.5,
     ) -> bool:
         """Wait for a cross-process turn lease without holding a SQLite lock.
 
@@ -5848,10 +5882,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         "session turn lease should_abort callback failed",
                         exc_info=True,
                     )
-            if self.try_acquire_session_turn_lease(
-                session_id, holder, ttl_seconds=ttl_seconds
-            ):
-                return True
+            try:
+                if self.try_acquire_session_turn_lease(
+                    session_id,
+                    holder,
+                    ttl_seconds=ttl_seconds,
+                    patience_s=acquire_patience_s,
+                ):
+                    return True
+            except sqlite3.Error as exc:
+                # Long holder transactions (compression publish, large
+                # flushes) can exhaust a single write-patience budget.
+                # Keep polling until wait_seconds or should_abort.
+                if classify_persistence_error(exc) != "locked":
+                    raise
             now = time.monotonic()
             remaining = deadline - now
             if remaining <= 0:
@@ -5883,10 +5927,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Extend a turn lease only while ``holder`` still owns it."""
         if not session_id or not holder:
             return False
-        conversation_id = self._session_turn_lease_key(session_id)
         expires_at = time.time() + max(0.1, float(ttl_seconds))
 
         def _do(conn):
+            conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
             cursor = conn.execute(
                 "UPDATE session_turn_leases SET expires_at = ? "
                 "WHERE conversation_id = ? AND holder = ?",
@@ -5900,9 +5944,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Release a turn lease iff ``holder`` still owns it; idempotent."""
         if not session_id or not holder:
             return
-        conversation_id = self._session_turn_lease_key(session_id)
 
         def _do(conn):
+            conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
             conn.execute(
                 "DELETE FROM session_turn_leases "
                 "WHERE conversation_id = ? AND holder = ?",
@@ -10041,6 +10085,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # =========================================================================
 
     def _is_explicit_fork_child_row(self, session: Dict[str, Any]) -> bool:
+        """True when ``session`` is a branch, delegate, or tool child of its parent.
+
+        Markers only count as a fork when they point at ``parent_session_id``.
+        Compression copies ``model_config`` onto the continuation
+        (``publish_compression_child`` callers pass
+        ``agent._session_init_model_config``), so a delegate's continuation
+        carries ``_delegate_from=<the delegate's own parent>``. Presence-only
+        matching would treat that real continuation as a fork — the same
+        misclassification ``_NON_CONTINUATION_CHILD_FILTER_SQL`` already
+        avoids by binding both markers to the queried parent.
+        """
         if session.get("source") == "tool":
             return True
         raw = session.get("model_config")
@@ -10050,10 +10105,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             cfg = json.loads(raw) if isinstance(raw, str) else raw
         except (TypeError, json.JSONDecodeError):
             return False
-        return isinstance(cfg, dict) and (
-            cfg.get("_branched_from") is not None
-            or cfg.get("_delegate_from") is not None
-        )
+        if not isinstance(cfg, dict):
+            return False
+        parent_id = session.get("parent_session_id")
+        branched = cfg.get("_branched_from")
+        delegated = cfg.get("_delegate_from")
+        if parent_id:
+            return branched == parent_id or delegated == parent_id
+        return branched is not None or delegated is not None
 
     def _is_compression_child_row(self, child: Dict[str, Any]) -> bool:
         parent_id = child.get("parent_session_id")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5819,17 +5819,44 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ttl_seconds: float = 300.0,
         wait_seconds: float = 1800.0,
         poll_interval_seconds: float = 0.1,
+        on_wait=None,
+        wait_notice_interval_seconds: float = 15.0,
     ) -> bool:
-        """Wait for a cross-process turn lease without holding a SQLite lock."""
+        """Wait for a cross-process turn lease without holding a SQLite lock.
+
+        ``on_wait(elapsed_seconds)`` is best-effort: invoked when the first
+        attempt fails (elapsed ~0) and again about every
+        ``wait_notice_interval_seconds`` while still waiting, so UIs can show
+        that another process holds the conversation.
+        """
         deadline = time.monotonic() + max(0.0, float(wait_seconds))
+        wait_started = None
+        last_notice_at = None
+        notice_every = max(0.0, float(wait_notice_interval_seconds))
         while True:
             if self.try_acquire_session_turn_lease(
                 session_id, holder, ttl_seconds=ttl_seconds
             ):
                 return True
-            remaining = deadline - time.monotonic()
+            now = time.monotonic()
+            remaining = deadline - now
             if remaining <= 0:
                 return False
+            if wait_started is None:
+                wait_started = now
+            if on_wait is not None and (
+                last_notice_at is None
+                or notice_every == 0.0
+                or (now - last_notice_at) >= notice_every
+            ):
+                try:
+                    on_wait(max(0.0, now - wait_started))
+                except Exception:
+                    logger.debug(
+                        "session turn lease on_wait callback failed",
+                        exc_info=True,
+                    )
+                last_notice_at = now
             time.sleep(min(max(0.01, float(poll_interval_seconds)), remaining))
 
     def refresh_session_turn_lease(

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -383,6 +383,13 @@ CREATE TABLE IF NOT EXISTS compression_locks (
     expires_at REAL NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS session_turn_leases (
+    conversation_id TEXT PRIMARY KEY,
+    holder TEXT NOT NULL,
+    acquired_at REAL NOT NULL,
+    expires_at REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS async_delegations (
     delegation_id TEXT PRIMARY KEY,
     origin_session TEXT NOT NULL,
@@ -419,6 +426,7 @@ CREATE INDEX IF NOT EXISTS idx_messages_assistant_calls_by_session
     ON messages(session_id)
     WHERE role = 'assistant' AND tool_calls IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
+CREATE INDEX IF NOT EXISTS idx_session_turn_leases_expires ON session_turn_leases(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery

--- a/run_agent.py
+++ b/run_agent.py
@@ -8275,14 +8275,18 @@ class AIAgent:
                 # The holder may have compressed and rotated the session while
                 # this process waited. Resolve and reload only AFTER admission;
                 # a caller-provided in-memory snapshot is necessarily stale.
-                latest_session_id = _turn_db.resolve_resume_session_id(session_id)
-                if latest_session_id:
-                    self.session_id = latest_session_id
-                    task_context["session_id"] = latest_session_id
-                conversation_history = _turn_db.get_messages_as_conversation(
-                    self.session_id,
-                    repair_alternation=True,
-                )
+                # Skip when acquisition was immediate — no other process held
+                # the lease, so the in-memory history is current and reloading
+                # would only cause an unnecessary prompt cache miss.
+                if _lease_waited:
+                    latest_session_id = _turn_db.resolve_resume_session_id(session_id)
+                    if latest_session_id:
+                        self.session_id = latest_session_id
+                        task_context["session_id"] = latest_session_id
+                    conversation_history = _turn_db.get_messages_as_conversation(
+                        self.session_id,
+                        repair_alternation=True,
+                    )
 
                 # Long model/tool/compression turns outlive a fixed TTL. Refresh
                 # in a daemon thread; holder-qualified UPDATE and DELETE fence a
@@ -8306,6 +8310,7 @@ class AIAgent:
                                 self.interrupt(message, hard_cancel=True)
                             except Exception:
                                 self._interrupt_requested = True
+                                self._interrupt_message = message
 
                     while not durable_turn_lease_stop.wait(_lease_refresh_interval):
                         try:
@@ -8411,9 +8416,11 @@ class AIAgent:
                 finally:
                     # The lease remains held through relay/task finalization, but
                     # those post-loop steps must not receive a late refresh
-                    # interrupt that poisons the next turn on this cached agent.
+                    # interrupt that poisons the next turn on a cached agent.
                     _stop_durable_turn_lease_refresher()
-                    _clear_durable_turn_lease_interrupt()
+                    # Interrupt clear is deferred to after thread join in the
+                    # outer finally: a refresher firing between stop and join
+                    # would otherwise set an interrupt that survives the clear.
             terminal = result if isinstance(result, dict) else {}
             if terminal.get("interrupted") is True:
                 relay_outcome = "cancelled"
@@ -8465,6 +8472,10 @@ class AIAgent:
                         and durable_turn_lease_thread.is_alive()
                     ):
                         durable_turn_lease_thread.join(timeout=1.0)
+                    # Clear any interrupt the refresher may have fired between
+                    # the inner stop and this join. Must run AFTER join so a
+                    # late interrupt does not survive into the next turn.
+                    _clear_durable_turn_lease_interrupt()
                     if durable_turn_lease is not None:
                         try:
                             _turn_db.release_session_turn_lease(

--- a/run_agent.py
+++ b/run_agent.py
@@ -2290,6 +2290,9 @@ class AIAgent:
                     compression_lock_holder=getattr(
                         self, "_active_compression_lock_holder", None
                     ),
+                    turn_lease_holder=getattr(
+                        self, "_active_session_turn_lease_holder", None
+                    ),
                 )
                 for _written in _batch_msgs:
                     _written[_DB_PERSISTED_MARKER] = True
@@ -3728,6 +3731,14 @@ class AIAgent:
                     + "the turn was stopped because another process was "
                     "compressing this session. Your message should already be "
                     "saved — please send it again after compression completes."
+                )
+            if cause == "turn_lease":
+                return (
+                    prefix
+                    + "the turn was stopped because another Hermes process "
+                    "took over this session. Your reply was not saved — wait "
+                    "for the other process to finish, then send your message "
+                    "again."
                 )
             if cause == "locked":
                 return (
@@ -8212,8 +8223,11 @@ class AIAgent:
                     }
 
                 # Assign only after admission so finally release cannot target a
-                # holder string that never owned the row.
+                # holder string that never owned the row. Persist paths read
+                # the agent attr so a late flush after reclaim is fenced in
+                # the same SQLite write transaction as the transcript insert.
                 durable_turn_lease = _durable_holder
+                self._active_session_turn_lease_holder = _durable_holder
                 if _lease_waited:
                     self._emit_status(
                         "Session is free; loading the latest transcript..."
@@ -8396,6 +8410,11 @@ class AIAgent:
                                 session_id,
                                 exc_info=True,
                             )
+                        if (
+                            getattr(self, "_active_session_turn_lease_holder", None)
+                            == durable_turn_lease
+                        ):
+                            self._active_session_turn_lease_holder = None
                     # Always clear mid-turn labels when the turn exits — including
                     # interrupted early returns that skip finalize_turn. Keep ts.
                     try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3722,6 +3722,13 @@ class AIAgent:
             )
         if reason == "session_persistence_failed":
             cause = persistence_cause or "unknown"
+            if cause == "compression":
+                return (
+                    prefix
+                    + "the turn was stopped because another process was "
+                    "compressing this session. Your message should already be "
+                    "saved — please send it again after compression completes."
+                )
             if cause == "locked":
                 return (
                     prefix
@@ -8061,12 +8068,108 @@ class AIAgent:
         )
         relay_lease = None
         relay_turn = None
+        durable_turn_lease = None
+        durable_turn_lease_stop = None
+        durable_turn_lease_thread = None
         token = None
         acct_token = None
         task_started = False
         task_finished = False
         relay_outcome = "failed"
         try:
+            # Serialize the full load -> run -> flush region across Hermes
+            # processes. Gateway's asyncio lease closes alias routing inside one
+            # process; this durable lease covers Desktop, CLI resume, gateway,
+            # and background delivery processes sharing state.db (#84234).
+            _turn_db = getattr(self, "_session_db", None)
+            _durable_session_exists = False
+            if _turn_db is not None and session_id:
+                try:
+                    _durable_session_exists = _turn_db.get_session(session_id) is not None
+                except Exception:
+                    logger.debug(
+                        "Could not check durable session before turn lease",
+                        exc_info=True,
+                    )
+            if (
+                _turn_db is not None
+                and session_id
+                and not getattr(self, "_persist_disabled", False)
+                # A fresh session id is process-unique and has no durable
+                # transcript to race over. More importantly, subagent/new-turn
+                # callers may intentionally supply an in-memory seed before the
+                # row exists; reloading an absent row would erase that seed.
+                and _durable_session_exists
+                # Test doubles and third-party DB shims may accept arbitrary
+                # MagicMock attributes without implementing the protocol. Check
+                # the concrete type so only real implementations opt in.
+                and callable(
+                    getattr(type(_turn_db), "acquire_session_turn_lease", None)
+                )
+            ):
+                # Resumed agents also defer their create check until the turn
+                # prologue. We just proved this row exists, so suppress the
+                # redundant create attempt after acquiring it.
+                self._session_db_created = True
+                durable_turn_lease = (
+                    f"pid={os.getpid()}:turn={relay_turn_id}:platform="
+                    f"{task_context['platform'] or 'unknown'}"
+                )
+                _lease_ttl = 300.0
+                if not _turn_db.acquire_session_turn_lease(
+                    session_id,
+                    durable_turn_lease,
+                    ttl_seconds=_lease_ttl,
+                    wait_seconds=1800.0,
+                ):
+                    raise TimeoutError(
+                        f"session turn lease wait timed out for {session_id}"
+                    )
+
+                # The holder may have compressed and rotated the session while
+                # this process waited. Resolve and reload only AFTER admission;
+                # a caller-provided in-memory snapshot is necessarily stale.
+                latest_session_id = _turn_db.resolve_resume_session_id(session_id)
+                if latest_session_id:
+                    self.session_id = latest_session_id
+                    task_context["session_id"] = latest_session_id
+                conversation_history = _turn_db.get_messages_as_conversation(
+                    self.session_id,
+                    repair_alternation=True,
+                )
+
+                # Long model/tool/compression turns outlive a fixed TTL. Refresh
+                # in a daemon thread; holder-qualified UPDATE and DELETE fence a
+                # late refresher/release from a successor lease.
+                durable_turn_lease_stop = threading.Event()
+
+                def _refresh_durable_turn_lease() -> None:
+                    while not durable_turn_lease_stop.wait(60.0):
+                        try:
+                            if not _turn_db.refresh_session_turn_lease(
+                                session_id,
+                                durable_turn_lease,
+                                ttl_seconds=_lease_ttl,
+                            ):
+                                logger.error(
+                                    "Lost session turn lease while turn is active: %s",
+                                    session_id,
+                                )
+                                return
+                        except Exception:
+                            logger.warning(
+                                "Failed to refresh session turn lease: %s",
+                                session_id,
+                                exc_info=True,
+                            )
+
+                durable_turn_lease_thread = threading.Thread(
+                    target=_refresh_durable_turn_lease,
+                    name="session-turn-lease-refresh",
+                    daemon=True,
+                )
+                durable_turn_lease_thread.start()
+
             relay_lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
                 profile_key=relay_runtime.current_profile_key(),
                 session_id=task_context["session_id"],
@@ -8166,6 +8269,24 @@ class AIAgent:
                             relay_lease
                         )
                 finally:
+                    if durable_turn_lease_stop is not None:
+                        durable_turn_lease_stop.set()
+                    if (
+                        durable_turn_lease_thread is not None
+                        and durable_turn_lease_thread.is_alive()
+                    ):
+                        durable_turn_lease_thread.join(timeout=1.0)
+                    if durable_turn_lease is not None:
+                        try:
+                            _turn_db.release_session_turn_lease(
+                                session_id, durable_turn_lease
+                            )
+                        except Exception:
+                            logger.error(
+                                "Failed to release session turn lease: %s",
+                                session_id,
+                                exc_info=True,
+                            )
                     # Always clear mid-turn labels when the turn exits — including
                     # interrupted early returns that skip finalize_turn. Keep ts.
                     try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8111,19 +8111,69 @@ class AIAgent:
                 # prologue. We just proved this row exists, so suppress the
                 # redundant create attempt after acquiring it.
                 self._session_db_created = True
-                durable_turn_lease = (
+                _durable_holder = (
                     f"pid={os.getpid()}:turn={relay_turn_id}:platform="
                     f"{task_context['platform'] or 'unknown'}"
                 )
                 _lease_ttl = 300.0
+                _lease_waited = False
+
+                def _on_session_turn_lease_wait(elapsed: float) -> None:
+                    nonlocal _lease_waited
+                    _lease_waited = True
+                    if elapsed < 1.0:
+                        self._emit_status(
+                            "⏳ Another Hermes process is using this session; "
+                            "waiting for it to finish before starting your turn..."
+                        )
+                    else:
+                        self._emit_status(
+                            "⏳ Still waiting for the other Hermes process on "
+                            f"this session ({int(elapsed)}s)..."
+                        )
+
                 if not _turn_db.acquire_session_turn_lease(
                     session_id,
-                    durable_turn_lease,
+                    _durable_holder,
                     ttl_seconds=_lease_ttl,
                     wait_seconds=1800.0,
+                    on_wait=_on_session_turn_lease_wait,
                 ):
-                    raise TimeoutError(
-                        f"session turn lease wait timed out for {session_id}"
+                    # Fail closed like gateway TurnLeaseTimeoutError: do not
+                    # enter load/run/flush, and surface a resend notice instead
+                    # of a bare TimeoutError that looks like a hang.
+                    timeout_msg = (
+                        "⏳ Another Hermes process kept this session busy too "
+                        "long. Your message was not processed - wait for the "
+                        "other process to finish, then send it again."
+                    )
+                    logger.error(
+                        "session turn lease wait timed out for %s",
+                        session_id,
+                    )
+                    try:
+                        self._emit_warning(timeout_msg)
+                    except Exception:
+                        logger.debug(
+                            "Failed to emit session turn lease timeout warning",
+                            exc_info=True,
+                        )
+                    relay_outcome = "timed_out"
+                    return {
+                        "final_response": timeout_msg,
+                        "messages": list(conversation_history or []),
+                        "api_calls": 0,
+                        "completed": False,
+                        "failed": True,
+                        "error": f"session_turn_lease_timeout:{session_id}",
+                    }
+
+                # Assign only after admission so finally release cannot target a
+                # holder string that never owned the row.
+                durable_turn_lease = _durable_holder
+                if _lease_waited:
+                    self._emit_status(
+                        "Session is free; loading the latest transcript..."
                     )
 
                 # The holder may have compressed and rotated the session while

--- a/run_agent.py
+++ b/run_agent.py
@@ -8086,11 +8086,21 @@ class AIAgent:
         durable_turn_lease = None
         durable_turn_lease_stop = None
         durable_turn_lease_thread = None
+        durable_turn_lease_activity_lock = threading.Lock()
+        durable_turn_lease_turn_active = False
         token = None
         acct_token = None
         task_started = False
         task_finished = False
         relay_outcome = "failed"
+
+        def _stop_durable_turn_lease_refresher() -> None:
+            nonlocal durable_turn_lease_turn_active
+            with durable_turn_lease_activity_lock:
+                durable_turn_lease_turn_active = False
+                if durable_turn_lease_stop is not None:
+                    durable_turn_lease_stop.set()
+
         try:
             # Serialize the full load -> run -> flush region across Hermes
             # processes. Gateway's asyncio lease closes alias routing inside one
@@ -8260,10 +8270,16 @@ class AIAgent:
 
                 def _refresh_durable_turn_lease() -> None:
                     def _interrupt_turn(message: str) -> None:
-                        try:
-                            self.interrupt(message, hard_cancel=True)
-                        except Exception:
-                            self._interrupt_requested = True
+                        with durable_turn_lease_activity_lock:
+                            if (
+                                durable_turn_lease_stop.is_set()
+                                or not durable_turn_lease_turn_active
+                            ):
+                                return
+                            try:
+                                self.interrupt(message, hard_cancel=True)
+                            except Exception:
+                                self._interrupt_requested = True
 
                     while not durable_turn_lease_stop.wait(_lease_refresh_interval):
                         try:
@@ -8300,6 +8316,8 @@ class AIAgent:
                             )
                             return
 
+                with durable_turn_lease_activity_lock:
+                    durable_turn_lease_turn_active = True
                 durable_turn_lease_thread = threading.Thread(
                     target=_refresh_durable_turn_lease,
                     name="session-turn-lease-refresh",
@@ -8348,19 +8366,25 @@ class AIAgent:
             # Keep the scope local instead of storing ContextVar tokens on the agent,
             # which may be observed from another thread.
             with bind_subagent_parent(self), scoped_runtime_main({}):
-                result = run_conversation(
-                    self,
-                    user_message,
-                    system_message,
-                    conversation_history,
-                    effective_task_id,
-                    stream_callback,
-                    persist_user_message,
-                    persist_user_timestamp=persist_user_timestamp,
-                    persist_user_display_kind=persist_user_display_kind,
-                    persist_user_display_metadata=persist_user_display_metadata,
-                    moa_config=moa_config,
-                )
+                try:
+                    result = run_conversation(
+                        self,
+                        user_message,
+                        system_message,
+                        conversation_history,
+                        effective_task_id,
+                        stream_callback,
+                        persist_user_message,
+                        persist_user_timestamp=persist_user_timestamp,
+                        persist_user_display_kind=persist_user_display_kind,
+                        persist_user_display_metadata=persist_user_display_metadata,
+                        moa_config=moa_config,
+                    )
+                finally:
+                    # The lease remains held through relay/task finalization, but
+                    # those post-loop steps must not receive a late refresh
+                    # interrupt that poisons the next turn on this cached agent.
+                    _stop_durable_turn_lease_refresher()
             terminal = result if isinstance(result, dict) else {}
             if terminal.get("interrupted") is True:
                 relay_outcome = "cancelled"
@@ -8406,8 +8430,7 @@ class AIAgent:
                             relay_lease
                         )
                 finally:
-                    if durable_turn_lease_stop is not None:
-                        durable_turn_lease_stop.set()
+                    _stop_durable_turn_lease_refresher()
                     if (
                         durable_turn_lease_thread is not None
                         and durable_turn_lease_thread.is_alive()

--- a/run_agent.py
+++ b/run_agent.py
@@ -2293,6 +2293,10 @@ class AIAgent:
                     turn_lease_holder=getattr(
                         self, "_active_session_turn_lease_holder", None
                     ),
+                    turn_lease_ttl_seconds=getattr(
+                        self, "_active_session_turn_lease_ttl_seconds", 300.0
+                    )
+                    or 300.0,
                 )
                 for _written in _batch_msgs:
                     _written[_DB_PERSISTED_MARKER] = True
@@ -8228,6 +8232,7 @@ class AIAgent:
                 # the same SQLite write transaction as the transcript insert.
                 durable_turn_lease = _durable_holder
                 self._active_session_turn_lease_holder = _durable_holder
+                self._active_session_turn_lease_ttl_seconds = _lease_ttl
                 if _lease_waited:
                     self._emit_status(
                         "Session is free; loading the latest transcript..."
@@ -8254,6 +8259,12 @@ class AIAgent:
                 )
 
                 def _refresh_durable_turn_lease() -> None:
+                    def _interrupt_turn(message: str) -> None:
+                        try:
+                            self.interrupt(message, hard_cancel=True)
+                        except Exception:
+                            self._interrupt_requested = True
+
                     while not durable_turn_lease_stop.wait(_lease_refresh_interval):
                         try:
                             if not _turn_db.refresh_session_turn_lease(
@@ -8270,21 +8281,24 @@ class AIAgent:
                                     "Lost session turn lease while turn is active: %s",
                                     getattr(self, "session_id", None) or session_id,
                                 )
-                                try:
-                                    self.interrupt(
-                                        "Session turn lease lost; stopping to "
-                                        "protect the transcript.",
-                                        hard_cancel=True,
-                                    )
-                                except Exception:
-                                    self._interrupt_requested = True
+                                _interrupt_turn(
+                                    "Session turn lease lost; stopping to protect "
+                                    "the transcript."
+                                )
                                 return
                         except Exception:
+                            if durable_turn_lease_stop.is_set():
+                                return
                             logger.warning(
                                 "Failed to refresh session turn lease: %s",
                                 getattr(self, "session_id", None) or session_id,
                                 exc_info=True,
                             )
+                            _interrupt_turn(
+                                "Session turn lease could not be refreshed; "
+                                "stopping to protect the transcript."
+                            )
+                            return
 
                 durable_turn_lease_thread = threading.Thread(
                     target=_refresh_durable_turn_lease,
@@ -8415,6 +8429,7 @@ class AIAgent:
                             == durable_turn_lease
                         ):
                             self._active_session_turn_lease_holder = None
+                            self._active_session_turn_lease_ttl_seconds = None
                     # Always clear mid-turn labels when the turn exits — including
                     # interrupted early returns that skip finalize_turn. Keep ts.
                     try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8088,6 +8088,7 @@ class AIAgent:
         durable_turn_lease_thread = None
         durable_turn_lease_activity_lock = threading.Lock()
         durable_turn_lease_turn_active = False
+        durable_turn_lease_interrupt_message = None
         token = None
         acct_token = None
         task_started = False
@@ -8100,6 +8101,29 @@ class AIAgent:
                 durable_turn_lease_turn_active = False
                 if durable_turn_lease_stop is not None:
                     durable_turn_lease_stop.set()
+
+        def _clear_durable_turn_lease_interrupt() -> None:
+            """Clear only the interrupt admitted by this turn's refresher."""
+            message = durable_turn_lease_interrupt_message
+            if not message:
+                return
+
+            def _clear_if_owned() -> None:
+                if getattr(self, "_interrupt_message", None) != message:
+                    return
+                self._interrupt_requested = False
+                self._interrupt_message = None
+                getattr(self, "_hard_interrupt_requested", threading.Event()).clear()
+                self._interrupt_thread_signal_pending = False
+                if self._execution_thread_id is not None:
+                    _set_interrupt(False, self._execution_thread_id)
+
+            redirect_lock = getattr(self, "_pending_redirect_lock", None)
+            if redirect_lock is None:
+                _clear_if_owned()
+            else:
+                with redirect_lock:
+                    _clear_if_owned()
 
         try:
             # Serialize the full load -> run -> flush region across Hermes
@@ -8270,12 +8294,14 @@ class AIAgent:
 
                 def _refresh_durable_turn_lease() -> None:
                     def _interrupt_turn(message: str) -> None:
+                        nonlocal durable_turn_lease_interrupt_message
                         with durable_turn_lease_activity_lock:
                             if (
                                 durable_turn_lease_stop.is_set()
                                 or not durable_turn_lease_turn_active
                             ):
                                 return
+                            durable_turn_lease_interrupt_message = message
                             try:
                                 self.interrupt(message, hard_cancel=True)
                             except Exception:
@@ -8316,14 +8342,12 @@ class AIAgent:
                             )
                             return
 
-                with durable_turn_lease_activity_lock:
-                    durable_turn_lease_turn_active = True
                 durable_turn_lease_thread = threading.Thread(
                     target=_refresh_durable_turn_lease,
                     name="session-turn-lease-refresh",
                     daemon=True,
                 )
-                durable_turn_lease_thread.start()
+
 
             relay_lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
                 profile_key=relay_runtime.current_profile_key(),
@@ -8367,6 +8391,10 @@ class AIAgent:
             # which may be observed from another thread.
             with bind_subagent_parent(self), scoped_runtime_main({}):
                 try:
+                    if durable_turn_lease_thread is not None:
+                        with durable_turn_lease_activity_lock:
+                            durable_turn_lease_turn_active = True
+                        durable_turn_lease_thread.start()
                     result = run_conversation(
                         self,
                         user_message,
@@ -8385,6 +8413,7 @@ class AIAgent:
                     # those post-loop steps must not receive a late refresh
                     # interrupt that poisons the next turn on this cached agent.
                     _stop_durable_turn_lease_refresher()
+                    _clear_durable_turn_lease_interrupt()
             terminal = result if isinstance(result, dict) else {}
             if terminal.get("interrupted") is True:
                 relay_outcome = "cancelled"

--- a/run_agent.py
+++ b/run_agent.py
@@ -8138,7 +8138,21 @@ class AIAgent:
                     ttl_seconds=_lease_ttl,
                     wait_seconds=1800.0,
                     on_wait=_on_session_turn_lease_wait,
+                    should_abort=lambda: getattr(self, "_interrupt_requested", False),
                 ):
+                    if getattr(self, "_interrupt_requested", False):
+                        logger.info(
+                            "session turn lease wait aborted by interrupt: %s",
+                            session_id,
+                        )
+                        relay_outcome = "cancelled"
+                        return {
+                            "final_response": "",
+                            "messages": list(conversation_history or []),
+                            "api_calls": 0,
+                            "completed": False,
+                            "interrupted": True,
+                        }
                     # Fail closed like gateway TurnLeaseTimeoutError: do not
                     # enter load/run/flush, and surface a resend notice instead
                     # of a bare TimeoutError that looks like a hang.
@@ -8192,24 +8206,35 @@ class AIAgent:
                 # in a daemon thread; holder-qualified UPDATE and DELETE fence a
                 # late refresher/release from a successor lease.
                 durable_turn_lease_stop = threading.Event()
+                _lease_refresh_interval = float(
+                    getattr(self, "_session_turn_lease_refresh_interval", 60.0)
+                )
 
                 def _refresh_durable_turn_lease() -> None:
-                    while not durable_turn_lease_stop.wait(60.0):
+                    while not durable_turn_lease_stop.wait(_lease_refresh_interval):
                         try:
                             if not _turn_db.refresh_session_turn_lease(
-                                session_id,
+                                getattr(self, "session_id", None) or session_id,
                                 durable_turn_lease,
                                 ttl_seconds=_lease_ttl,
                             ):
                                 logger.error(
                                     "Lost session turn lease while turn is active: %s",
-                                    session_id,
+                                    getattr(self, "session_id", None) or session_id,
                                 )
+                                try:
+                                    self.interrupt(
+                                        "Session turn lease lost; stopping to "
+                                        "protect the transcript.",
+                                        hard_cancel=True,
+                                    )
+                                except Exception:
+                                    self._interrupt_requested = True
                                 return
                         except Exception:
                             logger.warning(
                                 "Failed to refresh session turn lease: %s",
-                                session_id,
+                                getattr(self, "session_id", None) or session_id,
                                 exc_info=True,
                             )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -8087,10 +8087,19 @@ class AIAgent:
                 try:
                     _durable_session_exists = _turn_db.get_session(session_id) is not None
                 except Exception:
-                    logger.debug(
-                        "Could not check durable session before turn lease",
+                    # A locked / non-WAL read is not proof the row is absent.
+                    # Treating probe failure as "fresh session" skipped the
+                    # lease this block exists to take and ran fail-open on
+                    # the exact contention point (#84234). Acquire (or fail
+                    # closed if acquire itself cannot) rather than start
+                    # load/run/flush unsynchronized. get_session returns
+                    # None — it does not raise — when the row is missing.
+                    logger.warning(
+                        "Could not check durable session before turn lease; "
+                        "will acquire rather than run without serialization",
                         exc_info=True,
                     )
+                    _durable_session_exists = True
             if (
                 _turn_db is not None
                 and session_id
@@ -8146,13 +8155,33 @@ class AIAgent:
                             session_id,
                         )
                         relay_outcome = "cancelled"
-                        return {
-                            "final_response": "",
+                        interrupt_msg = (
+                            "Stopped waiting for another Hermes process on "
+                            "this session. Your message was not processed."
+                        )
+                        interrupt_result = {
+                            "final_response": interrupt_msg,
                             "messages": list(conversation_history or []),
                             "api_calls": 0,
                             "completed": False,
                             "interrupted": True,
                         }
+                        interrupt_message = getattr(
+                            self, "_interrupt_message", None
+                        )
+                        if interrupt_message:
+                            interrupt_result["interrupt_message"] = (
+                                interrupt_message
+                            )
+                        # Conversation-loop finalizer never runs on this
+                        # early return. Clear so a cached agent cannot
+                        # fail-close the next turn as interrupted.
+                        try:
+                            self.clear_interrupt()
+                        except Exception:
+                            self._interrupt_requested = False
+                            self._interrupt_message = None
+                        return interrupt_result
                     # Fail closed like gateway TurnLeaseTimeoutError: do not
                     # enter load/run/flush, and surface a resend notice instead
                     # of a bare TimeoutError that looks like a hang.
@@ -8218,6 +8247,11 @@ class AIAgent:
                                 durable_turn_lease,
                                 ttl_seconds=_lease_ttl,
                             ):
+                                # finally sets the stop event then releases.
+                                # A late holder-fenced miss after that join
+                                # timeout must not hard-interrupt the next turn.
+                                if durable_turn_lease_stop.is_set():
+                                    return
                                 logger.error(
                                     "Lost session turn lease while turn is active: %s",
                                     getattr(self, "session_id", None) or session_id,

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -300,6 +300,7 @@ def test_run_conversation_interrupts_when_lease_refresh_lost(monkeypatch):
     def track_interrupt(message=None, hard_cancel=False):
         interrupt_calls.append((message, hard_cancel))
         agent._interrupt_requested = True
+        agent._interrupt_message = message
 
     agent.interrupt = track_interrupt
 
@@ -349,6 +350,7 @@ def test_run_conversation_interrupts_when_lease_refresh_errors(monkeypatch):
     def track_interrupt(message=None, hard_cancel=False):
         interrupt_calls.append((message, hard_cancel))
         agent._interrupt_requested = True
+        agent._interrupt_message = message
 
     agent.interrupt = track_interrupt
 
@@ -391,29 +393,33 @@ def test_refresh_error_after_loop_completion_does_not_poison_next_turn(monkeypat
     agent._session_turn_lease_refresh_interval = 0.01
     refresh_started = threading.Event()
     release_refresh = threading.Event()
+    interrupt_started = threading.Event()
     interrupt_calls = []
 
     def track_interrupt(message=None, hard_cancel=False):
         interrupt_calls.append((message, hard_cancel))
+        interrupt_started.set()
+        release_refresh.wait(timeout=2.0)
         agent._interrupt_requested = True
+        agent._interrupt_message = message
 
     agent.interrupt = track_interrupt
 
     def delayed_refresh_error(session_id, holder, **kwargs):
         refresh_started.set()
-        release_refresh.wait(timeout=2.0)
         raise OSError("database unavailable")
 
     db.refresh_session_turn_lease = delayed_refresh_error
 
     def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
         assert refresh_started.wait(timeout=2.0)
+        assert interrupt_started.wait(timeout=2.0)
+        threading.Timer(0.05, release_refresh.set).start()
         return {"final_response": "ok", "messages": history, "failed": False}
 
     original_finish = relay_runtime.SESSION_COORDINATOR.finish_logical_calls
 
     def finish_after_refresh(turn, *, outcome):
-        release_refresh.set()
         time.sleep(0.05)
         return original_finish(turn, outcome=outcome)
 
@@ -431,8 +437,10 @@ def test_refresh_error_after_loop_completion_does_not_poison_next_turn(monkeypat
     )
 
     assert result["final_response"] == "ok"
-    assert interrupt_calls == []
+    assert len(interrupt_calls) == 1
+    assert interrupt_calls[0][1] is True
     assert agent._interrupt_requested is False
+    assert agent._interrupt_message is None
 
 
 def test_late_refresh_miss_after_release_does_not_interrupt(monkeypatch):
@@ -445,6 +453,7 @@ def test_late_refresh_miss_after_release_does_not_interrupt(monkeypatch):
     def track_interrupt(message=None, hard_cancel=False):
         interrupt_calls.append((message, hard_cancel))
         agent._interrupt_requested = True
+        agent._interrupt_message = message
 
     agent.interrupt = track_interrupt
 

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -6,16 +6,20 @@ from run_agent import AIAgent
 
 
 class _DB:
-    def __init__(self, session_exists=True):
+    def __init__(self, session_exists=True, acquire_result=True):
         self.events = []
         self.session_exists = session_exists
+        self.acquire_result = acquire_result
 
     def get_session(self, session_id):
         return {"id": session_id} if self.session_exists else None
 
     def acquire_session_turn_lease(self, session_id, holder, **kwargs):
         self.events.append(("acquire", session_id, holder))
-        return True
+        on_wait = kwargs.get("on_wait")
+        if on_wait is not None and self.acquire_result is False:
+            on_wait(0.0)
+        return self.acquire_result
 
     def resolve_resume_session_id(self, session_id):
         self.events.append(("resolve", session_id))
@@ -32,11 +36,10 @@ class _DB:
         self.events.append(("release", session_id, holder))
 
 
-def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
-    db = _DB()
+def _agent_with_db(db, *, session_id="stale-parent", platform="desktop"):
     agent = AIAgent.__new__(AIAgent)
-    agent.session_id = "stale-parent"
-    agent.platform = "desktop"
+    agent.session_id = session_id
+    agent.platform = platform
     agent.model = "test-model"
     agent._session_db = db
     agent._session_db_created = True
@@ -44,7 +47,20 @@ def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
     agent._parent_session_id = None
     agent._relay_pending_turn_id = None
     agent._reset_activity_labels_after_turn = lambda: None
-    agent._conversation_root_id = lambda: "stale-parent"
+    agent._conversation_root_id = lambda: session_id
+    agent.log_prefix = ""
+    agent._vprint = lambda *a, **k: None
+    agent.status_callback = None
+    return agent
+
+
+def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    status_events = []
+    agent.status_callback = lambda kind, text=None: status_events.append(
+        (kind, text)
+    )
 
     observed = {}
 
@@ -52,6 +68,16 @@ def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
         observed["history"] = history
         observed["session_id"] = _agent.session_id
         return {"final_response": "ok", "messages": history, "failed": False}
+
+    # Simulate a contended wait so the resume status path is covered.
+    def acquire_with_wait(session_id, holder, **kwargs):
+        db.events.append(("acquire", session_id, holder))
+        on_wait = kwargs.get("on_wait")
+        if on_wait is not None:
+            on_wait(0.0)
+        return True
+
+    db.acquire_session_turn_lease = acquire_with_wait
 
     monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
     result = AIAgent.run_conversation(
@@ -71,20 +97,25 @@ def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
         "reload",
         "release",
     ]
+    assert any(
+        kind == "lifecycle"
+        and text
+        and "waiting for it to finish" in text
+        for kind, text in status_events
+    )
+    assert any(
+        kind == "lifecycle"
+        and text
+        and "loading the latest transcript" in text
+        for kind, text in status_events
+    )
 
 
 def test_fresh_session_keeps_caller_seed_without_durable_lease(monkeypatch):
     db = _DB(session_exists=False)
-    agent = AIAgent.__new__(AIAgent)
-    agent.session_id = "fresh"
-    agent.platform = "subagent"
-    agent.model = "test-model"
-    agent._session_db = db
+    agent = _agent_with_db(db, session_id="fresh", platform="subagent")
     agent._session_db_created = False
-    agent._persist_disabled = False
     agent._parent_session_id = "parent"
-    agent._relay_pending_turn_id = None
-    agent._reset_activity_labels_after_turn = lambda: None
     agent._conversation_root_id = lambda: "parent"
 
     observed = {}
@@ -100,3 +131,38 @@ def test_fresh_session_keeps_caller_seed_without_durable_lease(monkeypatch):
 
     assert observed["history"] is seed
     assert db.events == []
+
+
+def test_run_conversation_lease_timeout_returns_resend_notice(monkeypatch):
+    db = _DB(acquire_result=False)
+    agent = _agent_with_db(db)
+    status_events = []
+    agent.status_callback = lambda kind, text=None: status_events.append(
+        (kind, text)
+    )
+
+    def boom(*_args, **_kwargs):
+        raise AssertionError("turn must not start without a lease")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", boom)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert "session_turn_lease_timeout:" in result["error"]
+    assert "send it again" in result["final_response"]
+    assert [event[0] for event in db.events] == ["acquire"]
+    assert any(
+        kind == "lifecycle"
+        and text
+        and "waiting for it to finish" in text
+        for kind, text in status_events
+    )
+    assert any(
+        kind == "warn" and text and "send it again" in text
+        for kind, text in status_events
+    )

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -133,6 +133,16 @@ def test_run_conversation_acquires_lease_when_session_probe_raises(monkeypatch):
     db.get_session = locked_get_session
     agent = _agent_with_db(db)
 
+    # Simulate a contended wait so the resolve+reload path is exercised.
+    def acquire_with_wait(session_id, holder, **kwargs):
+        db.events.append(("acquire", session_id, holder))
+        on_wait = kwargs.get("on_wait")
+        if on_wait is not None:
+            on_wait(0.0)
+        return True
+
+    db.acquire_session_turn_lease = acquire_with_wait
+
     observed = {}
 
     def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
@@ -507,6 +517,16 @@ def test_run_conversation_exposes_holder_for_fenced_flush(monkeypatch):
     agent._db_flush_scan_prefix = None
     agent._pending_cli_user_message = None
     agent._session_persist_lock = None
+
+    # Simulate a contended wait so the resolve+reload path is exercised.
+    def acquire_with_wait(session_id, holder, **kwargs):
+        db.events.append(("acquire", session_id, holder))
+        on_wait = kwargs.get("on_wait")
+        if on_wait is not None:
+            on_wait(0.0)
+        return True
+
+    db.acquire_session_turn_lease = acquire_with_wait
 
     def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
         captured["active"] = getattr(

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 from run_agent import AIAgent
 
 
@@ -166,3 +168,83 @@ def test_run_conversation_lease_timeout_returns_resend_notice(monkeypatch):
         kind == "warn" and text and "send it again" in text
         for kind, text in status_events
     )
+
+
+def test_run_conversation_lease_wait_honors_interrupt(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    agent._interrupt_requested = False
+
+    def acquire_with_abort(session_id, holder, **kwargs):
+        db.events.append(("acquire", session_id, holder))
+        should_abort = kwargs.get("should_abort")
+        assert callable(should_abort)
+        agent._interrupt_requested = True
+        assert should_abort()
+        return False
+
+    db.acquire_session_turn_lease = acquire_with_abort
+
+    def boom(*_args, **_kwargs):
+        raise AssertionError("turn must not start when lease wait is aborted")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", boom)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+
+    assert result.get("interrupted") is True
+    assert result.get("failed") is not True
+    assert "session_turn_lease_timeout" not in str(result.get("error", ""))
+    assert [event[0] for event in db.events] == ["acquire"]
+
+
+def test_run_conversation_interrupts_when_lease_refresh_lost(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    agent._session_turn_lease_refresh_interval = 0.01
+    interrupt_calls = []
+
+    def track_interrupt(message=None, hard_cancel=False):
+        interrupt_calls.append((message, hard_cancel))
+        agent._interrupt_requested = True
+
+    agent.interrupt = track_interrupt
+
+    def refresh_lost(session_id, holder, **kwargs):
+        return False
+
+    db.refresh_session_turn_lease = refresh_lost
+
+    observed = {"started": False}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["started"] = True
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if getattr(_agent, "_interrupt_requested", False):
+                return {
+                    "final_response": "",
+                    "messages": history,
+                    "api_calls": 0,
+                    "completed": False,
+                    "interrupted": True,
+                }
+            time.sleep(0.01)
+        raise AssertionError("refresh loss did not interrupt the turn")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "seed"}],
+    )
+
+    assert observed["started"] is True
+    assert result.get("interrupted") is True
+    assert interrupt_calls
+    assert interrupt_calls[0][1] is True
+    assert "lease lost" in str(interrupt_calls[0][0]).lower()

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import sqlite3
 import threading
 import time
+from types import SimpleNamespace
 
+from hermes_state import SessionDB
 from run_agent import AIAgent
 
 
@@ -379,3 +381,128 @@ def test_late_refresh_miss_after_release_does_not_interrupt(monkeypatch):
     assert result["final_response"] == "ok"
     assert interrupt_calls == []
     assert agent._interrupt_requested is False
+
+
+def test_run_conversation_exposes_holder_for_fenced_flush(monkeypatch):
+    """The acquired holder is visible to persist, then cleared on release."""
+    db = _DB()
+    captured = {}
+
+    def append_messages_batch(session_id, messages, **kwargs):
+        captured["session_id"] = session_id
+        captured["turn_lease_holder"] = kwargs.get("turn_lease_holder")
+        captured["count"] = len(messages)
+        return len(messages)
+
+    db.append_messages_batch = append_messages_batch
+    agent = _agent_with_db(db)
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._db_flush_scan_prefix = None
+    agent._pending_cli_user_message = None
+    agent._session_persist_lock = None
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        captured["active"] = getattr(
+            _agent, "_active_session_turn_lease_holder", None
+        )
+        ok = _agent._flush_messages_to_session_db(
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "done"},
+            ],
+            [],
+        )
+        captured["flush_ok"] = ok
+        return {"final_response": "done", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "durable latest"}],
+    )
+
+    assert result["final_response"] == "done"
+    assert captured["flush_ok"] is True
+    assert captured["active"]
+    assert captured["active"].startswith("pid=")
+    assert captured["turn_lease_holder"] == captured["active"]
+    assert captured["session_id"] == "compressed-tip"
+    assert captured["count"] == 2
+    assert getattr(agent, "_active_session_turn_lease_holder", None) is None
+    assert [event[0] for event in db.events] == [
+        "acquire",
+        "resolve",
+        "reload",
+        "release",
+    ]
+
+
+def _flush_agent(db, session_id):
+    """Bind the real flush onto a stand-in so we can use a live SessionDB."""
+    agent = SimpleNamespace(
+        _session_db=db,
+        _session_db_created=True,
+        _persist_disabled=False,
+        session_id=session_id,
+        _session_persist_lock=None,
+        _flushed_db_message_ids=set(),
+        _flushed_db_message_session_id=None,
+        _last_flushed_db_idx=0,
+        _db_flush_scan_prefix=None,
+        _persist_user_message_idx=None,
+        _persist_user_message_override=None,
+        _persist_user_message_timestamp=None,
+        _pending_cli_user_message=None,
+        _active_session_turn_lease_holder=None,
+        _last_persistence_error_cause=None,
+    )
+    agent._ensure_db_session = lambda: None
+    agent._flush_messages_to_session_db = (
+        AIAgent._flush_messages_to_session_db.__get__(agent, AIAgent)
+    )
+    agent._flush_messages_to_session_db_unlocked = (
+        AIAgent._flush_messages_to_session_db_unlocked.__get__(agent, AIAgent)
+    )
+    return agent
+
+
+def test_flush_messages_to_session_db_fences_stale_holder_on_live_db(tmp_path):
+    """A-loses / B-acquires / A-late-flush, through the real persist path."""
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+    first.create_session("shared", source="test")
+    stale_holder = "pid=1:turn=stale"
+    next_holder = "pid=2:turn=next"
+    assert first.try_acquire_session_turn_lease(
+        "shared", stale_holder, ttl_seconds=5
+    )
+
+    agent = _flush_agent(first, "shared")
+    agent._active_session_turn_lease_holder = stale_holder
+    owned = [{"role": "user", "content": "stale-owned"}]
+    assert agent._flush_messages_to_session_db(owned, []) is True
+    assert [m["content"] for m in first.get_messages("shared")] == ["stale-owned"]
+
+    first.release_session_turn_lease("shared", stale_holder)
+    assert second.try_acquire_session_turn_lease(
+        "shared", next_holder, ttl_seconds=5
+    )
+
+    late = [{"role": "assistant", "content": "late stale reply"}]
+    assert agent._flush_messages_to_session_db(late, []) is False
+    assert agent._last_persistence_error_cause == "turn_lease"
+    assert [m["content"] for m in second.get_messages("shared")] == ["stale-owned"]
+
+    agent._active_session_turn_lease_holder = next_holder
+    assert agent._flush_messages_to_session_db(late, []) is True
+    assert [m["content"] for m in second.get_messages("shared")] == [
+        "stale-owned",
+        "late stale reply",
+    ]
+    second.release_session_turn_lease("shared", next_holder)
+    first.close()
+    second.close()

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -1,0 +1,102 @@
+"""AIAgent enters turns only after acquiring and reloading durable state."""
+
+from __future__ import annotations
+
+from run_agent import AIAgent
+
+
+class _DB:
+    def __init__(self, session_exists=True):
+        self.events = []
+        self.session_exists = session_exists
+
+    def get_session(self, session_id):
+        return {"id": session_id} if self.session_exists else None
+
+    def acquire_session_turn_lease(self, session_id, holder, **kwargs):
+        self.events.append(("acquire", session_id, holder))
+        return True
+
+    def resolve_resume_session_id(self, session_id):
+        self.events.append(("resolve", session_id))
+        return "compressed-tip"
+
+    def get_messages_as_conversation(self, session_id, **kwargs):
+        self.events.append(("reload", session_id, kwargs))
+        return [{"role": "user", "content": "durable latest"}]
+
+    def refresh_session_turn_lease(self, session_id, holder, **kwargs):
+        return True
+
+    def release_session_turn_lease(self, session_id, holder):
+        self.events.append(("release", session_id, holder))
+
+
+def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
+    db = _DB()
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "stale-parent"
+    agent.platform = "desktop"
+    agent.model = "test-model"
+    agent._session_db = db
+    agent._session_db_created = True
+    agent._persist_disabled = False
+    agent._parent_session_id = None
+    agent._relay_pending_turn_id = None
+    agent._reset_activity_labels_after_turn = lambda: None
+    agent._conversation_root_id = lambda: "stale-parent"
+
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["history"] = history
+        observed["session_id"] = _agent.session_id
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+
+    assert result["final_response"] == "ok"
+    assert observed == {
+        "history": [{"role": "user", "content": "durable latest"}],
+        "session_id": "compressed-tip",
+    }
+    assert [event[0] for event in db.events] == [
+        "acquire",
+        "resolve",
+        "reload",
+        "release",
+    ]
+
+
+def test_fresh_session_keeps_caller_seed_without_durable_lease(monkeypatch):
+    db = _DB(session_exists=False)
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "fresh"
+    agent.platform = "subagent"
+    agent.model = "test-model"
+    agent._session_db = db
+    agent._session_db_created = False
+    agent._persist_disabled = False
+    agent._parent_session_id = "parent"
+    agent._relay_pending_turn_id = None
+    agent._reset_activity_labels_after_turn = lambda: None
+    agent._conversation_root_id = lambda: "parent"
+
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["history"] = history
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    seed = [{"role": "user", "content": "delegated context"}]
+
+    AIAgent.run_conversation(agent, "work", conversation_history=seed)
+
+    assert observed["history"] is seed
+    assert db.events == []

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -7,6 +7,7 @@ import threading
 import time
 from types import SimpleNamespace
 
+from agent import relay_runtime
 from hermes_state import SessionDB
 from run_agent import AIAgent
 
@@ -382,6 +383,56 @@ def test_run_conversation_interrupts_when_lease_refresh_errors(monkeypatch):
     assert interrupt_calls
     assert interrupt_calls[0][1] is True
     assert "could not be refreshed" in str(interrupt_calls[0][0]).lower()
+
+
+def test_refresh_error_after_loop_completion_does_not_poison_next_turn(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    agent._session_turn_lease_refresh_interval = 0.01
+    refresh_started = threading.Event()
+    release_refresh = threading.Event()
+    interrupt_calls = []
+
+    def track_interrupt(message=None, hard_cancel=False):
+        interrupt_calls.append((message, hard_cancel))
+        agent._interrupt_requested = True
+
+    agent.interrupt = track_interrupt
+
+    def delayed_refresh_error(session_id, holder, **kwargs):
+        refresh_started.set()
+        release_refresh.wait(timeout=2.0)
+        raise OSError("database unavailable")
+
+    db.refresh_session_turn_lease = delayed_refresh_error
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        assert refresh_started.wait(timeout=2.0)
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    original_finish = relay_runtime.SESSION_COORDINATOR.finish_logical_calls
+
+    def finish_after_refresh(turn, *, outcome):
+        release_refresh.set()
+        time.sleep(0.05)
+        return original_finish(turn, outcome=outcome)
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    monkeypatch.setattr(
+        relay_runtime.SESSION_COORDINATOR,
+        "finish_logical_calls",
+        finish_after_refresh,
+    )
+
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "seed"}],
+    )
+
+    assert result["final_response"] == "ok"
+    assert interrupt_calls == []
+    assert agent._interrupt_requested is False
 
 
 def test_late_refresh_miss_after_release_does_not_interrupt(monkeypatch):

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+import threading
 import time
 
 from run_agent import AIAgent
@@ -53,6 +55,11 @@ def _agent_with_db(db, *, session_id="stale-parent", platform="desktop"):
     agent.log_prefix = ""
     agent._vprint = lambda *a, **k: None
     agent.status_callback = None
+    agent._interrupt_requested = False
+    agent._interrupt_message = None
+    agent._pending_redirect = None
+    agent._execution_thread_id = None
+    agent._interrupt_thread_signal_pending = False
     return agent
 
 
@@ -111,6 +118,43 @@ def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
         and "loading the latest transcript" in text
         for kind, text in status_events
     )
+
+
+def test_run_conversation_acquires_lease_when_session_probe_raises(monkeypatch):
+    """A locked / non-WAL get_session must not skip the durable lease."""
+    db = _DB()
+
+    def locked_get_session(_session_id):
+        raise sqlite3.OperationalError("database is locked")
+
+    db.get_session = locked_get_session
+    agent = _agent_with_db(db)
+
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["history"] = history
+        observed["session_id"] = _agent.session_id
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+
+    assert result["final_response"] == "ok"
+    assert observed == {
+        "history": [{"role": "user", "content": "durable latest"}],
+        "session_id": "compressed-tip",
+    }
+    assert [event[0] for event in db.events] == [
+        "acquire",
+        "resolve",
+        "reload",
+        "release",
+    ]
 
 
 def test_fresh_session_keeps_caller_seed_without_durable_lease(monkeypatch):
@@ -173,13 +217,13 @@ def test_run_conversation_lease_timeout_returns_resend_notice(monkeypatch):
 def test_run_conversation_lease_wait_honors_interrupt(monkeypatch):
     db = _DB()
     agent = _agent_with_db(db)
-    agent._interrupt_requested = False
 
     def acquire_with_abort(session_id, holder, **kwargs):
         db.events.append(("acquire", session_id, holder))
         should_abort = kwargs.get("should_abort")
         assert callable(should_abort)
         agent._interrupt_requested = True
+        agent._interrupt_message = "follow-up while waiting"
         assert should_abort()
         return False
 
@@ -197,8 +241,51 @@ def test_run_conversation_lease_wait_honors_interrupt(monkeypatch):
 
     assert result.get("interrupted") is True
     assert result.get("failed") is not True
+    assert result.get("final_response")
+    assert "not processed" in result["final_response"]
+    assert result.get("interrupt_message") == "follow-up while waiting"
     assert "session_turn_lease_timeout" not in str(result.get("error", ""))
     assert [event[0] for event in db.events] == ["acquire"]
+    assert agent._interrupt_requested is False
+    assert agent._interrupt_message is None
+
+
+def test_run_conversation_second_turn_after_lease_wait_abort(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    turns = {"n": 0}
+
+    def acquire_then_succeed(session_id, holder, **kwargs):
+        db.events.append(("acquire", session_id, holder))
+        should_abort = kwargs.get("should_abort")
+        if turns["n"] == 0:
+            agent._interrupt_requested = True
+            agent._interrupt_message = "follow-up while waiting"
+            assert should_abort()
+            return False
+        assert not should_abort()
+        return True
+
+    db.acquire_session_turn_lease = acquire_then_succeed
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    first = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+    assert first.get("interrupted") is True
+    turns["n"] = 1
+    second = AIAgent.run_conversation(
+        agent,
+        "follow-up",
+        conversation_history=[{"role": "user", "content": "stale"}],
+    )
+    assert second["final_response"] == "ok"
+    assert agent._interrupt_requested is False
 
 
 def test_run_conversation_interrupts_when_lease_refresh_lost(monkeypatch):
@@ -248,3 +335,47 @@ def test_run_conversation_interrupts_when_lease_refresh_lost(monkeypatch):
     assert interrupt_calls
     assert interrupt_calls[0][1] is True
     assert "lease lost" in str(interrupt_calls[0][0]).lower()
+
+
+def test_late_refresh_miss_after_release_does_not_interrupt(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    agent._session_turn_lease_refresh_interval = 0.01
+    released = threading.Event()
+    interrupt_calls = []
+
+    def track_interrupt(message=None, hard_cancel=False):
+        interrupt_calls.append((message, hard_cancel))
+        agent._interrupt_requested = True
+
+    agent.interrupt = track_interrupt
+
+    def refresh_after_release(session_id, holder, **kwargs):
+        released.wait(timeout=2.0)
+        return False
+
+    db.refresh_session_turn_lease = refresh_after_release
+
+    orig_release = db.release_session_turn_lease
+
+    def release_and_signal(session_id, holder):
+        orig_release(session_id, holder)
+        released.set()
+
+    db.release_session_turn_lease = release_and_signal
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        time.sleep(0.03)
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "seed"}],
+    )
+
+    time.sleep(0.05)
+    assert result["final_response"] == "ok"
+    assert interrupt_calls == []
+    assert agent._interrupt_requested is False

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -339,6 +339,51 @@ def test_run_conversation_interrupts_when_lease_refresh_lost(monkeypatch):
     assert "lease lost" in str(interrupt_calls[0][0]).lower()
 
 
+def test_run_conversation_interrupts_when_lease_refresh_errors(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    agent._session_turn_lease_refresh_interval = 0.01
+    interrupt_calls = []
+
+    def track_interrupt(message=None, hard_cancel=False):
+        interrupt_calls.append((message, hard_cancel))
+        agent._interrupt_requested = True
+
+    agent.interrupt = track_interrupt
+
+    def refresh_error(session_id, holder, **kwargs):
+        raise OSError("database unavailable")
+
+    db.refresh_session_turn_lease = refresh_error
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if getattr(_agent, "_interrupt_requested", False):
+                return {
+                    "final_response": "",
+                    "messages": history,
+                    "api_calls": 0,
+                    "completed": False,
+                    "interrupted": True,
+                }
+            time.sleep(0.01)
+        raise AssertionError("refresh error did not interrupt the turn")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "seed"}],
+    )
+
+    assert result.get("interrupted") is True
+    assert interrupt_calls
+    assert interrupt_calls[0][1] is True
+    assert "could not be refreshed" in str(interrupt_calls[0][0]).lower()
+
+
 def test_late_refresh_miss_after_release_does_not_interrupt(monkeypatch):
     db = _DB()
     agent = _agent_with_db(db)

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -109,6 +109,16 @@ def test_explanation_persistence_locked_cause_says_busy_not_disk():
     assert "permission" not in lower
 
 
+def test_explanation_persistence_compression_cause_is_specific():
+    out = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed", "compression"
+    )
+    lower = out.lower()
+    assert "compression" in lower
+    assert "database" not in lower
+    assert "disk" not in lower
+
+
 def test_explanation_persistence_disk_cause_keeps_disk_wording():
     out = AIAgent._format_turn_completion_explanation(
         "session_persistence_failed", "disk"
@@ -194,7 +204,7 @@ def test_classify_persistence_error_reuses_disk_full_markers():
     ) == "disk"
 
 
-def test_classify_persistence_error_compression_busy_is_locked():
+def test_classify_persistence_error_compression_busy_is_distinct():
     """A live compression lease refusing the write is contention, not
     storage damage — but its message contains neither 'locked' nor 'busy',
     so it must classify by exception type (and by phrase for RPC-wrapped
@@ -209,17 +219,17 @@ def test_classify_persistence_error_compression_busy_is_locked():
         SessionCompressionInProgressError(
             "Session 'abc' is being compressed by another writer"
         )
-    ) == "locked"
+    ) == "compression"
     assert classify_persistence_error(
         CompressionSessionBusyError("Compression lease lost before publication: abc")
-    ) == "locked"
+    ) == "compression"
     # RPC-wrapped string forms (exception type lost in transit).
     assert classify_persistence_error(
         "Session 'abc' is being compressed by another writer"
-    ) == "locked"
+    ) == "compression"
     assert classify_persistence_error(
         "Compression lease lost before publication: abc"
-    ) == "locked"
+    ) == "compression"
 
 
 def test_persistence_error_causes_tuple_matches_classifier():
@@ -229,6 +239,7 @@ def test_persistence_error_causes_tuple_matches_classifier():
 
     probes = (
         "database is locked",
+        "Session 'abc' is being compressed by another writer",
         "database or disk is full",
         "something else entirely",
         None,

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -119,6 +119,18 @@ def test_explanation_persistence_compression_cause_is_specific():
     assert "disk" not in lower
 
 
+def test_explanation_persistence_turn_lease_cause_is_specific():
+    out = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed", "turn_lease"
+    )
+    lower = out.lower()
+    assert "took over" in lower
+    assert "not saved" in lower
+    assert "disk" not in lower
+    assert "compression" not in lower
+    assert "hermes doctor" not in lower
+
+
 def test_explanation_persistence_disk_cause_keeps_disk_wording():
     out = AIAgent._format_turn_completion_explanation(
         "session_persistence_failed", "disk"
@@ -232,6 +244,19 @@ def test_classify_persistence_error_compression_busy_is_distinct():
     ) == "compression"
 
 
+def test_classify_persistence_error_turn_lease_lost_is_distinct():
+    from hermes_state import SessionTurnLeaseLostError, classify_persistence_error
+
+    assert classify_persistence_error(
+        SessionTurnLeaseLostError(
+            "Session turn lease lost; refusing transcript write for 'abc'"
+        )
+    ) == "turn_lease"
+    assert classify_persistence_error(
+        "Session turn lease lost; refusing transcript write for 'abc'"
+    ) == "turn_lease"
+
+
 def test_persistence_error_causes_tuple_matches_classifier():
     """PERSISTENCE_ERROR_CAUSES must cover every value the classifier can
     return (consumers like cron suppression iterate it)."""
@@ -240,6 +265,7 @@ def test_persistence_error_causes_tuple_matches_classifier():
     probes = (
         "database is locked",
         "Session 'abc' is being compressed by another writer",
+        "Session turn lease lost; refusing transcript write for 'abc'",
         "database or disk is full",
         "something else entirely",
         None,

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -136,6 +136,28 @@ def test_find_live_child_returns_continuation_with_foreign_markers(
     assert child["id"] == "inherited-continuation"
 
 
+def test_compression_lineage_includes_continuation_with_foreign_markers(
+    db: SessionDB,
+) -> None:
+    """Lineage walk uses the same parent-bound marker rule as orphan recovery."""
+    _compression_parent(db, "delegate-session-3")
+    db.create_session(
+        "inherited-tip",
+        source="subagent",
+        parent_session_id="delegate-session-3",
+        model_config={"_delegate_from": "some-original-parent"},
+    )
+
+    assert db.get_compression_lineage("inherited-tip") == [
+        "delegate-session-3",
+        "inherited-tip",
+    ]
+    assert db.get_compression_lineage("delegate-session-3") == [
+        "delegate-session-3",
+        "inherited-tip",
+    ]
+
+
 def test_reopen_orphaned_compression_session_fails_closed_with_active_lease(
     db: SessionDB,
 ) -> None:

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import threading
 import time
 from types import SimpleNamespace
@@ -89,6 +90,166 @@ def test_turn_lease_does_not_serialize_delegate_child_with_parent(tmp_path):
     assert db.try_acquire_session_turn_lease(
         "delegate", delegate_holder, ttl_seconds=5
     )
+
+
+def test_turn_lease_walks_compression_child_that_inherited_fork_markers(tmp_path):
+    """Inherited ``_delegate_from`` / ``_branched_from`` must not stop the walk.
+
+    ``publish_compression_child`` copies ``model_config`` verbatim, so a
+    delegate or branch continuation carries a marker pointing at some other
+    session. Presence-only fork detection would key the child separately:
+    the holder still owns the parent-key lease, but the first refresh after
+    rotation looks up the child id and fail-closes with a hard interrupt.
+    """
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("original-parent", source="test")
+    db.create_session(
+        "delegate",
+        source="delegate",
+        parent_session_id="original-parent",
+        model_config={"_delegate_from": "original-parent"},
+    )
+    db.end_session("delegate", "compression")
+    db.create_session(
+        "delegate-continuation",
+        source="delegate",
+        parent_session_id="delegate",
+        model_config={"_delegate_from": "original-parent"},
+    )
+    db.create_session(
+        "branch",
+        source="test",
+        parent_session_id="original-parent",
+        model_config={"_branched_from": "original-parent"},
+    )
+    db.end_session("branch", "compression")
+    db.create_session(
+        "branch-continuation",
+        source="test",
+        parent_session_id="branch",
+        model_config={"_branched_from": "original-parent"},
+    )
+
+    assert db._session_turn_lease_key("delegate-continuation") == "delegate"
+    assert db._session_turn_lease_key("branch-continuation") == "branch"
+
+    delegate_holder = f"pid={os.getpid()}:turn=delegate"
+    assert db.try_acquire_session_turn_lease(
+        "delegate", delegate_holder, ttl_seconds=5
+    )
+    assert not db.try_acquire_session_turn_lease(
+        "delegate-continuation",
+        f"pid={os.getpid()}:turn=delegate-child",
+        ttl_seconds=5,
+    )
+    assert db.refresh_session_turn_lease(
+        "delegate-continuation", delegate_holder, ttl_seconds=5
+    )
+
+    branch_holder = f"pid={os.getpid()}:turn=branch"
+    assert db.try_acquire_session_turn_lease(
+        "branch", branch_holder, ttl_seconds=5
+    )
+    assert not db.try_acquire_session_turn_lease(
+        "branch-continuation",
+        f"pid={os.getpid()}:turn=branch-child",
+        ttl_seconds=5,
+    )
+    assert db.refresh_session_turn_lease(
+        "branch-continuation", branch_holder, ttl_seconds=5
+    )
+
+    original_holder = f"pid={os.getpid()}:turn=original"
+    assert db.try_acquire_session_turn_lease(
+        "original-parent", original_holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("delegate-continuation", delegate_holder)
+    db.release_session_turn_lease("branch-continuation", branch_holder)
+    db.release_session_turn_lease("original-parent", original_holder)
+
+
+def test_turn_lease_write_txn_does_not_trust_fail_open_key_helper(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Acquire/refresh/release walk inside the write txn.
+
+    The old helper swallowed get_session failures and returned the child id.
+    P2 then proceeded to acquire; the write succeeded under that child key
+    and the first working refresh walked to the parent and hard-interrupted.
+    Poisoning the outer helper must not change the conversation key.
+    """
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session(
+        "delegate",
+        source="delegate",
+        model_config={"_delegate_from": "original-parent"},
+    )
+    db.end_session("delegate", "compression")
+    db.create_session(
+        "delegate-continuation",
+        source="delegate",
+        parent_session_id="delegate",
+        model_config={"_delegate_from": "original-parent"},
+    )
+
+    monkeypatch.setattr(db, "_session_turn_lease_key", lambda sid: sid)
+    holder = f"pid={os.getpid()}:turn=delegate"
+    assert db.try_acquire_session_turn_lease(
+        "delegate", holder, ttl_seconds=5
+    )
+    assert not db.try_acquire_session_turn_lease(
+        "delegate-continuation",
+        f"pid={os.getpid()}:turn=child",
+        ttl_seconds=5,
+    )
+    assert db.refresh_session_turn_lease(
+        "delegate-continuation", holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("delegate-continuation", holder)
+    assert db.try_acquire_session_turn_lease(
+        "delegate", f"pid={os.getpid()}:turn=next", ttl_seconds=5
+    )
+
+
+def test_turn_lease_retries_locked_in_txn_key_walk(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """A locked lineage walk must retry, not INSERT under the child id."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session(
+        "delegate",
+        source="delegate",
+        model_config={"_delegate_from": "original-parent"},
+    )
+    db.end_session("delegate", "compression")
+    db.create_session(
+        "delegate-continuation",
+        source="delegate",
+        parent_session_id="delegate",
+        model_config={"_delegate_from": "original-parent"},
+    )
+
+    attempts = {"n": 0}
+    original = db._session_turn_lease_key_on_conn
+
+    def flaky_walk(conn, session_id):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise sqlite3.OperationalError("database is locked")
+        return original(conn, session_id)
+
+    monkeypatch.setattr(db, "_session_turn_lease_key_on_conn", flaky_walk)
+    holder = f"pid={os.getpid()}:turn=delegate"
+    assert db.try_acquire_session_turn_lease(
+        "delegate-continuation", holder, ttl_seconds=5
+    )
+    assert attempts["n"] >= 2
+    monkeypatch.setattr(db, "_session_turn_lease_key_on_conn", original)
+    assert not db.try_acquire_session_turn_lease(
+        "delegate", f"pid={os.getpid()}:turn=other", ttl_seconds=5
+    )
+    assert db.refresh_session_turn_lease("delegate", holder, ttl_seconds=5)
+    db.release_session_turn_lease("delegate-continuation", holder)
 
 
 def test_turn_lease_refresh_and_release_are_owner_fenced(tmp_path):
@@ -201,6 +362,52 @@ def test_acquire_turn_lease_honors_should_abort(tmp_path):
     assert time.monotonic() - started < 1.0
     assert abort_checks["count"] >= 1
     first.release_session_turn_lease("shared", first_holder)
+
+
+def test_acquire_turn_lease_retries_sqlite_lock(tmp_path, monkeypatch):
+    """Write-lock exhaustion is contended, not a hard abort of the wait."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    holder = f"pid={os.getpid()}:turn=waiter"
+    attempts = {"n": 0}
+    original = db.try_acquire_session_turn_lease
+
+    def flaky_acquire(*args, **kwargs):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise sqlite3.OperationalError(
+                "database is locked (another Hermes process held the "
+                "state.db write lock for over 20s)"
+            )
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(db, "try_acquire_session_turn_lease", flaky_acquire)
+    assert db.acquire_session_turn_lease(
+        "shared",
+        holder,
+        wait_seconds=2,
+        poll_interval_seconds=0.02,
+        acquire_patience_s=0.05,
+    )
+    assert attempts["n"] >= 2
+    db.release_session_turn_lease("shared", holder)
+
+
+def test_acquire_turn_lease_reraises_non_lock_sqlite_error(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+
+    def disk_full(*args, **kwargs):
+        raise sqlite3.OperationalError("database or disk is full")
+
+    monkeypatch.setattr(db, "try_acquire_session_turn_lease", disk_full)
+    with pytest.raises(sqlite3.OperationalError, match="disk is full"):
+        db.acquire_session_turn_lease(
+            "shared",
+            f"pid={os.getpid()}:turn=waiter",
+            wait_seconds=1,
+            poll_interval_seconds=0.02,
+        )
 
 
 def test_non_expired_turn_lease_from_dead_pid_is_reclaimed(

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -1,0 +1,128 @@
+"""Cross-process session turn lease behavior (#84234)."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+from hermes_state import SessionDB
+
+
+def test_turn_lease_serializes_separate_session_db_instances(tmp_path):
+    """A second process-shaped DB handle waits for the current turn owner."""
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+    first.create_session("shared", source="test")
+
+    first_holder = f"pid={os.getpid()}:turn=first"
+    second_holder = f"pid={os.getpid()}:turn=second"
+    assert first.try_acquire_session_turn_lease(
+        "shared", first_holder, ttl_seconds=5
+    )
+
+    released = threading.Event()
+
+    def release_first():
+        time.sleep(0.2)
+        first.release_session_turn_lease("shared", first_holder)
+        released.set()
+
+    thread = threading.Thread(target=release_first, daemon=True)
+    thread.start()
+    started = time.monotonic()
+    try:
+        assert second.acquire_session_turn_lease(
+            "shared",
+            second_holder,
+            ttl_seconds=5,
+            wait_seconds=2,
+            poll_interval_seconds=0.02,
+        )
+    finally:
+        thread.join(timeout=2)
+
+    assert released.is_set()
+    assert time.monotonic() - started >= 0.15
+    second.release_session_turn_lease("shared", second_holder)
+
+
+def test_turn_lease_is_scoped_to_conversation_root(tmp_path):
+    """Compression descendants share one durable serialization domain."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("root", source="test")
+    db.end_session("root", "compression")
+    db.create_session("child", source="test", parent_session_id="root")
+
+    root_holder = f"pid={os.getpid()}:turn=root"
+    child_holder = f"pid={os.getpid()}:turn=child"
+    assert db.try_acquire_session_turn_lease(
+        "root", root_holder, ttl_seconds=5
+    )
+    assert not db.try_acquire_session_turn_lease(
+        "child", child_holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("child", root_holder)
+
+
+def test_turn_lease_does_not_serialize_delegate_child_with_parent(tmp_path):
+    """Only compression continuation segments share a conversation lease."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("parent", source="test")
+    db.create_session(
+        "delegate",
+        source="delegate",
+        parent_session_id="parent",
+        model_config={"_delegate_from": "parent"},
+    )
+
+    parent_holder = f"pid={os.getpid()}:turn=parent"
+    delegate_holder = f"pid={os.getpid()}:turn=delegate"
+    assert db.try_acquire_session_turn_lease(
+        "parent", parent_holder, ttl_seconds=5
+    )
+    assert db.try_acquire_session_turn_lease(
+        "delegate", delegate_holder, ttl_seconds=5
+    )
+
+
+def test_turn_lease_refresh_and_release_are_owner_fenced(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+
+    current_holder = f"pid={os.getpid()}:turn=current"
+    stale_holder = f"pid={os.getpid()}:turn=stale"
+    next_holder = f"pid={os.getpid()}:turn=next"
+    assert db.try_acquire_session_turn_lease(
+        "shared", current_holder, ttl_seconds=5
+    )
+    assert not db.refresh_session_turn_lease(
+        "shared", stale_holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("shared", stale_holder)
+    assert not db.try_acquire_session_turn_lease(
+        "shared", next_holder, ttl_seconds=5
+    )
+
+    assert db.refresh_session_turn_lease(
+        "shared", current_holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("shared", current_holder)
+    assert db.try_acquire_session_turn_lease(
+        "shared", next_holder, ttl_seconds=5
+    )
+
+
+def test_expired_turn_lease_is_reclaimed(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    assert db.try_acquire_session_turn_lease(
+        "shared", "legacy-holder", ttl_seconds=0.05
+    )
+
+    time.sleep(0.15)
+
+    assert db.try_acquire_session_turn_lease(
+        "shared", "pid=202:turn=reclaimer", ttl_seconds=5
+    )

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -126,3 +126,42 @@ def test_expired_turn_lease_is_reclaimed(tmp_path):
     assert db.try_acquire_session_turn_lease(
         "shared", "pid=202:turn=reclaimer", ttl_seconds=5
     )
+
+
+def test_acquire_turn_lease_notifies_wait_callback(tmp_path):
+    """Waiters get a progress callback while another holder owns the lease."""
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+    first.create_session("shared", source="test")
+
+    first_holder = f"pid={os.getpid()}:turn=first"
+    second_holder = f"pid={os.getpid()}:turn=second"
+    assert first.try_acquire_session_turn_lease(
+        "shared", first_holder, ttl_seconds=5
+    )
+
+    notices = []
+
+    def release_first():
+        time.sleep(0.12)
+        first.release_session_turn_lease("shared", first_holder)
+
+    thread = threading.Thread(target=release_first, daemon=True)
+    thread.start()
+    try:
+        assert second.acquire_session_turn_lease(
+            "shared",
+            second_holder,
+            ttl_seconds=5,
+            wait_seconds=2,
+            poll_interval_seconds=0.02,
+            on_wait=notices.append,
+            wait_notice_interval_seconds=0.05,
+        )
+    finally:
+        thread.join(timeout=2)
+
+    assert notices
+    assert notices[0] < 0.05
+    second.release_session_turn_lease("shared", second_holder)

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -490,21 +490,29 @@ def test_turn_lease_fences_stale_transcript_flush_after_reclaim(tmp_path):
     db.release_session_turn_lease("shared", next_holder)
 
 
-def test_turn_lease_fences_flush_when_row_is_absent_or_expired(tmp_path):
+def test_turn_lease_revives_expired_row_still_owned_by_writer(tmp_path):
     db = SessionDB(tmp_path / "state.db")
     db.create_session("shared", source="test")
     holder = f"pid={os.getpid()}:turn=owner"
 
     assert db.try_acquire_session_turn_lease("shared", holder, ttl_seconds=0.05)
     time.sleep(0.12)
-    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
-        db.append_messages_batch(
-            "shared",
-            [{"role": "assistant", "content": "after ttl"}],
-            turn_lease_holder=holder,
-        )
+    assert db.append_messages_batch(
+        "shared",
+        [{"role": "assistant", "content": "after ttl"}],
+        turn_lease_holder=holder,
+        turn_lease_ttl_seconds=0.2,
+    ) == 1
+    assert not db.try_acquire_session_turn_lease(
+        "shared", f"pid={os.getpid()}:turn=contender", ttl_seconds=5
+    )
 
-    db.release_session_turn_lease("shared", holder)
+
+def test_turn_lease_fences_flush_when_row_is_absent(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    holder = f"pid={os.getpid()}:turn=owner"
+
     with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
         db.append_messages_batch(
             "shared",

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import os
 import threading
 import time
+from types import SimpleNamespace
 
+import pytest
+
+import hermes_state
 from hermes_state import SessionDB
 
 
@@ -165,3 +169,64 @@ def test_acquire_turn_lease_notifies_wait_callback(tmp_path):
     assert notices
     assert notices[0] < 0.05
     second.release_session_turn_lease("shared", second_holder)
+
+
+def test_acquire_turn_lease_honors_should_abort(tmp_path):
+    """Waiters stop immediately when should_abort() returns True."""
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+    first.create_session("shared", source="test")
+
+    first_holder = f"pid={os.getpid()}:turn=first"
+    second_holder = f"pid={os.getpid()}:turn=second"
+    assert first.try_acquire_session_turn_lease(
+        "shared", first_holder, ttl_seconds=60
+    )
+
+    abort_checks = {"count": 0}
+
+    def should_abort():
+        abort_checks["count"] += 1
+        return True
+
+    started = time.monotonic()
+    assert not second.acquire_session_turn_lease(
+        "shared",
+        second_holder,
+        wait_seconds=30,
+        poll_interval_seconds=0.05,
+        should_abort=should_abort,
+    )
+    assert time.monotonic() - started < 1.0
+    assert abort_checks["count"] >= 1
+    first.release_session_turn_lease("shared", first_holder)
+
+
+def test_non_expired_turn_lease_from_dead_pid_is_reclaimed(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A holder whose structured pid= no longer exists can be reclaimed early."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+
+    dead_holder = "pid=424242:turn=dead:platform=test"
+    assert db.try_acquire_session_turn_lease(
+        "shared", dead_holder, ttl_seconds=300
+    ) is True
+
+    probed: list[int] = []
+
+    def pid_exists(pid: int) -> bool:
+        probed.append(pid)
+        return False
+
+    monkeypatch.setattr(
+        hermes_state, "psutil", SimpleNamespace(pid_exists=pid_exists)
+    )
+
+    fresh_holder = "pid=525252:turn=fresh:platform=test"
+    assert db.try_acquire_session_turn_lease(
+        "shared", fresh_holder, ttl_seconds=300
+    ) is True
+    assert probed == [424242]

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 import pytest
 
 import hermes_state
-from hermes_state import SessionDB
+from hermes_state import SessionDB, SessionTurnLeaseLostError
 
 
 def test_turn_lease_serializes_separate_session_db_instances(tmp_path):
@@ -437,3 +437,225 @@ def test_non_expired_turn_lease_from_dead_pid_is_reclaimed(
         "shared", fresh_holder, ttl_seconds=300
     ) is True
     assert probed == [424242]
+
+
+def test_turn_lease_fences_stale_transcript_flush_after_reclaim(tmp_path):
+    """A lost holder cannot persist after B has taken the conversation.
+
+    Refresh-loss interrupt is cooperative; the lease itself must reject the
+    late append inside the same SQLite write transaction.
+    """
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    stale_holder = f"pid={os.getpid()}:turn=stale"
+    next_holder = f"pid={os.getpid()}:turn=next"
+
+    assert db.try_acquire_session_turn_lease(
+        "shared", stale_holder, ttl_seconds=5
+    )
+    assert db.append_messages_batch(
+        "shared",
+        [{"role": "user", "content": "stale-owned"}],
+        turn_lease_holder=stale_holder,
+    ) == 1
+
+    db.release_session_turn_lease("shared", stale_holder)
+    assert db.try_acquire_session_turn_lease(
+        "shared", next_holder, ttl_seconds=5
+    )
+
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "shared",
+            [{"role": "assistant", "content": "late stale reply"}],
+            turn_lease_holder=stale_holder,
+        )
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_message(
+            "shared",
+            "assistant",
+            "late stale single-row",
+            turn_lease_holder=stale_holder,
+        )
+
+    assert db.append_messages_batch(
+        "shared",
+        [{"role": "assistant", "content": "next reply"}],
+        turn_lease_holder=next_holder,
+    ) == 1
+    assert [m["content"] for m in db.get_messages("shared")] == [
+        "stale-owned",
+        "next reply",
+    ]
+    db.release_session_turn_lease("shared", next_holder)
+
+
+def test_turn_lease_fences_flush_when_row_is_absent_or_expired(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    holder = f"pid={os.getpid()}:turn=owner"
+
+    assert db.try_acquire_session_turn_lease("shared", holder, ttl_seconds=0.05)
+    time.sleep(0.12)
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "shared",
+            [{"role": "assistant", "content": "after ttl"}],
+            turn_lease_holder=holder,
+        )
+
+    db.release_session_turn_lease("shared", holder)
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "shared",
+            [{"role": "assistant", "content": "after release"}],
+            turn_lease_holder=holder,
+        )
+    assert db.get_messages("shared") == []
+
+
+def test_turn_lease_fence_walks_compression_child_to_root(tmp_path):
+    """A parent-key holder still fences writes against the rotated tip."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("root", source="test")
+    db.end_session("root", "compression")
+    db.create_session("child", source="test", parent_session_id="root")
+
+    root_holder = f"pid={os.getpid()}:turn=root"
+    stale_holder = f"pid={os.getpid()}:turn=stale"
+    assert db.try_acquire_session_turn_lease(
+        "root", root_holder, ttl_seconds=5
+    )
+    assert db.append_messages_batch(
+        "child",
+        [{"role": "user", "content": "owner on tip"}],
+        turn_lease_holder=root_holder,
+    ) == 1
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "child",
+            [{"role": "assistant", "content": "impostor"}],
+            turn_lease_holder=stale_holder,
+        )
+    db.release_session_turn_lease("child", root_holder)
+
+
+def test_lost_turn_lease_flush_fails_fast_without_patience_retry(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Sibling of test_a_lost_compression_lease_still_fails_fast.
+
+    SessionTurnLeaseLostError is permanent fencing, not a live-busy signal.
+    Retrying it would burn transcript write patience and still fail.
+    """
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("shared", source="test")
+    stale_holder = f"pid={os.getpid()}:turn=stale"
+    next_holder = f"pid={os.getpid()}:turn=next"
+    assert db.try_acquire_session_turn_lease(
+        "shared", stale_holder, ttl_seconds=5
+    )
+    db.release_session_turn_lease("shared", stale_holder)
+    assert db.try_acquire_session_turn_lease(
+        "shared", next_holder, ttl_seconds=5
+    )
+
+    sleeps = []
+    original = db._sleep_before_write_retry
+
+    def track_sleep(deadline, patience_s):
+        sleeps.append(patience_s)
+        return original(deadline, patience_s)
+
+    monkeypatch.setattr(db, "_sleep_before_write_retry", track_sleep)
+    monkeypatch.setattr(SessionDB, "_COMPRESSION_BUSY_WAIT_S", 5.0)
+
+    started = time.monotonic()
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "shared",
+            [{"role": "assistant", "content": "late stale reply"}],
+            turn_lease_holder=stale_holder,
+        )
+    assert time.monotonic() - started < 0.5
+    assert sleeps == []
+    assert db.get_messages("shared") == []
+    db.release_session_turn_lease("shared", next_holder)
+
+
+def test_turn_lease_fence_walks_continuation_that_inherited_fork_markers(tmp_path):
+    """Owner flush on a rotated tip must use the parent-key lease.
+
+    Presence-only ``_delegate_from`` / ``_branched_from`` detection would
+    treat the continuation as its own conversation. The presented parent
+    holder would then miss the row and fail-close a still-valid owner.
+    """
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("original-parent", source="test")
+    db.create_session(
+        "delegate",
+        source="delegate",
+        parent_session_id="original-parent",
+        model_config={"_delegate_from": "original-parent"},
+    )
+    db.end_session("delegate", "compression")
+    db.create_session(
+        "delegate-continuation",
+        source="delegate",
+        parent_session_id="delegate",
+        model_config={"_delegate_from": "original-parent"},
+    )
+    db.create_session(
+        "branch",
+        source="test",
+        parent_session_id="original-parent",
+        model_config={"_branched_from": "original-parent"},
+    )
+    db.end_session("branch", "compression")
+    db.create_session(
+        "branch-continuation",
+        source="test",
+        parent_session_id="branch",
+        model_config={"_branched_from": "original-parent"},
+    )
+
+    delegate_holder = f"pid={os.getpid()}:turn=delegate"
+    assert db.try_acquire_session_turn_lease(
+        "delegate", delegate_holder, ttl_seconds=5
+    )
+    assert db.append_messages_batch(
+        "delegate-continuation",
+        [{"role": "user", "content": "owner on inherited tip"}],
+        turn_lease_holder=delegate_holder,
+    ) == 1
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "delegate-continuation",
+            [{"role": "assistant", "content": "impostor"}],
+            turn_lease_holder=f"pid={os.getpid()}:turn=impostor",
+        )
+
+    branch_holder = f"pid={os.getpid()}:turn=branch"
+    assert db.try_acquire_session_turn_lease(
+        "branch", branch_holder, ttl_seconds=5
+    )
+    assert db.append_messages_batch(
+        "branch-continuation",
+        [{"role": "user", "content": "branch owner on inherited tip"}],
+        turn_lease_holder=branch_holder,
+    ) == 1
+    with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
+        db.append_messages_batch(
+            "branch-continuation",
+            [{"role": "assistant", "content": "branch impostor"}],
+            turn_lease_holder=f"pid={os.getpid()}:turn=branch-impostor",
+        )
+
+    assert [m["content"] for m in db.get_messages("delegate-continuation")] == [
+        "owner on inherited tip"
+    ]
+    assert [m["content"] for m in db.get_messages("branch-continuation")] == [
+        "branch owner on inherited tip"
+    ]
+    db.release_session_turn_lease("delegate-continuation", delegate_holder)
+    db.release_session_turn_lease("branch-continuation", branch_holder)


### PR DESCRIPTION
## Summary
Cross-process SQLite turn lease prevents concurrent resumes (Desktop + CLI, Desktop + gateway) from losing completed replies when one process holds a compression lease during another's flush.

## Changes
- `hermes_state_common.py`: new `session_turn_leases` table + expiry index
- `hermes_state.py`: `try_acquire`/`acquire`/`refresh`/`release_session_turn_lease` methods with compression lineage root resolution, expired/dead-holder reclamation, and `SessionTurnLeaseLostError` fencing; `compression`/`turn_lease` split from `locked` in `PERSISTENCE_ERROR_CAUSES`; `_is_explicit_fork_child_row` now binds markers to `parent_session_id` so compression continuations that inherited `_delegate_from`/`_branched_from` are not misclassified as forks
- `run_agent.py`: lease acquired before `run_conversation`, refresher daemon thread, post-admission transcript reload (only when contended), release in outer finally
- `agent/turn_finalizer.py`: error classification comment updated

## Salvage follow-up fixes (on top of contributor's 8 commits)
1. Moved `_clear_durable_turn_lease_interrupt()` to after refresher thread join — a late interrupt between inner stop and join could survive the clear and poison the next turn on a cached agent
2. Set `self._interrupt_message` in the except branch of `_interrupt_turn` — so `_clear_durable_turn_lease_interrupt` can match and clear it even when `self.interrupt()` itself raised
3. Gated `conversation_history` reload behind `_lease_waited` — avoids unnecessary DB read + prompt cache miss when acquisition was immediate (no contention)

## Tests
| | Before (main) | After (salvage) |
|---|---|---|
| Targeted suite | 49 passed | 84 passed |
| New tests | 0 | 35 |

## Attribution
Cherry-picked from PR #84287 by @fangliquanflq. Contributor commits preserved via cherry-pick; follow-up fixes authored separately.

Closes #84234
