### PR TITLE
fix(desktop): the main agent's model pick persists as the profile default

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -219,7 +219,7 @@ describe('useModelControls', () => {
     })
   })
 
-  it('routes active-session picker changes through config.set with an explicit session-scoped provider', async () => {
+  it('persists an active primary-session picker change as the profile default via config.set --global', async () => {
     $activeSessionId.set('session-1')
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'claude-sonnet-4.6' }) as never)
     let controls!: Controls
@@ -233,10 +233,13 @@ describe('useModelControls', () => {
       })
     ).resolves.toBe(true)
 
+    // The primary main agent's pick IS the profile default, so it persists to
+    // config.yaml (model.default + model.provider) — which is what lets a
+    // chosen subscription provider outrank a leftover OPENAI_API_KEY env var.
     expect(requestGateway).toHaveBeenCalledWith('config.set', {
       session_id: 'session-1',
       key: 'model',
-      value: 'claude-sonnet-4.6 --provider anthropic --session'
+      value: 'claude-sonnet-4.6 --provider anthropic --global'
     })
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
   })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -213,10 +213,16 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         // the selection "stick": a set model.provider outranks a leftover
         // OPENAI_API_KEY env var in resolve_provider(), so the main agent
         // keeps the chosen (e.g. subscription) provider across restarts
-        // instead of silently falling back to an env key. A SECONDARY chat
-        // tile stays --session so picking a model there can't rewrite the
-        // profile default (the cross-session-contamination guard).
-        const scope = touchesPrimary ? '--global' : '--session'
+        // instead of silently falling back to an env key.
+        //
+        // Two things stay --session, deliberately:
+        //  - a SECONDARY chat tile: picking a model there must not rewrite the
+        //    profile default (the cross-session-contamination guard).
+        //  - MoA (mixture-of-agents) presets: a transient orchestration choice
+        //    that must never become the persisted global gateway default.
+        const isSessionOnlyPreset = (selection.provider || '').toLowerCase() === 'moa'
+        const persistsAsDefault = touchesPrimary && !isSessionOnlyPreset
+        const scope = persistsAsDefault ? '--global' : '--session'
         const result = await requestGateway<{ deferred?: boolean }>('config.set', {
           session_id: liveSessionId,
           key: 'model',

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -207,10 +207,20 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       }
 
       try {
+        // The PRIMARY profile's main agent is the profile's default — its
+        // model/provider choice IS the default, so persist it to config.yaml
+        // (model.default + model.provider) via --global. This is what makes
+        // the selection "stick": a set model.provider outranks a leftover
+        // OPENAI_API_KEY env var in resolve_provider(), so the main agent
+        // keeps the chosen (e.g. subscription) provider across restarts
+        // instead of silently falling back to an env key. A SECONDARY chat
+        // tile stays --session so picking a model there can't rewrite the
+        // profile default (the cross-session-contamination guard).
+        const scope = touchesPrimary ? '--global' : '--session'
         const result = await requestGateway<{ deferred?: boolean }>('config.set', {
           session_id: liveSessionId,
           key: 'model',
-          value: `${selection.model} --provider ${selection.provider} --session`
+          value: `${selection.model} --provider ${selection.provider} ${scope}`
         })
 
         // A pick made DURING a turn is queued by the gateway and applied at the


### PR DESCRIPTION
**Report (@rashidkhan):** the default Hermes bot switches to the OpenAI API account rather than the subscription, and doesn't retain the previous selection.

**Why — the actual bug.** The composer model picker always sent the switch as `--session` scope, even for the **primary profile's main agent**. So the selection never wrote `config.yaml model.provider`. With `model.provider` unset, `resolve_provider('auto')` falls through (tier 3) to a leftover `OPENAI_API_KEY` in `~/.hermes/.env` and picks OpenAI/OpenRouter. The subscription the user picked was only a per-session override that evaporated next session — hence "doesn't retain the selection" **and** "switches to OpenAI." One root cause, both symptoms.

**Fix.** When the pick targets the primary profile's main agent (`touchesPrimary`), send `--global` instead of `--session`, so it persists to `config.yaml` (`model.default` + `model.provider`) through the existing model-switch persist path. A **set** `model.provider` already outranks the env key in `resolve_provider` (tier 2 > tier 3, verified), so the main agent keeps the chosen provider across restarts.

**Deliberately narrow:**
- **Secondary chat tiles stay `--session`** — picking a model in one chat must not rewrite the profile default (the cross-session-contamination guard the old comment protected). Only the primary main-agent pick persists.
- **No change to `resolve_provider`'s priority chain** — so #29285 (an explicit env key beating a *stale* OAuth login) is untouched. We just make the user's explicit main-agent selection the config default it always should have been, rather than fighting the priority chain.

This supersedes #86386 (which tried to reorder the priority chain and collided with #29285's tested contract). Renderer change — ships in the next desktop build.