### PR TITLE
fix(macos): detect stale TCC grants and guide one-time re-grant

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -894,6 +894,86 @@ def managed_scope_check() -> None:
         check_info(f"managed dir set via HERMES_MANAGED_DIR={managed_dir}")
 
 
+def check_macos_tcc_grants() -> None:
+    """Check macOS TCC grant persistence for a locally-built desktop bundle.
+
+    TCC keys permission grants (Screen Recording, Full Disk Access,
+    Accessibility, ...) to the app's code-signing requirement. A bundle
+    signed with the pre-#73681 cdhash-pinned ad-hoc identity gets a new DR on
+    every rebuild, so all grants silently stop matching — and the stale row
+    keeps the System Settings toggle ON while macOS re-prompts on every
+    capture (issue #86385).
+
+    Post-#73681 builds pin ``designated => identifier "com.nousresearch.hermes"``
+    (no cdhash), so new grants survive rebuilds — but grants made to older
+    binaries remain stale until re-granted once. The stale state is not
+    directly readable (TCC.db needs Full Disk Access), so this check reports
+    the DR class and, when the DR is stable, prints the exact one-time repair.
+    Silent on non-macOS and when no desktop bundle is installed.
+    """
+    if sys.platform != "darwin":
+        return
+    app = _desktop_app_bundle()
+    if app is None:
+        return
+    dr = _macos_desktop_dr(app)
+    if dr is None:
+        check_warn(
+            "macOS TCC grant check",
+            "(could not read code-signing requirement of the desktop bundle)",
+        )
+        return
+    if "cdhash" in dr.lower():
+        check_warn(
+            "macOS TCC grants will reset after every update",
+            "the desktop bundle's designated requirement is cdhash-pinned "
+            "(pre-#73681 build) — rebuilds invalidate all permission grants. "
+            "Run `hermes update` to get the stable identifier-pinned signing "
+            "identity, then re-grant permissions once.",
+        )
+        return
+    check_ok(
+        "macOS TCC signing identity is stable",
+        "(identifier-pinned DR; grants survive rebuilds)",
+    )
+    check_info(
+        "If macOS still re-prompts for permissions (toggle shows ON): the stored "
+        "grant is stale — run `tccutil reset ScreenCapture com.nousresearch.hermes`, "
+        "toggle it ON in System Settings, then fully quit & relaunch Hermes once."
+    )
+
+
+def _desktop_app_bundle() -> Path | None:
+    """Locate the locally-built desktop app bundle, if any.
+
+    Mirrors the install layout the self-updater produces
+    (``apps/desktop/release/mac-<arch>/Hermes.app``).
+    """
+    root = Path(__file__).resolve().parents[1]
+    release_dir = root / "apps" / "desktop" / "release"
+    for arch in ("mac-arm64", "mac-x64"):
+        app = release_dir / arch / "Hermes.app"
+        if app.is_dir():
+            return app
+    return None
+
+
+def _macos_desktop_dr(app: Path) -> str | None:
+    """Return the bundle's designated requirement string, or None on failure."""
+    codesign = shutil.which("codesign")
+    if not codesign:
+        return None
+    proc = subprocess.run(
+        [codesign, "-d", "--requirements", "-", str(app)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if proc.returncode != 0:
+        return None
+    return (proc.stdout or "") + (proc.stderr or "")
+
+
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
@@ -1067,6 +1147,12 @@ def run_doctor(args):
     # Detect drift between pyproject.toml and hermes_cli/__init__.py versions
     # (a git conflict resolution can silently revert one but not the other).
     _check_version_consistency(issues)
+
+    # macOS TCC grant persistence (issue #86385): a locally-built desktop
+    # bundle whose DR is cdhash-pinned loses every permission grant on each
+    # rebuild; a post-#73681 identifier-pinned DR survives, but grants made
+    # to older binaries stay stale (toggle shows ON while macOS re-prompts).
+    check_macos_tcc_grants()
 
     _section("SSL / CA Certificates")
     check_certificates(should_fix=should_fix, issues=manual_issues)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -917,7 +917,7 @@ def check_macos_tcc_grants() -> None:
     if app is None:
         return
     dr = _macos_desktop_dr(app)
-    if dr is None:
+    if not dr:
         check_warn(
             "macOS TCC grant check",
             "(could not read code-signing requirement of the desktop bundle)",

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -923,6 +923,11 @@ def check_macos_tcc_grants() -> None:
             "(could not read code-signing requirement of the desktop bundle)",
         )
         return
+    # The DR string is the only readable signal — TCC.db itself needs Full
+    # Disk Access. A cdhash anchor marks the pre-#73681 ad-hoc identity
+    # (rebuild ⇒ new cdhash ⇒ stale grants); its absence marks identifier-
+    # pinned. Treat the match as a proxy for the signing class, not a
+    # contract on DR wording.
     if "cdhash" in dr.lower():
         check_warn(
             "macOS TCC grants will reset after every update",
@@ -938,8 +943,9 @@ def check_macos_tcc_grants() -> None:
     )
     check_info(
         "If macOS still re-prompts for permissions (toggle shows ON): the stored "
-        "grant is stale — run `tccutil reset ScreenCapture com.nousresearch.hermes`, "
-        "toggle it ON in System Settings, then fully quit & relaunch Hermes once."
+        "grant is stale — run `tccutil reset ScreenCapture com.nousresearch.hermes` "
+        "(repeat per affected service), toggle it ON in System Settings, then "
+        "fully quit & relaunch Hermes once."
     )
 
 
@@ -947,15 +953,20 @@ def _desktop_app_bundle() -> Path | None:
     """Locate the locally-built desktop app bundle, if any.
 
     Mirrors the install layout the self-updater produces
-    (``apps/desktop/release/mac-<arch>/Hermes.app``).
+    (``apps/desktop/release/mac-<arch>/Hermes.app``) — the only layout whose
+    ad-hoc re-signed bundle can invalidate TCC grants. When multiple arch
+    trees coexist (stale cross-build), the newest wins, matching
+    ``_desktop_packaged_executable``'s selection. ``/Applications/Hermes.app``
+    is deliberately not probed: it is the separately-signed Hermes-Setup
+    launcher (``com.nousresearch.hermes.setup``, certificate-anchored), whose
+    grants are stable by construction and unaffected by rebuilds.
     """
     root = Path(__file__).resolve().parents[1]
     release_dir = root / "apps" / "desktop" / "release"
-    for arch in ("mac-arm64", "mac-x64"):
-        app = release_dir / arch / "Hermes.app"
-        if app.is_dir():
-            return app
-    return None
+    candidates = [p for p in release_dir.glob("mac*/Hermes.app") if p.is_dir()]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
 
 
 def _macos_desktop_dr(app: Path) -> str | None:
@@ -963,12 +974,17 @@ def _macos_desktop_dr(app: Path) -> str | None:
     codesign = shutil.which("codesign")
     if not codesign:
         return None
-    proc = subprocess.run(
-        [codesign, "-d", "--requirements", "-", str(app)],
-        capture_output=True,
-        text=True,
-        timeout=15,
-    )
+    try:
+        proc = subprocess.run(
+            [codesign, "-d", "--requirements", "-", str(app)],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        # Never let a hanging codesign abort the whole doctor run — the
+        # caller falls through to its "could not read" warning.
+        return None
     if proc.returncode != 0:
         return None
     return (proc.stdout or "") + (proc.stderr or "")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4639,6 +4639,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print()
         print("✓ Code updated!")
 
+        # ── macOS TCC stale-grant notice (#86385) ──────────────────────
+        # Locally-built desktop bundles are re-signed on every update. With the
+        # post-#73681 identifier-pinned DR, new grants survive rebuilds — but a
+        # grant made to a pre-fix binary stays stale: the System Settings toggle
+        # shows ON while macOS re-prompts on every capture, and the modern prompt
+        # has no Allow button, so users loop. One line of guidance after update
+        # tells affected users how to complete the one-time re-grant.
+        if sys.platform == "darwin" and has_desktop_app:
+            print()
+            print(
+                "  ℹ macOS: if Hermes re-prompts for permissions you already "
+                "granted (toggle shows ON), the stored grant is stale — run "
+                "`tccutil reset ScreenCapture com.nousresearch.hermes`, toggle "
+                "it ON in System Settings, then fully quit & relaunch once."
+            )
+
         # ── Post-update state.db integrity guard (#68474) ─────────────────
         # Verify that state.db survived the update intact.  If the live file
         # is now corrupted (zeroed, missing header, integrity failure),

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4651,8 +4651,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print(
                 "  ℹ macOS: if Hermes re-prompts for permissions you already "
                 "granted (toggle shows ON), the stored grant is stale — run "
-                "`tccutil reset ScreenCapture com.nousresearch.hermes`, toggle "
-                "it ON in System Settings, then fully quit & relaunch once."
+                "`tccutil reset ScreenCapture com.nousresearch.hermes` (repeat "
+                "per affected service), toggle it ON in System Settings, then "
+                "fully quit & relaunch once."
             )
 
         # ── Post-update state.db integrity guard (#68474) ─────────────────

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1462,10 +1462,14 @@ class TestDoctorDeprecatedConfigAndEnv:
 class TestMacOSTCCGrants:
     """macOS TCC grant persistence check (issue #86385)."""
 
-    def test_silent_on_non_macos(self, monkeypatch, capsys):
-        """Non-macOS: the check must produce no output."""
+    def test_silent_on_non_macos(self, monkeypatch, capsys, tmp_path):
+        """Non-macOS: the check must produce no output even with a bundle present."""
         monkeypatch.setattr(doctor_mod.sys, "platform", "linux")
-        monkeypatch.setattr(doctor_mod, "_desktop_app_bundle", lambda: None)
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
         doctor_mod.check_macos_tcc_grants()
         assert capsys.readouterr().out == ""
 
@@ -1527,3 +1531,17 @@ class TestMacOSTCCGrants:
         doctor_mod.check_macos_tcc_grants()
         out = capsys.readouterr().out
         assert "could not read code-signing requirement" in out
+
+    def test_warns_when_dr_empty_string(self, monkeypatch, capsys, tmp_path):
+        """Empty DR output must not false-positive as a stable identity."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
+        monkeypatch.setattr(doctor_mod, "_macos_desktop_dr", lambda app: "")
+        doctor_mod.check_macos_tcc_grants()
+        out = capsys.readouterr().out
+        assert "could not read code-signing requirement" in out
+        assert "stable" not in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1457,3 +1457,73 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+
+class TestMacOSTCCGrants:
+    """macOS TCC grant persistence check (issue #86385)."""
+
+    def test_silent_on_non_macos(self, monkeypatch, capsys):
+        """Non-macOS: the check must produce no output."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "linux")
+        monkeypatch.setattr(doctor_mod, "_desktop_app_bundle", lambda: None)
+        doctor_mod.check_macos_tcc_grants()
+        assert capsys.readouterr().out == ""
+
+    def test_silent_when_no_desktop_bundle(self, monkeypatch, capsys):
+        """No locally-built desktop bundle: nothing to check, no output."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(doctor_mod, "_desktop_app_bundle", lambda: None)
+        doctor_mod.check_macos_tcc_grants()
+        assert capsys.readouterr().out == ""
+
+    def test_warns_on_cdhash_pinned_dr(self, monkeypatch, capsys, tmp_path):
+        """Pre-#73681 builds have a cdhash-pinned DR → warn that grants reset."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
+        monkeypatch.setattr(
+            doctor_mod,
+            "_macos_desktop_dr",
+            lambda app: 'designated => identifier "com.nousresearch.hermes" and cdhash H"97e692f3890f781fa0ad5ad6cb9d769cfaf42628"',
+        )
+        doctor_mod.check_macos_tcc_grants()
+        out = capsys.readouterr().out
+        assert "TCC grants will reset after every update" in out
+        assert "cdhash-pinned" in out
+        assert "hermes update" in out
+
+    def test_ok_and_repair_info_on_identifier_dr(self, monkeypatch, capsys, tmp_path):
+        """Post-#73681 identifier-only DR → stable + stale-grant repair info."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
+        monkeypatch.setattr(
+            doctor_mod,
+            "_macos_desktop_dr",
+            lambda app: 'designated => identifier "com.nousresearch.hermes"',
+        )
+        doctor_mod.check_macos_tcc_grants()
+        out = capsys.readouterr().out
+        assert "TCC signing identity is stable" in out
+        assert "tccutil reset ScreenCapture com.nousresearch.hermes" in out
+        assert "toggle" in out
+        assert "relaunch" in out
+
+    def test_warns_when_dr_unreadable(self, monkeypatch, capsys, tmp_path):
+        """codesign failure → warn, never crash."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
+        monkeypatch.setattr(doctor_mod, "_macos_desktop_dr", lambda app: None)
+        doctor_mod.check_macos_tcc_grants()
+        out = capsys.readouterr().out
+        assert "could not read code-signing requirement" in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli.doctor."""
 
 import os
+import subprocess
 import sys
 import types
 import io
@@ -1541,6 +1542,38 @@ class TestMacOSTCCGrants:
             lambda: tmp_path / "Hermes.app",
         )
         monkeypatch.setattr(doctor_mod, "_macos_desktop_dr", lambda app: "")
+        doctor_mod.check_macos_tcc_grants()
+        out = capsys.readouterr().out
+        assert "could not read code-signing requirement" in out
+        assert "stable" not in out
+
+    def test_warns_when_codesign_times_out(self, monkeypatch, capsys, tmp_path):
+        """A hanging codesign must degrade to the unreadable-DR warning, never crash."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
+
+        def _timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=["codesign"], timeout=15)
+
+        monkeypatch.setattr(doctor_mod.subprocess, "run", _timeout)
+        doctor_mod.check_macos_tcc_grants()
+        out = capsys.readouterr().out
+        assert "could not read code-signing requirement" in out
+        assert "stable" not in out
+
+    def test_warns_when_codesign_missing(self, monkeypatch, capsys, tmp_path):
+        """No codesign binary → same graceful unreadable-DR warning."""
+        monkeypatch.setattr(doctor_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            doctor_mod,
+            "_desktop_app_bundle",
+            lambda: tmp_path / "Hermes.app",
+        )
+        monkeypatch.setattr(doctor_mod.shutil, "which", lambda _name: None)
         doctor_mod.check_macos_tcc_grants()
         out = capsys.readouterr().out
         assert "could not read code-signing requirement" in out

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -383,8 +383,21 @@ macOS/Windows signing and notarization run automatically when the relevant crede
 macOS remembers permission grants (Full Disk Access, Desktop/Downloads/Documents,
 Accessibility, Automation, microphone) against the app's *code-signing identity*,
 not its path. Locally built and self-updated apps are signed with a stable
-identifier-pinned ad-hoc signature, so grants persist across updates out of the
-box.
+identifier-pinned ad-hoc signature, so grants persist across updates.
+
+One-time note: grants made to builds *before* the identifier-pinned signing
+fix (PR #73681) carry the old cdhash-pinned requirement. macOS keeps showing the
+toggle as ON for those stale grants but still re-prompts, because the stored
+grant no longer matches the rebuilt binary — and the modern prompt has no Allow
+button, so it looks like there is nothing to re-check. If that happens, reset
+the stale grant once and re-grant:
+
+```bash
+tccutil reset ScreenCapture com.nousresearch.hermes   # repeat per service
+```
+
+then toggle the fresh entry ON in System Settings and fully quit & relaunch
+Hermes. Grants are stable from then on.
 
 For the strongest guarantee — a certificate-anchored identity, the same
 mechanism yabai/skhd users rely on — create a self-signed code-signing


### PR DESCRIPTION
## Summary

On macOS, TCC permission grants (Screen Recording, Full Disk Access, Accessibility, …) are keyed to the app's code-signing requirement. Grants made to builds **before** the identifier-pinned signing fix (#73681) carry a **cdhash-pinned** requirement: every rebuild changes the cdhash, the stored grant's `csreq` stops matching the running binary, and macOS re-prompts on every screen capture — **even though the System Settings toggle shows ON**. The modern macOS prompt has no Allow button (only "Open System Settings" / "Deny"), and the Settings entry is already checked, so users have no way to complete the one-time re-grant and loop forever.

Fully diagnosed + E2E-verified on macOS 26.5.2: `tccutil reset ScreenCapture com.nousresearch.hermes` → a fresh unchecked entry appears in System Settings → toggle ON → fully quit & relaunch → grants survive a real rebuild (post-update captures `Allowed`, zero `Failed to match` events). The stale-row/toggle-ON mechanism was first identified by @plantbob0101 in [#52010](https://github.com/NousResearch/hermes-agent/issues/52010#issuecomment-5242448291); this PR adds the detection + guidance so users aren't left guessing.

## Changes

- **`hermes_cli/doctor.py`** — new `check_macos_tcc_grants()`: reads the local desktop bundle's designated requirement via `codesign -d --requirements -` and reports the class:
  - cdhash-pinned (pre-#73681 build) → warns that all TCC grants will reset on every update, recommends `hermes update`;
  - identifier-pinned → reports stable, and prints the exact stale-grant repair (`tccutil reset ScreenCapture com.nousresearch.hermes`, toggle ON, fully quit & relaunch) for users who still see prompts.
  - Silent on non-macOS and when no desktop bundle is installed.
- **`hermes_cli/update_cmd.py`** — after a successful update on macOS with a desktop app installed, print the one-line stale-grant guidance so affected users can complete the re-grant immediately after the rebuild that invalidated it.
- **`website/docs/user-guide/desktop.md`** — corrects the "grants persist across updates out of the box" claim: new grants do persist, but pre-fix grants need a one-time reset/re-grant (the toggle-ON-but-still-prompting trap).
- **`tests/hermes_cli/test_doctor.py`** — 6 tests: platform guard, no-bundle silence, cdhash-pinned warning, identifier-pinned ok + repair info, unreadable DR, empty-string DR (no false positive).

## Verification

- `pytest tests/hermes_cli/test_doctor.py -q` → **58 passed** (52 existing + 6 new)
- Live macOS 26.5.2 validation (issue #86385): repair sequence verified end-to-end; post-repair `hermes update` rebuilt the bundle (cdhash `1ee64e6c…` → `ae310657…`) and captures returned `Auth Right: Allowed (System Set)` with **zero** `Failed to match` events — the identifier-only DR holds across rebuilds.

## Notes

- The check cannot read TCC.db directly (requires Full Disk Access), so it reports the DR class and prints the repair rather than detecting the stale row itself.
- Existing post-#73681 grants are unaffected; this only adds detection + guidance for the pre-fix stale-grant population.
- Note on signing identity: the post-update notice currently prints for all macOS desktop installs. A user with `desktop.macos_signing_identity` configured (certificate-anchored) won't hit cdhash invalidation, but keeping the check universal avoids silent failure if their cert config was bypassed. Open to maintaining this default unless maintainers prefer filtering by signing config.

Closes #86385
