### PR TITLE
fix(auth): active subscription login outranks a leftover OPENAI_API_KEY

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2153,6 +2153,32 @@ def resolve_provider(
     except Exception as e:
         logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)
 
+    # An ACTIVELY logged-in OAuth/subscription provider outranks a bare
+    # OPENAI_API_KEY / OPENROUTER_API_KEY env var. #29285 established that
+    # explicit user intent must beat a *stale* OAuth active_provider — but a
+    # subscription the user is CURRENTLY logged into is not stale; logging in
+    # is itself a deliberate, recent choice. A leftover env key silently
+    # hijacking an active subscription is the "default bot switched to OpenAI
+    # instead of my subscription" report. Gated on get_auth_status().logged_in
+    # (checked when _oauth_active is resolved below), so an expired/stale login
+    # still yields to the env key exactly as #29285 intended. config.yaml
+    # model.provider (checked above) still wins over both — an explicit pin is
+    # the strongest signal.
+    _active_login: Optional[str] = None
+    try:
+        _store_pre = _load_auth_store()
+        _maybe_pre = _store_pre.get("active_provider")
+        if (
+            _maybe_pre
+            and _maybe_pre in PROVIDER_REGISTRY
+            and get_auth_status(_maybe_pre).get("logged_in")
+        ):
+            _active_login = _maybe_pre
+    except Exception as e:
+        logger.debug("Could not pre-read active login provider: %s", e)
+    if _active_login:
+        return _active_login
+
     if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(os.getenv("OPENROUTER_API_KEY")):
         return "openrouter"
 

--- a/tests/hermes_cli/test_active_subscription_provider_priority.py
+++ b/tests/hermes_cli/test_active_subscription_provider_priority.py
@@ -1,0 +1,50 @@
+"""An ACTIVE subscription/OAuth login must outrank a leftover OPENAI_API_KEY
+env var in provider auto-resolution — while a STALE (logged-out) login must
+still yield to the env key (preserving the #29285 intent).
+
+Reported: "the default bot switches to the OpenAI API account rather than the
+Subscription one." Root cause: resolve_provider('auto') checked OPENAI/
+OPENROUTER env keys before the logged-in active_provider, so a leftover
+OPENAI_API_KEY silently hijacked an active subscription.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import auth, config as cfgmod
+
+
+def _resolve(cfg, active_provider, logged_in, env_key="sk-fake-key-000123456789"):
+    fake_store = {"active_provider": active_provider} if active_provider else {}
+    with patch.dict(os.environ, {"OPENAI_API_KEY": env_key}, clear=False), \
+         patch.object(cfgmod, "load_config", lambda: cfg), \
+         patch.object(auth, "_load_auth_store", lambda: fake_store), \
+         patch.object(auth, "get_auth_status", lambda p: {"logged_in": logged_in}):
+        return auth.resolve_provider("auto")
+
+
+def test_active_subscription_beats_leftover_openai_key():
+    # The bug: active login lost to a stray env key.
+    assert _resolve({"model": {}}, "nous", logged_in=True) == "nous"
+
+
+def test_active_xai_oauth_beats_openai_key():
+    assert _resolve({"model": {}}, "xai-oauth", logged_in=True) == "xai-oauth"
+
+
+def test_stale_login_still_yields_to_env_key():
+    # #29285 intent preserved: a logged-OUT active_provider is stale, so the
+    # explicit env key still wins.
+    assert _resolve({"model": {}}, "nous", logged_in=False) == "openrouter"
+
+
+def test_no_login_env_key_unchanged():
+    assert _resolve({"model": {}}, None, logged_in=False) == "openrouter"
+
+
+def test_explicit_config_pin_still_wins_over_active_login():
+    # An explicit model.provider pin is the strongest signal and outranks both
+    # the active login and the env key.
+    assert _resolve({"model": {"provider": "nous"}}, "xai-oauth", logged_in=True) == "nous"


### PR DESCRIPTION
**Report:** "the default bot switches to the OpenAI API account rather than the Subscription one — the default Hermes bot should retain the previous selection" (@rashidkhan).

**Root cause (repro'd empirically).** `resolve_provider('auto')` priority checked `OPENAI_API_KEY`/`OPENROUTER_API_KEY` env vars (tier 3) **before** the logged-in OAuth `active_provider` (tier 6). With config `model.provider` unset and a leftover `OPENAI_API_KEY` in `~/.hermes/.env`, an **actively logged-in subscription** (Nous, xAI, etc.) silently lost to the stray key. Repro: empty config + `OPENAI_API_KEY` → `openrouter`, even while logged into a subscription.

**Why this is a real bug, not the #29285 behavior.** #29285 deliberately made an explicit env key beat a **stale** `active_provider`. But a subscription the user is **currently logged into** is not stale — logging in is itself a recent, deliberate choice. The old order couldn't tell those apart.

**Fix.** Insert an active-login check immediately before the env-key tier, gated on `get_auth_status().logged_in`:
- **ACTIVE** login → wins over the env key (fixes the report)
- **STALE / logged-out** `active_provider` → still yields to the env key (**#29285 preserved**)
- explicit `config.yaml model.provider` pin → still outranks both (strongest signal, unchanged)

**Verified matrix** (`tests/hermes_cli/test_active_subscription_provider_priority.py`, 5/5):

| scenario | result |
|---|---|
| active nous + OPENAI key, no pin | **nous** (was: openrouter) |
| active xai-oauth + OPENAI key | **xai-oauth** |
| stale (logged-out) login + OPENAI key | openrouter (#29285 preserved) |
| no login + OPENAI key | openrouter (unchanged) |
| config pin + active login + key | the pin (unchanged) |

Note: not signed; author requires signed commits — will re-sign if that gate blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic provider selection now prioritizes an active login over leftover API keys.
  * Expired or unavailable logins continue to fall back to configured environment-based providers.
  * Explicit provider settings remain the highest-priority option.

* **Tests**
  * Added coverage for subscription logins, xAI OAuth authentication, stale logins, missing logins, and explicit provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->