### PR TITLE
fix(photon): mirror send-format.mjs and stream-staleness.mjs on read-only installs

### DIFF
--- a/plugins/platforms/photon/sidecar_paths.py
+++ b/plugins/platforms/photon/sidecar_paths.py
@@ -53,6 +53,8 @@ _MIRROR_FILES = (
     "package.json",
     "package-lock.json",
     "patch-spectrum-mixed-attachments.mjs",
+    "send-format.mjs",
+    "stream-staleness.mjs",
 )
 
 

--- a/tests/plugins/platforms/photon/test_sidecar_paths.py
+++ b/tests/plugins/platforms/photon/test_sidecar_paths.py
@@ -9,6 +9,7 @@ volume when a runtime install is unavoidable.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 import pytest
@@ -137,3 +138,25 @@ def test_adapter_import_does_not_resolve_sidecar_dir(monkeypatch) -> None:
         monkeypatch.undo()
         importlib.reload(photon_adapter)
         importlib.reload(photon_cli)
+
+
+def test_mirror_files_cover_all_local_sidecar_imports() -> None:
+    """Every local .mjs module imported by index.mjs must be mirrored.
+
+    The sidecar mirror on a read-only install is created from exactly
+    ``_MIRROR_FILES``. A module that ``index.mjs`` imports but which is
+    missing from that list crashes the sidecar at startup with
+    ``ERR_MODULE_NOT_FOUND`` (send-format.mjs and stream-staleness.mjs were
+    historically omitted). Guard the invariant directly instead of re-adding
+    files one outage at a time.
+    """
+    index = sidecar_paths.SOURCE_SIDECAR_DIR / "index.mjs"
+    source_text = index.read_text(encoding="utf-8")
+    imported = set(
+        re.findall(r'from ["\']\./([\w.-]+\.mjs)["\']', source_text)
+    )
+    assert imported, "expected local .mjs imports in index.mjs"
+    missing = imported - set(sidecar_paths._MIRROR_FILES)
+    assert not missing, (
+        f"_MIRROR_FILES omits modules imported by index.mjs: {sorted(missing)}"
+    )


### PR DESCRIPTION
## Problem

On hosted/managed images the Hermes install tree is read-only, so the Photon
sidecar runs from a mirror created in `$HERMES_HOME/photon/sidecar` by
`resolve_sidecar_dir()`, which copies exactly the files listed in
`_MIRROR_FILES`.

`_MIRROR_FILES` listed only `index.mjs`, `package.json`, `package-lock.json`,
and `patch-spectrum-mixed-attachments.mjs` — but `index.mjs` also imports
`./send-format.mjs` and `./stream-staleness.mjs`. Those two were never
mirrored, so on a read-only install the sidecar crashed at startup with
`ERR_MODULE_NOT_FOUND` (`.../photon/sidecar/send-format.mjs`), and the gateway
retried the connection every 300s indefinitely.

## Fix

Add `send-format.mjs` and `stream-staleness.mjs` to `_MIRROR_FILES`.

## Regression test

`test_mirror_files_cover_all_local_sidecar_imports` asserts that every local
`.mjs` module `index.mjs` imports is present in `_MIRROR_FILES`, so a future
sidecar module can't silently fall out of the mirror list again.

Verified the new test fails against the pre-fix tuple and passes with the fix.
