### PR TITLE
fix(cwd): keep local CLI and TUI sessions in their launch directory

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -223,7 +223,7 @@ from hermes_cli.browser_connect import (
     manual_chrome_debug_command,
     try_launch_chrome_debug,
 )
-from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.env_loader import load_hermes_dotenv, pin_local_cli_launch_cwd
 from utils import base_url_host_matches, fast_safe_load
 
 _hermes_home = get_hermes_home()
@@ -699,7 +699,10 @@ def load_cli_config() -> Dict[str, Any]:
                 if _is_gateway:
                     continue
                 # CLI: always export (overrides stale .env or inherited values)
-                os.environ[env_var] = str(terminal_config[config_key])
+                if effective_backend == "local":
+                    pin_local_cli_launch_cwd(terminal_config[config_key])
+                else:
+                    os.environ[env_var] = str(terminal_config[config_key])
                 continue
             if _file_has_terminal_config or env_var not in os.environ:
                 val = terminal_config[config_key]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3317,6 +3317,19 @@ TERMINAL_CONFIG_ENV_MAP = {
     "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
 }
 
+# A local CLI/TUI owns its launch directory for the lifetime of the process.
+# This provenance cannot live in TERMINAL_CWD itself because dotenv/config
+# reloads use the same variable as their carrier. The pin is intentionally
+# process-local so gateway, cron, and child entrypoints resolve independently.
+_LOCAL_CLI_LAUNCH_CWD: Optional[str] = None
+
+
+def pin_local_cli_launch_cwd(cwd: str | os.PathLike[str]) -> None:
+    """Make a local CLI/TUI launch directory authoritative in this process."""
+    global _LOCAL_CLI_LAUNCH_CWD
+    _LOCAL_CLI_LAUNCH_CWD = os.fspath(cwd)
+    os.environ["TERMINAL_CWD"] = _LOCAL_CLI_LAUNCH_CWD
+
 
 def _terminal_env_value(value: Any) -> str:
     if isinstance(value, (list, dict)):
