### PR TITLE
fix(vision): keep native images on local/custom Ollama instead of vision_analyze

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3467,7 +3467,14 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[st
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        runtime = resolve_runtime_provider(requested="custom")
+        # Resolve the default configured provider first. If it's a custom
+        # runtime (e.g. a user-defined named custom provider like
+        # ollama-launch) we use it directly; otherwise fall back to an
+        # explicit "custom" request so the legacy single-custom path still
+        # works.
+        runtime = resolve_runtime_provider(requested=None)
+        if not isinstance(runtime, dict) or runtime.get("provider") != "custom":
+            runtime = resolve_runtime_provider(requested="custom")
     except Exception as exc:
         logger.debug("Auxiliary client: custom runtime resolution failed: %s", exc)
         runtime = None

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1332,6 +1332,27 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     if tools_for_api is None:
         tools_for_api = agent.tools
 
+    # When the current turn already has a native image attached (an
+    # image_url content part on any message), suppress the vision_analyze
+    # tool so the model reads the pixels directly rather than calling a
+    # redundant — and on local/custom endpoints often unconfigured — tool.
+    has_native_images = False
+    for msg in api_messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "image_url":
+                    has_native_images = True
+                    break
+        if has_native_images:
+            break
+
+    if has_native_images and tools_for_api:
+        tools_for_api = [
+            t for t in tools_for_api
+            if not (isinstance(t, dict) and t.get("function", {}).get("name") == "vision_analyze")
+        ]
+
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
         anthropic_messages = agent._prepare_anthropic_messages_for_api(api_messages)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3114,8 +3114,6 @@ class TestVisionAutoSkipsKimiCoding:
         assert client is fake_or_client
         assert model == "google/gemini-3-flash-preview"
 
-
-
     def test_skip_set_covers_exactly_known_entries(self):
         """Guard against accidental widening of the skip list."""
         from agent.auxiliary_client import _PROVIDERS_WITHOUT_VISION
@@ -4612,3 +4610,28 @@ class TestFastModelTier:
             _FAST_MODEL_TASKS
         )
         assert not overlap
+
+
+def test_resolve_custom_runtime_with_named_custom_provider():
+    """``_resolve_custom_runtime`` should first try the default-configured
+    provider (which may be a named custom provider like ``ollama-launch``)
+    before falling back to an explicit ``requested="custom"`` call.
+    """
+    from agent.auxiliary_client import _resolve_custom_runtime
+
+    mock_runtime_first = {
+        "provider": "custom",
+        "api_mode": "chat_completions",
+        "base_url": "http://192.168.1.210:11434/v1",
+        "api_key": "ollama-key",
+    }
+
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value=mock_runtime_first,
+    ) as mock_resolve:
+        base, key, mode = _resolve_custom_runtime()
+        assert base == "http://192.168.1.210:11434/v1"
+        assert key == "ollama-key"
+        assert mode == "chat_completions"
+        mock_resolve.assert_called_once_with(requested=None)

