### PR TITLE
feat(desktop): add push-to-dictate composer hotkey

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -49,6 +49,7 @@ const ATTACH_IMAGES_EVENT = 'hermes:composer-attach-images'
 const INSERT_REFS_EVENT = 'hermes:composer-insert-refs'
 const SUBMIT_EVENT = 'hermes:composer-submit'
 const VOICE_TOGGLE_EVENT = 'hermes:composer-voice-toggle'
+const DICTATE_EVENT = 'hermes:composer-dictate'
 const MODEL_MENU_EVENT = 'hermes:composer-model-menu'
 
 /** Inline edit composer root — mounted only while a user bubble is being edited. */
@@ -281,6 +282,18 @@ export const requestVoiceToggle = (target: ComposerTarget | 'active' = 'active')
 
 export const onComposerVoiceToggleRequest = (handler: (target: ComposerTarget) => void) =>
   subscribe<{ target: ComposerTarget }>(VOICE_TOGGLE_EVENT, ({ target }) => handler(target))
+
+export type DictateRequest = 'cancel' | 'start' | 'stop' | 'toggle'
+
+/** Route dictation to the focused composer (or the visible main composer).
+ * This is intentionally separate from `composer.voice`: dictation only edits
+ * the draft and never submits a conversation turn. */
+export const requestComposerDictate = (request: DictateRequest, target: ComposerTarget | 'active' = 'active') =>
+  dispatch<{ request: DictateRequest; target: ComposerTarget }>(DICTATE_EVENT, { request, target: resolve(target) })
+
+export const onComposerDictateRequest = (
+  handler: (detail: { request: DictateRequest; target: ComposerTarget }) => void
+) => subscribe<{ request: DictateRequest; target: ComposerTarget }>(DICTATE_EVENT, handler)
 
 /** The chat surface inside the zone the pointer is over, if any. Mirrors the
  *  tab verbs' hover-first targeting (`tabTargetGroupId`, #74447): the model

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -13,7 +13,7 @@ import { $autoSpeakReplies, $voiceStopPhrase, setAutoSpeakReplies } from '@/stor
 import { resumeWakeAfterVoice } from '@/store/wake-word'
 
 import type { ComposerTarget } from '../focus'
-import { onComposerVoiceToggleRequest } from '../focus'
+import { onComposerDictateRequest, onComposerVoiceToggleRequest } from '../focus'
 import { useComposerScope } from '../scope'
 import type { ChatBarProps } from '../types'
 
@@ -65,12 +65,61 @@ export function useComposerVoice({
   const lastSpokenIdRef = useRef<string | null>(null)
   const ownsWakeIndicatorRef = useRef(false)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
+  const dictationStartingRef = useRef(false)
+  const dictationStopRequestedRef = useRef(false)
+  const dictationCancelRequestedRef = useRef(false)
+  // Key events can arrive before React paints the recorder status update.
+  // Keep the live capture truth in a ref so a quick hold/release cannot strand
+  // the mic waiting for its duration cap.
+  const dictationActiveRef = useRef(false)
+  const voiceConversationActiveRef = useRef(voiceConversationActive)
+  voiceConversationActiveRef.current = voiceConversationActive
 
-  const { dictate, voiceActivityState, voiceStatus } = useVoiceRecorder({
+  const wakePausedRef = useRef(false)
+  // Resolves once the in-flight wake.pause round-trip completes (mic released by
+  // the wake listener). Both conversation and dictation await this before
+  // opening the recorder, so Windows never sees two clients fighting for it.
+  const wakePauseBarrierRef = useRef<Promise<void> | null>(null)
+
+  const resumeWakeIfPaused = useCallback(() => {
+    if (!wakePausedRef.current) {
+      return
+    }
+
+    wakePausedRef.current = false
+    wakePauseBarrierRef.current = null
+    void resumeWakeAfterVoice()
+  }, [])
+
+  // The ref is a request token (did WE issue wake.pause?), not an atom mirror —
+  // it prevents either voice mode from rearming a detector owned elsewhere.
+  const pauseWakeForVoice = useCallback(() => {
+    wakePausedRef.current = true
+
+    const barrier = (async () => {
+      try {
+        await $gateway.get()?.request('wake.pause', {})
+      } catch {
+        // No wake listener / older backend — nothing held the mic.
+      }
+    })()
+
+    wakePauseBarrierRef.current = barrier
+
+    return barrier
+  }, [])
+
+  const finishDictation = useCallback(() => {
+    dictationActiveRef.current = false
+    resumeWakeIfPaused()
+  }, [resumeWakeIfPaused])
+
+  const { cancel, start, stop, voiceActivityState, voiceStatus } = useVoiceRecorder({
     focusInput,
     maxRecordingSeconds,
     onTranscript: insertText,
-    onTranscribeAudio
+    onTranscribeAudio,
+    onFinished: finishDictation
   })
 
   /** Auto-speak selector: the latest unspoken reply only — a backlog collapses to the newest. */
