### PR TITLE
feat(discord): guild scheduled-event REST actions

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience A6

--- a/tests/tools/test_discord_scheduled_events.py
+++ b/tests/tools/test_discord_scheduled_events.py
@@ -1,0 +1,279 @@
+"""Tests for tools.discord_api.scheduled_events request builders."""
+
+import pytest
+
+from tools.discord_api.scheduled_events import (
+    ScheduledEventError,
+    create_scheduled_event_request,
+    delete_scheduled_event_request,
+    edit_scheduled_event_request,
+    list_scheduled_events_request,
+)
+
+GUILD = "123456789012345678"
+EVENT = "987654321098765432"
+CHANNEL = "111222333444555666"
+
+START = "2026-09-01T18:00:00+00:00"
+END = "2026-09-01T21:00:00+00:00"
+
+LONG_NAME_100 = "n" * 100
+LONG_NAME_101 = "n" * 101
+DESC_1000 = "d" * 1000
+DESC_1001 = "d" * 1001
+
+
+# ---------------------------------------------------------------- create
+
+
+def test_create_minimal_external_defaults():
+    req = create_scheduled_event_request(
+        GUILD, name="Game Night", scheduled_start_time=START, scheduled_end_time=END
+    )
+    assert req["method"] == "POST"
+    assert req["path"] == f"/guilds/{GUILD}/scheduled-events"
+    assert req["json"] == {
+        "name": "Game Night",
+        "scheduled_start_time": START,
+        "entity_type": 1,
+        "privacy_level": 2,
+        "scheduled_end_time": END,
+    }
+
+
+def test_create_stage_event_with_channel():
+    req = create_scheduled_event_request(
+        GUILD,
+        name="Stage Show",
+        scheduled_start_time=START,
+        entity_type=2,
+        channel_id=CHANNEL,
+    )
+    assert req["path"] == f"/guilds/{GUILD}/scheduled-events"
+    assert req["json"]["entity_type"] == 2
+    assert req["json"]["channel_id"] == CHANNEL
+    assert "scheduled_end_time" not in req["json"]
+
+
+def test_create_voice_event_with_channel():
+    req = create_scheduled_event_request(
+        GUILD,
+        name="Voice Chat",
+        scheduled_start_time=START,
+        entity_type=3,
+        channel_id=CHANNEL,
+    )
+    assert req["json"]["entity_type"] == 3
+    assert req["json"]["channel_id"] == CHANNEL
+
+
+def test_create_full_body():
+    req = create_scheduled_event_request(
+        GUILD,
+        name="Movie Night",
+        scheduled_start_time=START,
+        entity_type=1,
+        description="Watch classics",
+        privacy_level=2,
+        scheduled_end_time=END,
+    )
+    assert req["json"]["description"] == "Watch classics"
+    assert req["json"]["privacy_level"] == 2
+    assert "channel_id" not in req["json"]
+
+
+def test_create_external_requires_end_time():
+    with pytest.raises(ScheduledEventError):
+        create_scheduled_event_request(GUILD, name="No End", scheduled_start_time=START)
+
+
+def test_create_external_rejects_channel_id():
+    with pytest.raises(ScheduledEventError):
+        create_scheduled_event_request(
+            GUILD,
+            name="Bad Channel",
+            scheduled_start_time=START,
+            channel_id=CHANNEL,
+            scheduled_end_time=END,
+        )
+
+
+def test_create_invalid_entity_type():
+    with pytest.raises(ScheduledEventError):
+        create_scheduled_event_request(
+            GUILD, name="X", scheduled_start_time=START, entity_type=5
+        )
+
+
+def test_create_start_time_must_be_iso8601():
+    for bad in ("not-a-time", "2026-13-99T99:99:99", "2026-09-01", 12345):
+        with pytest.raises(ScheduledEventError):
+            create_scheduled_event_request(
+                GUILD,
+                name="X",
+                scheduled_start_time=bad,
+                scheduled_end_time=END,
+            )
+
+
+def test_create_start_time_accepts_valid_variants():
+    for variant in ("2026-09-01T18:00:00Z", "2026-09-01 18:00:00", "2026-09-01T18:00:00+02:00"):
+        req = create_scheduled_event_request(
+            GUILD,
+            name="X",
+            scheduled_start_time=variant,
+            scheduled_end_time=END,
+        )
+        assert req["json"]["scheduled_start_time"] == variant
+
+
+def test_create_end_time_validation():
+    with pytest.raises(ScheduledEventError):
+        create_scheduled_event_request(
+            GUILD, name="X", scheduled_start_time=START, scheduled_end_time="tomorrow"
+        )
+
+
+def test_create_name_bounds():
+    for bad in ("", LONG_NAME_101):
+        with pytest.raises(ScheduledEventError):
+            create_scheduled_event_request(
+                GUILD, name=bad, scheduled_start_time=START, scheduled_end_time=END
+            )
+    # boundary values are fine
+    assert create_scheduled_event_request(
+        GUILD, name="n", scheduled_start_time=START, scheduled_end_time=END
+    )["json"]["name"] == "n"
+    assert create_scheduled_event_request(
+        GUILD, name=LONG_NAME_100, scheduled_start_time=START, scheduled_end_time=END
+    )["json"]["name"] == LONG_NAME_100
+
+
+def test_create_description_max():
+    assert create_scheduled_event_request(
+        GUILD,
+        name="X",
+        scheduled_start_time=START,
+        description=DESC_1000,
+        scheduled_end_time=END,
+    )["json"]["description"] == DESC_1000
+    with pytest.raises(ScheduledEventError):
+        create_scheduled_event_request(
+            GUILD,
+            name="X",
+            scheduled_start_time=START,
+            description=DESC_1001,
+            scheduled_end_time=END,
+        )
+
+
+def test_create_privacy_level_must_be_2():
+    with pytest.raises(ScheduledEventError):
+        create_scheduled_event_request(
+            GUILD,
+            name="X",
+            scheduled_start_time=START,
+            privacy_level=1,
+            scheduled_end_time=END,
+        )
+
+
+def test_create_snowflake_validation():
+    for bad_guild in ("abc", -1, 2**63, 1.5, True, None):
+        with pytest.raises(ScheduledEventError):
+            create_scheduled_event_request(
+                bad_guild, name="X", scheduled_start_time=START, scheduled_end_time=END
+            )
+    with pytest.raises(ScheduledEventError):
+        create_scheduled_event_request(
+            GUILD,
+            name="X",
+            scheduled_start_time=START,
+            entity_type=2,
+            channel_id="not-a-snowflake",
+        )
+
+
+# ----------------------------------------------------------------- edit
+
+
+def test_edit_only_provided_fields():
+    req = edit_scheduled_event_request(GUILD, EVENT, name="Renamed")
+    assert req["method"] == "PATCH"
+    assert req["path"] == f"/guilds/{GUILD}/scheduled-events/{EVENT}"
+    assert req["json"] == {"name": "Renamed"}
+
+
+def test_edit_multiple_fields_only_provided():
+    req = edit_scheduled_event_request(
+        GUILD, EVENT, name="Renamed", description="Updated desc"
+    )
+    assert req["json"] == {"name": "Renamed", "description": "Updated desc"}
+
+
+def test_edit_no_fields_yields_empty_body():
+    req = edit_scheduled_event_request(GUILD, EVENT)
+    assert req["method"] == "PATCH"
+    assert "json" not in req
+
+
+def test_edit_accepts_nullable_clear():
+    req = edit_scheduled_event_request(GUILD, EVENT, channel_id=None)
+    assert req["json"] == {"channel_id": None}
+
+
+def test_edit_validates_each_field():
+    bad_calls = [
+        {"name": ""},
+        {"name": LONG_NAME_101},
+        {"description": DESC_1001},
+        {"entity_type": 9},
+        {"privacy_level": 1},
+        {"scheduled_start_time": "nope"},
+        {"scheduled_end_time": "nope"},
+        {"channel_id": "bogus"},
+        {"unknown_field": 1},
+    ]
+    for kwargs in bad_calls:
+        with pytest.raises(ScheduledEventError):
+            edit_scheduled_event_request(GUILD, EVENT, **kwargs)
+
+
+def test_edit_external_cannot_set_channel_id():
+    with pytest.raises(ScheduledEventError):
+        edit_scheduled_event_request(GUILD, EVENT, entity_type=1, channel_id=CHANNEL)
+
+
+def test_edit_snowflake_validation():
+    with pytest.raises(ScheduledEventError):
+        edit_scheduled_event_request("bad", EVENT, name="X")
+    with pytest.raises(ScheduledEventError):
+        edit_scheduled_event_request(GUILD, -5, name="X")
+
+
+# --------------------------------------------------------------- delete
+
+
+def test_delete_request_shape():
+    req = delete_scheduled_event_request(GUILD, EVENT)
+    assert req == {"method": "DELETE", "path": f"/guilds/{GUILD}/scheduled-events/{EVENT}"}
+
+
+def test_delete_validates_snowflakes():
+    with pytest.raises(ScheduledEventError):
+        delete_scheduled_event_request(GUILD, "abc")
+    with pytest.raises(ScheduledEventError):
+        delete_scheduled_event_request(2**63, EVENT)
+
+
+# ----------------------------------------------------------------- list
+
+
+def test_list_request_shape():
+    req = list_scheduled_events_request(GUILD)
+    assert req == {"method": "GET", "path": f"/guilds/{GUILD}/scheduled-events"}
+
+
+def test_list_validates_guild_snowflake():
+    with pytest.raises(ScheduledEventError):
+        list_scheduled_events_request("not-a-guild")

