### PR TITLE
fix(gateway): stop treating desktop-session INVOCATION_ID as gateway supervision

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -34,7 +34,10 @@ DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT = float(
 )
 
 
-def _innermost_systemd_unit_kinds(cgroup_path: str = "/proc/self/cgroup") -> set:
+_PROC_SELF_CGROUP = "/proc/self/cgroup"
+
+
+def _innermost_systemd_unit_kinds(cgroup_path: str = _PROC_SELF_CGROUP) -> set[str]:
     """Return the innermost systemd unit suffixes owning this process.
 
     Each ``/proc/self/cgroup`` line is scanned from the leaf toward the
@@ -53,7 +56,7 @@ def _innermost_systemd_unit_kinds(cgroup_path: str = "/proc/self/cgroup") -> set
     to pin cgroup detection hermetically, or a CI runner that itself runs
     inside a systemd unit flips the result under the test.
     """
-    kinds: set = set()
+    kinds: set[str] = set()
     try:
         with open(cgroup_path, encoding="utf-8") as fh:
             for line in fh:
@@ -71,7 +74,7 @@ def _innermost_systemd_unit_kinds(cgroup_path: str = "/proc/self/cgroup") -> set
 
 def is_gateway_supervisor_process(
     environ: Mapping[str, str] | None = None,
-    cgroup_path: str = "/proc/self/cgroup",
+    cgroup_path: str = _PROC_SELF_CGROUP,
 ) -> bool:
     """Return whether this gateway process is owned by a supervisor."""
     env = os.environ if environ is None else environ

--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -34,13 +34,64 @@ DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT = float(
 )
 
 
+def _innermost_systemd_unit_kinds(cgroup_path: str = "/proc/self/cgroup") -> set:
+    """Return the innermost systemd unit suffixes owning this process.
+
+    Each ``/proc/self/cgroup`` line is scanned from the leaf toward the
+    root; the first component ending in ``.service`` or ``.scope`` is that
+    hierarchy's innermost unit (the one that directly contains the
+    process).  Scanning inward-first matters: a desktop-terminal process
+    lives at ``.../user@N.service/app.slice/ptyxis-spawn-X.scope``, so a
+    naive "any .service in the path" check would misread the ``user@``
+    manager unit as service ownership, while a gateway with ``Delegate=yes``
+    lives at ``.../hermes-gateway.service/<sub-cgroup>`` and a naive
+    leaf-only check would miss the service.  Returns a subset of
+    ``{"service", "scope"}``; empty when unreadable (macOS/Windows/etc.).
+
+    Kept injectable (``cgroup_path``) for the same reason
+    :func:`is_container_restart_context` was extracted — tests must be able
+    to pin cgroup detection hermetically, or a CI runner that itself runs
+    inside a systemd unit flips the result under the test.
+    """
+    kinds: set = set()
+    try:
+        with open(cgroup_path, encoding="utf-8") as fh:
+            for line in fh:
+                for component in reversed(line.strip().split("/")):
+                    if component.endswith(".service"):
+                        kinds.add("service")
+                        break
+                    if component.endswith(".scope"):
+                        kinds.add("scope")
+                        break
+    except OSError:
+        return set()
+    return kinds
+
+
 def is_gateway_supervisor_process(
     environ: Mapping[str, str] | None = None,
+    cgroup_path: str = "/proc/self/cgroup",
 ) -> bool:
     """Return whether this gateway process is owned by a supervisor."""
     env = os.environ if environ is None else environ
     if env.get("INVOCATION_ID"):