--- a/tests/agent/test_vision_suppression.py
+++ b/tests/agent/test_vision_suppression.py
@@ -1,0 +1,98 @@
+from unittest.mock import MagicMock, patch
+import pytest
+
+from agent.chat_completion_helpers import build_api_kwargs
+from tools.vision_tools import _supports_media_in_tool_results
+
+def test_supports_media_in_tool_results_for_custom_providers():
+    """Verify that _supports_media_in_tool_results returns True for custom and ollama-launch."""
+    assert _supports_media_in_tool_results("custom", "gemma4:latest") is True
+    assert _supports_media_in_tool_results("ollama-launch", "gemma4:latest") is True
+    assert _supports_media_in_tool_results("openai", "gpt-4o") is True
+    assert _supports_media_in_tool_results("unknown-provider", "some-model") is False
+
+def test_build_api_kwargs_suppresses_vision_analyze():
+    """Verify that build_api_kwargs filters out the vision_analyze tool when native images are present."""
+    # Create mock agent
+    agent = MagicMock()
+    agent.api_mode = "chat_completions"
+    agent.provider = "custom"
+    agent.model = "gemma4:latest"
+    agent.base_url = "http://localhost:11434/v1"
+    agent.max_tokens = 2048
+    agent.reasoning_config = None
+    agent.request_overrides = {}
+    agent.providers_allowed = None
+    agent.providers_ignored = None
+    agent.providers_order = None
+    agent.provider_sort = None
+    agent.provider_require_parameters = False
+    agent.provider_data_collection = None
+    agent._ephemeral_max_output_tokens = None
+    agent._ollama_num_ctx = None
+    agent.tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "vision_analyze",
+                "description": "Load an image",
+            }
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "run_command",
+                "description": "Run shell command",
+            }
+        }
+    ]
+    
+    # 1. Test when no native images are present
+    messages_no_images = [
+        {"role": "user", "content": "hello world"}
+    ]
+    
+    # Mock transport builder
+    mock_transport = MagicMock()
+    agent._get_transport.return_value = mock_transport
+    
+    # Mock the return value of _prepare_messages_for_non_vision_model
+    agent._prepare_messages_for_non_vision_model = lambda x: x
+    agent._is_qwen_portal.return_value = False
+    agent._is_openrouter_url.return_value = False
+    agent._is_azure_openai_url.return_value = False
+    agent._is_direct_openai_url.return_value = False
+    agent._supports_reasoning_extra_body.return_value = False
+    agent._resolved_api_call_timeout.return_value = 1800
+    agent._max_tokens_param = lambda x: {}
+    
+    # We patch the provider profile resolver to return None (so it hits the legacy flag path in build_api_kwargs)
+    with patch("providers.get_provider_profile", return_value=None):
+        build_api_kwargs(agent, messages_no_images)
+        
+        # Verify that all tools (including vision_analyze) are passed to transport
+        called_tools = mock_transport.build_kwargs.call_args[1].get("tools")
+        assert len(called_tools) == 2
+        assert any(t["function"]["name"] == "vision_analyze" for t in called_tools)
+        
+        # Reset mock
+        mock_transport.reset_mock()
+        
+        # 2. Test when a native image is attached
+        messages_with_images = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this image"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
+                ]
+            }
+        ]
+        
+        build_api_kwargs(agent, messages_with_images)
+        
+        # Verify that vision_analyze is filtered out of the tools list passed to transport
+        called_tools = mock_transport.build_kwargs.call_args[1].get("tools")
+        assert len(called_tools) == 1
+        assert called_tools[0]["function"]["name"] == "run_command"
+        assert not any(t["function"]["name"] == "vision_analyze" for t in called_tools)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1006,7 +1006,7 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         return True
 
     # OpenAI Chat Completions and Responses
-    if p in {"openai", "openai-chat", "openai-codex", "azure-openai"}:
+    if p in {"openai", "openai-chat", "openai-codex", "azure-openai", "custom", "ollama", "ollama-launch"}:
         return True
 
     # Gemini — gate on model name; older Gemini variants did not support


### PR DESCRIPTION
## What does this PR do?

After #54511, local Ollama vision models are detected via `/api/show` and can receive native `image_url` parts. Three follow-on gaps remain for named custom providers (e.g. `ollama-launch` pointing at a LAN Ollama):

1. `build_api_kwargs` still offers `vision_analyze` on a turn that already has a native image. On local/custom endpoints that tool is often unconfigured, so the model gets the pixels *and* a dead tool.
2. `_supports_media_in_tool_results` allowlists Anthropic / OpenAI / Gemini / aggregators only. Named custom providers are rewritten to `custom`, so screenshots and camera frames fall back to the text path.
3. `_resolve_custom_runtime` always calls `resolve_runtime_provider(requested="custom")`, which misses a configured named custom runtime. Resolve the default provider first, then fall back to the legacy `"custom"` path.

This does **not** re-add the `/api/show` probe (already on main) and does **not** put `ollama-cloud` in `_PROVIDERS_WITHOUT_VISION` (auto-detect already falls through when the main model is text-only).

## Related Issue

Follow-up to #54511. Supersedes the leftover local-Ollama pieces of #33047 (closed, unreviewed).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes a problem)
- [ ] ✨ New feature
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/chat_completion_helpers.py`: if any API message already has an `image_url` part, drop `vision_analyze` from the tool list for that call.
- `tools/vision_tools.py`: treat `custom`, `ollama`, and `ollama-launch` like other OpenAI-compatible vision stacks for media in tool results.
- `agent/auxiliary_client.py`: `_resolve_custom_runtime` tries the configured default provider first, then `requested="custom"`.
- Tests: `tests/agent/test_vision_suppression.py` (native-image tool filter + media allowlist); `test_resolve_custom_runtime_with_named_custom_provider` in `tests/agent/test_auxiliary_client.py`.

## How to Test

1. Named custom provider, tag not in models.dev:

   ```yaml
   model:
     provider: ollama-launch
     default: gemma4:latest
     base_url: http://localhost:11434/v1
     api_key: ollama
   ```

2. Send an image-bearing prompt. The model should receive the native `image_url` part and **not** be offered `vision_analyze`.
3. A tool that returns an image (screenshot / camera) should attach media on `custom` / `ollama-launch` instead of the aux text fallback.
4. `pytest tests/agent/test_vision_suppression.py tests/agent/test_auxiliary_client.py -q`

## Checklist

- [x] Conventional Commits
- [x] Scoped to this fix (no `/api/show` rewrite, no ollama-cloud skip-list)
- [x] Tests for the new behavior

Made with [Cursor](https://cursor.com)