@@ -121,14 +170,6 @@ export function useComposerVoice({
     clearDraft()
     await onSubmit(text)
   }
-
-  const wakePausedRef = useRef(false)
-  // Resolves once the in-flight wake.pause round-trip completes (mic released by
-  // the wake listener). The conversation awaits this before opening its own mic
-  // so the two never contend for the device — on Windows especially, opening the
-  // capture device while the wake listener still holds it makes getUserMedia
-  // fail and the conversation never starts listening.
-  const wakePauseBarrierRef = useRef<Promise<void> | null>(null)
 
   const conversation = useVoiceConversation({
     busy,
@@ -199,37 +240,6 @@ export function useComposerVoice({
     }
   }, [disabled, target, voiceConversationActive, voiceStartRequest])
 
-  const resumeWakeIfPaused = useCallback(() => {
-    if (!wakePausedRef.current) {
-      return
-    }
-
-    wakePausedRef.current = false
-    wakePauseBarrierRef.current = null
-    // Reconcile, don't just resume: the wake word is a persistent setting, so
-    // ending a voice chat must re-arm the listener whenever config says
-    // enabled — including when the raw resume loses the mic-release race.
-    void resumeWakeAfterVoice()
-  }, [])
-
-  // The ref is a request token (did WE issue wake.pause?), not an atom mirror —
-  // it guards resumeWakeIfPaused from resuming a detector another surface owns.
-  const pauseWakeForVoice = useCallback(() => {
-    wakePausedRef.current = true
-
-    const barrier = (async () => {
-      try {
-        await $gateway.get()?.request('wake.pause', {})
-      } catch {
-        // No wake listener / older backend — nothing held the mic.
-      }
-    })()
-
-    wakePauseBarrierRef.current = barrier
-
-    return barrier
-  }, [])
-
   useEffect(() => {
     if (voiceConversationActive) {
       pauseWakeForVoice()
@@ -260,6 +270,100 @@ export function useComposerVoice({
 
   useEffect(() => resumeWakeIfPaused, [resumeWakeIfPaused])
 
+  const startDictation = useCallback(async () => {
+    // Conversation owns the shared recorder. Do not stop or alter it from a
+    // dictate key; a stray hold while talking must be a harmless no-op.
+    if (disabled || voiceConversationActiveRef.current || voiceStatus !== 'idle' || dictationStartingRef.current) {
+      return
+    }
+
+    dictationStartingRef.current = true
+    dictationStopRequestedRef.current = false
+    dictationCancelRequestedRef.current = false
+
+    try {
+      await pauseWakeForVoice()
+
+      if (voiceConversationActiveRef.current) {
+        resumeWakeIfPaused()
+
+        return
+      }
+
+      if (!(await start())) {
+        resumeWakeIfPaused()
+
+        return
+      }
+
+      dictationActiveRef.current = true
+
+      // The focus bus deliberately defers commands. A very short hold can
+      // therefore queue stop immediately after start, before React has painted
+      // `voiceStatus: 'recording'`; retain that intent instead of leaving mic
+      // capture open until max duration.
+      if (dictationCancelRequestedRef.current) {
+        cancel()
+      } else if (dictationStopRequestedRef.current) {
+        void stop()
+      }
+    } finally {
+      dictationStartingRef.current = false
+    }
+  }, [cancel, disabled, pauseWakeForVoice, resumeWakeIfPaused, start, stop, voiceStatus])
+
+  const stopDictation = useCallback(() => {
+    if (dictationStartingRef.current) {
+      dictationStopRequestedRef.current = true
+
+      return
+    }
+
+    if (dictationActiveRef.current) {
+      void stop()
+    }
+  }, [stop])
+
+  const cancelDictation = useCallback(() => {
+    if (dictationStartingRef.current) {
+      dictationCancelRequestedRef.current = true
+
+      return
+    }
+
+    if (dictationActiveRef.current) {
+      cancel()
+    }
+  }, [cancel])
+
+  const toggleDictation = useCallback(() => {
+    if (dictationActiveRef.current || dictationStartingRef.current) {
+      stopDictation()
+    } else {
+      void startDictation()
+    }
+  }, [startDictation, stopDictation])
+
+  useEffect(
+    () =>
+      onComposerDictateRequest(({ request, target: requestTarget }) => {
+        if (requestTarget !== target) {
+          return
+        }
+
+        if (request === 'start') {
+          void startDictation()
+        } else if (request === 'stop') {
+          stopDictation()
+        } else if (request === 'cancel') {
+          cancelDictation()
+        } else {
+          toggleDictation()
+        }
+      }),
+    [cancelDictation, startDictation, stopDictation, target, toggleDictation]
+  )
+
   // Explicit start/end for the on-screen conversation controls (the hotkey uses
   // the gated toggle above).
   const startConversation = useCallback(() => setVoiceConversationActive(true), [])
@@ -285,7 +389,7 @@ export function useComposerVoice({
 
   return {
     conversation,
-    dictate,
+    dictate: toggleDictation,
     endConversation,
     handleToggleAutoSpeak,
     startConversation,

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.tsx
@@ -1,0 +1,137 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { MicRecording } from './use-mic-recorder'
+
+const handle = {
+  cancel: vi.fn(),
+  start: vi.fn(async () => undefined),
+  stop: vi.fn<() => Promise<MicRecording | null>>(async () => ({
+    audio: new Blob(['audio']),
+    durationMs: 100,
+    heardSpeech: true
+  }))
+}
+
+const notify = vi.fn()
+
+vi.mock('./use-mic-recorder', () => ({
+  useMicRecorder: () => ({ handle, level: 0, recording: false })
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      notifications: {
+        voice: {
+          noSpeechDetected: 'No speech detected',
+          recordingFailed: 'Recording failed',
+          transcriptionFailed: 'Transcription failed',
+          transcriptionUnavailable: 'Transcription unavailable',
+          tryRecordingAgain: 'Try again',
+          unavailable: 'Unavailable'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/notifications', () => ({ notify, notifyError: vi.fn() }))
+
+import { useVoiceRecorder } from './use-voice-recorder'
+
+afterEach(() => {
+  handle.cancel.mockReset()
+  handle.start.mockClear()
+  handle.stop.mockClear()
+  notify.mockClear()
+})
+
+describe('useVoiceRecorder dictation', () => {
+  it('inserts a completed transcript into the draft callback without submitting', async () => {
+    const onTranscript = vi.fn()
+
+    const onSubmit = vi.fn()
+
+    const { result } = renderHook(() =>
+      useVoiceRecorder({
+        focusInput: vi.fn(),
+        maxRecordingSeconds: 30,
+        onTranscript,
+        onTranscribeAudio: vi.fn(async () => 'dictated words')
+      })
+    )
+
+    await act(async () => {
+      await result.current.start()
+      await result.current.stop()
+    })
+
+    expect(onTranscript).toHaveBeenCalledWith('dictated words')
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('warns and leaves the draft untouched for an empty transcript', async () => {
+    const onTranscript = vi.fn()
+
+    const { result } = renderHook(() =>
+      useVoiceRecorder({
+        focusInput: vi.fn(),
+        maxRecordingSeconds: 30,
+        onTranscript,
+        onTranscribeAudio: vi.fn(async () => '  ')
+      })
+    )
+
+    await act(async () => {
+      await result.current.start()
+      await result.current.stop()
+    })
+
+    expect(onTranscript).not.toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ kind: 'warning', title: 'No speech detected' }))
+  })
+
+  it('discards a transcription that completes after cancellation', async () => {
+    const onTranscript = vi.fn()
+    let completeTranscription: (text: string) => void = () => undefined
+
+    const transcription = new Promise<string>(resolve => {
+      completeTranscription = resolve
+    })
+
+    const onTranscribeAudio = vi.fn(() => transcription)
+
+    const { result } = renderHook(() =>
+      useVoiceRecorder({
+        focusInput: vi.fn(),
+        maxRecordingSeconds: 30,
+        onTranscript,
+        onTranscribeAudio
+      })
+    )
+
+    await act(async () => {
+      await result.current.start()
+    })
+
+    let stopping!: Promise<void>
+    await act(async () => {
+      stopping = result.current.stop()
+      await Promise.resolve()
+    })
+
+    expect(onTranscribeAudio).toHaveBeenCalledOnce()
+
+    act(() => {
+      result.current.cancel()
+    })
+
+    await act(async () => {
+      completeTranscription('discard this')
+      await stopping!
+    })
+
+    expect(onTranscript).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
@@ -12,13 +12,16 @@ interface VoiceRecorderOptions {
   onTranscribeAudio?: (audio: Blob) => Promise<string>
   focusInput: () => void
   onTranscript: (text: string) => void
+  /** Called after a recording is stopped or cancelled, including max duration. */
+  onFinished?: () => void
 }
 
 export function useVoiceRecorder({
   maxRecordingSeconds,
   onTranscribeAudio,
   focusInput,
-  onTranscript
+  onTranscript,
+  onFinished
 }: VoiceRecorderOptions) {
   const { t } = useI18n()
   const voiceCopy = t.notifications.voice
@@ -28,6 +31,9 @@ export function useVoiceRecorder({
   const startedAtRef = useRef(0)
   const intervalRef = useRef<number | null>(null)
   const timeoutRef = useRef<number | null>(null)
+  // Cancelling while transcription is in flight cannot abort every configured
+  // STT transport, but it must make its eventual response harmless.
+  const recordingGenerationRef = useRef(0)
 
   const clearTimers = () => {
     if (intervalRef.current) {
@@ -44,17 +50,26 @@ export function useVoiceRecorder({
   useEffect(() => () => clearTimers(), [])
 
   const stop = async () => {
+    const generation = recordingGenerationRef.current
     clearTimers()
     const result = await handle.stop()
 
+    if (generation !== recordingGenerationRef.current) {
+      return
+    }
+
     if (!result) {
       setVoiceStatus('idle')
+
+      onFinished?.()
 
       return
     }
 
     if (!onTranscribeAudio) {
       setVoiceStatus('idle')
+
+      onFinished?.()
 
       return
     }
@@ -64,16 +79,25 @@ export function useVoiceRecorder({
     try {
       const transcript = (await onTranscribeAudio(result.audio)).trim()
 
+      if (generation !== recordingGenerationRef.current) {
+        return
+      }
+
       if (!transcript) {
         notify({ kind: 'warning', title: voiceCopy.noSpeechDetected, message: voiceCopy.tryRecordingAgain })
       } else {
         onTranscript(transcript)
       }
     } catch (error) {
-      notifyError(error, voiceCopy.transcriptionFailed)
+      if (generation === recordingGenerationRef.current) {
+        notifyError(error, voiceCopy.transcriptionFailed)
+      }
     } finally {
-      setVoiceStatus('idle')
-      focusInput()
+      if (generation === recordingGenerationRef.current) {
+        setVoiceStatus('idle')
+        focusInput()
+        onFinished?.()
+      }
     }
   }
 
@@ -81,10 +105,11 @@ export function useVoiceRecorder({
     if (!onTranscribeAudio) {
       notify({ kind: 'warning', title: voiceCopy.unavailable, message: voiceCopy.transcriptionUnavailable })
 
-      return
+      return false
     }
 
     try {
+      recordingGenerationRef.current += 1
       await handle.start({ onError: error => notifyError(error, voiceCopy.recordingFailed) })
       startedAtRef.current = Date.now()
       setElapsedSeconds(0)
@@ -92,10 +117,23 @@ export function useVoiceRecorder({
       intervalRef.current = window.setInterval(() => setElapsedSeconds((Date.now() - startedAtRef.current) / 1000), 250)
       const cap = Math.max(1, Math.min(Math.trunc(maxRecordingSeconds), 600))
       timeoutRef.current = window.setTimeout(() => void stop(), cap * 1000)
+
+      return true
     } catch (error) {
       setVoiceStatus('idle')
       notifyError(error, voiceCopy.recordingFailed)
+
+      return false
     }
+  }
+
+  const cancel = () => {
+    recordingGenerationRef.current += 1
+    clearTimers()
+    handle.cancel()
+    setVoiceStatus('idle')
+    focusInput()
+    onFinished?.()
   }
 
   const dictate = () => {
@@ -112,5 +150,5 @@ export function useVoiceRecorder({
     status: voiceStatus
   }
 
-  return { dictate, voiceActivityState, voiceStatus }
+  return { cancel, dictate, start, stop, voiceActivityState, voiceStatus }
 }

--- a/apps/desktop/src/app/hooks/use-keybinds.test.tsx
+++ b/apps/desktop/src/app/hooks/use-keybinds.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, renderHook } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { onComposerDictateRequest } from '@/app/chat/composer/focus'
+import { $dictateMode, resetBinding, setBinding } from '@/store/keybinds'
+
+import { useKeybinds } from './use-keybinds'
+
+const deps = {
+  openNewSessionTab: () => undefined,
+  startFreshSession: () => undefined,
+  toggleCommandCenter: () => undefined,
+  toggleSelectedPin: () => undefined
+}
+
+const flushDispatch = () => new Promise(resolve => window.setTimeout(resolve, 0))
+
+afterEach(() => {
+  resetBinding('composer.dictate')
+  $dictateMode.set('hold')
+})
+
+describe('composer.dictate keybind', () => {
+  it('starts once on keydown and stops on its matching keyup, ignoring repeat', async () => {
+    setBinding('composer.dictate', ['alt+v'])
+    const requests: string[] = []
+    const off = onComposerDictateRequest(({ request }) => requests.push(request))
+
+    renderHook(() => useKeybinds(deps), { wrapper: MemoryRouter })
+
+    fireEvent.keyDown(window, { altKey: true, code: 'KeyV', key: 'v' })
+    fireEvent.keyDown(window, { altKey: true, code: 'KeyV', key: 'v', repeat: true })
+    fireEvent.keyUp(window, { altKey: true, code: 'KeyV', key: 'v' })
+    await flushDispatch()
+    off()
+
+    expect(requests).toEqual(['start', 'stop'])
+  })
+})

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -26,7 +26,7 @@ import {
   openFindBar
 } from '@/store/find-in-page'
 import { toggleHud } from '@/store/hud'
-import { $capture, $comboIndex, endCapture, setBinding } from '@/store/keybinds'
+import { $capture, $comboIndex, $dictateMode, endCapture, setBinding } from '@/store/keybinds'
 import {
   requestSessionSearchFocus,
   setFileBrowserOpen,
@@ -61,7 +61,12 @@ import { toggleStatusbarVisible } from '@/store/statusbar-prefs'
 import { openNewWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
-import { requestComposerFocus, requestModelMenuToggle, requestVoiceToggle } from '../chat/composer/focus'
+import {
+  requestComposerDictate,
+  requestComposerFocus,
+  requestModelMenuToggle,
+  requestVoiceToggle
+} from '../chat/composer/focus'
 import { handleWindowPaste } from '../chat/composer/paste-to-focus'
 import { openSession } from '../open-session'
 import {
@@ -101,6 +106,10 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
   // Keep the latest closures without re-subscribing the listener.
   const handlersRef = useRef<HandlerMap>({})
   const commitSwitcherRef = useRef<() => void>(() => {})
+  // The physical key that started a hold. Keyup must match this rather than
+  // re-matching a combo because modifier keyup changes the combo mid-gesture.
+  const heldDictateCodeRef = useRef<string | null>(null)
+  const toggleDictateActiveRef = useRef(false)
 
   const profileSwitchHandlers: HandlerMap = {}
 
@@ -290,6 +299,9 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     []
   )
 
+  // This listener needs an event-local hold identity across keydown/keyup; it
+  // is intentionally a ref rather than render state (no paint belongs here).
+  // eslint-disable-next-line no-restricted-syntax
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       // Capture mode: the next real key becomes the binding. Swallow everything
@@ -328,6 +340,18 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
         return
       }
 
+      // Escape is a cancel gesture only while this dispatcher initiated a
+      // dictation recording. It discards audio (unlike keyup/blur, which
+      // transcribe) and otherwise leaves normal composer Escape untouched.
+      if (event.key === 'Escape' && (heldDictateCodeRef.current || toggleDictateActiveRef.current)) {
+        event.preventDefault()
+        heldDictateCodeRef.current = null
+        toggleDictateActiveRef.current = false
+        requestComposerDictate('cancel')
+
+        return
+      }
+
       const combo = comboFromEvent(event)
 
       if (!combo) {
@@ -362,6 +386,28 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
         return
       }
 
+      if (actionId === 'composer.dictate') {
+        // OS key-repeat must never create another MediaRecorder or flip toggle
+        // mode back off while the key is held.
+        if (event.repeat) {
+          event.preventDefault()
+
+          return
+        }
+
+        event.preventDefault()
+
+        if ($dictateMode.get() === 'hold') {
+          heldDictateCodeRef.current = event.code
+          requestComposerDictate('start')
+        } else {
+          toggleDictateActiveRef.current = !toggleDictateActiveRef.current
+          requestComposerDictate('toggle')
+        }
+
+        return
+      }
+
       // Soft `/` / Enter: gated so dialogs/buttons/terminal keep those keys.
       // Rebound chords fall through to the normal handler.
       if (actionId === 'composer.focus' && isComposerFocusSoftCombo(combo)) {
@@ -391,6 +437,11 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     // highlighted session. A window blur (Cmd+Tab away mid-switch) cancels so
     // the overlay never gets stranded waiting for a keyup that never comes.
     const onKeyUp = (event: KeyboardEvent) => {
+      if (heldDictateCodeRef.current === event.code) {
+        heldDictateCodeRef.current = null
+        requestComposerDictate('stop')
+      }
+
       if (event.key === 'Tab') {
         onSwitcherTabUp()
       }
@@ -400,7 +451,24 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
       }
     }
 
-    const onBlur = () => switcherActive() && closeSwitcher()
+    const stopDictationForLostFocus = () => {
+      if (heldDictateCodeRef.current || toggleDictateActiveRef.current) {
+        heldDictateCodeRef.current = null
+        toggleDictateActiveRef.current = false
+        requestComposerDictate('stop')
+      }
+    }
+
+    const onBlur = () => {
+      stopDictationForLostFocus()
+      switcherActive() && closeSwitcher()
+    }
+
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        stopDictationForLostFocus()
+      }
+    }
 
     // Swallow trailing contextmenu after Ctrl+click commit (Electron main menu).
     const onContextMenu = (event: MouseEvent) => {
@@ -413,6 +481,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     window.addEventListener('keydown', onKeyDown, { capture: true })
     window.addEventListener('keyup', onKeyUp, { capture: true })
     window.addEventListener('blur', onBlur)
+    document.addEventListener('visibilitychange', onVisibilityChange)
     window.addEventListener('contextmenu', onContextMenu, { capture: true })
     // Paste twin of type-to-focus: ⌘V on non-editable chrome routes the
     // clipboard (text AND images) into the active composer. Bubble phase so
@@ -423,6 +492,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
       window.removeEventListener('keydown', onKeyDown, { capture: true })
       window.removeEventListener('keyup', onKeyUp, { capture: true })
       window.removeEventListener('blur', onBlur)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
       window.removeEventListener('contextmenu', onContextMenu, { capture: true })
       window.removeEventListener('paste', handleWindowPaste)
     }

--- a/apps/desktop/src/app/settings/keybind-settings.tsx
+++ b/apps/desktop/src/app/settings/keybind-settings.tsx
@@ -22,12 +22,14 @@ import { arraysEqual } from '@/lib/storage'
 import {
   $bindings,
   $capture,
+  $dictateMode,
   beginCapture,
   bindingsFor,
   conflictsFor,
   endCapture,
   resetAllBindings,
-  resetBinding
+  resetBinding,
+  setDictateMode
 } from '@/store/keybinds'
 
 import { SettingsContent } from './primitives'
@@ -35,6 +37,7 @@ import { SettingsContent } from './primitives'
 export function KeybindSettings() {
   const { t } = useI18n()
   const bindings = useStore($bindings)
+  const dictateMode = useStore($dictateMode)
   const k = t.keybinds
   const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set())
   // Subscribe so contributed actions appear/disappear live in the map.
@@ -129,7 +132,7 @@ export function KeybindSettings() {
           ) : (
             <>
               {filteredActions?.map(action => (
-                <KeybindRow action={action} key={action.id} />
+                <KeybindRow action={action} dictateMode={dictateMode} key={action.id} />
               ))}
               {filteredReadonly?.map(shortcut => (
                 <ReadonlyRow key={shortcut.id} shortcut={shortcut} />
@@ -159,7 +162,8 @@ export function KeybindSettings() {
                   onToggle={() => toggleCategory(category)}
                   open={sectionOpen}
                 />
-                {sectionOpen && actions.map(action => <KeybindRow action={action} key={action.id} />)}
+                {sectionOpen &&
+                  actions.map(action => <KeybindRow action={action} dictateMode={dictateMode} key={action.id} />)}
                 {sectionOpen && readonly.map(shortcut => <ReadonlyRow key={shortcut.id} shortcut={shortcut} />)}
               </section>
             )
@@ -189,7 +193,7 @@ function CategoryHeader({ label, onToggle, open }: { label: string; onToggle: ()
   )
 }
 
-function KeybindRow({ action }: { action: KeybindActionMeta }) {
+function KeybindRow({ action, dictateMode }: { action: KeybindActionMeta; dictateMode?: 'hold' | 'toggle' }) {
   const { t } = useI18n()
   const k = t.keybinds
   const bindings = useStore($bindings)
@@ -210,6 +214,21 @@ function KeybindRow({ action }: { action: KeybindActionMeta }) {
   return (
     <div className="group flex items-center gap-2.5 rounded-lg px-2.5 py-1 transition-colors hover:bg-(--chrome-action-hover)">
       <span className="min-w-0 flex-1 truncate text-[0.82rem] text-foreground/90">{label}</span>
+
+      {action.id === 'composer.dictate' && (
+        <label className="flex shrink-0 items-center gap-1 text-[0.68rem] text-muted-foreground">
+          <span className="sr-only">{k.dictateMode}</span>
+          <select
+            aria-label={k.dictateMode}
+            className="rounded border border-border bg-transparent px-1 py-0.5 text-[0.68rem] outline-none"
+            onChange={event => setDictateMode(event.target.value === 'toggle' ? 'toggle' : 'hold')}
+            value={dictateMode ?? 'hold'}
+          >
+            <option value="hold">{k.hold}</option>
+            <option value="toggle">{k.toggle}</option>
+          </select>
+        </label>
+      )}
 
       {conflict && (
         <span className="flex size-4 items-center justify-center text-amber-500/90" title={k.conflictWith(conflict)}>

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -187,6 +187,9 @@ export const ar = defineLocale({
     resetAll: 'إعادة تعيين الكل',
     pressKey: 'اضغط مفتاحا...',
     set: 'مضبوط',
+    dictateMode: 'إيماءة الإملاء',
+    hold: 'اضغط باستمرار',
+    toggle: 'تبديل',
     conflictWith: label => `مرتبط أيضا بـ “${label}”`,
     categories: {
       composer: 'المحرّر',
@@ -226,6 +229,7 @@ export const ar = defineLocale({
       'workspace.openFolder': 'فتح مجلد كمشروع',
       'composer.focus': 'التركيز على المحرّر',
       'composer.modelPicker': 'فتح منتقي النموذج',
+      'composer.dictate': 'إملاء في المحرّر',
       'composer.voice': 'بدء / إيقاف المحادثة الصوتية',
       'view.toggleSidebar': 'تبديل الشريط الجانبي للجلسات',
       'view.toggleRightSidebar': 'تبديل متصفح الملفات',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -218,6 +218,9 @@ export const en: Translations = {
     resetAll: 'Reset all',
     pressKey: 'Press a key…',
     set: 'set',
+    dictateMode: 'Dictation gesture',
+    hold: 'Hold',
+    toggle: 'Toggle',
     conflictWith: label => `Also bound to “${label}”`,
     categories: {
       composer: 'Composer',
@@ -257,6 +260,7 @@ export const en: Translations = {
       'workspace.openFolder': 'Open folder as project',
       'composer.focus': 'Focus composer',
       'composer.modelPicker': 'Open model picker',
+      'composer.dictate': 'Dictate into composer',
       'composer.voice': 'Start / stop voice conversation',
       'view.toggleSidebar': 'Toggle sessions sidebar',
       'view.toggleRightSidebar': 'Toggle file browser',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -206,6 +206,15 @@ export const ja = defineLocale({
     openStarmap: 'メモリグラフを開く'
   },
 
+  keybinds: {
+    dictateMode: '音声入力の操作',
+    hold: '押している間',
+    toggle: '切り替え',
+    actions: {
+      'composer.dictate': '音声をコンポーザーに入力'
+    }
+  },
+
   language: {
     label: '言語',
     description: 'デスクトップインターフェイスの言語を選択します。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -260,6 +260,9 @@ export interface Translations {
     resetAll: string
     pressKey: string
     set: string
+    dictateMode: string
+    hold: string
+    toggle: string
     conflictWith: (label: string) => string
     categories: Record<string, string>
     actions: Record<string, string>

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -200,6 +200,15 @@ export const zhHant = defineLocale({
     openStarmap: '開啟記憶圖譜'
   },
 
+  keybinds: {
+    dictateMode: '聽寫手勢',
+    hold: '按住',
+    toggle: '切換',
+    actions: {
+      'composer.dictate': '聽寫到輸入框'
+    }
+  },
+
   language: {
     label: '語言',
     description: '選擇桌面介面的語言。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -213,6 +213,9 @@ export const zh: Translations = {
     resetAll: '全部重置',
     pressKey: '请按下按键…',
     set: '设置',
+    dictateMode: '听写手势',
+    hold: '按住',
+    toggle: '切换',
     conflictWith: label => `已绑定到“${label}”`,
     categories: {
       composer: '输入框',
@@ -252,6 +255,7 @@ export const zh: Translations = {
       'workspace.openFolder': '打开文件夹为项目',
       'composer.focus': '聚焦输入框',
       'composer.modelPicker': '打开模型选择器',
+      'composer.dictate': '听写到输入框',
       'composer.voice': '开始 / 停止语音对话',
       'view.toggleSidebar': '切换会话侧边栏',
       'view.toggleRightSidebar': '切换文件浏览器',

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -60,6 +60,9 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // Open WebUI, and Cherry Studio all ship the same chord). Opens the pill's
   // live dropdown on the pane under the pointer, else the active composer.
   { id: 'composer.modelPicker', category: 'composer', defaults: ['mod+shift+m'] },
+  // Push-to-dictate records into the draft only. It ships unbound: a window-
+  // focused hold chord must never collide with Quick Entry or sidebar keys.
+  { id: 'composer.dictate', category: 'composer', defaults: [] },
   // Voice conversation toggle. Matches the documented `voice.record_key`
   // (Ctrl+B). On macOS that's literally ⌃B — distinct from the ⌘B sidebar
   // toggle. Off macOS `ctrl` folds to `mod`, which IS the ⌘B/Ctrl+B sidebar

--- a/apps/desktop/src/store/keybinds.ts
+++ b/apps/desktop/src/store/keybinds.ts
@@ -6,6 +6,18 @@ import { canonicalizeCombo } from '@/lib/keybinds/combo'
 import { arraysEqual, persistString, storedString } from '@/lib/storage'
 
 const STORAGE_KEY = 'hermes.desktop.keybinds'
+const DICTATE_MODE_STORAGE_KEY = 'hermes.desktop.dictate-mode'
+
+export type DictateMode = 'hold' | 'toggle'
+
+const storedDictateMode = storedString(DICTATE_MODE_STORAGE_KEY)
+export const $dictateMode = atom<DictateMode>(storedDictateMode === 'toggle' ? 'toggle' : 'hold')
+
+$dictateMode.subscribe(mode => persistString(DICTATE_MODE_STORAGE_KEY, mode))
+
+export function setDictateMode(mode: DictateMode): void {
+  $dictateMode.set(mode)
+}
 
 // The user's raw stored overrides. Kept verbatim so an action CONTRIBUTED
 // after module init (plugins register late) still resolves its saved rebind —


### PR DESCRIPTION
## Summary

Adds a rebindable desktop `composer.dictate` action for push-to-dictate.

- Records into the focused composer draft without submitting a turn.
- Supports persisted Hold and Toggle gestures; ships unbound to avoid shortcut collisions.
- Stops safely on key release, blur, hidden window, or Escape, and shares the existing transcription and wake-word mic lifecycle.
- Adds coverage for hold key dispatch, draft insertion, empty transcripts, and cancellation while transcription is in flight.

## Why

Desktop already supports click-to-toggle dictation, but had no keyboard input modality. This supplies a window-focused push-to-talk path without adding backend or core-agent surface area.

## Validation

- `npx eslint` on all changed desktop files
- `git diff --check`
- Focused Vitest could not load the desktop tests because this checkout's dependency layout cannot resolve `react`; full typecheck is likewise blocked by missing `@assistant-ui/*` dependencies.