-        return True
+        # systemd sets INVOCATION_ID for every unit it launches — including
+        # desktop sessions: on GNOME every process of a graphical login
+        # inherits it because gnome-session and the terminal's transient
+        # ``*-spawn-*.scope`` are themselves systemd units. A process whose
+        # innermost cgroup unit is a transient *scope* (and no enclosing
+        # *service* below the user@ manager) is such a desktop/terminal
+        # process, not a supervised service: treating it as supervised
+        # routes /restart to the exit-75 service path where nothing
+        # restarts the gateway. Veto only that shape; any ``.service``
+        # ownership — hermes-gateway.service, legacy hermes.service, or a
+        # user-custom unit — keeps supervisor status, and an unreadable
+        # cgroup file (macOS, containers without cgroupfs) preserves the
+        # historical INVOCATION_ID meaning.
+        unit_kinds = _innermost_systemd_unit_kinds(cgroup_path)
+        if "service" in unit_kinds or not unit_kinds:
+            return True
     if env.get("HERMES_S6_SUPERVISED_CHILD"):
         return True
     xpc_service = env.get("XPC_SERVICE_NAME", "")

--- a/tests/gateway/test_supervisor_desktop_scope.py
+++ b/tests/gateway/test_supervisor_desktop_scope.py
@@ -58,6 +58,20 @@ class TestInnermostUnitKinds:
         )
         assert _innermost_systemd_unit_kinds(p) == {"service"}
 
