### PR TITLE
feat(discord): route-aware rate-limit contract

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience R1

--- a/tests/tools/test_discord_transport.py
+++ b/tests/tools/test_discord_transport.py
@@ -1,0 +1,150 @@
+"""Tests for the Discord route-aware rate-limit contract (feature R1)."""
+
+import pytest
+
+from tools.discord_api.transport import (
+    RateLimitInfo,
+    RouteBucket,
+    TransportError,
+    is_retriable,
+    parse_rate_limit_response,
+)
+
+
+class TestParseRateLimitResponse:
+    def test_parses_valid_429_body(self):
+        info = parse_rate_limit_response(
+            429,
+            {
+                "retry_after": 2.5,
+                "message": "You are being rate limited.",
+                "global": True,
+                "code": 20029,
+            },
+        )
+        assert isinstance(info, RateLimitInfo)
+        assert info.status == 429
+        assert info.retry_after == 2.5
+        assert info.message == "You are being rate limited."
+        assert info.global_ is True
+        assert info.code == 20029
+
+    def test_accepts_integer_retry_after(self):
+        info = parse_rate_limit_response(
+            429,
+            {"retry_after": 7, "message": "slow down", "global": False, "code": 20029},
+        )
+        assert info.retry_after == 7.0
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            None,
+            "not a dict",
+            [1, 2, 3],
+            {"retry_after": 1.0, "message": "m", "global": False},  # missing code
+            {"retry_after": 1.0, "message": "m", "code": 1},  # missing global
+            {"retry_after": 1.0, "global": False, "code": 1},  # missing message
+            {"message": "m", "global": False, "code": 1},  # missing retry_after
+            {"retry_after": "abc", "message": "m", "global": False, "code": 1},  # non-numeric
+            {"retry_after": -1.0, "message": "m", "global": False, "code": 1},  # negative
+            {"retry_after": 1.0, "message": 123, "global": False, "code": 1},  # wrong type
+            {"retry_after": 1.0, "message": "m", "global": "yes", "code": 1},  # wrong type
+            {"retry_after": 1.0, "message": "m", "global": False, "code": "nope"},  # wrong type
+            {"retry_after": 1.0, "message": "m", "global": False, "code": True},  # bool != int
+        ],
+    )
+    def test_malformed_body_raises_transport_error(self, body):
+        with pytest.raises(TransportError):
+            parse_rate_limit_response(429, body)
+
+    def test_transport_error_is_value_error(self):
+        with pytest.raises(ValueError):
+            parse_rate_limit_response(429, None)
+
+
+class TestIsRetriable:
+    def test_429_within_window_is_retriable(self):
+        assert is_retriable(429, "POST", 5.0) is True
+        assert is_retriable(429, "GET", 60) is True
+        assert is_retriable(429, "POST", "3.5") is True
+
+    def test_429_outside_window_is_not_retriable(self):
+        assert is_retriable(429, "GET", 60.5) is False
+        assert is_retriable(429, "GET", 61) is False
+
+    def test_429_without_retry_after_is_not_retriable(self):
+        assert is_retriable(429, "GET", None) is False
+
+    @pytest.mark.parametrize("method", ["GET", "PUT", "DELETE"])
+    def test_5xx_idempotent_methods_are_retriable(self, method):
+        assert is_retriable(500, method, None) is True
+        assert is_retriable(503, method.lower(), None) is True
+
+    @pytest.mark.parametrize("method", ["POST", "PATCH"])
+    def test_5xx_non_idempotent_methods_are_not_retriable(self, method):
+        assert is_retriable(500, method, None) is False
+        assert is_retriable(502, method, None) is False
+
+    def test_5xx_ignores_retry_after(self):
+        assert is_retriable(500, "GET", 999) is True
+
+    @pytest.mark.parametrize("status", [400, 401, 403])
+    @pytest.mark.parametrize("method", ["GET", "POST"])
+    def test_client_errors_never_retriable(self, status, method):
+        assert is_retriable(status, method, 5.0) is False
+
+    def test_other_status_codes_not_retriable(self):
+        assert is_retriable(200, "GET", None) is False
+        assert is_retriable(404, "GET", None) is False
+
+
+class _FakeClock:
+    """Deterministic stand-in for time.monotonic."""
+
+    def __init__(self, now=1000.0):
+        self.now = now
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+class TestRouteBucket:
+    def test_fresh_bucket_is_available(self):
+        assert RouteBucket("channels/123/messages").available() is True
+
+    def test_cooldown_makes_route_unavailable(self):
+        clock = _FakeClock(now=1000.0)
+        bucket = RouteBucket(route="channels/123/messages", clock=clock)
+        bucket.apply_rate_limit(5.0)
+        assert bucket.cooldown_until == 1005.0
+        assert bucket.available() is False
+
+    def test_route_becomes_available_after_cooldown_elapses(self):
+        clock = _FakeClock(now=1000.0)
+        bucket = RouteBucket(clock=clock)
+        bucket.apply_rate_limit(5.0)
+        clock.advance(4.9)
+        assert bucket.available() is False
+        clock.advance(0.2)
+        assert bucket.available() is True
+
+    def test_reset_clears_cooldown(self):
+        clock = _FakeClock(now=1000.0)
+        bucket = RouteBucket(clock=clock)
+        bucket.apply_rate_limit(30.0)
+        assert bucket.available() is False
+        bucket.reset()
+        assert bucket.available() is True
+        assert bucket.cooldown_until == 0.0
+
+    def test_new_rate_limit_overwrites_previous(self):
+        clock = _FakeClock(now=1000.0)
+        bucket = RouteBucket(clock=clock)
+        bucket.apply_rate_limit(1.0)
+        clock.advance(2.0)
+        bucket.apply_rate_limit(10.0)
+        assert bucket.cooldown_until == 1012.0

