### PR TITLE
feat(discord): interaction ACK + error discipline

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# Discord omniscience I6

--- a/plugins/platforms/discord/interaction_ack.py
+++ b/plugins/platforms/discord/interaction_ack.py
@@ -1,0 +1,96 @@
+"""Discord interaction ACK + error discipline.
+
+Pure state logic for the Discord interaction lifecycle.  A Discord
+interaction must be acknowledged (or deferred) inside Discord's 3-second
+ACK window -- before any expensive work is started -- and can receive
+exactly one initial response.
+"""
+
+from __future__ import annotations
+
+import enum
+
+
+class InteractionAckError(ValueError):
+    """Raised when an interaction lifecycle transition is illegal."""
+
+
+class InteractionState(enum.Enum):
+    PENDING = "PENDING"
+    ACKED = "ACKED"
+    DEFERRED = "DEFERRED"
+    RESPONDED = "RESPONDED"
+    EXPIRED = "EXPIRED"
+
+
+ACK_WINDOW_SECONDS = 3.0
+
+
+class InteractionLifecycle:
+    """Tracks the ACK/response lifecycle of a single Discord interaction.
+
+    State machine::
+
+        PENDING --ack--> ACKED --respond--> RESPONDED
+        PENDING --defer-> DEFERRED --respond--> RESPONDED
+        PENDING --(past 3s)--> EXPIRED (ack/defer raise InteractionAckError)
+
+    Rules:
+      * ``ack``/``defer`` only from PENDING, and only within the 3-second
+        ACK window (``now - created_at <= 3.0``).
+      * exactly one initial response: ``respond`` only from ACKED/DEFERRED,
+        and a second ``respond`` raises.
+    """
+
+    def __init__(self, created_at: float) -> None:
+        self.created_at = created_at
+        self.state = InteractionState.PENDING
+
+    def _enforce_ack_window(self, now: float) -> None:
+        """Mark EXPIRED and raise when the 3s ACK window has lapsed."""
+        if now - self.created_at > ACK_WINDOW_SECONDS:
+            self.state = InteractionState.EXPIRED
+            raise InteractionAckError(
+                "interaction ACK window (3s) expired: "
+                f"created_at={self.created_at!r}, now={now!r}"
+            )
+
+    def ack(self, now: float) -> None:
+        """Acknowledge the interaction inside the 3s window (PENDING -> ACKED)."""
+        if self.state is not InteractionState.PENDING:
+            raise InteractionAckError(
+                f"cannot ack interaction in state {self.state.value}"
+            )
+        self._enforce_ack_window(now)
+        self.state = InteractionState.ACKED
+
+    def defer(self, now: float) -> None:
+        """Defer the interaction inside the 3s window (PENDING -> DEFERRED)."""
+        if self.state is not InteractionState.PENDING:
+            raise InteractionAckError(
+                f"cannot defer interaction in state {self.state.value}"
+            )
+        self._enforce_ack_window(now)
+        self.state = InteractionState.DEFERRED
+
+    def respond(self, now: float) -> None:
+        """Send the one initial response (ACKED/DEFERRED -> RESPONDED).
+
+        Raises ``InteractionAckError`` if the interaction was already
+        responded to (single-response invariant) or is not in a state
+        from which an initial response is allowed.
+        """
+        if self.state is InteractionState.RESPONDED:
+            raise InteractionAckError(
+                "interaction already responded; only one initial response allowed"
+            )
+        if self.state not in (InteractionState.ACKED, InteractionState.DEFERRED):
+            raise InteractionAckError(
+                "cannot respond to interaction in state "
+                f"{self.state.value}; must be acked or deferred first"
+            )
+        self.state = InteractionState.RESPONDED
+
+    def is_within_ack_window(self, now: float) -> bool:
+        """True while ``now`` is still inside the 3s ACK window (<= 3.0)."""
+        return now - self.created_at <= ACK_WINDOW_SECONDS

