### PR TITLE
feat(discord): local reliability telemetry

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience R4

--- a/plugins/platforms/discord/reliability_telemetry.py
+++ b/plugins/platforms/discord/reliability_telemetry.py
@@ -1,0 +1,105 @@
+"""Discord local reliability telemetry (local-only, zero outbound).
+
+Pure in-memory counters guarded by a lock. No network and no disk I/O
+unless an explicit sink is provided by the caller.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Callable, Dict, Optional
+
+# Predefined reliability event names.
+CONNECT = "connect"
+READY = "ready"
+RECONNECT = "reconnect"
+SYNC = "sync"
+RATE_LIMIT_429 = "rate_limit_429"
+DROPPED_ATTACHMENT = "dropped_attachment"
+DELIVERY_FAILURE = "delivery_failure"
+VOICE_ATTACH = "voice_attach"
+VOICE_DETACH = "voice_detach"
+UNAUTHORIZED = "unauthorized"
+
+KNOWN_EVENTS = frozenset(
+    {
+        CONNECT,
+        READY,
+        RECONNECT,
+        SYNC,
+        RATE_LIMIT_429,
+        DROPPED_ATTACHMENT,
+        DELIVERY_FAILURE,
+        VOICE_ATTACH,
+        VOICE_DETACH,
+        UNAUTHORIZED,
+    }
+)
+
+
+class ReliabilityTelemetryError(ValueError):
+    """Raised when an unknown or empty telemetry event name is recorded."""
+
+
+class TelemetrySink:
+    """No-op sink interface.
+
+    Local-only default: ``emit`` does nothing, so telemetry never leaves
+    the process unless a concrete sink is supplied.
+    """
+
+    def emit(self, snapshot: Dict[str, int]) -> None:
+        """Handle a telemetry snapshot. Default implementation: no-op."""
+        del snapshot  # no-op sink; snapshot is intentionally discarded
+
+
+class CallbackSink(TelemetrySink):
+    """Sink that forwards each snapshot to a callable (testability hook)."""
+
+    def __init__(self, callback: Callable[[Dict[str, int]], None]) -> None:
+        if not callable(callback):
+            raise TypeError("callback must be callable")
+        self._callback = callback
+
+    def emit(self, snapshot: Dict[str, int]) -> None:
+        self._callback(snapshot)
+
+
+class ReliabilityTelemetry:
+    """Thread-safe in-memory counters for Discord reliability events."""
+
+    def __init__(self, sink: Optional[TelemetrySink] = None) -> None:
+        self._counts: Dict[str, int] = {}
+        self._lock = threading.Lock()
+        self._sink = sink if sink is not None else TelemetrySink()
+
+    def record_event(self, name: str, count: int = 1) -> None:
+        """Increment ``name`` by ``count`` (default 1).
+
+        Unknown or empty names are rejected so misspelled telemetry fails
+        loudly instead of silently drifting.
+        """
+        if not isinstance(name, str) or name not in KNOWN_EVENTS:
+            raise ReliabilityTelemetryError(
+                f"unknown or empty telemetry event name: {name!r}"
+            )
+        if count < 0:
+            raise ReliabilityTelemetryError("count must be non-negative")
+        with self._lock:
+            self._counts[name] = self._counts.get(name, 0) + count
+
+    def get_count(self, name: str) -> int:
+        """Return the recorded count for ``name`` (0 if never recorded)."""
+        with self._lock:
+            return self._counts.get(name, 0)
+
+    def snapshot(self) -> Dict[str, int]:
+        """Return a copy of all recorded name -> count pairs."""
+        with self._lock:
+            return dict(self._counts)
+
+    def flush(self) -> Dict[str, int]:
+        """Emit the current snapshot to the sink and return it."""
+        snap = self.snapshot()
+        self._sink.emit(snap)
+        return snap

--- a/tests/tools/test_discord_reliability_telemetry.py
+++ b/tests/tools/test_discord_reliability_telemetry.py
@@ -1,0 +1,143 @@
+"""Tests for Discord local reliability telemetry (feature R4)."""
+
+import threading
+
+import pytest
+
+from plugins.platforms.discord.reliability_telemetry import (
+    CONNECT,
+    DELIVERY_FAILURE,
+    DROPPED_ATTACHMENT,
+    RATE_LIMIT_429,
+    READY,
+    RECONNECT,
+    SYNC,
+    UNAUTHORIZED,
+    VOICE_ATTACH,
+    VOICE_DETACH,
+    CallbackSink,
+    ReliabilityTelemetry,
+    ReliabilityTelemetryError,
+    TelemetrySink,
+)
+
+
+def test_increment_and_get():
+    telemetry = ReliabilityTelemetry()
+    assert telemetry.get_count(CONNECT) == 0
+
+    telemetry.record_event(CONNECT)
+    telemetry.record_event(CONNECT)
+    telemetry.record_event(READY)
+
+    assert telemetry.get_count(CONNECT) == 2
+    assert telemetry.get_count(READY) == 1
+    assert telemetry.get_count(RECONNECT) == 0
+
+
+def test_record_event_with_count_argument():
+    telemetry = ReliabilityTelemetry()
+    telemetry.record_event(RATE_LIMIT_429, count=5)
+    assert telemetry.get_count(RATE_LIMIT_429) == 5
+
+
+def test_snapshot_returns_all_recorded_events():
+    telemetry = ReliabilityTelemetry()
+    telemetry.record_event(SYNC)
+    telemetry.record_event(SYNC)
+    telemetry.record_event(DELIVERY_FAILURE)
+
+    snap = telemetry.snapshot()
+    assert snap == {SYNC: 2, DELIVERY_FAILURE: 1}
+
+    # Snapshot is a copy; mutating it must not affect the telemetry.
+    snap[SYNC] = 999
+    assert telemetry.get_count(SYNC) == 2
+
+
+def test_snapshot_empty_when_nothing_recorded():
+    telemetry = ReliabilityTelemetry()
+    assert telemetry.snapshot() == {}
+
+
+def test_unknown_event_name_rejected():
+    telemetry = ReliabilityTelemetry()
+    with pytest.raises(ReliabilityTelemetryError) as excinfo:
+        telemetry.record_event("bogus_event")
+    assert isinstance(excinfo.value, ValueError)
+    assert telemetry.snapshot() == {}
+
+
+def test_empty_event_name_rejected():
+    telemetry = ReliabilityTelemetry()
+    with pytest.raises(ReliabilityTelemetryError):
+        telemetry.record_event("")
+    assert telemetry.snapshot() == {}
+
+
+def test_non_string_event_name_rejected():
+    telemetry = ReliabilityTelemetry()
+    with pytest.raises(ReliabilityTelemetryError):
+        telemetry.record_event(12345)
+    assert telemetry.snapshot() == {}
+
+
+def test_all_predefined_event_names_are_accepted():
+    telemetry = ReliabilityTelemetry()
+    for name in (
+        CONNECT,
+        READY,
+        RECONNECT,
+        SYNC,
+        RATE_LIMIT_429,
+        DROPPED_ATTACHMENT,
+        DELIVERY_FAILURE,
+        VOICE_ATTACH,
+        VOICE_DETACH,
+        UNAUTHORIZED,
+    ):
+        telemetry.record_event(name)
+    snap = telemetry.snapshot()
+    assert len(snap) == 10
+    assert all(value == 1 for value in snap.values())
+
+
+def test_callback_sink_receives_snapshot():
+    received = []
+    telemetry = ReliabilityTelemetry(sink=CallbackSink(received.append))
+
+    telemetry.record_event(CONNECT)
+    telemetry.record_event(CONNECT)
+    telemetry.record_event(UNAUTHORIZED)
+
+    snap = telemetry.flush()
+    assert snap == {CONNECT: 2, UNAUTHORIZED: 1}
+    assert received == [{CONNECT: 2, UNAUTHORIZED: 1}]
+
+
+def test_default_sink_is_noop():
+    # Default sink must be a no-op: flush with no sink must not raise.
+    telemetry = ReliabilityTelemetry()
+    telemetry.record_event(CONNECT)
+    assert telemetry.flush() == {CONNECT: 1}
+    assert isinstance(telemetry._sink, TelemetrySink)
+
+
+def test_thread_safety_concurrent_recording():
+    telemetry = ReliabilityTelemetry()
+    threads = 8
+    per_thread = 250
+
+    def worker():
+        for _ in range(per_thread):
+            telemetry.record_event(CONNECT)
+            telemetry.record_event(DELIVERY_FAILURE)
+
+    workers = [threading.Thread(target=worker) for _ in range(threads)]
+    for t in workers:
+        t.start()
+    for t in workers:
+        t.join()
+
+    assert telemetry.get_count(CONNECT) == threads * per_thread
+    assert telemetry.get_count(DELIVERY_FAILURE) == threads * per_thread


### PR DESCRIPTION
**Discord R4** (Part of #79564, Fixes #86441): local reliability telemetry in `plugins/platforms/discord/reliability_telemetry.py`. 11/11 tests pass. New module only.