--- a/tools/discord_api/scheduled_events.py
+++ b/tools/discord_api/scheduled_events.py
@@ -1,0 +1,239 @@
+"""Discord guild scheduled-event REST request builders.
+
+Pure request-builder module: every function validates its inputs and returns a
+request descriptor dict (``method``, ``path``, optional ``json`` body) ready to
+be handed to an HTTP client. Aligned with Discord REST API v10
+(``resources/guild-scheduled-event.mdx``).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from typing import Any, Dict, Optional
+
+__all__ = [
+    "ScheduledEventError",
+    "create_scheduled_event_request",
+    "edit_scheduled_event_request",
+    "delete_scheduled_event_request",
+    "list_scheduled_events_request",
+]
+
+# Discord snowflakes are unsigned 64-bit integers; real snowflakes fit in 63 bits.
+_SNOWFLAKE_MAX = 2**63 - 1
+
+# Guild Scheduled Event entity types (REST v10).
+ENTITY_TYPE_EXTERNAL = 1
+ENTITY_TYPE_STAGE = 2
+ENTITY_TYPE_VOICE = 3
+_ENTITY_TYPES = (ENTITY_TYPE_EXTERNAL, ENTITY_TYPE_STAGE, ENTITY_TYPE_VOICE)
+
+_NAME_MIN = 1
+_NAME_MAX = 100
+_DESCRIPTION_MAX = 1000
+# GUILD_ONLY is currently the only supported privacy level.
+_PRIVACY_LEVEL = 2
+
+# Loose ISO-8601 shape; full semantic validation is delegated to
+# datetime.fromisoformat (with ``Z`` normalized to ``+00:00``).
+_ISO8601_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?"
+    r"(Z|[+-]\d{2}:?\d{2})?$"
+)
+
+
+class ScheduledEventError(ValueError):
+    """Raised when a scheduled-event request cannot be validated."""
+
+
+def _validate_snowflake(value, field: str) -> int:
+    """Validate a Discord snowflake (int or numeric string); return the int."""
+    if isinstance(value, bool):
+        raise ScheduledEventError(f"{field} must be a valid snowflake, got {value!r}")
+    if isinstance(value, int):
+        num = value
+    elif isinstance(value, str):
+        if not value.isdigit():
+            raise ScheduledEventError(f"{field} must be a valid snowflake, got {value!r}")
+        num = int(value)
+    else:
+        raise ScheduledEventError(f"{field} must be a valid snowflake, got {value!r}")
+    if num < 0 or num > _SNOWFLAKE_MAX:
+        raise ScheduledEventError(f"{field} out of range for a Discord snowflake: {num}")
+    return num
+
+
+def _validate_iso8601(value, field: str) -> str:
+    """Validate an ISO-8601 timestamp string; return it unchanged."""
+    if not isinstance(value, str):
+        raise ScheduledEventError(f"{field} must be an ISO-8601 string, got {value!r}")
+    if not _ISO8601_RE.match(value):
+        raise ScheduledEventError(f"{field} must be an ISO-8601 string, got {value!r}")
+    try:
+        normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+        _dt.datetime.fromisoformat(normalized)
+    except ValueError:
+        raise ScheduledEventError(
+            f"{field} must be a valid ISO-8601 timestamp, got {value!r}"
+        ) from None
+    return value
+
+
+def _descriptor(
+    method: str, path: str, json_body: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    descriptor: Dict[str, Any] = {"method": method, "path": path}
+    if json_body:
+        descriptor["json"] = json_body
+    return descriptor
+
+
+def create_scheduled_event_request(
+    guild_id,
+    *,
+    name,
+    scheduled_start_time,
+    channel_id=None,
+    entity_type=ENTITY_TYPE_EXTERNAL,
+    description=None,
+    privacy_level=_PRIVACY_LEVEL,
+    scheduled_end_time=None,
+) -> Dict[str, Any]:
+    """Build a validated POST /guilds/{guild}/scheduled-events request.
+
+    Entity-type rules (REST v10):
+    - EXTERNAL (1): ``channel_id`` must be omitted and ``scheduled_end_time``
+      is required.
+    - STAGE_INSTANCE (2) / VOICE (3): ``channel_id`` refers to the stage/voice
+      channel the event is held in.
+    """
+    guild = _validate_snowflake(guild_id, "guild_id")
+
+    if not isinstance(name, str):
+        raise ScheduledEventError(f"name must be a string, got {name!r}")
+    if not (_NAME_MIN <= len(name) <= _NAME_MAX):
+        raise ScheduledEventError(
+            f"name must be between {_NAME_MIN} and {_NAME_MAX} characters"
+        )
+
+    start = _validate_iso8601(scheduled_start_time, "scheduled_start_time")
+
+    if entity_type not in _ENTITY_TYPES:
+        raise ScheduledEventError(
+            f"entity_type must be one of {_ENTITY_TYPES}, got {entity_type!r}"
+        )
+
+    if privacy_level != _PRIVACY_LEVEL:
+        raise ScheduledEventError(
+            f"privacy_level must be {_PRIVACY_LEVEL} (GUILD_ONLY), got {privacy_level!r}"
+        )
+
+    if channel_id is not None:
+        channel_id = _validate_snowflake(channel_id, "channel_id")
+
+    if description is not None:
+        if not isinstance(description, str):
+            raise ScheduledEventError(f"description must be a string, got {description!r}")
+        if len(description) > _DESCRIPTION_MAX:
+            raise ScheduledEventError(
+                f"description must be at most {_DESCRIPTION_MAX} characters"
+            )
+
+    end = None
+    if scheduled_end_time is not None:
+        end = _validate_iso8601(scheduled_end_time, "scheduled_end_time")
+
+    if entity_type == ENTITY_TYPE_EXTERNAL:
+        if channel_id is not None:
+            raise ScheduledEventError("external scheduled events cannot set channel_id")
+        if end is None:
+            raise ScheduledEventError(
+                "external scheduled events require scheduled_end_time"
+            )
+
+    body: Dict[str, Any] = {
+        "name": name,
+        "scheduled_start_time": start,
+        "entity_type": entity_type,
+        "privacy_level": privacy_level,
+    }
+    if channel_id is not None:
+        body["channel_id"] = str(channel_id)
+    if description is not None:
+        body["description"] = description
+    if end is not None:
+        body["scheduled_end_time"] = end
+
+    return _descriptor("POST", f"/guilds/{guild}/scheduled-events", body)
+
+
+def edit_scheduled_event_request(guild_id, event_id, **fields) -> Dict[str, Any]:
+    """Build a validated PATCH /guilds/{guild}/scheduled-events/{event} request.
+
+    Only the fields explicitly provided (including ``None`` values, which clear
+    a field) are included in the body. Unknown field names are rejected.
+    """
+    guild = _validate_snowflake(guild_id, "guild_id")
+    event = _validate_snowflake(event_id, "event_id")
+
+    body: Dict[str, Any] = {}
+    for key, value in fields.items():
+        if key == "name":
+            if not isinstance(value, str):
+                raise ScheduledEventError("name must be a string")
+            if not (_NAME_MIN <= len(value) <= _NAME_MAX):
+                raise ScheduledEventError(
+                    f"name must be between {_NAME_MIN} and {_NAME_MAX} characters"
+                )
+        elif key == "description":
+            if not isinstance(value, str):
+                raise ScheduledEventError("description must be a string")
+            if len(value) > _DESCRIPTION_MAX:
+                raise ScheduledEventError(
+                    f"description must be at most {_DESCRIPTION_MAX} characters"
+                )
+        elif key == "channel_id":
+            if value is not None:
+                value = str(_validate_snowflake(value, "channel_id"))
+        elif key == "entity_type":
+            if value not in _ENTITY_TYPES:
+                raise ScheduledEventError(
+                    f"entity_type must be one of {_ENTITY_TYPES}, got {value!r}"
+                )
+        elif key == "privacy_level":
+            if value != _PRIVACY_LEVEL:
+                raise ScheduledEventError(
+                    f"privacy_level must be {_PRIVACY_LEVEL} (GUILD_ONLY), got {value!r}"
+                )
+        elif key == "scheduled_start_time":
+            value = _validate_iso8601(value, "scheduled_start_time")
+        elif key == "scheduled_end_time":
+            if value is not None:
+                value = _validate_iso8601(value, "scheduled_end_time")
+        else:
+            raise ScheduledEventError(f"unsupported scheduled-event field: {key!r}")
+        body[key] = value
+
+    # Cross-field consistency for the fields provided in this call only.
+    if (
+        body.get("entity_type") == ENTITY_TYPE_EXTERNAL
+        and "channel_id" in body
+        and body["channel_id"] is not None
+    ):
+        raise ScheduledEventError("external scheduled events cannot set channel_id")
+
+    return _descriptor("PATCH", f"/guilds/{guild}/scheduled-events/{event}", body)
+
+
+def delete_scheduled_event_request(guild_id, event_id) -> Dict[str, Any]:
+    """Build a validated DELETE /guilds/{guild}/scheduled-events/{event} request."""
+    guild = _validate_snowflake(guild_id, "guild_id")
+    event = _validate_snowflake(event_id, "event_id")
+    return _descriptor("DELETE", f"/guilds/{guild}/scheduled-events/{event}")
+
+
+def list_scheduled_events_request(guild_id) -> Dict[str, Any]:
+    """Build a validated GET /guilds/{guild}/scheduled-events request."""
+    guild = _validate_snowflake(guild_id, "guild_id")
+    return _descriptor("GET", f"/guilds/{guild}/scheduled-events")


### PR DESCRIPTION
**Discord A6** (Part of #79564, Fixes #86465): guild scheduled-event REST actions in `tools/discord_api/scheduled_events.py`. 25/25 tests pass. New module only.