--- a/tests/tools/test_discord_interaction_ack.py
+++ b/tests/tools/test_discord_interaction_ack.py
@@ -1,0 +1,120 @@
+"""Tests for the Discord interaction ACK + error discipline state machine."""
+
+import pytest
+
+from plugins.platforms.discord.interaction_ack import (
+    ACK_WINDOW_SECONDS,
+    InteractionAckError,
+    InteractionLifecycle,
+    InteractionState,
+)
+
+
+def test_ack_happy_path():
+    lc = InteractionLifecycle(created_at=100.0)
+    lc.ack(now=102.0)
+    assert lc.state is InteractionState.ACKED
+
+
+def test_ack_exactly_at_deadline_succeeds():
+    lc = InteractionLifecycle(created_at=100.0)
+    lc.ack(now=100.0 + ACK_WINDOW_SECONDS)
+    assert lc.state is InteractionState.ACKED
+
+
+def test_ack_after_deadline_marks_expired_and_raises():
+    lc = InteractionLifecycle(created_at=100.0)
+    with pytest.raises(InteractionAckError):
+        lc.ack(now=100.0 + ACK_WINDOW_SECONDS + 0.000001)
+    assert lc.state is InteractionState.EXPIRED
+
+
+def test_ack_when_not_pending_raises():
+    lc = InteractionLifecycle(created_at=100.0)
+    lc.ack(now=101.0)
+    with pytest.raises(InteractionAckError):
+        lc.ack(now=101.5)
+    assert lc.state is InteractionState.ACKED
+
+
+def test_ack_error_is_value_error():
+    lc = InteractionLifecycle(created_at=100.0)
+    with pytest.raises(ValueError):
+        lc.ack(now=104.0)
+
+
+def test_defer_happy_path():
+    lc = InteractionLifecycle(created_at=100.0)
+    lc.defer(now=102.0)
+    assert lc.state is InteractionState.DEFERRED
+
+
+def test_defer_after_deadline_marks_expired_and_raises():
+    lc = InteractionLifecycle(created_at=100.0)
+    with pytest.raises(InteractionAckError):
+        lc.defer(now=100.0 + ACK_WINDOW_SECONDS + 0.000001)
+    assert lc.state is InteractionState.EXPIRED
+
+
+def test_respond_once_from_acked():
+    lc = InteractionLifecycle(created_at=100.0)
+    lc.ack(now=101.0)
+    lc.respond(now=102.0)
+    assert lc.state is InteractionState.RESPONDED
+
+
+def test_respond_once_from_deferred():
+    lc = InteractionLifecycle(created_at=100.0)
+    lc.defer(now=101.0)
+    lc.respond(now=120.0)  # response itself is not bounded by the 3s window
+    assert lc.state is InteractionState.RESPONDED
+
+
+def test_respond_twice_raises_single_response_invariant():
+    lc = InteractionLifecycle(created_at=100.0)
+    lc.ack(now=101.0)
+    lc.respond(now=101.5)
+    with pytest.raises(InteractionAckError):
+        lc.respond(now=102.0)
+    assert lc.state is InteractionState.RESPONDED
+
+
+def test_respond_twice_from_deferred_raises():
+    lc = InteractionLifecycle(created_at=100.0)
+    lc.defer(now=101.0)
+    lc.respond(now=101.5)
+    with pytest.raises(InteractionAckError):
+        lc.respond(now=102.0)
+
+
+def test_respond_without_ack_raises():
+    lc = InteractionLifecycle(created_at=100.0)
+    with pytest.raises(InteractionAckError):
+        lc.respond(now=101.0)
+    assert lc.state is InteractionState.PENDING
+
+
+def test_respond_after_expiry_raises():
+    lc = InteractionLifecycle(created_at=100.0)
+    with pytest.raises(InteractionAckError):
+        lc.ack(now=104.0)
+    with pytest.raises(InteractionAckError):
+        lc.respond(now=104.5)
+    assert lc.state is InteractionState.EXPIRED
+
+
+def test_is_within_ack_window_true_inside_window():
+    lc = InteractionLifecycle(created_at=100.0)
+    assert lc.is_within_ack_window(now=100.0) is True
+    assert lc.is_within_ack_window(now=102.9) is True
+
+
+def test_is_within_ack_window_boundary_exactly_three_seconds():
+    lc = InteractionLifecycle(created_at=100.0)
+    assert lc.is_within_ack_window(now=100.0 + ACK_WINDOW_SECONDS) is True
+
+
+def test_is_within_ack_window_false_outside_window():
+    lc = InteractionLifecycle(created_at=100.0)
+    assert lc.is_within_ack_window(now=100.0 + ACK_WINDOW_SECONDS + 0.000001) is False
+    assert lc.is_within_ack_window(now=200.0) is False


### PR DESCRIPTION
**Discord I6** (Part of #79564, Fixes #86484): interaction ACK + error discipline in `plugins/platforms/discord/interaction_ack.py`. 16/16 tests pass. New module only.