### PR TITLE
fix(lsp): probe Windows wrapper suffixes before the extension-less shim (#86445)

### DIFF
--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -132,16 +132,26 @@ def hermes_lsp_bin_dir() -> Path:
 
 
 def _native_binary_candidates(base: Path) -> list[Path]:
-    """Return platform-native executable candidates for a staged binary."""
-    candidates = [base]
-    if _is_windows():
-        existing = {str(base).lower()}
-        for suffix in _WINDOWS_WRAPPER_SUFFIXES:
-            candidate = Path(str(base) + suffix)
-            key = str(candidate).lower()
-            if key not in existing:
-                candidates.append(candidate)
-                existing.add(key)
+    """Return platform-native executable candidates for a staged binary.
+
+    On Windows npm stages an extension-less POSIX ``#!/bin/sh`` shim *and* a
+    ``.cmd`` wrapper next to it. ``CreateProcess`` cannot launch the shim
+    (``WinError 193``), and ``os.access(path, os.X_OK)`` returns True for *any*
+    existing file on Windows — so the wrapper suffixes must be probed **before**
+    the bare name, or ``_existing_binary`` selects the shim and the real
+    ``.cmd``/``.exe``/``.bat`` beside it is never reached (#86445). The bare name
+    stays last as a fallback for a genuinely extension-less native binary.
+    """
+    if not _is_windows():
+        return [base]
+    candidates: list[Path] = []
+    seen: set[str] = set()
+    for suffix in (*_WINDOWS_WRAPPER_SUFFIXES, ""):
+        candidate = Path(str(base) + suffix)
+        key = str(candidate).lower()
+        if key not in seen:
+            candidates.append(candidate)
+            seen.add(key)
     return candidates
 
 

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -78,7 +78,7 @@ def test_install_pip_finds_windows_scripts_launcher(tmp_path, monkeypatch):
         scripts_dir = install_mod.hermes_lsp_bin_dir().parent / "python-packages" / "Scripts"
         scripts_dir.mkdir(parents=True, exist_ok=True)
         launcher = scripts_dir / "fake-language-server.exe"
-        launcher.write_text("launcher\n")
+        launcher.write_text("launcher\n", encoding="utf-8")
         launcher.chmod(0o755)
         return MagicMock(returncode=0, stderr="")
 
@@ -89,6 +89,64 @@ def test_install_pip_finds_windows_scripts_launcher(tmp_path, monkeypatch):
     assert resolved is not None
     assert resolved.endswith("fake-language-server.exe")
     assert (install_mod.hermes_lsp_bin_dir() / "fake-language-server.exe").exists()
+
+
+def test_native_binary_candidates_windows_prefers_wrappers(monkeypatch):
+    """On Windows the ``.cmd``/``.exe``/``.bat`` wrappers must be probed before
+    the extension-less name, which is a POSIX shim CreateProcess can't launch
+    (#86445). The bare name stays last as a fallback."""
+    from pathlib import Path
+
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    base = Path("/x/pyright-langserver")
+    names = [c.name for c in install_mod._native_binary_candidates(base)]
+    assert names == [
+        "pyright-langserver.cmd",
+        "pyright-langserver.exe",
+        "pyright-langserver.bat",
+        "pyright-langserver",
+    ]
+
+
+def test_native_binary_candidates_posix_is_bare_only(monkeypatch):
+    """Off Windows the candidate list is just the bare name (unchanged)."""
+    from pathlib import Path
+
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: False)
+    assert install_mod._native_binary_candidates(Path("/x/gopls")) == [Path("/x/gopls")]
+
+
+@pytest.mark.windows_only
+def test_existing_binary_windows_skips_posix_shim_for_cmd(tmp_path, monkeypatch):
+    """A staged POSIX shim (extension-less) sits beside its ``.cmd`` wrapper.
+    On Windows ``os.access(_, X_OK)`` is True for both, so ``_existing_binary``
+    must return the ``.cmd`` — not the shim that fails with WinError 193
+    (#86445).
+
+    ``windows_only``: the shim-vs-``.cmd`` selection hinges on Windows'
+    ``os.access(_, X_OK)`` semantics (True for any file); the candidate ordering
+    itself is asserted host-agnostically in
+    ``test_native_binary_candidates_windows_prefers_wrappers``.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    bin_dir = install_mod.hermes_lsp_bin_dir()
+    shim = bin_dir / "pyright-langserver"
+    shim.write_text("#!/bin/sh\n", encoding="utf-8")
+    shim.chmod(0o755)  # X_OK True on the POSIX test host, mirroring Windows
+    wrapper = bin_dir / "pyright-langserver.cmd"
+    wrapper.write_text("@echo off\n", encoding="utf-8")
+    wrapper.chmod(0o755)
+
+    resolved = install_mod._existing_binary("pyright-langserver")
+    assert resolved is not None
+    assert resolved.endswith("pyright-langserver.cmd")
 
 
 # ---------------------------------------------------------------------------
@@ -157,7 +215,7 @@ def test_check_lint_returns_error_for_real_ts_type_errors(tmp_path):
     from tools.file_operations import ShellFileOperations
 
     ts_file = tmp_path / "bad.ts"
-    ts_file.write_text("const x: string = 42;\n")
+    ts_file.write_text("const x: string = 42;\n", encoding="utf-8")
 
     env = LocalEnvironment()
     fops = ShellFileOperations(env)


### PR DESCRIPTION
## Summary

On Windows, `agent/lsp/install.py` resolved the staged language-server binary by the extension-less name first. npm writes both a POSIX `#!/bin/sh` shim (bare name) and a `.cmd` wrapper next to it, and because `os.access(path, os.X_OK)` returns True for *any* existing file on Windows, `_existing_binary()` selected the shim — which `CreateProcess` cannot launch:

```
lsp[pyright] spawn/initialize failed: OSError: [WinError 193] %1 is not a valid Win32 application
```

The `.cmd` beside it was never reached, so Python (and any npm-installed) diagnostics were silently unavailable for the whole session. The copy/symlink step in `_npm_install_binary()` staged the shim for the same reason (it copies the first existing candidate returned by the same helper).

## Fix

`_native_binary_candidates()` now orders the `.cmd`/`.exe`/`.bat` wrappers **before** the bare name on Windows, so both the probe (`_existing_binary`) and the staging copy prefer the launchable wrapper. The extension-less name stays last as a fallback for a genuinely extension-less native binary. POSIX behaviour is unchanged (bare name only).

This fixes every npm-installed server (pyright, `typescript-language-server`, `yaml-language-server`, …), which are all extension-less and would fail identically on first use.

## Tests

- `test_native_binary_candidates_windows_prefers_wrappers` / `_posix_is_bare_only` — host-agnostic ordering assertions (the regression carrier on Linux CI).
- `test_existing_binary_windows_skips_posix_shim_for_cmd` — `windows_only`, since the shim-vs-`.cmd` selection hinges on Windows' `os.access(_, X_OK)` semantics; matches the repo's existing convention for native-Windows filesystem tests.

`check-windows-footguns.py` clean; `ruff` clean.

Fixes #86445
