### PR TITLE
feat(discord): read-only poll projection

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience M5

--- a/plugins/platforms/discord/poll_model.py
+++ b/plugins/platforms/discord/poll_model.py
@@ -1,0 +1,160 @@
+"""Read-only projection of Discord poll payloads into a typed model.
+
+Aligned with the Discord REST API v10 ``resources/poll.mdx`` schema. This is a
+pure, network-free parser: it projects a poll payload ``dict`` into typed
+dataclasses and raises :class:`PollError` (a :class:`ValueError` subclass) on
+any schema violation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+__all__ = [
+    "PollError",
+    "PollQuestion",
+    "PollAnswer",
+    "PollData",
+    "project_poll",
+    "QUESTION_TEXT_MAX",
+    "ANSWERS_MIN",
+    "ANSWERS_MAX",
+    "ANSWER_TEXT_MAX",
+    "DURATION_MIN",
+    "DURATION_MAX",
+    "DEFAULT_LAYOUT_TYPE",
+]
+
+QUESTION_TEXT_MAX = 300
+ANSWERS_MIN = 2
+ANSWERS_MAX = 15
+ANSWER_TEXT_MAX = 55
+DURATION_MIN = 1
+DURATION_MAX = 10080  # seconds == 7 days
+DEFAULT_LAYOUT_TYPE = 1
+
+
+class PollError(ValueError):
+    """Raised when a poll payload violates the Discord poll schema."""
+
+
+@dataclass(frozen=True)
+class PollQuestion:
+    """The poll question (Discord: ``question.text``)."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class PollAnswer:
+    """A single poll answer option."""
+
+    option_id: int
+    text: str
+
+
+@dataclass(frozen=True)
+class PollData:
+    """Typed read-only projection of a Discord poll."""
+
+    question: PollQuestion
+    answers: list[PollAnswer]
+    duration_seconds: Optional[int]
+    layout_type: int = DEFAULT_LAYOUT_TYPE
+
+
+def _is_int(value: Any) -> bool:
+    """True for real ints; excludes bool (a bool is an int subclass)."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def project_poll(payload: dict) -> PollData:
+    """Project a Discord poll payload ``dict`` into a typed :class:`PollData`.
+
+    Validation summary:
+
+    * question text: required, non-empty, at most ``QUESTION_TEXT_MAX`` (300).
+    * answers: between ``ANSWERS_MIN`` (2) and ``ANSWERS_MAX`` (15) entries,
+      each with an integer ``option_id`` and non-empty text of at most
+      ``ANSWER_TEXT_MAX`` (55) characters.
+    * ``duration_seconds``: ``None`` or an int within
+      ``DURATION_MIN``..``DURATION_MAX`` (1..10080 seconds, i.e. 7 days).
+    * ``layout_type``: int, defaulting to ``DEFAULT_LAYOUT_TYPE`` (1).
+
+    Raises:
+        PollError: on any violation of the above.
+    """
+    if not isinstance(payload, dict):
+        raise PollError(
+            f"poll payload must be a dict, got {type(payload).__name__}"
+        )
+
+    # --- question -----------------------------------------------------
+    question_raw = payload.get("question")
+    if not isinstance(question_raw, dict):
+        raise PollError("poll 'question' must be an object")
+    question_text = question_raw.get("text")
+    if not isinstance(question_text, str) or not question_text.strip():
+        raise PollError("poll question text is required and must be non-empty")
+    if len(question_text) > QUESTION_TEXT_MAX:
+        raise PollError(
+            f"poll question text must be at most {QUESTION_TEXT_MAX} characters, "
+            f"got {len(question_text)}"
+        )
+    question = PollQuestion(text=question_text)
+
+    # --- answers ------------------------------------------------------
+    answers_raw = payload.get("answers")
+    if not isinstance(answers_raw, list):
+        raise PollError("poll 'answers' must be a list")
+    if not (ANSWERS_MIN <= len(answers_raw) <= ANSWERS_MAX):
+        raise PollError(
+            f"poll must have between {ANSWERS_MIN} and {ANSWERS_MAX} answers, "
+            f"got {len(answers_raw)}"
+        )
+    answers: list[PollAnswer] = []
+    for index, answer_raw in enumerate(answers_raw):
+        if not isinstance(answer_raw, dict):
+            raise PollError(f"poll answer #{index} must be an object")
+        option_id = answer_raw.get("option_id")
+        if not _is_int(option_id):
+            raise PollError(
+                f"poll answer #{index} 'option_id' must be an integer"
+            )
+        answer_text = answer_raw.get("text")
+        if not isinstance(answer_text, str) or not answer_text.strip():
+            raise PollError(
+                f"poll answer #{index} text is required and must be non-empty"
+            )
+        if len(answer_text) > ANSWER_TEXT_MAX:
+            raise PollError(
+                f"poll answer #{index} text must be at most {ANSWER_TEXT_MAX} "
+                f"characters, got {len(answer_text)}"
+            )
+        answers.append(PollAnswer(option_id=option_id, text=answer_text))
+
+    # --- duration -----------------------------------------------------
+    duration_seconds = payload.get("duration_seconds")
+    if duration_seconds is not None:
+        if not _is_int(duration_seconds):
+            raise PollError(
+                "poll 'duration_seconds' must be an integer or null"
+            )
+        if not (DURATION_MIN <= duration_seconds <= DURATION_MAX):
+            raise PollError(
+                f"poll 'duration_seconds' must be between {DURATION_MIN} and "
+                f"{DURATION_MAX}, got {duration_seconds}"
+            )
+
+    # --- layout -------------------------------------------------------
+    layout_type = payload.get("layout_type", DEFAULT_LAYOUT_TYPE)
+    if not _is_int(layout_type):
+        raise PollError("poll 'layout_type' must be an integer")
+
+    return PollData(
+        question=question,
+        answers=answers,
+        duration_seconds=duration_seconds,
+        layout_type=layout_type,
+    )

--- a/tests/tools/test_discord_poll_model.py
+++ b/tests/tools/test_discord_poll_model.py
@@ -1,0 +1,251 @@
+"""Tests for the M5 Discord poll read-projection model."""
+
+import pytest
+
+from plugins.platforms.discord.poll_model import (
+    ANSWER_TEXT_MAX,
+    ANSWERS_MAX,
+    ANSWERS_MIN,
+    DURATION_MAX,
+    DURATION_MIN,
+    QUESTION_TEXT_MAX,
+    PollAnswer,
+    PollData,
+    PollError,
+    PollQuestion,
+    project_poll,
+)
+
+
+def _valid_payload(**overrides):
+    payload = {
+        "question": {"text": "What's your favorite color?"},
+        "answers": [
+            {"option_id": 1, "text": "Red"},
+            {"option_id": 2, "text": "Green"},
+        ],
+        "duration_seconds": 3600,
+        "layout_type": 1,
+    }
+    payload.update(overrides)
+    return payload
+
+
+# --- valid projection --------------------------------------------------------
+
+
+def test_valid_projection():
+    poll = project_poll(_valid_payload())
+
+    assert poll == PollData(
+        question=PollQuestion(text="What's your favorite color?"),
+        answers=[
+            PollAnswer(option_id=1, text="Red"),
+            PollAnswer(option_id=2, text="Green"),
+        ],
+        duration_seconds=3600,
+        layout_type=1,
+    )
+    assert isinstance(poll.question, PollQuestion)
+    assert all(isinstance(a, PollAnswer) for a in poll.answers)
+
+
+def test_question_text_boundary_max():
+    poll = project_poll(_valid_payload(question={"text": "q" * QUESTION_TEXT_MAX}))
+    assert len(poll.question.text) == QUESTION_TEXT_MAX
+
+
+def test_answer_count_minimum():
+    answers = [
+        {"option_id": i, "text": f"option {i}"}
+        for i in range(1, ANSWERS_MIN + 1)
+    ]
+    poll = project_poll(_valid_payload(answers=answers))
+    assert len(poll.answers) == ANSWERS_MIN
+
+
+def test_answer_count_maximum():
+    answers = [
+        {"option_id": i, "text": f"option {i}"}
+        for i in range(1, ANSWERS_MAX + 1)
+    ]
+    poll = project_poll(_valid_payload(answers=answers))
+    assert len(poll.answers) == ANSWERS_MAX
+
+
+def test_answer_text_boundary_max():
+    answers = [
+        {"option_id": 1, "text": "a" * ANSWER_TEXT_MAX},
+        {"option_id": 2, "text": "Green"},
+    ]
+    poll = project_poll(_valid_payload(answers=answers))
+    assert len(poll.answers[0].text) == ANSWER_TEXT_MAX
+
+
+# --- question validation -----------------------------------------------------
+
+
+def test_missing_question():
+    payload = _valid_payload()
+    del payload["question"]
+    with pytest.raises(PollError):
+        project_poll(payload)
+
+
+def test_question_missing_text():
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(question={}))
+
+
+def test_question_empty_text():
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(question={"text": ""}))
+
+
+def test_question_whitespace_text():
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(question={"text": "   "}))
+
+
+def test_question_too_long():
+    with pytest.raises(PollError):
+        project_poll(
+            _valid_payload(question={"text": "q" * (QUESTION_TEXT_MAX + 1)})
+        )
+
+
+# --- answer count / content validation ---------------------------------------
+
+
+def test_answer_count_too_few():
+    answers = [{"option_id": 1, "text": "only one"}]
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(answers=answers))
+
+
+def test_answer_count_too_many():
+    answers = [
+        {"option_id": i, "text": f"option {i}"}
+        for i in range(1, ANSWERS_MAX + 2)  # 16 answers
+    ]
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(answers=answers))
+
+
+def test_empty_answer_text():
+    answers = [
+        {"option_id": 1, "text": ""},
+        {"option_id": 2, "text": "Green"},
+    ]
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(answers=answers))
+
+
+def test_whitespace_answer_text():
+    answers = [
+        {"option_id": 1, "text": "   "},
+        {"option_id": 2, "text": "Green"},
+    ]
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(answers=answers))
+
+
+def test_answer_text_too_long():
+    answers = [
+        {"option_id": 1, "text": "a" * (ANSWER_TEXT_MAX + 1)},
+        {"option_id": 2, "text": "Green"},
+    ]
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(answers=answers))
+
+
+def test_answer_option_id_not_integer():
+    answers = [
+        {"option_id": "1", "text": "Red"},
+        {"option_id": 2, "text": "Green"},
+    ]
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(answers=answers))
+
+
+def test_answer_missing_option_id():
+    answers = [
+        {"text": "Red"},
+        {"option_id": 2, "text": "Green"},
+    ]
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(answers=answers))
+
+
+# --- duration validation -----------------------------------------------------
+
+
+@pytest.mark.parametrize("duration", [0, -1, DURATION_MAX + 1])
+def test_duration_out_of_bounds(duration):
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(duration_seconds=duration))
+
+
+def test_duration_minimum_ok():
+    poll = project_poll(_valid_payload(duration_seconds=DURATION_MIN))
+    assert poll.duration_seconds == DURATION_MIN
+
+
+def test_duration_maximum_ok():
+    poll = project_poll(_valid_payload(duration_seconds=DURATION_MAX))
+    assert poll.duration_seconds == DURATION_MAX
+
+
+def test_duration_not_integer():
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(duration_seconds="3600"))
+
+
+def test_duration_explicit_null():
+    poll = project_poll(_valid_payload(duration_seconds=None))
+    assert poll.duration_seconds is None
+
+
+def test_duration_missing_defaults_to_none():
+    payload = _valid_payload()
+    del payload["duration_seconds"]
+    poll = project_poll(payload)
+    assert poll.duration_seconds is None
+
+
+# --- layout validation -------------------------------------------------------
+
+
+def test_layout_default():
+    payload = _valid_payload()
+    del payload["layout_type"]
+    poll = project_poll(payload)
+    assert poll.layout_type == 1
+
+
+def test_layout_override():
+    poll = project_poll(_valid_payload(layout_type=2))
+    assert poll.layout_type == 2
+
+
+def test_layout_not_integer():
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(layout_type="1"))
+
+
+# --- payload shape validation ------------------------------------------------
+
+
+def test_payload_not_dict():
+    with pytest.raises(PollError):
+        project_poll("not a dict")  # type: ignore[arg-type]
+
+
+def test_answers_not_list():
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(answers={}))
+
+
+def test_answer_not_object():
+    with pytest.raises(PollError):
+        project_poll(_valid_payload(answers=[1, 2]))


### PR DESCRIPTION
**Discord M5** (Part of #79564, Fixes #86450): read-only poll projection in `plugins/platforms/discord/poll_model.py`. 31/31 tests pass. New module only.