### PR TITLE
feat(discord): role CRUD + assignment REST actions

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience A3

--- a/tests/tools/test_discord_roles.py
+++ b/tests/tools/test_discord_roles.py
@@ -1,0 +1,177 @@
+"""Tests for tools/discord_api.roles request builders (Discord REST v10)."""
+
+import pytest
+
+from tools.discord_api.roles import (
+    RoleError,
+    add_member_role_request,
+    create_role_request,
+    delete_role_request,
+    edit_role_request,
+    remove_member_role_request,
+)
+
+GUILD = 123456789012345678
+ROLE = 234567890123456789
+USER = 345678901234567890
+
+
+class TestCreateRoleRequest:
+    def test_shape(self):
+        desc = create_role_request(
+            GUILD, name="Moderator", permissions=0x8, color=0x00FF00,
+            hoist=True, mentionable=True,
+        )
+        assert desc["method"] == "POST"
+        assert desc["path"] == f"/guilds/{GUILD}/roles"
+        assert desc["json"] == {
+            "name": "Moderator",
+            "permissions": 0x8,
+            "color": 0x00FF00,
+            "hoist": True,
+            "mentionable": True,
+        }
+
+    def test_defaults_omit_optional_fields(self):
+        desc = create_role_request(GUILD)
+        assert desc["method"] == "POST"
+        assert desc["json"] == {}
+
+    def test_name_max_length_ok(self):
+        name = "x" * 100
+        assert create_role_request(GUILD, name=name)["json"]["name"] == name
+
+    @pytest.mark.parametrize("name", ["x" * 101, 123])
+    def test_name_invalid(self, name):
+        with pytest.raises(RoleError):
+            create_role_request(GUILD, name=name)
+
+    def test_name_too_long_raises(self):
+        with pytest.raises(RoleError):
+            create_role_request(GUILD, name="x" * 101)
+
+    @pytest.mark.parametrize("color", [0, 0xFFFFFF])
+    def test_color_bounds_ok(self, color):
+        assert create_role_request(GUILD, color=color)["json"]["color"] == color
+
+    @pytest.mark.parametrize("color", [-1, 0x1000000, "0xFF", 1.5, True])
+    def test_color_out_of_bounds_raises(self, color):
+        with pytest.raises(RoleError):
+            create_role_request(GUILD, color=color)
+
+    @pytest.mark.parametrize("permissions", [0, 1, 0x8, (1 << 64) - 1])
+    def test_permissions_bitfield_ok(self, permissions):
+        assert (
+            create_role_request(GUILD, permissions=permissions)["json"]["permissions"]
+            == permissions
+        )
+
+    @pytest.mark.parametrize("permissions", [-1, 1 << 64, "8", 8.0, True])
+    def test_permissions_invalid_raises(self, permissions):
+        with pytest.raises(RoleError):
+            create_role_request(GUILD, permissions=permissions)
+
+    def test_hoist_mentionable_false_omitted(self):
+        desc = create_role_request(GUILD, hoist=False, mentionable=False)
+        assert "hoist" not in desc["json"]
+        assert "mentionable" not in desc["json"]
+
+    def test_flag_type_validated(self):
+        with pytest.raises(RoleError):
+            create_role_request(GUILD, hoist="yes")
+
+
+class TestEditRoleRequest:
+    def test_shape(self):
+        desc = edit_role_request(GUILD, ROLE, name="Admin", color=0x0000FF)
+        assert desc["method"] == "PATCH"
+        assert desc["path"] == f"/guilds/{GUILD}/roles/{ROLE}"
+        assert desc["json"] == {"name": "Admin", "color": 0x0000FF}
+
+    def test_only_provided_fields(self):
+        desc = edit_role_request(GUILD, ROLE, mentionable=True)
+        assert desc["json"] == {"mentionable": True}
+
+    def test_no_fields_raises(self):
+        with pytest.raises(RoleError):
+            edit_role_request(GUILD, ROLE)
+
+    def test_unknown_field_raises(self):
+        with pytest.raises(RoleError):
+            edit_role_request(GUILD, ROLE, icon="data:image/png;base64,AA==")
+
+    def test_invalid_field_values_raise(self):
+        with pytest.raises(RoleError):
+            edit_role_request(GUILD, ROLE, name="x" * 101)
+        with pytest.raises(RoleError):
+            edit_role_request(GUILD, ROLE, color=-1)
+        with pytest.raises(RoleError):
+            edit_role_request(GUILD, ROLE, permissions=1 << 64)
+        with pytest.raises(RoleError):
+            edit_role_request(GUILD, ROLE, hoist="true")
+
+
+class TestDeleteRoleRequest:
+    def test_shape(self):
+        desc = delete_role_request(GUILD, ROLE)
+        assert desc["method"] == "DELETE"
+        assert desc["path"] == f"/guilds/{GUILD}/roles/{ROLE}"
+        assert "json" not in desc
+
+
+class TestMemberRoleAssignment:
+    def test_add_shape(self):
+        desc = add_member_role_request(GUILD, USER, ROLE)
+        assert desc["method"] == "PUT"
+        assert desc["path"] == f"/guilds/{GUILD}/members/{USER}/roles/{ROLE}"
+        assert "json" not in desc
+
+    def test_remove_shape(self):
+        desc = remove_member_role_request(GUILD, USER, ROLE)
+        assert desc["method"] == "DELETE"
+        assert desc["path"] == f"/guilds/{GUILD}/members/{USER}/roles/{ROLE}"
+        assert "json" not in desc
+
+
+INVALID_SNOWFLAKES = [0, -1, 1 << 64, "123", "123456789012345678", None, 1.5, True]
+
+
+class TestSnowflakeValidation:
+    @pytest.mark.parametrize("bad", INVALID_SNOWFLAKES)
+    def test_create_guild_id(self, bad):
+        with pytest.raises(RoleError):
+            create_role_request(bad)
+
+    @pytest.mark.parametrize("bad", INVALID_SNOWFLAKES)
+    def test_edit_guild_id(self, bad):
+        with pytest.raises(RoleError):
+            edit_role_request(bad, ROLE, name="x")
+
+    @pytest.mark.parametrize("bad", INVALID_SNOWFLAKES)
+    def test_edit_role_id(self, bad):
+        with pytest.raises(RoleError):
+            edit_role_request(GUILD, bad, name="x")
+
+    @pytest.mark.parametrize("bad", INVALID_SNOWFLAKES)
+    def test_delete_role_id(self, bad):
+        with pytest.raises(RoleError):
+            delete_role_request(GUILD, bad)
+
+    @pytest.mark.parametrize("bad", INVALID_SNOWFLAKES)
+    def test_add_user_id(self, bad):
+        with pytest.raises(RoleError):
+            add_member_role_request(GUILD, bad, ROLE)
+
+    @pytest.mark.parametrize("bad", INVALID_SNOWFLAKES)
+    def test_remove_role_id(self, bad):
+        with pytest.raises(RoleError):
+            remove_member_role_request(GUILD, USER, bad)
+
+    def test_role_error_is_value_error(self):
+        assert issubclass(RoleError, ValueError)
+
+    def test_max_snowflake_accepted(self):
+        top = (1 << 64) - 1
+        assert add_member_role_request(top, top, top)["path"] == (
+            f"/guilds/{top}/members/{top}/roles/{top}"
+        )