@@ -3358,8 +3371,10 @@ def apply_terminal_config_to_env(
     CLI without importing ``cli.py`` and paying for its startup side effects.
 
     Explicit keys in the user config's ``terminal`` section are authoritative
-    and override their matching env values.  Merged defaults only backfill
-    missing env vars; they never replace unrelated exported/.env values.
+    and override their matching env values. Merged defaults only backfill
+    missing env vars; they never replace unrelated exported/.env values. A
+    process-local CLI launch-directory pin is more specific than config.yaml
+    and remains authoritative across every bridge call in that process.
     """
     target = os.environ if env is None else env
 
@@ -3392,6 +3407,13 @@ def apply_terminal_config_to_env(
 
     for cfg_key, env_var in TERMINAL_CONFIG_ENV_MAP.items():
         if cfg_key not in terminal_cfg:
+            continue
+        if (
+            env_var == "TERMINAL_CWD"
+            and _LOCAL_CLI_LAUNCH_CWD is not None
+            and (env is None or target.get(env_var) == _LOCAL_CLI_LAUNCH_CWD)
+        ):
+            target[env_var] = _LOCAL_CLI_LAUNCH_CWD
             continue
         value = terminal_cfg[cfg_key]
         if cfg_key == "cwd":

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -52,6 +52,13 @@ _APPLIED_HOMES: set[str] = set()
 _SECRET_SOURCE_CACHE_LOCK = threading.RLock()
 
 
+def pin_local_cli_launch_cwd(cwd: str | os.PathLike[str]) -> None:
+    """Make a local CLI/TUI launch directory durable for this process."""
+    from hermes_cli.config import pin_local_cli_launch_cwd as _pin
+
+    _pin(cwd)
+
+
 def _known_hermes_env_keys() -> set[str]:
     """Return the combined set of known Hermes env-var keys.
 

--- a/tests/cli/test_cwd_env_respect.py
+++ b/tests/cli/test_cwd_env_respect.py
@@ -6,6 +6,8 @@ Rules:
 - Non-local with explicit path: keep as-is.
 """
 
+import os
+
 
 _CWD_PLACEHOLDERS = (".", "auto", "cwd")
 
@@ -97,3 +99,31 @@ class TestGatewayLazyImport:
         d = {"terminal": {"cwd": "/home/user"}}
         result = _resolve_cwd(tc, d, env)
         assert result == "/fake/getcwd"
+
+
+def test_real_local_cli_config_pin_survives_dotenv_reload(tmp_path, monkeypatch):
+    """Exercise the real CLI bridge and the later config re-apply together."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "terminal:\n"
+        "  backend: local\n"
+        "  cwd: /configured/gateway/workspace\n",
+        encoding="utf-8",
+    )
+    launch_cwd = tmp_path / "project"
+    launch_cwd.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+    monkeypatch.chdir(launch_cwd)
+
+    import cli
+    from hermes_cli.env_loader import load_hermes_dotenv
+
+    monkeypatch.setattr(cli, "_hermes_home", home)
+    cli.load_cli_config()
+    assert os.environ["TERMINAL_CWD"] == str(launch_cwd)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.environ["TERMINAL_CWD"] == str(launch_cwd)

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -539,6 +539,60 @@ def test_config_yaml_terminal_backend_overrides_stale_shell(tmp_path, monkeypatc
     assert os.getenv("TERMINAL_ENV") == "local"
 
 
+def test_local_cli_launch_cwd_survives_later_config_reapply(tmp_path, monkeypatch):
+    """A local CLI launch directory stays authoritative for the process."""
+    from hermes_cli import env_loader
+    from hermes_cli import config as config_mod
+
+    home = _seed_terminal_home(
+        tmp_path,
+        monkeypatch,
+        config_yaml=(
+            "terminal:\n"
+            "  backend: local\n"
+            "  cwd: /configured/gateway/workspace\n"
+            "  timeout: 777\n"
+        ),
+    )
+    launch_cwd = tmp_path / "project"
+    launch_cwd.mkdir()
+    monkeypatch.setattr(config_mod, "_LOCAL_CLI_LAUNCH_CWD", None)
+    monkeypatch.delenv("TERMINAL_TIMEOUT", raising=False)
+
+    env_loader.pin_local_cli_launch_cwd(launch_cwd)
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TERMINAL_CWD") == str(launch_cwd)
+    assert os.getenv("TERMINAL_TIMEOUT") == "777"
+
+    from tools import terminal_tool
+
+    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", False)
+    terminal_tool._ensure_terminal_env_bridged()
+    assert os.getenv("TERMINAL_CWD") == str(launch_cwd)
+
+
+def test_config_cwd_still_reapplies_without_local_cli_pin(tmp_path, monkeypatch):
+    """Gateway/cron reloads still re-apply an explicit terminal.cwd."""
+    from hermes_cli import config as config_mod
+
+    home = _seed_terminal_home(
+        tmp_path,
+        monkeypatch,
+        config_yaml=(
+            "terminal:\n"
+            "  backend: local\n"
+            "  cwd: /configured/gateway/workspace\n"
+        ),
+    )
+    monkeypatch.setattr(config_mod, "_LOCAL_CLI_LAUNCH_CWD", None)
+    monkeypatch.setenv("TERMINAL_CWD", "/stale/runtime/value")
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TERMINAL_CWD") == "/configured/gateway/workspace"
+
+
 def test_no_terminal_section_leaves_env_value_alone(tmp_path, monkeypatch):
     """When config.yaml has no terminal section, the .env value is still the
     user's active setting — the bridge must NOT clobber it with merged

--- a/tests/tui_gateway/test_launch_cwd.py
+++ b/tests/tui_gateway/test_launch_cwd.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_tui_entry_pins_local_launch_cwd_before_config_reload(tmp_path):
+    home = tmp_path / "hermes"
+    launch = tmp_path / "launch-project"
+    configured = tmp_path / "configured-workspace"
+    for path in (home, launch, configured):
+        path.mkdir()
+    (home / "config.yaml").write_text(
+        "terminal:\n"
+        "  backend: local\n"
+        f"  cwd: {configured.as_posix()}\n",
+        encoding="utf-8",
+    )
+
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env.update(
+        HERMES_HOME=str(home),
+        HERMES_CWD=str(launch),
+        HERMES_PYTHON_SRC_ROOT=str(repo_root),
+        TERMINAL_ENV="local",
+        TERMINAL_CWD=str(configured),
+    )
+    pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        f"{repo_root}{os.pathsep}{pythonpath}" if pythonpath else str(repo_root)
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os, sys; import tui_gateway.entry; "
+            "print('TUI_CWD=' + os.environ['TERMINAL_CWD'], file=sys.stderr)",
+        ],
+        cwd=launch,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+
+    assert f"TUI_CWD={launch}" in result.stderr.splitlines()

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -19,6 +19,21 @@ import traceback
 
 from tui_gateway._stdin_recovery import handle_spurious_eof
 
+
+def _pin_local_tui_launch_cwd() -> None:
+    """Preserve the wrapper's launch directory before server config reloads."""
+    backend = (os.environ.get("TERMINAL_ENV") or "local").strip().lower()
+    launch_cwd = (os.environ.get("HERMES_CWD") or "").strip()
+    if backend != "local" or not launch_cwd or not os.path.isdir(launch_cwd):
+        return
+
+    from hermes_cli.env_loader import pin_local_cli_launch_cwd
+
+    pin_local_cli_launch_cwd(launch_cwd)
+
+
+_pin_local_tui_launch_cwd()
+
 from tui_gateway import server
 from tui_gateway.server import _CRASH_LOG, dispatch, resolve_skin, write_json
 from tui_gateway.transport import TeeTransport


### PR DESCRIPTION
## What does this PR do?

Local CLI and TUI sessions now keep the directory from which Hermes was launched, even when `terminal.cwd` points elsewhere and configuration is reloaded during a turn. Without this fix, terminal and file tools can silently move to the configured directory after startup, and the system prompt can disagree with the workspace the user launched Hermes from.

### Symptom

For the local backend, Hermes initially resolves the launch directory correctly. A later dotenv or configuration bridge call can overwrite `TERMINAL_CWD` with the explicit `terminal.cwd`, so the first turn and later terminal or file operations run in a different directory.

The real TUI child had the same failure because its own process reloaded configuration without carrying the wrapper's launch-directory provenance.

### Impact

Affected local CLI and TUI users can run commands and relative file operations against the wrong workspace after startup. Gateway and cron processes must continue to honor their explicit configured cwd, so a global change to config precedence would regress those entry points.

### Bug Cause

**Trigger:** `hermes_cli/config.py` / `apply_terminal_config_to_env()` when an explicit `terminal.cwd` is bridged after local CLI or TUI startup

**Causal chain:**
1. Local CLI or TUI startup selects the launch directory as authoritative and exports it through `TERMINAL_CWD`.
2. A later `load_hermes_dotenv()` or terminal fallback bridge sees an explicit `terminal.cwd` but cannot distinguish it from the launch-time decision, so it overwrites the same environment variable.
3. Cwd resolvers and downstream terminal, file, and prompt paths observe the configured directory instead of the launch directory.

**Why it is wrong:** The same environment variable carried both user configuration and the runtime launch-directory decision, with no provenance indicating that local startup had already made the more specific choice.

**Working sibling / contrast:** Gateway and cron entry points do not establish a local CLI launch pin, so their explicit `terminal.cwd` remains authoritative.

**Ruled out:** The bug is not limited to the late `gateway.run` import. Repeated dotenv loads and terminal-tool fallback bridges reproduce the same overwrite, so removing one import side effect would leave sibling paths broken.

### Fix

Record local CLI/TUI launch-cwd provenance in process-local state and make every shared config-to-environment bridge preserve that pin. The classic CLI pins its validated local launch cwd, while the TUI gateway child restores the validated wrapper cwd before server imports reload configuration. Non-local backends and unpinned gateway or cron processes retain their existing config precedence.

## Related Issue

Closes #86411

## Type of Change

- [x] Bug fix

## Changes Made

- `cli.py` - pin the resolved local CLI launch cwd instead of exporting an untracked environment value.
- `hermes_cli/config.py` - add process-local launch-cwd provenance and preserve it across terminal config bridges.
- `hermes_cli/env_loader.py` - expose the bootstrap-safe pinning entry point used by CLI and TUI startup.
- `tui_gateway/entry.py` - restore the validated local TUI wrapper cwd before server configuration reloads.
- `tests/cli/test_cwd_env_respect.py` - cover local launch-directory pinning at CLI config load.
- `tests/hermes_cli/test_env_loader.py` - cover repeated reloads, terminal fallback bridges, and unpinned gateway behavior.
- `tests/tui_gateway/test_launch_cwd.py` - exercise the real TUI child process launch-cwd contract.

## How to Test

1. Configure a local backend with `terminal.cwd` different from the launch directory, start classic CLI or TUI from a project directory, trigger a turn-time configuration reload, and confirm cwd remains the project directory.
2. Start an unpinned gateway process with the same explicit configuration and confirm the configured cwd still wins.
3. Automated (already run locally, 47 passed):

```bash
scripts/run_tests.sh tests/cli/test_cwd_env_respect.py tests/hermes_cli/test_env_loader.py tests/tui_gateway/test_launch_cwd.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo's test entry on relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - the existing local launch-directory contract is restored without a user-facing configuration change
- [x] `cli-config.yaml.example` update: N/A - no config keys or documented defaults changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no contributor workflow changed
- [x] Cross-platform impact considered - path validation remains native and the provenance rule is process-local
- [x] Tool descriptions/schemas update: N/A - no model tool schema changed
