### PR TITLE
fix(tests): stop leaked tui notification pollers stealing later tests' completion queues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -431,6 +431,7 @@ markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",
     "real_agent_prewarm: opt out of the autouse stub that disables the tui_gateway deferred agent pre-warm timer",
+    "real_notification_poller: opt out of the autouse stub that disables the tui_gateway session notification poller thread",
     "requires_wal: needs the runtime to actually enable SQLite WAL mode (skipped where Hermes falls back to journal_mode=DELETE)",
     "no_isolate: opt out of per-file subprocess isolation (tests share mutable module-level state)",
     "ssh: marks tests requiring a reachable SSH server (skipped in normal CI)",

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -56,6 +56,37 @@ def _neuter_agent_prewarm_timer(request, monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def _neuter_notification_poller(request, monkeypatch):
+    """Stub the session notification poller for every test in this module.
+
+    Any path that reaches ``_init_session`` (eager ``session.resume``,
+    ``_start_agent_build``'s build thread, direct calls) starts a
+    ``_notification_poller_loop`` daemon thread. Nothing here ever sets the
+    session's ``_notif_stop`` event or ``_finalized`` flag, so that thread
+    OUTLIVES its test and keeps reading the process-global
+    ``process_registry.completion_queue`` *attribute* — which resolves to
+    whatever "isolated" Queue a later test has monkeypatched in. Its
+    belongs-elsewhere branch then steal-requeues that test's events (a queue
+    rotation), and its dispatch branch can consume them outright — the
+    intermittent set() == {batch_2, batch_3} failure in
+    test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_threading.
+
+    Tests that exercise the poller itself call
+    ``_notification_poller_loop`` directly and are unaffected. A test that
+    genuinely needs the real thread can opt back in with
+    ``@pytest.mark.real_notification_poller`` — it then owns stopping it
+    (set the returned Event AND join) before returning.
+    """
+    if request.node.get_closest_marker("real_notification_poller"):
+        yield
+        return
+    monkeypatch.setattr(
+        server, "_start_notification_poller", lambda *_a, **_k: threading.Event()
+    )
+    yield
+
+
 def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -5533,14 +5564,17 @@ def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_thread
         assert nested_started.wait(timeout=5)
         threads[0].join(timeout=5)
         assert not threads[0].is_alive()
-        # Membership, not order: the completion_queue is process-global, and
-        # notification pollers leaked by earlier session.init tests in this
-        # file legitimately steal-and-requeue foreign-session events (see
-        # _notification_poller_loop's belongs-elsewhere branch), rotating the
-        # queue. The requeue contract is that batch_2 and batch_3 both remain
-        # queued (never consumed) while batch_1's turn is in flight — so drain
-        # with a deadline (an event may be transiently held by a poller
-        # mid-cycle) and assert exactly {batch_2, batch_3} come back.
+        # Membership, not order: this test's requeue contract is that batch_2
+        # and batch_3 both remain queued (never consumed as turns) while
+        # batch_1's turn is in flight. That contract depends on batch_1 being
+        # drained FIRST — drain_notifications preserves queue order, so any
+        # rotation of the isolated queue before the post-turn drain breaks it:
+        # batch_2/batch_3 then dispatch as instant turns instead of being
+        # requeued, and this drain loop comes up empty. Notification pollers
+        # leaked by earlier tests did exactly that (see the
+        # _neuter_notification_poller autouse fixture at the top of this
+        # file). Drain with a deadline as defense-in-depth and assert exactly
+        # {batch_2, batch_3} come back.
         queued: dict = {}
         deadline = time.time() + 5.0
         while time.time() < deadline and set(queued) != {

--- a/tests/tui_gateway/test_review_summary_callback.py
+++ b/tests/tui_gateway/test_review_summary_callback.py
@@ -11,6 +11,7 @@ transcript line.
 
 from __future__ import annotations
 
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -58,6 +59,11 @@ def test_init_session_attaches_background_review_callback(server, monkeypatch):
     monkeypatch.setattr(server, "_session_info", lambda agent, session=None: {"model": "m"})
     monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
     monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "all")
+    # A real poller daemon thread would outlive the test and keep stealing
+    # events off process_registry.completion_queue in later tests.
+    monkeypatch.setattr(
+        server, "_start_notification_poller", lambda *_a, **_k: threading.Event()
+    )
 
     captured_emits: list = []
     monkeypatch.setattr(
@@ -111,6 +117,10 @@ def test_review_summary_callback_survives_agent_without_attribute(server, monkey
     monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
     monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "all")
     monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    # Same poller-leak guard as above.
+    monkeypatch.setattr(
+        server, "_start_notification_poller", lambda *_a, **_k: threading.Event()
+    )
 
     class LockedAgent:
         __slots__ = ("model",)


### PR DESCRIPTION
## What does this PR do?

This PR removes a flaky test failure. The fault is in the tests, not in the server code.

`test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_threading` passes in some runs and fails in other runs:

```
assert set(queued) == {"proc_batch_2", "proc_batch_3"}
AssertionError: assert set() == {'proc_batch_...proc_batch_3'}
[gateway-turn] TimeoutError: notification turn was not released
```

**Root cause.** Some tests call `_init_session`. This call starts a real `_notification_poller_loop` daemon thread (`tui_gateway/server.py:6857`). The teardown of these tests removes the session dict. The teardown does not set `_notif_stop` and does not set `_finalized`. As a result, the leaked thread runs until the interpreter exits.

The leaked thread reads the `process_registry.completion_queue` attribute each 0.5 s. A later test replaces this attribute with an "isolated" queue (monkeypatch). The leaked thread sees the new queue. The belongs-elsewhere branch (`server.py:9371`) takes each event and puts it back at the end of the queue. This rotates the queue.

`drain_notifications` keeps the queue order. The flaky test needs `proc_batch_1` at the front of the queue: its turn must block while the other two events wait. After a rotation, `proc_batch_3` starts a turn first. Then the turn for `proc_batch_1` blocks the 5 s release window. The drain loop finds no events. The assertion sees an empty set.

The leak has two sources: `test_init_session_fires_reset_hook` in `tests/test_tui_gateway_server.py`, and two `_init_session` tests in `tests/tui_gateway/test_review_summary_callback.py`.

**Proof.**

- A thread dump at the time of failure shows the leaked `Thread-17 (_notification_poller_loop)`. The dump also shows that `proc_batch_3` became a turn before `proc_batch_1`. This order is the rotation signature.
- A throwaway test leaked one poller in the same way, then installed a counting queue. The leaked poller made 20 get calls in 2 s with no other actor present.
- A manual rotation of one step causes the same failure on each run.

## Related Issue

No issue exists. The failure appeared in local runs of the test suite.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/test_tui_gateway_server.py`: add the autouse fixture `_neuter_notification_poller`. The fixture stubs `_start_notification_poller` for the whole module. It mirrors the existing `_neuter_agent_prewarm_timer` fixture. Also correct the stale comment in the flaky test. The old comment said that the requeue by a foreign poller was legitimate. That behavior was the bug. The deadline-drain loop stays as defense in depth.
- `tests/tui_gateway/test_review_summary_callback.py`: add the same stub to the two `_init_session` tests. This file cannot see the fixture in the other module.
- `pyproject.toml`: register the `real_notification_poller` marker. A test with this marker gets the real poller thread. That test must then stop the thread before it returns.

Tests that examine the poller call `_notification_poller_loop` directly. The stub does not touch them. `tests/tui_gateway/test_session_db_ownership_teardown.py` already stubs the poller in the same way.

## How to Test

1. On `main` without this patch, run: `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/test_tui_gateway_server.py`
2. Repeat the run 3 times. The requeue test fails in about 2 of 3 runs.
3. Apply this patch. Run the same command 5 times. All runs pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — via `scripts/run_tests.sh` (the CI-parity wrapper) on the two touched files
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — the fix hardens existing tests
- [x] I've tested on my platform: NixOS (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the fixture docstring documents the leak and the marker
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change is thread stubbing only, with no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before the fix, with `HERMES_TEST_FILE_RETRIES=0`:

```
=== Summary: 1 files, 552 tests passed, 0 failed ===
=== Summary: 1 files, 551 tests passed, 1 failed ===
FAILED tests/test_tui_gateway_server.py::test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_threading
⚠ FLAKY: failed on attempt 1, passed on retry (attempt 2).
```

After the fix, 5 of 5 runs (4 on the dev branch, 1 rebased on current `main`):

```
=== Summary: 2 files, 561 tests passed, 0 failed (100% complete) in 46.8s (32 workers) ===
=== Summary: 2 files, 561 tests passed, 0 failed (100% complete) in 44.5s (32 workers) ===
=== Summary: 2 files, 561 tests passed, 0 failed (100% complete) in 44.8s (32 workers) ===
=== Summary: 2 files, 561 tests passed, 0 failed (100% complete) in 59.2s (32 workers) ===
=== Summary: 2 files, 561 tests passed, 0 failed (100% complete) in 48.1s (32 workers) ===
```

The wall time for the file decreases from about 107 s to about 45 s. The leaked pollers burned CPU in every later test.