--- a/tools/discord_api/roles.py
+++ b/tools/discord_api/roles.py
@@ -1,0 +1,192 @@
+"""Discord role CRUD + assignment REST request builders.
+
+Pure, side-effect-free builders that validate inputs and produce request
+descriptors aligned with the Discord REST API v10 role resources:
+
+* ``POST   /guilds/{guild.id}/roles``                       - Create Guild Role
+* ``PATCH  /guilds/{guild.id}/roles/{role.id}``             - Modify Guild Role
+* ``DELETE /guilds/{guild.id}/roles/{role.id}``             - Delete Guild Role
+* ``PUT    /guilds/{guild.id}/members/{user.id}/roles/{role.id}`` - Add Guild Member Role
+* ``DELETE /guilds/{guild.id}/members/{user.id}/roles/{role.id}`` - Remove Guild Member Role
+
+Every descriptor is a plain dict of the form ``{"method": ..., "path": ...}``
+with an optional ``"json"`` key carrying the validated request body. No
+network, token, or base-URL handling lives here.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "RoleError",
+    "create_role_request",
+    "edit_role_request",
+    "delete_role_request",
+    "add_member_role_request",
+    "remove_member_role_request",
+]
+
+#: Discord snowflakes are unsigned 64-bit integers in the range 1..2**64-1.
+SNOWFLAKE_MIN = 1
+SNOWFLAKE_MAX = (1 << 64) - 1
+
+#: Role ``name`` is limited to 100 characters (REST v10 role object).
+NAME_MAX_LENGTH = 100
+
+#: Role ``color`` is an RGB integer in 0..0xFFFFFF (REST v10 role object).
+COLOR_MIN = 0
+COLOR_MAX = 0xFFFFFF
+
+#: ``permissions`` is a 64-bit permission bitfield (REST v10 permissions topic).
+PERMISSIONS_MIN = 0
+PERMISSIONS_MAX = (1 << 64) - 1
+
+#: Fields accepted by the role create/modify endpoints.
+ROLE_FIELDS = ("name", "permissions", "color", "hoist", "mentionable")
+
+
+class RoleError(ValueError):
+    """Raised when a role request descriptor cannot be validated."""
+
+
+def _validate_snowflake(value, field):
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RoleError(
+            f"{field} must be an integer snowflake, got {value!r}"
+        )
+    if not SNOWFLAKE_MIN <= value <= SNOWFLAKE_MAX:
+        raise RoleError(
+            f"{field} must be a snowflake in "
+            f"[{SNOWFLAKE_MIN}, {SNOWFLAKE_MAX}], got {value!r}"
+        )
+    return value
+
+
+def _validate_name(name):
+    if not isinstance(name, str):
+        raise RoleError(f"name must be a string, got {name!r}")
+    if len(name) > NAME_MAX_LENGTH:
+        raise RoleError(
+            f"name must be at most {NAME_MAX_LENGTH} characters, "
+            f"got {len(name)}"
+        )
+    return name
+
+
+def _validate_color(color):
+    if isinstance(color, bool) or not isinstance(color, int):
+        raise RoleError(f"color must be an integer, got {color!r}")
+    if not COLOR_MIN <= color <= COLOR_MAX:
+        raise RoleError(
+            f"color must be in 0..0x{COLOR_MAX:X}, got {color!r}"
+        )
+    return color
+
+
+def _validate_permissions(permissions):
+    if isinstance(permissions, bool) or not isinstance(permissions, int):
+        raise RoleError(f"permissions must be an integer bitfield, got {permissions!r}")
+    if not PERMISSIONS_MIN <= permissions <= PERMISSIONS_MAX:
+        raise RoleError(
+            f"permissions must be an integer bitfield in "
+            f"[{PERMISSIONS_MIN}, {PERMISSIONS_MAX}], got {permissions!r}"
+        )
+    return permissions
+
+
+def _validate_flag(value, field):
+    if not isinstance(value, bool):
+        raise RoleError(f"{field} must be a bool, got {value!r}")
+    return value
+
+
+def _validate_role_field(name, value):
+    """Validate one named role field; unknown fields are rejected."""
+    if name == "name":
+        return _validate_name(value)
+    if name == "permissions":
+        return _validate_permissions(value)
+    if name == "color":
+        return _validate_color(value)
+    if name in ("hoist", "mentionable"):
+        return _validate_flag(value, name)
+    raise RoleError(f"unsupported role field {name!r}")
+
+
+def create_role_request(guild_id, *, name=None, permissions=None, color=None,
+                        hoist=False, mentionable=False):
+    """Build a ``POST /guilds/{guild}/roles`` create-role request descriptor.
+
+    Optional body fields (``name``, ``permissions``, ``color``) are included
+    only when provided (not ``None``); ``hoist``/``mentionable`` are included
+    only when ``True``.
+    """
+    _validate_snowflake(guild_id, "guild_id")
+    body = {}
+    if name is not None:
+        body["name"] = _validate_name(name)
+    if permissions is not None:
+        body["permissions"] = _validate_permissions(permissions)
+    if color is not None:
+        body["color"] = _validate_color(color)
+    if hoist:
+        body["hoist"] = _validate_flag(hoist, "hoist")
+    if mentionable:
+        body["mentionable"] = _validate_flag(mentionable, "mentionable")
+    return {
+        "method": "POST",
+        "path": f"/guilds/{guild_id}/roles",
+        "json": body,
+    }
+
+
+def edit_role_request(guild_id, role_id, **fields):
+    """Build a ``PATCH /guilds/{guild}/roles/{role}`` modify-role descriptor.
+
+    Only the fields explicitly passed are included in the body; passing no
+    fields is a validation error.
+    """
+    _validate_snowflake(guild_id, "guild_id")
+    _validate_snowflake(role_id, "role_id")
+    if not fields:
+        raise RoleError("edit_role_request requires at least one field to edit")
+    unknown = set(fields) - set(ROLE_FIELDS)
+    if unknown:
+        raise RoleError(
+            f"unsupported role field(s) {sorted(unknown)!r}; "
+            f"supported: {sorted(ROLE_FIELDS)!r}"
+        )
+    body = {key: _validate_role_field(key, value) for key, value in fields.items()}
+    return {
+        "method": "PATCH",
+        "path": f"/guilds/{guild_id}/roles/{role_id}",
+        "json": body,
+    }
+
+
+def delete_role_request(guild_id, role_id):
+    """Build a ``DELETE /guilds/{guild}/roles/{role}`` delete-role descriptor."""
+    _validate_snowflake(guild_id, "guild_id")
+    _validate_snowflake(role_id, "role_id")
+    return {"method": "DELETE", "path": f"/guilds/{guild_id}/roles/{role_id}"}
+
+
+def add_member_role_request(guild_id, user_id, role_id):
+    """Build a ``PUT /guilds/{guild}/members/{user}/roles/{role}`` descriptor."""
+    _validate_snowflake(guild_id, "guild_id")
+    _validate_snowflake(user_id, "user_id")
+    _validate_snowflake(role_id, "role_id")
+    return {
+        "method": "PUT",
+        "path": f"/guilds/{guild_id}/members/{user_id}/roles/{role_id}",
+    }
+
+
+def remove_member_role_request(guild_id, user_id, role_id):
+    """Build a ``DELETE /guilds/{guild}/members/{user}/roles/{role}`` descriptor."""
+    _validate_snowflake(guild_id, "guild_id")
+    _validate_snowflake(user_id, "user_id")
+    _validate_snowflake(role_id, "role_id")
+    return {
+        "method": "DELETE",
+        "path": f"/guilds/{guild_id}/members/{user_id}/roles/{role_id}",
+    }


### PR DESCRIPTION
**Discord A3** (Part of #79564, Fixes #86461): role CRUD + assignment REST actions in `tools/discord_api/roles.py`. 82/82 tests pass. New module only.