### PR TITLE
feat(discord): forum starter/tag REST actions

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience T3

--- a/tests/tools/test_discord_forums.py
+++ b/tests/tools/test_discord_forums.py
@@ -1,0 +1,200 @@
+"""Tests for tools.discord_api.forums — forum starter/tag REST request builders."""
+
+import pytest
+
+from tools.discord_api.forums import (
+    FORUM_CHANNEL_TYPE,
+    ForumError,
+    create_forum_post_request,
+    list_forum_tags_request,
+    set_forum_post_tags_request,
+)
+
+
+# ---------------------------------------------------------------------------
+# create_forum_post_request — payload shape
+# ---------------------------------------------------------------------------
+
+
+def test_create_post_full_payload():
+    req = create_forum_post_request(
+        "123456789012345678",
+        name="Need help with setup",
+        message_content="Details here",
+        applied_tags=["111111111111111111", "222222222222222222"],
+    )
+    assert req["method"] == "POST"
+    assert req["path"] == "/channels/123456789012345678/threads"
+    assert req["payload"] == {
+        "name": "Need help with setup",
+        "type": FORUM_CHANNEL_TYPE,
+        "message": {"content": "Details here"},
+        "applied_tags": ["111111111111111111", "222222222222222222"],
+    }
+
+
+def test_create_post_minimal_payload():
+    req = create_forum_post_request("123", name="Hello")
+    assert req["payload"] == {"name": "Hello", "type": FORUM_CHANNEL_TYPE}
+    # optional keys are omitted, not present as None
+    assert "message" not in req["payload"]
+    assert "applied_tags" not in req["payload"]
+
+
+def test_create_post_int_channel_and_tag_ids_normalized_to_str():
+    req = create_forum_post_request(
+        123456789012345678,
+        name="Post",
+        message_content="body",
+        applied_tags=[111, 222],
+    )
+    assert req["path"] == "/channels/123456789012345678/threads"
+    assert req["payload"]["applied_tags"] == ["111", "222"]
+
+
+# ---------------------------------------------------------------------------
+# create_forum_post_request — name bounds
+# ---------------------------------------------------------------------------
+
+
+def test_create_post_name_bounds_ok():
+    one_char = create_forum_post_request("1", name="a")
+    assert one_char["payload"]["name"] == "a"
+    hundred_char = create_forum_post_request("1", name="x" * 100)
+    assert hundred_char["payload"]["name"] == "x" * 100
+
+
+def test_create_post_name_too_short():
+    with pytest.raises(ForumError):
+        create_forum_post_request("1", name="")
+
+
+def test_create_post_name_too_long():
+    with pytest.raises(ForumError):
+        create_forum_post_request("1", name="x" * 101)
+
+
+def test_create_post_name_not_str():
+    with pytest.raises(ForumError):
+        create_forum_post_request("1", name=123)
+
+
+# ---------------------------------------------------------------------------
+# tag count bounds
+# ---------------------------------------------------------------------------
+
+
+def test_create_post_max_five_tags_ok():
+    tags = [str(i) for i in range(5)]
+    req = create_forum_post_request("1", name="Post", applied_tags=tags)
+    assert req["payload"]["applied_tags"] == tags
+
+
+def test_create_post_six_tags_raises():
+    tags = [str(i) for i in range(6)]
+    with pytest.raises(ForumError):
+        create_forum_post_request("1", name="Post", applied_tags=tags)
+
+
+def test_set_tags_max_five_ok_and_empty_ok():
+    tags = [str(i) for i in range(5)]
+    req = set_forum_post_tags_request("42", tags)
+    assert req["payload"] == {"applied_tags": tags}
+    empty = set_forum_post_tags_request("42", [])
+    assert empty["payload"] == {"applied_tags": []}
+
+
+def test_set_tags_six_raises():
+    tags = [str(i) for i in range(6)]
+    with pytest.raises(ForumError):
+        set_forum_post_tags_request("42", tags)
+
+
+def test_applied_tags_not_a_list_raises():
+    with pytest.raises(ForumError):
+        create_forum_post_request("1", name="Post", applied_tags="111")
+    with pytest.raises(ForumError):
+        set_forum_post_tags_request("42", "111")
+
+
+# ---------------------------------------------------------------------------
+# snowflake validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "abc", "12a34", "-5", "1.5", "  ", None, True, 3.14, ["1"], {}],
+)
+def test_create_post_invalid_channel_id_raises(bad):
+    with pytest.raises(ForumError):
+        create_forum_post_request(bad, name="Post")
+
+
+@pytest.mark.parametrize("bad", ["", "abc", "12a34", "-5", None, True, 3.14])
+def test_create_post_invalid_tag_id_raises(bad):
+    with pytest.raises(ForumError):
+        create_forum_post_request("1", name="Post", applied_tags=[bad])
+    with pytest.raises(ForumError):
+        create_forum_post_request("1", name="Post", applied_tags=["1", bad])
+
+
+@pytest.mark.parametrize("bad", ["", "abc", "12a34", "-5", None, True, 3.14])
+def test_set_tags_invalid_tag_id_raises(bad):
+    with pytest.raises(ForumError):
+        set_forum_post_tags_request("42", [bad])
+
+
+def test_invalid_thread_id_raises():
+    with pytest.raises(ForumError):
+        set_forum_post_tags_request("nope", ["1"])
+
+
+# ---------------------------------------------------------------------------
+# list_forum_tags_request
+# ---------------------------------------------------------------------------
+
+
+def test_list_forum_tags_request():
+    req = list_forum_tags_request("987654321")
+    assert req["method"] == "GET"
+    assert req["path"] == "/channels/987654321/tags"
+    assert req["payload"] is None
+
+
+def test_list_forum_tags_request_invalid_channel_raises():
+    with pytest.raises(ForumError):
+        list_forum_tags_request("not-a-snowflake")
+
+
+# ---------------------------------------------------------------------------
+# set_forum_post_tags_request — payload shape
+# ---------------------------------------------------------------------------
+
+
+def test_set_tags_payload():
+    req = set_forum_post_tags_request("777", ["111", "222", "333"])
+    assert req["method"] == "PATCH"
+    assert req["path"] == "/channels/777"
+    assert req["payload"] == {"applied_tags": ["111", "222", "333"]}
+
+
+def test_set_tags_int_ids_normalized_to_str():
+    req = set_forum_post_tags_request(777, [111, 222])
+    assert req["payload"] == {"applied_tags": ["111", "222"]}
+
+
+def test_set_tags_missing_raises():
+    with pytest.raises(ForumError):
+        set_forum_post_tags_request("777", None)
+
+
+# ---------------------------------------------------------------------------
+# error type
+# ---------------------------------------------------------------------------
+
+
+def test_forum_error_is_value_error():
+    assert issubclass(ForumError, ValueError)
+    with pytest.raises(ValueError):
+        create_forum_post_request("1", name="x" * 200)

