### PR TITLE
feat(desktop): ship Linux AppImage on GitHub Release

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,106 @@
+# Build and attach Hermes Desktop installers to a GitHub Release.
+#
+# macOS DMG/zip, Windows NSIS/MSI, and Linux AppImage are produced on the
+# matching runners and uploaded next to the Python release created by
+# `scripts/release.py --publish`.
+#
+# Triggers:
+#   - release published (automatic)
+#   - workflow_dispatch with a tag (rebuild / attach to an existing release)
+name: Desktop Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attach installers to (e.g. v1.2.3)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: desktop-release-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  package:
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            label: macOS
+            dist: dist:mac
+            artifact: 'apps/desktop/release/Hermes-*.dmg apps/desktop/release/Hermes-*.zip'
+          - os: windows-latest
+            label: Windows
+            dist: dist:win
+            artifact: 'apps/desktop/release/Hermes-*.exe apps/desktop/release/Hermes-*.msi'
+          - os: ubuntu-latest
+            label: Linux AppImage
+            dist: dist:linux:appimage
+            artifact: 'apps/desktop/release/Hermes-*.AppImage'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 26
+          cache: npm
+
+      - name: grab npm 12
+        run: |
+          npm --version | grep -q '^12\.' || npm i -g npm@12
+        shell: bash
+
+      - uses: ./.github/actions/retry
+        with:
+          command: npm ci
+
+      - name: Linux AppImage system deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq libfuse2
+
+      - name: Build ${{ matrix.label }} installer
+        working-directory: apps/desktop
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+        run: npm run ${{ matrix.dist }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: desktop-${{ matrix.label }}
+          path: ${{ matrix.artifact }}
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Attach to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(${{ matrix.artifact }})
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No installer files matched ${{ matrix.artifact }}"
+            exit 1
+          fi
+          gh release upload "$TAG" "${files[@]}" --clobber

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -83,7 +83,10 @@ npm run dist:linux   # AppImage + deb + rpm
 npm run pack         # unpacked app under release/ (no installer)
 ```
 
-Installers are built and uploaded to GitHub Releases manually. macOS/Windows signing & notarization happen automatically when the relevant credentials are present in the environment (`CSC_LINK` / `CSC_KEY_PASSWORD` / `APPLE_*` for macOS, `WIN_CSC_*` for Windows).
+Installers are built by `.github/workflows/desktop-release.yml` on every GitHub
+Release (macOS DMG/zip, Windows NSIS/MSI, Linux AppImage) and can also be
+uploaded manually. macOS/Windows signing & notarization happen automatically when the relevant credentials are present in the environment (`CSC_LINK` / `CSC_KEY_PASSWORD` / `APPLE_*` for macOS, `WIN_CSC_*` for Windows).
+
 
 ### How it works
 

--- a/apps/desktop/electron/bootstrap-platform.test.ts
+++ b/apps/desktop/electron/bootstrap-platform.test.ts
@@ -7,7 +7,8 @@ import {
   detectRemoteDisplay,
   isWindowsBinaryPathInWsl,
   isWslEnvironment,
-  resolveLinuxPasswordStore
+  resolveLinuxPasswordStore,
+  resolveOzonePlatformHint
 } from './bootstrap-platform'
 
 test('isWslEnvironment detects WSL2 env vars on linux', () => {
@@ -123,3 +124,35 @@ test('resolveLinuxPasswordStore warns on unknown values instead of applying them
   assert.equal(result.store, null)
   assert.match(String(result.warning), /keychain-of-wonders/)
 })
+
+test('resolveOzonePlatformHint defaults to auto on native Wayland', () => {
+  assert.deepEqual(
+    resolveOzonePlatformHint({ env: { WAYLAND_DISPLAY: 'wayland-1' }, platform: 'linux' }),
+    { hint: 'auto', warning: null }
+  )
+})
+
+test('resolveOzonePlatformHint stays off on X11 and non-linux', () => {
+  assert.deepEqual(resolveOzonePlatformHint({ env: { DISPLAY: ':0' }, platform: 'linux' }), {
+    hint: null,
+    warning: null
+  })
+  assert.deepEqual(
+    resolveOzonePlatformHint({ env: { WAYLAND_DISPLAY: 'wayland-0' }, platform: 'darwin' }),
+    { hint: null, warning: null }
+  )
+})
+
+test('resolveOzonePlatformHint honors explicit overrides', () => {
+  assert.equal(
+    resolveOzonePlatformHint({ env: { HERMES_DESKTOP_OZONE_PLATFORM_HINT: 'x11' }, platform: 'linux' }).hint,
+    'x11'
+  )
+  assert.match(
+    String(
+      resolveOzonePlatformHint({ env: { HERMES_DESKTOP_OZONE_PLATFORM_HINT: 'quartz' }, platform: 'linux' }).warning
+    ),
+    /quartz/
+  )
+})
+

--- a/apps/desktop/electron/bootstrap-platform.ts
+++ b/apps/desktop/electron/bootstrap-platform.ts
@@ -141,10 +141,48 @@ function resolveLinuxPasswordStore(options: { env?: NodeJS.ProcessEnv; platform?
   return { store: requested, warning: null }
 }
 
+const OZONE_HINTS: Record<string, true> = { auto: true, wayland: true, x11: true }
+
+
+/**
+ * Chromium Ozone platform for Linux. `auto` picks native Wayland when
+ * WAYLAND_DISPLAY is set, otherwise X11 — the right default for AppImage
+ * on Hyprland/Sway/GNOME without bricking X11/VNC. Override with
+ * HERMES_DESKTOP_OZONE_PLATFORM_HINT. Must be applied before app `ready`.
+ */
+function resolveOzonePlatformHint(options: { env?: NodeJS.ProcessEnv; platform?: NodeJS.Platform } = {}) {
+  const env = options.env ?? process.env
+  const platform = options.platform ?? process.platform
+  const requested = String(env.HERMES_DESKTOP_OZONE_PLATFORM_HINT || '')
+    .trim()
+    .toLowerCase()
+
+  if (requested) {
+    if (OZONE_HINTS[requested]) {
+      return { hint: requested, warning: null }
+    }
+
+    return {
+      hint: null,
+      warning: `Unknown HERMES_DESKTOP_OZONE_PLATFORM_HINT "${requested}" (use auto, wayland, or x11).`
+    }
+  }
+
+  if (platform === 'linux' && env.WAYLAND_DISPLAY) {
+    return { hint: 'auto', warning: null }
+  }
+
+  return { hint: null, warning: null }
+}
+
+
+
 export {
   bundledRuntimeImportCheck,
   detectRemoteDisplay,
   isWindowsBinaryPathInWsl,
   isWslEnvironment,
-  resolveLinuxPasswordStore
+  resolveLinuxPasswordStore,
+  resolveOzonePlatformHint
 }
+

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -50,8 +50,10 @@ import {
   detectRemoteDisplay,
   isWindowsBinaryPathInWsl,
   isWslEnvironment,
-  resolveLinuxPasswordStore
+  resolveLinuxPasswordStore,
+  resolveOzonePlatformHint
 } from './bootstrap-platform'
+
 import { decideBootstrapRepair } from './bootstrap-repair-guard'
 import { runBootstrap } from './bootstrap-runner'
 import { applyConnectionChange, resolveTerminalConnection } from './connection-apply'
@@ -359,6 +361,18 @@ if (PASSWORD_STORE.store) {
   app.commandLine.appendSwitch('password-store', PASSWORD_STORE.store)
   console.log(`[hermes] using password-store backend: ${PASSWORD_STORE.store}`)
 }
+
+const OZONE = resolveOzonePlatformHint()
+
+if (OZONE.warning) {
+  console.warn(`[hermes] ${OZONE.warning}`)
+}
+
+if (OZONE.hint) {
+  app.commandLine.appendSwitch('ozone-platform-hint', OZONE.hint)
+  console.log(`[hermes] ozone-platform-hint=${OZONE.hint}`)
+}
+
 
 // Windows sandbox / GPU breakpoint crash recovery (#38216).
 //

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,8 +1,11 @@
 {
   "name": "hermes",
   "productName": "Hermes",
+  "desktopName": "Hermes",
   "private": true,
   "version": "0.17.0",
+
+
   "description": "Native desktop shell for Hermes Agent.",
   "author": "Nous Research",
   "type": "module",
@@ -37,6 +40,8 @@
     "dist:win:msi": "npm run build && npm run builder -- --win msi",
     "dist:win:nsis": "npm run build && npm run builder -- --win nsis",
     "dist:linux": "npm run build && npm run builder -- --linux AppImage deb rpm",
+    "dist:linux:appimage": "npm run build && npm run builder -- --linux AppImage",
+
     "perf": "node scripts/perf/run.mjs",
     "update:shim": "bash ../../scripts/desktop-update/repro.sh shim",
     "update:shim:fail": "bash ../../scripts/desktop-update/repro.sh shim-fail",
@@ -50,8 +55,10 @@
     "test:desktop:all": "node scripts/test-desktop.mjs all",
     "test:desktop:dmg": "node scripts/test-desktop.mjs dmg",
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
+    "test:desktop:appimage": "node scripts/test-desktop.mjs appimage",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
+
     "typecheck": "tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit && tsc -p tsconfig.e2e.json --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",
@@ -268,12 +275,22 @@
       "category": "Development",
       "maintainer": "Nous Research <support@nousresearch.com>",
       "synopsis": "Native desktop shell for Hermes Agent.",
+      "syncDesktopName": true,
+      "desktop": {
+        "entry": {
+          "StartupWMClass": "Hermes",
+          "MimeType": "x-scheme-handler/hermes;"
+        }
+      },
       "target": [
         "AppImage",
         "deb",
         "rpm"
       ]
     },
+
+
+
     "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,

--- a/apps/desktop/scripts/test-desktop.mjs
+++ b/apps/desktop/scripts/test-desktop.mjs
@@ -178,6 +178,38 @@ function ensureNsis() {
   run('npm', ['run', 'dist:win:nsis'])
 }
 
+function resolveAppImagePath() {
+  if (!exists(RELEASE_ROOT)) {
+    return path.join(RELEASE_ROOT, `Hermes-${PACKAGE_JSON.version}-linux-${ARCH}.AppImage`)
+  }
+
+  const prefix = `Hermes-${PACKAGE_JSON.version}`
+  const candidates = fs
+    .readdirSync(RELEASE_ROOT)
+    .filter(name => name.endsWith('.AppImage'))
+    .filter(name => name.startsWith(prefix))
+    .sort((a, b) => {
+      const aMtime = fs.statSync(path.join(RELEASE_ROOT, a)).mtimeMs
+      const bMtime = fs.statSync(path.join(RELEASE_ROOT, b)).mtimeMs
+      return bMtime - aMtime
+    })
+
+  return candidates.length > 0
+    ? path.join(RELEASE_ROOT, candidates[0])
+    : path.join(RELEASE_ROOT, `Hermes-${PACKAGE_JSON.version}-linux-${ARCH}.AppImage`)
+}
+
+function ensureAppImage() {
+  if (PLATFORM !== 'linux') {
+    die('AppImage mode is Linux-only; on macOS use `dmg`, on Windows use `nsis`.')
+  }
+  if (process.env.HERMES_DESKTOP_SKIP_BUILD === '1' && exists(resolveAppImagePath())) {
+    return
+  }
+  run('npm', ['run', 'dist:linux:appimage'])
+}
+
+
 function openApp() {
   if (!exists(APP.binary)) {
     die(`Missing packaged app: ${APP.binary}`)
@@ -387,7 +419,10 @@ function printArtifacts(options = {}) {
   } else if (PLATFORM === 'win32') {
     const exe = resolveNsisPath()
     if (exe) console.log(`  installer: ${exe}`)
+  } else {
+    console.log(`  appimage: ${resolveAppImagePath()}`)
   }
+
   console.log(`  runtime: ${runtimeRoot}`)
   if (stamp) {
     console.log(`  install-stamp: ${stamp.commit.slice(0, 12)} on ${stamp.branch}`)
@@ -403,6 +438,7 @@ function help() {
   npm run test:desktop:fresh     # build packaged app, launch with temp userData + HERMES_HOME
   npm run test:desktop:dmg       # (macOS only) build DMG and open it
   npm run test:desktop:nsis      # (win32 only) build NSIS installer
+  npm run test:desktop:appimage  # (Linux only) build AppImage
   npm run test:desktop:all       # build installer, validate app payload, print paths
 
 Fast rerun (skip rebuild if the packaged app already exists):
@@ -428,15 +464,19 @@ if (MODE === 'existing') {
 } else if (MODE === 'nsis') {
   ensureNsis()
   printArtifacts(validateBundle())
+} else if (MODE === 'appimage') {
+  ensureAppImage()
+  printArtifacts(validateBundle())
 } else if (MODE === 'all') {
   if (PLATFORM === 'darwin') {
     ensureDmg()
   } else if (PLATFORM === 'win32') {
     ensureNsis()
   } else {
-    ensurePackagedApp()
+    ensureAppImage()
   }
   printArtifacts(validateBundle())
 } else {
   help()
 }
+

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2616,6 +2616,11 @@ def main():
             changelog_file.unlink(missing_ok=True)
             print(f"  ✓ GitHub release created: {result.stdout.strip()}")
             print(f"\n  🎉 Release v{new_version} ({tag_name}) published!")
+            print(
+                "  Desktop installers (macOS DMG, Windows NSIS/MSI, Linux AppImage) "
+                "are built by .github/workflows/desktop-release.yml and attached to this release."
+            )
+
         else:
             if result is None:
                 print("  ✗ GitHub release skipped: `gh` CLI not found.")

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -373,10 +373,12 @@ Build installers:
 npm run dist:mac     # DMG + zip
 npm run dist:win     # NSIS + MSI
 npm run dist:linux   # AppImage + deb + rpm
+npm run dist:linux:appimage  # AppImage only
 npm run pack         # unpacked app under release/ (no installer)
 ```
 
-macOS/Windows signing and notarization run automatically when the relevant credentials are present in the environment (`CSC_LINK` / `CSC_KEY_PASSWORD` / `APPLE_*` for macOS, `WIN_CSC_*` for Windows).
+GitHub Releases attach those installers via `.github/workflows/desktop-release.yml` (macOS, Windows, and Linux AppImage). macOS/Windows signing and notarization run automatically when the relevant credentials are present in the environment (`CSC_LINK` / `CSC_KEY_PASSWORD` / `APPLE_*` for macOS, `WIN_CSC_*` for Windows).
+
 
 ### macOS permissions and local rebuilds (TCC)
 


### PR DESCRIPTION
## Summary
- Add `.github/workflows/desktop-release.yml` so a published GitHub Release (and `workflow_dispatch` with a tag) builds macOS DMG/zip, Windows NSIS/MSI, and Linux AppImage and attaches them to that release.
- `scripts/release.py --publish` notes that Desktop installers come from this workflow.
- Prefer `ozone-platform-hint=auto` on native Wayland so the AppImage uses the compositor instead of XWayland.

## Test plan
- [x] Local `vite build` + `electron-builder --linux AppImage` produces `apps/desktop/release/Hermes-0.17.0-linux-x86_64.AppImage`
- [ ] After merge, `workflow_dispatch` on an existing tag (or the next `release.py --publish`) attaches the three installer sets

---

**Stack** (merge bottom → top)

1. **#86397** feat(desktop): ship Linux AppImage on GitHub Release ← you are here
2. #86398 feat(desktop): attach SSH remotes to existing serve