### PR TITLE
feat(discord): REST pagination conformance

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience R2

--- a/tests/tools/test_discord_pagination.py
+++ b/tests/tools/test_discord_pagination.py
@@ -1,0 +1,151 @@
+"""Tests for tools.discord_api.pagination (feature R2: pagination conformance)."""
+
+import pytest
+
+from tools.discord_api.pagination import (
+    Page,
+    PaginationError,
+    has_more_page,
+    next_page_params,
+    page_params,
+)
+
+
+# ---------------------------------------------------------------------------
+# Page dataclass
+# ---------------------------------------------------------------------------
+class TestPage:
+    def test_defaults(self):
+        page = Page()
+        assert page.items == []
+        assert page.has_more is False
+
+    def test_values(self):
+        page = Page(items=[1, 2, 3], has_more=True)
+        assert page.items == [1, 2, 3]
+        assert page.has_more is True
+
+    def test_positional_construction(self):
+        page = Page(["a", "b"], True)
+        assert page.items == ["a", "b"]
+        assert page.has_more is True
+
+
+# ---------------------------------------------------------------------------
+# page_params
+# ---------------------------------------------------------------------------
+class TestPageParams:
+    def test_defaults(self):
+        assert page_params() == {"limit": 50}
+
+    def test_before_only(self):
+        assert page_params(before="123") == {"before": "123", "limit": 50}
+
+    def test_after_only(self):
+        assert page_params(after="456") == {"after": "456", "limit": 50}
+
+    def test_around_only(self):
+        assert page_params(around="789") == {"around": "789", "limit": 50}
+
+    def test_custom_limit_passthrough(self):
+        assert page_params(limit=25) == {"limit": 25}
+        assert page_params(before="1", limit=10) == {"before": "1", "limit": 10}
+
+    def test_limit_floor_clamped_to_one(self):
+        assert page_params(limit=0)["limit"] == 1
+        assert page_params(limit=-5)["limit"] == 1
+
+    def test_limit_ceiling_clamped_to_discord_max(self):
+        assert page_params(limit=101)["limit"] == 100
+        assert page_params(limit=1000)["limit"] == 100
+
+    def test_limit_boundaries_accepted(self):
+        assert page_params(limit=1)["limit"] == 1
+        assert page_params(limit=100)["limit"] == 100
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"before": "1", "after": "2"},
+            {"before": "1", "around": "2"},
+            {"after": "1", "around": "2"},
+            {"before": "1", "after": "2", "around": "3"},
+        ],
+        ids=["before+after", "before+around", "after+around", "all-three"],
+    )
+    def test_mutually_exclusive_raises(self, kwargs):
+        with pytest.raises(PaginationError):
+            page_params(**kwargs)
+
+    def test_mutually_exclusive_raises_value_error(self):
+        # PaginationError must remain a ValueError subclass.
+        with pytest.raises(ValueError):
+            page_params(before="1", after="2")
+
+    def test_mutually_exclusive_respects_clamped_limit(self):
+        with pytest.raises(PaginationError):
+            page_params(before="1", after="2", limit=500)
+
+
+# ---------------------------------------------------------------------------
+# has_more_page
+# ---------------------------------------------------------------------------
+class TestHasMorePage:
+    def test_full_page_has_more(self):
+        assert has_more_page(50, 50) is True
+
+    def test_partial_page_no_more(self):
+        assert has_more_page(10, 50) is False
+
+    def test_empty_page_no_more(self):
+        assert has_more_page(0, 50) is False
+
+    def test_full_page_discord_max_limit(self):
+        assert has_more_page(100, 100) is True
+
+    def test_partial_single_item(self):
+        assert has_more_page(1, 100) is False
+
+    def test_exactly_full_at_minimum_limit(self):
+        assert has_more_page(1, 1) is True
+
+    def test_not_full_by_one(self):
+        assert has_more_page(49, 50) is False
+
+
+# ---------------------------------------------------------------------------
+# next_page_params
+# ---------------------------------------------------------------------------
+class TestNextPageParams:
+    def test_before_flips_to_after(self):
+        current = page_params(before="999", limit=25)
+        assert next_page_params(current, "123") == {"after": "123", "limit": 25}
+
+    def test_around_flips_to_after(self):
+        current = page_params(around="999", limit=50)
+        assert next_page_params(current, "123") == {"after": "123", "limit": 50}
+
+    def test_plain_forward_uses_after(self):
+        current = page_params(limit=50)
+        assert next_page_params(current, "123") == {"after": "123", "limit": 50}
+
+    def test_after_raises(self):
+        current = page_params(after="999", limit=50)
+        with pytest.raises(PaginationError):
+            next_page_params(current, "123")
+
+    def test_after_raises_value_error(self):
+        current = {"after": "999", "limit": 50}
+        with pytest.raises(ValueError):
+            next_page_params(current, "123")
+
+    def test_keeps_current_limit(self):
+        current = page_params(before="999", limit=100)
+        assert next_page_params(current, "7") == {"after": "7", "limit": 100}
+
+    def test_missing_limit_defaults_to_50(self):
+        assert next_page_params({}, "123") == {"after": "123", "limit": 50}
+
+    def test_accepts_int_last_id(self):
+        current = page_params(before="999", limit=10)
+        assert next_page_params(current, 42) == {"after": 42, "limit": 10}

