### PR TITLE
feat(discord): structured inbound message model

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience M1

--- a/plugins/platforms/discord/message_model.py
+++ b/plugins/platforms/discord/message_model.py
@@ -1,0 +1,75 @@
+"""Discord structured inbound message model (M1).
+
+Pure typed projection of a Discord message payload (REST v10
+resources/message.mdx) into a small read-only dataclass. No network access.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class MessageProjectionError(ValueError):
+    """Raised when a message payload cannot be projected."""
+
+
+@dataclass
+class MessageContent:
+    """Read projection of a Discord message payload."""
+
+    content: str
+    embeds: list[dict] = field(default_factory=list)
+    attachments: list[str] = field(default_factory=list)
+    replied_to: str | None = None
+    thread_starter: bool = False
+    flags: int = 0
+    type: int = 0
+
+
+def project_message(payload: dict) -> MessageContent:
+    """Project a Discord message payload into a :class:`MessageContent`.
+
+    Raises:
+        MessageProjectionError: if ``payload`` is not a dict.
+    """
+    if not isinstance(payload, dict):
+        raise MessageProjectionError(
+            "message payload must be a dict, got "
+            f"{type(payload).__name__}"
+        )
+
+    content = payload.get("content")
+    content = content if isinstance(content, str) and content else ""
+
+    embeds = payload.get("embeds", [])
+    embeds = embeds if isinstance(embeds, list) else []
+
+    attachments: list[str] = []
+    raw_attachments = payload.get("attachments", [])
+    if isinstance(raw_attachments, list):
+        attachments = [
+            att["url"]
+            for att in raw_attachments
+            if isinstance(att, dict) and isinstance(att.get("url"), str)
+        ]
+
+    replied_to: str | None = None
+    referenced = payload.get("referenced_message")
+    if isinstance(referenced, dict) and isinstance(referenced.get("id"), str):
+        replied_to = referenced["id"]
+
+    msg_type = payload.get("type", 0)
+    msg_type = msg_type if isinstance(msg_type, int) else 0
+    thread_starter = msg_type == 21
+
+    flags = payload.get("flags", 0)
+    flags = flags if isinstance(flags, int) else 0
+
+    return MessageContent(
+        content=content,
+        embeds=embeds,
+        attachments=attachments,
+        replied_to=replied_to,
+        thread_starter=thread_starter,
+        flags=flags,
+        type=msg_type,
+    )

--- a/tests/tools/test_discord_message_model.py
+++ b/tests/tools/test_discord_message_model.py
@@ -1,0 +1,114 @@
+"""Tests for the Discord structured inbound message model (M1)."""
+
+import pytest
+
+from plugins.platforms.discord.message_model import (
+    MessageContent,
+    MessageProjectionError,
+    project_message,
+)
+
+
+def test_plain_content_message():
+    result = project_message(
+        {
+            "id": "100",
+            "content": "hello world",
+            "channel_id": "1",
+            "author": {"id": "42", "username": "alice"},
+        }
+    )
+    assert isinstance(result, MessageContent)
+    assert result.content == "hello world"
+    assert result.embeds == []
+    assert result.attachments == []
+    assert result.replied_to is None
+    assert result.thread_starter is False
+    assert result.flags == 0
+    assert result.type == 0
+
+
+def test_embed_only_message():
+    result = project_message(
+        {
+            "id": "101",
+            "content": "",
+            "embeds": [{"type": "rich", "title": "A title", "description": "desc"}],
+        }
+    )
+    assert result.content == ""
+    assert len(result.embeds) == 1
+    assert result.embeds[0]["title"] == "A title"
+
+
+def test_referenced_message_sets_replied_to():
+    result = project_message(
+        {
+            "id": "102",
+            "content": "replying",
+            "referenced_message": {"id": "50", "content": "original", "channel_id": "1"},
+        }
+    )
+    assert result.replied_to == "50"
+    assert result.content == "replying"
+
+
+def test_missing_referenced_message_gives_none():
+    result = project_message({"id": "103", "content": "no ref"})
+    assert result.replied_to is None
+
+
+def test_type_21_thread_starter():
+    result = project_message({"id": "104", "content": "", "type": 21})
+    assert result.thread_starter is True
+    assert result.type == 21
+
+
+def test_type_0_is_not_thread_starter():
+    result = project_message({"id": "105", "content": "regular", "type": 0})
+    assert result.thread_starter is False
+
+
+def test_missing_embeds_and_attachments_default_to_empty():
+    result = project_message({"id": "106", "content": "bare"})
+    assert result.embeds == []
+    assert result.attachments == []
+
+
+def test_attachments_projected_to_urls():
+    result = project_message(
+        {
+            "id": "107",
+            "content": "pic",
+            "attachments": [
+                {"id": "1", "filename": "a.png", "url": "https://cdn.example/a.png"},
+                {"id": "2", "filename": "b.png", "url": "https://cdn.example/b.png"},
+            ],
+        }
+    )
+    assert result.attachments == [
+        "https://cdn.example/a.png",
+        "https://cdn.example/b.png",
+    ]
+
+
+def test_flags_default_to_zero():
+    result = project_message({"id": "108", "content": "no flags"})
+    assert result.flags == 0
+
+
+def test_flags_parsed():
+    result = project_message({"id": "109", "content": "flagged", "flags": 1 << 6})
+    assert result.flags == 64
+
+
+def test_content_missing_defaults_to_empty_string():
+    result = project_message({"id": "110"})
+    assert result.content == ""
+
+
+def test_non_dict_payload_raises_projection_error():
+    assert issubclass(MessageProjectionError, ValueError)
+    for bad in ("not a dict", None, [1, 2, 3], 42):
+        with pytest.raises(MessageProjectionError):
+            project_message(bad)


### PR DESCRIPTION
**Discord M1** (Part of #79564, Fixes #86439): structured inbound message model in `plugins/platforms/discord/message_model.py`. 12/12 tests pass. New module only.