--- a/tools/discord_api/forums.py
+++ b/tools/discord_api/forums.py
@@ -1,0 +1,133 @@
+"""Discord forum starter/tag REST request builders (REST v10).
+
+Aligned with discord.com/developers/docs/resources/channel (forum channels).
+Pure request-builder module: validates inputs and returns validated request
+descriptors (``{"method", "path", "payload"}``); it performs no network I/O.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+__all__ = [
+    "ForumError",
+    "FORUM_CHANNEL_TYPE",
+    "MAX_APPLIED_TAGS",
+    "NAME_MAX_LENGTH",
+    "NAME_MIN_LENGTH",
+    "create_forum_post_request",
+    "list_forum_tags_request",
+    "set_forum_post_tags_request",
+]
+
+FORUM_CHANNEL_TYPE = 11
+MAX_APPLIED_TAGS = 5
+NAME_MIN_LENGTH = 1
+NAME_MAX_LENGTH = 100
+
+
+class ForumError(ValueError):
+    """Raised when a forum request descriptor fails validation."""
+
+
+def _snowflake(value: Any, field: str) -> str:
+    """Validate a Discord snowflake and normalize it to its canonical string form."""
+    if isinstance(value, bool):  # bool is an int subclass; reject explicitly
+        raise ForumError(f"{field} must be a snowflake, got {value!r}")
+    if isinstance(value, int):
+        text = str(value)
+    elif isinstance(value, str):
+        text = value.strip()
+    else:
+        raise ForumError(
+            f"{field} must be a snowflake (int or str), got {type(value).__name__}"
+        )
+    if not text or not text.isdigit():
+        raise ForumError(f"{field} must be a snowflake, got {value!r}")
+    return text
+
+
+def _applied_tags(value: Optional[List[Any]]) -> Optional[List[str]]:
+    """Validate an applied_tags list; ``None`` is the omit-the-key sentinel."""
+    if value is None:
+        return None
+    if not isinstance(value, (list, tuple)):
+        raise ForumError("applied_tags must be a list of snowflakes")
+    if len(value) > MAX_APPLIED_TAGS:
+        raise ForumError(
+            f"applied_tags may contain at most {MAX_APPLIED_TAGS} tags, got {len(value)}"
+        )
+    return [_snowflake(tag, f"applied_tags[{i}]") for i, tag in enumerate(value)]
+
+
+def create_forum_post_request(
+    channel_id: Any,
+    *,
+    name: str,
+    message_content: Optional[str] = None,
+    applied_tags: Optional[List[Any]] = None,
+) -> Dict[str, Any]:
+    """Build the POST /channels/{channel}/threads request that starts a forum post.
+
+    Args:
+        channel_id: Snowflake of the forum channel.
+        name: Post title, 1..100 characters.
+        message_content: Optional initial message content.
+        applied_tags: Optional list of tag snowflakes, max 5.
+
+    Returns:
+        A request descriptor dict: ``{"method": "POST", "path": ..., "payload": ...}``.
+
+    Raises:
+        ForumError: on any validation violation.
+    """
+    if not isinstance(name, str):
+        raise ForumError(f"name must be a str, got {type(name).__name__}")
+    if not (NAME_MIN_LENGTH <= len(name) <= NAME_MAX_LENGTH):
+        raise ForumError(
+            f"name must be {NAME_MIN_LENGTH}..{NAME_MAX_LENGTH} characters, got {len(name)}"
+        )
+    if message_content is not None and not isinstance(message_content, str):
+        raise ForumError(
+            f"message_content must be a str or None, got {type(message_content).__name__}"
+        )
+
+    channel = _snowflake(channel_id, "channel_id")
+    tags = _applied_tags(applied_tags)
+
+    payload: Dict[str, Any] = {"name": name, "type": FORUM_CHANNEL_TYPE}
+    if message_content is not None:
+        payload["message"] = {"content": message_content}
+    if tags is not None:
+        payload["applied_tags"] = tags
+
+    return {"method": "POST", "path": f"/channels/{channel}/threads", "payload": payload}
+
+
+def list_forum_tags_request(channel_id: Any) -> Dict[str, Any]:
+    """Build the GET /channels/{channel}/tags request listing a forum's tags."""
+    channel = _snowflake(channel_id, "channel_id")
+    return {"method": "GET", "path": f"/channels/{channel}/tags", "payload": None}
+
+
+def set_forum_post_tags_request(
+    thread_id: Any, tag_ids: List[Any]
+) -> Dict[str, Any]:
+    """Build the PATCH /channels/{thread} request setting a forum post's tags.
+
+    Args:
+        thread_id: Snowflake of the forum post (thread).
+        tag_ids: Tag snowflakes to apply; empty list clears tags. Max 5.
+
+    Returns:
+        A request descriptor dict: ``{"method": "PATCH", "path": ..., "payload": ...}``.
+    """
+    thread = _snowflake(thread_id, "thread_id")
+    tags = _applied_tags(tag_ids)
+    if tags is None:
+        raise ForumError("tag_ids is required")
+    return {
+        "method": "PATCH",
+        "path": f"/channels/{thread}",
+        "payload": {"applied_tags": tags},
+    }


### PR DESCRIPTION
**Discord T3** (Part of #79564, Fixes #86457): forum starter/tag REST actions in `tools/discord_api/forums.py`. 44/44 tests pass. New module only.