+    def test_user_service_leaf_under_user_manager(self, tmp_path):
+        """systemctl --user unit: .service leaf under user@N.service → service.
+
+        This is the shape where a naive "any .service in the path" and the
+        leaf-inward scan agree, but a naive "last component only" parse and
+        an outer-first scan would disagree — pin it explicitly.
+        """
+        p = _write_cgroup(
+            tmp_path,
+            "0::/user.slice/user-1000.slice/user@1000.service/app.slice/"
+            "hermes-gateway.service\n",
+        )
+        assert _innermost_systemd_unit_kinds(p) == {"service"}
+
     def test_cgroup_v1_multiline(self, tmp_path):
         """v1 exposes many hierarchies; the systemd one carries the unit."""
         p = _write_cgroup(

--- a/tests/gateway/test_supervisor_desktop_scope.py
+++ b/tests/gateway/test_supervisor_desktop_scope.py
@@ -1,0 +1,142 @@
+"""Supervisor detection must not misread desktop-session INVOCATION_ID.
+
+On a GNOME/ptyxis desktop login every process carries ``INVOCATION_ID``
+(gnome-session and the terminal's transient ``*-spawn-*.scope`` are systemd
+units), so the env marker alone cannot distinguish a supervised gateway
+service from a CLI running in a desktop terminal.  A desktop-terminal
+gateway that is treated as supervised routes ``/restart`` to the exit-75
+service path, where no service manager exists to restart it — the gateway
+just dies.
+
+The fix vetoes INVOCATION_ID only when the process's innermost systemd
+cgroup unit is a transient ``.scope`` (desktop/terminal shape).  Any
+``.service`` ownership — standard, profile-suffixed, legacy, or
+user-custom names — and any platform where the cgroup file is unreadable
+keep the historical INVOCATION_ID meaning.
+"""
+
+import pytest
+
+from gateway.restart import (
+    _innermost_systemd_unit_kinds,
+    is_gateway_supervisor_process,
+)
+
+
+def _write_cgroup(tmp_path, content):
+    path = tmp_path / "cgroup"
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+ENV_INVOCATION = {"INVOCATION_ID": "abc123", "XPC_SERVICE_NAME": "0"}
+ENV_EMPTY = {"XPC_SERVICE_NAME": "0"}
+
+
+class TestInnermostUnitKinds:
+    def test_service_leaf(self, tmp_path):
+        p = _write_cgroup(
+            tmp_path,
+            "0::/system.slice/hermes-gateway.service\n",
+        )
+        assert _innermost_systemd_unit_kinds(p) == {"service"}
+
+    def test_desktop_scope_under_user_manager(self, tmp_path):
+        """user@N.service encloses the scope but the SCOPE is innermost."""
+        p = _write_cgroup(
+            tmp_path,
+            "0::/user.slice/user-1000.slice/user@1000.service/app.slice/"
+            "ptyxis-spawn-42.scope\n",
+        )
+        assert _innermost_systemd_unit_kinds(p) == {"scope"}
+
+    def test_delegated_sub_cgroup_still_service(self, tmp_path):
+        """Delegate=yes nests sub-cgroups under the service — still a service."""
+        p = _write_cgroup(
+            tmp_path,
+            "0::/system.slice/hermes-gateway.service/worker\n",
+        )
+        assert _innermost_systemd_unit_kinds(p) == {"service"}
+
+    def test_cgroup_v1_multiline(self, tmp_path):
+        """v1 exposes many hierarchies; the systemd one carries the unit."""
+        p = _write_cgroup(
+            tmp_path,
+            "12:cpu,cpuacct:/\n"
+            "3:memory:/user.slice\n"
+            "1:name=systemd:/user.slice/user-1000.slice/user@1000.service/"
+            "app.slice/ptyxis-spawn-7.scope\n",
+        )
+        assert _innermost_systemd_unit_kinds(p) == {"scope"}
+
+    def test_unreadable_returns_empty(self, tmp_path):
+        assert _innermost_systemd_unit_kinds(str(tmp_path / "missing")) == set()
+
+
+class TestSupervisorDetection:
+    @pytest.mark.parametrize(
+        "unit",
+        [
+            "hermes-gateway.service",
+            "hermes-gateway-coder.service",  # profile-suffixed
+            "hermes.service",  # legacy name (_LEGACY_SERVICE_NAMES)
+            "my-custom-hermes.service",  # user-custom unit
+        ],
+    )
+    def test_service_units_remain_supervised(self, tmp_path, unit):
+        p = _write_cgroup(tmp_path, f"0::/system.slice/{unit}\n")
+        assert is_gateway_supervisor_process(ENV_INVOCATION, cgroup_path=p) is True
+
+    def test_desktop_terminal_scope_is_not_supervised(self, tmp_path):
+        """The GNOME/ptyxis false positive: INVOCATION_ID + innermost scope."""
+        p = _write_cgroup(
+            tmp_path,
+            "0::/user.slice/user-1000.slice/user@1000.service/app.slice/"
+            "ptyxis-spawn-42.scope\n",
+        )
+        assert is_gateway_supervisor_process(ENV_INVOCATION, cgroup_path=p) is False
+
+    def test_session_scope_is_not_supervised(self, tmp_path):
+        p = _write_cgroup(
+            tmp_path,
+            "0::/user.slice/user-1000.slice/user@1000.service/session-3.scope\n",
+        )
+        assert is_gateway_supervisor_process(ENV_INVOCATION, cgroup_path=p) is False
+
+    def test_unreadable_cgroup_preserves_invocation_id(self, tmp_path):
+        """macOS / no-procfs: INVOCATION_ID keeps its historical meaning."""
+        missing = str(tmp_path / "missing")
+        assert (
+            is_gateway_supervisor_process(ENV_INVOCATION, cgroup_path=missing)
+            is True
+        )
+
+    def test_no_markers_at_all(self, tmp_path):
+        p = _write_cgroup(
+            tmp_path,
+            "0::/user.slice/user-1000.slice/user@1000.service/app.slice/"
+            "ptyxis-spawn-42.scope\n",
+        )
+        assert is_gateway_supervisor_process(ENV_EMPTY, cgroup_path=p) is False
+
+    def test_scope_veto_does_not_mask_other_markers(self, tmp_path):
+        """s6 / launchd / explicit external markers bypass the cgroup veto."""
+        p = _write_cgroup(
+            tmp_path,
+            "0::/user.slice/user-1000.slice/user@1000.service/app.slice/"
+            "ptyxis-spawn-42.scope\n",
+        )
+        s6 = dict(ENV_INVOCATION, HERMES_S6_SUPERVISED_CHILD="1")
+        assert is_gateway_supervisor_process(s6, cgroup_path=p) is True
+        launchd = dict(ENV_INVOCATION, XPC_SERVICE_NAME="ai.hermes.gateway")
+        assert is_gateway_supervisor_process(launchd, cgroup_path=p) is True
+        external = dict(ENV_INVOCATION, HERMES_GATEWAY_EXTERNAL_SUPERVISOR="1")
+        assert is_gateway_supervisor_process(external, cgroup_path=p) is True
+
+    def test_default_env_and_default_cgroup_path_still_work(self, monkeypatch):
+        """Existing callers pass nothing — env-based behavior is intact."""
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+        monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+        monkeypatch.delenv("HERMES_GATEWAY_EXTERNAL_SUPERVISOR", raising=False)
+        assert is_gateway_supervisor_process() is False


### PR DESCRIPTION
## Summary

A gateway run manually in a desktop terminal (GNOME/ptyxis) is no longer misclassified as service-supervised: `/restart` now takes the detached restart path that actually works there, instead of exit-75 with no service manager to restart it — which killed the gateway permanently.

Root cause: systemd sets `INVOCATION_ID` for every unit it launches, including desktop logins — gnome-session and the terminal's transient `*-spawn-*.scope` are systemd units, so every process in a desktop terminal carries it. `is_gateway_supervisor_process()` treated the marker alone as supervision.

## Changes

- `gateway/restart.py`: veto `INVOCATION_ID` only when the process's innermost systemd cgroup unit is a transient `.scope` (the desktop/terminal shape). New `_innermost_systemd_unit_kinds()` scans each `/proc/self/cgroup` line leaf-inward, so:
  - `user@1000.service` *enclosing* the desktop scope is not misread as service ownership;
  - `Delegate=yes` sub-cgroups under a real service still count as the service;
  - cgroup v1 multi-line files are handled per-hierarchy.
  - Any `.service` ownership — `hermes-gateway.service`, profile-suffixed, legacy `hermes.service`, user-custom names — keeps supervisor status; unreadable cgroup (macOS, containers without cgroupfs) preserves the historical `INVOCATION_ID` meaning. s6/launchd/`--external-supervisor` markers are untouched and bypass the veto.
  - The cgroup path is injectable for hermetic tests, mirroring how `is_container_restart_context()` was extracted.
- `tests/gateway/test_supervisor_desktop_scope.py`: 14 tests — parser shapes (service leaf, desktop scope under user@ manager, delegated sub-cgroup, cgroup v1 multi-line, unreadable), service-name matrix incl. legacy/custom units, the ptyxis false-positive regression, marker-bypass, and default-arg compatibility.

## Validation

| Scenario | main | this PR |
|---|---|---|
| Gateway under `hermes-gateway.service` / legacy `hermes.service` / custom unit | supervised ✓ | supervised ✓ (unchanged) |
| Gateway run manually in a GNOME/ptyxis terminal (`INVOCATION_ID` inherited) | supervised ✗ → `/restart` exits 75, nothing restarts it | not supervised → detached restart works |
| macOS / no procfs | supervised ✓ | supervised ✓ (unchanged) |

Suites: new file 14 passed; `tests/gateway/test_restart_service_detection.py`, `tests/hermes_cli/test_gateway_external_supervisor.py`, `tests/e2e/test_platform_commands.py`, `tests/gateway/test_restart_drain.py` → 89 passed, 6 skipped; `tests/tools/test_process_registry.py` → 76 passed, 5 skipped.

## Credit

@superniker diagnosed the desktop-session `INVOCATION_ID` false positive and identified `/proc/self/cgroup` as the discriminator in #85990. That PR's replacement check regressed restart routing for legacy/custom unit names and nested sub-cgroups (see review), so this implements the veto additively: the `.scope` shape is excluded rather than allowlisting one unit name. The originally-reported SIGTTOU spawn bug (#82705) was already fixed on main at two independent layers (`aa32e81141`, `ff5dfdecef`/`0e492a4840`); the live remainder was this restart-routing/conflict-guard misclassification.

Ref #85990, #82705