--- a/tools/discord_api/transport.py
+++ b/tools/discord_api/transport.py
@@ -1,0 +1,182 @@
+"""Discord route-aware rate-limit contract (pure logic, no network I/O).
+
+This module models the rate-limit state machine and error taxonomy used by
+the Discord API transport layer:
+
+* :class:`RateLimitInfo` -- normalized view of a Discord 429 response.
+* :func:`parse_rate_limit_response` -- strict parsing of a 429 body.
+* :func:`is_retriable` -- route/method-aware retry classification.
+* :class:`RouteBucket` -- per-route 429 cooldown tracker.
+* :class:`TransportError` -- transport-level error (subclass of ValueError).
+
+It is intentionally free of any network calls so it can be unit-tested in
+isolation.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional
+
+__all__ = [
+    "RateLimitInfo",
+    "RouteBucket",
+    "TransportError",
+    "is_retriable",
+    "parse_rate_limit_response",
+]
+
+
+class TransportError(ValueError):
+    """Raised when a rate-limit payload is malformed or a transport-level
+    contract is violated. Subclasses :class:`ValueError`."""
+
+
+@dataclass(frozen=True)
+class RateLimitInfo:
+    """Normalized view of a Discord 429 (rate limited) response."""
+
+    status: int
+    code: Optional[int]
+    message: str
+    retry_after: float
+    global_: bool
+
+
+def _is_number(value: Any) -> bool:
+    """True for int/float (excluding bool) and numeric strings."""
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return True
+    if isinstance(value, str):
+        try:
+            float(value)
+        except ValueError:
+            return False
+        return True
+    return False
+
+
+def _to_float(value: Any) -> float:
+    return float(value)
+
+
+def parse_rate_limit_response(status_code: int, body_dict: Any) -> RateLimitInfo:
+    """Parse a Discord 429 response body into a :class:`RateLimitInfo`.
+
+    The expected body shape is::
+
+        {"retry_after": float, "message": str, "global": bool, "code": int}
+
+    Raises:
+        TransportError: if the body is not a mapping, is missing a required
+            key, or contains a value of the wrong type.
+    """
+    if not isinstance(body_dict, Mapping):
+        raise TransportError(
+            f"malformed rate-limit body: expected mapping, got {type(body_dict).__name__}"
+        )
+    body: Mapping[str, Any] = body_dict
+
+    try:
+        retry_after_raw = body["retry_after"]
+    except KeyError:
+        raise TransportError("malformed rate-limit body: missing 'retry_after'") from None
+    if not _is_number(retry_after_raw):
+        raise TransportError(
+            f"malformed rate-limit body: 'retry_after' must be numeric, got {retry_after_raw!r}"
+        )
+    retry_after = _to_float(retry_after_raw)
+    if retry_after < 0:
+        raise TransportError("malformed rate-limit body: 'retry_after' must be >= 0")
+
+    try:
+        message = body["message"]
+    except KeyError:
+        raise TransportError("malformed rate-limit body: missing 'message'") from None
+    if not isinstance(message, str):
+        raise TransportError(
+            f"malformed rate-limit body: 'message' must be str, got {type(message).__name__}"
+        )
+
+    try:
+        global_ = body["global"]
+    except KeyError:
+        raise TransportError("malformed rate-limit body: missing 'global'") from None
+    if not isinstance(global_, bool):
+        raise TransportError(
+            f"malformed rate-limit body: 'global' must be bool, got {type(global_).__name__}"
+        )
+
+    try:
+        code = body["code"]
+    except KeyError:
+        raise TransportError("malformed rate-limit body: missing 'code'") from None
+    if not isinstance(code, int) or isinstance(code, bool):
+        raise TransportError(
+            f"malformed rate-limit body: 'code' must be int, got {type(code).__name__}"
+        )
+
+    return RateLimitInfo(
+        status=status_code,
+        code=code,
+        message=message,
+        retry_after=retry_after,
+        global_=global_,
+    )
+
+
+_IDEMPOTENT_METHODS = frozenset({"GET", "PUT", "DELETE"})
+
+_MAX_RETRY_AFTER = 60.0
+
+
+def is_retriable(status_code: int, method: str, retry_after: Any = None) -> bool:
+    """Decide whether a failed request may be retried.
+
+    Rules:
+        * 429 (rate limited): retriable only when ``retry_after`` is numeric
+          and <= 60 seconds.
+        * 5xx (server errors): retriable only for idempotent methods
+          (GET/PUT/DELETE). Non-idempotent methods such as POST are never
+          retried on 5xx.
+        * 400/401/403 (client/auth errors): never retriable.
+    """
+    method = method.upper()
+    if status_code == 429:
+        return _is_number(retry_after) and _to_float(retry_after) <= _MAX_RETRY_AFTER
+    if 500 <= status_code < 600:
+        return method in _IDEMPOTENT_METHODS
+    return False
+
+
+class RouteBucket:
+    """Per-route 429 cooldown tracker.
+
+    After a 429, :meth:`apply_rate_limit` records a cooldown deadline; the
+    route is unavailable until that deadline passes. ``clock`` is injectable
+    for deterministic tests; it defaults to :func:`time.monotonic`.
+    """
+
+    def __init__(
+        self,
+        route: Optional[str] = None,
+        clock: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self.route = route
+        self.cooldown_until: float = 0.0
+        self._clock: Callable[[], float] = clock or time.monotonic
+
+    def apply_rate_limit(self, retry_after: float) -> None:
+        """Begin a cooldown that lasts ``retry_after`` seconds."""
+        self.cooldown_until = self._clock() + float(retry_after)
+
+    def available(self) -> bool:
+        """True when the route is not in a rate-limit cooldown."""
+        return self._clock() >= self.cooldown_until
+
+    def reset(self) -> None:
+        """Clear any active cooldown."""
+        self.cooldown_until = 0.0


### PR DESCRIPTION
**Discord R1** (Part of #79564, Fixes #86467): route-aware rate-limit contract in `tools/discord_api/transport.py`. 37/37 tests pass. New module only.