### PR TITLE
fix(desktop): sync active profile after reconnect

### DIFF
--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -14,21 +14,36 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const gatewayMocks = vi.hoisted(() => ({
   connect: vi.fn(async (_wsUrl: string): Promise<void> => {
     throw new Error('dialed a socket for a shared-primary profile')
-  })
+  }),
+  setConnection: vi.fn()
 }))
 
 vi.mock('@/hermes', () => ({
   HermesGateway: class {
     connectionState = 'closed'
-    connect = gatewayMocks.connect
+    connect = async (wsUrl: string): Promise<void> => {
+      await gatewayMocks.connect(wsUrl)
+      this.connectionState = 'open'
+    }
+    close = vi.fn()
     onEvent = vi.fn(() => () => {})
     onState = vi.fn(() => () => {})
   }
 }))
-vi.mock('@/store/session', () => ({ setGatewayState: vi.fn() }))
+vi.mock('@/store/session', () => ({
+  setConnection: gatewayMocks.setConnection,
+  setGatewayState: vi.fn()
+}))
 vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
 
-const { $gateway, configureGatewayRegistry, ensureGatewayForProfile, setPrimaryGateway } = await import('./gateway')
+const {
+  $gateway,
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  ensureActiveGatewayOpen,
+  ensureGatewayForProfile,
+  setPrimaryGateway
+} = await import('./gateway')
 
 type DesktopStub = { getConnection: ReturnType<typeof vi.fn> }
 
@@ -49,6 +64,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  closeSecondaryGateways()
   vi.clearAllMocks()
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
 })
@@ -94,5 +110,34 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
     expect(gatewayMocks.connect).toHaveBeenCalledOnce()
     expect(gatewayMocks.connect).toHaveBeenCalledWith(remoteWsUrl)
     expect($gateway.get()).not.toBe(primary)
+  })
+
+  it('refreshes the active connection after a pooled profile reconnect succeeds', async () => {
+    const connection = {
+      authMode: 'token',
+      baseUrl: 'https://worker.invalid',
+      mode: 'remote',
+      profile: 'worker',
+      token: 'fake-test-token',
+      wsUrl: 'wss://worker.invalid/api/ws?token=fake-test-token'
+    }
+
+    const getConnection = vi.fn(async () => connection)
+
+    setPrimaryGateway(makePrimary() as never, 'default')
+    installDesktop({ getConnection })
+
+    gatewayMocks.connect
+      .mockRejectedValueOnce(new Error('temporarily offline'))
+      .mockResolvedValueOnce(undefined)
+
+    await ensureGatewayForProfile('worker')
+
+    expect(gatewayMocks.setConnection).not.toHaveBeenCalled()
+
+    await ensureActiveGatewayOpen()
+
+    expect(gatewayMocks.setConnection).toHaveBeenCalledOnce()
+    expect(gatewayMocks.setConnection).toHaveBeenCalledWith(connection)
   })
 })

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -4,7 +4,7 @@ import { atom } from 'nanostores'
 import { HermesGateway } from '@/hermes'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
 import { markNativeNotifyBaseline } from '@/store/notify-baseline'
-import { setGatewayState } from '@/store/session'
+import { setConnection, setGatewayState } from '@/store/session'
 
 // ── Multi-profile gateway routing ──────────────────────────────────────────
 // Concurrent sessions across profiles need concurrent sockets: the renderer's
@@ -177,6 +177,11 @@ async function openSecondary(entry: Secondary): Promise<void> {
   const conn = await desktop.getConnection(entry.profile)
   const wsUrl = await resolveGatewayWsUrl(desktop, conn)
   await entry.gateway.connect(wsUrl)
+
+  if (g.activeKey === entry.profile) {
+    setConnection(conn)
+  }
+
   void desktop.touchBackend?.(entry.profile).catch(() => undefined)
 }
 


### PR DESCRIPTION
## Summary

- refresh the renderer's active connection descriptor when an active secondary profile reconnects successfully
- keep background secondary connections from replacing the foreground profile's connection state
- cover the delayed reconnect path where initial profile activation fails and a later retry succeeds

This fixes stale remote-host UI such as the status bar continuing to show the primary server after an isolated remote profile has connected.

## Validation

- `npm test -- --project ui src/store/gateway-shared-remote.test.ts src/store/profile.test.ts`
- `npm run typecheck`
- `npx eslint src/store/gateway.ts src/store/gateway-shared-remote.test.ts`