### PR TITLE
feat(kanban): add profile-safe home channel controls

### DIFF
--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -9,7 +9,7 @@
  * desktop's selection never flips the server-wide current-board pointer.
  */
 
-import { atom, type PluginRestOptions, type PluginStorage, queryClient } from '@hermes/plugin-sdk'
+import { atom, host, type PluginRestOptions, type PluginStorage, queryClient } from '@hermes/plugin-sdk'
 
 import type {
   BoardMeta,
@@ -87,6 +87,18 @@ export function bindApi(r: Rest, storage: PluginStorage, socket: Socket): () => 
   rest = r
   $homeChannelsSupported.set(null)
   const unsubs: Array<() => void> = []
+  let gatewayWasOffline = host.state.gateway.get() !== 'open'
+
+  unsubs.push(
+    host.state.gateway.listen(state => {
+      if (state !== 'open') {
+        gatewayWasOffline = true
+      } else if (gatewayWasOffline) {
+        gatewayWasOffline = false
+        $homeChannelsSupported.set(null)
+      }
+    })
+  )
 
   // Hydrate an atom from storage and keep storage in sync with it.
   const persist = <T>(atom: Persisted<T>, key: string, fallback: T) => {

--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -15,6 +15,7 @@ import type {
   BoardMeta,
   BoardsResponse,
   KanbanBoard,
+  KanbanHomeChannelsResponse,
   KanbanProfile,
   KanbanProject,
   KanbanTask,
@@ -42,6 +43,9 @@ export const $lanesByProfile = atom<boolean>(false)
 /** Per-lane collapse OVERRIDES (true=collapsed, false=expanded). Absence means
  *  auto: empty lanes collapse to a rail, occupied lanes expand. Persisted. */
 export const $collapsedLanes = atom<Record<string, boolean>>({})
+
+/** null until probed, false only when this backend session lacks the route. */
+export const $homeChannelsSupported = atom<null | boolean>(null)
 
 const BOARD_SLUG_KEY = 'boardSlug'
 const INTRO_KEY = 'introDismissed'
@@ -81,6 +85,7 @@ interface Persisted<T> {
  *  handshake, so a board switch closes + reopens it. */
 export function bindApi(r: Rest, storage: PluginStorage, socket: Socket): () => void {
   rest = r
+  $homeChannelsSupported.set(null)
   const unsubs: Array<() => void> = []
 
   // Hydrate an atom from storage and keep storage in sync with it.
@@ -116,9 +121,8 @@ function call<T>(path: string, opts?: PluginRestOptions): Promise<T> {
 }
 
 /** Append the selected board (and other params) to a path. */
-function withBoard(path: string, params: Record<string, string> = {}): string {
+function withBoard(path: string, params: Record<string, string> = {}, slug = $boardSlug.get()): string {
   const search = new URLSearchParams(params)
-  const slug = $boardSlug.get()
 
   if (slug) {
     search.set('board', slug)
@@ -134,6 +138,7 @@ function withBoard(path: string, params: Record<string, string> = {}): string {
 export const boardKey = (slug: string, archived: boolean) => ['kanban', 'board', slug, archived] as const
 export const taskKey = (slug: string, id: string) => ['kanban', 'task', slug, id] as const
 export const logKey = (slug: string, id: string) => ['kanban', 'log', slug, id] as const
+export const homeChannelsKey = (slug: string, id: string) => ['kanban', 'home-channels', slug, id] as const
 export const BOARDS_KEY = ['kanban', 'boards'] as const
 export const PROFILES_KEY = ['kanban', 'profiles'] as const
 export const PROJECTS_KEY = ['kanban', 'projects'] as const
@@ -145,6 +150,49 @@ export const fetchBoard = (archived: boolean) =>
   call<KanbanBoard>(withBoard('/board', archived ? { include_archived: 'true' } : {}))
 
 export const fetchTask = (id: string) => call<KanbanTaskDetail>(withBoard(`/tasks/${id}`))
+
+export function isMissingHomeChannelsEndpoint(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /(?:no such api endpoint|endpoint is likely missing)/i.test(message)
+}
+
+function isGenericNotFound(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  const statusCode = (error as { statusCode?: unknown } | null)?.statusCode
+
+  return (
+    (statusCode === 404 || /(?:^|\D)404(?:\D|$)/.test(message)) &&
+    /(?:detail["']?\s*:\s*["']?not found|404:\s*not found\s*$)/i.test(message)
+  )
+}
+
+export const fetchHomeChannels = async (id: string, board = $boardSlug.get()) => {
+  try {
+    const response = await call<KanbanHomeChannelsResponse>(withBoard('/home-channels', { task_id: id }, board))
+    $homeChannelsSupported.set(true)
+
+    return response
+  } catch (error) {
+    if ($homeChannelsSupported.get() !== true) {
+      let missing = isMissingHomeChannelsEndpoint(error)
+
+      if (!missing && isGenericNotFound(error)) {
+        try {
+          await call<KanbanHomeChannelsResponse>('/home-channels')
+        } catch (probeError) {
+          missing = isMissingHomeChannelsEndpoint(probeError) || isGenericNotFound(probeError)
+        }
+      }
+
+      if (missing) {
+        $homeChannelsSupported.set(false)
+      }
+    }
+
+    throw error
+  }
+}
 
 /** Worker stdout/stderr tail (last 16 KiB — plenty for the drawer). */
 export const fetchLog = (id: string) => call<WorkerLog>(withBoard(`/tasks/${id}/log`, { tail: '16384' }))
@@ -217,6 +265,12 @@ export const reclaimTask = (id: string) => nudged(call(withBoard(`/tasks/${id}/r
 
 export const uploadAttachment = (id: string, upload: { filename: string; contentType?: string; bytes: ArrayBuffer }) =>
   call(withBoard(`/tasks/${id}/attachments`), { method: 'POST', upload })
+
+export const subscribeHome = (id: string, platform: string, board = $boardSlug.get()) =>
+  call(withBoard(`/tasks/${id}/home-subscribe/${encodeURIComponent(platform)}`, {}, board), { method: 'POST' })
+
+export const unsubscribeHome = (id: string, platform: string, board = $boardSlug.get()) =>
+  call(withBoard(`/tasks/${id}/home-subscribe/${encodeURIComponent(platform)}`, {}, board), { method: 'DELETE' })
 
 export const createBoard = (slug: string, name: string, projectId?: string) =>
   call<{ board: { slug: string } }>('/boards', {

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -45,6 +45,7 @@ import {
   taskKey,
   uploadAttachment
 } from './api'
+import { HomeChannelNotifications } from './home-subscriptions'
 import { ModelOverrideField, overridePatch } from './model-override'
 import {
   type Diagnostic,
@@ -785,6 +786,8 @@ export function TaskDrawer({
               {ago(task.created_at) && <MetaRow label={k.metaCreated}>{ago(task.created_at)}</MetaRow>}
               {running && task.worker_pid ? <MetaRow label={k.metaWorkerPid}>{task.worker_pid}</MetaRow> : null}
             </div>
+
+            <HomeChannelNotifications taskId={task.id} />
 
             {task.status === 'ready' && !task.assignee && !defaultAssignee && (
               <Callout title={k.readyUnassignedTitle} tone={SEVERITY_TONE.warning}>

--- a/apps/desktop/src/plugins/kanban/home-subscriptions-api.test.ts
+++ b/apps/desktop/src/plugins/kanban/home-subscriptions-api.test.ts
@@ -1,0 +1,82 @@
+import type { PluginRestOptions, PluginStorage } from '@hermes/plugin-sdk'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $boardSlug,
+  bindApi,
+  fetchHomeChannels,
+  homeChannelsKey,
+  isMissingHomeChannelsEndpoint,
+  subscribeHome,
+  unsubscribeHome
+} from './api'
+
+const rest = vi.fn((_path: string, _opts?: PluginRestOptions): Promise<unknown> => Promise.resolve({}))
+let dispose: null | (() => void) = null
+
+beforeEach(() => {
+  const values = new Map<string, unknown>()
+
+  const storage = {
+    get: <T>(key: string, fallback: T) => (values.has(key) ? (values.get(key) as T) : fallback),
+    set: (key: string, value: unknown) => void values.set(key, value)
+  } as PluginStorage
+
+  dispose = bindApi(rest as never, storage, () => () => undefined)
+  $boardSlug.set('fleet alpha')
+})
+
+afterEach(() => {
+  dispose?.()
+  dispose = null
+  rest.mockClear()
+})
+
+describe('home-channel API', () => {
+  it('scopes query identity and reads to both board and task', async () => {
+    rest.mockResolvedValueOnce({ home_channels: [] })
+
+    expect(homeChannelsKey('fleet alpha', 't_123')).toEqual(['kanban', 'home-channels', 'fleet alpha', 't_123'])
+    await fetchHomeChannels('t_123')
+
+    expect(rest).toHaveBeenCalledWith('/home-channels?task_id=t_123&board=fleet+alpha', undefined)
+  })
+
+  it('uses the render-scoped board even if the selected board changes before dispatch', async () => {
+    rest.mockResolvedValueOnce({ home_channels: [] })
+    $boardSlug.set('new-board')
+
+    await fetchHomeChannels('t_123', 'fleet alpha')
+
+    expect(rest).toHaveBeenCalledWith('/home-channels?task_id=t_123&board=fleet+alpha', undefined)
+  })
+
+  it('sends only the platform in the path and never nudges the dispatcher', async () => {
+    rest.mockResolvedValue({ ok: true })
+
+    await subscribeHome('t_123', 'telegram')
+    await unsubscribeHome('t_123', 'discord')
+
+    expect(rest.mock.calls).toEqual([
+      ['/tasks/t_123/home-subscribe/telegram?board=fleet+alpha', { method: 'POST' }],
+      ['/tasks/t_123/home-subscribe/discord?board=fleet+alpha', { method: 'DELETE' }]
+    ])
+  })
+
+  it('distinguishes a missing route from a missing task', () => {
+    expect(isMissingHomeChannelsEndpoint(new Error('No such API endpoint: /home-channels'))).toBe(true)
+    expect(isMissingHomeChannelsEndpoint(new Error('404: Not Found'))).toBe(false)
+    expect(isMissingHomeChannelsEndpoint(new Error('404: task not found: t_123'))).toBe(false)
+  })
+
+  it('confirms a generic 404 with an unscoped route probe before caching unsupported', async () => {
+    rest.mockRejectedValueOnce(new Error('404: Not Found')).mockRejectedValueOnce(new Error('404: Not Found'))
+
+    await expect(fetchHomeChannels('t_123')).rejects.toThrow('404: Not Found')
+
+    expect(rest.mock.calls).toEqual([
+      ['/home-channels?task_id=t_123&board=fleet+alpha', undefined],
+      ['/home-channels', undefined]
+    ])
+  })
+})

--- a/apps/desktop/src/plugins/kanban/home-subscriptions-api.test.ts
+++ b/apps/desktop/src/plugins/kanban/home-subscriptions-api.test.ts
@@ -1,8 +1,9 @@
-import type { PluginRestOptions, PluginStorage } from '@hermes/plugin-sdk'
+import { host, type PluginRestOptions, type PluginStorage } from '@hermes/plugin-sdk'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   $boardSlug,
+  $homeChannelsSupported,
   bindApi,
   fetchHomeChannels,
   homeChannelsKey,
@@ -22,6 +23,7 @@ beforeEach(() => {
     set: (key: string, value: unknown) => void values.set(key, value)
   } as PluginStorage
 
+  ;(host.state.gateway as unknown as { set(value: string): void }).set('open')
   dispose = bindApi(rest as never, storage, () => () => undefined)
   $boardSlug.set('fleet alpha')
 })
@@ -78,5 +80,14 @@ describe('home-channel API', () => {
       ['/home-channels?task_id=t_123&board=fleet+alpha', undefined],
       ['/home-channels', undefined]
     ])
+  })
+
+  it('clears cached unsupported state after reconnect even with no drawer mounted', () => {
+    $homeChannelsSupported.set(false)
+
+    ;(host.state.gateway as unknown as { set(value: string): void }).set('closed')
+    ;(host.state.gateway as unknown as { set(value: string): void }).set('open')
+
+    expect($homeChannelsSupported.get()).toBeNull()
   })
 })

--- a/apps/desktop/src/plugins/kanban/home-subscriptions.test.tsx
+++ b/apps/desktop/src/plugins/kanban/home-subscriptions.test.tsx
@@ -1,0 +1,262 @@
+import { host } from '@hermes/plugin-sdk'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $boardSlug, $homeChannelsSupported } from './api'
+import { HomeChannelNotifications } from './home-subscriptions'
+import type { KanbanHomeChannelsResponse } from './types'
+
+const fetchHomeChannels = vi.fn<(_taskId: string, _board?: string) => Promise<KanbanHomeChannelsResponse>>()
+const subscribeHome = vi.fn<(_taskId: string, _platform: string, _board?: string) => Promise<unknown>>()
+const unsubscribeHome = vi.fn<(_taskId: string, _platform: string, _board?: string) => Promise<unknown>>()
+
+vi.mock('./api', async importOriginal => ({
+  ...(await importOriginal()),
+  fetchHomeChannels: (...args: Parameters<typeof fetchHomeChannels>) => fetchHomeChannels(...args),
+  subscribeHome: (...args: Parameters<typeof subscribeHome>) => subscribeHome(...args),
+  unsubscribeHome: (...args: Parameters<typeof unsubscribeHome>) => unsubscribeHome(...args)
+}))
+
+vi.mock('./ui', async importOriginal => ({
+  ...(await importOriginal()),
+  useKanban: () => ({
+    homeChannels: 'Home channel notifications',
+    homeChannelsHelp: 'Send this task’s updates to the selected homes.',
+    homeChannelAria: (home: string, platform: string) => `Notify ${home} on ${platform}`,
+    homeChannelsEmpty: 'No home channels for this profile. In a messaging chat, send /sethome.',
+    homeChannelsUnavailable: 'Home channels unavailable',
+    homeChannelsUnavailableBody: 'Couldn’t load this task’s messaging destinations.',
+    homeChannelsRetry: 'Retry',
+    homeChannelsOffline: 'Gateway offline — reconnect to change notifications.',
+    homeChannelsOrigin: 'already notified by task origin',
+    homeChannelsSaving: 'Saving…',
+    homeChannelsUpdateError: (platform: string, message: string) =>
+      `Couldn’t update ${platform} notifications: ${message}`,
+    homeChanged: (platform: string) => `${platform} home changed`,
+    homeChangedMove: (oldName: string, currentName: string) =>
+      `Updates still go to ${oldName}. Move them to ${currentName}, or stop home notifications.`,
+    homeChangedStop: (oldName: string) => `Updates still go to ${oldName}, which is no longer your home.`,
+    homePrevious: 'your previous home',
+    homeMove: (name: string) => `Move to ${name}`,
+    homeStop: 'Stop'
+  })
+}))
+
+const homes = (overrides: Partial<KanbanHomeChannelsResponse> = {}): KanbanHomeChannelsResponse => ({
+  home_channels: [
+    {
+      chat_id: '1',
+      name: 'Main TG',
+      platform: 'telegram',
+      subscribed: false,
+      subscription_state: 'none',
+      thread_id: ''
+    },
+    {
+      chat_id: '2',
+      name: 'Ops Discord',
+      platform: 'discord',
+      subscribed: true,
+      thread_id: '4'
+    }
+  ],
+  stale_home_subscriptions: [],
+  ...overrides
+})
+
+function deferred<T>() {
+  let reject!: (reason?: unknown) => void
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, reject, resolve }
+}
+
+function renderControls() {
+  const client = new QueryClient({ defaultOptions: { mutations: { retry: false }, queries: { retry: false } } })
+
+  render(
+    <QueryClientProvider client={client}>
+      <HomeChannelNotifications taskId="t_123" />
+    </QueryClientProvider>
+  )
+
+  return client
+}
+
+beforeEach(() => {
+  $boardSlug.set('fleet')
+  $homeChannelsSupported.set(null)
+  ;(host.state.gateway as unknown as { set(value: string): void }).set('open')
+  fetchHomeChannels.mockResolvedValue(homes())
+  subscribeHome.mockResolvedValue({ ok: true })
+  unsubscribeHome.mockResolvedValue({ ok: true })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('HomeChannelNotifications', () => {
+  it('does not paint false off switches while loading, then honors legacy subscribed defaults', async () => {
+    const pending = deferred<KanbanHomeChannelsResponse>()
+    fetchHomeChannels.mockReturnValueOnce(pending.promise)
+    renderControls()
+
+    expect(screen.queryByRole('switch')).toBeNull()
+
+    pending.resolve(homes())
+    const discord = await screen.findByRole('switch', { name: 'Notify Ops Discord on Discord' })
+    expect(discord.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('optimistically changes one platform while leaving the other usable', async () => {
+    const pending = deferred<unknown>()
+    subscribeHome.mockReturnValueOnce(pending.promise)
+    renderControls()
+
+    const telegram = await screen.findByRole('switch', { name: 'Notify Main TG on Telegram' })
+    const discord = screen.getByRole('switch', { name: 'Notify Ops Discord on Discord' })
+    fireEvent.click(telegram)
+
+    await waitFor(() => expect(telegram.getAttribute('aria-checked')).toBe('true'))
+    expect((telegram as HTMLButtonElement).disabled).toBe(true)
+    expect((discord as HTMLButtonElement).disabled).toBe(false)
+    expect(subscribeHome).toHaveBeenCalledWith('t_123', 'telegram', 'fleet')
+
+    pending.resolve({ ok: true })
+  })
+
+  it('rolls a failed save back and reports the backend error', async () => {
+    const notify = vi.spyOn(host, 'notify')
+    subscribeHome.mockRejectedValueOnce(new Error('permission denied'))
+    renderControls()
+
+    const telegram = await screen.findByRole('switch', { name: 'Notify Main TG on Telegram' })
+    fireEvent.click(telegram)
+
+    await waitFor(() => expect(telegram.getAttribute('aria-checked')).toBe('false'))
+    expect(notify).toHaveBeenCalledWith({
+      kind: 'error',
+      message: 'Couldn’t update Telegram notifications: permission denied'
+    })
+  })
+
+  it('keeps another platform optimistic when one overlapping save fails', async () => {
+    const telegramSave = deferred<unknown>()
+    const discordSave = deferred<unknown>()
+    const refresh = deferred<KanbanHomeChannelsResponse>()
+    fetchHomeChannels
+      .mockResolvedValueOnce(
+        homes({
+          home_channels: homes().home_channels.map(channel => ({
+            ...channel,
+            subscribed: false,
+            subscription_state: 'none'
+          }))
+        })
+      )
+      .mockReturnValueOnce(refresh.promise)
+    subscribeHome.mockImplementation((_taskId, platform) =>
+      platform === 'telegram' ? telegramSave.promise : discordSave.promise
+    )
+    renderControls()
+
+    const telegram = await screen.findByRole('switch', { name: 'Notify Main TG on Telegram' })
+    const discord = screen.getByRole('switch', { name: 'Notify Ops Discord on Discord' })
+    fireEvent.click(telegram)
+    await waitFor(() => expect(telegram.getAttribute('aria-checked')).toBe('true'))
+    fireEvent.click(discord)
+    await waitFor(() => expect(discord.getAttribute('aria-checked')).toBe('true'))
+
+    telegramSave.reject(new Error('telegram denied'))
+
+    await waitFor(() => expect(telegram.getAttribute('aria-checked')).toBe('false'))
+    expect(discord.getAttribute('aria-checked')).toBe('true')
+    expect(fetchHomeChannels).toHaveBeenCalledTimes(1)
+    discordSave.resolve({ ok: true })
+  })
+
+  it('offers explicit move and stop actions for changed homes', async () => {
+    fetchHomeChannels.mockResolvedValueOnce(
+      homes({
+        stale_home_subscriptions: [
+          { chat_id: 'old', name: 'Old Telegram', notifier_profile: 'default', platform: 'telegram', thread_id: '' }
+        ]
+      })
+    )
+    renderControls()
+
+    expect(await screen.findByText('Telegram home changed')).not.toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Move to Main TG' }))
+    await waitFor(() => expect(subscribeHome).toHaveBeenCalledWith('t_123', 'telegram', 'fleet'))
+  })
+
+  it('stops a stale home without silently moving it', async () => {
+    fetchHomeChannels.mockResolvedValueOnce(
+      homes({
+        stale_home_subscriptions: [
+          { chat_id: 'old', name: 'Old Telegram', notifier_profile: 'default', platform: 'telegram', thread_id: '' }
+        ]
+      })
+    )
+    renderControls()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Stop' }))
+
+    await waitFor(() => expect(unsubscribeHome).toHaveBeenCalledWith('t_123', 'telegram', 'fleet'))
+    expect(subscribeHome).not.toHaveBeenCalled()
+  })
+
+  it('keeps cached destinations visible but disables changes while offline', async () => {
+    const client = renderControls()
+    await screen.findByRole('switch', { name: 'Notify Main TG on Telegram' })
+
+    act(() => {
+      ;(host.state.gateway as unknown as { set(value: string): void }).set('closed')
+      client.setQueryData(['kanban', 'home-channels', 'fleet', 't_123'], homes())
+    })
+
+    expect(await screen.findByText('Gateway offline — reconnect to change notifications.')).not.toBeNull()
+    expect((screen.getByRole('switch', { name: 'Notify Main TG on Telegram' }) as HTMLButtonElement).disabled).toBe(
+      true
+    )
+  })
+
+  it('does not claim there are no homes when opened offline without a cache', async () => {
+    ;(host.state.gateway as unknown as { set(value: string): void }).set('closed')
+    renderControls()
+
+    expect(await screen.findByText('Gateway offline — reconnect to change notifications.')).not.toBeNull()
+    expect(screen.queryByText('No home channels for this profile. In a messaging chat, send /sethome.')).toBeNull()
+    expect(fetchHomeChannels).not.toHaveBeenCalled()
+  })
+
+  it('keeps cached destinations after a background refresh fails', async () => {
+    const client = renderControls()
+    await screen.findByRole('switch', { name: 'Notify Main TG on Telegram' })
+    fetchHomeChannels.mockRejectedValueOnce(new Error('network down'))
+
+    await client.invalidateQueries({ queryKey: ['kanban', 'home-channels', 'fleet', 't_123'] })
+
+    expect(screen.getByRole('switch', { name: 'Notify Main TG on Telegram' })).not.toBeNull()
+    expect(screen.queryByText('Home channels unavailable')).toBeNull()
+  })
+
+  it('omits only this section when an older backend lacks the endpoint', async () => {
+    fetchHomeChannels.mockImplementationOnce(async () => {
+      $homeChannelsSupported.set(false)
+      throw new Error('404: Not Found')
+    })
+    renderControls()
+
+    await waitFor(() => expect(fetchHomeChannels).toHaveBeenCalled())
+    await waitFor(() => expect(screen.queryByText('Home channel notifications')).toBeNull())
+  })
+})

--- a/apps/desktop/src/plugins/kanban/home-subscriptions.tsx
+++ b/apps/desktop/src/plugins/kanban/home-subscriptions.tsx
@@ -1,0 +1,293 @@
+import { Button, host, Skeleton, Switch, useMutation, useQuery, useQueryClient, useValue } from '@hermes/plugin-sdk'
+import { useEffect } from 'react'
+
+import {
+  $boardSlug,
+  $homeChannelsSupported,
+  fetchHomeChannels,
+  homeChannelsKey,
+  subscribeHome,
+  unsubscribeHome
+} from './api'
+import {
+  type KanbanHomeChannel,
+  type KanbanHomeChannelsResponse,
+  SEVERITY_TONE,
+  type StaleHomeSubscription
+} from './types'
+import { Callout, errText, Section, useKanban } from './ui'
+
+function platformLabel(platform: string): string {
+  return platform
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map(part => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ')
+}
+
+function hasHomeSource(channel: KanbanHomeChannel): boolean {
+  if (channel.subscription_state == null) {
+    return channel.subscribed
+  }
+
+  return channel.subscription_state === 'home' || channel.subscription_state === 'home_and_other'
+}
+
+function optimisticResponse(
+  response: KanbanHomeChannelsResponse | undefined,
+  platform: string,
+  enabled: boolean
+): KanbanHomeChannelsResponse | undefined {
+  if (!response) {
+    return response
+  }
+
+  return {
+    ...response,
+    home_channels: response.home_channels.map(channel => {
+      if (channel.platform !== platform) {
+        return channel
+      }
+
+      const hasOther = channel.subscription_state === 'other' || channel.subscription_state === 'home_and_other'
+
+      return {
+        ...channel,
+        subscribed: enabled || hasOther,
+        subscription_state: enabled ? (hasOther ? 'home_and_other' : 'home') : hasOther ? 'other' : 'none'
+      }
+    }),
+    stale_home_subscriptions: response.stale_home_subscriptions?.filter(stale => stale.platform !== platform)
+  }
+}
+
+function restorePlatform(
+  current: KanbanHomeChannelsResponse | undefined,
+  previous: KanbanHomeChannelsResponse,
+  platform: string
+): KanbanHomeChannelsResponse {
+  if (!current) {
+    return previous
+  }
+
+  const previousChannel = previous.home_channels.find(channel => channel.platform === platform)
+  const otherChannels = current.home_channels.filter(channel => channel.platform !== platform)
+  const currentOtherStale = (current.stale_home_subscriptions ?? []).filter(stale => stale.platform !== platform)
+  const previousPlatformStale = (previous.stale_home_subscriptions ?? []).filter(stale => stale.platform === platform)
+
+  return {
+    ...current,
+    home_channels: previousChannel ? [...otherChannels, previousChannel] : otherChannels,
+    stale_home_subscriptions: [...currentOtherStale, ...previousPlatformStale]
+  }
+}
+
+interface MutationContext {
+  previous?: KanbanHomeChannelsResponse
+}
+
+function useHomeMutation(taskId: string, platform: string) {
+  const k = useKanban()
+  const qc = useQueryClient()
+  const slug = useValue($boardSlug)
+  const key = homeChannelsKey(slug, taskId)
+  const mutationKey = ['kanban', 'home-channel-mutation', slug, taskId] as const
+
+  return useMutation<unknown, unknown, boolean, MutationContext>({
+    mutationKey,
+    mutationFn: enabled => (enabled ? subscribeHome(taskId, platform, slug) : unsubscribeHome(taskId, platform, slug)),
+    onMutate: async enabled => {
+      await qc.cancelQueries({ queryKey: key })
+      const previous = qc.getQueryData<KanbanHomeChannelsResponse>(key)
+      qc.setQueryData(key, optimisticResponse(previous, platform, enabled))
+
+      return { previous }
+    },
+    onError: (error, _enabled, context) => {
+      if (context?.previous) {
+        qc.setQueryData<KanbanHomeChannelsResponse | undefined>(key, current =>
+          restorePlatform(current, context.previous!, platform)
+        )
+      }
+
+      host.notify({
+        kind: 'error',
+        message: k.homeChannelsUpdateError(platformLabel(platform), errText(error))
+      })
+    },
+    onSettled: () => {
+      if (qc.isMutating({ exact: true, mutationKey }) === 1) {
+        void qc.invalidateQueries({ queryKey: key })
+      }
+    }
+  })
+}
+
+function HomeChannelRow({
+  channel,
+  offline,
+  taskId
+}: {
+  channel: KanbanHomeChannel
+  offline: boolean
+  taskId: string
+}) {
+  const k = useKanban()
+  const mutation = useHomeMutation(taskId, channel.platform)
+  const platform = platformLabel(channel.platform)
+  const checked = hasHomeSource(channel)
+  const hasOther = channel.subscription_state === 'other' || channel.subscription_state === 'home_and_other'
+
+  return (
+    <div className="flex min-h-13 items-center gap-2.5 py-1">
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[0.75rem] font-medium text-(--ui-text-secondary)">{platform}</div>
+        <div className="truncate text-[0.6875rem] text-(--ui-text-quaternary)">{channel.name}</div>
+        {hasOther && <div className="text-[0.625rem] text-(--ui-text-quaternary)">{k.homeChannelsOrigin}</div>}
+      </div>
+      {mutation.isPending && (
+        <span aria-live="polite" className="text-[0.625rem] text-(--ui-text-quaternary)">
+          {k.homeChannelsSaving}
+        </span>
+      )}
+      <Switch
+        aria-label={k.homeChannelAria(channel.name, platform)}
+        checked={checked}
+        disabled={offline || mutation.isPending}
+        onCheckedChange={enabled => mutation.mutate(enabled)}
+        size="xs"
+      />
+    </div>
+  )
+}
+
+function StaleHomeCallout({
+  current,
+  offline,
+  stale,
+  taskId
+}: {
+  current?: KanbanHomeChannel
+  offline: boolean
+  stale: StaleHomeSubscription
+  taskId: string
+}) {
+  const k = useKanban()
+  const mutation = useHomeMutation(taskId, stale.platform)
+  const platform = platformLabel(stale.platform)
+  const previousHome = k.homePrevious
+
+  return (
+    <Callout title={k.homeChanged(platform)} tone={SEVERITY_TONE.warning}>
+      <p className="text-[0.71rem] leading-relaxed text-(--ui-text-secondary)">
+        {current ? k.homeChangedMove(previousHome, current.name) : k.homeChangedStop(previousHome)}
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {current && (
+          <Button
+            disabled={offline || mutation.isPending}
+            onClick={() => mutation.mutate(true)}
+            size="xs"
+            variant="secondary"
+          >
+            {k.homeMove(current.name)}
+          </Button>
+        )}
+        <Button
+          disabled={offline || mutation.isPending}
+          onClick={() => mutation.mutate(false)}
+          size="xs"
+          variant="outline"
+        >
+          {k.homeStop}
+        </Button>
+      </div>
+    </Callout>
+  )
+}
+
+function LoadingRows() {
+  return (
+    <div className="flex flex-col gap-2" data-testid="home-channels-loading">
+      {[0, 1].map(index => (
+        <div className="flex min-h-13 items-center gap-2.5" key={index}>
+          <div className="flex flex-1 flex-col gap-1.5">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-2.5 w-32" />
+          </div>
+          <Skeleton className="h-4 w-7" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function HomeChannelNotifications({ taskId }: { taskId: string }) {
+  const k = useKanban()
+  const slug = useValue($boardSlug)
+  const gatewayState = useValue(host.state.gateway)
+  const supported = useValue($homeChannelsSupported)
+
+  const query = useQuery({
+    enabled: supported !== false && gatewayState === 'open',
+    queryFn: () => fetchHomeChannels(taskId, slug),
+    queryKey: homeChannelsKey(slug, taskId),
+    retry: false
+  })
+
+  useEffect(() => {
+    if (query.data) {
+      $homeChannelsSupported.set(true)
+    }
+  }, [query.data])
+
+  if (supported === false) {
+    return null
+  }
+
+  const offline = gatewayState !== 'open'
+
+  const homes = [...(query.data?.home_channels ?? [])].sort((a, b) =>
+    platformLabel(a.platform).localeCompare(platformLabel(b.platform))
+  )
+
+  const stale = query.data?.stale_home_subscriptions ?? []
+  const stalePlatforms = new Set(stale.map(item => item.platform))
+
+  return (
+    <Section label={k.homeChannels}>
+      <p className="text-[0.6875rem] leading-relaxed text-(--ui-text-quaternary)">{k.homeChannelsHelp}</p>
+      {query.isPending && !offline ? (
+        <LoadingRows />
+      ) : query.error && !query.data ? (
+        <Callout icon="error" title={k.homeChannelsUnavailable} tone="var(--destructive, #f87171)">
+          <p className="text-[0.71rem] leading-relaxed text-(--ui-text-secondary)">{k.homeChannelsUnavailableBody}</p>
+          <Button onClick={() => void query.refetch()} size="xs" variant="outline">
+            {k.homeChannelsRetry}
+          </Button>
+        </Callout>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {offline && <p className="text-[0.6875rem] text-(--ui-text-quaternary)">{k.homeChannelsOffline}</p>}
+          {stale.map(item => (
+            <StaleHomeCallout
+              current={homes.find(home => home.platform === item.platform)}
+              key={`${item.platform}:${item.chat_id}:${item.thread_id}`}
+              offline={offline}
+              stale={item}
+              taskId={taskId}
+            />
+          ))}
+          {homes
+            .filter(home => !stalePlatforms.has(home.platform))
+            .map(home => (
+              <HomeChannelRow channel={home} key={home.platform} offline={offline} taskId={taskId} />
+            ))}
+          {!offline && homes.length === 0 && stale.length === 0 && (
+            <p className="text-[0.75rem] text-(--ui-text-quaternary)">{k.homeChannelsEmpty}</p>
+          )}
+        </div>
+      )}
+    </Section>
+  )
+}

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -123,6 +123,23 @@ type KanbanMessages = {
   metaCreatedBy: string
   metaCreated: string
   metaWorkerPid: string
+  homeChannels: string
+  homeChannelsHelp: string
+  homeChannelAria: (home: string, platform: string) => string
+  homeChannelsEmpty: string
+  homeChannelsUnavailable: string
+  homeChannelsUnavailableBody: string
+  homeChannelsRetry: string
+  homeChannelsOffline: string
+  homeChannelsOrigin: string
+  homeChannelsSaving: string
+  homeChannelsUpdateError: (platform: string, message: string) => string
+  homeChanged: (platform: string) => string
+  homeChangedMove: (oldName: string, currentName: string) => string
+  homeChangedStop: (oldName: string) => string
+  homePrevious: string
+  homeMove: (name: string) => string
+  homeStop: string
   readyUnassignedTitle: string
   readyUnassignedBody: string
   diagnosticsN: (n: number) => string
@@ -312,6 +329,24 @@ const en: KanbanMessages = {
   metaCreatedBy: 'Created by',
   metaCreated: 'Created',
   metaWorkerPid: 'Worker pid',
+  homeChannels: 'Home channel notifications',
+  homeChannelsHelp: 'Send this task’s updates to the selected homes.',
+  homeChannelAria: (home, platform) => `Notify ${home} on ${platform}`,
+  homeChannelsEmpty: 'No home channels for this profile. In a messaging chat, send /sethome.',
+  homeChannelsUnavailable: 'Home channels unavailable',
+  homeChannelsUnavailableBody: 'Couldn’t load this task’s messaging destinations.',
+  homeChannelsRetry: 'Retry',
+  homeChannelsOffline: 'Gateway offline — reconnect to change notifications.',
+  homeChannelsOrigin: 'already notified by task origin',
+  homeChannelsSaving: 'Saving…',
+  homeChannelsUpdateError: (platform, message) => `Couldn’t update ${platform} notifications: ${message}`,
+  homeChanged: platform => `${platform} home changed`,
+  homeChangedMove: (oldName, currentName) =>
+    `Updates still go to ${oldName}. Move them to ${currentName}, or stop home notifications.`,
+  homeChangedStop: oldName => `Updates still go to ${oldName}, which is no longer your home.`,
+  homePrevious: 'your previous home',
+  homeMove: name => `Move to ${name}`,
+  homeStop: 'Stop',
   readyUnassignedTitle: 'Ready, but unassigned — this card will never run.',
   readyUnassignedBody:
     'The dispatcher only claims Ready cards that have an assignee. Pick a profile in the Assignee field above (or set a default assignee in the orchestration settings) and it runs within a minute.',
@@ -503,6 +538,25 @@ const ja: KanbanMessages = {
   metaCreatedBy: '作成者',
   metaCreated: '作成',
   metaWorkerPid: 'ワーカー PID',
+  homeChannels: 'ホームチャンネル通知',
+  homeChannelsHelp: 'このタスクの更新を選択したホームに送信します。',
+  homeChannelAria: (home, platform) => `${platform} の ${home} に通知`,
+  homeChannelsEmpty:
+    'このプロフィールにはホームチャンネルがありません。メッセージチャットで /sethome を送信してください。',
+  homeChannelsUnavailable: 'ホームチャンネルを利用できません',
+  homeChannelsUnavailableBody: 'このタスクのメッセージ送信先を読み込めませんでした。',
+  homeChannelsRetry: '再試行',
+  homeChannelsOffline: 'ゲートウェイはオフラインです — 再接続して通知を変更してください。',
+  homeChannelsOrigin: 'タスクの送信元からも通知されます',
+  homeChannelsSaving: '保存中…',
+  homeChannelsUpdateError: (platform, message) => `${platform} の通知を更新できませんでした: ${message}`,
+  homeChanged: platform => `${platform} のホームが変更されました`,
+  homeChangedMove: (oldName, currentName) =>
+    `更新は引き続き ${oldName} に送られます。${currentName} に移動するか、ホーム通知を停止してください。`,
+  homeChangedStop: oldName => `更新は引き続き ${oldName} に送られますが、現在のホームではありません。`,
+  homePrevious: '以前のホーム',
+  homeMove: name => `${name} に移動`,
+  homeStop: '停止',
   readyUnassignedTitle: 'Ready ですが未割り当て — このカードは実行されません。',
   readyUnassignedBody:
     'ディスパッチャは担当のある Ready カードのみ取得します。上の担当フィールドでプロフィールを選ぶ（またはオーケストレーション設定でデフォルトの担当を設定する）と、1分以内に実行されます。',
@@ -693,6 +747,23 @@ const zh: KanbanMessages = {
   metaCreatedBy: '创建者',
   metaCreated: '创建于',
   metaWorkerPid: '工作单元 PID',
+  homeChannels: '主频道通知',
+  homeChannelsHelp: '将此任务的更新发送到所选主频道。',
+  homeChannelAria: (home, platform) => `在 ${platform} 的 ${home} 中通知`,
+  homeChannelsEmpty: '此配置文件没有主频道。请在消息聊天中发送 /sethome。',
+  homeChannelsUnavailable: '主频道不可用',
+  homeChannelsUnavailableBody: '无法加载此任务的消息目标。',
+  homeChannelsRetry: '重试',
+  homeChannelsOffline: '网关离线 — 重新连接后才能更改通知。',
+  homeChannelsOrigin: '任务来源也会发送通知',
+  homeChannelsSaving: '正在保存…',
+  homeChannelsUpdateError: (platform, message) => `无法更新 ${platform} 通知：${message}`,
+  homeChanged: platform => `${platform} 主频道已更改`,
+  homeChangedMove: (oldName, currentName) => `更新仍发送到 ${oldName}。请将其移至 ${currentName}，或停止主频道通知。`,
+  homeChangedStop: oldName => `更新仍发送到 ${oldName}，但它已不是你的主频道。`,
+  homePrevious: '你之前的主频道',
+  homeMove: name => `移至 ${name}`,
+  homeStop: '停止',
   readyUnassignedTitle: '就绪但未分配 — 这张卡片永远不会运行。',
   readyUnassignedBody:
     '调度器只领取有负责人的就绪卡片。在上面的负责人字段选择一个配置档（或在编排设置中设置默认负责人），它会在一分钟内运行。',
@@ -881,6 +952,23 @@ const zhHant: KanbanMessages = {
   metaCreatedBy: '建立者',
   metaCreated: '建立於',
   metaWorkerPid: '工作單元 PID',
+  homeChannels: '主頻道通知',
+  homeChannelsHelp: '將此任務的更新傳送到所選主頻道。',
+  homeChannelAria: (home, platform) => `在 ${platform} 的 ${home} 中通知`,
+  homeChannelsEmpty: '此設定檔沒有主頻道。請在訊息聊天中傳送 /sethome。',
+  homeChannelsUnavailable: '主頻道無法使用',
+  homeChannelsUnavailableBody: '無法載入此任務的訊息目的地。',
+  homeChannelsRetry: '重試',
+  homeChannelsOffline: '閘道離線 — 重新連線後才能變更通知。',
+  homeChannelsOrigin: '任務來源也會傳送通知',
+  homeChannelsSaving: '正在儲存…',
+  homeChannelsUpdateError: (platform, message) => `無法更新 ${platform} 通知：${message}`,
+  homeChanged: platform => `${platform} 主頻道已變更`,
+  homeChangedMove: (oldName, currentName) => `更新仍傳送到 ${oldName}。請將其移至 ${currentName}，或停止主頻道通知。`,
+  homeChangedStop: oldName => `更新仍傳送到 ${oldName}，但它已不是你的主頻道。`,
+  homePrevious: '你先前的主頻道',
+  homeMove: name => `移至 ${name}`,
+  homeStop: '停止',
   readyUnassignedTitle: '就緒但未指派 — 這張卡片永遠不會執行。',
   readyUnassignedBody:
     '排程器只領取有負責人的就緒卡片。在上方的負責人欄位選擇一個設定檔（或在編排設定中設定預設負責人），它會在一分鐘內執行。',

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -122,6 +122,29 @@ export interface KanbanTaskDetail {
   runs: KanbanRun[]
 }
 
+export interface KanbanHomeChannel {
+  platform: string
+  chat_id: string
+  thread_id: string
+  name: string
+  subscribed: boolean
+  subscription_state?: 'none' | 'home' | 'other' | 'home_and_other'
+  mutable?: boolean
+}
+
+export interface StaleHomeSubscription {
+  platform: string
+  chat_id: string
+  thread_id: string
+  name: string
+  notifier_profile: string
+}
+
+export interface KanbanHomeChannelsResponse {
+  home_channels: KanbanHomeChannel[]
+  stale_home_subscriptions?: StaleHomeSubscription[]
+}
+
 /** GET /boards — every board on disk + which one is the server's current. */
 export interface BoardMeta {
   slug: string

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -315,6 +315,14 @@ class GatewayKanbanWatchersMixin:
                             getattr(platform, "value", str(platform)).lower()
                             for platform in _profile_adapter_map.keys()
                         )
+                    _relay = getattr(self, "adapters", {}).get(_Platform.RELAY)
+                    _fronts_platform = getattr(_relay, "fronts_platform", None)
+                    if callable(_fronts_platform):
+                        active_platforms.update(
+                            platform.value
+                            for platform in _Platform
+                            if platform != _Platform.RELAY and _fronts_platform(platform)
+                        )
                     if not active_platforms:
                         logger.debug("kanban notifier: no connected adapters; skipping tick")
                         return deliveries
@@ -435,6 +443,7 @@ class GatewayKanbanWatchersMixin:
                                     old_cursor, cursor, events = _kb.claim_unseen_events_for_sub(
                                         conn,
                                         task_id=sub["task_id"],
+                                        notifier_profile=sub.get("notifier_profile"),
                                         platform=sub["platform"],
                                         chat_id=sub["chat_id"],
                                         thread_id=sub.get("thread_id") or "",
@@ -476,10 +485,15 @@ class GatewayKanbanWatchersMixin:
                     try:
                         plat = _Platform(platform_str)
                     except ValueError:
-                        # Unknown platform string; skip and advance cursor so
-                        # we don't replay forever.
+                        # Unknown logical platforms fail closed. Keep the event
+                        # pending rather than silently consuming it or falling
+                        # back to an unrelated adapter.
                         await asyncio.to_thread(
-                            self._kanban_advance, sub, d["cursor"], board_slug,
+                            self._kanban_rewind,
+                            sub,
+                            d["cursor"],
+                            d.get("old_cursor", 0),
+                            board_slug,
                         )
                         continue
                     sub_profile = sub.get("notifier_profile") or ""
@@ -493,6 +507,13 @@ class GatewayKanbanWatchersMixin:
                     # exists to fix). The helper returns None only when the profile
                     # (or default) genuinely has no adapter for the platform.
                     adapter = self._authorization_adapter(plat, sub_profile or None)
+                    relay_delivery = False
+                    if adapter is None:
+                        relay = getattr(self, "adapters", {}).get(_Platform.RELAY)
+                        fronts_platform = getattr(relay, "fronts_platform", None)
+                        if callable(fronts_platform) and fronts_platform(plat):
+                            adapter = relay
+                            relay_delivery = True
                     if adapter is None:
                         logger.debug(
                             "kanban notifier: adapter %s disconnected before delivery for %s; rewinding claim",
@@ -513,7 +534,7 @@ class GatewayKanbanWatchersMixin:
                     # ``else`` clause) needs it even when every event in the
                     # claim was skipped before reaching the send site.
                     sub_key = (
-                        sub["task_id"], sub["platform"],
+                        sub["task_id"], sub_profile, sub["platform"],
                         sub["chat_id"], sub.get("thread_id") or "",
                     )
                     mode = sub.get("delivery_mode") or "notify"
@@ -633,6 +654,10 @@ class GatewayKanbanWatchersMixin:
 
                         if sub.get("thread_id") and not metadata.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
+                        if sub.get("user_id") and not metadata.get("user_id"):
+                            metadata["user_id"] = sub["user_id"]
+                        if relay_delivery:
+                            metadata["_relay_logical_platform"] = platform_str
                         # Adapters with no push channel (the API server —
                         # ``supports_async_delivery = False``) can NEVER
                         # satisfy a text-send: ``send()`` always reports
@@ -1025,6 +1050,7 @@ class GatewayKanbanWatchersMixin:
             _kb.advance_notify_cursor(
                 conn,
                 task_id=sub["task_id"],
+                notifier_profile=sub.get("notifier_profile"),
                 platform=sub["platform"],
                 chat_id=sub["chat_id"],
                 thread_id=sub.get("thread_id") or "",
@@ -1040,6 +1066,7 @@ class GatewayKanbanWatchersMixin:
             _kb.remove_notify_sub(
                 conn,
                 task_id=sub["task_id"],
+                notifier_profile=sub.get("notifier_profile"),
                 platform=sub["platform"],
                 chat_id=sub["chat_id"],
                 thread_id=sub.get("thread_id") or "",
@@ -1061,6 +1088,7 @@ class GatewayKanbanWatchersMixin:
             _kb.rewind_notify_cursor(
                 conn,
                 task_id=sub["task_id"],
+                notifier_profile=sub.get("notifier_profile"),
                 platform=sub["platform"],
                 chat_id=sub["chat_id"],
                 thread_id=sub.get("thread_id") or "",

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -1534,7 +1534,26 @@ class RelayAdapter(BasePlatformAdapter):
         pre-media behaviour — media delivery is progressive enhancement,
         never a regression when the connector predates the op.
         """
-        if self._transport is None or not self.descriptor.supports_op("send_media"):
+        media_metadata: Dict[str, Any] = dict(metadata or {})
+        explicit_platform = media_metadata.pop("_relay_logical_platform", None)
+        if explicit_platform and not self.fronts_platform(explicit_platform):
+            return SendResult(
+                success=False,
+                error=f"relay does not front platform {explicit_platform}",
+            )
+        descriptor = self.descriptor
+        if explicit_platform and self._transport is not None:
+            resolve = getattr(self._transport, "descriptor_for_platform", None)
+            if callable(resolve):
+                try:
+                    resolved = cast(
+                        Optional[CapabilityDescriptor],
+                        resolve(str(explicit_platform)),
+                    )
+                except Exception:  # noqa: BLE001 - capability lookup is best-effort
+                    resolved = None
+                descriptor = resolved or descriptor
+        if self._transport is None or not descriptor.supports_op("send_media"):
             return None
         source_url = source
         if source_is_path:
@@ -1550,7 +1569,6 @@ class RelayAdapter(BasePlatformAdapter):
         # unresolved anchor threads an image under the user's DM message in
         # flat mode, and loses the per-message thread entirely in thread mode
         # (threadTs() reads metadata only). Route through the shared helper.
-        media_metadata: Dict[str, Any] = dict(metadata or {})
         effective_reply_to = self._apply_slack_thread_anchor(
             chat_id, reply_to, media_metadata
         )
@@ -1568,7 +1586,11 @@ class RelayAdapter(BasePlatformAdapter):
         try:
             result = await self._transport.send_outbound(
                 action,
-                platform=self._platform_by_chat.get(str(chat_id)),
+                platform=(
+                    str(explicit_platform)
+                    if explicit_platform
+                    else self._platform_by_chat.get(str(chat_id))
+                ),
             )
         except Exception:  # noqa: BLE001 - transport failure degrades to the caller's fallback
             logger.debug("relay send_media transport failure", exc_info=True)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -553,6 +553,10 @@ class GatewaySlashCommandsMixin:
                                     # message and wake the destination agent.
                                     delivery_mode="notify+wake",
                                     delivery_metadata=delivery_metadata,
+                                    source_kind="origin",
+                                    source_key=(
+                                        f"{platform_str}:{chat_id}:{thread_id or ''}"
+                                    ),
                                 )
                             finally:
                                 conn.close()

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -857,6 +857,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_nrm.add_argument("--platform", required=True)
     p_nrm.add_argument("--chat-id", required=True)
     p_nrm.add_argument("--thread-id", default=None)
+    p_nrm.add_argument(
+        "--notifier-profile", default=None,
+        help="Profile-owned route to remove (default: active profile)",
+    )
 
     # --- log ---
     p_log = sub.add_parser(
@@ -2979,6 +2983,7 @@ def _cmd_notify_unsubscribe(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
         ok = kb.remove_notify_sub(
             conn, task_id=args.task_id,
+            notifier_profile=args.notifier_profile or _profile_author(),
             platform=args.platform, chat_id=args.chat_id,
             thread_id=args.thread_id,
         )

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2981,12 +2981,24 @@ def _cmd_notify_list(args: argparse.Namespace) -> int:
 
 def _cmd_notify_unsubscribe(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
+        notifier_profile = (
+            _profile_author()
+            if args.notifier_profile is None
+            else args.notifier_profile
+        )
         ok = kb.remove_notify_sub(
             conn, task_id=args.task_id,
-            notifier_profile=args.notifier_profile or _profile_author(),
+            notifier_profile=notifier_profile,
             platform=args.platform, chat_id=args.chat_id,
             thread_id=args.thread_id,
         )
+        if not ok and args.notifier_profile is None:
+            ok = kb.remove_notify_sub(
+                conn, task_id=args.task_id,
+                notifier_profile="",
+                platform=args.platform, chat_id=args.chat_id,
+                thread_id=args.thread_id,
+            )
     if not ok:
         print("(no such subscription)", file=sys.stderr)
         return 1

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1500,18 +1500,40 @@ CREATE TABLE IF NOT EXISTS task_attachments (
 -- the original requester so human-in-the-loop workflows close the loop.
 CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     task_id       TEXT NOT NULL,
+    notifier_profile TEXT NOT NULL DEFAULT '',
     platform      TEXT NOT NULL,
     chat_id       TEXT NOT NULL,
     thread_id     TEXT NOT NULL DEFAULT '',
     user_id       TEXT,
     user_id_alt   TEXT,
     chat_type     TEXT,
-    notifier_profile TEXT,
     delivery_mode TEXT NOT NULL DEFAULT 'notify',
     delivery_metadata TEXT,
     created_at    INTEGER NOT NULL,
     last_event_id INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (task_id, platform, chat_id, thread_id)
+    PRIMARY KEY (task_id, notifier_profile, platform, chat_id, thread_id)
+);
+
+CREATE TABLE IF NOT EXISTS kanban_notify_sources (
+    task_id       TEXT NOT NULL,
+    notifier_profile TEXT NOT NULL DEFAULT '',
+    platform      TEXT NOT NULL,
+    chat_id       TEXT NOT NULL,
+    thread_id     TEXT NOT NULL DEFAULT '',
+    source_kind TEXT NOT NULL
+        CHECK (source_kind IN ('origin','home','manual','legacy')),
+    source_key TEXT NOT NULL,
+    delivery_mode TEXT NOT NULL DEFAULT 'notify'
+        CHECK (delivery_mode IN ('notify','notify+wake','wake')),
+    user_id       TEXT,
+    user_id_alt   TEXT,
+    chat_type     TEXT,
+    delivery_metadata TEXT,
+    created_at    INTEGER NOT NULL,
+    PRIMARY KEY (
+        task_id, notifier_profile, platform, chat_id, thread_id,
+        source_kind, source_key
+    )
 );
 
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
@@ -1524,6 +1546,7 @@ CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, start
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+CREATE INDEX IF NOT EXISTS idx_notify_sources_task   ON kanban_notify_sources(task_id);
 """
 
 
@@ -2798,6 +2821,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         )
 
     _rebuild_drifted_tables(conn)
+    _ensure_notify_sources(conn)
 
 
 # Legacy DBs defined these tables with a ``TEXT PRIMARY KEY`` id (or, for
@@ -2847,13 +2871,14 @@ _REBUILD_SPECS = {
     ),
     "kanban_notify_subs": (
         "CREATE TABLE kanban_notify_subs ("
-        " task_id TEXT NOT NULL, platform TEXT NOT NULL, chat_id TEXT NOT NULL,"
+        " task_id TEXT NOT NULL, notifier_profile TEXT NOT NULL DEFAULT '',"
+        " platform TEXT NOT NULL, chat_id TEXT NOT NULL,"
         " thread_id TEXT NOT NULL DEFAULT '', user_id TEXT, user_id_alt TEXT,"
         " chat_type TEXT,"
-        " notifier_profile TEXT, delivery_mode TEXT NOT NULL DEFAULT 'notify',"
+        " delivery_mode TEXT NOT NULL DEFAULT 'notify',"
         " delivery_metadata TEXT, created_at INTEGER NOT NULL,"
         " last_event_id INTEGER NOT NULL DEFAULT 0,"
-        " PRIMARY KEY (task_id, platform, chat_id, thread_id))",
+        " PRIMARY KEY (task_id, notifier_profile, platform, chat_id, thread_id))",
         ("CREATE INDEX idx_notify_task ON kanban_notify_subs(task_id)",),
     ),
 }
@@ -2866,7 +2891,19 @@ def _table_has_drifted(conn: sqlite3.Connection, table: str) -> bool:
         return False  # table absent — nothing to rebuild
     if table == "kanban_notify_subs":
         lei = next((c for c in info if c["name"] == "last_event_id"), None)
-        return lei is not None and (lei["type"] or "").upper() != "INTEGER"
+        profile = next((c for c in info if c["name"] == "notifier_profile"), None)
+        pk = [c["name"] for c in sorted(info, key=lambda c: c["pk"] or 99) if c["pk"]]
+        return (
+            lei is not None
+            and (
+                (lei["type"] or "").upper() != "INTEGER"
+                or profile is None
+                or not profile["notnull"]
+                or pk != [
+                    "task_id", "notifier_profile", "platform", "chat_id", "thread_id"
+                ]
+            )
+        )
     # task_events / task_comments / task_runs: id must be INTEGER and a PK.
     id_col = next((c for c in info if c["name"] == "id"), None)
     if id_col is None:
@@ -2906,12 +2943,22 @@ def _rebuild_drifted_tables(conn: sqlite3.Connection) -> None:
             conn.execute(create_sql)
             new_cols = {c["name"] for c in conn.execute(f"PRAGMA table_info({table})")}
             if table == "kanban_notify_subs":
-                # Cast the legacy TEXT cursor to INTEGER; NULL / non-numeric → 0.
-                shared = [c for c in old_cols if c in new_cols and c != "last_event_id"]
-                cols_csv = ", ".join(shared)
+                shared = [
+                    c for c in old_cols
+                    if c in new_cols and c not in {"last_event_id", "notifier_profile"}
+                ]
+                insert_cols = ["notifier_profile", *shared, "last_event_id"]
+                cols_csv = ", ".join(insert_cols)
+                selected = ", ".join(shared)
+                profile_expr = (
+                    "COALESCE(notifier_profile, '')"
+                    if "notifier_profile" in old_cols
+                    else "''"
+                )
                 conn.execute(
-                    f"INSERT INTO {table} ({cols_csv}, last_event_id) "
-                    f"SELECT {cols_csv}, COALESCE(CAST(last_event_id AS INTEGER), 0) "
+                    f"INSERT INTO {table} ({cols_csv}) "
+                    f"SELECT {profile_expr}, {selected}, "
+                    "COALESCE(CAST(last_event_id AS INTEGER), 0) "
                     f"FROM {table}_legacy"
                 )
             else:
@@ -2932,6 +2979,63 @@ def _rebuild_drifted_tables(conn: sqlite3.Connection) -> None:
         except sqlite3.OperationalError:
             pass
         raise
+
+
+def _ensure_notify_sources(conn: sqlite3.Connection) -> None:
+    """Create source ownership and classify pre-source routes as legacy."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS kanban_notify_sources (
+            task_id TEXT NOT NULL,
+            notifier_profile TEXT NOT NULL DEFAULT '',
+            platform TEXT NOT NULL,
+            chat_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL DEFAULT '',
+            source_kind TEXT NOT NULL CHECK (source_kind IN ('origin','home','manual','legacy')),
+            source_key TEXT NOT NULL,
+            delivery_mode TEXT NOT NULL DEFAULT 'notify'
+                CHECK (delivery_mode IN ('notify','notify+wake','wake')),
+            user_id TEXT,
+            user_id_alt TEXT,
+            chat_type TEXT,
+            delivery_metadata TEXT,
+            created_at INTEGER NOT NULL,
+            PRIMARY KEY (
+                task_id, notifier_profile, platform, chat_id, thread_id,
+                source_kind, source_key
+            )
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notify_sources_task "
+        "ON kanban_notify_sources(task_id)"
+    )
+    if conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+        "AND name = 'kanban_notify_subs'"
+    ).fetchone() is None:
+        return
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO kanban_notify_sources
+            (task_id, notifier_profile, platform, chat_id, thread_id,
+             source_kind, source_key, delivery_mode, user_id, user_id_alt,
+             chat_type, delivery_metadata, created_at)
+        SELECT task_id, notifier_profile, platform, chat_id, thread_id,
+               'legacy', 'route', delivery_mode, user_id, user_id_alt,
+               chat_type, delivery_metadata, created_at
+          FROM kanban_notify_subs r
+         WHERE NOT EXISTS (
+               SELECT 1 FROM kanban_notify_sources s
+                WHERE s.task_id = r.task_id
+                  AND s.notifier_profile = r.notifier_profile
+                  AND s.platform = r.platform
+                  AND s.chat_id = r.chat_id
+                  AND s.thread_id = r.thread_id
+         )
+        """
+    )
 
 
 def _check_file_length_invariant(conn: sqlite3.Connection) -> None:
@@ -3589,6 +3693,41 @@ def _inherit_notify_subs(
             *parent_ids,
         ),
     )
+    conn.execute(
+        f"""
+        INSERT OR IGNORE INTO kanban_notify_sources
+            (task_id, notifier_profile, platform, chat_id, thread_id,
+             source_kind, source_key, delivery_mode, user_id, user_id_alt,
+             chat_type, delivery_metadata, created_at)
+        SELECT ?, notifier_profile, platform, chat_id, thread_id,
+               source_kind, source_key, delivery_mode, user_id, user_id_alt,
+               chat_type, delivery_metadata, ?
+          FROM kanban_notify_sources
+         WHERE task_id IN ({placeholders})
+        """,
+        (
+            child_id,
+            int(created_at if created_at is not None else time.time()),
+            *parent_ids,
+        ),
+    )
+    inherited_routes = conn.execute(
+        """
+        SELECT DISTINCT notifier_profile, platform, chat_id, thread_id
+          FROM kanban_notify_sources
+         WHERE task_id = ?
+        """,
+        (child_id,),
+    ).fetchall()
+    for route in inherited_routes:
+        _recompute_notify_route(
+            conn,
+            task_id=child_id,
+            notifier_profile=str(route["notifier_profile"]),
+            platform=str(route["platform"]),
+            chat_id=str(route["chat_id"]),
+            thread_id=str(route["thread_id"]),
+        )
 
 
 def get_task(conn: sqlite3.Connection, task_id: str) -> Optional[Task]:
@@ -7439,6 +7578,7 @@ def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
+        conn.execute("DELETE FROM kanban_notify_sources WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
         cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         return cur.rowcount == 1
@@ -7462,6 +7602,7 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
         conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
+        conn.execute("DELETE FROM kanban_notify_sources WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
     recompute_ready(conn)
     return True
@@ -10960,6 +11101,143 @@ def _decode_notify_delivery_metadata(raw: Any) -> dict[str, Any]:
     }
 
 
+_NOTIFY_SOURCE_KINDS = {"origin", "home", "manual", "legacy"}
+_NOTIFY_SOURCE_PRIORITY = {"origin": 0, "manual": 1, "home": 2, "legacy": 3}
+
+
+def _notify_profile(value: Optional[str]) -> str:
+    return str(value or "").strip()
+
+
+def _notify_route_key(
+    *, task_id: str, notifier_profile: Optional[str], platform: str,
+    chat_id: str, thread_id: Optional[str],
+) -> tuple[str, str, str, str, str]:
+    return (
+        task_id, _notify_profile(notifier_profile), platform, chat_id, thread_id or ""
+    )
+
+
+def _effective_notify_mode(modes: Iterable[str]) -> str:
+    values = set(modes)
+    wants_notify = bool(values & {"notify", "notify+wake"})
+    wants_wake = bool(values & {"wake", "notify+wake"})
+    if wants_notify and wants_wake:
+        return "notify+wake"
+    if wants_wake:
+        return "wake"
+    return "notify"
+
+
+def _recompute_notify_route(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    notifier_profile: Optional[str],
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+) -> bool:
+    key = _notify_route_key(
+        task_id=task_id,
+        notifier_profile=notifier_profile,
+        platform=platform,
+        chat_id=chat_id,
+        thread_id=thread_id,
+    )
+    rows = conn.execute(
+        """
+        SELECT * FROM kanban_notify_sources
+         WHERE task_id = ? AND notifier_profile = ? AND platform = ?
+           AND chat_id = ? AND thread_id = ?
+        """,
+        key,
+    ).fetchall()
+    if not rows:
+        conn.execute(
+            "DELETE FROM kanban_notify_subs WHERE task_id = ? AND notifier_profile = ? "
+            "AND platform = ? AND chat_id = ? AND thread_id = ?",
+            key,
+        )
+        return False
+
+    sources = sorted(
+        (dict(row) for row in rows),
+        key=lambda row: (
+            _NOTIFY_SOURCE_PRIORITY.get(str(row.get("source_kind")), 99),
+            str(row.get("source_key") or ""),
+        ),
+    )
+    metadata: dict[str, Any] = {}
+    for source in sources:
+        for field, value in _decode_notify_delivery_metadata(
+            source.get("delivery_metadata")
+        ).items():
+            metadata.setdefault(field, value)
+
+    def first(field: str) -> Optional[str]:
+        for source in sources:
+            value = source.get(field)
+            if value not in (None, ""):
+                return str(value)
+        return None
+
+    conn.execute(
+        """
+        UPDATE kanban_notify_subs
+           SET user_id = ?, user_id_alt = ?, chat_type = ?, delivery_mode = ?,
+               delivery_metadata = ?
+         WHERE task_id = ? AND notifier_profile = ? AND platform = ?
+           AND chat_id = ? AND thread_id = ?
+        """,
+        (
+            first("user_id"),
+            first("user_id_alt"),
+            first("chat_type") or "dm",
+            _effective_notify_mode(str(source.get("delivery_mode") or "notify") for source in sources),
+            _encode_notify_delivery_metadata(metadata),
+            *key,
+        ),
+    )
+    return True
+
+
+def list_notify_sources(
+    conn: sqlite3.Connection,
+    task_id: Optional[str] = None,
+    *,
+    notifier_profile: Optional[str] = None,
+    platform: Optional[str] = None,
+    source_kind: Optional[str] = None,
+) -> list[dict]:
+    clauses: list[str] = []
+    params: list[Any] = []
+    for column, value in (
+        ("task_id", task_id),
+        ("notifier_profile", _notify_profile(notifier_profile) if notifier_profile is not None else None),
+        ("platform", platform),
+        ("source_kind", source_kind),
+    ):
+        if value is not None:
+            clauses.append(f"{column} = ?")
+            params.append(value)
+    sql = "SELECT * FROM kanban_notify_sources"
+    if clauses:
+        sql += " WHERE " + " AND ".join(clauses)
+    sql += (
+        " ORDER BY task_id, notifier_profile, platform, chat_id, thread_id, "
+        "source_kind, source_key"
+    )
+    result = []
+    for row in conn.execute(sql, params).fetchall():
+        item = dict(row)
+        item["delivery_metadata"] = _decode_notify_delivery_metadata(
+            item.get("delivery_metadata")
+        )
+        result.append(item)
+    return result
+
+
 def add_notify_sub(
     conn: sqlite3.Connection,
     *,
@@ -10973,9 +11251,12 @@ def add_notify_sub(
     notifier_profile: Optional[str] = None,
     delivery_mode: Optional[str] = None,
     delivery_metadata: Optional[Mapping[str, Any]] = None,
+    source_kind: str = "manual",
+    source_key: str = "route",
+    _allow_nested: bool = False,
 ) -> None:
     """Register a gateway source that wants terminal-state notifications
-    for ``task_id``. Idempotent on (task, platform, chat, thread).
+    for ``task_id``. Idempotent on the profile-scoped route plus source.
 
     ``user_id_alt`` records the originating source's platform-specific stable
     alt ID (Signal UUID, Feishu union_id, ...) alongside ``user_id``. Active-wake
@@ -11015,7 +11296,12 @@ def add_notify_sub(
     insert_chat_type = chat_type or "dm"
     now = int(time.time())
     metadata_json = _encode_notify_delivery_metadata(delivery_metadata)
-    with write_txn(conn):
+    profile = _notify_profile(notifier_profile)
+    if source_kind not in _NOTIFY_SOURCE_KINDS:
+        raise ValueError(f"invalid notification source kind: {source_kind!r}")
+    kind = source_kind
+    source_key = str(source_key or "route")
+    with write_txn(conn, allow_nested=_allow_nested):
         conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs
@@ -11033,7 +11319,7 @@ def add_notify_sub(
                 user_id,
                 user_id_alt,
                 insert_chat_type,
-                notifier_profile,
+                profile,
                 insert_mode,
                 metadata_json,
                 now,
@@ -11046,9 +11332,10 @@ def add_notify_sub(
                 """
                 UPDATE kanban_notify_subs
                    SET chat_type = ?
-                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                 WHERE task_id = ? AND notifier_profile = ? AND platform = ?
+                   AND chat_id = ? AND thread_id = ?
                 """,
-                (chat_type, task_id, platform, chat_id, thread_id or ""),
+                (chat_type, task_id, profile, platform, chat_id, thread_id or ""),
             )
         if user_id_alt:
             # Self-heal legacy rows created before alternate IDs were tracked.
@@ -11056,21 +11343,11 @@ def add_notify_sub(
                 """
                 UPDATE kanban_notify_subs
                    SET user_id_alt = ?
-                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                 WHERE task_id = ? AND notifier_profile = ? AND platform = ?
+                   AND chat_id = ? AND thread_id = ?
                    AND (user_id_alt IS NULL OR user_id_alt = '')
                 """,
-                (user_id_alt, task_id, platform, chat_id, thread_id or ""),
-            )
-        if notifier_profile:
-            # Self-heal legacy rows that predate notifier ownership.
-            conn.execute(
-                """
-                UPDATE kanban_notify_subs
-                   SET notifier_profile = ?
-                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
-                   AND (notifier_profile IS NULL OR notifier_profile = '')
-                """,
-                (notifier_profile, task_id, platform, chat_id, thread_id or ""),
+                (user_id_alt, task_id, profile, platform, chat_id, thread_id or ""),
             )
         if delivery_mode in _NOTIFY_DELIVERY_MODES:
             # Explicit delivery_mode is last-write-wins on re-subscribe.
@@ -11078,9 +11355,10 @@ def add_notify_sub(
                 """
                 UPDATE kanban_notify_subs
                    SET delivery_mode = ?
-                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                 WHERE task_id = ? AND notifier_profile = ? AND platform = ?
+                   AND chat_id = ? AND thread_id = ?
                 """,
-                (delivery_mode, task_id, platform, chat_id, thread_id or ""),
+                (delivery_mode, task_id, profile, platform, chat_id, thread_id or ""),
             )
         if metadata_json:
             # Refresh the routing anchor for duplicate subscriptions.
@@ -11088,10 +11366,228 @@ def add_notify_sub(
                 """
                 UPDATE kanban_notify_subs
                    SET delivery_metadata = ?
-                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                 WHERE task_id = ? AND notifier_profile = ? AND platform = ?
+                   AND chat_id = ? AND thread_id = ?
                 """,
-                (metadata_json, task_id, platform, chat_id, thread_id or ""),
+                (metadata_json, task_id, profile, platform, chat_id, thread_id or ""),
             )
+        conn.execute(
+            """
+            INSERT INTO kanban_notify_sources
+                (task_id, notifier_profile, platform, chat_id, thread_id,
+                 source_kind, source_key, delivery_mode, user_id, user_id_alt,
+                 chat_type, delivery_metadata, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (
+                task_id, notifier_profile, platform, chat_id, thread_id,
+                source_kind, source_key
+            ) DO UPDATE SET
+                delivery_mode = CASE WHEN ? = 1
+                    THEN excluded.delivery_mode ELSE delivery_mode END,
+                user_id = COALESCE(excluded.user_id, user_id),
+                user_id_alt = COALESCE(excluded.user_id_alt, user_id_alt),
+                chat_type = COALESCE(excluded.chat_type, chat_type),
+                delivery_metadata = COALESCE(
+                    excluded.delivery_metadata, delivery_metadata
+                )
+            """,
+            (
+                task_id, profile, platform, chat_id, thread_id or "",
+                kind, source_key, insert_mode, user_id, user_id_alt,
+                chat_type, metadata_json, now,
+                int(delivery_mode in _NOTIFY_DELIVERY_MODES),
+            ),
+        )
+        _recompute_notify_route(
+            conn,
+            task_id=task_id,
+            notifier_profile=profile,
+            platform=platform,
+            chat_id=chat_id,
+            thread_id=thread_id,
+        )
+
+
+def replace_home_notify_source(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    notifier_profile: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    user_id_alt: Optional[str] = None,
+    chat_type: Optional[str] = None,
+    delivery_metadata: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    """Atomically move this profile/platform's home intent to ``chat_id``."""
+    profile = _notify_profile(notifier_profile)
+    current_key = (task_id, profile, platform, chat_id, thread_id or "")
+    with write_txn(conn):
+        previous = conn.execute(
+            """
+            SELECT task_id, notifier_profile, platform, chat_id, thread_id
+              FROM kanban_notify_sources
+             WHERE task_id = ? AND notifier_profile = ? AND platform = ?
+               AND source_kind = 'home' AND source_key = ?
+            """,
+            (task_id, profile, platform, profile),
+        ).fetchall()
+        for row in previous:
+            old_key = tuple(row)
+            if old_key == current_key:
+                continue
+            conn.execute(
+                """
+                DELETE FROM kanban_notify_sources
+                 WHERE task_id = ? AND notifier_profile = ? AND platform = ?
+                   AND chat_id = ? AND thread_id = ?
+                   AND source_kind = 'home' AND source_key = ?
+                """,
+                (*old_key, profile),
+            )
+            _recompute_notify_route(
+                conn,
+                task_id=str(row["task_id"]),
+                notifier_profile=str(row["notifier_profile"]),
+                platform=str(row["platform"]),
+                chat_id=str(row["chat_id"]),
+                thread_id=str(row["thread_id"]),
+            )
+        add_notify_sub(
+            conn,
+            task_id=task_id,
+            notifier_profile=profile,
+            platform=platform,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            user_id=user_id,
+            user_id_alt=user_id_alt,
+            chat_type=chat_type,
+            delivery_mode="notify",
+            delivery_metadata=delivery_metadata,
+            source_kind="home",
+            source_key=profile,
+            _allow_nested=True,
+        )
+    return {"replaced": sum(tuple(row) != current_key for row in previous)}
+
+
+def remove_home_notify_sources(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    notifier_profile: str,
+    platform: str,
+) -> dict[str, Any]:
+    """Remove current and stale home intents without touching other sources."""
+    profile = _notify_profile(notifier_profile)
+    with write_txn(conn):
+        rows = conn.execute(
+            """
+            SELECT task_id, notifier_profile, platform, chat_id, thread_id
+              FROM kanban_notify_sources
+             WHERE task_id = ? AND notifier_profile = ? AND platform = ?
+               AND source_kind = 'home' AND source_key = ?
+            """,
+            (task_id, profile, platform, profile),
+        ).fetchall()
+        conn.execute(
+            """
+            DELETE FROM kanban_notify_sources
+             WHERE task_id = ? AND notifier_profile = ? AND platform = ?
+               AND source_kind = 'home' AND source_key = ?
+            """,
+            (task_id, profile, platform, profile),
+        )
+        delivery_active = False
+        for row in rows:
+            delivery_active = _recompute_notify_route(
+                conn,
+                task_id=str(row["task_id"]),
+                notifier_profile=str(row["notifier_profile"]),
+                platform=str(row["platform"]),
+                chat_id=str(row["chat_id"]),
+                thread_id=str(row["thread_id"]),
+            ) or delivery_active
+    return {"removed": len(rows), "delivery_active": delivery_active}
+
+
+def adopt_passive_legacy_home_source(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    notifier_profile: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+) -> bool:
+    """Narrowly adopt an exact profile-owned passive legacy route as home."""
+    profile = _notify_profile(notifier_profile)
+    key = (task_id, profile, platform, chat_id, thread_id or "")
+    with write_txn(conn):
+        route = conn.execute(
+            """
+            SELECT delivery_mode FROM kanban_notify_subs
+             WHERE task_id = ? AND notifier_profile = ? AND platform = ?
+               AND chat_id = ? AND thread_id = ?
+            """,
+            key,
+        ).fetchone()
+        if route is None or route["delivery_mode"] != "notify":
+            return False
+        sources = conn.execute(
+            """
+            SELECT * FROM kanban_notify_sources
+             WHERE task_id = ? AND notifier_profile = ? AND platform = ?
+               AND chat_id = ? AND thread_id = ?
+             ORDER BY source_kind, source_key
+            """,
+            key,
+        ).fetchall()
+        if not sources or any(
+            source["source_kind"] != "legacy"
+            or source["delivery_mode"] != "notify"
+            for source in sources
+        ):
+            return False
+        source = sources[0]
+        conn.execute(
+            """
+            DELETE FROM kanban_notify_sources
+             WHERE task_id = ? AND notifier_profile = ? AND platform = ?
+               AND chat_id = ? AND thread_id = ? AND source_kind = 'legacy'
+            """,
+            key,
+        )
+        conn.execute(
+            """
+            INSERT INTO kanban_notify_sources
+                (task_id, notifier_profile, platform, chat_id, thread_id,
+                 source_kind, source_key, delivery_mode, user_id, user_id_alt,
+                 chat_type, delivery_metadata, created_at)
+            VALUES (?, ?, ?, ?, ?, 'home', ?, 'notify', ?, ?, ?, ?, ?)
+            """,
+            (
+                *key,
+                profile,
+                source["user_id"],
+                source["user_id_alt"],
+                source["chat_type"],
+                source["delivery_metadata"],
+                source["created_at"],
+            ),
+        )
+        _recompute_notify_route(
+            conn,
+            task_id=task_id,
+            notifier_profile=profile,
+            platform=platform,
+            chat_id=chat_id,
+            thread_id=thread_id,
+        )
+    return True
 
 
 def _notify_profile_filter(
@@ -11118,7 +11614,7 @@ def _notify_profile_filter(
         )
         params.extend(profiles)
     if include_unowned:
-        clauses.append("notifier_profile IS NULL OR notifier_profile = ''")
+        clauses.append("notifier_profile = ''")
     if not clauses:
         return "0", []
     return "(" + ") OR (".join(clauses) + ")", params
@@ -11234,15 +11730,24 @@ def remove_notify_sub(
     conn: sqlite3.Connection,
     *,
     task_id: str,
+    notifier_profile: Optional[str] = None,
     platform: str,
     chat_id: str,
     thread_id: Optional[str] = None,
 ) -> bool:
     with write_txn(conn):
+        profile = _notify_profile(notifier_profile)
+        conn.execute(
+            "DELETE FROM kanban_notify_sources WHERE task_id = ? "
+            "AND notifier_profile = ? AND platform = ? AND chat_id = ? "
+            "AND thread_id = ?",
+            (task_id, profile, platform, chat_id, thread_id or ""),
+        )
         cur = conn.execute(
             "DELETE FROM kanban_notify_subs WHERE task_id = ? "
-            "AND platform = ? AND chat_id = ? AND thread_id = ?",
-            (task_id, platform, chat_id, thread_id or ""),
+            "AND notifier_profile = ? AND platform = ? AND chat_id = ? "
+            "AND thread_id = ?",
+            (task_id, profile, platform, chat_id, thread_id or ""),
         )
     return cur.rowcount > 0
 
@@ -11278,6 +11783,17 @@ def purge_stale_done_notify_subs(
         return 0
     cutoff = int(time.time()) - days * 86400
     with write_txn(conn):
+        conn.execute(
+            "DELETE FROM kanban_notify_sources WHERE task_id IN ("
+            " SELECT t.id FROM tasks t"
+            " WHERE t.status = 'done'"
+            " AND COALESCE("
+            "  (SELECT MAX(e.created_at) FROM task_events e"
+            "   WHERE e.task_id = t.id),"
+            "  t.completed_at, t.created_at, 0"
+            " ) < ?)",
+            (cutoff,),
+        )
         cur = conn.execute(
             "DELETE FROM kanban_notify_subs WHERE task_id IN ("
             " SELECT t.id FROM tasks t"
@@ -11296,6 +11812,7 @@ def unseen_events_for_sub(
     conn: sqlite3.Connection,
     *,
     task_id: str,
+    notifier_profile: Optional[str] = None,
     platform: str,
     chat_id: str,
     thread_id: Optional[str] = None,
@@ -11309,8 +11826,9 @@ def unseen_events_for_sub(
     """
     row = conn.execute(
         "SELECT last_event_id FROM kanban_notify_subs "
-        "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
-        (task_id, platform, chat_id, thread_id or ""),
+        "WHERE task_id = ? AND notifier_profile = ? AND platform = ? "
+        "AND chat_id = ? AND thread_id = ?",
+        (task_id, _notify_profile(notifier_profile), platform, chat_id, thread_id or ""),
     ).fetchone()
     if row is None:
         return 0, []
@@ -11345,6 +11863,7 @@ def claim_unseen_events_for_sub(
     conn: sqlite3.Connection,
     *,
     task_id: str,
+    notifier_profile: Optional[str] = None,
     platform: str,
     chat_id: str,
     thread_id: Optional[str] = None,
@@ -11367,8 +11886,9 @@ def claim_unseen_events_for_sub(
     with write_txn(conn):
         row = conn.execute(
             "SELECT last_event_id FROM kanban_notify_subs "
-            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
-            (task_id, platform, chat_id, thread_id or ""),
+            "WHERE task_id = ? AND notifier_profile = ? AND platform = ? "
+            "AND chat_id = ? AND thread_id = ?",
+            (task_id, _notify_profile(notifier_profile), platform, chat_id, thread_id or ""),
         ).fetchone()
         if row is None:
             return 0, 0, []
@@ -11376,6 +11896,7 @@ def claim_unseen_events_for_sub(
         new_cursor, events = unseen_events_for_sub(
             conn,
             task_id=task_id,
+            notifier_profile=notifier_profile,
             platform=platform,
             chat_id=chat_id,
             thread_id=thread_id,
@@ -11385,9 +11906,13 @@ def claim_unseen_events_for_sub(
             return old_cursor, old_cursor, []
         conn.execute(
             "UPDATE kanban_notify_subs SET last_event_id = ? "
-            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
+            "WHERE task_id = ? AND notifier_profile = ? AND platform = ? "
+            "AND chat_id = ? AND thread_id = ? "
             "AND last_event_id = ?",
-            (int(new_cursor), task_id, platform, chat_id, thread_id or "", int(old_cursor)),
+            (
+                int(new_cursor), task_id, _notify_profile(notifier_profile), platform,
+                chat_id, thread_id or "", int(old_cursor),
+            ),
         )
         return old_cursor, new_cursor, events
 
@@ -11396,6 +11921,7 @@ def advance_notify_cursor(
     conn: sqlite3.Connection,
     *,
     task_id: str,
+    notifier_profile: Optional[str] = None,
     platform: str,
     chat_id: str,
     thread_id: Optional[str] = None,
@@ -11404,8 +11930,12 @@ def advance_notify_cursor(
     with write_txn(conn):
         conn.execute(
             "UPDATE kanban_notify_subs SET last_event_id = ? "
-            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
-            (int(new_cursor), task_id, platform, chat_id, thread_id or ""),
+            "WHERE task_id = ? AND notifier_profile = ? AND platform = ? "
+            "AND chat_id = ? AND thread_id = ?",
+            (
+                int(new_cursor), task_id, _notify_profile(notifier_profile), platform,
+                chat_id, thread_id or "",
+            ),
         )
 
 
@@ -11413,6 +11943,7 @@ def rewind_notify_cursor(
     conn: sqlite3.Connection,
     *,
     task_id: str,
+    notifier_profile: Optional[str] = None,
     platform: str,
     chat_id: str,
     thread_id: Optional[str] = None,
@@ -11428,10 +11959,12 @@ def rewind_notify_cursor(
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE kanban_notify_subs SET last_event_id = ? "
-            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
+            "WHERE task_id = ? AND notifier_profile = ? AND platform = ? "
+            "AND chat_id = ? AND thread_id = ? "
             "AND last_event_id = ?",
             (
-                int(old_cursor), task_id, platform, chat_id, thread_id or "",
+                int(old_cursor), task_id, _notify_profile(notifier_profile), platform,
+                chat_id, thread_id or "",
                 int(claimed_cursor),
             ),
         )

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2079,6 +2079,9 @@ def _configured_home_channels() -> list[dict]:
             "chat_id": hc.chat_id,
             "thread_id": hc.thread_id or "",
             "name": hc.name or "Home",
+            "user_id": hc.user_id,
+            "scope_id": hc.scope_id,
+            "chat_type": getattr(hc, "chat_type", None),
         })
     # Stable order for deterministic UI — platform name alphabetical.
     result.sort(key=lambda r: r["platform"])
@@ -2115,26 +2118,92 @@ def get_home_channels(
     — useful for the "no task selected" state of the UI.
     """
     homes = _configured_home_channels()
-    subscribed_homes: set[tuple[str, str, str]] = set()
+    subscriptions: list[dict] = []
+    sources: list[dict] = []
+    profile = _active_profile_name()
     if task_id:
         board = _resolve_board(board)
         conn = _conn(board=board)
         try:
-            subs = kanban_db.list_notify_subs(conn, task_id)
+            for home in homes:
+                kanban_db.adopt_passive_legacy_home_source(
+                    conn,
+                    task_id=task_id,
+                    notifier_profile=profile,
+                    platform=home["platform"],
+                    chat_id=home["chat_id"],
+                    thread_id=home["thread_id"] or None,
+                )
+            subscriptions = kanban_db.list_notify_subs(
+                conn, task_id, notifier_profiles={profile}
+            )
+            sources = kanban_db.list_notify_sources(
+                conn, task_id, notifier_profile=profile
+            )
         finally:
             conn.close()
-        for sub in subs:
-            key = (
-                str(sub.get("platform") or ""),
-                str(sub.get("chat_id") or ""),
-                str(sub.get("thread_id") or ""),
-            )
-            subscribed_homes.add(key)
+    route_keys = {
+        (
+            str(sub.get("platform") or ""),
+            str(sub.get("chat_id") or ""),
+            str(sub.get("thread_id") or ""),
+        )
+        for sub in subscriptions
+    }
+    source_keys: dict[tuple[str, str, str], set[str]] = {}
+    for source in sources:
+        key = (
+            str(source.get("platform") or ""),
+            str(source.get("chat_id") or ""),
+            str(source.get("thread_id") or ""),
+        )
+        source_keys.setdefault(key, set()).add(str(source.get("source_kind") or ""))
     result = []
     for home in homes:
         key = (home["platform"], home["chat_id"], home["thread_id"])
-        result.append({**home, "subscribed": key in subscribed_homes})
-    return {"home_channels": result}
+        kinds = source_keys.get(key, set())
+        has_home = "home" in kinds
+        has_other = bool(kinds - {"home"})
+        if has_home and has_other:
+            state = "home_and_other"
+        elif has_home:
+            state = "home"
+        elif has_other:
+            state = "other"
+        else:
+            state = "none"
+        result.append({
+            **{k: v for k, v in home.items() if k not in {"user_id", "scope_id", "chat_type"}},
+            "subscribed": key in route_keys,
+            "subscription_state": state,
+            "mutable": not (has_home and has_other),
+        })
+    current_keys = {
+        (home["platform"], home["chat_id"], home["thread_id"])
+        for home in homes
+    }
+    stale = [
+        {
+            "platform": str(source["platform"]),
+            "chat_id": str(source["chat_id"]),
+            "thread_id": str(source.get("thread_id") or ""),
+            "name": " / ".join(
+                part for part in (
+                    str(source["chat_id"]), str(source.get("thread_id") or "")
+                ) if part
+            ),
+            "notifier_profile": str(source["notifier_profile"]),
+        }
+        for source in sources
+        if source.get("source_kind") == "home"
+        and (
+            str(source["platform"]),
+            str(source["chat_id"]),
+            str(source.get("thread_id") or ""),
+        ) not in current_keys
+    ]
+    stale.sort(key=lambda item: (item["platform"], item["chat_id"], item["thread_id"]))
+    return {"home_channels": result, "stale_home_subscriptions": stale}
 
 
 @router.post("/tasks/{task_id}/home-subscribe/{platform}")
@@ -2159,40 +2228,44 @@ def subscribe_home(task_id: str, platform: str, board: Optional[str] = Query(Non
         task = kanban_db.get_task(conn, task_id)
         if task is None:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
-        kanban_db.add_notify_sub(
+        metadata = {
+            key: home[key]
+            for key in ("user_id", "scope_id")
+            if home.get(key)
+        }
+        kanban_db.replace_home_notify_source(
             conn,
             task_id=task_id,
             platform=platform,
             chat_id=home["chat_id"],
             thread_id=home["thread_id"] or None,
             notifier_profile=_active_profile_name(),
+            user_id=home.get("user_id"),
+            chat_type=home.get("chat_type"),
+            delivery_metadata=metadata,
         )
-        return {"ok": True, "task_id": task_id, "home_channel": home}
+        public_home = {
+            key: home[key]
+            for key in ("platform", "chat_id", "thread_id", "name")
+        }
+        return {"ok": True, "task_id": task_id, "home_channel": public_home}
     finally:
         conn.close()
 
 
 @router.delete("/tasks/{task_id}/home-subscribe/{platform}")
 def unsubscribe_home(task_id: str, platform: str, board: Optional[str] = Query(None)):
-    """Remove any notify subscription on *task_id* that matches *platform*'s home."""
-    homes = _configured_home_channels()
-    home = next((h for h in homes if h["platform"] == platform), None)
-    if not home:
-        raise HTTPException(
-            status_code=404,
-            detail=f"No home channel configured for platform {platform!r}.",
-        )
+    """Remove this profile's current or stale home intent idempotently."""
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        kanban_db.remove_notify_sub(
+        result = kanban_db.remove_home_notify_sources(
             conn,
             task_id=task_id,
             platform=platform,
-            chat_id=home["chat_id"],
-            thread_id=home["thread_id"] or None,
+            notifier_profile=_active_profile_name(),
         )
-        return {"ok": True, "task_id": task_id, "home_channel": home}
+        return {"ok": True, "task_id": task_id, **result}
     finally:
         conn.close()
 

--- a/tests/gateway/relay/test_relay_media.py
+++ b/tests/gateway/relay/test_relay_media.py
@@ -102,6 +102,25 @@ async def test_send_image_url_passes_through_without_upload():
 
 
 @pytest.mark.asyncio
+async def test_send_media_uses_explicit_platform_without_warm_chat_cache():
+    adapter, stub, _fake = _adapter()
+    assert adapter._platform_by_chat == {}
+
+    result = await adapter.send_image(
+        "cold-chat",
+        "https://fal.media/x.png",
+        metadata={
+            "_relay_logical_platform": "telegram",
+            "scope_id": "scope-1",
+        },
+    )
+
+    assert result.success is True
+    assert stub.sent_platforms[-1] == "telegram"
+    assert stub.sent[-1]["metadata"] == {"scope_id": "scope-1"}
+
+
+@pytest.mark.asyncio
 async def test_local_path_lanes_upload_first(tmp_path: Path):
     adapter, stub, fake = _adapter()
     f = tmp_path / "clip.ogg"

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,6 +1,7 @@
 import asyncio
 import sqlite3
 from pathlib import Path
+from typing import Any, cast
 
 
 from gateway.config import Platform
@@ -22,6 +23,11 @@ class RecordingAdapter:
 
     async def handle_message(self, event):
         self.handled.append(event)
+
+
+class RecordingRelayAdapter(RecordingAdapter):
+    def fronts_platform(self, platform):
+        return platform == Platform.TELEGRAM
 
 
 class DisconnectedAdapters(dict):
@@ -168,6 +174,60 @@ def test_active_named_profile_subscription_is_delivered(tmp_path, monkeypatch):
     assert "blocked" in message
 
 
+def test_notifier_prefers_native_adapter_over_relay(tmp_path, monkeypatch):
+    db_path = tmp_path / "native-before-relay.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="native route", assignee="worker")
+        kb.add_notify_sub(
+            conn, task_id=task_id, notifier_profile="default",
+            platform="telegram", chat_id="chat-native",
+        )
+        kb.complete_task(conn, task_id, summary="done")
+    finally:
+        conn.close()
+
+    native = RecordingAdapter()
+    relay = RecordingRelayAdapter()
+    runner = _make_runner(native)
+    runner.adapters[Platform.RELAY] = cast(Any, relay)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert [item["chat_id"] for item in native.sent] == ["chat-native"]
+    assert relay.sent == []
+
+
+def test_notifier_falls_back_to_relay_for_fronted_logical_platform(
+    tmp_path, monkeypatch,
+):
+    db_path = tmp_path / "relay-fallback.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="relay route", assignee="worker")
+        kb.add_notify_sub(
+            conn, task_id=task_id, notifier_profile="default",
+            platform="telegram", chat_id="chat-relay", user_id="user-1",
+            delivery_metadata={"scope_id": "scope-1"},
+        )
+        kb.complete_task(conn, task_id, summary="done")
+    finally:
+        conn.close()
+
+    relay = RecordingRelayAdapter()
+    runner = _make_runner(relay)
+    runner.adapters = cast(Any, {Platform.RELAY: relay})
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert [item["chat_id"] for item in relay.sent] == ["chat-relay"]
+    assert relay.sent[0]["metadata"]["_relay_logical_platform"] == "telegram"
+    assert relay.sent[0]["metadata"]["user_id"] == "user-1"
+    assert relay.sent[0]["metadata"]["scope_id"] == "scope-1"
+
+
 def test_non_dispatch_gateway_claims_only_its_profile_subscriptions(
     tmp_path, monkeypatch,
 ):
@@ -212,7 +272,11 @@ def test_non_dispatch_gateway_claims_only_its_profile_subscriptions(
 
     assert [delivery["chat_id"] for delivery in adapter.sent] == ["writer-chat"]
     assert owned_tid in adapter.sent[0]["text"]
-    assert len(_unseen_terminal_events_for(foreign_tid, "default-chat")) == 1
+    assert len(
+        _unseen_terminal_events_for(
+            foreign_tid, "default-chat", notifier_profile="default"
+        )
+    ) == 1
 
 
 def test_legacy_subscription_requires_confirmed_dispatcher_lock_owner(
@@ -501,12 +565,13 @@ def test_notifier_wakeup_uses_subscription_chat_type(tmp_path, monkeypatch):
     assert ":group:" not in wake_key
 
 
-def _unseen_terminal_events_for(tid, chat_id):
+def _unseen_terminal_events_for(tid, chat_id, notifier_profile=None):
     conn = kb.connect()
     try:
         _, events = kb.unseen_events_for_sub(
             conn,
             task_id=tid,
+            notifier_profile=notifier_profile,
             platform="telegram",
             chat_id=chat_id,
             kinds=["completed", "blocked", "gave_up", "crashed", "timed_out"],

--- a/tests/gateway/test_kanban_notifier_wake_only_ordering.py
+++ b/tests/gateway/test_kanban_notifier_wake_only_ordering.py
@@ -188,7 +188,7 @@ def test_wake_only_failure_cap_drops_subscription(tmp_path, monkeypatch):
     runner = _make_runner(adapter)
     # Simulate 11 prior consecutive failures (MAX_SEND_FAILURES = 12).
     runner._kanban_sub_fail_counts = {
-        (tid, "telegram", "chat-1", ""): 11,
+        (tid, "", "telegram", "chat-1", ""): 11,
     }
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -126,6 +126,7 @@ def test_notify_sub_crud(kanban_home):
         # Duplicate add is a no-op.
         kb.add_notify_sub(
             conn, task_id=tid, platform="telegram", chat_id="123",
+            notifier_profile="default",
             delivery_metadata={
                 "chat_type": "dm",
                 "telegram_reply_to_message_id": "43",
@@ -138,12 +139,14 @@ def test_notify_sub_crud(kanban_home):
         # Distinct thread is a new row.
         kb.add_notify_sub(
             conn, task_id=tid, platform="telegram", chat_id="123",
+            notifier_profile="default",
             thread_id="5",
         )
         assert len(kb.list_notify_subs(conn, tid)) == 2
         # Remove one.
         ok = kb.remove_notify_sub(
-            conn, task_id=tid, platform="telegram", chat_id="123",
+            conn, task_id=tid, notifier_profile="default",
+            platform="telegram", chat_id="123",
         )
         assert ok is True
         assert len(kb.list_notify_subs(conn, tid)) == 1

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -86,6 +86,18 @@ def test_legacy_text_pk_tables_rebuilt_to_integer_autoincrement(tmp_path, monkey
         lei = {r["name"]: r for r in conn.execute("PRAGMA table_info(kanban_notify_subs)")}
         assert lei["last_event_id"]["type"].upper() == "INTEGER"
         assert "delivery_metadata" in lei
+        assert lei["notifier_profile"]["notnull"] == 1
+        pk = [
+            row["name"]
+            for row in sorted(
+                conn.execute("PRAGMA table_info(kanban_notify_subs)"),
+                key=lambda row: row["pk"] or 99,
+            )
+            if row["pk"]
+        ]
+        assert pk == [
+            "task_id", "notifier_profile", "platform", "chat_id", "thread_id"
+        ]
 
         # Data preserved across the rebuild.
         assert len(conn.execute("SELECT * FROM task_events").fetchall()) == 2
@@ -93,6 +105,9 @@ def test_legacy_text_pk_tables_rebuilt_to_integer_autoincrement(tmp_path, monkey
         assert len(conn.execute("SELECT * FROM task_runs").fetchall()) == 1
         # Non-numeric legacy cursor ("e-1") casts to 0.
         assert conn.execute("SELECT last_event_id FROM kanban_notify_subs").fetchone()["last_event_id"] == 0
+        legacy_source = conn.execute("SELECT * FROM kanban_notify_sources").fetchone()
+        assert legacy_source["source_kind"] == "legacy"
+        assert legacy_source["notifier_profile"] == ""
 
         # Indexes restored, including idx_events_run (added by the additive pass).
         indexes = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")}

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -38,7 +38,7 @@ def _assert_inherited_notify_sub(subs: list[dict]) -> None:
 def test_notify_sub_delivery_mode_persists_and_last_write_wins(kanban_home):
     """delivery_mode persists; an explicit re-subscribe is last-write-wins, a
     ``None`` re-subscribe leaves the existing mode untouched, an unknown value
-    is ignored, and none of this clobbers the notifier_profile owner."""
+    is ignored, within one profile-scoped route identity."""
     import hermes_cli.kanban_db as kb
 
     conn = kb.connect()
@@ -54,11 +54,10 @@ def test_notify_sub_delivery_mode_persists_and_last_write_wins(kanban_home):
         assert subs[0]["delivery_mode"] == "notify"
         assert subs[0]["notifier_profile"] == "owner-a"
 
-        # Explicit re-subscribe changes the mode (last-write-wins) and must NOT
-        # overwrite the existing owner (owner self-heals only when unset).
+        # Explicit re-subscribe changes the mode for this profile's route.
         kb.add_notify_sub(
             conn, task_id=tid, platform="telegram", chat_id="chat1",
-            notifier_profile="owner-b", delivery_mode="wake",
+            notifier_profile="owner-a", delivery_mode="wake",
         )
         subs = kb.list_notify_subs(conn, tid)
         assert len(subs) == 1
@@ -66,17 +65,170 @@ def test_notify_sub_delivery_mode_persists_and_last_write_wins(kanban_home):
         assert subs[0]["notifier_profile"] == "owner-a"
 
         # A None re-subscribe leaves the existing mode untouched.
-        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="chat1",
+            notifier_profile="owner-a",
+        )
         subs = kb.list_notify_subs(conn, tid)
         assert subs[0]["delivery_mode"] == "wake"
 
         # An unknown mode is ignored (treated like None: no clobber).
         kb.add_notify_sub(
             conn, task_id=tid, platform="telegram", chat_id="chat1",
+            notifier_profile="owner-a",
             delivery_mode="bogus",
         )
         subs = kb.list_notify_subs(conn, tid)
         assert subs[0]["delivery_mode"] == "wake"
+    finally:
+        conn.close()
+
+
+def test_notify_routes_are_profile_scoped_and_cursor_updates_are_isolated(kanban_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="shared destination")
+        for profile in ("default", "writer"):
+            kb.add_notify_sub(
+                conn,
+                task_id=task_id,
+                platform="telegram",
+                chat_id="same-chat",
+                notifier_profile=profile,
+                source_kind="manual",
+                source_key="route",
+            )
+
+        subs = kb.list_notify_subs(conn, task_id)
+        assert {sub["notifier_profile"] for sub in subs} == {"default", "writer"}
+
+        kb._append_event(conn, task_id, kind="blocked", payload={"reason": "wait"})
+        baseline = {sub["notifier_profile"]: sub["last_event_id"] for sub in subs}
+        old_cursor, new_cursor, events = kb.claim_unseen_events_for_sub(
+            conn,
+            task_id=task_id,
+            notifier_profile="default",
+            platform="telegram",
+            chat_id="same-chat",
+        )
+        assert events and new_cursor > old_cursor
+        assert kb.rewind_notify_cursor(
+            conn,
+            task_id=task_id,
+            notifier_profile="default",
+            platform="telegram",
+            chat_id="same-chat",
+            claimed_cursor=new_cursor,
+            old_cursor=old_cursor,
+        )
+        refreshed = {
+            sub["notifier_profile"]: sub for sub in kb.list_notify_subs(conn, task_id)
+        }
+        assert refreshed["default"]["last_event_id"] == old_cursor
+        assert refreshed["writer"]["last_event_id"] == baseline["writer"]
+    finally:
+        conn.close()
+
+
+def test_home_source_coexists_with_origin_without_downgrading_or_deleting(kanban_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="co-owned route")
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="telegram",
+            chat_id="chat1",
+            notifier_profile="default",
+            delivery_mode="notify+wake",
+            delivery_metadata={"session_id": "origin-session", "scope_id": "origin-scope"},
+            source_kind="origin",
+            source_key="origin-session",
+        )
+
+        kb.replace_home_notify_source(
+            conn,
+            task_id=task_id,
+            notifier_profile="default",
+            platform="telegram",
+            chat_id="chat1",
+            delivery_metadata={"scope_id": "home-scope", "user_id": "home-user"},
+        )
+
+        route = kb.list_notify_subs(conn, task_id)[0]
+        assert route["delivery_mode"] == "notify+wake"
+        assert route["delivery_metadata"] == {
+            "scope_id": "origin-scope",
+            "session_id": "origin-session",
+            "user_id": "home-user",
+        }
+        assert {s["source_kind"] for s in kb.list_notify_sources(conn, task_id)} == {
+            "origin",
+            "home",
+        }
+
+        result = kb.remove_home_notify_sources(
+            conn,
+            task_id=task_id,
+            notifier_profile="default",
+            platform="telegram",
+        )
+        assert result["removed"] == 1
+        assert result["delivery_active"] is True
+        remaining = kb.list_notify_subs(conn, task_id)
+        assert len(remaining) == 1
+        assert remaining[0]["delivery_mode"] == "notify+wake"
+        assert remaining[0]["delivery_metadata"]["scope_id"] == "origin-scope"
+    finally:
+        conn.close()
+
+
+def test_replacing_stale_home_moves_only_home_source_without_replay(kanban_home):
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="moving home")
+        kb.replace_home_notify_source(
+            conn,
+            task_id=task_id,
+            notifier_profile="default",
+            platform="telegram",
+            chat_id="old-chat",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            notifier_profile="default",
+            platform="telegram",
+            chat_id="old-chat",
+            delivery_mode="notify+wake",
+            source_kind="origin",
+            source_key="origin-session",
+        )
+        kb._append_event(conn, task_id, kind="blocked", payload={"reason": "before move"})
+
+        kb.replace_home_notify_source(
+            conn,
+            task_id=task_id,
+            notifier_profile="default",
+            platform="telegram",
+            chat_id="new-chat",
+        )
+
+        routes = {sub["chat_id"]: sub for sub in kb.list_notify_subs(conn, task_id)}
+        assert set(routes) == {"old-chat", "new-chat"}
+        assert routes["old-chat"]["delivery_mode"] == "notify+wake"
+        assert kb.unseen_events_for_sub(
+            conn,
+            task_id=task_id,
+            notifier_profile="default",
+            platform="telegram",
+            chat_id="new-chat",
+        )[1] == []
+        sources = kb.list_notify_sources(conn, task_id)
+        assert {(s["source_kind"], s["chat_id"]) for s in sources} == {
+            ("origin", "old-chat"),
+            ("home", "new-chat"),
+        }
     finally:
         conn.close()
 
@@ -108,6 +260,57 @@ def test_child_task_inherits_parent_delivery_mode(kanban_home):
     assert subs[0]["user_id_alt"] == "alt-u1"
     assert subs[0]["notifier_profile"] == "default"
     assert subs[0]["delivery_mode"] == "notify+wake"
+
+
+def test_multi_parent_inheritance_recomputes_source_union(kanban_home):
+    conn = kb.connect()
+    try:
+        origin_parent = kb.create_task(conn, title="origin parent")
+        home_parent = kb.create_task(conn, title="home parent")
+        kb.add_notify_sub(
+            conn,
+            task_id=origin_parent,
+            notifier_profile="default",
+            platform="telegram",
+            chat_id="shared-chat",
+            delivery_mode="wake",
+            user_id="origin-user",
+            delivery_metadata={"origin_key": "origin-value"},
+            source_kind="origin",
+            source_key="session-1",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=home_parent,
+            notifier_profile="default",
+            platform="telegram",
+            chat_id="shared-chat",
+            delivery_mode="notify",
+            delivery_metadata={"scope_id": "scope-1"},
+            source_kind="home",
+            source_key="default",
+        )
+
+        child = kb.create_task(
+            conn,
+            title="merged child",
+            parents=[home_parent, origin_parent],
+        )
+        route = kb.list_notify_subs(conn, child)[0]
+        sources = kb.list_notify_sources(conn, child)
+    finally:
+        conn.close()
+
+    assert route["delivery_mode"] == "notify+wake"
+    assert route["user_id"] == "origin-user"
+    assert route["delivery_metadata"] == {
+        "origin_key": "origin-value",
+        "scope_id": "scope-1",
+    }
+    assert {(source["source_kind"], source["source_key"]) for source in sources} == {
+        ("origin", "session-1"),
+        ("home", "default"),
+    }
 
 
 def test_notify_sub_chat_type_persists_and_last_write_wins(kanban_home):
@@ -1123,7 +1326,8 @@ def test_gc_archived_rows_already_removed_by_unsub(kanban_home):
         # The notifier removes the sub at archive time; the GC targets only
         # ``done`` tasks, so an archived task contributes nothing to purge.
         kb.remove_notify_sub(
-            conn, task_id=tid, platform="telegram", chat_id="c-arch",
+            conn, task_id=tid, notifier_profile="default",
+            platform="telegram", chat_id="c-arch",
         )
         _backdate_task(kb, conn, tid, days=365)
         assert kb.purge_stale_done_notify_subs(conn, max_age_days=30) == 0

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -1,8 +1,10 @@
+import argparse
 import asyncio
 import pytest
 
 from pathlib import Path
 from types import SimpleNamespace
+from hermes_cli import kanban as kanban_cli
 from hermes_cli import kanban_db as kb
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -128,6 +130,70 @@ def test_notify_routes_are_profile_scoped_and_cursor_updates_are_isolated(kanban
         assert refreshed["writer"]["last_event_id"] == baseline["writer"]
     finally:
         conn.close()
+
+
+def test_cli_unsubscribe_without_profile_removes_migrated_unowned_route(kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_PROFILE_NAME", "default")
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="legacy route")
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="telegram",
+            chat_id="legacy-chat",
+            notifier_profile="",
+            source_kind="legacy",
+            source_key="legacy",
+        )
+    finally:
+        conn.close()
+
+    result = kanban_cli._cmd_notify_unsubscribe(
+        argparse.Namespace(
+            task_id=task_id,
+            platform="telegram",
+            chat_id="legacy-chat",
+            thread_id=None,
+            notifier_profile=None,
+        )
+    )
+
+    assert result == 0
+    with kb.connect_closing() as conn:
+        assert kb.list_notify_subs(conn, task_id) == []
+
+
+def test_cli_unsubscribe_with_explicit_empty_profile_targets_unowned_route(kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_PROFILE_NAME", "default")
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="explicit legacy route")
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="telegram",
+            chat_id="legacy-chat",
+            notifier_profile="",
+            source_kind="legacy",
+            source_key="legacy",
+        )
+    finally:
+        conn.close()
+
+    result = kanban_cli._cmd_notify_unsubscribe(
+        argparse.Namespace(
+            task_id=task_id,
+            platform="telegram",
+            chat_id="legacy-chat",
+            thread_id=None,
+            notifier_profile="",
+        )
+    )
+
+    assert result == 0
+    with kb.connect_closing() as conn:
+        assert kb.list_notify_subs(conn, task_id) == []
 
 
 def test_home_source_coexists_with_origin_without_downgrading_or_deleting(kanban_home):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -81,6 +81,189 @@ def test_board_empty(client):
     assert data["latest_event_id"] == 0
 
 
+def test_home_subscription_reports_current_and_stale_profile_owned_sources(
+    client, kanban_home, monkeypatch
+):
+    from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+
+    current_home = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="new-chat",
+        thread_id="topic",
+        name="Current Telegram",
+        user_id="user-1",
+        scope_id="scope-1",
+    )
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                home_channel=current_home,
+            )
+        }
+    )
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
+
+    task = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "stale home"}
+    ).json()["task"]
+    with kb.connect() as conn:
+        kb.replace_home_notify_source(
+            conn,
+            task_id=task["id"],
+            notifier_profile="default",
+            platform="telegram",
+            chat_id="old-chat",
+            thread_id="old-topic",
+        )
+
+    response = client.get(
+        f"/api/plugins/kanban/home-channels?task_id={task['id']}"
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["home_channels"] == [
+        {
+            "platform": "telegram",
+            "chat_id": "new-chat",
+            "thread_id": "topic",
+            "name": "Current Telegram",
+            "subscribed": False,
+            "subscription_state": "none",
+            "mutable": True,
+        }
+    ]
+    assert payload["stale_home_subscriptions"] == [
+        {
+            "platform": "telegram",
+            "chat_id": "old-chat",
+            "thread_id": "old-topic",
+            "name": "old-chat / old-topic",
+            "notifier_profile": "default",
+        }
+    ]
+
+    response = client.post(
+        f"/api/plugins/kanban/tasks/{task['id']}/home-subscribe/telegram"
+    )
+    assert response.status_code == 200
+    with kb.connect() as conn:
+        sources = kb.list_notify_sources(conn, task["id"])
+        assert [(s["source_kind"], s["chat_id"]) for s in sources] == [
+            ("home", "new-chat")
+        ]
+        assert sources[0]["delivery_metadata"] == {
+            "scope_id": "scope-1",
+            "user_id": "user-1",
+        }
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: GatewayConfig())
+    response = client.delete(
+        f"/api/plugins/kanban/tasks/{task['id']}/home-subscribe/telegram"
+    )
+    assert response.status_code == 200
+    assert response.json()["delivery_active"] is False
+    with kb.connect() as conn:
+        assert kb.list_notify_subs(conn, task["id"]) == []
+
+
+def test_home_read_adopts_only_exact_passive_profile_legacy_route(
+    client, monkeypatch
+):
+    from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                home_channel=HomeChannel(
+                    platform=Platform.TELEGRAM,
+                    chat_id="current-chat",
+                    thread_id="topic",
+                    name="Current Telegram",
+                ),
+            )
+        }
+    )
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
+
+    adopted_task = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "adopt legacy"}
+    ).json()["task"]
+    wake_task = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "retain wake legacy"}
+    ).json()["task"]
+    other_task = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "other source"}
+    ).json()["task"]
+    with kb.connect() as conn:
+        for task_id, mode in (
+            (adopted_task["id"], "notify"),
+            (wake_task["id"], "notify+wake"),
+        ):
+            kb.add_notify_sub(
+                conn,
+                task_id=task_id,
+                notifier_profile="default",
+                platform="telegram",
+                chat_id="current-chat",
+                thread_id="topic",
+                delivery_mode=mode,
+                source_kind="legacy",
+                source_key="route",
+            )
+        kb.add_notify_sub(
+            conn,
+            task_id=other_task["id"],
+            notifier_profile="default",
+            platform="telegram",
+            chat_id="current-chat",
+            thread_id="topic",
+            source_kind="manual",
+            source_key="route",
+        )
+
+    adopted = client.get(
+        f"/api/plugins/kanban/home-channels?task_id={adopted_task['id']}"
+    ).json()["home_channels"][0]
+    wake = client.get(
+        f"/api/plugins/kanban/home-channels?task_id={wake_task['id']}"
+    ).json()["home_channels"][0]
+    other = client.get(
+        f"/api/plugins/kanban/home-channels?task_id={other_task['id']}"
+    ).json()["home_channels"][0]
+
+    assert adopted["subscription_state"] == "home"
+    assert adopted["mutable"] is True
+    assert wake["subscription_state"] == "other"
+    assert wake["mutable"] is True
+    assert other["subscription_state"] == "other"
+    assert other["mutable"] is True
+
+    assert client.post(
+        f"/api/plugins/kanban/tasks/{other_task['id']}/home-subscribe/telegram"
+    ).status_code == 200
+    shared = client.get(
+        f"/api/plugins/kanban/home-channels?task_id={other_task['id']}"
+    ).json()["home_channels"][0]
+    assert shared["subscription_state"] == "home_and_other"
+    assert shared["mutable"] is False
+    detached = client.delete(
+        f"/api/plugins/kanban/tasks/{other_task['id']}/home-subscribe/telegram"
+    ).json()
+    assert detached["delivery_active"] is True
+
+    with kb.connect() as conn:
+        assert [
+            source["source_kind"]
+            for source in kb.list_notify_sources(conn, adopted_task["id"])
+        ] == ["home"]
+        assert [
+            source["source_kind"]
+            for source in kb.list_notify_sources(conn, wake_task["id"])
+        ] == ["legacy"]
+
+
 # ---------------------------------------------------------------------------
 # POST /tasks then GET /board sees it
 # ---------------------------------------------------------------------------

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1599,6 +1599,12 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             notifier_profile=notifier_profile,
             delivery_mode=delivery_mode,
             delivery_metadata=delivery_metadata or None,
+            source_kind="origin",
+            source_key=(
+                get_session_env("HERMES_SESSION_ID", "")
+                or get_session_env("HERMES_SESSION_KEY", "")
+                or f"{platform}:{chat_id}:{thread_id or ''}"
+            ),
         )
         return True
     except Exception as _exc:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9394,6 +9394,7 @@ def _collect_kanban_notifications(session: dict) -> list:
                 _old, _new, events = _kb.claim_unseen_events_for_sub(
                     conn,
                     task_id=sub["task_id"],
+                    notifier_profile=sub.get("notifier_profile"),
                     platform=sub["platform"],
                     chat_id=sub["chat_id"],
                     thread_id=sub.get("thread_id") or "",
@@ -9415,6 +9416,7 @@ def _collect_kanban_notifications(session: dict) -> list:
                         _kb.remove_notify_sub(
                             conn,
                             task_id=sub["task_id"],
+                            notifier_profile=sub.get("notifier_profile"),
                             platform=sub["platform"],
                             chat_id=sub["chat_id"],
                             thread_id=sub.get("thread_id") or "",


### PR DESCRIPTION
## Summary
- make Kanban notification routes profile-scoped and track normalized subscription sources (`origin`, `home`, `manual`, `legacy`)
- expose the dashboard home-channel subscription lifecycle with exact profile ownership, stale-route visibility, safe legacy adoption, and shared-source detach semantics
- add task-scoped Desktop home-channel controls with per-platform switches, explicit stale-home Move/Stop actions, offline/cache handling, and an older-backend capability fallback
- deliver through a profile-native adapter first, then Relay when it fronts the logical platform, preserving logical-platform metadata for messages and artifacts
- preserve source semantics and recompute effective routes across task inheritance

## Verification
### Backend
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_notify.py tests/plugins/test_kanban_dashboard_plugin.py tests/gateway/test_kanban_notifier.py tests/gateway/relay/test_relay_media.py tests/hermes_cli/test_kanban_db_init.py tests/tui_gateway/test_kanban_notify_poller.py -q` — 91 passed
- broader Kanban sweep — 366 passed, 2 skipped; one unrelated test failed and one could not collect because optional `acp` and `aiohttp` packages are absent from this dev venv
- `ruff check` on all changed Python files — passed

### Desktop
- focused home-channel tests — 15 passed
- `npm run test:ui` — 430 files, 3,863 tests passed
- `npm run typecheck` — passed
- ESLint on all changed Desktop files — passed
- `npm run build` — passed
- regression sabotage confirmed legacy checked-state and cross-platform rollback tests fail when their fixes are removed
- independent staged-diff review — passed after fixes for cached/offline state, board scoping, overlapping mutation races, and missing-endpoint detection

### Shared
- `git diff --check` — passed
- backend regression sabotage confirmed the profile-isolation and Relay fallback tests fail when the fixed behavior is removed

## Risk / compatibility
- existing routes are migrated in place and represented as `legacy` sources
- empty legacy notifier profiles remain unowned and are never claimed across profiles
- wake-capable, stale, unowned, and cross-profile legacy routes are not auto-adopted as home subscriptions
- the Desktop section remains hidden when an unscoped probe confirms an older backend lacks the additive route
- legacy Desktop response fields still derive the checked state when newer source-state fields are absent
