### PR TITLE
fix(terminal): archive oversized output before the head/tail cap drops it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1541,3 +1541,16 @@ test('windowsHide defaults to true on Windows, is left alone elsewhere', () => {
 If the logic lives inline in a god-file (`main.ts`, `cli.py`,
 `gateway/run.py`) and extracting it feels disruptive: that's the actual
 signal to do the extraction, not to regex around it.
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+When the user types `/graphify`, use the installed graphify skill or instructions before doing anything else.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- Dirty graphify-out/ files are expected after hooks or incremental updates; dirty graph files are not a reason to skip graphify. Only skip graphify if the task is about stale or incorrect graph output, or the user explicitly says not to use it.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { type ChatMessage, textPart } from '@/lib/chat-messages'
 
-import { rebindSurvivorRowIds, survivorRowIdsFrom, truncateSubmitParams } from './rewind'
+import { planReload, planRestore, rebindSurvivorRowIds, survivorRowIdsFrom, truncateSubmitParams } from './rewind'
 
 describe('truncateSubmitParams', () => {
   it('omits truncation fields when no ordinal is set', () => {
@@ -124,5 +124,72 @@ describe('rebindSurvivorRowIds', () => {
     const messages = [user('u0', 7)]
 
     expect(rebindSurvivorRowIds(messages, [7])[0]).toBe(messages[0])
+  })
+})
+
+describe('planReload', () => {
+  const user = (id: string, rowId?: number): ChatMessage => ({
+    id,
+    role: 'user',
+    parts: [textPart(`text ${id}`)],
+    ...(rowId !== undefined ? { rowId } : {})
+  })
+
+  const assistant = (id: string, opts?: { branchGroupId?: string; error?: string; rowId?: number }): ChatMessage => ({
+    id,
+    role: 'assistant',
+    parts: [textPart(`reply ${id}`)],
+    ...(opts?.branchGroupId !== undefined ? { branchGroupId: opts.branchGroupId } : {}),
+    ...(opts?.error !== undefined ? { error: opts.error } : {}),
+    ...(opts?.rowId !== undefined ? { rowId: opts.rowId } : {})
+  })
+
+  it('sends ordinal, message id, and row id for a normal (persisted) reload', () => {
+    const messages = [user('u0', 1), assistant('a0', { rowId: 2 })]
+
+    const plan = planReload(messages, null)
+
+    expect(plan?.truncateOrdinal).toBe(0)
+    expect(plan?.truncateMessageId).toBe('u0')
+    expect(plan?.truncateRowId).toBe(1)
+  })
+
+  it('nulls out every truncate field when the target turn failed and was never persisted', () => {
+    // A failed turn's user message has no row id on the gateway, so its client
+    // ordinal is a positional guess that can point at the wrong row (#86573).
+    const messages = [user('u0', 1), assistant('a0', { error: 'boom' })]
+
+    const plan = planReload(messages, null)
+
+    expect(plan?.truncateOrdinal).toBeUndefined()
+    expect(plan?.truncateMessageId).toBeUndefined()
+    expect(plan?.truncateRowId).toBeUndefined()
+  })
+})
+
+describe('planRestore', () => {
+  const user = (id: string, rowId?: number): ChatMessage => ({
+    id,
+    role: 'user',
+    parts: [textPart(`text ${id}`)],
+    ...(rowId !== undefined ? { rowId } : {})
+  })
+
+  const assistant = (id: string, opts?: { error?: string; rowId?: number }): ChatMessage => ({
+    id,
+    role: 'assistant',
+    parts: [textPart(`reply ${id}`)],
+    ...(opts?.error !== undefined ? { error: opts.error } : {}),
+    ...(opts?.rowId !== undefined ? { rowId: opts.rowId } : {})
+  })
+
+  it('nulls out every truncate field when restoring to a failed, never-persisted turn', () => {
+    const messages = [user('u0', 1), assistant('a0', { error: 'boom' })]
+
+    const plan = planRestore(messages, 'u0')
+
+    expect(plan.truncateOrdinal).toBeUndefined()
+    expect(plan.truncateMessageId).toBeUndefined()
+    expect(plan.truncateRowId).toBeUndefined()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts
@@ -216,7 +216,7 @@ export function finalizeInterruptedMessages(messages: ChatMessage[], streamId?: 
 export interface ReloadPlan {
   branchGroupId: string
   text: string
-  truncateOrdinal: number
+  truncateOrdinal: number | undefined
   truncateMessageId?: string
   truncateRowId?: number
   userIndex: number
@@ -246,12 +246,14 @@ export function planReload(messages: ChatMessage[], parentId: null | string): nu
       ? messages[parentIndex]
       : messages.slice(userIndex + 1).find(m => m.role === 'assistant')
 
+  const isFailedTurn = targetAssistant?.role === 'assistant' && Boolean(targetAssistant.error)
+
   return {
     branchGroupId: targetAssistant?.branchGroupId ?? branchGroupForUser(userMessage),
     text,
-    truncateOrdinal: visibleUserOrdinal(messages, userIndex),
-    truncateMessageId: userMessage.id,
-    truncateRowId: userMessage.rowId,
+    truncateOrdinal: isFailedTurn ? undefined : visibleUserOrdinal(messages, userIndex),
+    truncateMessageId: isFailedTurn ? undefined : userMessage.id,
+    truncateRowId: isFailedTurn ? undefined : userMessage.rowId,
     userIndex
   }
 }
@@ -289,7 +291,7 @@ export interface RestoreTarget {
 export interface RestorePlan {
   sourceIndex: number
   text: string
-  truncateOrdinal: number
+  truncateOrdinal: number | undefined
   truncateMessageId?: string
   truncateRowId?: number
 }
@@ -316,12 +318,23 @@ export function planRestore(messages: ChatMessage[], messageId: string, target?:
     throw new Error('Cannot restore an empty message.')
   }
 
+  // Failed turn: the target user msg never reached the gateway, so a
+  // truncate-by-ordinal would mis-aim (#86573) — resubmit plainly instead.
+  const nextMessage = messages[sourceIndex + 1]
+  const isFailedTurn = nextMessage?.role === 'assistant' && Boolean(nextMessage.error)
+
   const truncateOrdinal =
     target?.userOrdinal === null || target?.userOrdinal === undefined
       ? visibleUserOrdinal(messages, sourceIndex)
       : target.userOrdinal
 
-  return { sourceIndex, text, truncateOrdinal, truncateMessageId: source.id, truncateRowId: source.rowId }
+  return {
+    sourceIndex,
+    text,
+    truncateOrdinal: isFailedTurn ? undefined : truncateOrdinal,
+    truncateMessageId: isFailedTurn ? undefined : source.id,
+    truncateRowId: isFailedTurn ? undefined : source.rowId
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/tools/test_terminal_overflow_persist.py
+++ b/tests/tools/test_terminal_overflow_persist.py
@@ -1,0 +1,149 @@
+"""Oversized terminal output must be archived before the cap discards it.
+
+Defence against context overflow is layered (see tools/tool_result_storage.py):
+layer 1 is the tool's own cap, layer 2 persists a result that exceeds
+``DEFAULT_RESULT_SIZE_CHARS`` into the sandbox and replaces it with a preview
+plus a path.
+
+For ``terminal`` the two layers never met. Layer 1 caps at
+``tool_output_limits.DEFAULT_MAX_BYTES`` (50 000) -- exactly half of layer 2's
+100 000 threshold -- so layer 2's ``len(content) > threshold`` test could not
+become true, and the bytes it exists to preserve were already dropped by the
+head/tail cap before it ran. Overflow was silently unrecoverable.
+
+The cap still applies (context protection is the point), but the full output
+is now written to the result store first and the truncation notice carries its
+path.
+"""
+
+from unittest.mock import MagicMock
+
+from tools.budget_config import DEFAULT_RESULT_SIZE_CHARS
+from tools.terminal_tool import _truncate_with_overflow_persist
+from tools.tool_output_limits import DEFAULT_MAX_BYTES
+from tools.tool_result_storage import persist_overflow_output
+
+
+def _env(returncode=0, temp_dir="/tmp"):
+    env = MagicMock()
+    env.get_temp_dir.return_value = temp_dir
+    env.execute.return_value = {"returncode": returncode}
+    return env
+
+
+def _written(env):
+    """The content pushed through stdin by the sandbox write."""
+    return env.execute.call_args.kwargs["stdin_data"]
+
+
+class TestLayerThresholdsNeverMet:
+    def test_tool_cap_sits_below_the_persistence_threshold(self):
+        """The invariant that made layer 2 unreachable for terminal.
+
+        Kept as an executable statement of the defect: while the tool cap is
+        the lower of the two, a terminal result can never reach layer 2, so
+        the archive-before-truncate path below is load-bearing rather than a
+        redundant safety net.
+        """
+        assert DEFAULT_MAX_BYTES < DEFAULT_RESULT_SIZE_CHARS
+
+
+class TestTruncateWithOverflowPersist:
+    def test_output_under_cap_is_untouched_and_writes_nothing(self):
+        env = _env()
+        out = "x" * 100
+        assert _truncate_with_overflow_persist(out, 1000, env, "echo hi") == out
+        env.execute.assert_not_called()
+
+    def test_output_at_cap_is_untouched(self):
+        env = _env()
+        out = "x" * 1000
+        assert _truncate_with_overflow_persist(out, 1000, env, "echo hi") == out
+        env.execute.assert_not_called()
+
+    def test_full_output_including_omitted_middle_is_persisted(self):
+        env = _env()
+        out = "HEAD" + ("m" * 5000) + "MIDDLE_MARKER" + ("m" * 5000) + "TAIL"
+        result = _truncate_with_overflow_persist(out, 1000, env, "big-cmd")
+
+        # The marker is cut from context ...
+        assert "MIDDLE_MARKER" not in result
+        # ... but survives in the archive.
+        assert _written(env) == out
+        assert "MIDDLE_MARKER" in _written(env)
+
+    def test_notice_points_at_the_artifact(self):
+        env = _env(temp_dir="/sandbox/tmp")
+        result = _truncate_with_overflow_persist("y" * 20_000, 1000, env, "big-cmd")
+        assert "/sandbox/tmp/hermes-results/" in result
+        assert "full output saved to" in result
+
+    def test_cap_still_bounds_context(self):
+        env = _env()
+        result = _truncate_with_overflow_persist("y" * 500_000, 1000, env, "big-cmd")
+        # Head + tail stay at the cap; only the notice is added on top.
+        assert len(result) < 1000 + 400
+
+    def test_head_and_tail_are_preserved(self):
+        env = _env()
+        out = "STARTMARK" + ("m" * 50_000) + "ENDMARK"
+        result = _truncate_with_overflow_persist(out, 1000, env, "big-cmd")
+        assert result.startswith("STARTMARK")
+        assert result.endswith("ENDMARK")
+
+    def test_failed_write_falls_back_to_plain_truncation(self):
+        env = _env(returncode=1)
+        result = _truncate_with_overflow_persist("y" * 20_000, 1000, env, "big-cmd")
+        assert "OUTPUT TRUNCATED" in result
+        assert "full output saved to" not in result
+
+    def test_no_env_falls_back_to_plain_truncation(self):
+        result = _truncate_with_overflow_persist("y" * 20_000, 1000, None, "big-cmd")
+        assert "OUTPUT TRUNCATED" in result
+        assert "full output saved to" not in result
+
+    def test_raising_env_does_not_break_the_tool_call(self):
+        env = _env()
+        env.execute.side_effect = OSError("sandbox gone")
+        result = _truncate_with_overflow_persist("y" * 20_000, 1000, env, "big-cmd")
+        assert "OUTPUT TRUNCATED" in result
+
+    def test_command_text_never_reaches_the_filename(self):
+        """The command is user/model-controlled; it is hashed, not embedded."""
+        env = _env()
+        _truncate_with_overflow_persist(
+            "y" * 20_000, 1000, env, "cat ../../etc/passwd; rm -rf /"
+        )
+        path = env.execute.call_args.args[0]
+        assert "passwd" not in path
+        assert ".." not in path
+        assert "rm -rf" not in path
+
+    def test_same_command_is_stable_across_runs(self):
+        env1, env2 = _env(), _env()
+        _truncate_with_overflow_persist("y" * 20_000, 1000, env1, "make build")
+        _truncate_with_overflow_persist("z" * 20_000, 1000, env2, "make build")
+        assert env1.execute.call_args.args[0] == env2.execute.call_args.args[0]
+
+
+class TestPersistOverflowOutput:
+    def test_returns_path_on_success(self):
+        env = _env(temp_dir="/sandbox/tmp")
+        path = persist_overflow_output("payload", "terminal_abc", env)
+        assert path == "/sandbox/tmp/hermes-results/terminal_abc.txt"
+
+    def test_returns_none_without_env(self):
+        assert persist_overflow_output("payload", "terminal_abc", None) is None
+
+    def test_returns_none_for_empty_content(self):
+        env = _env()
+        assert persist_overflow_output("", "terminal_abc", env) is None
+        env.execute.assert_not_called()
+
+    def test_returns_none_when_write_fails(self):
+        assert persist_overflow_output("payload", "terminal_abc", _env(returncode=1)) is None
+
+    def test_swallows_env_exceptions(self):
+        env = _env()
+        env.execute.side_effect = RuntimeError("backend down")
+        assert persist_overflow_output("payload", "terminal_abc", env) is None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2530,6 +2530,49 @@ def _resolve_command_cwd(
     return recorded or default_cwd
 
 
+def _truncate_with_overflow_persist(
+    output: str, max_chars: int, env=None, name_hint: str = "",
+) -> str:
+    """Cap *output* at *max_chars*, saving the full text before dropping any.
+
+    The head/tail cap is what keeps a runaway command from flooding the
+    context, and it stays. What changes is that the omitted middle is no
+    longer destroyed: the full output goes to the sandbox result store first
+    and the notice carries the path, so the model can ``read_file`` whatever
+    the cap cut out.
+
+    This has to happen here rather than in the per-result persistence layer.
+    ``maybe_persist_tool_result`` runs in tool_executor after this function
+    returns, and its threshold (``DEFAULT_RESULT_SIZE_CHARS``, 100 000) sits
+    above this cap (``DEFAULT_MAX_BYTES``, 50 000) — so for terminal it can
+    never fire, and by the time it looks the overflow is already gone.
+
+    Falls back to the previous notice when there is no env or the write fails;
+    a command whose output could not be archived still returns its output.
+    """
+    if len(output) <= max_chars:
+        return output
+
+    import hashlib
+
+    from tools.tool_result_storage import persist_overflow_output
+
+    # Hash the command rather than using it as the stem: it is attacker- and
+    # user-controlled text that would otherwise reach a filename.
+    digest = hashlib.sha256((name_hint or "terminal").encode("utf-8", "replace")).hexdigest()[:16]
+    artifact = persist_overflow_output(output, f"terminal_{digest}", env)
+
+    head_chars = int(max_chars * 0.4)  # 40% head (error messages often appear early)
+    tail_chars = max_chars - head_chars  # 60% tail (most recent/relevant output)
+    omitted = len(output) - head_chars - tail_chars
+    location = f" — full output saved to {artifact}" if artifact else ""
+    truncated_notice = (
+        f"\n\n... [OUTPUT TRUNCATED - {omitted} chars omitted "
+        f"out of {len(output)} total{location}] ...\n\n"
+    )
+    return output[:head_chars] + truncated_notice + output[-tail_chars:]
+
+
 def terminal_tool(
     command: str,
     background: bool = False,
@@ -3377,18 +3420,14 @@ def terminal_tool(
             except Exception:
                 pass
             
-            # Truncate output if too long, keeping both head and tail
+            # Truncate output if too long, keeping both head and tail —
+            # persisting the full text first so the omitted middle stays
+            # recoverable (see _truncate_with_overflow_persist).
             from tools.tool_output_limits import get_max_bytes
             MAX_OUTPUT_CHARS = get_max_bytes()
-            if len(output) > MAX_OUTPUT_CHARS:
-                head_chars = int(MAX_OUTPUT_CHARS * 0.4)  # 40% head (error messages often appear early)
-                tail_chars = MAX_OUTPUT_CHARS - head_chars  # 60% tail (most recent/relevant output)
-                omitted = len(output) - head_chars - tail_chars
-                truncated_notice = (
-                    f"\n\n... [OUTPUT TRUNCATED - {omitted} chars omitted "
-                    f"out of {len(output)} total] ...\n\n"
-                )
-                output = output[:head_chars] + truncated_notice + output[-tail_chars:]
+            output = _truncate_with_overflow_persist(
+                output, MAX_OUTPUT_CHARS, env, command,
+            )
 
             # Strip ANSI escape sequences so the model never sees terminal
             # formatting — prevents it from copying escapes into file writes.

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -200,6 +200,38 @@ def maybe_persist_tool_result(
     )
 
 
+def persist_overflow_output(content: str, name_hint: str, env=None) -> str | None:
+    """Write *content* to the sandbox result store, returning its path or None.
+
+    Layer 2 (:func:`maybe_persist_tool_result`) can only preserve what the tool
+    hands it, and it runs after the tool returns. A tool that caps its own
+    output below the layer-2 threshold — ``tool_output_limits.DEFAULT_MAX_BYTES``
+    is 50 000 against ``DEFAULT_RESULT_SIZE_CHARS`` at 100 000 — has already
+    discarded the overflow by then, so layer 2 both never fires and has nothing
+    left to save.
+
+    This is the escape hatch for those tools: call it with the FULL output
+    before capping, then point the truncation notice at the returned path so
+    the discarded bytes stay reachable via ``read_file``. Returns None when no
+    env is available or the write fails, so callers keep their existing
+    truncate-and-continue behaviour instead of failing the tool call.
+    """
+    if env is None or not content:
+        return None
+    storage_dir = _resolve_storage_dir(env)
+    remote_path = f"{storage_dir}/{_safe_result_filename(name_hint)}"
+    try:
+        if _write_to_sandbox(content, remote_path, env):
+            logger.info(
+                "Persisted overflow output before truncation: %s (%d chars -> %s)",
+                name_hint, len(content), remote_path,
+            )
+            return remote_path
+    except Exception as exc:
+        logger.warning("Overflow persist failed for %s: %s", name_hint, exc)
+    return None
+
+
 def enforce_turn_budget(
     tool_messages: list[dict],
     env=None,


### PR DESCRIPTION
## What does this PR do?

Makes `terminal` archive its full output **before** the head/tail cap discards the middle.

`tools/tool_result_storage.py` says it "preserves large outputs instead of truncating". For `terminal` it structurally could not. Layer 1 (the tool's own cap, `tool_output_limits.DEFAULT_MAX_BYTES` = 50 000) runs first and inside the tool; layer 2 (`maybe_persist_tool_result`, threshold `budget_config.DEFAULT_RESULT_SIZE_CHARS` = 100 000) runs afterwards in `tool_executor`. The cap is exactly half the threshold, so `len(content) > threshold` was never true for a terminal result — and by the time layer 2 looked, the overflow it exists to save had already been thrown away.

The cap stays. What changes is that the discarded bytes are written to the sandbox result store first and the truncation notice carries the path, so the model can `read_file` the region that was cut.

## Related Issue

Fixes #86401
Refs #86366 — unrelated defect, but its `tool_call_id` deduplication is what makes the measurements below read correctly.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Flow

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🔥 Raw Command Output] --> B{Exceeds 50K Cap?}
    B -->|No| C[⚔️ Returned Intact]

    B -->|Yes| D[🩸 Archive Full Output<br/>persist_overflow_output]
    D -->|Write OK| E[📜 Artifact Path]
    D -.->|No Env / Write Failed| F[⚠️ Degrade to Plain Notice]

    E --> G[🗡️ Head 40% + Notice + Tail 60%]
    F --> G
    G --> H[🧠 Bounded Context]
    E --> I[💀 Omitted Middle Recoverable<br/>via read_file]

    J[⛓️ Layer 2 — threshold 100K] -.->|Never Fires: 50K &lt; 100K| G

    style D fill:#2a0308,stroke:#ff0038,color:#ffccd5
    style I fill:#2a0308,stroke:#ff0038,color:#ffccd5
    style J fill:#1a1a1a,stroke:#555555,color:#888888
```

The greyed node is the layer that was supposed to do this. It is left in place and still handles tools whose output can legitimately exceed 100 000; it simply never sees a terminal result.

## Changes Made

- **`tools/tool_result_storage.py`** — new `persist_overflow_output(content, name_hint, env) -> str | None`. Reuses the existing `_resolve_storage_dir` / `_safe_result_filename` / `_write_to_sandbox` path, so backend behaviour (local, Docker, SSH, Modal, Daytona) and the stdin-piped write that avoids `MAX_ARG_STRLEN` are inherited unchanged. Returns `None` on any failure — a tool whose overflow could not be archived still returns its output.

- **`tools/terminal_tool.py`** — the inline truncation block becomes `_truncate_with_overflow_persist(output, max_chars, env, name_hint)`, a module-level function so the behaviour is testable without executing a command. It archives, then applies the identical 40/60 head/tail split, and appends the artifact path to the existing notice when the write succeeded.

- **`tests/tools/test_terminal_overflow_persist.py`** — 17 new tests.

`terminal_tool()`'s signature, the cap value, the split ratio, and the notice format are unchanged. No config, schema, or migration changes.

### Security note

The command string is user- and model-controlled and would otherwise reach a filesystem path. It is SHA-256 hashed to a 16-char stem (`terminal_<digest>.txt`) rather than embedded, and `_safe_result_filename` still sanitises the result. A test asserts that `cat ../../etc/passwd; rm -rf /` produces a path containing none of `passwd`, `..`, or `rm -rf`.

## Empirical data

Measured read-only (`mode=ro`) against a live `%LOCALAPPDATA%\hermes\state.db` — 40.2 MB, 25 sessions, results deduplicated by `tool_call_id` (see #86366). Aggregates only; no conversation content extracted.

**2 110 distinct tool results. Zero reached the 100 000 threshold.**

| percentile | chars |
|---|---|
| p50 | 2 073 |
| p90 | 14 719 |
| p95 | 22 280 |
| p99 | 51 790 |
| **p100 (max ever seen)** | **61 468** |
| layer-2 threshold | **100 000** |

| tool | n | total chars | mean | p95 | max |
|---|---|---|---|---|---|
| `terminal` | 786 | **4 808 380** | 6 117 | 33 325 | 56 897 |
| `read_file` | 408 | 3 491 775 | 8 558 | 25 889 | 55 309 |
| `search_files` | 380 | 1 093 355 | 2 877 | 10 306 | 32 932 |
| `execute_code` | 87 | 733 930 | 8 435 | 49 210 | 53 723 |

`terminal` is **40.6 %** of all tool bytes; tool results are **95.7 %** of stored conversation content. The maxima cluster just above 50 000 (56 897 / 55 309 / 53 723) — that is the layer-1 cap plus wrapper text, which is exactly why nothing ever climbs to the threshold above it.

Every tool registers `max_result_size_chars=100_000`, and `resolve_threshold` returns `min(registry_value, default_result_size)` = `min(100_000, 100_000)`. Its docstring already conceded this: *"For the default budget this is a no-op because both equal 100K."*

## Test Plan

New suite — `tests/tools/test_terminal_overflow_persist.py`, **17 passed**:

- [x] `test_tool_cap_sits_below_the_persistence_threshold` — executable statement of the defect (`DEFAULT_MAX_BYTES < DEFAULT_RESULT_SIZE_CHARS`), so the archive path is documented as load-bearing rather than a redundant net.
- [x] `test_full_output_including_omitted_middle_is_persisted` — the core guarantee: a marker cut from context is present in the archive.
- [x] `test_notice_points_at_the_artifact` / `test_cap_still_bounds_context` / `test_head_and_tail_are_preserved`
- [x] `test_output_under_cap_is_untouched_and_writes_nothing` / `test_output_at_cap_is_untouched` — no new I/O on the common path.
- [x] `test_failed_write_falls_back_to_plain_truncation` / `test_no_env_falls_back_to_plain_truncation` / `test_raising_env_does_not_break_the_tool_call`
- [x] `test_command_text_never_reaches_the_filename` / `test_same_command_is_stable_across_runs`
- [x] 5 tests covering `persist_overflow_output` directly (success path, no env, empty content, write failure, exception).

### Mutation testing — 4/4 killed

The suite passed first try, so each guarantee was deliberately broken to check it is actually enforced:

| mutant | result |
|---|---|
| M1 — drop the archive call (pre-fix behaviour) | **KILLED** (4 failed) |
| M2 — use the raw command as the filename stem | **KILLED** (1 failed) |
| M3 — archive only the truncated text | **KILLED** (1 failed) |
| M4 — remove the cap entirely | **KILLED** (6 failed) |

File restored and re-verified clean (17 passed) after each run.

### Regression sweep

- `tests/tools/test_tool_result_storage.py`, `test_budget_config.py`, `test_search_budget_truncation.py`, `test_delegate_summary_budget.py`, `test_mcp_rapid_drop_budget.py` — **56 passed, 0 failed**.
- `tests/tools/` filtered to `-k terminal` — **256 passed, 7 failed, 4 skipped**.
- Baseline comparison against `origin/main` on the four files containing those failures, run both ways: **no failure appears under the patch that is not already present in the baseline.** Two baseline failures (`test_file_tools_live.py::TestPatchReplace::test_multiline_patch`, `test_interrupted_command_cwd.py::TestCwdObservedFlag::test_interrupted_command_reports_no_cwd`) *passed* under the patch — these suites execute real commands and are timing-flaky. The remaining failures are Windows environment noise in `cwd`-echo tests, unrelated to output size.
- Collecting the new suite against `origin/main` fails with `ImportError` on `_truncate_with_overflow_persist`, confirming the tests genuinely bind to the new code.
- `ruff check` clean on all three files.

## Scope explicitly left out

- **`execute_code` is not fixed here.** It has the identical threshold inversion (`MAX_STDOUT_BYTES = 50_000`), but it drains stdout through a head/tail ring buffer while the process streams (`code_execution_tool.py:1524-1586`) — the full output is never materialised, so there is nothing to archive at cap time. Preserving it means streaming to disk, a different change with different failure modes. Documented in #86401 rather than half-done here.
- **`read_file` stays exempt.** `PINNED_THRESHOLDS` pins it to `inf` to prevent a persist → read → persist loop. Deliberate, unchanged.
- **Neither constant is retuned.** Raising `DEFAULT_MAX_BYTES` above the threshold would admit a much larger payload into context, which is what the cap prevents. Lowering `DEFAULT_RESULT_SIZE_CHARS` below the cap would let layer 2 fire on the *already-truncated* text and still lose the middle. The overflow has to be captured where it still exists.

---

 
