### PR TITLE
feat(discord): channel/category CRUD REST actions

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience A1

--- a/tests/tools/test_discord_channels.py
+++ b/tests/tools/test_discord_channels.py
@@ -1,0 +1,253 @@
+"""Tests for tools.discord_api.channels request builders (feature A1).
+
+Covers request descriptor shapes for create/edit/delete, name bounds,
+topic bound, rate_limit_per_user bounds, snowflake validation, and
+only-provided-fields editing semantics.
+"""
+
+import pytest
+
+from tools.discord_api.channels import (
+    ChannelError,
+    create_channel_request,
+    delete_channel_request,
+    edit_channel_request,
+)
+
+GUILD = "123456789012345678"
+CHANNEL = "987654321098765432"
+PARENT = "112233445566778899"
+
+MAX_SNOWFLAKE = 2**63 - 1
+
+
+# ---------------------------------------------------------------------------
+# create_channel_request
+# ---------------------------------------------------------------------------
+
+def test_create_channel_request_shape():
+    req = create_channel_request(GUILD, name="general")
+    assert req == {
+        "method": "POST",
+        "path": f"/guilds/{GUILD}/channels",
+        "json": {
+            "name": "general",
+            "type": 0,
+            "nsfw": False,
+            "rate_limit_per_user": 0,
+        },
+    }
+
+
+def test_create_channel_full_payload():
+    req = create_channel_request(
+        GUILD,
+        name="mod-archive",
+        type=4,
+        topic="Archived mod threads",
+        nsfw=True,
+        rate_limit_per_user=30,
+        parent_id=PARENT,
+    )
+    assert req["method"] == "POST"
+    assert req["path"] == f"/guilds/{GUILD}/channels"
+    assert req["json"] == {
+        "name": "mod-archive",
+        "type": 4,
+        "topic": "Archived mod threads",
+        "nsfw": True,
+        "rate_limit_per_user": 30,
+        "parent_id": PARENT,
+    }
+
+
+def test_create_category_via_type_4():
+    req = create_channel_request(GUILD, name="Games", type=4)
+    assert req["json"]["type"] == 4
+
+
+def test_create_name_is_trimmed():
+    req = create_channel_request(GUILD, name="  general  ")
+    assert req["json"]["name"] == "general"
+
+
+def test_create_name_empty_raises():
+    with pytest.raises(ChannelError):
+        create_channel_request(GUILD, name="   ")
+
+
+def test_create_name_too_long_raises():
+    with pytest.raises(ChannelError):
+        create_channel_request(GUILD, name="a" * 101)
+
+
+def test_create_name_100_chars_ok():
+    req = create_channel_request(GUILD, name="a" * 100)
+    assert req["json"]["name"] == "a" * 100
+
+
+def test_create_name_non_string_raises():
+    with pytest.raises(ChannelError):
+        create_channel_request(GUILD, name=123)
+
+
+def test_create_topic_too_long_raises():
+    with pytest.raises(ChannelError):
+        create_channel_request(GUILD, name="x", topic="t" * 1025)
+
+
+def test_create_topic_1024_chars_ok():
+    req = create_channel_request(GUILD, name="x", topic="t" * 1024)
+    assert req["json"]["topic"] == "t" * 1024
+
+
+def test_create_topic_omitted_when_none():
+    req = create_channel_request(GUILD, name="x")
+    assert "topic" not in req["json"]
+
+
+def test_create_rate_limit_bounds():
+    with pytest.raises(ChannelError):
+        create_channel_request(GUILD, name="x", rate_limit_per_user=-1)
+    with pytest.raises(ChannelError):
+        create_channel_request(GUILD, name="x", rate_limit_per_user=21601)
+    req = create_channel_request(GUILD, name="x", rate_limit_per_user=21600)
+    assert req["json"]["rate_limit_per_user"] == 21600
+    req = create_channel_request(GUILD, name="x", rate_limit_per_user=0)
+    assert req["json"]["rate_limit_per_user"] == 0
+
+
+def test_create_rate_limit_non_int_raises():
+    with pytest.raises(ChannelError):
+        create_channel_request(GUILD, name="x", rate_limit_per_user="10")
+
+
+def test_create_type_must_be_int():
+    with pytest.raises(ChannelError):
+        create_channel_request(GUILD, name="x", type="text")
+    with pytest.raises(ChannelError):
+        create_channel_request(GUILD, name="x", type=True)
+
+
+def test_create_nsfw_must_be_bool():
+    with pytest.raises(ChannelError):
+        create_channel_request(GUILD, name="x", nsfw="yes")
+
+
+def test_create_guild_snowflake_validation():
+    for bad in ("", "abc", "12a4", "-123", "1.5", None, MAX_SNOWFLAKE + 1):
+        with pytest.raises(ChannelError):
+            create_channel_request(bad, name="x")
+
+
+def test_create_parent_id_snowflake_validation():
+    with pytest.raises(ChannelError):
+        create_channel_request(GUILD, name="x", parent_id="not-a-snowflake")
+    with pytest.raises(ChannelError):
+        create_channel_request(GUILD, name="x", parent_id=-5)
+
+
+def test_create_accepts_int_snowflakes():
+    req = create_channel_request(123456789, name="x", parent_id=987654321)
+    assert req["path"] == "/guilds/123456789/channels"
+    assert req["json"]["parent_id"] == "987654321"
+
+
+# ---------------------------------------------------------------------------
+# edit_channel_request
+# ---------------------------------------------------------------------------
+
+def test_edit_channel_request_shape():
+    req = edit_channel_request(CHANNEL, name="renamed")
+    assert req["method"] == "PATCH"
+    assert req["path"] == f"/channels/{CHANNEL}"
+    assert req["json"] == {"name": "renamed"}
+
+
+def test_edit_only_provided_fields():
+    req = edit_channel_request(CHANNEL, topic="new topic")
+    assert req["json"] == {"topic": "new topic"}
+    req = edit_channel_request(CHANNEL, nsfw=True)
+    assert req["json"] == {"nsfw": True}
+    req = edit_channel_request(CHANNEL, parent_id=PARENT)
+    assert req["json"] == {"parent_id": PARENT}
+
+
+def test_edit_multiple_fields():
+    req = edit_channel_request(
+        CHANNEL, name="x", topic="t", nsfw=False, parent_id=PARENT
+    )
+    assert req["json"] == {
+        "name": "x",
+        "topic": "t",
+        "nsfw": False,
+        "parent_id": PARENT,
+    }
+
+
+def test_edit_no_fields_raises():
+    with pytest.raises(ChannelError):
+        edit_channel_request(CHANNEL)
+
+
+def test_edit_name_validated():
+    with pytest.raises(ChannelError):
+        edit_channel_request(CHANNEL, name="   ")
+    with pytest.raises(ChannelError):
+        edit_channel_request(CHANNEL, name="a" * 101)
+
+
+def test_edit_name_is_trimmed():
+    req = edit_channel_request(CHANNEL, name="  padded  ")
+    assert req["json"]["name"] == "padded"
+
+
+def test_edit_topic_validated():
+    with pytest.raises(ChannelError):
+        edit_channel_request(CHANNEL, topic="t" * 1025)
+
+
+def test_edit_channel_snowflake_validation():
+    with pytest.raises(ChannelError):
+        edit_channel_request("bad-id", name="x")
+
+
+def test_edit_nsfw_must_be_bool():
+    with pytest.raises(ChannelError):
+        edit_channel_request(CHANNEL, nsfw=1)
+
+
+def test_edit_parent_snowflake_validation():
+    with pytest.raises(ChannelError):
+        edit_channel_request(CHANNEL, parent_id="nope")
+
+
+# ---------------------------------------------------------------------------
+# delete_channel_request
+# ---------------------------------------------------------------------------
+
+def test_delete_channel_request_shape():
+    req = delete_channel_request(CHANNEL)
+    assert req == {"method": "DELETE", "path": f"/channels/{CHANNEL}", "json": None}
+
+
+def test_delete_channel_snowflake_validation():
+    with pytest.raises(ChannelError):
+        delete_channel_request("nope")
+    with pytest.raises(ChannelError):
+        delete_channel_request(MAX_SNOWFLAKE + 1)
+
+
+def test_delete_accepts_int_snowflake():
+    req = delete_channel_request(42)
+    assert req["path"] == "/channels/42"
+
+
+# ---------------------------------------------------------------------------
+# error semantics
+# ---------------------------------------------------------------------------
+
+def test_channel_error_is_value_error():
+    assert issubclass(ChannelError, ValueError)
+    with pytest.raises(ValueError):
+        delete_channel_request("bad")

