### PR TITLE
fix(email-gateway): use IMAP BODY.PEEK[] so inbound mail keeps its unread state

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -835,7 +835,13 @@ class EmailAdapter(BasePlatformAdapter):
                     if uid in self._seen_uids:
                         continue
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    # Use BODY.PEEK[] instead of RFC822 so the fetch does not set the
+                    # \Seen flag on the server. RFC822 is aliased to BODY[]
+                    # by RFC 3501; Gmail (and most IMAP servers) auto-flag
+                    # any non-PEEK body fetch, which silently marks incoming
+                    # mail as read for every user of the gateway. PEEK returns
+                    # identical bytes without touching flags.
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         # Transient per-UID fetch refusal: leave the UID out of
                         # _seen_uids so the next poll retries it.


### PR DESCRIPTION
## Summary

The email platform adapter (`plugins/platforms/email/adapter.py`) fetches every incoming message with `IMAP UID FETCH <uid> (RFC822)`. Per [RFC 3501 §6.4.5](https://datatracker.ietf.org/doc/html/rfc3501#section-6.4.5), `RFC822` is a synonym for `BODY[]` — a non-PEEK body fetch — and the server is required to set the `\Seen` flag as a side effect.

Because the gateway needs the body to run its automated-sender / DMARC / addressed-to-agent checks, it fetches **every** UNSEEN message in the inbox — not just messages actually addressed to the agent. The result: every inbound email is silently marked read on the server before the user ever sees it in their normal mail client. On Gmail this is especially noticeable because the "unread" bolding disappears from all fresh mail.

The user cannot disable this behaviour without disabling the email platform entirely, and there is no configuration option to opt into PEEK semantics.

## Fix

One-line change from `(RFC822)` to `(BODY.PEEK[])`. Per RFC 3501 §6.4.5, `BODY.PEEK[]` returns byte-for-byte identical content but explicitly instructs the server NOT to update the `\Seen` flag. All downstream parsing (`email_lib.message_from_bytes`, header extraction, DMARC check, dispatch) is unchanged because the bytes returned are the same.

## Reproduction

1. Configure the email platform against any IMAP server (Gmail confirmed).
2. Send a test message to the connected mailbox from another account.
3. Observe in the mail client of choice that the message arrives, is briefly unread, and is marked read within one poll interval — even though the gateway never surfaced it to the agent (it was filtered out as "not addressed to the agent").

After this patch, step 3 no longer happens: the message stays unread on the server.

## Impact / risk

- **Behaviour change for the gateway's own logic:** none. It processes the same messages the same way.
- **Behaviour change on the mailbox:** previously-marked-read messages are not un-marked (server-side only). Only future mail is preserved.
- **Compatibility:** `BODY.PEEK[]` is mandatory-to-implement for IMAP4rev1 ([RFC 3501](https://datatracker.ietf.org/doc/html/rfc3501)) and IMAP4rev2 ([RFC 9051](https://datatracker.ietf.org/doc/html/rfc9051)). Every server the adapter can currently connect to supports it.

## Test plan

- [x] Manual: applied the patch to a running deployment against a Gmail account; sent a test message and confirmed it stayed unread on both webmail and mobile clients after the next poll interval.
- [ ] Unit test — happy to add one if the maintainers point me at the preferred harness for adapter tests; couldn't find an existing fixture for the email platform.
