### PR TITLE
fix(browser): reclaim idle multiplexed sessions before Chromium leaks

### DIFF
--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -1,6 +1,10 @@
 """Regression tests for browser session cleanup and screenshot recovery."""
 
+from pathlib import Path
 from unittest.mock import patch
+
+from agent import secret_scope
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
 
 class TestScreenshotPathRecovery:
@@ -30,6 +34,8 @@ class TestBrowserCleanup:
         self.browser_tool = browser_tool
         self.orig_active_sessions = browser_tool._active_sessions.copy()
         self.orig_session_last_activity = browser_tool._session_last_activity.copy()
+        self.orig_session_profile_homes = browser_tool._session_profile_homes.copy()
+        self.orig_cleanup_failure_counts = browser_tool._cleanup_failure_counts.copy()
         self.orig_recording_sessions = browser_tool._recording_sessions.copy()
         self.orig_cleanup_done = browser_tool._cleanup_done
 
@@ -38,6 +44,12 @@ class TestBrowserCleanup:
         self.browser_tool._active_sessions.update(self.orig_active_sessions)
         self.browser_tool._session_last_activity.clear()
         self.browser_tool._session_last_activity.update(self.orig_session_last_activity)
+        self.browser_tool._session_profile_homes.clear()
+        self.browser_tool._session_profile_homes.update(self.orig_session_profile_homes)
+        self.browser_tool._cleanup_failure_counts.clear()
+        self.browser_tool._cleanup_failure_counts.update(
+            self.orig_cleanup_failure_counts
+        )
         self.browser_tool._recording_sessions.clear()
         self.browser_tool._recording_sessions.update(self.orig_recording_sessions)
         self.browser_tool._cleanup_done = self.orig_cleanup_done
@@ -49,6 +61,8 @@ class TestBrowserCleanup:
             "bb_session_id": None,
         }
         browser_tool._session_last_activity["task-1"] = 123.0
