### PR TITLE
fix(desktop): cold start no longer hides Cloud agents until Portal re-login

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -21,6 +21,7 @@ import {
   buildGatewayWsUrlWithTicket,
   connectionScopeKey,
   cookiesHaveLiveSession,
+  cookiesHavePrivyAccessToken,
   cookiesHavePrivySession,
   cookiesHaveSession,
   gatewayTicketFailure,
@@ -569,6 +570,42 @@ test('cookiesHavePrivySession is false for unrelated cookies and non-arrays', ()
   assert.equal(cookiesHavePrivySession(null), false)
   assert.equal(cookiesHavePrivySession(undefined), false)
   assert.equal(cookiesHavePrivySession([]), false)
+})
+
+test('cookiesHavePrivySession treats refresh-token material as a (renewable) session', () => {
+  // #73495: after a restart the ~1h `privy-token` is often gone while the
+  // 30-day renewal cookies survive. That jar is still SIGNED IN (renewable),
+  // so the session check must accept it — the access check below is what
+  // distinguishes "can discovery succeed right now".
+  assert.equal(cookiesHavePrivySession([{ name: 'privy-refresh-token', value: 'x' }]), true)
+})
+
+// --- cookiesHavePrivyAccessToken (short-lived access state for /api/agents) ---
+
+test('cookiesHavePrivyAccessToken detects privy-token and its secured prefixes', () => {
+  assert.equal(cookiesHavePrivyAccessToken([{ name: 'privy-token', value: 'jwt' }]), true)
+  assert.equal(cookiesHavePrivyAccessToken([{ name: '__Host-privy-token', value: 'x' }]), true)
+  assert.equal(cookiesHavePrivyAccessToken([{ name: '__Secure-privy-token', value: 'x' }]), true)
+})
+
+test('cookiesHavePrivyAccessToken rejects renewal-only jars (the #73495 cold-start state)', () => {
+  // Session/refresh material present, access token absent: signed in but
+  // discovery would 401 → the silent-renewal path must trigger, not re-login.
+  const renewalOnly = [
+    { name: 'privy-session', value: 'x' },
+    { name: 'privy-refresh-token', value: 'x' }
+  ]
+
+  assert.equal(cookiesHavePrivySession(renewalOnly), true)
+  assert.equal(cookiesHavePrivyAccessToken(renewalOnly), false)
+})
+
+test('cookiesHavePrivyAccessToken is false for empty values, gateway cookies, and non-arrays', () => {
+  assert.equal(cookiesHavePrivyAccessToken([{ name: 'privy-token', value: '' }]), false)
+  assert.equal(cookiesHavePrivyAccessToken([{ name: 'hermes_session_at', value: 'x' }]), false)
+  assert.equal(cookiesHavePrivyAccessToken(null), false)
+  assert.equal(cookiesHavePrivyAccessToken(undefined), false)
+  assert.equal(cookiesHavePrivyAccessToken([]), false)
 })
 
 // --- tokenPreview ---

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -44,7 +44,21 @@ const RT_COOKIE_VARIANTS = ['__Host-hermes_session_rt', '__Secure-hermes_session
 // sign-in / discovery liveness must look for the Privy cookie, NOT the gateway
 // cookies above. `privy-token` is the access token (the required signal);
 // variants cover the secured-prefix forms and the older `privy-session` name.
-const PRIVY_SESSION_COOKIE_VARIANTS = ['__Host-privy-token', '__Secure-privy-token', 'privy-token', 'privy-session']
+const PRIVY_SESSION_COOKIE_VARIANTS = [
+  '__Host-privy-token',
+  '__Secure-privy-token',
+  'privy-token',
+  'privy-session',
+  'privy-refresh-token'
+]
+
+// The short-lived Privy ACCESS token only — the credential `/api/agents`
+// actually validates. `privy-session` / `privy-refresh-token` are long-lived
+// renewal material: their presence means the session is RENEWABLE (signed in,
+// no interactive login needed), but discovery still 401s until a fresh
+// `privy-token` is minted. Distinguishing the two is what lets a cold start
+// silently renew instead of demanding a re-login (#73495).
+const PRIVY_ACCESS_COOKIE_VARIANTS = ['__Host-privy-token', '__Secure-privy-token', 'privy-token']
 // Keep this aligned with hermes_cli.profiles.validate_profile_name(). `default`
 // is the built-in root alias; these names cannot be created as profiles.
 const RESERVED_REMOTE_PROFILES = new Set(['hermes', 'test', 'tmp', 'root', 'sudo'])
@@ -557,6 +571,22 @@ function cookiesHavePrivySession(cookies) {
   return cookies.some(c => c && c.value && PRIVY_SESSION_COOKIE_VARIANTS.includes(c.name))
 }
 
+/**
+ * True only when the short-lived Privy ACCESS token (`privy-token`) is present
+ * — the exact cookie `/api/agents` validates. A jar can satisfy
+ * `cookiesHavePrivySession` (renewable session: `privy-session` /
+ * `privy-refresh-token`) while failing this check; that gap is the cold-start
+ * "Signed in" + "No agents found" contradiction, and the signal that a silent
+ * renewal (not an interactive re-login) is the right recovery (#73495).
+ */
+function cookiesHavePrivyAccessToken(cookies) {
+  if (!Array.isArray(cookies)) {
+    return false
+  }
+
+  return cookies.some(c => c && c.value && PRIVY_ACCESS_COOKIE_VARIANTS.includes(c.name))
+}
+
 export {
   AT_COOKIE_VARIANTS,
   authModeFromStatus,
@@ -564,6 +594,7 @@ export {
   buildGatewayWsUrlWithTicket,
   connectionScopeKey,
   cookiesHaveLiveSession,
+  cookiesHavePrivyAccessToken,
   cookiesHavePrivySession,
   cookiesHaveSession,
   gatewayTicketFailure,
@@ -576,6 +607,7 @@ export {
   normalizeSshConfig,
   normAuthMode,
   pathWithGlobalRemoteProfile,
+  PRIVY_ACCESS_COOKIE_VARIANTS,
   PRIVY_SESSION_COOKIE_VARIANTS,
   profileHasRemoteConnection,
   profileRemoteOverride,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -61,6 +61,7 @@ import {
   buildGatewayWsUrlWithTicket,
   connectionScopeKey,
   cookiesHaveLiveSession,
+  cookiesHavePrivyAccessToken,
   cookiesHavePrivySession,
   cookiesHaveSession,
   gatewayTicketFailure,
@@ -6510,7 +6511,61 @@ function resolvePortalBaseUrl() {
 // checks for the `privy-token` cookie on the portal host (NOT
 // hasLiveOauthSession, which looks for hermes_session_at/rt that the portal
 // never sets). See connection-config.ts cookiesHavePrivySession.
+//
+// Mirrors hasLiveOauthSession's cold-start guard (#73495): a `persist:`
+// partition's cookie store hydrates lazily, so the FIRST read on a fresh boot
+// can come back empty even for a signed-in user. The renderer checks Cloud
+// status exactly once on entering cloud mode, so a single false-negative here
+// used to clear the discovered agent list and demand a re-login that a plain
+// retry would have avoided. Warm the store and re-read with a short backoff
+// before trusting a negative.
 async function hasLivePortalSession() {
+  const sess = getOauthSession()
+
+  if (!sess) {
+    return false
+  }
+
+  const portalBaseUrl = resolvePortalBaseUrl()
+  const parsed = new URL(portalBaseUrl)
+
+  const readPortal = async () => {
+    try {
+      const cookies = await sess.cookies.get({ url: portalBaseUrl })
+
+      return cookiesHavePrivySession(cookies)
+    } catch {
+      try {
+        const cookies = await sess.cookies.get({ domain: parsed.hostname })
+
+        return cookiesHavePrivySession(cookies)
+      } catch {
+        return false
+      }
+    }
+  }
+
+  if (await readPortal()) {
+    return true
+  }
+
+  await warmOauthCookieStore()
+
+  for (const delayMs of [30, 60, 90]) {
+    if (await readPortal()) {
+      return true
+    }
+
+    await new Promise(resolve => setTimeout(resolve, delayMs))
+  }
+
+  return readPortal()
+}
+
+// Whether the jar holds the short-lived Privy ACCESS token — the exact cookie
+// `/api/agents` validates. hasLivePortalSession() answers "signed in at all?"
+// (renewal material counts); this answers "can discovery succeed right now?".
+async function hasPortalAccessToken() {
   const sess = getOauthSession()
 
   if (!sess) {
@@ -6523,16 +6578,145 @@ async function hasLivePortalSession() {
   try {
     const cookies = await sess.cookies.get({ url: portalBaseUrl })
 
-    return cookiesHavePrivySession(cookies)
+    return cookiesHavePrivyAccessToken(cookies)
   } catch {
     try {
       const cookies = await sess.cookies.get({ domain: parsed.hostname })
 
-      return cookiesHavePrivySession(cookies)
+      return cookiesHavePrivyAccessToken(cookies)
     } catch {
       return false
     }
   }
+}
+
+// Bounded silent renewal of the short-lived Privy access token (#73495).
+//
+// After a Desktop restart the long-lived `privy-session` / `privy-refresh-token`
+// cookies routinely survive while the ~1h `privy-token` access cookie has
+// expired. Discovery then 401s and the only offered recovery used to be a full
+// interactive re-login — even though the persisted refresh material can mint a
+// fresh access token with no user action: loading any portal page runs the
+// Privy client, which rotates a new `privy-token` from the refresh session.
+//
+// This drives exactly that, headlessly: a hidden window on the portal root in
+// the OAuth partition, polled until the access cookie lands, torn down on a
+// bounded timeout. Never shown — if renewal can't complete silently the caller
+// falls back to the interactive needsCloudLogin path. The in-flight promise is
+// shared so concurrent discovery + cascade calls ride one renewal.
+let portalAccessRenewal: Promise<boolean> | null = null
+
+function renewPortalAccessSilently() {
+  if (portalAccessRenewal) {
+    return portalAccessRenewal
+  }
+
+  portalAccessRenewal = (async () => {
+    if (!app.isReady()) {
+      return false
+    }
+
+    const sess = getOauthSession()
+
+    if (!sess) {
+      return false
+    }
+
+    // No renewal material at all → nothing to renew; interactive login is
+    // genuinely required.
+    if (!(await hasLivePortalSession())) {
+      return false
+    }
+
+    if (await hasPortalAccessToken()) {
+      return true
+    }
+
+    const portalBaseUrl = resolvePortalBaseUrl()
+
+    return await new Promise<boolean>(resolve => {
+      let settled = false
+      let win = null
+      let pollTimer = null
+      let deadlineTimer = null
+
+      const finish = (ok: boolean) => {
+        if (settled) {
+          return
+        }
+
+        settled = true
+
+        if (pollTimer) {
+          clearInterval(pollTimer)
+        }
+
+        if (deadlineTimer) {
+          clearTimeout(deadlineTimer)
+        }
+
+        try {
+          if (win && !win.isDestroyed()) {
+            win.destroy()
+          }
+        } catch {
+          // window already torn down
+        }
+
+        rememberLog(`[cloud] silent portal access renewal ${ok ? 'succeeded' : 'did not complete'}`)
+        resolve(ok)
+      }
+
+      const checkCookie = async () => {
+        if (settled) {
+          return
+        }
+
+        if (await hasPortalAccessToken()) {
+          finish(true)
+        }
+      }
+
+      try {
+        win = new BrowserWindow({
+          width: 520,
+          height: 720,
+          show: false,
+          title: 'Renewing Hermes Cloud session…',
+          autoHideMenuBar: true,
+          webPreferences: {
+            contextIsolation: true,
+            nodeIntegration: false,
+            sandbox: true,
+            session: sess,
+            webSecurity: true
+          }
+        })
+      } catch {
+        finish(false)
+
+        return
+      }
+
+      win.webContents.on('did-navigate', () => void checkCookie())
+      win.webContents.on('did-redirect-navigation', () => void checkCookie())
+      win.webContents.on('did-frame-navigate', () => void checkCookie())
+      installWindowRendererLifecycle(win, { kind: 'portal-renew', callbacks: { log: rememberLog } })
+      pollTimer = setInterval(() => void checkCookie(), 500)
+      // Hard deadline: this window is never revealed, so an unrenewable session
+      // (revoked refresh token, portal down) must resolve false rather than
+      // hang the discovery call behind an invisible window.
+      deadlineTimer = setTimeout(() => finish(false), 12_000)
+
+      win.on('closed', () => finish(false))
+
+      win.loadURL(portalBaseUrl).catch(() => finish(false))
+    })
+  })().finally(() => {
+    portalAccessRenewal = null
+  }) as Promise<boolean>
+
+  return portalAccessRenewal
 }
 
 // Drive a one-time interactive portal sign-in in the OAuth partition. Unlike
@@ -6663,37 +6847,65 @@ async function discoverCloudAgents(org?: string) {
     throw err
   }
 
+  // Renewable session present but the short-lived access token `/api/agents`
+  // validates is gone (typical after a restart — `privy-token` is ~1h,
+  // `privy-session`/`privy-refresh-token` last ~30 days). Renew silently up
+  // front instead of letting the request 401 into a re-login demand (#73495).
+  if (!(await hasPortalAccessToken())) {
+    await renewPortalAccessSilently()
+  }
+
   const orgQuery = org ? `?org=${encodeURIComponent(org)}` : ''
   let body
 
-  try {
-    body = (await fetchJsonViaOauthSession(`${portalBaseUrl}/api/agents${orgQuery}`, {
+  const fetchAgents = () =>
+    fetchJsonViaOauthSession(`${portalBaseUrl}/api/agents${orgQuery}`, {
       method: 'GET',
       timeoutMs: 15_000
-    })) as any
-  } catch (error) {
-    // A 401 means the portal session lapsed between the liveness check and the
-    // call — surface it as a re-login, not a generic failure.
-    if (error && error.statusCode === 401) {
-      const err = new Error('Your Hermes Cloud session has expired. Open Settings → Gateway and sign in again.') as any
-      err.needsCloudLogin = true
-      err.cause = error
-      throw err
-    }
+    })
 
-    // A 409 means we're a multi-org user who hasn't picked an org. The body
-    // carries the user's org list; surface it so the renderer shows a picker
-    // and re-calls discovery with the chosen org. (fetchJsonViaOauthSession
-    // throws on >=400 with err.statusCode + err.message "409: <json body>".)
-    if (error && error.statusCode === 409) {
-      const orgs = parseOrgSelectionError(error)
+  try {
+    body = (await fetchAgents()) as any
+  } catch (initialError) {
+    let error = initialError as any
 
-      if (orgs) {
-        return { needsOrgSelection: true, orgs }
+    // A 401 with renewal material still in the jar: attempt ONE bounded silent
+    // renewal and retry, so a lapsed access token doesn't surface as a full
+    // interactive re-login while a 30-day refresh session sits unused. Only a
+    // rejected/failed renewal (or a second 401 on genuinely fresh access)
+    // falls through to needsCloudLogin.
+    if (error && error.statusCode === 401 && (await renewPortalAccessSilently())) {
+      try {
+        body = (await fetchAgents()) as any
+      } catch (retryError) {
+        error = retryError
       }
     }
 
-    throw error
+    if (body === undefined) {
+      // A 401 means the portal session lapsed (and silent renewal could not
+      // recover it) — surface it as a re-login, not a generic failure.
+      if (error && error.statusCode === 401) {
+        const err = new Error('Your Hermes Cloud session has expired. Open Settings → Gateway and sign in again.') as any
+        err.needsCloudLogin = true
+        err.cause = error
+        throw err
+      }
+
+      // A 409 means we're a multi-org user who hasn't picked an org. The body
+      // carries the user's org list; surface it so the renderer shows a picker
+      // and re-calls discovery with the chosen org. (fetchJsonViaOauthSession
+      // throws on >=400 with err.statusCode + err.message "409: <json body>".)
+      if (error && error.statusCode === 409) {
+        const orgs = parseOrgSelectionError(error)
+
+        if (orgs) {
+          return { needsOrgSelection: true, orgs }
+        }
+      }
+
+      throw error
+    }
   }
 
   return { agents: trimCloudAgents(body), org: trimCloudOrg(body?.org) }
@@ -6783,6 +6995,14 @@ async function cloudAgentSilentSignIn(dashboardUrl) {
     const err = new Error('Your Hermes Cloud session has expired. Sign in to Hermes Cloud again.') as any
     err.needsCloudLogin = true
     throw err
+  }
+
+  // The cascade rides the portal's auto-approve, which needs the short-lived
+  // access state just like discovery. If only renewal material survived the
+  // restart, mint a fresh access token first so the hidden cascade window
+  // auto-SSOs instead of stalling on an interactive chooser (#73495).
+  if (!(await hasPortalAccessToken())) {
+    await renewPortalAccessSilently()
   }
 
   await openOauthLoginWindow(baseUrl, { silent: true })


### PR DESCRIPTION
## Summary

After a full Desktop restart, the configured Hermes Cloud agent no longer vanishes behind a "No agents found" / "session expired" re-login demand while a perfectly renewable Portal session sits in the persistent partition. Fixes #73495.

Root cause was two-fold:
1. `hasLivePortalSession()` trusted the first `cookies.get()` on the lazily-hydrating `persist:` partition — the exact cold-start false-negative PR #67769 already fixed for the per-agent gateway check, but never applied to the Portal check. The renderer reads Cloud status once on entering cloud mode, so one false negative cleared the agent list.
2. Discovery (`/api/agents`) authenticates with the ~1h `privy-token` access cookie, but the signed-in check accepted the 30-day `privy-session` cookie — so after a restart the panel showed "Signed in" while discovery 401'd straight into an interactive re-login, ignoring the renewable refresh material in the jar.

## Changes

- `connection-config.ts`: new `cookiesHavePrivyAccessToken()` + `PRIVY_ACCESS_COOKIE_VARIANTS` split "signed in (renewable)" from "discovery can succeed right now"; `PRIVY_SESSION_COOKIE_VARIANTS` learns `privy-refresh-token` so renewal-only jars still count as signed in.
- `main.ts`:
  - `hasLivePortalSession()` now reuses `warmOauthCookieStore()` + the bounded 30/60/90ms reread loop before trusting a negative (mirrors `hasLiveOauthSession`).
  - New `renewPortalAccessSilently()`: one bounded (12s deadline), hidden, in-flight-deduped portal load in the OAuth partition that lets the Privy client rotate a fresh `privy-token` from persisted refresh state. Never shown to the user.
  - `discoverCloudAgents()` renews up front when access state is missing, and on a 401 attempts exactly one silent renewal + retry before surfacing `needsCloudLogin`.
  - `cloudAgentSilentSignIn()` gets the same pre-renewal so the hidden cascade window auto-SSOs instead of stalling.
- `connection-config.test.ts`: 5 new tests, including the exact renewal-only cold-start jar from the issue repro (session check true, access check false).

## Validation

| Check | Result |
|---|---|
| `npx vitest run electron/connection-config.test.ts` | 79/79 pass (5 new) |
| `npx tsc --noEmit` (apps/desktop) | clean |
| `npx eslint` on the 3 touched files | 0 problems |

Interactive login is still requested when renewal genuinely fails (revoked refresh token, portal unreachable) — the 12s deadline resolves false and the existing `needsCloudLogin` path takes over.

## Infographic

![Cloud agents survive cold start](https://files.catbox.moe/4luq8x.png)
