### PR TITLE
fix(tests): reap leaked TUI notification pollers between tests

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -56,6 +56,41 @@ def _neuter_agent_prewarm_timer(request, monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def _reap_leaked_notification_pollers():
+    """Stop and join notification pollers leaked by each test.
+
+    session.init/create paths start a per-session poller daemon thread. A
+    poller left running by one test steals-and-requeues events off the
+    PROCESS-GLOBAL process_registry.completion_queue while a later test is
+    asserting on it — the root cause of the flaky
+    test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_threading
+    (two CI hits on unrelated PRs, Aug 2026). Set every registered poller's
+    stop event (the loop wakes at least every 0.5s), then join with ONE
+    small shared budget — never per-thread — so teardown stays O(seconds)
+    for the whole file even when many tests leaked pollers.
+    """
+    yield
+    pollers = [
+        (stop, thread)
+        for stop, thread in list(server._notification_pollers)
+        if thread.is_alive()
+    ]
+    for stop, _thread in pollers:
+        stop.set()
+    deadline = time.time() + 3.0
+    for _stop, thread in pollers:
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            break
+        thread.join(timeout=remaining)
+    server._notification_pollers[:] = [
+        (stop, thread)
+        for stop, thread in server._notification_pollers
+        if thread.is_alive()
+    ]
+
+
 def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9779,6 +9779,12 @@ def _wire_desktop_ui() -> None:
     _desktop_ui_wired = True
 
 
+# (stop_event, thread) for every poller ever started in this process.
+# Pruned of dead threads on each spawn; consumed by test teardowns to reap
+# leaked pollers (see _start_notification_poller).
+_notification_pollers: list = []
+
+
 def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     """Start the background notification poller for a TUI session."""
     _wire_agent_terminal_output()
@@ -9788,7 +9794,18 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
         target=_notification_poller_loop,
         args=(stop, sid, session),
         daemon=True,
+        # Stable, greppable name for debuggers and test teardowns.
+        name=f"tui-notif-poller-{sid}",
     )
+    # Registry of (stop, thread) pairs so test teardowns can reap pollers
+    # leaked by session.init/create tests — an unjoined poller steals
+    # events off the process-global completion_queue mid-assertion in a
+    # LATER test (flaky test_run_prompt_submit_requeues_all_unstarted_...).
+    # Bounded: entries for dead threads are pruned on each spawn.
+    _notification_pollers[:] = [
+        (s, th) for (s, th) in _notification_pollers if th.is_alive()
+    ]
+    _notification_pollers.append((stop, t))
     t.start()
     return stop
 


### PR DESCRIPTION
## Summary
Kills the flaky `test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_threading` — it failed on CI twice in one hour on two unrelated PRs (#86371, #86374) with `assert set() == {'proc_batch_2', 'proc_batch_3'}` while passing locally 14/14.

Root cause: session.init/create tests earlier in the file start real per-session notification poller daemon threads and never stop them. Leaked pollers keep polling the process-global `process_registry.completion_queue` and steal-and-requeue the target test's events mid-assertion, starving its bounded drain loop.

Reproduced deterministically-ish: 30 leaked foreign-session pollers injected via a sabotage conftest → target test fails standalone ~1 in 3 with the exact CI assertion; with the reap fixture active it passed 8/8 under the same sabotage.

## Changes
- `tui_gateway/server.py`: `_start_notification_poller()` registers `(stop_event, thread)` in a module-level `_notification_pollers` list (dead entries pruned on each spawn); poller threads get a stable `tui-notif-poller-<sid>` name.
- `tests/test_tui_gateway_server.py`: autouse fixture sets every registered live poller's stop event after each test and joins under ONE shared 3s budget. No per-thread timeouts, no session-dict mutation (a first draft that did both hung the file).

## Validation
| | Before | After |
|---|---|---|
| target test with 30 leaked pollers | fails ~1 in 3 | 8/8 pass |
| full file (`scripts/run_tests.sh`) | 13.2s baseline | 555/555 in 16.1s |
| CI hits on unrelated PRs | 2 in one hour | poller leak class removed |

## Infographic

![Ghost threads reaped between tests](https://files.catbox.moe/34duel.png)
