### PR TITLE
fix(tui-gateway): route /context through the live session

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10525,6 +10525,65 @@ def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_slash_exec_context_routes_to_live_session_without_worker(monkeypatch):
+    """Non-compute-host sessions get /context from the live session state.
+
+    /context moved from _ISOLATED_SESSION_READ_COMMANDS to
+    _LIVE_SESSION_DIRECT_COMMANDS; before that, a normal session's /context
+    fell through to an isolated _SlashWorker, reporting a fresh worker's
+    context instead of the live conversation's. The exploding worker asserts
+    the worker path is never taken; the mirrored usage snapshot asserts the
+    output comes from the live session.
+    """
+
+    class _ExplodingWorker:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("slash worker should not run for live /context")
+
+    server._sessions["sid"] = {
+        # agent=None is a real session state (lazy sessions keep the agent
+        # slot empty until first turn) — _session() would substitute a dummy
+        # SimpleNamespace, which changes the usage-snapshot branch.
+        "agent": None,
+        "session_key": "session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        "_metadata_mirror": {
+            "model": "live-model",
+            "provider": "live-provider",
+            "usage": {
+                "model": "live-model",
+                "context_used": 432,
+                "context_max": 1000,
+                "context_percent": 43,
+            },
+        },
+    }
+    monkeypatch.setattr(server, "_SlashWorker", _ExplodingWorker)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "slash.exec",
+                "params": {"command": "/context", "session_id": "sid"},
+            }
+        )
+        assert "result" in resp, resp
+        assert "432" in resp["result"]["output"]
+        assert "live-model" in resp["result"]["output"]
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_prompt_submit_sets_approval_session_key(monkeypatch):
     from tools.approval import get_current_session_key
 
@@ -17996,7 +18055,7 @@ def test_slash_exec_concurrent_first_use_spawns_single_worker(monkeypatch):
             {
                 "id": str(n),
                 "method": "slash.exec",
-                "params": {"command": "/context", "session_id": "race-spawn"},
+                "params": {"command": "/diff", "session_id": "race-spawn"},
             }
         )
         results.append(resp)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10584,6 +10584,86 @@ def test_slash_exec_context_routes_to_live_session_without_worker(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_slash_exec_context_without_metadata_mirror(monkeypatch):
+    """/context on a session with NO _metadata_mirror (lazy/older session).
+
+    _metadata_mirror() is a safe accessor ({} when absent) and
+    _session_usage_snapshot falls back to the agent's own counters, so the
+    output must degrade to a real answer, not raise or render blank
+    (review point on PR #86434: the mirror-present case was the only one
+    pinned)."""
+    import threading as _threading
+
+    class _Agent:
+        model = "mirrorless-model"
+        provider = "mirrorless-provider"
+        session_input_tokens = 111
+        session_output_tokens = 22
+        session_total_tokens = 133
+        session_api_calls = 2
+
+    server._sessions["sid"] = {
+        "agent": _Agent(),
+        "session_key": "",
+        "history": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "there"},
+        ],
+        "history_lock": _threading.Lock(),
+        "history_version": 1,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        # deliberately NO _metadata_mirror key
+    }
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "slash.exec",
+                "params": {"command": "/context", "session_id": "sid"},
+            }
+        )
+        assert resp is not None, "handle_request returned None"
+        assert "result" in resp, resp
+        out = resp["result"]["output"]
+        assert "Conversation: 2 messages" in out
+        assert "mirrorless-model" in out
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_slash_exec_context_unknown_session_clear_error(monkeypatch):
+    """Unknown/never-loaded session id: slash.exec fails at _sess_nowait
+    (4001 session not found) BEFORE the live/isolated dispatch — the
+    command has no live branch there, and the contract is a clear error,
+    never an unhandled branch (review point on PR #86434)."""
+    assert "no-such-session" not in server._sessions
+
+    class _ExplodingWorker:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("worker must not run for unknown session")
+
+    monkeypatch.setattr(server, "_SlashWorker", _ExplodingWorker)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "slash.exec",
+            "params": {"command": "/context", "session_id": "no-such-session"},
+        }
+    )
+    assert resp is not None, "handle_request returned None"
+    assert "error" in resp, resp
+    assert resp["error"]["code"] == 4001
+    assert "not found" in resp["error"]["message"]
+
+
 def test_prompt_submit_sets_approval_session_key(monkeypatch):
     from tools.approval import get_current_session_key
 
@@ -18055,7 +18135,7 @@ def test_slash_exec_concurrent_first_use_spawns_single_worker(monkeypatch):
             {
                 "id": str(n),
                 "method": "slash.exec",
-                "params": {"command": "/diff", "session_id": "race-spawn"},
+                "params": {"command": "/tools", "session_id": "race-spawn"},
             }
         )
         results.append(resp)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -15666,6 +15666,7 @@ _LIVE_SESSION_DIRECT_COMMANDS = frozenset(
     {
         "clear",
         "compress",
+        "context",
         "effort",
         "history",
         "models",
@@ -15677,7 +15678,7 @@ _LIVE_SESSION_DIRECT_COMMANDS = frozenset(
     }
 )
 
-_ISOLATED_SESSION_READ_COMMANDS = frozenset({"context", "tools", "help"})
+_ISOLATED_SESSION_READ_COMMANDS = frozenset({"tools", "help"})
 
 
 def _format_live_review_output(session: Optional[dict], arg: str) -> str:


### PR DESCRIPTION
## What does this PR do?

`/context` was listed in `_ISOLATED_SESSION_READ_COMMANDS`, so executing it spawned an isolated worker and reported a *fresh session's* context state instead of the live conversation's. Move it to `_LIVE_SESSION_DIRECT_COMMANDS` so it reflects (and applies to) the running session, matching `/effort` and `/history`.

## Related Issue

None found on the tracker.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux 43