--- a/tools/discord_api/channels.py
+++ b/tools/discord_api/channels.py
@@ -1,0 +1,155 @@
+"""Discord channel/category CRUD REST request builders (REST API v10).
+
+Pure request-descriptor builders aligned with the Discord REST API v10
+``resources/channel.mdx`` (Create Guild Channel, Modify Channel, Delete
+Channel) and ``resources/guild.mdx`` snowflake semantics. No network I/O;
+each function validates its inputs and returns a plain descriptor dict::
+
+    {"method": "POST", "path": "/guilds/{guild_id}/channels", "json": {...}}
+
+Paths use the validated, normalized snowflake as a string. ``json`` is
+``None`` for requests that carry no body.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+# Discord snowflakes are unsigned 64-bit integers; Discord reserves the top
+# bit, so the valid range is 0 .. 2**63 - 1.
+_MAX_SNOWFLAKE = 2**63 - 1
+
+
+class ChannelError(ValueError):
+    """Raised when a channel request descriptor cannot be validated."""
+
+
+def _validate_snowflake(value: Any, field: str) -> str:
+    """Return *value* normalized to a digit string, or raise ``ChannelError``."""
+    if isinstance(value, bool):
+        raise ChannelError(f"{field} must be a snowflake, got bool")
+    if isinstance(value, int):
+        text = str(value)
+    elif isinstance(value, str):
+        text = value.strip()
+    else:
+        raise ChannelError(
+            f"{field} must be a snowflake (integer or digit string), "
+            f"got {type(value).__name__}"
+        )
+    if not text or not text.isdigit():
+        raise ChannelError(f"{field} must be a snowflake of digits only, got {value!r}")
+    if len(text) > 20 or int(text) > _MAX_SNOWFLAKE:
+        raise ChannelError(
+            f"{field} out of snowflake range (0..{_MAX_SNOWFLAKE}), got {value!r}"
+        )
+    return text
+
+
+def _validate_name(name: Any, field: str = "name") -> str:
+    """Trim and validate a channel name (1..100 chars)."""
+    if not isinstance(name, str):
+        raise ChannelError(f"{field} must be a string, got {type(name).__name__}")
+    trimmed = name.strip()
+    if not trimmed:
+        raise ChannelError(f"{field} must be 1-100 characters after trimming, got empty")
+    if len(trimmed) > 100:
+        raise ChannelError(
+            f"{field} must be at most 100 characters, got {len(trimmed)}"
+        )
+    return trimmed
+
+
+def _validate_topic(topic: Any) -> str:
+    if not isinstance(topic, str):
+        raise ChannelError(f"topic must be a string, got {type(topic).__name__}")
+    if len(topic) > 1024:
+        raise ChannelError(f"topic must be at most 1024 characters, got {len(topic)}")
+    return topic
+
+
+def _validate_type(channel_type: Any) -> int:
+    if isinstance(channel_type, bool) or not isinstance(channel_type, int):
+        raise ChannelError(
+            f"type must be an integer channel type, got {type(channel_type).__name__}"
+        )
+    return channel_type
+
+
+def _validate_nsfw(nsfw: Any) -> bool:
+    if not isinstance(nsfw, bool):
+        raise ChannelError(f"nsfw must be a bool, got {type(nsfw).__name__}")
+    return nsfw
+
+
+def _validate_rate_limit(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ChannelError(
+            f"rate_limit_per_user must be an integer, got {type(value).__name__}"
+        )
+    if not 0 <= value <= 21600:
+        raise ChannelError(
+            f"rate_limit_per_user must be between 0 and 21600, got {value}"
+        )
+    return value
+
+
+def create_channel_request(
+    guild_id: Any,
+    *,
+    name: str,
+    type: int = 0,
+    topic: Optional[str] = None,
+    nsfw: bool = False,
+    rate_limit_per_user: int = 0,
+    parent_id: Any = None,
+) -> Dict[str, Any]:
+    """Build a Create Guild Channel request (POST /guilds/{guild}/channels)."""
+    gid = _validate_snowflake(guild_id, "guild_id")
+    payload: Dict[str, Any] = {
+        "name": _validate_name(name),
+        "type": _validate_type(type),
+        "nsfw": _validate_nsfw(nsfw),
+        "rate_limit_per_user": _validate_rate_limit(rate_limit_per_user),
+    }
+    if topic is not None:
+        payload["topic"] = _validate_topic(topic)
+    if parent_id is not None:
+        payload["parent_id"] = _validate_snowflake(parent_id, "parent_id")
+    return {"method": "POST", "path": f"/guilds/{gid}/channels", "json": payload}
+
+
+def edit_channel_request(
+    channel_id: Any,
+    *,
+    name: Optional[str] = None,
+    topic: Optional[str] = None,
+    nsfw: Optional[bool] = None,
+    parent_id: Any = None,
+) -> Dict[str, Any]:
+    """Build a Modify Channel request (PATCH /channels/{channel}).
+
+    Only explicitly provided fields are included in the payload; ``None``
+    means "leave unchanged". At least one field must be provided.
+    """
+    cid = _validate_snowflake(channel_id, "channel_id")
+    payload: Dict[str, Any] = {}
+    if name is not None:
+        payload["name"] = _validate_name(name)
+    if topic is not None:
+        payload["topic"] = _validate_topic(topic)
+    if nsfw is not None:
+        payload["nsfw"] = _validate_nsfw(nsfw)
+    if parent_id is not None:
+        payload["parent_id"] = _validate_snowflake(parent_id, "parent_id")
+    if not payload:
+        raise ChannelError(
+            "edit_channel_request requires at least one field to modify"
+        )
+    return {"method": "PATCH", "path": f"/channels/{cid}", "json": payload}
+
+
+def delete_channel_request(channel_id: Any) -> Dict[str, Any]:
+    """Build a Delete Channel request (DELETE /channels/{channel})."""
+    cid = _validate_snowflake(channel_id, "channel_id")
+    return {"method": "DELETE", "path": f"/channels/{cid}", "json": None}


### PR DESCRIPTION
**Discord A1** (Part of #79564, Fixes #86459): channel/category CRUD REST actions in `tools/discord_api/channels.py`. 32/32 tests pass. New module only.