### PR TITLE
feat(discord): command guild-scope + installation-context normalization

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience I2

--- a/plugins/platforms/discord/command_scope.py
+++ b/plugins/platforms/discord/command_scope.py
@@ -1,0 +1,103 @@
+"""Discord command guild-scope + installation-context normalization.
+
+Pure logic module (no Discord API dependency) used to decide a slash
+command's guild scope and integration (installation) context.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Discord snowflakes are unsigned 63-bit integers in [1, 2**63 - 1].
+MAX_SNOWFLAKE = (1 << 63) - 1
+
+# Discord integration types (ApplicationIntegrationType):
+#   0 = GUILD_INSTALL, 1 = USER_INSTALL
+GUILD_INSTALL = 0
+USER_INSTALL = 1
+
+
+class CommandScopeError(ValueError):
+    """Raised when a command scope value is invalid."""
+
+
+@dataclass
+class CommandScope:
+    """Resolved scope for a Discord command.
+
+    ``guild_id`` is the snowflake the command is restricted to (``None``
+    means no guild restriction). ``integration_types`` is the normalized
+    list of installation contexts the command is available in.
+    """
+
+    guild_id: str | None
+    integration_types: list[int]
+
+
+def _is_snowflake(value: str) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    # ASCII-only digit check: str.isdigit() accepts non-ASCII digits
+    # (e.g. Arabic-Indic "١٢٣") and superscripts such as "²", which int()
+    # cannot parse or would parse as values Discord never uses.
+    if not (value.isascii() and value.isdigit()):
+        return False
+    return 1 <= int(value) <= MAX_SNOWFLAKE
+
+
+def _validate_snowflake(value: str, label: str) -> None:
+    if not _is_snowflake(value):
+        raise CommandScopeError(
+            f"{label} must be a Discord snowflake "
+            f"(string of digits in 1..{MAX_SNOWFLAKE}), got {value!r}"
+        )
+
+
+def resolve_guild_scope(
+    config_guild: str | None, *, default_guild: str | None = None
+) -> str | None:
+    """Resolve the guild a command should be scoped to.
+
+    ``config_guild`` wins when provided; otherwise ``default_guild`` is
+    used; otherwise the command is not guild-scoped (``None``). Any
+    provided value that is not a valid Discord snowflake raises
+    :class:`CommandScopeError`.
+    """
+    if config_guild is not None:
+        _validate_snowflake(config_guild, "config_guild")
+        return config_guild
+    if default_guild is not None:
+        _validate_snowflake(default_guild, "default_guild")
+        return default_guild
+    return None
+
+
+def normalize_integration_types(types: list | None) -> list[int]:
+    """Normalize a raw integration-types list to valid Discord values.
+
+    ``None`` or an empty list maps to ``[0]`` (GUILD_INSTALL). Only
+    ``0`` (guild install) and ``1`` (user install) are accepted; any
+    other value raises :class:`CommandScopeError`. Duplicates are removed
+    preserving first-seen order.
+    """
+    if types is None:
+        return [GUILD_INSTALL]
+    normalized: list[int] = []
+    for raw in types:
+        if (
+            isinstance(raw, bool)
+            or not isinstance(raw, int)
+            or raw not in (GUILD_INSTALL, USER_INSTALL)
+        ):
+            raise CommandScopeError(
+                "integration type must be 0 (guild install) or 1 (user install), "
+                f"got {raw!r}"
+            )
+        if raw not in normalized:
+            normalized.append(raw)
+    return normalized or [GUILD_INSTALL]
+
+
+def is_guild_scoped(scope: CommandScope) -> bool:
+    """True when the scope is guild-install only (integration_types == [0])."""
+    return scope.integration_types == [GUILD_INSTALL]

--- a/tests/tools/test_discord_command_scope.py
+++ b/tests/tools/test_discord_command_scope.py
@@ -1,0 +1,93 @@
+"""Tests for plugins.platforms.discord.command_scope (feature I2).
+
+Covers: guild scope resolution (config wins, default fallback, None),
+snowflake validation, integration-types default [0], dedupe, rejection
+of non-0/1 values, and is_guild_scoped.
+"""
+
+import pytest
+
+from plugins.platforms.discord.command_scope import (
+    CommandScope,
+    CommandScopeError,
+    is_guild_scoped,
+    normalize_integration_types,
+    resolve_guild_scope,
+)
+
+
+class TestResolveGuildScope:
+    def test_config_guild_wins_over_default(self):
+        assert (
+            resolve_guild_scope("123456789012345678", default_guild="999999999")
+            == "123456789012345678"
+        )
+
+    def test_default_fallback_when_config_none(self):
+        assert (
+            resolve_guild_scope(None, default_guild="123456789012345678")
+            == "123456789012345678"
+        )
+
+    def test_none_when_nothing_provided(self):
+        assert resolve_guild_scope(None) is None
+        assert resolve_guild_scope(None, default_guild=None) is None
+
+    def test_invalid_config_guild_raises(self):
+        for bad in ("abc", "", "-1", "0", "12.5", "123 456", "١٢٣", "²", "+5"):
+            with pytest.raises(CommandScopeError):
+                resolve_guild_scope(bad)
+
+    def test_invalid_default_guild_raises(self):
+        with pytest.raises(CommandScopeError):
+            resolve_guild_scope(None, default_guild="not-a-snowflake")
+
+    def test_error_is_value_error_subclass(self):
+        with pytest.raises(ValueError):
+            resolve_guild_scope("not-a-snowflake")
+
+    def test_snowflake_boundaries(self):
+        assert resolve_guild_scope("1") == "1"
+        assert resolve_guild_scope("9223372036854775807") == "9223372036854775807"
+        with pytest.raises(CommandScopeError):
+            resolve_guild_scope("9223372036854775808")  # 2**63, out of range
+
+
+class TestNormalizeIntegrationTypes:
+    def test_defaults_to_guild_install(self):
+        assert normalize_integration_types(None) == [0]
+        assert normalize_integration_types([]) == [0]
+
+    def test_keeps_valid_values(self):
+        assert normalize_integration_types([0]) == [0]
+        assert normalize_integration_types([1]) == [1]
+        assert normalize_integration_types([0, 1]) == [0, 1]
+        assert normalize_integration_types([1, 0]) == [1, 0]
+
+    def test_dedupes_preserving_first_seen_order(self):
+        assert normalize_integration_types([0, 0, 1, 0, 1]) == [0, 1]
+        assert normalize_integration_types([1, 1, 0]) == [1, 0]
+
+    def test_rejects_non_0_1_values(self):
+        for bad in ([2], [-1], [0, 2], [1, 99], ["0"], [True], [False], [None], ["1"]):
+            with pytest.raises(CommandScopeError):
+                normalize_integration_types(bad)
+
+    def test_error_is_value_error_subclass(self):
+        with pytest.raises(ValueError):
+            normalize_integration_types([7])
+
+
+class TestIsGuildScoped:
+    def test_guild_install_only_is_guild_scoped(self):
+        assert is_guild_scoped(CommandScope(guild_id=None, integration_types=[0])) is True
+
+    def test_guild_id_does_not_change_result(self):
+        assert is_guild_scoped(CommandScope(guild_id="123456", integration_types=[0])) is True
+
+    def test_user_install_included_is_not_guild_scoped(self):
+        assert is_guild_scoped(CommandScope(guild_id=None, integration_types=[0, 1])) is False
+        assert is_guild_scoped(CommandScope(guild_id=None, integration_types=[1])) is False
+
+    def test_empty_integration_types_is_not_guild_scoped(self):
+        assert is_guild_scoped(CommandScope(guild_id=None, integration_types=[])) is False


### PR DESCRIPTION
**Discord I2** (Part of #79564, Fixes #86474): command scope + installation-context normalization in `plugins/platforms/discord/command_scope.py`. 16/16 tests pass. New module only.