+        browser_tool._session_profile_homes["task-1"] = "/profile-a"
+        browser_tool._cleanup_failure_counts["task-1"] = 2
 
         with (
             patch("tools.browser_tool._maybe_stop_recording") as mock_stop,
@@ -62,6 +76,8 @@ class TestBrowserCleanup:
 
         assert "task-1" not in browser_tool._active_sessions
         assert "task-1" not in browser_tool._session_last_activity
+        assert "task-1" not in browser_tool._session_profile_homes
+        assert "task-1" not in browser_tool._cleanup_failure_counts
         mock_stop.assert_called_once_with("task-1")
         mock_run.assert_called_once_with("task-1", "close", [], timeout=10)
 
@@ -73,6 +89,10 @@ class TestBrowserCleanup:
         browser_tool._active_sessions["task-2"] = {"session_name": "sess-2"}
         browser_tool._session_last_activity["task-1"] = 1.0
         browser_tool._session_last_activity["task-2"] = 2.0
+        browser_tool._session_profile_homes.update(
+            {"task-1": "/profile-a", "task-2": "/profile-b"}
+        )
+        browser_tool._cleanup_failure_counts.update({"task-1": 1, "task-2": 2})
         browser_tool._recording_sessions.update({"task-1", "task-2"})
 
         with patch("tools.browser_tool.cleanup_all_browsers") as mock_cleanup_all:
@@ -81,5 +101,104 @@ class TestBrowserCleanup:
         mock_cleanup_all.assert_called_once_with()
         assert browser_tool._active_sessions == {}
         assert browser_tool._session_last_activity == {}
+        assert browser_tool._session_profile_homes == {}
+        assert browser_tool._cleanup_failure_counts == {}
         assert browser_tool._recording_sessions == set()
         assert browser_tool._cleanup_done is True
+
+    def test_inactivity_cleanup_restores_each_sessions_profile_scope(
+        self, tmp_path, monkeypatch
+    ):
+        browser_tool = self.browser_tool
+        profile_a = tmp_path / "profile-a"
+        profile_b = tmp_path / "profile-b"
+        profile_a.mkdir()
+        profile_b.mkdir()
+        (profile_a / ".env").write_text("CAMOFOX_URL=https://a.example\n")
+        (profile_b / ".env").write_text("CAMOFOX_URL=https://b.example\n")
+
+        monkeypatch.setattr(browser_tool, "_session_profile_homes", {}, raising=False)
+        monkeypatch.setattr(browser_tool, "_cleanup_failure_counts", {}, raising=False)
+        monkeypatch.setattr(browser_tool, "BROWSER_SESSION_INACTIVITY_TIMEOUT", 30)
+        monkeypatch.setattr(browser_tool.time, "time", lambda: 100.0)
+
+        secret_scope.set_multiplex_active(True)
+        try:
+            for task_id, profile_home in (
+                ("task-a", profile_a),
+                ("task-b", profile_b),
+            ):
+                home_token = set_hermes_home_override(str(profile_home))
+                scope_token = secret_scope.set_secret_scope(
+                    secret_scope.build_profile_secret_scope(profile_home)
+                )
+                try:
+                    browser_tool._update_session_activity(task_id)
+                    browser_tool._session_last_activity[task_id] = 0.0
+                finally:
+                    secret_scope.reset_secret_scope(scope_token)
+                    reset_hermes_home_override(home_token)
+
+            cleaned = []
+
+            def cleanup_in_owning_scope(task_id):
+                cleaned.append(
+                    (
+                        task_id,
+                        Path(browser_tool.get_hermes_home()),
+                        secret_scope.get_secret("CAMOFOX_URL"),
+                    )
+                )
+
+            monkeypatch.setattr(browser_tool, "cleanup_browser", cleanup_in_owning_scope)
+            browser_tool._cleanup_inactive_browser_sessions()
+        finally:
+            secret_scope.set_multiplex_active(False)
+
+        assert cleaned == [
+            ("task-a", profile_a, "https://a.example"),
+            ("task-b", profile_b, "https://b.example"),
+        ]
+        assert browser_tool._session_last_activity == {}
+
+    def test_inactivity_cleanup_force_reaps_after_three_failures(self, monkeypatch):
+        browser_tool = self.browser_tool
+        monkeypatch.setattr(browser_tool, "_session_profile_homes", {}, raising=False)
+        monkeypatch.setattr(browser_tool, "_cleanup_failure_counts", {}, raising=False)
+        monkeypatch.setattr(browser_tool, "BROWSER_SESSION_INACTIVITY_TIMEOUT", 30)
+        monkeypatch.setattr(browser_tool.time, "time", lambda: 100.0)
+        browser_tool._session_last_activity["task-1"] = 0.0
+
+        def fail_cleanup(_task_id):
+            raise RuntimeError("persistent teardown failure")
+
+        force_reaped = []
+
+        def force_reap(task_id):
+            force_reaped.append(task_id)
+            browser_tool._session_last_activity.pop(task_id, None)
+
+        monkeypatch.setattr(browser_tool, "cleanup_browser", fail_cleanup)
+        monkeypatch.setattr(
+            browser_tool, "_force_reap_browser_session", force_reap, raising=False
+        )
+
+        browser_tool._cleanup_inactive_browser_sessions()
+        browser_tool._cleanup_inactive_browser_sessions()
+        assert force_reaped == []
+        assert browser_tool._session_last_activity == {"task-1": 0.0}
+
+        browser_tool._cleanup_inactive_browser_sessions()
+
+        assert force_reaped == ["task-1"]
+        assert browser_tool._cleanup_failure_counts == {}
+
+    def test_session_activity_resets_cleanup_failure_budget(self, monkeypatch):
+        browser_tool = self.browser_tool
+        monkeypatch.setattr(browser_tool.time, "time", lambda: 200.0)
+        browser_tool._cleanup_failure_counts["task-1"] = 2
+
+        browser_tool._update_session_activity("task-1")
+
+        assert browser_tool._session_last_activity["task-1"] == 200.0
+        assert "task-1" not in browser_tool._cleanup_failure_counts

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1644,6 +1644,12 @@ BROWSER_SESSION_INACTIVITY_TIMEOUT = _get_session_inactivity_timeout()
 
 # Track last activity time per session
 _session_last_activity: Dict[str, float] = {}
+# Non-secret profile identity used to rebuild the owning scope in the
+# process-global inactivity janitor.  Capturing the janitor thread's context
+# would pin whichever profile happened to start it first.
+_session_profile_homes: Dict[str, str] = {}
+_cleanup_failure_counts: Dict[str, int] = {}
+MAX_INACTIVITY_CLEANUP_FAILURES = 3
 
 # Background cleanup thread state
 _cleanup_thread = None
@@ -1716,6 +1722,8 @@ def _emergency_cleanup_all_sessions():
             with _cleanup_lock:
                 _active_sessions.clear()
                 _session_last_activity.clear()
+                _session_profile_homes.clear()
+                _cleanup_failure_counts.clear()
                 _recording_sessions.clear()
 
     # Sweep orphans from other crashed hermes processes.  Safe even if we
@@ -1760,12 +1768,68 @@ def _cleanup_inactive_browser_sessions():
         try:
             elapsed = int(current_time - _session_last_activity.get(task_id, current_time))
             logger.info("Cleaning up inactive session for task: %s (inactive for %ss)", task_id, elapsed)
-            cleanup_browser(task_id)
             with _cleanup_lock:
-                if task_id in _session_last_activity:
-                    del _session_last_activity[task_id]
+                profile_home = _session_profile_homes.get(task_id)
+
+            if profile_home is None:
+                cleanup_browser(task_id)
+            else:
+                from agent.secret_scope import (
+                    build_profile_secret_scope,
+                    reset_secret_scope,
+                    set_secret_scope,
+                )
+                from hermes_constants import (
+                    reset_hermes_home_override,
+                    set_hermes_home_override,
+                )
+                from hermes_cli.env_loader import hydrate_profile_secret_sources
+
+                home_token = set_hermes_home_override(profile_home)
+                try:
+                    hydrate_profile_secret_sources(profile_home)
+                    scope_token = set_secret_scope(
+                        build_profile_secret_scope(Path(profile_home))
+                    )
+                    try:
+                        cleanup_browser(task_id)
+                    finally:
+                        reset_secret_scope(scope_token)
+                finally:
+                    reset_hermes_home_override(home_token)
+
+            with _cleanup_lock:
+                _session_last_activity.pop(task_id, None)
+                _session_profile_homes.pop(task_id, None)
+                _cleanup_failure_counts.pop(task_id, None)
         except Exception as e:
-            logger.warning("Error cleaning up inactive session %s: %s", task_id, e)
+            with _cleanup_lock:
+                failures = _cleanup_failure_counts.get(task_id, 0) + 1
+                _cleanup_failure_counts[task_id] = failures
+            if failures < MAX_INACTIVITY_CLEANUP_FAILURES:
+                logger.warning(
+                    "Error cleaning up inactive session %s (attempt %d/%d): %s",
+                    task_id,
+                    failures,
+                    MAX_INACTIVITY_CLEANUP_FAILURES,
+                    e,
+                )
+                continue
+
+            logger.error(
+                "Browser cleanup failed %d times for inactive session %s; "
+                "force-reaping its tracked local daemon: %s",
+                failures,
+                task_id,
+                e,
+            )
+            try:
+                _force_reap_browser_session(task_id)
+            finally:
+                with _cleanup_lock:
+                    _session_last_activity.pop(task_id, None)
+                    _session_profile_homes.pop(task_id, None)
+                    _cleanup_failure_counts.pop(task_id, None)
 
 
 def _write_owner_pid(socket_dir: str, session_name: str) -> None:
@@ -2052,6 +2116,8 @@ def _update_session_activity(task_id: str):
     """Update the last activity timestamp for a session."""
     with _cleanup_lock:
         _session_last_activity[task_id] = time.time()
+        _session_profile_homes.setdefault(task_id, str(get_hermes_home()))
+        _cleanup_failure_counts.pop(task_id, None)
 
 
 # Register cleanup thread stop on exit
@@ -4795,6 +4861,69 @@ def _cleanup_old_recordings(max_age_hours=72):
 # Cleanup and Management Functions
 # ============================================================================
 
+def _reap_tracked_browser_daemon(session_info: Dict[str, Any]) -> None:
+    """Kill the local daemon represented by trusted in-memory session state."""
+    session_name = session_info.get("session_name", "")
+    if not session_name:
+        return
+
+    socket_dir = os.path.join(
+        _socket_safe_tmpdir(), f"agent-browser-{session_name}"
+    )
+    if not os.path.exists(socket_dir):
+        return
+
+    pid_file = os.path.join(socket_dir, f"{session_name}.pid")
+    if os.path.isfile(pid_file):
+        try:
+            from tools.process_registry import ProcessRegistry
+
+            daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
+            ProcessRegistry._terminate_host_pid(daemon_pid)
+            logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
+        except (ProcessLookupError, ValueError, PermissionError, OSError):
+            logger.debug(
+                "Could not kill daemon pid for %s (already dead or inaccessible)",
+                session_name,
+            )
+    shutil.rmtree(socket_dir, ignore_errors=True)
+
+
+def _force_reap_browser_session(task_id: str) -> None:
+    """Best-effort local teardown after repeated normal cleanup failures."""
+    if _is_local_sidecar_key(task_id):
+        session_keys = [task_id]
+        bare_task_id = task_id[: -len(_LOCAL_SUFFIX)]
+    else:
+        bare_task_id = task_id
+        session_keys = [task_id, f"{task_id}{_LOCAL_SUFFIX}"]
+
+    with _cleanup_lock:
+        tracked = [
+            (session_key, _active_sessions.pop(session_key, None))
+            for session_key in session_keys
+        ]
+        for session_key in session_keys:
+            _session_last_activity.pop(session_key, None)
+            _session_profile_homes.pop(session_key, None)
+            _cleanup_failure_counts.pop(session_key, None)
+            _recording_sessions.discard(session_key)
+
+    for session_key, session_info in tracked:
+        try:
+            _stop_cdp_supervisor(session_key)
+        except Exception as exc:
+            logger.debug(
+                "Could not stop CDP supervisor during force-reap for %s: %s",
+                session_key,
+                exc,
+            )
+        if session_info:
+            _reap_tracked_browser_daemon(session_info)
+
+    _last_active_session_key.pop(bare_task_id, None)
+
+
 def cleanup_browser(task_id: Optional[str] = None) -> None:
     """
     Clean up browser session(s) for a task.
@@ -4896,6 +5025,8 @@ def _cleanup_single_browser_session(task_id: str) -> None:
         with _cleanup_lock:
             _active_sessions.pop(task_id, None)
             _session_last_activity.pop(task_id, None)
+            _session_profile_homes.pop(task_id, None)
+            _cleanup_failure_counts.pop(task_id, None)
 
         # Cloud mode: close the cloud browser session via provider API.
         # Local sidecars have bb_session_id=None so this no-ops for them.
@@ -4907,22 +5038,8 @@ def _cleanup_single_browser_session(task_id: str) -> None:
                 except Exception as e:
                     logger.warning("Could not close cloud browser session: %s", e)
 
-        # Kill the daemon process and clean up socket directory
-        session_name = session_info.get("session_name", "")
-        if session_name:
-            socket_dir = os.path.join(_socket_safe_tmpdir(), f"agent-browser-{session_name}")
-            if os.path.exists(socket_dir):
-                # agent-browser writes {session}.pid in the socket dir
-                pid_file = os.path.join(socket_dir, f"{session_name}.pid")
-                if os.path.isfile(pid_file):
-                    try:
-                        from tools.process_registry import ProcessRegistry
-                        daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
-                        ProcessRegistry._terminate_host_pid(daemon_pid)
-                        logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
-                    except (ProcessLookupError, ValueError, PermissionError, OSError):
-                        logger.debug("Could not kill daemon pid for %s (already dead or inaccessible)", session_name)
-                shutil.rmtree(socket_dir, ignore_errors=True)
+        # Kill the daemon process and clean up socket directory.
+        _reap_tracked_browser_daemon(session_info)
 
         logger.debug("Removed task %s from active sessions", task_id)
     else:


### PR DESCRIPTION
## What does this PR do?

Idle browser sessions in multiplexed gateways can now be reclaimed without losing the owning profile's secret scope. This prevents the inactivity janitor from retrying the same failed cleanup forever while its local Chromium daemon remains alive, and bounds unrelated persistent teardown failures to three attempts before a trusted tracked daemon is force-reaped.

### Symptom

With `gateway.multiplex_profiles: true`, the browser inactivity janitor calls cleanup from a process-global thread with no profile secret scope. Cleanup raises `UnscopedSecretError` while resolving browser credentials, leaves the session tracked, and retries it every 30 seconds.

### Impact

Affected multiplexed gateways can retain one Chromium process per stuck browser session for the gateway's remaining lifetime. Issue #86402 reports 8 stuck sessions and 79 repeated errors over 14 days, with leaked Chromium processes consuming 57 MiB to 646 MiB each.

### Bug Cause

**Trigger:** `tools/browser_tool.py` / `_cleanup_inactive_browser_sessions()` / an idle tracked session in a multiplexed gateway

**Causal chain:**
1. A browser session outlives its turn and exceeds the configured inactivity timeout.
2. The process-global janitor calls `cleanup_browser()` without the owning profile's `ContextVar` secret scope.
3. Browser credential lookup fails closed with `UnscopedSecretError`, so cleanup does not remove tracking or terminate the local daemon.
4. The same session is retried on every janitor pass.

**Why it is wrong:** The janitor serves every profile, so it cannot safely inherit the first profile's context. It also had no bounded fallback for persistent teardown failures.

**Working sibling / contrast:** Foreground gateway work runs inside the selected profile's runtime scope, so its browser credential lookup uses that profile's current `HERMES_HOME` and secrets.

**Ruled out:** Copying the janitor thread's starting context was rejected because the process-global thread would then reuse the first browser-opening profile's secrets while cleaning other profiles' sessions.

### Fix

Record each browser session's non-secret profile-home identity when activity is updated. During idle cleanup, rebuild that profile's current `HERMES_HOME` and secret scope only around the owning session's teardown, then reset both contexts. Track consecutive cleanup failures per session; after three failures, stop its CDP supervisor, force-reap only the trusted in-memory local daemon, and clear all related tracking state.

## Related Issue

Closes #86402

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_tool.py` - retain per-session profile identity, restore the owning scope for idle teardown, and bound persistent cleanup retries with trusted local force-reaping.
- `tests/tools/test_browser_cleanup.py` - cover two-profile scope isolation, retry exhaustion, failure-budget reset, and cleanup-state removal.

## How to Test

1. Run the focused inactivity-cleanup regression to verify that two multiplexed sessions resolve different profile secrets from the scope-less janitor path.
2. Run the browser cleanup test file to verify profile restoration, force-reaping after three failures, and tracking-state cleanup.
3. Run the related browser, secret-scope, hybrid-routing, and multiplex API-server tests.

```bash
scripts/run_tests.sh tests/tools/test_browser_cleanup.py -v
```

Verified locally: 65 related tests passed; the focused browser cleanup file passed all 7 tests. Phase B independently reran the owning-profile regression and the full cleanup test file at commit `c72323364`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for this bug fix
- [x] I've tested on my platform: Windows 10, Python 3.11.15

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - no user-facing configuration or workflow changed
- [x] `cli-config.yaml.example` update: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow contract changed
- [x] Cross-platform impact considered: the scope bookkeeping and cleanup logic are host-independent; local daemon termination continues through `ProcessRegistry`
- [x] Tool descriptions/schemas update: N/A - no browser tool schema changed

## Screenshots / Logs

N/A - this is a background lifecycle fix covered by deterministic regression tests.
