### PR TITLE
feat(discord): thread lifecycle REST actions

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience T1

--- a/tests/tools/test_discord_threads.py
+++ b/tests/tools/test_discord_threads.py
@@ -1,0 +1,210 @@
+"""Tests for the tools.discord_api.threads request builders."""
+
+import pytest
+
+from tools.discord_api.threads import (
+    NAME_MAX_LENGTH,
+    NAME_MIN_LENGTH,
+    ThreadError,
+    archive_thread_request,
+    join_thread_request,
+    list_active_threads_request,
+    rename_thread_request,
+    start_thread_request,
+)
+
+CHANNEL = "123456789012345678"
+MESSAGE = "234567890123456789"
+THREAD = "345678901234567890"
+MAX_SNOWFLAKE = (1 << 63) - 1
+
+
+# ---------------------------------------------------------------- shapes
+
+
+def test_start_thread_public_shape():
+    req = start_thread_request(CHANNEL, name="general-news", type=11)
+    assert req == {
+        "method": "POST",
+        "path": f"/channels/{CHANNEL}/threads",
+        "payload": {"name": "general-news", "type": 11},
+        "query": {},
+    }
+
+
+def test_start_thread_from_message_shape():
+    req = start_thread_request(CHANNEL, name="from-msg", message_id=MESSAGE, type=12)
+    assert req == {
+        "method": "POST",
+        "path": f"/channels/{CHANNEL}/messages/{MESSAGE}/threads",
+        "payload": {"name": "from-msg", "type": 12},
+        "query": {},
+    }
+
+
+def test_start_thread_without_type_omits_key():
+    req = start_thread_request(CHANNEL, name="plain")
+    assert req == {
+        "method": "POST",
+        "path": f"/channels/{CHANNEL}/threads",
+        "payload": {"name": "plain"},
+        "query": {},
+    }
+
+
+def test_rename_thread_shape():
+    req = rename_thread_request(THREAD, name="new name")
+    assert req == {
+        "method": "PATCH",
+        "path": f"/channels/{THREAD}",
+        "payload": {"name": "new name"},
+        "query": {},
+    }
+
+
+def test_archive_thread_shape():
+    req = archive_thread_request(THREAD)
+    assert req == {
+        "method": "PATCH",
+        "path": f"/channels/{THREAD}",
+        "payload": {"archived": True, "locked": False},
+        "query": {},
+    }
+
+
+def test_list_active_threads_shape():
+    req = list_active_threads_request(CHANNEL)
+    assert req == {
+        "method": "GET",
+        "path": f"/channels/{CHANNEL}/threads/active",
+        "payload": None,
+        "query": {},
+    }
+
+
+def test_join_thread_shape():
+    req = join_thread_request(THREAD)
+    assert req == {
+        "method": "PUT",
+        "path": f"/channels/{THREAD}/thread-members/@me",
+        "payload": None,
+        "query": {},
+    }
+
+
+def test_descriptor_has_expected_keys():
+    for req in (
+        start_thread_request(CHANNEL, name="x"),
+        rename_thread_request(THREAD, name="x"),
+        archive_thread_request(THREAD),
+        list_active_threads_request(CHANNEL),
+        join_thread_request(THREAD),
+    ):
+        assert set(req) == {"method", "path", "payload", "query"}
+
+
+# ------------------------------------------------------- thread types
+
+
+@pytest.mark.parametrize("thread_type", [10, 11, 12])
+def test_start_thread_accepts_valid_types(thread_type):
+    req = start_thread_request(CHANNEL, name="t", type=thread_type)
+    assert req["payload"]["type"] == thread_type
+
+
+@pytest.mark.parametrize("thread_type", [0, 9, 13, "11", 11.0, True])
+def test_start_thread_rejects_invalid_types(thread_type):
+    with pytest.raises(ThreadError):
+        start_thread_request(CHANNEL, name="t", type=thread_type)
+
+
+# ------------------------------------------------------------ name rules
+
+
+def test_start_thread_name_is_trimmed():
+    req = start_thread_request(CHANNEL, name="  padded  ")
+    assert req["payload"]["name"] == "padded"
+
+
+def test_rename_thread_name_is_trimmed():
+    req = rename_thread_request(THREAD, name="\t padded \n")
+    assert req["payload"]["name"] == "padded"
+
+
+@pytest.mark.parametrize("bad_name", ["", "   ", "x" * (NAME_MAX_LENGTH + 1)])
+def test_start_thread_rejects_bad_name(bad_name):
+    with pytest.raises(ThreadError):
+        start_thread_request(CHANNEL, name=bad_name)
+
+
+@pytest.mark.parametrize("bad_name", ["", "   ", "x" * (NAME_MAX_LENGTH + 1)])
+def test_rename_thread_rejects_bad_name(bad_name):
+    with pytest.raises(ThreadError):
+        rename_thread_request(THREAD, name=bad_name)
+
+
+@pytest.mark.parametrize(
+    "good_name", ["x", "x" * NAME_MIN_LENGTH, "x" * NAME_MAX_LENGTH]
+)
+def test_start_thread_accepts_boundary_names(good_name):
+    req = start_thread_request(CHANNEL, name=good_name)
+    assert req["payload"]["name"] == good_name
+
+
+def test_non_string_name_rejected():
+    with pytest.raises(ThreadError):
+        start_thread_request(CHANNEL, name=None)
+
+
+# ------------------------------------------------------ snowflake rules
+
+
+@pytest.mark.parametrize(
+    "value", [0, 1, "0", CHANNEL, MAX_SNOWFLAKE, str(MAX_SNOWFLAKE)]
+)
+def test_start_thread_accepts_valid_snowflakes(value):
+    req = start_thread_request(value, name="ok")
+    assert req["path"] == f"/channels/{value}/threads"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, True, False, -1, -(1 << 63), 1 << 63, "abc", "12.5", "", "   ", [], {}],
+)
+def test_start_thread_rejects_invalid_snowflakes(value):
+    with pytest.raises(ThreadError):
+        start_thread_request(value, name="ok")
+
+
+def test_start_thread_rejects_bad_message_id():
+    with pytest.raises(ThreadError):
+        start_thread_request(CHANNEL, name="x", message_id="not-a-snowflake")
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [
+        lambda: archive_thread_request("bad"),
+        lambda: rename_thread_request("bad", name="x"),
+        lambda: list_active_threads_request("bad"),
+        lambda: join_thread_request("bad"),
+    ],
+    ids=["archive", "rename", "list_active", "join"],
+)
+def test_all_builders_validate_snowflake(builder):
+    with pytest.raises(ThreadError):
+        builder()
+
+
+# ------------------------------------------------------- payload detail
+
+
+def test_archive_thread_explicit_payload():
+    req = archive_thread_request(THREAD, archived=False, locked=True)
+    assert req["payload"] == {"archived": False, "locked": True}
+
+
+def test_thread_error_is_value_error():
+    assert issubclass(ThreadError, ValueError)
+    with pytest.raises(ValueError):
+        start_thread_request("bad", name="x")

