### PR TITLE
fix(kanban): coerce workspace_kind=dir with no path to scratch on decompose

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7307,8 +7307,7 @@ def decompose_triage_task(
             # branch above then propagates None into every child.
             # Fall back to 'scratch' rather than writing a row that is
             # guaranteed to fail on dispatch and trip the circuit
-            # breaker after `failure_threshold` retries. See #<PR> for
-            # the incident that surfaced this.
+            # breaker after `failure_threshold` retries.
             if child_ws_kind == "dir" and not child_ws_path:
                 child_ws_kind = "scratch"
                 child_ws_path = None

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7298,6 +7298,20 @@ def decompose_triage_task(
                 child_ws_path = root_ws_path
             else:
                 child_ws_path = None
+            # `workspace_kind='dir'` REQUIRES an explicit path — the
+            # dispatcher refuses to spawn a worker for a dir-mode task
+            # with no path and marks it `spawn_failed`. This happens
+            # whenever the root task itself has kind='dir' with no path
+            # (common for user-created triage cards created via the
+            # dashboard "Add task" button), because the inheritance
+            # branch above then propagates None into every child.
+            # Fall back to 'scratch' rather than writing a row that is
+            # guaranteed to fail on dispatch and trip the circuit
+            # breaker after `failure_threshold` retries. See #<PR> for
+            # the incident that surfaced this.
+            if child_ws_kind == "dir" and not child_ws_path:
+                child_ws_kind = "scratch"
+                child_ws_path = None
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "


### PR DESCRIPTION
## Summary

`decompose_triage_task` in `hermes_cli/kanban_db.py` (the DB helper called by both `kanban decompose` and the dashboard "Decompose" action) can create child rows with `workspace_kind='dir'` and `workspace_path=NULL`. The dispatcher refuses to spawn a worker for such rows and marks them `spawn_failed`; after `failure_threshold` retries the circuit breaker trips and the card is stuck in a `Block → Unblock → spawn_failed → gave_up` loop that the dashboard **Unblock** button cannot escape (it only flips status, not the malformed workspace columns).

The reproducer is trivial and hits users routinely:

1. Create a triage task via the dashboard "Add task" button (the resulting row has `workspace_kind='dir'` with no path — the UI does not force a path here).
2. Click **Decompose**.
3. Every child row inherits `workspace_kind='dir'` with `workspace_path=NULL` from the root and immediately begins failing.

This is not a rare edge case. It fires every time a user decomposes a triage task they created interactively without setting an explicit workspace path — which is the common path in practice, since the UI's default kind is `dir`. My board just accumulated 11 broken cards across 3 unrelated decompositions before I traced the pattern.

## Root cause

Inside the workspace-inheritance block in `decompose_triage_task` (post-fix line numbers ~7295-7314 on `main`):

```python
child_ws_kind = child.get("workspace_kind") or root_ws_kind
if child.get("workspace_path"):
    child_ws_path = child.get("workspace_path")
elif child_ws_kind == "worktree":
    # ...safe: dispatch materializes a per-child worktree from the anchor.
    child_ws_path = None
elif child_ws_kind == root_ws_kind:
    child_ws_path = root_ws_path        # <-- propagates the root's None here
else:
    child_ws_path = None
```

The `worktree` branch has an explicit safety comment because the dispatcher knows how to materialize a worktree from the board anchor when the path is `None`. The `dir` case has no such fallback: the dispatcher requires a real path for `kind='dir'` and refuses the spawn. So when `root_ws_kind == 'dir'` and `root_ws_path is None` (the "Add task" default in the UI), every child inherits the same malformed state.

Diagnostic surfaced by `hermes kanban diag` / `hermes kanban show <id>`:

```
workspace: task t_XXXXXXXX has workspace_kind=dir but no workspace_path
```

## Fix

Add a defensive coercion right before the `INSERT`: when the resolved `child_ws_kind == 'dir'` but no path could be established (neither explicit on the child nor inherited from the root), fall back to `workspace_kind='scratch'` (an auto-managed temp dir) rather than write a row that is guaranteed to fail on dispatch.

Explicit paths supplied by the child dict are still honoured — the coercion only fires when the code was about to write `('dir', NULL)`. `scratch` is the same fallback the module already uses on line ~7261 (`root_ws_kind = root_row["workspace_kind"] or "scratch"`), so this preserves the module's existing "when in doubt, use scratch" invariant.

Alternative considered: raise a `ValueError` from `decompose_triage_task` when the root row itself has `('dir', NULL)`, forcing the caller to supply a path. That would push the failure to a nicer location (before any children are written), but it also breaks decompose-from-dashboard entirely for the most common triage-task shape, and the dashboard has no UI to recover from the error. Silent coercion to `scratch` is the graceful path and matches the intent of the existing `worktree` safety branch immediately above.

## Test plan

- [x] Manual: applied the patch to a running deployment, re-decomposed a triage task with `workspace_kind='dir'` / `workspace_path=NULL`, verified all children are created with `workspace_kind='scratch'` / `workspace_path=NULL` and dispatch cleanly (`hermes kanban show <id>` reports `workspace: scratch` and no `spawn_failed` events).
- [ ] Unit test — happy to add one if the maintainers point me at the preferred harness for `kanban_db` tests.

## User-side cleanup (for anyone who lands here from a search)

If you already have stuck cards from this bug, patching the code is not enough — the malformed rows already exist in your `kanban.db`. Direct SQL is the only durable repair (there is no `hermes kanban set-workspace` command):

```python
import sqlite3
conn = sqlite3.connect("/opt/data/kanban.db")   # or wherever your board lives
cur = conn.cursor()
cur.execute("""
    UPDATE tasks
       SET workspace_kind = 'scratch',
           workspace_path = NULL,
           consecutive_failures = 0,
           last_failure_error = NULL
     WHERE workspace_kind = 'dir'
       AND (workspace_path IS NULL OR workspace_path = '')
""")
conn.commit()
```

Then `hermes kanban unblock <id> [<id> ...]` on any card that was already `blocked` so the CLI logs the correct transition event.