--- a/tools/discord_api/pagination.py
+++ b/tools/discord_api/pagination.py
@@ -1,0 +1,128 @@
+"""Discord REST pagination conformance helpers.
+
+Pure logic only -- no network I/O. Implements the parameter shapes the
+Discord REST API expects for paginated list endpoints:
+
+* ``before`` / ``after`` / ``around`` are mutually exclusive (Discord
+  rejects requests that send more than one of them).
+* ``limit`` must be within 1..100 (Discord's minimum and maximum;
+  Discord's own default is 100).
+* A full page (``returned_count == limit``) means more results may exist.
+* Forward continuation after a ``before``/``around`` page flips to
+  ``after`` keyed on the last item's id.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+__all__ = [
+    "Page",
+    "PaginationError",
+    "has_more_page",
+    "next_page_params",
+    "page_params",
+]
+
+#: Discord's allowed limit range for paginated list endpoints.
+MIN_LIMIT = 1
+MAX_LIMIT = 100
+
+#: Discord's own default page size (used when no limit is supplied).
+DISCORD_DEFAULT_LIMIT = 100
+
+
+class PaginationError(ValueError):
+    """Raised for invalid pagination parameter combinations."""
+
+
+@dataclass
+class Page:
+    """A single page of results from a paginated Discord REST endpoint."""
+
+    items: List[Any] = field(default_factory=list)
+    has_more: bool = False
+
+
+def page_params(
+    before: Optional[Union[str, int]] = None,
+    after: Optional[Union[str, int]] = None,
+    around: Optional[Union[str, int]] = None,
+    limit: int = 50,
+) -> Dict[str, Any]:
+    """Build validated query params for a Discord paginated list request.
+
+    Args:
+        before: Snowflake id; return messages before this id.
+        after: Snowflake id; return messages after this id.
+        around: Snowflake id; return messages around this id.
+        limit: Max number of results; clamped to Discord's 1..100 range.
+
+    Returns:
+        A dict suitable for ``requests.get(..., params=...)``, e.g.
+        ``{"before": "123", "limit": 50}``. Only the given cursor key is
+        included; ``limit`` is always present.
+
+    Raises:
+        PaginationError: if more than one of ``before``/``after``/``around``
+            is supplied.
+    """
+    given = [
+        name
+        for name, value in (("before", before), ("after", after), ("around", around))
+        if value is not None
+    ]
+    if len(given) > 1:
+        raise PaginationError(
+            "before, after, and around are mutually exclusive; "
+            f"got: {', '.join(given)}"
+        )
+
+    clamped_limit = max(MIN_LIMIT, min(MAX_LIMIT, int(limit)))
+
+    params: Dict[str, Any] = {"limit": clamped_limit}
+    if before is not None:
+        params["before"] = before
+    elif after is not None:
+        params["after"] = after
+    elif around is not None:
+        params["around"] = around
+    return params
+
+
+def has_more_page(returned_count: int, limit: int) -> bool:
+    """Return True when a full page was returned, so more may exist.
+
+    Discord pagination heuristic: if the API returned exactly ``limit``
+    items, the page is full and there is likely another page after it;
+    a partial (or empty) page means the end was reached.
+    """
+    return returned_count == limit
+
+
+def next_page_params(current_params: Dict[str, Any], last_id: Union[str, int]) -> Dict[str, Any]:
+    """Build params for the next (forward) page after ``current_params``.
+
+    Forward continuation uses ``after=<last item id>``. When the current
+    page was fetched with ``before`` or ``around`` (or no cursor), the
+    continuation flips to ``after``; when the current params already use
+    ``after``, there is no valid forward continuation and a
+    ``PaginationError`` is raised.
+
+    Args:
+        current_params: Params previously returned by :func:`page_params`
+            (or an equivalent dict with a ``limit`` key).
+        last_id: Snowflake id of the last item on the current page.
+
+    Returns:
+        ``{"after": last_id, "limit": <current limit>}``.
+
+    Raises:
+        PaginationError: if ``current_params`` already contains ``after``.
+    """
+    if "after" in current_params:
+        raise PaginationError(
+            "cannot continue forward from params that already use 'after'"
+        )
+
+    limit = current_params.get("limit", 50)
+    return {"after": last_id, "limit": limit}


### PR DESCRIPTION
**Discord R2** (Part of #79564, Fixes #86436): REST pagination conformance in `tools/discord_api/pagination.py`. 32/32 tests pass. New module only.