--- a/tools/discord_api/threads.py
+++ b/tools/discord_api/threads.py
@@ -1,0 +1,158 @@
+"""Discord REST API v10 thread lifecycle request builders.
+
+Pure request-descriptor builders aligned with the Discord REST API v10
+``topics/threads`` documentation.  Each builder validates its inputs and
+returns a descriptor dict with exactly four keys::
+
+    {"method": str, "path": str, "payload": dict | None, "query": dict}
+
+No network I/O is performed; descriptors are meant to be executed by a
+transport layer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Union
+
+SNOWFLAKE_MAX = (1 << 63) - 1
+
+# Thread types (REST v10, topics/threads.mdx).
+THREAD_TYPE_NEWS = 10  # Announcement Thread (news channel)
+THREAD_TYPE_PUBLIC = 11  # Public Thread
+THREAD_TYPE_PRIVATE = 12  # Private Thread
+VALID_THREAD_TYPES = (THREAD_TYPE_NEWS, THREAD_TYPE_PUBLIC, THREAD_TYPE_PRIVATE)
+
+NAME_MIN_LENGTH = 1
+NAME_MAX_LENGTH = 100
+
+
+class ThreadError(ValueError):
+    """Raised when a thread request cannot be built from invalid input."""
+
+
+def _validate_snowflake(value: Union[int, str], field: str) -> str:
+    """Validate ``value`` is a Discord snowflake and return it as a string."""
+    if value is None or isinstance(value, bool) or not isinstance(value, (int, str)):
+        raise ThreadError(f"{field} must be a valid snowflake, got {value!r}")
+    if isinstance(value, str):
+        text = value.strip()
+        if not text.isdigit():
+            raise ThreadError(f"{field} must be a valid snowflake, got {value!r}")
+        snowflake = int(text)
+    else:
+        snowflake = value
+    if snowflake < 0 or snowflake > SNOWFLAKE_MAX:
+        raise ThreadError(
+            f"{field} must be a snowflake in [0, {SNOWFLAKE_MAX}], got {value!r}"
+        )
+    return str(snowflake)
+
+
+def _validate_name(name: str, field: str = "name") -> str:
+    """Validate and trim a thread name (1..100 chars after trimming)."""
+    if not isinstance(name, str):
+        raise ThreadError(f"{field} must be a string, got {type(name).__name__}")
+    trimmed = name.strip()
+    if not (NAME_MIN_LENGTH <= len(trimmed) <= NAME_MAX_LENGTH):
+        raise ThreadError(
+            f"{field} must be {NAME_MIN_LENGTH}-{NAME_MAX_LENGTH} characters "
+            f"after trimming, got {len(trimmed)}"
+        )
+    return trimmed
+
+
+def start_thread_request(
+    channel_id: Union[int, str],
+    *,
+    name: str,
+    message_id: Optional[Union[int, str]] = None,
+    type: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Build a request to start a thread.
+
+    Without ``message_id``: POST ``/channels/{channel}/threads`` (public or
+    news thread).  With ``message_id``: POST
+    ``/channels/{channel}/messages/{message}/threads`` (thread from an
+    existing message).  ``type`` may be 10 (news), 11 (public) or 12
+    (private); when omitted it is left out of the payload.
+    """
+    channel = _validate_snowflake(channel_id, "channel_id")
+    trimmed = _validate_name(name)
+    payload: Dict[str, Any] = {"name": trimmed}
+    if type is not None:
+        if (
+            not isinstance(type, int)
+            or isinstance(type, bool)
+            or type not in VALID_THREAD_TYPES
+        ):
+            raise ThreadError(
+                f"type must be one of {VALID_THREAD_TYPES}, got {type!r}"
+            )
+        payload["type"] = type
+    if message_id is not None:
+        message = _validate_snowflake(message_id, "message_id")
+        path = f"/channels/{channel}/messages/{message}/threads"
+    else:
+        path = f"/channels/{channel}/threads"
+    return {"method": "POST", "path": path, "payload": payload, "query": {}}
+
+
+def rename_thread_request(
+    thread_id: Union[int, str], name: str
+) -> Dict[str, Any]:
+    """Build a request to rename a thread (PATCH ``/channels/{thread}``)."""
+    thread = _validate_snowflake(thread_id, "thread_id")
+    trimmed = _validate_name(name)
+    return {
+        "method": "PATCH",
+        "path": f"/channels/{thread}",
+        "payload": {"name": trimmed},
+        "query": {},
+    }
+
+
+def archive_thread_request(
+    thread_id: Union[int, str],
+    archived: bool = True,
+    locked: bool = False,
+) -> Dict[str, Any]:
+    """Build a request to archive/unarchive (and optionally lock) a thread.
+
+    PATCH ``/channels/{thread}`` with payload
+    ``{"archived": bool, "locked": bool}``.
+    """
+    thread = _validate_snowflake(thread_id, "thread_id")
+    return {
+        "method": "PATCH",
+        "path": f"/channels/{thread}",
+        "payload": {"archived": bool(archived), "locked": bool(locked)},
+        "query": {},
+    }
+
+
+def list_active_threads_request(channel_id: Union[int, str]) -> Dict[str, Any]:
+    """Build a request to list a channel's active threads.
+
+    GET ``/channels/{channel}/threads/active``.
+    """
+    channel = _validate_snowflake(channel_id, "channel_id")
+    return {
+        "method": "GET",
+        "path": f"/channels/{channel}/threads/active",
+        "payload": None,
+        "query": {},
+    }
+
+
+def join_thread_request(thread_id: Union[int, str]) -> Dict[str, Any]:
+    """Build a request to join a thread as the current user.
+
+    PUT ``/channels/{thread}/thread-members/@me``.
+    """
+    thread = _validate_snowflake(thread_id, "thread_id")
+    return {
+        "method": "PUT",
+        "path": f"/channels/{thread}/thread-members/@me",
+        "payload": None,
+        "query": {},
+    }


### PR DESCRIPTION
**Discord T1** (Part of #79564, Fixes #86453): thread lifecycle REST actions in `tools/discord_api/threads.py`. 54/54 tests pass. New module only.